### PR TITLE
fix(testpage): name a RunObject target in its own object kind's id space, not the page's

### DIFF
--- a/AlRunner/Patches/RecordPatches.AlPageParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlPageParser.cs
@@ -477,6 +477,40 @@ public static partial class RecordPatches
     }
 
     /// <summary>
+    /// <paramref name="objectId"/>'s declared NAME within the object kind
+    /// <paramref name="runObjectKind"/> names — <c>Page</c>, <c>Report</c>, <c>Codeunit</c>,
+    /// <c>XmlPort</c> or <c>Query</c>. Null when this run knows no object of that kind with
+    /// that id.
+    ///
+    /// <para>AL gives every object kind its OWN id namespace, so <c>report 64701</c> and
+    /// <c>page 64701</c> are two different objects that coexist. Resolving an id without
+    /// saying which kind it belongs to therefore answers the wrong object rather than
+    /// nothing, and it does so most often in the message a developer is reading to find out
+    /// what went wrong (#2943).</para>
+    ///
+    /// <para>Kind matching goes through <see cref="NormalizeObjectTypeName"/>, so the
+    /// inventory's <c>"XmlPort"</c> and BC's <c>RunObjectType.XMLport</c> compare equal
+    /// without a second spelling table to keep in step.</para>
+    /// </summary>
+    internal static string? TryGetObjectNameOfKind(string runObjectKind, int objectId)
+    {
+        if (objectId <= 0 || string.IsNullOrWhiteSpace(runObjectKind)) return null;
+
+        // A page keeps its dedicated lookup: it is the one kind with a precompiled-dependency
+        // fallback, which the source inventory below does not carry.
+        var wanted = NormalizeObjectTypeName(runObjectKind);
+        if (wanted == "page") return TryGetAnyPageName(objectId);
+
+        foreach (var (kind, id, name, _) in EnumerateKnownAlObjects())
+            if (id == objectId
+                && !string.IsNullOrEmpty(name)
+                && NormalizeObjectTypeName(kind) == wanted)
+                return name;
+
+        return null;
+    }
+
+    /// <summary>
     /// Control id → source-table field number for every field control on the page, INCLUDING
     /// the ones contributed by pageextensions that extend it.
     /// <para>An extension's controls are keyed in the EXTENSION's own id space, because BC's

--- a/AlRunner/Patches/RunnerPageInstance.ActionRunObject.cs
+++ b/AlRunner/Patches/RunnerPageInstance.ActionRunObject.cs
@@ -617,7 +617,13 @@ internal sealed partial class RunnerPageInstance
         return new ActionRunTarget(
             action.RunObjectType,
             action.TargetID,
-            RecordPatches.TryGetAnyPageName(action.TargetID),
+            // Resolved WITHIN the kind the action declares, not as a page (#2943). AL gives
+            // each object kind its own id namespace, so `report 64701` and `page 64701` are
+            // two different objects at once; a page-only lookup answered the PAGE's name for
+            // a report target, and the refusal below then named an object the AL never
+            // mentioned. Measured: an action declaring `RunObject = report "Prb Decoy Report"`
+            // refused with "RunObject = Report 'Prb Decoy Page' (64701)".
+            RecordPatches.TryGetObjectNameOfKind(action.RunObjectType.ToString(), action.TargetID),
             action.RunPageOnRec,
             LinksFromMetadata(action));
     }

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -67,7 +67,7 @@
         "testpage-lookup-tablerelation-oos": { "tests": 3 },
         "testpage-precompiled-dep-control": { "tests": 2 },
         "testpage-precompiled-member-names": { "tests": 8 },
-        "testpage-promoted-actionref": { "tests": 14 },
+        "testpage-promoted-actionref": { "tests": 18 },
         "testpage-trigger-inject-timing": { "tests": 2 },
         "user-system-table-triggers": { "tests": 10 },
         "user-table-baseapp-subscriber": { "tests": 5 },

--- a/tests/runner-extras/testpage-promoted-actionref/ParDecoyReport.Report.al
+++ b/tests/runner-extras/testpage-promoted-actionref/ParDecoyReport.Report.al
@@ -1,0 +1,31 @@
+/// A report whose id 64547 is ALSO the id of `page 64547 "Par RunObject Target"`.
+///
+/// That collision is the whole point and it is entirely legal: AL gives every object kind its
+/// own id namespace, so a report and a page may share a number and both exist. It is also not
+/// exotic — the runner's own inventory already keeps pages and pageextensions in separate
+/// dictionaries for exactly this reason (#1710).
+///
+/// It exists to pin a defect fixed in #2943. `ResolveRunTargetFromMetadata` named a RunObject
+/// target with `TryGetAnyPageName(action.TargetID)` — a PAGE lookup — whatever kind the action
+/// actually declared. With this collision in place the old code answered the PAGE's name for
+/// this report, and the runner's refusal read:
+///
+///     RunObject = Report 'Par RunObject Target' (64547)
+///
+/// naming an object the AL never mentions. The refusal was loud, and confidently wrong about
+/// which object it had declined — a silent wrong answer wearing a loud failure, which is the
+/// shape `loud-failures.md` exists to prevent.
+///
+/// Nothing runs this report. Its only job is to be a report at an id a page also occupies.
+report 64547 "Par Decoy Report"
+{
+    ProcessingOnly = true;
+    UseRequestPage = false;
+
+    dataset
+    {
+        dataitem(Row; "Par Row")
+        {
+        }
+    }
+}

--- a/tests/runner-extras/testpage-promoted-actionref/ParHostPage.Page.al
+++ b/tests/runner-extras/testpage-promoted-actionref/ParHostPage.Page.al
@@ -18,6 +18,14 @@
 ///                                       link SELECTS is pinned upstream in the al-language
 ///                                       corpus (handlers/TestPageActionRunPageLink.al).
 ///   ReportRunObjectAction               a RunObject naming a REPORT: in scope, not implemented.
+///   CodeunitRunObjectAction             ... a CODEUNIT, same.
+///   XmlPortRunObjectAction              ... an XMLPORT, same.
+///   QueryRunObjectAction                ... a QUERY, same. All four kinds now have an arm;
+///                                       until #2943 only the report did, so a regression on
+///                                       the other three had nothing watching it.
+///   DecoyReportRunObjectAction          a REPORT whose id collides with a PAGE's, which is
+///                                       legal (separate id namespaces per kind) and is what
+///                                       pins #2943's mislabeling defect.
 ///   NoEffectAction / NoEffectRef        neither a trigger nor a RunObject, so genuinely
 ///                                       nothing to run; the refusal that names the actionref's
 ///                                       TARGET lives here.
@@ -128,6 +136,40 @@ page 64541 "Par Host Page"
                 ApplicationArea = All;
                 Caption = 'Report Run Object Action';
                 RunObject = report "Par Noop Report";
+            }
+
+            // The other three non-page kinds. RunObject accepts five; the runner performs
+            // exactly one (Page) and refuses the rest. Until these were added, only the REPORT
+            // arm of that refusal had a test, so a regression that made a codeunit, xmlport or
+            // query target do nothing QUIETLY would not have been caught by anything.
+            action(CodeunitRunObjectAction)
+            {
+                ApplicationArea = All;
+                Caption = 'Codeunit Run Object Action';
+                RunObject = codeunit "Par Noop Runner";
+            }
+
+            action(XmlPortRunObjectAction)
+            {
+                ApplicationArea = All;
+                Caption = 'XmlPort Run Object Action';
+                RunObject = xmlport "Par Noop XmlPort";
+            }
+
+            action(QueryRunObjectAction)
+            {
+                ApplicationArea = All;
+                Caption = 'Query Run Object Action';
+                RunObject = query "Par Noop Query";
+            }
+
+            // The regression guard for #2943's mislabeling defect. Its target is a REPORT whose
+            // id collides with the page "Par RunObject Target" — see ParDecoyReport.Report.al.
+            action(DecoyReportRunObjectAction)
+            {
+                ApplicationArea = All;
+                Caption = 'Decoy Report Run Object Action';
+                RunObject = report "Par Decoy Report";
             }
 
             action(NoEffectAction)

--- a/tests/runner-extras/testpage-promoted-actionref/ParNoopQuery.Query.al
+++ b/tests/runner-extras/testpage-promoted-actionref/ParNoopQuery.Query.al
@@ -1,0 +1,19 @@
+/// A query that exists solely to be the TARGET of an action's `RunObject = query ...`.
+/// Sibling of "Par Noop Report", "Par Noop Runner" and "Par Noop XmlPort".
+///
+/// A query has no trigger of any kind, so unlike the other three this fixture cannot record
+/// its own execution — which is why the arm that invokes it asserts only on the refusal. That
+/// is a real limit of the object kind, not a weaker test: there is nothing in a query for a
+/// regression to run.
+query 64551 "Par Noop Query"
+{
+    QueryType = Normal;
+
+    elements
+    {
+        dataitem(Row; "Par Row")
+        {
+            column(No; "No.") { }
+        }
+    }
+}

--- a/tests/runner-extras/testpage-promoted-actionref/ParNoopRunner.Codeunit.al
+++ b/tests/runner-extras/testpage-promoted-actionref/ParNoopRunner.Codeunit.al
@@ -1,0 +1,26 @@
+/// A codeunit that exists solely to be the TARGET of an action's `RunObject = codeunit ...`.
+///
+/// It is a SIBLING of "Par Noop Report", and the reason there are now four of these rather
+/// than one is the shape rule: `RunObject` accepts five object kinds, the runner performs
+/// exactly one of them (Page), and until this bundle grew the other three targets only the
+/// REPORT arm of that refusal had a test. A regression that made a codeunit, xmlport or query
+/// target do nothing quietly — the exact failure `loud-failures.md` exists to prevent — would
+/// have gone uncaught, because nothing invoked one.
+///
+/// TableNo is deliberately absent. `Codeunit.Run` on a codeunit with no TableNo takes no
+/// record, so nothing here depends on which record BC would hand it — the question the corpus
+/// PR asks a service tier. This fixture's only job is to be a codeunit-kind target, so it
+/// stays silent on everything that is still unmeasured.
+///
+/// Nothing invokes it as a codeunit: if the refusal it is here to prove ever regresses into
+/// actually running it, OnRun writes a log row and the test that watches for that fails
+/// loudly, which is what makes the refusal falsifiable rather than merely expected.
+codeunit 64549 "Par Noop Runner"
+{
+    trigger OnRun()
+    var
+        OpenLog: Record "Par Open Log";
+    begin
+        OpenLog.Log('CODEUNIT-RAN');
+    end;
+}

--- a/tests/runner-extras/testpage-promoted-actionref/ParNoopXmlPort.XmlPort.al
+++ b/tests/runner-extras/testpage-promoted-actionref/ParNoopXmlPort.XmlPort.al
@@ -1,0 +1,34 @@
+/// An xmlport that exists solely to be the TARGET of an action's `RunObject = xmlport ...`.
+/// Sibling of "Par Noop Report" and "Par Noop Runner"; see the codeunit for why all four kinds
+/// now have a target rather than only the report.
+///
+/// Direction = Export with no request page, so nothing here waits on a stream a test session
+/// cannot supply — the fixture must be refusable for being an XMLPORT, not for being an
+/// xmlport that could not have run anyway.
+///
+/// As with the codeunit, OnPreXmlPort writes a log row so that a regression which actually RAN
+/// the xmlport is caught, instead of being indistinguishable from the refusal.
+xmlport 64550 "Par Noop XmlPort"
+{
+    Direction = Export;
+    Format = Xml;
+    UseRequestPage = false;
+
+    schema
+    {
+        textelement(RootNode)
+        {
+            tableelement(Row; "Par Row")
+            {
+                fieldattribute(No; Row."No.") { }
+            }
+        }
+    }
+
+    trigger OnPreXmlPort()
+    var
+        OpenLog: Record "Par Open Log";
+    begin
+        OpenLog.Log('XMLPORT-RAN');
+    end;
+}

--- a/tests/runner-extras/testpage-promoted-actionref/ParTests.Codeunit.al
+++ b/tests/runner-extras/testpage-promoted-actionref/ParTests.Codeunit.al
@@ -294,6 +294,117 @@ codeunit 64545 "Par Tests"
             'the refusal must cite the OPEN issue tracking the gap, not the one whose fix closed');
     end;
 
+    // Runner-specific, #2943: the CODEUNIT kind. Sibling of the report arm above, and added
+    // because that arm was the only one of the four non-page kinds with a test at all — so a
+    // regression on any of the other three had nothing watching it.
+    //
+    // Two claims, and the second is what the report arm above cannot make: the refusal names
+    // the kind, AND the target was not quietly run anyway. A refusal that raised while still
+    // performing the work would pass a message-only assertion, which is the shape
+    // `loud-failures.md` warns about from the other direction.
+    [Test]
+    procedure RunObjectNamingACodeunitRefusesAsANotYetImplementedGap()
+    var
+        HostPage: TestPage "Par Host Page";
+        OpenLog: Record "Par Open Log";
+    begin
+        Initialize();
+
+        HostPage.OpenEdit();
+        asserterror HostPage.CodeunitRunObjectAction.Invoke();
+
+        Assert.Contains(GetLastErrorText(), 'not-yet-implemented',
+            'a RunObject naming a codeunit must be refused with a gap anchor');
+        Assert.Contains(GetLastErrorText(), 'Codeunit',
+            'the refusal must name the object KIND it declined, so the reader knows which gap this is');
+        Assert.Contains(GetLastErrorText(), '2943',
+            'the refusal must cite the OPEN issue tracking the gap');
+        Assert.IsFalse(OpenLog.Get('CODEUNIT-RAN'),
+            'the refused codeunit target must not have been run: a refusal that still does the work is worse than no refusal');
+    end;
+
+    // Runner-specific, #2943: the XMLPORT kind. Same pair of claims as the codeunit arm.
+    [Test]
+    procedure RunObjectNamingAnXmlPortRefusesAsANotYetImplementedGap()
+    var
+        HostPage: TestPage "Par Host Page";
+        OpenLog: Record "Par Open Log";
+    begin
+        Initialize();
+
+        HostPage.OpenEdit();
+        asserterror HostPage.XmlPortRunObjectAction.Invoke();
+
+        Assert.Contains(GetLastErrorText(), 'not-yet-implemented',
+            'a RunObject naming an xmlport must be refused with a gap anchor');
+        // 'XMLport' is BC's own RunObjectType spelling, not a typo: the message prints the
+        // enum member, and asserting a prettier spelling would pin something the runtime does
+        // not say.
+        Assert.Contains(GetLastErrorText(), 'XMLport',
+            'the refusal must name the object KIND it declined, so the reader knows which gap this is');
+        Assert.Contains(GetLastErrorText(), '2943',
+            'the refusal must cite the OPEN issue tracking the gap');
+        Assert.IsFalse(OpenLog.Get('XMLPORT-RAN'),
+            'the refused xmlport target must not have been run');
+    end;
+
+    // Runner-specific, #2943: the QUERY kind, and the fourth of four. A query has no trigger,
+    // so unlike the codeunit and xmlport arms there is nothing it could have run — the message
+    // assertions are the whole claim, and that is a limit of the object kind rather than a
+    // weaker test.
+    //
+    // Worth stating because BC does NOT treat this kind the way the message groups it: BC's
+    // ActionBuilder routes a Query target through the same CreateNavOpenTaskPageAction as a
+    // Page, with DataSourceType.Query. The runner still refuses it, because what that becomes
+    // in a test session is unmeasured — see the corpus PR linked from #2943.
+    [Test]
+    procedure RunObjectNamingAQueryRefusesAsANotYetImplementedGap()
+    var
+        HostPage: TestPage "Par Host Page";
+    begin
+        Initialize();
+
+        HostPage.OpenEdit();
+        asserterror HostPage.QueryRunObjectAction.Invoke();
+
+        Assert.Contains(GetLastErrorText(), 'not-yet-implemented',
+            'a RunObject naming a query must be refused with a gap anchor');
+        Assert.Contains(GetLastErrorText(), 'Query',
+            'the refusal must name the object KIND it declined, so the reader knows which gap this is');
+        Assert.Contains(GetLastErrorText(), '2943',
+            'the refusal must cite the OPEN issue tracking the gap');
+    end;
+
+    // Runner-specific, #2943, and the arm that pins a WRONG ANSWER rather than a missing one.
+    //
+    // "Par Decoy Report" is report 64547; "Par RunObject Target" is page 64547. AL gives each
+    // object kind its own id namespace, so both exist at once. The runner used to name a
+    // RunObject target with a PAGE lookup regardless of the kind the action declared, so this
+    // action -- whose AL plainly says `RunObject = report "Par Decoy Report"` -- refused with:
+    //
+    //     RunObject = Report 'Par RunObject Target' (64547)
+    //
+    // The refusal fired, so every message assertion in the arms above still passed; it simply
+    // named a different object, of a different kind, that the AL never mentions. A developer
+    // reading it would go looking at the wrong object. That is why this arm asserts the name
+    // that must be there AND the name that must not: asserting only the first would still pass
+    // if the resolver went back to answering both.
+    [Test]
+    procedure ARefusalNamesTheObjectOfTheKindTheActionDeclared()
+    var
+        HostPage: TestPage "Par Host Page";
+    begin
+        Initialize();
+
+        HostPage.OpenEdit();
+        asserterror HostPage.DecoyReportRunObjectAction.Invoke();
+
+        Assert.Contains(GetLastErrorText(), 'Par Decoy Report',
+            'the refusal must name the REPORT the action declared, resolved in the report id space');
+        Assert.NotContains(GetLastErrorText(), 'Par RunObject Target',
+            'the refusal must not name the PAGE that happens to share the report''s id: that is the #2943 defect');
+    end;
+
     // Runner-specific: an action with neither a trigger nor a RunObject genuinely has nothing to
     // run. Invoking it must refuse loudly rather than do nothing — doing nothing is what made an
     // unrun action surface one step later as an assertion about its missing effect.


### PR DESCRIPTION
## The defect

An action's `RunObject` target was named with `TryGetAnyPageName(action.TargetID)` — a **PAGE** lookup — whatever kind the action actually declared.

AL gives every object kind its **own id namespace**, so `report 64701` and `page 64701` are two different objects that coexist. Resolving an id without saying which kind it belongs to therefore answers the **wrong object** rather than nothing.

Measured on a probe bundle, not inferred. With `page 64701 "Prb Decoy Page"`, `report 64701 "Prb Decoy Report"`, and an action declaring `RunObject = report "Prb Decoy Report"`, the runner refused with:

```
RunObject = Report 'Prb Decoy Page' (64701)
```

The AL says `report "Prb Decoy Report"`. The message names **a different object, of a different kind, that the AL never mentions.**

Why this is worth fixing rather than cosmetic: the refusal *fired*, so every existing message assertion still passed. It simply sent a developer to the wrong object. A silent wrong answer wearing a loud failure is the shape `loud-failures.md` exists to prevent, and it is worst here — in the message someone is reading precisely because they are already confused.

## The fix

`RecordPatches.TryGetObjectNameOfKind(kind, id)` resolves through the same kind-aware inventory (`EnumerateKnownAlObjects`) that already backs the `AllObj` virtual table — no second inventory. Kinds compare through `NormalizeObjectTypeName`, so BC's `RunObjectType.XMLport` and the inventory's `"XmlPort"` match without a second spelling table to keep in step.

`Page` keeps its dedicated lookup: it is the one kind with a precompiled-dependency fallback the source inventory does not carry.

## What this does NOT do

**It implements none of the four kinds, and issue 2943 must stay OPEN after this merges.** What BC does with a non-page `RunObject` in a test session is still unmeasured. The refusals stay, and stay loud — they are now merely *accurate about what they refused*.

## Coverage hole the fix uncovered

`RunObject` accepts five kinds; the runner performs exactly one. Of the four refusals, **only the REPORT arm had a test**. A regression that made a codeunit, xmlport or query target do nothing *quietly* had nothing watching it.

All four now have an arm. The codeunit and xmlport arms additionally assert their target **was not run** — a refusal that still did the work would pass a message-only assertion.

## RED → GREEN, and two mutations

On `tests/runner-extras/testpage-promoted-actionref`:

| step | result |
|---|---|
| **RED** | the decoy arm reports `'Par RunObject Target'` (a page) for a report target |
| **GREEN** | 18/18 pass |
| **mutation 1** — call site back to `TryGetAnyPageName` | the decoy arm fails, **and only it** |
| **mutation 2** — kind check dropped from the resolver | same arm fails |

Both mutations were caught, so the call site *and* the kind-matching logic are each proven load-bearing rather than assumed. The four kind arms correctly stay green under both, since they pin the refusal, which the mutation does not touch — that asymmetry is what shows each test fails for its own reason.

Also run: `dotnet test AlRunner.Tests --filter "FullyQualifiedName~RunObject|FullyQualifiedName~ActionRun"` (11/11) and `~AllObj|~PageParser|~ObjectName` (12/12).

## Fixing the shape, not the reported line

- **Same wrong pattern at another call site?** `TryGetAnyPageName`'s only other caller is `GetPageExtensionIdsForPage`, which genuinely takes a page id and is correct. No other consumer resolves a possibly-non-page id through a page lookup.
- **Sibling assumption?** The symbols route (`ResolveRunTargetFromSymbols`) was already kind-aware — it is where the 73-shared-names ambiguity guard lives. Only the **metadata** route made the page assumption; the two disagreeing is itself why this went unnoticed.
- **Issue-queue scan.** #3223 lands in the same file but is a distinct BC-verdict question (the modal-dialog arm) with no tier answer, so it stays separate. #2457 is request-page actions, a different surface. Nothing folded.

## The BC question is upstream and open

The four kinds are four different dispatches in BC (`ActionBuilder.CreateRunObject` builds `InvokeCodeUnitAction`, `RunReportAction`, `RunXmlPortAction`, and `CreateNavOpenTaskPageAction` for Query), and what each becomes in a **test session** is what a service tier has to say. That corpus PR is open now and its eight legs are running:

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/273

It asks, per kind: does a report target open its request page or run the body directly (and does `UseRequestPage = false` change it); does a codeunit target run and which record does it get; does `RunPageOnRec` mean anything on a non-page target; does an xmlport run; what is "opening a query" at all. Implementation of the kinds should wait on those answers — this PR deliberately does not pre-empt them.


**Update — the tier has answered, and it does not change this PR.** Corpus run `34150170570` produced an identical failing set on all eight cloud legs (OnPrem legs run the smaller suite and are unaffected), which is a verdict rather than a flake. What real BC does, per kind:

| kind | what the eight legs measured |
|---|---|
| Report | `The method RunReport is not supported for TestPages.` — refused in a test session |
| XMLport | `The method RunXmlPort is not supported for TestPages.` |
| Query | `The method GetQueryTableMetadata is not supported for TestPages.` — refused one step earlier |
| Codeunit | **runs**, and is handed the host page's current row: the arm expecting `''` measured `Bravo` |

The codeunit answer also settles the `RunPageOnRec` sub-question in the other direction from the corpus test's guess: the WITH-`RunPageOnRec` arm (`RunObjectNamingACodeunitWithRunPageOnRecIsHandedTheHostsRow`, asserting `'Bravo'`) **passed** while the WITHOUT arm expecting `''` failed with `Bravo`, so `RunPageOnRec` has **no observable effect on a codeunit target** — it is handed the host's row either way.

None of that alters this diff. This PR does not implement any kind; it fixes which object a refusal NAMES. The runner-side arms pin the runner's own refusal (`asserterror` + a `not-yet-implemented` anchor) and its internal consistency — `Assert.IsFalse(OpenLog.Get('CODEUNIT-RAN'))` says "when the runner refuses, it must not have run the target anyway", which is a claim about the runner's refusal, not a claim that BC refuses. Flipping it to `IsTrue` would assert the runner runs the codeunit, contradicting the refusal asserted three lines above in the same test.

The correction the verdict does demand is upstream, in corpus #273's own expectations — tracked there, not here.

No linked issue: the four RunObject kinds stay refused pending corpus #273, so this PR corrects the refusal message only and leaves 2943 open.

Tracked by issue 2943, which remains open — deliberately written without a linking keyword so GitHub does not auto-close it.

---

Written by agent `stma-auto-32`, an automated implementation agent acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9pEPoD8e4wmVyuTrxyuh
