### PR TITLE
fix(testpage): render a blank Date, Time or DateTime control as '', the way BC does

### DIFF
--- a/AlRunner.Tests/TestPageBlankTemporalValueTests.cs
+++ b/AlRunner.Tests/TestPageBlankTemporalValueTests.cs
@@ -1,0 +1,156 @@
+// TestPageBlankTemporalValueTests — issue #2361 (a blank Date/Time/DateTime read through a
+// TestPage control rendered as 01/01/0001 00:00:00 where real BC renders '').
+//
+// RUNNER-MECHANISM test, not a claim about what real BC does. It pins the predicate
+// TestPageBlankTemporalValue applies — "blank" is exactly NavDateTimeValue.IsZeroOrEmpty, i.e.
+// the wrapped DateTime equal to default(DateTime) — and, just as importantly, that it declines
+// on everything else so the caller's existing rendering chain still runs.
+//
+// The BEHAVIOURAL claim (what a blank vs populated temporal control reads as on a real service
+// tier) is proven upstream in the corpus: codeunit 60662 "TP Blank Temporal Tests", merged as
+// StefanMaron/BusinessCentral.AL.Language.Tests#154, with the typed-AssertEquals arm added in
+// #267. Per bc-behavior-tests-go-upstream.md that is where it belongs; this file exists so a
+// regression in OUR OWN predicate fails in milliseconds without the BC engine loaded twice.
+//
+// Both entry points are covered because they are reached by different callers and neither
+// implies the other: Format() sees the stored NavValue (the Value getter's path), FormatObject()
+// sees the already-unwrapped CLR value (the ValueToString path BC's ALAssertEquals drives for a
+// TYPED expected argument). Deleting the FormatObject half left every pre-existing corpus test
+// passing, which is why the typed-argument tests were added upstream — and why it is asserted
+// separately here.
+
+using System.Globalization;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestPageBlankTemporalValueTests
+{
+    // ---------------------------------------------------------------- Format (the NavValue path)
+
+    [Fact]
+    public void Format_BlankNavDateTime_AnswersTheEmptyString()
+    {
+        var blank = NavDateTime.Create(default(DateTime));
+
+        Assert.Equal(string.Empty, TestPageBlankTemporalValue.Format(blank));
+    }
+
+    [Fact]
+    public void Format_BlankNavDate_AnswersTheEmptyString()
+    {
+        var blank = NavDate.Create(default(DateTime));
+
+        Assert.Equal(string.Empty, TestPageBlankTemporalValue.Format(blank));
+    }
+
+    [Fact]
+    public void Format_BlankNavTime_AnswersTheEmptyString()
+    {
+        var blank = NavTime.Create(default(DateTime));
+
+        Assert.Equal(string.Empty, TestPageBlankTemporalValue.Format(blank));
+    }
+
+    // The guard on all three above: a POPULATED temporal must be declined (null), not blanked,
+    // so the caller falls through to its normal rendering. An implementation answering "" for
+    // every temporal would satisfy the blank cases and fail here — that mutation was run and is
+    // caught by the corpus suite's populated arm too.
+    [Fact]
+    public void Format_PopulatedNavDateTime_DeclinesSoTheCallerRendersIt()
+    {
+        var populated = NavDateTime.Create(
+            DateTime.SpecifyKind(new DateTime(2024, 3, 17, 14, 30, 0), DateTimeKind.Local));
+
+        Assert.Null(TestPageBlankTemporalValue.Format(populated));
+    }
+
+    [Fact]
+    public void Format_PopulatedNavDate_DeclinesSoTheCallerRendersIt()
+    {
+        var populated = NavDate.Create(
+            DateTime.SpecifyKind(new DateTime(2024, 3, 17), DateTimeKind.Local));
+
+        Assert.Null(TestPageBlankTemporalValue.Format(populated));
+    }
+
+    // A non-temporal NavValue must be declined too, or this helper would swallow values that
+    // belong to the Option/Numeric/Boolean arms sitting beside it in the same chain.
+    [Fact]
+    public void Format_ANonTemporalNavValue_IsDeclined()
+    {
+        Assert.Null(TestPageBlankTemporalValue.Format(NavText.Create("not a temporal")));
+        Assert.Null(TestPageBlankTemporalValue.Format(NavInteger.Create(0)));
+    }
+
+    [Fact]
+    public void Format_Null_IsDeclined()
+        => Assert.Null(TestPageBlankTemporalValue.Format(null));
+
+    // ------------------------------------------------------- FormatObject (the ValueToString path)
+
+    // BC's NavTestField.ALAssertEquals renders a TYPED expected value through ValueToString and
+    // compares it ordinally against the control, so this half has to agree with Format above or
+    // AssertEquals(<a blank DateTime variable>) can never match. All three temporal types reach
+    // it as a bare DateTime, because NavDate, NavTime and NavDateTime all derive from
+    // NavDateTimeValue, whose ClientObject hands back the wrapped DateTime.
+    [Fact]
+    public void FormatObject_DefaultDateTime_AnswersTheEmptyString()
+        => Assert.Equal(string.Empty, TestPageBlankTemporalValue.FormatObject(default(DateTime)));
+
+    [Fact]
+    public void FormatObject_APopulatedDateTime_DeclinesSoTheCallerRendersIt()
+        => Assert.Null(TestPageBlankTemporalValue.FormatObject(new DateTime(2024, 3, 17, 14, 30, 0)));
+
+    // BC's smallest representable Date is DateTimeMinimum = 0001-01-02, one day after the CLR
+    // minimum, so a real temporal can never BE default(DateTime). This pins that the predicate
+    // stops at the CLR default and does not blank the value one tick above it — which is what
+    // makes suppressing default(DateTime) lossless rather than a guess about a boundary.
+    [Fact]
+    public void FormatObject_BcsSmallestRepresentableDate_IsNotTreatedAsBlank()
+    {
+        var bcMinimum = new DateTime(1, 1, 2);
+
+        Assert.Null(TestPageBlankTemporalValue.FormatObject(bcMinimum));
+        Assert.Null(TestPageBlankTemporalValue.FormatObject(default(DateTime).AddTicks(1)));
+    }
+
+    [Fact]
+    public void FormatObject_ANonDateTimeValue_IsDeclined()
+    {
+        Assert.Null(TestPageBlankTemporalValue.FormatObject("01/01/0001 00:00:00"));
+        Assert.Null(TestPageBlankTemporalValue.FormatObject(0));
+        Assert.Null(TestPageBlankTemporalValue.FormatObject(null));
+    }
+
+    // The two halves must agree on the SAME value, since one renders the control and the other
+    // renders the expected argument compared against it. Asserted directly rather than left to
+    // follow from the pairs above.
+    [Fact]
+    public void FormatAndFormatObject_AgreeOnABlankAndOnAPopulatedValue()
+    {
+        var populated = DateTime.SpecifyKind(new DateTime(2024, 3, 17, 14, 30, 0), DateTimeKind.Local);
+
+        Assert.Equal(
+            TestPageBlankTemporalValue.Format(NavDateTime.Create(default(DateTime))),
+            TestPageBlankTemporalValue.FormatObject(default(DateTime)));
+
+        Assert.Equal(
+            TestPageBlankTemporalValue.Format(NavDateTime.Create(populated)),
+            TestPageBlankTemporalValue.FormatObject(populated));
+    }
+
+    // What the runner used to answer, kept as a literal so the regression is named rather than
+    // implied: this is the string issue #2361 reports reaching AL, and the one BC's own
+    // formatters suppress via `if (navX.IsZeroOrEmpty) return string.Empty;`.
+    [Fact]
+    public void TheOldRendering_IsWhatFormatObjectNowSuppresses()
+    {
+        Assert.Equal(
+            "01/01/0001 00:00:00",
+            Convert.ToString(default(DateTime), CultureInfo.InvariantCulture));
+
+        Assert.Equal(string.Empty, TestPageBlankTemporalValue.FormatObject(default(DateTime)));
+    }
+}

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -2915,6 +2915,66 @@ internal static class TestPageNumericValue
             : null;
 }
 
+/// <summary>
+/// How a BLANK temporal control renders: the empty string, for Date, Time and DateTime alike.
+///
+/// <para>Issue #2361. The runner fell through to <c>Convert.ToString(ObjectValue)</c>, which
+/// renders the underlying <c>DateTime</c> and so answered <c>01/01/0001 00:00:00</c> where real
+/// BC answers <c>''</c> — the same string for all three types, because all three wrap one
+/// <c>DateTime</c> (see below). Microsoft's own <c>UserCardTest.GenerateWebServiceKeyNoExpires</c>
+/// asserts <c>AssertEquals('')</c> on page 9807's blank <c>WebServiceExpiryDate</c>.</para>
+///
+/// <para><b>The rule is read out of BC, not inferred.</b> Each of BC's three temporal formatters
+/// opens with the identical guard — <c>NavDateFormatter</c>, <c>NavTimeFormatter</c> and
+/// <c>NavDateTimeFormatter.FormatWithFormatNumber</c> in <c>Ncl.dll</c>, all three:</para>
+/// <code>
+///   if (navX.IsZeroOrEmpty) return string.Empty;
+/// </code>
+/// <para>and <c>NavDateTimeValue.IsZeroOrEmpty</c> — the base class of all of <c>NavDate</c>,
+/// <c>NavTime</c> and <c>NavDateTime</c> — is <c>Value == NavDateTimeHelper.DateTimeUndefined</c>,
+/// where <c>DateTimeUndefined</c> is <c>default(DateTime)</c>. So the predicate below is BC's
+/// own, spelled the same way.</para>
+///
+/// <para><b>Why <c>default(DateTime)</c> is never a legitimate value to suppress.</b> BC's
+/// smallest representable Date is <c>DateTimeMinimum</c> = <c>0001-01-02</c>, one day after the
+/// CLR minimum, and its C/SIDE encoding maps 0 to undefined and 1 to that minimum. A real
+/// temporal therefore cannot BE <c>default(DateTime)</c>, so blanking it loses nothing —
+/// which is what lets the populated half of the corpus suite keep passing.</para>
+///
+/// <para>Read through by BOTH <see cref="LiveNavTestField"/> (Rec-bound) and
+/// <see cref="PageVariableTestField"/> (page-global), the same pairing
+/// <see cref="TestPageBooleanValue"/> and <see cref="TestPageOptionValue"/> already use, so
+/// neither binding shape can drift from the other — the corpus suite asserts both.</para>
+///
+/// <para><b>Interaction with the WRITE side (#3384 / PR #3394), which lands in this same
+/// file.</b> That change reads a typed <c>SetValue</c> argument back through the spelling
+/// <c>ValueToString</c> produces. This one changes that spelling for a BLANK temporal only,
+/// from <c>01/01/0001 00:00:00</c> to <c>""</c> — and an empty string is not a value its
+/// round-trip branch is meant to parse, so it declines and falls through to BC's own evaluator,
+/// which is the correct outcome: writing a blank temporal is a separate question from rendering
+/// one, and neither change should silently answer the other's. Named
+/// <c>TestPageBlankTemporalValue</c> rather than <c>TestPageTemporalValue</c> so the two helpers
+/// can coexist in this file whichever merges first.</para>
+///
+/// <para>It must also be what <c>ValueToString</c> answers, for the reason spelled out in
+/// <see cref="TestPageBooleanValue"/>: <c>NavTestField.ALAssertEquals</c> converts the EXPECTED
+/// value through <c>ValueToString</c> and compares it ORDINALLY against the getter, so moving
+/// the getter alone would leave <c>AssertEquals('')</c> failing — which is a distinct test in
+/// the corpus suite and was failing in exactly that way before this fix.</para>
+/// </summary>
+internal static class TestPageBlankTemporalValue
+{
+    /// <summary>The stored NavValue's rendering — <c>""</c> when blank, otherwise null to let
+    /// the caller's existing chain render it.</summary>
+    internal static string? Format(NavValue? navValue)
+        => navValue is NavDateTimeValue t && t.IsZeroOrEmpty ? string.Empty : null;
+
+    /// <summary>The same rule for an already-unwrapped CLR value, as ValueToString sees it —
+    /// <c>ClientObject</c> on all three types hands back the bare <c>DateTime</c>.</summary>
+    internal static string? FormatObject(object? value)
+        => value is DateTime dt && dt == default ? string.Empty : null;
+}
+
 internal static class TestPageBooleanValue
 {
     /// <summary>
@@ -3279,6 +3339,8 @@ internal sealed class LiveNavTestField : ITestField
                ?? TestPageNumericValue.Format(_record.GetFieldValue(_fieldNo) as NavValue)
                // #2795: "Yes"/"No", not Convert.ToString's "True"/"False".
                ?? TestPageBooleanValue.Format(_record.GetFieldValue(_fieldNo) as NavValue)
+               // #2361: a blank Date/Time/DateTime is '', not the rendered CLR minimum.
+               ?? TestPageBlankTemporalValue.Format(_record.GetFieldValue(_fieldNo) as NavValue)
                ?? Convert.ToString(ObjectValue, CultureInfo.InvariantCulture)
                ?? string.Empty;
         // appendRefreshSuffix: true — a Rec-bound control stages a row edit, and real BC's
@@ -3480,6 +3542,8 @@ internal sealed class LiveNavTestField : ITestField
            // ordinally against the control's Value, so this has to answer with the same word the
            // getter above does or AssertEquals(<Boolean>) can never match.
            ?? TestPageBooleanValue.FormatObject(value)
+           // #2361: same reason, for a blank temporal — AssertEquals('') is its own corpus test.
+           ?? TestPageBlankTemporalValue.FormatObject(value)
            ?? Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
 
     // AL that walks an option set (building a picker, asserting the members a field offers) got
@@ -3557,6 +3621,9 @@ internal sealed class PageVariableTestField : ITestField
                ?? TestPageNumericValue.Format(RunnerPageInstance.GetValue(_expression))
                // #2795: the page-global half of the same rule — see TestPageBooleanValue.Format.
                ?? TestPageBooleanValue.Format(RunnerPageInstance.GetValue(_expression))
+               // #2361: the page-global half of the blank-temporal rule — see the Rec-bound
+               // sibling. Base Application page 9807 binds WebServiceExpiryDate this way.
+               ?? TestPageBlankTemporalValue.Format(RunnerPageInstance.GetValue(_expression))
                ?? Convert.ToString(ObjectValue, CultureInfo.InvariantCulture)
                ?? string.Empty;
         // appendRefreshSuffix: false — a page-global control stages no row edit, so there is
@@ -3715,6 +3782,8 @@ internal sealed class PageVariableTestField : ITestField
                CurrentOption() is { } option ? _page.TryGetOptionCaptions(_controlId, option) : null)
            // #2795: the page-global half of the same rule — see the Rec-bound sibling above.
            ?? TestPageBooleanValue.FormatObject(value)
+           // #2361: the page-global half of the blank-temporal rule.
+           ?? TestPageBlankTemporalValue.FormatObject(value)
            ?? Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
     public string GetOption(int index)
         => CurrentOption() is { } option

--- a/tests/expectations/known-gaps-testpage-blank-temporal.json
+++ b/tests/expectations/known-gaps-testpage-blank-temporal.json
@@ -2,57 +2,9 @@
   {
     "codeunitId": 60662,
     "CodeunitName": "TP Blank Temporal Tests",
-    "Method": "TestPageField_Value_BlankRecBoundDateTime_ReadsEmptyString",
-    "Mode": "expect-fail-known-gap",
-    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2361",
-    "Note": "Pulled in by this PR's submodule pin bump, NOT caused by it. The pin had to advance to bce7c87 to consume StefanMaron/BusinessCentral.AL.Language.Tests#155 (the upstream half of #2524), and corpus master had meanwhile merged four other agents' PRs on top of the previous pin -- corpus history is linear, so #155 cannot be taken without them. A blank Date/Time/DateTime reads as '01/01/0001 00:00:00' through a TestPage control where real BC reads ''. Tracked as #2361, which is open and is NOT closed by this PR; the fix for it removes this entry."
-  },
-  {
-    "codeunitId": 60662,
-    "CodeunitName": "TP Blank Temporal Tests",
-    "Method": "TestPageField_AssertEquals_BlankRecBoundDateTime_AcceptsEmptyString",
-    "Mode": "expect-fail-known-gap",
-    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2361",
-    "Note": "Pulled in by this PR's submodule pin bump, NOT caused by it. The pin had to advance to bce7c87 to consume StefanMaron/BusinessCentral.AL.Language.Tests#155 (the upstream half of #2524), and corpus master had meanwhile merged four other agents' PRs on top of the previous pin -- corpus history is linear, so #155 cannot be taken without them. A blank Date/Time/DateTime reads as '01/01/0001 00:00:00' through a TestPage control where real BC reads ''. Tracked as #2361, which is open and is NOT closed by this PR; the fix for it removes this entry."
-  },
-  {
-    "codeunitId": 60662,
-    "CodeunitName": "TP Blank Temporal Tests",
-    "Method": "TestPageField_Value_BlankRecBoundDate_ReadsEmptyString",
-    "Mode": "expect-fail-known-gap",
-    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2361",
-    "Note": "Pulled in by this PR's submodule pin bump, NOT caused by it. The pin had to advance to bce7c87 to consume StefanMaron/BusinessCentral.AL.Language.Tests#155 (the upstream half of #2524), and corpus master had meanwhile merged four other agents' PRs on top of the previous pin -- corpus history is linear, so #155 cannot be taken without them. A blank Date/Time/DateTime reads as '01/01/0001 00:00:00' through a TestPage control where real BC reads ''. Tracked as #2361, which is open and is NOT closed by this PR; the fix for it removes this entry."
-  },
-  {
-    "codeunitId": 60662,
-    "CodeunitName": "TP Blank Temporal Tests",
-    "Method": "TestPageField_Value_BlankRecBoundTime_ReadsEmptyString",
-    "Mode": "expect-fail-known-gap",
-    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2361",
-    "Note": "Pulled in by this PR's submodule pin bump, NOT caused by it. The pin had to advance to bce7c87 to consume StefanMaron/BusinessCentral.AL.Language.Tests#155 (the upstream half of #2524), and corpus master had meanwhile merged four other agents' PRs on top of the previous pin -- corpus history is linear, so #155 cannot be taken without them. A blank Date/Time/DateTime reads as '01/01/0001 00:00:00' through a TestPage control where real BC reads ''. Tracked as #2361, which is open and is NOT closed by this PR; the fix for it removes this entry."
-  },
-  {
-    "codeunitId": 60662,
-    "CodeunitName": "TP Blank Temporal Tests",
-    "Method": "TestPageField_Value_BlankVariableBoundDateTime_ReadsEmptyString",
-    "Mode": "expect-fail-known-gap",
-    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2361",
-    "Note": "Pulled in by this PR's submodule pin bump, NOT caused by it. The pin had to advance to bce7c87 to consume StefanMaron/BusinessCentral.AL.Language.Tests#155 (the upstream half of #2524), and corpus master had meanwhile merged four other agents' PRs on top of the previous pin -- corpus history is linear, so #155 cannot be taken without them. A blank Date/Time/DateTime reads as '01/01/0001 00:00:00' through a TestPage control where real BC reads ''. Tracked as #2361, which is open and is NOT closed by this PR; the fix for it removes this entry."
-  },
-  {
-    "codeunitId": 60662,
-    "CodeunitName": "TP Blank Temporal Tests",
-    "Method": "TestPageField_Value_VariableBoundDateTime_StaysBlankOnAPopulatedRow",
-    "Mode": "expect-fail-known-gap",
-    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2361",
-    "Note": "Pulled in by this PR's submodule pin bump, NOT caused by it. The pin had to advance to bce7c87 to consume StefanMaron/BusinessCentral.AL.Language.Tests#155 (the upstream half of #2524), and corpus master had meanwhile merged four other agents' PRs on top of the previous pin -- corpus history is linear, so #155 cannot be taken without them. A blank Date/Time/DateTime reads as '01/01/0001 00:00:00' through a TestPage control where real BC reads ''. Tracked as #2361, which is open and is NOT closed by this PR; the fix for it removes this entry."
-  },
-  {
-    "codeunitId": 60662,
-    "CodeunitName": "TP Blank Temporal Tests",
     "Method": "TestPageField_AssertEquals_BlankDateTimeVariable_IsRefusedByAPopulatedControl",
     "Mode": "expect-fail-known-gap",
-    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2361",
-    "Note": "Pulled in by PR #3445's pin advance to ccc10f12, NOT caused by it: corpus history is linear, so #274 cannot be taken without #267 (7153eb5), which added this test. The same #2361 gap as the six entries above, reached through a TYPED AssertEquals argument: the refusal names Expected = '01/01/0001 00:00:00' where BC names ''. Declared in THIS file rather than a new one, so the drift guard sees one declaration per test. Tracked as #2361, which is open and is NOT closed by that PR; open PR #3410 fixes it and removes this entry."
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3458",
+    "Note": "The last entry left in this file, and it survives for a DIFFERENT reason than the six PR #3410 removed -- measured, not assumed, at pin ccc10f12 with that PR's fix applied:\n\n  Expected: AssertEquals for Field: RecWhen Expected = ''\n  Actual:   AssertEquals for Field: Rec When Expected = '', Actual = '03/17/2024 13:30:00'\n\nThe Expected = '' half is ALREADY RIGHT. That half is what #2361 was about, and PR #3410's fix delivers it here as it does in the six drifted entries. What still differs is the FIELD NAME: the runner names the field CAPTION 'Rec When' where BC names the page CONTROL 'RecWhen'. That is an AssertEquals message-construction gap with nothing temporal about it -- the same mismatch would appear on a Text or Integer control -- so it is tracked separately as #3458 and NOT as #2361, which PR #3410 does close.\n\nKept in this file rather than moved to a new one so the drift guard sees exactly one declaration per test; the file name is now historical."
   }
 ]


### PR DESCRIPTION
Closes #2361

A blank `DateTime`, `Date` or `Time` read through a `TestPage` control rendered as `01/01/0001 00:00:00` where real BC renders `''`.

## Where the value was actually lost

Not where the issue guessed. The issue offered two candidates and leaned toward the second — "the value never reaches the control at all" — on the strength of a **non**-blank arm that also failed. That arm was a different defect (page 9807's `OnAfterGetRecord` never ran, #2522, fixed by #2742) and is already gone; impl-6 had narrowed this issue to the rendering rule before I picked it up. My measurements agree with that narrowing: on a blank row every temporal control was wrong, and on a populated row every one of them was already right.

The loss is in the `Value` getter's fallthrough. Both `LiveNavTestField` (Rec-bound) and `PageVariableTestField` (page-global) render through a chain — Option, then Numeric, then Boolean — and anything unmatched lands on `Convert.ToString(ObjectValue, InvariantCulture)`. For a temporal that renders the underlying `DateTime`, so the blank sentinel reached AL looking like a real value.

## The rule, read out of BC rather than inferred

All three of BC's temporal formatters in `Ncl.dll` open with the identical guard — `NavDateFormatter`, `NavTimeFormatter` and `NavDateTimeFormatter.FormatWithFormatNumber`:

```csharp
if (navX.IsZeroOrEmpty) return string.Empty;
```

and `NavDateTimeValue.IsZeroOrEmpty` is `Value == NavDateTimeHelper.DateTimeUndefined`, where `DateTimeUndefined = default(DateTime)`.

That also answers the question impl-6 flagged as unresolved — why a blank `Date` and a blank `Time` both rendered as a full date **and** time. `NavDate`, `NavTime` and `NavDateTime` all derive from `NavDateTimeValue`, which holds a single `DateTime value`, and `ClientObject` hands that back. One shared conversion, three symptoms, as suspected.

**Suppressing `default(DateTime)` is lossless, not a heuristic.** BC's smallest representable Date is `DateTimeMinimum` = `0001-01-02`, one day above the CLR minimum, and its C/SIDE encoding maps 0 to undefined and 1 to that minimum — so a real temporal can never *be* the sentinel. That boundary is asserted directly in the unit tests.

## Do the two reported symptoms share one cause?

**No, and that matters for anyone reading the issue.** The blank-rendering symptom is this fix. The non-blank symptom in the issue body was #2522, a different defect in a different layer, already fixed. Nothing here touches it.

## Applied at four sites, because none implies the others

Two binding shapes (Rec-bound, page-global) times two entry points (`Value`, `ValueToString`). The `ValueToString` half is not symmetry for its own sake — BC's `NavTestField.ALAssertEquals` renders a **typed** expected value through `ValueToString` and compares it ordinally against the getter:

```csharp
if (!(value is NavStringValue)) {
    value = NavValue.CreateNavValueFromObject(
                NavValueMetadata.DefaultMetadata(testField.FieldType), value);
    text  = testField.ValueToString(value.ClientObject);
} else
    text  = value.ToString();
```

so the two halves have to move together or `AssertEquals(<a blank DateTime>)` can never match.

## RED → GREEN, and the mutation that found a real coverage hole

RED, corpus codeunit 60662 (already merged upstream as corpus #154 and already in our pin) — 6 failures, all `01/01/0001 00:00:00`, with the 3 populated guards passing:

```
FAIL TestPageField_Value_BlankRecBoundDateTime_ReadsEmptyString
     Expected:<> (Text). Actual:<01/01/0001 00:00:00> (Text).
FAIL TestPageField_AssertEquals_BlankRecBoundDateTime_AcceptsEmptyString
FAIL TestPageField_Value_BlankRecBoundDate_ReadsEmptyString
FAIL TestPageField_Value_BlankRecBoundTime_ReadsEmptyString
FAIL TestPageField_Value_BlankVariableBoundDateTime_ReadsEmptyString
FAIL TestPageField_Value_VariableBoundDateTime_StaysBlankOnAPopulatedRow
```

GREEN: all 6 pass, the 3 populated guards still pass. Full corpus **2977/2977, 0 fail**, count baseline matched. `AlRunner.Tests --filter ~TestPage`: **299 passed, 0 failed**, 15 skipped.

**Mutation 1** — make the predicate unconditional so every temporal renders `''`. Caught by all three populated guards.

**Mutation 2** — delete only the `ValueToString` half. **Not caught: every existing test still passed.** The reason is the `ALAssertEquals` branch above — `AssertEquals('')` passes a *string*, takes the `NavStringValue` fast path, and never reaches `ValueToString`. The suite pinned the typed route only for populated values, so blank-through-the-typed-route was unpinned.

That is a genuine hole in the upstream suite, not something to paper over locally, so it went upstream: **corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#267** adds four tests — blank `DateTime`/`Date`/`Time` through a typed `AssertEquals` argument, plus the negative direction where a blank expected value must be *refused* by a populated control. With those added, mutation 2 fails three of them:

```
FAIL TestPageField_AssertEquals_BlankDateTimeVariable_MatchesTheBlankControl
     AssertEquals for Field: Rec When Expected = '01/01/0001 00:00:00', Actual = ''
FAIL TestPageField_AssertEquals_BlankDateVariable_MatchesTheBlankControl
FAIL TestPageField_AssertEquals_BlankTimeVariable_MatchesTheBlankControl
```

and the negative guard correctly keeps passing.

## Is the corpus verdict trustworthy on this surface?

This is a UI surface, so the patched-tier caveat applies. I checked `src/StartupHook/StartupHook.cs` in `StefanMaron/MsDyn365Bc.On.Linux`: none of the 32 numbered patches touches `NavTestField`, `ValueToString`, or any temporal formatter. The nearest UI patch, #21 (`NavOpenTaskPageAction.ShowForm`), is a different route and is itself fixed. So the corpus answer here is BC's, not a patch artifact.

## Pin bump

**None in this PR, deliberately.** The proving tests for the behaviour already merged upstream (corpus #154) and are already in the current pin — which is why RED was reproducible without touching the submodule. Corpus #267 only *strengthens* the suite against a mutation; it is not needed for this fix to be correct, and folding an un-merged pin in would make this PR red by construction. It should land as a catch-up bump once #267 merges.

## Test placement

The behavioural claim lives upstream (corpus 60662 + #267), per `bc-behavior-tests-go-upstream.md`. `AlRunner.Tests/TestPageBlankTemporalValueTests.cs` is a runner-**mechanism** test — 13 assertions pinning the predicate and, as much, that it *declines* on populated temporals, non-temporal `NavValue`s, non-`DateTime` objects and null, so the neighbouring Option/Numeric/Boolean arms still run.

## Sibling scan

- **#3384 / PR #3394** (agent fbk-1) edits this same file and is the reason my helper is named `TestPageBlankTemporalValue` rather than `TestPageTemporalValue`: that PR introduces a class of the latter name, and two definitions would not compile. Not folded — it is the **write** path (`TryResolve`, evaluating a `SetValue` argument), a different mechanism from this read path, and it is open and currently red on a gate. There is a real semantic interaction, noted in the code: its round-trip branch parses the spelling `ValueToString` produces, and this change alters that spelling for blank values only. An empty string is not something that branch is meant to parse, so it declines and falls through to BC's own evaluator — the correct outcome, since writing a blank temporal is a separate question from rendering one. Whichever merges second may need a trivial textual rebase; the two helpers coexist by name.
- **#2362** (`AssistEdit()` never fires `OnAssistEdit` on a precompiled page) and **#2457** (a custom request-page action does nothing) — same `area: precompiled-testpage` group, both about *invoking* a trigger rather than rendering a value, and neither is fixed by this. Not folded.
- No other open PR carries `Closes #2361`.

---

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/267

Written by agent `stma-auto-3`, an automated implementation agent acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9pEPoD8e4wmVyuTrxyuh
