### PR TITLE
feat(ci): run the whole Microsoft surface (40,530 tests) from one manual dispatch

### DIFF
--- a/.claude/skills/running-ms-test-buckets/SKILL.md
+++ b/.claude/skills/running-ms-test-buckets/SKILL.md
@@ -152,7 +152,9 @@ Do not run all 33 at once to answer a question. Pick by what you are asking:
   and its cluster ranking has matched the full run's. Big enough to rank work, small enough to
   finish.
 - **The complete picture** — all buckets, but expect hours and size the worker count from
-  measured headroom.
+  measured headroom. On a hosted runner this is a single dispatch of
+  `.github/workflows/ms-surface.yml` (below); on a developer machine it competes with
+  everything else for memory and has OOMed the box.
 
 Memory, measured after the per-worker GC tuning: roughly **1.1 GB per worker** without test
 data, **~2.3 GB with it** (including its backup-reader sidecar). Derive the job count from free
@@ -205,10 +207,18 @@ together.
 
 ## In CI
 
-`.github/workflows/ms-bucket.yml` runs one bucket on a hosted runner with the full
-configuration, `workflow_dispatch` only. It is a measurement job, not a gate: green means it
-produced a number, not that the suite passed. Prefer it over a developer machine when the
-machine is also doing something else.
+`.github/workflows/ms-bucket.yml` runs one bucket — or a list of them, sequentially in one
+job — on a hosted runner with the full configuration, `workflow_dispatch` only. It is a
+measurement job, not a gate: green means it produced a number, not that the suite passed.
+Prefer it over a developer machine when the machine is also doing something else.
+
+`.github/workflows/ms-surface.yml` is the whole surface: one dispatch, one job, all 32
+non-empty buckets in sequence, one combined total (#3409). Each bucket's numbers reach the job
+summary and the run's annotations as that bucket finishes, so a run that hits the 360-minute
+hosted ceiling still hands over everything that completed. It excludes `Tests-TestLibraries`
+(a library, zero tests) and `Tests-Local` (empty in the W1 artifact); the bucket list is held
+to the artifact's own inventory by `AlRunner.Tests/MsSurfaceWorkflowTests.cs`. For a subset,
+dispatch `ms-bucket.yml` with its `buckets` input rather than editing the surface list.
 
 ## Sister material
 

--- a/.claude/skills/running-ms-test-buckets/SKILL.md
+++ b/.claude/skills/running-ms-test-buckets/SKILL.md
@@ -5,8 +5,15 @@ description: Run Microsoft's BaseApp test buckets through AL Runner to find real
 
 # Running Microsoft's BaseApp test buckets
 
-Microsoft ships 33 test buckets inside the BC artifact — about **40,550 tests** — and they run
-through AL Runner as ordinary bundles, with no container. That makes them the largest supply of
+Microsoft ships **34 `Tests-*` buckets** inside the BC artifact, 32 of them non-empty, holding
+**40,530 `[Test]` methods** — counted per bucket on the 28.1.49838.53507 platform artifact
+(#3409). They run through AL Runner as ordinary bundles, with no container.
+
+Older notes in this repository say "about 40,550", and three of them stay that way on purpose:
+`ParallelFanOut.cs` and the two `ParallelFanOut*TimeoutTests` describe one specific past run
+("a 40,550-test run down to 14,856"), and rewriting a recorded measurement to match a later
+count would falsify it. 40,530 is the counted figure for the artifact; 40,550 is what that run
+totalled. That makes them the largest supply of
 real, un-guessed work available: every failure is a concrete difference between the runner and
 what Microsoft's own tests expect.
 

--- a/.github/workflows/ms-bucket-nightly.yml
+++ b/.github/workflows/ms-bucket-nightly.yml
@@ -51,7 +51,8 @@ name: MS bucket (nightly)
 # number from it can be compared against something. A nightly's job is DRIFT DETECTION, not
 # work generation.
 #
-# Not Tests-ERM (9,496) and not the full surface (~40,550): those are hours, and GitHub Actions
+# Not Tests-ERM (9,496) and not the full surface (40,530, counted — ms-surface.yml runs it
+# on demand): those are hours, and GitHub Actions
 # concurrency is per-ACCOUNT, shared with this repo's own eight-leg matrix and with the corpus
 # repository's. A multi-hour nightly would contend with PR CI every night for a number nobody
 # needs daily. Ranking work across the Microsoft surface is what the MANUAL dispatch is for.

--- a/.github/workflows/ms-bucket.yml
+++ b/.github/workflows/ms-bucket.yml
@@ -20,8 +20,7 @@ name: MS bucket (manual)
 #   Each bucket's numbers are written to the job summary and emitted as a workflow
 #   annotation BEFORE the next bucket starts. A hosted job cannot run longer than 360
 #   minutes and that ceiling cannot be raised, so a long list must not have "the job was
-#   killed, so you get nothing" as its failure mode. Reporting as it goes is what makes one
-#   job safe here, and it is far cheaper than sharding across six.
+#   killed, so you get nothing" as its failure mode.
 #
 # This is a VERIFICATION NET, not a gate:
 #   * `on: workflow_dispatch` only. No push, no pull_request, no schedule. A 9,500-test
@@ -167,6 +166,14 @@ on:
         type: string
         required: false
         default: ''
+      expected-tests:
+        description: >-
+          How many tests this set of buckets is expected to hold; 0 = do not compare. Set it on
+          a partial-surface dispatch too — without it the shortfall warning is off, and a bundle
+          lost to COMPILE FAIL vanishes from the totals rather than failing them (#2715).
+        type: number
+        required: false
+        default: 0
       bc-version:
         description: >-
           BC build: a full four-part build (28.4.53241.54318) or a prefix (28.4) resolved to

--- a/.github/workflows/ms-bucket.yml
+++ b/.github/workflows/ms-bucket.yml
@@ -1,8 +1,27 @@
 name: MS bucket (manual)
 
-# Runs ONE Microsoft BaseApp test bucket (default Tests-ERM, 9,496 tests) through AL Runner
-# in the full configuration — including --test-data — and reports total / pass / fail /
-# error and wall time in the job summary. Issue #2724.
+# Runs Microsoft BaseApp test buckets through AL Runner in the full configuration —
+# including --test-data — and reports total / pass / fail / error and wall time in the job
+# summary. Issue #2724.
+#
+# ONE BUCKET, OR A LIST OF THEM IN ONE JOB (#3409)
+#   `bucket` takes one name; `buckets` takes several, comma- or newline-separated, and wins
+#   when both are given. A list runs SEQUENTIALLY in this single job — provisioning, the
+#   977 MB backup and the compile caches are paid once for all of them, which is the whole
+#   reason a list exists. .github/workflows/ms-surface.yml passes all 32 non-empty buckets
+#   this way to measure the full Microsoft surface.
+#
+#   Each bucket gets its OWN runner process. Peak RSS tracks how many bundles a process
+#   loads, not how many tests it runs — measured, 3 bundles / 939 tests peaked at 4.4 GB
+#   against 1 bundle / 1,027 tests at 3.7 GB — so handing 32 bundle directories to one
+#   invocation would stack their memory on a runner that has already peaked at 10.9 GiB on
+#   Tests-ERM alone. Separate processes reset it between buckets.
+#
+#   Each bucket's numbers are written to the job summary and emitted as a workflow
+#   annotation BEFORE the next bucket starts. A hosted job cannot run longer than 360
+#   minutes and that ceiling cannot be raised, so a long list must not have "the job was
+#   killed, so you get nothing" as its failure mode. Reporting as it goes is what makes one
+#   job safe here, and it is far cheaper than sharding across six.
 #
 # This is a VERIFICATION NET, not a gate:
 #   * `on: workflow_dispatch` only. No push, no pull_request, no schedule. A 9,500-test
@@ -86,7 +105,32 @@ on:
       bucket:
         description: Microsoft BaseApp test bucket, e.g. Tests-SMB or Tests-ERM.
         type: string
-        required: true
+        required: false
+        default: ''
+      buckets:
+        description: >-
+          Several buckets, comma- or newline-separated, run sequentially in this one job.
+          Wins over `bucket` when both are given.
+        type: string
+        required: false
+        default: ''
+      label:
+        description: >-
+          Names the run in the job title, the concurrency group and the uploaded artifact.
+          Defaults to the single bucket's name. A list run MUST pass one: without it every
+          list run shares one concurrency group and they queue behind each other silently.
+        type: string
+        required: false
+        default: ''
+      expected-tests:
+        description: >-
+          How many tests this set of buckets is expected to hold. 0 = do not compare. The
+          combined-total step says so when the measured total falls well short, because a
+          bundle lost to COMPILE FAIL vanishes from the totals rather than failing them
+          (#2715).
+        type: number
+        required: false
+        default: 0
       bc-version:
         description: >-
           BC build or prefix. Empty = the newest prefix in .github/bc-versions.txt.
@@ -106,8 +150,23 @@ on:
           (Tests-ERM, Tests-SCM, Tests-Misc, Tests-Cash Flow, …). A wrong name fails fast and
           lists what the artifact ships.
         type: string
-        required: true
+        required: false
         default: Tests-ERM
+      buckets:
+        description: >-
+          Several buckets instead of one, comma- or newline-separated (Tests-SMB,Tests-Bank).
+          Wins over `bucket` when both are filled in. They run SEQUENTIALLY in this one job
+          and share its provisioning, backup and compile caches.
+        type: string
+        required: false
+        default: ''
+      label:
+        description: >-
+          Names the run in the job title, the concurrency group and the artifact. Defaults to
+          the single bucket's name.
+        type: string
+        required: false
+        default: ''
       bc-version:
         description: >-
           BC build: a full four-part build (28.4.53241.54318) or a prefix (28.4) resolved to
@@ -127,10 +186,15 @@ on:
 permissions:
   contents: read
 
-# One run per bucket at a time. A second dispatch of the same bucket queues behind the first
-# rather than cancelling a multi-hour measurement in flight.
+# One run per bucket (or per labelled set) at a time. A second dispatch of the same thing
+# queues behind the first rather than cancelling a multi-hour measurement in flight.
+#
+# The label is in the group for a reason that is invisible when it goes wrong: a list run
+# passes no `bucket`, so on `ms-bucket-${{ inputs.bucket }}` alone every list run would land
+# in the group `ms-bucket-` and, with cancel-in-progress false, wait for the previous one.
+# That is a silent queue, not an error.
 concurrency:
-  group: ms-bucket-${{ inputs.bucket }}
+  group: ms-bucket-${{ inputs.label || inputs.bucket || 'list' }}
   cancel-in-progress: false
 
 env:
@@ -139,10 +203,12 @@ env:
 
 jobs:
   run:
-    name: ${{ inputs.bucket }} on BC ${{ inputs.bc-version || 'newest' }}
+    name: ${{ inputs.label || inputs.bucket || 'buckets' }} on BC ${{ inputs.bc-version || 'newest' }}
     runs-on: ubuntu-latest
-    # The hosted maximum. Tests-SINGLESERVER (834 tests) takes ~4 minutes warm; Tests-ERM is
-    # 11x the tests plus a cold build, provisioning and a cold emit.
+    # The hosted maximum, and it cannot be raised. Tests-SINGLESERVER (834 tests) takes ~4
+    # minutes warm; Tests-ERM is 11x the tests plus a cold build, provisioning and a cold
+    # emit; the whole 40,530-test surface is a few hours. This is why every bucket's numbers
+    # are reported as it finishes rather than at the end.
     timeout-minutes: 360
     steps:
       - uses: actions/checkout@v6
@@ -178,19 +244,55 @@ jobs:
           echo "version=$full" >> "$GITHUB_OUTPUT"
           echo "BC build: $full"
 
+      # BEFORE provisioning on purpose: an empty or duplicated list costs seconds to reject
+      # here and 12 minutes of provisioning to reject after it.
+      - name: Resolve the bucket list
+        id: plan
+        env:
+          BUCKET: ${{ inputs.bucket }}
+          BUCKETS: ${{ inputs.buckets }}
+        run: |
+          list="$BUCKETS"
+          if [ -n "$(printf '%s' "$list" | tr -d '[:space:],')" ]; then
+            if [ -n "$(printf '%s' "$BUCKET" | tr -d '[:space:]')" ]; then
+              echo "::notice::both 'bucket' and 'buckets' were given; the list wins and '$BUCKET' is ignored"
+            fi
+          else
+            list="$BUCKET"
+          fi
+          # Comma OR newline separated, so a caller can write either.
+          printf '%s\n' "$list" | tr ',' '\n' \
+            | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | grep . > "$RUNNER_TEMP/buckets.txt" || true
+          count=$(wc -l < "$RUNNER_TEMP/buckets.txt")
+          if [ "$count" -eq 0 ]; then
+            echo "::error::no bucket to run — give 'bucket' or 'buckets'"
+            exit 1
+          fi
+          # A bucket named twice would be RUN twice and counted twice in the combined total,
+          # which is a wrong number rather than a failure — so it is refused here.
+          dupes=$(sort "$RUNNER_TEMP/buckets.txt" | uniq -d)
+          if [ -n "$dupes" ]; then
+            echo "::error::bucket(s) named more than once, which would double-count them: $dupes"
+            exit 1
+          fi
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "Running $count bucket(s):"
+          nl -ba "$RUNNER_TEMP/buckets.txt"
+
       - uses: ./.github/actions/provision-bc
         with:
           bc-version: ${{ steps.bc.outputs.version }}
 
       - name: Fetch the bucket sources
-        env:
-          BUCKET: ${{ inputs.bucket }}
         run: |
-          dotnet run --project tools/DownloadArtifacts -- \
-            test-sources ${{ steps.bc.outputs.version }} "$RUNNER_TEMP/ms-buckets" "$BUCKET"
-          bundle="$RUNNER_TEMP/ms-buckets/$BUCKET"
-          echo "AL files in $bundle: $(find "$bundle" -name '*.al' | wc -l)"
-          test -f "$bundle/app.json"
+          mapfile -t BUCKET_LIST < "$RUNNER_TEMP/buckets.txt"
+          for bucket in "${BUCKET_LIST[@]}"; do
+            dotnet run --project tools/DownloadArtifacts -- \
+              test-sources ${{ steps.bc.outputs.version }} "$RUNNER_TEMP/ms-buckets" "$bucket"
+            bundle="$RUNNER_TEMP/ms-buckets/$bucket"
+            echo "AL files in $bundle: $(find "$bundle" -name '*.al' | wc -l)"
+            test -f "$bundle/app.json"
+          done
 
       - name: Install the backup reader (bcbak)
         if: ${{ inputs.test-data }}
@@ -281,65 +383,105 @@ jobs:
           path: ~/.al-runner/test-data/${{ steps.bc.outputs.version }}
           key: bc-test-data-w1-${{ steps.bc.outputs.version }}
 
-      - name: Run the bucket
+      - name: Run the bucket(s)
         id: run
         env:
           # The 120 s default is sized for a corpus app, not a 9,500-test bucket whose emit
           # alone is minutes. #2721 scales the default by --jobs worker count; this is a single
           # process, so the base value is what applies.
           AL_RUNNER_EMIT_TIMEOUT_SEC: "3600"
-          BUCKET: ${{ inputs.bucket }}
+          # Explicit, not left to the runner's core count. Server GC sizes its heaps from the
+          # CPU count and those heaps are ~90% of peak RSS: Tests-ERM peaked at 10.9 GiB on a
+          # 12-core box, and a hosted runner has 4 vCPU and 16 GB. Two heaps buys margin on the
+          # largest bucket at a small throughput cost.
+          #
+          # DOTNET_GCHeapHardLimit is deliberately NOT used and must not be added: below about
+          # 1.25 GB it silently changed test RESULTS (259 passing became 212), so it would
+          # corrupt the number this workflow exists to produce rather than fail loudly.
+          #
+          # The value is read as HEX, like every DOTNET_GC* knob. "2" means 2 either way; a
+          # later edit to "16" would mean 22 heaps, not 16.
+          DOTNET_GCHeapCount: "2"
           BC_VERSION: ${{ steps.bc.outputs.version }}
           WITH_TEST_DATA: ${{ inputs.test-data }}
+          READER: ${{ steps.reader.outputs.tag }}
         run: |
           set +e
-          bundle="$RUNNER_TEMP/ms-buckets/$BUCKET"
+          mapfile -t BUCKET_LIST < "$RUNNER_TEMP/buckets.txt"
+          total=${#BUCKET_LIST[@]}
           bak="$HOME/.al-runner/test-data/$BC_VERSION/BusinessCentral-W1.bak"
-          args=( "$bundle"
-                 --package-cache "$HOME/.al-runner/platform-apps"
-                 --package-cache "$HOME/.al-runner/test-apps"
-                 --cache "$RUNNER_TEMP/al-runner-cache"
-                 --output-junit "$GITHUB_WORKSPACE/junit.xml"
-                 --out "$GITHUB_WORKSPACE/results.json"
-                 --quiet )
-          if [ "$WITH_TEST_DATA" = "true" ]; then
-            # SQL form of the company name: trailing underscore. With a period the run fails
-            # loudly and lists both companies.
-            args+=( "--test-data=$bak" --test-data-company "CRONUS International Ltd_" )
-          fi
           # cwd OUTSIDE the checkout: the runner auto-probes ./tests/expectations from cwd as
           # a fallback (ExpectationsDirectoryResolution.cs), and the corpus manifest has no
           # business reclassifying a Microsoft bucket.
           cd "$RUNNER_TEMP"
-          start=$SECONDS
-          "$GITHUB_WORKSPACE/AlRunner/bin/Release/net8.0/al-runner" "${args[@]}" 2>&1 \
-            | tee "$GITHUB_WORKSPACE/run.log"
-          rc=${PIPESTATUS[0]}
-          echo "rc=$rc" >> "$GITHUB_OUTPUT"
-          echo "elapsed=$(( SECONDS - start ))" >> "$GITHUB_OUTPUT"
-          echo "runner exit code: $rc (1 = tests failed, the expected outcome; the summary step decides the verdict)"
+          i=0
+          for bucket in "${BUCKET_LIST[@]}"; do
+            i=$((i + 1))
+            # Bucket names contain spaces (Tests-Cash Flow); the directory name must not.
+            slug=$(printf '%s' "$bucket" | tr ' /' '__')
+            out="$GITHUB_WORKSPACE/results/$slug"
+            mkdir -p "$out"
+            printf '%s\n' "$bucket" > "$out/bucket.txt"
+            args=( "$RUNNER_TEMP/ms-buckets/$bucket"
+                   --package-cache "$HOME/.al-runner/platform-apps"
+                   --package-cache "$HOME/.al-runner/test-apps"
+                   --cache "$RUNNER_TEMP/al-runner-cache"
+                   --output-junit "$out/junit.xml"
+                   --out "$out/results.json"
+                   --quiet )
+            if [ "$WITH_TEST_DATA" = "true" ]; then
+              # SQL form of the company name: trailing underscore. With a period the run fails
+              # loudly and lists both companies.
+              args+=( "--test-data=$bak" --test-data-company "CRONUS International Ltd_" )
+            fi
+            echo "::group::[$i/$total] $bucket"
+            start=$SECONDS
+            "$GITHUB_WORKSPACE/AlRunner/bin/Release/net8.0/al-runner" "${args[@]}" 2>&1 \
+              | tee "$out/run.log"
+            rc=${PIPESTATUS[0]}
+            elapsed=$(( SECONDS - start ))
+            echo "runner exit code: $rc (1 = tests failed, the expected outcome)"
+            echo "::endgroup::"
+            printf '%s\n' "$rc" > "$out/rc.txt"
+            printf '%s\n' "$elapsed" > "$out/elapsed.txt"
+            # This bucket's numbers reach the job summary and the run's annotations NOW, before
+            # the next one starts. --notice is what survives a job killed at the 360-minute
+            # ceiling: an annotation is emitted through the log stream as it happens, whereas a
+            # step summary is only finalised when the step ends, and this step is the whole run.
+            python3 "$GITHUB_WORKSPACE/scripts/ms-bucket-summary.py" \
+              --log "$out/run.log" --junit "$out/junit.xml" \
+              --rc "$rc" --elapsed "$elapsed" \
+              --bucket "$bucket" --bc-version "$BC_VERSION" \
+              --test-data "$WITH_TEST_DATA" --reader "$READER" \
+              --notice \
+              --out "$out/summary.md" \
+              --step-summary "$GITHUB_STEP_SUMMARY"
+          done
+          # Always 0: the verdict belongs to the combined-total step below, which sees every
+          # bucket. Failing here would skip it and lose the one number this run is for.
+          exit 0
 
-      - name: Job summary
+      # The verdict, and the deliverable. Green when every requested bucket produced a number
+      # (runner exit 0/1 plus a JUnit file); red when one did not. Thousands of FAILING tests
+      # are the expected outcome of a Microsoft bucket and are reported, not failed on.
+      - name: Combined total
         if: always()
         run: |
-          # Exit 0 = a number was produced (runner exit 0/1 + JUnit); 1 = no measurement.
-          python3 scripts/ms-bucket-summary.py \
-            --log run.log --junit junit.xml \
-            --rc "${{ steps.run.outputs.rc || 2 }}" \
-            --elapsed "${{ steps.run.outputs.elapsed || 0 }}" \
-            --bucket "${{ inputs.bucket }}" \
+          python3 scripts/ms-bucket-total.py \
+            --results results \
+            --buckets "$RUNNER_TEMP/buckets.txt" \
             --bc-version "${{ steps.bc.outputs.version }}" \
             --test-data "${{ inputs.test-data }}" \
-            --reader "${{ steps.reader.outputs.tag }}" \
+            --expected-tests "${{ inputs.expected-tests || 0 }}" \
             --step-summary "$GITHUB_STEP_SUMMARY"
 
+      # One directory per bucket: results/<bucket>/{junit.xml,results.json,run.log,summary.md}.
+      # if: always() so a job killed at the 360-minute ceiling still hands over every bucket
+      # that finished — the same reason the per-bucket summaries are written inside the loop.
       - name: Upload results (JUnit for clustering, classification JSON, full log)
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: ms-bucket-${{ inputs.bucket }}-${{ steps.bc.outputs.version }}
-          path: |
-            junit.xml
-            results.json
-            run.log
+          name: ms-bucket-${{ inputs.label || inputs.bucket || 'list' }}-${{ steps.bc.outputs.version }}
+          path: results
           if-no-files-found: ignore

--- a/.github/workflows/ms-surface.yml
+++ b/.github/workflows/ms-surface.yml
@@ -11,23 +11,17 @@ name: MS surface (manual)
 #
 # ─── ONE JOB, NOT A MATRIX ───────────────────────────────────────────────────────────────────
 #
-# The surface is ~90 minutes of execution at the measured 142 ms/test, so call it 2.5-3.3 hours
-# on a hosted 4-vCPU runner plus provisioning paid once. ms-bucket.yml's timeout-minutes is 360
-# — the hosted maximum, which cannot be raised — so one runner fits with real margin.
+# The surface is ~3 hours on a hosted runner and ms-bucket.yml's timeout-minutes is 360, the
+# hosted maximum, so one runner fits. Sharding it six ways was designed and rejected: it buys
+# about two hours and costs six queue slots and six provisionings out of an Actions queue that
+# is per-ACCOUNT and shared with the corpus repository and with every open PR's CI. The full
+# argument is in #3409.
 #
-# Sharding six ways was designed and rejected. It would take roughly 3 hours down to 1, and cost
-# six queue slots, six provisionings (.github/actions/provision-bc has no actions/cache, so
-# every job re-downloads and rebuilds — 10-15 minutes each) and three pieces of machinery to
-# maintain. GitHub Actions concurrency is per-ACCOUNT and shared with the corpus repository and
-# with every open PR's own CI, so those five extra runners are taken from work that gates
-# merges. For a manually dispatched measurement that trade is not worth it.
-#
-# What made a single job tempting to shard was its failure mode: hit the 360-minute ceiling and
-# you get nothing. That is removed rather than traded around — every bucket's numbers go to the
-# job summary AND out as a workflow annotation the moment that bucket finishes, and the results
-# artifact is uploaded with if: always(). A run killed at the ceiling still hands over every
-# bucket that completed. Incremental reporting is much cheaper than a matrix, and it is the
-# reason one job is safe here.
+# What made sharding tempting was this job's failure mode — hit the ceiling and you get
+# nothing. That is removed rather than traded around: every bucket's numbers go to the job
+# summary AND out as a workflow annotation the moment that bucket finishes, and the results
+# artifact uploads with if: always(). A run killed at the ceiling still hands over every bucket
+# that completed. AlRunner.Tests/MsSurfaceWorkflowTests.cs holds that property in place.
 #
 # ─── WHAT IT REUSES ──────────────────────────────────────────────────────────────────────────
 #
@@ -102,9 +96,13 @@ jobs:
       expected-tests: 40530
       bc-version: ${{ inputs.bc-version }}
       test-data: ${{ inputs.test-data }}
-      # Ordered biggest first: Tests-ERM and Tests-SCM are 44% of the surface between them, and
-      # if anything is going to be lost to the 360-minute ceiling it should be the small tail,
-      # not the two buckets everything else is compared against.
+      # Tests-ERM (9,496) and Tests-SCM (8,524) lead deliberately: 44% of the 40,530 between
+      # them, measured on the 28.1.49838.53507 artifact (#3409), so if anything is lost to the
+      # 360-minute ceiling it should not be the two buckets everything else is compared
+      # against. The remaining 30 are in #3409's grouping order and are NOT ranked by size —
+      # per-bucket counts for them were never measured, so no ordering claim is made about
+      # them. The combined-total table reports each bucket's wall time, which is what a future
+      # ordering should be based on.
       buckets: |
         Tests-ERM
         Tests-SCM

--- a/.github/workflows/ms-surface.yml
+++ b/.github/workflows/ms-surface.yml
@@ -1,0 +1,140 @@
+name: MS surface (manual)
+
+# Runs the WHOLE Microsoft BaseApp test surface — 40,530 tests across 32 non-empty buckets —
+# through AL Runner in one manual dispatch, and reports one combined total. Issue #3409.
+#
+# It is a VERIFICATION NET, not a gate, on exactly the same terms as ms-bucket.yml: green
+# means it produced numbers, red means it did not. Thousands of failing tests are the expected
+# outcome of running Microsoft's own tests against the runner, and are reported rather than
+# failed on. Not a required check, not in any branch ruleset; `main`'s gate is and stays
+# "BC test matrix passed" (test-matrix.yml).
+#
+# ─── ONE JOB, NOT A MATRIX ───────────────────────────────────────────────────────────────────
+#
+# The surface is ~90 minutes of execution at the measured 142 ms/test, so call it 2.5-3.3 hours
+# on a hosted 4-vCPU runner plus provisioning paid once. ms-bucket.yml's timeout-minutes is 360
+# — the hosted maximum, which cannot be raised — so one runner fits with real margin.
+#
+# Sharding six ways was designed and rejected. It would take roughly 3 hours down to 1, and cost
+# six queue slots, six provisionings (.github/actions/provision-bc has no actions/cache, so
+# every job re-downloads and rebuilds — 10-15 minutes each) and three pieces of machinery to
+# maintain. GitHub Actions concurrency is per-ACCOUNT and shared with the corpus repository and
+# with every open PR's own CI, so those five extra runners are taken from work that gates
+# merges. For a manually dispatched measurement that trade is not worth it.
+#
+# What made a single job tempting to shard was its failure mode: hit the 360-minute ceiling and
+# you get nothing. That is removed rather than traded around — every bucket's numbers go to the
+# job summary AND out as a workflow annotation the moment that bucket finishes, and the results
+# artifact is uploaded with if: always(). A run killed at the ceiling still hands over every
+# bucket that completed. Incremental reporting is much cheaper than a matrix, and it is the
+# reason one job is safe here.
+#
+# ─── WHAT IT REUSES ──────────────────────────────────────────────────────────────────────────
+#
+# Everything. This file is POLICY — which buckets, how many tests to expect — and ms-bucket.yml
+# is the MECHANICS: provisioning through the shared composite action, the 977 MB backup and its
+# cache, the pinned bcbak reader, both package caches, the raised emit timeout, the private
+# --cache root, the company name in SQL form, one runner process per bucket, and the summary
+# scripts. A second spelling of any of that is how bc-tests.yml's provisioning drifted four
+# times and failed two releases (#1976) — and here it would silently produce a number measured
+# under a different configuration from the nightly's, which is worse than no number at all.
+#
+# ─── WHAT IT DOES NOT RUN, AND WHY ───────────────────────────────────────────────────────────
+#
+# The platform artifact ships 35 *.Source.zip files under Applications/BaseApp/Test/. Three are
+# not in the list below:
+#
+#   * Tests-TestLibraries — 204 .al files and zero [Test] methods. It is the library the other
+#     buckets compile against, not a bucket; running it would report a zero that reads like a
+#     failure.
+#   * Tests-Local — empty in the W1 artifact. It is the country-specific bucket and ships tests
+#     only in a localised artifact.
+#   * Library-NoTransactions — a shared library source, not a Tests-* bucket at all.
+#
+# AlRunner.Tests/MsSurfaceWorkflowTests.cs holds the list to the artifact's own measured
+# inventory in BOTH directions: nothing invented, and nothing the artifact ships left silently
+# out. If Microsoft adds a bucket, that test is what turns a quietly smaller total into a red
+# PR check.
+#
+# ─── PARTIAL RUNS ────────────────────────────────────────────────────────────────────────────
+#
+# There is no bucket filter here on purpose: this workflow means "all of it". To run a subset,
+# dispatch ms-bucket.yml directly — its `buckets` input takes a comma- or newline-separated
+# list and runs it in exactly this single-job, one-process-per-bucket way.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bc-version:
+        description: >-
+          BC build: a full four-part build (28.4.53241.54318) or a prefix (28.4) resolved to
+          its newest published build. Empty = the newest prefix in .github/bc-versions.txt.
+        type: string
+        required: false
+        default: ''
+      test-data:
+        description: >-
+          Hydrate the demo company from the sandbox backup (--test-data). Leave it on:
+          without it roughly 40% of the failures are missing setup data rather than defects, and
+          the two numbers are not comparable.
+        type: boolean
+        required: false
+        default: true
+
+permissions:
+  contents: read
+
+# One surface run at a time. A second dispatch queues rather than cancelling a multi-hour
+# measurement in flight.
+concurrency:
+  group: ms-surface
+  cancel-in-progress: false
+
+jobs:
+  surface:
+    uses: ./.github/workflows/ms-bucket.yml
+    with:
+      label: surface
+      # 40,530 tests, measured on the 28.1.49838.53507 artifact. Handed down so the
+      # combined-total step can say when the measured total falls well short of it: a bundle
+      # lost to COMPILE FAIL vanishes from the totals rather than failing them (#2715), so a
+      # run can finish, report a number, and have quietly measured two thirds of the surface.
+      expected-tests: 40530
+      bc-version: ${{ inputs.bc-version }}
+      test-data: ${{ inputs.test-data }}
+      # Ordered biggest first: Tests-ERM and Tests-SCM are 44% of the surface between them, and
+      # if anything is going to be lost to the 360-minute ceiling it should be the small tail,
+      # not the two buckets everything else is compared against.
+      buckets: |
+        Tests-ERM
+        Tests-SCM
+        Tests-SCM-Service
+        Tests-SCM-Assembly
+        Tests-SCM-Manufacturing
+        Tests-Misc
+        Tests-SINGLESERVER
+        Tests-Bank
+        Tests-Data Exchange
+        Tests-Rapid Start
+        Tests-Graph
+        Tests-Monitor Sensitive Fields
+        Tests-Workflow
+        Tests-CRM integration
+        Tests-Report
+        Tests-Cost Accounting
+        Tests-Integration
+        Tests-User
+        Tests-VAT
+        Tests-Dimension
+        Tests-Marketing
+        Tests-Fixed Asset
+        Tests-Resource
+        Tests-Physical Inventory
+        Tests-Job
+        Tests-SMB
+        Tests-General Journal
+        Tests-Prepayment
+        Tests-Cash Flow
+        Tests-Reverse
+        Tests-Permissions
+        Tests-Upgrade

--- a/AlRunner.Tests/MsSurfaceWorkflowTests.cs
+++ b/AlRunner.Tests/MsSurfaceWorkflowTests.cs
@@ -1,0 +1,362 @@
+// Issue #3409: .github/workflows/ms-surface.yml runs the WHOLE Microsoft BaseApp surface —
+// 40,530 tests across 32 non-empty buckets — from one manual dispatch, in ONE job, and reports
+// one combined total.
+//
+// A YAML workflow cannot be unit-tested the way the C# behind it can, so this file pins the
+// properties that are load-bearing and cheap to lose in an edit. Two of them are the reason the
+// file exists:
+//
+//   1. THE BUCKET LIST IS THE WHOLE SURFACE. Every non-empty bucket appears exactly once; no
+//      entry names something the artifact does not ship; the three sources that are NOT run are
+//      accounted for by name. A list that silently drops a bucket still produces a total, and
+//      that total is wrong in a way nobody notices.
+//
+//   2. THE SURFACE WORKFLOW REUSES ms-bucket.yml rather than re-spelling it. bc-tests.yml's
+//      provisioning drifted four times and failed two releases (#1976) because a copy existed;
+//      ms-bucket.yml already owns provisioning, the backup cache, the pinned reader, the
+//      company name, the emit timeout and the private cache root.
+//
+// THE INDEPENDENT REFERENCE, AND WHY IT IS DUPLICATED ON PURPOSE
+// --------------------------------------------------------------
+// ArtifactInventory below is the artifact's OWN listing, measured — not derived from the
+// workflow this test is checking. Reading the reference out of the file under test is how a
+// drift test comes to pass vacuously: "every bucket in the list is in the list" cannot fail. So
+// the same fact is stated twice, independently, and the two must agree.
+//
+// Measured against BC 28.4.53241.54318 with the ranged central-directory read
+// tools/DownloadArtifacts already does:
+//
+//     dotnet run --project tools/DownloadArtifacts -- test-sources 28.4.53241.54318 /tmp/x __NOSUCH__
+//
+// whose error path lists every Applications/BaseApp/Test/*.Source.zip the artifact ships. That
+// is a fact about one BC build: if Microsoft adds a bucket, this constant is what has to be
+// re-measured, and the assertions below are what make that a red test rather than a quietly
+// smaller total. A run that names a bucket the artifact does NOT ship fails earlier still — the
+// fetch step lists what it does ship and stops.
+using Xunit;
+
+namespace AlRunner.Tests;
+
+internal static class WorkflowBlockScalar
+{
+    /// <summary>
+    /// The lines of a <c>key: |</c> block scalar, trimmed, with comments and blanks dropped.
+    /// Ends at the first non-blank line indented no deeper than the key. Empty when the key is
+    /// absent — callers must assert a count, never just iterate.
+    /// </summary>
+    internal static IReadOnlyList<string> Of(string workflowText, string key)
+    {
+        var lines = workflowText.Replace("\r\n", "\n").Split('\n');
+        var values = new List<string>();
+        var keyIndent = -1;
+        foreach (var raw in lines)
+        {
+            var line = raw.TrimEnd();
+            var indent = line.Length - line.TrimStart().Length;
+            if (keyIndent < 0)
+            {
+                var trimmed = line.TrimStart();
+                if (trimmed == key + ": |" || trimmed == key + ": |-") keyIndent = indent;
+                continue;
+            }
+            if (line.Trim().Length == 0) continue;
+            if (indent <= keyIndent) break;
+            var value = line.Trim();
+            if (value.StartsWith('#')) continue;
+            values.Add(value);
+        }
+        return values;
+    }
+}
+
+public sealed class MsSurfaceWorkflowTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static readonly string GithubDir = Path.Combine(RepoRoot, ".github");
+
+    private const string SurfaceWorkflow = "workflows/ms-surface.yml";
+    private const string BucketWorkflow = "workflows/ms-bucket.yml";
+
+    /// <summary>
+    /// The 35 <c>*.Source.zip</c> entries under <c>Applications/BaseApp/Test/</c>, measured —
+    /// 32 non-empty test buckets, 2 empty ones, and one shared library source.
+    /// </summary>
+    private static readonly string[] ArtifactInventory =
+    {
+        "Library-NoTransactions",
+        "Tests-Bank", "Tests-CRM integration", "Tests-Cash Flow", "Tests-Cost Accounting",
+        "Tests-Data Exchange", "Tests-Dimension", "Tests-ERM", "Tests-Fixed Asset",
+        "Tests-General Journal", "Tests-Graph", "Tests-Integration", "Tests-Job",
+        "Tests-Local", "Tests-Marketing", "Tests-Misc", "Tests-Monitor Sensitive Fields",
+        "Tests-Permissions", "Tests-Physical Inventory", "Tests-Prepayment",
+        "Tests-Rapid Start", "Tests-Report", "Tests-Resource", "Tests-Reverse",
+        "Tests-SCM", "Tests-SCM-Assembly", "Tests-SCM-Manufacturing", "Tests-SCM-Service",
+        "Tests-SINGLESERVER", "Tests-SMB", "Tests-TestLibraries", "Tests-Upgrade",
+        "Tests-User", "Tests-VAT", "Tests-Workflow",
+    };
+
+    /// <summary>
+    /// What the artifact ships and this workflow deliberately does NOT run. Tests-TestLibraries
+    /// is 204 .al files with no <c>[Test]</c> method — a library the other buckets compile
+    /// against; Tests-Local is empty in the W1 artifact; Library-NoTransactions is not a bucket
+    /// at all. Running any of them would report a zero that reads like a failure.
+    /// </summary>
+    private static readonly string[] NotRun =
+        { "Library-NoTransactions", "Tests-Local", "Tests-TestLibraries" };
+
+    // The surface, measured on the 28.1.49838.53507 artifact. Constants, so a workflow whose
+    // bucket list enumerates NOTHING fails loudly here instead of satisfying every "for each
+    // bucket, …" assertion below by having nothing to iterate.
+    private const int ExpectedTests = 40_530;
+    private const int ExpectedBuckets = 32;
+
+    private static string Read(string relative)
+    {
+        var path = Path.Combine(GithubDir, relative);
+        Assert.True(File.Exists(path), $"expected {relative} at {path}");
+        return File.ReadAllText(path);
+    }
+
+    private static string CodeOnly(string text) =>
+        string.Join('\n', text.Split('\n').Where(l => !l.TrimStart().StartsWith('#')));
+
+    private static IReadOnlyList<string> SurfaceBuckets() =>
+        WorkflowBlockScalar.Of(CodeOnly(Read(SurfaceWorkflow)), "buckets");
+
+    // ---- the block-scalar reader, proven on constructed text ---------------------------
+
+    [Fact]
+    public void BlockScalarOf_ReadsTheBlock_AndStopsAtTheNextKey()
+    {
+        const string wf = """
+            jobs:
+              surface:
+                with:
+                  buckets: |
+                    Tests-ERM
+                    Tests-Cash Flow
+
+                    # a comment inside the block
+                    Tests-SMB
+                  test-data: true
+            """;
+
+        Assert.Equal(new[] { "Tests-ERM", "Tests-Cash Flow", "Tests-SMB" },
+            WorkflowBlockScalar.Of(wf, "buckets"));
+    }
+
+    [Fact]
+    public void BlockScalarOf_IsEmptyWhenTheKeyIsAbsentOrNotABlock()
+    {
+        Assert.Empty(WorkflowBlockScalar.Of("with:\n  test-data: true\n", "buckets"));
+        Assert.Empty(WorkflowBlockScalar.Of("with:\n  buckets: Tests-ERM\n", "buckets"));
+    }
+
+    // ---- the bucket list is the whole surface ------------------------------------------
+
+    /// <summary>
+    /// The counts, asserted against constants BEFORE anything is compared element by element.
+    /// A truncated or empty list fails here rather than passing the set comparisons below by
+    /// having nothing in it.
+    /// </summary>
+    [Fact]
+    public void SurfaceWorkflow_RunsEveryNonEmptyBucketExactlyOnce()
+    {
+        var buckets = SurfaceBuckets();
+
+        Assert.Equal(ExpectedBuckets, buckets.Count);
+        var duplicated = buckets.GroupBy(b => b, StringComparer.Ordinal)
+            .Where(g => g.Count() > 1).Select(g => g.Key).OrderBy(b => b).ToArray();
+        Assert.Equal(Array.Empty<string>(), duplicated);
+        Assert.Equal(ExpectedBuckets, buckets.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    /// <summary>
+    /// Both directions against the measured artifact listing: nothing invented, and nothing the
+    /// artifact ships left silently out. The second half is the one that matters when Microsoft
+    /// adds a bucket — without it, a 33-bucket artifact keeps producing a confident 32-bucket
+    /// total.
+    /// </summary>
+    [Fact]
+    public void SurfaceWorkflow_NamesOnlyRealBuckets_AndAccountsForEverythingTheArtifactShips()
+    {
+        var buckets = SurfaceBuckets();
+        var inventory = ArtifactInventory.ToHashSet(StringComparer.Ordinal);
+
+        Assert.Equal(Array.Empty<string>(),
+            buckets.Where(b => !inventory.Contains(b)).OrderBy(b => b).ToArray());
+
+        var accounted = buckets.Concat(NotRun).ToList();
+        Assert.Equal(Array.Empty<string>(),
+            ArtifactInventory.Where(s => !accounted.Contains(s, StringComparer.Ordinal))
+                .OrderBy(s => s).ToArray());
+        Assert.Equal(ArtifactInventory.Length, accounted.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    /// <summary>
+    /// The three sources that are not run are named in the workflow with the reason, so the
+    /// operator reading "32 buckets" can see which two of the artifact's 34 Tests-* entries are
+    /// missing and why — rather than wondering whether the list is just incomplete.
+    /// </summary>
+    [Fact]
+    public void SurfaceWorkflow_SaysWhichSourcesItDoesNotRun()
+    {
+        var text = Read(SurfaceWorkflow);
+        var buckets = SurfaceBuckets();
+
+        foreach (var skipped in NotRun)
+        {
+            Assert.DoesNotContain(skipped, buckets);
+            Assert.Contains(skipped, text, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// 40,530 is not decoration: it is handed to ms-bucket.yml as <c>expected-tests</c>, and the
+    /// combined-total step compares the measured total against it and says so when a large slice
+    /// of the surface never ran. A bundle lost to COMPILE FAIL vanishes from the totals (#2715),
+    /// so "the run finished and reported a number" is not the same as "the number covers the
+    /// surface".
+    /// </summary>
+    [Fact]
+    public void SurfaceWorkflow_DeclaresTheExpectedSurfaceSize_SoAShortfallIsVisible()
+    {
+        var code = CodeOnly(Read(SurfaceWorkflow));
+
+        Assert.Contains($"expected-tests: {ExpectedTests}", code, StringComparison.Ordinal);
+    }
+
+    // ---- the surface workflow's shape --------------------------------------------------
+
+    /// <summary>
+    /// Manual dispatch ONLY. A multi-hour, 40,530-test job against an Actions queue shared
+    /// account-wide with the corpus repository must never be started by a push, a pull request
+    /// or a cron. <c>workflow_call</c> is forbidden too: this file is the POLICY (which buckets,
+    /// how many), and anything wanting the mechanics calls ms-bucket.yml, which is what it is
+    /// for.
+    /// </summary>
+    [Fact]
+    public void SurfaceWorkflow_IsManualDispatchOnly()
+    {
+        Assert.Equal(new[] { "workflow_dispatch" }, WorkflowTriggers.TriggersOf(Read(SurfaceWorkflow)));
+    }
+
+    /// <summary>
+    /// It calls ms-bucket.yml and therefore contains none of the configuration ms-bucket.yml
+    /// owns. A second spelling of the company name, the package caches or the reader pin is how
+    /// provisioning drifted four times (#1976) — and here it would silently produce a number
+    /// measured under a different configuration from the nightly's, which is worse than no
+    /// number.
+    /// </summary>
+    [Fact]
+    public void SurfaceWorkflow_ReusesTheBucketWorkflow_RatherThanRespellingIt()
+    {
+        var code = CodeOnly(Read(SurfaceWorkflow));
+
+        Assert.Contains("uses: ./.github/workflows/ms-bucket.yml", code, StringComparison.Ordinal);
+        foreach (var owned in new[]
+                 {
+                     "--package-cache", "READER_TAG", "--test-data-company",
+                     "CRONUS International Ltd_", "AL_RUNNER_EMIT_TIMEOUT_SEC",
+                     "provision-bc", "al-runner",
+                 })
+            Assert.DoesNotContain(owned, code, StringComparison.Ordinal);
+    }
+
+    // ---- what the surface needs from ms-bucket.yml -------------------------------------
+
+    /// <summary>
+    /// The surface is several buckets in ONE job, so ms-bucket.yml grew a list input beside the
+    /// singular one. The singular <c>bucket</c> stays — MsBucketWorkflowTests pins the rest of
+    /// that file's shape and the nightly passes it.
+    /// </summary>
+    [Fact]
+    public void BucketWorkflow_TakesABucketList_WithoutLosingTheSingularInput()
+    {
+        var code = CodeOnly(Read(BucketWorkflow));
+
+        Assert.Contains("      bucket:", code, StringComparison.Ordinal);
+        Assert.Contains("      buckets:", code, StringComparison.Ordinal);
+        Assert.Contains("      label:", code, StringComparison.Ordinal);
+        Assert.Contains("      expected-tests:", code, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The concurrency group must still vary when <c>bucket</c> is empty. It used to be
+    /// <c>ms-bucket-${{ inputs.bucket }}</c>; a surface run passes only <c>buckets</c>, so
+    /// without the label every list run would land in the group named <c>ms-bucket-</c> and
+    /// queue behind any other list run — with <c>cancel-in-progress: false</c> that is a silent
+    /// wait, not an error.
+    /// </summary>
+    [Fact]
+    public void BucketWorkflow_ConcurrencyGroupVariesWhenOnlyAListIsGiven()
+    {
+        var code = CodeOnly(Read(BucketWorkflow));
+        var group = code.Split('\n').First(l => l.TrimStart().StartsWith("group:", StringComparison.Ordinal));
+
+        Assert.Contains("inputs.label", group, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The runner is invoked once PER BUCKET, in separate processes. Peak RSS tracks how many
+    /// bundles a process loads, not how many tests it runs — measured, 3 bundles / 939 tests
+    /// peaked at 4.4 GB against 1 bundle / 1,027 tests at 3.7 GB — so handing 32 bundle
+    /// directories to one invocation stacks their memory on a 16 GB runner that has already
+    /// peaked at 10.9 GiB on Tests-ERM alone. Separate invocations reset it and still pay
+    /// provisioning once.
+    ///
+    /// DOTNET_GCHeapCount is set explicitly rather than left to the runner's core count, and
+    /// DOTNET_GCHeapHardLimit is forbidden: under ~1.25 GB it silently changed test results
+    /// (259 -> 212 passing), so it would corrupt the very number this workflow exists to
+    /// produce.
+    /// </summary>
+    [Fact]
+    public void BucketWorkflow_RunsOneProcessPerBucket_WithAnExplicitHeapCount()
+    {
+        var code = CodeOnly(Read(BucketWorkflow));
+
+        Assert.Contains("for bucket in \"${BUCKET_LIST[@]}\"", code, StringComparison.Ordinal);
+        Assert.Contains("DOTNET_GCHeapCount:", code, StringComparison.Ordinal);
+        Assert.DoesNotContain("DOTNET_GCHeapHardLimit", code, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Each bucket's numbers reach the job summary and the run's annotations BEFORE the next
+    /// bucket starts, and the combined total comes after the loop. This is what makes a single
+    /// job safe at a 360-minute ceiling that cannot be raised: a design whose failure mode is
+    /// "the job was killed, so you get nothing" is the argument for sharding, and reporting as
+    /// it goes removes it far more cheaply than a matrix does.
+    ///
+    /// Asserted as an ORDER, because that is the actual claim — a summary step placed after the
+    /// loop would contain all the same strings and report nothing until the end.
+    /// </summary>
+    [Fact]
+    public void BucketWorkflow_ReportsEachBucketBeforeTheNextOneStarts()
+    {
+        var code = CodeOnly(Read(BucketWorkflow));
+
+        var loop = code.IndexOf("for bucket in \"${BUCKET_LIST[@]}\"", StringComparison.Ordinal);
+        var perBucket = code.IndexOf("ms-bucket-summary.py", StringComparison.Ordinal);
+        var combined = code.IndexOf("ms-bucket-total.py", StringComparison.Ordinal);
+
+        Assert.True(loop >= 0, "the bucket loop is gone");
+        Assert.True(perBucket > loop,
+            "ms-bucket-summary.py must run INSIDE the loop, so a killed job still carries every "
+            + "finished bucket's numbers");
+        Assert.True(combined > perBucket, "the combined total comes after the per-bucket summaries");
+        // The per-bucket append target, and the live annotation that survives a step the
+        // runner never got to finalise — a step summary is written out when its step ENDS, and
+        // here the whole run is one step.
+        Assert.Contains("--step-summary \"$GITHUB_STEP_SUMMARY\"", code, StringComparison.Ordinal);
+        Assert.Contains("--notice", code, StringComparison.Ordinal);
+        Assert.Contains("::notice title=",
+            File.ReadAllText(Path.Combine(RepoRoot, "scripts", "ms-bucket-summary.py")),
+            StringComparison.Ordinal);
+
+        // The combined total is the VERDICT, so it must run even after a bucket blew up — a
+        // step that only runs on success would skip the one number the run exists to produce.
+        Assert.Contains("- name: Combined total\n        if: always()", code, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner.Tests/MsSurfaceWorkflowTests.cs
+++ b/AlRunner.Tests/MsSurfaceWorkflowTests.cs
@@ -122,6 +122,21 @@ public sealed class MsSurfaceWorkflowTests
     private static string CodeOnly(string text) =>
         string.Join('\n', text.Split('\n').Where(l => !l.TrimStart().StartsWith('#')));
 
+    /// <summary>
+    /// One named step's text, from its <c>- name:</c> line to the next step's. Assertions
+    /// about ORDER need this: <c>ms-bucket.yml</c> has two <c>for bucket in …</c> loops, so an
+    /// index taken over the whole file answers a question about the FETCH loop while reading
+    /// like a question about the run loop.
+    /// </summary>
+    private static string StepBody(string code, string stepName)
+    {
+        const string marker = "      - name: ";
+        var start = code.IndexOf(marker + stepName, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"no step named \"{stepName}\" in the workflow");
+        var next = code.IndexOf(marker, start + marker.Length, StringComparison.Ordinal);
+        return next < 0 ? code[start..] : code[start..next];
+    }
+
     private static IReadOnlyList<string> SurfaceBuckets() =>
         WorkflowBlockScalar.Of(CodeOnly(Read(SurfaceWorkflow)), "buckets");
 
@@ -324,33 +339,52 @@ public sealed class MsSurfaceWorkflowTests
 
     /// <summary>
     /// Each bucket's numbers reach the job summary and the run's annotations BEFORE the next
-    /// bucket starts, and the combined total comes after the loop. This is what makes a single
-    /// job safe at a 360-minute ceiling that cannot be raised: a design whose failure mode is
-    /// "the job was killed, so you get nothing" is the argument for sharding, and reporting as
-    /// it goes removes it far more cheaply than a matrix does.
+    /// bucket starts. This is the property the whole single-job design rests on: a hosted job
+    /// cannot run past 360 minutes and that ceiling cannot be raised, so "the job was killed,
+    /// so you get nothing" must not be the failure mode. Reporting as it goes removes it far
+    /// more cheaply than sharding does.
     ///
-    /// Asserted as an ORDER, because that is the actual claim — a summary step placed after the
-    /// loop would contain all the same strings and report nothing until the end.
+    /// The assertion is that the reporting call sits INSIDE the loop — between the `for` and
+    /// its `done` — not merely somewhere after the loop began. An earlier version of this test
+    /// compared indices against the loop's START, and a reviewer showed it passing on the exact
+    /// regression it claims to catch: reporting moved into a second loop after `done`, which
+    /// reports everything at the end and nothing during the run. `done` is also after the
+    /// loop's start, so that arrangement satisfied the old comparison with 24 green tests.
+    ///
+    /// Two loops named `for bucket in "${BUCKET_LIST[@]}"` exist in the file — the fetch step
+    /// has one too, and it comes FIRST — so this reads indices inside the run step's own body
+    /// rather than over the whole file. The old version did not, which made it weaker still
+    /// than the paragraph above admits: it was satisfied by anything after the FETCH loop.
     /// </summary>
     [Fact]
     public void BucketWorkflow_ReportsEachBucketBeforeTheNextOneStarts()
     {
         var code = CodeOnly(Read(BucketWorkflow));
+        var runStep = StepBody(code, "Run the bucket(s)");
 
-        var loop = code.IndexOf("for bucket in \"${BUCKET_LIST[@]}\"", StringComparison.Ordinal);
-        var perBucket = code.IndexOf("ms-bucket-summary.py", StringComparison.Ordinal);
+        var loop = runStep.IndexOf("for bucket in \"${BUCKET_LIST[@]}\"", StringComparison.Ordinal);
+        Assert.True(loop >= 0, "the bucket loop is gone from the run step");
+        var done = runStep.IndexOf("\n          done", loop, StringComparison.Ordinal);
+        Assert.True(done > loop, "the bucket loop in the run step never closes");
+
+        var perBucket = runStep.IndexOf("ms-bucket-summary.py", StringComparison.Ordinal);
+        Assert.True(perBucket > loop && perBucket < done,
+            "ms-bucket-summary.py must be called INSIDE the bucket loop, between `for` and "
+            + "`done`. After `done` it reports every bucket only once the whole run has "
+            + "finished, so a job killed at the 360-minute ceiling carries away every number "
+            + "it had already measured — the failure mode this design exists to avoid.");
+
+        // The combined total is the opposite: once, after the loop, in its own step.
         var combined = code.IndexOf("ms-bucket-total.py", StringComparison.Ordinal);
+        Assert.True(combined > code.IndexOf(runStep, StringComparison.Ordinal) + runStep.Length,
+            "the combined total belongs after the run step, not inside it");
+        Assert.DoesNotContain("ms-bucket-total.py", runStep, StringComparison.Ordinal);
 
-        Assert.True(loop >= 0, "the bucket loop is gone");
-        Assert.True(perBucket > loop,
-            "ms-bucket-summary.py must run INSIDE the loop, so a killed job still carries every "
-            + "finished bucket's numbers");
-        Assert.True(combined > perBucket, "the combined total comes after the per-bucket summaries");
         // The per-bucket append target, and the live annotation that survives a step the
         // runner never got to finalise — a step summary is written out when its step ENDS, and
         // here the whole run is one step.
-        Assert.Contains("--step-summary \"$GITHUB_STEP_SUMMARY\"", code, StringComparison.Ordinal);
-        Assert.Contains("--notice", code, StringComparison.Ordinal);
+        Assert.Contains("--step-summary \"$GITHUB_STEP_SUMMARY\"", runStep, StringComparison.Ordinal);
+        Assert.Contains("--notice", runStep, StringComparison.Ordinal);
         Assert.Contains("::notice title=",
             File.ReadAllText(Path.Combine(RepoRoot, "scripts", "ms-bucket-summary.py")),
             StringComparison.Ordinal);

--- a/scripts/ms-bucket-summary.py
+++ b/scripts/ms-bucket-summary.py
@@ -183,6 +183,19 @@ def compose(meta, totals, scan, rc, elapsed_s):
     return "\n".join(out)
 
 
+def notice_line(meta, totals, elapsed_s):
+    """A one-line workflow annotation carrying this bucket's numbers.
+
+    Emitted per bucket by a LIST run (#3409), where the whole thing is one step: a step
+    summary is only finalised when its step ends, so a job killed at the 360-minute hosted
+    ceiling would take every finished bucket's numbers with it. An annotation goes out
+    through the log stream as it happens and survives that.
+    """
+    return (f"::notice title={meta['bucket']} on BC {meta['bc_version']}::"
+            f"{totals['tests']} tests — {totals['passed']} pass, {totals['failures']} fail, "
+            f"{totals['errors']} error, {totals['skipped']} skipped, in {fmt_elapsed(elapsed_s)}")
+
+
 def main(argv=None):
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--log", required=True)
@@ -194,6 +207,9 @@ def main(argv=None):
     ap.add_argument("--reader", default="")
     ap.add_argument("--junit", default=None)
     ap.add_argument("--out", default=None)
+    ap.add_argument("--notice", action="store_true",
+                    help="also emit a one-line ::notice:: annotation with this bucket's totals "
+                         "(a list run reports each bucket as it finishes, not at the end)")
     ap.add_argument("--step-summary", default=None,
                     help="also append the markdown here; defaults to $GITHUB_STEP_SUMMARY when set")
     a = ap.parse_args(argv)
@@ -220,6 +236,8 @@ def main(argv=None):
             f.write(md + "\n")
 
     ok = measured(a.rc, totals is not None)
+    if ok and a.notice:
+        print(notice_line(meta, totals, a.elapsed))
     if not ok:
         # A GitHub workflow annotation, so the REASON travels with the run-list entry and the
         # scheduled-failure notification instead of living in a log nobody opens. This is what

--- a/scripts/ms-bucket-total.py
+++ b/scripts/ms-bucket-total.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Combined total across every bucket of one ms-bucket.yml run (issue #3409).
+
+`.github/workflows/ms-surface.yml` runs all 32 non-empty Microsoft BaseApp buckets in ONE
+job, sequentially, and each bucket's own numbers are already in the job summary by the time
+the next one starts (scripts/ms-bucket-summary.py, called inside the loop). This script adds
+the thing that is only knowable at the end: one total across the whole set, and the verdict.
+
+WHAT IT IS DRIVEN BY, AND WHY THAT MATTERS
+------------------------------------------
+The REQUESTED bucket list, not the files that happen to be on disk. A bucket whose runner
+process died before writing a JUnit leaves no directory at all, so a script that globbed for
+results would report a confident total over the buckets that worked and never mention the
+ones that did not. Driven by the request, a missing bucket is a named row and a non-zero
+exit.
+
+THE VERDICT, unchanged from ms-bucket.yml's existing contract: exit 0 when every requested
+bucket produced a number (runner exit 0 or 1 AND a JUnit file), exit 1 when one did not.
+Thousands of FAILING tests are the expected outcome of a Microsoft bucket and are reported,
+never failed on.
+
+--expected-tests is a SHORTFALL check, not a baseline. A bundle lost to COMPILE FAIL vanishes
+from the totals rather than failing them (#2715), so a run can finish, report a number, and
+have quietly measured two thirds of the surface. A total well below what the set is known to
+hold says so — as a warning, because Microsoft's own counts move between BC versions and a
+version bump must not read as a defect.
+
+Usage:
+  ms-bucket-total.py --results DIR --buckets FILE --bc-version V --test-data true|false
+                     [--expected-tests N] [--step-summary FILE]
+"""
+import argparse
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+# A bucket's results live in <results>/<slug>/, where the slug is the bucket name with the
+# characters a directory name cannot carry replaced. Kept in step with ms-bucket.yml's
+# `tr ' /' '__'` — bucket names really do contain spaces (Tests-Cash Flow).
+SLUG_TRANSLATION = str.maketrans({" ": "_", "/": "_"})
+
+# Below this fraction of --expected-tests, say so. Microsoft's counts drift a little between
+# BC versions; losing a bundle loses whole percent of the surface at once.
+SHORTFALL_FRACTION = 0.95
+
+
+def slug(bucket):
+    return bucket.translate(SLUG_TRANSLATION)
+
+
+def read_buckets(path):
+    """The requested bucket list, in order, blanks dropped."""
+    with open(path, encoding="utf-8") as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+def parse_junit_totals(xml_text):
+    """Totals from a JUnit <testsuites> root, plus derived passed."""
+    root = ET.fromstring(xml_text)
+    if root.tag != "testsuites":
+        raise ValueError(f"expected a <testsuites> root, got <{root.tag}>")
+    totals = {k: int(root.attrib.get(k, "0")) for k in ("tests", "failures", "errors", "skipped")}
+    totals["passed"] = totals["tests"] - totals["failures"] - totals["errors"] - totals["skipped"]
+    return totals
+
+
+def _read_int(path, default=None):
+    try:
+        with open(path, encoding="utf-8") as f:
+            return int(f.read().strip())
+    except (OSError, ValueError):
+        return default
+
+
+def collect(results_dir, buckets):
+    """One record per REQUESTED bucket, in request order. `measured` is the verdict input."""
+    out = []
+    for bucket in buckets:
+        d = os.path.join(results_dir, slug(bucket))
+        rc = _read_int(os.path.join(d, "rc.txt"))
+        elapsed = _read_int(os.path.join(d, "elapsed.txt"), 0)
+        junit = os.path.join(d, "junit.xml")
+        totals = None
+        if os.path.exists(junit):
+            try:
+                with open(junit, encoding="utf-8") as f:
+                    totals = parse_junit_totals(f.read())
+            except (OSError, ET.ParseError, ValueError):
+                totals = None
+        out.append({
+            "bucket": bucket,
+            "rc": rc,
+            "elapsed": elapsed or 0,
+            "totals": totals,
+            # Identical rule to ms-bucket-summary.measured: a number exists only when the
+            # runner finished normally AND wrote JUnit.
+            "measured": totals is not None and rc in (0, 1),
+        })
+    return out
+
+
+def fmt_elapsed(seconds):
+    seconds = int(seconds)
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    return f"{h}h {m}m {s}s" if h else f"{m}m {s}s"
+
+
+def sum_totals(records):
+    keys = ("tests", "passed", "failures", "errors", "skipped")
+    out = {k: 0 for k in keys}
+    for r in records:
+        if r["totals"] is None:
+            continue
+        for k in keys:
+            out[k] += r["totals"][k]
+    return out
+
+
+def shortfall(total_tests, expected_tests):
+    """(is_short, missing) against --expected-tests; (False, 0) when no expectation given."""
+    if not expected_tests or expected_tests <= 0:
+        return False, 0
+    return total_tests < expected_tests * SHORTFALL_FRACTION, expected_tests - total_tests
+
+
+def compose(records, meta):
+    with_td = "with --test-data" if meta["test_data"] else "without --test-data"
+    combined = sum_totals(records)
+    unmeasured = [r["bucket"] for r in records if not r["measured"]]
+    wall = sum(r["elapsed"] for r in records)
+
+    out = [f"## Combined total — {len(records)} bucket(s) on BC {meta['bc_version']} ({with_td})", ""]
+    if len(records) > 1:
+        out += ["| bucket | total | pass | fail | error | skipped | time |",
+                "|---|---|---|---|---|---|---|"]
+        for r in records:
+            t = r["totals"]
+            if t is None:
+                out.append(f"| `{r['bucket']}` | **no number** (runner exit {r['rc']}) | | | | | "
+                           f"{fmt_elapsed(r['elapsed'])} |")
+            else:
+                out.append(f"| `{r['bucket']}` | {t['tests']} | {t['passed']} | {t['failures']} | "
+                           f"{t['errors']} | {t['skipped']} | {fmt_elapsed(r['elapsed'])} |")
+        out.append(f"| **total** | **{combined['tests']}** | **{combined['passed']}** | "
+                   f"**{combined['failures']}** | **{combined['errors']}** | "
+                   f"**{combined['skipped']}** | **{fmt_elapsed(wall)}** |")
+        out.append("")
+    else:
+        out += [f"{combined['tests']} tests — {combined['passed']} pass, {combined['failures']} fail, "
+                f"{combined['errors']} error, {combined['skipped']} skipped, "
+                f"in {fmt_elapsed(wall)}.", ""]
+
+    short, missing = shortfall(combined["tests"], meta["expected_tests"])
+    if short:
+        out += [f"**{combined['tests']} tests is short of the {meta['expected_tests']} this set is "
+                f"expected to hold — {missing} unaccounted for.** A bundle lost to COMPILE FAIL "
+                "vanishes from the totals rather than failing them (#2715), so read the per-bucket "
+                "caveats above before quoting this number. Microsoft's counts also move between BC "
+                "versions, which is why this is a warning and not a failure.", ""]
+    elif meta["expected_tests"]:
+        out += [f"Expected about {meta['expected_tests']} tests for this set; measured "
+                f"{combined['tests']}.", ""]
+
+    if unmeasured:
+        out += [f"**No number from {len(unmeasured)} of {len(records)} bucket(s):** "
+                + ", ".join(f"`{b}`" for b in unmeasured) + ".",
+                "", "The combined total above covers only the buckets that produced one.", ""]
+    else:
+        out += [f"Every one of the {len(records)} requested bucket(s) produced a number.", ""]
+    return "\n".join(out), combined, unmeasured
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--results", required=True, help="directory holding <bucket-slug>/ result dirs")
+    ap.add_argument("--buckets", required=True, help="file listing the REQUESTED buckets, one per line")
+    ap.add_argument("--bc-version", required=True)
+    ap.add_argument("--test-data", required=True, help="true|false")
+    ap.add_argument("--expected-tests", type=int, default=0)
+    ap.add_argument("--step-summary", default=None,
+                    help="also append the markdown here; defaults to $GITHUB_STEP_SUMMARY when set")
+    a = ap.parse_args(argv)
+
+    buckets = read_buckets(a.buckets)
+    if not buckets:
+        print(f"::error title=No buckets::{a.buckets} lists no bucket, so there is nothing to total")
+        return 1
+
+    records = collect(a.results, buckets)
+    meta = {"bc_version": a.bc_version,
+            "test_data": a.test_data.strip().lower() == "true",
+            "expected_tests": a.expected_tests}
+    md, combined, unmeasured = compose(records, meta)
+
+    print(md)
+    step = a.step_summary or os.environ.get("GITHUB_STEP_SUMMARY")
+    if step:
+        with open(step, "a", encoding="utf-8") as f:
+            f.write(md + "\n")
+
+    if unmeasured:
+        print(f"::error title=No measurement ({len(unmeasured)} of {len(buckets)} bucket(s) on BC "
+              f"{a.bc_version})::" + ", ".join(unmeasured)
+              + " produced no number — read each one's block in the job summary.")
+        return 1
+
+    short, missing = shortfall(combined["tests"], a.expected_tests)
+    if short:
+        print(f"::warning title=Short of the expected surface::measured {combined['tests']} tests "
+              f"against about {a.expected_tests} expected — {missing} unaccounted for.")
+    print(f"::notice title=Combined total on BC {a.bc_version}::{combined['tests']} tests — "
+          f"{combined['passed']} pass, {combined['failures']} fail, {combined['errors']} error, "
+          f"{combined['skipped']} skipped, across {len(buckets)} bucket(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/ms-bucket-total.test.py
+++ b/scripts/tests/ms-bucket-total.test.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/ms-bucket-total.py (issue #3409).
+
+The combined total across a multi-bucket run is the deliverable of
+.github/workflows/ms-surface.yml, and the ways it can be quietly WRONG are the point of
+these tests, not the happy path:
+
+  * a bucket that produced no number must not be silently dropped from a total that then
+    looks complete (the whole reason the script is driven by the REQUESTED list rather
+    than by whatever directories exist);
+  * a runner exit code that means "did not finish" must not be counted as a measurement,
+    even though a JUnit file exists;
+  * a total well short of what the set is known to hold must say so.
+
+RED before #3409: the script did not exist. Run: python3 scripts/tests/ms-bucket-total.test.py
+"""
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "ms-bucket-total.py"
+_spec = importlib.util.spec_from_file_location("ms_bucket_total", SCRIPT_PATH)
+mbt = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mbt)
+
+
+def junit(tests, failures=0, errors=0, skipped=0):
+    return (f'<?xml version="1.0" encoding="utf-8"?>\n'
+            f'<testsuites tests="{tests}" failures="{failures}" errors="{errors}" '
+            f'skipped="{skipped}" time="1.0"></testsuites>\n')
+
+
+class Fixture:
+    """A results/ tree plus the requested-bucket file, as ms-bucket.yml writes them."""
+
+    def __init__(self, tmp):
+        self.root = Path(tmp)
+        self.results = self.root / "results"
+        self.results.mkdir()
+        self.requested = []
+
+    def bucket(self, name, *, rc=1, elapsed=60, xml=None):
+        self.requested.append(name)
+        if xml is None and rc is not None:
+            xml = junit(100, failures=40)
+        d = self.results / name.translate(mbt.SLUG_TRANSLATION)
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "bucket.txt").write_text(name + "\n")
+        if rc is not None:
+            (d / "rc.txt").write_text(f"{rc}\n")
+            (d / "elapsed.txt").write_text(f"{elapsed}\n")
+        if xml is not None:
+            (d / "junit.xml").write_text(xml)
+        return self
+
+    def missing(self, name):
+        """A bucket that was requested and left NOTHING behind — the runner died first."""
+        self.requested.append(name)
+        return self
+
+    def buckets_file(self):
+        p = self.root / "buckets.txt"
+        p.write_text("\n".join(self.requested) + "\n")
+        return str(p)
+
+    def run(self, *extra):
+        return mbt.main(["--results", str(self.results), "--buckets", self.buckets_file(),
+                         "--bc-version", "28.4.1.2", "--test-data", "true", *extra])
+
+
+class SlugTests(unittest.TestCase):
+    def test_bucket_names_with_spaces_become_directory_names(self):
+        # Tests-Cash Flow, Tests-Data Exchange and friends are real bucket names.
+        self.assertEqual("Tests-Cash_Flow", mbt.slug("Tests-Cash Flow"))
+        self.assertEqual("Tests-ERM", mbt.slug("Tests-ERM"))
+
+
+class CollectTests(unittest.TestCase):
+    def test_totals_are_summed_across_buckets(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            f = Fixture(tmp)
+            f.bucket("Tests-A", xml=junit(1000, failures=400, errors=10, skipped=5))
+            f.bucket("Tests-B", xml=junit(500, failures=100))
+            records = mbt.collect(str(f.results), f.requested)
+            combined = mbt.sum_totals(records)
+
+            self.assertEqual(1500, combined["tests"])
+            self.assertEqual(500, combined["failures"])
+            self.assertEqual(10, combined["errors"])
+            self.assertEqual(5, combined["skipped"])
+            # 1000-400-10-5 = 585, plus 500-100 = 400.
+            self.assertEqual(985, combined["passed"])
+
+    def test_a_requested_bucket_with_no_directory_is_a_record_not_an_omission(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            f = Fixture(tmp)
+            f.bucket("Tests-A", xml=junit(100))
+            f.missing("Tests-Vanished")
+            records = mbt.collect(str(f.results), f.requested)
+
+            self.assertEqual(2, len(records))
+            self.assertEqual("Tests-Vanished", records[1]["bucket"])
+            self.assertFalse(records[1]["measured"])
+            self.assertIsNone(records[1]["totals"])
+
+    def test_a_junit_file_with_a_crash_exit_code_is_not_a_measurement(self):
+        # The trap: the file EXISTS, so a naive "did it write JUnit" check says yes.
+        with tempfile.TemporaryDirectory() as tmp:
+            f = Fixture(tmp)
+            f.bucket("Tests-A", rc=139, xml=junit(30))
+            records = mbt.collect(str(f.results), f.requested)
+
+            self.assertFalse(records[0]["measured"])
+            self.assertEqual(30, records[0]["totals"]["tests"])
+
+    def test_exit_codes_0_and_1_both_count_as_measured(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            f = Fixture(tmp)
+            f.bucket("Tests-A", rc=0, xml=junit(10))
+            f.bucket("Tests-B", rc=1, xml=junit(10, failures=3))
+            self.assertEqual([True, True], [r["measured"] for r in mbt.collect(str(f.results), f.requested)])
+
+
+class ShortfallTests(unittest.TestCase):
+    def test_no_expectation_never_reports_a_shortfall(self):
+        self.assertEqual((False, 0), mbt.shortfall(1, 0))
+
+    def test_a_total_below_95_percent_is_short(self):
+        short, missing = mbt.shortfall(30_000, 40_530)
+        self.assertTrue(short)
+        self.assertEqual(10_530, missing)
+
+    def test_a_small_version_to_version_drift_is_not_short(self):
+        self.assertFalse(mbt.shortfall(40_100, 40_530)[0])
+
+
+class VerdictTests(unittest.TestCase):
+    def test_every_bucket_measured_exits_zero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            f = Fixture(tmp)
+            f.bucket("Tests-A").bucket("Tests-Cash Flow")
+            self.assertEqual(0, f.run())
+
+    def test_one_bucket_without_a_number_exits_one(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            f = Fixture(tmp)
+            f.bucket("Tests-A").missing("Tests-B")
+            self.assertEqual(1, f.run())
+
+    def test_an_empty_request_list_is_an_error_not_an_empty_success(self):
+        # The vacuous case: zero buckets means every bucket trivially produced a number.
+        with tempfile.TemporaryDirectory() as tmp:
+            f = Fixture(tmp)
+            self.assertEqual(1, f.run())
+
+    def test_a_shortfall_does_not_fail_the_run(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            f = Fixture(tmp)
+            f.bucket("Tests-A", xml=junit(10))
+            self.assertEqual(0, f.run("--expected-tests", "40530"))
+
+
+class SummaryTests(unittest.TestCase):
+    def _summary(self, f, *extra):
+        out = f.root / "summary.md"
+        rc = f.run("--step-summary", str(out), *extra)
+        return rc, out.read_text()
+
+    def test_the_table_carries_every_bucket_and_a_total_row(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            f = Fixture(tmp)
+            f.bucket("Tests-A", xml=junit(1000, failures=400))
+            f.bucket("Tests-B", xml=junit(500, failures=100))
+            _, md = self._summary(f)
+
+            self.assertIn("`Tests-A`", md)
+            self.assertIn("`Tests-B`", md)
+            self.assertIn("**1500**", md)
+            self.assertIn("Every one of the 2 requested bucket(s) produced a number.", md)
+
+    def test_a_bucket_with_no_number_is_named_in_the_summary(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            f = Fixture(tmp)
+            f.bucket("Tests-A", xml=junit(1000))
+            f.missing("Tests-Vanished")
+            rc, md = self._summary(f)
+
+            self.assertEqual(1, rc)
+            self.assertIn("Tests-Vanished", md)
+            self.assertIn("No number from 1 of 2 bucket(s)", md)
+            self.assertIn("covers only the buckets that produced one", md)
+
+    def test_a_shortfall_is_stated_with_both_numbers(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            f = Fixture(tmp)
+            f.bucket("Tests-A", xml=junit(30_000, failures=10_000))
+            _, md = self._summary(f, "--expected-tests", "40530")
+
+            self.assertIn("short of the 40530", md)
+            self.assertIn("10530 unaccounted for", md)
+
+    def test_a_single_bucket_gets_a_sentence_rather_than_a_one_row_table(self):
+        # The nightly runs one bucket and already printed its own block; a table repeating
+        # it is noise.
+        with tempfile.TemporaryDirectory() as tmp:
+            f = Fixture(tmp)
+            f.bucket("Tests-SMB", xml=junit(1027, failures=432))
+            _, md = self._summary(f)
+
+            self.assertNotIn("| bucket |", md)
+            self.assertIn("1027 tests — 595 pass", md)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)


### PR DESCRIPTION
Closes #3409

Runs the whole Microsoft BaseApp surface — 40,530 tests across 32 non-empty buckets — from one manual dispatch, in one job, and reports one combined total.

Filed and implemented by an agent (`coord-1`).

## One job, not a matrix

The issue proposed six shards. That was designed and then rejected on the repo owner's challenge, and the reasoning is worth recording because it inverts what the issue says.

At the measured 142 ms/test, the surface is about 90 minutes of execution — call it 2.5-3.3 hours on a hosted 4-vCPU runner, plus provisioning paid once. `ms-bucket.yml` already sets `timeout-minutes: 360`, the hosted maximum, so one runner fits with margin. Sharding takes roughly 3 hours down to 1 and costs six queue slots, six provisionings (`.github/actions/provision-bc` has no `actions/cache`, so every job re-downloads and rebuilds — 10-15 minutes each) and three pieces of machinery. The Actions queue is per-account and shared with the corpus repository and with every open PR's own CI, so those five extra runners come out of work that gates merges. For a manually dispatched measurement that is not a good trade.

What made sharding tempting was the single job's failure mode: hit the ceiling and you get nothing. That is removed rather than traded around — see "reporting as it goes" below.

## What changed

**`.github/workflows/ms-bucket.yml`** — a `buckets` list input beside the singular `bucket`, plus `label` and `expected-tests`. A list runs sequentially in the same single job, so provisioning, the 977 MB backup and the compile caches are paid once.

* **One runner process per bucket.** Peak RSS tracks how many bundles a process loads, not how many tests it runs (3 bundles / 939 tests = 4.4 GB against 1 bundle / 1,027 tests = 3.7 GB), so handing 32 bundle directories to one invocation would stack their memory. Separate processes reset it.
* **`DOTNET_GCHeapCount: "2"`, explicitly.** Server GC sizes heaps from the CPU count and those heaps are ~90% of peak RSS; `Tests-ERM` peaked at 10.9 GiB on a 12-core box against a hosted runner's 16 GB. `DOTNET_GCHeapHardLimit` is **not** used and the test forbids it: under ~1.25 GB it silently changed test results (259 → 212 passing), which would corrupt the number this workflow exists to produce.
* **Reporting as it goes.** Each bucket's numbers are appended to `$GITHUB_STEP_SUMMARY` and emitted as a `::notice::` annotation *before the next bucket starts*, and the results artifact uploads with `if: always()`. The annotation is the belt-and-braces half: a step summary is only finalised when its step ends, and here the whole run is one step, so an annotation is what survives a job killed at the ceiling.
* **The concurrency group now includes the label.** It was `ms-bucket-${{ inputs.bucket }}`; a list run passes no `bucket`, so every list run would have landed in the group `ms-bucket-` and, with `cancel-in-progress: false`, queued behind the previous one — a silent wait, not an error. There is a test for exactly this.
* **The bucket-list resolver runs before provisioning**, so an empty or duplicated list costs seconds rather than 12 minutes. A duplicate is refused outright: it would run twice and be counted twice, which is a wrong number rather than a failure.

**`.github/workflows/ms-surface.yml`** (new) — policy only: the 32 bucket names, `expected-tests: 40530`, and `workflow_dispatch`. Every mechanism stays in `ms-bucket.yml`; a test asserts the surface file contains none of the configuration that file owns (`--package-cache`, `READER_TAG`, the company name, the emit timeout, `provision-bc`). Deliberately no bucket filter — for a subset, dispatch `ms-bucket.yml` with its `buckets` input.

**`scripts/ms-bucket-total.py`** (new) — the combined total and the verdict. Driven by the **requested** bucket list, not by whatever directories exist: a bucket whose runner died before writing JUnit leaves no directory, so a glob-driven script would report a confident total over the buckets that worked and never mention the ones that did not. `--expected-tests` is a shortfall *warning*, not a baseline, because a bundle lost to COMPILE FAIL vanishes from the totals rather than failing them (#2715) — and Microsoft's counts move between BC versions, so it must not read as a defect.

**`scripts/ms-bucket-summary.py`** — one additive flag, `--notice`. Its 25 existing tests still pass.

## RED → GREEN

`AlRunner.Tests/MsSurfaceWorkflowTests.cs`: 12 tests, **10 failing before the implementation** (the 2 that passed are the pure block-scalar parser, which depends on no file). All 12 green after. `MsBucketWorkflowTests`'s 12 assertions still pass unchanged, as do the other workflow-shape classes — 94 tests over `MsSurface`, `MsBucket`, `MainVerdictFloor`, `PullRequestMatrixScope`, `ReleaseTestParity`, `BcLegRerun` and `ArtifactDownloaderMsBucket`.

`scripts/tests/ms-bucket-total.test.py`: 16 tests, covering the ways the total can be quietly wrong — a requested bucket that left nothing behind, a JUnit file that exists next to a crash exit code, an empty request list (zero buckets would otherwise mean every bucket trivially produced a number), and a shortfall.

### The counts are asserted explicitly, and the check was broken on purpose to prove it can fail

`ExpectedBuckets = 32` is asserted **before** any set comparison, so a truncated or empty list fails loudly instead of satisfying the "for each bucket" comparisons by having nothing to iterate. `ArtifactInventory` — the artifact's own 35 `*.Source.zip` entries — is stated independently of the file under test, because reading the reference out of the file being checked is how a drift test comes to pass vacuously.

Four deliberate breaks, each reverted:

| break | what it did |
|---|---|
| removed `Tests-Cash Flow` from the list | 2 red. Count 31 ≠ 32, **and** the inventory reconciliation named `Tests-Cash Flow` as shipped-but-unaccounted-for. |
| added `Tests-Nonexistent` | 2 red. Count 33 ≠ 32, **and** the "names only real buckets" arm listed it as invented. |
| appended a second `Tests-SMB` (33 entries) | 1 red — the count assertion fires first, so this did **not** exercise the duplicate arm. |
| replaced `Tests-Cash Flow` with a second `Tests-SMB` (still 32 entries) | 2 red. This is the one that proves the duplicate arm: the count is unchanged, so only the duplicate-group check and the inventory reconciliation can see it. Both did. |

The third break is why the fourth exists — a count-preserving duplicate is the case a count check cannot catch, and without it I would have reported a passing duplicate check that had never actually run.

### Beyond the unit tests

* Every `run:` block in `ms-bucket.yml` passes `bash -n`.
* The bucket-list resolver's real bash was exercised against seven inputs: single bucket, comma list, newline list, both inputs given (list wins, with a notice), neither given (exit 1), whitespace only (exit 1), duplicate (exit 1, naming it).
* The loop was run end to end against a stub `al-runner`: two buckets produced `results/Tests-ERM/` and `results/Tests-Cash_Flow/` with `junit.xml`, `rc.txt`, `elapsed.txt`, `run.log` and `summary.md` each, two per-bucket `::notice::` annotations in order, two per-bucket summary blocks plus one combined block in the step summary, the combined total, and the shortfall warning against `--expected-tests 40530`.
* The 32 bucket names were verified against the real 28.4.53241.54318 artifact via `tools/DownloadArtifacts test-sources`'s listing path: 35 sources ship, and the 32 run plus `Tests-TestLibraries`, `Tests-Local` and `Library-NoTransactions` account for exactly all of them.

I did **not** run the surface workflow. Six-plus hours of hosted runner belongs to the owner to dispatch.

## Wall-time estimate, and what it rests on

**2.5-4 hours**, most likely around 3. That rests on: 40,530 tests at the measured 142 ms/test = ~96 minutes on a 12-core box; a hosted 4-vCPU runner assumed 1.5-2x slower per test (~2.4-3.2 h); plus ~12-15 minutes of provisioning and backup fetch paid once, plus per-bucket emit, which is minutes for the large bundles and is the least well characterised term. `DOTNET_GCHeapCount: "2"` also trades some throughput for memory margin and is not in the 142 ms/test figure. It is an extrapolation, and the first real run is what settles it — the per-bucket wall times are in the combined-total table for exactly that.

The 360-minute ceiling is the risk this estimate carries. If it is hit, the buckets are ordered biggest-first so the loss is the small tail, and every completed bucket's numbers are already in the summary and the annotations.

## Sibling scan

Scanned the open queue for `ms-bucket`, `bucket`, `workflow`, `surface`. Nothing folds: #3130 (`--count-baseline` skips a declared suite that produced no bucket) is the nearest neighbour and is genuinely adjacent — it is the same failure shape, a suite vanishing from a total — but it lands in the runner's baseline comparison, not in these workflow files, and fixing it needs a different proving test. #2328 and #3399 are runtime defects the surface run will *surface*, not code this PR touches. #3389 is about reading a corpus PR's leg set.

## Corpus

This asserts nothing about Business Central. It is whether a workflow file and a bucket list agree with the artifact's own inventory, and whether a bash loop writes the files the summary scripts read. No service tier can adjudicate any of it, so nothing is owed upstream and no corpus PR is needed.

Corpus-NA: CI-only change — a workflow, a bucket list checked against the platform artifact's inventory, and the scripts that summarise a run. No AL is compiled or executed differently, and no claim about BC behaviour is made.

https://claude.ai/code/session_01F7HLDeNwiGQoLT5wFanqmH
