### PR TITLE
fix(provisioning): stop an unanswered CDN probe from demoting a provisioning tier

### DIFF
--- a/AlRunner.Provisioning/ArtifactDownloader.cs
+++ b/AlRunner.Provisioning/ArtifactDownloader.cs
@@ -769,6 +769,24 @@ public static class ArtifactDownloader
     // PREFIX); this answers "does this exact version exist at all".
     // -----------------------------------------------------------------------
     public static bool VersionExists(string version, Action<string>? log = null)
+        => ProbeVersion(version, log).IsPublished;
+
+    /// <summary>
+    /// Three-state form of <see cref="VersionExists"/> — issue #2981. The bool above cannot
+    /// distinguish "the CDN answered 404" from "the probe never got an answer", and
+    /// <see cref="AlRunner.Infrastructure.BcArtifacts.ResolveProvisionTargetCore"/> reads the
+    /// bool as the first, so a five-second network blip walked a user down to the
+    /// KNOWN-DEGRADED major-fallback tier. Retries once before answering
+    /// <see cref="CdnProbeResult.Undetermined"/>, because the fault reported in #2981 was
+    /// intermittent (4 of 15 connects black-holed while curl succeeded 5/5 moments later).
+    ///
+    /// <see cref="VersionExists"/> stays for the callers that genuinely only want a yes/no and
+    /// are not making a tier decision off it.
+    /// </summary>
+    public static CdnProbeResult ProbeVersion(string version, Action<string>? log = null)
+        => ProbeWithRetry(() => ProbeVersionOnce(version, log));
+
+    private static CdnProbeResult ProbeVersionOnce(string version, Action<string>? log)
     {
         var logf = L(log);
         var url = $"{CdnBase}/{version}/platform";
@@ -776,28 +794,35 @@ public static class ArtifactDownloader
         {
             using var http = ArtifactHttpClient.Create(log: logf);
             using var resp = http.Send(new HttpRequestMessage(HttpMethod.Head, url));
-            return resp.IsSuccessStatusCode;
+            // A response is the only thing that licenses a statement about what Microsoft has
+            // published — the rule NetworkDiagnosis was built around in #2926.
+            return resp.IsSuccessStatusCode ? CdnProbeResult.Published : CdnProbeResult.NotPublished;
         }
         catch (Exception ex)
         {
-            // Issue #2926. Two things wrong here, and the second is the one that bites.
-            //
-            // Only HttpRequestException was caught, so a timeout escaped as an unhandled
-            // exception from a method whose whole contract is "answer true or false".
-            //
-            // And `false` here does not mean what the caller reads it as.
-            // BcArtifacts.ResolveProvisionTargetCore treats false as "this exact build is not
-            // published" and walks down to the major-fallback tier, whose own comment calls
-            // that "the one genuinely degraded outcome" — so a five-second network blip gets
-            // reported to the user as Microsoft having withdrawn the build. The signature
-            // cannot carry the third state without changing that contract (tracked separately),
-            // so the log at least has to stop asserting something that was never established.
-            NetworkDiagnosis.Describe(ex, $"BC {version}", url).WriteTo(logf);
-            logf($"       Could not determine whether BC {version} is published. Treating it as " +
-                 "unavailable and falling back; that is a consequence of the failure above, not " +
-                 "evidence the build was withdrawn.");
-            return false;
+            // Issue #2926 caught the exception here (only HttpRequestException was caught
+            // before, so a timeout escaped a method whose contract is "answer true or false")
+            // and stopped the log claiming the build was withdrawn. Issue #2981 stops the
+            // RETURN VALUE claiming it: the failure is reported as its own state, carrying the
+            // kind #2926 already computes, so the tier resolver can decline to demote on it.
+            var report = NetworkDiagnosis.Describe(ex, $"BC {version}", url);
+            report.WriteTo(logf);
+            return CdnProbeResult.Undetermined(report.Kind);
         }
+    }
+
+    /// <summary>
+    /// Retry an inconclusive probe once, then take whatever the second attempt says. Internal
+    /// seam so #2981's retry is testable without a network: the delegate is the whole probe.
+    ///
+    /// Only <see cref="CdnProbeResult.IsUndetermined"/> is retried. A 404 is a fact and
+    /// re-asking would double the cost of the ordinary withdrawn-build path for nothing, and a
+    /// 200 needs no confirmation.
+    /// </summary>
+    public static CdnProbeResult ProbeWithRetry(Func<CdnProbeResult> probe)
+    {
+        var first = probe();
+        return first.IsUndetermined ? probe() : first;
     }
 
     // -----------------------------------------------------------------------
@@ -805,6 +830,23 @@ public static class ArtifactDownloader
     // Microsoft's public index. Returns null when nothing matches.
     // -----------------------------------------------------------------------
     public static string? ResolveVersion(string prefix, Action<string>? log = null)
+        => ProbeVersionPrefix(prefix, log).Version;
+
+    /// <summary>
+    /// Three-state form of <see cref="ResolveVersion"/> — issue #2981, the same defect one
+    /// tier down. A <c>null</c> return meant both "the index was read and nothing matched the
+    /// prefix" and "the index was never fetched", and
+    /// <see cref="AlRunner.Infrastructure.BcArtifacts.ResolveProvisionTargetCore"/> read it as
+    /// the first, demoting to the KNOWN-DEGRADED major-fallback tier on an unanswered
+    /// question. Retries once for the same reason <see cref="ProbeVersion"/> does.
+    /// </summary>
+    public static CdnPrefixResult ProbeVersionPrefix(string prefix, Action<string>? log = null)
+    {
+        var first = ResolvePrefixOnce(prefix, log);
+        return first.IsUndetermined ? ResolvePrefixOnce(prefix, log) : first;
+    }
+
+    private static CdnPrefixResult ResolvePrefixOnce(string prefix, Action<string>? log)
     {
         var logf = L(log);
         var indexUrl = $"{CdnBase}/indexes/w1.json";
@@ -817,9 +859,11 @@ public static class ArtifactDownloader
             // Issue #2926: this used to print "Error fetching index: One or more errors
             // occurred. (A task was canceled.)" — an AggregateException's ToString, which names
             // neither what failed nor where. NetworkDiagnosis unwraps it and reports the
-            // observation.
-            NetworkDiagnosis.Describe(ex, $"the BC version index (prefix '{prefix}')", indexUrl).WriteTo(logf);
-            return null;
+            // observation. #2981: and the return value now says the index was never read,
+            // rather than reporting it as read-and-empty.
+            var report = NetworkDiagnosis.Describe(ex, $"the BC version index (prefix '{prefix}')", indexUrl);
+            report.WriteTo(logf);
+            return CdnPrefixResult.Undetermined(report.Kind);
         }
 
         var searchPrefix = prefix + ".";
@@ -835,7 +879,7 @@ public static class ArtifactDownloader
             idx = end + 1;
         }
 
-        if (versions.Count == 0) { logf($"No versions found for prefix '{prefix}'"); return null; }
+        if (versions.Count == 0) { logf($"No versions found for prefix '{prefix}'"); return CdnPrefixResult.NoMatch; }
 
         versions.Sort((a, b) =>
         {
@@ -851,7 +895,7 @@ public static class ArtifactDownloader
 
         var resolved = versions.Last();
         logf($"Resolved: {prefix} -> {resolved}");
-        return resolved;
+        return CdnPrefixResult.Resolved(resolved);
     }
 
     // ----------------------------- ZIP helpers -----------------------------

--- a/AlRunner.Provisioning/CdnProbeResult.cs
+++ b/AlRunner.Provisioning/CdnProbeResult.cs
@@ -1,0 +1,76 @@
+// Issue #2981: the three-state answer ArtifactDownloader's CDN probes were returning as a
+// bool (and as a nullable string). See docs/provisioning-tiers.md#undetermined for the full
+// argument; the short version, which is the part that would change what you TYPE here:
+//
+//   "the CDN said no" and "we could not ask the CDN" are different answers, and the second
+//   one must never be widened into the first. Collapsing them is what let a five-second
+//   network blip select a KNOWN-DEGRADED BC artifact.
+using System.Diagnostics.CodeAnalysis;
+
+namespace AlRunner.Provisioning;
+
+/// <summary>
+/// The answer to "is this exact build published on the CDN?" — three states, not two.
+/// <see cref="Undetermined"/> carries the <see cref="NetworkFailureKind"/> that
+/// <see cref="NetworkDiagnosis"/> already computes, so a caller can say WHY it could not ask
+/// rather than inventing a reason.
+/// </summary>
+public readonly record struct CdnProbeResult
+{
+    private CdnProbeResult(bool published, bool undetermined, NetworkFailureKind? kind)
+    {
+        IsPublished = published;
+        IsUndetermined = undetermined;
+        FailureKind = kind;
+    }
+
+    /// <summary>The CDN answered, and the answer was yes.</summary>
+    public static CdnProbeResult Published { get; } = new(published: true, undetermined: false, kind: null);
+
+    /// <summary>The CDN answered, and the answer was no. Only a response licenses this.</summary>
+    public static CdnProbeResult NotPublished { get; } = new(published: false, undetermined: false, kind: null);
+
+    /// <summary>The probe never got an answer. Not a "no" — a missing answer.</summary>
+    public static CdnProbeResult Undetermined(NetworkFailureKind kind)
+        => new(published: false, undetermined: true, kind: kind);
+
+    public bool IsPublished { get; }
+    public bool IsUndetermined { get; }
+
+    /// <summary>Non-null exactly when <see cref="IsUndetermined"/> — what was observed.</summary>
+    public NetworkFailureKind? FailureKind { get; }
+}
+
+/// <summary>
+/// The answer to "what is the latest build matching this prefix?". Same three states, with the
+/// resolved version on the positive one. <see cref="NoMatch"/> means the index was fetched and
+/// read and contained nothing matching; <see cref="Undetermined"/> means the index was never
+/// read at all, which the old <c>string?</c> return could not distinguish from it.
+/// </summary>
+public readonly record struct CdnPrefixResult
+{
+    private CdnPrefixResult(string? version, bool undetermined, NetworkFailureKind? kind)
+    {
+        Version = version;
+        IsUndetermined = undetermined;
+        FailureKind = kind;
+    }
+
+    public static CdnPrefixResult Resolved(string version)
+        => new(version ?? throw new ArgumentNullException(nameof(version)), undetermined: false, kind: null);
+
+    /// <summary>The index was read and nothing matched the prefix.</summary>
+    public static CdnPrefixResult NoMatch { get; } = new(version: null, undetermined: false, kind: null);
+
+    /// <summary>The index could not be fetched or parsed. No statement about its contents.</summary>
+    public static CdnPrefixResult Undetermined(NetworkFailureKind kind)
+        => new(version: null, undetermined: true, kind: kind);
+
+    public string? Version { get; }
+
+    [MemberNotNullWhen(true, nameof(Version))]
+    public bool IsResolved => Version is not null;
+
+    public bool IsUndetermined { get; }
+    public NetworkFailureKind? FailureKind { get; }
+}

--- a/AlRunner.Tests/DefaultProvisionTargetTests.cs
+++ b/AlRunner.Tests/DefaultProvisionTargetTests.cs
@@ -18,6 +18,7 @@
 // network, no BC engine — proving each tier decision and, most importantly, that a cache
 // miss with a CDN hit does NOT collapse to the major (the exact defect from #2033).
 using AlRunner.Infrastructure;
+using AlRunner.Provisioning;
 using Xunit;
 
 namespace AlRunner.Tests;
@@ -56,7 +57,7 @@ public sealed class DefaultProvisionTargetTests : IDisposable
 
         var result = BcArtifacts.ResolveProvisionTargetCore(
             engineVersion, _root,
-            cdnHasExactVersion: v => v == "28.1.49838.50794",
+            cdnHasExactVersion: v => v == "28.1.49838.50794" ? CdnProbeResult.Published : CdnProbeResult.NotPublished,
             cdnResolvePrefix: p => throw new InvalidOperationException(
                 $"must not fall through to prefix resolution when the exact build is on the CDN (asked for '{p}')"),
             out var tier);
@@ -81,8 +82,8 @@ public sealed class DefaultProvisionTargetTests : IDisposable
 
         var result = BcArtifacts.ResolveProvisionTargetCore(
             engineVersion, _root,
-            cdnHasExactVersion: v => false, // withdrawn build, e.g. #2010
-            cdnResolvePrefix: p => p == "28.1" ? "28.1.55555.66666" : null,
+            cdnHasExactVersion: v => CdnProbeResult.NotPublished, // withdrawn build, e.g. #2010
+            cdnResolvePrefix: p => p == "28.1" ? CdnPrefixResult.Resolved("28.1.55555.66666") : CdnPrefixResult.NoMatch,
             out var tier);
 
         Assert.Equal("28.1.55555.66666", result);
@@ -101,8 +102,8 @@ public sealed class DefaultProvisionTargetTests : IDisposable
 
         var result = BcArtifacts.ResolveProvisionTargetCore(
             engineVersion, _root,
-            cdnHasExactVersion: v => false,
-            cdnResolvePrefix: p => null,
+            cdnHasExactVersion: v => CdnProbeResult.NotPublished,
+            cdnResolvePrefix: p => CdnPrefixResult.NoMatch,
             out var tier);
 
         Assert.Equal("28", result);
@@ -141,7 +142,7 @@ public sealed class DefaultProvisionTargetTests : IDisposable
 
         var result = BcArtifacts.ResolveProvisionTargetCore(
             engineVersion, _root,
-            cdnHasExactVersion: v => false,
+            cdnHasExactVersion: v => CdnProbeResult.NotPublished,
             cdnResolvePrefix: p => throw new InvalidOperationException(
                 "must not resolve via CDN when the engine's own minor is already cached"),
             out var tier);

--- a/AlRunner.Tests/UndeterminedCdnProbeTests.cs
+++ b/AlRunner.Tests/UndeterminedCdnProbeTests.cs
@@ -1,0 +1,267 @@
+// Issue #2981. ArtifactDownloader.VersionExists answered a THREE-state question with a bool:
+// the CDN said 404 (not published), the CDN said 200 (published), and the probe never got an
+// answer at all (DNS failed, the connect timed out, this host has no route). The third
+// collapsed into `false`, and BcArtifacts.ResolveProvisionTargetCore reads `false` as the
+// first — so a five-second network blip walked a user from `cdn-exact` down to
+// `major-fallback`, a configuration that file's own comment calls "the one genuinely degraded
+// outcome" and #2020 measured at dozens of extra test failures from engine/artifact skew.
+//
+// #2926 fixed the reporting half: the notices stopped stating the thing the bool cannot
+// support. What was left is that the runner still BEHAVED identically in both cases. These
+// tests pin the behaviour.
+//
+// The design call, argued at the ResolveProvisionTargetCore call site: an undetermined probe
+// never demotes a tier. Demotion is the only branch that can silently select a KNOWN-DEGRADED
+// artifact, and it is the branch an unanswered question has no licence to take.
+//
+// None of these tests touch the network. Every probe result is injected, so the verdict is a
+// property of the resolver and not of this box's connectivity.
+using AlRunner.Infrastructure;
+using AlRunner.Provisioning;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class UndeterminedCdnProbeTests : IDisposable
+{
+    private readonly string _root;
+    private static readonly Version Engine = new("28.1.49838.50794");
+
+    public UndeterminedCdnProbeTests()
+    {
+        _root = TestScratch.Dir("al-runner-undetermined-probe");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    // ---------------------------------------------------------------------------
+    // The three states are distinguishable in the type system, not collapsed to bool.
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void ProbeResult_DistinguishesAllThreeStates()
+    {
+        var published = CdnProbeResult.Published;
+        var notPublished = CdnProbeResult.NotPublished;
+        var undetermined = CdnProbeResult.Undetermined(NetworkFailureKind.Timeout);
+
+        Assert.True(published.IsPublished);
+        Assert.False(published.IsUndetermined);
+
+        Assert.False(notPublished.IsPublished);
+        Assert.False(notPublished.IsUndetermined);
+
+        Assert.False(undetermined.IsPublished);
+        Assert.True(undetermined.IsUndetermined);
+
+        // The kind #2926 already computes is carried, not discarded — that is what lets a
+        // caller say WHY it could not ask.
+        Assert.Equal(NetworkFailureKind.Timeout, undetermined.FailureKind);
+        Assert.Null(published.FailureKind);
+        Assert.Null(notPublished.FailureKind);
+
+        // NotPublished and Undetermined must not compare equal. Collapsing them is the bug.
+        Assert.NotEqual(notPublished, undetermined);
+    }
+
+    // ---------------------------------------------------------------------------
+    // THE #2981 proving case, both directions.
+    // ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// The exact-build probe could not be answered. The engine's exact build must still be
+    /// the target: an unanswered question is not a 404, and demoting on it is what took a
+    /// user from `cdn-exact` to `major-fallback` on a five-second blip.
+    /// </summary>
+    [Fact]
+    public void EmptyCache_ExactProbeUndetermined_KeepsTheEngineExactBuild_NeverMajorFallback()
+    {
+        var result = BcArtifacts.ResolveProvisionTargetCore(
+            Engine, _root,
+            cdnHasExactVersion: _ => CdnProbeResult.Undetermined(NetworkFailureKind.Timeout),
+            cdnResolvePrefix: p => throw new InvalidOperationException(
+                $"must not fall through to prefix resolution when the exact probe was never answered (asked for '{p}')"),
+            out var tier);
+
+        Assert.Equal("28.1.49838.50794", result);
+        Assert.Equal("cdn-exact-undetermined", tier);
+
+        // ...and specifically NOT the degraded outcome the bool produced.
+        Assert.NotEqual("major-fallback", tier);
+        Assert.NotEqual("28", result);
+    }
+
+    /// <summary>
+    /// The negative direction, and the one that keeps this from being a rubber stamp: a
+    /// GENUINE 404 must still demote exactly as before. #2010 (Microsoft withdrew a build) is
+    /// a real scenario and the fix must not blunt it.
+    /// </summary>
+    [Fact]
+    public void EmptyCache_ExactProbeSaysNotPublished_StillDemotes()
+    {
+        var result = BcArtifacts.ResolveProvisionTargetCore(
+            Engine, _root,
+            cdnHasExactVersion: _ => CdnProbeResult.NotPublished,
+            cdnResolvePrefix: p => p == "28.1" ? CdnPrefixResult.Resolved("28.1.55555.66666") : CdnPrefixResult.NoMatch,
+            out var tier);
+
+        Assert.Equal("28.1.55555.66666", result);
+        Assert.Equal("cdn-minor", tier);
+    }
+
+    /// <summary>
+    /// A 404 on the exact build AND an unanswerable prefix resolution. The 404 licenses the
+    /// first demotion; the unanswered index fetch does not license the second. Target the
+    /// engine's own minor prefix — the tier the probe was asking about — rather than the bare
+    /// major, which is the KNOWN-DEGRADED one.
+    /// </summary>
+    [Fact]
+    public void EmptyCache_ExactNotPublished_PrefixUndetermined_StopsAtTheEngineMinor()
+    {
+        var result = BcArtifacts.ResolveProvisionTargetCore(
+            Engine, _root,
+            cdnHasExactVersion: _ => CdnProbeResult.NotPublished,
+            cdnResolvePrefix: _ => CdnPrefixResult.Undetermined(NetworkFailureKind.NameResolution),
+            out var tier);
+
+        Assert.Equal("28.1", result);
+        Assert.Equal("cdn-minor-undetermined", tier);
+        Assert.NotEqual("28", result);
+    }
+
+    /// <summary>
+    /// Both probes answered, and both said no. This is the only route to `major-fallback`
+    /// left, and it must still work — the tier exists for #2010 and removing it would be a
+    /// different bug.
+    /// </summary>
+    [Fact]
+    public void EmptyCache_BothProbesAnsweredNo_StillFallsBackToMajor()
+    {
+        var result = BcArtifacts.ResolveProvisionTargetCore(
+            Engine, _root,
+            cdnHasExactVersion: _ => CdnProbeResult.NotPublished,
+            cdnResolvePrefix: _ => CdnPrefixResult.NoMatch,
+            out var tier);
+
+        Assert.Equal("28", result);
+        Assert.Equal("major-fallback", tier);
+    }
+
+    /// <summary>
+    /// An undetermined probe must not defeat the cache. A cached exact build wins without the
+    /// CDN being consulted at all, exactly as before — the fix must not make a working offline
+    /// run depend on a reachable CDN.
+    /// </summary>
+    [Fact]
+    public void CachedExactBuild_StillWinsWithoutProbingAtAll()
+    {
+        Directory.CreateDirectory(Path.Combine(_root, "28.1.49838.50794"));
+
+        var result = BcArtifacts.ResolveProvisionTargetCore(
+            Engine, _root,
+            cdnHasExactVersion: _ => throw new InvalidOperationException("must not probe the CDN when already cached"),
+            cdnResolvePrefix: _ => throw new InvalidOperationException("must not probe the CDN when already cached"),
+            out var tier);
+
+        Assert.Equal("28.1.49838.50794", result);
+        Assert.Equal("cached-exact", tier);
+    }
+
+    // ---------------------------------------------------------------------------
+    // The probe retries once before answering Undetermined (#2981's suggested shape 2).
+    // ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// The reproducer in #2981 was intermittent — 4 of 15 TCP connects black-holed while curl
+    /// succeeded 5/5 moments later — so a single retry clears the common case outright. Proves
+    /// the retry actually re-probes and that the SECOND answer is the one returned.
+    /// </summary>
+    [Fact]
+    public void ProbeWithRetry_TransientFailureThenSuccess_AnswersPublished()
+    {
+        var attempts = 0;
+        var result = ArtifactDownloader.ProbeWithRetry(() =>
+        {
+            attempts++;
+            return attempts == 1
+                ? CdnProbeResult.Undetermined(NetworkFailureKind.Timeout)
+                : CdnProbeResult.Published;
+        });
+
+        Assert.Equal(2, attempts);
+        Assert.True(result.IsPublished);
+    }
+
+    /// <summary>
+    /// A definite answer is never retried — a 404 is a fact, and re-asking would double the
+    /// cost of the common "this build was withdrawn" path for nothing.
+    /// </summary>
+    [Fact]
+    public void ProbeWithRetry_DefiniteAnswer_IsNotRetried()
+    {
+        var attempts = 0;
+        var result = ArtifactDownloader.ProbeWithRetry(() => { attempts++; return CdnProbeResult.NotPublished; });
+
+        Assert.Equal(1, attempts);
+        Assert.False(result.IsPublished);
+        Assert.False(result.IsUndetermined);
+    }
+
+    /// <summary>
+    /// A persistent fault stays Undetermined and carries the kind through — the retry must not
+    /// launder a real outage into a definite "not published".
+    /// </summary>
+    [Fact]
+    public void ProbeWithRetry_PersistentFailure_StaysUndetermined_AndKeepsTheKind()
+    {
+        var attempts = 0;
+        var result = ArtifactDownloader.ProbeWithRetry(() =>
+        {
+            attempts++;
+            return CdnProbeResult.Undetermined(NetworkFailureKind.NoRouteToAddress);
+        });
+
+        Assert.Equal(2, attempts);
+        Assert.True(result.IsUndetermined);
+        Assert.False(result.IsPublished);
+        Assert.Equal(NetworkFailureKind.NoRouteToAddress, result.FailureKind);
+    }
+
+    // ---------------------------------------------------------------------------
+    // The user-facing notice for an undetermined tier says which of the two happened.
+    // #2981's shape 3: "the tier name should distinguish 'the CDN says no' from 'we could
+    // not ask', so the warning text can stop hedging."
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void UndeterminedNotice_NamesTheNetworkFailure_AndDoesNotBlameMicrosoft()
+    {
+        var notice = AlRunner.ProgramSupport.UndeterminedProbeNotice("28.1.49838.50794", "28.1.49838.50794");
+
+        // It must not repeat #2926's defect in a new spelling.
+        Assert.DoesNotContain("is not published", notice);
+        Assert.DoesNotContain("not available", notice);
+        // It must say plainly that the question went unanswered...
+        Assert.Contains("could not be reached", notice);
+        // ...and that the runner deliberately did NOT demote because of it, which is the whole
+        // behavioural change and the thing a reader needs to know to interpret a later failure.
+        Assert.Contains("28.1.49838.50794", notice);
+        Assert.DoesNotContain("KNOWN-DEGRADED", notice);
+    }
+
+    /// <summary>
+    /// The mirror case: a tier that demoted on a real 404 must still carry the degraded
+    /// warning. Proving the notices did not all become reassuring.
+    /// </summary>
+    [Fact]
+    public void MajorFallbackWarning_IsStillLoudlyDegraded()
+    {
+        var notice = AlRunner.ProgramSupport.MajorFallbackWarning("28.1.49838.50794", "28.1", "28");
+        Assert.Contains("KNOWN-DEGRADED", notice);
+        Assert.Contains("warning:", notice);
+    }
+}

--- a/AlRunner/Infrastructure/BcArtifacts.cs
+++ b/AlRunner/Infrastructure/BcArtifacts.cs
@@ -465,12 +465,15 @@ public static class BcArtifacts
     /// <param name="tier">
     /// Which tier won: "cached-exact"/"cached-minor" (already local, nothing to fetch,
     /// identical to <see cref="DefaultVersionPrefix"/>'s outcome), "cdn-exact"/"cdn-minor"
-    /// (not cached but the CDN has it — provisioning will fetch exactly this), or
-    /// "major-fallback" (neither the engine's exact build nor its minor is available from
-    /// either source — genuinely degraded; the caller must warn, per issue #2020).
+    /// (not cached but the CDN has it — provisioning will fetch exactly this),
+    /// "cdn-exact-undetermined"/"cdn-minor-undetermined" (the CDN could not be asked; the tier
+    /// is held rather than demoted — issue #2981), or "major-fallback" (neither the engine's
+    /// exact build nor its minor is available from either source — genuinely degraded; the
+    /// caller must warn, per issue #2020).
     /// </param>
     public static string ResolveProvisionTargetCore(Version engineVersion, string artifactsRoot,
-        Func<string, bool> cdnHasExactVersion, Func<string, string?> cdnResolvePrefix, out string tier)
+        Func<string, AlRunner.Provisioning.CdnProbeResult> cdnHasExactVersion,
+        Func<string, AlRunner.Provisioning.CdnPrefixResult> cdnResolvePrefix, out string tier)
     {
         // Tier 1: the exact 4-part build — cached, or fetchable from the CDN.
         var exact = engineVersion.ToString();
@@ -481,9 +484,21 @@ public static class BcArtifacts
             return exact;
         }
         catch (InvalidOperationException) { /* not cached — try the CDN, then fall through */ }
-        if (cdnHasExactVersion(exact))
+        var exactProbe = cdnHasExactVersion(exact);
+        if (exactProbe.IsPublished)
         {
             tier = "cdn-exact";
+            return exact;
+        }
+        // Issue #2981: the probe went unanswered, so hold the tier instead of demoting.
+        // Demotion is the only branch here that can hand back a KNOWN-DEGRADED artifact, and
+        // the single observation licensing it is the CDN saying no — which this is not.
+        // Nothing is swallowed: the download that follows either succeeds (the transient blip
+        // #2981 reported) or fails with NetworkDiagnosis's classified observation.
+        // Why this rather than throwing, per loud-failures.md: docs/provisioning-tiers.md#undetermined.
+        if (exactProbe.IsUndetermined)
+        {
+            tier = "cdn-exact-undetermined";
             return exact;
         }
 
@@ -496,17 +511,26 @@ public static class BcArtifacts
             return majorMinor;
         }
         catch (InvalidOperationException) { /* not cached — try the CDN, then fall through */ }
-        var minorResolved = cdnResolvePrefix(majorMinor);
-        if (minorResolved != null)
+        var minorProbe = cdnResolvePrefix(majorMinor);
+        if (minorProbe.IsResolved)
         {
             tier = "cdn-minor";
-            return minorResolved;
+            return minorProbe.Version;
+        }
+        // #2981, same reasoning one tier down. Return the PREFIX, not a resolved build:
+        // nothing here resolved one, and inventing a build number the index never confirmed
+        // would be the same overreach. Provisioning resolves it once the network recovers.
+        if (minorProbe.IsUndetermined)
+        {
+            tier = "cdn-minor-undetermined";
+            return majorMinor;
         }
 
         // Tier 3: neither the exact build nor the engine's own minor is available from
         // either source (e.g. Microsoft withdrew the build — #2010). Fall back to the bare
         // major; the caller resolves+downloads the latest build of it and must warn loud —
-        // this is the one genuinely degraded outcome, not the default-path norm.
+        // this is the one genuinely degraded outcome, not the default-path norm. Reaching here
+        // now requires BOTH probes to have actually answered.
         tier = "major-fallback";
         return engineVersion.Major.ToString();
     }
@@ -518,8 +542,8 @@ public static class BcArtifacts
     public static string DefaultProvisionTarget(Version engineVersion, string artifactsRoot, out string tier,
         Action<string>? log = null)
         => ResolveProvisionTargetCore(engineVersion, artifactsRoot,
-            v => AlRunner.Provisioning.ArtifactDownloader.VersionExists(v, log),
-            p => AlRunner.Provisioning.ArtifactDownloader.ResolveVersion(p, log),
+            v => AlRunner.Provisioning.ArtifactDownloader.ProbeVersion(v, log),
+            p => AlRunner.Provisioning.ArtifactDownloader.ProbeVersionPrefix(p, log),
             out tier);
 
     /// <summary>

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1156,6 +1156,14 @@ if (bcVersionArg == null && artifactPathArg == null)
                     Console.Error.WriteLine(ProgramSupport.CdnMinorProvisionNotice(
                         engineVersion.ToString(), engineMajorMinor));
                     break;
+                case "cdn-exact-undetermined":
+                case "cdn-minor-undetermined":
+                    // #2981: the CDN could not be asked, so the tier was HELD rather than
+                    // demoted. Immediate like its "cdn-*" siblings above and for the same
+                    // reason — a download is about to start and this is the only signal of it.
+                    Console.Error.WriteLine(ProgramSupport.UndeterminedProbeNotice(
+                        engineVersion.ToString(), bcVersionArg ?? engineVersion.ToString()));
+                    break;
                 case "major-fallback-offline":
                     // No network step is coming (--no-auto-provision, or the rare case where
                     // engineVersion resolved but auto-provisioning is off) — this can only speak

--- a/AlRunner/ProgramSupport/ProvisionNotices.cs
+++ b/AlRunner/ProgramSupport/ProvisionNotices.cs
@@ -32,8 +32,25 @@ internal static partial class ProgramSupport
            $"Microsoft.Dynamics.Nav.CodeAnalysis. Fix with: al-runner provision --bc-version {engineVersion}";
 
     /// <summary>
+    /// The "cdn-exact-undetermined"/"cdn-minor-undetermined" tiers — issue #2981. The CDN was
+    /// never reached, so nothing here may state what it does or does not hold; the whole point
+    /// of the tier is that the runner declined to demote on a question that went unanswered.
+    /// Deliberately NOT a KNOWN-DEGRADED warning: the target is still the one version
+    /// selection wants, and if the fault persists the download that follows fails with
+    /// NetworkDiagnosis's classified observation rather than quietly running on the wrong
+    /// artifact.
+    /// </summary>
+    /// <param name="target">What provisioning will now fetch — the held tier's version or prefix.</param>
+    internal static string UndeterminedProbeNotice(string engineVersion, string target)
+        => $"[bc] no --bc-version given and the CDN could not be reached to check BC {engineVersion} " +
+           $"— see the observation above. Keeping BC {target} as the provisioning target rather than " +
+           $"falling back to an older minor: a probe that went unanswered is not evidence the build " +
+           $"was withdrawn. If the fault persists the download below will fail and name it.";
+
+    /// <summary>
     /// "major-fallback" tier: neither the engine's exact build nor its minor could be obtained
     /// from cache or the CDN. Genuinely degraded — but not necessarily Microsoft's doing.
+    /// Reaching this tier now requires both CDN probes to have actually answered (#2981).
     /// </summary>
     internal static string MajorFallbackWarning(string engineVersion, string engineMajorMinor, string engineMajor)
         => $"[bc] warning: BC {engineMajorMinor}.x is not cached and could not be obtained " +

--- a/docs/provisioning-tiers.md
+++ b/docs/provisioning-tiers.md
@@ -1,0 +1,79 @@
+# Provisioning-tier selection, and what an unanswered CDN probe may buy
+
+`BcArtifacts.ResolveProvisionTargetCore` decides which BC artifact auto-provisioning will
+fetch when the user gave no `--bc-version`. It walks three tiers, and at each one asks the
+cache first and the CDN second:
+
+| tier | meaning |
+|---|---|
+| `cached-exact` / `cached-minor` | already on disk; nothing to fetch |
+| `cdn-exact` / `cdn-minor` | not cached, but the CDN says it has it |
+| `cdn-exact-undetermined` / `cdn-minor-undetermined` | the CDN could not be asked; the tier is **held**, not demoted |
+| `major-fallback` | both probes answered "no" — the genuinely degraded outcome |
+| `major-fallback-offline` | no network step is coming at all (`--no-auto-provision`) |
+
+Only `major-fallback` is KNOWN-DEGRADED. #2020 measured it at dozens of extra test failures
+from engine/artifact minor skew (28.1 selected: 1041 pass / 35 fail; 28.2 selected: 996 pass /
+77 fail / 3 error, on the same binary and dep set).
+
+## <a name="undetermined"></a>Why an unanswered probe holds the tier instead of throwing
+
+Issue #2981. `ArtifactDownloader.VersionExists` answered a three-state question with a bool —
+the CDN said 404, the CDN said 200, and *the probe never got an answer* — and the third
+collapsed into `false`. `ResolveProvisionTargetCore` read `false` as "not published" and
+dropped a tier, so a five-second network blip walked a user from `cdn-exact` to
+`major-fallback`. The reproducer: 4 of 15 TCP connects to the CDN's IPv4 address black-holed
+for ~135 s while `curl` succeeded 5/5 at 12 ms moments later. `ResolveVersion`'s `string?`
+had the identical defect one tier down — "the index was read and nothing matched" and "the
+index was never fetched" were the same `null`.
+
+Three options were on the table.
+
+**Demote anyway (the old behavior).** Rejected: this is the bug. A demotion is the only branch
+in the resolver that can hand the caller a KNOWN-DEGRADED artifact, and the single observation
+that licenses it is a response from the CDN. An unanswered question is not that observation.
+`loud-failures.md` is the general form — a signal must not be reported as a stronger conclusion
+than it supports — and `NetworkDiagnosis`'s own header states the rule this violates: *a claim
+about the remote service requires bytes from the remote service.*
+
+**Throw.** This reads like the `loud-failures.md` answer, and it is not, because holding is
+*already* the loud outcome and strictly better. What follows the tier decision is the download
+of the held target, which has exactly two ends: it succeeds, in which case the fault was the
+transient blip and the user gets the artifact version selection actually wanted; or it fails,
+and fails with `NetworkDiagnosis`'s classified observation naming the real fault. Neither end
+is a silent degradation, and only the holding end can still recover. Throwing would convert
+every transient blip into a hard provisioning failure — worse on a flaky CI network than the
+problem being fixed, which is the trade the issue explicitly asks to be made deliberately.
+
+**Hold the tier (implemented).** The target stays the version selection wanted. The tier name
+records that the CDN was never reached, so `ProgramSupport.UndeterminedProbeNotice` can say
+that plainly instead of hedging — issue #2981's third suggested shape, and the thing #2926
+could not do because the bool gave it nothing to say it with.
+
+## The retry
+
+`ArtifactDownloader.ProbeVersion` and `ProbeVersionPrefix` retry **once** when the answer is
+`Undetermined`, before returning it. The reported fault was intermittent, so a single retry
+clears the common case outright. A definite answer is never retried: a 404 is a fact, and
+re-asking would double the cost of the ordinary withdrawn-build path for nothing.
+
+`ProbeWithRetry(Func<CdnProbeResult>)` is the seam — the whole probe is the delegate, so the
+retry is testable without a network (`AlRunner.Tests/UndeterminedCdnProbeTests.cs`).
+
+## The other `ResolveVersion` callers were checked and are correct
+
+Four sites in `ProgramSupport/Provisioning.cs` plus one in `Program.cs` also call
+`ResolveVersion` and read `null`. None has this defect: every one of them **stops** — returns
+exit 2, or warns and returns — rather than selecting a different artifact. "No version, no
+work" is a sound reading of `null` whichever of the two states produced it, and their messages
+("could not resolve a full BC version for prefix ...") already claim nothing about what
+Microsoft published, with `NetworkDiagnosis`'s observation printed above them. They keep the
+`string?` wrapper deliberately; only the tier resolver needs the third state, because only the
+tier resolver treats a missing answer as licence to pick something else.
+
+## Sister reading
+
+- `.claude/rules/loud-failures.md` — a signal may not be reported as a stronger conclusion
+  than it supports
+- `AlRunner.Provisioning/NetworkDiagnosis.cs` — the `NetworkFailureKind` the undetermined
+  states carry, and the #2926 argument they come from


### PR DESCRIPTION
Closes #2981

`ArtifactDownloader.VersionExists` answered a three-state question with a bool — the CDN said
404 (not published), the CDN said 200 (published), and **the probe never got an answer** (DNS
failed, the connect timed out, this host has no route). The third collapsed into `false`, and
`BcArtifacts.ResolveProvisionTargetCore` reads `false` as the first and drops a tier. A
five-second network blip therefore walked a user from `cdn-exact` down to `major-fallback` —
the configuration that file's own comment calls "the one genuinely degraded outcome", measured
by #2020 at dozens of extra test failures from engine/artifact minor skew.

`ResolveVersion`'s `string?` had the identical defect one tier down: "the index was read and
nothing matched the prefix" and "the index was never fetched" were the same `null`.

#2926 fixed the *reporting* half — the notices stopped stating what the bool cannot support.
What was left is that the runner still **behaved** identically in both cases. This fixes that.

## The design call for the unreachable case: hold the tier, do not throw

The issue asks for this decision to be made deliberately rather than as a side effect, so the
full argument is in the new `docs/provisioning-tiers.md#undetermined`. Short version of the
three options:

- **Demote anyway** (old behavior) — this is the bug. Demotion is the only branch in the
  resolver that can hand back a KNOWN-DEGRADED artifact, and the single observation licensing
  it is a response from the CDN. An unanswered question is not that observation.
- **Throw**, which reads like the `loud-failures.md` answer — **rejected**, because holding is
  already the loud outcome and is strictly better. What follows the tier decision is the
  download of the held target, which either succeeds (the fault was the transient blip #2981
  reported, and the user gets the artifact version selection actually wanted) or fails with
  `NetworkDiagnosis`'s classified observation naming the real fault. Neither end is a silent
  degradation, and only the holding end can still recover. Throwing converts every transient
  blip into a hard provisioning failure — on a flaky CI network, worse than the problem, which
  is the trade the issue explicitly flags.
- **Hold the tier** (implemented). The target stays what version selection wanted, and the tier
  name records that the CDN was never reached — so `UndeterminedProbeNotice` can say so plainly
  instead of hedging. That is issue #2981's third suggested shape, and the thing #2926 could
  not do because the bool gave it nothing to say it with.

Plus the issue's suggested shape 2: the probe **retries once** before answering `Undetermined`.
The reported fault was intermittent (4 of 15 TCP connects black-holed while `curl` succeeded
5/5 moments later), so one retry clears the common case outright. A definite answer is never
retried — a 404 is a fact, and re-asking would double the cost of the ordinary withdrawn-build
path for nothing.

## What changed

- **`AlRunner.Provisioning/CdnProbeResult.cs`** (new) — `CdnProbeResult`
  (`Published`/`NotPublished`/`Undetermined`) and `CdnPrefixResult`
  (`Resolved`/`NoMatch`/`Undetermined`), each carrying the `NetworkFailureKind` #2926 already
  computes, so a caller can say *why* it could not ask instead of inventing a reason.
- **`ArtifactDownloader`** — `ProbeVersion` / `ProbeVersionPrefix` return those, with
  `ProbeWithRetry` as the retry seam. `VersionExists` / `ResolveVersion` stay as thin wrappers
  for the callers that genuinely only want a yes/no and are not making a tier decision off it.
- **`ResolveProvisionTargetCore`** — two new tiers, `cdn-exact-undetermined` and
  `cdn-minor-undetermined`. Reaching `major-fallback` now requires **both** probes to have
  actually answered. The minor-tier hold returns the *prefix*, not a resolved build: nothing
  resolved one, and inventing a build number the index never confirmed would be the same
  overreach in a new spelling.
- **`ProgramSupport.UndeterminedProbeNotice`** + two `Program.cs` switch arms.
- **`docs/provisioning-tiers.md`** (new) — the tier table and the rejected-alternatives
  argument, per the "where the prose goes" rule; the resolver keeps a 6-line comment pointing
  at it.

## RED → GREEN

RED, before implementing: `AlRunner.Tests/UndeterminedCdnProbeTests.cs` failed to compile —
`CdnProbeResult`, `CdnPrefixResult`, `ProbeWithRetry` and `UndeterminedProbeNotice` did not
exist. GREEN after: **45 passed, 0 failed** across `UndeterminedCdnProbeTests`,
`DefaultProvisionTargetTests`, `ProvisionNoticeClaimsTests`,
`ArtifactDownloaderNetworkDiagnosisTests`, `ArtifactDownloader404Tests`.

Because "it compiles" is not proof, the fix was then **mutated** — the two `IsUndetermined`
holds deleted, collapsing the states back into `NotPublished`, i.e. the reported bug restored.
Two tests failed, and failed with exactly the reported symptom:

```
Failed EmptyCache_ExactNotPublished_PrefixUndetermined_StopsAtTheEngineMinor
  Expected: "28.1"
  Actual:   "28"
```

Both directions are covered, which is what stops this being a rubber stamp:

| test | proves |
|---|---|
| `EmptyCache_ExactProbeUndetermined_KeepsTheEngineExactBuild_NeverMajorFallback` | an unanswered probe does **not** demote |
| `EmptyCache_ExactProbeSaysNotPublished_StillDemotes` | a genuine 404 **still** demotes (#2010 is real; the fix must not blunt it) |
| `EmptyCache_BothProbesAnsweredNo_StillFallsBackToMajor` | `major-fallback` still reachable — the only route left |
| `EmptyCache_ExactNotPublished_PrefixUndetermined_StopsAtTheEngineMinor` | the two demotions are licensed independently |
| `CachedExactBuild_StillWinsWithoutProbingAtAll` | an offline run does not become CDN-dependent (probes throw if called) |
| `ProbeWithRetry_*` (3) | retries an inconclusive answer, does **not** retry a definite one, and a persistent fault stays `Undetermined` with its kind — the retry must not launder an outage into "not published" |
| `UndeterminedNotice_NamesTheNetworkFailure_AndDoesNotBlameMicrosoft` / `MajorFallbackWarning_IsStillLoudlyDegraded` | the new notice makes no claim about Microsoft's publishing, and the notices did not all become reassuring |

Also run: `DefaultProvisionTargetMessagingTests`, `AutoProvisionDefaultTests`,
`ProvisionExplicitModesTests` — **15 passed, 0 failed**, the ones that spawn the runner
subprocess and exercise the tier switch end-to-end. `tools/DownloadArtifacts` (another
`ResolveVersion` caller) builds clean. No new compiler warnings from any file in this diff.

**No test in this PR touches the network.** Every probe result is injected, so the verdict is a
property of the resolver and not of the box it ran on.

## Where the test lives

Runner infrastructure — network probing and provisioning-tier selection. It asserts nothing
about Business Central: no AL, no service tier, no BC semantics, and the question "what does
the runner do when it cannot reach a CDN" is meaningless without the runner. So it owes **no**
upstream corpus test, and a C# test in `AlRunner.Tests` is the right home
(`bc-behavior-tests-go-upstream.md` requires this answer either way).

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes, and it is fixed: `ResolveVersion`'s `null`
   had the identical two-states-in-one-value collapse, and `ResolveProvisionTargetCore` read it
   the same wrong way at the minor tier. Fixing only the reported `VersionExists` would have
   left the second demotion still firing on an unanswered question.
2. **Do sibling functions make the same assumption?** Checked all five other `ResolveVersion`
   callers — four in `ProgramSupport/Provisioning.cs`, one in `Program.cs`. **None has this
   defect.** Every one of them *stops* on `null` (returns exit 2, or warns and returns) rather
   than selecting a different artifact, and "no version, no work" is sound whichever state
   produced the `null`. Their messages already claim nothing about what Microsoft published,
   with `NetworkDiagnosis`'s observation printed above them. They keep the `string?` wrapper
   deliberately: only the tier resolver treats a missing answer as licence to pick something
   else, which is precisely why it is the one that had the bug. Recorded in
   `docs/provisioning-tiers.md` so the next reader does not re-derive it.
3. **Two paths writing the same state, same invariant?** The tier is also computed in
   `Program.cs`'s offline branch (`major-fallback-offline`). It consults no CDN, so it cannot
   produce an undetermined tier — the invariant holds, and the two paths stay distinguishable
   for the reason #2033 made them distinguishable.

## Sibling issues scanned, not folded

`#2661` (provision `--platform-apps`/`--service-tier` still use a glob-based, not
content-verified, entry guard) was checked as the nearest neighbour. **Not folded:** it lands in
`RunExplicitProvisionModes`/`ForceProvisionMode` and needs new completeness predicates for the
platform-app R2R set and the ~55-DLL service-tier closure — different functions, different
files, and reasoning a reviewer would have to hold separately from this one
(`batch-sibling-issues-by-file.md` point 4). #2226, #2232, #2223, #2956 are provisioning-area
but touch neither the CDN probes nor the tier resolver.

## Nothing deliberately left out

The behaviour, the retry and the notice are all here. The one judgement worth flagging to a
reviewer: the minor-tier hold hands provisioning a *prefix* rather than a resolved build, which
is correct but means provisioning re-resolves it when the network recovers — a second index
fetch on that path, which is the honest cost of not inventing a build number.

---

Written by agent `stma-auto-5`, an automated implementation agent acting on the account
holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9pEPoD8e4wmVyuTrxyuh