### PR TITLE
fix(agents): give each agent a private scratchpad path, and refuse a shared one

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -61,6 +61,33 @@ Read it: `gh issue view <N> --repo StefanMaron/BusinessCentral.AL.Runner`.
 
 ## Step 3 — Implement (strict TDD)
 
+### The session scratchpad is SHARED — namespace before you write to it
+
+The scratchpad directory in your prompt looks per-agent and is not: every agent of
+this session gets the same one. Measured 2026-09-07 in one session's scratchpad —
+**200 entries, one of them namespaced.** It has published PRs #2973/#2974/#3181
+carrying another agent's body and a wrong `Closes #N`, buried a bug report inside a
+closed issue (#3073), and made a full-corpus run silently omit the tests it was
+measuring (#2980). Those are wrong answers in the shape of results, not tidiness.
+
+Get a private path rather than remembering to invent one:
+
+```bash
+p=$(tools/agent_scratchpad.py path pr-body.md --agent-id <AGENT-ID>)
+gh pr create --title "..." --body-file "$p"
+
+tools/agent_scratchpad.py dir --agent-id <AGENT-ID>       # clone corpora in here
+tools/agent_scratchpad.py check <path> --agent-id <AGENT-ID>   # exit 1 if shared
+```
+
+Never stage a PR body, clone a corpus, or write a probe bundle at a bare path in
+the scratchpad root — `body.md`, `corpus/`, `probe/` are the exact names that have
+already collided. `docs/agent-scratchpad.md` has the incident list.
+
+**And after `gh pr create`/`gh pr edit`, re-read what you published:**
+`gh pr view <N> --json closingIssuesReferences` must list exactly the issues you
+meant. That is what caught #3181 before it merged.
+
 ### Isolate your working tree first
 
 If you were not handed an isolated checkout, run `git status --short` on the tree you were given before touching git. Uncommitted changes you did not make mean another agent is mid-edit there — do **not** `git checkout -b`, you will either drag their work onto your branch or yank the tree out from under them. Take a worktree instead.

--- a/.claude/hooks/shared-scratchpad-guard.py
+++ b/.claude/hooks/shared-scratchpad-guard.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""PreToolUse warning: a Bash command is about to use a SHARED scratchpad path.
+
+Three agents in one session each knew the scratchpad was shared and were caught
+anyway (#2980), because the sharing is invisible at the moment of use: the path
+in the prompt looks private, `gh pr create --body-file` reads whatever is there,
+and `cp -r` onto an existing clone succeeds. This hook is the part that fires at
+that moment.
+
+It warns on a scratchpad path with no `agent-` owner directory in it -- writing
+one, reading one into a `gh`/`git` command, or cloning onto one. It does NOT
+warn when the path already carries an agent directory, which is what makes it a
+usable signal rather than noise on every command.
+
+ADVISORY, exit 0, never blocks. Blocking would be wrong here: a shared path is
+sometimes exactly right (reading another agent's log to diagnose a collision is
+the obvious case), and a hook that blocks legitimate work gets switched off,
+taking the warning with it. The refusal that CAN block lives in
+`tools/agent_scratchpad.py check`, where a caller opts into it explicitly.
+
+Tested by .claude/hooks/test_shared_scratchpad_guard.py. NOTE that no CI job runs
+.claude/hooks/test_*.py -- `pr-gate.yml`'s tools-tests job globs `tools/test_*.py`
+only -- so the logic this hook depends on lives in tools/agent_scratchpad.py,
+which that glob does cover.
+"""
+import json
+import os
+import re
+import sys
+
+# The session scratchpad, as the harness names it: /tmp/claude-<uid>/<slug>/<uuid>/scratchpad
+SCRATCHPAD_PATH = re.compile(r'(/tmp/claude-\d+/[^\s"\':;|&]*?/scratchpad)(/[^\s"\':;|&)]*)?')
+
+# A path is SAFE once it names an agent directory anywhere below the scratchpad.
+OWNED = re.compile(r'/agent-[A-Za-z0-9][A-Za-z0-9._-]*(?:/|$)')
+
+# Verbs that make a shared path dangerous rather than merely present. A bare
+# `ls <scratchpad>` or `cat` of a log is fine and must not nudge -- the cost of
+# this hook is paid on every Bash call, so it has to be quiet.
+DANGEROUS = re.compile(
+    r'(?:^|[|;&]\s*)\s*(?:command\s+)?'
+    r'(?:cp|mv|rm|git\s+clone|git\s+-C|tee|mkdir)\b'
+    r'|>\s*\S*'                                  # any redirection into a path
+    r'|<<\s*[\'"]?\w+'                           # heredoc
+    r'|--body-file|--body-path|-F\s|--file\b'    # gh reading a staged body
+)
+
+MESSAGE = (
+    "Shared-scratchpad warning (advisory, nothing was blocked).\n"
+    "This command uses a session-scratchpad path with no `agent-<id>/` owner in it.\n"
+    "That directory is SHARED by every agent of this session -- it looks per-agent and\n"
+    "is not. Measured 2026-09-07: 200 entries in one session's scratchpad, ONE of them\n"
+    "namespaced. It has published PRs #2973/#2974/#3181 with another agent's body and a\n"
+    "wrong `Closes #N`, buried a bug report inside a closed issue (#3073), and made a\n"
+    "full-corpus run silently omit the tests it was measuring (#2980).\n"
+    "Use a private path:\n"
+    "  p=$(tools/agent_scratchpad.py path pr-body.md --agent-id <YOUR-ID>)\n"
+    "  tools/agent_scratchpad.py check <path> --agent-id <YOUR-ID>   # exit 1 if shared\n"
+    "  tools/agent_scratchpad.py scan                                # what is unowned\n"
+    "Reading another agent's file on purpose is fine -- this is a reminder, not a rule."
+)
+
+
+def flagged_paths(cmd: str) -> list:
+    """Scratchpad paths in `cmd` that name no agent directory."""
+    out = []
+    for m in SCRATCHPAD_PATH.finditer(cmd):
+        full = m.group(0)
+        if OWNED.search(full):
+            continue
+        # The scratchpad root alone, with no child, is usually `ls`/`cd` -- only
+        # interesting when a dangerous verb is about to write into it.
+        out.append(full)
+    return out
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+    if payload.get("tool_name") != "Bash":
+        return 0
+    cmd = (payload.get("tool_input") or {}).get("command", "") or ""
+    if not SCRATCHPAD_PATH.search(cmd):
+        return 0
+    if not DANGEROUS.search(cmd):
+        return 0
+    paths = flagged_paths(cmd)
+    if not paths:
+        return 0
+    print(MESSAGE, file=sys.stderr)
+    print("Shared path(s) in this command:", file=sys.stderr)
+    for p in sorted(set(paths))[:5]:
+        print(f"  {p}", file=sys.stderr)
+    # Exit 0: advisory only, for the reason in the module docstring.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/test_shared_scratchpad_guard.py
+++ b/.claude/hooks/test_shared_scratchpad_guard.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Unit tests for shared-scratchpad-guard.py.
+
+The hook is advisory, so "did it fire" is the whole observable behaviour. The
+cases below are drawn from real commands in this repository's session
+scratchpads -- the ones that caused #2980 must fire, and the ordinary reads that
+happen on every task must not, because a hook that cries on everything gets
+ignored and then it is not a mechanism at all.
+
+Usage: python3 .claude/hooks/test_shared_scratchpad_guard.py
+"""
+import json
+import pathlib
+import subprocess
+import sys
+
+HOOK = pathlib.Path(__file__).resolve().parent / "shared-scratchpad-guard.py"
+SP = "/tmp/claude-1000/-home-stefan-Documents-Repos-Comunity-BusinessCentral-AL-Runner/2a9b731a/scratchpad"
+
+CASES = []
+
+
+def case(name, command, should_fire, tool="Bash"):
+    CASES.append((name, command, should_fire, tool))
+
+
+# --- the incidents on #2980: these MUST fire ---
+case("staging a PR body with a heredoc at a shared path",
+     f"cat > {SP}/pr-body.md <<'EOF'\nCloses #2980\nEOF", True)
+case("gh pr create reading a shared body file",
+     f"gh pr create --title x --body-file {SP}/body.md", True)
+case("cloning the corpus onto a shared path",
+     f"git clone https://github.com/x/y {SP}/corpus", True)
+case("git -C against a shared corpus clone",
+     f"git -C {SP}/corpus checkout -b mybranch", True)
+case("cp -r a probe bundle onto a shared path",
+     f"cp -r bundle {SP}/probe", True)
+case("redirecting a run log to a shared path",
+     f"dotnet run --project AlRunner -- run x | tee {SP}/run.log", True)
+case("rm on a shared path", f"rm -rf {SP}/corpus", True)
+
+# --- already private: these must NOT fire, or the tool teaches nothing ---
+case("heredoc into an agent-owned path",
+     f"cat > {SP}/agent-stma-auto-23/pr-body.md <<'EOF'\nx\nEOF", False)
+case("gh pr create with an agent-owned body file",
+     f"gh pr create --body-file {SP}/agent-stma-auto-23/body.md", False)
+case("cloning into an agent-owned directory",
+     f"git clone https://github.com/x/y {SP}/agent-stma-auto-23/corpus", False)
+case("a nested path under an agent directory",
+     f"cp -r bundle {SP}/agent-impl-4/probe/run1", False)
+
+# --- ordinary reads: must NOT fire, so the warning stays worth reading ---
+case("listing the scratchpad", f"ls -la {SP}", False)
+case("reading a log with sed", f"sed -n '1,50p' {SP}/leg-284.log", False)
+case("grepping a shared log to diagnose", f"command grep -n FAIL {SP}/base-cold.log", False)
+case("a command with no scratchpad path at all",
+     "cat > /tmp/other/pr-body.md <<'EOF'\nx\nEOF", False)
+case("a non-Bash tool is ignored",
+     f"cat > {SP}/pr-body.md <<'EOF'\nx\nEOF", False, tool="Write")
+
+
+def run():
+    failures = 0
+    for name, command, should_fire, tool in CASES:
+        payload = json.dumps({"tool_name": tool, "tool_input": {"command": command}})
+        r = subprocess.run([sys.executable, str(HOOK)], input=payload,
+                           capture_output=True, text=True)
+        fired = "Shared-scratchpad warning" in r.stderr
+        if r.returncode != 0:
+            print(f"  FAIL {name}: hook exited {r.returncode}, must always be 0")
+            failures += 1
+        elif fired != should_fire:
+            print(f"  FAIL {name}: fired={fired}, expected {should_fire}")
+            failures += 1
+        else:
+            print(f"  ok   {name}")
+    if failures:
+        print(f"\n{failures} FAILED")
+        return 1
+    print(f"\nall {len(CASES)} passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/prefer-code-navigation.py\""
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/shared-scratchpad-guard.py\""
           }
         ]
       }

--- a/docs/agent-scratchpad.md
+++ b/docs/agent-scratchpad.md
@@ -1,0 +1,118 @@
+# The session scratchpad is shared, and the private path is one command away
+
+The scratchpad directory injected into an agent's prompt looks per-agent. It is
+not: **every subagent of one session gets the same directory.** Nothing in the
+path says so, and nothing fails when two agents use the same name.
+
+## The measurement
+
+One session's scratchpad on the development box, 2026-09-07:
+
+| | |
+|---|---|
+| entries | **200** |
+| entries carrying an agent identity | **1** |
+
+Agents *do* disambiguate — but by PR or issue number, not by identity:
+`pr3385.body`, `pr3386.body`, `pr3387.body`, `pr3388.body`; `c-3379.md` …
+`c-3393.md`; `corpus-267`, `corpus-3405`. That works within one agent and fails
+across two, because two agents each handling a corpus PR both reach for
+`corpus/`. Left bare and unqualified in the same directory: `body.md`,
+`pr-body.md`, `prbody.md`, `corpus/`, `probe/`, `red/`, `green/`, `backup/`,
+`err.txt`.
+
+## What it has cost
+
+All on [#2980](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2980):
+
+- **PRs #2973 and #2974** published carrying another agent's body, both declaring
+  `Closes #2743` — an issue belonging to a third agent's work.
+- **#3073** published with one defect's title and an unrelated defect's body. A PR
+  then fixed the title's defect and closed the issue, so an undiagnosed reproducer
+  ended up **inside a closed issue behind a merged PR**, where it reads as fixed.
+  Re-filed as #3105.
+- **PR #3181** published with #3101's body; `closingIssuesReferences` read `[2771]`
+  instead of `[3057]` until the agent re-read it. Had it merged in that window,
+  #2771 would have been closed by the wrong PR and #3057 left open, silently.
+- **A shared corpus clone** checked out onto another agent's branch mid-task. The
+  second agent's full-corpus runs then ran *without its own tests*: the failure
+  count was identical before and after its fix, because its codeunit was not
+  there. A confident, wrong RED→GREEN.
+- **A corpus commit on the wrong branch** — `eaf1f6e` landed on
+  `agent/stma-auto-3/…` (corpus PR #267) instead of its author's branch, so a
+  runner PR read as having upstream proof it did not have.
+
+The class matters more than any instance. This is not "two agents overwrite a
+file and notice". It is **silent wrong answers in the shape of results** — the
+same family as the `grep`-function and `rg --hidden` traps in `CLAUDE.md`.
+
+## The mechanism
+
+`tools/agent_scratchpad.py`. Every path it returns contains the agent identity,
+so two identities cannot collide; every path it is asked to *check* is refused
+unless it is outside the scratchpad or owned by the caller.
+
+```bash
+# a private path, parent directory created
+p=$(tools/agent_scratchpad.py path pr-body.md --agent-id stma-auto-23)
+gh pr create --body-file "$p"
+
+# your private directory, e.g. to clone into
+tools/agent_scratchpad.py dir --agent-id stma-auto-23
+
+# refuse before reading something another agent may own -- exit 1 if shared
+tools/agent_scratchpad.py check "$SOME_PATH" --agent-id stma-auto-23
+
+# audit: what in this scratchpad is owned by nobody
+tools/agent_scratchpad.py scan
+```
+
+Layout: `<scratchpad>/agent-<id>/…`. The `agent-` prefix is what lets `scan`
+tell an owned directory from a bare one without a registry, and what lets a
+human attribute a stray file.
+
+Options are accepted on either side of the subcommand, because
+`path pr-body.md --agent-id x` is what people type.
+
+### It refuses rather than falling back
+
+There is no path on which this module returns a shared location. A missing
+identity is an error, not a default — a default would put two agents back on one
+path, which is the whole defect. `..` is refused rather than clamped, because a
+clamp writes somewhere the caller did not ask for and never tells them. This is
+`.claude/rules/loud-failures.md` applied to tooling: a tool that silently reads
+another agent's file is the same defect class as a patch that silently returns a
+default.
+
+`assert_private` deliberately **allows** any path outside the scratchpad — a
+worktree file, a package cache — so the guard can be wrapped around real commands
+without becoming useless.
+
+### The hook, for the moment of use
+
+`.claude/hooks/shared-scratchpad-guard.py` warns when a Bash command writes to,
+clones onto, or reads a `--body-file` from a scratchpad path with no `agent-`
+owner in it. It is **advisory** and never blocks: reading another agent's log to
+diagnose a collision is legitimate, and a hook that blocks legitimate work gets
+switched off, taking the warning with it. The refusal that *can* stop something
+is `agent_scratchpad.py check`, which a caller opts into.
+
+It stays quiet on ordinary reads (`ls`, `sed -n`, `grep` of a log) and on paths
+that already carry an agent directory. That is deliberate: a warning that fires
+on everything is not a mechanism.
+
+## Why a mechanism and not a rule
+
+The issue's own cheapest proposal was a documented convention. The 1-in-200
+namespacing rate above **is** that convention's measured adoption — three agents
+in one session each knew the scratchpad was shared and were caught anyway,
+because the sharing is invisible at the moment of use. So the private path is
+made the easy one to get, and the shared one is made to refuse.
+
+## Testing note
+
+`tools/test_agent_scratchpad.py` is picked up by `pr-gate.yml`'s `tools-tests`
+job, which globs `tools/test_*.py`. **No CI job globs `.claude/hooks/test_*.py`**
+— so `test_prefer_code_navigation.py` had never run in CI — and that suite
+therefore delegates to every `.claude/hooks/test_*.py`, which makes them gate by
+the same discovery argument without a workflow change.

--- a/tools/agent_scratchpad.py
+++ b/tools/agent_scratchpad.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Give each agent a private directory in the shared session scratchpad, and
+refuse a path that belongs to somebody else.
+
+The session scratchpad LOOKS per-agent and is not: every subagent of one session
+gets the same directory injected into its prompt. Measured on this box on
+2026-09-07, in one session's scratchpad: 200 entries, of which exactly ONE
+carried an agent identity. Agents do disambiguate -- by PR or issue number
+(`pr3388.body`, `c-3391.md`, `corpus-3405`) -- which works within one agent and
+fails across two, because two agents handling two corpus PRs both reach for
+`corpus/`. Bare `body.md`, `pr-body.md`, `corpus/`, `probe/`, `red/`, `green/`
+and `backup/` were all present unqualified.
+
+What that has cost, all recorded on #2980:
+
+  * PRs #2973 and #2974 published with another agent's body, both declaring
+    `Closes #2743` -- an issue belonging to a third agent's work.
+  * #3073 published with one defect's title and an unrelated defect's body; the
+    body's bug was then buried inside a closed issue behind a merged PR.
+  * PR #3181 published with #3101's body; `closingIssuesReferences` read [2771]
+    instead of [3057] until an agent re-read it.
+  * A shared corpus clone checked out onto another agent's branch mid-run, so a
+    full-corpus run silently executed WITHOUT the tests under measurement and
+    reported an unchanged failure count.
+
+Why a mechanism and not another line in the agent definition
+------------------------------------------------------------
+Three agents in one session each knew the scratchpad was shared and were caught
+anyway, because the sharing is invisible at the moment of use: the path in the
+prompt looks private, `gh pr create --body-file` reads whatever is there, and a
+`cp -r` onto an existing clone succeeds. The issue's own "cheapest version" was
+a documented convention; the 1-in-200 namespacing rate above is that convention's
+measured adoption. So this module makes the private path the one that is easy to
+get, and makes the shared path REFUSE rather than answer.
+
+The failure mode of everything here is raising `ScratchpadCollision`. Nothing in
+this file ever falls back to a shared path, because a fallback is precisely the
+silent wrong answer being prevented -- the same reasoning as
+`.claude/rules/loud-failures.md`, applied to tooling instead of to AL surfaces.
+
+Usage
+-----
+    # a private path, created for you
+    tools/agent_scratchpad.py path pr-body.md --agent-id stma-auto-23
+    #   -> <scratchpad>/agent-stma-auto-23/pr-body.md
+
+    # refuse before reading a file somebody else may own
+    tools/agent_scratchpad.py check <path> --agent-id stma-auto-23
+
+    # what in this scratchpad is shared and owned by nobody
+    tools/agent_scratchpad.py scan
+
+See docs/agent-scratchpad.md for the full rationale and the incident list.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+# Every private directory carries this prefix, so `scan` can tell an owned
+# directory from a bare one without a registry, and a human reading the
+# scratchpad can attribute a stray file to the agent that wrote it.
+AGENT_DIR_PREFIX = "agent-"
+
+# An identity becomes a directory name, so it may not contain a separator or a
+# `..`. Matching the shape used for branches and worktrees (`stma-auto-23`,
+# `impl-4`) rather than accepting anything path-safe: an identity that does not
+# look like an identity is far more likely to be a bug in the caller than a new
+# naming scheme.
+_VALID_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+# The harness injects the scratchpad path into the prompt rather than the
+# environment, so an agent normally passes --scratchpad. These are checked
+# first for the case where a wrapper has exported one.
+_SCRATCHPAD_ENV = ("CLAUDE_SCRATCHPAD_DIR", "AL_RUNNER_SCRATCHPAD")
+_AGENT_ENV = "AL_RUNNER_AGENT_ID"
+
+
+class ScratchpadCollision(Exception):
+    """A path is shared, escapes its owner's directory, or has no owner.
+
+    Raised instead of returning a shared path. Callers are expected to let it
+    propagate: there is no correct recovery that still writes somewhere.
+    """
+
+
+def resolve_agent_id(agent_id: str | None = None, env: dict | None = None) -> str:
+    """The identity, from the argument or the environment. Never guessed.
+
+    A default -- the login name, a PID, a constant -- would put two agents back
+    on one path, which is the entire defect. So a missing identity is an error.
+    """
+    env = os.environ if env is None else env
+    value = agent_id if agent_id is not None else env.get(_AGENT_ENV)
+    if value is None or not str(value).strip():
+        raise ScratchpadCollision(
+            "no agent identity: refusing to guess one, because a default would put "
+            "two agents on one path -- which is the collision this exists to prevent. "
+            f"Pass --agent-id <id>, or export {_AGENT_ENV}=<id>. Use the identity from "
+            "your invoking prompt, the same string as your `agent:` label and your "
+            "branch prefix (e.g. stma-auto-23)."
+        )
+    value = str(value).strip()
+    if not _VALID_ID.match(value):
+        raise ScratchpadCollision(
+            f"agent identity {value!r} is not a plain name. It becomes a directory, so "
+            "a separator or `..` in it could resolve into another agent's space. Expected "
+            "the shape used for branches and worktrees, e.g. `stma-auto-23` or `impl-4`."
+        )
+    return value
+
+
+def resolve_scratchpad(scratchpad: str | None = None, env: dict | None = None) -> str:
+    env = os.environ if env is None else env
+    if scratchpad:
+        return os.path.realpath(scratchpad)
+    for key in _SCRATCHPAD_ENV:
+        if env.get(key):
+            return os.path.realpath(env[key])
+    raise ScratchpadCollision(
+        "no scratchpad directory known. Pass --scratchpad <dir> (the path from your "
+        f"prompt), or export one of {', '.join(_SCRATCHPAD_ENV)}."
+    )
+
+
+def agent_dir(agent_id: str | None = None, scratchpad: str | None = None,
+              env: dict | None = None, create: bool = True) -> str:
+    """This agent's private directory inside the shared scratchpad."""
+    root = resolve_scratchpad(scratchpad, env)
+    path = os.path.join(root, AGENT_DIR_PREFIX + resolve_agent_id(agent_id, env))
+    if create:
+        os.makedirs(path, exist_ok=True)
+    return path
+
+
+def agent_path(name: str, agent_id: str | None = None, scratchpad: str | None = None,
+               env: dict | None = None, create: bool = True) -> str:
+    """A private path for `name`, with its parent directory created.
+
+    `name` is relative and may contain subdirectories. Anything that resolves
+    outside this agent's directory is refused rather than clamped -- a clamp
+    would silently write somewhere the caller did not ask for, and the caller
+    would never learn its path was wrong.
+    """
+    base = agent_dir(agent_id, scratchpad, env, create=create)
+    if os.path.isabs(name):
+        raise ScratchpadCollision(
+            f"{name!r} is absolute. Pass a name relative to your agent directory; "
+            f"this function decides where that is ({base})."
+        )
+    full = os.path.realpath(os.path.join(base, name))
+    if full != os.path.realpath(base) and not full.startswith(os.path.realpath(base) + os.sep):
+        raise ScratchpadCollision(
+            f"{name!r} resolves to {full}, outside your agent directory {base}. "
+            "A `..` here lands in the shared scratchpad or in another agent's "
+            "directory, which is the collision this exists to prevent."
+        )
+    if create:
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+    return full
+
+
+def owner_of(path: str, scratchpad: str | None = None, env: dict | None = None) -> str | None:
+    """Which agent owns `path`: an identity, or None for shared/outside.
+
+    None means one of two very different things -- outside the scratchpad
+    entirely, or directly inside it and therefore owned by nobody. Callers that
+    care about the difference use `assert_private`, which does.
+    """
+    root = os.path.realpath(resolve_scratchpad(scratchpad, env))
+    full = os.path.realpath(path)
+    if full == root or not full.startswith(root + os.sep):
+        return None
+    first = full[len(root) + 1:].split(os.sep)[0]
+    if first.startswith(AGENT_DIR_PREFIX):
+        return first[len(AGENT_DIR_PREFIX):] or None
+    return None
+
+
+def assert_private(path: str, agent_id: str | None = None, scratchpad: str | None = None,
+                   env: dict | None = None) -> str:
+    """Refuse `path` unless it is outside the scratchpad or owned by this agent.
+
+    A path OUTSIDE the scratchpad is deliberately allowed: a worktree file, a
+    package cache, `/etc/hosts` -- none of them are this tool's business, and
+    refusing them would make the guard useless to wrap around real commands.
+    What is refused is the shared scratchpad itself, and another agent's
+    directory, which are the two places #2980's losses came from.
+    """
+    root = os.path.realpath(resolve_scratchpad(scratchpad, env))
+    me = resolve_agent_id(agent_id, env)
+    full = os.path.realpath(path)
+    if full != root and not full.startswith(root + os.sep):
+        return path                      # not in the scratchpad; not our concern
+    owner = owner_of(full, scratchpad, env)
+    if owner == me:
+        return path
+    suggested = os.path.join(root, AGENT_DIR_PREFIX + me, os.path.basename(full))
+    if owner is None:
+        raise ScratchpadCollision(
+            f"{full} is directly in the SHARED session scratchpad, which every agent of "
+            f"this session writes to -- it is owned by nobody and any agent may overwrite "
+            f"it between your write and your read. That is how PRs #2973/#2974/#3181 were "
+            f"published with another agent's body and a wrong closing reference (#2980).\n"
+            f"Use your own path instead:\n  {suggested}\n"
+            f"  tools/agent_scratchpad.py path {os.path.basename(full)} --agent-id {me}"
+        )
+    raise ScratchpadCollision(
+        f"{full} belongs to agent {owner!r}, not to you ({me}). Reading it measures their "
+        f"work; writing it destroys it -- a shared corpus clone checked out onto another "
+        f"agent's branch is how a full-corpus run silently omitted the tests under "
+        f"measurement (#2980).\nUse your own path instead:\n  {suggested}"
+    )
+
+
+def scan_shared(scratchpad: str | None = None, env: dict | None = None) -> list[str]:
+    """Entries sitting directly in the scratchpad, i.e. owned by nobody.
+
+    The audit half. Sorted so two runs are comparable.
+    """
+    root = resolve_scratchpad(scratchpad, env)
+    if not os.path.isdir(root):
+        return []
+    return sorted(
+        os.path.join(root, e) for e in os.listdir(root)
+        if not e.startswith(AGENT_DIR_PREFIX)
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Private per-agent paths in the shared session scratchpad (#2980).",
+        epilog="Exit 0 = fine, 1 = collision refused, 2 = usage/setup problem.")
+    # Both options are accepted BEFORE and AFTER the subcommand. argparse puts
+    # parent options before it only, and `... path pr-body.md --agent-id x` is
+    # what anyone actually types -- it failed with "unrecognized arguments",
+    # which is a usage error for the correct intent. A tool whose safe path is
+    # annoying to use gets worked around, and the workaround here is the shared
+    # file this exists to prevent.
+    # SUPPRESS, not None, is load-bearing: a subparser option with default=None
+    # OVERWRITES a value the parent already parsed, so `--scratchpad X path f`
+    # silently lost X and reported "no scratchpad directory known" for a command
+    # that had supplied one. SUPPRESS leaves the attribute unset when the flag is
+    # absent, so whichever position carried it wins and neither erases the other.
+    def add_common(parser):
+        parser.add_argument("--agent-id", default=argparse.SUPPRESS,
+                            help=f"your identity, e.g. stma-auto-23 (or ${_AGENT_ENV})")
+        parser.add_argument("--scratchpad", default=argparse.SUPPRESS,
+                            help="the session scratchpad directory from your prompt")
+
+    add_common(ap)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p_path = sub.add_parser("path", help="print a private path, creating its parent")
+    p_path.add_argument("name", help="a name relative to your agent directory")
+    add_common(p_path)
+
+    p_dir = sub.add_parser("dir", help="print your private directory")
+    add_common(p_dir)
+
+    p_check = sub.add_parser("check", help="refuse a path that is shared or foreign")
+    p_check.add_argument("paths", nargs="+")
+    add_common(p_check)
+
+    add_common(sub.add_parser("scan", help="list scratchpad entries owned by nobody"))
+
+    args = ap.parse_args(argv)
+    agent_id = getattr(args, "agent_id", None)
+    scratch = getattr(args, "scratchpad", None)
+    try:
+        if args.cmd == "path":
+            print(agent_path(args.name, agent_id, scratch))
+        elif args.cmd == "dir":
+            print(agent_dir(agent_id, scratch))
+        elif args.cmd == "check":
+            for p in args.paths:
+                assert_private(p, agent_id, scratch)
+            print(f"OK -- {len(args.paths)} path(s) are yours or outside the scratchpad.")
+        elif args.cmd == "scan":
+            shared = scan_shared(scratch)
+            if not shared:
+                print("No shared entries: every entry is owned by an agent.")
+                return 0
+            print(f"{len(shared)} entry/entries owned by NOBODY in the shared scratchpad.")
+            print("Any agent of this session can overwrite these between your write and "
+                  "your read (#2980):")
+            for p in shared:
+                print(f"  {p}")
+            return 0
+    except ScratchpadCollision as exc:
+        print(f"REFUSED: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_agent_scratchpad.py
+++ b/tools/test_agent_scratchpad.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/agent_scratchpad.py.
+
+The claim under test is not "the function returns a string". It is the two
+properties that would have prevented the incidents on #2980:
+
+  1. Two different agent identities NEVER resolve to the same path, for any
+     relative name -- so a collision is impossible rather than unlikely.
+  2. A path that IS shared -- a bare name directly in the session scratchpad --
+     is REFUSED with a message naming the owner, rather than silently read or
+     overwritten.
+
+Both are asserted by mutation in the tests below: the namespacing test compares
+across identities, and the guard tests assert on the refusal, so removing either
+mechanism fails a test rather than quietly passing.
+
+Run: python3 tools/test_agent_scratchpad.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location(
+    "agent_scratchpad", os.path.join(HERE, "agent_scratchpad.py"))
+asp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(asp)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name}  {detail}")
+        FAILURES.append(name)
+
+
+def test_distinct_identities_never_share_a_path() -> None:
+    """The property, over many names and many identities -- not one example."""
+    with tempfile.TemporaryDirectory() as root:
+        names = ["pr-body.md", "corpus", "body.md", "probe/run.log", "red", "a.json"]
+        ids = ["stma-auto-1", "stma-auto-2", "stma-auto-23", "impl-4", "stma-auto-11"]
+        seen: dict[str, tuple[str, str]] = {}
+        collisions = []
+        for agent in ids:
+            for n in names:
+                p = asp.agent_path(n, agent_id=agent, scratchpad=root)
+                if p in seen and seen[p][0] != agent:
+                    collisions.append((p, seen[p], (agent, n)))
+                seen[p] = (agent, n)
+        check("no two identities resolve to one path", not collisions, str(collisions[:2]))
+        # ...and the same identity+name IS stable, or nothing could be resumed.
+        a = asp.agent_path("pr-body.md", agent_id="stma-auto-23", scratchpad=root)
+        b = asp.agent_path("pr-body.md", agent_id="stma-auto-23", scratchpad=root)
+        check("same identity+name is stable across calls", a == b, f"{a} != {b}")
+        # The identity must actually appear, so a reader can attribute a stray file.
+        check("the identity appears in the path", "stma-auto-23" in a, a)
+
+
+def test_the_directory_is_created_and_is_under_the_scratchpad() -> None:
+    with tempfile.TemporaryDirectory() as root:
+        p = asp.agent_path("probe/run.log", agent_id="stma-auto-23", scratchpad=root)
+        check("parent directory is created", os.path.isdir(os.path.dirname(p)), p)
+        check("path stays under the scratchpad root",
+              os.path.realpath(p).startswith(os.path.realpath(root)), p)
+
+
+def test_escaping_the_agent_directory_is_refused() -> None:
+    """`../` would put one agent back in another's space -- the whole point."""
+    with tempfile.TemporaryDirectory() as root:
+        for bad in ["../body.md", "a/../../body.md", "/etc/passwd"]:
+            try:
+                asp.agent_path(bad, agent_id="stma-auto-23", scratchpad=root)
+                check(f"refuses escaping name {bad!r}", False, "no exception raised")
+            except asp.ScratchpadCollision:
+                check(f"refuses escaping name {bad!r}", True)
+
+
+def test_a_shared_bare_path_is_refused_loudly() -> None:
+    """The #2980 shape: a bare name in the session scratchpad, owned by nobody."""
+    with tempfile.TemporaryDirectory() as root:
+        shared = os.path.join(root, "pr-body.md")
+        with open(shared, "w") as fh:
+            fh.write("Closes #2743\n")
+        try:
+            asp.assert_private(shared, agent_id="stma-auto-23", scratchpad=root)
+            check("a bare shared path is refused", False, "no exception raised")
+        except asp.ScratchpadCollision as exc:
+            msg = str(exc)
+            check("a bare shared path is refused", True)
+            check("the refusal names the offending path", "pr-body.md" in msg, msg)
+            check("the refusal offers the private path",
+                  "stma-auto-23" in msg, msg)
+
+
+def test_another_agents_private_path_is_refused_and_names_the_owner() -> None:
+    with tempfile.TemporaryDirectory() as root:
+        theirs = asp.agent_path("pr-body.md", agent_id="stma-auto-9", scratchpad=root)
+        with open(theirs, "w") as fh:
+            fh.write("Closes #3101\n")
+        try:
+            asp.assert_private(theirs, agent_id="stma-auto-23", scratchpad=root)
+            check("another agent's path is refused", False, "no exception raised")
+        except asp.ScratchpadCollision as exc:
+            check("another agent's path is refused", True)
+            check("the refusal names the OWNER, not just the path",
+                  "stma-auto-9" in str(exc), str(exc))
+
+
+def test_my_own_private_path_is_accepted() -> None:
+    """A guard that refuses everything is as useless as one that refuses nothing."""
+    with tempfile.TemporaryDirectory() as root:
+        mine = asp.agent_path("pr-body.md", agent_id="stma-auto-23", scratchpad=root)
+        with open(mine, "w") as fh:
+            fh.write("Closes #2980\n")
+        ok = True
+        try:
+            asp.assert_private(mine, agent_id="stma-auto-23", scratchpad=root)
+        except asp.ScratchpadCollision as exc:
+            ok = False
+            detail = str(exc)
+        check("my own private path is accepted", ok, "" if ok else detail)
+        # A path outside the scratchpad entirely is not this tool's business.
+        outside = os.path.join(root, "..", "elsewhere.md")
+        ok2 = True
+        try:
+            asp.assert_private(outside, agent_id="stma-auto-23", scratchpad=root)
+        except asp.ScratchpadCollision:
+            ok2 = False
+        check("a path outside the scratchpad is not refused", ok2)
+
+
+def test_identity_is_required_and_never_guessed() -> None:
+    """No identity must be an ERROR. A default would re-create the shared path."""
+    with tempfile.TemporaryDirectory() as root:
+        env = {k: v for k, v in os.environ.items() if k != "AL_RUNNER_AGENT_ID"}
+        try:
+            asp.agent_path("x.md", agent_id=None, scratchpad=root, env=env)
+            check("a missing identity is refused, not defaulted", False,
+                  "no exception raised")
+        except asp.ScratchpadCollision as exc:
+            check("a missing identity is refused, not defaulted", True)
+            check("the refusal explains how to supply one",
+                  "AL_RUNNER_AGENT_ID" in str(exc), str(exc))
+        # ...and the environment variable IS honoured when present.
+        env2 = dict(env, AL_RUNNER_AGENT_ID="stma-auto-23")
+        p = asp.agent_path("x.md", agent_id=None, scratchpad=root, env=env2)
+        check("AL_RUNNER_AGENT_ID supplies the identity",
+              "stma-auto-23" in p, p)
+
+
+def test_a_malformed_identity_cannot_forge_a_path() -> None:
+    with tempfile.TemporaryDirectory() as root:
+        for bad in ["../stma-auto-9", "a/b", "", "   "]:
+            try:
+                asp.agent_path("x.md", agent_id=bad, scratchpad=root)
+                check(f"refuses malformed identity {bad!r}", False, "no exception")
+            except asp.ScratchpadCollision:
+                check(f"refuses malformed identity {bad!r}", True)
+
+
+def test_scan_reports_shared_entries_with_no_owner() -> None:
+    """The audit half: point it at a real scratchpad and it names the hazards."""
+    with tempfile.TemporaryDirectory() as root:
+        open(os.path.join(root, "body.md"), "w").close()
+        open(os.path.join(root, "pr-body.md"), "w").close()
+        os.makedirs(os.path.join(root, "corpus"))
+        asp.agent_path("safe.md", agent_id="stma-auto-23", scratchpad=root)
+        shared = asp.scan_shared(scratchpad=root)
+        names = {os.path.basename(p) for p in shared}
+        check("scan finds the bare shared files", {"body.md", "pr-body.md"} <= names, str(names))
+        check("scan finds the bare shared directory", "corpus" in names, str(names))
+        check("scan does not report an agent-owned directory",
+              asp.AGENT_DIR_PREFIX + "stma-auto-23" not in names, str(names))
+
+
+def _cli(args: list[str]) -> tuple[int, str, str]:
+    r = subprocess.run(
+        [sys.executable, os.path.join(HERE, "agent_scratchpad.py")] + args,
+        capture_output=True, text=True,
+        env={k: v for k, v in os.environ.items() if k != "AL_RUNNER_AGENT_ID"})
+    return r.returncode, r.stdout.strip(), r.stderr.strip()
+
+
+def test_cli_accepts_options_on_either_side_of_the_subcommand() -> None:
+    """Both real defects found by smoke-testing this CLI, pinned.
+
+    1. Options only on the parent -> `path f --agent-id x` died with
+       "unrecognized arguments" for exactly the spelling anyone types.
+    2. Options on the subparser with default=None -> the subparser OVERWROTE the
+       parent's parsed value, so `--scratchpad X path f` silently lost X and
+       refused a command that had supplied one. That is a silent wrong answer in
+       a tool whose entire job is to prevent one.
+    """
+    with tempfile.TemporaryDirectory() as root:
+        rc_a, out_a, err_a = _cli(
+            ["path", "pr-body.md", "--agent-id", "stma-auto-23", "--scratchpad", root])
+        rc_b, out_b, err_b = _cli(
+            ["--agent-id", "stma-auto-23", "--scratchpad", root, "path", "pr-body.md"])
+        check("options AFTER the subcommand work", rc_a == 0, err_a)
+        check("options BEFORE the subcommand work", rc_b == 0, err_b)
+        check("both spellings give the SAME path", out_a == out_b and bool(out_a),
+              f"{out_a!r} != {out_b!r}")
+
+
+def test_cli_check_exits_1_and_explains_on_a_shared_path() -> None:
+    """A wrapper reads the exit code, so it has to discriminate."""
+    with tempfile.TemporaryDirectory() as root:
+        shared = os.path.join(root, "pr-body.md")
+        open(shared, "w").close()
+        rc, out, err = _cli(["check", shared, "--agent-id", "stma-auto-23",
+                             "--scratchpad", root])
+        check("check exits 1 on a shared path", rc == 1, f"rc={rc}")
+        check("the refusal goes to stderr", "REFUSED" in err, err)
+        mine = asp.agent_path("pr-body.md", agent_id="stma-auto-23", scratchpad=root)
+        open(mine, "w").close()
+        rc2, _, err2 = _cli(["check", mine, "--agent-id", "stma-auto-23",
+                             "--scratchpad", root])
+        check("check exits 0 on my own path", rc2 == 0, err2)
+
+
+def test_cli_refuses_rather_than_defaulting_without_an_identity() -> None:
+    with tempfile.TemporaryDirectory() as root:
+        rc, out, err = _cli(["path", "pr-body.md", "--scratchpad", root])
+        check("no identity -> exit 1, not a path", rc == 1, f"rc={rc} out={out!r}")
+        check("nothing is printed to stdout", out == "", out)
+
+
+def test_the_hook_suite_runs_here_because_no_CI_job_globs_it() -> None:
+    """`.claude/hooks/test_*.py` is discovered by NOTHING.
+
+    `pr-gate.yml`'s tools-tests job globs `tools/test_*.py` only, so
+    `.claude/hooks/test_prefer_code_navigation.py` has never run in CI and
+    neither would the new hook's suite. That is the same defect the tools-tests
+    job was created to fix, one directory over: a test file that exists, passes
+    locally, and gates nothing.
+
+    Rather than edit a workflow -- this box's token has no `workflow` scope, so a
+    PR touching .github/workflows/ cannot be merged from here -- this delegates
+    from a suite the glob DOES pick up. Any .claude/hooks/test_*.py now gates the
+    day it lands, by the same discovery argument, with no workflow change.
+    """
+    hooks = sorted(pathlib.Path(HERE).parent.joinpath(".claude", "hooks").glob("test_*.py"))
+    check("hook suites are discovered", len(hooks) >= 2, f"found {[h.name for h in hooks]}")
+    for h in hooks:
+        r = subprocess.run([sys.executable, str(h)], capture_output=True, text=True)
+        check(f"{h.name} passes", r.returncode == 0,
+              (r.stdout + r.stderr)[-600:])
+
+
+def main() -> int:
+    for fn in sorted(
+        (v for k, v in globals().items() if k.startswith("test_")),
+        key=lambda f: f.__name__,
+    ):
+        print(fn.__name__)
+        fn()
+    if FAILURES:
+        print(f"\n{len(FAILURES)} FAILED: {FAILURES}")
+        return 1
+    print("\nall passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #2980

The session scratchpad injected into an agent's prompt looks per-agent and is not: every
subagent of one session gets the same directory. Nothing in the path says so, and nothing
fails when two agents pick the same name.

## Where the collisions actually happen (measured, not assumed)

One session's scratchpad on the development box, 2026-09-07:

| | |
|---|---|
| entries | **200** |
| entries carrying an agent identity | **1** |

Agents *do* disambiguate — but by PR or issue number, not by identity: `pr3385.body`,
`pr3386.body`, `pr3387.body`, `pr3388.body`; `c-3379.md` … `c-3393.md`; `corpus-267`,
`corpus-3405`. That scheme works within one agent and fails across two, because two agents
each handling a corpus PR both reach for `corpus/`. Left bare in the same directory:
`body.md`, `pr-body.md`, `prbody.md`, `corpus/`, `probe/`, `red/`, `green/`, `backup/`,
`err.txt`.

So the hazard is wider than the `pr-body.md` the issue names, and the issue's own cheapest
proposal — a documented convention — already exists in the `autonomous-cycle` skill
("namespace anything per-contributor"). **1 in 200 is that convention's measured adoption.**

## Why a mechanism rather than another rule

Three agents in one session each *knew* the scratchpad was shared and were caught anyway,
because the sharing is invisible at the moment of use: the path looks private,
`gh pr create --body-file` reads whatever is there, and `cp -r` onto an existing clone
succeeds. A rule cannot fix an invisibility problem. So this makes the private path the one
that is easy to get, and makes the shared path refuse.

**`tools/agent_scratchpad.py`** — every path it returns contains the agent identity, so two
identities cannot collide; `assert_private` refuses a bare scratchpad path or another
agent's directory and names the owner. There is no path in the module that falls back to a
shared location: a missing identity is an **error**, not a default (a default puts two
agents back on one path — the whole defect), and `..` is **refused**, not clamped (a clamp
writes somewhere the caller did not ask for and never tells them). This is
`.claude/rules/loud-failures.md` applied to tooling: a tool that silently reads another
agent's file is the same defect class as a patch that silently returns a default.

`assert_private` deliberately **allows** paths outside the scratchpad, so the guard can wrap
real commands without becoming useless.

**`.claude/hooks/shared-scratchpad-guard.py`** — fires at the moment of use. Advisory by
design and never blocks: reading another agent's log to diagnose a collision is legitimate,
and a hook that blocks legitimate work gets switched off, taking the warning with it. It
stays quiet on ordinary reads and on paths that already carry an `agent-` directory — a
warning that fires on everything is not a mechanism. The refusal that *can* stop something is
`agent_scratchpad.py check`, which a caller opts into.

## RED → GREEN, and the mutation evidence

RED: `tools/test_agent_scratchpad.py` written first; failed with `FileNotFoundError` on the
missing module. GREEN: 30 assertions pass.

The tests assert properties, not return values — that *no two identities share a path* across
5 identities × 6 names, and that a collision is *refused with the owner named*. Seven
mutations, each reverting one mechanism, each caught:

| # | mutation | caught by |
|---|---|---|
| 1 | agent dir → shared root (remove namespacing) | 5 assertions, incl. `stma-auto-1`/`stma-auto-2` both landing on `pr-body.md` **and** `corpus` |
| 2 | `assert_private` returns unconditionally | shared path + foreign path no longer refused |
| 3 | missing identity defaults to `"default"` | 3 assertions |
| 4 | clamp `../` instead of refusing | 2 escape assertions |
| 5 | `argparse.SUPPRESS` → `None` | both option spellings no longer agree |
| 6 | drop options from subparsers | 6 assertions |
| 7 | hook fires unconditionally | propagates through the CI delegation below |

Mutations 5 and 6 pin **two real defects I found by smoke-testing the CLI against the live
scratchpad**, both worth naming because the second is the very class being fixed:

- Options only on the parent parser → `path pr-body.md --agent-id x` died with
  `unrecognized arguments` for exactly the spelling anyone types. A safe path that is
  annoying to use gets worked around, and the workaround is the shared file.
- Options on the subparser with `default=None` → the subparser **silently overwrote** the
  parent's parsed value, so `--scratchpad X path f` lost `X` and refused a command that had
  supplied one. A silent wrong answer inside the tool whose job is to prevent silent wrong
  answers. `argparse.SUPPRESS` fixes it; the test asserts both spellings produce the *same*
  path.

## A discovery gap found on the way

**No CI job globs `.claude/hooks/test_*.py`** — `pr-gate.yml`'s `tools-tests` job globs
`tools/test_*.py` only. So `test_prefer_code_navigation.py` has never run in CI, and neither
would the new hook's suite: the same defect `tools-tests` was created to fix, one directory
over. `tools/test_agent_scratchpad.py` delegates to every `.claude/hooks/test_*.py`, so hook
suites now gate by the same discovery argument — **no workflow edit**, which also avoids the
`workflow` scope this box's token does not have. Mutation 7 confirms a broken hook fails the
gating suite.

## Verification

All 8 `tools/test_*.py` suites pass, as `pr-gate.yml` runs them. The 16 hook cases are drawn
from real commands in this repository's scratchpads.

Dogfooded: this PR body was staged at
`<scratchpad>/agent-stma-auto-23/pr-body.md`, obtained from the tool.

## Corpus

**No upstream corpus test is owed.** This is agent tooling — Python under `tools/` and
`.claude/` — and asserts nothing whatsoever about Business Central behavior, so there is
nothing a service tier could adjudicate (`bc-behavior-tests-go-upstream.md` requires the
answer either way).

Corpus-NA: agent/session tooling only; no AL and no BC-behavior claim in this diff.

## Deliberately left out

- **`~/.cache/claude-tmp/al-runner-pkgdedup/`** — named in the issue as related but separate,
  and tracked in **#2967**. It is a content-addressed cache written non-atomically, not a
  naming problem; the fix there is atomic write-and-rename, not namespacing.
- **Migrating the 207 existing shared entries.** `scan` reports them; moving another agent's
  live files mid-session is precisely the destructive act this PR exists to prevent.
- **Making the hook block.** Argued above — it would be switched off, and the opt-in refusal
  already exists in `check`.
- **A `workflow`-scope change** adding a `.claude/hooks/` job to `pr-gate.yml`. The
  delegation achieves it without one; a dedicated job would be marginally more direct if a
  maintainer wants it later.
- **Scratchpad-path detection in the hook is regex over `/tmp/claude-<uid>/…/scratchpad`.**
  A session using a different scratchpad root gets no warning — the `tools/` refusal still
  works there, since it takes the root as an argument.

---

*Written by `stma-auto-23`, an automated implementation agent acting on the account holder's
behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9pEPoD8e4wmVyuTrxyuh
