### PR TITLE
fix(tests): fence NclShadowPublishDiagnosisTests in the console-serial collection

### DIFF
--- a/AlRunner.Tests/NclShadowPublishDiagnosisTests.cs
+++ b/AlRunner.Tests/NclShadowPublishDiagnosisTests.cs
@@ -24,6 +24,12 @@ using Xunit;
 
 namespace AlRunner.Tests;
 
+// CaptureStderr swaps the process-wide Console.Error and reads the sink back, so this class
+// must sit in a collection xunit will not run in parallel — ConsoleSwapIsolationGuardTests
+// enforces that. The swap is load-bearing here (the WARN text IS the assertion), so dropping
+// it is not the alternative it is for a class that only silences noise. This class needs no
+// other serial collection: it touches no process-global state besides the console.
+[Collection(ConsoleFilterSerialCollection.Name)]
 public sealed class NclShadowPublishDiagnosisTests
 {
     private const string MarkerFileName = ".al-runner-shadow-source";


### PR DESCRIPTION
Closes #3417

`main` is red. `NclShadowPublishDiagnosisTests` (added by #3385) captures stderr through a `Console.SetError` swap but carries no `[Collection]`, so `ConsoleSwapIsolationGuardTests` (added by #3395) fails on `main` and on every branch rebased onto it. Neither PR was wrong on its own — the guard derives its accepted set by reading `DisableParallelization` off every `[CollectionDefinition]` at its own branch point, before #3385's file existed. The conflict is semantic and only appears with both on `main`.

## The change

Six lines in one file: `[Collection(ConsoleFilterSerialCollection.Name)]` on the class, plus a comment recording why that collection and why the swap is not simply dropped.

## Why ConsoleFilterSerialCollection

Read off the guard rather than copied from a sibling. The guard accepts *any* collection whose `[CollectionDefinition]` sets `DisableParallelization = true`, so the question is which one fits, not which name is blessed:

- The class's `CaptureStderr` helper swaps `Console.Error`, runs the body, restores in a `finally` and **reads the sink back** — every one of the 8 tests asserts on the captured WARN text. So the swap is load-bearing. The guard's message offers "if this class only redirects to silence noise, dropping the swap is better than fencing it"; that alternative does not apply here, because the captured text *is* the assertion.
- It needs no other serial collection for an unrelated reason: grepped for `Log.`, `Environment.`, `AL_RUNNER`, `RecordPatches` and mutable statics, and it touches none — only its own temp dirs. So the `ProvisionGapLog` case (in `RecordPatchesSerialCollection` for process-global state, already satisfying the guard) does not apply either.
- The three `NclShadow*` siblings are unfenced and correctly so: none of them swap the console. The fence is needed only because of `CaptureStderr`.

## RED -> GREEN

The guard **is** the proving test and it was already RED. No new test is added, and none is owed: this is a one-line attribute whose entire claim — "every console-swapping class is in a non-parallel collection" — is exactly what `ConsoleSwapIsolationGuardTests.EveryTestClassSwappingTheConsole_IsInANonParallelCollection` already asserts over the whole assembly. A new test would restate it.

Measured in this worktree, branched from `520e7728` (current `main`, newer than the `00aae297` in the issue — so the failure is confirmed on the tip, not only where it was reported):

| | result |
|---|---|
| RED, before the change | `Failed: 1, Passed: 28` — failure names `NclShadowPublishDiagnosisTests.cs` verbatim |
| GREEN, cold | `Failed: 0, Passed: 37` (guard + the 8 diagnosis tests) |
| GREEN, warm (`--no-build`) | `Failed: 0, Passed: 37` — identical |

## Did forcing the class serial change its own behaviour

No. Ran every console-fenced class plus every `NclShadow*` sibling together — the set whose scheduling this change actually alters: `Failed: 0, Passed: 145`. The class surfaced no ordering assumption it had previously got away with.

## Deliberately not fixed here

The guard cannot fail at **PR** time on a file `main` gained after the branch point — which is the mechanism that let this reach `main` with both PRs individually green. That is a real gap and worth closing, but `main` being red is the emergency and a one-line attribute is the smallest reviewable change that clears it. Filed separately as #3419 rather than folded in.

Also not done: weakening or exempting the guard. It caught a real parallelism hazard and an allowlist entry would be the default-returning version of it.

## Scope notes

- Touches only `AlRunner.Tests/`, not `AlRunner/`, so `require-tests` does not fire.
- Asserts nothing about Business Central — this is runner test-infrastructure hygiene — so no upstream corpus test is owed.

Corpus-NA: test-infrastructure hygiene; the change is an xunit collection attribute and makes no claim about BC behaviour that a service tier could adjudicate.

---
Written by agent `stma-auto-2`, an automated implementation agent acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9pEPoD8e4wmVyuTrxyuh
