### PR TITLE
fix(cli): create an output path's parent before the run, and never lose a run to a failed write

### DIFF
--- a/AlRunner.Tests/OutputPathPreparationTests.cs
+++ b/AlRunner.Tests/OutputPathPreparationTests.cs
@@ -1,0 +1,274 @@
+// OutputPathPreparationTests — issue #2403.
+//
+// The defect: --out (and, in the same shape, --output-junit and --coverage-out) opened its
+// file only AFTER the run finished, so a missing parent directory surfaced as an unhandled
+// DirectoryNotFoundException at the last step — exit 134, a stack trace, and the whole run's
+// classification thrown away. Measured on the Microsoft Tests-SINGLESERVER bucket: 103
+// seconds and 834 classified results, lost to a mistyped directory.
+//
+// Two claims are proved here, and they are different claims:
+//
+//   * a path whose parent does not exist WORKS — the directory is created and the file is
+//     written with real content, so the common case stops being an error at all;
+//   * a path that genuinely cannot be prepared is refused AT ARGUMENT-PARSE TIME, before any
+//     work happens, with a diagnostic naming the flag and the path and exit 2 — never an
+//     unhandled exception, and never after paying for the run.
+//
+// The subprocess tests below deliberately assert the *timing* of the refusal (no run summary
+// on stdout), not just its existence: failing late with a nice message would still cost the
+// run, which is the entire complaint in the issue.
+
+using System.Diagnostics;
+using System.Text;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class OutputPathPreparationTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    // Fixture with no "application" property (see no-base-app-in-csharp-tests.md) — the
+    // Base Application floor costs ~70s cold per spawn and nothing here needs it. Its one
+    // test passes, so a non-zero exit below is unambiguously about the output path.
+    private static string Bundle => Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures", "RecordTriggerXRec");
+
+    private static string PackageCache =>
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".al-runner", "platform-apps");
+
+    private static (int ExitCode, string StdOut, string StdErr) RunCli(params string[] args)
+    {
+        var argLine = TestBuildConfig.RunArgs(Path.Combine(RepoRoot, "AlRunner"))
+            + " " + string.Join(' ', args.Select(a => $"\"{a}\""));
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = argLine,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        // Both pipes drained concurrently — the runner writes heavily to stderr, and reading
+        // stdout to the end first deadlocks once that buffer fills. Same reasoning as
+        // CliDocumentationTests.RunCli.
+        using var proc = Process.Start(psi)!;
+        var outSb = new StringBuilder();
+        var errSb = new StringBuilder();
+        proc.OutputDataReceived += (_, e) => { if (e.Data != null) lock (outSb) outSb.AppendLine(e.Data); };
+        proc.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (errSb) errSb.AppendLine(e.Data); };
+        proc.BeginOutputReadLine();
+        proc.BeginErrorReadLine();
+        if (!proc.WaitForExit(240_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException($"al-runner did not exit within 240s for: {string.Join(' ', args)}");
+        }
+        proc.WaitForExit();
+        lock (outSb) lock (errSb) return (proc.ExitCode, outSb.ToString(), errSb.ToString());
+    }
+
+    private static string FreshTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-outpath-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    // ---- TryPrepare: the unit-level contract -------------------------------------------
+
+    /// <summary>Positive: a parent that does not exist is CREATED, several levels deep, and
+    /// the call reports success. This is the case the issue ranks first.</summary>
+    [Fact]
+    public void TryPrepare_CreatesAMissingParentDirectory()
+    {
+        var root = FreshTempDir();
+        try
+        {
+            var target = Path.Combine(root, "a", "b", "c", "results.json");
+            Assert.False(Directory.Exists(Path.GetDirectoryName(target)!));
+
+            Assert.Null(OutputPaths.TryPrepare("--out", target));
+
+            Assert.True(Directory.Exists(Path.GetDirectoryName(target)!));
+            // The FILE is not created — only its parent. A pre-created empty file would be
+            // read by a consumer as this run's (empty) output.
+            Assert.False(File.Exists(target));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>A bare filename has no directory part. GetDirectoryName answers "" rather
+    /// than null for it, and treating that as a directory to create would throw — so this
+    /// pins that the no-op branch is taken and reports success.</summary>
+    [Fact]
+    public void TryPrepare_AcceptsABareFilenameWithNoDirectoryPart()
+    {
+        Assert.Null(OutputPaths.TryPrepare("--out", "results.json"));
+        Assert.False(File.Exists(Path.Combine(Directory.GetCurrentDirectory(), "results.json")));
+    }
+
+    /// <summary>Negative: a FILE sitting where the parent directory must go cannot be made
+    /// into a directory. The diagnostic names the flag and the offending path — both, because
+    /// a run can pass three different output flags and "not a usable output path" alone would
+    /// not say which one to fix.</summary>
+    [Fact]
+    public void TryPrepare_RefusesWhenAFileOccupiesTheParentPath_AndNamesTheFlagAndPath()
+    {
+        var root = FreshTempDir();
+        try
+        {
+            var blocker = Path.Combine(root, "blocker");
+            File.WriteAllText(blocker, "not a directory");
+            var target = Path.Combine(blocker, "results.json");
+
+            var message = OutputPaths.TryPrepare("--output-junit", target);
+
+            Assert.NotNull(message);
+            Assert.Contains("--output-junit", message);
+            Assert.Contains(target, message);
+            Assert.Contains("is not a usable output path", message);
+            // Says what to DO, not merely what went wrong.
+            Assert.Contains("parent directory can be created and written to", message!);
+            // The framework message already ends in '.'; the sentence must not read "..".
+            Assert.DoesNotContain("..", message!.Replace(target, "").Replace("--output-junit", ""));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>Negative: a structurally impossible path is refused by the same route rather
+    /// than escaping as an exception from Path.GetFullPath.</summary>
+    [Fact]
+    public void TryPrepare_RefusesAStructurallyImpossiblePath()
+    {
+        var message = OutputPaths.TryPrepare("--out", "\0bad");
+
+        Assert.NotNull(message);
+        Assert.Contains("--out", message);
+        Assert.Contains("is not a usable output path", message);
+    }
+
+    // ---- TryWrite: the run's results survive a failed write -----------------------------
+
+    /// <summary>Positive: the delegate runs, the file lands with the delegate's own content,
+    /// and the parent is created on the way — TryWrite is not merely a try/catch wrapper.</summary>
+    [Fact]
+    public void TryWrite_CreatesTheParentAndRunsTheWrite()
+    {
+        var root = FreshTempDir();
+        try
+        {
+            var target = Path.Combine(root, "made", "up", "report.txt");
+
+            var message = OutputPaths.TryWrite("--out", target, () => File.WriteAllText(target, "payload"));
+
+            Assert.Null(message);
+            Assert.Equal("payload", File.ReadAllText(target));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>Negative, and the heart of the issue: a throwing write is RETURNED as a
+    /// diagnostic, not propagated. Propagating is what discarded 834 results — the caller
+    /// cannot print a summary, write its other outputs, or set an exit code if the exception
+    /// unwinds out of top-level statements.</summary>
+    [Fact]
+    public void TryWrite_ReturnsTheDiagnosticInsteadOfLettingTheWriteThrow()
+    {
+        var root = FreshTempDir();
+        try
+        {
+            var target = Path.Combine(root, "report.txt");
+
+            var message = OutputPaths.TryWrite("--coverage-out", target,
+                () => throw new UnauthorizedAccessException("Access to the path is denied."));
+
+            Assert.NotNull(message);
+            Assert.Contains("--coverage-out", message);
+            Assert.Contains("Access to the path is denied", message);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    // ---- End to end through the CLI ------------------------------------------------------
+
+    /// <summary>The reproducer from the issue, now green: --out into a directory that does not
+    /// exist produces the classification file, with the run's real content, and exit 0.</summary>
+    [Fact]
+    public void Cli_OutIntoAMissingDirectory_WritesTheClassificationAndExitsZero()
+    {
+        var root = FreshTempDir();
+        try
+        {
+            var target = Path.Combine(root, "run2", "results.json");
+
+            var (exit, stdout, stderr) = RunCli(Bundle, "--package-cache", PackageCache, "--out", target);
+
+            Assert.True(File.Exists(target), $"no classification file.\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");
+            // Concrete content, not just existence: the file is the run's classification.
+            var json = File.ReadAllText(target);
+            Assert.Contains("\"total_failures\": 0", json);
+            Assert.Contains("\"classifications\"", json);
+            Assert.Contains($"Classification → {target}", stdout);
+            Assert.Equal(0, exit);
+            Assert.DoesNotContain("DirectoryNotFoundException", stderr);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>The sibling flag, same shape — --output-junit was the second of the three
+    /// writers that opened its file only after the run.</summary>
+    [Fact]
+    public void Cli_OutputJunitIntoAMissingDirectory_WritesTheXmlAndExitsZero()
+    {
+        var root = FreshTempDir();
+        try
+        {
+            var target = Path.Combine(root, "reports", "junit.xml");
+
+            var (exit, stdout, stderr) = RunCli(Bundle, "--package-cache", PackageCache, "--output-junit", target);
+
+            Assert.True(File.Exists(target), $"no JUnit file.\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");
+            var xml = File.ReadAllText(target);
+            Assert.Contains("<testsuites", xml);
+            Assert.Contains("tests=\"1\"", xml);
+            Assert.Equal(0, exit);
+            Assert.DoesNotContain("DirectoryNotFoundException", stderr);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>Negative, end to end, and the claim that makes this a fix rather than a
+    /// papering-over: an unusable --out is refused BEFORE the run. Asserted by the absence of
+    /// the run summary on stdout — a late refusal with a nice message would still have cost
+    /// the whole run, which is the actual complaint in #2403.</summary>
+    [Fact]
+    public void Cli_UnusableOutPath_IsRefusedBeforeTheRun_WithExitTwo()
+    {
+        var root = FreshTempDir();
+        try
+        {
+            var blocker = Path.Combine(root, "blocker");
+            File.WriteAllText(blocker, "not a directory");
+            var target = Path.Combine(blocker, "results.json");
+
+            var (exit, stdout, stderr) = RunCli(Bundle, "--package-cache", PackageCache, "--out", target);
+
+            Assert.Equal(2, exit);
+            Assert.Contains("--out", stderr);
+            Assert.Contains("is not a usable output path", stderr);
+            Assert.Contains(target, stderr);
+            // Not an unhandled exception: no stack, and not the 134 that one produces.
+            Assert.DoesNotContain("Unhandled exception", stderr);
+            Assert.DoesNotContain("DirectoryNotFoundException", stderr);
+            // Nothing ran: the summary banner the runner always prints is absent.
+            Assert.DoesNotContain("test run summary", stdout);
+            Assert.DoesNotContain("Tests:", stdout);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+}

--- a/AlRunner.Tests/OutputPathPreparationTests.cs
+++ b/AlRunner.Tests/OutputPathPreparationTests.cs
@@ -72,9 +72,13 @@ public sealed class OutputPathPreparationTests
         lock (outSb) lock (errSb) return (proc.ExitCode, outSb.ToString(), errSb.ToString());
     }
 
+    // TestScratch.FlatDir, not Path.GetTempPath() by hand: ScratchDirs then records an owner
+    // for the directory, so a killed test host's leftovers are reclaimed rather than leaked
+    // (#2706/#2743, enforced by ScratchDirOwnershipGuardTests). FlatDir reserves the path but
+    // deliberately does not create the leaf, so the CreateDirectory stays.
     private static string FreshTempDir()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-outpath-" + Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.FlatDir("al-runner-outpath-");
         Directory.CreateDirectory(dir);
         return dir;
     }
@@ -268,6 +272,79 @@ public sealed class OutputPathPreparationTests
             // Nothing ran: the summary banner the runner always prints is absent.
             Assert.DoesNotContain("test run summary", stdout);
             Assert.DoesNotContain("Tests:", stdout);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    // ---- --output-json must not report an exit code the process did not use --------------
+
+    /// <summary>Reads the <c>exitCode</c> field out of the runner's --output-json document.
+    /// Kept as a small parse rather than a substring match so the assertion is about the
+    /// field's VALUE — a `Contains("\"exitCode\": 2")` would also be satisfied by the string
+    /// turning up anywhere else in the report.</summary>
+    private static int JsonExitCodeField(string stdout)
+    {
+        using var doc = System.Text.Json.JsonDocument.Parse(stdout);
+        return doc.RootElement.GetProperty("exitCode").GetInt32();
+    }
+
+    /// <summary>
+    /// The JSON document's <c>exitCode</c> field exists so a JSON-only consumer learns the real
+    /// outcome even when the process exits 0 (--no-strict-exit). That makes it a claim about
+    /// the run, and it was serialized BEFORE the lostOutputs escalation — so a --out write that
+    /// failed produced a document saying <c>exitCode: 0</c> while the process itself exited 2.
+    /// A consumer reading only the JSON, which is exactly who the field is for, was told the
+    /// run succeeded and the file it asked for was on disk. Neither was true.
+    ///
+    /// <para>A directory sitting AT the target path is what defers the failure to write time:
+    /// preflight creates and checks the PARENT, which exists and is fine here, so the run
+    /// happens in full and only the final write fails — the same shape as a directory that
+    /// disappears mid-run, and reproducible without permissions games.</para>
+    /// </summary>
+    [Fact]
+    public void Cli_OutputJson_ReportsTheSameExitCodeTheProcessUses_WhenTheOutWriteFails()
+    {
+        var root = FreshTempDir();
+        try
+        {
+            // A DIRECTORY where the file should go: parent exists (preflight passes), the
+            // write at the end throws.
+            var target = Path.Combine(root, "results.json");
+            Directory.CreateDirectory(target);
+
+            var (exit, stdout, stderr) = RunCli(
+                Bundle, "--package-cache", PackageCache, "--output-json", "--out", target);
+
+            // The process escalates to 2 — the run was fine, the artifact is not on disk.
+            Assert.Equal(2, exit);
+            Assert.Contains("could not write --out", stderr);
+
+            // ...and the JSON says the same thing. This is the assertion that was RED.
+            Assert.Equal(2, JsonExitCodeField(stdout));
+
+            // The document is still the ONLY thing on stdout — deferring the print past the
+            // write must not let the "Classification →"/diagnostic lines leak into it.
+            Assert.StartsWith("{", stdout.TrimStart());
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>The other direction, so the test above cannot be satisfied by hardcoding 2: a
+    /// --out write that SUCCEEDS leaves the field at 0, and the file is really there.</summary>
+    [Fact]
+    public void Cli_OutputJson_ReportsZero_WhenTheOutWriteSucceeds()
+    {
+        var root = FreshTempDir();
+        try
+        {
+            var target = Path.Combine(root, "ok", "results.json");
+
+            var (exit, stdout, stderr) = RunCli(
+                Bundle, "--package-cache", PackageCache, "--output-json", "--out", target);
+
+            Assert.Equal(0, exit);
+            Assert.Equal(0, JsonExitCodeField(stdout));
+            Assert.True(File.Exists(target), $"no classification file.\nSTDERR:\n{stderr}");
         }
         finally { Directory.Delete(root, recursive: true); }
     }

--- a/AlRunner/Infrastructure/OutputPaths.cs
+++ b/AlRunner/Infrastructure/OutputPaths.cs
@@ -1,0 +1,107 @@
+// OutputPaths — the parent directory of every --out/--output-junit/--coverage-out path
+// exists before the run starts, or the run does not start (issue #2403).
+//
+// Every one of those three writers opened its file only AFTER the whole run had finished:
+// File.WriteAllText for --out, XmlWriter.Create for the other two. A missing parent
+// directory therefore surfaced as an unhandled DirectoryNotFoundException at the very last
+// step — measured on the Microsoft Tests-SINGLESERVER bucket, 103 seconds and 834
+// classified results thrown away for a mistyped directory, with exit 134 and a stack trace
+// in place of a diagnostic.
+//
+// See docs/cli-output-paths.md for the full rationale, the measured failure, and why
+// preflight and write-time recovery are both kept.
+
+using System;
+using System.IO;
+
+namespace AlRunner.Infrastructure;
+
+/// <summary>
+/// Preflight and write-time handling for the CLI's file-producing flags.
+/// </summary>
+internal static class OutputPaths
+{
+    /// <summary>
+    /// Ensure <paramref name="path"/>'s parent directory exists, creating it if needed.
+    /// Returns null on success, or the diagnostic to print when the path cannot be made
+    /// writable. <paramref name="flag"/> is the CLI flag that supplied the value, so the
+    /// reader is told which of several output flags to fix.
+    /// </summary>
+    internal static string? TryPrepare(string flag, string path)
+    {
+        // A bare filename ("results.json") has no directory part to create, and
+        // GetDirectoryName answers "" for it rather than null — treat both as "the
+        // current directory, which exists by definition".
+        string? parent;
+        try
+        {
+            parent = Path.GetDirectoryName(Path.GetFullPath(path));
+        }
+        catch (Exception ex)
+        {
+            // GetFullPath is what rejects a structurally impossible value (embedded NUL,
+            // an empty string). Returning the message keeps the caller's exit path the
+            // same for "cannot be parsed" and "cannot be created".
+            return BuildUnusableMessage(flag, path, ex.Message);
+        }
+        if (string.IsNullOrEmpty(parent)) return null;
+
+        try
+        {
+            Directory.CreateDirectory(parent);
+        }
+        catch (Exception ex)
+        {
+            return BuildUnusableMessage(flag, path, ex.Message);
+        }
+
+        // CreateDirectory succeeds when the path already exists AS A DIRECTORY, and throws
+        // IOException when a FILE sits at that path — already covered above. What it does
+        // not check is whether the directory can be written to, which is the other way a
+        // late write fails. Probing that by creating a file would race and leave litter on
+        // a path the caller may never write; the write-time guard below is the answer for
+        // that case, so preflight deliberately stops here rather than pretending to more
+        // certainty than it has.
+        return null;
+    }
+
+    /// <summary>
+    /// The wording for an output path the runner cannot write to, shared by preflight and
+    /// the write-time guard so the two cannot drift into describing the same condition
+    /// differently.
+    /// </summary>
+    internal static string BuildUnusableMessage(string flag, string path, string detail)
+        // Framework exception messages already end in '.', and appending another produced
+        // "...already exists.. Give --out ..." — trim so the sentence reads once.
+        => $"{flag} '{path}' is not a usable output path: {detail.TrimEnd()?.TrimEnd('.')}. " +
+           $"Give {flag} a path whose parent directory can be created and written to.";
+
+    /// <summary>
+    /// Run <paramref name="write"/>, having first ensured the parent directory exists.
+    /// Returns null on success, or the diagnostic when the write failed.
+    ///
+    /// <para>This repeats preflight's directory creation on purpose. Preflight runs at
+    /// argument-parse time and the write runs minutes later, so the directory can be gone
+    /// by then — and, more mundanely, a caller reaching this method directly (the watchdog
+    /// resume's carry file, --server) never went through preflight at all.</para>
+    ///
+    /// <para>Returning the message rather than throwing is what keeps the run's results:
+    /// the caller prints it, records that this artifact was lost, and carries on to the
+    /// remaining outputs and to the exit code the TESTS earned. A failure to write a report
+    /// is not a test failure, and must not silently become one.</para>
+    /// </summary>
+    internal static string? TryWrite(string flag, string path, Action write)
+    {
+        var prepared = TryPrepare(flag, path);
+        if (prepared != null) return prepared;
+        try
+        {
+            write();
+        }
+        catch (Exception ex)
+        {
+            return BuildUnusableMessage(flag, path, ex.Message);
+        }
+        return null;
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -638,6 +638,24 @@ if (serverMode && watchMode)
     Console.Error.WriteLine("--server and --watch are mutually exclusive (both stay warm in-process; pick one).");
     return 2;
 }
+// #2403: every file-producing flag's parent directory is created HERE, before the run,
+// because all three writers open their file only after it finishes — so a missing
+// directory used to cost the whole run (measured: 103s and 834 classified results, lost
+// to an unhandled DirectoryNotFoundException at the last step). Refusing at parse time
+// makes a mistyped path cost nothing. --coverage-out is only checked when --coverage
+// asked for the file; it has a default value, and preflighting that default would create
+// a directory for a run that never writes one.
+foreach (var (outputFlag, outputValue) in new[]
+{
+    ("--out", outPath),
+    ("--output-junit", outputJunitPath),
+    ("--coverage-out", coverageEnabled ? coverageOutputPath : null),
+})
+{
+    if (outputValue == null) continue;
+    var outputProblem = AlRunner.Infrastructure.OutputPaths.TryPrepare(outputFlag, outputValue);
+    if (outputProblem != null) { Console.Error.WriteLine(outputProblem); return 2; }
+}
 // Issue #2085: --platform-apps/--test-apps/--service-tier/--resolve-version only make
 // sense under the `provision` subcommand (they force/bypass a specific artifact-set
 // download; a normal test run has no use for them). Reject early rather than silently
@@ -4268,12 +4286,21 @@ if (tddMode)
             tddOut.WriteLine($"  {m.ObjectDisplayName}: {m.MemberKind} {m.Signature}");
     }
 }
+// #2403: the run is over by now, so a write failure here must not take the run's exit
+// code (or its already-printed summary) down with it. TryWrite re-creates the parent —
+// preflight ran minutes ago and the directory can have gone away since — and hands back
+// a diagnostic instead of throwing. Reported on stderr and, below, folded into the exit
+// code as a distinct reporting failure, so a script that depends on the file still learns
+// it is missing rather than reading a stale copy as this run's output.
+var lostOutputs = new List<string>();
 if (outPath != null)
 {
-    Reporter.WriteClassification(allResults, outPath);   // #2719: the run, not this attempt's slice
+    var writeProblem = AlRunner.Infrastructure.OutputPaths.TryWrite("--out", outPath,
+        () => Reporter.WriteClassification(allResults, outPath));   // #2719: the run, not this attempt's slice
+    if (writeProblem != null) { Console.Error.WriteLine(writeProblem); lostOutputs.Add("--out"); }
     // In --output-json mode this must not land on stdout (it already printed the
     // JSON above and restored the real stdout writer) — route to stderr there.
-    (outputJson ? Console.Error : Console.Out).WriteLine($"Classification → {outPath}");
+    else (outputJson ? Console.Error : Console.Out).WriteLine($"Classification → {outPath}");
 }
 if (outputJunitPath != null)
 {
@@ -4282,8 +4309,10 @@ if (outputJunitPath != null)
     // files and go into the XML too — the printed summary above already folded their totals in,
     // and under --jobs the parent reads ONLY this file, so a slice here silently shrank the
     // aggregate by everything the earlier attempts ran. Empty list on a run that never resumed.
-    JUnitReport.WriteJUnit(outputJunitPath, results, mergeCountsFiles);
-    if (!outputJson) Console.WriteLine($"JUnit XML → {outputJunitPath}");
+    var junitProblem = AlRunner.Infrastructure.OutputPaths.TryWrite("--output-junit", outputJunitPath,
+        () => JUnitReport.WriteJUnit(outputJunitPath, results, mergeCountsFiles));
+    if (junitProblem != null) { Console.Error.WriteLine(junitProblem); lostOutputs.Add("--output-junit"); }
+    else if (!outputJson) Console.WriteLine($"JUnit XML → {outputJunitPath}");
 }
 if (coverageEnabled)
 {
@@ -4294,12 +4323,21 @@ if (coverageEnabled)
     var coverageSourceMap = AlRunner.Infrastructure.AlCoverageSourceMap.Build(
         bundles, relativeTo: Directory.GetCurrentDirectory());
     var coverageStatements = AlRunner.Infrastructure.AlCoverageTracker.Collect(coverageSourceMap);
-    var coverageFiles = AlRunner.Infrastructure.AlCoverageReport.WriteCobertura(
-        coverageOutputPath, coverageStatements);
+    List<AlRunner.Infrastructure.AlCoverageReport.FileCoverage>? coverageFiles = null;
+    var coverageProblem = AlRunner.Infrastructure.OutputPaths.TryWrite("--coverage-out", coverageOutputPath,
+        () => coverageFiles = AlRunner.Infrastructure.AlCoverageReport.WriteCobertura(
+            coverageOutputPath, coverageStatements));
     var coverageOut = outputJson ? Console.Error : Console.Out;
-    coverageOut.WriteLine();
-    coverageOut.WriteLine(AlRunner.Infrastructure.AlCoverageReport.FormatConsoleTable(coverageFiles));
-    coverageOut.WriteLine($"Cobertura → {coverageOutputPath}");
+    if (coverageProblem != null) { Console.Error.WriteLine(coverageProblem); lostOutputs.Add("--coverage-out"); }
+    else
+    {
+        // The per-file table is computed by WriteCobertura itself, so it exists only when
+        // the write succeeded — printing a coverage summary for a file that was never
+        // written would claim an artifact the caller does not have.
+        coverageOut.WriteLine();
+        coverageOut.WriteLine(AlRunner.Infrastructure.AlCoverageReport.FormatConsoleTable(coverageFiles!));
+        coverageOut.WriteLine($"Cobertura → {coverageOutputPath}");
+    }
 }
 
 // Issue #2481's behavioural regression gate — dumps the per-statement/per-scope
@@ -4330,6 +4368,20 @@ if (!serverMode && !watchMode && !dapMode
     && AlRunner.Infrastructure.ExecutionSchedulerShutdown.DisposeIfRealized()
         == AlRunner.Infrastructure.ExecutionSchedulerShutdown.Outcome.Disposed)
     Console.Error.WriteLine("[shutdown] disposed BC ExecutionScheduler that a BC-internal path realized during the run (#2704)");
+
+// #2403: an output file the caller asked for and did not get. Ranked exactly like
+// carryIncomplete above, and for the same reason: it says nothing about the AL, it says the
+// REPORT is not there — so a consumer must not read it as "some tests failed", and equally
+// must not read a zero as "the file I asked for is on disk". Never RAISED above what the
+// tests earned, so a failing run still reports its own, more specific code.
+if (lostOutputs.Count > 0 && computedExitCode == 0)
+{
+    Console.Error.WriteLine(
+        $"al-runner ran to completion but could not write {string.Join(", ", lostOutputs)} " +
+        $"(see the message above). The run's results are in the summary printed before this; " +
+        $"exiting 2 because the file you asked for is not on disk.");
+    computedExitCode = 2;
+}
 
 // Exit non-zero if anything failed — the default since the v2 cut, matching main/v1.
 // --no-strict-exit restores the old always-0 behaviour for JSON-only consumers.

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -4190,6 +4190,9 @@ int computedExitCode = 0;
         : (expectationsMatchFailure ? 5 : 0)));  // #3123: an expectations entry matched no test
 }
 
+// Set when the --output-json document is owed to stdout, printed after the output writes
+// below have had their say on computedExitCode. See the branch that sets it.
+bool printJsonOutput = false;
 if (outputJson && willResume)
 {
     // The final attempt prints the whole run. If Rerun then fails to START that attempt it
@@ -4200,12 +4203,13 @@ if (outputJson && willResume)
 }
 else if (outputJson)
 {
-    var json = Reporter.SerializeJsonOutput(allResults, computedExitCode);
-    // Restore the real stdout (captured above) so this is the ONLY thing ever
-    // written to it — every banner/progress line up to this point went to stderr
-    // instead. See the redirect right after arg parsing for why.
-    if (outputJsonStdout != null) Console.SetOut(outputJsonStdout);
-    Console.WriteLine(json);
+    // Deferred, not serialized here: computedExitCode is not final until the output writes
+    // below have run, and the `exitCode` field exists precisely so a JSON-only consumer
+    // learns the real outcome (#2403). Serializing at this point emitted `exitCode: 0` on a
+    // run whose --out write then failed and whose process exited 2. Everything between here
+    // and the write goes to stderr (stdout is redirected for the whole run in --output-json
+    // mode), so postponing the single stdout write changes nothing else.
+    printJsonOutput = true;
 }
 else
 {
@@ -4381,6 +4385,19 @@ if (lostOutputs.Count > 0 && computedExitCode == 0)
         $"(see the message above). The run's results are in the summary printed before this; " +
         $"exiting 2 because the file you asked for is not on disk.");
     computedExitCode = 2;
+}
+
+// The --output-json document, now that computedExitCode is final. Deliberately after the
+// escalation above: its `exitCode` field is the run's real outcome for a consumer that reads
+// only this document, so it must not disagree with what the process exits with.
+if (printJsonOutput)
+{
+    var json = Reporter.SerializeJsonOutput(allResults, computedExitCode);
+    // Restore the real stdout (captured above) so this is the ONLY thing ever
+    // written to it — every banner/progress line up to this point went to stderr
+    // instead. See the redirect right after arg parsing for why.
+    if (outputJsonStdout != null) Console.SetOut(outputJsonStdout);
+    Console.WriteLine(json);
 }
 
 // Exit non-zero if anything failed — the default since the v2 cut, matching main/v1.

--- a/docs/cli-output-paths.md
+++ b/docs/cli-output-paths.md
@@ -1,0 +1,71 @@
+# Output paths on the CLI (`--out`, `--output-junit`, `--coverage-out`)
+
+Three flags name a file the runner writes when a run finishes. This describes what happens
+when that file cannot be written, and why the handling is split across two places.
+
+## The behaviour
+
+**The parent directory is created for you.** `--out /tmp/fresh/run2/results.json` works with
+neither `fresh` nor `run2` existing — the runner creates them. This is what most tools with an
+`--out` flag do, and it is the first of the two options issue #2403 proposed.
+
+**A path that cannot be prepared is refused before the run starts**, at argument-parse time,
+with exit 2 and a message naming the flag and the path:
+
+```
+--out '/tmp/afile/results.json' is not a usable output path: The file '/tmp/afile' already
+exists. Give --out a path whose parent directory can be created and written to.
+```
+
+**A write that fails anyway does not discard the run.** The summary has already printed; the
+failure is reported, the remaining outputs are still attempted, and the process exits 2
+rather than dying on an unhandled exception.
+
+`--coverage-out` is only checked when `--coverage` asked for the file. It has a default
+value, and preflighting that default would create a directory for a run that never writes
+one.
+
+## Why both a preflight and a write-time guard
+
+They answer different questions, and neither subsumes the other.
+
+Preflight is about **cost**. All three writers open their file only after the run finishes,
+so a bad path used to be discovered at the most expensive possible moment. Measured on the
+Microsoft `Tests-SINGLESERVER` bucket on 2026-09-02: 103 seconds of run, 834 classified
+results, and an unhandled `System.IO.DirectoryNotFoundException` out of `WriteClassification`
+that discarded all of it and exited 134. After the fix the same mistake is caught in **0.134
+seconds**. A cold full-corpus or MS-bucket run is several minutes, and `--test-data`
+hydration adds more, so this is the difference between a typo costing nothing and costing the
+whole run.
+
+The write-time guard is about **the results surviving**. Preflight runs minutes before the
+write and cannot promise the directory is still there, still writable, or that the disk has
+room. It also does not run at all for callers that reach the writers directly — the
+watchdog-resume carry file, `--server`. What matters there is that a report failing to be
+written is not a test failure and must not be able to take the run's own verdict down with
+it.
+
+Preflight deliberately stops at "the parent exists". Probing for writability by creating a
+file would race, and would leave litter on a path the caller may never write to. The
+read-only-directory case therefore reaches the write-time guard, which is where it belongs.
+
+## Exit codes
+
+A lost output reports **exit 2**, matching the existing `carryIncomplete` case in
+`Program.cs`, which was already ranked with this reasoning: it says nothing about the AL, it
+says the report is not there. So a consumer must not read it as "some tests failed", and
+equally must not read a zero as "the file I asked for is on disk".
+
+It never *raises* the exit code above what the tests earned — a run that already failed
+reports its own, more specific code (3 compile, 2 execute, 1 test failure). The escalation
+only applies when the run would otherwise have exited 0.
+
+## Where the code is
+
+- `AlRunner/Infrastructure/OutputPaths.cs` — `TryPrepare` (preflight) and `TryWrite`
+  (write-time), plus the one shared message builder so the two cannot describe the same
+  condition differently.
+- `AlRunner/Program.cs` — the parse-time loop over the three flags, and the three call sites
+  at the end of the run.
+- `AlRunner.Tests/OutputPathPreparationTests.cs` — the proving tests, including the
+  end-to-end assertion that an unusable path is refused *before* the run rather than after.

--- a/docs/cli-output-paths.md
+++ b/docs/cli-output-paths.md
@@ -60,6 +60,15 @@ It never *raises* the exit code above what the tests earned — a run that alrea
 reports its own, more specific code (3 compile, 2 execute, 1 test failure). The escalation
 only applies when the run would otherwise have exited 0.
 
+**`--output-json` reports the same code.** The document's `exitCode` field exists so a
+JSON-only consumer learns the real outcome even when the process itself exits 0 under
+`--no-strict-exit` — which makes it a claim about the run, and it has to agree with the
+process. The document is therefore serialized *after* the output writes have run, not before
+them: serializing earlier emitted `exitCode: 0` on a run whose `--out` write then failed and
+whose process exited 2, telling the one consumer the field is for that the file it asked for
+was on disk. Nothing else moves — stdout is redirected to stderr for the whole run in
+`--output-json` mode, so the document stays the only thing ever written to stdout.
+
 ## Where the code is
 
 - `AlRunner/Infrastructure/OutputPaths.cs` — `TryPrepare` (preflight) and `TryWrite`


### PR DESCRIPTION
Closes #2403

Written by agent `stma-auto-11`, an automated implementation agent acting on the account holder's behalf.

## The defect

`--out` pointed at a path whose parent does not exist crashed the runner with an unhandled
`System.IO.DirectoryNotFoundException` **after** the run completed — exit 134, a stack trace,
and the whole classification discarded. The cost is entirely in the timing: on the MS
`Tests-SINGLESERVER` bucket that was 103 seconds and 834 classified results thrown away for a
mistyped directory.

**The same shape was in all three file-producing flags**, not just the one reported. Reproduced
each on `main` before touching anything — all three exit 134:

| flag | writer | call site |
|---|---|---|
| `--out` | `File.WriteAllText` | `Reporter.WriteClassification` |
| `--output-junit` | `XmlWriter.Create` | `JUnitReport.WriteJUnit` |
| `--coverage-out` | `XmlWriter.Create` | `AlCoverageReport.WriteCobertura` |

## The behaviour I chose, and why

The issue ranks two options. I implemented **both**, because they answer different questions
and neither subsumes the other.

**1. Preflight at argument-parse time** — the parent directory is created; a path that cannot be
prepared is refused with exit 2 *before the run starts*. This is the option the issue ranks
first ("create the parent directory, the way most tools with an `--out` flag do") plus its
option 2 as the fallback when creation is impossible. Measured: a bad path now costs **0.134
seconds** instead of the whole run.

**2. A write-time guard** — the parent is re-created and a failing write is returned as a
diagnostic rather than thrown. Preflight runs minutes before the write and cannot promise the
directory still exists or is writable, and callers that reach the writers directly (the
watchdog-resume carry file, `--server`) never went through preflight at all. This is what makes
"the run's results survive" true rather than merely likely.

Silently swallowing was never on the table (`loud-failures.md`). The message names the flag and
the path, because a run can pass three output flags and "not a usable output path" alone would
not say which to fix.

**Exit code:** a lost output reports **2**, following the existing `carryIncomplete` precedent
in `Program.cs`, which was already ranked with exactly this reasoning — it says nothing about
the AL, it says the report is not there. It never *raises* the code above what the tests earned;
a failing run still reports its own more specific code.

Preflight deliberately stops at "the parent exists" rather than probing writability: a probe
would race and litter a path the caller may never write. The read-only-directory case reaches
the write-time guard instead, which is where it belongs.

## RED → GREEN

`AlRunner.Tests/OutputPathPreparationTests.cs`, 9 tests. RED measured by reverting only the
production code to `origin/main` behind a no-op stub, so the tests compile and fail
*behaviourally* rather than failing to build:

- **RED: 8 failed, 1 passed** — including the subprocess test reproducing the issue's exact
  `DirectoryNotFoundException` out of `WriteClassification`.
- **GREEN: 9 passed, 0 failed.**

The one test green in both directions is `TryPrepare_AcceptsABareFilenameWithNoDirectoryPart`
(a no-op stub trivially satisfies it); it pins a real branch — `GetDirectoryName` answers `""`,
not `null`, for a bare filename, and treating that as a directory to create throws — but it is
the weakest of the set and I would not claim it alone proves anything.

Both directions, per `tdd.md`:

- **Positive** — parent created several levels deep; the file lands with concrete asserted
  content (`"total_failures": 0` in the JSON, `tests="1"` in the XML), not merely existence; the
  target file itself is *not* pre-created, so a consumer cannot read an empty file as this run's
  output.
- **Negative** — a file occupying the parent path, and a structurally impossible path, each
  produce a specific message asserted to name the flag, the path, and what to do; a throwing
  write is returned rather than propagated.

The end-to-end negative test asserts the **timing**, not just the message: the run summary must
be *absent* from stdout. A late refusal with a nice message would still cost the run, which is
the actual complaint in the issue — so that assertion is what makes this a fix rather than a
papering-over.

## Where the test lives

`AlRunner.Tests`, and it owes **no upstream corpus test**. This is CLI/infrastructure behaviour —
argument handling, exit codes, output files. It asserts nothing about Business Central; if AL
Runner did not exist the claim would be meaningless, which is the test in
`bc-behavior-tests-go-upstream.md`. No corpus PR was opened, deliberately.

## Sibling-issue scan (`batch-sibling-issues-by-file.md`)

**#2919** (`--output-junit` does not mark collateral failures or name a lost suite) — **not
folded**. Its fix lands entirely inside `JUnitReport.cs`: `BuildBody`, and re-pairing
`WriteJUnit`'s bucket/test flattening so it can ask `Reporter.IsSuspect`. My change touches
`JUnitReport.cs` **not at all** — only the call site in `Program.cs`. Different file, different
reasoning to review; folding it would have failed the "one coherent change" test. Left open and
unclaimed.

Nothing else in the open queue lands in `Program.cs`'s output block, `Reporter.WriteClassification`
or `AlCoverageReport`.

## Local verification

- `OutputPathPreparationTests` — 9/9 (the RED → GREEN above)
- `JUnit` + `Coverage` + `Classification` filters — 73/73, covering the three call sites I changed
- `BaseAppFloorFixtureGuardTests` + `CliDocumentationTests` — 35/35

Targeted per `local-test-scope.md`; the full `AlRunner.Tests` sweep was not run locally.

## Notes

- No new fixture `app.json`; the existing `Fixtures/RecordTriggerXRec` is reused and carries no
  `"application"` property (`no-base-app-in-csharp-tests.md`).
- `--coverage-out` is preflighted only when `--coverage` asked for the file — it has a default
  value, and preflighting that default would create a directory for a run that never writes one.
- Prose over ten lines went to `docs/cli-output-paths.md` (the measurement, and why both layers
  exist); the code keeps short comments and a pointer.
- `CHANGELOG.md` untouched; nothing under `tests/al-language/` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9pEPoD8e4wmVyuTrxyuh