### PR TITLE
test(corpus): advance the pin to e6a0a0c, where the SingleInstance fixtures stop sharing

### DIFF
--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -1457,3 +1457,37 @@ The starting point is `ddb9b5ab`/2978, not `408c39fe`/2969: `5ad50bc2` on `main`
 pin and the count in one commit, and its own step is already recorded by that PR.
 
 Written by agent stma-auto-11 (automated implementation agent).
+
+### 2977 -> 2978 (pin 9ee6bbcd -> e6a0a0cd, catch-up bump)
+
+One upstream commit, [#262](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/262),
+which fixes corpus issue #261: three test codeunits shared one `SingleInstance` cache fixture
+that latches on first read, so they passed or failed depending on execution order once harness
+commit `26d88ffc` stopped giving each codeunit a fresh session. The fix gives each test codeunit
+its own fixture codeunit and adds a `.github/` script that fails the corpus build when one
+`SingleInstance` codeunit is instantiated from more than one test codeunit.
+
+The net +1 is a split, not new coverage of a new surface:
+
+| | test |
+|---|---|
+| removed | `Codeunit60600.TestCodeunit_SingleInstance_DoesNotLeakAcrossTests` |
+| added | `Codeunit60600.TestCodeunit_SingleInstance_SurvivesACodeunitBoundary` |
+| added | `Codeunit60600.TestCodeunit_NonSingleInstance_DoesNotSurviveACodeunitBoundary` |
+
+**2978 is the number the guard itself reported**, not one computed by adding 1 to 2977.
+Measured on BC 28.1.49838.53910 on a real 3-bundle run: with the pin moved and the baseline
+still at 2977 the run exited 4 with
+`GROWTH: suite 'al-language' tests count: expected 2977, actual 2978 (BC 28.1)`, and 2978 is
+that `actual`. Re-run after the bump: **3007 tests total, 3007 pass, 0 fail, exit 0**, of which
+`al-language-onprem` contributes 29 and `al-language-internals-fixture` 0 — both unchanged and
+neither reporting a mismatch.
+
+**No newly-failing test, so no expectations entry moved.** The classification split is
+unchanged across the bump: 3 `pass-oos`, 11 `pass-known-gap`, 1 `pass-divergence`, and
+`--expectations-require-match` reported no unmatched entry in either direction.
+
+This is a **catch-up** bump per `.claude/rules/al-language-submodule.md`: #262 is a corpus-side
+fixture fix needing no runner change, so a bump alone is green rather than red by construction.
+
+Written by agent stma-auto-22 (automated implementation agent).

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Schema, semantics and how to bump: README.md in this directory. Per-bump rationale: history.md, never a prose line in here (#2485).",
   "suites": {
     "al-language": {
-      "tests": { "default": 2977 },
+      "tests": { "default": 2978 },
       "appGroups": { "default": 1 }
     },
     "al-language-internals-fixture": { "tests": { "default": 0 }, "appGroups": { "default": 1 } },


### PR DESCRIPTION
Catch-up bump of `tests/al-language` from `9ee6bbcd` to **`e6a0a0cd`**, plus the count baseline that moves with it.

This PR closes no issue — it is a catch-up bump per `.claude/rules/al-language-submodule.md`, so there is deliberately no closing keyword anywhere in this body.

## What came in — one commit, not seventeen

I was briefed to expect a 17-commit gap. **The real gap was one commit.** The shared submodule working directory in the top-level checkout was sitting at `17b015ef`, an *older* corpus commit left checked out by another agent, and reading it as the pin makes the gap look 17 commits wide. The pin recorded in `origin/main`'s tree was already `9ee6bbcd` (advanced by #3362, merged as `b7784d88`), so `9ee6bbcd..origin/master` is:

```
e6a0a0c test(codeunit): give each SingleInstance test codeunit its own cache fixture (#262)
```

Worth stating because the same misreading is available to the next agent: `git ls-tree origin/main tests/al-language` is the pin; `git -C tests/al-language rev-parse HEAD` is whatever the last process to touch the shared clone left behind.

Corpus PR [#262](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/262) fixes corpus issue #261. Three test codeunits shared one `SingleInstance` cache fixture that latches on first read, so they passed or failed by execution order once harness commit `26d88ffc` stopped giving each codeunit a fresh session. Upstream gives each test codeunit its own fixture codeunit and adds `.github/scripts/check-singleinstance-fixture-owners.py`, which fails the corpus build when one `SingleInstance` codeunit is instantiated from more than one test codeunit.

## Measurement

BC 28.1.49838.53910, run exactly as `.github/workflows/bc-tests.yml` does — all three corpus apps via `scripts/corpus-app-dirs.py`, `--strict --expectations-require-match --count-baseline`.

| run | pin | baseline | result |
|---|---|---|---|
| before (cold) | `9ee6bbcd` | 2977 | 3006/3006 pass, **exit 0** |
| after (cold) | `e6a0a0cd` | 2977 | 3007/3007 pass, 0 fail, 0 error, exit 4 — count only |
| after (warm) | `e6a0a0cd` | 2978 | 3007/3007 pass, **exit 0** |

**Zero newly-failing tests**, so there is nothing to classify: no `expect-oos`, no `expect-fail-known-gap`, no `expect-divergence` entry added, and none removed. The classification split is identical across the bump — 3 `pass-oos`, 11 `pass-known-gap`, 1 `pass-divergence` — and `--expectations-require-match` reported no unmatched entry in either direction.

The prior cycle's measurement of 26 newly-failing tests is stale, as the brief anticipated: it was taken against a 17-commit gap that no longer exists, and its four gating issues (#3216, #3185, #3071, #3176) are all closed.

**Cold vs warm.** Cold: AL emit 6.8s, C# compile 17.7s. Warm: both 0.0s, confirming a compile-cache HIT rather than a silent recompile. Same 3007/3007 both ways, so no cache-sensitive defect of the kind `local-test-scope.md` warns about.

**The two other CI corpus legs**, run locally on the bumped pin:

- xmlport order-independence guard (`--test Codeunit6020 --strict`): 63/63, exit 0.
- `tests/runner-extras` with the shared baseline: 363/363, exit 0, matching its baseline exactly.

## Why the count moves by one

2977 -> 2978, and it is a split rather than new coverage of a new surface:

| | test |
|---|---|
| removed | `Codeunit60600.TestCodeunit_SingleInstance_DoesNotLeakAcrossTests` |
| added | `Codeunit60600.TestCodeunit_SingleInstance_SurvivesACodeunitBoundary` |
| added | `Codeunit60600.TestCodeunit_NonSingleInstance_DoesNotSurviveACodeunitBoundary` |

**2978 is the number `--count-baseline` itself reported as `actual`**, not one computed by adding 1 to 2977 — the run with the pin moved and the baseline still at 2977 exited 4 with `GROWTH: suite 'al-language' tests count: expected 2977, actual 2978 (BC 28.1)`.

## Verified by execution, not by a tick

Per `verify-execution-not-the-tick.md`, "the total went up by one" does not prove the new tests ran. Diffing PASS/FAIL/ERROR names between the before and after logs gives exactly the three names above and nothing else, and the four tests that had been red on corpus master before #262 and `MsDyn365Bc.On.Linux#76` all report `PASS` by name here:

```
PASS  Codeunit60378.IsolatedStorage_SetEncrypted_GetRoundTripsPlaintext (2ms)
PASS  Codeunit60614.TestCodeunit_SingleInstance_SurvivesACodeunitRunScope (4ms)
PASS  Codeunit60613.TestCodeunit_SingleInstance_SurvivesCreatingScopeExit (5ms)
PASS  Codeunit60615.TestCodeunit_SingleInstance_SurvivesAScopeThatErrored (4ms)
```

## One environmental failure, not a finding

The first `runner-extras` run reported EXEC-FAIL on 18 bundles with `Could not load file or assembly '~/.cache/al-runner/ncl-shadow/f0240d0c…/AlRunner.QueryJoin.dll'`. That directory did not exist by the time I looked, and `pgrep` showed three other agents driving the runner concurrently against the same shared shadow cache. It is the race `f461e5bf` addresses on the publish side, not a consequence of this pin. Re-run clean: 363/363, exit 0. Recording it so the next person reading a corpus log on this box recognizes the shape rather than diagnosing the pin.

## Scope

- Nothing under `tests/al-language/` is edited — only the pin moves.
- No `AlRunner/` file is touched, so `require-tests` does not trigger.
- `CHANGELOG.md` untouched.
- Corpus `master` was re-checked at `e6a0a0cd` immediately before pushing, so **the SHA pinned here is the SHA I actually ran.** Corpus PRs #264 and #265 were still open and unmerged; nothing from them is in this pin.
- Nothing was left unpinned. `e6a0a0cd` is corpus `master`'s tip, so there is no remainder and no issue holding one.

Written by agent `stma-auto-22`, an automated agent acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9pEPoD8e4wmVyuTrxyuh



No linked issue: catch-up submodule pin bump per `.claude/rules/al-language-submodule.md` — the corpus fix (corpus PR #262) already merged upstream, so this PR only advances the pin and the count baseline and has no runner-side issue to close.
