### PR TITLE
fix(diagnostics): report paired counters from one snapshot, not two loads

### DIFF
--- a/AlRunner.Tests/InstrumentationCounterPairSnapshotTests.cs
+++ b/AlRunner.Tests/InstrumentationCounterPairSnapshotTests.cs
@@ -1,0 +1,210 @@
+// InstrumentationCounterPairSnapshotTests — the proving tests for #3169, the #3025 shape at
+// two more sites: a diagnostic that prints several counters read one at a time can print a
+// combination that never existed. Here the pairs have a real invariant to violate — the
+// second number is a subset of the first (BC MethodLoad events ⊆ MethodLoad events; calls
+// that did work ⊆ calls made) — so an inversion is provably impossible at any single instant
+// and provably possible from two loads.
+//
+// The behavioural tests are hammers, not forced interleavings: there is no seam that pins the
+// reader between two loads. Against the pre-fix code they reproduced within a second, every
+// run (163 of 511,095 listener snapshots; 56,845 of 1,937,753 dap snapshots inverted). After
+// the fix a snapshot is one load of one value, so there is no interleaving left to hit —
+// green is a proof, red was an observation.
+//
+// The IL guards pin the read half the way TestDataProvisionerTallyAtomicityTests does for
+// #3025: the dump line and the listener snapshot take each pair through exactly one
+// CountPair.Read, and the three subsystems keep no standalone integer counter a future edit
+// could print alongside it.
+using AlRunner.Infrastructure;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class InstrumentationCounterPairSnapshotTests
+{
+    // ───────────────────────────────────────────────────────── behavioural hammers ──
+
+    private static (long Inversions, long Reads) Hammer(
+        Action bump, Func<(long Total, long Part)> read, int milliseconds = 1500)
+    {
+        using var stop = new CancellationTokenSource(milliseconds);
+        var writers = Enumerable.Range(0, Math.Max(2, Environment.ProcessorCount - 1))
+            .Select(_ => new Thread(() => { while (!stop.IsCancellationRequested) bump(); }))
+            .ToArray();
+        foreach (var w in writers) w.Start();
+        long inversions = 0, reads = 0;
+        while (!stop.IsCancellationRequested)
+        {
+            var (total, part) = read();
+            reads++;
+            if (part > total) inversions++;
+        }
+        foreach (var w in writers) w.Join();
+        return (inversions, reads);
+    }
+
+    /// <summary>The mechanism itself: writers bump Total then Part; a reader must never see
+    /// Part ahead of Total. Mutating Read back to two loads of two fields fails this.</summary>
+    [Fact]
+    public void CountPair_ReadNeverReportsPartAboveTotal()
+    {
+        var pair = new CountPair();
+        var (inversions, reads) = Hammer(
+            () => { pair.IncrementTotal(); pair.IncrementPart(); },
+            () => { var s = pair.Read(); return (s.Total, s.Part); });
+        Assert.True(reads > 0);
+        Assert.True(inversions == 0, $"{inversions} of {reads} reads reported Part > Total");
+    }
+
+    /// <summary>Both halves land at once and the returned snapshot is the post-add state, so
+    /// the JIT callback's verbose-log cap reads the BC count it just produced.</summary>
+    [Fact]
+    public void CountPair_AddPublishesBothHalvesTogether()
+    {
+        var pair = new CountPair();
+        Assert.Equal(new CountPair.Snapshot(1, 0), pair.Add(1, 0));
+        Assert.Equal(new CountPair.Snapshot(2, 1), pair.Add(1, 1));
+        Assert.Equal(new CountPair.Snapshot(2, 4), pair.Add(0, 3));
+        pair.ClearPart();
+        Assert.Equal(new CountPair.Snapshot(2, 0), pair.Read());
+    }
+
+    /// <summary>Site 1: the Spike4 ProcessExit summary reads while the EventPipe callback
+    /// thread is still counting; it must never print more BC MethodLoad events than
+    /// MethodLoad events in total.</summary>
+    [Fact]
+    public void MethodLoadTallies_NeverReportMoreBcEventsThanEventsInTotal()
+    {
+        // Constructing the listener subscribes it to the runtime's real JIT events, so genuine
+        // non-BC MethodLoads are counted alongside the hammer's BC ones — Total > Bc is expected.
+        using var listener = new EventPipeJitListener();
+        var (inversions, reads) = Hammer(
+            () => listener.CountMethodLoad(isBc: true),
+            () => { var s = listener.SnapshotCounters(); return (s.Total, s.Bc); });
+        Assert.True(reads > 0);
+        Assert.True(inversions == 0,
+            $"{inversions} of {reads} snapshots reported more BC MethodLoad events than MethodLoad events in total");
+        var final = listener.SnapshotCounters();
+        Assert.True(final.Bc > 0 && final.Bc <= final.Total, $"expected 0 < Bc <= Total, got {final}");
+    }
+
+    /// <summary>Site 2, the clearest pair on the dump line: OnStmtHit increments the call
+    /// count, passes the Enabled gate, then increments the work count. Driven through the real
+    /// hook with int.MaxValue, which returns right after the work increment and before the
+    /// scope is touched, so a null scope is safe.</summary>
+    [Fact]
+    public void DapCounters_NeverReportMoreWorkThanCalls()
+    {
+        var was = AlDapSession.Enabled;
+        AlDapSession.Enabled = true;
+        try
+        {
+            var (inversions, reads) = Hammer(
+                () => AlDapSession.OnStmtHit(null!, int.MaxValue),
+                () => { var s = AlDapSession.Counts.Read(); return (s.Total, s.Part); });
+            Assert.True(reads > 0);
+            Assert.True(inversions == 0,
+                $"{inversions} of {reads} snapshots reported WorkPerformedCount > CallCount");
+        }
+        finally { AlDapSession.Enabled = was; }
+    }
+
+    // ────────────────────────────────────────────────────────────────── IL guards ──
+
+    private static AssemblyDefinition Assembly()
+        => AssemblyDefinition.ReadAssembly(typeof(CountPair).Assembly.Location);
+
+    private static IEnumerable<TypeDefinition> WithNested(TypeDefinition t)
+        => new[] { t }.Concat(t.NestedTypes.SelectMany(WithNested));
+
+    private static IEnumerable<MethodDefinition> AllMethods(TypeDefinition type)
+        => WithNested(type).SelectMany(t => t.Methods).Where(m => m.HasBody);
+
+    private static readonly string[] DumpLineSubsystems =
+        { typeof(AlCoverageTracker).FullName!, typeof(AlValueCapture).FullName!, typeof(AlDapSession).FullName! };
+
+    private static bool IsCountPairRead(Instruction i)
+        => (i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt) && i.Operand is MethodReference mr
+           && mr.DeclaringType.FullName == typeof(CountPair).FullName && mr.Name == nameof(CountPair.Read);
+
+    /// <summary>The AL_RUNNER_DUMP_INSTRUMENTATION_COUNTERS line takes each subsystem's pair
+    /// through exactly one CountPair.Read and touches nothing else on those types — no
+    /// counter field, no Collect(), no dictionary-derived bool that a second load could
+    /// contradict. Located by its own literal, so it can live in whatever method top-level
+    /// statements compile to.</summary>
+    [Fact]
+    public void TheDumpLine_ReadsEachPairExactlyOnceAndNothingElse()
+    {
+        using var asm = Assembly();
+        var dumpMethods = asm.MainModule.Types.SelectMany(AllMethods)
+            .Where(m => m.Body.Instructions.Any(i =>
+                i.OpCode == OpCodes.Ldstr && i.Operand is string s && s.Contains("[instrumentation-counters]")))
+            .ToArray();
+        Assert.True(dumpMethods.Length == 1,
+            $"expected one method to print [instrumentation-counters], found {dumpMethods.Length}: "
+            + string.Join(", ", dumpMethods.Select(m => m.FullName)));
+        var all = dumpMethods[0].Body.Instructions;
+        // Top-level statements compile into one very large method that elsewhere enables
+        // coverage and collects it for --coverage; bound the scan to the dump block itself,
+        // from the env-var literal to the WriteLine after the line's own literal.
+        int start = all.Select((i, n) => (i, n)).First(x =>
+            x.i.OpCode == OpCodes.Ldstr && (string)x.i.Operand == "AL_RUNNER_DUMP_INSTRUMENTATION_COUNTERS").n;
+        int lineAt = all.Select((i, n) => (i, n)).First(x =>
+            x.i.OpCode == OpCodes.Ldstr && ((string)x.i.Operand).Contains("[instrumentation-counters]")).n;
+        int end = all.Select((i, n) => (i, n)).First(x => x.n > lineAt
+            && x.i.Operand is MethodReference { Name: "WriteLine" }).n;
+        Assert.True(start < lineAt && lineAt < end, $"dump block not bounded: {start} < {lineAt} < {end}");
+        var body = all.Skip(start).Take(end - start + 1).ToArray();
+
+        Assert.Equal(DumpLineSubsystems.Length, body.Count(IsCountPairRead));
+
+        var otherTouches = body
+            .Where(i => i.Operand is MemberReference { DeclaringType: not null } mr
+                        && DumpLineSubsystems.Contains(mr.DeclaringType.FullName)
+                        && mr.Name != "Counts")
+            .Select(i => $"{i.OpCode} {((MemberReference)i.Operand).FullName}")
+            .Distinct()
+            .ToArray();
+        Assert.True(otherTouches.Length == 0,
+            "the dump line reads instrumentation state other than through Counts.Read(): "
+            + string.Join("; ", otherTouches) + " (#3169 — a second load can contradict the first)");
+    }
+
+    /// <summary>The three subsystems hold no standalone integer counter: the pair is the only
+    /// tally, so there is nothing a future dump-line edit could print next to it from a
+    /// separate load.</summary>
+    [Fact]
+    public void NoDumpLineSubsystem_KeepsAStandaloneIntegerCounter()
+    {
+        using var asm = Assembly();
+        var strays = DumpLineSubsystems
+            .Select(n => asm.MainModule.GetType(n)!)
+            .SelectMany(t => t.Fields.Where(f => f.IsStatic
+                && (f.FieldType.FullName == typeof(long).FullName || f.FieldType.FullName == typeof(int).FullName)
+                && f.Name.Contains("Count", StringComparison.Ordinal)))
+            .Select(f => f.FullName)
+            .ToArray();
+        Assert.True(strays.Length == 0,
+            "standalone counter field(s) next to the CountPair: " + string.Join(", ", strays));
+    }
+
+    /// <summary>Site 1's read half: SnapshotCounters loads exactly one field of the listener
+    /// and it is the CountPair. The code this replaced loaded two int fields.</summary>
+    [Fact]
+    public void SnapshotCounters_LoadsTheListenerStateExactlyOnce()
+    {
+        using var asm = Assembly();
+        var listener = asm.MainModule.GetType(typeof(EventPipeJitListener).FullName);
+        Assert.True(listener != null);
+        var snapshot = listener!.Methods.Single(m => m.Name == nameof(EventPipeJitListener.SnapshotCounters));
+        var loads = snapshot.Body.Instructions
+            .Where(i => (i.OpCode == OpCodes.Ldfld || i.OpCode == OpCodes.Ldflda) && i.Operand is FieldReference)
+            .Select(i => (FieldReference)i.Operand)
+            .ToArray();
+        Assert.Single(loads);
+        Assert.Equal(typeof(CountPair).FullName, loads[0].FieldType.FullName);
+        Assert.Equal(1, snapshot.Body.Instructions.Count(IsCountPairRead));
+    }
+}

--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -706,10 +706,10 @@ public static partial class BcRuntime
             {
                 var jl = JitListener;
                 if (jl == null) return;
-                jl.SnapshotCounters();
+                var counts = jl.SnapshotCounters();
                 Console.Error.WriteLine($"[Spike4] === EventPipe DryRun summary ===");
-                Console.Error.WriteLine($"[Spike4] Total MethodLoad events: {jl.TotalMethodLoadEvents}");
-                Console.Error.WriteLine($"[Spike4] BC MethodLoad events:    {jl.BcMethodLoadEvents}");
+                Console.Error.WriteLine($"[Spike4] Total MethodLoad events: {counts.Total}");
+                Console.Error.WriteLine($"[Spike4] BC MethodLoad events:    {counts.Bc}");
                 int i = 0;
                 foreach (var s in jl.DryBcSamples)
                 {

--- a/AlRunner/Infrastructure/AlCoverageTracker.cs
+++ b/AlRunner/Infrastructure/AlCoverageTracker.cs
@@ -55,7 +55,11 @@ public static class AlCoverageTracker
         string, System.Collections.Concurrent.ConcurrentDictionary<(Type ScopeType, int Stmt), int>> _perTestHits = new();
 
     /// <summary>Reset between coverage collections (tests). Exposed for test isolation.</summary>
-    public static void Reset() => _hits.Clear();
+    public static void Reset()
+    {
+        _hits.Clear();
+        Counts.ClearPart();
+    }
 
     /// <summary>Reset between per-test coverage collections — the per-test analogue of
     /// <see cref="Reset"/>, kept SEPARATE so a caller that only wants aggregate
@@ -77,20 +81,16 @@ public static class AlCoverageTracker
     public static void EndTest() => _currentTestKey = null;
 
     /// <summary>
-    /// Issue #2481's behavioural regression gate: incremented UNCONDITIONALLY, first
-    /// thing, on every call — proving the Cecil-rewritten call site actually fires on
-    /// every AL statement, independent of <see cref="Enabled"/>. Paired with <see
-    /// cref="HasRecordedAnyHits"/> (which stays false whenever <see cref="Enabled"/>
-    /// stays false): a plain run must show <c>CallCount &gt; 0</c> (the hook fired) AND
-    /// <c>HasRecordedAnyHits == false</c> (it did no bookkeeping work) — see
+    /// Issue #2481's behavioural regression gate. <c>Total</c> is incremented UNCONDITIONALLY,
+    /// first thing, on every call — proving the Cecil-rewritten call site actually fires on
+    /// every AL statement, independent of <see cref="Enabled"/>. <c>Part</c> counts entries
+    /// recorded into <see cref="_hits"/> and stays zero whenever <see cref="Enabled"/> stays
+    /// false: a plain run must show <c>Total &gt; 0</c> (the hook fired) AND <c>Part == 0</c>
+    /// (it did no bookkeeping work). One value, not a counter plus a dictionary read, so the
+    /// dump line reports a pair that existed (#3169). See
     /// AlRunner.Tests/PlainRunInstrumentationGateTests.cs.
     /// </summary>
-    internal static long CallCount;
-
-    /// <summary>True once <see cref="_hits"/> has recorded at least one entry — i.e. real
-    /// coverage bookkeeping actually happened. Stays false for the lifetime of a process
-    /// that never sets <see cref="Enabled"/>, however many statements ran.</summary>
-    internal static bool HasRecordedAnyHits => !_hits.IsEmpty;
+    internal static readonly CountPair Counts = new();
 
     /// <summary>
     /// Hook target for the Cecil-rewritten NavMethodScope.StmtHit(int). Public static,
@@ -107,7 +107,7 @@ public static class AlCoverageTracker
     /// </summary>
     public static void OnStmtHit(NavMethodScope scope, int currentStatementNumber)
     {
-        System.Threading.Interlocked.Increment(ref CallCount);
+        Counts.IncrementTotal();
         AlCurrentStatement.Update(scope, currentStatementNumber);
         var observed = AlValueCapture.OnStmtHit(scope, currentStatementNumber);
         // NavMethodScope.ExitStatementNumber (int.MaxValue) is written directly by
@@ -119,7 +119,10 @@ public static class AlCoverageTracker
         if (AlIterationTracker.Enabled)
             AlIterationTracker.OnStmtHit(scope, currentStatementNumber, observed);
         if (Enabled)
+        {
             _hits.AddOrUpdate((scope.GetType(), currentStatementNumber), 1, static (_, c) => c + 1);
+            Counts.IncrementPart();
+        }
         // #2135: per-test attribution — a SEPARATE flag/dictionary from the aggregate
         // one above, so the two opt-ins are priced independently (see PerTestEnabled's
         // doc comment). _currentTestKey is null outside any test's window (e.g. the

--- a/AlRunner/Infrastructure/AlDapSession.cs
+++ b/AlRunner/Infrastructure/AlDapSession.cs
@@ -275,17 +275,14 @@ public static class AlDapSession
         _pauseGate?.Release();
     }
 
-    /// <summary>Issue #2481's behavioural regression gate: incremented UNCONDITIONALLY,
-    /// first thing, proving the Cecil-rewritten call site fires on every AL statement
-    /// regardless of <see cref="Enabled"/>.</summary>
-    internal static long CallCount;
-
-    /// <summary>Incremented only once execution passes the <c>!Enabled || _detached</c>
-    /// gate above — i.e. only when this call actually did breakpoint/step evaluation
-    /// work (took <see cref="_bpLock"/>, walked the step-depth chain, …). Stays zero for
-    /// the lifetime of a process that never had an active --dap session, however many
-    /// statements ran. See AlRunner.Tests/PlainRunInstrumentationGateTests.cs.</summary>
-    internal static long WorkPerformedCount;
+    /// <summary>Issue #2481's behavioural regression gate. <c>Total</c> is incremented
+    /// UNCONDITIONALLY, first thing, proving the Cecil-rewritten call site fires on every AL
+    /// statement regardless of <see cref="Enabled"/>; <c>Part</c> only once execution passes
+    /// the <c>!Enabled || _detached</c> gate, i.e. when this call actually did breakpoint/step
+    /// evaluation work, and stays zero for a process that never had an active --dap session.
+    /// One value, not two fields, so the dump line reports a pair that existed (#3169). See
+    /// AlRunner.Tests/PlainRunInstrumentationGateTests.cs.</summary>
+    internal static readonly CountPair Counts = new();
 
     /// <summary>
     /// Hook target for the Cecil-rewritten NavMethodScope.StmtHit(int)/CStmtHit(int[,
@@ -297,9 +294,9 @@ public static class AlDapSession
     /// </summary>
     public static void OnStmtHit(NavMethodScope scope, int currentStatementNumber)
     {
-        System.Threading.Interlocked.Increment(ref CallCount);
+        Counts.IncrementTotal();
         if (!Enabled || _detached) return;
-        System.Threading.Interlocked.Increment(ref WorkPerformedCount);
+        Counts.IncrementPart();
         // Same ExitStatementNumber guard as AlCoverageTracker.OnStmtHit — Exit() writes
         // int.MaxValue directly, StmtHit never receives it from generated code.
         if (currentStatementNumber == int.MaxValue) return;

--- a/AlRunner/Infrastructure/AlValueCapture.cs
+++ b/AlRunner/Infrastructure/AlValueCapture.cs
@@ -97,6 +97,7 @@ public static class AlValueCapture
     {
         _series = new List<AlCapturedValue>();
         _frames.Clear();
+        Counts.ClearPart();
     }
 
     /// <summary>Every value change observed since the last Reset(), in execution order —
@@ -108,13 +109,15 @@ public static class AlValueCapture
         _series ?? (IReadOnlyList<AlCapturedValue>)Array.Empty<AlCapturedValue>();
 
     /// <summary>
-    /// Issue #2481's behavioural regression gate: incremented UNCONDITIONALLY, first
-    /// thing in <see cref="OnStmtHit"/>/<see cref="OnExit"/>, proving those Cecil-
-    /// rewritten call sites fire regardless of <see cref="Enabled"/>. Paired with
-    /// <see cref="Collect"/>'s emptiness (which stays empty whenever <see
-    /// cref="Enabled"/> stays false) — see AlRunner.Tests/PlainRunInstrumentationGateTests.cs.
+    /// Issue #2481's behavioural regression gate. <c>Total</c> is incremented UNCONDITIONALLY,
+    /// first thing in <see cref="OnStmtHit"/>/<see cref="OnExit"/>, proving those Cecil-
+    /// rewritten call sites fire regardless of <see cref="Enabled"/>; <c>Part</c> is the number
+    /// of records appended to the series, bumped at both append sites, and stays zero whenever
+    /// <see cref="Enabled"/> stays false. One value, not a counter plus a list read, so the
+    /// dump line reports a pair that existed (#3169). See
+    /// AlRunner.Tests/PlainRunInstrumentationGateTests.cs.
     /// </summary>
-    internal static long CallCount;
+    internal static readonly CountPair Counts = new();
 
     /// <summary>
     /// Feeds the per-execution series from BC's own StmtHit(N) — called from
@@ -140,7 +143,7 @@ public static class AlValueCapture
     /// </summary>
     public static IReadOnlyList<AlCapturedValue> OnStmtHit(NavMethodScope scope, int currentStatementNumber)
     {
-        System.Threading.Interlocked.Increment(ref CallCount);
+        Counts.IncrementTotal();
         if (!Enabled) return Array.Empty<AlCapturedValue>();
         if (!scope.IsTopLevelCall) return Array.Empty<AlCapturedValue>();
         // NavMethodScope.ExitStatementNumber (int.MaxValue) is written directly by
@@ -174,7 +177,11 @@ public static class AlValueCapture
             changed = DiffAndUpdate(scopeName, previous, fields, state.LastKnown, isBaseline,
                 isBaseline ? null : AssignedBetween(syntax, previous, currentStatementNumber));
         }
-        if (changed.Count > 0) (_series ??= new List<AlCapturedValue>()).AddRange(changed);
+        if (changed.Count > 0)
+        {
+            (_series ??= new List<AlCapturedValue>()).AddRange(changed);
+            Counts.Add(0, changed.Count);
+        }
         state.LastStatementId = currentStatementNumber;
         return changed;
     }
@@ -195,7 +202,7 @@ public static class AlValueCapture
     /// </summary>
     public static void OnExit(NavMethodScope scope)
     {
-        System.Threading.Interlocked.Increment(ref CallCount);
+        Counts.IncrementTotal();
         // #2056: every scope exit also ends its open loop instances (AlIterationTracker
         // self-gates), so this must run even when captureValues is off.
         IReadOnlyList<AlCapturedValue> changed = Array.Empty<AlCapturedValue>();
@@ -216,7 +223,11 @@ public static class AlValueCapture
             var assigned = AlScopeSyntaxResolver.Resolve(scope.GetType())?.Writes.TargetsOf(statementId);
 
             changed = DiffAndUpdate(scopeName, statementId, NamedFields(scope), lastKnown, isBaseline: false, assigned);
-            if (changed.Count > 0) (_series ??= new List<AlCapturedValue>()).AddRange(changed);
+            if (changed.Count > 0)
+            {
+                (_series ??= new List<AlCapturedValue>()).AddRange(changed);
+                Counts.Add(0, changed.Count);
+            }
         }
         AlIterationTracker.OnScopeExit(scope, changed);
     }

--- a/AlRunner/Infrastructure/CountPair.cs
+++ b/AlRunner/Infrastructure/CountPair.cs
@@ -1,0 +1,36 @@
+namespace AlRunner.Infrastructure;
+
+/// <summary>
+/// Two counters that are always reported together and where <c>Part</c> can never exceed
+/// <c>Total</c> — calls made / calls that did work, MethodLoad events / BC MethodLoad events.
+/// Both halves live in one <see cref="long"/> (Total high 32 bits, Part low 32), so every
+/// write is a single Interlocked op and <see cref="Read"/> is a single load: the pair it
+/// returns existed at one instant, which two separate loads of two separate counters cannot
+/// promise (#3169, the #3025 shape). No lock: readers run on a ProcessExit handler and the
+/// JIT callback thread; writers run on every AL statement. Each half wraps at 2^32 — these
+/// are diagnostics, not meters.
+/// </summary>
+internal sealed class CountPair
+{
+    private const int Shift = 32;
+    private const long PartMask = 0xFFFFFFFFL;
+
+    private long _packed;
+
+    public readonly record struct Snapshot(long Total, long Part);
+
+    public Snapshot IncrementTotal() => Add(1, 0);
+    public Snapshot IncrementPart() => Add(0, 1);
+
+    /// <summary>One atomic add to both halves, so a caller that must bump Total and Part for
+    /// the same event publishes them together rather than one after the other.</summary>
+    public Snapshot Add(long total, long part)
+        => Unpack(Interlocked.Add(ref _packed, (total << Shift) | (part & PartMask)));
+
+    public void ClearPart() => Interlocked.And(ref _packed, ~PartMask);
+
+    public Snapshot Read() => Unpack(Volatile.Read(ref _packed));
+
+    private static Snapshot Unpack(long packed)
+        => new((packed >> Shift) & PartMask, packed & PartMask);
+}

--- a/AlRunner/Patches/EventPipeJitListener.cs
+++ b/AlRunner/Patches/EventPipeJitListener.cs
@@ -76,8 +76,6 @@ public sealed class EventPipeJitListener : EventListener
     private readonly List<(string TypeFqn, string MethodName, MethodInfo Replacement, MethodBase? Original)> _targets = new();
 
     // Diagnostics
-    public int TotalMethodLoadEvents   { get; private set; }
-    public int BcMethodLoadEvents      { get; private set; }
     public bool BcEventsObserved       { get; private set; } = false;
     private readonly object _lock = new();
 
@@ -160,13 +158,10 @@ public sealed class EventPipeJitListener : EventListener
 
             if (methodNamespace == null || methodName == null) return;
 
-            // Count total and BC-specific events
-            Interlocked.Increment(ref _rawTotalMethodLoadEvents);
-
             bool isBc = methodNamespace.StartsWith("Microsoft.Dynamics.Nav", StringComparison.Ordinal);
+            long bcCount = CountMethodLoad(isBc).Bc;
             if (isBc)
             {
-                int bcCount = Interlocked.Increment(ref _rawBcEvents);
                 BcEventsObserved = true;
 
                 if (dry)
@@ -314,14 +309,25 @@ public sealed class EventPipeJitListener : EventListener
 
     // Shared atomic counters (writable from any thread via Interlocked)
     private int _rawTotalEvents;
-    private int _rawTotalMethodLoadEvents;
-    private int _rawBcEvents;
+    // Total and BC MethodLoad events as ONE value (#3169): the JIT callback thread is still
+    // live when the ProcessExit handler reads them, and two loads could report Bc > Total.
+    private readonly AlRunner.Infrastructure.CountPair _methodLoads = new();
 
-    // Snapshot for public properties (called from test runner thread after warm-up)
-    public void SnapshotCounters()
+    public readonly record struct MethodLoadCounts(long Total, long Bc);
+
+    /// <summary>One atomic add for both halves; extracted so the tally can be driven without
+    /// a live EventPipe session.</summary>
+    internal MethodLoadCounts CountMethodLoad(bool isBc)
     {
-        TotalMethodLoadEvents = _rawTotalMethodLoadEvents;
-        BcMethodLoadEvents    = _rawBcEvents;
+        var s = _methodLoads.Add(1, isBc ? 1 : 0);
+        return new(s.Total, s.Part);
+    }
+
+    /// <summary>The pair as it stood at one instant — one load, never two.</summary>
+    public MethodLoadCounts SnapshotCounters()
+    {
+        var s = _methodLoads.Read();
+        return new(s.Total, s.Part);
     }
 
     // ── Compiled-body JMP patch ────────────────────────────────────────────────

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -4358,17 +4358,21 @@ if (coverageEnabled)
 // fired on every statement, but did zero bookkeeping work" for a plain run. Never
 // printed on a normal run: opt-in via an undocumented env var, not a CLI flag, because
 // this exists for AlRunner.Tests/PlainRunInstrumentationGateTests.cs only. Computing
-// and printing four longs/bools costs nothing worth gating further.
+// and printing four longs/bools costs nothing worth gating further. Each pair is ONE read
+// (#3169): two loads could print WorkPerformedCount > CallCount, a state that never existed.
 if (Environment.GetEnvironmentVariable("AL_RUNNER_DUMP_INSTRUMENTATION_COUNTERS") == "1")
 {
+    var coverage = AlRunner.Infrastructure.AlCoverageTracker.Counts.Read();
+    var captureValues = AlRunner.Infrastructure.AlValueCapture.Counts.Read();
+    var dap = AlRunner.Infrastructure.AlDapSession.Counts.Read();
     Console.Error.WriteLine(
         "[instrumentation-counters] " +
-        $"coverage.CallCount={AlRunner.Infrastructure.AlCoverageTracker.CallCount} " +
-        $"coverage.HasRecordedAnyHits={AlRunner.Infrastructure.AlCoverageTracker.HasRecordedAnyHits} " +
-        $"captureValues.CallCount={AlRunner.Infrastructure.AlValueCapture.CallCount} " +
-        $"captureValues.CollectedCount={AlRunner.Infrastructure.AlValueCapture.Collect().Count} " +
-        $"dap.CallCount={AlRunner.Infrastructure.AlDapSession.CallCount} " +
-        $"dap.WorkPerformedCount={AlRunner.Infrastructure.AlDapSession.WorkPerformedCount}");
+        $"coverage.CallCount={coverage.Total} " +
+        $"coverage.HasRecordedAnyHits={coverage.Part > 0} " +
+        $"captureValues.CallCount={captureValues.Total} " +
+        $"captureValues.CollectedCount={captureValues.Part} " +
+        $"dap.CallCount={dap.Total} " +
+        $"dap.WorkPerformedCount={dap.Part}");
 }
 
 // #2704 second layer: if a BC-internal path realized NavEnvironment's lazy ExecutionScheduler


### PR DESCRIPTION
Closes #3169

## Both sites had the shape, and both reproduced

The issue extends the shape PR #3170 fixed for the `--test-data` summary: a diagnostic that prints several counters read one at a time, while another thread is still incrementing them, can print a combination that never existed. Here each pair has a hard invariant — the second number is a subset of the first — so an inversion is impossible at any single instant and possible from two loads.

- **`EventPipeJitListener.SnapshotCounters()`** — two plain loads of two `Interlocked` ints. The Spike4 `ProcessExit` handler reads them while the EventPipe callback thread is still live.
- **The `AL_RUNNER_DUMP_INSTRUMENTATION_COUNTERS` line** — three pairs from three subsystems, each assembled from separate loads: `dap` from two `long` counters, `coverage` from a counter plus `_hits.IsEmpty`, `captureValues` from a counter plus `Collect().Count`.

I did not take the premise on trust. A hammer (writers bumping the pair, a reader taking snapshots for 1.5 s) against the pre-fix code, driven through the real code paths — `CountMethodLoad` (extracted, same body) and the real `AlDapSession.OnStmtHit` — inverted on the first run of each:

```
MethodLoadTallies: 163 of 511,095 snapshots reported more BC MethodLoad events than MethodLoad events in total
DapCounters:    56,845 of 1,937,753 snapshots reported WorkPerformedCount > CallCount
```

About 3% of dap snapshots were impossible states. The issue called this "the least likely of the three to bite"; measured, it bites on every run.

## GREEN

`AlRunner/Infrastructure/CountPair.cs`: both halves of a pair live in one `long` (Total high 32 bits, Part low 32). Every write is one `Interlocked.Add`, and when one event must bump both halves — a BC MethodLoad — it is *one* add, so there is no intermediate state where only Total moved. `Read()` is one `Volatile.Read`, so the pair it returns existed at one instant. No lock, no allocation on the per-statement path — readers run on a `ProcessExit` handler and the JIT callback path, writers on every AL statement.

All four pairs moved onto it: the listener's `(Total, Bc)`, and `AlDapSession`, `AlCoverageTracker`, `AlValueCapture`'s `Counts`. The dump line reads each `Counts` once. `SnapshotCounters()` returns a `MethodLoadCounts` record from one load instead of publishing two properties from two loads; `BcRuntime` is the only caller and is updated.

For `coverage` and `captureValues` the "work" half was previously *derived* from a collection (`_hits.IsEmpty`, `Collect().Count`), which cannot be packed. Both now count at the write site — one `IncrementPart()` next to `_hits.AddOrUpdate`, one `Add(0, changed.Count)` at each of the two `_series` append sites — and `Reset()` clears the Part half with `Interlocked.And`. The printed values mean the same thing (`HasRecordedAnyHits` is `Part > 0`; `CollectedCount` is the number of records appended since the last reset); `Collect()` itself is untouched, it is a public API and not a diagnostic.

**One deliberate limit, stated:** each half wraps at 2^32 — a departure from the previous `long` counters. An immutable record swapped by CompareExchange, #3170's mechanism, would allocate on every AL statement, which is not acceptable on that path; a packed long is the only allocation-free single-word representation. These are diagnostics read by one test, and 4.29 billion statements in one process is the wrap point. The type's doc comment says so in one line.

## Mutation evidence

With the fix in place, `CountPair` was mutated back to the pre-fix shape — two fields, two `Interlocked` ops in `Add`, two loads in `Read` — leaving every call site and every IL guard untouched. All three behavioural tests failed:

```
CountPair_ReadNeverReportsPartAboveTotal:       467 of 3,627,946 reads reported Part > Total
MethodLoadTallies_...:                            10 of 1,831,662 snapshots inverted
DapCounters_NeverReportMoreWorkThanCalls:         43 of 4,492,105 snapshots inverted
```

Restored, rebuilt: 7/7. The IL guards were unaffected by that mutation by construction; their teeth were shown the other way, against the pre-fix code, where `TheDumpLine_ReadsEachPairExactlyOnceAndNothingElse` and `SnapshotCounters_LoadsTheListenerStateExactlyOnce` both fail (0 `CountPair.Read` calls; two int-field loads).

## The tests, and what each one claims

`AlRunner.Tests/InstrumentationCounterPairSnapshotTests.cs`:

- Three hammers (the mechanism, site 1, site 2's `dap` pair through the real `OnStmtHit`). Hammers, not forced interleavings — there is no seam to pin one; the file says so. Green is a proof because after the fix a snapshot is one load and there is no interleaving left to hit.
- `CountPair_AddPublishesBothHalvesTogether` — exact post-add values, so the `bcCount <= MaxVerboseLog` cap in the JIT callback reads the count it just produced.
- `TheDumpLine_ReadsEachPairExactlyOnceAndNothingElse` — bounded to the dump block inside `<Main>$` (from the env-var literal to the `WriteLine` after the line's literal, because that method also legitimately enables and collects coverage elsewhere): exactly three `CountPair.Read`, and no other member of the three types touched.
- `NoDumpLineSubsystem_KeepsAStandaloneIntegerCounter` — the pair is the only tally, so nothing exists for a future edit to print from a separate load.
- `SnapshotCounters_LoadsTheListenerStateExactlyOnce`.

The `coverage` and `captureValues` pairs are not hammered at the site: `AlCoverageTracker.OnStmtHit` dereferences the scope before recording a hit, and a `NavMethodScope` cannot be constructed without BC state. They ride the mechanism test plus the IL guards, which pin that their dump-line read is a single `CountPair.Read`.

## Fixing the shape, not the reported line

**Same wrong pattern at another call site?** I scanned `AlRunner/` for every remaining `*Count*` static read alongside another. `RecordPatches.cs:568`'s `[parse-counts]` line prints `ParseObjectTextCallCount - _diagBefore` — a single-thread before/after delta of *one* counter, no second number to skew against. Not the shape. Nothing else found.

**Sibling function with the same assumption?** `EventPipeJitListener._rawTotalEvents` is incremented and never read, and `TestDataProvisioner.DeferredLoadsWrittenOff` was already left standalone by #3170 for the same reason: neither is read alongside anything, so neither has a set to skew.

**Two paths writing the same state?** `Reset()` in both `AlCoverageTracker` and `AlValueCapture` cleared the collection but would have left a packed Part half standing; both now clear it in the same call. That was not in the issue.

**Open-issue queue:** searched for counter/snapshot/diagnostic issues; none lands in these files.

## Does any of this assert BC behaviour?

No. Every claim is about the internal consistency of the runner's own diagnostics — how many loads a snapshot takes and whether the pair it prints existed. Nothing here would be a meaningful statement about AL or Business Central if AL Runner did not exist, so per `.claude/rules/bc-behavior-tests-go-upstream.md` the tests are C# in `AlRunner.Tests` and no corpus PR is owed. No submodule pin is touched.

Corpus-NA: runner-internal diagnostic consistency, no BC behaviour asserted.

## Tests run

- `InstrumentationCounterPairSnapshotTests` — 2/2 RED on the pre-fix code; 7/7 GREEN; 3/7 failing under the mutation; 7/7 restored.
- `--filter "~AlValueCapture|~InstrumentationCounterPair|~PlainRunInstrumentation|~AlStatementTable"` — **43 passed, 0 failed** (17 s). `PlainRunInstrumentationGateTests` spawns the runner and parses the dump line, so the printed format is proven unchanged.

No output format changed, so no `README.md`, `PrintGuide()`, `docs/limitations.md` or `docs/scope.md` update is due. `docs/`, `.claude/` and `.github/` were swept for the renamed members: no references.

---
Opened by `stma-auto-29`, an automated implementation agent acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9pEPoD8e4wmVyuTrxyuh
