### PR TITLE
fix(shadow): retry the shadow-dir publish when the source is locked, instead of crashing the process

### DIFF
--- a/AlRunner.Tests/NclShadowLockedSourcePublishTests.cs
+++ b/AlRunner.Tests/NclShadowLockedSourcePublishTests.cs
@@ -1,0 +1,159 @@
+// NclShadowLockedSourcePublishTests — #3364: publishing the shadow dir can fail on the
+// SOURCE side, not the destination side. Windows refuses to rename a directory while any
+// process holds an open handle to any file inside it, and an on-access AV scanner's plain
+// FileShare.Read handle on the ~50 MB Ncl.dll the build has just written is enough. That
+// raises IOException naming the source path with shadowDir still ABSENT — the case
+// #2512's `when (Directory.Exists(shadowDir))` filter could not match, so it escaped
+// PublishShadowDir, EnsureShadowDir and TryShadowReexec and killed the process (exit 82)
+// before any test ran.
+//
+// The move is injected rather than provoked with a real file lock because a real lock only
+// blocks a rename on Windows — POSIX rename(2) succeeds with open handles, so a
+// handle-based test would be permanently green on the Linux CI legs and prove nothing
+// there.
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class NclShadowLockedSourcePublishTests
+{
+    private const string MarkerFileName = ".al-runner-shadow-source";
+    private const string EntryDllName = "al-runner.dll";
+    private const string NclFileName = "Microsoft.Dynamics.Nav.Ncl.dll";
+
+    private static string NewTempDir(string label)
+    {
+        var dir = TestScratch.FlatDir($"ncl-shadow-locked-{label}-");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static void WriteCompleteShadowDir(string dir, string origFull, byte[] dllBytes)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllBytes(Path.Combine(dir, EntryDllName), dllBytes);
+        File.WriteAllBytes(Path.Combine(dir, NclFileName), new byte[] { 4, 5, 6 });
+        File.WriteAllText(Path.Combine(dir, "al-runner.deps.json"), "{}");
+        File.WriteAllText(Path.Combine(dir, "al-runner.runtimeconfig.json"), "{}");
+        // Marker last, same invariant the real build holds.
+        File.WriteAllText(Path.Combine(dir, MarkerFileName), origFull);
+    }
+
+    /// <summary>Positive: the lock clears after a few attempts (the field case — an AV scan
+    /// finishes in milliseconds). The rename must be RETRIED, with a delay between attempts,
+    /// and the publish must then succeed normally. Before this fix the very first
+    /// IOException escaped, so there was no second attempt at all.</summary>
+    [Fact]
+    public void PublishShadowDir_SourceLockedThenReleased_RetriesWithBackoffAndPublishes()
+    {
+        var root = NewTempDir("transient");
+        try
+        {
+            var origFull = @"C:\install\any";
+            var tempDir = Path.Combine(root, "key.building.abc");
+            WriteCompleteShadowDir(tempDir, origFull, dllBytes: new byte[] { 9, 9, 9 });
+            var shadowDir = Path.Combine(root, "key");
+
+            var attempts = 0;
+            var delays = new List<int>();
+            var result = NclShadowRuntime.PublishShadowDir(
+                tempDir, shadowDir, origFull,
+                move: (src, dst) =>
+                {
+                    attempts++;
+                    // Exactly the exception .NET raises for ERROR_ACCESS_DENIED on the
+                    // SOURCE of a directory rename, message and all.
+                    if (attempts <= 3) throw new IOException($"Access to the path '{src}' is denied.");
+                    Directory.Move(src, dst);
+                },
+                sleep: delays.Add);
+
+            Assert.Equal(shadowDir, result);
+            Assert.Equal(4, attempts);
+            Assert.Equal(3, delays.Count);
+            Assert.All(delays, d => Assert.InRange(d, 1, 500));
+            // Backoff, not a fixed spin: later waits are never shorter than earlier ones,
+            // and at least one pair strictly grows.
+            for (var i = 1; i < delays.Count; i++) Assert.True(delays[i] >= delays[i - 1]);
+            Assert.True(delays[^1] > delays[0], "the delay must grow across attempts");
+
+            Assert.False(Directory.Exists(tempDir), "temp dir must be consumed by the successful move");
+            Assert.True(NclShadowRuntime.IsShadowDirComplete(shadowDir, origFull));
+            Assert.Equal(new byte[] { 9, 9, 9 }, File.ReadAllBytes(Path.Combine(shadowDir, EntryDllName)));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>Negative: the lock never clears. The process must NOT die — that is the
+    /// #3364 crash — and the returned directory must be one that actually exists and is
+    /// complete, so the caller's re-exec has something to run. Returning the never-created
+    /// shadowDir here is what produced "The application to execute does not exist".</summary>
+    [Theory]
+    [InlineData(true)]   // IOException — what MoveDirectory raises for ERROR_ACCESS_DENIED
+    [InlineData(false)]  // UnauthorizedAccessException — the same refusal, other mapping
+    public void PublishShadowDir_SourceLockedForever_DoesNotThrowAndRunsFromTheCompleteTempDir(bool ioException)
+    {
+        var root = NewTempDir(ioException ? "stuck-io" : "stuck-uae");
+        try
+        {
+            var origFull = @"C:\install\any";
+            var tempDir = Path.Combine(root, "key.building.abc");
+            WriteCompleteShadowDir(tempDir, origFull, dllBytes: new byte[] { 7, 7, 7 });
+            var shadowDir = Path.Combine(root, "key");
+
+            var attempts = 0;
+            var result = NclShadowRuntime.PublishShadowDir(
+                tempDir, shadowDir, origFull,
+                move: (src, _) =>
+                {
+                    attempts++;
+                    if (ioException) throw new IOException($"Access to the path '{src}' is denied.");
+                    throw new UnauthorizedAccessException($"Access to the path '{src}' is denied.");
+                },
+                sleep: _ => { });
+
+            Assert.Equal(tempDir, result);
+            Assert.True(attempts >= 20, $"every attempt must be spent before giving up, saw {attempts}");
+            Assert.True(Directory.Exists(tempDir), "the fallback directory must survive, it is what runs");
+            Assert.True(NclShadowRuntime.IsShadowDirComplete(tempDir, origFull));
+            Assert.Equal(new byte[] { 7, 7, 7 }, File.ReadAllBytes(Path.Combine(result, EntryDllName)));
+            Assert.False(Directory.Exists(shadowDir), "nothing may be published under a name we never renamed to");
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>The source-side failure must not be confused with the destination-side one:
+    /// when the rename fails BECAUSE a sibling published a complete dir in the meantime,
+    /// the existing adopt path still wins — no retry loop, no fallback to tempDir.</summary>
+    [Fact]
+    public void PublishShadowDir_MoveFailsBecauseASiblingPublished_StillAdoptsTheWinner()
+    {
+        var root = NewTempDir("adopt");
+        try
+        {
+            var origFull = @"C:\install\any";
+            var tempDir = Path.Combine(root, "key.building.abc");
+            WriteCompleteShadowDir(tempDir, origFull, dllBytes: new byte[] { 1, 1, 1 });
+            var shadowDir = Path.Combine(root, "key");
+
+            var attempts = 0;
+            var result = NclShadowRuntime.PublishShadowDir(
+                tempDir, shadowDir, origFull,
+                move: (_, dst) =>
+                {
+                    attempts++;
+                    // The sibling lands between our Exists check and our rename.
+                    WriteCompleteShadowDir(dst, origFull, dllBytes: new byte[] { 2, 2, 2 });
+                    throw new IOException("Cannot create a file when that file already exists.");
+                },
+                sleep: _ => throw new Xunit.Sdk.XunitException("must not back off when there is a winner to adopt"));
+
+            Assert.Equal(shadowDir, result);
+            Assert.Equal(1, attempts);
+            Assert.False(Directory.Exists(tempDir), "our own build must be discarded");
+            Assert.Equal(new byte[] { 2, 2, 2 }, File.ReadAllBytes(Path.Combine(shadowDir, EntryDllName)));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+}

--- a/AlRunner/Infrastructure/NclShadowRuntime.cs
+++ b/AlRunner/Infrastructure/NclShadowRuntime.cs
@@ -216,6 +216,10 @@ public static class NclShadowRuntime
         Directory.CreateDirectory(shadowRoot);
         var tempDir = Path.Combine(shadowRoot, $"{key}.building.{Guid.NewGuid():N}");
         Directory.CreateDirectory(tempDir);
+        // Where the publish actually landed. Normally shadowDir; tempDir when a locked
+        // source defeated every rename attempt (#3364) — the re-exec then runs from the
+        // temp dir this once rather than from a path that was never created.
+        var publishedDir = shadowDir;
         try
         {
             MirrorInstallDirectory(origFull, tempDir, entrySource);
@@ -233,19 +237,20 @@ public static class NclShadowRuntime
             // shadowDir that isn't complete.
             File.WriteAllText(Path.Combine(tempDir, MarkerFileName), origFull);
 
-            PublishShadowDir(tempDir, shadowDir, origFull);
+            publishedDir = PublishShadowDir(tempDir, shadowDir, origFull);
         }
         finally
         {
             // Belt-and-braces cleanup if something above threw for an unrelated reason
             // (e.g. RewriteInPlace failing), or PublishShadowDir already consumed/moved
             // tempDir away — don't leave a half-built temp dir behind.
-            try { if (Directory.Exists(tempDir)) Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+            if (!string.Equals(publishedDir, tempDir, StringComparison.OrdinalIgnoreCase))
+                try { if (Directory.Exists(tempDir)) Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
         }
 
-        PruneStaleShadowDirs(shadowRoot, shadowDir, keepNewest: 4);
+        PruneStaleShadowDirs(shadowRoot, publishedDir, keepNewest: 4);
 
-        return shadowDll;
+        return Path.Combine(publishedDir, EntryDllName);
     }
 
     // #2489: the issue's own field observation of "incomplete published dir" listed
@@ -335,9 +340,35 @@ public static class NclShadowRuntime
     ///    normal file writes always have for concurrent readers: an already-open handle
     ///    keeps seeing the old bytes/inode, and a fresh open after the write sees the new
     ///    ones — nobody's path resolution ever goes missing.
+    /// 4. <b>The source directory is locked</b> (#3364) — Windows refuses to rename a
+    ///    directory while any process holds an open handle to any file inside it, and an
+    ///    on-access AV scanner's plain <c>FileShare.Read</c> handle on the ~50 MB
+    ///    <c>Microsoft.Dynamics.Nav.Ncl.dll</c> this method has just written is enough.
+    ///    That raises <c>IOException</c> naming the SOURCE path, with
+    ///    <paramref name="shadowDir"/> still absent — the case the old
+    ///    <c>when (Directory.Exists(shadowDir))</c> filter could not match, so it escaped
+    ///    all the way out of <c>Main</c> and killed the process before any test ran. The
+    ///    lock is transient, so this retries with backoff, exactly as
+    ///    <c>NclCecilRewrite.AtomicReplace</c> already does for the file-level rename of
+    ///    the same bytes one layer down.
     /// </summary>
-    internal static void PublishShadowDir(string tempDir, string shadowDir, string origFull)
+    /// <returns>The directory the caller should exec from: <paramref name="shadowDir"/>
+    /// normally, or <paramref name="tempDir"/> when a sustained source-side lock defeated
+    /// every publish attempt and the temp dir is itself complete. Returning a directory
+    /// rather than <c>void</c> is what stops the exhausted path handing back a path that
+    /// was never created (the caller would re-exec into it and die with "The application
+    /// to execute does not exist").</returns>
+    /// <param name="move">Test seam for the rename; production passes null and gets
+    /// <see cref="Directory.Move"/>. A real file lock only blocks a rename on Windows,
+    /// so the retry behaviour is untestable on the Linux CI legs without it.</param>
+    /// <param name="sleep">Test seam for the backoff delay, so a test that never lets the
+    /// move succeed costs no wall time.</param>
+    internal static string PublishShadowDir(
+        string tempDir, string shadowDir, string origFull,
+        Action<string, string>? move = null, Action<int>? sleep = null)
     {
+        move ??= Directory.Move;
+        sleep ??= System.Threading.Thread.Sleep;
         const int maxAttempts = 20;
         for (var attempt = 1; attempt <= maxAttempts; attempt++)
         {
@@ -345,14 +376,23 @@ public static class NclShadowRuntime
             {
                 try
                 {
-                    Directory.Move(tempDir, shadowDir);
-                    return;
+                    move(tempDir, shadowDir);
+                    return shadowDir;
                 }
-                catch (IOException) when (Directory.Exists(shadowDir))
+                catch (IOException) { }
+                catch (UnauthorizedAccessException) { }
+
+                if (!Directory.Exists(shadowDir))
                 {
-                    // A sibling published between our Exists check and our Move —
-                    // fall through to the adopt/self-heal logic below.
+                    // Nothing to adopt or heal — the destination is still absent, so the
+                    // refusal came from the SOURCE side (case 4 above). Back off and try
+                    // the rename again rather than falling into the heal logic, which has
+                    // no directory to heal.
+                    if (attempt < maxAttempts) sleep(Math.Min(attempt * 100, 500));
+                    continue;
                 }
+                // A sibling published between our Exists check and our Move —
+                // fall through to the adopt/self-heal logic below.
             }
 
             if (IsShadowDirComplete(shadowDir, origFull))
@@ -360,7 +400,7 @@ public static class NclShadowRuntime
                 // Lost the race, but to a COMPLETE, content-equivalent directory (only
                 // ever produced by this same rename-into-place path) — adopt it.
                 try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
-                return;
+                return shadowDir;
             }
 
             // shadowDir exists but is incomplete — heal in place (see the doc comment
@@ -396,18 +436,31 @@ public static class NclShadowRuntime
             {
                 Console.Error.WriteLine($"[reexec] Self-healed incomplete shadow dir at {shadowDir} in place");
                 try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
-                return;
+                return shadowDir;
             }
             // Still incomplete (a transient per-file collision above, or a sibling
             // racing the same heal) — loop around and retry.
         }
 
-        // Exhausted retries under sustained contention — leave tempDir for the finally
-        // block in EnsureShadowDir to clean up, and let the caller rebuild next call
-        // rather than publish something we can no longer prove is complete.
+        // Exhausted every attempt. Our own tempDir is complete (the marker went in last,
+        // before this method was called), so run from it in place rather than returning a
+        // path that was never created: the caller re-execs into whatever comes back, and a
+        // missing directory there means "The application to execute does not exist" and no
+        // tests at all. Cost of the fallback is one .building.* dir that PruneStaleShadowDirs
+        // deliberately never reaps (#2512) — accepted for a path only a sustained lock or
+        // sustained contention reaches, and the next invocation republishes normally.
+        if (IsShadowDirComplete(tempDir, origFull))
+        {
+            Console.Error.WriteLine(
+                $"[reexec] WARN: could not publish shadow dir at {shadowDir} after {maxAttempts} attempts " +
+                $"(source locked, or sustained contention) — running from {tempDir} this once");
+            return tempDir;
+        }
+
         Console.Error.WriteLine(
             $"[reexec] WARN: could not publish shadow dir at {shadowDir} after {maxAttempts} attempts " +
             "under contention — will retry on the next invocation");
+        return shadowDir;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #3364

`PublishShadowDir` renames `<key>.building.<guid>` onto `<key>`. Its only handler was `catch (IOException) when (Directory.Exists(shadowDir))`, which covers exactly one failure — the destination already exists. Windows produces a second one at the same call: `ERROR_ACCESS_DENIED` on the **source**, because it refuses to rename a directory while any process holds an open handle to any file inside it. An on-access AV scanner's plain `FileShare.Read` handle on the ~50 MB `Ncl.dll` this method has just written is enough. That exception escaped `PublishShadowDir`, `EnsureShadowDir` and `TryShadowReexec` and killed the process (exit 82) with zero tests run.

Not a race: it reproduces with one process on a private `--cache` root, and both field sightings retried clean.

## What changed

1. Catch `IOException`/`UnauthorizedAccessException` from the move with no `Directory.Exists` filter. If the destination now exists, fall through to the existing adopt/self-heal logic unchanged; if it does not, the refusal came from the source, so retry.
2. Back off between attempts — `min(attempt * 100, 500) ms`, ~9 s across the 20 attempts. The loop previously had **no delay at all**, so 20 attempts were spent instantly and a lock measured in milliseconds defeated every one of them. `NclCecilRewrite.AtomicReplace` already documents this exact AV behaviour one layer down, for the file-level rename of the same bytes, and defends with 60 retries at 500 ms.
3. `PublishShadowDir` returns the directory the caller should exec from. Exhaustion used to return `void` after a WARN, and `EnsureShadowDir` then handed back `<key>\al-runner.dll` under a `<key>` that was never created — the re-exec dies with `The application to execute does not exist`. It now returns the complete temp dir, and `EnsureShadowDir` skips deleting it in that one case.

Cost of the fallback: one `.building.*` dir that `PruneStaleShadowDirs` deliberately never reaps (#2512). Accepted for a path only a sustained lock reaches, and the next invocation republishes normally — measured once per fallback below.

## RED → GREEN

**End-to-end, one process, no concurrency.** A watcher opens the first file that appears in the `.building.*` dir with `FileShare.Read` and holds it across the rename — what a scanner does. Harness inlined in #3364.

| build | crashes | leftover `.building.*` | tests run |
|---|---|---|---|
| `main` (packed dev tool) | **3/3** with the exact field stack | 1 per crash | 0 |
| this branch (`Release` from the worktree) | **0/3** | 1 per fallback | 10 total, 10 pass, under the fallback path |

The leftover counts on the fixed build include a ghost directory carried over from the previous iteration (the prior fallback's temp dir, emptied but not removed), so the raw numbers read 1 and 2 rather than 1 each. One per fallback is the claim.

The fallback's stderr on the runs that took it:

```
[reexec] WARN: could not publish shadow dir at ...\<key> after 20 attempts
(source locked, or sustained contention) - running from ...\<key>.building.<guid> this once
```

**Unit** — `AlRunner.Tests/NclShadowLockedSourcePublishTests.cs`, 4 tests, all Linux-safe: the move is injected rather than provoked with a real handle, because a real lock only blocks a rename on Windows and a handle-based test would be permanently green on the CI legs. They assert the retry count, that the delay grows and stays in range, that a permanent refusal returns the *complete temp dir* and never throws (both exception types), and that a destination-side failure still adopts the sibling's dir on the first attempt with no backoff. RED confirmed by reverting `NclShadowRuntime.cs` to its parent commit: the test file does not compile, `CS1739 ... does not have a parameter named 'move'`, `CS0815 Cannot assign void`. GREEN: 4/4.

`dotnet test AlRunner.Tests --filter FullyQualifiedName~NclShadow`: 30 passed, 3 failed. The three failures are pre-existing and environmental — `NclShadowRuntimeTests` symlink assertions, which cannot pass on a Windows box without Developer Mode ("non-Win32Stubs directories should still be symlinked"). `MirrorInstallDirectory` is untouched by this diff; whether they pass on the Linux legs is CI's to say, not mine.

## Shape scan

- **Other `Directory.Move` call sites**: three, all in the pkgdedup layer, all already correct — `PkgDedupStaging.Publish` catches broadly, retries with injected backoff and falls back to its own scratch dir (the same shape adopted here); `TryMoveAside` catches everything and reports false; `PkgDedupCache`'s prune catches both exception types. Nothing to fix, and they independently corroborate the design.
- **Sibling assumption in the same file**: the exhausted path was the second half of the same defect and is fixed here rather than filed.
- **The truncated-shadow report** (a published dir missing `System.Diagnostics.EventLog.Messages.dll`), which would be a `IsShadowDirComplete`/self-heal gap in this file rather than this one: checked all four published dirs on the reporting box against their recorded source installs — each is a complete mirror (85 source entries against 87, the extra two being the marker and `Ncl.dll`), and that DLL is not in the install at all. No evidence, so nothing folded and nothing filed; if it recurs it needs its own reproduction.
- **Open-issue queue**: #2375 and #2374 are the only other open issues in `NclShadowRuntime.cs` (the re-exec's CLR-start cost, and crossgen2 inside the shadow build). Both are startup *performance* with entirely different reasoning; folding either would make one diff a reviewer cannot hold. Not folded.

## No corpus PR

This is runner startup plumbing — a directory rename against a locked source. It asserts nothing about Business Central, so there is nothing for a service tier to adjudicate and no corpus test to write.

Comment prose: no block over ten lines was added. The mechanism went into the existing `PublishShadowDir` doc comment as a fourth numbered outcome alongside the three it already lists; the measurements and the rejected alternatives are here in the PR body.

---

Opened by agent `fbk-3`. Related, not closed by this PR: #2489, #2512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016YetuBaizYtaWMHmsDsLNh
