### PR TITLE
docs(prose): bound the audit justification's form, and pilot a comment reduction on three files

### DIFF
--- a/.claude/rules/loud-failures.md
+++ b/.claude/rules/loud-failures.md
@@ -58,6 +58,61 @@ behaviour for in-scope test code. If it isn't, it throws instead. Existing patch
 rule; a `SCOPE-AUDIT.md` exercise classifies each as faithful / silent-fake / TODO, and
 silent-fakes are converted to throws as they're identified.
 
+### The justification is a claim plus a citation, not the derivation behind it
+
+The obligation above is unchanged and not negotiable: **no patch ships without a stated reason
+why its answer is observably equivalent**, and a patch that cannot state one throws instead.
+What this section bounds is the *form* of that statement, because the requirement was being
+discharged by writing the whole investigation into the file.
+
+Measured over `AlRunner/Patches/` (155 files, 30,655 comment lines, 48.4% of non-blank lines),
+attributing each comment block by its vocabulary:
+
+| | share of comment mass in `Patches/` |
+|---|---|
+| blocks stating an equivalence/scope claim only | 8.6% |
+| blocks that are pure derivation — corpus narration, measurements, rejected attempts | 25.1% |
+| blocks mixing a claim with its derivation | 18.8% |
+| blocks doing neither (ordinary explanation) | 47.5% |
+
+85% of that pure-derivation mass sits in blocks longer than ten lines. So the obligation
+accounts for well under a tenth of what is in these files, and the prose it is embedded in
+accounts for several times more — which is the evidence that the *form*, not the requirement,
+is what needs bounding.
+
+**What the audit justification must contain, at the line:**
+
+1. **The claim** — what an in-scope caller observes, and why that equals what real BC answers.
+   One to three sentences.
+2. **The citation** — what settled it. A corpus codeunit number and its verdict
+   (`corpus 60940, green on 27.5 and 28.3`), an issue number, a `docs/` anchor, or the BC member
+   whose body decides it. A citation is a pointer a reader can follow, not a summary of what
+   they would find.
+3. **The trap, if there is one** — the thing a later editor would get wrong. "Re-check the call
+   count if a BC version changes shape" is worth its line; the scan that produced the count is not.
+
+**What belongs elsewhere**, with the pointer left behind:
+
+| | goes to |
+|---|---|
+| how the corpus adjudicated it, leg by leg | `docs/`, cited by anchor |
+| the decompiled BC internals you walked to reach the conclusion | `docs/`, or the citation alone |
+| what you tried first and why it failed | the PR body |
+| a measurement table | `docs/`, where it is versioned and can be re-run |
+
+A justification that has been reduced this way is **still a justification** and still satisfies
+this rule. A reviewer may ask for one to be shortened; a reviewer may never ask for one to be
+removed, and may never accept a patch that has none. Where the shortened claim and the `docs/`
+section disagree, the `docs/` section is the one under test — it is the copy a drift test can
+check, and the code carries a pointer to it rather than a second copy of it.
+
+**The failure mode this creates, and what to do about it.** Prose moved out of the code can stop
+matching the code with nothing failing. That is a real cost and it is why the pointer is
+mandatory rather than optional: a reader who finds the claim finds the document. Where the moved
+prose carries a load-bearing claim, pin it with a drift test — this repository already has
+roughly ten of them (`BcMatrixDocumentationDriftTests`, `CliDocumentationTests` and siblings),
+so the pattern is established rather than proposed.
+
 ## Anti-patterns (don't ship these)
 
 - `public static string ALDatabase_ALSid(string userName) => "S-1-0-0";` — silent fake. Either

--- a/.claude/rules/precompiled-dll-respect.md
+++ b/.claude/rules/precompiled-dll-respect.md
@@ -63,3 +63,17 @@ When you find a method that NREs / misbehaves on the skeleton runtime:
 3. **Our own AL output?** We can rewrite freely, but in practice the right fix is almost always
    a runtime-engine patch instead, because the same fix then also helps integration tests of
    MS/ISV code.
+
+## Where the note about a rewrite belongs
+
+A Cecil rewrite that could violate one of the forbidden rows above — a token shift, a layout
+assumption, a signature the precompiled chain depends on — carries a note **at the call site
+that could violate it**, because that is where the next edit happens. Keep it to the constraint
+and its citation.
+
+The walk that established the constraint does not belong there: which BC members you decompiled,
+what `find_callers` returned, which versions you compared with `compare_symbols`, what you tried
+before this. That goes to `docs/` or the PR body, with a one-line pointer left at the call site.
+`loud-failures.md` § "The justification is a claim plus a citation, not the derivation behind it"
+is the same split, stated once for both rules; it bounds the *form* of these notes and never
+whether one is required.

--- a/AlRunner.Tests/ProseRelocationPointerTests.cs
+++ b/AlRunner.Tests/ProseRelocationPointerTests.cs
@@ -1,0 +1,139 @@
+// ProseRelocationPointerTests — issue #3260: when explanatory prose moves out of AlRunner/ into
+// docs/, the pointer left behind is the only thing connecting a reader to it, and a pointer can
+// rot in three ways with nothing failing.
+//
+// The maintainer's decision on #3260 names the drift test as the load-bearing part of moving
+// prose out: "the failure mode when prose moves out is not 'the doc is far away', it is 'the doc
+// silently stops matching the code'". This holds the pointers themselves honest — that the file
+// exists, that a named #anchor is really in it, and that a doc written to hold one file's
+// derivation still has that file pointing at it.
+//
+// It is deliberately NOT a check that the prose is accurate; nothing can check that. It checks
+// the cheap half that is currently unchecked and that breaks first: a renamed doc, a removed
+// anchor, an orphaned relocation.
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ProseRelocationPointerTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    /// <summary>
+    /// Every `docs/<file>.md` or `docs/<file>.md#anchor` mention in a C# source file under
+    /// `AlRunner/`, with the file it was found in. Matches inside comments and string literals
+    /// alike: a doc link held in a `const string` (the shape
+    /// `RecordPatches.ObjectMetadataSystemTable` uses for its refusals) is a pointer that can rot
+    /// exactly like one in a comment.
+    /// </summary>
+    private static IEnumerable<(string Source, string Doc, string? Anchor)> Pointers()
+    {
+        var root = Path.Combine(RepoRoot, "AlRunner");
+        // The anchor must not swallow a sentence-ending period, and it must not end in one:
+        // `docs/x.md#a-b.` in running prose is a pointer to `#a-b`, not to `#a-b.`. Measured —
+        // the first draft of this regex reported three false failures for exactly that reason.
+        var rx = new Regex(@"docs/(?<file>[A-Za-z0-9._-]+\.md)(#(?<anchor>[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*))?",
+            RegexOptions.Compiled);
+        foreach (var cs in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+        {
+            var rel = Path.GetRelativePath(RepoRoot, cs).Replace('\\', '/');
+            if (rel.Contains("/obj/", StringComparison.Ordinal)) continue;
+            if (rel.Contains("/bin/", StringComparison.Ordinal)) continue;
+            foreach (Match m in rx.Matches(File.ReadAllText(cs)))
+            {
+                var anchor = m.Groups["anchor"].Success ? m.Groups["anchor"].Value : null;
+                // `docs/scope.md#anchor` in RunnerOutOfScopeException is prose describing the
+                // SHAPE of a link the parser strips, not a link to follow. A placeholder that
+                // named a real section would be worse, so it is excluded rather than "fixed".
+                if (anchor == "anchor") anchor = null;
+                yield return (rel, m.Groups["file"].Value, anchor);
+            }
+        }
+    }
+
+    [Fact]
+    public void EveryDocPointerFromAlRunnerNamesAFileThatExists()
+    {
+        var missing = Pointers()
+            .Where(p => !File.Exists(Path.Combine(RepoRoot, "docs", p.Doc)))
+            .Select(p => $"{p.Source} -> docs/{p.Doc}")
+            .Distinct()
+            .OrderBy(s => s)
+            .ToList();
+
+        Assert.True(missing.Count == 0,
+            "A code comment points at a docs/ file that does not exist. Prose moved out of "
+            + "AlRunner/ is reachable only through its pointer, so a renamed or deleted doc "
+            + "silently strands it:\n  " + string.Join("\n  ", missing));
+    }
+
+    [Fact]
+    public void EveryAnchoredDocPointerNamesAnAnchorThatExists()
+    {
+        var broken = new List<string>();
+        foreach (var p in Pointers().Where(p => p.Anchor != null).Distinct())
+        {
+            var path = Path.Combine(RepoRoot, "docs", p.Doc);
+            if (!File.Exists(path)) continue;   // the sibling test above owns that failure
+            if (!DocHasAnchor(File.ReadAllText(path), p.Anchor!))
+                broken.Add($"{p.Source} -> docs/{p.Doc}#{p.Anchor}");
+        }
+
+        Assert.True(broken.Count == 0,
+            "A code comment points at a docs/ anchor that is not in that file. The pointer still "
+            + "resolves to the document, so nothing looks broken, and the reader lands on the "
+            + "wrong section:\n  " + string.Join("\n  ", broken.Distinct().OrderBy(s => s)));
+    }
+
+    /// <summary>
+    /// An anchor exists if the document declares it explicitly (<c>&lt;a id="..."&gt;</c>) or if
+    /// a markdown heading slugifies to it. Both spellings are in use under `docs/` — the explicit
+    /// form in `limitations.md`, heading slugs everywhere else — so accepting only one would fail
+    /// on live, correct pointers.
+    /// </summary>
+    private static bool DocHasAnchor(string markdown, string anchor)
+    {
+        if (markdown.Contains($"<a id=\"{anchor}\"", StringComparison.OrdinalIgnoreCase)) return true;
+        if (markdown.Contains($"<a name=\"{anchor}\"", StringComparison.OrdinalIgnoreCase)) return true;
+
+        foreach (var line in markdown.Split('\n'))
+        {
+            var t = line.TrimStart();
+            if (!t.StartsWith('#')) continue;
+            if (string.Equals(Slug(t.TrimStart('#').Trim()), anchor, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>GitHub's heading-to-anchor rule: lowercase, drop punctuation, spaces to dashes.</summary>
+    private static string Slug(string heading)
+    {
+        var chars = heading.ToLowerInvariant()
+            .Where(c => char.IsLetterOrDigit(c) || c == ' ' || c == '-' || c == '_')
+            .Select(c => c == ' ' ? '-' : c);
+        return new string(chars.ToArray());
+    }
+
+    /// <summary>
+    /// A doc created to hold one file's relocated derivation is orphaned the moment nothing points
+    /// at it — the prose is then unreachable from the code it explains, which is the failure this
+    /// whole file exists to prevent. Named explicitly rather than inferred: a general "every doc
+    /// must be referenced" rule would wrongly fail the many docs/ files that are entry points in
+    /// their own right (scope.md, limitations.md, expectations.md).
+    /// </summary>
+    [Theory]
+    [InlineData("blob-store-isolation.md", "AlRunner/Patches/BlobStoreIsolationPatches.cs")]
+    public void ARelocationDocIsStillPointedAtByTheFileItWasSplitFrom(string doc, string source)
+    {
+        Assert.True(File.Exists(Path.Combine(RepoRoot, "docs", doc)),
+            $"docs/{doc} is missing; {source} was reduced on the promise that it exists.");
+
+        var text = File.ReadAllText(Path.Combine(RepoRoot, source));
+        Assert.True(text.Contains($"docs/{doc}", StringComparison.Ordinal),
+            $"{source} no longer points at docs/{doc}. The derivation was moved out of that file "
+            + "and is now unreachable from it — either restore the pointer or fold the prose back in.");
+    }
+}

--- a/AlRunner/Infrastructure/AlCoverageTracker.cs
+++ b/AlRunner/Infrastructure/AlCoverageTracker.cs
@@ -3,17 +3,13 @@
 // hook on Microsoft.Dynamics.Nav.Ncl.dll's NavMethodScope.StmtHit(int) — see
 // NclCecilRewrite.RewriteStmtHit — and turns the result into a Cobertura XML report.
 //
-// StmtHit already maintains NavMethodScope.StatementNumber (decompiled and confirmed;
-// see the #1922 investigation notes), which AlCallStackCapture depends on for AL
-// stack-trace "line L". The Cecil rewrite PREPENDS the hook call before StmtHit's
-// existing body — it does not replace or touch that assignment — so stack traces are
-// unaffected whether or not --coverage is passed.
+// The rewrite PREPENDS the hook — it never replaces or touches StmtHit's own body, which
+// maintains NavMethodScope.StatementNumber that AlCallStackCapture reads for stack-trace
+// "line L". Keep it a prepend.
 //
-// Counters are only recorded when Enabled is set (by --coverage); the hook call itself
-// is unconditional in the rewritten IL (so the cached, rewritten Ncl.dll is identical
-// whether or not a given run passes --coverage), but OnStmtHit no-ops immediately when
-// Enabled is false. Observable behaviour on the default path — test results, timing,
-// output — is therefore unchanged.
+// The hook call is unconditional in the rewritten IL, so the cached Ncl.dll is identical
+// whether or not a run passes --coverage; OnStmtHit no-ops immediately when Enabled is false.
+// Observable behaviour on the default path is unchanged.
 using System.Reflection;
 using Microsoft.Dynamics.Nav.Runtime;
 
@@ -102,18 +98,12 @@ public static class AlCoverageTracker
     /// without boxing the int. Must stay side-effect-free beyond counting: it runs on
     /// every AL statement of every test, coverage or not.
     ///
-    /// Also feeds AlCurrentStatement (#2117) UNCONDITIONALLY — i.e. before the Enabled
-    /// check below, not gated by it. That tracker answers "which AL statement is
-    /// executing right now" for RunnerClientCallback's Message() capture, which (unlike
-    /// coverage/capturedValues) has no request-side opt-in — see AlCurrentStatement's
-    /// and AlMessageCapture's doc comments for why session.CurrentMethodScope could not
-    /// answer that question and this hook's own scope argument can.
+    /// Feeds AlCurrentStatement (#2117) UNCONDITIONALLY — before the Enabled check, not gated
+    /// by it: Message() capture has no request-side opt-in.
     ///
-    /// Also feeds AlValueCapture.OnStmtHit (#2074) — the per-execution half of
-    /// --capture-values, SELF-gated by AlValueCapture.Enabled (a separate flag from this
-    /// class's own Enabled), so a coverage:false/captureValues:true request still gets
-    /// per-statement value diffing, and a plain corpus run (neither flag set) pays only
-    /// the volatile-bool check inside that method.
+    /// Feeds AlValueCapture.OnStmtHit (#2074), SELF-gated by AlValueCapture.Enabled — a separate
+    /// flag from this class's, so captureValues works without coverage and a run with neither
+    /// pays only a volatile-bool check.
     /// </summary>
     public static void OnStmtHit(NavMethodScope scope, int currentStatementNumber)
     {
@@ -248,27 +238,13 @@ public static class AlCoverageTracker
     /// Distinct scope Types that have recorded at least one hit since the last
     /// <see cref="Reset"/> — i.e. scopes genuinely invoked in the CURRENT run.
     ///
-    /// #2042's <see cref="CollectStatementTable"/> scans exactly this set instead of
-    /// every SourceSpans-carrying type currently loaded in the process (which is what
-    /// <see cref="Collect"/> does), because a warm <c>--server</c> process is not the
-    /// single-generation world <c>Collect</c> was built for: <c>RunBundleForServer</c>
-    /// calls <c>Assembly.Load(assemblyBytes)</c> again on EVERY request that isn't a
-    /// cross-bundle-dedup reuse — including a pure AL-output cache HIT with
-    /// byte-identical content — so re-running the SAME bundle N times against one warm
-    /// server leaves N distinct Assembly generations resident (assemblies are never
-    /// unloaded). Scanning "every loaded assembly" after <see cref="Reset"/> then
-    /// reports the SAME AL statement once per generation: the CURRENT generation with
-    /// its real hit count, plus one ghost entry per STALE generation showing 0 (its
-    /// Type is still reflectable; Reset() only cleared the dictionary, not the type
-    /// itself) — reproduced empirically by sending an identical `coverage:true`
-    /// `runTests` request twice to one warm server and observing duplicate
-    /// {id, line} entries, one live and one phantom-zero, per statement. Restricting
-    /// to _hits' own keys sidesteps this entirely: a stale generation's Type recorded
-    /// zero hits THIS run (Reset() cleared it and nothing in this run touched it), so
-    /// it is simply absent from the key set — no "which generation is live" logic
-    /// needed. <see cref="Collect"/> (--coverage, CLI-only) does not need this fix: a
-    /// CLI invocation is one short-lived process, so exactly one generation ever
-    /// exists there.
+    /// <para><see cref="CollectStatementTable"/> scans this set rather than every loaded
+    /// SourceSpans-carrying type (what <see cref="Collect"/> does), because a warm
+    /// <c>--server</c> process holds N Assembly generations of the same bundle — assemblies are
+    /// never unloaded — and a stale generation's Type is still reflectable after
+    /// <see cref="Reset"/>, so the whole-process scan emits a phantom hits:0 twin of every live
+    /// statement. Keying off _hits sidesteps it: a stale Type recorded nothing this run, so it
+    /// is simply absent. <see cref="Collect"/> is CLI-only and single-generation (#2042).</para>
     /// </summary>
     private static IReadOnlyCollection<Type> GetHitTrackedTypes() =>
         _hits.Keys.Select(k => k.ScopeType).Distinct().ToArray();
@@ -311,28 +287,15 @@ public static class AlCoverageTracker
         return result;
     }
 
-    // Shared by CollectStatementTable AND CollectPerTestStatementTable (#2135) —
-    // originally two independent copies of this exact chain (SourceSpans attribute,
-    // EncodedSpans, ParseObjectTypeAndId, the id==0 guard, the sourceMap lookup,
-    // GetAlName), which is exactly the kind of duplication that drifts: a future fix
-    // to how any of those five steps resolves would silently reach only whichever
-    // copy got edited. Consolidated into one helper instead of leaving the aggregate
-    // path's inline version as-is. [NavName] on the scope class itself is the AL
-    // procedure/trigger/test method name — the SAME attribute AlValueCapture reads
-    // off scope FIELDS for local names, here read off the TYPE instead (both are
-    // MemberInfo — see AlNavNameReflection). Confirmed via BCCOMPILER_DUMP_CS=1:
-    // `[NavName("Run")] private sealed class Run_Scope__... : NavMethodScope<...>`.
+    // The one resolution chain, shared by CollectStatementTable and
+    // CollectPerTestStatementTable (#2135) — keep it that way; it was two copies, and a fix to
+    // any of its five steps reached only whichever copy got edited. [NavName] on the scope CLASS
+    // is the AL procedure/trigger/test name (the same attribute AlValueCapture reads off scope
+    // FIELDS for local names; both are MemberInfo — see AlNavNameReflection).
     //
-    // CollectPerTestStatementTable additionally MEMOIZES this per scope Type across
-    // every test whose bucket touched it — the file/scope/position identity of a
-    // given (Type, statementId) pair does not vary per test, only the hit count
-    // does, so re-running this chain once per (type, test) pair the way
-    // CollectStatementTable's single-pass loop does (once per type, since
-    // GetHitTrackedTypes() already de-duplicates) would be wasted repeat work
-    // across a suite with many tests hitting the SAME codeunit. Null means "not a
-    // coverable, mapped AL scope" (framework type, or owning object outside
-    // sourceMap) — CollectPerTestStatementTable's memo caches null too, so a miss
-    // is not re-attempted per test either.
+    // Null means "not a coverable, mapped AL scope" — a framework type, or an owning object
+    // outside sourceMap. CollectPerTestStatementTable memoizes per scope Type, nulls included,
+    // because the (Type, statementId) identity does not vary per test and only the hit count does.
     private static (string FilePath, string ScopeName, long[] Spans)? ResolveScopeInfo(
         Type type, IReadOnlyDictionary<(string Label, int Id), string> sourceMap)
     {
@@ -364,24 +327,12 @@ public static class AlCoverageTracker
     /// dictionary <see cref="CollectStatementTable"/> uses, so `perTestCoverage:true`
     /// works independently of `coverage:true` (and vice versa).
     ///
-    /// A test with an EMPTY entry (declared but recorded zero hits — e.g. every
-    /// statement it touched belonged to a scope Type outside <paramref
-    /// name="sourceMap"/>, such as a framework codeunit) is OMITTED from the
-    /// returned dictionary entirely, matching the "positive list of what a test
-    /// touched" shape: a mutation-testing consumer wants "which tests could possibly
-    /// kill this mutant", and a test that touched nothing mappable can never answer
-    /// yes for any mutant — recording it as `[]` would only cost the caller a
-    /// pointless lookup.
-    ///
-    /// This is a NARROWER membership than <see cref="CollectStatementTable"/>'s own
-    /// list, deliberately: that one walks every instrumented statement (via <see
-    /// cref="AlCoverageInstrumentedStatements"/>) and emits a hits:0 record for ones
-    /// no test ever hit, because "instrumented but never covered" is a fact its
-    /// callers need. This method never emits a hits:0 record for anything — a
-    /// statement absent from a given test's list means "this test didn't execute
-    /// it", not "it wasn't instrumented"; a caller that needs to tell those two
-    /// apart has to cross-reference <see cref="CollectStatementTable"/>'s own
-    /// output (i.e. request `coverage:true` alongside `perTestCoverage:true`).
+    /// <para>A test that recorded zero mappable hits is OMITTED entirely, not returned as
+    /// `[]`. This is a positive list of what each test touched, and deliberately NARROWER than
+    /// <see cref="CollectStatementTable"/>, which does emit hits:0 for instrumented-but-uncovered
+    /// statements. So an absent statement here means "this test did not execute it", NOT "it was
+    /// not instrumented" — a caller needing to tell those apart must request `coverage:true`
+    /// alongside `perTestCoverage:true`.</para>
     /// </summary>
     public static Dictionary<string, List<AlStatementRecord>> CollectPerTestStatementTable(
         IReadOnlyDictionary<(string Label, int Id), string> sourceMap)

--- a/AlRunner/Patches/BlobStoreIsolationPatches.cs
+++ b/AlRunner/Patches/BlobStoreIsolationPatches.cs
@@ -1,68 +1,21 @@
-// BlobStoreIsolationPatches — keeps a database-backed row's BLOB out of the
-// record variable that inserted it, without disturbing the temporary-table shape.
+// BlobStoreIsolationPatches — keeps a database-backed row's BLOB out of the record variable
+// that inserted it, without disturbing the temporary-table shape.
 //
-// ── The divergence this exists for (issue #1751) ─────────────────────────────
+// Two contracts, not one, and a blanket fix breaks the other half: on real BC a BLOB written
+// with CreateOutStream and no following Modify() is invisible to a database-backed row, and
+// visible through a `temporary` one. Corpus 60940 "Test Blob Uncomm Isolation" pins both,
+// green on BC 27.5 and 28.3; corpus 60944 "Test Blob Rename Isolation" pins the Rename
+// boundary, which is not symmetric with Insert/Modify. Issues #1751 and #1765.
 //
-// Both halves below are measured against a real service tier by corpus codeunit
-// 60940 "Test Blob Uncomm Isolation", green on BC 27.5 and 28.3:
+// The runner leaks the database case because every table is backed by Ncl's
+// TempTableDataProvider — the same code real BC runs for `temporary` records — so it inherits
+// the temporary contract. The fix is three Cecil prepends: Insert latches whether the provider
+// is database-backed, CloneBlobs deep-copies the stored row's BLOBs when it is, and
+// ModifyAllTrees marks a renamed temporary row's carried-over BLOB as ineligible for
+// CalcFields reload. Prepends, not replacements, so Ncl's own bodies still run.
 //
-//   * Database-backed record — a BLOB written through CreateOutStream with NO
-//     following Modify() is invisible to the stored row. A second Record instance
-//     that Get()s the row reads it empty, and a re-Get() on the writing instance
-//     discards the write.
-//
-//   * `temporary` record — the very same write IS visible through the store.
-//     Get() reads the unpersisted bytes straight back, and so does a second
-//     variable sharing the buffer via Copy(..., true).
-//
-// The corpus file was originally written asserting isolation for BOTH shapes;
-// real BC rejected exactly the two temporary assertions and passed every control.
-// So this is not a BC bug we may normalise away — it is two different contracts,
-// and a blanket copy at the store boundary would fix one by breaking the other.
-//
-// ── Why the runner leaks the database case ───────────────────────────────────
-//
-// Every table in the runner is backed by Ncl's TempTableDataProvider (see
-// RecordPatches.NavDataAccessSource_GetDataAccessForTable). That provider is the
-// same code real BC runs for `temporary` records, so the runner inherits the
-// temporary contract for database-backed tables too. Concretely, in Ncl:
-//
-//   TempTableDataProvider.Insert
-//     items = recordBuffer.ToArray()                  // BLOB copied BY REFERENCE
-//     new TempTableRecordBuffer(metaTable, items)
-//     value.CloneBlobs(recordBuffer)                  // clones ONLY dirty BLOBs
-//   DataAccess.InsertAsync
-//     CreateNewBufferFromOutputBufferTransferBlobValuesFromOldRecord
-//       newBuffer[i] = oldRecord.GetChangedFieldValue(i)   // SAME object again
-//
-// A BLOB that carried no value at Insert is not dirty, so CloneBlobs skips it and
-// the stored row keeps the record's own NavBLOB — which the record then goes on
-// using. `Content.CreateOutStream(o); o.WriteText(...)` mutates that one object
-// and the stored row changes with it. On real BC this only ever happens for
-// temporary records, because a database-backed row lives in SQL and there is no
-// shared object to mutate.
-//
-// ── The fix ──────────────────────────────────────────────────────────────────
-//
-// Give the store its own NavBLOB at Insert, but ONLY for the providers that stand
-// in for SQL. Two Cecil prepends (see NclCecilRewrite):
-//
-//   1. TempTableDataProvider.Insert  → OnBeforeStoreInsert(provider) records, for
-//      the duration of this insert, whether the provider is database-backed.
-//   2. TempTableRecordBuffer.CloneBlobs → DetachStoredBlobs(stored) deep-copies
-//      every NavBLOB the stored row holds, so it shares none with the record.
-//
-// Prepends, not replacements: Ncl's own CloneBlobs body still runs afterwards and
-// re-clones the dirty BLOBs exactly as before, so the write-before-Insert shape is
-// untouched. For a temporary provider the flag is false, nothing is detached, and
-// the aliasing real BC exhibits is preserved verbatim.
-//
-// Modify() needs no equivalent. TempTableDataProvider.Modify itself constructs no
-// NavBLOB; the construction is in TempTableDataProvider.ModifyAllTrees, which Modify
-// calls and is its only caller — and it stores
-// `new NavBLOB(navBLOB.GetBytes(), useContentInstance: true)`, a distinct NavBLOB.
-// So a second uncommitted write after Modify() does not reach the row. Verified by
-// probe before this patch was written, and pinned by 60940's committed controls.
+// derivation, per-leg corpus results and the rejected value-keyed attempt:
+// docs/blob-store-isolation.md
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -80,17 +33,12 @@ public static class BlobStoreIsolationPatches
     private static readonly ConditionalWeakTable<object, object> _databaseBackedProviders = new();
     private static readonly object _sentinel = new();
 
-    // Set by the TempTableDataProvider.Insert prepend and read by the CloneBlobs
-    // prepend, so it is never reset — which is safe only because CloneBlobs has
-    // exactly ONE call site in the whole of Ncl: TempTableDataProvider.Insert, called
-    // synchronously. Nothing else can observe a stale value, and every insert sets it
-    // afresh. That is measured, not assumed — the call sites were counted by scanning
-    // Microsoft.Dynamics.Nav.Ncl.dll (28.1) with Cecil, not read off a decompile.
-    //
-    // The whole patch's correctness rests on that count, so re-check it if a future BC
-    // version changes shape: a second CloneBlobs caller outside Insert would read a
-    // flag left over from an unrelated insert. Thread-static rather than static so
-    // concurrent sessions cannot see each other's latch either.
+    // Never reset, which is safe only because CloneBlobs has exactly ONE call site in Ncl:
+    // TempTableDataProvider.Insert, called synchronously (counted with Cecil over Ncl.dll 28.1
+    // — docs/blob-store-isolation.md#the-cloneblobs-call-count). The whole patch rests on that
+    // count: RE-CHECK IT if a future BC version changes shape, because a second CloneBlobs
+    // caller outside Insert would read a flag left over from an unrelated insert. Thread-static
+    // so concurrent sessions cannot see each other's latch either.
     [ThreadStatic] private static bool _currentInsertIsDatabaseBacked;
 
     private static MethodInfo? _mNavBlobDeepCopy;
@@ -134,19 +82,17 @@ public static class BlobStoreIsolationPatches
         => provider != null && _databaseBackedProviders.TryGetValue(provider, out _);
 
     /// <summary>
-    /// Cecil prepend on TempTableRecordBuffer.CloneBlobs. For a database-backed
-    /// table, replaces every NavBLOB in the freshly stored row with a deep copy, so
-    /// the row shares no BLOB object with the record variable that inserted it.
+    /// Cecil prepend on TempTableRecordBuffer.CloneBlobs. For a database-backed table,
+    /// replaces every NavBLOB in the freshly stored row with a deep copy, so the row shares no
+    /// BLOB object with the record variable that inserted it.
     ///
-    /// Observable equivalence: the copy holds exactly the bytes the record's BLOB
-    /// held at Insert, so every read of the stored row answers as before. What
-    /// changes is only what real BC also refuses to do — later in-memory writes on
-    /// the inserting record no longer reach the row without Modify(). Corpus 60940
-    /// pins both directions.
+    /// <para>Observably equivalent: the copy holds exactly the bytes the record's BLOB held at
+    /// Insert, so every read of the stored row answers as before. What changes is only what
+    /// real BC also refuses to do — later in-memory writes on the inserting record no longer
+    /// reach the row without Modify(). Corpus 60940 pins both directions.</para>
     ///
-    /// Scanning values rather than metadata (`stored[i] is NavBLOB`) is deliberate:
-    /// only BLOB fields ever hold a NavBLOB, and it avoids depending on the shape of
-    /// NCLMetaTable.BlobFields.
+    /// <para>Scanning values rather than metadata (`stored[i] is NavBLOB`) is deliberate: only
+    /// BLOB fields ever hold a NavBLOB, and it avoids depending on NCLMetaTable.BlobFields.</para>
     /// </summary>
     public static void DetachStoredBlobs(TempTableRecordBuffer? stored)
     {
@@ -165,89 +111,27 @@ public static class BlobStoreIsolationPatches
         }
     }
 
-    // ── Rename store-aliasing boundary for `temporary` records (issue #1765) ────
+    // Rename boundary for `temporary` records (#1765). Corpus 60944 measures that a BLOB
+    // committed with Modify() BEFORE a Rename() is LOST on real BC — CalcFields() after Get()
+    // on the renamed row reads HasValue() = false — while the same sequence without the Rename
+    // round-trips. Ncl's own store faithfully keeps those bytes, so the runner would otherwise
+    // reload them; this table marks the (row, field index) pairs FlowFieldPatches.LoadBlobField
+    // must treat as not-found, reproducing BC's measured result.
     //
-    // Follow-up measurement to #1751/60940: does Rename() have the same BLOB
-    // store-aliasing boundary as Insert()/Modify()? Corpus 60944 "Test Blob Rename
-    // Isolation" (green on BC 27.5 and 28.3) answers NO, and the shape is not
-    // symmetric with Insert/Modify at all:
+    // Keyed by the ROW object (workTableBuffer), never by the NavBLOB value: Get()'s Find()-based
+    // read materialises a different NavBLOB instance than TryGetValue returns, so a value-keyed
+    // marker misses a path. The row object is stable — it is the same TempTableRecordBuffer Ncl
+    // adds to the tree and returns back out.
     //
-    //   * Database-backed record — Rename() re-persists the record variable's whole
-    //     current buffer under the new key (proven by the scalar-field control:
-    //     an uncommitted plain-Text write also survives a Rename). A BLOB committed
-    //     earlier with Modify() survives an unrelated Rename() intact — expected,
-    //     needs no patch, and the runner already matches it via Ncl's own
-    //     TempTableDataProvider.Modify (Rename routes through the very same method
-    //     with primaryKeyChanged=true — see ModifyAllTrees below).
-    //
-    //   * `temporary` record — an uncommitted write (never Modify()'d) still leaks
-    //     through a Rename, unsurprising and already covered by the temporary half
-    //     of #1751's aliasing. But a BLOB that WAS committed with Modify() BEFORE
-    //     the Rename() call is LOST — CalcFields() after Get() on the renamed row
-    //     reads HasValue() = false, even though the exact same Insert→write→Modify
-    //     sequence WITHOUT the Rename() round-trips correctly (60940's temporary
-    //     positive control). Measured, not assumed: this is the one genuine surprise
-    //     of 60944, identical on both BC versions.
-    //
-    // ── Why the runner does not reproduce the loss on its own ───────────────────
-    //
-    // TempTableDataProvider.Modify is also what Rename() calls (RecordImplementation
-    // .RenameRecordAsync builds a rekeyed buffer and calls dataAccess.ModifyAsync,
-    // same as a plain Modify). Its private ModifyAllTrees only replaces a BLOB field
-    // in the row being stored when Ncl's own dirty-tracking calls that field
-    // "changed" (`GetChangedFieldValue(j) != null && navBLOB.IsDirty`) — for a
-    // Rename that does not touch the BLOB, it is not dirty, so the row keeps
-    // whatever NavBLOB object the pre-rename baseline already held. For a
-    // `temporary` table that object legitimately still carries the bytes Modify()
-    // persisted — Ncl's own store faithfully keeps them. Our own
-    // FlowFieldPatches.LoadBlobField (added for #1724) then finds that row by
-    // primary key on the next CalcFields() and loads it — correctly, by our own
-    // read of Ncl's state, but NOT what real BC's temporary-table blob JIT-load
-    // does once a Rename has run. Real BC's mechanism is closed; the measured
-    // *result* is what corpus 60944 pins, and this patch reproduces the result.
-    //
-    // ── The fix ──────────────────────────────────────────────────────────────────
-    //
-    // A third Cecil prepend, on the SAME TempTableDataProvider.ModifyAllTrees that
-    // #1751's comment above already names as Modify's real BLOB-write path. When,
-    // for a NON-database-backed (temporary) provider, this call is a rename
-    // (`workTableBuffer` is a fresh buffer, not the same object as the removed
-    // `storedTableBuffer`) AND a BLOB field is NOT dirty on this call (it is
-    // carrying over a value from before the rename, not a fresh write), that FIELD
-    // INDEX on the *row* (`workTableBuffer`, the object Ncl adds to the AVL tree) is
-    // marked as ineligible for FlowFieldPatches.LoadBlobField's by-primary-key
-    // reload fallback.
-    //
-    // Keyed by the row object, not the NavBLOB value object: a first attempt marked
-    // the NavBLOB instance itself, but Get()'s own Find()-based read materialises a
-    // DIFFERENT NavBLOB instance for `parentBuffer.ReadOnlyBuffer` than the one
-    // TempTableDataProvider.TryGetValue returns from the tree directly (same bytes,
-    // different object identity) — so a value-keyed marker silently failed to catch
-    // the one path (LoadBlobField's Step 1, sizing the JIT-load placeholder from
-    // `original.ALLength`) that made ALHasValue true regardless of whether Step 4's
-    // byte-copy ran. The *row* object, in contrast, is verified stable: it is
-    // literally the same `TempTableRecordBuffer` `list[k].Add(workTableBuffer)`
-    // inserts into the tree and `TryGetValue` returns back out.
-    //
-    // A future successful Modify() calls this same method again with a fresh
-    // `workTableBuffer`/`storedTableBuffer` pair (Ncl always constructs a new
-    // TempTableRecordBuffer per Modify — see TempTableDataProvider.Modify above),
-    // so the OLD row object holding the marker is simply never looked up again;
-    // ConditionalWeakTable lets it be collected once nothing else references it.
-    //
-    // Scoped to non-database-backed providers only: the database-backed shape
-    // (test3/Blob_CommittedWrite_Rename_SecondInstanceGet_ReadsWrittenBytes) must
-    // keep working — and does, because MarkDatabaseBacked() (see above) means
-    // _databaseBackedProviders.TryGetValue succeeds for it and this method never
-    // marks anything for that provider.
+    // derivation, the per-leg 60944 results and the rejected value-keyed attempt:
+    // docs/blob-store-isolation.md#rename
     private static readonly ConditionalWeakTable<object, HashSet<int>> _rowsWithUnloadableBlobFields = new();
 
     /// <summary>
-    /// Cecil prepend on TempTableDataProvider.ModifyAllTrees (`this`, mutableRecordBuffer,
-    /// workTableBuffer, storedTableBuffer — the trailing `primaryKeyChanged bool` is not
-    /// forwarded; renames are detected via `workTableBuffer` being a distinct object from
-    /// `storedTableBuffer`, which Ncl's own Modify() guarantees is true if and only if
-    /// primaryKeyChanged was true — see TempTableDataProvider.Modify's two branches).
+    /// Cecil prepend on TempTableDataProvider.ModifyAllTrees. The trailing `primaryKeyChanged
+    /// bool` is deliberately not forwarded: a rename is detected by `workTableBuffer` being a
+    /// distinct object from `storedTableBuffer`, which Ncl's Modify() guarantees is equivalent
+    /// (docs/blob-store-isolation.md#the-rename-fix).
     /// </summary>
     public static void OnModifyAllTrees(
         object? provider, object? mutableRecordBuffer, object? workTableBuffer, object? storedTableBuffer)
@@ -291,12 +175,9 @@ public static class BlobStoreIsolationPatches
                 ?.GetValue(field);
             if (fieldNclType is not NavNclType.NavBlob) continue;
 
-            // Mirror Ncl's OWN predicate for "this call writes the BLOB" exactly
-            // (TempTableDataProvider.ModifyAllTrees: `navBLOB != null && navBLOB.IsDirty`).
-            // GetChangedFieldValue(j) being non-null is NOT enough on its own — a
-            // Rename's rekeyed buffer carries a non-null NavBLOB for every field
-            // (built via `recordBuffer.ToArray()`), but that object's OWN IsDirty flag
-            // is false unless this call is the one that actually wrote new bytes.
+            // Mirror Ncl's OWN predicate exactly (`navBLOB != null && navBLOB.IsDirty`).
+            // Non-null is NOT enough: a Rename's rekeyed buffer carries a non-null NavBLOB for
+            // every field, dirty only where this call wrote bytes.
             var changedBlob = _mGetChangedFieldValue.Invoke(mutableRecordBuffer, new object[] { j }) as NavBLOB;
             if (changedBlob != null && changedBlob.IsDirty) continue;
 
@@ -310,14 +191,11 @@ public static class BlobStoreIsolationPatches
     private static MethodInfo? _mGetChangedFieldValue;
 
     /// <summary>
-    /// Read by FlowFieldPatches.LoadBlobField before it reloads a temporary record's
-    /// BLOB field by primary key on CalcFields(). A marked (row, field index) pair
-    /// must be treated as not-found — matching real BC losing that value after a
-    /// Rename (60944) — rather than faithfully reloading what Ncl's own store still
-    /// (correctly, by its own rules) holds. <paramref name="storedRow"/> is the
-    /// TempTableRecordBuffer TryGetValue returned, NOT the BLOB value itself — see
-    /// the comment above OnModifyAllTrees for why value-object identity does not
-    /// work for this check.
+    /// Read by FlowFieldPatches.LoadBlobField before it reloads a temporary record's BLOB field
+    /// by primary key on CalcFields(). A marked (row, field index) pair is treated as not-found,
+    /// matching real BC losing that value after a Rename (corpus 60944).
+    /// <paramref name="storedRow"/> is the TempTableRecordBuffer TryGetValue returned, NOT the
+    /// BLOB value — value-object identity does not work here (see OnModifyAllTrees above).
     /// </summary>
     public static bool IsFieldIneligibleForCalcFieldsReload(object? storedRow, int fieldIdx)
         => storedRow != null

--- a/AlRunner/Patches/RecordPatches.FeatureKeyVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.FeatureKeyVirtualTable.cs
@@ -25,7 +25,7 @@
 //        "+Feature;-Feature" string, empty by default and therefore a no-op.
 //     3. ApplyECSConfigurationFiltering — runs only when a feature sets IsConfiguredByECS AND
 //        ServerUserSettings.Instance.CopilotApiServicesEnabled is true. It calls an external
-//        Copilot ECS service, which is permanently out of scope (docs/scope.md#http).
+//        Copilot ECS service, which is permanently out of scope (docs/scope.md#external-http).
 //
 //   So the whole gap was the missing route. Rebuilding the list here would be a second,
 //   drifting copy of a list BC already owns — and inserting one hardcoded row to steer a single

--- a/AlRunner/Patches/RecordPatches.ObjectMetadataSystemTable.cs
+++ b/AlRunner/Patches/RecordPatches.ObjectMetadataSystemTable.cs
@@ -1,217 +1,49 @@
 // RecordPatches.ObjectMetadataSystemTable — managed row source for the "Object Metadata"
-// (2000000071) application-database system table.
+// (2000000071) application-database system table. Issue #2519.
 //
-// WHY THIS EXISTS (issue #2519)
-//   Object Metadata routed to the same empty in-memory store as every other table the runner
-//   has no rows for, so:
+// 2000000071 is NOT a virtual table: it is one of the 43 ids in BC's own
+// SystemTables.ApplicationDatabaseTables, a real SQL table that publishing writes into. The
+// runner has no application database, so it synthesises one row per id in that list.
 //
-//       ObjectMetadata.SetRange("Object Type", ..."Object Type"::Table);
-//       ObjectMetadata.FindLast();   ->  "There is no Object Metadata within the filter."
+// The row set is a tier verdict, not an inference: corpus codeunit 61200
+// (tests/al-language-onprem/record/TestObjectMetadataSystemTable.al, corpus PR #179) pins it at
+// exactly 43 rows on all eight OnPrem legs, BC 27.0 through 28.4 — including that ObsoleteState
+// Pending (2000000001) and Removed (2000000151) ids both get rows. Reading Microsoft's DELETE
+// migration alone proves only a subset relation; an earlier version of this header rested the
+// row set on it and claimed more than that evidence carried.
 //
-//   Microsoft's own Tests-SINGLESERVER bucket hits this in
-//   Codeunit136608.VerifyValidatePackageCodeunitFailed, which reads one row purely to pick an
-//   object id that exists and never gets past the FindLast.
+// Three columns are answered truthfully — "Object Type" (ordinal resolved BY NAME out of the
+// metatable's own option string, never hardcoded), "Object ID", and "Emit Version"
+// (NavEnvironment.Instance.EmitVersion, BC's own value for this process; it is the third
+// primary-key field, so it must be real). The nine compiled-metadata payload columns REFUSE BY
+// NAME on read (#2771) rather than answering blank, because 0 / '' / false / a 0-byte BLOB are
+// legitimate values and a caller could not otherwise tell "no source" from "genuinely empty".
 //
-// ── WHAT REAL BC HAS IN THIS TABLE (and what it does NOT) ────────────────────────────────
-//   2000000071 is NOT a virtual table. It does not appear in
-//   Microsoft.Dynamics.Nav.Types.SystemTables.VirtualTables, it has no DataProvider in
-//   Ncl.dll, and Microsoft.Dynamics.Nav.Runtime.Apps.ObjectMetadataStorage reads it with plain
-//   SQL against the APPLICATION database. It is one of the 43 ids in
-//   SystemTables.ApplicationDatabaseTables — it stores itself.
+// The refusal is on the READ of the column, never at row-build time: throwing while building
+// the row would take FindSet / FindLast / Count / IsEmpty with it, which is the bug #2519
+// closed. And it fires only over rows the runner SYNTHESISED — --test-data can carry real
+// published rows for this table, so ProviderHasAnyRow declines to synthesise and tells the
+// guard, letting restored values through.
 //
-//   Its content is NOT "one row per compiled object". Microsoft says so twice, in code we ship
-//   with every artifact:
+// ADDING A REFUSAL HERE: every one goes through ObjectMetadataShapeGap, and none of them is a
+// scope boundary — this table is IN SCOPE and this file implements it, so the anchor is
+// "not-yet-implemented" and the doc link is limitations.md, never scope.md (#2894). Two buckets,
+// and the line between them is whether the runner obtained the information at all:
+//   * the read SUCCEEDED and the answer was merely unwelcome (BC's list came back empty, the
+//     artifact has no field 3, a skeleton singleton the RUNNER populates is null, the store
+//     wiring handed no provider over) -> RunnerOutOfScopeException. An unwelcome answer is not
+//     an unreadable one.
+//   * the runner could not READ BC's internals (the primaryTree sites) -> BcShapeGapException.
+// Sites 2/3/8/10 (a BC type or member that is not there) are the same family as the second
+// bucket and are deliberately NOT converted here; that sweep spans this file and the 48 sites
+// in RecordPatches.VirtualTableShapeGap.cs and is tracked separately.
 //
-//   1. The table's own AL declaration, System.app
-//      src/Application Database Tables/ObjectMetadata.Table.al:
+// PRECOMPILED-DLL RESPECT: runtime-engine and Types-assembly members only (SystemTables,
+// NavEnvironment, NCLMetaTable, NCLMetaField, NavValue, ReadOnlyRecordBuffer,
+// TempTableDataProvider). No AL business-logic body is touched.
 //
-//        /// The [Object Metadata] table contains the metadata information for system tables
-//        /// with a SQL schema.
-//        /// This table originally contained metadata for all objects, but this role is now
-//        /// taken by [Application Object Metadata]. Later on, it only contained the metadata
-//        /// for all system objects, before being now limited to Application database tables.
-//        /// If the list of system objects needs to be accessed, the [System Object] table
-//        /// should be used instead.
-//
-//   2. Microsoft.BusinessCentral.SystemApp.CleanupObjectMetadataFromNonApplicationDatabaseTables,
-//      a [DbMigration(DatabaseType.Application, PreUpgrade, Order = 10)] whose whole body is:
-//
-//        DELETE FROM [dbo].[Object Metadata]
-//        WHERE [Object Type] <> 1 OR [Object ID] NOT IN (<SystemTables.ApplicationDatabaseTables>)
-//
-//   NOTE WHAT THAT DELETE DOES AND DOES NOT ESTABLISH. It bounds the retained set from ABOVE:
-//   nothing outside "Object Type = Table over ApplicationDatabaseTables" survives. It does NOT
-//   create a row per id, so on its own it proves a SUBSET relation, not equality. An earlier
-//   version of this header rested the row set on it and claimed the runner and a real tier
-//   "cannot disagree about which ids belong" — a stronger claim than that evidence carries.
-//
-//   THE INSERT SIDE IS WHAT SELECTS THE ROWS, in
-//   Microsoft.BusinessCentral.InPlacePublisher.InPlacePublisher.UpsertIntoMetadataStorageImpl,
-//   on the branch taken when the package being published is the System app
-//   (record.RuntimePackageId == NavAppPackageCompiler.InternalSystemAppRuntimePackageId):
-//
-//        List<NavAppObjectMetadata> records = (from m in MovedObjectHelpers.ExcludeMovedObjects(outputter)
-//            where m.ObjectType == ObjectType.Table
-//            where SystemTables.ApplicationDatabaseTables.Contains(m.ObjectId)
-//            where NCLMetaTable.GetStaticTableMetadataXml(m.ObjectId) == null
-//            select m).ToList();
-//        objectMetadataUpdater.UpdateOrInsertMetadataRecords(records, nodeId);
-//
-//   Three filters over the System app's own compilation output. Two are no-ops for this id
-//   range, checked rather than assumed:
-//     * GetStaticTableMetadataXml returns non-null for exactly ONE id — 2000001071, "Object
-//       Metadata Snapshot" — and throws for seven withdrawn ids. For every id in
-//       ApplicationDatabaseTables it returns null.
-//     * ExcludeMovedObjects is a pass-through unless the package carries a MovedObjectManifest
-//       resource. System.app carries none on BC 27.0 or BC 28.1.
-//   So the row set is (System.app's table objects) INTERSECT ApplicationDatabaseTables.
-//   Enumerating the .al sources shipped inside System.app: on BOTH BC 27.0 and BC 28.1 every
-//   one of the 43 ids has a table object, none missing, highest 2000000400.
-//
-// ── SETTLED BY A SERVICE TIER, AND WHAT IT TOOK ──────────────────────────────────────────
-//   This section used to open "NO SERVICE TIER HAS CONFIRMED THIS ROW SET". One has, since
-//   StefanMaron/BusinessCentral.AL.Language.Tests#179 merged: the corpus grew a Target = OnPrem
-//   app, and tests/al-language-onprem/record/TestObjectMetadataSystemTable.al measures the row
-//   set on all eight OnPrem legs, BC 27.0 through 28.4. It confirms, against a real tier:
-//
-//     * 43 rows under Object Type = Table — one per id on
-//       SystemTables.ApplicationDatabaseTables, exactly the equality the insert predicate and
-//       Microsoft's DELETE each bound from one side without establishing;
-//     * every row carries Object Type = Table;
-//     * ObsoleteState = Pending does NOT keep an id off the list (2000000001);
-//     * ObsoleteState = Removed does NOT either (2000000151) — which was the one sub-question
-//       this comment recorded as open on Microsoft-code reading alone;
-//     * virtual system tables (2000000026, 2000000038) and ordinary application tables (18)
-//       get no row;
-//     * FindLast under a Table filter lands on 2000000400;
-//     * "Emit Version" is the build's own emit version, uniform within one published app.
-//
-//   WHY THAT TOOK A SECOND CORPUS APP. Corpus PR #153 tried it from the Cloud-target app and
-//   was withdrawn: all 8 BC legs of run 33968379281 refused the only route such an app has —
-//   "You cannot open record 2000000071 from a RecordRef data type when you are using target
-//   Cloud" (NavRecordRef.CheckIsOpenAllowed; 2000000071 is in SystemTables.InternalTables, and
-//   the escape hatch SystemTables.OnPremSystemTableRecordRefAllowed is only {2000000187,
-//   2000000188}). Both refusals are decided by the CALLING APP'S compilation target and by
-//   nothing else — NavRecordRef.IsOpenAllowed returns true outright for an OnPrem target — so
-//   one app with a different target was all it took.
-//
-//   Everything in the section above is still read off Microsoft's code, which
-//   .claude/rules/ask-the-corpus-before-claiming-bc-behavior.md ranks BELOW a tier verdict. It
-//   is kept because it explains WHY the row set is what it is; the tier verdict is what makes
-//   it true. Where they ever disagree, the tier wins and
-//   EnumerateApplicationDatabaseTableIds is the one place to fix it.
-//
-//   A hypothesis raised in review and CHECKED, recorded so it is not re-raised: that 2000000004
-//   (Permission Set) and 2000000005 (Permission) are excluded because SystemTables.VirtualTables
-//   appends them when UsePermissionSetsFromExtensions is on (it defaults to true), leaving 41
-//   rows. The insert predicate above never consults IsVirtualTable or VirtualTables — that
-//   setting routes DATA ACCESS for those tables, it does not decide whether their compiled
-//   metadata is published — and both are ordinary Scope = Cloud, ObsoleteState = Pending table
-//   objects present in System.app on 27.0 and 28.1. So 43, not 41, on this evidence.
-//
-//   What is STILL not tier-adjudicated: the compiled-metadata payload columns below. The
-//   upstream file asserts CalcFields(Metadata) has a payload on a real tier, and the runner
-//   declares its blank answer as an expect-divergence rather than pretending otherwise.
-//
-// ── THE COLUMNS, AND WHICH ONES ARE A DECLARED DIVERGENCE ────────────────────────────────
-//   Answered truthfully:
-//     "Object Type"    — option ordinal for "Table", resolved BY NAME out of the metatable's
-//                        own option string (never a hardcoded ordinal).
-//     "Object ID"      — the application-database system table id.
-//     "Emit Version"   — NavEnvironment.Instance.EmitVersion, BC's own value for THIS process.
-//                        It is the third primary-key field, so it has to be a real value, not
-//                        an invented one.
-//
-//   NOT answered — the compiled-metadata payload:
-//     Metadata, "User Code", "User AL Code", "Symbol Reference" (BLOBs), "Metadata Version",
-//     Hash, "Object Subtype", "Has Subscribers", "Schema Hash".
-//
-//   On a real tier those carry the output of publishing the system app into the application
-//   database. The runner never publishes anything into a database and has no such payload. The
-//   row still carries BC's own NavValue.GetDefaultNavValue in those slots — it has to, or
-//   FindSet / Count / IsEmpty / keyed Get could not answer at all — but READING one of them now
-//   REFUSES BY NAME (#2771). See RecordPatches.NoSourceColumns.cs for the two seams and why
-//   there are two of them.
-//
-//   Until #2771 those blanks went back to AL as ordinary values, and that was the defect: a
-//   0-byte BLOB reports HasValue() false and yields an empty CreateInStream, and 0 / '' / false
-//   are legitimate column values, so a caller could not tell "the runner has no source for this"
-//   from "this is genuinely empty". The refusal is on the READ, never at row-build time —
-//   throwing while building the row would take out FindSet / FindLast / Count / IsEmpty as well,
-//   which is the bug this file closes and would make the three columns that CAN be answered
-//   unreadable too.
-//
-// ── PRECEDENCE AGAINST --test-data ───────────────────────────────────────────────────────
-//   Unlike a virtual table, 2000000071 is a real SQL table and a restored backup can genuinely
-//   carry rows for it. So the branch in GetDataAccessForTableCore lets the --test-data
-//   on-demand loader run FIRST on a freshly created store, and this populator then does nothing
-//   at all if the store already has any row. Real rows always win over synthesised ones; the
-//   synthesis is the fallback for the (normal) case of a run with no application database.
-//
-// ── THE REFUSALS: WHAT EACH ONE CLAIMS, AND WHY NONE OF THEM IS A SCOPE BOUNDARY (#2894) ──
-//   Every refusal in this file goes through ObjectMetadataShapeGap. All twelve used to end
-//   "; see docs/scope.md", which was wrong twice over: docs/scope.md contains no
-//   object-metadata text (the write-up is docs/limitations.md#object-metadata-system-table),
-//   and citing scope.md ASSERTS that the surface is out of scope forever. It is not. Object
-//   Metadata is an AL record on a real BC table and this file implements it;
-//   .claude/rules/loud-failures.md puts AL records squarely in scope.
-//
-//   So none of the twelve is category (1) "genuinely out of scope", and none is category (3)
-//   "implementable now" — there is nothing to build, they are preconditions that hold in every
-//   supported configuration. All twelve are category (2): IN SCOPE, and the runner cannot
-//   answer for the shape it actually found. Reason anchor "not-yet-implemented". What the
-//   anchor tracks is issue #2946: the runner has no exception that says "I could not read BC's
-//   internals here", and the three conventions in this directory disagree about which to use.
-//
-//     PopulateObjectMetadataSystemTable
-//       1. data access has no in-memory provider
-//          -> (2) the runner's own store wiring did not hand one over. Nothing to populate,
-//             and inventing a store would answer with rows nobody can read back.
-//     EnumerateApplicationDatabaseTableIds
-//       2. SystemTables type not found          -> (2) unsupported BC assembly shape
-//       3. ApplicationDatabaseTables not found  -> (2) unsupported BC assembly shape
-//       4. ApplicationDatabaseTables is empty   -> (2) BC's own list is the row set; with no
-//          list there is no row set, and a hardcoded fallback would be an invented answer.
-//     EnsureObjectMetadataObjectTypeOrdinal
-//       5. metatable has no field 3             -> (2) unsupported artifact metadata shape
-//       6. "Object Type" has no option metadata -> (2) same
-//       7. option string has no "Table" member  -> (2) same. Refusing beats guessing ordinal
-//          1: the ordinal is a primary-key value, so a wrong guess silently mis-keys 43 rows.
-//     ReadNavEnvironmentEmitVersion
-//       8. NavEnvironment type not found        -> (2) unsupported BC assembly shape
-//       9. NavEnvironment.Instance is null      -> (2) skeleton state not initialised at this
-//          point. Note the difference from a skeleton Instance whose EmitVersion READS 0: that
-//          0 is BC's own answer and is kept (see the columns section). A null Instance has no
-//          answer at all, and this is the third primary-key field.
-//      10. EmitVersion property not found       -> (2) unsupported BC assembly shape
-//     ProviderHasAnyRow (both added by #2837)
-//      11. primaryTree field not found          -> (4) BC's private provider layout moved
-//      12. primaryTree is not enumerable        -> (4) same
-//
-//   BUCKET (4), ADDED BY #2946: the runner could not READ BC's internals. These two are the
-//   only sites in this file in it, and they raise BcShapeGapException rather than
-//   RunnerOutOfScopeException — see AlRunner/Infrastructure/BcShapeGapException.cs. The line
-//   is whether the runner obtained the information at all. Sites 2, 3, 8 and 10 are the same
-//   family (a BC type or member that is not there) and are NOT converted here, because
-//   reclassifying them one at a time across this file and the 48 sites in
-//   RecordPatches.VirtualTableShapeGap.cs is a per-site sweep with its own issue; #2946 is the
-//   type convention, and this file's two primaryTree readers are the defect it names.
-//   Sites 1, 4, 5, 6, 7 and 9 stay in bucket (2) on purpose and would be WRONG in (4): each of
-//   those reads SUCCEEDED and the answer was merely unwelcome — BC's list came back empty, the
-//   artifact genuinely has no field 3, a skeleton singleton the RUNNER populates is null, the
-//   runner's own store wiring handed no provider over. An unwelcome answer is not an
-//   unreadable one.
-//
-//   The same "; see docs/scope.md" wording sits on the equivalent provider-null guard in
-//   roughly fifteen sibling virtual-table populators in this directory (AllObj, Integer,
-//   Field, ...). Same defect, different files; issue #2945 tracks that sweep rather than
-//   widening this change past the file the issue named.
-//
-// PRECOMPILED-DLL RESPECT
-//   Runtime-engine and Types-assembly members only (SystemTables, NavEnvironment, NCLMetaTable,
-//   NCLMetaField, NavValue, ReadOnlyRecordBuffer, TempTableDataProvider), reached the same way
-//   every sibling provider in this directory reaches them. No AL business-logic body is touched.
-
+// row set, columns, the twelve preconditions, the Cloud/OnPrem target asymmetry, the two read
+// seams and the expectation entries: docs/limitations.md#object-metadata-system-table
 using System.Collections;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -265,17 +97,13 @@ public static partial class RecordPatches
     private const string ObjectMetadataDocLink = "docs/limitations.md#object-metadata-system-table";
 
     /// <summary>
-    /// The one place a refusal for this table is built — see the REFUSALS section of the file
-    /// header for the per-site classification, and .claude/rules/loud-failures.md for the rule.
+    /// The one place a refusal for this table is built. See the file header for which bucket a
+    /// new refusal belongs in, and .claude/rules/loud-failures.md for the rule.
     ///
-    /// <para>Reason anchor <c>not-yet-implemented</c>, deliberately. Object Metadata is IN
-    /// SCOPE — this file implements it — so none of these twelve is a scope boundary; each one
-    /// says the runner cannot answer for the shape it found. That is not cosmetic: for an AL
-    /// <c>[TryFunction]</c>, ApplicationObjectBasePatches.IsPermanentOutOfScope traps a refusal
-    /// into <c>false</c> UNLESS the reason starts <c>not-yet-implemented</c>. Under the old
-    /// <c>object-metadata-system-table</c> anchor a runner gap here read as a clean
-    /// <c>if not TryX()</c>, which is the silent default loud-failures.md forbids. Now it tears
-    /// through.</para>
+    /// <para>Reason anchor <c>not-yet-implemented</c> is load-bearing, not cosmetic:
+    /// ApplicationObjectBasePatches.IsPermanentOutOfScope traps a refusal into <c>false</c> for
+    /// an AL <c>[TryFunction]</c> UNLESS the reason starts with it, so any other anchor makes a
+    /// runner gap here read as a clean <c>if not TryX()</c> (#2894).</para>
     /// </summary>
     internal static RunnerOutOfScopeException ObjectMetadataShapeGap(string detail)
         => new(ObjectMetadataApi,
@@ -329,31 +157,16 @@ public static partial class RecordPatches
     /// Run <paramref name="populate"/> at most once per provider, and never let a populate
     /// that REFUSED be remembered as one that succeeded.
     ///
-    /// <para>WHY THE FAILURE PATH EXISTS (#2786 review). The claim below is taken BEFORE any
-    /// of the work, which is what makes the populate once-only under the concurrent handout
-    /// in GetDataAccessForTableCore. Ten things after that claim can throw:
-    /// <see cref="ProviderHasAnyRow"/>, the nine <see cref="RunnerOutOfScopeException"/>
-    /// throws across <see cref="EnsureObjectMetadataObjectTypeOrdinal"/>,
-    /// <see cref="ReadNavEnvironmentEmitVersion"/> and
-    /// <see cref="EnumerateApplicationDatabaseTableIds"/>, and an <c>InsertVirtualRow</c> that
-    /// fails part-way through the row set. Left alone, every one of them marked table
-    /// 2000000071 "populated" holding whatever it had at the moment it failed — usually
-    /// nothing — and every later access read an empty table with no diagnostic.</para>
+    /// <para>The claim is taken BEFORE the work, which is what makes the populate once-only
+    /// under the concurrent handout in GetDataAccessForTableCore. Ten things after it can throw,
+    /// and left alone each marked 2000000071 "populated" holding whatever it had when it failed,
+    /// so every later access read an empty table with no diagnostic (#2786). Reachable from AL:
+    /// <c>asserterror</c> is an unfiltered <c>catch</c> and can wrap this record-open path.</para>
     ///
-    /// <para>THAT IS REACHABLE FROM AL, not just in theory. A runner refusal IS catchable:
-    /// AL's <c>asserterror</c> is MethodScopePatches.NavMethodScope_AssertError, an unfiltered
-    /// <c>catch (Exception ex)</c>, and this populate runs on the record-open path an
-    /// <c>asserterror</c> can wrap. So the refusal gets swallowed and the empty table is what
-    /// the rest of the test sees.</para>
-    ///
-    /// <para>A REFUSAL IS REPLAYED, NOT RETRIED. Retrying looks kinder and is worse: an
-    /// <c>InsertVirtualRow</c> that failed on row 20 leaves 19 rows behind, so the retry's own
-    /// <see cref="ProviderHasAnyRow"/> answers "already populated" and returns quietly — a
-    /// silently PARTIAL table, which is the bug this method exists to prevent wearing a
-    /// different hat. None of these failures is transient anyway: BC's layout does not change
-    /// mid-run. Same principle as RowVersionPatches' "no loud-once-then-silent latch"
-    /// (#1986), in the opposite direction — there the latch made a failure go quiet, here it
-    /// is what keeps it loud.</para>
+    /// <para>A REFUSAL IS REPLAYED, NOT RETRIED. A retry after a part-way
+    /// <c>InsertVirtualRow</c> finds rows already there, so <see cref="ProviderHasAnyRow"/>
+    /// answers "already populated" and returns a silently PARTIAL table — the same bug in
+    /// another hat. None of these failures is transient: BC's layout does not change mid-run.</para>
     /// </summary>
     private static void RunObjectMetadataPopulateOnce(object provider, Action populate)
     {
@@ -404,17 +217,12 @@ public static partial class RecordPatches
 
     /// <summary>
     /// BC's own list of application-database system tables, read off
-    /// <c>Microsoft.Dynamics.Nav.Types.SystemTables.ApplicationDatabaseTables</c> — the very
-    /// collection Microsoft's publisher intersects with the System app's own table objects to
-    /// decide which rows to INSERT, and the one its cleanup migration interpolates into its
-    /// DELETE. Ascending, so a FindLast without a filter and a FindLast filtered to Table agree
-    /// about which row is last.
+    /// <c>Microsoft.Dynamics.Nav.Types.SystemTables.ApplicationDatabaseTables</c>. Ascending, so
+    /// a FindLast without a filter and one filtered to Table agree about which row is last.
     ///
-    /// <para>This is an UPPER BOUND on what a real tier holds, not a confirmed equality. No
-    /// service tier has adjudicated it — see the file header for why the upstream corpus test
-    /// could not be written, and for the 11 <c>ObsoleteState = Removed</c> ids that are the
-    /// open part of the question. If a tier ever disagrees, this method is the one place to
-    /// filter.</para>
+    /// <para>A service tier has adjudicated this row set as an EQUALITY — 43 rows, corpus
+    /// codeunit 61200 on eight OnPrem legs (corpus PR #179). If a tier ever disagrees, this
+    /// method is the one place to filter.</para>
     /// </summary>
     private static int[] EnumerateApplicationDatabaseTableIds()
     {
@@ -511,37 +319,22 @@ public static partial class RecordPatches
     /// <c>TempTableDataProvider.primaryTree</c> the stored-table census reads, where a null
     /// tree is BC's own representation of "no row was ever inserted".
     ///
-    /// <para>THE TWO REASONS THIS READ CAN COME BACK EMPTY ARE NOT THE SAME REASON (#2786).
-    /// A null <c>primaryTree</c> is BC's own "no row was ever inserted", and answering FALSE —
-    /// "go ahead and synthesise" — is right. The field being ABSENT means BC renamed or
-    /// restructured it and the runner has no idea what the store holds; answering FALSE there
-    /// would silently shadow whatever --test-data restored into this table, disabling the
-    /// precedence rule in this file's header with no diagnostic anywhere. It used to do
-    /// exactly that. Now it refuses, naming the member. See .claude/rules/loud-failures.md.</para>
+    /// <para>A NULL tree and an ABSENT field are not the same answer (#2786). Null is BC's own
+    /// "no row was ever inserted", so FALSE — synthesise — is right. Absent means BC's layout
+    /// moved and the runner cannot see what the store holds; answering FALSE would silently
+    /// shadow whatever --test-data restored, so it refuses instead, naming the member.</para>
     ///
-    /// <para>THE TYPE IS <see cref="BcShapeGapException"/>, NOT
-    /// <see cref="RunnerOutOfScopeException"/> (#2946). Both of these two refusals are BUG
-    /// REPORTS ABOUT THE RUNNER rather than scope boundaries, and this file used to say so in a
-    /// comment and then raise the scope exception anyway — which is the disagreement #2946 was
-    /// filed about: four readers of this same private structure raised three different types
-    /// between them. Two consequences follow the type rather than the wording. A shape gap can
-    /// never be absorbed by an <c>expect-oos</c> manifest entry, so a BC-layout regression
-    /// cannot be declared expected — it is a property of which BC build is on disk, not of the
-    /// runner, so it can be true on one BC leg and false on another in the same run. And it
-    /// tears through AL's <c>asserterror</c> as well as through a <c>[TryFunction]</c>, which a
-    /// <see cref="RunnerOutOfScopeException"/> does not: <c>asserterror</c> is
-    /// MethodScopePatches.NavMethodScope_AssertError, and on real BC this record-open SUCCEEDS,
-    /// so catching the gap would make an <c>asserterror</c> around it pass where BC fails it.
-    /// <see cref="RunObjectMetadataPopulateOnce"/> still remembers a refusal, because the other
-    /// ten throw sites in this file remain catchable.</para>
+    /// <para>The type is <see cref="BcShapeGapException"/>, not
+    /// <see cref="RunnerOutOfScopeException"/> (#2946): a shape gap cannot be absorbed by an
+    /// <c>expect-oos</c> entry (it is a property of which BC build is on disk, so it can differ
+    /// per leg) and it tears through AL's <c>asserterror</c>, which matters because on real BC
+    /// this record-open SUCCEEDS.</para>
     ///
-    /// <para>Resolution goes through <see cref="BcShape"/>, which uses
-    /// <see cref="PrivateMemberLookup"/> rather than a plain <c>GetField</c>, because
-    /// <c>primaryTree</c> is PRIVATE on <c>TempTableDataProvider</c> and
-    /// <c>GetField(NonPublic)</c> on a DERIVED type does not return a base class's private
-    /// fields — BC's own <c>CrmTableConnection.CrmTestDataProvider</c> derives from it (#2725).
-    /// Reading a derived provider's inherited field as "absent" would turn a perfectly readable
-    /// store into a hard failure now that absence refuses.</para>
+    /// <para>Resolution goes through <see cref="BcShape"/> / <see cref="PrivateMemberLookup"/>,
+    /// never a plain <c>GetField</c>: <c>primaryTree</c> is private on
+    /// <c>TempTableDataProvider</c> and <c>GetField(NonPublic)</c> on a DERIVED type does not
+    /// return a base class's private fields — BC's <c>CrmTestDataProvider</c> derives from it,
+    /// and reading its inherited field as "absent" would refuse over a readable store (#2725).</para>
     /// </summary>
     private static bool ProviderHasAnyRow(object provider)
     {

--- a/docs/blob-store-isolation.md
+++ b/docs/blob-store-isolation.md
@@ -1,0 +1,173 @@
+# BLOB store isolation: why a database-backed row must not share a NavBLOB with the record that inserted it
+
+Derivation behind `AlRunner/Patches/BlobStoreIsolationPatches.cs`. The code carries the claims
+and the citations; this file carries the evidence they rest on and the reasoning that produced
+them. Issues #1751 and #1765.
+
+<a id="the-divergence"></a>
+
+## The divergence (#1751)
+
+Both halves are measured against a real service tier by corpus codeunit 60940
+"Test Blob Uncomm Isolation", green on BC 27.5 and 28.3:
+
+* **Database-backed record** — a BLOB written through `CreateOutStream` with **no** following
+  `Modify()` is invisible to the stored row. A second `Record` instance that `Get()`s the row
+  reads it empty, and a re-`Get()` on the writing instance discards the write.
+* **`temporary` record** — the very same write **is** visible through the store. `Get()` reads
+  the unpersisted bytes straight back, and so does a second variable sharing the buffer via
+  `Copy(..., true)`.
+
+The corpus file was originally written asserting isolation for **both** shapes; real BC rejected
+exactly the two temporary assertions and passed every control. So this is not a BC bug to
+normalise away — it is two different contracts, and a blanket copy at the store boundary would
+fix one by breaking the other.
+
+<a id="why-the-runner-leaks"></a>
+
+## Why the runner leaked the database case
+
+Every table in the runner is backed by Ncl's `TempTableDataProvider` (see
+`RecordPatches.NavDataAccessSource_GetDataAccessForTable`). That provider is the same code real
+BC runs for `temporary` records, so the runner inherited the temporary contract for
+database-backed tables too. Concretely, in Ncl:
+
+```
+TempTableDataProvider.Insert
+  items = recordBuffer.ToArray()                  // BLOB copied BY REFERENCE
+  new TempTableRecordBuffer(metaTable, items)
+  value.CloneBlobs(recordBuffer)                  // clones ONLY dirty BLOBs
+DataAccess.InsertAsync
+  CreateNewBufferFromOutputBufferTransferBlobValuesFromOldRecord
+    newBuffer[i] = oldRecord.GetChangedFieldValue(i)   // SAME object again
+```
+
+A BLOB that carried no value at `Insert` is not dirty, so `CloneBlobs` skips it and the stored
+row keeps the record's own `NavBLOB` — which the record then goes on using.
+`Content.CreateOutStream(o); o.WriteText(...)` mutates that one object and the stored row
+changes with it. On real BC this only ever happens for temporary records, because a
+database-backed row lives in SQL and there is no shared object to mutate.
+
+<a id="the-insert-fix"></a>
+
+## The Insert-side fix
+
+Give the store its own `NavBLOB` at `Insert`, but **only** for the providers that stand in for
+SQL. Two Cecil prepends (see `NclCecilRewrite`):
+
+1. `TempTableDataProvider.Insert` → `OnBeforeStoreInsert(provider)` records, for the duration of
+   this insert, whether the provider is database-backed.
+2. `TempTableRecordBuffer.CloneBlobs` → `DetachStoredBlobs(stored)` deep-copies every `NavBLOB`
+   the stored row holds, so it shares none with the record.
+
+Prepends, not replacements: Ncl's own `CloneBlobs` body still runs afterwards and re-clones the
+dirty BLOBs exactly as before, so the write-before-`Insert` shape is untouched. For a temporary
+provider the flag is false, nothing is detached, and the aliasing real BC exhibits is preserved
+verbatim.
+
+`Modify()` needs no equivalent. `TempTableDataProvider.Modify` itself constructs no `NavBLOB`;
+the construction is in `TempTableDataProvider.ModifyAllTrees`, which `Modify` calls and is its
+only caller — and it stores `new NavBLOB(navBLOB.GetBytes(), useContentInstance: true)`, a
+distinct `NavBLOB`. So a second uncommitted write after `Modify()` does not reach the row.
+Verified by probe before the patch was written, and pinned by 60940's committed controls.
+
+<a id="the-cloneblobs-call-count"></a>
+
+## The single-call-site count `_currentInsertIsDatabaseBacked` rests on
+
+The latch set by the `Insert` prepend and read by the `CloneBlobs` prepend is never reset. That
+is safe only because `CloneBlobs` has exactly **one** call site in the whole of Ncl:
+`TempTableDataProvider.Insert`, called synchronously. Nothing else can observe a stale value,
+and every insert sets it afresh.
+
+That is measured, not assumed — the call sites were counted by scanning
+`Microsoft.Dynamics.Nav.Ncl.dll` (28.1) with Cecil, not read off a decompile. The whole patch's
+correctness rests on the count, so **re-check it if a future BC version changes shape**: a second
+`CloneBlobs` caller outside `Insert` would read a flag left over from an unrelated insert.
+
+<a id="rename"></a>
+
+## The Rename boundary (#1765)
+
+Follow-up measurement to #1751/60940: does `Rename()` have the same BLOB store-aliasing boundary
+as `Insert()`/`Modify()`? Corpus 60944 "Test Blob Rename Isolation" (green on BC 27.5 and 28.3)
+answers **no**, and the shape is not symmetric with Insert/Modify at all:
+
+* **Database-backed record** — `Rename()` re-persists the record variable's whole current buffer
+  under the new key (proven by the scalar-field control: an uncommitted plain-`Text` write also
+  survives a `Rename`). A BLOB committed earlier with `Modify()` survives an unrelated
+  `Rename()` intact — expected, needs no patch, and the runner already matches it via Ncl's own
+  `TempTableDataProvider.Modify` (`Rename` routes through the very same method with
+  `primaryKeyChanged=true`).
+* **`temporary` record** — an uncommitted write (never `Modify()`'d) still leaks through a
+  `Rename`, unsurprising and already covered by the temporary half of #1751's aliasing. But a
+  BLOB that **was** committed with `Modify()` **before** the `Rename()` call is **lost** —
+  `CalcFields()` after `Get()` on the renamed row reads `HasValue()` = false, even though the
+  exact same Insert→write→Modify sequence **without** the `Rename()` round-trips correctly
+  (60940's temporary positive control). Measured, not assumed: this is the one genuine surprise
+  of 60944, identical on both BC versions.
+
+### Why the runner does not reproduce the loss on its own
+
+`TempTableDataProvider.Modify` is also what `Rename()` calls
+(`RecordImplementation.RenameRecordAsync` builds a rekeyed buffer and calls
+`dataAccess.ModifyAsync`, same as a plain `Modify`). Its private `ModifyAllTrees` only replaces a
+BLOB field in the row being stored when Ncl's own dirty-tracking calls that field "changed"
+(`GetChangedFieldValue(j) != null && navBLOB.IsDirty`) — for a `Rename` that does not touch the
+BLOB, it is not dirty, so the row keeps whatever `NavBLOB` object the pre-rename baseline
+already held.
+
+For a `temporary` table that object legitimately still carries the bytes `Modify()` persisted —
+Ncl's own store faithfully keeps them. The runner's `FlowFieldPatches.LoadBlobField` (added for
+#1724) then finds that row by primary key on the next `CalcFields()` and loads it — correctly, by
+the runner's own read of Ncl's state, but **not** what real BC's temporary-table blob JIT-load
+does once a `Rename` has run. Real BC's mechanism is closed; the measured *result* is what corpus
+60944 pins, and the patch reproduces the result.
+
+<a id="the-rename-fix"></a>
+
+## The Rename-side fix, and why it is keyed by the row object
+
+A third Cecil prepend, on the same `TempTableDataProvider.ModifyAllTrees` that #1751's Insert
+path already names as `Modify`'s real BLOB-write path. When, for a **non**-database-backed
+(temporary) provider, this call is a rename (`workTableBuffer` is a fresh buffer, not the same
+object as the removed `storedTableBuffer`) **and** a BLOB field is **not** dirty on this call (it
+is carrying over a value from before the rename, not a fresh write), that field index on the
+*row* (`workTableBuffer`, the object Ncl adds to the AVL tree) is marked as ineligible for
+`FlowFieldPatches.LoadBlobField`'s by-primary-key reload fallback.
+
+**Keyed by the row object, not the `NavBLOB` value object.** A first attempt marked the `NavBLOB`
+instance itself, but `Get()`'s own `Find()`-based read materialises a **different** `NavBLOB`
+instance for `parentBuffer.ReadOnlyBuffer` than the one `TempTableDataProvider.TryGetValue`
+returns from the tree directly (same bytes, different object identity) — so a value-keyed marker
+silently failed to catch the one path (`LoadBlobField`'s Step 1, sizing the JIT-load placeholder
+from `original.ALLength`) that made `ALHasValue` true regardless of whether Step 4's byte-copy
+ran. The *row* object, in contrast, is verified stable: it is literally the same
+`TempTableRecordBuffer` that `list[k].Add(workTableBuffer)` inserts into the tree and
+`TryGetValue` returns back out.
+
+A future successful `Modify()` calls the same method again with a fresh
+`workTableBuffer`/`storedTableBuffer` pair (Ncl always constructs a new `TempTableRecordBuffer`
+per `Modify`), so the old row object holding the marker is simply never looked up again;
+`ConditionalWeakTable` lets it be collected once nothing else references it.
+
+Scoped to non-database-backed providers only: the database-backed shape
+(`test3/Blob_CommittedWrite_Rename_SecondInstanceGet_ReadsWrittenBytes`) must keep working — and
+does, because `MarkDatabaseBacked()` means `_databaseBackedProviders.TryGetValue` succeeds for it
+and the method never marks anything for that provider.
+
+### Mirroring Ncl's own dirty predicate exactly
+
+`OnModifyAllTrees` reproduces Ncl's own test for "this call writes the BLOB"
+(`TempTableDataProvider.ModifyAllTrees`: `navBLOB != null && navBLOB.IsDirty`).
+`GetChangedFieldValue(j)` being non-null is **not** enough on its own — a `Rename`'s rekeyed
+buffer carries a non-null `NavBLOB` for every field (built via `recordBuffer.ToArray()`), but
+that object's own `IsDirty` flag is false unless this call is the one that actually wrote new
+bytes.
+
+### Why the prepend does not forward `primaryKeyChanged`
+
+The Cecil prepend receives `this, mutableRecordBuffer, workTableBuffer, storedTableBuffer`; the
+trailing `primaryKeyChanged bool` is not forwarded. Renames are detected via `workTableBuffer`
+being a distinct object from `storedTableBuffer`, which Ncl's own `Modify()` guarantees is true
+if and only if `primaryKeyChanged` was true — see `TempTableDataProvider.Modify`'s two branches.

--- a/tools/comment-density.py
+++ b/tools/comment-density.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Measure the comment/code split of a C# tree.
+
+Exists so successive passes at issue #3260 measure the same way instead of
+re-deriving a classifier each time and comparing incomparable numbers.
+
+Classification, per physical line:
+
+  blank    nothing but whitespace
+  comment  the line's non-whitespace content is entirely comment: a `//` or
+           `///` line, or a line wholly inside a `/* ... */` block
+  code     anything else, including a line with a trailing `// ...` comment
+
+A trailing comment counts as CODE, not comment. That is deliberate and
+conservative: it under-counts comment mass rather than over-counting it, so a
+reduction measured with this script is never flattered by it.
+
+`//` and `/*` inside a string or char literal do not open a comment; the
+scanner tracks string, verbatim-string, interpolated-string and char state so
+that `var s = "// not a comment";` classifies as code.
+
+Usage:
+    tools/comment-density.py [ROOT ...] [--top N] [--json] [--min-lines N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass, asdict
+
+SKIP_DIRS = {"obj", "bin", "graphify-out", ".git", "node_modules"}
+
+
+@dataclass
+class Counts:
+    total: int = 0
+    comment: int = 0
+    code: int = 0
+    blank: int = 0
+
+    def add(self, other: "Counts") -> None:
+        self.total += other.total
+        self.comment += other.comment
+        self.code += other.code
+        self.blank += other.blank
+
+    @property
+    def share(self) -> float:
+        """Comment share of NON-BLANK lines, which is the figure #3260 quotes."""
+        nonblank = self.comment + self.code
+        return (self.comment / nonblank * 100.0) if nonblank else 0.0
+
+
+def classify(text: str) -> Counts:
+    """Classify every physical line of a C# source file."""
+    counts = Counts()
+    in_block = False          # inside /* ... */
+    for raw in text.splitlines():
+        counts.total += 1
+        stripped = raw.strip()
+        if not stripped and not in_block:
+            counts.blank += 1
+            continue
+
+        saw_code = False
+        saw_comment = in_block
+        i = 0
+        n = len(raw)
+        while i < n:
+            ch = raw[i]
+            if in_block:
+                if ch == "*" and i + 1 < n and raw[i + 1] == "/":
+                    in_block = False
+                    i += 2
+                    continue
+                i += 1
+                continue
+            if ch == "/" and i + 1 < n and raw[i + 1] == "/":
+                saw_comment = True
+                break  # rest of the line is a line comment
+            if ch == "/" and i + 1 < n and raw[i + 1] == "*":
+                in_block = True
+                saw_comment = True
+                i += 2
+                continue
+            if ch == "@" and i + 1 < n and raw[i + 1] == '"':
+                saw_code = True
+                i = _skip_verbatim(raw, i + 2)
+                continue
+            if ch == '"':
+                saw_code = True
+                i = _skip_quoted(raw, i + 1, '"')
+                continue
+            if ch == "'":
+                saw_code = True
+                i = _skip_quoted(raw, i + 1, "'")
+                continue
+            if not ch.isspace():
+                saw_code = True
+            i += 1
+
+        if saw_code:
+            counts.code += 1
+        elif saw_comment:
+            counts.comment += 1
+        elif stripped:
+            counts.code += 1
+        else:
+            counts.blank += 1
+    return counts
+
+
+def _skip_quoted(line: str, i: int, quote: str) -> int:
+    """Advance past a regular string/char literal opened just before `i`."""
+    n = len(line)
+    while i < n:
+        if line[i] == "\\":
+            i += 2
+            continue
+        if line[i] == quote:
+            return i + 1
+        i += 1
+    return i
+
+
+def _skip_verbatim(line: str, i: int) -> int:
+    """Advance past a @"..." literal, where "" is an escaped quote."""
+    n = len(line)
+    while i < n:
+        if line[i] == '"':
+            if i + 1 < n and line[i + 1] == '"':
+                i += 2
+                continue
+            return i + 1
+        i += 1
+    return i
+
+
+def walk(roots: list[str]) -> list[str]:
+    found: list[str] = []
+    for root in roots:
+        if os.path.isfile(root):
+            found.append(root)
+            continue
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+            for name in filenames:
+                if name.endswith(".cs"):
+                    found.append(os.path.join(dirpath, name))
+    return sorted(found)
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("roots", nargs="*", default=["AlRunner"],
+                    help="directories or files to scan (default: AlRunner)")
+    ap.add_argument("--top", type=int, default=15,
+                    help="how many worst-offender files to list (default 15)")
+    ap.add_argument("--min-lines", type=int, default=200,
+                    help="only rank files with at least this many lines (default 200)")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    args = ap.parse_args(argv)
+
+    roots = args.roots or ["AlRunner"]
+    files = walk(roots)
+    if not files:
+        print(f"no .cs files under {roots}", file=sys.stderr)
+        return 1
+
+    per_file: dict[str, Counts] = {}
+    total = Counts()
+    for path in files:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            c = classify(fh.read())
+        per_file[path] = c
+        total.add(c)
+
+    if args.json:
+        print(json.dumps({
+            "roots": roots,
+            "files": len(files),
+            "total": asdict(total) | {"share": round(total.share, 2)},
+            "per_file": {p: asdict(c) | {"share": round(c.share, 2)}
+                         for p, c in per_file.items()},
+        }, indent=2))
+        return 0
+
+    print(f"{'/'.join(roots)}  {len(files)} files")
+    print(f"  total   {total.total:>7,}")
+    print(f"  comment {total.comment:>7,}")
+    print(f"  code    {total.code:>7,}")
+    print(f"  blank   {total.blank:>7,}")
+    print()
+    print(f"comment share of non-blank lines : {total.share:.1f}%")
+
+    ranked = sorted(
+        ((c, p) for p, c in per_file.items() if c.total >= args.min_lines),
+        key=lambda t: t[0].share, reverse=True)[:args.top]
+    if ranked:
+        print()
+        print(f"worst offenders (files of >= {args.min_lines} lines):")
+        print(f"{'share':>7}  {'cmt/code':>10}  file")
+        for c, p in ranked:
+            print(f"{c.share:>6.1f}%  {c.comment:>4}/{c.code:<5}  {p}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/test_comment_density.py
+++ b/tools/test_comment_density.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/comment-density.py's line classifier.
+
+The classifier is the whole tool: every number #3260 quotes, and every
+before/after a reduction pass reports, is whatever this function decided. A
+classifier that miscounts in a stable direction produces a self-consistent set
+of wrong figures and nothing contradicts it -- which is exactly the shape
+`verify-execution-not-the-tick.md` warns about, so the fixtures below are the
+cases where a naive `line.strip().startswith("//")` gets a DIFFERENT answer
+from this one.
+
+Run: python3 tools/test_comment_density.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location(
+    "comment_density", os.path.join(HERE, "comment-density.py"))
+cd = importlib.util.module_from_spec(_spec)
+# Registered before exec: @dataclass resolves its own module out of sys.modules,
+# and raises AttributeError on a module that is not in there yet.
+sys.modules["comment_density"] = cd
+_spec.loader.exec_module(cd)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        FAILURES.append(name)
+
+
+def counts(src: str):
+    return cd.classify(src)
+
+
+def expect(name: str, src: str, *, comment: int, code: int, blank: int) -> None:
+    c = counts(src)
+    check(name,
+          (c.comment, c.code, c.blank) == (comment, code, blank),
+          f"got comment={c.comment} code={c.code} blank={c.blank}, "
+          f"want comment={comment} code={code} blank={blank}")
+
+
+print("line kinds")
+
+expect("a // line is a comment", "// hello\n", comment=1, code=0, blank=0)
+expect("a /// doc line is a comment", "/// <summary>x</summary>\n",
+       comment=1, code=0, blank=0)
+expect("a plain statement is code", "var x = 1;\n", comment=0, code=1, blank=0)
+expect("whitespace is blank", "   \n\t\n", comment=0, code=0, blank=2)
+
+print()
+print("a trailing comment counts as CODE, not comment")
+# Deliberate and conservative: it under-counts comment mass, so a measured
+# reduction is never flattered by the classifier.
+expect("code with a trailing //", "var x = 1; // why\n", comment=0, code=1, blank=0)
+expect("code with a trailing /* */", "var x = 1; /* why */\n",
+       comment=0, code=1, blank=0)
+
+print()
+print("block comments")
+expect("a whole /* */ block is comment",
+       "/* one\n   two\n   three */\n", comment=3, code=0, blank=0)
+expect("a blank line INSIDE a block is comment, not blank",
+       "/* one\n\n   three */\n", comment=3, code=0, blank=0)
+expect("code after a block ends on the same line is code",
+       "/* x */ var y = 2;\n", comment=0, code=1, blank=0)
+# A line holding only comments -- even two of them -- is a comment line; the
+# second block then carries over. Written out because the naive expectation is
+# "reopening implies code", and it does not.
+expect("a line of two blocks is comment, and the second carries over",
+       "/* a */ /* b\n   c */\n", comment=2, code=0, blank=0)
+expect("...but real code before the reopened block makes it a code line",
+       "var x = 1; /* a */ /* b\n   c */\n", comment=1, code=1, blank=0)
+
+print()
+print("// and /* inside a literal do not open a comment")
+# This is the case a naive scanner gets wrong, and it is common in this
+# repository: refusal messages, doc-link constants, regex patterns.
+expect("a // in a string is code",
+       'var s = "// not a comment";\n', comment=0, code=1, blank=0)
+expect("a /* in a string is code",
+       'var s = "/* not a comment";\n', comment=0, code=1, blank=0)
+expect("a doc-link constant is code, and does not swallow the next line",
+       'const string D = "docs/limitations.md#anchor";\nvar y = 2;\n',
+       comment=0, code=2, blank=0)
+expect("a verbatim @\"...\" containing // is code",
+       'var s = @"C:\\\\a//b";\nvar y = 2;\n', comment=0, code=2, blank=0)
+expect("a doubled quote inside a verbatim string does not end it",
+       'var s = @"say ""// hi"" ok";\nvar y = 2;\n', comment=0, code=2, blank=0)
+expect("an escaped quote does not end a regular string",
+       'var s = "a\\" // still string";\nvar y = 2;\n', comment=0, code=2, blank=0)
+expect("a // in a char literal is code",
+       "var c = '/';\nvar y = 2;\n", comment=0, code=2, blank=0)
+
+print()
+print("share is over NON-BLANK lines")
+c = counts("// a\n// b\nvar x = 1;\n\n\n")
+check("blank lines are excluded from the share",
+      abs(c.share - (2 / 3 * 100)) < 1e-9, f"got {c.share}")
+check("an all-blank file reports 0.0 rather than dividing by zero",
+      counts("\n\n\n").share == 0.0, str(counts("\n\n\n").share))
+
+print()
+print("the walker skips build output")
+check("obj/ and bin/ are skipped", {"obj", "bin"} <= cd.SKIP_DIRS, str(cd.SKIP_DIRS))
+check("graphify-out is skipped too", "graphify-out" in cd.SKIP_DIRS, str(cd.SKIP_DIRS))
+
+print()
+print("regression: the real pilot files reproduce their reported figures")
+# Guards the reduction claim in the PR for #3260 against a later classifier
+# change silently restating it. Anchored to the file, not to a literal, so it
+# tracks further reduction instead of pinning one moment.
+REPO = os.path.dirname(HERE)
+for rel, ceiling in [
+    ("AlRunner/Patches/BlobStoreIsolationPatches.cs", 60.0),
+    ("AlRunner/Patches/RecordPatches.ObjectMetadataSystemTable.cs", 60.0),
+    ("AlRunner/Infrastructure/AlCoverageTracker.cs", 60.0),
+]:
+    path = os.path.join(REPO, rel)
+    if not os.path.exists(path):
+        check(f"{rel} exists", False, "file missing")
+        continue
+    with open(path, encoding="utf-8") as fh:
+        share = cd.classify(fh.read()).share
+    check(f"{os.path.basename(rel)} stays under {ceiling}% comment",
+          share < ceiling, f"got {share:.1f}%")
+
+print()
+if FAILURES:
+    print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")
+    sys.exit(1)
+print("all checks passed")


### PR DESCRIPTION
Part of #3260. **This does not close that issue** — it delivers the pilot and the rule
amendment; the repo-wide reduction pass and the `GenerateDocumentationFile` question stay open
there. See "What remains" at the bottom.

The pilot is **comment-only**: every code line in all four touched `AlRunner/` files is
byte-identical to `main`. Verification is described under "How I proved it is comment-only".

---

## 1. A rule change, called out separately because it needs reviewing as one

**This is the part to read first.** `.claude/rules/loud-failures.md` gains a subsection under its
existing "Audit obligation", and `.claude/rules/precompiled-dll-respect.md` gains a short section
pointing at it. Neither weakens the obligation.

**Before** — the whole of the audit obligation:

> Any new patch under `AlRunner/Patches/` (or anywhere else substituting BC method behaviour)
> must justify in a code comment why its return value is **observably equivalent** to the real BC
> behaviour for in-scope test code. If it isn't, it throws instead.

**After** — that paragraph is unchanged, and a subsection is added saying the justification is
**a claim plus a citation, not the derivation behind it**:

- **stays at the line**: the claim (what an in-scope caller observes, and why it equals BC), the
  citation (a corpus codeunit and its verdict, an issue number, a `docs/` anchor, the BC member
  that decides it), and the trap a later editor would otherwise fall into;
- **moves to `docs/` or the PR body**: how the corpus adjudicated it leg by leg, the decompiled
  internals you walked through, what you tried first, measurement tables.

It states explicitly that **a reviewer may ask for a justification to be shortened, never for one
to be removed, and may never accept a patch that has none.**

### The evidence for it, since a rule change should not rest on assertion

`#3260` measured that ~94% of comment mass is explanatory prose rather than changelog. Breaking
that 94% down further, attributing each comment **block** by vocabulary across
`AlRunner/Patches/` (155 files, 30,655 comment lines, 48.4% of non-blank lines):

| block content | share of comment mass in `Patches/` |
|---|---|
| an equivalence/scope claim only | **8.6%** |
| pure derivation — corpus narration, measurements, rejected attempts | **25.1%** |
| a claim mixed with its derivation | 18.8% |
| ordinary explanation, neither | 47.5% |

85% of the pure-derivation mass sits in blocks longer than ten lines. So the obligation itself
accounts for under a tenth of these files, and the prose it is embedded in accounts for roughly
five times more — which is the argument that the *form*, not the requirement, is what needed
bounding.

**Caveat on that table, stated because it matters:** attribution is by vocabulary, so it is
indicative, not exact. It is reproducible from `tools/comment-density.py` plus the block-walker
described in the commit; a reviewer who disagrees with the split can re-derive it.

---

## 2. The pilot — three files, chosen and measured

Measured with `tools/comment-density.py` (added in this PR):

| file | comment lines | share | code |
|---|---|---|---|
| `AlRunner/Patches/BlobStoreIsolationPatches.cs` | 216 → **94** | 70.8% → 51.4% | 89 → 89 |
| `AlRunner/Patches/RecordPatches.ObjectMetadataSystemTable.cs` | 366 → **160** | 69.6% → 50.0% | 160 → 160 |
| `AlRunner/Infrastructure/AlCoverageTracker.cs` | 220 → **171** | 57.3% → 51.0% | 164 → 164 |
| **total** | **802 → 425 (-47%)** | | **413 → 413** |

**Repo-wide: 46.0% → 45.8%.** That 0.2-point movement is the sizing answer the issue asked for,
and it is the most useful number here — see "Is this worth doing repo-wide?" below.

`NclShadowRuntime.cs` was excluded because PR #3385 is editing it, and
`RecordPatches.TransactionSnapshot.cs` because PR #3381 is. Both were on the issue's candidate
list. Checked against every open PR's file list before starting.

### What moved, what was deleted, what was kept

**Moved to `docs/blob-store-isolation.md` (new, 173 lines), with pointers left behind.** The
whole derivation behind `BlobStoreIsolationPatches.cs`: the per-leg corpus 60940 and 60944
results, the Ncl `TempTableDataProvider.Insert` / `CloneBlobs` call trace, the Cecil scan that
established the single-call-site count, and the rejected value-keyed attempt. Nothing here was
deleted — this file carries a measurement (the Cecil call-site count) and two corpus verdicts
that exist nowhere else, so a move was mandatory rather than optional.

**Replaced by a pointer to prose that already existed.** The 214-line header of
`RecordPatches.ObjectMetadataSystemTable.cs` turned out to be a near-verbatim duplicate of
`docs/limitations.md#object-metadata-system-table`, which the header itself already pointed at —
and the doc is **more current**: it names #3154, which the header does not. Nothing was lost by
pointing at it.

**Deleted as stale or self-narrating.** A doc comment on `EnumerateApplicationDatabaseTableIds`
still said "**No service tier has adjudicated it**" and described the 11 `ObsoleteState = Removed`
ids as an open question. Corpus PR #179 settled that on eight OnPrem legs, and the same file's
header already said so. That is the exact failure this issue predicts, and it was found by
reading rather than by any guard.

**Deliberately kept.** The `observably equivalent` justification on `DetachStoredBlobs`, the
"re-check the CloneBlobs call count if a future BC version changes shape" trap, the
`PRECOMPILED-DLL RESPECT` note, the two-bucket classification telling a later editor which
exception type a *new* refusal in the Object Metadata file should raise, and the "keep this a
prepend" constraint in `AlCoverageTracker`. Each of these changes what the next person types.

---

## 3. `tools/comment-density.py` + `tools/test_comment_density.py`

The issue asked for the measurement to be reproducible. Reproducing the filing baseline first:
my classifier gives **exactly** the issue's figures for the three candidate files that have not
changed since filing — `ALDatabasePatches.cs` 288/201, `AlDapSession.cs` 199/143,
`AlCoverageTracker.cs` 220/164 — and 46.0% repo-wide against the maintainer's re-measured 45.7%
(295 files then, 297 now).

A trailing `// comment` counts as **code**, deliberately: that under-counts comment mass, so a
reduction measured with this tool is never flattered by it.

`tools/test_comment_density.py` is auto-discovered by `pr-gate.yml`'s glob (`tools/test_*.py`),
so it gates from the day it lands with no workflow edit. Its fixtures are the cases where a naive
`startswith("//")` disagrees — `//` inside a string, verbatim `@"..."` literals, a doc-link
constant, a blank line inside a `/* */` block. One of my own expectations in it was wrong and the
tool was right; the test now records the real behavior with a note saying why the naive
expectation fails.

---

## 4. `ProseRelocationPointerTests` — and the defect it found immediately

The maintainer's comment on #3260 names the drift test as the load-bearing part of moving prose
out: *"the failure mode when prose moves out is not 'the doc is far away', it is 'the doc silently
stops matching the code'."*

This checks the cheap half that breaks first — that a `docs/x.md` pointer names a file that
exists, that a `#anchor` really is in that file, and that a doc created to hold one file's
derivation is still pointed at by it. It does not, and cannot, check that the prose is accurate.

**It found four broken pointers on its first run.** Three were my regex's fault (a sentence-ending
period swallowed into the anchor; a literal `#anchor` placeholder that is prose about link format,
not a link) and are fixed in the test. **One was real:**
`AlRunner/Patches/RecordPatches.FeatureKeyVirtualTable.cs` pointed at `docs/scope.md#http`, which
does not exist — the anchor is `#external-http`. Fixed here, comment-only.

I verified the test is not a no-op by renaming an anchor in `docs/blob-store-isolation.md` and
confirming it fails with the pointer named, then restoring it.

---

## How I proved the pilot is comment-only

For each changed file under `AlRunner/`, I extracted the code-classified lines from `HEAD:<file>`
and from the working copy using the same stateful scanner the measurement tool uses, and compared
the lists:

```
CODE IDENTICAL  AlRunner/Infrastructure/AlCoverageTracker.cs
CODE IDENTICAL  AlRunner/Patches/BlobStoreIsolationPatches.cs
CODE IDENTICAL  AlRunner/Patches/RecordPatches.FeatureKeyVirtualTable.cs
CODE IDENTICAL  AlRunner/Patches/RecordPatches.ObjectMetadataSystemTable.cs
```

This is stronger than reading the diff, because it is insensitive to how the diff happens to align
comment and code hunks.

**Tests run**, and this is all I ran — no claim about anything else:

- `dotnet test AlRunner.Tests --filter FullyQualifiedName~ProseRelocationPointerTests` — 3 passed.
- `dotnet test AlRunner.Tests --filter "…Documentation|…Drift|…ObjectMetadata|…Coverage|…Blob"` —
  **114 passed, 0 failed**, 1 skipped (a submodule-availability skip, unrelated).
- `python3 tools/test_comment_density.py` — all checks pass.
- `dotnet build AlRunner/AlRunner.csproj` — 0 errors; all 40 warnings pre-existing, none in the
  touched files.

The `Tests updated` gate is satisfied by a real new test file, not by a bypass label.

---

## Is this worth doing repo-wide? My reading of the numbers

**On the worst files, yes; as an undirected sweep, no** — and the 0.2-point repo-wide movement is
the reason. Extrapolating -47% across all 297 files would be wrong: these three were picked from
the top of the distribution, and the reduction came from three specific conditions that do not
hold everywhere.

Where it pays, in descending order of confidence:

1. **A header duplicating a `docs/` section it already points at.** `ObjectMetadataSystemTable.cs`
   dropped 206 comment lines and lost nothing, because the doc was already better. This is
   mechanical and safe, and worth grepping for directly: a file pointing at a `docs/` anchor *and*
   carrying a header over ~50 lines is the signature.
2. **Blocks over ten lines**, which hold 60.4% of all comment mass repo-wide (62.9% inside
   `Patches/`). That is where the `impl-agent.md` trigger already points.
3. **Files with a corpus-verdict narration**, where a `docs/` move is genuinely required rather
   than optional because the measurement exists nowhere else.

Where it does not pay: `AlCoverageTracker.cs` only reached -22% (220 → 171) with real effort,
because its prose is mostly *ordinary explanation* — the 47.5% row of the table above — which is
the category the issue is right to protect. A sweep optimizing the percentage would start
deleting that, and the result would be worse than the prose it removed.

So my recommendation is **a targeted pass over files matching signature (1), not a density
target.** A percentage goal is the wrong instrument here: it rewards deleting the cheapest lines
rather than the most redundant ones, and 47.5% of the mass is prose that should stay.

---

## What remains open on #3260

- The repo-wide reduction pass (this is a pilot over 3 of 297 files).
- `GenerateDocumentationFile` is still `false` in `AlRunner/AlRunner.csproj:14`, with the CS1591
  cost noted in the issue.
- Whether to adopt the targeted-pass recommendation above, or to set a density target after all.

---

*Written by `stma-auto-21`, an automated agent acting on the account holder's behalf. The
measurements are mine and reproducible from `tools/comment-density.py`. **The keep/move split
remains the maintainer's call** — I applied it to three files as a concrete proposal, and the rule
amendment in section 1 is a proposal to review as one, not a settled decision.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9pEPoD8e4wmVyuTrxyuh



No linked issue: #3260 stays open deliberately — this PR delivers the rule amendment and a three-file pilot, while the repo-wide reduction that issue asks for remains outstanding and is a decision for the maintainer.


Corpus-NA: comment-only in all four `AlRunner/` files — the code lines are byte-identical to `origin/main` (verified by extracting code-classified lines from both sides, not by reading the diff), so nothing AL can observe changes and there is no behaviour for a service tier to adjudicate.
