### PR TITLE
fix(integer-virtual-table): implement the window guard the file promised, on all four request paths

### DIFF
--- a/AlRunner.Tests/IntegerVirtualTableWindowGuardTests.cs
+++ b/AlRunner.Tests/IntegerVirtualTableWindowGuardTests.cs
@@ -113,7 +113,7 @@ public sealed class IntegerVirtualTableWindowGuardTests
         // Pins the two constants the refusal quotes, so a change to either has to be
         // deliberate. -1000 is the edge the AL suite's below-the-window test rests on, and
         // it is the one a guard written only against IntegerWindowMax would leave open.
-        Assert.Equal(-1000, RecordPatches.IntegerWindowMin);
+        Assert.Equal(-1000, RecordPatches.IntegerWindowMinDefault);
         Assert.Equal(100000, RecordPatches.IntegerWindowMaxDefault);
 
         // Real BC clamps rather than refuses, at bounds three orders of magnitude wider:
@@ -143,5 +143,30 @@ public sealed class IntegerVirtualTableWindowGuardTests
         // docs/scope.md is the permanently-out-of-scope manifest and names no table; citing it
         // here would tell the next reader the surface will never work (#2945).
         Assert.DoesNotContain("docs/scope.md", gap.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BothWindowEdges_AreOverridable_SoTheRefusalsAdviceCanBeFollowed()
+    {
+        // The lower edge was a hard `const` while the upper one read an environment variable.
+        // Harmless while nothing compared a request against either edge; a dead end as soon as
+        // the guard began refusing, because the refusal advised raising
+        // AL_RUNNER_INTEGER_WINDOW_MAX for a bound the MIN edge had rejected — advice that
+        // cannot work. Measured against the corpus tests on the upstream branch: with
+        // AL_RUNNER_INTEGER_WINDOW_MAX=300000 the far-above test passed and the far-below one
+        // still failed; with both variables set, all seven passed.
+        //
+        // Asserting the property rather than the plumbing: an override must be able to widen
+        // each edge past the bound the corpus tests name.
+        var minProp = typeof(RecordPatches).GetProperty("IntegerWindowMin",
+            BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
+        var maxProp = typeof(RecordPatches).GetProperty("IntegerWindowMax",
+            BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
+
+        Assert.True(minProp != null,
+            "IntegerWindowMin must be a property reading AL_RUNNER_INTEGER_WINDOW_MIN, not a "
+            + "const — otherwise the refusal for a below-window bound names a variable that "
+            + "cannot widen the edge that refused it.");
+        Assert.True(maxProp != null, "IntegerWindowMax must stay overridable.");
     }
 }

--- a/AlRunner.Tests/IntegerVirtualTableWindowGuardTests.cs
+++ b/AlRunner.Tests/IntegerVirtualTableWindowGuardTests.cs
@@ -1,0 +1,147 @@
+// IntegerVirtualTableWindowGuardTests — issue #2350, with #3376 decided in the same pass.
+//
+// This is a RUNNER-MECHANISM test, not a claim about BC. The behavioural half — that a
+// filter past the materialised window is refused by name on each of the four request paths,
+// and that a filter inside it and an UNBOUNDED one are still served — is proven in AL by
+// tests/runner-extras/integer-virtual-table-window (codeunit 64591), which is where a
+// regression in the refusal itself shows up.
+//
+// What that AL suite cannot see is a guard that stops being REACHED. Three of the four hooks
+// are installed by Cecil prepends in NclCecilRewrite.Runtime.cs, and CLAUDE.md records the
+// failure mode directly: "an orphaned hook and a live one look identical" in the knowledge
+// graph, because a registration that is deleted, renamed, or never added is not a compile
+// error anywhere. It is exactly how #2350 came to exist — the file's header described an
+// "IntegerWindowGuard" whose identifier appeared precisely once in the whole repository, in
+// that comment, for a full release.
+//
+// So this test asserts the wiring: each guard helper exists with the signature
+// PrependStaticCall emits (public static, (object, object)), and each is named by a
+// registration in the rewrite source. Deleting a prepend line turns the corresponding AL
+// test red only when the AL suite is run against a rebuilt runner; it turns this test red at
+// once, and says which path went missing.
+using System.Reflection;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class IntegerVirtualTableWindowGuardTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static string RewriteSource => File.ReadAllText(
+        Path.Combine(RepoRoot, "AlRunner", "Infrastructure", "NclCecilRewrite.Runtime.cs"));
+
+    private static string FindInterceptSource => File.ReadAllText(
+        Path.Combine(RepoRoot, "AlRunner", "Patches", "RecordPatches.FieldFindIntercept.cs"));
+
+    // The three Cecil-prepended paths. The find path is wired differently — through the
+    // DataAccess_IsManagedFindRequest predicate rather than a prepend of its own — and is
+    // asserted separately below.
+    [Theory]
+    [InlineData("DataAccess_IntegerWindowGuardForCount")]
+    [InlineData("DataAccess_IntegerWindowGuardForExists")]
+    [InlineData("DataAccess_IntegerWindowGuardForGet")]
+    public void EachGuardHelper_HasTheSignaturePrependStaticCallEmits(string helperName)
+    {
+        var m = typeof(RecordPatches).GetMethod(
+            helperName, BindingFlags.Public | BindingFlags.Static);
+
+        Assert.True(m != null,
+            $"RecordPatches.{helperName} is missing or not public static. PrependStaticCall "
+            + "resolves it by name at rewrite time, so a rename here is not a compile error — "
+            + "it silently produces a runner with no guard on that path (issue #2350).");
+
+        var ps = m!.GetParameters();
+        Assert.True(ps.Length == 2 && ps.All(p => p.ParameterType == typeof(object)),
+            $"RecordPatches.{helperName} must take (object self, object request) to match the "
+            + "two argSlots the prepend pushes; got ("
+            + string.Join(", ", ps.Select(p => p.ParameterType.Name)) + ").");
+        Assert.Equal(typeof(void), m.ReturnType);
+    }
+
+    [Theory]
+    [InlineData("DataAccess_IntegerWindowGuardForCount", "CountAsync", "CountCacheRequest")]
+    [InlineData("DataAccess_IntegerWindowGuardForExists", "ExistsAsync", "ExistsCacheRequest")]
+    [InlineData("DataAccess_IntegerWindowGuardForGet", "InternalTryGetByPrimaryKeyAsync", "PrimaryKeyCacheRequest")]
+    public void EachGuard_IsRegisteredAgainstItsOwnDataAccessEntryPoint(
+        string helperName, string method, string requestType)
+    {
+        var src = RewriteSource;
+
+        Assert.True(src.Contains(helperName, StringComparison.Ordinal),
+            $"No Cecil registration names {helperName}. Record.Count(), Record.IsEmpty() and "
+            + "Record.Get() reach three DIFFERENT DataAccess entry points, so a guard missing "
+            + "from any one of them answers that path from the window silently — the shape "
+            + "#3006 found for Date after the count guard's comment had claimed to cover "
+            + "IsEmpty() for a whole release.");
+
+        // The registration must sit against the right entry point, not merely exist. A guard
+        // pointed at the wrong method compiles, rewrites cleanly, and never fires for the path
+        // it was written for.
+        var at = src.IndexOf(helperName, StringComparison.Ordinal);
+        var window = src.Substring(Math.Max(0, at - 400), Math.Min(500, src.Length - Math.Max(0, at - 400)));
+        Assert.True(window.Contains(method, StringComparison.Ordinal),
+            $"{helperName} is registered, but not against DataAccess.{method}.");
+        Assert.True(window.Contains(requestType, StringComparison.Ordinal),
+            $"{helperName} is registered, but not against a {requestType}.");
+    }
+
+    [Fact]
+    public void FindPath_IsGuardedThroughTheManagedFindPredicate()
+    {
+        // The find path has no prepend of its own: DataAccess.InnerFindAsync already carries
+        // the Field-table branch, and Date and Aggregate Permission Set take their side effects
+        // inside that same predicate. Integer joins them there rather than adding a fourth
+        // prepend to one method.
+        var src = FindInterceptSource;
+
+        var at = src.IndexOf("DataAccess_IsManagedFindRequest", StringComparison.Ordinal);
+        Assert.True(at >= 0, "DataAccess_IsManagedFindRequest is gone from the find intercept.");
+
+        var body = src.Substring(at);
+        Assert.True(body.Contains("EnsureIntegerWindowCoversRequest", StringComparison.Ordinal),
+            "The managed-find predicate no longer calls EnsureIntegerWindowCoversRequest, so a "
+            + "FindSet() past the window is served from the window again — the original #2350 "
+            + "defect, on the path a report dataitem actually takes.");
+    }
+
+    [Fact]
+    public void TheWindowIsInclusiveAtBothEdges_AndTheRefusalNamesBoundAndWindow()
+    {
+        // Pins the two constants the refusal quotes, so a change to either has to be
+        // deliberate. -1000 is the edge the AL suite's below-the-window test rests on, and
+        // it is the one a guard written only against IntegerWindowMax would leave open.
+        Assert.Equal(-1000, RecordPatches.IntegerWindowMin);
+        Assert.Equal(100000, RecordPatches.IntegerWindowMaxDefault);
+
+        // Real BC clamps rather than refuses, at bounds three orders of magnitude wider:
+        // IntegerDataProvider.GetValuesWithinRangeForKeyField and CountValuesWithinRange both
+        // call GetInclusiveIntegerBounds(-1000000000, 1000000000, ...) — decompiled from
+        // Ncl.dll, byte-identical in 27.0 and 28.4. So the window is a runner limit, and the
+        // refusal must say so rather than reading as a statement about BC.
+        Assert.True(RecordPatches.IntegerWindowMaxDefault < 1_000_000_000,
+            "The materialised window must stay inside the range a service tier serves; past "
+            + "that the refusal would be claiming BC cannot answer something it can.");
+    }
+
+    [Fact]
+    public void TheRefusalIsAnchoredNotYetImplemented_SoATryFunctionCannotSwallowIt()
+    {
+        // Issue #2965's rule. ApplicationObjectBasePatches.IsPermanentOutOfScope reads the
+        // reason's FIRST token; anchored anywhere else, an AL [TryFunction] traps the refusal
+        // into `false` and the caller carries on having quietly done without the table — the
+        // silent default .claude/rules/loud-failures.md exists to prevent. The AL suite pins
+        // the runtime consequence; this pins the anchor the whole mechanism turns on.
+        var gap = RecordPatches.IntegerShapeGap("probe detail");
+
+        Assert.StartsWith("not-yet-implemented", gap.Reason, StringComparison.Ordinal);
+        Assert.Contains("integer-virtual-table", gap.Reason, StringComparison.Ordinal);
+        Assert.Contains("Integer (virtual table 2000000026)", gap.Message, StringComparison.Ordinal);
+
+        // docs/scope.md is the permanently-out-of-scope manifest and names no table; citing it
+        // here would tell the next reader the surface will never work (#2945).
+        Assert.DoesNotContain("docs/scope.md", gap.Message, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
@@ -1026,6 +1026,20 @@ public static partial class NclCecilRewrite
                 H(recordPatches, "DataAccess_FieldGuardForCount"),
                 argSlots: 2); // `this` — the DataAccess — and the count request
 
+            // ── DataAccess.CountAsync — Integer virtual table (2000000026) window guard ───
+            // Issue #2350. The Integer window ([-1000..100000] by default) is materialised
+            // eagerly, and until now nothing compared an incoming filter against it on ANY
+            // path — the file's own header spent a release claiming otherwise, naming an
+            // "IntegerWindowGuard" that did not exist. Record.Count() over Number in
+            // [1..250000] answered 100000: short by 150000, and a number that looks real.
+            // A service tier computes this table per request and clamps to [-1e9..1e9]
+            // (IntegerDataProvider.CountValuesWithinRange, decompiled), so the missing rows
+            // are rows BC would have returned.
+            PrependStaticCall(nclMod,
+                ByParams(Rt + "DataAccess", "CountAsync", "CountCacheRequest"),
+                H(recordPatches, "DataAccess_IntegerWindowGuardForCount"),
+                argSlots: 2); // `this` — the DataAccess — and the count request
+
             // ── DataAccess.InternalTryGetByPrimaryKeyAsync — Aggregate Permission Set live
             //    redrive (issue #2504) ──────────────────────────────────────────────────
             // Record.Get() with a full primary key never reaches InnerFindAsync at all — it
@@ -1066,6 +1080,17 @@ public static partial class NclCecilRewrite
             PrependStaticCall(nclMod,
                 ByParams(Rt + "DataAccess", "InternalTryGetByPrimaryKeyAsync", "PrimaryKeyCacheRequest"),
                 H(recordPatches, "DataAccess_FieldGuardForGet"),
+                argSlots: 2); // `this` — the DataAccess — and the primary-key request
+
+            // ── DataAccess.InternalTryGetByPrimaryKeyAsync — Integer window guard (#2350) ────
+            // The Integer table shares the primary-key path described above and was left behind
+            // by both #2504 and #2648. A keyed Get reaches neither the find guard nor the count
+            // one, so Record.Get(250000) answered FALSE — indistinguishable from "no such row",
+            // when a service tier plainly has one. The bound comes from the RECORD ID, because a
+            // keyed Get carries its key there and may name no "Number" filter at all.
+            PrependStaticCall(nclMod,
+                ByParams(Rt + "DataAccess", "InternalTryGetByPrimaryKeyAsync", "PrimaryKeyCacheRequest"),
+                H(recordPatches, "DataAccess_IntegerWindowGuardForGet"),
                 argSlots: 2); // `this` — the DataAccess — and the primary-key request
 
             // ── DataAccess.ExistsAsync — Date virtual table (2000000007), the FOURTH path ───
@@ -1125,6 +1150,18 @@ public static partial class NclCecilRewrite
             PrependStaticCall(nclMod,
                 ByParams(Rt + "DataAccess", "ExistsAsync", "ExistsCacheRequest"),
                 H(recordPatches, "DataAccess_FieldGuardForExists"),
+                argSlots: 2); // `this` — the DataAccess — and the exists request
+
+            // ── DataAccess.ExistsAsync — Integer virtual table (2000000026), the FOURTH path ──
+            // Issue #2350, and the same omission #3006 found for Date and Field. Record.IsEmpty()
+            // never reaches CountAsync, so with the find, count and Get guards all in place
+            // IsEmpty() over Number in [1..250000] still answered FALSE from the 100000 rows the
+            // window happens to hold — true by accident, and a statement about a range nobody
+            // asked about. ExistsAsync is a large async state machine, so unlike the tiny
+            // FindAsync it is not R2R-inlined past the prepend.
+            PrependStaticCall(nclMod,
+                ByParams(Rt + "DataAccess", "ExistsAsync", "ExistsCacheRequest"),
+                H(recordPatches, "DataAccess_IntegerWindowGuardForExists"),
                 argSlots: 2); // `this` — the DataAccess — and the exists request
 
             // ── Why there is NO DataAccess.GetBlobContentAsync prepend here (#2771) ─────────

--- a/AlRunner/Patches/RecordPatches.FieldFindIntercept.cs
+++ b/AlRunner/Patches/RecordPatches.FieldFindIntercept.cs
@@ -133,6 +133,11 @@ public static partial class RecordPatches
     /// filter names, or throws RunnerOutOfScopeException when that would exceed the row cap.
     /// The find request is the first and only place the runner sees that filter, so it is the
     /// only place the check can happen. See RecordPatches.DateVirtualTable.cs.
+    ///
+    /// Table 2000000026 (Integer) passes through here the same way, for the narrower reason that
+    /// its window is materialised eagerly: there is nothing to widen, so the side effect is only
+    /// EnsureIntegerWindowCoversRequest refusing a find whose "Number" filter closes a bound past
+    /// the window. See RecordPatches.IntegerVirtualTable.cs.
     /// </summary>
     public static bool DataAccess_IsManagedFindRequest(object self, object request)
     {
@@ -140,6 +145,15 @@ public static partial class RecordPatches
         if (tableId == DateVirtualTableId)
         {
             EnsureDateWindowCoversRequest(self, request);
+            return false;
+        }
+        if (tableId == IntegerVirtualTableId)
+        {
+            // Issue #2350. The Integer window is materialised eagerly, so unlike Date there is
+            // nothing to widen — the only thing a find can need here is a refusal when its
+            // "Number" filter closes a bound past the window. Fall through to the ORIGINAL
+            // InnerFindAsync when it does not, which is every request inside the window.
+            EnsureIntegerWindowCoversRequest(self, request);
             return false;
         }
         if (tableId == AggregatePermissionSetVirtualTableId)

--- a/AlRunner/Patches/RecordPatches.IntegerVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.IntegerVirtualTable.cs
@@ -31,12 +31,28 @@
 //   from the metatable at runtime, never hardcoded.
 //
 // THE WINDOW, AND WHY IT IS NOT A SILENT TRUNCATION
-//   The real table is unbounded, so it cannot be materialised. We materialise
-//   [IntegerWindowMin .. IntegerWindowMax] and — this is the load-bearing part —
-//   a request that reaches past the window THROWS RunnerOutOfScopeException naming
-//   the requested bound and the window (see IntegerWindowGuard below). Answering a
-//   larger request with fewer rows would reproduce, one level up, the exact silent
-//   wrong answer this file exists to remove.
+//   Real BC is bounded too, just far more widely than we can materialise.
+//   IntegerDataProvider.GetValuesWithinRangeForKeyField, decompiled from Ncl.dll and
+//   byte-identical in 27.0 and 28.4, opens with
+//
+//       if (range.GetInclusiveIntegerBounds(-1000000000, 1000000000, out var low, out var high))
+//
+//   and CountValuesWithinRange applies the same two constants. So a service tier clamps
+//   every request to [-1e9 .. 1e9] and serves an UNBOUNDED filter as exactly that range;
+//   it never refuses one. 2,000,000,001 rows is not something we can materialise.
+//
+//   We materialise [IntegerWindowMin .. IntegerWindowMax] and — this is the load-bearing
+//   part — a request whose filter CLOSES a bound past the window THROWS
+//   RunnerOutOfScopeException naming the requested bound and the window (see
+//   DataAccess_IntegerWindowGuardFor* below). Answering a larger request with fewer rows
+//   would reproduce, one level up, the exact silent wrong answer this file exists to remove.
+//
+//   An UNBOUNDED filter is served from the window instead of refused, because that is the
+//   shape BC itself answers by inventing a bound, and because BaseApp leans on it: 18 of its
+//   658 reports drive a `dataitem(x; Integer)` with no upper bound and stop via MaxIteration
+//   (#3374). Refusing there would turn working reports into hard failures while diverging
+//   from the service tier. The residual divergence — 101,001 rows where BC yields
+//   2,000,000,001 — is real and is recorded in docs/limitations.md, not papered over.
 //
 // PRECOMPILED-DLL RESPECT
 //   No BC business-logic body is touched. VirtualDataProvider, NCLMetaTable, NavValue,
@@ -255,5 +271,327 @@ public static partial class RecordPatches
                 "NavValue.GetDefaultNavValue(INavValueMetadata,bool) not found — BC metadata shape changed");
 
         _ivtReflectionReady = true;
+    }
+
+    // ── THE WINDOW GUARD ─────────────────────────────────────────────────────────────────
+    //
+    // Four DataAccess entry points reach this table, and each carries a different request
+    // type, so one guard cannot cover them. The set and the reasoning are the Date table's,
+    // established over #2648 / #3006 / #2504 and re-used here rather than rediscovered:
+    //
+    //   find    InnerFindAsync(FindCacheRequest)          — via DataAccess_IsManagedFindRequest
+    //   count   CountAsync(CountCacheRequest)             — Record.Count()
+    //   exists  ExistsAsync(ExistsCacheRequest)           — Record.IsEmpty(), which never
+    //                                                       reaches CountAsync
+    //   get     InternalTryGetByPrimaryKeyAsync(...)      — Record.Get(), which reaches
+    //                                                       neither find nor count
+    //
+    // Unlike Date's guard this one never widens anything: the Integer window is materialised
+    // eagerly and in full at handout, so there is nothing to top up. The only question a
+    // guard can answer here is "does this request reach past what we hold", and the only
+    // honest answer when it does is a refusal.
+
+    /// <summary>
+    /// Field number of Integer's "Number" column as BC's own metadata declares it. Bound at
+    /// populate time from the metatable (<see cref="EnsureIntegerNumberFieldNo"/>) rather than
+    /// hardcoded; this cache lets the guard read a filter without re-walking the field list on
+    /// every request. Null until the table has been handed out once, which is also the only
+    /// state in which there is nothing to protect.
+    /// </summary>
+    private static int? IntegerNumberFieldNoOrNull => _ivtNumberFieldNo;
+
+    /// <summary>
+    /// Refuse when <paramref name="cacheRequest"/>'s "Number" filter closes a bound outside
+    /// [<see cref="IntegerWindowMin"/> .. <see cref="IntegerWindowMax"/>].
+    ///
+    /// <para>THE RULE, and why it is about CLOSED bounds only. BC's own
+    /// <c>Range.GetInclusiveIntegerBounds(min, max, ...)</c> substitutes its <c>min</c> for an
+    /// open low bound and its <c>max</c> for an open high one, then clamps whatever the filter
+    /// did name into that interval. We mirror the first half exactly — an open bound means "as
+    /// far as this provider goes", which is the window — and deliberately diverge on the
+    /// second: where BC silently clamps a closed bound of 2e9 down to 1e9, we refuse a closed
+    /// bound of 250000 rather than clamp it to 100000. Clamping is safe for BC because the
+    /// rows between its clamp and the request are rows that do not exist; clamping here would
+    /// drop rows a service tier would have returned.</para>
+    ///
+    /// <para>Every non-empty range in the filter is checked, so <c>'1..50|200000..300000'</c>
+    /// is refused on its second range even though its first is comfortably inside. A filter we
+    /// cannot read at all falls through to being served: that is the pre-existing behaviour,
+    /// and a refusal we cannot justify from a bound we actually read would be a worse failure
+    /// than the one this guard removes.</para>
+    /// </summary>
+    internal static void EnsureIntegerWindowCoversRequest(object dataAccess, object cacheRequest)
+    {
+        // A `Record Integer temporary` holds exactly the rows AL inserted, and the real table's
+        // rows were never injected into its private store. Refusing on its filter would refuse a
+        // read that has nothing to do with the virtual table. Same carve-out as Date's (#2524).
+        if (IsTemporaryRecordDataAccess(dataAccess)) return;
+
+        // Nothing has been materialised yet, so the "Number" field number is not bound and there
+        // is no populated store whose limits could be exceeded. PrepareIntegerVirtualTable
+        // populates before any request is served.
+        if (IntegerNumberFieldNoOrNull is not int numberFieldNo) return;
+
+        int? closedLow, closedHigh;
+        try
+        {
+            EnsureIntegerGuardReflection(dataAccess, cacheRequest);
+            if (!TryReadClosedNumberBounds(cacheRequest, dataAccess, numberFieldNo, out closedLow, out closedHigh))
+                return;
+        }
+        catch (RunnerOutOfScopeException) { throw; }
+        catch
+        {
+            // Reading the filter is best-effort. A shape we cannot parse is served from the
+            // window exactly as it was before this guard existed — see the class comment: a
+            // refusal must rest on a bound we actually read.
+            return;
+        }
+
+        if (closedLow is int lo && lo < IntegerWindowMin) throw IntegerWindowRefusal(lo);
+        if (closedHigh is int hi && hi > IntegerWindowMax) throw IntegerWindowRefusal(hi);
+    }
+
+    /// <summary>
+    /// The refusal, naming the bound that was asked for and the window that could not answer
+    /// it — the two facts a reader needs to decide between raising
+    /// <c>AL_RUNNER_INTEGER_WINDOW_MAX</c> and narrowing the filter.
+    /// </summary>
+    private static RunnerOutOfScopeException IntegerWindowRefusal(int requested)
+        => IntegerShapeGap(
+            System.FormattableString.Invariant(
+                $"an Integer filter names Number {requested}, past the materialised window ")
+            + System.FormattableString.Invariant(
+                $"[{IntegerWindowMin}..{IntegerWindowMax}]. ")
+            + "Real BC computes this table per request and serves [-1000000000..1000000000], so "
+            + "the rows between the window and the bound asked for are rows a service tier would "
+            + "have returned. Raise AL_RUNNER_INTEGER_WINDOW_MAX, or narrow the filter");
+
+    /// <summary>
+    /// The lowest closed low bound and the highest closed high bound this request's "Number"
+    /// filter names, read through BC's own <c>FilterExpression.ToRangeList</c>. An open bound
+    /// contributes nothing, exactly as <c>GetInclusiveIntegerBounds</c> treats it.
+    /// </summary>
+    /// <returns>False when there is no readable "Number" filter, so nothing can be judged.</returns>
+    private static bool TryReadClosedNumberBounds(
+        object cacheRequest, object dataAccess, int numberFieldNo, out int? low, out int? high)
+    {
+        low = null;
+        high = null;
+
+        if (_pFiltersAndMarks!.GetValue(cacheRequest) is not object fam) return false;
+        var filter = NumberFilterIn(fam, numberFieldNo);
+        if (filter == null) return false;
+        if (_ivtDaSession!.GetValue(dataAccess) is not object session) return false;
+
+        var rangeList = _ivtToRangeList!.Invoke(filter, new[] { session });
+        if (rangeList == null) return false;
+        if (_ivtRangeListRanges!.GetValue(rangeList) is not System.Collections.IEnumerable ranges) return false;
+
+        foreach (var range in ranges)
+        {
+            if (range == null) continue;
+            if ((bool)_ivtRangeIsEmpty!.GetValue(range)!) continue;
+
+            // IsLowIsMinimum / IsHighMaximum are the same two flags BC's own
+            // GetInclusiveIntegerBounds branches on before substituting its own limits.
+            if (!(bool)_ivtRangeLowIsMin!.GetValue(range)!
+                && ToInt32OrNull(_ivtRangeLowValue!.GetValue(range)) is int lo)
+                low = low == null || lo < low ? lo : low;
+
+            if (!(bool)_ivtRangeHighIsMax!.GetValue(range)!
+                && ToInt32OrNull(_ivtRangeHighValue!.GetValue(range)) is int hi)
+                high = high == null || hi > high ? hi : high;
+        }
+
+        return low != null || high != null;
+    }
+
+    /// <summary>The "Number" FilterExpression inside a <c>FiltersAndMarks</c>, if any.</summary>
+    private static object? NumberFilterIn(object fam, int numberFieldNo)
+    {
+        var filters = _pFamFilters!.GetValue(fam);
+        if (filters == null) return null;
+        if (_pFfdItems!.GetValue(filters) is not Array items) return null;
+
+        foreach (var item in items)
+        {
+            if (item == null) continue;
+            var tupleType = item.GetType();
+            var fieldMeta = tupleType.GetProperty("Item1")?.GetValue(item);
+            var expr = tupleType.GetProperty("Item2")?.GetValue(item);
+            if (fieldMeta == null || expr == null) continue;
+            if (_pFieldNo?.GetValue(fieldMeta) is int fieldNo && fieldNo == numberFieldNo)
+                return expr;
+        }
+        return null;
+    }
+
+    private static int? ToInt32OrNull(object? navValue)
+    {
+        if (navValue == null) return null;
+        try
+        {
+            return _ivtNavValueToInt32!.Invoke(navValue, null) is int i ? i : null;
+        }
+        catch { return null; }
+    }
+
+    /// <summary>
+    /// The primary-key value a keyed <c>Record.Get(Number)</c> names. Integer's primary key is
+    /// ("Number") alone, so it is the FIRST and only key value — unlike Date's, where
+    /// "Period Start" is the second.
+    /// </summary>
+    /// <param name="hasRecordId">
+    /// False for a SystemIdCacheRequest, which carries no RecordId. A Get by SystemId cannot
+    /// name a row outside the window: the SystemId of a row that was never materialised has
+    /// never been handed out, so there is nothing to refuse.
+    /// </param>
+    private static int? PrimaryKeyNumber(object request, out bool hasRecordId)
+    {
+        hasRecordId = false;
+        try
+        {
+            var recordId = request.GetType().GetProperty("RecordId",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(request);
+            if (recordId == null) return null;
+            hasRecordId = true;
+
+            var fields = recordId.GetType().GetProperty("Fields",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(recordId);
+            if (fields is not System.Collections.IList list || list.Count < 1) return null;
+
+            return ToInt32OrNull(list[0]);
+        }
+        catch { return null; }
+    }
+
+    private static volatile bool _ivtGuardReady;
+    private static PropertyInfo? _ivtDaSession;
+    private static MethodInfo? _ivtToRangeList;
+    private static PropertyInfo? _ivtRangeListRanges;
+    private static PropertyInfo? _ivtRangeLowIsMin, _ivtRangeHighIsMax;
+    private static PropertyInfo? _ivtRangeLowValue, _ivtRangeHighValue, _ivtRangeIsEmpty;
+    private static MethodInfo? _ivtNavValueToInt32;
+
+    /// <summary>
+    /// Bind the filter-reading reflection this guard needs, with a hard throw when a member is
+    /// genuinely absent — the same shape as <see cref="EnsureIntegerReflection"/>, and for the
+    /// same reason: a silent bind failure here would turn the guard back into the no-op this
+    /// file's header spent a release claiming it was not.
+    /// </summary>
+    private static void EnsureIntegerGuardReflection(object dataAccess, object cacheRequest)
+    {
+        if (_ivtGuardReady) return;
+
+        // Shares the FiltersAndMarks / FilterFieldDictionary accessors with the Field-table find
+        // interception; EnsureFilterReflection binds those.
+        EnsureFilterReflection(cacheRequest);
+
+        var nclAsm = cacheRequest.GetType().Assembly;
+        const string rt = "Microsoft.Dynamics.Nav.Runtime.";
+        const BindingFlags anyInstance = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+
+        var tCacheRequest = nclAsm.GetType(rt + "DataCacheRequest")
+            ?? throw new InvalidOperationException("DataCacheRequest not found — BC metadata shape changed");
+        _pFiltersAndMarks ??= tCacheRequest.GetProperty("FiltersAndMarks", anyInstance)
+            ?? throw new InvalidOperationException("DataCacheRequest.FiltersAndMarks not found — BC metadata shape changed");
+
+        var tDataAccess = nclAsm.GetType(rt + "DataAccess")
+            ?? throw new InvalidOperationException("DataAccess not found — BC metadata shape changed");
+        _ivtDaSession = tDataAccess.GetProperty("Session", anyInstance)
+            ?? tDataAccess.GetProperty("session", anyInstance)
+            ?? throw new InvalidOperationException("DataAccess.Session not found — BC metadata shape changed");
+
+        var tFilterExpr = nclAsm.GetType(rt + "FilterExpression")
+            ?? throw new InvalidOperationException("FilterExpression not found — BC metadata shape changed");
+        _ivtToRangeList = tFilterExpr.GetMethods(anyInstance)
+            .FirstOrDefault(m => m.Name == "ToRangeList" && m.GetParameters().Length == 1)
+            ?? throw new InvalidOperationException("FilterExpression.ToRangeList(1 arg) not found — BC metadata shape changed");
+
+        var tRangeList = nclAsm.GetType(rt + "RangeList")
+            ?? throw new InvalidOperationException("RangeList not found — BC metadata shape changed");
+        _ivtRangeListRanges = tRangeList.GetProperty("Ranges", anyInstance)
+            ?? throw new InvalidOperationException("RangeList.Ranges not found — BC metadata shape changed");
+
+        var tRange = nclAsm.GetType(rt + "Range")
+            ?? throw new InvalidOperationException("Range not found — BC metadata shape changed");
+        PropertyInfo NeedProp(string name) => tRange.GetProperty(name, anyInstance)
+            ?? throw new InvalidOperationException($"Range.{name} not found — BC metadata shape changed");
+        _ivtRangeLowIsMin = NeedProp("IsLowIsMinimum");
+        _ivtRangeHighIsMax = NeedProp("IsHighMaximum");
+        _ivtRangeLowValue = NeedProp("LowValue");
+        _ivtRangeHighValue = NeedProp("HighValue");
+        _ivtRangeIsEmpty = NeedProp("IsEmptyRange");
+
+        var tNavValue = ResolveType(rt + "NavValue", "Microsoft.Dynamics.Nav.Types.NavValue")
+            ?? throw new InvalidOperationException("NavValue type not found — BC metadata shape changed");
+        _ivtNavValueToInt32 = tNavValue.GetMethod("ToInt32",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            binder: null, types: Type.EmptyTypes, modifiers: null)
+            ?? throw new InvalidOperationException("NavValue.ToInt32() not found — BC metadata shape changed");
+
+        _ivtGuardReady = true;
+    }
+
+    /// <summary>
+    /// Prepended to DataAccess.CountAsync(CountCacheRequest) for every table. <c>Record.Count()</c>
+    /// builds a CountCacheRequest, not a FindCacheRequest, so the find guard never sees it —
+    /// without this, a Count over [1..250000] answers 100000, a number that looks entirely real
+    /// and is short by 150000. For every table but 2000000026 this is one integer comparison
+    /// and a return.
+    /// </summary>
+    public static void DataAccess_IntegerWindowGuardForCount(object self, object request)
+    {
+        if (FindRequestTableId(request) != IntegerVirtualTableId) return;
+        EnsureIntegerWindowCoversRequest(self, request);
+    }
+
+    /// <summary>
+    /// Prepended to DataAccess.ExistsAsync(ExistsCacheRequest) for every table.
+    /// <c>Record.IsEmpty()</c> does not take the count path: RecordImplementation.IsEmptyAsync
+    /// builds its own ExistsCacheRequest and reaches DataAccess.ExistsAsync, never CountAsync —
+    /// established for the Date table in #3006, where the same omission had IsEmpty() answering
+    /// TRUE on a range Count() answered 7 for. Without this guard IsEmpty() over [1..250000]
+    /// answers FALSE from the rows the window happens to hold: true by accident, and a statement
+    /// about a range nobody asked about.
+    /// </summary>
+    public static void DataAccess_IntegerWindowGuardForExists(object self, object request)
+    {
+        if (FindRequestTableId(request) != IntegerVirtualTableId) return;
+        EnsureIntegerWindowCoversRequest(self, request);
+    }
+
+    /// <summary>
+    /// Prepended to DataAccess.InternalTryGetByPrimaryKeyAsync for every table. A full-primary-key
+    /// <c>Record.Get()</c> reaches neither the find path nor the count path — DataAccess has its
+    /// own primary-key route straight to the provider, which is why #2504 needed a separate guard
+    /// there for Aggregate Permission Set and #2648 another for Date. Integer was left behind by
+    /// both: <c>Get(250000)</c> answered FALSE, which reads as "no such row" when a service tier
+    /// plainly has one.
+    ///
+    /// <para>The bound comes from the RECORD ID rather than from a filter, because a keyed Get
+    /// carries its key there and may carry no "Number" filter at all.</para>
+    /// </summary>
+    public static void DataAccess_IntegerWindowGuardForGet(object self, object request)
+    {
+        if (FindRequestTableId(request) != IntegerVirtualTableId) return;
+        if (IsTemporaryRecordDataAccess(self)) return;
+
+        int? wanted;
+        try
+        {
+            EnsureIntegerGuardReflection(self, request);
+            wanted = PrimaryKeyNumber(request, out _);
+        }
+        catch (RunnerOutOfScopeException) { throw; }
+        catch
+        {
+            // Unreadable request — served from the window, as before this guard existed.
+            return;
+        }
+
+        if (wanted is not int n) return;
+        if (n < IntegerWindowMin || n > IntegerWindowMax) throw IntegerWindowRefusal(n);
     }
 }

--- a/AlRunner/Patches/RecordPatches.IntegerVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.IntegerVirtualTable.cs
@@ -83,16 +83,39 @@ public static partial class RecordPatches
     internal const int IntegerVirtualTableId = 2000000026;
 
     /// <summary>
-    /// Materialised window of Number. Real BC spans the signed integer range; we cannot.
-    /// Chosen to cover every realistic synthetic-dataset use (report row generators,
-    /// loop drivers) with headroom, while staying cheap enough to insert eagerly.
-    /// A request beyond the window throws rather than returning a short answer.
-    /// Override with AL_RUNNER_INTEGER_WINDOW_MAX for a one-off larger run.
+    /// Materialised window of Number. Real BC serves [-1e9..1e9] computed per request; we
+    /// cannot materialise 2,000,000,001 rows. Chosen to cover every realistic synthetic-dataset
+    /// use (report row generators, loop drivers) with headroom, while staying cheap enough to
+    /// insert eagerly. A request that CLOSES a bound beyond the window throws rather than
+    /// returning a short answer.
+    ///
+    /// <para>Both edges are overridable, and symmetrically so. The lower edge was a hard
+    /// <c>const</c> while the upper one already read an environment variable — invisible while
+    /// nothing compared a request against either edge, and a dead end the moment #2350's guard
+    /// started refusing: a filter naming -250000 was refused with a message advising the reader
+    /// to raise <c>AL_RUNNER_INTEGER_WINDOW_MAX</c>, which could not widen the edge that had
+    /// actually refused it. Measured: with <c>AL_RUNNER_INTEGER_WINDOW_MAX=300000</c> the
+    /// upper-range corpus test passed and the lower-range one still failed.</para>
     /// </summary>
-    internal const int IntegerWindowMin = -1000;
+    internal const int IntegerWindowMinDefault = -1000;
     internal const int IntegerWindowMaxDefault = 100000;
 
+    private static int? _ivtWindowMin;
     private static int? _ivtWindowMax;
+
+    internal static int IntegerWindowMin
+    {
+        get
+        {
+            if (_ivtWindowMin.HasValue) return _ivtWindowMin.Value;
+            var raw = Environment.GetEnvironmentVariable("AL_RUNNER_INTEGER_WINDOW_MIN");
+            // Only a value that WIDENS the window is honoured: a "min" above the default would
+            // narrow the materialised set and start refusing reads that work today.
+            _ivtWindowMin = int.TryParse(raw, out var v) && v < IntegerWindowMinDefault
+                ? v : IntegerWindowMinDefault;
+            return _ivtWindowMin.Value;
+        }
+    }
 
     internal static int IntegerWindowMax
     {
@@ -365,7 +388,13 @@ public static partial class RecordPatches
                 $"[{IntegerWindowMin}..{IntegerWindowMax}]. ")
             + "Real BC computes this table per request and serves [-1000000000..1000000000], so "
             + "the rows between the window and the bound asked for are rows a service tier would "
-            + "have returned. Raise AL_RUNNER_INTEGER_WINDOW_MAX, or narrow the filter");
+            + "have returned. "
+            // Name the variable that moves the edge that actually refused. Advising
+            // AL_RUNNER_INTEGER_WINDOW_MAX for a bound below the window sends the reader to a
+            // setting that cannot widen it, and the advice fails silently.
+            + (requested < IntegerWindowMin
+                ? "Lower AL_RUNNER_INTEGER_WINDOW_MIN, or narrow the filter"
+                : "Raise AL_RUNNER_INTEGER_WINDOW_MAX, or narrow the filter"));
 
     /// <summary>
     /// The lowest closed low bound and the highest closed high bound this request's "Number"

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -740,7 +740,15 @@ by `MaxIteration` rather than by the filter. Real BC serves that shape too, from
 yields 101,001 rows here against 2,000,000,001 on a service tier. Code that iterates an
 unbounded `Integer` range to the end stops at the window edge instead of at 1,000,000,000.
 
-`AL_RUNNER_INTEGER_WINDOW_MAX` raises the upper edge for a one-off run.
+`AL_RUNNER_INTEGER_WINDOW_MAX` raises the upper edge for a one-off run, and
+`AL_RUNNER_INTEGER_WINDOW_MIN` lowers the lower one. Both only ever **widen** the window:
+a `MIN` above the default, or a non-positive `MAX`, is ignored rather than narrowing the
+materialised set and refusing reads that work today.
+
+The lower edge was a hard constant until #2350. That was invisible while nothing compared a
+request against either edge, and became a dead end the moment the guard started refusing —
+a filter naming -250000 was refused with a message telling the reader to raise
+`AL_RUNNER_INTEGER_WINDOW_MAX`, which cannot widen the edge that rejected it.
 
 ---
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -688,6 +688,62 @@ reflection), so the runner cannot disagree with the service tier about any of it
 
 ---
 
+### `Record Integer` — a filter reaching past the materialised window is refused, not truncated
+
+<a id="integer-virtual-table"></a>
+
+The `Integer` system virtual table (2000000026) is computed per request on the service
+tier by `IntegerDataProvider`, a `RangeBasedComputedDataProvider`. It is **not** unbounded
+there either. Decompiled from `Microsoft.Dynamics.Nav.Ncl` and byte-identical in 27.0 and
+28.4, both of its entry points open the same way:
+
+```csharp
+// GetValuesWithinRangeForKeyField, and CountValuesWithinRange
+if (range.GetInclusiveIntegerBounds(-1000000000, 1000000000, out var low, out var high))
+```
+
+So real BC clamps every request to **[-1,000,000,000 .. 1,000,000,000]**, and serves a
+filter with an open bound as exactly that range rather than refusing it —
+`Range.GetInclusiveIntegerBounds` substitutes its `minimum` for an open low bound and its
+`maximum` for an open high one.
+
+2,000,000,001 rows is not something the runner can materialise into an in-memory store.
+What it does instead:
+
+- The window **[-1000 .. 100000]** (101,001 rows) is materialised eagerly when the table
+  is first handed out. Unlike `Record Date` there is no lazy narrowing and nothing to
+  widen: the window is fixed for the run.
+- A filter that **closes** a bound outside that window raises
+  `RunnerOutOfScopeException`, naming the bound asked for and the window. It never
+  answers a wider request with fewer rows. `SetRange(Number, 1, 250000)` is refused
+  rather than answered with 100,000 rows, because the 150,000 rows in between are rows a
+  service tier would have returned.
+- The refusal covers all **four** request paths a `Record Integer` read can take, since
+  each carries a different request type and no single guard sees them all:
+
+  | AL | `DataAccess` method | request type |
+  |---|---|---|
+  | `Find` / `FindSet` / `FindFirst` / `FindLast` | `InnerFindAsync` | `FindCacheRequest` |
+  | `Count` | `CountAsync` | `CountCacheRequest` |
+  | `IsEmpty` | `ExistsAsync` | `ExistsCacheRequest` |
+  | `Get(Number)` | `InternalTryGetByPrimaryKeyAsync` | `PrimaryKeyCacheRequest` |
+
+  Before #2350 none of the four was guarded, although the source file's own header had
+  described the guard as existing for a full release — the identifier it named appeared
+  exactly once in the repository, in that comment.
+
+The one case the window does not cover is an **unbounded** filter, and the runner
+deliberately serves it rather than refusing it: `dataitem(Number; Integer)` with no upper
+bound is a standard idiom, and 18 of the Base Application's 658 reports drive one, bounded
+by `MaxIteration` rather than by the filter. Real BC serves that shape too, from its own
+±1e9 bound. So the divergence is a **row count, not a refusal**: an unbounded enumeration
+yields 101,001 rows here against 2,000,000,001 on a service tier. Code that iterates an
+unbounded `Integer` range to the end stops at the window edge instead of at 1,000,000,000.
+
+`AL_RUNNER_INTEGER_WINDOW_MAX` raises the upper edge for a one-off run.
+
+---
+
 ### `Record "Windows Language"` — the license and installed-resource columns are chosen values
 
 <a id="windows-language-virtual-table"></a>
@@ -1317,6 +1373,11 @@ https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues.
   ([#2945](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2945)). Time Zone
   and Windows Language have documented *divergences* as well — see their own sections above —
   and those are answers the runner gives on purpose, not refusals.
+
+  `Date` and `Integer` refuse for a second, different reason on top of that one: both are
+  computed per request on the service tier over a range too large to materialise, so a filter
+  reaching past the window each one materialises is refused rather than answered short. See
+  [`Record Date`](#date-virtual-table) and [`Record Integer`](#integer-virtual-table).
 - **`Session` (2000000009) answers one row — the reading session — and two of its columns are
   blank.** That single row is not a runner simplification: BC's own `SessionDataProvider`
   returns `new ReadOnlyRecordBuffer[1]` unconditionally, with `My Session` a constant `true`,

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -28,6 +28,7 @@
         "http-egress-boundary-oos": { "tests": 4 },
         "install-trigger-seed": { "tests": 3 },
         "install-trigger-text-constant": { "tests": 2 },
+        "integer-virtual-table-window": { "tests": 9 },
         "manual-binding-dep": { "tests": 3, "absentOn": ["27.0", "27.3", "27.5"] },
         "microsoft-dependencies": { "tests": 26 },
         "microsoft-test-library": { "tests": 3, "absentOn": ["27.0", "27.3", "27.5"] },

--- a/tests/runner-extras/integer-virtual-table-window/IvtwAssert.Codeunit.al
+++ b/tests/runner-extras/integer-virtual-table-window/IvtwAssert.Codeunit.al
@@ -1,0 +1,28 @@
+// Standalone Assert codeunit — this suite must stand alone (tests/runner-extras/README.md),
+// it does not import from tests/al-language.
+codeunit 64590 "Ivtw Assert"
+{
+    procedure AreEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        if Format(Expected) <> Format(Actual) then
+            Error('Expected %1 but got %2: %3', Format(Expected), Format(Actual), Msg);
+    end;
+
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then
+            Error('Expected true: %1', Msg);
+    end;
+
+    procedure IsFalse(Condition: Boolean; Msg: Text)
+    begin
+        if Condition then
+            Error('Expected false: %1', Msg);
+    end;
+
+    procedure ExpectedError(Fragment: Text)
+    begin
+        if StrPos(GetLastErrorText(), Fragment) = 0 then
+            Error('Expected error containing ''%1'' but got ''%2''', Fragment, GetLastErrorText());
+    end;
+}

--- a/tests/runner-extras/integer-virtual-table-window/IvtwTests.Codeunit.al
+++ b/tests/runner-extras/integer-virtual-table-window/IvtwTests.Codeunit.al
@@ -1,0 +1,232 @@
+// Issues #2350 and #3376 — the runner-specific half of the Integer system virtual table
+// (2000000026).
+//
+// On the service tier the table is computed per request by IntegerDataProvider, which is a
+// RangeBasedComputedDataProvider. Decompiled from Ncl.dll, and byte-identical in 27.0 and 28.4:
+//
+//     protected override IEnumerable<ReadOnlyRecordBuffer> GetValuesWithinRangeForKeyField(...)
+//     {
+//         if (range.GetInclusiveIntegerBounds(-1000000000, 1000000000, out var low, out var high))
+//             for (int thisKey = ...; thisKey >= low && thisKey <= high; ...)
+//                 yield return CreateVirtualRecordBuffer(...);
+//     }
+//
+// So real BC is NOT unbounded either: it clamps every request to [-1e9..1e9], and an unbounded
+// filter is served as exactly that range rather than refused. CountValuesWithinRange applies the
+// same two constants. That is the behaviour codeunit 60369 pins upstream, against a service tier.
+//
+// The runner serves the table from an in-memory store, so it has to materialise rows, and 2e9+1
+// of them is not on the table. It materialises [-1000..100000] and — this is the claim below —
+// refuses by name when a request reaches past that, rather than answering with the rows it
+// happens to hold.
+//
+// What the rows themselves say — that 0 and negative Numbers are real rows, that a range yields
+// every value in ascending order, that an inverted range matches nothing — is plain BC behaviour
+// and lives upstream in the al-language corpus (codeunit 60368, "Test Integer Virtual Table").
+// None of it is repeated here.
+//
+// The damaging case without the guard: a report dataitem filtered to Number in [1..250000]
+// silently iterates 100000 times and reports success. The dataset is short by 150000 rows and
+// nothing says so.
+
+codeunit 64591 "Ivtw Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit "Ivtw Assert";
+
+    [Test]
+    procedure Integer_ClosedRangePastTheWindow_ThrowsOutOfScopeOnTheFindPath()
+    var
+        IntRec: Record Integer;
+    begin
+        // [GIVEN] a closed range whose upper bound is past the materialised window but far
+        // inside the +-1e9 range a service tier would serve, so BC itself answers this with
+        // 250000 rows and refusing is a runner limit rather than a statement about BC.
+        IntRec.SetRange(Number, 1, 250000);
+
+        // [THEN] the runner refuses by name rather than answering from the window it holds.
+        // Answering would return 100000 rows for a request BC answers with 250000 — and the
+        // caller reads the short count as the real one.
+        asserterror IntRec.FindSet();
+        Assert.ExpectedError('out-of-scope: Integer (virtual table 2000000026)');
+        Assert.ExpectedError('past the');
+    end;
+
+    [Test]
+    procedure Integer_ClosedRangePastTheWindow_ThrowsOnTheCountPathToo()
+    var
+        IntRec: Record Integer;
+    begin
+        // Count() builds a CountCacheRequest, not a FindCacheRequest, so the find guard never
+        // sees it. Without a guard on this path Count() answers 100000 — a number that looks
+        // entirely real, and is short by 150000.
+        IntRec.SetRange(Number, 1, 250000);
+
+        asserterror CountRows(IntRec);
+        Assert.ExpectedError('out-of-scope: Integer (virtual table 2000000026)');
+        Assert.ExpectedError('past the');
+    end;
+
+    [Test]
+    procedure Integer_ClosedRangePastTheWindow_ThrowsOnTheIsEmptyPathToo()
+    var
+        IntRec: Record Integer;
+    begin
+        // IsEmpty() is a third request path: RecordImplementation.IsEmptyAsync builds an
+        // ExistsCacheRequest and reaches DataAccess.ExistsAsync, never CountAsync (#3006 proved
+        // exactly this for the Date table). Without a guard here IsEmpty() answers FALSE from
+        // the rows it happens to hold — true by accident, and says nothing about the range asked
+        // for.
+        IntRec.SetRange(Number, 1, 250000);
+
+        asserterror IsEmptyRows(IntRec);
+        Assert.ExpectedError('out-of-scope: Integer (virtual table 2000000026)');
+        Assert.ExpectedError('past the');
+    end;
+
+    [Test]
+    procedure Integer_KeyedGetPastTheWindow_ThrowsOutOfScope()
+    var
+        IntRec: Record Integer;
+    begin
+        // A full-primary-key Get never reaches the find path: DataAccess has its own
+        // primary-key route straight to the provider (#2504 for Aggregate Permission Set, #2648
+        // for Date). Without a guard there, Get(250000) answers FALSE — which reads as "no such
+        // row", when on a service tier row 250000 plainly exists.
+        asserterror GetRow(IntRec, 250000);
+        Assert.ExpectedError('out-of-scope: Integer (virtual table 2000000026)');
+        Assert.ExpectedError('past the');
+    end;
+
+    [Test]
+    procedure Integer_ClosedRangeBelowTheWindow_ThrowsOutOfScope()
+    var
+        IntRec: Record Integer;
+    begin
+        // The window has a LOWER edge too, at -1000, and it is the one nothing else in this
+        // suite touches. A guard that only compared against IntegerWindowMax would pass every
+        // other test here and still answer this one short: BC serves [-5000..-4000] with 1001
+        // rows, the runner holds none of them and would report 0.
+        IntRec.SetRange(Number, -5000, -4000);
+
+        asserterror CountRows(IntRec);
+        Assert.ExpectedError('out-of-scope: Integer (virtual table 2000000026)');
+        Assert.ExpectedError('past the');
+    end;
+
+    [Test]
+    procedure Integer_RangeInsideTheWindow_StillAnswersNormally()
+    var
+        IntRec: Record Integer;
+        Seen: Integer;
+    begin
+        // The control, and the reason this suite cannot pass with a guard that simply throws on
+        // every Integer read. A range wholly inside the window is answered, not refused, and the
+        // rows are the real ones in the real order.
+        IntRec.SetRange(Number, 10, 14);
+
+        Assert.AreEqual(5, IntRec.Count(), 'Expected 5 rows for Number in [10..14].');
+        Assert.IsFalse(IntRec.IsEmpty(), 'Number in [10..14] is not empty.');
+        Assert.IsTrue(IntRec.FindSet(), 'Record Integer found no row for Number in [10..14].');
+        Assert.AreEqual(10, IntRec.Number, 'Expected the range to start at 10.');
+
+        repeat
+            Seen += 1;
+        until IntRec.Next() = 0;
+        Assert.AreEqual(5, Seen, 'Expected to iterate exactly 5 rows.');
+    end;
+
+    [Test]
+    procedure Integer_KeyedGetAtTheWindowEdges_StillAnswers()
+    var
+        IntRec: Record Integer;
+    begin
+        // The boundary control for the keyed-Get guard. Both edges of the window are INCLUSIVE,
+        // so a guard written with > instead of >= (or < instead of <=) refuses a row it holds
+        // and fails here while passing every other test in this suite.
+        Assert.IsTrue(IntRec.Get(100000), 'Number 100000 is the window''s upper edge and must be readable.');
+        Assert.AreEqual(100000, IntRec.Number, 'Get(100000) returned a different row.');
+
+        Assert.IsTrue(IntRec.Get(-1000), 'Number -1000 is the window''s lower edge and must be readable.');
+        Assert.AreEqual(-1000, IntRec.Number, 'Get(-1000) returned a different row.');
+    end;
+
+    [Test]
+    procedure Integer_UnboundedFilter_IsServedFromTheWindowRatherThanRefused()
+    var
+        IntRec: Record Integer;
+        Seen: Integer;
+    begin
+        // Issue #3376 asked for the opposite of this test, and the decompile is why it does not
+        // get it. #3376 reads the unbounded case as "you asked for all of them and we invented a
+        // bound", and proposes refusing it. But BC invents a bound too — GetInclusiveIntegerBounds
+        // substitutes -1e9 for an open low and +1e9 for an open high — so refusing would diverge
+        // from a service tier on a shape BaseApp uses constantly. 18 of BaseApp's 658 reports
+        // declare MaxIteration over an unbounded `dataitem(x; Integer)`, and #3374's fix makes
+        // exactly those loops stop after one row; refusing here would turn every one of them
+        // from a working report into a hard failure.
+        //
+        // So the unbounded case is served, and this test pins that it is served rather than
+        // refused. The runner's remaining divergence from BC — 101,001 rows where BC yields
+        // 2,000,000,001 — is real, and is recorded in docs/limitations.md rather than papered
+        // over here.
+        IntRec.SetFilter(Number, '>=1');
+
+        Assert.IsTrue(IntRec.FindFirst(), 'An unbounded Integer filter must be served, not refused.');
+        Assert.AreEqual(1, IntRec.Number, 'Expected the unbounded range to start at 1.');
+
+        // Not merely "it did not throw": the window's own upper edge is reachable through it.
+        IntRec.SetFilter(Number, '>=99998');
+        Assert.IsTrue(IntRec.FindSet(), 'Expected rows at the top of the window.');
+        repeat
+            Seen += 1;
+        until IntRec.Next() = 0;
+        Assert.AreEqual(3, Seen, 'Expected 99998, 99999 and 100000 — the window''s last three rows.');
+    end;
+
+    [Test]
+    procedure Integer_WindowRefusal_TearsThroughATryFunction_InsteadOfReadingAsFalse()
+    var
+        IntRec: Record Integer;
+        Reached: Boolean;
+    begin
+        // Issue #2965's rule, applied to this table. ApplicationObjectBasePatches.
+        // IsPermanentOutOfScope reads the reason's FIRST token:
+        //
+        //     return oos != null && !oos.Reason.StartsWith("not-yet-implemented", ...);
+        //
+        // so a refusal anchored anywhere else is trapped by an AL [TryFunction] into `false` —
+        // the silent default loud-failures.md exists to prevent. AL would carry on having quietly
+        // done without the table and the test would go green. The Integer window is a runner
+        // limit, not a permanent scope boundary: a service tier answers this read.
+        IntRec.SetRange(Number, 1, 250000);
+
+        asserterror Reached := TryFindSet(IntRec);
+        Assert.ExpectedError('out-of-scope: Integer (virtual table 2000000026)');
+        Assert.IsFalse(Reached, 'TryFindSet must not have completed.');
+    end;
+
+    local procedure CountRows(var IntRec: Record Integer): Integer
+    begin
+        exit(IntRec.Count());
+    end;
+
+    local procedure IsEmptyRows(var IntRec: Record Integer): Boolean
+    begin
+        exit(IntRec.IsEmpty());
+    end;
+
+    local procedure GetRow(var IntRec: Record Integer; Number: Integer): Boolean
+    begin
+        exit(IntRec.Get(Number));
+    end;
+
+    [TryFunction]
+    local procedure TryFindSet(var IntRec: Record Integer)
+    begin
+        IntRec.FindSet();
+    end;
+}

--- a/tests/runner-extras/integer-virtual-table-window/app.json
+++ b/tests/runner-extras/integer-virtual-table-window/app.json
@@ -1,0 +1,19 @@
+{
+  "id": "3d7c9e25-4b18-4f6a-9c13-2e5b8a0f7d41",
+  "name": "Runner Extras - Integer Virtual Table Window",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Issues #2350 and #3376: the Integer system virtual table (2000000026) is computed on demand on the service tier, where IntegerDataProvider clamps every request to [-1000000000..1000000000]. The runner materialises a far smaller window and, until now, answered a request reaching past it with however many rows it happened to hold. This suite pins the runner-specific half: a request past the window throws RunnerOutOfScopeException naming the bound and the window, on every request path, instead of returning a short answer.",
+  "description": "What the Integer table itself answers - that Number 0 and negatives are real rows, that a range filter yields every value in order, that an inverted range matches nothing - is plain BC behaviour and is covered upstream in the al-language corpus (Test Integer Virtual Table, codeunit 60368). This suite deliberately asserts none of that. It asserts only what exists because this is the runner: that the materialised window is not a silent truncation. The default window is -1000..100000 (AL_RUNNER_INTEGER_WINDOW_MAX raises the upper edge), so a filter naming 250000 is past it while staying far inside the +-1e9 bound a service tier would apply.",
+  "dependencies": [],
+  "idRanges": [
+    {
+      "from": 64590,
+      "to": 64599
+    }
+  ],
+  "platform": "27.0.0.0",
+  "application": "27.0.0.0",
+  "runtime": "15.0",
+  "target": "Cloud"
+}


### PR DESCRIPTION
Closes #2350

`RecordPatches.IntegerVirtualTable.cs` named a guard as the load-bearing justification for its bounded window — "a request that reaches past the window THROWS RunnerOutOfScopeException naming the requested bound and the window (see IntegerWindowGuard below)". No such guard existed. The identifier appeared exactly once in the repository: in the comment forward-referencing it. A filter past the window was answered with however many rows the window held.

## RED → GREEN

New AL suite `tests/runner-extras/integer-virtual-table-window` (codeunit 64591), same runner build both times:

| | pass | fail |
|---|---|---|
| **RED** (guard absent) | 3 | **6** |
| **GREEN** (guard present) | **9** | 0 |

The six that moved are the refusals. The three that passed in both arms are the controls, and they are the reason the suite cannot be satisfied by a guard that simply throws on every Integer read: a range inside the window still answers with the right rows in the right order, a keyed `Get` at each window edge still works (both edges are inclusive, so a `>` written for a `>=` fails here and nowhere else), and an unbounded filter is still served.

## What BC actually does — this changed the fix

`IntegerDataProvider` is a `RangeBasedComputedDataProvider`, and both of its entry points open the same way:

```csharp
// GetValuesWithinRangeForKeyField, and CountValuesWithinRange
if (range.GetInclusiveIntegerBounds(-1000000000, 1000000000, out var low, out var high))
```

Decompiled from `Microsoft.Dynamics.Nav.Ncl`; `compare_symbols` reports `bodyChanged: false` for both methods between 27.0 and 28.4.

So **real BC is bounded too** — it clamps to ±1e9 — and `Range.GetInclusiveIntegerBounds` substitutes those bounds for an *open* one rather than refusing it. The issue body's premise that "the real table is unbounded" is corrected in the file header rather than left in place.

## The guard

Refuses only a **closed** bound outside `[IntegerWindowMin .. IntegerWindowMax]`, on all four `DataAccess` paths — the set established for `Date` over #2648 / #3006 / #2504, because each carries a different request type and no single guard sees them all:

| AL | method | request type |
|---|---|---|
| `FindSet` etc. | `InnerFindAsync` | `FindCacheRequest` |
| `Count` | `CountAsync` | `CountCacheRequest` |
| `IsEmpty` | `ExistsAsync` | `ExistsCacheRequest` |
| `Get(Number)` | `InternalTryGetByPrimaryKeyAsync` | `PrimaryKeyCacheRequest` |

A filter the runner cannot parse falls through to being served, unchanged from before — a refusal that cannot name the bound it read would be worse than the defect it replaces. `Record Integer temporary` is carved out, as for `Date` (#2524).

## #3376 is answered here, and the answer is "no"

#3376 asks for the **unbounded** case to be refused too. The decompile decides against it: BC invents a bound for that shape rather than refusing, and BaseApp leans on it — 18 of its 658 reports drive an unbounded `dataitem(x; Integer)` bounded by `MaxIteration`, which is #3374 / PR #3383. Refusing would turn every one of those from a working report into a hard failure *and* diverge from the service tier.

So the unbounded case is served, one test pins that it is served, and the residual divergence — 101,001 rows against BC's 2,000,000,001 — is written into `docs/limitations.md` as a row count rather than papered over. I have left #3376 open with a comment rather than closing it via this PR, since it asks for a behaviour I am deliberately not implementing and that call deserves to be visible.

## The shape, not just the reported line

Three questions, answered:

1. **Same wrong pattern at another call site?** The window has a **lower** edge nobody had tested. A guard written only against `IntegerWindowMax` passes every other test in the suite and still answers `[-5000..-4000]` with zero rows. `Integer_ClosedRangeBelowTheWindow_ThrowsOutOfScope` covers it.
2. **Sibling making the same assumption?** Yes, and it is the find-time hook: `DataAccess_IsManagedFindRequest` already carried `Date` and Aggregate Permission Set side effects, and its docstring named only `Date`. Integer joins it there rather than adding a fourth prepend to one method.
3. **Two paths writing the same state with different invariants?** Yes — **found by the corpus tests, not predicted**. `IntegerWindowMin` was a hard `const` while `IntegerWindowMax` read an environment variable. Invisible while nothing compared a request against either edge; a dead end the moment the guard began refusing, because the refusal advised raising `AL_RUNNER_INTEGER_WINDOW_MAX` for a bound the *min* edge had rejected. Measured against the corpus branch:

   | | result |
   |---|---|
   | no overrides | 5 passed, 2 failed |
   | `MAX=300000` | 6 passed, 1 failed — far-below still refused |
   | `MAX=300000 MIN=-300000` | **7 passed, 0 failed** |

   Both variables now only ever *widen*; the refusal names whichever edge actually refused.

## Where the proving tests live

**Split, deliberately.**

- **Runner-specific → `tests/runner-extras/`.** That the refusal happens, with a named reason, on each of the four paths, and that it survives a `[TryFunction]` rather than being trapped into `false` (#2965's rule — the anchor is `not-yet-implemented`). None of this is a statement about BC.
- **BC behaviour → upstream.** How far the table reaches and that an open filter is answered are claims about BC, so they go to a service tier: **StefanMaron/BusinessCentral.AL.Language.Tests#265**, three tests added to the existing codeunit 60368. That PR is open; I have not waited for its legs, and **this PR does not bump the submodule pin** — the new corpus tests are refused by design on the default window, so the pin bump belongs with whatever widens it, not here.
- **C# mechanism test** for the thing neither can see: three of the four hooks are installed **by name** from Cecil prepends, so a deleted or renamed registration is not a compile error anywhere — precisely how #2350 arose. `IntegerVirtualTableWindowGuardTests` asserts each helper's signature, that each is registered against its own entry point *and request type*, that the find path still calls the guard, and that the anchor holds.

  Verified it detects removal rather than merely passing: reverting the exists registration to the Field guard and deleting the find-path call turned exactly those two tests red (7 passed, 2 failed); restoring gave 10/10.

## What was run

| | result |
|---|---|
| `tests/runner-extras/integer-virtual-table-window` | **9/9** |
| `AlRunner.Tests --filter ~IntegerVirtualTableWindowGuardTests` | **10/10** |
| full corpus, `--strict --count-baseline` | **2977/2977**, 0 fail |
| `tests/runner-extras/date-virtual-table-window` | **9/9** |
| `tests/runner-extras/temporary-virtual-table-isolation` | **6/6** |

The last three are the blast-radius checks: this touches the shared find predicate and adds three prepends to methods every table passes through. Corpus codeunit 60368 was confirmed to have actually executed (4 PASS lines), not merely to have been counted in a green total.

The full `AlRunner.Tests` suite was **not** run locally — per `.claude/rules/local-test-scope.md`, the unit legs run it in CI.

## Docs

`docs/limitations.md` gains a `Record Integer` section beside the existing `Record Date` one, plus a cross-reference from the shape-gaps list. No flag changed, so `README.md` and `PrintGuide()` are untouched. `CHANGELOG.md` untouched.

## Not folded in

- **#3374 / #3370** (`MaxIteration` dropped) — same *table*, different files (`BcAppSymbolCache.cs`, `DependencyReportMetadata.cs`), and already in flight as PR #3383. Related only in that it is why unbounded Integer loops matter, which is what decided #3376 above.
- **#3376** — same file, and answered by this PR's reasoning, but the answer is "do not implement what it asks for", so it stays open for a human to close.

---

Written by agent `stma-auto-3`, an automated implementation agent acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9pEPoD8e4wmVyuTrxyuh


Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/265
