### PR TITLE
fix(tablerelation): refuse an unrepresentable relation shape instead of dropping it silently

### DIFF
--- a/AlRunner.Tests/TableRelationUnrepresentableShapeRefusalTests.cs
+++ b/AlRunner.Tests/TableRelationUnrepresentableShapeRefusalTests.cs
@@ -1,0 +1,321 @@
+// TableRelationUnrepresentableShapeRefusalTests — issue #3326.
+//
+// WHAT IS PINNED
+// --------------
+// The PARSER's two TableRelation refusal sites used to answer `null` — dropping the whole
+// relation — and carry on. #3306 fixed the same end state one layer down in the BUILDER; these
+// two sites were left, and they are strictly worse placed, because `RelationArms = null` never
+// reaches the builder at all, so #3306's guard at `EvaluateRelation` cannot see it.
+//
+// A dropped relation leaves `FieldRef.Relation` answering 0 and `Validate` accepting a value
+// with no row in the related table — both silent wrong answers in the direction that looks like
+// success, which `.claude/rules/loud-failures.md` forbids.
+//
+// WHY A THROW AND NOT A NOTE (the design question #3326 asked to be settled by measurement)
+// ----------------------------------------------------------------------------------------
+// #3326 offered two routes and asked which the evidence supports. Measured on this tree:
+//
+//   * The condition-shape site is reachable ONLY from AL that the AL compiler rejects, and
+//     the runner refuses to run that AL. Both reaching shapes are proof of this:
+//       - `SimpleFieldExpressionSyntax` in an if() — `error AL0489: The property expression is
+//         not valid. A CONST or FILTER expression is expected.`
+//       - `InvalidPropertyExpressionSyntax` — the AL parser's ERROR-RECOVERY node, which by
+//         construction exists only where the parse already failed.
+//     A bundle carrying either fails to compile and runs zero tests; the same shape in a
+//     DEPENDENCY is refused with "source dependency does not compile".
+//   * The whole al-language corpus (2978 tests) and all of tests/runner-extras (361 tests)
+//     produced ZERO hits at either site with both instrumented to print unconditionally.
+//
+// So there is no AL-observable state to record a note FOR: no AL that reaches these sites ever
+// executes. A note keyed on (tableId, fieldId) would be bookkeeping for a state that cannot be
+// observed — which is what #3326 warned against building. What IS worth having is that the
+// runner stops treating an unrepresentable shape as a silent success, because reaching either
+// site means the runner's own model of AL has diverged from the compiler's.
+//
+// That makes this the `NclCecilRewrite` case: a shape the runner believes cannot occur, which
+// throws loudly if it ever does, rather than degrading into a wrong answer.
+//
+// WHY THE RELATED-TABLE-NAME SITE IS GONE ENTIRELY RATHER THAN CONVERTED
+// ---------------------------------------------------------------------
+// `ParseRelationArms`' `parts.Count is not (1 or 2)` guard cannot fire, and that is structural
+// rather than a matter of what AL anyone has written:
+//
+//   * `RelationTargetNameParts` returns `parts.Count <= 2 ? parts : parts.GetRange(...2)`, so
+//     its result is 0, 1 or 2 — never more. The comment's "3-part name" has been impossible
+//     since #2851 clamped it.
+//   * 0 is unproducible. `NameSyntax` has exactly three subclasses in
+//     Microsoft.Dynamics.Nav.CodeAnalysis 28.1 — `SimpleNameSyntax` (abstract),
+//     `IdentifierNameSyntax` and `QualifiedNameSyntax` — and `NameParts` walks both concrete
+//     ones, appending at least one part for each. AL's error recovery synthesises a MISSING
+//     `IdentifierNameSyntax` rather than nothing, so even unparseable input yields 1 part with
+//     empty text.
+//
+// Fifteen probes covering three-, four- and five-part names, a quoted name containing a dot, an
+// empty quoted name, a leading/trailing/bare dot, an integer literal, a parenthesized name, a
+// keyword, a string literal and an absent value all returned 1 or 2 parts. `EmptyRelationTarget`
+// below pins the one thing that actually matters downstream — an empty target NAME is carried
+// as 1 part and refused by the builder, which is #3306's business, not the parser's.
+//
+// BC-BEHAVIOUR ANSWER
+// -------------------
+// None of this asserts anything about BC. Real BC never sees these shapes: its own compiler
+// rejects them, exactly as the runner's does, because both ARE Microsoft's AL compiler. The
+// claim is purely "the runner must not silently drop a relation whose shape it cannot carry",
+// which is a runner-local claim about a runner-side surface. There is nothing for a service
+// tier to adjudicate, so no corpus test is owed. The BC-behaviour half — that `Validate`
+// enforces a TableRelation at all — is already pinned upstream (corpus codeunit 60482
+// TestFieldRefRelation and corpus PRs 207/222), and this file deliberately does not duplicate it.
+using System.Reflection;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TableRelationUnrepresentableShapeRefusalTests
+{
+    /// <summary>
+    /// Drive <c>RelationConditionList</c> — the site that used to print and return null — over a
+    /// real AL syntax tree, so the shapes under test are the ones Microsoft's parser actually
+    /// produces rather than ones this test asserts into existence.
+    /// </summary>
+    private static object? InvokeRelationConditionList(
+        Microsoft.Dynamics.Nav.CodeAnalysis.Syntax.TableFilterExpressionSyntax? filter,
+        string fieldName, bool allowFieldLinks, bool fromCompiledSource = true)
+    {
+        var m = typeof(RecordPatches).GetMethod(
+                    "RelationConditionList",
+                    BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "RecordPatches.RelationConditionList not found — this test drives the "
+                    + "parser's condition-shape refusal site directly.");
+        try
+        {
+            return m.Invoke(null,
+                new object?[] { filter, fieldName, allowFieldLinks, fromCompiledSource });
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo
+                .Capture(tie.InnerException).Throw();
+            throw; // unreachable
+        }
+    }
+
+    /// <summary>
+    /// The <c>TableRelation</c> property value of the single field of a one-field table, parsed
+    /// out of real AL text by the AL compiler's own parser.
+    /// </summary>
+    private static Microsoft.Dynamics.Nav.CodeAnalysis.Syntax.TableRelationPropertyValueSyntax
+        ParseRelation(string relationText)
+    {
+        var src = $$"""
+            table 50100 "URS Probe"
+            {
+                fields
+                {
+                    field(1; "Code"; Code[20]) { }
+                    field(2; "Kind"; Code[20]) { }
+                    field(3; "Link"; Code[20]) { TableRelation = {{relationText}}; }
+                }
+            }
+            """;
+        var m = typeof(RecordPatches).GetMethod(
+                    "ParseAlObjects", BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new InvalidOperationException("RecordPatches.ParseAlObjects not found.");
+        var objects = (System.Collections.IEnumerable)m.Invoke(null, new object?[] { src })!;
+
+        foreach (var obj in objects)
+        {
+            if (obj is not Microsoft.Dynamics.Nav.CodeAnalysis.Syntax.TableSyntax t) continue;
+            if (t.Fields == null) continue;
+            foreach (var f in t.Fields.Fields)
+            {
+                if (f is not Microsoft.Dynamics.Nav.CodeAnalysis.Syntax.FieldSyntax fs) continue;
+                if (fs.PropertyList == null) continue;
+                foreach (var p in fs.PropertyList.Properties)
+                    if (p is Microsoft.Dynamics.Nav.CodeAnalysis.Syntax.PropertySyntax ps
+                        && string.Equals(ps.Name?.ToString()?.Trim(), "TableRelation",
+                            StringComparison.OrdinalIgnoreCase)
+                        && ps.Value is Microsoft.Dynamics.Nav.CodeAnalysis.Syntax
+                            .TableRelationPropertyValueSyntax tr)
+                        return tr;
+            }
+        }
+        throw new InvalidOperationException(
+            $"no TableRelation property parsed out of '{relationText}'");
+    }
+
+    [Fact]
+    public void IfConditionCarryingAFieldLink_ThrowsNamingTheShapeAndTheField()
+    {
+        // The one shape #3326 could construct, and the reason the site exists at all: BC models
+        // an if() condition as MetaCondition, whose NCLMetaFilter.CreateFromMetaCondition has
+        // CONST and FILTER cases only. Microsoft's own compiler rejects it first with AL0489 —
+        // which is exactly why a throw is right and a note would be unobservable bookkeeping.
+        var tr = ParseRelation("""if ("Kind" = field("Code")) "URS Parent" """);
+        var cond = tr.IfExpression?.IfTableRelationCondition;
+        Assert.NotNull(cond);
+        // Pin the PRECONDITION rather than assuming it: this really is the field-link node, so
+        // the test is exercising the refusal and not some unrelated parse failure.
+        Assert.Contains(cond!.Conditions, c =>
+            c is Microsoft.Dynamics.Nav.CodeAnalysis.Syntax.SimpleFieldExpressionSyntax);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => InvokeRelationConditionList(cond, "Link", allowFieldLinks: false));
+
+        // The message must name WHICH field, WHICH position and WHICH syntax shape — without all
+        // three it is no more actionable than the silent null it replaces.
+        Assert.Contains("Link", ex.Message);
+        Assert.Contains("if()", ex.Message);
+        Assert.Contains("SimpleFieldExpressionSyntax", ex.Message);
+        // ...and it must say the runner believes this cannot happen, so whoever sees it knows
+        // this is a runner-model divergence rather than bad AL to be fixed in the test.
+        Assert.Contains("AL0489", ex.Message);
+        Assert.Contains("#3326", ex.Message);
+    }
+
+    [Fact]
+    public void ErrorRecoveryConditionNode_ThrowsNamingTheShape()
+    {
+        // The OTHER reaching shape, and the more general one: InvalidPropertyExpressionSyntax is
+        // the AL parser's error-recovery node. It appears only where the parse already failed, so
+        // a bundle carrying it never compiles — but if the runner ever meets one it must say so
+        // rather than drop the relation and answer 0.
+        var tr = ParseRelation("""Customer where("No." = bogus("X"))""");
+        var filt = tr.TableFilter?.Filter;
+        Assert.NotNull(filt);
+        Assert.Contains(filt!.Conditions, c =>
+            c is Microsoft.Dynamics.Nav.CodeAnalysis.Syntax.InvalidPropertyExpressionSyntax);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => InvokeRelationConditionList(filt, "Link", allowFieldLinks: true));
+
+        Assert.Contains("Link", ex.Message);
+        Assert.Contains("where()", ex.Message);
+        Assert.Contains("InvalidPropertyExpressionSyntax", ex.Message);
+    }
+
+    [Fact]
+    public void EveryShapeTheCompilerAccepts_IsCarriedAndNotRefused()
+    {
+        // The scoping control, and the half that must pass in BOTH states. These six are every
+        // condition shape Microsoft's binder accepts — verified by compiling them through the
+        // runner, which drives Microsoft's own compiler: 1P/0F/0E, no refusal. If the throw above
+        // were keyed on anything coarser than the unrepresentable node types, this fails.
+        //
+        // const/filter are legal in both positions; the four field() spellings only in where().
+        foreach (var (relation, inWhere) in new (string, bool)[]
+        {
+            ("""if ("Kind" = const('A')) Customer""", false),
+            ("""if ("Kind" = filter('A'|'B')) Customer""", false),
+            ("""Customer where("No." = const('A'))""", true),
+            ("""Customer where("No." = filter('A'|'B'))""", true),
+            ("""Customer where("No." = field("Code"))""", true),
+            ("""Customer where("No." = field(filter("Code")))""", true),
+            ("""Customer where("No." = field(upperlimit("Code")))""", true),
+            ("""Customer where("No." = field(upperlimit(filter("Code"))))""", true),
+        })
+        {
+            var tr = ParseRelation(relation);
+            var filt = inWhere ? tr.TableFilter?.Filter : tr.IfExpression?.IfTableRelationCondition;
+            Assert.True(filt != null, $"no condition list parsed out of '{relation}'");
+
+            var carried = InvokeRelationConditionList(filt, "Link", allowFieldLinks: inWhere);
+
+            // Not merely "did not throw": the list must actually carry the condition. A method
+            // that returned an empty list for everything would pass a no-throw assertion.
+            Assert.NotNull(carried);
+            var count = (int)carried!.GetType().GetProperty("Count")!.GetValue(carried)!;
+            Assert.Equal(1, count);
+        }
+    }
+
+    [Fact]
+    public void SameShapeFromAPrecompiledAppSymbol_RefusesQuietlyInsteadOfThrowing()
+    {
+        // The direction that decides the whole design, and the one an unconditional throw got
+        // wrong. `TryParseRelationArmsText` feeds a STRING out of a precompiled .app's
+        // SymbolReference.json through the same parser. Nothing vetted that string — Microsoft's
+        // compiler never saw it — and an if() field() link really is unrepresentable there,
+        // because BC's own NCLMetaFilter.CreateFromMetaCondition has CONST and FILTER cases only
+        // and throws NotSupportedException on FIELD. So refusing the PROPERTY is BC's constraint
+        // rather than a runner bug, and null is the correct permanent answer.
+        //
+        // Measured on Base Application 28.1.49838.53910: 1,155 of 7,787 relation-bearing fields
+        // carry a where(... = field(...)) link, so this path is live, not hypothetical.
+        var m = typeof(RecordPatches).GetMethod(
+                    "TryParseRelationArmsText", BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "RecordPatches.TryParseRelationArmsText not found — this test drives the "
+                    + "precompiled-.app symbol path.");
+
+        var arms = m.Invoke(null, new object?[]
+        {
+            """if ("Kind" = field("Kind")) "URS Parent"."Code" """, "Link",
+        });
+
+        // Null, not an exception: the caller's documented contract is to read this as
+        // "no relation". A throw here aborts reading the whole .app.
+        Assert.Null(arms);
+    }
+
+    [Fact]
+    public void RepresentableShapeFromAPrecompiledAppSymbol_IsStillCarried()
+    {
+        // The scoping half of the pair. If the symbol path had been made to refuse everything —
+        // or if the provenance flag were wired backwards — this fails. A `where()` field() link
+        // IS representable (BC models it as MetaFilter/FilterType.FIELD), so it must come back
+        // carried, with the arm naming its target concretely.
+        var m = typeof(RecordPatches).GetMethod(
+                    "TryParseRelationArmsText", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        var arms = m.Invoke(null, new object?[]
+        {
+            "\"URS Parent\".\"Code\" where(\"Group\" = field(\"Kind\"))", "Link",
+        });
+
+        Assert.NotNull(arms);
+        var list = (System.Collections.IList)arms!;
+        Assert.Single(list);
+
+        // Assert the CONTENT, not just that something came back: a method returning one empty
+        // arm for everything would pass a count-only check.
+        var arm = list[0]!;
+        var target = arm.GetType().GetProperty("TableName")!.GetValue(arm);
+        Assert.Equal("URS Parent", target);
+        var filters = (System.Collections.ICollection)arm.GetType()
+            .GetProperty("Filters")!.GetValue(arm)!;
+        Assert.Single(filters);
+    }
+
+    [Fact]
+    public void EmptyRelationTargetName_IsCarriedAsOnePartNotRefusedByTheParser()
+    {
+        // Why the related-table-name site is deleted rather than converted to a throw: its guard
+        // cannot fire. `""` is the closest thing to an empty target AL admits, and it arrives as
+        // ONE part whose text is empty — not zero parts. Refusing an empty NAME is the builder's
+        // job (#3306), which is where it is already done, and pinning that here keeps the
+        // deletion honest: the parser is not silently dropping this case, it never had it.
+        var m = typeof(RecordPatches).GetMethod(
+                    "RelationTargetNameParts", BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "RecordPatches.RelationTargetNameParts not found.");
+
+        foreach (var (relation, expected) in new (string, int)[]
+        {
+            ("""Customer""", 1),                                   // plain
+            ("""Customer."No." """, 2),                            // table + field
+            ("""Microsoft.Sales.Customer."No." """, 2),            // namespace-qualified, clamped
+            ("""A.B.C.D.E""", 2),                                  // five parts, clamped
+            ("\"\"", 1),                                          // empty quoted name -> 1 part
+        })
+        {
+            var tr = ParseRelation(relation);
+            var parts = (System.Collections.ICollection)m.Invoke(
+                null, new object?[] { tr.RelatedTableField })!;
+            Assert.Equal(expected, parts.Count);
+            // The property the deleted guard depended on, asserted directly: never 0, never >2.
+            Assert.InRange(parts.Count, 1, 2);
+        }
+    }
+}

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -473,7 +473,7 @@ public static partial class RecordPatches
         if (!isFlowField && !isFlowFilter
             && PropValue(props, "TableRelation") is NavSyntax.TableRelationPropertyValueSyntax tr)
         {
-            relationArms = ParseRelationArms(tr, fname);
+            relationArms = ParseRelationArms(tr, fname, fromCompiledSource: true);
         }
 
         // MinValue / MaxValue (#2495): raw AL expression text, unquoted — these are numeric
@@ -497,25 +497,53 @@ public static partial class RecordPatches
     /// exactly how real BC treats it: the else arm carries NO condition, not the complement
     /// of the earlier arms' conditions (verified against a real service tier; see corpus
     /// codeunit 60239, Record_Rename_ConditionalRelation_ElseTableRename_UpdatesIfArmRowsToo).
-    /// Returns null — refusing the whole relation — on any arm this representation cannot
-    /// carry faithfully.
+    /// <para>How it refuses depends on where the text came from (#3326). The related-table-name
+    /// check below always THROWS, because no input of either provenance can fail it. An
+    /// unrepresentable condition SHAPE throws only for AL this runner compiled — Microsoft's
+    /// compiler has already vetted that, so reaching it means the runner's model of AL has
+    /// diverged — and returns null for text read back out of a precompiled <c>.app</c>, where
+    /// refusing the property is the correct permanent answer. A silent null on the source path
+    /// would drop the whole relation, and unlike the builder's drop that #3306 covers, it never
+    /// reaches the builder at all, so nothing downstream could see it. Measurement:
+    /// <c>docs/tablerelation-parser-refusals.md</c>.</para>
     /// </summary>
+    /// <param name="fromCompiledSource">
+    /// True when the relation text came from AL this runner is compiling, so Microsoft's own
+    /// compiler has already vetted it and an unrepresentable shape means the runner's model of AL
+    /// has diverged — a throw. False when it was read back as a STRING out of a precompiled
+    /// <c>.app</c>'s <c>SymbolReference.json</c>, where nothing gates it and refusing the property
+    /// is the correct permanent answer (#3326).
+    /// </param>
     private static List<ParsedRelationArm>? ParseRelationArms(
-        NavSyntax.TableRelationPropertyValueSyntax tr, string fieldName)
+        NavSyntax.TableRelationPropertyValueSyntax tr, string fieldName, bool fromCompiledSource)
     {
         var arms = new List<ParsedRelationArm>();
         for (var node = tr; node != null; node = node.ElseExpression?.ElseTableRelationCondition)
         {
             var parts = RelationTargetNameParts(node.RelatedTableField);
             // 1 part = table; 2 parts = table + field, OR namespace + table — BuildMetaFieldRelations
-            // tries both readings and that ambiguity is already its job. RelationTargetNameParts drops
-            // any leading namespace segments (#2851), so reaching here with any other count means the
-            // name did not read as a name at all, and the relation stays uncaptured.
+            // tries both readings and that ambiguity is already its job.
+            //
+            // Neither 0 nor >2 can occur, so this throws rather than dropping the relation (#3326;
+            // see docs/tablerelation-parser-refusals.md for the measurement). >2 has been
+            // impossible since #2851 made RelationTargetNameParts clamp to the last two parts; 0
+            // is unproducible because NameParts appends a part for each of the only two CONCRETE
+            // NameSyntax shapes the AL compiler has, and AL's error recovery synthesises a
+            // *missing* IdentifierNameSyntax rather than nothing. Dropping the relation here
+            // would leave FieldRef.Relation answering 0 and Validate accepting a value real BC
+            // refuses — the silent wrong answer #3306 fixed one layer down, and one its guard at
+            // EvaluateRelation cannot see, because a null RelationArms never reaches the builder.
             if (parts.Count is not (1 or 2))
             {
-                Console.Error.WriteLine(
-                    $"[TableRelation] REFUSED {fieldName}: {parts.Count}-part related-table name '{node.RelatedTableField}'");
-                return null;
+                throw new InvalidOperationException(
+                    $"[TableRelation] #3326: field '{fieldName}' has a {parts.Count}-part "
+                    + $"related-table name '{node.RelatedTableField}' "
+                    + $"(node {node.RelatedTableField?.GetType().Name ?? "null"}). "
+                    + "RelationTargetNameParts clamps to at most 2 and NameParts always yields at "
+                    + "least 1, so this is unreachable — the runner's model of AL has diverged "
+                    + "from the compiler's. Do not commit a workaround: fix NameParts or "
+                    + "RelationTargetNameParts, or the relation is silently dropped and "
+                    + "FieldRef.Relation answers 0.");
             }
             // The two lists differ in ONE way, and it is not cosmetic (#2518): a where(...)
             // filter may carry a `field(...)` link, an if(...) condition may not. BC models
@@ -523,9 +551,9 @@ public static partial class RecordPatches
             // MetaCondition, whose NCLMetaFilter.CreateFromMetaCondition has CONST and FILTER
             // cases only and throws NotSupportedException on FIELD.
             var conditions = RelationConditionList(node.IfExpression?.IfTableRelationCondition,
-                fieldName, allowFieldLinks: false);
+                fieldName, allowFieldLinks: false, fromCompiledSource);
             var filters = RelationConditionList(node.TableFilter?.Filter,
-                fieldName, allowFieldLinks: true);
+                fieldName, allowFieldLinks: true, fromCompiledSource);
             if (conditions == null || filters == null) return null;
             arms.Add(new ParsedRelationArm(parts[0], parts.Count == 2 ? parts[1] : null,
                 conditions, filters));
@@ -549,15 +577,22 @@ public static partial class RecordPatches
     /// CONST and FILTER cases only, throwing <c>NotSupportedException</c> on FIELD; carrying
     /// one there would build metadata BC cannot load, so it still refuses the whole relation.
     /// </para>
-    /// <para>Refusing returns null — the WHOLE relation is dropped, never half-captured. That
-    /// is deliberate for an unrepresentable shape, but it is also why this list matters: a
-    /// dropped relation leaves <c>FieldRef.Relation</c> answering 0, which is
-    /// indistinguishable from "no TableRelation declared". Before #2518 every
-    /// <c>where(... = field(...))</c> relation was dropped for exactly that reason — 826 of
-    /// them in Base Application 28.1, including <c>Customer.City</c>.</para>
+    /// <para>An unrepresentable shape throws when <paramref name="fromCompiledSource"/> (#3326),
+    /// and otherwise still returns null. It used to always return null, dropping the WHOLE
+    /// relation and leaving <c>FieldRef.Relation</c> answering 0 — indistinguishable from "no
+    /// TableRelation declared". Before #2518 every <c>where(... = field(...))</c> relation was
+    /// dropped for exactly that reason: 826 of them in Base Application 28.1, including
+    /// <c>Customer.City</c>. That is the cost of getting this list wrong, and why the shapes it
+    /// does not carry must be loud rather than silent. Measurement, including why no
+    /// compiler-accepted AL reaches the throw:
+    /// <c>docs/tablerelation-parser-refusals.md</c>.</para>
     /// </summary>
+    /// <param name="fromCompiledSource">See <see cref="ParseRelationArms"/>: true for AL this
+    /// runner compiles (an unrepresentable shape throws), false for relation text read back out
+    /// of a precompiled <c>.app</c>'s <c>SymbolReference.json</c> (it returns null).</param>
     private static List<ParsedCalcFilter>? RelationConditionList(
-        NavSyntax.TableFilterExpressionSyntax? filter, string fieldName, bool allowFieldLinks)
+        NavSyntax.TableFilterExpressionSyntax? filter, string fieldName, bool allowFieldLinks,
+        bool fromCompiledSource)
     {
         var list = new List<ParsedCalcFilter>();
         if (filter == null) return list;
@@ -616,11 +651,44 @@ public static partial class RecordPatches
                     break;
 
                 default:
-                    Console.Error.WriteLine(
-                        $"[TableRelation] REFUSED {fieldName}: unsupported " +
-                        (allowFieldLinks ? "where() entry " : "if() condition ") +
-                        $"{cond?.GetType().Name} ({cond})");
-                    return null;
+                    // Two provenances, two correct answers (#3326;
+                    // docs/tablerelation-parser-refusals.md has the probes and the counts).
+                    //
+                    // From a PRECOMPILED .app's SymbolReference.json the relation arrives as a
+                    // string nothing has vetted, and an unrepresentable shape is a real, permanent
+                    // fact rather than a runner bug: an if() condition becomes a MetaCondition,
+                    // and NCLMetaFilter.CreateFromMetaCondition has CONST and FILTER cases only,
+                    // throwing NotSupportedException on FIELD. Refusing the property is what BC
+                    // itself would have to do, so return null and let the caller read it as "no
+                    // relation" — the contract TryParseRelationArmsText documents.
+                    //
+                    // From AL this runner COMPILES, Microsoft's own compiler has already rejected
+                    // every shape that reaches here — an if() field() link as AL0489, and
+                    // InvalidPropertyExpressionSyntax only ever exists after a failed parse — so
+                    // arriving here means the runner's model of AL has diverged from the
+                    // compiler's, and a silent null would drop the whole relation. That leaves
+                    // FieldRef.Relation answering 0 and Validate accepting a value real BC
+                    // refuses, and #3306's guard cannot catch it because a null RelationArms
+                    // never reaches the builder that records the note.
+                    if (!fromCompiledSource)
+                    {
+                        Console.Error.WriteLine(
+                            $"[TableRelation] REFUSED {fieldName}: unsupported " +
+                            (allowFieldLinks ? "where() entry " : "if() condition ") +
+                            $"{cond?.GetType().Name} ({cond})");
+                        return null;
+                    }
+                    throw new InvalidOperationException(
+                        $"[TableRelation] #3326: field '{fieldName}' has an unsupported "
+                        + (allowFieldLinks ? "where() entry " : "if() condition ")
+                        + $"{cond?.GetType().Name} ({cond}) in AL this runner compiled. No AL the "
+                        + "compiler accepts produces this shape — an if() field() link is rejected "
+                        + "as AL0489, and InvalidPropertyExpressionSyntax only exists after a "
+                        + "failed parse — so reaching it means the runner's model of AL has "
+                        + "diverged from the compiler's. Do not commit a workaround that drops the "
+                        + "relation: that makes FieldRef.Relation answer 0 and Validate accept a "
+                        + "value real BC refuses. Carry the shape, or establish that BC cannot "
+                        + "represent it.");
             }
         }
         return list;
@@ -1246,7 +1314,7 @@ public static partial class RecordPatches
             if (obj is not NavSyntax.TableSyntax table || table.Fields == null) continue;
             foreach (var f in table.Fields.Fields)
                 if (PropValue(f.PropertyList, "TableRelation") is NavSyntax.TableRelationPropertyValueSyntax tr)
-                    return ParseRelationArms(tr, fieldName);
+                    return ParseRelationArms(tr, fieldName, fromCompiledSource: false);
         }
         return null;
     }

--- a/docs/tablerelation-parser-refusals.md
+++ b/docs/tablerelation-parser-refusals.md
@@ -1,0 +1,119 @@
+# The TableRelation parser's two refusal sites (#3326)
+
+`AlRunner/Patches/RecordPatches.AlSourceParser.cs` refuses a `TableRelation` in two places.
+Both used to write a line to stderr and return `null`, dropping the whole relation. Since
+#3326 both throw.
+
+This file records the measurement behind that choice, so nobody has to re-derive it.
+
+## Why a silent drop was worse here than in the builder
+
+#3306 fixed the same end state one layer down, in `BuildMetaFieldRelations`: a relation whose
+target table or field NAME did not resolve was dropped, so `Validate` accepted a value real BC
+refuses and `FieldRef.Relation` answered 0. It records the reason and refuses at
+`RecordImplementation.EvaluateRelation`.
+
+The parser's sites set `ParsedField.RelationArms = null`, and that never reaches the builder at
+all — so #3306's guard cannot see it. Same AL-observable wrong answer, with nothing downstream
+able to catch it.
+
+## Two provenances, and they do not get the same answer
+
+The parser has **two** entry points, and conflating them is the trap in this issue. `#3326`
+described the source path; the symbol path is the one that decides the design.
+
+| entry point | where the relation text comes from | vetted by the AL compiler? | right answer on an unrepresentable shape |
+|---|---|---|---|
+| `ParseFieldSyntax` -> `ParseRelationArms` | AL this runner is compiling | **yes** | **throw** — reaching it means the runner's model of AL diverged from the compiler's |
+| `TryParseRelationArmsText` -> `ParseRelationArms` | a **string** in a precompiled `.app`'s `SymbolReference.json` | **no** | **return null** — refusing the property is the correct permanent answer |
+
+`ParseRelationArms` and `RelationConditionList` therefore take a `fromCompiledSource` flag, and
+the condition-shape site branches on it. The symbol path has two call sites —
+`BcAppSymbolCache.cs` and `BcAppSymbolCache.TableExtensions.cs` — and both pass `false`.
+
+Getting this wrong is not theoretical: an unconditional throw broke the five
+`TableRelationWhereFieldLinkTests`, which exist for #2518 and deliberately pin the null on the
+symbol path. Field 10 of that fixture puts a `field()` link in an `if()` condition precisely
+because BC's `MetaCondition` cannot represent it, so refusing that property is BC's own
+constraint rather than a runner limitation.
+
+## Why the source path throws instead of recording a note
+
+#3326 offered both routes and asked which the evidence supports. On the source path it is the
+throw, because there is no observable state to record a note for: **no AL that reaches it ever
+executes.**
+
+### The condition-shape site
+
+Exactly two syntax shapes reach the `default:` arm of `RelationConditionList`, and both are
+already compiler errors:
+
+| shape | why it reaches the default | what the compiler says |
+|---|---|---|
+| `SimpleFieldExpressionSyntax` in an `if()` | `allowFieldLinks: false` — BC models an `if()` as `MetaCondition`, and `NCLMetaFilter.CreateFromMetaCondition` has CONST and FILTER cases only | `error AL0489: The property expression is not valid. A CONST or FILTER expression is expected.` |
+| `InvalidPropertyExpressionSyntax` | it is the AL parser's error-recovery node | whatever syntax error produced it (`AL0104`, `AL0292`, …) |
+
+Measured against the runner, which drives Microsoft's own compiler:
+
+- A bundle whose table carries `TableRelation = if ("Kind" = field("Kind")) "Parent";` reports
+  `AL0489` and runs **0 tests** (`COMPILE FAIL`). The refusal site *is* reached during that
+  failed compile — confirmed with both sites instrumented to print unconditionally — but no AL
+  runs, so the silent wrong answer is unobservable. (That is the SOURCE path. The same text
+  arriving from a precompiled `.app` is not a compile error and must not throw — see the
+  provenance table above.)
+- The same table as a **dependency** app is refused before it can be used:
+  `source dependency 'DepMix Dep' does not compile (1 error(s)): AL0489`.
+- Every condition shape Microsoft's binder accepts is carried, with no refusal:
+  `const(...)` and `filter(...)` in both positions, and `field(...)`, `field(filter(...))`,
+  `field(upperlimit(...))`, `field(upperlimit(filter(...)))` in `where()`. A bundle declaring
+  all of them passes `1P/0F/0E`.
+
+### The related-table-name site
+
+`parts.Count is not (1 or 2)` cannot fire, and that is structural:
+
+- `RelationTargetNameParts` returns `parts.Count <= 2 ? parts : parts.GetRange(parts.Count - 2, 2)`,
+  so its result is 0, 1 or 2 — never more. The "3-part name" the old message named has been
+  impossible since #2851.
+- 0 is unproducible. `NameSyntax` has exactly **three** subclasses in
+  `Microsoft.Dynamics.Nav.CodeAnalysis` 28.1 — `SimpleNameSyntax` (abstract),
+  `IdentifierNameSyntax` and `QualifiedNameSyntax` — and `NameParts` walks both concrete ones,
+  appending at least one part for each. AL's error recovery synthesises a *missing*
+  `IdentifierNameSyntax` rather than nothing, so even unparseable input yields 1 part.
+
+Thirty-three probes, each parsed with the AL compiler's own parser, all returned 1 or 2 parts —
+fifteen written as AL source, and eighteen more feeding the arbitrary-garbage strings the SYMBOL
+path can carry (`""`, `";"`, `"))"`, `"@#$%"`, `"1 = 2"`, an unterminated quote, bare keywords).
+This is why the name-parts guard throws unconditionally, with no provenance branch: it is
+unreachable on both paths.
+
+| input | parts |
+|---|---|
+| `Microsoft.Sales.Customer."No."` | 2 (clamped) |
+| `A.B.C.D`, `A.B.C.D.E` | 2 (clamped) |
+| `"Probe.Tbl"` (quoted name containing a dot) | 1 |
+| `""` (empty quoted name) | 1, empty text |
+| `.Customer`, `Customer.`, `.` | 2 |
+| `18`, `(Customer)`, `'Customer'`, `if`, whitespace, absent | 1, empty text |
+
+An empty target *name* is therefore carried as one part and refused by the **builder**, which is
+#3306's business — the parser never had that case to drop.
+
+## Corpus sweep
+
+With both sites instrumented to print unconditionally:
+
+| suite | tests | hits |
+|---|---|---|
+| `tests/al-language/tests/al-language` | 2978 | 0 |
+| `tests/runner-extras` | 361 | 0 |
+| `tests/al-language/tests/al-language-internals-fixture` | 0 | 0 |
+
+## The sibling this did not cover
+
+`CalcFormulaFrom`'s `where()` `default:` arm (same file) has the identical shape — it prints
+`[CalcFormula] REFUSED ...` and returns `null`, and the CalcFormula note sink from #3279 is in
+the builder, so a parser-level drop is invisible there too. Not folded in: it is a different
+property with a different set of reaching shapes, and it needs its own reachability measurement
+before anyone converts it, and the provenance split above is the trap it has to avoid. Filed as
+**#3367**.


### PR DESCRIPTION
Closes #3326

*Implemented by agent `stma-auto-14` (automated implementation agent).*

Corpus-NA: no BC-behaviour claim here — both refusal sites are runner-side parser internals, and every shape that reaches them is one Microsoft's own AL compiler rejects (AL0489), so there is nothing a service tier could be asked to adjudicate. Detail under "Does this assert anything about BC?" below.

## The route I chose, and the evidence that decided it

#3326 offered two routes — a `(tableId, fieldId)` note like #3306, or a hard throw — and asked for the reachability to be measured first. **The answer turned out to be neither uniformly**, because the parser has **two entry points** and they need different answers. That split is the actual fix.

| entry point | where the relation text comes from | vetted by the AL compiler? | answer on an unrepresentable shape |
|---|---|---|---|
| `ParseFieldSyntax` → `ParseRelationArms` | AL this runner is compiling | **yes** | **throw** |
| `TryParseRelationArmsText` → `ParseRelationArms` | a **string** in a precompiled `.app`'s `SymbolReference.json` | **no** | **return null** |

`ParseRelationArms` and `RelationConditionList` now take a `fromCompiledSource` flag. Both symbol-path call sites — `BcAppSymbolCache.cs:2071` and `BcAppSymbolCache.TableExtensions.cs:284` — reach the parser through `TryParseRelationArmsText` and pass `false`.

### Line 620 (`RelationConditionList`) — reachable, but only from AL the compiler rejects

Exactly two syntax shapes reach the `default:` arm, and both are already errors:

- `SimpleFieldExpressionSyntax` in an `if()` — BC models an `if()` as `MetaCondition`, and `NCLMetaFilter.CreateFromMetaCondition` has CONST and FILTER cases only. Microsoft's compiler rejects it first.
- `InvalidPropertyExpressionSyntax` — the AL parser's **error-recovery node**, which by construction exists only where the parse already failed.

Exact diagnostics from my probes, compiled through the runner (which drives Microsoft's own compiler):

```
error AL0489: The property expression is not valid. A CONST or FILTER expression is expected.
```

on `TableRelation = if ("Kind" = field("Kind")) "AL0489 Parent";` — the bundle reports `COMPILE FAIL` and runs **0 tests**. The refusal site *is* reached during that failed compile (confirmed with both sites instrumented to print unconditionally), but no AL executes, so the silent wrong answer is unobservable on that path. The same table as a **dependency** never gets used either:

```
[layered] Failed to emit symbols for impl 'DepMix Dep': source dependency 'DepMix Dep'
does not compile (1 error(s)): AL0489 The property expression is not valid.
```

Every shape the binder *accepts* is carried, with no refusal — `const(...)` and `filter(...)` in both positions, and `field(...)`, `field(filter(...))`, `field(upperlimit(...))`, `field(upperlimit(filter(...)))` in `where()`. A bundle declaring all of them passes `1P/0F/0E`. (My first attempt at three of those spellings produced `AL0490`; that was my AL being wrong, not a finding — corrected against the parser and re-run.)

So on the **source** path there is no observable state a note could be recorded for, and a throw is the honest answer. This is the `NclCecilRewrite` case #3326 anticipated.

### …but an unconditional throw was wrong, and the existing tests caught it

Converting both sites to throws **broke five `TableRelationWhereFieldLinkTests`**. That suite exists for #2518 and deliberately pins the null on the symbol path: its fixture field 10 puts a `field()` link in an `if()` condition *precisely because* BC's `MetaCondition` cannot represent it, so refusing that property is BC's own constraint rather than a runner limitation. `TryParseRelationArmsText` documents the contract in so many words — *"Returns null when the property is absent or its shape is refused, which the caller must treat as 'no relation'"* — and a throw there aborts reading the whole `.app`.

This path is live, not hypothetical: **1,155 of 7,787** relation-bearing fields in Base Application 28.1 carry a `where(... = field(...))` link. I did not change that test; I changed my fix to respect it.

### Line 517 (`ParseRelationArms` name parts) — structurally unreachable, so it throws unconditionally

`parts.Count is not (1 or 2)` cannot fire on either path:

- `RelationTargetNameParts` returns `parts.Count <= 2 ? parts : parts.GetRange(parts.Count - 2, 2)` — so 0, 1 or 2, never more. The "3-part name" its own message describes has been impossible since #2851.
- 0 is unproducible. `NameSyntax` has exactly **three** subclasses in `Microsoft.Dynamics.Nav.CodeAnalysis` 28.1 — `SimpleNameSyntax` (abstract), `IdentifierNameSyntax`, `QualifiedNameSyntax` — and `NameParts` walks both concrete ones, appending at least one part each. AL error recovery synthesises a **missing** `IdentifierNameSyntax` rather than nothing.

**33 probes, all returning 1 or 2 parts.** Fifteen as AL source (three-, four- and five-part names, a quoted name containing a dot, an empty quoted name, leading/trailing/bare dot, an integer literal, a parenthesized name, a keyword, a string literal, an absent value); eighteen more feeding the arbitrary garbage the symbol path can carry (`""`, `";"`, `"))"`, `"@#$%"`, `"1 = 2"`, an unterminated quote, bare keywords). Several produce `AL0107` and still yield 1 part with empty text — which is the mechanism.

## RED → GREEN

RED, before the fix — the two refusal tests fail with exactly the silent drop:

```
Failed IfConditionCarryingAFieldLink_ThrowsNamingTheShapeAndTheField
   Assert.Throws() Failure: No exception was thrown
Failed ErrorRecoveryConditionNode_ThrowsNamingTheShape
   Assert.Throws() Failure: No exception was thrown
Failed!  - Failed: 2, Passed: 2, Total: 4
```

The two that already passed are the controls — they pin behaviour that must not change.

GREEN, after: `Passed! - Failed: 0, Passed: 6, Total: 6`.

Six tests, four of them scoping controls rather than restatements of the fix:

- `IfConditionCarryingAFieldLink_ThrowsNamingTheShapeAndTheField` / `ErrorRecoveryConditionNode_ThrowsNamingTheShape` — the source path throws, and the message names the field, the position and the syntax node. Both assert the *precondition* too (that the parsed node really is the shape under test), so a refusal for some unrelated parse failure cannot pass.
- `SameShapeFromAPrecompiledAppSymbol_RefusesQuietlyInsteadOfThrowing` — the symbol path returns null for the identical text. This is the one an unconditional throw fails.
- `RepresentableShapeFromAPrecompiledAppSymbol_IsStillCarried` — and a representable shape on that path is still **carried**, asserting the arm's target name and filter count, not just "did not throw".
- `EveryShapeTheCompilerAccepts_IsCarriedAndNotRefused` — all eight binder-accepted spellings, asserting `Count == 1` rather than absence of a throw, so a method returning an empty list for everything fails.
- `EmptyRelationTargetName_IsCarriedAsOnePartNotRefusedByTheParser` — pins the property the deleted guard depended on: never 0, never >2.

Would any of these pass against an implementation returning a default? No — the throw tests assert message content, and the carry tests assert concrete counts and names.

## Wider verification

| suite | result |
|---|---|
| corpus (`tests/al-language/tests/al-language`, `--strict --count-baseline`) | **2978P / 0F / 0E** |
| `tests/runner-extras` | **361P / 0F / 0E** |
| `AlRunner.Tests` filtered (`TableRelation` \| `CalcFormula` \| `SymbolCache`) | **110 passed, 0 failed** |

Both AL suites match the pre-change baseline exactly. With both sites instrumented to print unconditionally, corpus + runner-extras + internals-fixture produced **zero** hits — reproducing #3326's measurement rather than taking it on trust.

## Does this assert anything about BC?

**No, and that is why there is no corpus PR.** Real BC never sees these shapes: its compiler rejects them, exactly as the runner's does, because they are the same compiler. The claim is "the runner must not silently drop a relation whose shape it cannot carry" — a runner-local claim about a runner-side surface, with nothing for a service tier to adjudicate. The BC-behaviour half, that `Validate` enforces a `TableRelation` at all, is already pinned upstream (corpus codeunit 60482 `TestFieldRefRelation`, and corpus PRs 207/222), and this PR deliberately does not duplicate it. `check_corpus_linkage.sh` run against this diff accepts the `Corpus-NA:` declaration above.

## Fixing the shape, not the reported line

- **Same wrong pattern at another call site?** Yes — `ParseRelationArms` has two callers, and the second is the symbol path. That is the finding that changed the design; both are handled.
- **Sibling function making the same assumption?** Yes — `CalcFormulaFrom`'s `where()` `default:` arm and its sign site, same file, same silent `null`, and the #3279 CalcFormula note sink is likewise builder-only so a parser-level drop is invisible there too. **Not folded in** (`batch-sibling-issues-by-file.md` point 5): different property, different set of reaching shapes, and #3326's whole point is that the reachability claim must be *measured*, not transferred. Filed as **#3367**, including the provenance trap that would break it the same way it nearly broke this one.
- **Two paths writing the same state maintaining the same invariant?** This is exactly that question, and the answer was no — the source and symbol paths needed different invariants. Now stated explicitly in the signature rather than left implicit.

## Where the prose went

The measurement — the probe tables, the 33 name-part results, the corpus sweep, the provenance table — is in **`docs/tablerelation-parser-refusals.md`**, versioned and re-runnable, with short `see docs/...` pointers left at both sites. The code comments carry only what changes what the next person would type: which provenance gets which answer, and why a drop is worse here than in the builder.

## Deliberately left out

- No `CacheVersion` bump. `ParsedField` is unchanged and no serialize path is touched, so no persisted payload can replay a pre-fix answer — the same reasoning #3327 recorded, and the symbol path's observable behaviour is unchanged by construction.
- The `[ColumnFilter]` refusals in the same file are a different property again, untouched and unmeasured here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4
