### PR TITLE
fix(prepass): keep the provisioning-gap report when a source pre-pass wraps the failure

### DIFF
--- a/AlRunner.Tests/LayeredPrePassProvisioningReportingTests.cs
+++ b/AlRunner.Tests/LayeredPrePassProvisioningReportingTests.cs
@@ -1,0 +1,374 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #2956 — the LAYERED pre-pass's own dependency resolve happens inside the emit
+/// <c>try</c>, whose <c>catch (Exception ex)</c> rethrew every cause as a plain
+/// <c>InvalidOperationException</c>. A <see cref="AlRunner.Infrastructure.MissingDependencyException"/>
+/// therefore reached Program.cs only as an <c>InnerException</c>, so the
+/// <c>catch (… is IDependencyProvisioningDiagnostic)</c> clause #2095 added never matched
+/// and the reader got the short one-liner under a "COMPILE-FAIL" label instead:
+/// <code>
+///   &lt;layered-deps&gt;: COMPILE-FAIL — [layered] Failed to emit symbols for impl
+///     'LSC Chain Middle' from …: Dependency not found: AL Runner/LSC Chain Base v1.0.0.0
+/// </code>
+/// exit 3, mislabelled as "your AL code did not compile" when it is a provisioning gap.
+///
+/// The sibling <c>BuildSiblingSourceDeps</c> path already reported this correctly
+/// (SiblingSourceDepProvisioningReportingTests), because its resolve throws OUTSIDE the
+/// emit try. These tests are the layered mirror, and they pin the DETAILED text rather
+/// than the substring the pre-existing LayeredSourceChainTests assert — "Dependency not
+/// found" and the app name appear in BOTH the wrapped and unwrapped forms, so neither
+/// can tell the two apart.
+///
+/// Four tests:
+///   - CLI positive: the #2095 provisioning-gap report, exit 2, no COMPILE-FAIL.
+///   - CLI composition: the impl whose closure failed is still named — the one thing
+///     the wrapper carried that ToDetailedMessage does not.
+///   - Server positive: the same request over --server reports the detailed text too.
+///     Before this fix, CLI and server mode disagreed about this surface.
+///   - Negative: a genuine non-provisioning failure on the SAME call site still reports
+///     COMPILE-FAIL + exit 3, proving the special case did not swallow the general one.
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips (visibly) when absent.
+/// </summary>
+public class LayeredPrePassProvisioningReportingTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static string NewScratch(string tag) =>
+        TestScratch.Dir(Path.Combine("al-runner-layered-provisioning", tag));
+
+    private static string ServerReq(params string[] bundles) => JsonSerializer.Serialize(new
+    {
+        command = "runTests",
+        sourcePaths = bundles,
+        packagePaths = Array.Empty<string>(),
+    });
+
+    private static (string Output, int Exit) RunRunner(string scratchRoot, params string[] bundles)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        foreach (var b in bundles) args.Append($" \"{b}\"");
+        args.Append($" --cache \"{Path.Combine(scratchRoot, "al-out")}\"");
+        var platformApps = TestArtifacts.PlatformAppsDir();
+        if (Directory.Exists(platformApps)) args.Append($" --package-cache \"{platformApps}\"");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(300_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    // ── Fixtures: middle -> base, with base genuinely absent everywhere ─────────
+    // Deliberately NOT the LayeredSourceChainTests GUIDs/ids: those tests assert the old
+    // wrapped wording is gone, and sharing a workspace-deps cache key between the two
+    // classes would let one answer for the other.
+
+    private static void WriteMiddleApp(string dir, Guid middleId, Guid baseId)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{middleId}}",
+          "name": "LPP Chain Middle",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{baseId}}", "name": "LPP Chain Base", "publisher": "AL Runner", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 60860, "to": 60869 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "ChainMiddleApi.Codeunit.al"), """
+        codeunit 60860 "LPP Chain Middle Api"
+        {
+            procedure ReadValue(RowCode: Code[20]): Integer
+            var
+                ChainRow: Record "LPP Chain Row";
+            begin
+                ChainRow.Get(RowCode);
+                exit(ChainRow."Row Value");
+            end;
+        }
+        """);
+    }
+
+    private static void WriteTestApp(string dir, Guid testsId, Guid middleId)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{testsId}}",
+          "name": "LPP Chain Test",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{middleId}}", "name": "LPP Chain Middle", "publisher": "AL Runner", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 60870, "to": 60879 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "ChainTests.al"), """
+        codeunit 60870 "LPP Chain Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure NeverReached()
+            var
+                MiddleApi: Codeunit "LPP Chain Middle Api";
+            begin
+                if MiddleApi.ReadValue('X') <> 0 then
+                    Error('should never compile far enough to run this');
+            end;
+        }
+        """);
+    }
+
+    /// <summary>
+    /// An impl that resolves fine but fails the emit for a REAL compile reason. Two
+    /// codeunits share object id 60881, so BC raises AL0264 and the symbol emit throws
+    /// from inside the very <c>try</c> whose <c>catch</c> #2956 changes — verified by
+    /// hand against the built runner, because most AL errors (AL0118, an out-of-range id)
+    /// surface further down the pipeline instead and would have made this control
+    /// vacuous. The negative control: this must keep the wrapped COMPILE-FAIL wording and
+    /// exit 3.
+    /// </summary>
+    private static void WriteBadMiddleApp(string dir, Guid middleId)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{middleId}}",
+          "name": "LPP Bad Middle",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 60880, "to": 60889 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Api.Codeunit.al"), """
+        codeunit 60881 "LPP Bad Middle Api"
+        {
+            procedure Answer(): Integer
+            begin
+                exit(42);
+            end;
+        }
+        """);
+        // Same id as above — AL0264, raised during the impl's symbol emit.
+        File.WriteAllText(Path.Combine(dir, "Dup.Codeunit.al"), """
+        codeunit 60881 "LPP Bad Middle Dup"
+        {
+            procedure Other(): Integer
+            begin
+                exit(7);
+            end;
+        }
+        """);
+    }
+
+    private static void WriteTestAppFor(string dir, Guid testsId, Guid middleId, string middleName)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{testsId}}",
+          "name": "LPP Bad Test",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{middleId}}", "name": "{{middleName}}", "publisher": "AL Runner", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 60890, "to": 60899 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Tests.al"), """
+        codeunit 60890 "LPP Bad Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure NeverReached()
+            var
+                Api: Codeunit "LPP Bad Middle Api";
+            begin
+                if Api.Answer() <> 42 then
+                    Error('unreachable');
+            end;
+        }
+        """);
+    }
+
+    // ── CLI: the #2095 report must reach the reader ─────────────────────────────
+
+    /// <summary>
+    /// The claim #2956 is about. With the base app genuinely absent, the layered pre-pass
+    /// fails — and what surfaces must be the detailed provisioning-gap report, NOT the
+    /// wrapped one-liner under a COMPILE-FAIL label.
+    ///
+    /// Every assertion here fails against the pre-fix binary: the wrapped form contains
+    /// "COMPILE-FAIL", lacks every line of ToDetailedMessage, and exits 3 not 2.
+    /// </summary>
+    [SkippableFact]
+    public void LayeredPrePass_BaseAppAbsent_ReportsProvisioningGap_NotCompileFail()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var scratch = NewScratch("absent-cli");
+        Guid baseId = Guid.NewGuid(), middleId = Guid.NewGuid(), testsId = Guid.NewGuid();
+        var chainRoot = Path.Combine(scratch, "chain");
+        var middleDir = Path.Combine(chainRoot, "middle-app");
+        var testsDir = Path.Combine(chainRoot, "tests-app");
+        WriteMiddleApp(middleDir, middleId, baseId);
+        WriteTestApp(testsDir, testsId, middleId);
+
+        var (output, exit) = RunRunner(scratch, middleDir, testsDir);
+
+        // NOT mislabelled as a compile failure, and not an unhandled crash.
+        Assert.DoesNotContain("COMPILE-FAIL", output);
+        Assert.DoesNotContain("Unhandled exception", output);
+        // The detailed #2095 report, line by line — none of these appear in the wrapper.
+        Assert.Contains("A required dependency package is missing from your package cache.", output);
+        Assert.Contains("This is a PROVISIONING gap — your code is NOT the problem.", output);
+        Assert.Contains("Missing: AL Runner/LPP Chain Base v1.0.0.0", output);
+        Assert.Contains($"App ID:  {baseId}", output);
+        Assert.Contains("Resolve it:", output);
+        // Third-party branch of ToDetailedMessage: the runner cannot download this, so the
+        // advice must be --package-cache, never "al-runner provision".
+        Assert.Contains("Add the missing package to your --package-cache <dir>", output);
+        Assert.DoesNotContain("al-runner provision", output);
+        // Exit 2 ("execution error"), the code every other provisioning gap returns —
+        // not 3 ("compilation error").
+        Assert.Equal(2, exit);
+    }
+
+    /// <summary>
+    /// Composition, not plain unwrapping: <c>ToDetailedMessage</c> knows the missing
+    /// dependency but not which impl asked for it, and in a multi-impl invocation that is
+    /// information the reader needs. The wrapper carried it; the fix must keep it.
+    /// </summary>
+    [SkippableFact]
+    public void LayeredPrePass_BaseAppAbsent_ProvisioningGapStillNamesTheImplBeingBuilt()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var scratch = NewScratch("absent-impl-named");
+        Guid baseId = Guid.NewGuid(), middleId = Guid.NewGuid(), testsId = Guid.NewGuid();
+        var chainRoot = Path.Combine(scratch, "chain");
+        var middleDir = Path.Combine(chainRoot, "middle-app");
+        var testsDir = Path.Combine(chainRoot, "tests-app");
+        WriteMiddleApp(middleDir, middleId, baseId);
+        WriteTestApp(testsDir, testsId, middleId);
+
+        var (output, exit) = RunRunner(scratch, middleDir, testsDir);
+
+        Assert.Equal(2, exit);
+        // Which impl, and where its source is — both concrete, neither in ToDetailedMessage.
+        Assert.Contains("Reached while building source dependency 'LPP Chain Middle' (layered pre-pass).", output);
+        Assert.Contains($"Its source: {middleDir}", output);
+        // And the composed report still carries the inner diagnostic in full.
+        Assert.Contains("This is a PROVISIONING gap — your code is NOT the problem.", output);
+    }
+
+    // ── Server mode: the same request must report the same way ──────────────────
+
+    /// <summary>
+    /// #2956 flagged that CLI and server mode disagreed about where this failure surfaces:
+    /// server mode had no <c>IDependencyProvisioningDiagnostic</c> special case at all and
+    /// flattened everything into "LAYERED-PREPASS-FAIL: {ex.Message}". A caller driving the
+    /// runner over the server protocol got strictly less than a CLI caller, for the same
+    /// gap on the same fixture.
+    /// </summary>
+    [SkippableFact]
+    public async Task ServerRunTests_BaseAppAbsent_ReportsProvisioningGap_NotPrepassFail()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var scratch = NewScratch("absent-server");
+        Guid baseId = Guid.NewGuid(), middleId = Guid.NewGuid(), testsId = Guid.NewGuid();
+        var chainRoot = Path.Combine(scratch, "chain");
+        var middleDir = Path.Combine(chainRoot, "middle-app");
+        var testsDir = Path.Combine(chainRoot, "tests-app");
+        WriteMiddleApp(middleDir, middleId, baseId);
+        WriteTestApp(testsDir, testsId, middleId);
+
+        await using var server = await CliServer.StartAsync(new[] { "--cache", Path.Combine(scratch, "al-out") });
+        var lines = await server.SendRequestStreamingAsync(ServerReq(middleDir, testsDir), TimeSpan.FromSeconds(300));
+        var (_, summary) = ProtocolV2Streaming.Split(lines);
+
+        Assert.NotEqual(0, summary.GetProperty("exitCode").GetInt32());
+        Assert.True(summary.TryGetProperty("compilationErrors", out var compileErrors),
+            $"expected compilationErrors when base app is absent: {string.Join(" | ", lines)}");
+        var allErrorText = string.Join(" | ", compileErrors.EnumerateArray()
+            .SelectMany(g => g.GetProperty("errors").EnumerateArray().Select(e => e.GetString())));
+
+        // The detailed report, delivered through the protocol — not the flattened one-liner.
+        Assert.Contains("This is a PROVISIONING gap — your code is NOT the problem.", allErrorText);
+        Assert.Contains("Missing: AL Runner/LPP Chain Base v1.0.0.0", allErrorText);
+        Assert.Contains("Add the missing package to your --package-cache <dir>", allErrorText);
+        Assert.Contains("Reached while building source dependency 'LPP Chain Middle'", allErrorText);
+        Assert.DoesNotContain("LAYERED-PREPASS-FAIL", allErrorText);
+    }
+
+    // ── Negative: a genuine compile failure must NOT be reclassified ─────────────
+
+    /// <summary>
+    /// The guard against over-reaching. A real AL compile error inside the impl's emit —
+    /// AL0543, nothing to do with dependency resolution — must still report exactly as it
+    /// does today: the wrapped "[layered] Failed to emit symbols" text under
+    /// <c>&lt;layered-deps&gt;: COMPILE-FAIL</c>, exit 3. If this went to exit 2 as well,
+    /// the fix would have turned every layered failure into a "provisioning gap" and told
+    /// users to fix their package cache when their AL genuinely does not compile.
+    /// </summary>
+    [SkippableFact]
+    public void LayeredPrePass_GenuineCompileFailure_StillReportsCompileFail_Exit3()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var scratch = NewScratch("compile-fail");
+        Guid middleId = Guid.NewGuid(), testsId = Guid.NewGuid();
+        var chainRoot = Path.Combine(scratch, "chain");
+        var middleDir = Path.Combine(chainRoot, "middle-app");
+        var testsDir = Path.Combine(chainRoot, "tests-app");
+        WriteBadMiddleApp(middleDir, middleId);
+        WriteTestAppFor(testsDir, testsId, middleId, "LPP Bad Middle");
+
+        var (output, exit) = RunRunner(scratch, middleDir, testsDir);
+
+        Assert.Contains("<layered-deps>: COMPILE-FAIL", output);
+        Assert.Contains("[layered] Failed to emit symbols for impl 'LPP Bad Middle'", output);
+        Assert.Contains("AL0264", output);
+        Assert.DoesNotContain("Unhandled exception", output);
+        // Emphatically NOT reclassified as a provisioning gap.
+        Assert.DoesNotContain("PROVISIONING gap", output);
+        Assert.DoesNotContain("Add the missing package to your --package-cache", output);
+        Assert.Equal(3, exit);
+    }
+}

--- a/AlRunner.Tests/LayeredSourceChainTests.cs
+++ b/AlRunner.Tests/LayeredSourceChainTests.cs
@@ -24,6 +24,8 @@ namespace AlRunner.Tests;
 ///     'LSC Chain Middle' ...: Dependency not found: AL Runner/LSC Chain Base v1.0.0.0
 ///     ... Searched: &lt;platform-apps&gt;, &lt;test-apps&gt;
 /// </code>
+/// (that COMPILE-FAIL rendering is itself #2956, fixed since — a genuinely missing
+/// dependency now reports the provisioning-gap report instead.)
 /// naming an app the runner had written itself one line earlier.
 ///
 /// Two apps was the deepest shape with coverage, and two apps never exercises it: the one
@@ -358,6 +360,15 @@ public class LayeredSourceChainTests
     /// search set is only correct if it stops widening at "what actually exists"; a fix
     /// that made resolution succeed unconditionally would turn this into a green run
     /// with a silently missing dependency.
+    ///
+    /// <para>#2956 changed HOW that failure is rendered, not whether it happens. The
+    /// short one-liner ("Dependency not found: …") these two used to assert was the
+    /// symptom of the wrapper defeating #2095's report; what surfaces now is
+    /// MissingDependencyException.ToDetailedMessage, which names the same missing app in
+    /// the "Missing:" line. The claim under test — absent dependency still fails, and
+    /// says which one — is unchanged; only the string carrying it moved. See
+    /// LayeredPrePassProvisioningReportingTests for the tests that pin the new
+    /// rendering itself.</para>
     /// </summary>
     [SkippableFact]
     public void LayeredPrePass_BaseAppAbsent_FailsNamingTheMissingDependency()
@@ -378,7 +389,7 @@ public class LayeredSourceChainTests
 
         Assert.NotEqual(0, exit);
         Assert.Contains("LSC Chain Base", output);
-        Assert.Contains("Dependency not found", output);
+        Assert.Contains("Missing: AL Runner/LSC Chain Base v1.0.0.0", output);
     }
 
     [SkippableFact]
@@ -404,6 +415,6 @@ public class LayeredSourceChainTests
         var allErrorText = string.Join(" | ", compileErrors.EnumerateArray()
             .SelectMany(g => g.GetProperty("errors").EnumerateArray().Select(e => e.GetString())));
         Assert.Contains("LSC Chain Base", allErrorText);
-        Assert.Contains("Dependency not found", allErrorText);
+        Assert.Contains("Missing: AL Runner/LSC Chain Base v1.0.0.0", allErrorText);
     }
 }

--- a/AlRunner/Infrastructure/LayeredDependencyProvisioningException.cs
+++ b/AlRunner/Infrastructure/LayeredDependencyProvisioningException.cs
@@ -1,0 +1,51 @@
+// LayeredDependencyProvisioningException — the composing wrapper the layered/source-dep
+// pre-passes throw when the thing that failed underneath them is a provisioning gap
+// (MissingDependencyException / DependencyVersionMismatchException), not a compile failure.
+//
+// See: .claude/rules/loud-failures.md, docs/limitations.md
+
+namespace AlRunner.Infrastructure;
+
+/// <summary>
+/// Wraps an <see cref="IDependencyProvisioningDiagnostic"/> raised while a source pre-pass
+/// was building one specific impl / source dependency, and is itself one — so a
+/// <c>catch (… is IDependencyProvisioningDiagnostic)</c> in Program.cs still recognizes it
+/// and still renders the detailed report, with the impl this happened for named on top.
+/// </summary>
+public sealed class LayeredDependencyProvisioningException : Exception, IDependencyProvisioningDiagnostic
+{
+    /// <summary>The pre-pass stage tag, e.g. <c>"layered"</c> or <c>"source-dep"</c>.</summary>
+    public string Stage { get; }
+    /// <summary>Name of the impl / source dependency being built when this surfaced.</summary>
+    public string ImplName { get; }
+    /// <summary>Source directory of that impl.</summary>
+    public string ImplPath { get; }
+    /// <summary>The provisioning diagnostic this composes over.</summary>
+    public IDependencyProvisioningDiagnostic Diagnostic { get; }
+
+    public LayeredDependencyProvisioningException(
+        string stage, string implName, string implPath, Exception inner)
+        : base($"[{stage}] Failed to emit symbols for impl '{implName}' from {implPath}: {inner.Message}", inner)
+    {
+        Stage = stage;
+        ImplName = implName;
+        ImplPath = implPath;
+        Diagnostic = (IDependencyProvisioningDiagnostic)inner;
+    }
+
+    /// <summary>
+    /// AUDIT (loud-failures.md): observably equivalent to the inner diagnostic's own report,
+    /// plus two lines naming which impl was being built. The inner text is reproduced verbatim
+    /// — nothing is summarized, reworded or dropped — so the reader gets the same missing app,
+    /// searched dirs, dependency chain and fix commands #2095 built, and additionally learns
+    /// which of several impls in the invocation asked for it. Rationale: PR body for #2956.
+    /// </summary>
+    public string ToDetailedMessage(string? bcVersion = null)
+        => string.Join(Environment.NewLine, new[]
+        {
+            Diagnostic.ToDetailedMessage(bcVersion),
+            "",
+            $"  Reached while building source dependency '{ImplName}' ({Stage} pre-pass).",
+            $"  Its source: {ImplPath}",
+        });
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -4491,6 +4491,19 @@ return strictExitCode ? computedExitCode : 0;
             {
                 packageCacheDirs = RunLayeredPrePass(bundleList, packageCacheDirs, workspaceScratch);
             }
+            // #2956: the same #2095 special case the CLI path applies, which server mode
+            // never had — a missing/too-old package reported as "LAYERED-PREPASS-FAIL:
+            // Dependency not found: …" told a protocol caller strictly less than a CLI
+            // caller got for the identical gap on the identical bundle. Exit 2 to match
+            // the CLI's provisioning-gap code, not 3 ("compilation error").
+            catch (Exception ex) when (ex is AlRunner.Infrastructure.IDependencyProvisioningDiagnostic diag)
+            {
+                var bcVer = AlRunner.Infrastructure.BcArtifacts.SelectedVersion.ToString();
+                return new List<ServerRunResult>
+                {
+                    ServerRunResult.Failure(2, "<inter-bundle-deps>", diag.ToDetailedMessage(bcVer), new())
+                };
+            }
             catch (Exception ex)
             {
                 // Loud per-bundle failure below (dep resolution during the per-bundle
@@ -4506,6 +4519,15 @@ return strictExitCode ? computedExitCode : 0;
         try
         {
             packageCacheDirs = BuildSiblingSourceDeps(bundleList, packageCacheDirs, workspaceScratch);
+        }
+        // Same #2956 provisioning-gap special case as the layered pre-pass above.
+        catch (Exception ex) when (ex is AlRunner.Infrastructure.IDependencyProvisioningDiagnostic diag)
+        {
+            var bcVer = AlRunner.Infrastructure.BcArtifacts.SelectedVersion.ToString();
+            return new List<ServerRunResult>
+            {
+                ServerRunResult.Failure(2, "<sibling-source-deps>", diag.ToDetailedMessage(bcVer), new())
+            };
         }
         catch (Exception ex)
         {

--- a/AlRunner/ProgramSupport/SiblingCompile.cs
+++ b/AlRunner/ProgramSupport/SiblingCompile.cs
@@ -313,21 +313,6 @@ internal static partial class ProgramSupport
     // within the SAME process (--watch, --server) — see that class's own header for why.
     internal static BcCompiler GetDepSymbolCompiler(string dir) => AlRunner.Infrastructure.DepSymbolCompilerCache.GetOrCreate(dir);
 
-    // ── Layered source build pre-pass ─────────────────────────────────────────
-    // Detects inter-bundle dependencies, emits impl bundles in topo order into a
-    // per-run workspace cache dir, and prepends that dir to packageCacheDirs.
-    // Completely inert when bundles.Count <= 1 or no inter-bundle dep edges exist.
-    /// <param name="implAppPathsOut">Optional. Receives, for every impl this call handled, the
-    /// path of the workspace package a dependent bundle will resolve it from — whether this call
-    /// wrote that package or served it from its content-keyed directory.
-    ///
-    /// <para>Comparing this map between two <c>--watch</c> cycles is how a dependent bundle
-    /// learns that its dependency moved (#2683). Deliberately NOT "did this call re-synthesise
-    /// it": each impl's directory is keyed on its source content, so reverting an edit resolves
-    /// back to a package written cycles ago and re-synthesises nothing — and the dependent, which
-    /// has been running the EDITED module in between, still has to be told. A test that only ever
-    /// moved forward would pass while the revert kept executing the code the developer just
-    /// undid.</para></param>
     /// <summary>
     /// The loud rethrow both source pre-passes use when building one impl fails (#2956).
     /// A provisioning gap keeps its detailed report by travelling in a wrapper that is
@@ -345,6 +330,21 @@ internal static partial class ProgramSupport
                 message ?? $"[{stage}] Failed to emit symbols for impl '{implName}' from {implPath}: {inner.Message}",
                 inner);
 
+    // ── Layered source build pre-pass ─────────────────────────────────────────
+    // Detects inter-bundle dependencies, emits impl bundles in topo order into a
+    // per-run workspace cache dir, and prepends that dir to packageCacheDirs.
+    // Completely inert when bundles.Count <= 1 or no inter-bundle dep edges exist.
+    /// <param name="implAppPathsOut">Optional. Receives, for every impl this call handled, the
+    /// path of the workspace package a dependent bundle will resolve it from — whether this call
+    /// wrote that package or served it from its content-keyed directory.
+    ///
+    /// <para>Comparing this map between two <c>--watch</c> cycles is how a dependent bundle
+    /// learns that its dependency moved (#2683). Deliberately NOT "did this call re-synthesise
+    /// it": each impl's directory is keyed on its source content, so reverting an edit resolves
+    /// back to a package written cycles ago and re-synthesises nothing — and the dependent, which
+    /// has been running the EDITED module in between, still has to be told. A test that only ever
+    /// moved forward would pass while the revert kept executing the code the developer just
+    /// undid.</para></param>
     internal static List<string> RunLayeredPrePass(List<string> bundles, List<string> packageCacheDirs, List<string> workspaceDirsOut,
         IDictionary<Guid, string>? implAppPathsOut = null)
     {

--- a/AlRunner/ProgramSupport/SiblingCompile.cs
+++ b/AlRunner/ProgramSupport/SiblingCompile.cs
@@ -328,6 +328,23 @@ internal static partial class ProgramSupport
     /// has been running the EDITED module in between, still has to be told. A test that only ever
     /// moved forward would pass while the revert kept executing the code the developer just
     /// undid.</para></param>
+    /// <summary>
+    /// The loud rethrow both source pre-passes use when building one impl fails (#2956).
+    /// A provisioning gap keeps its detailed report by travelling in a wrapper that is
+    /// itself an <c>IDependencyProvisioningDiagnostic</c>, so Program.cs's #2095 handlers
+    /// — CLI and server — still recognize it and still render
+    /// <c>ToDetailedMessage</c>, with this impl named. Everything else stays exactly the
+    /// <c>InvalidOperationException</c> it was, so a genuine compile failure still reports
+    /// COMPILE-FAIL / exit 3 and is never relabelled as a package the reader must go find.
+    /// </summary>
+    private static Exception WrapEmitFailure(
+        string stage, string implName, string implPath, Exception inner, string? message = null)
+        => inner is AlRunner.Infrastructure.IDependencyProvisioningDiagnostic
+            ? new AlRunner.Infrastructure.LayeredDependencyProvisioningException(stage, implName, implPath, inner)
+            : new InvalidOperationException(
+                message ?? $"[{stage}] Failed to emit symbols for impl '{implName}' from {implPath}: {inner.Message}",
+                inner);
+
     internal static List<string> RunLayeredPrePass(List<string> bundles, List<string> packageCacheDirs, List<string> workspaceDirsOut,
         IDictionary<Guid, string>? implAppPathsOut = null)
     {
@@ -533,14 +550,13 @@ internal static partial class ProgramSupport
             //   * a WARM workspace (hadSymbols) never resolved at all, so a dependency that has
             //     since gone missing did not fail here; the per-bundle resolve reports it later,
             //     with the message and exit code Program.cs's own handlers decide;
-            //   * a COLD one wrapped the failure in "[layered] Failed to emit symbols for impl
-            //     '<name>' from <path>: <reason>" (LayeredSourceChainTests pins that text).
+            //   * a COLD one reports through WrapEmitFailure below.
             //
-            // Letting a MissingDependencyException escape from here instead does produce a
-            // better message — Program.cs's #2095 handler renders ToDetailedMessage's
-            // provisioning-gap report, which the wrapper defeats — but that is an error-reporting
-            // change with its own blast radius across CLI and server mode, not part of a cache
-            // key fix. Filed as #2956, with both messages measured against the same fixture.
+            // #2956 resolved the reporting half: a provisioning gap now travels in a wrapper
+            // that IS an IDependencyProvisioningDiagnostic, so Program.cs's #2095 handler still
+            // renders ToDetailedMessage; everything else stays an InvalidOperationException
+            // reported as COMPILE-FAIL. The retry below is unchanged and still needed — the
+            // resolve must throw from inside the emit try for either classification to happen.
             IReadOnlyList<(AppManifest Manifest, string AppPath)> implDeps = Array.Empty<(AppManifest, string)>();
             string? implResolveFailure = null;
             try { implDeps = implResolver.Resolve(implId.Dependencies); }
@@ -595,9 +611,8 @@ internal static partial class ProgramSupport
                     // GetSharedReferences excludes the impl from its own specs (self-ref guard).
                     //
                     // If the resolve failed, redo it so it throws HERE — inside this try, whose
-                    // catch produces the "[layered] Failed to emit symbols for impl …" message
-                    // this path has always produced. The retry only runs on a path that is about
-                    // to abort.
+                    // catch classifies it (WrapEmitFailure: provisioning gap vs. compile
+                    // failure, #2956). The retry only runs on a path that is about to abort.
                     if (implResolveFailure != null)
                         implDeps = implResolver.Resolve(implId.Dependencies);
                     BcCompiler.SetResolvedDeps(implDeps, implSymbolDirs);
@@ -644,8 +659,8 @@ internal static partial class ProgramSupport
                 {
                     // Loud failure per repo rule — the dependent bundle cannot compile
                     // against this impl without its symbols, so don't continue silently.
-                    throw new InvalidOperationException(
-                        $"[layered] Failed to emit symbols for impl '{implId.Name}' from {implPath}: {ex.Message}", ex);
+                    // #2956: a provisioning gap keeps its own report (see WrapEmitFailure).
+                    throw WrapEmitFailure("layered", implId.Name, implPath, ex);
                 }
             }
 
@@ -673,8 +688,9 @@ internal static partial class ProgramSupport
                 catch (Exception ex)
                 {
                     // Loud failure per repo rule — never silently continue.
-                    throw new InvalidOperationException(
-                        $"[layered] Failed to emit impl package '{implId.Name}' from {implPath}: {ex.Message}", ex);
+                    // #2956: a provisioning gap keeps its own report (see WrapEmitFailure).
+                    throw WrapEmitFailure("layered", implId.Name, implPath, ex,
+                        $"[layered] Failed to emit impl package '{implId.Name}' from {implPath}: {ex.Message}");
                 }
             }
 
@@ -910,8 +926,9 @@ internal static partial class ProgramSupport
                 catch (Exception ex)
                 {
                     // Loud failure per repo rule — never silently continue.
-                    throw new InvalidOperationException(
-                        $"[source-dep] Failed to emit source dependency '{sid.Name}' from {dir}: {ex.Message}", ex);
+                    // #2956: a provisioning gap keeps its own report (see WrapEmitFailure).
+                    throw WrapEmitFailure("source-dep", sid.Name, dir, ex,
+                        $"[source-dep] Failed to emit source dependency '{sid.Name}' from {dir}: {ex.Message}");
                 }
             }
             // Compile-visible half: emit the dep's AL symbols (*.symbols.json) + deps
@@ -965,8 +982,9 @@ internal static partial class ProgramSupport
                 }
                 catch (Exception ex)
                 {
-                    throw new InvalidOperationException(
-                        $"[source-dep] Failed to emit symbols for '{sid.Name}' from {dir}: {ex.Message}", ex);
+                    // #2956: a provisioning gap keeps its own report (see WrapEmitFailure).
+                    throw WrapEmitFailure("source-dep", sid.Name, dir, ex,
+                        $"[source-dep] Failed to emit symbols for '{sid.Name}' from {dir}: {ex.Message}");
                 }
             }
 


### PR DESCRIPTION
Closes #2956

Written by agent `stma-auto-28`, an automated implementation agent acting on the account holder's behalf.

## The premise held — measured, not read off the code

Issue premises have been wrong five times this session, so this one was reproduced before anything changed. Three-app chain (`test -> middle -> base`) with the base app genuinely absent, run against the built runner.

**Before** — the entire output on stderr, exit **3**:

```
<layered-deps>: COMPILE-FAIL — [layered] Failed to emit symbols for impl 'LSC Chain Middle' from /…/middle-app: Dependency not found: AL Runner/LSC Chain Base v1.0.0.0 (id=7c9ea7a8-…). Searched: /home/stefan/.al-runner/platform-apps, …
```

**After** — exit **2**:

```
A required dependency package is missing from your package cache.
  This is a PROVISIONING gap — your code is NOT the problem.

  Missing: AL Runner/LSC Chain Base v1.0.0.0
  App ID:  7c9ea7a8-0c6d-48b5-af04-3fc2088becee
  Searched: "/home/stefan/.al-runner/platform-apps", "…/platform-apps", "…/test-apps"
  Dependency chain: LSC Chain Base

  Resolve it:

  Add the missing package to your --package-cache <dir> (usually your
  project's .alpackages). Verify the package version satisfies the
  minimum declared in app.json.

  Reached while building source dependency 'LSC Chain Middle' (layered pre-pass).
  Its source: /…/middle-app
```

## Where the wrap happens

`AlRunner/ProgramSupport/SiblingCompile.cs`. The layered pre-pass's dependency resolve runs *inside* the symbol-emit `try` (deliberately — #2846 moved it above the workspace key and retries it there so it throws from the same place it always did). That `try`'s `catch (Exception ex)` rethrew **every** cause as a plain `InvalidOperationException`, so a `MissingDependencyException` arrived at `Program.cs` only as an `InnerException`.

`Program.cs`'s #2095 handlers match on the **outer** type — `catch (Exception ex) when (ex is IDependencyProvisioningDiagnostic diag)` — so they never fired, and the generic `catch` printed `COMPILE-FAIL — {ex.Message}` (the short `BuildShortMessage` form) instead.

`BuildSiblingSourceDeps` was already correct on the CLI, because *its* resolve throws outside the emit `try` — which is why `SiblingSourceDepProvisioningReportingTests` passes today and this went unnoticed.

## Compose, not unwrap — and why

Weighed as the issue asked:

- **Does the wrapper carry information the inner exception lacks?** Yes. `ToDetailedMessage` names the missing dependency but never says *which impl asked for it*; in a multi-impl invocation that is exactly what the reader needs to know. Plain unwrapping would have discarded it, trading one loss of information for another.
- **Is the wrap load-bearing for control flow?** No. Nothing anywhere catches `InvalidOperationException` from these call sites, and nothing matches the wrapper's message text. Verified across `AlRunner/`, `AlRunner.Tests/`, `tests/` and `docs/`: the only consumers were two assertions in `LayeredSourceChainTests`.
- So: `AlRunner/Infrastructure/LayeredDependencyProvisioningException.cs` — a wrapper that **is itself** an `IDependencyProvisioningDiagnostic`. The existing handlers recognize it unchanged, `ToDetailedMessage` reproduces the inner report **verbatim** (nothing summarized, reworded or dropped), and two lines naming the impl and its source are appended.

`loud-failures.md` audit justification sits at the type, as a claim plus a citation pointing here rather than the derivation.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site?** Yes — **four**, all in `SiblingCompile.cs`: the layered symbol emit (the reported one), the layered `.app` emit, the source-dep symbol emit, and the source-dep `.app` emit. All four rethrew unconditionally as `InvalidOperationException`. All four now go through one `WrapEmitFailure` helper, so the classification cannot drift apart between them again.
2. **Does a sibling make the same assumption?** Yes, and it is the more serious half: **server mode had no #2095 case at all.** Both its pre-pass catches flattened every cause into `LAYERED-PREPASS-FAIL: {ex.Message}` / `SIBLING-SOURCE-DEPS-FAIL: {ex.Message}` with exit 3. So a caller driving the runner over the protocol got strictly less than a CLI caller for the identical gap on the identical bundle — the CLI/server disagreement #2956 flagged. Both now carry the same special case and return exit 2, matching the CLI.
3. **Two paths writing the same state, same invariant?** The CLI and server paths are exactly that pair, and they did not hold the same invariant. They do now.

Deliberately **not** changed: `implResolveFailure`, the string `ComputeSourceWorkspaceKey` hashes (#2846's cache key). It still records `MissingDependencyException: …`, so cache-key behavior is untouched — confirmed by diff.

## RED → GREEN, and mutation evidence

New: `AlRunner.Tests/LayeredPrePassProvisioningReportingTests.cs`, 4 tests.

**RED (before the fix): 4 failed, 0 passed**, each on the predicted assertion — `COMPILE-FAIL` present, the detailed lines absent, exit 3 not 2, and the server response reading `LAYERED-PREPASS-FAIL`.

**GREEN (after): 4 passed, 0 failed.**

The tests assert the **specific text** — `"This is a PROVISIONING gap — your code is NOT the problem."`, `"Missing: AL Runner/LPP Chain Base v1.0.0.0"`, `"App ID:  {baseId}"`, `"Add the missing package to your --package-cache <dir>"`, the composed `"Reached while building source dependency 'LPP Chain Middle' (layered pre-pass)."` and its source path, plus exit 2. None of these appear in the wrapper's generic text, so none could pass against the old behavior. They deliberately do **not** rest on `"Dependency not found"` or the app name, which appear in **both** forms and therefore prove nothing.

**Mutation testing** — two independent mutations, each caught with exact granularity:

| mutation | result |
|---|---|
| `WrapEmitFailure`'s type test forced to `false` (classification disabled, everything rewrapped as before) | **3 failed** — the three positive tests; the negative control correctly still passed |
| server-mode `IDependencyProvisioningDiagnostic` catch deleted | **1 failed** — precisely `ServerRunTests_BaseAppAbsent_…`, and only it |

Both reverted; `git status` clean afterwards, verified.

**The negative control is load-bearing.** A fix that reclassified *every* layered failure as a provisioning gap would tell users to go fix their package cache when their AL genuinely does not compile. `LayeredPrePass_GenuineCompileFailure_StillReportsCompileFail_Exit3` uses two codeunits sharing object id 60881 — AL0264, raised from inside the very `try` whose `catch` changed — and asserts `COMPILE-FAIL` + exit 3 + `AL0264`, and `DoesNotContain("PROVISIONING gap")`.

That fixture was found empirically and the first two attempts were wrong: an AL0543 page and an undefined-procedure AL0118 both surface *further down the pipeline* and never reach that catch at all, so either would have made the control vacuous while looking correct. Recorded in the test's doc comment so the next person does not re-derive it.

## Two pre-existing assertions moved

`LayeredSourceChainTests`' two negative tests asserted `"Dependency not found"` — the short one-liner, i.e. the symptom of the wrapper defeating #2095 rather than the claim being made. They now assert `"Missing: AL Runner/LSC Chain Base v1.0.0.0"` from the detailed report. Their actual claim — an absent dependency still fails, and the failure says which app — is unchanged and still enforced, alongside the untouched `Assert.Contains("LSC Chain Base", …)`. The issue predicted this update and asked that it be argued rather than slipped in.

## Where the test lives

Runner diagnostics and provisioning: which exception type carries a message, which exit code the runner returns, and what its server protocol emits. Nothing here is a statement about Business Central — a real service tier has no opinion on how AL Runner reports a missing package — so **no upstream corpus test is owed** and none was written. C# tests in `AlRunner.Tests` are the right home.

Corpus-NA: runner diagnostics/provisioning only — exception classification, exit codes and server-protocol payload. No BC behavior is asserted, so a service tier cannot adjudicate it.

## Sibling issue scan

Searched the open queue for provisioning / `MissingDependency` / `ToDetailedMessage` / `SiblingCompile` / layered-prepass issues. **Nothing folded — nothing else lands in these files.** The map:

- **#2193** (version floors read only from the bundle's own `app.json`) — nearest neighbor, and genuinely dependency-resolution adjacent, but the fix is in `DependencyResolver`'s floor computation, a different file and a different question (*what* to resolve, not how a failure is reported).
- **#2232**, **#2226**, **#2227**, **#2190** — provisioning-flavored but all in the artifact/provision path (`ProvisioningCheck`, `BcArtifacts`, `--precompile` dispatch), none in `SiblingCompile.cs` or the pre-pass catches.
- **#3282** — touches source-dependency handling in the layered pre-pass area but concerns the RAD snapshot's page/xmlport metadata registry, not failure reporting.

## Tests run

- `LayeredPrePassProvisioningReportingTests` — 4/4 (RED 0/4 → GREEN 4/4)
- `LayeredSourceChainTests` + `SiblingSourceDepProvisioningReportingTests` — 12/12
- `MissingDependency*` + `ProvisionGap*` + `DependencyResolverTests` + `AlOutputCacheDoNotCacheTests` + `SourceWorkspaceKeyDependencyContentTests` — 62/62

Filtered runs per `local-test-scope.md`; the full suite is CI's job.

## Nothing deliberately left out

Every wrap site found was fixed, and both the CLI and server paths now agree. One thing worth a reviewer's eye: the server-mode exit code moved from 3 to 2 for this case, matching the CLI's provisioning-gap code (`docs/server-mode.md`'s ladder — 2 "execution error", 3 "compilation error"). That is a deliberate behavior change and the point of the fix, not a side effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9pEPoD8e4wmVyuTrxyuh
