### PR TITLE
feat(installed-apps): seed NAV App Installed App from the loaded-app closure

### DIFF
--- a/AlRunner/Patches/RecordPatches.PublishedApplicationSystemTable.cs
+++ b/AlRunner/Patches/RecordPatches.PublishedApplicationSystemTable.cs
@@ -106,6 +106,12 @@ public static partial class RecordPatches
     /// <c>Exist(...)</c> FlowField is computed over. Seeded alongside 2000000206 (#3066).</summary>
     internal const int InstalledApplicationSystemTableId = 2000000212;
 
+    /// <summary>NAV App Installed App — the TENANT-database registry of installed apps
+    /// (#2961). Seeded alongside 2000000206/2000000212 from the same loaded-app closure, so
+    /// the three tables cannot disagree about which apps are present. Unlike those two it is
+    /// <c>Scope = Cloud</c>, so ordinary Cloud-target AL can name it directly.</summary>
+    internal const int NavAppInstalledAppSystemTableId = 2000000153;
+
     private static bool _publishedApplicationBundleRowSeededForThisBundle;
 
     internal static void ResetPublishedApplicationSystemTableForNewBundle()
@@ -163,6 +169,11 @@ public static partial class RecordPatches
         // practice (both ship in System.app), so this is a guard, not an expected path.
         var installedMeta = EnsureTableInMetadataCache(InstalledApplicationSystemTableId);
 
+        // NAV App Installed App (2000000153), same guard and the same reason: a closure can
+        // carry 2000000206 without it, and this table simply stays empty as it did before
+        // #2961 rather than the whole seed failing.
+        var navAppInstalledMeta = EnsureTableInMetadataCache(NavAppInstalledAppSystemTableId);
+
         var source = ResolveSkeletonDataAccessSource();
         if (source == null)
         {
@@ -183,6 +194,7 @@ public static partial class RecordPatches
         if (modules.Count == 0) return;
 
         int seeded = 0, alreadyPresent = 0, installedSeeded = 0, installedAlreadyPresent = 0;
+        int navAppSeeded = 0, navAppAlreadyPresent = 0;
         var failed = new List<string>();
 
         SeedOutcome Run(string label, Action insert)
@@ -225,6 +237,19 @@ public static partial class RecordPatches
                 case SeedOutcome.Inserted: installedSeeded++; break;
                 case SeedOutcome.AlreadyPresent: installedAlreadyPresent++; break;
             }
+
+            if (navAppInstalledMeta == null) continue;
+
+            // Attempted independently of both rows above, for the reason given there: these
+            // are separate inserts into separate tables, and skipping this one because a
+            // sibling was already present would leave an app published-and-installed on one
+            // pair of tables and absent from the one ordinary Cloud AL actually reads.
+            switch (Run($"{moduleLabel} (nav app installed)",
+                        () => InsertNavAppInstalledAppRow(navAppInstalledMeta, source, m)))
+            {
+                case SeedOutcome.Inserted: navAppSeeded++; break;
+                case SeedOutcome.AlreadyPresent: navAppAlreadyPresent++; break;
+            }
         }
 
         // A PARTIAL row set must not be allowed to continue, and specifically must not be
@@ -244,17 +269,21 @@ public static partial class RecordPatches
                 $"[PublishedApplication] seeded only {seeded + alreadyPresent} of {modules.Count} "
                 + $"{what} row(s) into table {PublishedApplicationSystemTableId} and "
                 + $"{installedSeeded + installedAlreadyPresent} into table "
-                + $"{InstalledApplicationSystemTableId}; refusing to continue "
+                + $"{InstalledApplicationSystemTableId} and "
+                + $"{navAppSeeded + navAppAlreadyPresent} into table "
+                + $"{NavAppInstalledAppSystemTableId}; refusing to continue "
                 + "because a partial row set would be captured into the install baseline and "
                 + "restored silently by later runs. Failures: " + string.Join(" | ", failed)
                 + " — see AlRunner#2963.");
 
-        if (seeded > 0 || installedSeeded > 0)
+        if (seeded > 0 || installedSeeded > 0 || navAppSeeded > 0)
             PerfTrace.Log(
                 $"PublishedApplication: seeded {seeded} {what} row(s)"
                 + (alreadyPresent > 0 ? $" ({alreadyPresent} already present)" : "")
                 + $", {installedSeeded} installed-application row(s)"
-                + (installedAlreadyPresent > 0 ? $" ({installedAlreadyPresent} already present)" : ""));
+                + (installedAlreadyPresent > 0 ? $" ({installedAlreadyPresent} already present)" : "")
+                + $", {navAppSeeded} nav-app-installed-app row(s)"
+                + (navAppAlreadyPresent > 0 ? $" ({navAppAlreadyPresent} already present)" : ""));
     }
 
     /// <summary>
@@ -318,6 +347,53 @@ public static partial class RecordPatches
                 // Part of this table's primary key ("Runtime Package ID", "Tenant ID") and the
                 // same blank the Published Application row carries, for the same reason.
                 Set("Tenant ID", string.Empty);
+            });
+    }
+
+    /// <summary>
+    /// One NAV App Installed App (2000000153) row per loaded app (#2961) — the TENANT-database
+    /// registry, keyed on "App ID" alone, that ordinary Cloud-target AL reads when it asks
+    /// which apps are installed.
+    /// </summary>
+    /// <remarks>
+    /// <para>Built from the SAME <c>BcRuntime.RegisteredModules()</c> closure and the SAME
+    /// <c>AppPackageIdentity</c> values as the 2000000206 and 2000000212 rows seeded beside it,
+    /// so the three tables cannot disagree about which apps are present or which package id
+    /// names an app. That agreement is the point: BC's own
+    /// <c>TenantApplicationStorageRepository</c> joins this table to Tenant Application Storage
+    /// ON <c>[Package ID]</c>, so a package id here that differed from the one on the published
+    /// row would be a registry that answers about a different app than it names.</para>
+    /// <para>Columns deliberately left at <c>NCLMetaField.EmptyValue</c>, BC's own per-field
+    /// default, because the runner has no faithful value for them and inventing one would be
+    /// the silent-fake shape <c>.claude/rules/loud-failures.md</c> forbids: "Content Hash" and
+    /// "Hash Algorithm" (a real tier computes these over the .app payload at publish time — the
+    /// runner never hashes a package), the four "Compatibility" columns (BC's own publish SQL
+    /// inserts literal 0 for all four, which is what EmptyValue already gives), "Extension
+    /// Type", and "Published As". The last is the one worth naming: its OptionMembers are
+    /// Global/PTE/Dev, so EmptyValue reads as Global — which is what a platform app loaded from
+    /// an artifact cache actually is, not a guess dressed as a measurement. A bundle published
+    /// as a PTE on a real tier would read PTE there and Global here; no runner-side test asserts
+    /// that column, and no corpus test may either until a tier has adjudicated it.</para>
+    /// </remarks>
+    private static void InsertNavAppInstalledAppRow(
+        NCLMetaTable meta, object source,
+        (Guid AppId, string Name, string Publisher, string Version) module)
+    {
+        var (major, minor, build, revision) = SplitManifestVersion(module.Version);
+
+        InsertApplicationTableRow(
+            NavAppInstalledAppSystemTableId, meta, source,
+            fill: Set =>
+            {
+                // The whole primary key of this table, and the id every reader filters on.
+                Set("App ID", module.AppId);
+                Set("Package ID", AppPackageIdentity.PackageIdFor(module.AppId));
+                Set("Name", module.Name);
+                Set("Publisher", module.Publisher);
+                Set("Version Major", major);
+                Set("Version Minor", minor);
+                Set("Version Build", build);
+                Set("Version Revision", revision);
             });
     }
 

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -33,6 +33,8 @@
         "microsoft-test-library": { "tests": 3, "absentOn": ["27.0", "27.3", "27.5"] },
         "navapp-callermodule-dispatch-dep": { "tests": 0 },
         "navapp-callermodule-dispatch-main": { "tests": 4 },
+        "navapp-installed-app-dep": { "tests": 0 },
+        "navapp-installed-app-system-table": { "tests": 6 },
         "navapp-moduleinfo-dep": { "tests": 0 },
         "navapp-moduleinfo-main": { "tests": 15 },
         "object-metadata-system-table": { "tests": 6 },

--- a/tests/runner-extras/navapp-installed-app-dep/NiadDummy.Codeunit.al
+++ b/tests/runner-extras/navapp-installed-app-dep/NiadDummy.Codeunit.al
@@ -1,0 +1,10 @@
+// Deliberately empty of behaviour. This app is a fixture: what the test next door reads is its
+// MANIFEST identity, reflected into NAV App Installed App (2000000153) by the runner's seeder.
+// An object has to exist for the app to compile and be loaded at all.
+codeunit 65770 "NIAD Dummy"
+{
+    procedure Ping(): Integer
+    begin
+        exit(973);
+    end;
+}

--- a/tests/runner-extras/navapp-installed-app-dep/app.json
+++ b/tests/runner-extras/navapp-installed-app-dep/app.json
@@ -1,0 +1,17 @@
+{
+  "id": "5f2a9c74-1b83-4e07-9d62-8a4c3e015b9f",
+  "name": "NavAppInstalledApp Dep",
+  "publisher": "AL Runner",
+  "version": "9.7.5.3",
+  "brief": "Issue #2961. Dependency half of the NAV App Installed App (2000000153) registry reproducer: a second loaded app, with a deliberately distinctive four-part version, so the consuming bundle can prove the registry discriminates BETWEEN apps rather than answering the same row for all of them.",
+  "description": "Carries no logic. Its whole purpose is to exist in the loaded closure with an identity — app id, name, publisher and a 9.7.5.3 version whose four parts are all different and none of them 0 or 1 — that cannot be confused with the consuming bundle's 1.0.0.0. A registry that fabricated rows, shared one package id, or echoed the bundle's own manifest back would pass the single-app tests next door and fail here.",
+  "dependencies": [],
+  "idRanges": [
+    {
+      "from": 65770,
+      "to": 65779
+    }
+  ],
+  "platform": "27.0.0.0",
+  "runtime": "15.0"
+}

--- a/tests/runner-extras/navapp-installed-app-system-table/NiaAssert.Codeunit.al
+++ b/tests/runner-extras/navapp-installed-app-system-table/NiaAssert.Codeunit.al
@@ -1,0 +1,25 @@
+// Standalone Assert — this suite must stand alone, it does not import from tests/al-language.
+codeunit 65760 "NIA Assert"
+{
+    procedure AreEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        if Format(Expected) <> Format(Actual) then
+            Error('Expected %1 but got %2: %3', Format(Expected), Format(Actual), Msg);
+    end;
+
+    procedure AreNotEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        if Format(Expected) = Format(Actual) then
+            Error('Expected a value other than %1: %2', Format(Expected), Msg);
+    end;
+
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then Error('Expected true: %1', Msg);
+    end;
+
+    procedure IsFalse(Condition: Boolean; Msg: Text)
+    begin
+        if Condition then Error('Expected false: %1', Msg);
+    end;
+}

--- a/tests/runner-extras/navapp-installed-app-system-table/NiaTests.Codeunit.al
+++ b/tests/runner-extras/navapp-installed-app-system-table/NiaTests.Codeunit.al
@@ -1,0 +1,193 @@
+// Issue #2961. NAV App Installed App (2000000153) on the runner: where the rows come from when
+// nothing was ever installed, and the properties that make them mean anything.
+//
+// WHY THIS IS A RUNNER TEST AND NOT A CORPUS TEST
+//   It is both, and the split is the same one Published Application (2000000206) already makes
+//   next door. What this table CONTAINS on a real tier is plain BC behaviour and is adjudicated
+//   upstream, where a service tier answers it.
+//
+//   The two tables differ in one way that matters for WHERE the upstream test can live.
+//   2000000206 is Scope = OnPrem, so naming it from the Cloud-target corpus app reports
+//   `error AL0296`, and its upstream test needed the corpus's second, OnPrem-target app.
+//   2000000153 is Scope = Cloud, so its upstream test lives in the MAIN corpus app and is
+//   adjudicated on the eight required cloud legs rather than the eight non-gating OnPrem ones.
+//
+//   What stays HERE is only what the RUNNER does, for a bundle that is not the corpus app:
+//   that rows exist at all with nothing installed, that THIS bundle's own manifest identity is
+//   among them, and that the identity columns discriminate BETWEEN apps.
+//
+// WHY THE DISCRIMINATION TEST IS THE IMPORTANT ONE
+//   On a real tier these rows exist because INSTALLING an app wrote them. The runner never
+//   installs anything, so it seeds one row per loaded app from the manifests it already parses
+//   for NavApp.GetModuleInfo — the same closure, and the same AppPackageIdentity values, as the
+//   2000000206 and 2000000212 rows seeded in the same pass.
+//
+//   Seeding the table while letting every row share a package id would make BC's own join in
+//   TenantApplicationStorageRepository —
+//
+//     ON [Tenant Application Storage].[Package ID] = [NAV App Installed App].[Package ID]
+//
+//   — match the wrong app, or every app. That is green-for-the-wrong-reason and is
+//   indistinguishable from a fix until something unrelated breaks, which is why
+//   PackageIdsDiscriminateBetweenApps and RowIdentityMatchesThePublishedApplicationRow are not
+//   decoration.
+codeunit 65762 "NIA Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit "NIA Assert";
+
+    [Test]
+    procedure RowsExistEvenThoughNothingWasEverInstalled()
+    var
+        NavAppInstalledApp: Record "NAV App Installed App";
+    begin
+        // Before #2961 the runner had no view of installed apps at all: this table was empty,
+        // read cleanly, and every AL question about which apps are installed got a wrong
+        // answer rather than a refusal.
+        Assert.IsTrue(
+            NavAppInstalledApp.Count() > 0,
+            'NAV App Installed App must list the apps the runner loaded.');
+    end;
+
+    [Test]
+    procedure TheBundlesOwnAppIsListedWithItsManifestIdentity()
+    var
+        NavAppInstalledApp: Record "NAV App Installed App";
+        Mi: ModuleInfo;
+    begin
+        NavApp.GetCurrentModuleInfo(Mi);
+
+        // Found the way every reader finds it: by App ID, which is this table's whole
+        // primary key.
+        Assert.IsTrue(
+            NavAppInstalledApp.Get(Mi.Id()),
+            'The bundle under test must have a NAV App Installed App row of its own.');
+
+        // The values are the manifest's, not invented ones.
+        Assert.AreEqual(Mi.Name(), NavAppInstalledApp.Name, 'Name must come from the manifest.');
+        Assert.AreEqual(Mi.Publisher(), NavAppInstalledApp.Publisher, 'Publisher must come from the manifest.');
+        Assert.AreEqual(1, NavAppInstalledApp."Version Major", 'Version Major must be the manifest version''s major part.');
+        Assert.AreEqual(0, NavAppInstalledApp."Version Minor", 'Version Minor must be the manifest version''s minor part.');
+    end;
+
+    [Test]
+    procedure TheDependencyAppIsListedWithItsOwnDistinctIdentity()
+    var
+        NavAppInstalledApp: Record "NAV App Installed App";
+        DepId: Guid;
+    begin
+        // The dependency's version is 9.7.5.3: four DIFFERENT parts, none of them 0 or 1, so a
+        // seeder that echoed the consuming bundle's 1.0.0.0 back, or that parsed only the first
+        // part and defaulted the rest, cannot pass this by coincidence.
+        DepId := '{5F2A9C74-1B83-4E07-9D62-8A4C3E015B9F}';
+
+        Assert.IsTrue(NavAppInstalledApp.Get(DepId),
+            'The loaded dependency app must have a NAV App Installed App row of its own.');
+
+        Assert.AreEqual('NavAppInstalledApp Dep', NavAppInstalledApp.Name, 'Name must be the dependency''s own.');
+        Assert.AreEqual('AL Runner', NavAppInstalledApp.Publisher, 'Publisher must be the dependency''s own.');
+        Assert.AreEqual(9, NavAppInstalledApp."Version Major", 'Version Major must be the dependency''s own 9.');
+        Assert.AreEqual(7, NavAppInstalledApp."Version Minor", 'Version Minor must be the dependency''s own 7.');
+        Assert.AreEqual(5, NavAppInstalledApp."Version Build", 'Version Build must be the dependency''s own 5.');
+        Assert.AreEqual(3, NavAppInstalledApp."Version Revision", 'Version Revision must be the dependency''s own 3.');
+    end;
+
+    [Test]
+    procedure PackageIdsDiscriminateBetweenApps()
+    var
+        NavAppInstalledApp: Record "NAV App Installed App";
+        Mine: Guid;
+        Theirs: Guid;
+        Mi: ModuleInfo;
+        DepId: Guid;
+        Blank: Guid;
+    begin
+        // If every row carried the same Package ID — or the type default — BC's own join in
+        // TenantApplicationStorageRepository
+        //   ON [Tenant Application Storage].[Package ID] = [NAV App Installed App].[Package ID]
+        // would match the wrong app, or every app. That failure is invisible to a
+        // single-app test, which is why this suite loads a dependency at all.
+        DepId := '{5F2A9C74-1B83-4E07-9D62-8A4C3E015B9F}';
+        NavApp.GetCurrentModuleInfo(Mi);
+
+        NavAppInstalledApp.Get(Mi.Id());
+        Mine := NavAppInstalledApp."Package ID";
+        NavAppInstalledApp.Get(DepId);
+        Theirs := NavAppInstalledApp."Package ID";
+
+        Assert.AreNotEqual(Blank, Mine, 'This app''s Package ID must not be the type default.');
+        Assert.AreNotEqual(Blank, Theirs, 'The dependency''s Package ID must not be the type default.');
+        Assert.AreNotEqual(Mine, Theirs, 'Two different apps must not share a Package ID.');
+
+        // And the App ID key really is the discriminator, not an accident of row order.
+        Assert.AreNotEqual(Mi.Id(), DepId, 'The two apps must have different app ids.');
+    end;
+
+    [Test]
+    procedure EveryRowIsReachableByItsOwnAppIdKey()
+    var
+        NavAppInstalledApp: Record "NAV App Installed App";
+        Probe: Record "NAV App Installed App";
+        Mi: ModuleInfo;
+        DepId: Guid;
+        Walked: Integer;
+        Blank: Guid;
+        SawMine: Boolean;
+        SawDep: Boolean;
+    begin
+        DepId := '{5F2A9C74-1B83-4E07-9D62-8A4C3E015B9F}';
+        NavApp.GetCurrentModuleInfo(Mi);
+        // A row present in a FindSet walk but not gettable by its own primary key would mean
+        // the seeder wrote an App ID that does not match the key it inserted under — a registry
+        // that lists an app it cannot then answer about.
+        Assert.IsTrue(NavAppInstalledApp.FindSet(), 'There must be rows to walk.');
+        repeat
+            Assert.AreNotEqual(Blank, NavAppInstalledApp."App ID", 'No row may carry a blank App ID.');
+            Assert.IsTrue(Probe.Get(NavAppInstalledApp."App ID"),
+                'Every listed row must be gettable by its own App ID.');
+            Assert.AreEqual(NavAppInstalledApp.Name, Probe.Name, 'The keyed read must return the same row.');
+            if NavAppInstalledApp."App ID" = Mi.Id() then SawMine := true;
+            if NavAppInstalledApp."App ID" = DepId then SawDep := true;
+            Walked += 1;
+        until NavAppInstalledApp.Next() = 0;
+
+        // Deliberately NOT an exact count. How many apps share the process depends on how the
+        // runner was invoked — six when this suite runs alone, 79 when the whole runner-extras
+        // tree runs in one process — and pinning that number would make this test a statement
+        // about the invocation rather than about the registry. What must hold either way is
+        // that the walk found this bundle and its dependency among whatever else is loaded, and
+        // that every row it found was reachable by its own key (asserted in the loop above).
+        Assert.IsTrue(Walked >= 2,
+            'The walk must reach at least this bundle and its dependency.');
+        Assert.IsTrue(SawMine, 'The walk must reach this bundle''s own row.');
+        Assert.IsTrue(SawDep, 'The walk must reach the dependency''s row.');
+    end;
+
+    [Test]
+    procedure RowIdentityMatchesThePublishedApplicationRowForTheSameApp()
+    var
+        NavAppInstalledApp: Record "NAV App Installed App";
+        Mi: ModuleInfo;
+    begin
+        // 2000000153 is seeded in the SAME pass, from the SAME loaded-app closure and the SAME
+        // AppPackageIdentity values, as 2000000206/2000000212. This pins the half of that
+        // agreement a Cloud-target bundle can see: the version parts and the identity columns
+        // this table carries are the manifest's own, so a reader that resolves an app through
+        // this table and a reader that resolves it through GetModuleInfo agree.
+        //
+        // The 2000000206 side of the comparison cannot be named here — that table is
+        // Scope = OnPrem and this bundle is Cloud-target — which is exactly why the
+        // cross-table claim is asserted in the OnPrem suite next door and only the
+        // Cloud-visible half is asserted here.
+        NavApp.GetCurrentModuleInfo(Mi);
+        Assert.IsTrue(NavAppInstalledApp.Get(Mi.Id()), 'The bundle must have a row.');
+
+        Assert.AreEqual(Mi.Id(), NavAppInstalledApp."App ID",
+            'App ID must be the manifest app id GetModuleInfo reports.');
+        Assert.AreEqual(0, NavAppInstalledApp."Version Build", 'Version Build must be the manifest version''s build part.');
+        Assert.AreEqual(0, NavAppInstalledApp."Version Revision", 'Version Revision must be the manifest version''s revision part.');
+    end;
+}

--- a/tests/runner-extras/navapp-installed-app-system-table/app.json
+++ b/tests/runner-extras/navapp-installed-app-system-table/app.json
@@ -1,0 +1,24 @@
+{
+  "id": "3d7c1e58-9a26-4b0f-8c41-6e5b2a9d7f04",
+  "name": "Runner Extras - NAV App Installed App System Table",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Issue #2961: NAV App Installed App (2000000153) is the tenant-database registry of installed apps. The runner has no install step, so the table was empty and every read answered nothing. This suite pins the runner's side: rows exist for the apps the runner loaded, this bundle is among them, and the identity columns discriminate between apps.",
+  "description": "What the table CONTAINS on a real tier is plain BC behaviour and is adjudicated upstream in the corpus (BusinessCentral.AL.Language.Tests). Unlike Published Application (2000000206), which is Scope = OnPrem and needed the corpus's OnPrem-target app, 2000000153 is Scope = Cloud, so the upstream test lives in the main Cloud corpus app. What stays HERE is only what the RUNNER does for a bundle that is not the corpus app: that rows exist at all with nothing installed, that this bundle's own manifest identity is among them, and that App ID and Package ID discriminate BETWEEN apps rather than every row sharing a default.",
+  "dependencies": [
+    {
+      "id": "5f2a9c74-1b83-4e07-9d62-8a4c3e015b9f",
+      "name": "NavAppInstalledApp Dep",
+      "publisher": "AL Runner",
+      "version": "9.7.5.3"
+    }
+  ],
+  "idRanges": [
+    {
+      "from": 65760,
+      "to": 65769
+    }
+  ],
+  "platform": "27.0.0.0",
+  "runtime": "15.0"
+}


### PR DESCRIPTION
Closes #2961

Table **2000000153 `NAV App Installed App`** is the tenant-database registry AL reads to ask which apps are installed and at what version. The runner has no install step, so the table was empty **and read cleanly** — every such question got a wrong answer rather than a refusal, which is the silent-fake shape `loud-failures.md` forbids.

## Scope: what this issue actually still is

The issue body describes two things. Half of it landed already and the remaining half is narrower than the title suggests — recorded here so nobody re-derives it:

- **`NavApp.VersionInstalled` / `GetModuleInfo` by id** was fixed in #3225 (`BcRuntime.TryGetModuleInfoByAppId`). The stack trace at the top of #2961 no longer reproduces.
- **Table 2000000153 was still unserved.** Nothing in #3225 touches it, and the survey #2961 asks for had not been done. That is what this PR does.

## Two premises in the issue body that I checked rather than took as given

**1. "The runner has no view of installed apps at all" is stale.** #3004/#3074 added Published Application (2000000206) and Installed Application (2000000212), both seeded from `BcRuntime.RegisteredModules()`. The gap was specifically 2000000153.

**2. Whether the corpus can express this at all.** The nearest precedent argued it could not: 2000000206 is `Scope = OnPrem`, so a Cloud-target corpus app cannot even name it (`error AL0296`), which is why the corpus grew a second OnPrem-target app for it. I measured 2000000153 instead of assuming it followed:

| | 2000000206 / 2000000212 | 2000000153 |
|---|---|---|
| `SystemTables.InternalTables` | **in it** | **not in it** |
| id set | `ApplicationDatabaseTables` | `TenantDatabaseSystemTables` |
| `Scope` | OnPrem | **Cloud** |

Read out of `Microsoft.Dynamics.Nav.Types.dll` by reflection and confirmed byte-identical on **27.0, 27.5, 28.1 and 28.4**; the `Scope` line is from System.app's own `src/Tenant Database Tables/NAVAppInstalledApp.Table.al`.

So this one **is** expressible in the main Cloud corpus app, and the upstream test is adjudicated on the eight *required* cloud legs rather than the eight non-gating OnPrem ones. That is a stronger position than the sibling table's, and it is the opposite of what the precedent predicted.

## The fix

Seeded in the **same pass**, from the **same** `RegisteredModules()` closure and the **same** `AppPackageIdentity` values, as the 2000000206/2000000212 rows already seeded there — so the three tables cannot disagree about which apps are present or which package id names an app. That agreement is load-bearing: BC's own `TenantApplicationStorageRepository` joins this table to Tenant Application Storage `ON [Package ID]`, so a package id here differing from the published row's would be a registry that answers about a different app than it names.

Both existing seeding passes (dependency and bundle) already flow through one function, so this is one insert added to that loop rather than a second mechanism.

## Columns deliberately left at `NCLMetaField.EmptyValue`

Not filled, because the runner has no faithful value and inventing one is exactly what `loud-failures.md` forbids: `Content Hash` / `Hash Algorithm` (a real tier hashes the `.app` payload at publish time — the runner never hashes a package), the four `Compatibility` columns (BC's own publish SQL inserts literal `0`, which is what `EmptyValue` already gives), `Extension Type`, and `Published As`.

`Published As` is the one worth naming: its OptionMembers are `Global,PTE,Dev`, so `EmptyValue` reads as `Global` — which is what a platform app loaded from an artifact cache actually is, not a guess dressed as a measurement. **No test asserts that column**, here or upstream, until a tier has adjudicated it.

## RED → GREEN

**Runner-extras** (`tests/runner-extras/navapp-installed-app-system-table`, 6 tests): `0P/3F` → `6P/0F`. Full `tests/runner-extras` with `--strict` and the count-baseline gate: **369/369**.

**Corpus** (5 tests, run against this branch): `2P/3F` → `5P/0F`. The two passing in both states are the negative cases, correctly — they assert *absence*, which an empty table also satisfies. That is why the positive tests carry the claim.

## Mutation testing

I broke the fix three ways and confirmed the tests catch each:

| mutation | caught by |
|---|---|
| seeding removed entirely | **all 6** |
| every row shares one Package ID | `PackageIdsDiscriminateBetweenApps` (1 of 6) |
| version parts collapsed to `0` after Major | `TheDependencyAppIsListedWithItsOwnDistinctIdentity` (1 of 6) |

Mutations 2 and 3 are the reason this suite loads a **dependency app** rather than testing a single bundle. Both would have passed a single-app suite: the bundle's own `1.0.0.0` version survives mutation 3 unchanged, and one shared package id is indistinguishable from a correct one when there is only one row. The dependency's version is `9.7.5.3` — four different parts, none of them `0` or `1` — so neither can pass by coincidence.

## One test I had to weaken, and why that was right

`EveryRowIsReachableByItsOwnAppIdKey` first asserted `Walked = 2`. It passed alone and **failed in the full `tests/runner-extras` run with 79 apps in one process** — the runner loads every bundle's closure into a shared process. The count was a property of the invocation, not of the registry. It now asserts reachability plus that the walk found both known apps, which holds under either invocation. Worth stating because it was caught by running the wider suite, not by reading the test.

## Sibling scan

No open issue lands in `RecordPatches.PublishedApplicationSystemTable.cs`, so nothing was folded in. The nearest candidates and why they are separate:

- **#2279** (AllObj / Table Metadata leak across app groups) — a registry-reset defect in `Program.cs`'s run loop and `AddSourceDirs`, different file, different mechanism.
- **#3282**, **#3250** — process-wide registry reuse in the RAD-snapshot and server paths.
- **#2350**, **#3376** — the Integer virtual table's window guard.

No open PR touches this file, so no forced merge order.

## Deliberately not built

An app-lifecycle model. There is no publish step, no install/uninstall transition, and no way to make an app read as *not* installed — the runner loads a closure and every app in it is loaded. Modelling states the runner cannot enter would be inventing behaviour, not reporting it. What is served is the truth the runner already holds: these are the apps that are here, with their real manifest identities.

## Merge order

This asserts BC behaviour, so it merges **after** corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#268 is green and merged. This PR does **not** bump the submodule pin — the corpus test lives in the corpus app and needs no runner-side pin bump to be adjudicated there; a catch-up bump is its own PR.

---
Opened by agent `stma-auto-4`, an automated implementation agent acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9pEPoD8e4wmVyuTrxyuh
