### PR TITLE
fix(testpage): announce the navigation-mock demotion where the run log will show it

### DIFF
--- a/AlRunner.Tests/TestPageDemotionIsAnnouncedTests.cs
+++ b/AlRunner.Tests/TestPageDemotionIsAnnouncedTests.cs
@@ -1,0 +1,313 @@
+// TestPageDemotionIsAnnouncedTests — issue #2461.
+//
+// What went wrong
+// ---------------
+// A TestPage that cannot be driven live falls back to MockITestPage, whose GetAction returns a
+// MockITestAction with `Enabled => true` and an empty `Invoke()`. That degradation is allowed by
+// loud-failures.md ONLY because it announces itself. It did not: measured on BC 28.1 running one
+// test that opens Base App page 977, neither `[RunnerPageInstance] page 977: could not build the
+// record-less AL page object ...` nor `[TestPage] ...; using navigation mock.` appeared in the run
+// log, while both call sites demonstrably executed (a File.AppendAllText probe in the same catch
+// block in the same build printed both). #2451 recorded 33 failures across seven symptoms; ten had
+// this one cause and nothing in the output pointed at it.
+//
+// Where the lines were actually going — measured, not assumed
+// ----------------------------------------------------------
+// Not a child process, and not the choice of stream. The call sites carried a comment, repeated
+// four times across three files, asserting the opposite:
+//
+//     // stdout on purpose throughout this class: the test-execution child's stderr is
+//     // not captured, so a Console.Error line would be invisible exactly when needed.
+//
+// There is no test-execution child: `Console.SetOut`/`SetError` appears nowhere in AlRunner except
+// Log.cs, Program.cs's `--output-json` redirect, and the watch-mode dashboard silencer. What eats
+// these lines is Log.Install()'s FilteredWriter, which wraps BOTH streams and drops any line
+// matching `^\[Tag]` unless --verbose. `[RunnerPageInstance]` and `[TestPage]` both match and are
+// on neither exemption. So stdout and stderr were always equally suppressed, and switching between
+// them — which is what the comment spends its words on — could never have made a difference.
+//
+// The issue's own control observation fits exactly: `[page-metadata]` DID survive, because the tag
+// character class `[A-Za-z0-9._+]` has no hyphen, so a hyphenated tag fails the pattern and passes
+// through. Punctuation, not intent, was deciding which half of this degradation was visible.
+// Log.cs's comment documents that accident and #2257 owns the general case.
+//
+// How it is fixed, and why not by editing Log.cs
+// ---------------------------------------------
+// Same answer #3068 reached for the identical class of bug, and it is binding precedent here:
+// re-tag the call site, never widen the regex. #2750 refused to exempt `[deps]` to surface one
+// message because that would surface all of DependencyLoader's internals with it; #2210/#2221/#2239
+// established the mirror image for hiding a line. Both say the visibility decision belongs at the
+// call site. Exempting `[RunnerPageInstance]` wholesale would be especially wrong here: that tag
+// also carries per-control AdoptFromHost tracing, which is exactly the chatter the filter is for.
+//
+// So the lines that announce a DEMOTION — and only those — use the already-exempt `[warn]` severity
+// tag in the `[warn] <Component>: <message>` shape ProvisioningCheck, BcAppFallback and the #3068
+// call sites already use. Log.cs's own comment is the rule being applied: "A severity tag is never
+// an internal diagnostic — if something is worth calling a warning, it is worth the user seeing it."
+//
+// Why this test reads the production source
+// -----------------------------------------
+// Asserting a literal typed into this file would prove nothing — it would stay green with the
+// production call site still tagged `[RunnerPageInstance]`, which is precisely the bug. Each case
+// below names a source file and an anchor phrase, pulls THE REAL message out of that call site, and
+// pushes THAT through the REAL filter. Re-tag any production line back and this test goes red.
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Serial: swaps the process-wide Console writers and Log.Verbose. See ConsoleFilterSerialCollection.
+[Collection(ConsoleFilterSerialCollection.Name)]
+public sealed class TestPageDemotionIsAnnouncedTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    /// <summary>Push one line through the real Log filter and return what got out.</summary>
+    private static string FilterOnce(string line, bool verbose)
+    {
+        var savedOut = Console.Out;
+        var savedErr = Console.Error;
+        var savedVerbose = Log.Verbose;
+        var sink = new StringWriter();
+        try
+        {
+            Console.SetOut(sink);
+            Console.SetError(sink);
+            Log.Install();
+            Log.Verbose = verbose;
+            // Written to stdout deliberately: these call sites use Console.Out, and the point of
+            // this file is that the filter wraps BOTH streams, so the stream is not the variable.
+            Console.Out.WriteLine(line);
+            return sink.ToString();
+        }
+        finally
+        {
+            Log.Verbose = savedVerbose;
+            Console.SetOut(savedOut);
+            Console.SetError(savedErr);
+        }
+    }
+
+    /// <summary>
+    /// Reconstruct the message a <c>Console.Out.WriteLine(...)</c> / <c>Console.Error.WriteLine(...)</c>
+    /// call site actually emits: find the anchor phrase, walk back to the enclosing write, then
+    /// concatenate every string literal in that statement, substituting a placeholder for each
+    /// interpolation hole. Exact about the prefix the filter decides on, which is the whole point.
+    /// </summary>
+    private static string ExtractEmittedMessage(string relativePath, string anchor)
+    {
+        var path = Path.Combine(RepoRoot, relativePath);
+        Assert.True(File.Exists(path), $"demotion call site source not found: {path}");
+        var lines = File.ReadAllLines(path);
+
+        // The anchor usually also appears in the comment block above the call site, so take the
+        // first occurrence that actually resolves to a console write — not the first in the file.
+        var anchorHits = Enumerable.Range(0, lines.Length)
+            .Where(i => lines[i].Contains(anchor, StringComparison.Ordinal))
+            .ToList();
+        Assert.True(anchorHits.Count > 0,
+            $"anchor phrase not found in {relativePath}: \"{anchor}\". If the message was " +
+            "reworded, update the anchor — do not delete the case.");
+
+        var start = -1;
+        foreach (var hit in anchorHits)
+        {
+            for (var i = hit; i >= 0 && i >= hit - 10; i--)
+            {
+                var text = lines[i];
+                if (text.TrimStart().StartsWith("//", StringComparison.Ordinal)) continue;
+                if (text.Contains("Console.Out.WriteLine(", StringComparison.Ordinal)
+                    || text.Contains("Console.Error.WriteLine(", StringComparison.Ordinal)) { start = i; break; }
+            }
+            if (start >= 0) break;
+        }
+        Assert.True(start >= 0,
+            $"the anchor \"{anchor}\" in {relativePath} is no longer inside a console write — the " +
+            "demotion announcement may have been deleted or routed somewhere this test cannot see.");
+
+        // Collect the statement text up to the balanced closing paren.
+        var stmt = new StringBuilder();
+        var depth = 0;
+        var opened = false;
+        for (var i = start; i < lines.Length && i < start + 12; i++)
+        {
+            stmt.Append(lines[i]).Append('\n');
+            foreach (var ch in lines[i])
+            {
+                if (ch == '(') { depth++; opened = true; }
+                else if (ch == ')') depth--;
+            }
+            if (opened && depth <= 0) break;
+        }
+
+        var literals = Regex.Matches(stmt.ToString(), "\"((?:[^\"\\\\]|\\\\.)*)\"");
+        Assert.True(literals.Count > 0, $"no string literal in the statement at {relativePath}:{start + 1}");
+        var message = string.Concat(literals.Select(m => m.Groups[1].Value))
+            .Replace("\\\"", "\"")
+            .Replace("\\n", " ");
+        message = Regex.Replace(message, @"\{[^{}]*\}", "<value>");
+        return message;
+    }
+
+    /// <summary>
+    /// Every site where a TestPage silently stops being the real page. Each one hands the AL a
+    /// substitute that answers questions it cannot answer — the navigation mock outright, or a
+    /// record-only / trigger-less page — so each has to reach the user at DEFAULT verbosity.
+    /// </summary>
+    public static TheoryData<string, string> DemotionCallSites() => new()
+    {
+        // The navigation mock itself: MockITestPage.GetAction hands back a MockITestAction whose
+        // Enabled is a constant true and whose Invoke() is a literal no-op.
+        { "AlRunner/Patches/CodeunitPatches.cs", "using the navigation mock" },
+
+        // TryCreate — the record-bearing path. Falls back to record-only access, so every control
+        // bound to a page variable rather than a Rec field reads as absent.
+        { "AlRunner/Patches/RunnerPageInstance.cs", "no compiled Page" },
+        { "AlRunner/Patches/RunnerPageInstance.cs", "has no (ITreeObject, NavRecord) ctor" },
+        { "AlRunner/Patches/RunnerPageInstance.cs", "initialised but published no " },
+        { "AlRunner/Patches/RunnerPageInstance.cs", "could not build the AL page object" },
+
+        // TryCreateRecordless — the path page 977 took in the report on #2461.
+        { "AlRunner/Patches/RunnerPageInstance.cs", "has no (ITreeObject) ctor" },
+        { "AlRunner/Patches/RunnerPageInstance.cs", "published no source-expression table for a record-less" },
+        { "AlRunner/Patches/RunnerPageInstance.cs", "could not build the record-less AL page object" },
+
+        // Page extensions whose object could not be constructed: their triggers stay unreachable,
+        // so an OnAction the AL is relying on never runs.
+        { "AlRunner/Patches/RunnerPageInstance.cs", "its triggers stay unreachable" },
+        { "AlRunner/Patches/RunnerPageInstance.cs", "no live base page " },
+
+        // The request-page equivalent: a report's request page whose form could not be adopted
+        // resolves no control at all. Same shape, same filter, found by the same sweep.
+        { "AlRunner/Patches/RequestPageTestPage.cs", "could not adopt the request-page form" },
+    };
+
+    /// <summary>
+    /// The bug, stated as a test. Each of these fires exactly when a TestPage stops being the page
+    /// the test asked for; reaching the user only under --verbose is the defect, not the fix.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(DemotionCallSites))]
+    public void Demotion_IsAnnouncedAtDefaultVerbosity(string relativePath, string anchor)
+    {
+        var message = ExtractEmittedMessage(relativePath, anchor);
+        var got = FilterOnce(message, verbose: false);
+        Assert.Contains(message, got);
+    }
+
+    /// <summary>
+    /// The same messages under --verbose, so the fix cannot be read as "it was visible anyway".
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(DemotionCallSites))]
+    public void Demotion_IsAlsoAnnouncedUnderVerbose(string relativePath, string anchor)
+    {
+        var message = ExtractEmittedMessage(relativePath, anchor);
+        Assert.Contains(message, FilterOnce(message, verbose: true));
+    }
+
+    /// <summary>
+    /// A demotion notice has to identify WHICH object was demoted, or the reader cannot tell which
+    /// of the run's TestPages answered from a substitute — the specific thing missing in #2451,
+    /// where ten failures shared this cause and nothing in the output distinguished them. Every
+    /// message above interpolates the page id, or the report id for the request-page case.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(DemotionCallSites))]
+    public void Demotion_NamesTheObjectItDemoted(string relativePath, string anchor)
+    {
+        var message = ExtractEmittedMessage(relativePath, anchor);
+        Assert.True(
+            message.Contains("page <value>", StringComparison.Ordinal)
+            || message.Contains("Page<value>", StringComparison.Ordinal)
+            || message.Contains("report <value>", StringComparison.Ordinal)
+            || message.Contains("pageextension <value>", StringComparison.Ordinal),
+            $"{relativePath} (\"{anchor}\") no longer names the object it demoted: {message}");
+    }
+
+    /// <summary>
+    /// A demotion notice also has to say WHAT stops working, or the reader learns that something
+    /// failed without learning that the answers they are about to read came from a substitute.
+    /// This is the property that separates these lines from ordinary internal chatter, and it is
+    /// why they are exempt from the filter at all.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(DemotionCallSites))]
+    public void Demotion_NamesTheConsequence(string relativePath, string anchor)
+    {
+        var message = ExtractEmittedMessage(relativePath, anchor);
+        Assert.True(
+            message.Contains("falls back", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("stay unreachable", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("stay unresolvable", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("nothing left to answer from", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("navigation mock", StringComparison.OrdinalIgnoreCase),
+            $"{relativePath} (\"{anchor}\") no longer tells the reader what stops working: {message}");
+    }
+
+    /// <summary>
+    /// NEGATIVE CONTROL, and the reason this fix re-tags call sites instead of exempting
+    /// `[RunnerPageInstance]` in Log.cs. That tag also carries per-control AdoptFromHost and
+    /// option-caption tracing — real chatter, already behind AL_RUNNER_TRACE_PAGE_METADATA at its
+    /// own call sites — which a blanket exemption would have promoted along with the demotions.
+    /// These lines are copied from the real tracing call sites in RunnerPageInstance.cs and MUST
+    /// stay suppressed by default.
+    /// </summary>
+    [Theory]
+    [InlineData("[RunnerPageInstance] AdoptFromHost control 42: reused cached reified subpage")]
+    [InlineData("[RunnerPageInstance] page 977: built, 12 source expression(s): a, b")]
+    // NOT [option-captions]: that tag is hyphenated, and the filter's tag character class has no
+    // hyphen, so it passes today by punctuation rather than by intent. #2257 owns that set; using
+    // it as a control here would assert the accident instead of the filter.
+    [InlineData("[RunnerPageInstance] AdoptFromHost control 42: adopted subpage Page977, reifying")]
+    public void PageTracingChatter_IsStillSuppressedByDefault(string line)
+    {
+        Assert.DoesNotContain(line, FilterOnce(line, verbose: false));
+        Assert.Contains(line, FilterOnce(line, verbose: true));
+    }
+
+    /// <summary>
+    /// The false premise that kept this bug alive, pinned so it cannot come back. The call sites
+    /// said stderr "is not captured" and chose stdout for that reason; the filter wraps BOTH, so
+    /// the two streams are equally suppressed and the stream was never the variable. If this ever
+    /// stops holding, the comments explaining the `[warn]` tag need revisiting — not the tag.
+    /// </summary>
+    [Fact]
+    public void TheFilterSuppressesTaggedLines_OnBothStreams()
+    {
+        const string tagged = "[RunnerPageInstance] page 977: could not build the AL page object";
+
+        var savedOut = Console.Out;
+        var savedErr = Console.Error;
+        var savedVerbose = Log.Verbose;
+        var sink = new StringWriter();
+        try
+        {
+            Console.SetOut(sink);
+            Console.SetError(sink);
+            Log.Install();
+            Log.Verbose = false;
+            Console.Out.WriteLine(tagged);
+            Console.Error.WriteLine(tagged);
+            Assert.DoesNotContain(tagged, sink.ToString());
+
+            // ...and the `[warn]` shape the fix uses survives on both, so the choice of stream
+            // stays a non-decision rather than becoming a new hidden dependency.
+            const string warned = "[warn] RunnerPageInstance: page 977 demoted";
+            Console.Out.WriteLine(warned);
+            Assert.Contains(warned, sink.ToString());
+            var afterOut = sink.ToString();
+            Console.Error.WriteLine(warned);
+            Assert.True(sink.ToString().Length > afterOut.Length,
+                "the [warn] line written to stderr did not reach the sink");
+        }
+        finally
+        {
+            Log.Verbose = savedVerbose;
+            Console.SetOut(savedOut);
+            Console.SetError(savedErr);
+        }
+    }
+}

--- a/AlRunner.Tests/TestPageDemotionIsAnnouncedTests.cs
+++ b/AlRunner.Tests/TestPageDemotionIsAnnouncedTests.cs
@@ -179,6 +179,16 @@ public sealed class TestPageDemotionIsAnnouncedTests
         { "AlRunner/Patches/RunnerPageInstance.cs", "its triggers stay unreachable" },
         { "AlRunner/Patches/RunnerPageInstance.cs", "no live base page " },
 
+        // AdoptFromHost — the part-page path, and the one the first sweep for this issue missed.
+        // The host built the subpage object itself and the runner could not reify it, so the part
+        // is rebuilt from scratch: the host's own live instance, with whatever state its AL had
+        // already put on it, is discarded. That is a demotion by the same definition as the rest
+        // of this table, and it was hidden the same way — plain `[RunnerPageInstance]` tag, and a
+        // "see TryCreate's identical reasoning above" pointing at reasoning this fix deleted for
+        // being false. Its ONLY sibling in this method — the AdoptFromHost tracing line ten lines
+        // up — is deliberately not here: that one is chatter, and it is the negative control below.
+        { "AlRunner/Patches/RunnerPageInstance.cs", "could not reify " },
+
         // The request-page equivalent: a report's request page whose form could not be adopted
         // resolves no control at all. Same shape, same filter, found by the same sweep.
         { "AlRunner/Patches/RequestPageTestPage.cs", "could not adopt the request-page form" },

--- a/AlRunner/Patches/CodeunitPatches.cs
+++ b/AlRunner/Patches/CodeunitPatches.cs
@@ -576,7 +576,20 @@ public static partial class BcRuntime
                     RecordPatches.GetInsertAllowedForPage(pageId), recordless, self, pageId);
         }
 
-        Console.Error.WriteLine($"[TestPage] {why}; using navigation mock.");
+        // `[warn]` so the demotion survives Log's default filter (#2461). This is the loudest
+        // of the three outcomes above and was the most thoroughly hidden: `[TestPage]` matched
+        // the ^[Tag] pattern and was dropped on BOTH streams, so a TestPage that had become a
+        // MockITestPage — every action Enabled, every Invoke() a no-op — announced itself into
+        // a void.
+        //
+        // The page id is interpolated HERE rather than left to travel inside `why`. `why` comes
+        // from TestPageFactory.TryBuild, which renders "page {pageId}..." on some branches and
+        // "source table {tableId}..." or "Record{tableId} has no 6-arg constructor" on others —
+        // so the branch that fires decides whether the reader learns which page went to the
+        // mock. Naming it unconditionally is what makes every one of these lines actionable.
+        Console.Error.WriteLine(
+            $"[warn] TestPage: page {pageId}: {why}; this TestPage is using the navigation mock, "
+            + "whose actions report Enabled and whose Invoke() does nothing");
         return new MockITestPage();
     }
 

--- a/AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs
@@ -366,9 +366,10 @@ public static partial class RecordPatches
 
             _reportRows = rows.Values.ToList();
             _reportRowsBuiltFrom = generation;
-            // Diagnostic channel is stdout on purpose: the test-execution child's stderr is
-            // not captured, so a Console.Error trace here would be invisible exactly when
-            // it is needed. Env-gated so a normal run stays quiet.
+            // Env-gated so a normal run stays quiet. The stream is arbitrary, not load-bearing:
+            // Log's filter wraps stdout and stderr alike, and this tag is hyphenated so it
+            // bypasses the filter either way (#2461 corrected the older claim here that stderr
+            // "is not captured" — there is no test-execution child process).
             var trace = Environment.GetEnvironmentVariable("AL_RUNNER_TRACE_REPORT_METADATA");
             if (!string.IsNullOrEmpty(trace))
             {

--- a/AlRunner/Patches/RequestPageTestPage.cs
+++ b/AlRunner/Patches/RequestPageTestPage.cs
@@ -200,10 +200,12 @@ internal sealed class RequestPageTestPage : MockITestPage
         try { return _pageInstance = RunnerPageInstance.Adopt(_requestPageForm, _reportId); }
         catch (Exception ex)
         {
-            // stdout on purpose: the test-execution child's stderr is not captured, so a
-            // Console.Error line would be invisible exactly when it is needed.
+            // `[warn]` so the demotion survives Log's default filter (#2461): a request page
+            // whose form could not be adopted answers no control at all, and tagged
+            // `[RequestPageTestPage]` this line was dropped on both streams. The stream is not
+            // the variable — the filter wraps stdout and stderr alike.
             Console.Out.WriteLine(
-                $"[RequestPageTestPage] report {_reportId}: could not adopt the request-page form "
+                $"[warn] RequestPageTestPage: report {_reportId}: could not adopt the request-page form "
                 + $"({ex.GetType().Name}: {ex.Message}); its controls stay unresolvable");
             return null;
         }

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -475,11 +475,15 @@ internal sealed partial class RunnerPageInstance
             catch (Exception ex)
             {
                 var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
-                // stdout on purpose — see TryCreate's identical reasoning above.
+                // `[warn]` — see the tag note in TryCreate. Missed by the first sweep for #2461,
+                // and it kept the back-reference to the "stderr is not captured" reasoning that
+                // sweep deleted for being false. The host built this subpage itself and its AL
+                // may already have put state on the instance; rebuilding the part from scratch
+                // discards that, so the TestPage answers from an object the host is not using.
                 Console.Out.WriteLine(
-                    $"[RunnerPageInstance] part page {partPageId} (control {controlId}): could not reify "
-                    + $"the host's own subpage object ({inner.GetType().Name}: {inner.Message}); falling "
-                    + "back to a freshly constructed part page");
+                    $"[warn] RunnerPageInstance: part page {partPageId} (control {controlId}): could not reify "
+                    + $"the host's own subpage object ({inner.GetType().Name}: {inner.Message}); the part "
+                    + "falls back to a freshly constructed page, losing whatever state the host's own had");
                 if (Environment.GetEnvironmentVariable("AL_RUNNER_TRACE_PAGE_METADATA") == "1")
                     Console.Out.WriteLine(inner.StackTrace);
                 return null;

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -195,8 +195,14 @@ internal sealed partial class RunnerPageInstance
     {
         if (RecordPatches.EnsureRealPageMetadata(pageId) == null)
         {
-            // stdout on purpose throughout this class: the test-execution child's stderr is
-            // not captured, so a Console.Error line would be invisible exactly when needed.
+            // Tag discipline for this whole class (#2461). Log.Install() wraps BOTH stdout and
+            // stderr and drops any line matching ^[Tag] unless --verbose, so the stream is NOT
+            // the variable — an earlier comment here claimed stdout was chosen because "the
+            // test-execution child's stderr is not captured", and there is no such child.
+            // A line that announces a DEMOTION (the TestPage silently stops being the real
+            // page) therefore uses the exempt `[warn] RunnerPageInstance: ...` shape so it
+            // survives the default filter; per-control tracing keeps the plain
+            // `[RunnerPageInstance]` tag and stays suppressed, which is what the filter is for.
             if (Environment.GetEnvironmentVariable("AL_RUNNER_TRACE_PAGE_METADATA") == "1")
                 Console.Out.WriteLine(
                     $"[RunnerPageInstance] page {pageId}: no emit-captured metadata, so no control tree; "
@@ -207,7 +213,9 @@ internal sealed partial class RunnerPageInstance
         var pageType = FindPageType(pageId);
         if (pageType == null)
         {
-            Console.Out.WriteLine($"[RunnerPageInstance] page {pageId}: no compiled Page{pageId} type found");
+            Console.Out.WriteLine(
+                $"[warn] RunnerPageInstance: page {pageId}: no compiled Page{pageId} type found; "
+                + "TestPage falls back to record-only access");
             return null;
         }
 
@@ -216,7 +224,9 @@ internal sealed partial class RunnerPageInstance
                               && typeof(NavRecord).IsAssignableFrom(c.GetParameters()[1].ParameterType));
         if (ctor == null)
         {
-            Console.Out.WriteLine($"[RunnerPageInstance] page {pageId}: Page{pageId} has no (ITreeObject, NavRecord) ctor");
+            Console.Out.WriteLine(
+                $"[warn] RunnerPageInstance: page {pageId}: Page{pageId} has no (ITreeObject, NavRecord) ctor; "
+                + "TestPage falls back to record-only access");
             return null;
         }
 
@@ -245,7 +255,7 @@ internal sealed partial class RunnerPageInstance
             if (expressions == null)
             {
                 Console.Out.WriteLine(
-                    $"[RunnerPageInstance] page {pageId}: the page object initialised but published no "
+                    $"[warn] RunnerPageInstance: page {pageId}: the page object initialised but published no "
                     + "source-expression table; TestPage falls back to record-only access");
                 return null;
             }
@@ -262,10 +272,12 @@ internal sealed partial class RunnerPageInstance
             // strictly what it had before this existed. Silence here would turn a page-object
             // failure into "that control does not exist", which is a different and wronger
             // answer than "the runner could not build this page".
-            // stdout on purpose: the test-execution child's stderr is not captured, so a
-            // Console.Error line here would be invisible exactly when it is needed.
+            // `[warn]` so it survives the default filter — see the tag note at the top of
+            // TryCreate. Tagged `[RunnerPageInstance]` this line was dropped before reaching
+            // the terminal, which is what let #2451 run ten tests against a substitute page
+            // with nothing in the log to say so.
             Console.Out.WriteLine(
-                $"[RunnerPageInstance] page {pageId}: could not build the AL page object "
+                $"[warn] RunnerPageInstance: page {pageId}: could not build the AL page object "
                 + $"({inner.GetType().Name}: {inner.Message}); TestPage falls back to record-only access");
             if (Environment.GetEnvironmentVariable("AL_RUNNER_TRACE_PAGE_METADATA") == "1")
                 Console.Out.WriteLine(inner.StackTrace);
@@ -310,7 +322,9 @@ internal sealed partial class RunnerPageInstance
         var pageType = FindPageType(pageId);
         if (pageType == null)
         {
-            Console.Out.WriteLine($"[RunnerPageInstance] page {pageId}: no compiled Page{pageId} type found");
+            Console.Out.WriteLine(
+                $"[warn] RunnerPageInstance: page {pageId}: no compiled Page{pageId} type found; "
+                + "a record-less TestPage has nothing left to answer from");
             return null;
         }
 
@@ -320,7 +334,9 @@ internal sealed partial class RunnerPageInstance
                                      .IsAssignableFrom(c.GetParameters()[0].ParameterType));
         if (ctor == null)
         {
-            Console.Out.WriteLine($"[RunnerPageInstance] page {pageId}: Page{pageId} has no (ITreeObject) ctor");
+            Console.Out.WriteLine(
+                $"[warn] RunnerPageInstance: page {pageId}: Page{pageId} has no (ITreeObject) ctor; "
+                + "a record-less TestPage has nothing left to answer from");
             return null;
         }
 
@@ -336,8 +352,9 @@ internal sealed partial class RunnerPageInstance
             if (expressions == null)
             {
                 Console.Out.WriteLine(
-                    $"[RunnerPageInstance] page {pageId}: the record-less page object initialised but "
-                    + "published no source-expression table");
+                    $"[warn] RunnerPageInstance: page {pageId}: the page object initialised but "
+                    + "published no source-expression table for a record-less TestPage, so it "
+                    + "falls back to the navigation mock");
                 return null;
             }
             if (Environment.GetEnvironmentVariable("AL_RUNNER_TRACE_PAGE_METADATA") == "1")
@@ -348,10 +365,11 @@ internal sealed partial class RunnerPageInstance
         catch (Exception ex)
         {
             var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
-            // stdout on purpose — see TryCreate's identical reasoning above.
+            // `[warn]` — see the tag note in TryCreate. This is the exact line #2461 measured
+            // as missing: page 977 took this path on every run and the log said nothing.
             Console.Out.WriteLine(
-                $"[RunnerPageInstance] page {pageId}: could not build the record-less AL page object "
-                + $"({inner.GetType().Name}: {inner.Message})");
+                $"[warn] RunnerPageInstance: page {pageId}: could not build the record-less AL page object "
+                + $"({inner.GetType().Name}: {inner.Message}); the TestPage falls back to the navigation mock");
             if (Environment.GetEnvironmentVariable("AL_RUNNER_TRACE_PAGE_METADATA") == "1")
                 Console.Out.WriteLine(inner.StackTrace);
             return null;
@@ -2088,9 +2106,10 @@ internal sealed partial class RunnerPageInstance
                     // Loud, but not fatal: FindTrigger treats a null instance exactly like "this
                     // extension declares no matching trigger", which for OnAction/OnLookup still
                     // surfaces as a refusal (never a silent no-op) once every extension has been
-                    // tried. stdout on purpose — see TryCreate's identical reasoning above.
+                    // tried. `[warn]` — see the tag note in TryCreate; tagged
+                    // `[RunnerPageInstance]` this never reached the terminal.
                     Console.Out.WriteLine(
-                        $"[RunnerPageInstance] pageextension {extensionId} on page {_pageId}: could not "
+                        $"[warn] RunnerPageInstance: pageextension {extensionId} on page {_pageId}: could not "
                         + $"construct the AL page extension object ({inner.GetType().Name}: "
                         + $"{inner.Message}); its triggers stay unreachable");
                 }
@@ -2150,10 +2169,11 @@ internal sealed partial class RunnerPageInstance
             catch (Exception ex)
             {
                 var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
+                // `[warn]` — see the tag note in TryCreate.
                 Console.Out.WriteLine(
-                    $"[RunnerPageInstance] pageextension {extensionId} on page {pageId} (no live base page "
+                    $"[warn] RunnerPageInstance: pageextension {extensionId} on page {pageId} (no live base page "
                     + $"object): could not construct the AL page extension object "
-                    + $"({inner.GetType().Name}: {inner.Message})");
+                    + $"({inner.GetType().Name}: {inner.Message}); its triggers stay unreachable");
                 continue;
             }
 


### PR DESCRIPTION
Closes #2461

Written by agent `stma-auto-2`, an automated implementation agent acting on the account holder's behalf.

## Where the diagnostic was actually going

Not a child process, and not the stream. The call sites carried this comment, repeated four times across three files:

```
// stdout on purpose throughout this class: the test-execution child's stderr is
// not captured, so a Console.Error line would be invisible exactly when needed.
```

Every part of that is false. `Console.SetOut`/`SetError` appears nowhere in `AlRunner/` except `Log.cs`, `Program.cs`'s `--output-json` redirect, and the watch-mode dashboard silencer — there is no test-execution child.

What eats the lines is **`Log.Install()`'s `FilteredWriter`**, which wraps **both** stdout and stderr and drops any line matching `^\[Tag]` unless `--verbose`. `[RunnerPageInstance]` and `[TestPage]` both match the pattern and are on neither exemption, so the two streams were always *equally* suppressed — the thing the comment spends all its words on could never have made a difference.

Verified against the real regex before writing any code:

| line | verdict |
|---|---|
| `[RunnerPageInstance] page 977: could not build the record-less AL page object (...)` | SUPPRESSED |
| `[TestPage] page 977 declares no SourceTable; using navigation mock.` | SUPPRESSED |
| `[page-metadata] loaded real metadata for page 977` | PASSES |
| `[warn] RunnerPageInstance: page 977 demoted` | PASSES |

That third row is the issue's own control observation, and it fits exactly: `[page-metadata]` survives because the tag character class `[A-Za-z0-9._+]` has **no hyphen**, so a hyphenated tag fails the pattern. `Log.cs`'s own comment documents that accident; #2257 owns the general case. Punctuation, not intent, was deciding which half of this degradation the reader got to see.

One incidental correction to the issue: the `[page-metadata] loaded real metadata for page 977` line the report cites is itself behind `AL_RUNNER_TRACE_PAGE_METADATA=1`, so the reporter had that variable set. It still makes the point — under the same variable, the `[RunnerPageInstance]` lines stayed invisible.

## The design call: (a) route it somewhere visible

Of the three options in the brief, this is (a), and the precedent is binding rather than a preference. **#3068 fixed exactly this class of bug** — three call sites commented "Loud, never silent" that the filter silenced — and resolved it by re-tagging the call site, explicitly not by widening the regex. #2750 refused to exempt `[deps]` to surface one message because it would have surfaced all of `DependencyLoader`'s internals; #2210/#2221/#2239 established the mirror image for hiding a line. Both say the visibility decision belongs at the call site.

Exempting `[RunnerPageInstance]` wholesale would be especially wrong here: that tag also carries per-control `AdoptFromHost` and option-caption tracing — real chatter, already env-gated — which a blanket exemption would have promoted along with the demotions. So only the lines that announce a **demotion** move to the exempt `[warn] <Component>: <message>` shape that `ProvisioningCheck`, `BcAppFallback` and the #3068 sites already use. `Log.cs` states the rule being applied: "A severity tag is never an internal diagnostic — if something is worth calling a warning, it is worth the user seeing it."

**(c) — refusing outright — was considered and deliberately not taken here.** The issue itself flags it as needing its own measurement ("every test that currently passes over a mocked page would surface at once"), and that is a behavior change of unknown blast radius, not a diagnostics fix. It remains the right question for `MockITestAction.Invoke()`; this PR makes the demotion *visible*, which is the precondition for measuring how often it fires before deciding whether to refuse. Nothing here forecloses it.

## Fixing the shape, not the reported line

The issue named two call sites. Sweeping for the shape found **eleven**, in four files:

- `RunnerPageInstance.TryCreate` — 4 demotion lines (no compiled type, no ctor, no source-expression table, ctor threw)
- `RunnerPageInstance.TryCreateRecordless` — 4 more, the path page 977 took
- `RunnerPageInstance` page-extension construction — 2 sites, where "its triggers stay unreachable"
- `CodeunitPatches.CreateTestPageClient` — the navigation mock itself
- **`RequestPageTestPage`** — a sibling the issue did not mention, same false comment, same suppression: a report request page whose form could not be adopted resolves no control at all

Two further things the sweep turned up:

1. **The page id was not guaranteed to be in the mock's message.** It travelled inside `why`, which `TestPageFactory.TryBuild` renders as `page {pageId}...` on some branches but `source table {tableId}...` or `Record{tableId} has no 6-arg constructor` on others — so *which branch fired* decided whether the reader learned which page went to the mock. The id is now interpolated at the call site unconditionally. A test asserts it, which is how it was found.
2. **The false comment had spread to a fifth site** — `RecordPatches.ReportMetadataVirtualTable.cs`. That one is env-gated tracing and needed no retag, but the comment is corrected so the next reader does not inherit the wrong mental model.

## RED → GREEN

New file `AlRunner.Tests/TestPageDemotionIsAnnouncedTests.cs`, extending the mechanism `LoudDiagnosisReachesTheUserTests` established for #3068: each case names a **production source file and an anchor phrase**, pulls the real message out of that call site, and pushes **that** through the **real** `Log` filter.

That matters for the "would this pass against a no-op?" test. A literal typed into the test file would stay green with the production line still tagged `[RunnerPageInstance]` — which is precisely the bug. Re-tag any call site back and the test goes red.

- **RED**: `Failed: 19, Passed: 15, Total: 34`. The decisive shape was `Assert.Contains() Failure ... String: ""` — the demotion line reached the sink as *nothing*, exactly as diagnosed.
- **GREEN**: `Failed: 0, Passed: 48, Total: 48`.

Four assertions per call site, positive and negative:

- `Demotion_IsAnnouncedAtDefaultVerbosity` — the claim: it survives the filter with no flags.
- `Demotion_IsAlsoAnnouncedUnderVerbose` — so the fix cannot be read as "it was visible anyway".
- `Demotion_NamesTheObjectItDemoted` — the page (or report) id is present. This is the assertion that caught finding 1 above.
- `Demotion_NamesTheConsequence` — the message says what stops working, which is what separates these lines from chatter and is the whole justification for exempting them.

Negative controls: three real tracing lines copied from the same files must **still** be suppressed by default and appear under `--verbose`. Deliberately *not* using `[option-captions]` as a control — it is hyphenated, so it passes by punctuation rather than intent, and using it would assert the #2257 accident instead of the filter. Plus one test pinning the false premise itself: the filter suppresses a tagged line on **both** streams, and the `[warn]` shape survives on both.

Sibling suites re-run unchanged: `LoudDiagnosisReachesTheUser`, `LogUserFacingTags`, `CorruptSidecar` — `Failed: 0, Passed: 52`.

## Where the test lives

Runner-specific, so no upstream corpus test is owed. The subject is the runner's own diagnostic filter and its own TestPage fallback — neither exists in Business Central, and a service tier has nothing to adjudicate. `bc-behavior-tests-go-upstream.md` requires the answer either way, so: stated, and it is "no".

Verified rather than asserted, because this is the check that is invisible when it is wrong: filtering the whole `AlRunner/` diff for lines that are neither comments nor `Console.Out`/`Console.Error.WriteLine` arguments leaves **nothing at all**. Every change is log-tag and message wording. The one addition that is not pure text — interpolating `{pageId}` into the `[TestPage]` line — reads a parameter already in scope two lines above, so no signature and no control flow moves either.

Corpus-NA: the entire AlRunner/ diff is diagnostic message text — the log tag and the wording of eleven Console.Out/Console.Error.WriteLine calls. Filtering it for non-comment, non-WriteLine changes leaves nothing, so nothing an AL test can observe changes and a real service tier has nothing to adjudicate.

## Queue scan — what did not fold

Per `batch-sibling-issues-by-file.md`, nothing else lands in these files:

- **#2913** (`ConsoleFilterSerialCollection` only fences the `Log.Install()` classes) — named in the brief as possibly sharing a root cause. It does not. It is about *test-class parallelism hygiene* in `AlRunner.Tests`, not about anything suppressing production output; the fix lands in collection attributes across several unrelated test classes. My new class correctly joins that collection, so this PR neither worsens nor addresses it.
- **#2257** (the regex cannot match hyphenated tags, so 26 tags bypass the filter) — same file I deliberately did **not** edit. It is the mirror image: tags escaping the filter by accident, where mine were caught by it. Its fix is a retagging sweep across ~83 call sites.
- **#2221** (the filter defaults to hiding tagged output, so five user-facing fixes shipped as no-ops) — the general form of this bug. #2461 is a sixth instance; the established remedy is per-call-site retagging, which is what this does.

None share a file with this diff, and folding any would mean editing `Log.cs`, which the precedent above says not to do.

## Follow-up commit: the sibling the first sweep missed

`AdoptFromHost`'s reify-failure notice in `RunnerPageInstance.cs` was the same defect class this PR exists to fix, and it survived the first pass. The host builds the subpage object itself; when the runner cannot reify it the part is rebuilt from scratch, so the TestPage answers from an object the host is not using and any state the host's own AL had put on its instance is gone. That is a demotion by the same definition as the other ten — and it was hidden the same way, tagged plain `[RunnerPageInstance]`.

It also carried a **dangling back-reference**: `// stdout on purpose — see TryCreate's identical reasoning above`, pointing at reasoning this PR deleted for asserting something false. The other two sites carrying that comment were updated in the first commit; this one was not, so it was left citing an explanation that now says the opposite.

Proven, not asserted, by one entry in the existing theory table — which reads the **real production call site**, so it goes red against the unfixed source:

- `Demotion_IsAnnouncedAtDefaultVerbosity` — the real line came out of the filter as `""`. Fully suppressed, which is the defect exactly.
- `Demotion_NamesTheConsequence` — rejected the wording, since "falling back to a freshly constructed part page" did not say what the reader loses.

Both green after the re-tag: `Failed: 0, Passed: 52` (was `Failed: 2, Passed: 50`).

Swept the rest of the surface rather than fixing only the reported line: every remaining plain `[RunnerPageInstance]` line in these files sits behind `AL_RUNNER_TRACE_PAGE_METADATA`, which is opt-in tracing and precisely what the filter is for. Two of them are already this file's negative control. Nothing ungated is left.

## Left deliberately undone

- `MockITestAction.Invoke()` stays a no-op. That is the issue's own point 3 and needs its own measurement — see the design-call section.
- The other ~26 hyphenated tags bypassing the filter stay as they are; that is #2257's sweep, not this change's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9pEPoD8e4wmVyuTrxyuh
