### PR TITLE
fix(tools): refuse when nothing vouches for the running copy, and make --timeout 0 a real single pass

### DIFF
--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -12,25 +12,33 @@ something that resolves whether or not anyone is watching, and the verdict costs
 read afterwards. This is a standing instruction from the repository owner and it replaces the
 older advice in this file, which told agents to wait in the foreground.
 
-**`tools/ci-wait.py <PR> --timeout 1`** is the read. One pass, one answer, back in about a second:
+**`tools/ci-wait.py <PR> --timeout 0`** is the read. One pass, one answer, back in about a
+second:
 
 ```bash
-tools/ci-wait.py 2379 --timeout 1     # reads the verdict now; does not block
+tools/ci-wait.py 2379 --timeout 0     # reads the verdict now; does not block
 ```
 
-**It must be `--timeout 1`, never `--timeout 0`.** The poll is `deadline = time.time() +
-args.timeout` followed by `while time.time() < deadline:`, so a zero timeout never enters the
-loop and falls through to a bare `return 2`: **exits 0, 1 and 4 become unreachable and no check
-is ever looked at.** The pre-loop work still runs, so the head SHA and the required-context set
-are fetched and exit 3 remains reachable — a stale-worktree refusal is the likeliest thing you
-will actually hit. It is otherwise silent: the output is the ordinary still-running line, and
-the tell is that its parentheses are empty, `STILL RUNNING after 0s ()`, where the count of
-completed and failing checks belongs. Measured on one head seconds apart — `--timeout 0` exit 2,
-`--timeout 1` exit 0 GREEN with 10/10 ruleset contexts.
+**`--timeout 0` means a single pass**, and says so in its own `--help`: look once, report
+whatever has reported, do not wait. A negative value is refused by `argparse` rather than
+silently behaving like zero.
 
-That also means **"I ran it and got STILL RUNNING" proves nothing** on its own: that is what a
-green PR, a red PR and a PR with no checks all print under a zero timeout. Check a read against
-a PR you already know the state of before trusting a new invocation.
+This file said the opposite until #3351 — *"it must be `--timeout 1`, never `--timeout 0`"* —
+and the reasoning was correct about the code at the time. The poll was `deadline = time.time()
++ args.timeout` followed by `while time.time() < deadline:`, so a zero timeout never entered
+the loop, fell through to a bare `return 2`, and made exits 0, 1 and 4 unreachable without
+looking at a single check. Its only tell was empty parentheses — `STILL RUNNING after 0s ()` —
+where the progress detail belongs. `--timeout 1` was standing in for a single-pass mode by
+accident of timing: one second happens to be long enough for one poll.
+
+The loop is now a do-while, so the body always runs at least once, and the still-running line
+can no longer be emitted with an empty reason. **`--timeout 1` still works** and still means
+"wait up to a second"; it is simply no longer the way to express "look once".
+
+The general lesson outlives the specific bug: **an answer that could not have come out any
+other way is not evidence.** "I ran it and got STILL RUNNING" proved nothing under the old
+zero-timeout path, because a green PR, a red PR and a PR with no checks all printed it. Check
+a read against a PR whose state you already know before trusting a new invocation.
 
 Everything else in this file is about *how* to read a verdict, and none of it changes: a
 verdict belongs to one commit, a cancelled run is not a failure, and a failed job's log must
@@ -49,7 +57,7 @@ Move on; read again later. It is never a green, and never a reason to re-roll an
 The anti-poll argument this section used to make still holds *within* one read: never
 hand-roll `gh run view` plus `sleep`. Measured across one session's 17 subagents, CI waiting
 was 328 of 3,282 Bash calls, shaped as 107 `gh run view` polls and 37 `sleep` loops against
-only 29 proper waits. One `--timeout 1` call replaces all of it.
+only 29 proper waits. One `--timeout 0` call replaces all of it.
 
 | exit | meaning |
 |---|---|
@@ -124,7 +132,7 @@ Two things it cannot do, so do them yourself:
   for f in ci-wait.py agent_self_freshness.py; do
     git show "origin/main:tools/$f" > "$d/tools/$f"
   done
-  python3 "$d/tools/ci-wait.py" <PR> --timeout 1
+  python3 "$d/tools/ci-wait.py" <PR> --timeout 0
   ```
   **Extract both files, not just `ci-wait.py`** (#3295). A lone copy cannot import its sibling
   guard, and that used to print a note and judge the PR anyway — so the recipe *recommended
@@ -256,7 +264,7 @@ it can dispatch any of the eight against your branch. And the leg-set evidence i
 thinner on a PR: three legs give far fewer distinguishable failing sets than eight, so prefer
 the dispatch or an empty commit over reading a pattern out of three data points.
 
-Read the result with `tools/ci-wait.py <PR> --timeout 1`; do **not** block on it and do not
+Read the result with `tools/ci-wait.py <PR> --timeout 0`; do **not** block on it and do not
 hand-roll a `gh run view` poll loop (section 0). Anything other than `completed` means "not yet
 reported", never "green" — leave the PR and read it again on your next pass.
 

--- a/.claude/rules/no-backgrounding-long-commands.md
+++ b/.claude/rules/no-backgrounding-long-commands.md
@@ -10,7 +10,7 @@ the foreground command or truly move on.
 **CI is the one thing you never wait for, in the foreground or anywhere else.** A workflow run
 is not your child process: it completes whether or not this turn is alive, and its verdict is
 there to read whenever you come back. So push, open the PR, and move on — then read the result
-later with `tools/ci-wait.py <PR> --timeout 1`. `ci-verdicts.md` §0 is the rule; this one
+later with `tools/ci-wait.py <PR> --timeout 0`. `ci-verdicts.md` §0 is the rule; this one
 governs work running locally.
 
 A cold full-corpus run (build + AL emit + C# compile + execute ~2000 tests) is not a
@@ -52,7 +52,7 @@ so the loss is survivable; or genuinely abandon it and say so. "Start it, end th
 wait" is not on the list.
 
 For a pull request, the correct shape is different and simpler: push, open it, hand back. Read
-the verdict on a later pass with `tools/ci-wait.py <PR> --timeout 1`, which answers at once and
+the verdict on a later pass with `tools/ci-wait.py <PR> --timeout 0`, which answers at once and
 refuses to call a still-running check a result — see `ci-verdicts.md` for the exit codes.
 
 ## Sister rules

--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -225,7 +225,7 @@ Merge when **all of**:
 3. The proving test exists. If the claim is about BC's behavior, that test is upstream and
    merged, or merging in the same pass.
 
-**Read the verdict with `tools/ci-wait.py <PR> --timeout 1`; never block on it.** One pass,
+**Read the verdict with `tools/ci-wait.py <PR> --timeout 0`; never block on it.** One pass,
 one answer, returns at once: 0 green on current head, 1 failed with the log already fetched,
 2 still running (*not* a verdict), 3 undetermined, 4 blocked with everything green — a
 cancelled required context (below), or a required context that produced no check run at all

--- a/tools/agent_self_freshness.py
+++ b/tools/agent_self_freshness.py
@@ -87,10 +87,18 @@ separates them is whether anything OUTSIDE git vouches for the running code:
   identical  no merge base (shallow clone), but the file is byte-identical to
              origin/main's blob. Identity is provenance; the history is beside
              the point once the bytes match.
-  unvouched  everything else. Tracked in a repository with no origin/main;
-             untracked inside one; differing from origin/main with no merge base
-             to judge by. Nothing here says the copy is current, and its age is
-             unknowable from git -- so there is no answer to give.
+  unvouched  everything else. Untracked inside a repository; differing from
+             origin/main with no merge base to judge by; or no origin/main
+             ANYWHERE -- not locally and not from the remote when asked. Nothing
+             here says the copy is current, and its age is unknowable from git.
+
+A missing LOCAL origin/main ref is deliberately NOT in that list, because it is
+not the same fact as "origin/main is out of reach". GitHub Actions checks out
+with fetch-depth 1 and a refspec covering only the branch under test, so
+refs/remotes/origin/main does not exist on any CI run -- while the remote answers
+fine. Treating the two as one refused every CI run (caught in review on the first
+version of this fix). The remote is asked before anything is refused, via
+FETCH_HEAD, which creates and moves no ref.
 
 Only "unvouched" refuses. That keeps the temp-directory recipe working, which
 matters because it is the ONLY route open to a copy older than this check.
@@ -142,6 +150,9 @@ class Freshness:
       "behind-unfetchable" it did not, and the fetch failed.
       "unreachable"        the remote could not be reached at all.
       "no-ref"             the remote has no refs/heads/main.
+      "fetched-direct"     there was no local refs/remotes/<remote>/<branch>, so the
+                           comparison base came from the remote via FETCH_HEAD. It
+                           needs no further confirmation: it IS the remote's answer.
       "skipped"            remote_check was off, or the answer was already stale.
     """
 
@@ -204,6 +215,99 @@ def _remedy(relpath: str) -> str:
             f"    git show origin/main:{relpath} > /tmp/{os.path.basename(relpath)} "
             f"&& python3 /tmp/{os.path.basename(relpath)} <args>\n"
             "  or work from a checkout that is up to date with origin/main.")
+
+
+def _fetch_head(runner, root: str, remote: str, branch: str, *,
+                timeout: int | None = 30) -> tuple[str | None, str]:
+    """`origin/main`'s commit via FETCH_HEAD, without creating or moving any ref.
+
+    For a checkout that has no refs/remotes/<remote>/<branch> -- the shape
+    actions/checkout produces, and the shape a never-fetched clone has. Returns
+    (sha, why): sha is None when the remote would not answer, and `why` then says
+    what happened, because "could not reach the remote" and "this copy is stale"
+    are different facts and the caller has to be able to say which it hit.
+
+    `git fetch <remote> <branch>` with no refspec updates FETCH_HEAD only. That
+    matters: this module is a read, and a guard that quietly reorganises the
+    caller's refs to answer a question is doing something the caller did not ask
+    for. Deepening a shallow clone was the alternative and is rejected for the
+    same reason -- it rewrites the object store to answer a question that
+    FETCH_HEAD already answers.
+    """
+    # `--refmap=` with an explicit source ref suppresses the configured refspec,
+    # so NOTHING under refs/remotes/ is created or moved -- only FETCH_HEAD.
+    # Without it git applies remote.origin.fetch anyway and helpfully recreates
+    # refs/remotes/<remote>/<branch>, which a later call then reads as a local
+    # ref and trusts. Measured: that made a genuinely stale file read as current
+    # on the second call, because the ref it resurrected was already behind.
+    rc, _, err = _git(runner, root, "fetch", "--quiet", "--refmap=",
+                      remote, f"refs/heads/{branch}", timeout=timeout)
+    if rc != 0:
+        return None, (err or "fetch failed")[:120]
+    sha = _rev(runner, root, "FETCH_HEAD")
+    if not sha:
+        return None, "fetch succeeded but FETCH_HEAD could not be resolved"
+    return sha, ""
+
+
+def _is_shallow(runner, root: str) -> bool:
+    """True for a shallow clone -- the only shape deepening can help."""
+    rc, out, _ = _git(runner, root, "rev-parse", "--is-shallow-repository")
+    return rc == 0 and out.strip() == "true"
+
+
+# Deepening steps. Bounded on purpose: a branch point is normally a few tens of
+# commits back, and an unbounded --unshallow on a large repository is a very
+# different operation from the ~8s measured here. If none of these reaches a
+# merge base, the honest answer is that this checkout cannot establish it.
+_DEEPEN_STEPS = (100, 500)
+
+
+def _deepen(runner, root: str, remote: str, branch: str, *,
+            timeout: int | None = 30) -> bool:
+    """Pull in history so a shallow clone's grafted boundary stops lying.
+
+    Unconditional, unlike _deepen_for_merge_base below: a shallow clone always
+    HAS a merge base -- git reports the graft point, which for a freshly fetched
+    tip is that tip itself -- so "stop as soon as one resolves" would stop
+    immediately, on the wrong answer. Measured: before deepening, mb ==
+    FETCH_HEAD and a stale file reads as current; after, the comparison is
+    truthful in both directions.
+    """
+    rc, _, _ = _git(runner, root, "fetch", "--quiet", "--refmap=",
+                    f"--deepen={_DEEPEN_STEPS[0]}", remote, f"refs/heads/{branch}",
+                    timeout=timeout)
+    return rc == 0
+
+
+def _deepen_for_merge_base(runner, root: str, remote: str, branch: str,
+                           base: str, *, timeout: int | None = 30) -> str | None:
+    """Deepen a shallow clone until a merge base with `base` resolves; else None.
+
+    Adds history objects only -- measured on a real depth-1 CI clone: HEAD
+    unchanged, every ref unchanged, working tree clean. Nothing the repository
+    POINTS AT is altered, which is the property that makes this acceptable in a
+    read-only guard where creating or moving a ref would not be.
+
+    That property depends entirely on `--refmap=`, which is why every fetch in
+    this module carries it. Without it git applies the configured
+    remote.origin.fetch refspec and RECREATES refs/remotes/<remote>/<branch> as
+    a side effect. Measured consequence: a second assess() call then found that
+    resurrected ref, took the local-ref path instead of this one, and trusted a
+    ref that was already behind -- reporting a genuinely stale file as current.
+    A guard that silently rewrites the state it is about to read is worse than
+    one that refuses.
+    """
+    for depth in _DEEPEN_STEPS:
+        rc, _, _ = _git(runner, root, "fetch", "--quiet", "--refmap=",
+                        f"--deepen={depth}", remote, f"refs/heads/{branch}",
+                        timeout=timeout)
+        if rc != 0:
+            return None
+        rc, mb, _ = _git(runner, root, "merge-base", "HEAD", base)
+        if rc == 0 and mb:
+            return mb.strip()
+    return None
 
 
 def _detached(path: str, directory: str) -> Freshness:
@@ -279,22 +383,59 @@ def assess(path: str, *, remote_check: bool = True, remote: str = "origin",
             "meant the extract-to-a-temp-directory recipe, extract to a directory "
             "that is not inside a repository.", path)
 
+    notes: list[str] = []
     base = _rev(runner, root, ref)
     if not base:
-        # A real repository with the file tracked in it, and no origin/main to
-        # compare against. The content can be arbitrarily old and nothing in
-        # reach says otherwise -- this is the case #3296 was filed about.
-        return _unvouched(
-            f"note: REFUSING to vouch for {relpath} -- this repository has no {ref} "
-            "to compare against, so nothing has established that this copy carries "
-            "the latest fixes.", path, relpath=relpath)
+        # No LOCAL origin/main ref. That is not the same fact as "origin/main is
+        # out of reach", and conflating them refuses every CI run: GitHub Actions
+        # checks out with fetch-depth 1 and a refspec narrowed to the PR branch,
+        # so refs/remotes/origin/main does not exist -- while the remote itself
+        # answers perfectly well.
+        #
+        # So ASK THE REMOTE before giving up. `git fetch <remote> <branch>` with
+        # no refspec writes FETCH_HEAD and creates or moves no branch ref, so
+        # this stays a read: the caller's repository is not reorganised by a
+        # tool whose whole job is to answer a question about it.
+        # Deepen FIRST when the clone is shallow. A shallow clone's grafted
+        # boundary makes git report the freshly-fetched tip as its own merge
+        # base -- measured: mb == FETCH_HEAD, so mb_blob == base_blob and a
+        # genuinely stale file reads as current. Deepening dissolves the graft
+        # and the comparison becomes truthful again (measured both ways).
+        # Without this the fallback would trade a refusal for a rubber stamp,
+        # which is worse than refusing.
+        if _is_shallow(runner, root):
+            _deepen(runner, root, remote, branch, timeout=timeout)
+        base, why = _fetch_head(runner, root, remote, branch, timeout=timeout)
+        if not base:
+            # Genuinely nothing to compare against: no local ref AND the remote
+            # would not answer. This is the case #3296 is about -- a long-lived
+            # clone that never fetched -- and it is now reached only when the
+            # remote has also been asked and declined.
+            return _unvouched(
+                f"note: REFUSING to vouch for {relpath} -- this repository has no {ref}, "
+                f"and {remote}/{branch} could not be reached to compare against either "
+                f"({why}). Nothing has established that this copy carries the latest "
+                "fixes.", path, relpath=relpath)
+        notes.append(
+            f"note: this repository has no {ref}, so {relpath} was compared against "
+            f"{remote}/{branch} fetched directly ({base[:8]}). Normal for a shallow "
+            "CI checkout, whose refspec covers only the branch under test.")
 
-    notes: list[str] = []
-    result = _evaluate(runner, root, relpath, base, notes)
+    # True when `base` came from the remote just now rather than from a local
+    # ref. The confirmation block below exists to close the window in which a
+    # SHARED local ref has drifted from the remote; a base fetched seconds ago
+    # has no such window, and re-deriving it from `ref` would read None in a CI
+    # checkout and report a healthy run as "behind-unfetchable".
+    base_from_remote = not _rev(runner, root, ref)
+
+    result = _evaluate(runner, root, relpath, base, notes, remote=remote,
+                       branch=branch, timeout=timeout)
+    if base_from_remote:
+        result.base_confirmed = "fetched-direct"
 
     # The remote confirmation runs only when the local answer was NOT already
     # stale: a refusal should be instant and should not depend on the network.
-    if result.state != "stale" and remote_check:
+    if result.state != "stale" and remote_check and not base_from_remote:
         rc, out, _ = _git(runner, root, "ls-remote", "--exit-code", remote,
                           f"refs/heads/{branch}", timeout=timeout)
         tip, tip_state = parse_ls_remote(rc, out)
@@ -307,7 +448,8 @@ def assess(path: str, *, remote_check: bool = True, remote: str = "origin",
             if frc == 0 and new_base:
                 notes.append(f"note: {ref} was behind {remote}/{branch} and has been "
                              f"fetched ({base[:8]} -> {new_base[:8]}).")
-                result = _evaluate(runner, root, relpath, new_base, notes)
+                result = _evaluate(runner, root, relpath, new_base, notes,
+                                   remote=remote, branch=branch, timeout=timeout)
                 result.base_confirmed = "refreshed"
             else:
                 result.base_confirmed = "behind-unfetchable"
@@ -332,7 +474,9 @@ def assess(path: str, *, remote_check: bool = True, remote: str = "origin",
     return result
 
 
-def _evaluate(runner, root: str, relpath: str, base: str, notes: list[str]) -> Freshness:
+def _evaluate(runner, root: str, relpath: str, base: str, notes: list[str],
+              *, remote: str = "origin", branch: str = "main",
+              timeout: int | None = 30) -> Freshness:
     """The staleness question itself, against one resolved origin/main commit."""
     base_blob = _rev(runner, root, f"{base}:{relpath}")
     local_blob = None
@@ -362,6 +506,31 @@ def _evaluate(runner, root: str, relpath: str, base: str, notes: list[str]) -> F
             return Freshness("unknown", False, base_confirmed="skipped",
                              local_blob=local_blob, base_blob=base_blob,
                              provenance="identical")
+        # The file DIFFERS and there is no merge base, so the question is
+        # genuinely open: a branch that edits the tool and a stale copy look
+        # identical from here. Before refusing, try to make it answerable --
+        # a shallow clone has no merge base because it has no history, and
+        # history is fetchable.
+        #
+        # Deepening is a bigger step than the FETCH_HEAD read above, so it is
+        # last, bounded, and only on this branch -- never when the blobs already
+        # match. Measured on a real depth-1 CI clone of this repository: ~8s,
+        # HEAD unchanged, every ref unchanged, working tree clean. It only adds
+        # history objects: the repository learns more and points at nothing new.
+        # That is why it is acceptable where creating or moving a ref would not
+        # be -- the objection to mutation is about what a repository POINTS AT,
+        # which this does not touch.
+        if _is_shallow(runner, root):
+            mb = _deepen_for_merge_base(runner, root, remote, branch, base,
+                                        timeout=timeout)
+            if mb:
+                notes.append(
+                    f"note: no merge base with origin/main for {relpath} in a shallow "
+                    f"checkout, so history was deepened until one resolved ({mb[:8]}). "
+                    "No ref was created or moved.")
+                return _judge_against_merge_base(runner, root, relpath, mb, base_blob,
+                                                 local_blob, notes)
+
         notes.append(
             f"note: REFUSING to vouch for {relpath} -- no merge base with "
             "origin/main (shallow clone?), and the file differs from origin/main's "
@@ -372,6 +541,19 @@ def _evaluate(runner, root: str, relpath: str, base: str, notes: list[str]) -> F
                          local_blob=local_blob, base_blob=base_blob,
                          provenance="unvouched")
 
+    return _judge_against_merge_base(runner, root, relpath, mb, base_blob,
+                                     local_blob, notes)
+
+
+def _judge_against_merge_base(runner, root: str, relpath: str, mb: str,
+                              base_blob: str, local_blob: str | None,
+                              notes: list[str]) -> Freshness:
+    """The staleness verdict itself, given a resolved merge base.
+
+    Shared by the ordinary path and the deepened-shallow-clone path so the two
+    cannot drift: a second copy of this comparison is a second place for the
+    definition of "stale" to be wrong.
+    """
     mb_blob = _rev(runner, root, f"{mb}:{relpath}")
 
     if mb_blob != base_blob:

--- a/tools/agent_self_freshness.py
+++ b/tools/agent_self_freshness.py
@@ -75,10 +75,25 @@ worktrees are recycled. Nothing that lives inside the file can fix a copy of the
 file that is older than the fix -- only the invocation rule in
 `.claude/rules/ci-verdicts.md` covers those.
 
-A copy moved outside a git repository is UNKNOWN, and answers with a loud note
-rather than refusing. That is deliberate: the remedy this module prints is to run
-`origin/main`'s copy out of a temp directory, and a remedy that refuses itself is
-not a remedy.
+The two unknowns (#3296)
+------------------------
+"Could not establish" is not one situation, and resolving all of it toward an
+answer is how a guard reaches a verdict with its own safety check skipped. What
+separates them is whether anything OUTSIDE git vouches for the running code:
+
+  detached   the file is not in a git repository. The caller extracted it and
+             put it there -- that is the remedy this module prints, and a remedy
+             that refuses itself is not a remedy. Provenance is the caller's act.
+  identical  no merge base (shallow clone), but the file is byte-identical to
+             origin/main's blob. Identity is provenance; the history is beside
+             the point once the bytes match.
+  unvouched  everything else. Tracked in a repository with no origin/main;
+             untracked inside one; differing from origin/main with no merge base
+             to judge by. Nothing here says the copy is current, and its age is
+             unknowable from git -- so there is no answer to give.
+
+Only "unvouched" refuses. That keeps the temp-directory recipe working, which
+matters because it is the ONLY route open to a copy older than this check.
 """
 from __future__ import annotations
 
@@ -105,9 +120,21 @@ class Freshness:
                  has not incorporated. REFUSE: the running code is known to be
                  behind a published change to itself.
       "new"      the file does not exist on origin/main at all. Not refused.
-      "unknown"  could not be established -- outside a git repository, no
-                 origin/main ref, git missing, a shallow clone with no merge
-                 base. Not refused; said out loud.
+      "unknown"  could not be established. Whether that refuses depends on
+                 `provenance` below -- see the module docstring.
+
+    provenance: only meaningful when state is "unknown". Which of the two
+    unknowns this is: whether anything outside git vouches for the running code.
+      "detached"   the file is not inside a git repository at all, so the caller
+                   put it where it is. That is the documented extract-to-/tmp
+                   recipe, whose provenance IS the guarantee. NOT refused.
+      "identical"  no merge base (shallow clone), but the file is byte-identical
+                   to origin/main's blob. That identity is the guarantee. NOT
+                   refused.
+      "unvouched"  nothing vouches for it: tracked in a repository with no
+                   origin/main, untracked inside one, or differing from
+                   origin/main with no merge base to judge by. REFUSED.
+      "n/a"        state is not "unknown".
 
     base_confirmed:
       "confirmed"          the local origin/main ref matches the remote's main.
@@ -122,6 +149,7 @@ class Freshness:
     refuse: bool
     notes: list[str] = field(default_factory=list)
     base_confirmed: str = "skipped"
+    provenance: str = "n/a"
     local_blob: str | None = None
     base_blob: str | None = None
 
@@ -178,6 +206,33 @@ def _remedy(relpath: str) -> str:
             "  or work from a checkout that is up to date with origin/main.")
 
 
+def _detached(path: str, directory: str) -> Freshness:
+    """Outside a repository: the caller's own extraction is the provenance.
+
+    This is the one unknown that answers. See the module docstring; the note is
+    loud because the guarantee rests entirely on the caller having followed the
+    documented recipe, and nobody but the caller can check that.
+    """
+    return Freshness("unknown", False, [
+        f"note: {os.path.basename(path)} is not inside a git repository "
+        f"({directory}), so its freshness cannot be checked here. Answering on "
+        "the caller's PROVENANCE: this is the documented recipe of extracting "
+        "origin/main's copy to a temp directory, and that extraction is the "
+        "guarantee. If you did NOT just extract it from origin/main, this answer "
+        "is not vouched for by anything."], provenance="detached")
+
+
+def _unvouched(note: str, path: str, relpath: str | None = None) -> Freshness:
+    """Nothing vouches for this copy, so there is no answer to give (#3296).
+
+    Refusing rather than noting is the whole point: a note next to a verdict is
+    read as a caveat on a result, and the result is what the caller acts on.
+    """
+    return Freshness("unknown", True,
+                     [note, _remedy(relpath or f"tools/{os.path.basename(path)}")],
+                     provenance="unvouched")
+
+
 def assess(path: str, *, remote_check: bool = True, remote: str = "origin",
            branch: str = "main", runner=None, timeout: int = 20) -> Freshness:
     """Whether the copy of `path` on disk is behind origin/<branch> on that file.
@@ -197,26 +252,42 @@ def assess(path: str, *, remote_check: bool = True, remote: str = "origin",
 
     path = os.path.abspath(path)
     directory = os.path.dirname(path)
-    rc, root, _ = _git(runner, None, "-C", directory, "rev-parse", "--show-toplevel")
+    rc, root, err = _git(runner, None, "-C", directory, "rev-parse", "--show-toplevel")
     if rc != 0 or not root:
-        return Freshness("unknown", False, [
-            f"note: could not establish whether {os.path.basename(path)} is current -- "
-            f"{directory} is not inside a git repository (or git is unavailable). "
-            "Answering anyway; nothing here has checked that this copy of the tool "
-            "carries the latest fixes."])
+        # "Not a repository" and "git is not installed" used to share this branch
+        # and its answer. They are opposite facts: the first is the documented
+        # extract-to-/tmp recipe, whose provenance is the caller's own act; the
+        # second means the check could not run at all, which vouches for nothing.
+        # git says "not a git repository" on stderr; _default_runner puts the
+        # OSError text there when the binary is missing.
+        if "not a git repository" in err.lower():
+            return _detached(path, directory)
+        return _unvouched(
+            f"note: REFUSING to vouch for {os.path.basename(path)} -- git could not "
+            f"be run to check it ({err[:120]}). Nothing here has established that "
+            "this copy carries the latest fixes.", path)
 
     rc, relpath, _ = _git(runner, root, "ls-files", "--full-name", "--", path)
     relpath = relpath.splitlines()[0].strip() if relpath else ""
     if rc != 0 or not relpath:
-        return Freshness("unknown", False, [
-            f"note: could not establish whether {os.path.basename(path)} is current -- "
-            f"it is not a tracked file in {root}. Answering anyway."])
+        # Inside a repository but untracked. Not the temp-directory recipe (that
+        # lands OUTSIDE a repository), and being untracked is exactly what makes
+        # the file's age unknowable from git.
+        return _unvouched(
+            f"note: REFUSING to vouch for {os.path.basename(path)} -- it is not a "
+            f"tracked file in {root}, so git can say nothing about its age. If you "
+            "meant the extract-to-a-temp-directory recipe, extract to a directory "
+            "that is not inside a repository.", path)
 
     base = _rev(runner, root, ref)
     if not base:
-        return Freshness("unknown", False, [
-            f"note: could not establish whether {relpath} is current -- this "
-            f"repository has no {ref}. Answering anyway."])
+        # A real repository with the file tracked in it, and no origin/main to
+        # compare against. The content can be arbitrarily old and nothing in
+        # reach says otherwise -- this is the case #3296 was filed about.
+        return _unvouched(
+            f"note: REFUSING to vouch for {relpath} -- this repository has no {ref} "
+            "to compare against, so nothing has established that this copy carries "
+            "the latest fixes.", path, relpath=relpath)
 
     notes: list[str] = []
     result = _evaluate(runner, root, relpath, base, notes)
@@ -277,17 +348,29 @@ def _evaluate(runner, root: str, relpath: str, base: str, notes: list[str]) -> F
 
     rc, mb, _ = _git(runner, root, "merge-base", "HEAD", base)
     if rc != 0 or not mb:
-        # No merge base (shallow clone, unrelated history): fall back to comparing
-        # the working file itself. Weaker -- it cannot tell a legitimate local edit
-        # from staleness -- so it only NOTES, it does not refuse.
-        if local_blob and local_blob != base_blob:
+        # No merge base (shallow clone, unrelated history), so the branch-point
+        # comparison is unavailable. origin/main IS resolvable here, though, so
+        # the file can be compared to it directly -- and that splits the case in
+        # two rather than leaving it one blanket unknown (#3296).
+        if local_blob and local_blob == base_blob:
+            # Byte-identical to origin/main's copy. The history is beside the
+            # point once the bytes match: this IS the published version.
             notes.append(
-                f"note: could not establish whether {relpath} is current -- no merge "
-                f"base with origin/main (shallow clone?). The file differs from "
-                "origin/main's copy, which may be a local edit or may be staleness. "
-                "Answering anyway.")
-        return Freshness("unknown", False, base_confirmed="skipped",
-                         local_blob=local_blob, base_blob=base_blob)
+                f"note: no merge base with origin/main for {relpath} (shallow "
+                "clone?), but the file is byte-identical to origin/main's copy, "
+                "which is what the check would have established anyway. Answering.")
+            return Freshness("unknown", False, base_confirmed="skipped",
+                             local_blob=local_blob, base_blob=base_blob,
+                             provenance="identical")
+        notes.append(
+            f"note: REFUSING to vouch for {relpath} -- no merge base with "
+            "origin/main (shallow clone?), and the file differs from origin/main's "
+            "copy. That may be a local edit or may be staleness, and without a "
+            "merge base there is nothing here that can tell them apart.")
+        notes.append(_remedy(relpath))
+        return Freshness("unknown", True, base_confirmed="skipped",
+                         local_blob=local_blob, base_blob=base_blob,
+                         provenance="unvouched")
 
     mb_blob = _rev(runner, root, f"{mb}:{relpath}")
 

--- a/tools/ci-wait.py
+++ b/tools/ci-wait.py
@@ -33,13 +33,15 @@ Usage
 -----
     tools/ci-wait.py 2379                 # wait for PR 2379's required checks
     tools/ci-wait.py 2379 --timeout 2400  # bound the wait (default 1800s)
+    tools/ci-wait.py 2379 --timeout 0     # single pass: look once, do not wait
     tools/ci-wait.py 2379 --no-log        # skip the failure log fetch
 
 Exit codes
 ----------
     0  every required check passed ON THE CURRENT HEAD -- safe to report green
     1  at least one required check failed; the failing log is printed
-    2  timed out while still running -- NOT a verdict, call again
+    2  no verdict yet -- the wait timed out, or a single pass (--timeout 0) found
+       required checks that had not reported. NOT a verdict, call again
     3  could not determine state (auth, network, no checks reported, the
        required-context set could not be established without narrowing it, or
        THIS FILE is behind origin/main -- see "Which copy is running" below)
@@ -1100,7 +1102,14 @@ def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("pr")
-    ap.add_argument("--timeout", type=int, default=1800)
+    # 0 means ONE pass -- look once, do not wait. It used to mean "a loop whose
+    # condition is false on entry", which could only ever return exit 2 with an
+    # empty reason: a non-verdict shaped exactly like a real one (#3351). A
+    # negative value is a caller error, not a mode, so argparse rejects it here
+    # rather than silently behaving like 0.
+    ap.add_argument("--timeout", type=int, default=1800, metavar="SECONDS",
+                    help="how long to keep polling; 0 = a single pass, look once "
+                         "and report whatever has reported so far (default: 1800)")
     ap.add_argument("--interval", type=int, default=25)
     ap.add_argument("--no-log", action="store_true")
     # Skips only the `git ls-remote` that confirms the local origin/main ref
@@ -1109,6 +1118,9 @@ def main() -> int:
     # branch that edits this tool -- is already not refused.
     ap.add_argument("--no-freshness-fetch", action="store_true")
     args = ap.parse_args()
+    if args.timeout < 0:
+        ap.error("--timeout must be 0 or greater; 0 means a single pass "
+                 "(look once, do not wait)")
 
     # BEFORE anything is asked of GitHub: is the copy of this file that is
     # running actually current? A stale copy answers confidently and wrongly,
@@ -1143,6 +1155,7 @@ def main() -> int:
         # THAT is a stale guard -- the same blind spot one level down. The remote
         # confirmation is asked for once and reused, so this costs one ls-remote.
         refused = False
+        why = ""
         confirm = not args.no_freshness_fetch
         for target in (os.path.abspath(__file__),
                        os.path.abspath(_freshness.__file__)):
@@ -1150,18 +1163,29 @@ def main() -> int:
             confirm = False  # one ls-remote, not one per file
             for note in fresh.notes:
                 print(note)
+            if fresh.refuse and not why:
+                # Two different facts reach this refusal and they call for
+                # different fixes: "STALE" means fast-forward, "unvouched" means
+                # nothing established the copy's age at all (#3296). Saying
+                # "STALE" for both sends the reader after the wrong remedy.
+                why = ("a STALE ci-wait.py" if fresh.state == "stale"
+                       else "a ci-wait.py NOTHING VOUCHES FOR")
             refused = refused or fresh.refuse
         if refused:
-            print("\nREFUSING to judge PR #%s from a STALE ci-wait.py. This is NOT a "
-                  "verdict -- nothing was asked of GitHub." % args.pr)
+            print("\nREFUSING to judge PR #%s from %s. This is NOT a "
+                  "verdict -- nothing was asked of GitHub." % (args.pr, why))
             return 3
 
     sha = head_sha(args.pr)
     if not sha:
         print(f"could not read PR #{args.pr} head SHA", file=sys.stderr)
         return 3
-    print(f"PR #{args.pr} head {sha[:8]} -- waiting for required checks "
-          f"(up to {args.timeout}s, polling internally)")
+    if args.timeout == 0:
+        print(f"PR #{args.pr} head {sha[:8]} -- reading required checks once "
+              "(single pass, not waiting)")
+    else:
+        print(f"PR #{args.pr} head {sha[:8]} -- waiting for required checks "
+              f"(up to {args.timeout}s, polling internally)")
 
     # Ask the ruleset what it requires RIGHT NOW rather than trusting a tuple
     # frozen into this file (#2785) -- but never accept an answer NARROWER than
@@ -1175,9 +1199,17 @@ def main() -> int:
               "to judge this PR on a narrower one. This is NOT a verdict.")
         return 3
 
+    # A do-while, not a while: the body runs at least once regardless of the
+    # deadline. `--timeout 0` therefore means the obvious thing -- look once, do
+    # not wait -- instead of a loop that never enters and falls through to the
+    # unconditional `return 2` below with nothing in its parentheses (#3351).
+    # That made exits 0, 1, 3 and 4 unreachable, so the answer could not fail,
+    # which is what made it worthless as evidence.
     deadline = time.time() + args.timeout
     last = ""
-    while time.time() < deadline:
+    polled = False
+    while not polled or time.time() < deadline:
+        polled = True
         # ORDER MATTERS: the workflow-run list is read FIRST, the check-run
         # rollup second. Read the other way round, a run completing between the
         # two calls gives a STALE rollup (context still missing) next to a FRESH
@@ -1197,11 +1229,19 @@ def main() -> int:
         wf_runs = workflow_runs_for(sha)
         if wf_runs is None:
             # The run list is load-bearing for the verdict now, so failing to read
-            # it is "no verdict yet", never "green" (#2807).
+            # it is "no verdict yet", never "green" (#2807). Record WHY: on a
+            # single pass this is the whole explanation the caller gets, and an
+            # unexplained non-verdict is the #3351 defect in another costume.
+            last = "could not read the workflow-run list for this commit"
+            if time.time() >= deadline:
+                break
             time.sleep(args.interval)
             continue
         runs = required_checks(sha)
         if runs is None:
+            last = "could not read the check-run rollup for this commit"
+            if time.time() >= deadline:
+                break
             time.sleep(args.interval)
             continue
         v = classify(runs, contexts, wf_runs)
@@ -1258,10 +1298,21 @@ def main() -> int:
             print("Confirm this SHA is still the PR head before reporting it.")
             return 0
 
+        if time.time() >= deadline:
+            break
         time.sleep(args.interval)
 
-    print(f"\nSTILL RUNNING after {args.timeout}s ({last}). "
-          "This is NOT a verdict -- call again; do not report a result.")
+    # Never emit this line with an empty reason. Empty parentheses were the ONLY
+    # tell that the tool had declined to look at all, and nothing in the sentence
+    # said so -- so the line read exactly like a genuine "not reported yet"
+    # (#3351). If the reason is missing now, say that it is missing.
+    reason = last or "no progress detail was recorded, which should not happen"
+    if args.timeout == 0:
+        print(f"\nNOT YET REPORTED on {sha[:8]} ({reason}). Read once, as asked; "
+              "this is NOT a verdict -- call again, or drop --timeout 0 to wait.")
+    else:
+        print(f"\nSTILL RUNNING after {args.timeout}s ({reason}). "
+              "This is NOT a verdict -- call again; do not report a result.")
     return 2
 
 

--- a/tools/pr-body.py
+++ b/tools/pr-body.py
@@ -625,17 +625,23 @@ def freshness_refusal(printer=None) -> int | None:
                 "nothing has checked that this copy carries the latest guards.")
         return None
     refused = False
+    stale = False
     confirm = True
     for target in (os.path.abspath(__file__), os.path.abspath(_freshness.__file__)):
         fresh = _freshness.assess(target, remote_check=confirm)
         confirm = False  # one ls-remote, not one per file
         for note in fresh.notes:
             printer(note)
+        stale = stale or fresh.state == "stale"
         refused = refused or fresh.refuse
     if refused:
-        printer("\nREFUSING TO WRITE -- this copy of pr-body.py is STALE. Its guards "
-                "are older than origin/main's, and a guard you do not have cannot "
-                "refuse anything. Nothing was read or written.")
+        # "STALE" and "nothing vouches for it" are different facts with different
+        # remedies -- fast-forward versus establish where the copy came from
+        # (#3296) -- so the message names the one that applies.
+        printer("\nREFUSING TO WRITE -- this copy of pr-body.py is %s. Its guards "
+                "are not known to match origin/main's, and a guard you do not have "
+                "cannot refuse anything. Nothing was read or written."
+                % ("STALE" if stale else "one NOTHING VOUCHES FOR"))
         return EXIT_PRECONDITION
     return None
 

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -2514,6 +2514,7 @@ def freshness_refusal(printer=None, *, remote_check: bool = True) -> Optional[in
                 "thresholds.")
         return None
     refused = False
+    stale = False
     confirm = remote_check
     for target in (os.path.abspath(__file__), os.path.abspath(_freshness.__file__)):
         # Both halves: the staleness rule itself lives in the sibling module, and
@@ -2522,12 +2523,17 @@ def freshness_refusal(printer=None, *, remote_check: bool = True) -> Optional[in
         confirm = False
         for note in fresh.notes:
             printer(note)
+        stale = stale or fresh.state == "stale"
         refused = refused or fresh.refuse
     if refused:
-        printer("\nREFUSING TO REPORT ON THIS BOX -- this copy of preflight.py is STALE. It "
-                "would apply an older set of checks and thresholds without saying so, and a "
-                "copy predating #2936 reports a HEALTHY box as unable to push. NOTHING WAS "
-                "PROBED; this is not a verdict about the box.")
+        # Since #3296 this also fires when nothing VOUCHES for the running copy --
+        # a different fact from staleness, with a different remedy, so it is named
+        # as itself rather than reported as "STALE".
+        printer("\nREFUSING TO REPORT ON THIS BOX -- this copy of preflight.py is %s. It "
+                "would apply a set of checks and thresholds not known to match "
+                "origin/main's without saying so, and a copy predating #2936 reports a "
+                "HEALTHY box as unable to push. NOTHING WAS PROBED; this is not a verdict "
+                "about the box." % ("STALE" if stale else "one NOTHING VOUCHES FOR"))
         return 3
     return None
 

--- a/tools/test_agent_self_freshness.py
+++ b/tools/test_agent_self_freshness.py
@@ -57,6 +57,14 @@ def git(cwd, *args):
     return p.stdout.strip()
 
 
+def has_ref(cwd: str, ref: str) -> bool:
+    """True if `ref` resolves. `git rev-parse --verify` exits 1 when it does not,
+    which is an answer rather than a failure, so this must not use git() above."""
+    p = subprocess.run(["git", "-C", cwd, "rev-parse", "--verify", "--quiet", ref],
+                       capture_output=True, text=True)
+    return p.returncode == 0 and bool(p.stdout.strip())
+
+
 def make_repo(tmp: str) -> tuple[str, str]:
     remote = os.path.join(tmp, "remote.git")
     work = os.path.join(tmp, "work")
@@ -181,6 +189,10 @@ try:
     # about that says the running copy is current -- unlike the temp-directory
     # case above, where the extraction itself is the provenance. Answering here is
     # the guard reaching a verdict with the safety check skipped.
+    # No local ref AND no remote to ask: nothing anywhere can vouch for this, so
+    # there is no answer to give. Note the repository has no `origin` at all --
+    # that is what makes it unvouched, NOT the missing local ref on its own (see
+    # the shallow-CI case below, which has no local ref and is answered).
     noremote = os.path.join(tmp, "noremote")
     os.makedirs(os.path.join(noremote, "tools"), exist_ok=True)
     subprocess.run(["git", "init", "-b", "main", noremote], capture_output=True, check=True)
@@ -190,12 +202,14 @@ try:
     git(noremote, "add", "-A")
     git(noremote, "commit", "-m", "tools, of unknown age")
     r = asf.assess(os.path.join(noremote, "tools/ci-wait.py"), remote_check=False)
-    check("a tracked file in a repo with NO origin/main REFUSES",
+    check("no origin/main locally AND no remote to ask REFUSES",
           r.state == "unknown" and r.refuse is True, f"{r.state} refuse={r.refuse} {r.notes}")
     check("...and is classified as unvouched, not detached",
           r.provenance == "unvouched", f"{r.provenance}")
     check("...and names the missing ref",
           any("refs/remotes/origin/main" in n for n in r.notes), r.notes)
+    check("...and says the remote was asked too, not just the local ref",
+          any("could not be reached" in n for n in r.notes), r.notes)
     check("...and does not claim to be answering anyway",
           not any("answering anyway" in n.lower() for n in r.notes), r.notes)
 
@@ -273,6 +287,106 @@ try:
           r.base_confirmed == "behind-unfetchable", r.base_confirmed)
     check("...and says the check ran against the OLDER ref",
           any("OLDER ref" in n for n in r.notes), r.notes)
+
+    # --- a shallow CI checkout: no local origin/main, but a reachable remote ---
+    # THE REGRESSION THIS SECTION EXISTS FOR. GitHub Actions checks out with
+    # fetch-depth 1 and a refspec covering only the branch under test, so
+    # refs/remotes/origin/main does not exist on any CI run. The first version of
+    # this fix refused there -- every run, including the three checks below --
+    # because it read "no local ref" as "nothing can vouch for this". The remote
+    # answers fine; it just has to be asked.
+    #
+    # Built as a REAL shallow clone rather than a mocked one, because the whole
+    # question is what git does in that shape.
+    ci = os.path.join(tmp, "ci-shallow")
+    subprocess.run(["git", "clone", "--depth", "1", "-b", "main", "file://" + remote, ci],
+                   capture_output=True, check=True)
+    check("the CI-shaped checkout really is shallow",
+          git(ci, "rev-parse", "--is-shallow-repository") == "true")
+    subprocess.run(["git", "-C", ci, "config", "remote.origin.fetch",
+                    "+refs/heads/main:refs/remotes/origin/main-only"],
+                   capture_output=True, check=True)
+    subprocess.run(["git", "-C", ci, "update-ref", "-d", "refs/remotes/origin/main"],
+                   capture_output=True)
+    check("...and really has no refs/remotes/origin/main",
+          not has_ref(ci, "refs/remotes/origin/main"),
+          git(ci, "for-each-ref", "refs/remotes"))
+
+    r = asf.assess(os.path.join(ci, "tools/ci-wait.py"), remote_check=False)
+    check("a shallow CI checkout with no local origin/main is NOT refused",
+          r.refuse is False, f"{r.state}/{r.provenance} {r.notes}")
+    check("...and says the base was fetched directly from the remote",
+          r.base_confirmed == "fetched-direct", f"{r.base_confirmed} {r.notes}")
+    check("...and says why, naming the shallow CI checkout",
+          any("shallow" in n.lower() for n in r.notes), r.notes)
+
+    # The fallback must not silently reorganise the caller's repository: it is a
+    # read. `git fetch <remote> <branch>` with no refspec writes FETCH_HEAD only.
+    check("...and creates no refs/remotes/origin/main behind the caller's back",
+          not has_ref(ci, "refs/remotes/origin/main"),
+          git(ci, "for-each-ref", "refs/remotes"))
+
+    # It must still be able to say STALE there -- an answer that can only ever be
+    # "fine" is not a guard. origin/main moves the file; the shallow checkout has
+    # not incorporated it.
+    land_on_remote(tmp, remote, "tools/ci-wait.py", "# vNEXT -- landed after the CI clone\n")
+    r = asf.assess(os.path.join(ci, "tools/ci-wait.py"), remote_check=False)
+    check("a shallow CI checkout still detects a file main has moved past",
+          r.state == "stale" and r.refuse is True, f"{r.state} refuse={r.refuse} {r.notes}")
+
+    # --- the shape that ACTUALLY runs in CI: shallow AND on a divergent branch -
+    # The case above clones `main` itself, so the file matches and the `identical`
+    # route answers. A real PR run is a shallow clone of a BRANCH THAT EDITS the
+    # guarded tool -- the file differs AND there is no merge base, which is the
+    # `unvouched` route. That refused every CI run on the first version of this
+    # fix, and the synthetic test above did not catch it because its shallow
+    # clone had nothing to diverge from. Reproduced here for real.
+    branchy = os.path.join(tmp, "ci-branch")
+    subprocess.run(["git", "clone", "--depth", "1", "-b", "main",
+                    "file://" + remote, branchy], capture_output=True, check=True)
+    git(branchy, "config", "user.email", "t@t")
+    git(branchy, "config", "user.name", "t")
+    subprocess.run(["git", "-C", branchy, "update-ref", "-d",
+                    "refs/remotes/origin/main"], capture_output=True)
+    git(branchy, "checkout", "-b", "agent/x/issue-9")
+    write(branchy, "tools/ci-wait.py", "# my in-flight fix to the tool\n")
+    git(branchy, "add", "-A")
+    git(branchy, "commit", "-m", "edit the guarded tool, as this very PR does")
+    check("the CI-branch checkout is shallow, divergent, and has no origin/main",
+          git(branchy, "rev-parse", "--is-shallow-repository") == "true"
+          and not has_ref(branchy, "refs/remotes/origin/main"))
+
+    _head_before = git(branchy, "rev-parse", "HEAD")
+    _refs_before = git(branchy, "for-each-ref", "refs/heads")
+    r = asf.assess(os.path.join(branchy, "tools/ci-wait.py"), remote_check=False)
+    check("a shallow checkout of a branch EDITING the tool is not refused",
+          r.refuse is False, f"{r.state}/{r.provenance} {r.notes}")
+    check("...and is judged CURRENT -- a branch that edits the tool, not a stale one",
+          r.state == "current", f"{r.state} {r.notes}")
+    check("...and says the base was fetched directly, no local ref needed",
+          r.base_confirmed == "fetched-direct", f"{r.base_confirmed} {r.notes}")
+
+    # Whatever route it took, it is a READ: HEAD and every ref untouched. The
+    # deepen step adds history objects only, and this holds whether or not it ran.
+    check("...and moves HEAD nowhere",
+          git(branchy, "rev-parse", "HEAD") == _head_before)
+    check("...and creates or moves no branch ref",
+          git(branchy, "for-each-ref", "refs/heads") == _refs_before)
+    # THE BUG THIS PINS: a plain `git fetch <remote> <branch>` applies the
+    # configured refspec and helpfully RECREATES refs/remotes/origin/main. A
+    # later call then reads that resurrected ref as a local one and trusts it --
+    # and it is already behind, so a genuinely stale file read as current.
+    # `--refmap=` is what stops it.
+    check("...and does NOT resurrect refs/remotes/origin/main",
+          not has_ref(branchy, "refs/remotes/origin/main"),
+          git(branchy, "for-each-ref", "refs/remotes"))
+
+    # And it must still say STALE in that shape, or the fallback has traded a
+    # refusal for a rubber stamp.
+    land_on_remote(tmp, remote, "tools/ci-wait.py", "# vLATER -- published after the branch\n")
+    r = asf.assess(os.path.join(branchy, "tools/ci-wait.py"), remote_check=False)
+    check("a shallow divergent checkout still detects a genuinely STALE tool",
+          r.state == "stale" and r.refuse is True, f"{r.state} refuse={r.refuse} {r.notes}")
 
     # --- no merge base: the blob itself is the provenance, or there is none ----
     # A shallow clone has no merge base with origin/main, so the branch-point

--- a/tools/test_agent_self_freshness.py
+++ b/tools/test_agent_self_freshness.py
@@ -147,9 +147,12 @@ try:
           r.state == "stale", f"{r.state} {r.notes}")
 
     # --- a file origin/main does not have at all --------------------------------
+    # A path that does not exist is untracked, so nothing vouches for it -- and a
+    # tool asked about a file that is not there has established nothing at all.
     r = asf.assess(os.path.join(work, "tools/brand-new.py"), remote_check=False)
-    check("a file that does not exist locally is UNKNOWN, not stale",
-          r.state == "unknown" and r.refuse is False, f"{r.state} {r.notes}")
+    check("a file that does not exist locally is UNKNOWN and unvouched",
+          r.state == "unknown" and r.refuse is True and r.provenance == "unvouched",
+          f"{r.state}/{r.provenance} refuse={r.refuse}")
 
     write(work, "tools/brand-new.py", "# new\n")
     git(work, "add", "-A")
@@ -167,8 +170,45 @@ try:
     r = asf.assess(os.path.join(loose, "ci-wait.py"), remote_check=False)
     check("a copy outside any git repository is UNKNOWN and answers anyway",
           r.state == "unknown" and r.refuse is False, f"{r.state} {r.notes}")
-    check("...and says why it could not be established",
-          any("could not" in n.lower() for n in r.notes), r.notes)
+    check("...and says the freshness could not be checked there",
+          any("cannot be checked here" in n for n in r.notes), r.notes)
+    check("...and is classified as detached, the one unknown with a provenance story",
+          r.state == "unknown" and r.provenance == "detached", f"{r.state}/{r.provenance}")
+
+    # --- an unknown with NO provenance story must REFUSE (#3296) ----------------
+    # The sharper case the issue does not cover: a REAL repository, the tools
+    # tracked in it, content of any age, and no refs/remotes/origin/main. Nothing
+    # about that says the running copy is current -- unlike the temp-directory
+    # case above, where the extraction itself is the provenance. Answering here is
+    # the guard reaching a verdict with the safety check skipped.
+    noremote = os.path.join(tmp, "noremote")
+    os.makedirs(os.path.join(noremote, "tools"), exist_ok=True)
+    subprocess.run(["git", "init", "-b", "main", noremote], capture_output=True, check=True)
+    git(noremote, "config", "user.email", "t@t")
+    git(noremote, "config", "user.name", "t")
+    write(noremote, "tools/ci-wait.py", "# arbitrarily old\n")
+    git(noremote, "add", "-A")
+    git(noremote, "commit", "-m", "tools, of unknown age")
+    r = asf.assess(os.path.join(noremote, "tools/ci-wait.py"), remote_check=False)
+    check("a tracked file in a repo with NO origin/main REFUSES",
+          r.state == "unknown" and r.refuse is True, f"{r.state} refuse={r.refuse} {r.notes}")
+    check("...and is classified as unvouched, not detached",
+          r.provenance == "unvouched", f"{r.provenance}")
+    check("...and names the missing ref",
+          any("refs/remotes/origin/main" in n for n in r.notes), r.notes)
+    check("...and does not claim to be answering anyway",
+          not any("answering anyway" in n.lower() for n in r.notes), r.notes)
+
+    # An UNTRACKED file inside a real repository: same absence of a story. It is
+    # not the extract-to-/tmp recipe (that lands outside a repository), and being
+    # untracked is precisely what makes its age unknowable from git.
+    write(work, "tools/untracked-tool.py", "# who knows how old\n")
+    r = asf.assess(os.path.join(work, "tools/untracked-tool.py"), remote_check=False)
+    check("an UNTRACKED file inside a repository REFUSES",
+          r.state == "unknown" and r.refuse is True, f"{r.state} refuse={r.refuse} {r.notes}")
+    check("...and is classified as unvouched",
+          r.provenance == "unvouched", f"{r.provenance}")
+    os.remove(os.path.join(work, "tools/untracked-tool.py"))
 
     # --- the remote confirmation is never allowed to REFUSE ---------------------
     # `origin/main` is a repository-level ref shared by every worktree, and on this
@@ -233,6 +273,38 @@ try:
           r.base_confirmed == "behind-unfetchable", r.base_confirmed)
     check("...and says the check ran against the OLDER ref",
           any("OLDER ref" in n for n in r.notes), r.notes)
+
+    # --- no merge base: the blob itself is the provenance, or there is none ----
+    # A shallow clone has no merge base with origin/main, so the branch-point
+    # comparison is unavailable. But origin/main IS resolvable here, so the file
+    # can be compared to it directly -- and a byte-identical file is vouched for
+    # by that identity, whatever its history. A file that DIFFERS has nothing:
+    # it may be a local edit or may be staleness, and the tool cannot tell.
+    shallow = os.path.join(tmp, "shallow")
+    subprocess.run(["git", "clone", "--depth", "1", "file://" + remote, shallow],
+                   capture_output=True, check=True)
+    git(shallow, "config", "user.email", "t@t")
+    git(shallow, "config", "user.name", "t")
+
+    def no_merge_base(args, timeout=None):
+        if "merge-base" in args:
+            return 128, "", "fatal: no merge base"
+        return asf._default_runner(args, timeout)
+
+    same = os.path.join(shallow, "tools/ci-wait.py")
+    r = asf.assess(same, remote_check=False, runner=asf.make_runner(no_merge_base))
+    check("no merge base, but the file MATCHES origin/main's blob: not refused",
+          r.refuse is False, f"{r.state}/{r.provenance} {r.notes}")
+    check("...and is vouched for by the blob identity",
+          r.provenance == "identical", f"{r.provenance}")
+
+    write(shallow, "tools/ci-wait.py", "# something else entirely\n")
+    r = asf.assess(same, remote_check=False, runner=asf.make_runner(no_merge_base))
+    check("no merge base and the file DIFFERS from origin/main: REFUSES",
+          r.state == "unknown" and r.refuse is True,
+          f"{r.state} refuse={r.refuse} {r.notes}")
+    check("...and is classified as unvouched",
+          r.provenance == "unvouched", f"{r.provenance}")
 
     # --- `remote` is a remote NAME, not a URL ---------------------------------
     # A URL resolves no refs/remotes/<name>/main, so it would answer "unknown" --
@@ -331,6 +403,112 @@ try:
     r = asf.assess(os.path.join(work, "tools/ci-wait.py"), remote_check=False)
     check("the same file on a fast-forwarded checkout is not refused",
           r.refuse is False, f"{r.state} {r.notes}")
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
+
+# ---------------------------------------------------------------------------
+# ci-wait.py end to end on the two unknowns, which must be handled DIFFERENTLY.
+# The temp-directory recipe in .claude/rules/ci-verdicts.md must keep working --
+# that recipe exists because the guard cannot help a copy older than itself --
+# while a repository that vouches for nothing must not reach a verdict (#3296).
+
+print("\nci-wait.py separates a vouched-for unknown from an unvouched one")
+
+
+def run_ci_wait(path: str, argv: list[str]) -> tuple[int, str, list[str]]:
+    """Import ci-wait.py from `path`, run main() with argv, spy on every gh call."""
+    spec = importlib.util.spec_from_file_location("ci_wait_case_" + str(len(FAILURES)) + path[-14:].replace("/", "_").replace(".", "_"), path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    asked: list[str] = []
+
+    def gh_spy(args, attempts=4):
+        asked.append(" ".join(args))
+        return 0, json.dumps([])
+
+    mod.gh = gh_spy
+    old = sys.argv
+    sys.argv = ["ci-wait.py", *argv]
+    buf = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
+            code = mod.main()
+    finally:
+        sys.argv = old
+    return code, buf.getvalue(), asked
+
+
+tmp = tempfile.mkdtemp()
+try:
+    # (a) UNVOUCHED: a real repository, tools tracked, no origin/main. Nothing
+    # here has checked the running code, so there must be no verdict.
+    repo = os.path.join(tmp, "novouch")
+    os.makedirs(os.path.join(repo, "tools"), exist_ok=True)
+    subprocess.run(["git", "init", "-b", "main", repo], capture_output=True, check=True)
+    git(repo, "config", "user.email", "t@t")
+    git(repo, "config", "user.name", "t")
+    for name in ("ci-wait.py", "agent_self_freshness.py"):
+        shutil.copy(os.path.join(HERE, name), os.path.join(repo, "tools", name))
+    git(repo, "add", "-A")
+    git(repo, "commit", "-m", "tools of unknown age")
+
+    code, text, asked = run_ci_wait(os.path.join(repo, "tools/ci-wait.py"),
+                                    ["2971", "--timeout", "1", "--interval", "0", "--no-log"])
+    check("ci-wait.py in a repo with no origin/main exits 3", code == 3,
+          f"code={code} {text[:400]}")
+    check("...and asks GitHub NOTHING", asked == [], asked)
+    check("...and says it is not a verdict", "not a verdict" in text.lower(), text[:400])
+    # The remedy for "nothing vouches for this" is not the remedy for "stale", so
+    # the refusal must not report one as the other.
+    check("...and does NOT call an unvouched copy stale",
+          "NOTHING VOUCHES FOR" in text and "STALE ci-wait.py" not in text, text[:600])
+
+    # (b) DETACHED: the documented extract-to-a-temp-directory recipe. Both files
+    # come straight out of origin/main by hand, so their provenance IS the
+    # guarantee -- this must still answer, or the remedy refuses itself.
+    loose = os.path.join(tmp, "loose")
+    os.makedirs(loose, exist_ok=True)
+    for name in ("ci-wait.py", "agent_self_freshness.py"):
+        shutil.copy(os.path.join(HERE, name), os.path.join(loose, name))
+    code, text, asked = run_ci_wait(os.path.join(loose, "ci-wait.py"),
+                                    ["2971", "--timeout", "1", "--interval", "0", "--no-log"])
+    check("the extract-to-/tmp recipe still reaches GitHub", asked != [],
+          f"code={code} {text[:300]}")
+    check("...and does not refuse for freshness", code != 3 or "STALE" not in text,
+          f"code={code} {text[:300]}")
+    check("...and says out loud that provenance is the caller's",
+          "provenance" in text.lower(), text[:600])
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
+
+# ---------------------------------------------------------------------------
+# --timeout 0 must not produce a verdict-shaped non-verdict (#3351).
+
+print("\nci-wait.py --timeout 0 is a single pass, not an instant non-answer")
+
+tmp = tempfile.mkdtemp()
+try:
+    loose = os.path.join(tmp, "loose")
+    os.makedirs(loose, exist_ok=True)
+    for name in ("ci-wait.py", "agent_self_freshness.py"):
+        shutil.copy(os.path.join(HERE, name), os.path.join(loose, name))
+
+    code, text, asked = run_ci_wait(os.path.join(loose, "ci-wait.py"),
+                                    ["2971", "--timeout", "0", "--interval", "0", "--no-log"])
+    # The defect: the poll loop never ran, so no GitHub call was made and the
+    # unconditional `return 2` fired with an empty reason in its parentheses.
+    check("--timeout 0 actually LOOKS at the PR", asked != [],
+          f"code={code} asked={asked} {text[:300]}")
+    check("--timeout 0 never claims to have waited",
+          "STILL RUNNING after 0s ()" not in text, text[:400])
+    check("--timeout 0 does not advertise polling it will not do",
+          "up to 0s, polling internally" not in text, text[:400])
+
+    # A still-running answer must always carry a reason. An empty pair of
+    # parentheses is the tell that the tool declined to look, and it is the only
+    # thing distinguishing this from a genuine "not reported yet".
+    check("no still-running line is ever emitted with an empty reason",
+          "()" not in text, text[:400])
 finally:
     shutil.rmtree(tmp, ignore_errors=True)
 

--- a/tools/test_ci_wait.py
+++ b/tools/test_ci_wait.py
@@ -1275,6 +1275,8 @@ class _FreshStub:
     class _R:
         notes: list[str] = []
         refuse = False
+        state = "current"
+        provenance = "n/a"
 
     @staticmethod
     def assess(target, remote_check=False):
@@ -1297,6 +1299,8 @@ class _StaleStub(_FreshStub):
     class _R:
         notes = ["note: this copy is behind origin/main"]
         refuse = True
+        state = "stale"
+        provenance = "n/a"
 
     @staticmethod
     def assess(target, remote_check=False):
@@ -1312,6 +1316,40 @@ with _main_with(_StaleStub()) as _buf:
         _reached = True
 check("a stale copy is still refused with exit 3 (the #3020 guard is intact)",
       _code == 3 and not _reached, f"(code={_code}, reached={_reached})")
+check("...and the refusal calls it STALE, which is what it is",
+      "STALE ci-wait.py" in _buf.getvalue(), _buf.getvalue()[:300])
+
+
+class _UnvouchedStub(_FreshStub):
+    """An UNKNOWN that nothing vouches for: refused, but not for staleness (#3296).
+
+    The remedy differs -- fast-forward versus establish where this copy came from
+    -- so reporting one as the other sends the reader after the wrong fix.
+    """
+
+    class _R:
+        notes = ["note: REFUSING to vouch for tools/ci-wait.py -- no origin/main"]
+        refuse = True
+        state = "unknown"
+        provenance = "unvouched"
+
+    @staticmethod
+    def assess(target, remote_check=False):
+        return _UnvouchedStub._R()
+
+
+_reached = False
+_code = None
+with _main_with(_UnvouchedStub()) as _buf:
+    try:
+        _code = cw.main()
+    except _ReachedGitHub:
+        _reached = True
+check("an unvouched copy is refused with exit 3 and asks GitHub nothing",
+      _code == 3 and not _reached, f"(code={_code}, reached={_reached})")
+check("...and is NOT reported as stale",
+      "NOTHING VOUCHES FOR" in _buf.getvalue()
+      and "STALE ci-wait.py" not in _buf.getvalue(), _buf.getvalue()[:300])
 
 # End to end, the exact invocation .claude/rules/ci-verdicts.md used to
 # recommend: a copy of this file alone in a directory with no tools/ beside it.


### PR DESCRIPTION
Closes #3296
Closes #3351

Two guards that resolved "could not determine" toward an answer. They ship together because both edit `tools/ci-wait.py`'s verdict path and #3296 also edits `tools/agent_self_freshness.py`, which `ci-wait.py` imports — splitting them would manufacture a conflict. Sequencing them into one merge also pays the `agent_self_freshness` staleness wave once instead of twice: expect a burst of exit-3 refusals in other worktrees afterwards, which is the guard working, not an outage.

Both are instances of the class in #3363 (guards resolve "could not determine" toward success, inconsistently). This PR is two instances, not the rule — no closing keyword for it.

## #3296 — where the line between the two unknowns falls

`assess()` returned `Freshness("unknown", refuse=False)` on three routes and answered on all of them. Only one has a story. The distinction I drew is **whether anything outside git vouches for the running code** — not "is the state knowable", which is what conflated them:

| route | new `provenance` | refuses | why |
|---|---|---|---|
| not inside a git repository | `detached` | no | the caller extracted it and put it there; that act *is* the guarantee, and it is the documented remedy this module prints |
| no merge base, file byte-identical to `origin/main`'s blob | `identical` | no | identity is provenance — once the bytes match, the history is beside the point |
| tracked, but the repository has no `origin/main` | `unvouched` | **yes** | content can be arbitrarily old and nothing in reach says otherwise — the case the issue was filed about |
| untracked inside a repository | `unvouched` | **yes** | being untracked is exactly what makes the age unknowable from git |
| no merge base, file differs from `origin/main` | `unvouched` | **yes** | may be a local edit, may be staleness; without a merge base nothing can tell them apart |
| git binary unavailable | `unvouched` | **yes** | previously shared a branch with "not a repository" — opposite facts, so they are now separated on git's own stderr |

Getting this wrong in the strict direction would break the extract-to-`/tmp` recipe in `.claude/rules/ci-verdicts.md`, which exists precisely because the guard cannot help a copy older than itself. **Verified it still works**, against a real PR:

```
$ python3 "$d/tools/ci-wait.py" 3356 --timeout 0     # both files extracted by hand
GREEN on e0abe1dd -- all 13 required checks passed (10/10 ruleset context(s) accounted for).
```

and that the case the issue is about now refuses:

```
$ python3 "$d/tools/ci-wait.py" 3356 --timeout 0     # real repo, tools tracked, no origin/main
note: REFUSING to vouch for tools/ci-wait.py -- this repository has no
refs/remotes/origin/main to compare against, so nothing has established that this
copy carries the latest fixes.
REFUSING to judge PR #3356 from a ci-wait.py NOTHING VOUCHES FOR. This is NOT a
verdict -- nothing was asked of GitHub.     [exit 3, no GitHub call]
```

The two facts also get different words now. All three tools hardcoded "is STALE" in their refusal; an unvouched copy is not stale, and the remedies differ (fast-forward vs. establish where the copy came from), so each names the one that applies.

**`preflight.py`'s call site: checked, and needs no edit.** All three callers (`ci-wait.py`, `pr-body.py`, `preflight.py`) read `fresh.refuse` from the shared `assess()`, so the fix reaches all three — as the issue's own "one fix covers all three" argument predicted. The issue's "Related" line says issue 3164 (preflight unguarded) is open; that issue was in fact already COMPLETED about an hour before #3296 was filed, and `preflight.py` does now carry `freshness_refusal()`. That strengthens the issue rather than weakening it. Confirmed `preflight.py` still runs normally on a legitimate branch (`11 passed, 3 warned, 0 failed`, exit 0) — a guard that refuses a healthy box is the failure mode it exists to prevent.

## #3351 — which single-pass design, and why

The issue offered two options. I took the second: **the loop runs at least once regardless of the deadline**, so `--timeout 0` means the obvious thing — look once, do not wait.

Rejecting the first (argparse refuses anything below 1) is the substantive choice. It removes the false verdict but leaves the real gap in place: there is no way to say "check once and tell me", and `--timeout 1` goes on standing in for it by accident of timing — one second happens to be long enough for one poll. That accident is what the rules had standardised on. A do-while makes the intent expressible, and would have made PR #3340 correct as originally written.

A negative timeout is a caller error rather than a mode, so `argparse` rejects it instead of silently behaving like 0.

Two smaller things in the same defect:
- The line *before* the loop advertised `(up to 0s, polling internally)` — work it could not do. A single pass now says `reading required checks once (single pass, not waiting)`.
- The still-running line can no longer be emitted with an empty reason. Empty parentheses were the **only** tell that the tool had declined to look, and nothing in the sentence said so. Each `continue` path now records why it could not answer, and a single pass that finds nothing reported says `NOT YET REPORTED ... (reason)` rather than claiming to have waited.

Measured on one head, the same PR the issue used:

```
before:  $ tools/ci-wait.py 3356 --timeout 0
         PR #3356 head e0abe1dd -- waiting for required checks (up to 0s, polling internally)
         STILL RUNNING after 0s (). This is NOT a verdict -- call again.       [exit 2]

after:   $ tools/ci-wait.py 3356 --timeout 0
         PR #3356 head e0abe1dd -- reading required checks once (single pass, not waiting)
         GREEN on e0abe1dd -- all 13 required checks passed (10/10 ruleset contexts).  [exit 0]
```

## RED → GREEN

`tools/test_agent_self_freshness.py` passed before this change, so it caught neither defect. Both proofs went RED first:

**#3296** — RED on `AttributeError: 'Freshness' object has no attribute 'provenance'`, then on refusal. The test that matters is the reviewer's sharper case, not the issue's: a **real** repository with the tools tracked in it and no `origin/main` ref. It asserts a **refusal**, not a message — a test asserting only that a warning is printed would pass against a guard that then answers anyway, which is the defect. Also covers: untracked-inside-a-repo refuses; the shallow-clone split both ways (identical → answers, differing → refuses); the detached recipe still reaching GitHub end to end; and that an unvouched refusal is not reported as staleness.

**#3351** — RED on all four: `--timeout 0` asked GitHub nothing, printed `STILL RUNNING after 0s ()`, and advertised polling it would not do. Asserts the exit code and that the output does not claim to have waited, plus that no still-running line is ever emitted with empty parentheses.

Two pre-existing assertions changed, both because they encoded the old behavior: a path that does not exist is now unvouched rather than answered (a tool asked about a file that is not there has established nothing), and one assertion matched the detached note on an exact phrase I reworded.

## What I ran

All four `tools/` suites, to completion, exit 0: `test_agent_self_freshness.py`, `test_ci_wait.py`, `test_pr_body.py`, `test_preflight.py`. `test_ci_wait.py` needed its two freshness stubs taught the `state` field they mirror, plus a new stub for the unvouched case.

No `AlRunner/` change, so `require-tests` does not trigger and no AL or corpus test is owed. Rather than assume that, I ran the gate against the actual diff: `check_corpus_linkage.sh` → *"No file in this diff can change what AL observes, so no corpus declaration is required"*, exit 0. So no `Corpus-NA:` line is needed.

## Docs

`.claude/rules/ci-verdicts.md` §0 told agents *"it must be `--timeout 1`, never `--timeout 0`"* — correct about the code at the time, obsolete now. Rewritten to document the single pass, keeping the history of why the workaround existed and the lesson that outlives it: an answer that could not have come out any other way is not evidence. Call sites in that file, `no-backgrounding-long-commands.md` and `orchestrating-a-session/SKILL.md` now say `--timeout 0`; `--timeout 1` still works and still means "wait up to a second".

Per the comment-placement rule: the reasoning that would have been a long comment block — how the two unknowns divide — is in `agent_self_freshness.py`'s module docstring under "The two unknowns", where a reader goes deliberately, with the per-route detail on the `provenance` field itself.

---

Implemented by the `stma-auto-15` agent on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4


---

## Follow-up: the first version refused every CI run

Caught in review. GitHub Actions checks out with `fetch-depth: 1` and a refspec covering only the branch under test, so **`refs/remotes/origin/main` does not exist on any CI run** — and the first version read "no local ref" as "nothing can vouch for this copy". Three checks failed, two of them tests written for this very PR.

### Is "no `origin/main` ref" one state or two?

**Two, and they are distinguishable — but not by shallowness.** Shallowness is a correlated symptom, not the distinction. What actually separates them is whether **`origin/main` is reachable at all**:

| | local ref | remote answers | verdict |
|---|---|---|---|
| shallow CI checkout | absent | **yes** | answerable — just not by the local-ref mechanism |
| long-lived clone that never fetched | absent | yes, if online | answerable too |
| genuinely isolated clone | absent | **no** | `unvouched` — the case #3296 is about |

So the fix is not a CI carve-out. A missing *local* ref is no longer sufficient to refuse: the remote is asked first, via `FETCH_HEAD`. Only "no local ref **and** the remote would not answer" is unvouched. I deliberately did not use `GITHUB_ACTIONS`/`CI` env sniffing (trivially set, and it rots) or a shallowness heuristic — both answer "where am I running", when the real question is "can this be established".

### Two things this had to get right to be worth doing

**1. It must still detect staleness there, or it has traded a refusal for a rubber stamp.** A shallow clone's grafted boundary makes git report the freshly-fetched tip as its own merge base, so `mb_blob == base_blob` and a stale file reads as *current*. History is deepened first, which dissolves the graft. Verified against a real depth-1 clone of this repository, both directions:

```
branch that EDITS ci-wait.py (this PR)            -> current, refuse=False
branch based BEFORE a published change to it      -> stale,   refuse=True
```

**2. It must stay a read.** I originally rejected deepening as mutation. Measured, that objection was about the wrong thing: deepening leaves **HEAD unchanged, every ref unchanged, working tree clean** — it only adds history objects, so the repository knows more and points at nothing new. That is materially different from creating or moving a ref.

But a plain `git fetch <remote> <branch>` *does* create one: git applies the configured refspec and **recreates `refs/remotes/origin/main`** as a side effect. Measured consequence — a second `assess()` call then found that resurrected ref, took the local-ref path, and trusted a ref that was already behind, **reporting a genuinely stale file as current**. Every fetch in the module now carries `--refmap=`, and a test pins it. A guard that silently rewrites the state it is about to read is worse than one that refuses.

### Tests

Real shallow clones, not mocked git — the whole question is what git does in that shape. Both shapes are covered, because the first synthetic test missed the second: a shallow clone of `main` itself (file matches, `identical` route) and a shallow clone of a **branch that edits the guarded tool** (file differs, no merge base — the shape that actually runs on every PR). Each asserts staleness is still detected, that HEAD and refs are untouched, and that `refs/remotes/origin/main` is not resurrected.

Verified by cloning this branch at `--depth 1` and running all four `tools/` suites in it: **all pass**, in the exact environment that produced the three failures.
