### PR TITLE
fix(rad): stop the incremental fast path shipping a caller bound to a moved object id

### DIFF
--- a/AlRunner.Tests/BcCompilerIncrementalObjectIdRebindTests.cs
+++ b/AlRunner.Tests/BcCompilerIncrementalObjectIdRebindTests.cs
@@ -1,0 +1,414 @@
+// BcCompilerIncrementalObjectIdRebindTests — issue #2929.
+//
+// The FOURTH folding an unmodified caller performs, and the one #2928's FoldedOrdinalMoved
+// cannot see: the callee's own OBJECT ID.
+//
+// #2548 found the first hole in BcCompiler.Incremental.cs's "an unmodified caller never needs
+// re-emitting" argument (an added overload); #2571/#2928 found the second family — a caller
+// folds an enum value's ordinal, an Option member's position and a field's id into its OWN
+// generated C# as literals. This file pins the object id, which is folded the same way and by
+// the same callers, and which FoldedOrdinalMoved declines to answer for by construction:
+// changing an object's id makes it VACATE one (Kind, Id) identity and APPEAR under another, so
+// the old identity is absent from the after-surface, RadFoldedOrdinals has no entry for it, and
+// the guard returns "cannot answer" rather than "moved".
+//
+// Measured with --dump-csharp, BC 28.1, a bundle of two codeunits (90310/90311), two enums
+// (90320/90321) and one caller that references all four. Swapping each PAIR's ids, leaving every
+// name and every body byte-for-byte identical, changes the CALLER's generated C# in four places
+// while only the CALLEES' files were edited:
+//
+//     -   this.a = new NavCodeunitHandle(this, 90310);
+//     +   this.a = new NavCodeunitHandle(this, 90311);
+//     -   this.b = new NavCodeunitHandle(this, 90311);
+//     +   this.b = new NavCodeunitHandle(this, 90310);
+//     -   public NavOption e = NavOption.Create(NCLEnumMetadata.Create(90320), 0);
+//     +   public NavOption e = NavOption.Create(NCLEnumMetadata.Create(90321), 0);
+//     -   this.e = NavOption.Create(NCLEnumMetadata.Create(90320), 1);
+//     +   this.e = NavOption.Create(NCLEnumMetadata.Create(90321), 1);
+//
+// The swap is the silent sub-case the issue singles out, and the measurement above is what
+// makes it silent rather than merely suspected: after the swap every folded id STILL RESOLVES —
+// to the other object. `A.Who()` dispatches member id -636290258 on a handle to 90311, and both
+// codeunits declare `Who`, so the member id matches too. No exception, no diagnostic, no log
+// line; the caller simply calls the wrong codeunit and reads the wrong enum's metadata.
+//
+// A plain RENUMBER (one object moves to an id nothing occupies) is the other sub-case. It is
+// expected to be louder at runtime — the handle names an object that no longer exists — but the
+// invariant the fast path has to hold is the same one the #2571 tests assert and does not depend
+// on how loud the symptom is: what the fast path ships must equal what a cold build produces.
+//
+// Each RED test has a control that would be broken by "just always fall back", which would
+// delete the fast path this file exists to protect.
+using Xunit;
+using AlRunner;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class BcCompilerIncrementalObjectIdRebindTests : IDisposable
+{
+    private readonly string _root;
+    private readonly BcEngineFixture _engine;
+
+    public BcCompilerIncrementalObjectIdRebindTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = TestScratch.Dir("al-runner-incremental-objid-tests");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private void WriteAl(string fileName, string content) => File.WriteAllText(Path.Combine(_root, fileName), content);
+
+    private static Dictionary<string, string> ByName(BcEmitOutput output)
+        => output.Sources.ToDictionary(s => s.Name, s => s.Code);
+
+    // ---------------------------------------------------------------------------------------
+    // Sub-case 2 from the issue: a SWAP of two same-kind object ids. Every folded id still
+    // resolves, to the other object, so nothing can throw.
+    // ---------------------------------------------------------------------------------------
+
+    private const string CodeunitABefore = """
+        codeunit 90310 "Incr ObjId A"
+        {
+            procedure Who(): Integer
+            begin
+                exit(1);
+            end;
+        }
+        """;
+
+    private const string CodeunitBBefore = """
+        codeunit 90311 "Incr ObjId B"
+        {
+            procedure Who(): Integer
+            begin
+                exit(2);
+            end;
+        }
+        """;
+
+    /// <summary>The hazardous edit, half one: `Incr ObjId A` takes the id `Incr ObjId B` had.
+    /// Its name, its members and its body are untouched.</summary>
+    private const string CodeunitASwapped = """
+        codeunit 90311 "Incr ObjId A"
+        {
+            procedure Who(): Integer
+            begin
+                exit(1);
+            end;
+        }
+        """;
+
+    /// <summary>The hazardous edit, half two: the mirror. Applied in the SAME cycle, so neither
+    /// id is ever free and the pair swaps atomically.</summary>
+    private const string CodeunitBSwapped = """
+        codeunit 90310 "Incr ObjId B"
+        {
+            procedure Who(): Integer
+            begin
+                exit(2);
+            end;
+        }
+        """;
+
+    /// <summary>The caller, byte-for-byte identical across every edit. It folds BOTH callees'
+    /// object ids into its own generated C# as `new NavCodeunitHandle(this, &lt;id&gt;)`.</summary>
+    private const string ObjIdCallerSrc = """
+        codeunit 90312 "Incr ObjId Caller"
+        {
+            procedure CallA(): Integer
+            var
+                A: Codeunit "Incr ObjId A";
+            begin
+                exit(A.Who());
+            end;
+
+            procedure CallB(): Integer
+            var
+                B: Codeunit "Incr ObjId B";
+            begin
+                exit(B.Who());
+            end;
+        }
+        """;
+
+    /// <summary>Compiles the fixture, records an incremental baseline, then applies the given
+    /// callee edits and returns both the incremental attempt and an independent cold build of the
+    /// same post-edit tree. The CALLER's file is never rewritten.</summary>
+    private (BcEmitOutput? Incremental, string FallbackReason, Dictionary<string, string> Baseline, Dictionary<string, string> Fresh)
+        RunCodeunitEdit(string editedA, string editedB)
+    {
+        WriteAl("ObjIdA.al", CodeunitABefore);
+        WriteAl("ObjIdB.al", CodeunitBBefore);
+        WriteAl("ObjIdCaller.al", ObjIdCallerSrc);
+
+        var compiler = new BcCompiler();
+        var baselineOut = compiler.Emit(new[] { _root }, "ObjIdModule", trackIncrementalBaseline: true);
+        Assert.Empty(baselineOut.Diagnostics);
+        var baselineByName = ByName(baselineOut);
+
+        // Edit ONLY the callees.
+        WriteAl("ObjIdA.al", editedA);
+        WriteAl("ObjIdB.al", editedB);
+
+        var incrOut = compiler.TryEmitIncremental(
+            new[] { _root }, "ObjIdModule", appRootDir: null, out var fallbackReason);
+
+        var freshOut = new BcCompiler().Emit(new[] { _root }, "ObjIdModuleFresh");
+        Assert.Empty(freshOut.Diagnostics);
+        return (incrOut, fallbackReason, baselineByName, ByName(freshOut));
+    }
+
+    /// <summary>
+    /// The hazard, and the silent sub-case. Swapping two codeunits' object ids must not leave the
+    /// fast path shipping a caller that still folds each callee's PREVIOUS id.
+    /// </summary>
+    [SkippableFact]
+    public void TryEmitIncremental_SwappingTwoCodeunitObjectIds_FallsBackInsteadOfShippingAStaleCaller()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var (incremental, fallbackReason, baseline, fresh) = RunCodeunitEdit(CodeunitASwapped, CodeunitBSwapped);
+
+        // Fixture guard: the edit really did move what the caller folded. Without this the whole
+        // test could pass against an edit that changed nothing.
+        Assert.NotEqual(baseline["Incr ObjId Caller"], fresh["Incr ObjId Caller"]);
+
+        // ...and it moved exactly the thing this test is about: the folded object id literal.
+        Assert.Contains("new NavCodeunitHandle(this, 90310)", baseline["Incr ObjId Caller"], StringComparison.Ordinal);
+        Assert.Contains("new NavCodeunitHandle(this, 90311)", baseline["Incr ObjId Caller"], StringComparison.Ordinal);
+
+        Assert.True(incremental == null,
+            "the incremental path took the fast path after two codeunits swapped object ids. The "
+            + "caller was not re-emitted, so `CallA` still holds a NavCodeunitHandle to 90310 — "
+            + "which is now `Incr ObjId B`. Every folded id still RESOLVES, to the other object, "
+            + "and both codeunits declare `Who`, so the member id matches too: nothing throws and "
+            + "the run goes green calling the wrong codeunit. Shipped caller C# "
+            + (incremental != null && ByName(incremental)["Incr ObjId Caller"] == fresh["Incr ObjId Caller"]
+                ? "matched a cold build, so something else changed — re-derive this test."
+                : "did NOT match a cold build.")
+            + $" fallbackReason: '{fallbackReason}'");
+
+        // A fallback nobody can read is the silent default loud-failures.md forbids: the reason
+        // must name the object and the shape.
+        Assert.Contains("Incr ObjId", fallbackReason, StringComparison.Ordinal);
+        Assert.Contains("object id", fallbackReason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Sub-case 1 from the issue: a plain RENUMBER, where the vacated id is left free. Expected to
+    /// be louder at runtime than the swap, but the invariant is the same — the fast path must not
+    /// ship a caller whose folded id disagrees with a cold build.
+    /// </summary>
+    [SkippableFact]
+    public void TryEmitIncremental_RenumberingACodeunitObjectId_FallsBackInsteadOfShippingAStaleCaller()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        // Only A moves, to an id nothing occupies. B is untouched.
+        const string aRenumbered = """
+            codeunit 90319 "Incr ObjId A"
+            {
+                procedure Who(): Integer
+                begin
+                    exit(1);
+                end;
+            }
+            """;
+
+        var (incremental, fallbackReason, baseline, fresh) = RunCodeunitEdit(aRenumbered, CodeunitBBefore);
+
+        Assert.NotEqual(baseline["Incr ObjId Caller"], fresh["Incr ObjId Caller"]);
+        Assert.Contains("new NavCodeunitHandle(this, 90310)", baseline["Incr ObjId Caller"], StringComparison.Ordinal);
+        Assert.Contains("new NavCodeunitHandle(this, 90319)", fresh["Incr ObjId Caller"], StringComparison.Ordinal);
+
+        Assert.True(incremental == null,
+            "the incremental path took the fast path after a codeunit was renumbered. The caller "
+            + "was not re-emitted, so `CallA` still holds a NavCodeunitHandle to 90310 even though "
+            + "`Incr ObjId A` is now 90319 and nothing declares 90310 at all. Shipped caller C# "
+            + (incremental != null && ByName(incremental)["Incr ObjId Caller"] == fresh["Incr ObjId Caller"]
+                ? "matched a cold build, so something else changed — re-derive this test."
+                : "did NOT match a cold build.")
+            + $" fallbackReason: '{fallbackReason}'");
+
+        Assert.Contains("Incr ObjId A", fallbackReason, StringComparison.Ordinal);
+        Assert.Contains("object id", fallbackReason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The control, and the reason the fallback above is not simply "give up whenever a callee's
+    /// file changed": editing a callee's BODY moves no object id, so every folded literal already
+    /// in cached C# stays correct and the fast path must still apply — and what it ships must
+    /// equal a cold build.
+    /// </summary>
+    [SkippableFact]
+    public void TryEmitIncremental_EditingOnlyACodeunitBody_StaysOnTheFastPathAndMatchesAColdBuild()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        const string aBodyEdited = """
+            codeunit 90310 "Incr ObjId A"
+            {
+                procedure Who(): Integer
+                begin
+                    exit(41 + 1);
+                end;
+            }
+            """;
+
+        var (incremental, fallbackReason, _, fresh) = RunCodeunitEdit(aBodyEdited, CodeunitBBefore);
+
+        Assert.True(incremental != null,
+            "editing only a codeunit's method BODY fell back to a full compile. No object id moved, "
+            + "so no caller's folded handle can be stale — the guard is keyed on 'a callee's file "
+            + $"changed' rather than on 'an object id moved'. fallbackReason: {fallbackReason}");
+
+        var incrementalByName = ByName(incremental!);
+        Assert.Equal(fresh["Incr ObjId Caller"], incrementalByName["Incr ObjId Caller"]);
+    }
+
+    /// <summary>
+    /// The second control: ADDING a codeunit under a new name and an unused id. No existing
+    /// object's id moves and no existing caller can reference the new one, so the fast path must
+    /// still apply. This is the control that stops the guard degenerating into "any appeared or
+    /// vacated identity falls back", which would be most of the fast path.
+    /// </summary>
+    [SkippableFact]
+    public void TryEmitIncremental_AddingACodeunitUnderANewIdAndName_StaysOnTheFastPathAndMatchesAColdBuild()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        WriteAl("ObjIdA.al", CodeunitABefore);
+        WriteAl("ObjIdB.al", CodeunitBBefore);
+        WriteAl("ObjIdCaller.al", ObjIdCallerSrc);
+
+        var compiler = new BcCompiler();
+        var baselineOut = compiler.Emit(new[] { _root }, "ObjIdAddModule", trackIncrementalBaseline: true);
+        Assert.Empty(baselineOut.Diagnostics);
+
+        // A brand-new object, at an id and a name the baseline never saw.
+        WriteAl("ObjIdC.al", """
+            codeunit 90318 "Incr ObjId C"
+            {
+                procedure Who(): Integer
+                begin
+                    exit(3);
+                end;
+            }
+            """);
+
+        var incremental = compiler.TryEmitIncremental(
+            new[] { _root }, "ObjIdAddModule", appRootDir: null, out var fallbackReason);
+
+        var freshOut = new BcCompiler().Emit(new[] { _root }, "ObjIdAddModuleFresh");
+        Assert.Empty(freshOut.Diagnostics);
+        var fresh = ByName(freshOut);
+
+        Assert.True(incremental != null,
+            "adding a codeunit under an id and a name the baseline never saw fell back to a full "
+            + "compile. Nothing an existing caller folded moved — the guard is over-triggering on "
+            + $"an APPEARED identity that vacated nothing. fallbackReason: {fallbackReason}");
+
+        var incrementalByName = ByName(incremental!);
+        Assert.Equal(fresh["Incr ObjId Caller"], incrementalByName["Incr ObjId Caller"]);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The same folding through an ENUM's object id. --dump-csharp shows the caller writing
+    // `NavOption.Create(NCLEnumMetadata.Create(90320), 1)` — so it folds the enum's OBJECT id
+    // alongside the value ordinal #2928 already guards. An enum emits a ZERO-BYTE C# file, so
+    // there is no dispatch surface here at all and nothing can be loud.
+    // ---------------------------------------------------------------------------------------
+
+    private const string EnumOneBefore = """
+        enum 90320 "Incr ObjId Enum One"
+        {
+            Extensible = false;
+            value(0; Alpha) { }
+            value(1; Beta) { }
+        }
+        """;
+
+    private const string EnumTwoBefore = """
+        enum 90321 "Incr ObjId Enum Two"
+        {
+            Extensible = false;
+            value(0; Alpha) { }
+            value(1; Beta) { }
+        }
+        """;
+
+    private const string EnumCallerSrc = """
+        codeunit 90322 "Incr ObjId Enum Caller"
+        {
+            procedure UseOne(): Integer
+            var
+                E: Enum "Incr ObjId Enum One";
+            begin
+                E := Enum::"Incr ObjId Enum One"::Beta;
+                exit(E.AsInteger());
+            end;
+
+            procedure UseTwo(): Integer
+            var
+                E: Enum "Incr ObjId Enum Two";
+            begin
+                E := Enum::"Incr ObjId Enum Two"::Beta;
+                exit(E.AsInteger());
+            end;
+        }
+        """;
+
+    /// <summary>
+    /// The hazard through an enum's object id, and the most invisible shape of all: the two enums
+    /// swap ids while every VALUE keeps its ordinal, so FoldedOrdinalMoved has nothing to report
+    /// even where it can see an object at all, and the enums' own emitted C# is zero bytes.
+    /// </summary>
+    [SkippableFact]
+    public void TryEmitIncremental_SwappingTwoEnumObjectIds_FallsBackInsteadOfShippingAStaleCaller()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        WriteAl("ObjIdEnumOne.al", EnumOneBefore);
+        WriteAl("ObjIdEnumTwo.al", EnumTwoBefore);
+        WriteAl("ObjIdEnumCaller.al", EnumCallerSrc);
+
+        var compiler = new BcCompiler();
+        var baselineOut = compiler.Emit(new[] { _root }, "ObjIdEnumModule", trackIncrementalBaseline: true);
+        Assert.Empty(baselineOut.Diagnostics);
+        var baseline = ByName(baselineOut);
+
+        // Swap the two enums' object ids in one cycle. Names, values and ordinals untouched.
+        WriteAl("ObjIdEnumOne.al", EnumOneBefore.Replace("enum 90320", "enum 90321", StringComparison.Ordinal));
+        WriteAl("ObjIdEnumTwo.al", EnumTwoBefore.Replace("enum 90321", "enum 90320", StringComparison.Ordinal));
+
+        var incremental = compiler.TryEmitIncremental(
+            new[] { _root }, "ObjIdEnumModule", appRootDir: null, out var fallbackReason);
+
+        var freshOut = new BcCompiler().Emit(new[] { _root }, "ObjIdEnumModuleFresh");
+        Assert.Empty(freshOut.Diagnostics);
+        var fresh = ByName(freshOut);
+
+        Assert.NotEqual(baseline["Incr ObjId Enum Caller"], fresh["Incr ObjId Enum Caller"]);
+        Assert.Contains("NCLEnumMetadata.Create(90320)", baseline["Incr ObjId Enum Caller"], StringComparison.Ordinal);
+
+        Assert.True(incremental == null,
+            "the incremental path took the fast path after two enums swapped object ids. The caller "
+            + "was not re-emitted, so `UseOne` still writes NCLEnumMetadata.Create(90320) — which is "
+            + "now `Incr ObjId Enum Two`. Every value kept its ordinal, so FoldedOrdinalMoved has "
+            + "nothing to report, and an enum emits a zero-byte C# file, so there is no dispatch "
+            + "surface to be loud on. Shipped caller C# "
+            + (incremental != null && ByName(incremental)["Incr ObjId Enum Caller"] == fresh["Incr ObjId Enum Caller"]
+                ? "matched a cold build, so something else changed — re-derive this test."
+                : "did NOT match a cold build.")
+            + $" fallbackReason: '{fallbackReason}'");
+
+        Assert.Contains("Incr ObjId Enum", fallbackReason, StringComparison.Ordinal);
+        Assert.Contains("object id", fallbackReason, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/AlRunner/BcCompiler.Incremental.cs
+++ b/AlRunner/BcCompiler.Incremental.cs
@@ -657,6 +657,16 @@ public sealed partial class BcCompiler
             }
         }
 
+        // #2929: snapshot both sets BEFORE the pairing loop below consumes them. A SWAP of two
+        // same-kind object ids presents as two vacated and two appeared identities whose
+        // IdentityKeys cross over — A vacates `Codeunit|id:90310` and B appears at
+        // `Codeunit|id:90310` — so the loop pairs each vacated id with the OTHER object and
+        // empties both dictionaries. Reading them afterwards therefore sees nothing at all, which
+        // is precisely the silent case: measured, that pairing is what let a swap through with an
+        // EMPTY fallbackReason. See ObjectIdMoved.
+        var vacatedBeforePairing = vacated.Values.Select(v => v.Identity).ToList();
+        var appearedBeforePairing = appeared.Values.Select(a => a.Identity).ToList();
+
         // Pair vacated <-> appeared identities (renames/moves): from BC's point of view these
         // are Modified, not Removed+Added — see this file's header comment.
         var renamePairs = new List<(RadObjectIdentity Identity, string OldPath, string NewPath, NavSyntax.SyntaxTree Tree)>();
@@ -680,6 +690,25 @@ public sealed partial class BcCompiler
                     "duplicate declaration, only the compiler can adjudicate that";
                 return null;
             }
+        }
+
+        // #2929: the THIRD hole in this file's "an unmodified caller is always safe" argument.
+        // A caller folds the CALLEE'S OWN OBJECT ID into its generated C#, exactly as it folds
+        // the ordinals #2571's guard covers — see ObjectIdMoved for the measurement and for why
+        // FoldedOrdinalMoved structurally cannot see this one. Checked HERE rather than beside
+        // the other two guards below because the evidence is `vacated`/`appeared`, which exist
+        // by this point and are gone by the time the module definitions are built.
+        if (ObjectIdMoved(vacatedBeforePairing, appearedBeforePairing, baseline.ObjectByPath.Values) is { } idMoved)
+        {
+            fallbackReason =
+                $"{idMoved} no longer has the object id it had last cycle. A caller folds a callee's "
+                + "OBJECT ID into its OWN generated C# as a literal — `new NavCodeunitHandle(this, "
+                + "90310)` for a cross-object call, `NCLEnumMetadata.Create(90320)` for an "
+                + "enum-typed variable — so reusing an UNMODIFIED caller's cached C# would leave it "
+                + "naming the PREVIOUS id. That is not reliably loud: when two objects of the same "
+                + "kind SWAP ids every folded id still resolves, to the other object, and an enum "
+                + "emits no dispatch surface at all. Falling back to a full compile for this cycle";
+            return null;
         }
 
         // Entitlement: no ModuleDefinition representation at all, so every TRACKED entitlement
@@ -1685,6 +1714,101 @@ public sealed partial class BcCompiler
             foreach (var (name, ordinal) in previous)
                 if (!current.TryGetValue(name, out var now) || now != ordinal)
                     return $"{id.Kind} '{id.Name}' ({name})";
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Names the first object whose OWN OBJECT ID moved this cycle — it vacated one
+    /// <c>(Kind, Id)</c> identity and reappeared under the same kind and name at a different id —
+    /// or null when none did. Issue #2929: the third hole in this file's header argument, and
+    /// like #2548's and #2571's it can be silent.
+    ///
+    /// <para><b>Why FoldedOrdinalMoved cannot see this.</b> That guard reduces each CHANGED
+    /// identity to a name-to-ordinal map on both sides and reports a name whose value moved. An
+    /// object id change is not a value moving WITHIN an identity — it moves the identity itself,
+    /// so the old <c>(Kind, Id)</c> is absent from the after-surface and the new one is absent
+    /// from the before-surface. <c>RadFoldedOrdinals</c> then has no entry to compare and returns
+    /// the same "cannot answer" non-answer #2548's guard uses for an ambiguous object. Consistent,
+    /// and not sufficient. This is why the check is a companion rather than an edit to it.</para>
+    ///
+    /// <para><b>What is folded, measured with <c>--dump-csharp</c> on BC 28.1.</b> A bundle of two
+    /// codeunits, two enums and one caller referencing all four. Swapping each pair's ids, with
+    /// every name and body byte-for-byte unchanged, moved four literals in the CALLER's generated
+    /// C# while only the CALLEES' files were edited: <c>new NavCodeunitHandle(this, 90310)</c> and
+    /// its mirror, and <c>NavOption.Create(NCLEnumMetadata.Create(90320), …)</c> twice.</para>
+    ///
+    /// <para><b>Why a swap is silent.</b> After it, every folded id still RESOLVES — to the other
+    /// object. The dispatch that follows is <c>Invoke(memberId, …)</c>, and two codeunits
+    /// declaring the same procedure name hash to the same member id, so even that matches: the
+    /// caller runs the wrong codeunit's body with no exception and no diagnostic. An enum is worse
+    /// still, emitting a zero-byte C# file, so there is no dispatch surface to be loud on at all.
+    /// A plain renumber to a free id is expected to be louder, but the invariant this protects
+    /// does not depend on which — what the fast path ships must equal what a cold build produces.
+    /// </para>
+    ///
+    /// <para><b>Deliberately narrow: only a MOVE triggers.</b> The trigger is a vacated identity
+    /// whose kind and NAME reappear at a different id — an object that is still there under the
+    /// name callers wrote, holding a different number. An object ADDED under a new name and id
+    /// vacates nothing and cannot be referenced by code compiled before it existed; an object
+    /// RENAMED in place keeps its id, so its old name matches nothing that appeared and every
+    /// folded literal stays correct; an object genuinely REMOVED reappears nowhere; a body or
+    /// property edit never reaches here at all. Without that narrowness the guard would degenerate
+    /// into "any added or removed file falls back", which is most of the fast path.</para>
+    ///
+    /// <para><b>Both sets are read BEFORE the rename pairing consumes them</b>, and that ordering
+    /// is the whole reason a swap is caught. The pairing loop keys on <c>IdentityKey</c>, i.e. on
+    /// <c>(Kind, Id)</c>: in a swap, A vacates <c>Codeunit|id:90310</c> and B appears at
+    /// <c>Codeunit|id:90310</c>, so the loop reads that as a rename of one object and empties both
+    /// dictionaries. Measured: a check placed after it saw two empty sets and let the swap through
+    /// with an EMPTY <c>fallbackReason</c>. Matching on <c>(Kind, Name)</c> instead is what
+    /// re-associates each object with the id it actually now holds.</para>
+    ///
+    /// <para><b>The id-less kinds are excluded, and must be.</b> Interface, controladdin, profile,
+    /// pagecustomization, profileextension and entitlement are Name-keyed with <c>Id = null</c>
+    /// (see this file's header comment) — the reflected numeric id BC reports for some of them is
+    /// its own SymbolMap bookkeeping and is not stable across independently-constructed
+    /// Compilations, so comparing it would report phantom moves. They have no AL-visible object id
+    /// for a caller to fold in the first place.</para>
+    ///
+    /// <para><b>Why the baseline is consulted as well.</b> A vacated identity's name is taken from
+    /// the baseline's own record for that <c>(Kind, Id)</c> where one exists, rather than from the
+    /// identity handed in — for a file whose declared identity changed in place, the vacated
+    /// identity is reconstructed at the call site and the baseline is the authority on what that
+    /// id was called last cycle.</para>
+    /// </summary>
+    private static string? ObjectIdMoved(
+        IEnumerable<RadObjectIdentity> vacatedIds,
+        IEnumerable<RadObjectIdentity> appearedIds,
+        IEnumerable<RadObjectIdentity> baselineIds)
+    {
+        // (Kind, Name) -> the id it now holds, for everything that appeared this cycle.
+        var appearedByName = new Dictionary<(NavCA.SymbolKind, string), int>();
+        foreach (var id in appearedIds)
+        {
+            if (!id.Id.HasValue || IdlessSymbolKinds.Contains(id.Kind)) continue;
+            appearedByName[(id.Kind, id.Name)] = id.Id.Value;
+        }
+        if (appearedByName.Count == 0) return null;
+
+        // A vacated identity's Name is authoritative when the baseline recorded one for that exact
+        // (Kind, Id); fall back to the identity's own Name otherwise.
+        var baselineNameById = new Dictionary<(NavCA.SymbolKind, int), string>();
+        foreach (var id in baselineIds)
+            if (id.Id.HasValue && !IdlessSymbolKinds.Contains(id.Kind))
+                baselineNameById[(id.Kind, id.Id.Value)] = id.Name;
+
+        foreach (var vacatedId in vacatedIds)
+        {
+            if (!vacatedId.Id.HasValue || IdlessSymbolKinds.Contains(vacatedId.Kind)) continue;
+            var name = baselineNameById.TryGetValue((vacatedId.Kind, vacatedId.Id.Value), out var recorded)
+                ? recorded
+                : vacatedId.Name;
+            if (!appearedByName.TryGetValue((vacatedId.Kind, name), out var nowId)) continue;
+            // Same kind, same name, same id: nothing a caller folded moved. Cheap, and it keeps
+            // the rule literally "the id MOVED" rather than "the identity was touched".
+            if (nowId == vacatedId.Id.Value) continue;
+            return $"{vacatedId.Kind} '{name}' (was {vacatedId.Id.Value}, now {nowId})";
         }
         return null;
     }


### PR DESCRIPTION
Closes #2929

Written by agent `stma-auto-11`, an automated implementation agent acting on the account holder's behalf.

## The measurement came first, and it is positive

#2929 asked for a measurement before anything was built, and named two sub-cases with expectations it deliberately did not claim. Both were measured with `--dump-csharp` on BC 28.1, the same instrument #2571 used, before a line of the guard existed.

Fixture: two codeunits (90310/90311), two enums (90320/90321), and one caller referencing all four. Each pair's object ids were swapped — every name, every body and every value ordinal byte-for-byte unchanged. Only the CALLEES' files were edited. Diff of the CALLER's generated C#:

```
-   this.a = new NavCodeunitHandle(this, 90310);
+   this.a = new NavCodeunitHandle(this, 90311);
-   this.b = new NavCodeunitHandle(this, 90311);
+   this.b = new NavCodeunitHandle(this, 90310);
-   public NavOption e = NavOption.Create(NCLEnumMetadata.Create(90320), 0);
+   public NavOption e = NavOption.Create(NCLEnumMetadata.Create(90321), 0);
-   this.e = NavOption.Create(NCLEnumMetadata.Create(90320), 1);
+   this.e = NavOption.Create(NCLEnumMetadata.Create(90321), 1);
```

So the object id is a fourth folding, in both forms the issue predicted. The enums' own emitted C# is zero bytes, as #2571 recorded.

**Sub-case 2 (swap) is confirmed silent, and it is worse than the issue expected.** Every folded id still resolves — to the other object — and the dispatch that follows is `Invoke(memberId, …)`, where two codeunits declaring the same procedure name hash to the same member id. So the member id matches too: the caller runs the wrong codeunit's body with no exception, no diagnostic and no log line. **Sub-case 1 (plain renumber) is expected to be louder at runtime**, but the invariant this protects does not depend on which — what the fast path ships must equal what a cold build produces — so both are covered rather than reasoning per-edit about which renumbers happen to be loud.

## Why `FoldedOrdinalMoved` cannot see it — confirmed, as the issue reasoned

That guard reduces each *changed* identity to a name-to-ordinal map on both sides. An object id change is not a value moving *within* an identity; it moves the identity itself, so the old `(Kind, Id)` is absent from the after-surface, `RadFoldedOrdinals` has no entry to compare, and it returns the same "cannot answer" non-answer #2548's guard uses for an ambiguous object. Consistent, and not sufficient — which is why this is a companion check rather than an edit to it, keeping #2571's measured behavior untouched and independently reviewable.

## RED → GREEN

`AlRunner.Tests/BcCompilerIncrementalObjectIdRebindTests.cs`, driving `TryEmitIncremental` through the same harness as #2571's `BcCompilerIncrementalConstantRebindTests`.

**RED**, on the unmodified fast path — 3 failed, 2 passed. In each hazard the fast path was taken with an **empty `fallbackReason`** and the shipped caller C# did **not** match a cold build of the same post-edit tree:

- `SwappingTwoCodeunitObjectIds…`
- `SwappingTwoEnumObjectIds…`
- `RenumberingACodeunitObjectId…`

**GREEN** after the fix: all 5 pass.

Two of the five are **controls**, and both already passed before the fix, so they are real controls rather than assertions the fix happens to satisfy. Each would be broken by "just always fall back", which would delete the fast path this file exists to provide:

- editing only a codeunit's method body
- adding a codeunit under a new name and an unused id (an appeared identity that vacated nothing)

Every hazard test also carries a fixture guard asserting the edit really moved what the caller folded (`Assert.NotEqual(baseline, fresh)` plus the specific folded literal), so none can pass against an edit that changed nothing.

## Mutation testing — two mutations, and the second is the interesting one

1. **Disable the guard's trigger** (`if (false && ObjectIdMoved(...))`), everything else intact → exactly the 3 RED hazards return, 2 controls still pass. The tests are load-bearing on the guard.
2. **Keep the guard, read the sets AFTER the rename pairing loop** — the naive placement → the renumber test passes but **both swap tests fail**.

Mutation 2 is why the change has two parts. The pairing loop keys on `IdentityKey`, i.e. `(Kind, Id)`: in a swap, A vacates `Codeunit|id:90310` and B appears at `Codeunit|id:90310`, so the loop reads that as a rename of one object and empties both dictionaries. A check placed after it sees two empty sets and lets the swap through with an empty `fallbackReason` — the silent case, unguarded. Snapshotting both sets *before* the loop, and matching on `(Kind, Name)` to re-associate each object with the id it now holds, is what catches it. That measurement is recorded at both the snapshot site and in `ObjectIdMoved`'s summary, because it is exactly what would otherwise be deleted as a redundant copy.

## Where the proving test lives, and why no corpus PR is owed

This asserts nothing about what Business Central does. It is entirely about the runner's own compile-cache/incremental machinery: that `TryEmitIncremental` declines the fast path when what it would ship disagrees with a cold build. `bc-behavior-tests-go-upstream.md`'s test — "if AL Runner did not exist, would this still be a meaningful statement about AL/BC?" — answers **no**, so a C# test in `AlRunner.Tests` is the correct home and **no upstream corpus test is owed**. The `--dump-csharp` measurement is a fact about BC's compiler output, but it is used here only to establish that the runner's cache can go stale; nothing in the assertions claims BC behaves a particular way.

`precompiled-dll-respect.md`: the change is entirely inside the compile pipeline, at the point that decides whether to take the fast path at all, and runs before any DLL is finalised. No load-time pass, no cached artifact touched.

## Fix the shape, not the reported line

- **Same wrong pattern at another call site?** The guard sits inside `TryEmitIncremental`, which has three callers (`Program.cs` `--watch`, `Program.cs` `--server` with `affectedOnly`, and `BcCompiler.EmitDepSymbolsIncremental`), so one change covers all three — the same reach #2928's guard has.
- **Sibling function making the same assumption?** Yes, and it is the reason for the placement. `OverloadAddedUnderAnExistingName` looks only at `Methods`; `FoldedOrdinalMoved` looks only at values/fields *within* a surviving identity. Neither can see an identity that moved. The new check is their counterpart on the third axis.
- **Two code paths writing the same state with different invariants?** The "genuinely zero work" early return replays `baseline.LastOutput` without any of the three guards, and that stays correct: it only fires when every file hashes identical, so no object id can have moved. Checked, not assumed.
- **Both enum and codeunit forms covered**, not just the one that reads as the obvious case — the enum form is the more invisible of the two, since every value keeps its ordinal (so `FoldedOrdinalMoved` has nothing to report even where it can see an object) and the enum emits a zero-byte C# file.

## Sibling-issue scan — nothing folded, here is the map

Scanned the open queue for the incremental/RAD area before implementing. Four candidates, none folded, and no open PR carries `Closes #2929`:

| issue | lands in | why not folded |
|---|---|---|
| #3282 | **same file** — `CaptureRadMetadataSnapshotFull` | Same file, materially different change: a different function, a different mechanism (a dep path reading the process-wide page/xmlport registry), and a different harness (`bc-engine-serial`, two compilers in one process). Folding it would put two unrelated reasoning threads in one diff — `batch-sibling-issues-by-file.md` point 4. Unclaimed and still open. |
| #2672 | `Program.cs`, `SiblingCompile.cs` | `EmitSiblingSymbols` routing; does not touch this file. |
| #2655 | metadata registries | Report/enum registry retention across `--watch`; different subsystem. |
| #3337 | server-mode test selection | `affectedOnly` selection breadth, not the emit guard. |

## What I ran

- The 5 new tests: RED confirmed (3 fail / 2 pass) before the fix, all 5 GREEN after, plus the two mutations above.
- **Cold + warm**: the new tests three times (cold, then two warm passes) — stable at 5/5. `local-test-scope.md` calls out cache-sensitive defects visible only on a warm run, and this change is in the incremental/cache path.
- `dotnet test AlRunner.Tests --filter "…~Incremental|~Watch|~Tdd|~DepSymbols|~Rad"` — **127 passed, 0 failed**, run **twice** (cold 1m51s, warm 2m44s). This is the filter that would surface an over-triggering guard, and it includes `EmitDepSymbolsIncremental`'s own tests since the new guard could otherwise make dep-symbol synthesis fall back more often.
- `BaseAppFloorFixtureGuardTests` — 15 passed. The new tests write no `app.json` at all, so `no-base-app-in-csharp-tests.md` cannot be violated by them.

Not run: the full `AlRunner.Tests` suite (15-31 min, and the filtered run above covers the changed surface) and the AL corpus. CI covers both.

## Deliberately left out

Nothing about this defect. The guard falls back to a full compile rather than performing a targeted one-hop rebind of the affected callers — that would need the object-reference graph #2571 prices at ~2,000 lines, and it is a *speed* improvement, not a correctness one, exactly as #2571's own re-assessment and #2928 both record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9pEPoD8e4wmVyuTrxyuh


Corpus-NA: compile-cache machinery only — the change adds a fallback that abandons the incremental fast path and does a full compile when an object id moved, so it can only make the runner *more* conservative about reusing cached C#. Nothing alters what AL code observes at runtime, so there is no behaviour for a service tier to adjudicate; the proving test is a C# test over the cache decision itself.
