### PR TITLE
fix(testpage): classify the refused-close refusal as the gap it is, so a TryFunction cannot swallow it

### DIFF
--- a/AlRunner.Tests/RunnerFormCloseHandlerTests.cs
+++ b/AlRunner.Tests/RunnerFormCloseHandlerTests.cs
@@ -13,6 +13,7 @@
 //   branch into "show a message" would look identical to it while quietly rewriting the
 //   envelope of a connection loss, a missing UI handler, or a runner-internal failure.
 using System;
+using AlRunner;
 using AlRunner.Infrastructure;
 using AlRunner.Patches;
 using Microsoft.Dynamics.Nav.Types;
@@ -131,5 +132,64 @@ public class RunnerFormCloseHandlerTests
 
         Assert.Same(original, thrown);
         Assert.Null(probe.Seen);
+    }
+    // ── The refusal's CLASSIFICATION, not its text (#3179) ───────────────────────────────
+    //
+    // RunnerOutOfScopeException carries two kinds of refusal, and which kind decides whether an
+    // AL [TryFunction] may swallow it (ApplicationObjectBasePatches.IsPermanentOutOfScope):
+    //
+    //   permanent ("SMTP does not exist here")  -> TryInvoke returns false, matching a real BC
+    //                                              environment that also lacks the surface
+    //   "not-yet-implemented" (an in-scope gap) -> tears through, so a gap can never read green
+    //
+    // The test is a STRING PREFIX on the reason, so a gap whose reason merely says
+    // not-implemented in prose is classified permanent and silently swallowed. That is the
+    // defect issue #2966 was filed and closed for; this surface is a later instance of it,
+    // introduced with the close handler itself in #3057 and therefore not covered by that sweep.
+    //
+    // A page whose close BC refuses IS in scope -- #3179 is open and tracks building it -- so
+    // the refusal must tear through a [TryFunction], not become `false`.
+
+    [Fact]
+    public void CloseRefusedAfterMessage_IsClassifiedAsAnInScopeGap_NotAPermanentRefusal()
+    {
+        var probe = new FakeTestExecution(handled: true);
+
+        var oos = Assert.Throws<RunnerOutOfScopeException>(() =>
+            RunnerFormCloseHandler.RefuseCloseAfter(new NavNCLDialogException("boom"), probe));
+
+        // The prefix IS the classification. Asserting the surface name too, so a rewording that
+        // kept the prefix but lost the surface still fails here.
+        Assert.StartsWith("not-yet-implemented", oos.Reason, StringComparison.Ordinal);
+        Assert.Contains("testpage-close-refused-after-message", oos.Reason, StringComparison.Ordinal);
+    }
+
+    // The property the classification exists to produce, asserted through the real decision
+    // point rather than by re-reading the string: a [TryFunction] must NOT swallow this refusal.
+    [Fact]
+    public void CloseRefusedAfterMessage_TearsThroughATryFunction()
+    {
+        var probe = new FakeTestExecution(handled: true);
+
+        var oos = Assert.Throws<RunnerOutOfScopeException>(() =>
+            BcRuntime.NavApplicationObjectBase_TryInvoke(
+                null,
+                () => RunnerFormCloseHandler.RefuseCloseAfter(new NavNCLDialogException("boom"), probe)));
+
+        Assert.Contains("testpage-close-refused-after-message", oos.Reason, StringComparison.Ordinal);
+    }
+
+    // Negative control for the pair above, and the reason they are two tests rather than one:
+    // a genuinely permanent refusal must still be trapped into `false`. An "everything tears
+    // through" change would pass both tests above and fail this one.
+    [Fact]
+    public void APermanentRefusal_IsStillTrappedByATryFunction()
+    {
+        var trapped = BcRuntime.NavApplicationObjectBase_TryInvoke(
+            null,
+            () => throw new RunnerOutOfScopeException(
+                "NavEmail.Send", "email-smtp — see docs/scope.md#email", "email"));
+
+        Assert.False(trapped);
     }
 }

--- a/AlRunner.Tests/SourceFilesAreSearchableGuardTests.cs
+++ b/AlRunner.Tests/SourceFilesAreSearchableGuardTests.cs
@@ -1,0 +1,132 @@
+// SourceFilesAreSearchableGuardTests — issue #3179.
+//
+// A raw NUL byte in a .cs file makes it read as BINARY to file(1) and to ripgrep, and ripgrep
+// then SKIPS it. Not "reports it differently" — skips it, silently, so a search across the tree
+// comes back with no match rather than with an error. That is the exact false-negative family
+// CLAUDE.md documents for `grep -E` (rejects the flag, exits 0, prints nothing) and for `rg`
+// without --hidden (skips dot-directories): a failure wearing the costume of a result.
+//
+// It was not hypothetical here. AlRunner/Patches/ApplicationObjectBasePatches.cs carried one, in
+//
+//     if (!_oosTrapReported.TryAdd($"{oos.Api}<NUL>{oos.Reason}", 0)) return;
+//
+// where a literal NUL had been typed instead of the escape \0. The byte is a perfectly
+// reasonable separator and the code was correct — but that file also holds
+// IsPermanentOutOfScope, the method deciding whether an AL [TryFunction] may swallow a runner
+// refusal. So `rg "oos-in-try"` and `rg "IsPermanentOutOfScope"` both returned NOTHING while the
+// logic sat right there, and the only way to find it was `grep -r`, which reported
+// "binary file matches" and no line. Writing it as \0 keeps the identical key and the identical
+// behaviour while leaving the file searchable.
+//
+// WHY A GUARD RATHER THAN JUST THE FIX
+// ------------------------------------
+// The failure is invisible by construction. Nothing about a silently-skipped file appears in a
+// diff, a build log, or a test run — the next literal NUL would restore the blind spot and no
+// one would learn of it until a search came back empty and was believed. A structural fix needs
+// a structural test (the same reasoning BracelessIfSecondStatementGuardTests sets out), so this
+// asserts the property directly against the tree.
+//
+// THE DETECTOR IS HELD HONEST TOO
+// -------------------------------
+// A scanner that quietly stops matching passes forever and guards nothing. So the detector is
+// tested in both directions before it is trusted: fed content that must trip it, and content
+// that must not — including the escape sequence \0 spelled as source text, which is the whole
+// point of the fix and must never be flagged.
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class SourceFilesAreSearchableGuardTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    /// <summary>
+    /// The property ripgrep actually applies: a NUL byte anywhere in the file makes it binary.
+    /// Deliberately not "is it valid UTF-8" — a file can be valid UTF-8 and still be skipped,
+    /// which is exactly what happened, so testing the encoding would have missed it.
+    /// </summary>
+    private static bool ReadsAsBinaryToRipgrep(byte[] content) => Array.IndexOf(content, (byte)0) >= 0;
+
+    // ── Negative: the detector must fire on the shape, and only on it ──
+
+    [Fact]
+    public void Detector_FiresOnALiteralNul_AndNotOnTheEscapeSequence()
+    {
+        // The bug: a real NUL byte in the file.
+        var withLiteralNul = "var k = $\"{a}\0{b}\";"u8.ToArray();
+        Assert.True(ReadsAsBinaryToRipgrep(withLiteralNul),
+            "a literal NUL byte must be detected — that is the whole failure mode");
+
+        // The fix: the same key written as a two-character escape. Must NOT be flagged, otherwise
+        // the guard would forbid its own remedy.
+        var withEscape = "var k = $\"{a}\\0{b}\";"u8.ToArray();
+        Assert.False(ReadsAsBinaryToRipgrep(withEscape),
+            "the \\0 escape is ordinary source text and must never be flagged");
+
+        // Near misses that must stay clean: other control characters and non-ASCII text do not
+        // make ripgrep skip a file, so flagging them would be a false positive.
+        Assert.False(ReadsAsBinaryToRipgrep("tab\there\r\nnewline"u8.ToArray()));
+        Assert.False(ReadsAsBinaryToRipgrep("em dash — and \"smart quotes\""u8.ToArray()));
+    }
+
+    // ── Positive: the tree itself is clean ──
+
+    [Fact]
+    public void CSharpSources_AreAllSearchable_NoneReadAsBinary()
+    {
+        var offenders = SourceFiles()
+            .Where(f => ReadsAsBinaryToRipgrep(File.ReadAllBytes(f)))
+            .Select(f => Path.GetRelativePath(RepoRoot, f))
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(offenders.Count == 0,
+            "these .cs files contain a literal NUL byte, so ripgrep SKIPS them silently and a "
+            + "search across the tree returns a false negative rather than an error. Write the "
+            + "byte as the escape \\0 instead — same value, searchable file:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// The one site this issue fixed, pinned by name. The sweep above would catch a regression
+    /// anywhere; this says out loud which file taught us the lesson, so a reader who reintroduces
+    /// it here gets the history rather than a generic complaint.
+    /// </summary>
+    [Fact]
+    public void TheOutOfScopeClassifier_IsSearchable()
+    {
+        var path = Path.Combine(RepoRoot, "AlRunner", "Patches", "ApplicationObjectBasePatches.cs");
+        Assert.True(File.Exists(path), $"expected the out-of-scope classifier at {path}");
+
+        var bytes = File.ReadAllBytes(path);
+        Assert.False(ReadsAsBinaryToRipgrep(bytes),
+            "ApplicationObjectBasePatches.cs holds IsPermanentOutOfScope, which decides whether "
+            + "an AL [TryFunction] may swallow a runner refusal. A NUL byte here makes every "
+            + "ripgrep search of that logic come back empty — see this file's header.");
+
+        // Guard against a fix that removed the byte by removing the dedup key with it.
+        var text = System.Text.Encoding.UTF8.GetString(bytes);
+        Assert.Contains("_oosTrapReported.TryAdd", text, StringComparison.Ordinal);
+    }
+
+    private static System.Collections.Generic.List<string> SourceFiles()
+    {
+        var files = new[] { "AlRunner", "AlRunner.Tests" }
+            .Select(d => Path.Combine(RepoRoot, d))
+            .Where(Directory.Exists)
+            .SelectMany(d => Directory.EnumerateFiles(d, "*.cs", SearchOption.AllDirectories))
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                     && !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToList();
+
+        // If the walk finds nothing, the guard is vacuous — say so instead of passing.
+        Assert.True(files.Count > 50,
+            $"expected the source tree to hold many .cs files, found {files.Count}");
+        return files;
+    }
+}

--- a/AlRunner/Infrastructure/BackupReaderServe.cs
+++ b/AlRunner/Infrastructure/BackupReaderServe.cs
@@ -230,7 +230,10 @@ internal static class BackupReaderServe
             if (_disabled) return false;
             if (!TryBuildReadRequest(args, _nextId + 1, out var request) || request == null) return false;
 
-            var key = request.Backup + " " + (request.Symbols ?? "");
+            // "\0" as an escape, not a literal NUL byte: written literally it makes this file
+            // read as binary to ripgrep, which then skips it silently -- see
+            // AlRunner.Tests/SourceFilesAreSearchableGuardTests. Same separator, same key.
+            var key = request.Backup + "\0" + (request.Symbols ?? "");
             try
             {
                 if (_sessionKey != key) Start(request.Backup, request.Symbols, key);

--- a/AlRunner/Patches/ApplicationObjectBasePatches.cs
+++ b/AlRunner/Patches/ApplicationObjectBasePatches.cs
@@ -240,7 +240,11 @@ public static partial class BcRuntime
     /// </summary>
     private static void ReportOosTrappedByTryFunction(AlRunner.Infrastructure.RunnerOutOfScopeException oos)
     {
-        if (!_oosTrapReported.TryAdd($"{oos.Api} {oos.Reason}", 0)) return;
+        // The separator is an escape, NOT a literal NUL byte. Written literally it made this
+        // file read as binary to file(1) and to ripgrep, which then SKIPPED it silently --
+        // so a search for the classification logic below came back empty rather than wrong
+        // (the CLAUDE.md false-negative family). Same key, same behaviour, searchable file.
+        if (!_oosTrapReported.TryAdd($"{oos.Api}\0{oos.Reason}", 0)) return;
         Console.Error.WriteLine(
             $"[oos-in-try] {oos.Api} — {oos.Reason} — reached inside an AL [TryFunction]; " +
             $"returning false, which is what real BC does in an environment that also lacks " +

--- a/AlRunner/Patches/RunnerFormCloseHandler.cs
+++ b/AlRunner/Patches/RunnerFormCloseHandler.cs
@@ -121,12 +121,24 @@ internal static class RunnerFormCloseHandler
         // is the same boundary MockTestPage.Close already names for an OnQueryClosePage veto
         // (#2999) — the runner has no model for a page that refuses to close and keeps running.
         // Throwing says so; returning false would let the caller force the page shut and report
-        // a close BC did not perform. Tracked in #3179.
+        // a close BC did not perform.
+        //
+        // The reason MUST start "not-yet-implemented", and the prefix is load-bearing rather
+        // than cosmetic: ApplicationObjectBasePatches.IsPermanentOutOfScope classifies by that
+        // string prefix, and anything else is treated as PERMANENTLY out of scope, which an AL
+        // [TryFunction] then swallows into `false`. This surface is in scope and tracked open in
+        // #3179, so swallowing it would turn the gap into a green test that lies
+        // (.claude/rules/loud-failures.md). It read "testpage-close-refused-after-message …"
+        // until #3179 — the same defect #2966 was filed for, on a site created after that sweep.
+        // docs/limitations.md, not docs/scope.md, for the same reason: this is a gap, not a
+        // permanent boundary.
         throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
             "TestPage page close (OnQueryClosePage)",
-            "testpage-close-refused-after-message — OnQueryClosePage raised an error, a "
-            + "[MessageHandler] consumed it, and BC then leaves the page OPEN. The runner has no "
-            + "model for a page that outlives its own close. See docs/scope.md");
+            "not-yet-implemented — testpage-close-refused-after-message: OnQueryClosePage raised "
+            + "an error, a [MessageHandler] consumed it, and BC then leaves the page OPEN. The "
+            + "runner has no model for a page that outlives its own close. "
+            + "See docs/limitations.md#testpage-shape-gaps",
+            "todo");
     }
 
     private static bool IsNavBaseException(Exception ex)

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1357,8 +1357,11 @@ https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues.
   no `[MessageHandler]` declared the test sees BC's `Unhandled UI: Message …` refusal, exactly
   as a service tier produces it. With a `[MessageHandler]` declared the handler consumes the
   text and control returns to a page real BC has left open, which the runner has no model for;
-  it raises `RunnerOutOfScopeException` with reason `testpage-close-refused-after-message`
-  rather than force the page shut and report a close BC did not perform
+  it raises `RunnerOutOfScopeException` with reason
+  `not-yet-implemented — testpage-close-refused-after-message` rather than force the page shut
+  and report a close BC did not perform. The `not-yet-implemented` prefix is load-bearing: it is
+  what stops an AL `[TryFunction]` from swallowing the refusal into `false`, since this surface
+  is an open gap rather than a permanent boundary
   ([#3057](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3057),
   [#3179](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3179)).
 


### PR DESCRIPTION
Refs #3179 — deliberately NOT `Closes`, see "The scope call" below and the reasoning comment on the issue: this PR fixes a defect found while working #3179 and does not deliver its acceptance criteria, so the issue stays open behind corpus PR #272.

No linked issue: the runner's refusal is a correct scope boundary pending corpus #272; this PR adds the loud-failure fix without closing #3179.

Opened by agent `stma-auto-26`, an automated implementation agent acting on the account holder's behalf.

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/272

## The scope call first, because it decides what this PR is

**The refusal is right and it stays.** #3179 proposes removing `testpage-close-refused-after-message` and reproducing whatever BC does instead. That step is not takeable yet: what a real service tier leaves behind after a `[MessageHandler]` consumes a close-time message has never been measured, and implementing a guess would be exactly the assumption-based fix `no-assumption-fixes.md` forbids. Returning `false` instead would let the caller force the page shut and report a close BC did not perform — the silent divergence `loud-failures.md` exists to prevent. So the refusal keeps standing until the corpus answers, and the corpus PR above is that question.

What was genuinely wrong is not *that* the runner refuses but **how the refusal was classified**, and that is provable today without any BC verdict.

## The defect

`ApplicationObjectBasePatches.IsPermanentOutOfScope` decides whether an AL `[TryFunction]` may swallow a `RunnerOutOfScopeException`, and it decides on a **string prefix**:

```csharp
return oos != null && !oos.Reason.StartsWith("not-yet-implemented", StringComparison.Ordinal);
```

The reason raised here began `testpage-close-refused-after-message` and cited `docs/scope.md`. So an in-scope surface — tracked open in #3179, with work planned — was classified as a **permanent** boundary like SMTP, and a `[TryFunction]` trapped it into `false`. A test touching the surface went green having quietly done without it, which is the failure mode `loud-failures.md` is written to stop.

This is the defect **#2966** was filed and closed for ("a refusal that is really a gap, but whose reason does not start `not-yet-implemented`, gets trapped into `false`"). This site was created *after* that sweep, with the close handler itself in #3057, so it was never covered.

Found by writing the corpus test: the first probe run printed

```
[oos-in-try] TestPage page close (OnQueryClosePage) — testpage-close-refused-after-message …
```

— the runner's own loud line reporting that a `[TryFunction]` had absorbed it.

## RED → GREEN

`AlRunner.Tests/RunnerFormCloseHandlerTests.cs`, three tests added to the existing suite:

| test | RED (before) |
|---|---|
| `CloseRefusedAfterMessage_IsClassifiedAsAnInScopeGap_NotAPermanentRefusal` | `Assert.StartsWith() Failure … String: "testpage-close-refused-after-message — On"···  Expected start: "not-yet-implemented"` |
| `CloseRefusedAfterMessage_TearsThroughATryFunction` | `Assert.Throws() Failure: No exception was thrown` — the TryFunction had swallowed it |
| `APermanentRefusal_IsStillTrappedByATryFunction` | passed before and after — the negative control |

After: **9/9 green** in that class, 18/18 across it plus `TryFunctionOutOfScopeTrapTests` and the new guard.

The third test is why the first two are not enough on their own: a change that made *everything* tear through would satisfy both and break the SMTP-style trap that is genuinely faithful. It fails that change.

### Mutation testing

| mutation | caught by |
|---|---|
| remove only the `not-yet-implemented` prefix, leave the `"todo"` anchor | both new tests (2 failed) |
| keep the prefix, `return false` instead of throwing | 3 tests, including the pre-existing `AlError_IsHandedToTheMessageChannelVerbatim` |
| restore the literal NUL byte | the guard's sweep **and** its named test |

Restored clean and re-verified green after each; the working tree was checked for mutation residue rather than assumed.

## Second finding: two source files ripgrep was silently skipping

`AlRunner/Patches/ApplicationObjectBasePatches.cs` contained a **literal NUL byte** in a dedup key (`$"{oos.Api}<NUL>{oos.Reason}"`) instead of the escape `\0`. The value was correct; the consequence was not. A NUL makes a file read as binary, and **ripgrep skips it entirely** — so `rg "IsPermanentOutOfScope"` and `rg "oos-in-try"` both returned *nothing* while the logic sat in that file. `grep -r` reported only `binary file matches`, with no line.

That is the same silent-false-negative family `CLAUDE.md` documents for `grep -E` and for `rg` without `--hidden`, and it was hiding the exact method this PR is about.

`AlRunner.Tests/SourceFilesAreSearchableGuardTests.cs` pins the property, and its detector is tested in both directions before it is trusted — including that the `\0` escape itself must never be flagged, since that is the remedy.

**The sweep then found a second instance I did not know about**: `AlRunner/Infrastructure/BackupReaderServe.cs`, same shape, same fix. That is the "fix the shape, not the reported line" payoff, and it came from the test rather than from grepping.

## Independent verification of the issue's decompilation

The issue quotes `NavFormCloseHandler.ExecuteCloseCore` from `Client.UI.dll`. Verified directly against BC 28.1 (`ui281`), not taken on faith — the quoted `catch (NavBaseException ex12)` block is **verbatim accurate**, including `return false`.

Two corrections worth recording, neither of which changes the conclusion:

- the namespace is `Microsoft.Dynamics.Nav.Client.UIPatterns`, not what the issue implies;
- the excerpt hides that **eleven** more specific catch clauses precede it, and `NavBaseException` is the family's base type. So "an AL error lands in the last catch" is a claim about none of the earlier ones matching — which the existing `RunnerFormCloseHandler.NotAMessage` list already encodes correctly. `NavTestWrappedException` in particular is caught earlier and **rethrows**.

`NavTestExecution.TestHandleMessage` (Ncl 28.4) was also read: it returns `true` when a handler consumed the text, confirming control does return to the close handler's `return false` — the issue's mechanism is sound.

## The corpus tier can adjudicate this surface

Checked before relying on any corpus verdict, per `ask-the-corpus-before-claiming-bc-behavior.md`. `StartupHook.cs` in `MsDyn365Bc.On.Linux` patches **nothing** on the close or message path: no `NavFormCloseHandler`, no `ExecuteCloseCore`, no `TestPageMessageHelper`, no `ShowMessage`. Patch #21 — the one that blinded a UI surface in #2986 — targets `NavOpenTaskPageAction.ShowForm`, a page-**open** method, and is now a faithful re-implementation rather than a no-op.

## What is deliberately not in this PR

- **Removing the refusal and its `docs/limitations.md` entry.** That is #3179's suggested acceptance step 2, and it needs the corpus verdict first. The issue stays open behind corpus PR #272; this PR does not close that half prematurely.
- **A `known-gaps` expectation entry.** There is no corpus test in the pinned submodule that touches this surface yet, so there is nothing to classify. When #272 merges and the pin is bumped, that bump is the right place for it.

## Files

| file | change |
|---|---|
| `AlRunner/Patches/RunnerFormCloseHandler.cs` | reason prefixed `not-yet-implemented`, `"todo"` anchor, cites `docs/limitations.md#testpage-shape-gaps` (anchor verified to exist) |
| `AlRunner/Patches/ApplicationObjectBasePatches.cs` | literal NUL → `\0` |
| `AlRunner/Infrastructure/BackupReaderServe.cs` | literal NUL → `\0` |
| `AlRunner.Tests/RunnerFormCloseHandlerTests.cs` | 3 tests |
| `AlRunner.Tests/SourceFilesAreSearchableGuardTests.cs` | new guard |
| `docs/limitations.md` | records the new reason and why the prefix is load-bearing |

Comment prose: the only block over ten lines is the header of the new guard test, where the reasoning is the test's subject — everything else went in this PR body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9pEPoD8e4wmVyuTrxyuh
