### PR TITLE
fix(shadow): name the rename's real failure, and refuse to hand back a directory that cannot be exec'd

### DIFF
--- a/AlRunner.Tests/NclShadowPublishDiagnosisTests.cs
+++ b/AlRunner.Tests/NclShadowPublishDiagnosisTests.cs
@@ -1,0 +1,357 @@
+// NclShadowPublishDiagnosisTests — #3371: two shapes that survived #3368's fix for #3364,
+// both inside NclShadowRuntime.PublishShadowDir.
+//
+// 1. The move's exception was discarded by empty `catch (IOException) { }` /
+//    `catch (UnauthorizedAccessException) { }` handlers, and the exhaustion WARN then
+//    asserted "(source locked, or sustained contention)" regardless of what was actually
+//    caught. A cross-device rename, PathTooLongException, a full disk or a permission
+//    problem on the shadow root all reach that WARN and are all mis-attributed to a lock
+//    or contention — and the one thing that distinguished them, the exception, was gone.
+//
+// 2. The last `return shadowDir` was reached exactly when every attempt was exhausted AND
+//    IsShadowDirComplete(tempDir) was false, and it handed back a directory whose validity
+//    the `if` above had just disproved: absent entirely on the source-lock route, or
+//    present-but-incomplete on the contention route. The caller re-execs into
+//    Path.Combine(that, "al-runner.dll"), so the observable is the child dying with "The
+//    application to execute does not exist" or hostfxr refusing a dir missing
+//    al-runner.deps.json — the exact third symptom #3364 was filed for.
+//
+// The move is injected rather than provoked with a real lock for the same reason
+// NclShadowLockedSourcePublishTests gives: a real file lock only blocks a rename on
+// Windows, so a handle-based test is permanently green on the Linux CI legs.
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class NclShadowPublishDiagnosisTests
+{
+    private const string MarkerFileName = ".al-runner-shadow-source";
+    private const string EntryDllName = "al-runner.dll";
+    private const string NclFileName = "Microsoft.Dynamics.Nav.Ncl.dll";
+
+    private static string NewTempDir(string label)
+    {
+        var dir = TestScratch.FlatDir($"ncl-shadow-diag-{label}-");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static void WriteCompleteShadowDir(string dir, string origFull, byte[] dllBytes)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllBytes(Path.Combine(dir, EntryDllName), dllBytes);
+        File.WriteAllBytes(Path.Combine(dir, NclFileName), new byte[] { 4, 5, 6 });
+        File.WriteAllText(Path.Combine(dir, "al-runner.deps.json"), "{}");
+        File.WriteAllText(Path.Combine(dir, "al-runner.runtimeconfig.json"), "{}");
+        // Marker last, same invariant the real build holds.
+        File.WriteAllText(Path.Combine(dir, MarkerFileName), origFull);
+    }
+
+    /// <summary>Writes a dir that passes nothing: marker present (so it is not simply
+    /// "absent"), entry DLL missing — exactly the incomplete-publish shape #2489 measured,
+    /// which IsShadowDirComplete must reject.</summary>
+    private static void WriteIncompleteShadowDir(string dir, string origFull)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllBytes(Path.Combine(dir, NclFileName), new byte[] { 4, 5, 6 });
+        File.WriteAllText(Path.Combine(dir, "al-runner.deps.json"), "{}");
+        File.WriteAllText(Path.Combine(dir, "al-runner.runtimeconfig.json"), "{}");
+        File.WriteAllText(Path.Combine(dir, MarkerFileName), origFull);
+        // No EntryDllName — the file hostfxr needs most.
+    }
+
+    private static string CaptureStderr(Action body)
+    {
+        var prev = Console.Error;
+        var sw = new StringWriter();
+        Console.SetError(sw);
+        try { body(); }
+        finally { Console.SetError(prev); }
+        return sw.ToString();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Shape 1 — the exhaustion WARN must name what was actually caught
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>The rename fails for a reason that is neither a lock nor contention — a
+    /// cross-device rename, which is the field case that motivated this: the shadow root
+    /// and the temp dir land on different filesystems, every one of the 20 attempts is
+    /// spent on a condition that can never clear, and the operator is told to go look for
+    /// an antivirus scanner. The WARN must carry the exception's own type and message, so
+    /// the real cause is readable from the log alone.</summary>
+    [Fact]
+    public void PublishShadowDir_MoveFailsForANonLockReason_WarnNamesTheActualExceptionNotAGuessedCause()
+    {
+        var root = NewTempDir("crossdevice");
+        try
+        {
+            var origFull = @"C:\install\any";
+            var tempDir = Path.Combine(root, "key.building.abc");
+            WriteCompleteShadowDir(tempDir, origFull, dllBytes: new byte[] { 7, 7, 7 });
+            var shadowDir = Path.Combine(root, "key");
+
+            const string realMessage = "Source and destination path must have identical roots. Move will not work across volumes.";
+            string? result = null;
+            var stderr = CaptureStderr(() =>
+                result = NclShadowRuntime.PublishShadowDir(
+                    tempDir, shadowDir, origFull,
+                    move: (_, _) => throw new IOException(realMessage),
+                    sleep: _ => { }));
+
+            // The fallback itself is unchanged (#3368): run from the complete temp dir.
+            Assert.Equal(tempDir, result);
+
+            // The exception's own message must survive to the WARN — this is the whole
+            // point: it is the only thing separating a cross-volume move from an AV lock.
+            Assert.Contains(realMessage, stderr);
+            // And its type, because two IOExceptions with different messages are two
+            // different diagnoses and the type is what a reader greps for first.
+            Assert.Contains(nameof(IOException), stderr);
+
+            // The WARN must NOT assert a cause it never measured. Before this fix it said
+            // exactly this, unconditionally.
+            Assert.DoesNotContain("source locked, or sustained contention", stderr);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>The same claim for the other refusal mapping, and with a different
+    /// exception type, so a fix that hardcodes "IOException" into the message cannot pass
+    /// both. UnauthorizedAccessException on a rename whose DESTINATION root is read-only
+    /// is a permission problem on the shadow root, not a transient scanner handle.</summary>
+    [Fact]
+    public void PublishShadowDir_MoveFailsWithUnauthorizedAccess_WarnNamesThatTypeAndMessage()
+    {
+        var root = NewTempDir("denied");
+        try
+        {
+            var origFull = @"C:\install\any";
+            var tempDir = Path.Combine(root, "key.building.abc");
+            WriteCompleteShadowDir(tempDir, origFull, dllBytes: new byte[] { 8, 8, 8 });
+            var shadowDir = Path.Combine(root, "key");
+
+            const string realMessage = "Access to the path 'D:\\shadow-root' is denied.";
+            string? result = null;
+            var stderr = CaptureStderr(() =>
+                result = NclShadowRuntime.PublishShadowDir(
+                    tempDir, shadowDir, origFull,
+                    move: (_, _) => throw new UnauthorizedAccessException(realMessage),
+                    sleep: _ => { }));
+
+            Assert.Equal(tempDir, result);
+            Assert.Contains(realMessage, stderr);
+            Assert.Contains(nameof(UnauthorizedAccessException), stderr);
+            Assert.DoesNotContain(nameof(IOException), stderr);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>Only the LAST exception is reported, and it is the last one actually
+    /// raised — not the first, which on a changing condition is the least informative.
+    /// A disk that fills up mid-retry is the shape: the early attempts fail for one
+    /// reason and the one the operator needs to see is what it settled into.</summary>
+    [Fact]
+    public void PublishShadowDir_CauseChangesAcrossAttempts_WarnReportsTheLastOneRaised()
+    {
+        var root = NewTempDir("changing");
+        try
+        {
+            var origFull = @"C:\install\any";
+            var tempDir = Path.Combine(root, "key.building.abc");
+            WriteCompleteShadowDir(tempDir, origFull, dllBytes: new byte[] { 5, 5, 5 });
+            var shadowDir = Path.Combine(root, "key");
+
+            const string firstMessage = "The process cannot access the file because it is being used by another process.";
+            const string lastMessage = "There is not enough space on the disk.";
+            var attempts = 0;
+            string? result = null;
+            var stderr = CaptureStderr(() =>
+                result = NclShadowRuntime.PublishShadowDir(
+                    tempDir, shadowDir, origFull,
+                    move: (_, _) =>
+                    {
+                        attempts++;
+                        throw new IOException(attempts <= 5 ? firstMessage : lastMessage);
+                    },
+                    sleep: _ => { }));
+
+            Assert.Equal(tempDir, result);
+            Assert.Contains(lastMessage, stderr);
+            Assert.DoesNotContain(firstMessage, stderr);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Shape 2 — the exhausted-and-incomplete path must not hand back a path the
+    // condition above it just disproved
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Source-lock route, incomplete temp dir: every attempt is spent with
+    /// shadowDir never created, and our own tempDir does not pass the completeness check
+    /// either. There is no directory to return. Before this fix the method returned
+    /// shadowDir — a path that was never created — and the caller re-exec'd into it and
+    /// died with "The application to execute does not exist", the third symptom #3364 was
+    /// filed for. It must throw, naming both directories and the state, rather than hand
+    /// back a value it has just established is unusable.</summary>
+    [Fact]
+    public void PublishShadowDir_ExhaustedAndTempDirIncomplete_ThrowsInsteadOfReturningANeverCreatedPath()
+    {
+        var root = NewTempDir("phantom");
+        try
+        {
+            var origFull = @"C:\install\any";
+            var tempDir = Path.Combine(root, "key.building.abc");
+            WriteIncompleteShadowDir(tempDir, origFull);
+            var shadowDir = Path.Combine(root, "key");
+
+            const string realMessage = "Access to the path 'x' is denied.";
+            var ex = Assert.Throws<IOException>(() =>
+                NclShadowRuntime.PublishShadowDir(
+                    tempDir, shadowDir, origFull,
+                    move: (_, _) => throw new IOException(realMessage),
+                    sleep: _ => { }));
+
+            // Names the directory the caller would otherwise have been handed...
+            Assert.Contains(shadowDir, ex.Message);
+            // ...the one we built and could not use...
+            Assert.Contains(tempDir, ex.Message);
+            // ...and the underlying refusal, so shape 1's information is not lost on the
+            // one path that cannot fall back.
+            Assert.Contains(realMessage, ex.ToString());
+
+            Assert.False(Directory.Exists(shadowDir),
+                "the phantom directory must still not exist — the point is that returning it was wrong");
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>Contention route, incomplete published dir: shadowDir DOES exist here, so
+    /// the failure mode is different and worse to diagnose — the returned path resolves,
+    /// and hostfxr then refuses a directory missing al-runner.deps.json. The condition
+    /// that got us here is `IsShadowDirComplete(tempDir) == false`, and shadowDir is
+    /// incomplete by the loop's own exit condition, so neither is returnable.</summary>
+    [Fact]
+    public void PublishShadowDir_ExhaustedWithBothDirsIncomplete_ThrowsRatherThanReturningTheIncompleteShadowDir()
+    {
+        var root = NewTempDir("both-incomplete");
+        try
+        {
+            var origFull = @"C:\install\any";
+            var tempDir = Path.Combine(root, "key.building.abc");
+            WriteIncompleteShadowDir(tempDir, origFull);
+            var shadowDir = Path.Combine(root, "key");
+            // A sibling published an incomplete dir; the heal cannot complete it because
+            // our own source is incomplete too (the entry DLL exists nowhere).
+            WriteIncompleteShadowDir(shadowDir, origFull);
+
+            var ex = Assert.Throws<IOException>(() =>
+                NclShadowRuntime.PublishShadowDir(
+                    tempDir, shadowDir, origFull,
+                    move: (_, _) => throw new Xunit.Sdk.XunitException("must not attempt a move onto an existing dir"),
+                    sleep: _ => { }));
+
+            Assert.Contains(shadowDir, ex.Message);
+            Assert.Contains(tempDir, ex.Message);
+            // The entry DLL is what is missing, and saying so is the difference between
+            // "hostfxr refused something" and a diagnosis.
+            Assert.Contains(EntryDllName, ex.Message);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>The throw must carry its whole diagnosis in the exception, because the
+    /// caller's `finally` reaps the incomplete tempDir on the way out (it is exactly the
+    /// "half-built temp dir" that block exists to clean up). A message that told the
+    /// operator to go look in a directory the stack unwind has just deleted would be no
+    /// better than the phantom path it replaced — so the missing-file list is a string,
+    /// captured before anything is reaped, not a pointer at on-disk state.</summary>
+    [Fact]
+    public void PublishShadowDir_ExhaustedAndIncomplete_DiagnosisIsSelfContainedInTheMessage()
+    {
+        var root = NewTempDir("self-contained");
+        try
+        {
+            var origFull = @"C:\install\any";
+            var tempDir = Path.Combine(root, "key.building.abc");
+            WriteIncompleteShadowDir(tempDir, origFull);
+            var shadowDir = Path.Combine(root, "key");
+
+            var ex = Assert.Throws<IOException>(() =>
+                NclShadowRuntime.PublishShadowDir(
+                    tempDir, shadowDir, origFull,
+                    move: (_, _) => throw new IOException("Not enough space on the disk."),
+                    sleep: _ => { }));
+
+            // Simulate the caller's finally reaping the temp dir, then re-read the
+            // message: everything needed to act on it must still be there.
+            Directory.Delete(tempDir, recursive: true);
+            Assert.Contains(EntryDllName, ex.Message);
+            Assert.Contains("Not enough space on the disk.", ex.Message);
+            Assert.IsType<IOException>(ex.InnerException);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>The heal loop's own failures are the same shape one level down: when the
+    /// in-place heal is what could not complete, its copy exceptions were discarded too,
+    /// so the exhaustion message had nothing to say about the route that actually failed.
+    /// Here the heal cannot finish because the entry DLL is missing from BOTH dirs, and
+    /// the message must still distinguish this from a rename that was never attempted for
+    /// a different reason — it says which file is missing.</summary>
+    [Fact]
+    public void PublishShadowDir_HealCannotComplete_ErrorNamesTheMissingFileNotJustTheFailure()
+    {
+        var root = NewTempDir("heal-stuck");
+        try
+        {
+            var origFull = @"C:\install\any";
+            var tempDir = Path.Combine(root, "key.building.abc");
+            WriteIncompleteShadowDir(tempDir, origFull);
+            var shadowDir = Path.Combine(root, "key");
+            WriteIncompleteShadowDir(shadowDir, origFull);
+
+            var ex = Assert.Throws<IOException>(() =>
+                NclShadowRuntime.PublishShadowDir(
+                    tempDir, shadowDir, origFull,
+                    move: (_, _) => throw new Xunit.Sdk.XunitException("destination exists; no move should be attempted"),
+                    sleep: _ => { }));
+
+            // No rename ever ran on this route, and saying so is the fact that separates
+            // it from a source-side refusal — not a cause invented to fill the sentence.
+            Assert.Contains("no rename was attempted", ex.Message);
+            Assert.Null(ex.InnerException);
+            Assert.Contains(EntryDllName, ex.Message);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>Guard against over-correcting shape 2 into a throw on the healthy
+    /// fallback: when the temp dir IS complete, the exhausted path must still return it
+    /// and must still not throw — that is #3368's fix for the actual #3364 crash, and
+    /// this pins it against a fix that turns every exhaustion into an exception.</summary>
+    [Fact]
+    public void PublishShadowDir_ExhaustedButTempDirComplete_StillReturnsItWithoutThrowing()
+    {
+        var root = NewTempDir("still-falls-back");
+        try
+        {
+            var origFull = @"C:\install\any";
+            var tempDir = Path.Combine(root, "key.building.abc");
+            WriteCompleteShadowDir(tempDir, origFull, dllBytes: new byte[] { 3, 3, 3 });
+            var shadowDir = Path.Combine(root, "key");
+
+            var result = NclShadowRuntime.PublishShadowDir(
+                tempDir, shadowDir, origFull,
+                move: (src, _) => throw new IOException($"Access to the path '{src}' is denied."),
+                sleep: _ => { });
+
+            Assert.Equal(tempDir, result);
+            Assert.True(NclShadowRuntime.IsShadowDirComplete(result, origFull));
+            Assert.Equal(new byte[] { 3, 3, 3 }, File.ReadAllBytes(Path.Combine(result, EntryDllName)));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+}

--- a/AlRunner/Infrastructure/NclShadowRuntime.cs
+++ b/AlRunner/Infrastructure/NclShadowRuntime.cs
@@ -352,12 +352,17 @@ public static class NclShadowRuntime
     ///    <c>NclCecilRewrite.AtomicReplace</c> already does for the file-level rename of
     ///    the same bytes one layer down.
     /// </summary>
-    /// <returns>The directory the caller should exec from: <paramref name="shadowDir"/>
-    /// normally, or <paramref name="tempDir"/> when a sustained source-side lock defeated
-    /// every publish attempt and the temp dir is itself complete. Returning a directory
-    /// rather than <c>void</c> is what stops the exhausted path handing back a path that
-    /// was never created (the caller would re-exec into it and die with "The application
-    /// to execute does not exist").</returns>
+    /// <returns>The directory the caller should exec from, and it always exists and is
+    /// complete: <paramref name="shadowDir"/> normally, or <paramref name="tempDir"/> when
+    /// a sustained source-side lock defeated every publish attempt and the temp dir is
+    /// itself complete. Returning a directory rather than <c>void</c> is what stops the
+    /// exhausted path handing back a path that was never created (the caller would re-exec
+    /// into it and die with "The application to execute does not exist").</returns>
+    /// <exception cref="IOException">Every attempt was exhausted AND
+    /// <paramref name="tempDir"/> is itself incomplete, so neither directory is
+    /// exec-able (#3371). The message names both directories, which required file is
+    /// missing, and the rename's own last exception, which is also the
+    /// <see cref="Exception.InnerException"/>.</exception>
     /// <param name="move">Test seam for the rename; production passes null and gets
     /// <see cref="Directory.Move"/>. A real file lock only blocks a rename on Windows,
     /// so the retry behaviour is untestable on the Linux CI legs without it.</param>
@@ -370,6 +375,15 @@ public static class NclShadowRuntime
         move ??= Directory.Move;
         sleep ??= System.Threading.Thread.Sleep;
         const int maxAttempts = 20;
+        // #3371: the rename's exception is the ONLY thing that separates a transient
+        // scanner handle (retrying clears it) from a cause that never will — a
+        // cross-volume rename, PathTooLongException, a full disk, a permission problem on
+        // the shadow root. Discarding it and then asserting "source locked, or sustained
+        // contention" in the exhaustion message named a cause that was never measured, and
+        // sent the operator after antivirus when the answer was the disk or the path.
+        // Keep the LAST one: on a condition that changes mid-retry, what it settled into
+        // is what the operator has to act on.
+        Exception? lastMoveFailure = null;
         for (var attempt = 1; attempt <= maxAttempts; attempt++)
         {
             if (!Directory.Exists(shadowDir))
@@ -379,8 +393,8 @@ public static class NclShadowRuntime
                     move(tempDir, shadowDir);
                     return shadowDir;
                 }
-                catch (IOException) { }
-                catch (UnauthorizedAccessException) { }
+                catch (IOException ex) { lastMoveFailure = ex; }
+                catch (UnauthorizedAccessException ex) { lastMoveFailure = ex; }
 
                 if (!Directory.Exists(shadowDir))
                 {
@@ -442,25 +456,69 @@ public static class NclShadowRuntime
             // racing the same heal) — loop around and retry.
         }
 
-        // Exhausted every attempt. Our own tempDir is complete (the marker went in last,
-        // before this method was called), so run from it in place rather than returning a
-        // path that was never created: the caller re-execs into whatever comes back, and a
-        // missing directory there means "The application to execute does not exist" and no
-        // tests at all. Cost of the fallback is one .building.* dir that PruneStaleShadowDirs
-        // deliberately never reaps (#2512) — accepted for a path only a sustained lock or
-        // sustained contention reaches, and the next invocation republishes normally.
+        // Exhausted every attempt. Our own tempDir is normally complete (the marker went in
+        // last, before this method was called), so run from it in place rather than
+        // returning a path that was never created: the caller re-execs into whatever comes
+        // back, and a missing directory there means "The application to execute does not
+        // exist" and no tests at all. Cost of the fallback is one .building.* dir that
+        // PruneStaleShadowDirs deliberately never reaps (#2512) — accepted for a path only a
+        // sustained lock or sustained contention reaches, and the next invocation
+        // republishes normally. The check below is what makes that "normally" a fact rather
+        // than an assumption; #3371 is what happens when it comes back false.
+        // #3371: report what was actually caught, never a cause we assumed. `null` here is
+        // the contention route — every attempt found shadowDir already present and the
+        // heal never completed, so no move was ever attempted and there is no exception to
+        // name; saying "no rename was attempted" is itself the distinguishing fact.
+        var cause = lastMoveFailure != null
+            ? $"last failure: {lastMoveFailure.GetType().Name}: {lastMoveFailure.Message}"
+            : "no rename was attempted — the destination existed on every attempt and the in-place heal never completed";
+
         if (IsShadowDirComplete(tempDir, origFull))
         {
             Console.Error.WriteLine(
                 $"[reexec] WARN: could not publish shadow dir at {shadowDir} after {maxAttempts} attempts " +
-                $"(source locked, or sustained contention) — running from {tempDir} this once");
+                $"({cause}) — running from {tempDir} this once");
             return tempDir;
         }
 
-        Console.Error.WriteLine(
-            $"[reexec] WARN: could not publish shadow dir at {shadowDir} after {maxAttempts} attempts " +
-            "under contention — will retry on the next invocation");
-        return shadowDir;
+        // #3371: every attempt is spent AND our own tempDir just failed the completeness
+        // check, so neither directory is usable — shadowDir is either absent (the
+        // source-lock route never created it) or incomplete (the loop only exits here
+        // having failed to heal it). Returning either one hands the caller a path it will
+        // pass straight to `dotnet exec`: an absent one dies with "The application to
+        // execute does not exist" (#3364's third symptom), and an incomplete one is
+        // refused by hostfxr for the missing manifest. A fallback whose validity the
+        // condition above it just disproved is a silent failure with extra steps, so this
+        // throws and names the state instead (.claude/rules/loud-failures.md).
+        var missing = string.Join(", ", MissingRequiredNames(tempDir, origFull));
+        throw new IOException(
+            $"Could not publish the Ncl shadow runtime dir at {shadowDir} after {maxAttempts} attempts, " +
+            $"and the build at {tempDir} is itself incomplete (missing: {missing}) — " +
+            $"neither directory can be exec'd, so there is nothing to re-exec into ({cause})",
+            lastMoveFailure);
+    }
+
+    /// <summary>The required names <see cref="IsShadowDirComplete"/> did not find, so an
+    /// error can say WHICH file is missing rather than only that something was. Same
+    /// definition of "required" as that method, read from the same two lists.</summary>
+    private static IEnumerable<string> MissingRequiredNames(string dir, string origFull)
+    {
+        if (!Directory.Exists(dir)) { yield return "(the directory itself)"; yield break; }
+        foreach (var name in new[] { EntryDllName, NclFileName }.Concat(RequiredManifestNames))
+            if (!File.Exists(Path.Combine(dir, name))) yield return name;
+
+        var marker = Path.Combine(dir, MarkerFileName);
+        if (!File.Exists(marker)) yield return MarkerFileName;
+        else
+        {
+            string? recorded = null;
+            try { recorded = File.ReadAllText(marker); } catch (IOException) { } catch (UnauthorizedAccessException) { }
+            // Byte-for-byte, exactly as IsShadowDirComplete compares it — a diagnostic
+            // that judged the marker more loosely than the check it is explaining would
+            // report "nothing missing" for a dir that check had just rejected.
+            if (recorded != origFull)
+                yield return $"{MarkerFileName} (records '{recorded}', expected '{origFull}')";
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #3371

Both shapes land in `NclShadowRuntime.PublishShadowDir`, so they are one diff.

## 1. The move's exception is discarded, and the WARN names a cause nobody measured

`catch (IOException) { }` / `catch (UnauthorizedAccessException) { }` threw the rename's
exception away, and the exhaustion WARN then asserted `(source locked, or sustained
contention)` unconditionally. A cross-volume rename, a full disk, `PathTooLongException`
or a permission problem on the shadow root all reach that message, all spend ~8.5 s of
retries on a condition that can never clear, and all send the operator after an antivirus
scanner. The exception was the only thing that distinguished them.

The handlers now capture into `lastMoveFailure`, and the message reports its type and
message. The **last** one is kept deliberately: on a condition that changes mid-retry, what
it settled into is what the operator has to act on.

Where there is genuinely no exception to report — the contention route, where every attempt
found `shadowDir` already present so no rename was ever attempted — the message says
`no rename was attempted`. That is a fact, not a cause invented to fill the sentence, and it
is what separates that route from a source-side refusal.

## 2. The last `return shadowDir` handed back a path the `if` above it had disproved

Reached only when every attempt is exhausted **and** `IsShadowDirComplete(tempDir, origFull)`
is false. `EnsureShadowDir` does `Path.Combine(publishedDir, EntryDllName)` and
`TryShadowReexec` passes that to `dotnet exec`, so the observable was the child dying with
`The application to execute does not exist` on the source-lock route (`shadowDir` never
created), or hostfxr refusing a directory missing `al-runner.deps.json` on the contention
route.

It now throws an `IOException` naming both directories, **which** required file is missing,
and the underlying refusal — carried both in the message and as `InnerException`. Per
`loud-failures.md`: a fallback whose validity the condition above it just disproved is a
silent failure with extra steps.

The missing-file list comes from a new `MissingRequiredNames`, which reads the same two
lists as `IsShadowDirComplete` and compares the marker byte-for-byte exactly as that method
does — a diagnostic that judged the marker more loosely than the check it explains would
report "nothing missing" for a directory that check had just rejected.

## RED → GREEN

`AlRunner.Tests/NclShadowPublishDiagnosisTests.cs`, 8 tests. RED first, against `origin/main`:

```
Failed!  - Failed: 5, Passed: 1, Skipped: 0, Total: 6
```

The one green was `PublishShadowDir_ExhaustedButTempDirComplete_StillReturnsItWithoutThrowing`,
deliberately — it pins #3368's existing fallback so this change cannot over-correct into
throwing on every exhaustion. GREEN after:

```
Passed!  - Failed: 0, Passed: 8, Skipped: 0, Total: 8
```

Two of the eight were written after the fix and are pins rather than RED→GREEN, and I am
flagging that rather than claiming otherwise: `HealCannotComplete_ErrorNamesTheMissingFileNotJustTheFailure`
(the heal route was already covered by the `no rename was attempted` arm) and
`ExhaustedAndIncomplete_DiagnosisIsSelfContainedInTheMessage`.

Regression scope, both run to completion:

- `--filter FullyQualifiedName~NclShadow` — **39/39 passed**, including every #3368 and
  #2489 pin.
- `--filter "FullyQualifiedName~NclShadow|FullyQualifiedName~Reexec|FullyQualifiedName~ShadowReexec"`
  — **59/59 passed**.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes, in the same method — the heal loop's
   `File.Copy` handlers at the per-file and marker copies discard the same way. The
   per-file one has a real justification (a concurrent sibling create is a normal outcome
   and the comment says so). The marker copy had none, and when the heal is what failed,
   that discarded exception was the only record of why. Both are now covered by the
   exhaustion message, which distinguishes the heal route explicitly.
2. **Sibling function making the same assumption?** `IsShadowDirComplete` answers
   `bool` and swallows `IOException` to return `false` — same shape, but there it is
   correct and documented (a sibling racing a delete on that exact directory), and its
   callers all branch on the bool rather than reporting a cause. Left alone. It is now the
   single definition `MissingRequiredNames` reads from, so the two cannot drift.
3. **Two paths writing the same state with different invariants?** `EnsureShadowDir`'s
   `finally` reaps `tempDir` when `publishedDir != tempDir`, which on the new throw path
   means the incomplete temp dir is deleted during the unwind. That is correct — it is
   exactly the half-built dir that block exists to clean up — but it makes the exception's
   message the only surviving diagnosis. Pinned by
   `ExhaustedAndIncomplete_DiagnosisIsSelfContainedInTheMessage`, which deletes the temp dir
   and then re-reads the message.

I also tightened the comment above the exhaustion branch: it stated "Our own tempDir is
complete" as flat fact when the `if` beneath it is precisely the test of that. That
unexamined assumption is what shape 2 was made of.

## Where the test lives

**Runner-specific — it does not owe an upstream corpus test**, and `bc-behavior-tests-go-upstream.md`
asks for that answer either way. Nothing here is a claim about what Business Central does:
the subject is the runner's own shadow-dir publishing, its `[reexec]` diagnostic text, and
what its private helper returns. If AL Runner did not exist, none of it would be a
meaningful statement about AL or BC, and no service tier could adjudicate it. A C# test in
`AlRunner.Tests` is the correct home.

## Sibling issues in this file

I scanned the open queue for `NclShadowRuntime.cs`. **Nothing folds.** The nearest
neighbours are all a different file or a different surface:

- **#2375** (shadow re-exec costs a full CLR start) and **#2374** (crossgen2 the IL-only
  DLLs inside the shadow build) are startup-cost work on the shadow *build*, not on publish
  failure handling; neither touches `PublishShadowDir`, and both would need their own
  measurement to review.
- **#3132** (ncl-cecil keeps 8 entries against a per-checkout key) is the `ncl-cecil` cache
  eviction policy in `NclCecilRewrite`, one layer down.

No open PR touches `NclShadowRuntime.cs`.

## Deliberately not in scope

The `.building.*` directory each successful fallback leaves behind. `PruneStaleShadowDirs`
never reaps those by design (#2489/#2512), so a box with a persistent handle-holder
accumulates one per fallback. The issue names this as out of scope and I agree: a reaper
safe against a live sibling build is different reasoning and would make one diff hard to
hold. This change does not make it worse — the new throw path's temp dir is reaped by
`EnsureShadowDir`'s existing `finally`.

---

Opened by agent `stma-auto-2`, an automated implementation agent acting on the account
holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9pEPoD8e4wmVyuTrxyuh
