### PR TITLE
feat(test-data): opt-in company normalization, blanking the restored Additional Reporting Currency

### DIFF
--- a/.claude/skills/running-ms-test-buckets/SKILL.md
+++ b/.claude/skills/running-ms-test-buckets/SKILL.md
@@ -72,6 +72,28 @@ until someone replicates the preparation blueprint.
 failures first. Chasing the recipe to reach 100% green is the *very end* of the work, once
 nothing else is left.
 
+**One piece of the recipe now exists as an opt-in flag: `--test-data-normalize-company`.** It
+rewrites named, measured fields of the restored company towards the DemoTool one; today the
+rule set is a single field, `General Ledger Setup."Additional Reporting Currency" := ''`.
+
+**It is off by default and every number below was measured without it.** Turning it on changes
+which company the tests run against, so a normalized run's counts are not comparable with any
+recorded here — including the 259/595 Tests-SMB figures. The run says so itself: with the flag
+on, the summary prints every rule, what it changed and from which value, and names the rules
+that never fired.
+
+Measured on this box (BC 28.1, `--test-data`, one bucket, everything else identical):
+
+| | without the flag | with it |
+|---|---|---|
+| Tests-SMB (1,028 discovered) | 727 pass / 286 fail / 15 error | **727 / 286 / 15 — no change** |
+| Tests-ERM `Codeunit134157` in isolation | 3 pass / 3 fail | **6 pass / 0 fail** |
+
+So the flag pays where the ACY is actually load-bearing and costs nothing where it is not.
+Tests-SMB has no ACY-sensitive assertion; #2730's clusters are in Tests-ERM. Do not read the
+flat Tests-SMB row as the flag not working — the run reported `1 of 1 row(s) changed (was
+'EUR')` in both cases.
+
 #### The triage rule
 
 When a Microsoft bucket test fails, ask **"is this a data-recipe failure?" before treating it

--- a/AlRunner.Tests/CliDocumentationTests.cs
+++ b/AlRunner.Tests/CliDocumentationTests.cs
@@ -293,6 +293,10 @@ public sealed class CliDocumentationTests
         // Base/System Application file entirely, not just an extra flag on the same w1
         // download — so it belongs here by this list's own "which code path" test.
         "--country",
+        // Issue #2730: --test-data-normalize-company changes the VALUES the run executes
+        // against, so two runs differing only by this flag produce different pass/fail counts.
+        // That is squarely "what gets executed", not "how the result is reported".
+        "--test-data-normalize-company",
     };
 
     /// <summary>Negative: an unknown documentation flag must not be silently accepted.</summary>

--- a/AlRunner.Tests/TestDataCompanyHelpTextTests.cs
+++ b/AlRunner.Tests/TestDataCompanyHelpTextTests.cs
@@ -1,0 +1,107 @@
+// TestDataCompanyHelpTextTests — the proving tests for issue #2290 (the --test-data-company
+// help text promised a default the runner refuses to apply) and for the help/guide entries
+// #2730 adds alongside it.
+//
+// WHY THESE ARE TEXT ASSERTIONS AND NOT A SUBPROCESS SPAWN
+//   CliDocumentationTests already proves every recognised flag APPEARS in --help, by scraping
+//   Program.cs — a NAME-level check. #2290 is the class that check cannot see: the flag was
+//   present and its description was wrong. So this file asserts on the description, and it
+//   calls ProgramSupport.PrintHelp/PrintGuide directly rather than spawning al-runner, because the claim is about the text
+//   this repository ships and ProgramSupport (AlRunner/ProgramSupport/CliText.cs) is where that text lives. A subprocess would prove the
+//   same sentence at ~6s per test.
+//
+// WHAT #2290 ACTUALLY WAS
+//   --help said "Default: the first company the backup reports". The runner refuses to choose —
+//   picking silently would mean every hydrated row came from a company nobody selected — and
+//   the shipped W1 backup holds TWO companies, so anyone following the help text on the default
+//   artifact got an EXEC-FAIL. The runtime behaviour is the intended one; the help was
+//   documenting an earlier design.
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestDataCompanyHelpTextTests
+{
+    private static string Help()
+    {
+        var w = new StringWriter();
+        ProgramSupport.PrintHelp(w);
+        return w.ToString();
+    }
+
+    private static string Guide()
+    {
+        var w = new StringWriter();
+        ProgramSupport.PrintGuide(w);
+        return w.ToString();
+    }
+
+    /// <summary>
+    /// The exact sentence #2290 is about. It has to be gone, not merely reworded around: a
+    /// reader who takes it at face value on the shipped W1 backup gets an EXEC-FAIL.
+    /// </summary>
+    [Fact]
+    public void Help_DoesNotPromiseADefaultCompanyTheRunnerRefusesToPick()
+    {
+        var help = Help();
+
+        Assert.DoesNotContain("Default: the first", help, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("the first company the backup reports", help, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The positive half. Deleting the wrong sentence is not enough — the help now has to say
+    /// what the runner actually does, or a reader is worse off than before.
+    /// </summary>
+    [Fact]
+    public void Help_SaysTheCompanyIsRequiredWhenTheBackupHoldsMoreThanOne()
+    {
+        var help = Help();
+
+        Assert.Contains("--test-data-company NAME", help, StringComparison.Ordinal);
+        Assert.Contains("REQUIRED when the", help, StringComparison.Ordinal);
+        Assert.Contains("more than one company", help, StringComparison.Ordinal);
+        Assert.Contains("refuses to", help, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The help must not have swung to the opposite error either: a single-company backup IS
+    /// hydrated without the flag, so "always pass it" would be wrong in the other direction.
+    /// </summary>
+    [Fact]
+    public void Help_StillSaysASingleCompanyBackupNeedsNoFlag()
+    {
+        Assert.Contains("exactly one company is hydrated without this flag", Help(), StringComparison.Ordinal);
+    }
+
+    // ────────────────────────────────────── #2730's own flag ──
+
+    /// <summary>
+    /// --test-data-normalize-company changes which VALUES a run executes against, so its help
+    /// entry has to carry the two facts a reader cannot recover on their own: that it is off by
+    /// default, and that its numbers are not comparable with a run without it.
+    /// </summary>
+    [Fact]
+    public void Help_DocumentsTheNormalizationFlagAsOffByDefaultAndNotComparable()
+    {
+        var help = Help();
+
+        Assert.Contains("--test-data-normalize-company", help, StringComparison.Ordinal);
+        Assert.Contains("OFF BY DEFAULT", help, StringComparison.Ordinal);
+        Assert.Contains("NOT comparable", help, StringComparison.Ordinal);
+        Assert.Contains("Additional Reporting", help, StringComparison.Ordinal);
+    }
+
+    /// <summary>--guide is where an agent starts (CLAUDE.md / the al-runner-workflow skill), so
+    /// the same two facts have to survive there as well.</summary>
+    [Fact]
+    public void Guide_DocumentsTheNormalizationFlagAndItsIncomparability()
+    {
+        var guide = Guide();
+
+        Assert.Contains("--test-data-normalize-company", guide, StringComparison.Ordinal);
+        Assert.Contains("OFF by default", guide, StringComparison.Ordinal);
+        Assert.Contains("NOT comparable", guide, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner.Tests/TestDataCompanyNormalizationTests.cs
+++ b/AlRunner.Tests/TestDataCompanyNormalizationTests.cs
@@ -1,0 +1,395 @@
+// TestDataCompanyNormalizationTests — the proving tests for --test-data-normalize-company
+// (issue #2730).
+//
+// WHAT IS PROVED HERE, AND WHY IT IS HERE
+//   Every claim below is about the RUNNER: a flag that is off by default, a cache key that
+//   changes when it is on, a rule set that rewrites the reader's rows, and a report that says
+//   what it changed. None of them is a statement about what Business Central does — BC's
+//   residual-entry rule given an additional reporting currency is CORRECT and is not what this
+//   change touches. What changes is which COMPANY the tests run against. So
+//   .claude/rules/bc-behavior-tests-go-upstream.md sends nothing upstream here, and there is no
+//   corpus PR and no pin bump.
+//
+//   They are also not expressible as an AL bundle in tests/runner-extras/: CI runs that whole
+//   directory WITHOUT --test-data and with no 900 MB backup on the machine, so an AL test
+//   asserting on hydrated General Ledger Setup rows would fail there by construction.
+//
+// THE ONE THAT MUST NOT BE FAKEABLE
+//   The dominant failure mode in this repository is a check that cannot fail. The claim being
+//   made is "the field is blank AFTER a restore that presented it as EUR" — not "a setter was
+//   called". So the tests below drive the SAME wire-shaped JSON row the backup reader emits for
+//   General Ledger Setup through the SAME entry point the hydration path calls
+//   (TestDataNormalization.Apply), then push the result through the SAME codec that turns it
+//   into the NavValue that lands in the store (RecordPatches.ConvertTestDataValue), and assert
+//   the resulting AL value is blank. Both halves of the chain that can go wrong are covered:
+//   a rule that does not fire, and a rule that fires with the wrong value.
+//
+//   Verified by deliberately breaking the implementation twice — making Apply a no-op, and
+//   making the rule write "USD" instead of blank. Both breaks turn these red. See the PR body.
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestDataCompanyNormalizationTests : IDisposable
+{
+    public TestDataCompanyNormalizationTests() => TestDataNormalization.ResetForTests();
+    public void Dispose() => TestDataNormalization.ResetForTests();
+
+    private const int GeneralLedgerSetupTableId = 98;
+    private const string AcyField = "Additional Reporting Currency";
+
+    /// <summary>
+    /// One General Ledger Setup row in the shape the backup reader emits, measured against
+    /// sandbox/28.1.49838.50621's BusinessCentral-W1.bak company 'CRONUS International Ltd_'.
+    /// Written as a JSON literal rather than read from the backup for the reason
+    /// TestDataDateValueHydrationTests gives: CI has no backup and no reader binary, and demo
+    /// values are not guaranteed identical across the eight BC versions in the matrix.
+    /// EUR is the value #2730 is about; the other fields are here so the row is a row and not
+    /// a one-field stub a rule could not tell apart from an empty one.
+    /// </summary>
+    private static IReadOnlyList<IReadOnlyDictionary<string, JsonElement>> RestoredGeneralLedgerSetup(
+        string additionalReportingCurrency = "EUR")
+        => ParseRows($$"""
+            [ { "Primary Key": "",
+                "LCY Code": "GBP",
+                "Additional Reporting Currency": "{{additionalReportingCurrency}}",
+                "Global Dimension 1 Code": "DEPARTMENT",
+                "Global Dimension 2 Code": "CUSTOMERGROUP",
+                "Enable Data Check": true } ]
+            """);
+
+    private static IReadOnlyList<IReadOnlyDictionary<string, JsonElement>> ParseRows(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.EnumerateArray()
+            .Select(e => (IReadOnlyDictionary<string, JsonElement>)e.EnumerateObject()
+                .ToDictionary(p => p.Name, p => p.Value.Clone(), StringComparer.Ordinal))
+            .ToList();
+    }
+
+    private static string? Acy(IReadOnlyDictionary<string, JsonElement> row)
+        => row[AcyField].GetString();
+
+    // ───────────────────────────────────────────────────── default off ──
+
+    /// <summary>
+    /// The constraint that matters most: `--test-data` alone must keep behaving exactly as it
+    /// does today, because every pass/fail number recorded in this repository — the skill's
+    /// Tests-SMB figures, the corpus counts, the full-surface floor run — was measured against
+    /// the un-normalized restore. If this test ever goes red, all of those silently stop
+    /// meaning what they say.
+    /// </summary>
+    [Fact]
+    public void WithoutTheFlag_TheRestoredEurIsLeftExactlyAsTheBackupPresentsIt()
+    {
+        var rows = RestoredGeneralLedgerSetup();
+
+        var result = TestDataNormalization.Apply(GeneralLedgerSetupTableId, "General Ledger Setup", rows);
+
+        Assert.Same(rows, result);
+        Assert.Equal("EUR", Acy(result[0]));
+        Assert.Null(TestDataNormalization.Describe());
+    }
+
+    [Fact]
+    public void WithoutTheFlag_NothingIsParsedFromTheCommandLine()
+    {
+        Assert.False(TestDataNormalization.TryParseArg("--test-data"));
+        Assert.False(TestDataNormalization.TryParseArg("--test-data-company"));
+        Assert.False(TestDataNormalization.Enabled);
+    }
+
+    [Fact]
+    public void TheFlagIsRecognizedAndTurnsTheRuleSetOn()
+    {
+        Assert.True(TestDataNormalization.TryParseArg("--test-data-normalize-company"));
+        Assert.True(TestDataNormalization.Enabled);
+    }
+
+    // ────────────────────────────────────────── the rewrite itself ──
+
+    /// <summary>
+    /// The claim #2730 is about, at the level the defect lives at: a row the backup presented
+    /// as EUR is handed to the hydration path as blank.
+    /// </summary>
+    [Fact]
+    public void WithTheFlag_AdditionalReportingCurrencyIsBlankedOnARowThatArrivedAsEur()
+    {
+        TestDataNormalization.Enabled = true;
+        var rows = RestoredGeneralLedgerSetup();
+        Assert.Equal("EUR", Acy(rows[0]));   // the precondition, asserted rather than assumed
+
+        var result = TestDataNormalization.Apply(GeneralLedgerSetupTableId, "General Ledger Setup", rows);
+
+        Assert.Equal("", Acy(result[0]));
+        // The input is left alone: HydrateOne's caller still holds it, and a rule that mutated
+        // the reader's rows in place would make the "without the flag" claim above depend on
+        // call order.
+        Assert.Equal("EUR", Acy(rows[0]));
+    }
+
+    /// <summary>
+    /// Negative direction, and the one a no-op implementation passes: no OTHER field of the
+    /// same row may move. A rule set that blanked the row, or wrote the target into the wrong
+    /// column, would be caught here and nowhere else.
+    /// </summary>
+    [Fact]
+    public void WithTheFlag_NoOtherFieldOfTheSameRowIsTouched()
+    {
+        TestDataNormalization.Enabled = true;
+
+        var result = TestDataNormalization.Apply(
+            GeneralLedgerSetupTableId, "General Ledger Setup", RestoredGeneralLedgerSetup());
+
+        Assert.Equal("GBP", result[0]["LCY Code"].GetString());
+        Assert.Equal("DEPARTMENT", result[0]["Global Dimension 1 Code"].GetString());
+        // #3429 names Global Dimension 2 as a NEXT candidate and explains why it cannot be a
+        // field write on a company that already has posted entries dimensioned by CUSTOMERGROUP.
+        // This asserts it was not attempted.
+        Assert.Equal("CUSTOMERGROUP", result[0]["Global Dimension 2 Code"].GetString());
+        Assert.True(result[0]["Enable Data Check"].GetBoolean());
+    }
+
+    /// <summary>
+    /// A table no rule targets is returned untouched and unallocated. Without this, a rule set
+    /// that rewrote something in every table would still pass every assertion above.
+    /// </summary>
+    [Fact]
+    public void WithTheFlag_ATableNoRuleTargetsIsReturnedUnchanged()
+    {
+        TestDataNormalization.Enabled = true;
+        var rows = ParseRows("""[ { "Code": "EUR", "Description": "Euro" } ]""");
+
+        var result = TestDataNormalization.Apply(4, "Currency", rows);
+
+        Assert.Same(rows, result);
+        Assert.Equal("EUR", result[0]["Code"].GetString());
+    }
+
+    // ──────────────────────────── the value that reaches the store ──
+
+    /// <summary>
+    /// The chain closed end to end. Rewriting the reader's JSON only matters if the AL value
+    /// built from it is blank, so this pushes the normalized cell through the SAME codec
+    /// RecordPatches.HydrateTestDataTable uses to build the NavValue that lands in the store,
+    /// and asserts the AL-observable result — not that a dictionary key changed.
+    ///
+    /// `Additional Reporting Currency` is Code[10], so the field metadata is NavCode.
+    /// </summary>
+    [Fact]
+    public void WithTheFlag_TheAlValueBuiltFromTheNormalizedCellIsBlank()
+    {
+        TestDataNormalization.Enabled = true;
+
+        var normalized = TestDataNormalization.Apply(
+            GeneralLedgerSetupTableId, "General Ledger Setup", RestoredGeneralLedgerSetup());
+
+        var value = BuildAlValue(normalized[0][AcyField]);
+        Assert.Equal("", Assert.IsType<NavCode>(value).Value);
+        // BC's own blank test, the one AL's `if X = '' then` resolves to. Asserting the string
+        // alone would not distinguish a blank Code from one this codec failed to build.
+        Assert.True(value.IsZeroOrEmpty, "a blanked Code field must read as AL's blank, not as a 3-character code");
+    }
+
+    /// <summary>The control for the test above: the SAME codec, the SAME field, fed the
+    /// UN-normalized cell, produces EUR. Without this pair, "the value is blank" could be a
+    /// property of the codec rather than of the normalization.</summary>
+    [Fact]
+    public void WithoutTheFlag_TheAlValueBuiltFromTheSameCellIsEur()
+    {
+        var untouched = TestDataNormalization.Apply(
+            GeneralLedgerSetupTableId, "General Ledger Setup", RestoredGeneralLedgerSetup());
+
+        var value = BuildAlValue(untouched[0][AcyField]);
+        Assert.Equal("EUR", Assert.IsType<NavCode>(value).Value);
+        Assert.False(value.IsZeroOrEmpty);
+    }
+
+    private sealed class CodeFieldMetadata : INavValueMetadata
+    {
+        public NavType NavType => NavType.Code;
+        public NavNclType NclType => NavNclType.NavCode;
+        public int NavDefinedLengthMetadata => 10;
+        public NCLOptionMetadata NavOptionMetadata => null!;
+    }
+
+    private static NavValue BuildAlValue(JsonElement cell)
+        => RecordPatches.ConvertTestDataValue(
+            new RecordPatches.TestDataFieldFacts(
+                new CodeFieldMetadata(),
+                () => throw new InvalidOperationException("a non-null Code cell must not reach the empty value"),
+                storedCompressed: false),
+            cell, GeneralLedgerSetupTableId, "General Ledger Setup", 3, AcyField);
+
+    // ────────────────────────────────────────────── loud reporting ──
+
+    /// <summary>
+    /// .claude/rules/loud-failures.md. The report must name the rule, the value it replaced and
+    /// how many rows moved, so a pass/fail count from this run can never be read without knowing
+    /// which company produced it.
+    /// </summary>
+    [Fact]
+    public void WithTheFlag_TheReportNamesTheRuleTheOldValueAndTheRowCount()
+    {
+        TestDataNormalization.Enabled = true;
+        TestDataNormalization.Apply(
+            GeneralLedgerSetupTableId, "General Ledger Setup", RestoredGeneralLedgerSetup());
+
+        var report = TestDataNormalization.Describe();
+
+        Assert.NotNull(report);
+        Assert.Contains("General Ledger Setup", report!, StringComparison.Ordinal);
+        Assert.Contains(AcyField, report, StringComparison.Ordinal);
+        Assert.Contains("'EUR'", report, StringComparison.Ordinal);
+        Assert.Contains("1 row(s) changed", report, StringComparison.Ordinal);
+        Assert.Contains("NOT comparable", report, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The rule fired and changed NOTHING, because the backup already matched. That is a real
+    /// outcome and must not read like the rule having done work — otherwise a future backup
+    /// that ships a blank ACY would look as though normalization were still buying something.
+    /// </summary>
+    [Fact]
+    public void WithTheFlag_ARowThatAlreadyMatchesIsReportedAsChangingNothing()
+    {
+        TestDataNormalization.Enabled = true;
+        TestDataNormalization.Apply(GeneralLedgerSetupTableId, "General Ledger Setup",
+            RestoredGeneralLedgerSetup(additionalReportingCurrency: ""));
+
+        var report = TestDataNormalization.Describe()!;
+
+        Assert.Contains("0 row(s) changed", report, StringComparison.Ordinal);
+        Assert.Contains("1 already matched", report, StringComparison.Ordinal);
+        Assert.DoesNotContain("'EUR'", report, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The flag was on and the rule never fired, because the run never touched table 98. Saying
+    /// so is the whole point: a run that reports "normalization ON" while nothing was normalized
+    /// is the measurement trap this rule set exists to avoid.
+    /// </summary>
+    [Fact]
+    public void WithTheFlag_ARuleThatNeverFiredIsReportedAsNotApplied()
+    {
+        TestDataNormalization.Enabled = true;
+
+        var report = TestDataNormalization.Describe()!;
+
+        Assert.Contains("DID NOT APPLY", report, StringComparison.Ordinal);
+        Assert.Contains("never touched that table", report, StringComparison.Ordinal);
+        Assert.DoesNotContain("row(s) changed", report, StringComparison.Ordinal);
+    }
+
+    // ───────────────────────────────────────────── loud refusal ──
+
+    /// <summary>
+    /// A rule naming a field the loaded rows do not carry throws. The alternative — skipping it
+    /// — is a run that reports a normalization it did not perform, which is the exact
+    /// check-that-cannot-fail shape this file's header is about.
+    /// </summary>
+    [Fact]
+    public void ARuleWhoseFieldIsAbsentFromEveryRow_Throws_RatherThanReportingSuccess()
+    {
+        TestDataNormalization.Enabled = true;
+        var rows = ParseRows("""[ { "Primary Key": "", "LCY Code": "GBP" } ]""");
+
+        var ex = Assert.Throws<TestDataNormalizationException>(
+            () => TestDataNormalization.Apply(GeneralLedgerSetupTableId, "General Ledger Setup", rows));
+
+        Assert.Contains(AcyField, ex.Message, StringComparison.Ordinal);
+        Assert.Contains("cannot fire", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>An EMPTY table is not a missing field: there is nothing to normalize and nothing
+    /// is wrong. It must not throw, and it must not claim to have changed anything.</summary>
+    [Fact]
+    public void ATableWithNoRows_IsNotMistakenForAMisnamedField()
+    {
+        TestDataNormalization.Enabled = true;
+        var rows = ParseRows("[]");
+
+        var result = TestDataNormalization.Apply(GeneralLedgerSetupTableId, "General Ledger Setup", rows);
+
+        Assert.Empty(result);
+        Assert.Null(TestDataNormalization.OutcomeOf(TestDataNormalization.Rules[0]));
+    }
+
+    // ─────────────────────────────────────────────── cache key ──
+
+    /// <summary>
+    /// The silent-wrong-answer guard, and the same argument #2258 made for --test-data itself: a
+    /// baseline captured WITHOUT normalization must not be restored into a run that asked FOR
+    /// it. The two tiers of the install-baseline cache are keyed by this string and nothing
+    /// else, so this is the level the defect would live at.
+    /// </summary>
+    [Fact]
+    public void TheNormalizationFlagChangesTheInstallBaselineCacheKey()
+    {
+        const string bak = "/artifacts/28.1.49838.50621/w1/BusinessCentral-W1.bak";
+        const string company = "CRONUS International Ltd_";
+        const string reader = "readerhash0000ab";
+
+        Assert.Equal("", TestDataNormalization.CacheIdentity());
+        var withoutNormalization = TestDataOptions.BuildCacheIdentity(bak, company, reader, "");
+
+        TestDataNormalization.Enabled = true;
+        var identity = TestDataNormalization.CacheIdentity();
+        Assert.NotEqual("", identity);
+
+        var withNormalization = TestDataOptions.BuildCacheIdentity(bak, company, reader, identity);
+        Assert.NotEqual(withoutNormalization, withNormalization);
+    }
+
+    /// <summary>The rule-set version is part of the key, so adding or changing a rule
+    /// invalidates baselines captured under the old set. A cache cannot detect for itself that
+    /// the VALUES it holds were produced by different rules.</summary>
+    [Fact]
+    public void TheCacheIdentityCarriesTheRuleSetVersionAndTheRuleCount()
+    {
+        TestDataNormalization.Enabled = true;
+        var identity = TestDataNormalization.CacheIdentity();
+
+        Assert.Contains($"v{TestDataNormalization.RuleSetVersion}", identity, StringComparison.Ordinal);
+        Assert.Contains($"/{TestDataNormalization.Rules.Count}", identity, StringComparison.Ordinal);
+    }
+
+    // ───────────────────────────────────── the rule set itself ──
+
+    /// <summary>#3429 names Global Dimension 2 and shortcut dimensions 3-6 as the next
+    /// candidates and explains why they are master data rather than field writes — the target
+    /// dimension PROJECT does not exist in the restored company at all. A rule for one of them
+    /// would produce a company referencing a dimension that is not there, which is worse than
+    /// the difference it closes.</summary>
+    [Fact]
+    public void TheRuleSetDoesNotAttemptTheMasterDataDifferences()
+    {
+        var fields = TestDataNormalization.Rules.Select(r => r.FieldName).ToList();
+
+        Assert.DoesNotContain("Global Dimension 2 Code", fields);
+        Assert.DoesNotContain("Shortcut Dimension 3 Code", fields);
+        Assert.DoesNotContain("Shortcut Dimension 4 Code", fields);
+        Assert.DoesNotContain("Shortcut Dimension 5 Code", fields);
+        Assert.DoesNotContain("Shortcut Dimension 6 Code", fields);
+    }
+
+    /// <summary>Every rule has to be printable and explicable: the report prints the reason with
+    /// every application, and a rule whose reason is not worth printing is not worth applying.</summary>
+    [Fact]
+    public void EveryRuleCarriesATargetThatParsesAndAReasonWorthPrinting()
+    {
+        Assert.NotEmpty(TestDataNormalization.Rules);
+        foreach (var rule in TestDataNormalization.Rules)
+        {
+            Assert.True(rule.TableId > 0);
+            Assert.False(string.IsNullOrWhiteSpace(rule.FieldName));
+            Assert.True(rule.Why.Length > 40, $"rule for '{rule.FieldName}' needs a reason a reader can act on");
+            TestDataNormalization.ParseTarget(rule);   // throws if the literal is not JSON
+        }
+    }
+}

--- a/AlRunner.Tests/TestDataProvisioningTests.cs
+++ b/AlRunner.Tests/TestDataProvisioningTests.cs
@@ -109,6 +109,76 @@ public sealed class TestDataProvisioningTests : IDisposable
         }
     }
 
+    /// <summary>
+    /// #2730's half of the same regression, and the reason it is HERE rather than beside the
+    /// rest of the normalization tests: a normalized run and an un-normalized one must not
+    /// share an install-baseline cache entry either. Getting that wrong is worse than the
+    /// --test-data case it mirrors, because it is durable — a cache populated by one arm serves
+    /// the other silently, across runs, and every number measured afterwards is wrong with
+    /// nothing indicating it.
+    ///
+    /// Like its sibling above, this goes through TestExecutor.CurrentInstallBaselineCacheKey().
+    /// That is the whole point. TestDataNormalizationTests asserts that BuildCacheIdentity is
+    /// injective in its normalization argument, which is a claim about a pure function and
+    /// stays true even if the CALL SITE stops passing one. Measured: replacing the fourth
+    /// argument at TestDataOptions.cs's CacheIdentity() with a "" literal left that test — and
+    /// all 210 tests matching InstallBaseline|CacheKey|CacheIdentity|TestData — green. Only
+    /// driving the live CacheIdentity() catches it.
+    /// </summary>
+    [Fact]
+    public void NormalizedRun_AndUnnormalizedRun_DoNotShareAnInstallBaselineCacheKey()
+    {
+        var dir = Directory.CreateTempSubdirectory("al-runner-normalize-cachekey");
+        var previousEnv = Environment.GetEnvironmentVariable(BackupReaderTool.ExecutableEnvVar);
+        try
+        {
+            var fakeReader = Path.Combine(dir.FullName, "bcbak");
+            File.WriteAllBytes(fakeReader, new byte[] { 0x7f, 0x45, 0x4c, 0x46 });
+            var backup = Path.Combine(dir.FullName, "BusinessCentral-W1.bak");
+            File.WriteAllBytes(backup, new byte[256]);
+            Environment.SetEnvironmentVariable(BackupReaderTool.ExecutableEnvVar, fakeReader);
+            BackupReaderTool.ResetForTests();
+
+            void ArmTestData()
+            {
+                // ResetForTests() first: CacheIdentity() memoises into _cachedIdentity, so a
+                // second read after flipping the normalization flag would return the first
+                // answer and this test would pass for the wrong reason.
+                TestDataOptions.ResetForTests();
+                TestDataOptions.Enabled = true;
+                TestDataOptions.ExplicitBackupPath = backup;
+                TestDataOptions.CompanyOverride = "CRONUS International Ltd_";
+            }
+
+            TestDataNormalization.ResetForTests();
+            ArmTestData();
+            var unnormalized = TestExecutor.CurrentInstallBaselineCacheKey();
+
+            ArmTestData();
+            TestDataNormalization.Enabled = true;
+            var normalized = TestExecutor.CurrentInstallBaselineCacheKey();
+
+            Assert.NotEqual(unnormalized, normalized);
+            // Both still carry --test-data's own marker. The normalization term goes INSIDE
+            // BuildCacheIdentity's hashed payload, so the two keys differ in the `td<hash>`
+            // segment rather than by one being a prefix of the other — but neither may have
+            // LOST the test-data identity, which is what this asserts.
+            Assert.Contains("td", unnormalized, StringComparison.Ordinal);
+            Assert.Contains("td", normalized, StringComparison.Ordinal);
+
+            // And the difference must survive into the DISK key, which is a different function.
+            Assert.NotEqual(
+                InstallBaselineDiskCache.BuildKeyText(unnormalized, 1),
+                InstallBaselineDiskCache.BuildKeyText(normalized, 1));
+        }
+        finally
+        {
+            TestDataNormalization.ResetForTests();
+            Environment.SetEnvironmentVariable(BackupReaderTool.ExecutableEnvVar, previousEnv);
+            dir.Delete(recursive: true);
+        }
+    }
+
     [Fact]
     public void CacheIdentity_ChangesWithTheBackup_TheCompany_AndTheReaderBuild()
     {

--- a/AlRunner.Tests/TestDataProvisioningTests.cs
+++ b/AlRunner.Tests/TestDataProvisioningTests.cs
@@ -117,16 +117,16 @@ public sealed class TestDataProvisioningTests : IDisposable
         const string company = "CRONUS International Ltd_";
         const string reader = "readerhash0000ab";
 
-        var baseline = TestDataOptions.BuildCacheIdentity(bak, company, reader);
+        var baseline = TestDataOptions.BuildCacheIdentity(bak, company, reader, "");
 
-        Assert.NotEqual(baseline, TestDataOptions.BuildCacheIdentity(other, company, reader));
-        Assert.NotEqual(baseline, TestDataOptions.BuildCacheIdentity(bak, "My Company", reader));
+        Assert.NotEqual(baseline, TestDataOptions.BuildCacheIdentity(other, company, reader, ""));
+        Assert.NotEqual(baseline, TestDataOptions.BuildCacheIdentity(bak, "My Company", reader, ""));
         // A reader upgrade that changes decoded VALUES must invalidate the snapshot; that is
         // why the extractor identity is part of the key rather than a comment.
-        Assert.NotEqual(baseline, TestDataOptions.BuildCacheIdentity(bak, company, "readerhash0000cd"));
+        Assert.NotEqual(baseline, TestDataOptions.BuildCacheIdentity(bak, company, "readerhash0000cd", ""));
 
         // Stable for identical inputs — a key that churned would defeat the cache entirely.
-        Assert.Equal(baseline, TestDataOptions.BuildCacheIdentity(bak, company, reader));
+        Assert.Equal(baseline, TestDataOptions.BuildCacheIdentity(bak, company, reader, ""));
     }
 
     [Fact]
@@ -137,12 +137,12 @@ public sealed class TestDataProvisioningTests : IDisposable
         {
             var bak = Path.Combine(dir.FullName, "BusinessCentral-W1.bak");
             File.WriteAllBytes(bak, new byte[64]);
-            var first = TestDataOptions.BuildCacheIdentity(bak, "CRONUS", "reader");
+            var first = TestDataOptions.BuildCacheIdentity(bak, "CRONUS", "reader", "");
 
             // A different backup written to the same path is a different database.
             File.WriteAllBytes(bak, new byte[128]);
             File.SetLastWriteTimeUtc(bak, DateTime.UtcNow.AddMinutes(5));
-            var second = TestDataOptions.BuildCacheIdentity(bak, "CRONUS", "reader");
+            var second = TestDataOptions.BuildCacheIdentity(bak, "CRONUS", "reader", "");
 
             Assert.NotEqual(first, second);
         }

--- a/AlRunner/Infrastructure/TestDataNormalization.cs
+++ b/AlRunner/Infrastructure/TestDataNormalization.cs
@@ -1,20 +1,11 @@
 // TestDataNormalization — the opt-in `--test-data-normalize-company` rule set (issue #2730).
 //
 // WHAT IT IS FOR
-//   `--test-data` restores the sandbox artifact's BusinessCentral-W1.bak. Microsoft does not
-//   build the company its BaseApp test buckets run against that way: it generates one from
-//   scratch with the legacy DemoTool at pipeline time (#3429). The two companies differ, and
-//   the differences are not runner defects — they are a different, also-valid BC configuration.
-//   This file narrows named, measured differences so a bucket runs against something closer to
-//   the company its assertions were written for.
-//
-//   The first rule is General Ledger Setup."Additional Reporting Currency". Microsoft's is
-//   blank by construction (`<AdditionalCurrency/>` is empty in all 25 DemoDataConfig.xml files
-//   and CreateGeneralLedgerSetup only writes the field when it is non-empty); the restored
-//   backup's is EUR, which is what Contoso codeunit 5627 produces on a GBP LCY. Given an ACY,
-//   BC's residual rule correctly writes an extra G/L Entry, so every Microsoft test that counts
-//   G/L Entries after a posting sees one more than it expects. The runner is not wrong anywhere
-//   in that chain — the company is.
+//   `--test-data` restores the demo backup as shipped; Microsoft generates the company its
+//   BaseApp tests run against with the legacy DemoTool instead. This file narrows named,
+//   measured differences between the two. Which fields differ, and why the ACY one costs
+//   tests: docs/limitations.md § "Which company --test-data presents", and #3429 for the
+//   derivation.
 //
 // WHY OPT-IN, AND WHY IT MUST STAY OPT-IN
 //   Every pass/fail number recorded in this repository was measured against the un-normalized

--- a/AlRunner/Infrastructure/TestDataNormalization.cs
+++ b/AlRunner/Infrastructure/TestDataNormalization.cs
@@ -1,0 +1,277 @@
+// TestDataNormalization — the opt-in `--test-data-normalize-company` rule set (issue #2730).
+//
+// WHAT IT IS FOR
+//   `--test-data` restores the sandbox artifact's BusinessCentral-W1.bak. Microsoft does not
+//   build the company its BaseApp test buckets run against that way: it generates one from
+//   scratch with the legacy DemoTool at pipeline time (#3429). The two companies differ, and
+//   the differences are not runner defects — they are a different, also-valid BC configuration.
+//   This file narrows named, measured differences so a bucket runs against something closer to
+//   the company its assertions were written for.
+//
+//   The first rule is General Ledger Setup."Additional Reporting Currency". Microsoft's is
+//   blank by construction (`<AdditionalCurrency/>` is empty in all 25 DemoDataConfig.xml files
+//   and CreateGeneralLedgerSetup only writes the field when it is non-empty); the restored
+//   backup's is EUR, which is what Contoso codeunit 5627 produces on a GBP LCY. Given an ACY,
+//   BC's residual rule correctly writes an extra G/L Entry, so every Microsoft test that counts
+//   G/L Entries after a posting sees one more than it expects. The runner is not wrong anywhere
+//   in that chain — the company is.
+//
+// WHY OPT-IN, AND WHY IT MUST STAY OPT-IN
+//   Every pass/fail number recorded in this repository was measured against the un-normalized
+//   restore. If normalization became the default, all of them would silently stop meaning what
+//   they say, and a normalized run compared against a recorded un-normalized one would read as
+//   the runner having improved. So: separate flag, default off, and `--test-data` alone behaves
+//   exactly as it did.
+//
+//   The same argument is why the flag is folded into the install-baseline cache key
+//   (TestDataOptions.BuildCacheIdentity). A baseline captured WITHOUT normalization restored
+//   into a run that asked FOR it would proceed against un-normalized rows with no error
+//   anywhere — the silent-wrong-answer class .claude/rules/loud-failures.md exists to prevent,
+//   and the identical argument #2258 made for --test-data itself.
+//
+// WHY IT IS LOUD (.claude/rules/loud-failures.md)
+//   A normalization that happens quietly is a measurement trap. Every rule reports what it
+//   changed, from which value, in how many rows — and a rule that did NOT fire reports why
+//   (the table was never touched, or the value already matched). See Describe().
+//
+//   A rule naming a field the loaded rows do not carry THROWS. That is a bug in the rule set,
+//   and the alternative is a run that reports "normalized" while nothing was normalized —
+//   exactly the check-that-cannot-fail shape this repository keeps producing.
+//
+// WHERE IT IS APPLIED
+//   On the reader's parsed JSON rows, in TestDataProvisioner.HydrateOne, BEFORE
+//   RecordPatches.HydrateTestDataTable turns them into NavValues. That one point covers both
+//   the rows that land in the live store and the `pristineRows` handed to AppendBaselineTable,
+//   so the value cannot be normalized in the store and un-normalized in the snapshot that
+//   replaces it at the next test boundary.
+//
+// ADDING A RULE
+//   Append to Rules. A rule is (AL table id, field name, target JSON literal, why). What does
+//   NOT belong here: anything that is not a field write on an existing row. #3429 names Global
+//   Dimension 2 and shortcut dimensions 3-6 as the next candidates, and they are master data —
+//   changing Global Dimension 2 on a company that already has posted entries dimensioned by
+//   CUSTOMERGROUP is not a field write in BC, and the target value PROJECT does not exist as a
+//   Dimension in the restored company at all. Do not add them as field writes.
+using System.Text.Json;
+
+namespace AlRunner.Infrastructure;
+
+/// <summary>Thrown when a normalization rule cannot be applied as written. Loud on purpose:
+/// the alternative is a run reporting normalization it did not perform.</summary>
+public sealed class TestDataNormalizationException : Exception
+{
+    public TestDataNormalizationException(string message) : base(message) { }
+}
+
+/// <summary>One field write against one table's restored rows.</summary>
+/// <param name="TableId">AL table id, not the backup's table name — the name varies by
+/// country layer, the id does not.</param>
+/// <param name="TableName">For diagnostics only.</param>
+/// <param name="FieldName">AL field name, as the backup reader emits it.</param>
+/// <param name="TargetJson">The value to write, as a JSON literal, so a future rule can set a
+/// number or a boolean without changing this type.</param>
+/// <param name="Why">Printed with every application. A rule whose reason is not worth printing
+/// is not worth applying.</param>
+internal sealed record CompanyNormalizationRule(
+    int TableId, string TableName, string FieldName, string TargetJson, string Why);
+
+internal static class TestDataNormalization
+{
+    /// <summary>Off unless --test-data-normalize-company was passed. Absent the flag, Apply()
+    /// returns its input unchanged and nothing is printed.</summary>
+    internal static bool Enabled { get; set; }
+
+    /// <summary>Bump when a rule is added, removed or changed. Folded into the install-baseline
+    /// cache key so a baseline captured under one rule set is never restored into a run using
+    /// another — the rules change which VALUES are in the store, which is precisely what a
+    /// baseline holds.
+    ///
+    /// 1 — #2730, the first rule: General Ledger Setup."Additional Reporting Currency" := ''.</summary>
+    internal const int RuleSetVersion = 1;
+
+    internal static readonly IReadOnlyList<CompanyNormalizationRule> Rules = new[]
+    {
+        new CompanyNormalizationRule(
+            TableId: 98,
+            TableName: "General Ledger Setup",
+            FieldName: "Additional Reporting Currency",
+            TargetJson: "\"\"",
+            Why: "Microsoft's DemoTool-built test company has no additional reporting currency "
+               + "(<AdditionalCurrency/> is empty in all 25 DemoDataConfig.xml files); the restored "
+               + "backup's EUR makes BC correctly write an extra residual G/L Entry, so every "
+               + "Microsoft test counting G/L Entries after a posting sees one more than it expects"),
+    };
+
+    /// <summary>What one rule did over the whole run. Accumulated rather than reported per
+    /// application so the run-end summary can also name the rules that never fired.</summary>
+    internal sealed record RuleOutcome(
+        CompanyNormalizationRule Rule, int Applications, int RowsChanged, int RowsAlreadyMatching,
+        IReadOnlyList<string> ReplacedValues);
+
+    private static readonly object _gate = new();
+    private static readonly Dictionary<CompanyNormalizationRule, RuleOutcome> _outcomes = new();
+
+    internal static void ResetForTests()
+    {
+        Enabled = false;
+        lock (_gate) _outcomes.Clear();
+    }
+
+    /// <summary>Parse one argument. False when it is not this flag, so the caller's flag loop
+    /// is unchanged for everything else.</summary>
+    internal static bool TryParseArg(string arg)
+    {
+        if (arg != "--test-data-normalize-company") return false;
+        Enabled = true;
+        return true;
+    }
+
+    /// <summary>The part of the install-baseline cache key this flag owns. Empty when off, so
+    /// the key of every run that does not opt in is byte-identical to what it was before.</summary>
+    internal static string CacheIdentity()
+        => Enabled ? $"normalize-company/v{RuleSetVersion}/{Rules.Count}" : "";
+
+    /// <summary>
+    /// Apply every rule that targets <paramref name="tableId"/> to <paramref name="rows"/>,
+    /// returning the rows to hydrate. A no-op returning the input when the flag is off or no
+    /// rule targets the table, so the hot path costs one dictionary miss.
+    /// </summary>
+    /// <exception cref="TestDataNormalizationException">A rule names a field the rows do not
+    /// carry. See the file header for why that is fatal rather than skipped.</exception>
+    internal static IReadOnlyList<IReadOnlyDictionary<string, JsonElement>> Apply(
+        int tableId, string tableNameForDiagnostics,
+        IReadOnlyList<IReadOnlyDictionary<string, JsonElement>> rows)
+    {
+        if (!Enabled) return rows;
+        var applicable = Rules.Where(r => r.TableId == tableId).ToList();
+        if (applicable.Count == 0) return rows;
+        if (rows.Count == 0) return rows;
+
+        var working = rows.Select(r => new Dictionary<string, JsonElement>(r, StringComparer.Ordinal)).ToList();
+
+        foreach (var rule in applicable)
+        {
+            var carriers = working.Count(r => r.ContainsKey(rule.FieldName));
+            if (carriers == 0)
+                throw new TestDataNormalizationException(
+                    $"--test-data-normalize-company: rule for table {rule.TableId} '{rule.TableName}' names "
+                    + $"field '{rule.FieldName}', which none of the {working.Count} restored row(s) of "
+                    + $"'{tableNameForDiagnostics}' carries — the rule cannot fire, so the run would report a "
+                    + "normalization it did not perform. Fix the rule (the column set the reader emitted was: "
+                    + string.Join(", ", working[0].Keys.OrderBy(k => k, StringComparer.Ordinal).Take(12)) + "…).");
+
+            var target = ParseTarget(rule);
+            var targetText = Render(target);
+            var changed = 0;
+            var alreadyMatching = 0;
+            var replaced = new List<string>();
+
+            foreach (var row in working)
+            {
+                if (!row.TryGetValue(rule.FieldName, out var current)) continue;
+                var currentText = Render(current);
+                if (string.Equals(currentText, targetText, StringComparison.Ordinal)) { alreadyMatching++; continue; }
+                replaced.Add(currentText);
+                row[rule.FieldName] = target;
+                changed++;
+            }
+
+            Console.Error.WriteLine(
+                $"[test-data] NORMALIZED table {rule.TableId} '{rule.TableName}'.'{rule.FieldName}' := {targetText} — "
+                + $"{changed} of {working.Count} row(s) changed"
+                + (replaced.Count > 0 ? $" (was {string.Join(", ", replaced.Distinct().Take(4))})" : "")
+                + $", {alreadyMatching} already matched. Why: {rule.Why}.");
+
+            Record(rule, changed, alreadyMatching, replaced);
+        }
+
+        return working;
+    }
+
+    private static void Record(CompanyNormalizationRule rule, int changed, int alreadyMatching, List<string> replaced)
+    {
+        lock (_gate)
+        {
+            _outcomes.TryGetValue(rule, out var prior);
+            var values = prior == null
+                ? replaced.Distinct().ToList()
+                : prior.ReplacedValues.Concat(replaced).Distinct().ToList();
+            _outcomes[rule] = new RuleOutcome(
+                rule,
+                (prior?.Applications ?? 0) + 1,
+                (prior?.RowsChanged ?? 0) + changed,
+                (prior?.RowsAlreadyMatching ?? 0) + alreadyMatching,
+                values);
+        }
+    }
+
+    /// <summary>The outcome of one rule so far, or null if it never fired. Exists so a test can
+    /// assert on what a rule did without parsing stderr.</summary>
+    internal static RuleOutcome? OutcomeOf(CompanyNormalizationRule rule)
+    {
+        lock (_gate) return _outcomes.TryGetValue(rule, out var o) ? o : null;
+    }
+
+    /// <summary>
+    /// The run-end report. Null when the flag is off, so a default run's output is unchanged.
+    /// Otherwise EVERY rule appears — including the ones that never fired, with the reason —
+    /// because the whole point is that a pass/fail number from this run can never be read
+    /// without knowing which company produced it.
+    /// </summary>
+    internal static string? Describe()
+    {
+        if (!Enabled) return null;
+        var lines = new List<string>
+        {
+            $"[test-data] company normalization ON (--test-data-normalize-company, rule set v{RuleSetVersion}, "
+            + $"{Rules.Count} rule(s)). These numbers are NOT comparable with a run without it:",
+        };
+        foreach (var rule in Rules)
+        {
+            var outcome = OutcomeOf(rule);
+            if (outcome == null)
+            {
+                lines.Add(
+                    $"[test-data]   table {rule.TableId} '{rule.TableName}'.'{rule.FieldName}': DID NOT APPLY — "
+                    + "the run never touched that table, so its rows were never loaded and nothing was changed.");
+                continue;
+            }
+            var was = outcome.ReplacedValues.Count > 0
+                ? $" (was {string.Join(", ", outcome.ReplacedValues.Take(4))})"
+                : "";
+            lines.Add(
+                $"[test-data]   table {rule.TableId} '{rule.TableName}'.'{rule.FieldName}' := "
+                + $"{Render(ParseTarget(rule))}: {outcome.RowsChanged} row(s) changed{was}, "
+                + $"{outcome.RowsAlreadyMatching} already matched, over {outcome.Applications} load(s).");
+        }
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    /// <summary>The rule's target as a detached JsonElement. Clone() is what makes it outlive
+    /// the JsonDocument it was parsed from.</summary>
+    internal static JsonElement ParseTarget(CompanyNormalizationRule rule)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(rule.TargetJson);
+            return doc.RootElement.Clone();
+        }
+        catch (JsonException ex)
+        {
+            throw new TestDataNormalizationException(
+                $"--test-data-normalize-company: rule for table {rule.TableId} '{rule.TableName}'.'{rule.FieldName}' "
+                + $"has an unparseable target '{rule.TargetJson}' ({ex.Message}).");
+        }
+    }
+
+    /// <summary>A JSON value rendered the way the report prints it. A blank string reads as
+    /// <c>''</c> rather than as nothing at all, which is the difference between "we set it to
+    /// blank" and "we printed no value".</summary>
+    internal static string Render(JsonElement value)
+        => value.ValueKind switch
+        {
+            JsonValueKind.String => $"'{value.GetString()}'",
+            JsonValueKind.Null => "(null)",
+            _ => value.GetRawText(),
+        };
+}

--- a/AlRunner/Infrastructure/TestDataOptions.cs
+++ b/AlRunner/Infrastructure/TestDataOptions.cs
@@ -80,6 +80,7 @@ internal static class TestDataOptions
         ExplicitBackupPath = null;
         CompanyOverride = null;
         _cachedIdentity = null;
+        TestDataNormalization.ResetForTests();
     }
 
     /// <summary>
@@ -164,7 +165,8 @@ internal static class TestDataOptions
     {
         if (!Enabled) return "";
         return _cachedIdentity ??= BuildCacheIdentity(
-            ResolveBackupPath(), CompanyOverride, BackupReaderTool.ExtractorIdentity());
+            ResolveBackupPath(), CompanyOverride, BackupReaderTool.ExtractorIdentity(),
+            TestDataNormalization.CacheIdentity());
     }
 
     /// <summary>
@@ -174,7 +176,13 @@ internal static class TestDataOptions
     /// than a content hash: the backup is ~1 GB and re-hashing it on every run would cost far
     /// more than the whole hydration it guards.
     /// </summary>
-    internal static string BuildCacheIdentity(string backupPath, string? company, string extractorIdentity)
+    /// <param name="normalizationIdentity">#2730: which company-normalization rule set (if any)
+    /// rewrote the hydrated values. A baseline captured WITHOUT normalization restored into a run
+    /// that asked FOR it would proceed against un-normalized rows with no error anywhere — the
+    /// same silent-wrong-answer argument the rest of this key is made of. Empty when the flag is
+    /// off, which is what keeps a non-opting run's key byte-identical.</param>
+    internal static string BuildCacheIdentity(
+        string backupPath, string? company, string extractorIdentity, string normalizationIdentity)
     {
         var full = Path.GetFullPath(backupPath);
         long length = -1;
@@ -183,7 +191,7 @@ internal static class TestDataOptions
         if (info.Exists) { length = info.Length; writeTicks = info.LastWriteTimeUtc.Ticks; }
         var payload = string.Join('|',
             "testdata", HydrationSchemaVersion.ToString(), full, length.ToString(),
-            writeTicks.ToString(), company ?? "<first>", extractorIdentity);
+            writeTicks.ToString(), company ?? "<first>", extractorIdentity, normalizationIdentity);
         using var sha = System.Security.Cryptography.SHA256.Create();
         return "td" + Convert.ToHexString(
             sha.ComputeHash(System.Text.Encoding.UTF8.GetBytes(payload)))[..16];

--- a/AlRunner/Infrastructure/TestDataOptions.cs
+++ b/AlRunner/Infrastructure/TestDataOptions.cs
@@ -80,7 +80,13 @@ internal static class TestDataOptions
         ExplicitBackupPath = null;
         CompanyOverride = null;
         _cachedIdentity = null;
-        TestDataNormalization.ResetForTests();
+        // NOT TestDataNormalization: each option class resets its own statics, and the classes
+        // that mutate them run in PARALLEL under xunit. Resetting the normalization flag from
+        // here made TestDataProvisioningTests' Dispose clear a flag
+        // TestDataCompanyNormalizationTests was mid-assertion on — measured, as
+        // CacheIdentity() == "" in a test that had just set Enabled = true. Decoupling removes
+        // the race outright, where serialising the classes would only have hidden it from the
+        // two that happened to be named.
     }
 
     /// <summary>

--- a/AlRunner/Infrastructure/TestDataOptions.cs
+++ b/AlRunner/Infrastructure/TestDataOptions.cs
@@ -68,8 +68,8 @@ internal static class TestDataOptions
     /// artifact cache".</summary>
     internal static string? ExplicitBackupPath { get; set; }
 
-    /// <summary>Company to hydrate. Null means "the first company the backup reports", which
-    /// is logged at hydration time — a stated choice, not a guess about which company matters.</summary>
+    /// <summary>Company to hydrate. Null is only usable on a backup holding exactly one
+    /// company: ResolveCompany refuses to pick when there are several (#2290).</summary>
     internal static string? CompanyOverride { get; set; }
 
     private static string? _cachedIdentity;

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -476,6 +476,10 @@ for (int i = 0; i < args.Length; i++)
     // `al-runner --test-data tests/foo` would be ambiguous. See TestDataOptions.
     if (args[i] == "--test-data-company" && i + 1 < args.Length)
     { AlRunner.Infrastructure.TestDataOptions.CompanyOverride = args[++i]; continue; }
+    // #2730: opt-in company normalization, default OFF. --test-data alone keeps behaving
+    // exactly as it does today, because every pass/fail number recorded in this repository was
+    // measured against the un-normalized restore. See TestDataNormalization.
+    if (AlRunner.Infrastructure.TestDataNormalization.TryParseArg(args[i])) { continue; }
     if (AlRunner.Infrastructure.TestDataOptions.TryParseArg(args[i])) { continue; }
     if (args[i] == "--bc-version" && i + 1 < args.Length) { bcVersionArg = args[++i]; continue; }
     if (args[i] == "--artifact-path" && i + 1 < args.Length) { artifactPathArg = args[++i]; continue; }

--- a/AlRunner/ProgramSupport/CliText.cs
+++ b/AlRunner/ProgramSupport/CliText.cs
@@ -170,7 +170,18 @@ internal static partial class ProgramSupport
         w.WriteLine("  cost tracks what the suite actually uses:");
         w.WriteLine("    al-runner --test-data <bundle-dir>              # the shipped backup for the selected version/country");
         w.WriteLine("    al-runner --test-data=/path/to/X.bak <dirs>     # an explicit backup");
-        w.WriteLine("    al-runner --test-data --test-data-company NAME  # a specific company inside it");
+        w.WriteLine("    al-runner --test-data --test-data-company NAME  # which company inside it (required");
+        w.WriteLine("                                                    # when the backup holds more than one)");
+        w.WriteLine("    al-runner --test-data --test-data-normalize-company  # narrow the restored company");
+        w.WriteLine("                                                    # towards Microsoft's test company");
+        w.WriteLine("  --test-data-normalize-company is OFF by default and only does anything alongside");
+        w.WriteLine("  --test-data. The backup is a valid BC company but not the one Microsoft's BaseApp");
+        w.WriteLine("  tests were written against: Microsoft generates theirs with the legacy DemoTool, and");
+        w.WriteLine("  the restored one carries an Additional Reporting Currency theirs does not, which makes");
+        w.WriteLine("  BC correctly post an extra residual G/L Entry. The flag rewrites named, measured");
+        w.WriteLine("  fields after the restore and prints exactly which rules fired and what each changed,");
+        w.WriteLine("  so a pass/fail count is never readable without knowing which company produced it.");
+        w.WriteLine("  Numbers from a normalized run are NOT comparable with numbers from one without it.");
         w.WriteLine("  You do not have to know in advance which failures those are: when a test fails on a");
         w.WriteLine("  table that has NO rows in this run, the runner prints a one-line [test-data] note");
         w.WriteLine("  under the failure naming that table. BC's own message is left exactly as it was —");
@@ -509,9 +520,29 @@ internal static partial class ProgramSupport
         w.WriteLine("                          reason, never silently dropped.");
         w.WriteLine("  --test-data=PATH        As --test-data, but from an explicit .bak file.");
         w.WriteLine("  --test-data-company NAME");
-        w.WriteLine("                          Company inside the backup to hydrate. Default: the first");
-        w.WriteLine("                          company the backup reports, which is printed at the start");
-        w.WriteLine("                          of the run.");
+        // #2290: this used to promise "Default: the first company the backup reports". The
+        // runner deliberately refuses to choose — picking silently would mean every hydrated
+        // row came from a company nobody selected — and the shipped W1 backup holds TWO
+        // companies, so anyone following the old text on the default artifact hit an
+        // EXEC-FAIL. The runtime behaviour is the intended one; the help text was wrong.
+        w.WriteLine("                          Company inside the backup to hydrate. REQUIRED when the");
+        w.WriteLine("                          backup holds more than one company — the runner refuses to");
+        w.WriteLine("                          choose for you, and names the companies it found. A backup");
+        w.WriteLine("                          holding exactly one company is hydrated without this flag,");
+        w.WriteLine("                          and the company used is printed at the start of the run.");
+        w.WriteLine("  --test-data-normalize-company");
+        w.WriteLine("                          OFF BY DEFAULT. With --test-data, rewrite named fields of");
+        w.WriteLine("                          the restored company to match the company Microsoft's");
+        w.WriteLine("                          BaseApp tests are written against (Microsoft builds theirs");
+        w.WriteLine("                          with the legacy DemoTool, not from this backup). Currently");
+        w.WriteLine("                          one rule: General Ledger Setup.\"Additional Reporting");
+        w.WriteLine("                          Currency\" := blank, because the backup's EUR makes BC");
+        w.WriteLine("                          correctly post an extra residual G/L Entry that Microsoft's");
+        w.WriteLine("                          G/L-Entry-counting tests do not expect. Every rule reports");
+        w.WriteLine("                          what it changed, from which value, in how many rows — and a");
+        w.WriteLine("                          rule that did not fire reports why. Pass/fail numbers from a");
+        w.WriteLine("                          normalized run are NOT comparable with numbers from a run");
+        w.WriteLine("                          without it.");
         w.WriteLine("  --auto-provision        Download the BC artifacts for the project's version if");
         w.WriteLine("                          they are missing, then continue the run. ON BY DEFAULT");
         w.WriteLine("                          since issue #2024 — this flag is now redundant with a");

--- a/AlRunner/Reporter.cs
+++ b/AlRunner/Reporter.cs
@@ -237,6 +237,13 @@ public static class Reporter
         var testData = AlRunner.TestDataProvisioner.LastSummary;
         if (testData != null)
             w.WriteLine(testData.Describe());
+        // #2730: printed whenever --test-data-normalize-company is on, INCLUDING when no rule
+        // fired. A normalization that happens silently is a measurement trap — someone compares
+        // a normalized run against a recorded un-normalized one and reads it as the runner
+        // having improved. Null (nothing printed) when the flag is off.
+        var normalization = AlRunner.Infrastructure.TestDataNormalization.Describe();
+        if (normalization != null)
+            w.WriteLine(normalization);
         // A dependency no loader tier can serve is reported once, per bundle, on stderr at
         // dependency-resolution time — then the run spends minutes compiling and says nothing
         // more about it. Measured on npcore: four such blocks at ~20s, 212s of emit and compile,

--- a/AlRunner/TestDataProvisioner.cs
+++ b/AlRunner/TestDataProvisioner.cs
@@ -605,8 +605,14 @@ internal static class TestDataProvisioner
                 $"table '{entry.TableName}': the reader's JSON could not be parsed ({ex.Message})");
         }
 
+        // #2730: normalize BEFORE the rows become NavValues. This one point covers both the
+        // rows that land in the live store and the `pristineRows` handed to AppendBaselineTable,
+        // so a value cannot be normalized in the store and un-normalized in the snapshot that
+        // replaces it at the next test boundary. A no-op unless --test-data-normalize-company.
+        var toHydrate = TestDataNormalization.Apply(entry.AlTableId.Value, entry.TableName, rows);
+
         return RecordPatches.HydrateTestDataTable(
-            entry.AlTableId.Value, entry.TableName, rows, intoSource, out metaTable, out pristineRows);
+            entry.AlTableId.Value, entry.TableName, toHydrate, intoSource, out metaTable, out pristineRows);
     }
 
     /// <summary>

--- a/AlRunner/TestDataProvisioner.cs
+++ b/AlRunner/TestDataProvisioner.cs
@@ -497,8 +497,16 @@ internal static class TestDataProvisioner
     /// the way it would on real BC with the row present, and a load-on-read design gets that
     /// case silently wrong.
     ///
-    /// Never throws. A table this build cannot rebuild is reported and left empty — the same
-    /// per-table refusal the eager policy had, just reported at the moment of the touch.
+    /// A table this build cannot rebuild is reported and left empty — the same per-table
+    /// refusal the eager policy had, just reported at the moment of the touch.
+    ///
+    /// ONE exception is deliberately allowed to escape, and it is not a data problem:
+    /// TestDataNormalizationException, raised when a --test-data-normalize-company rule names a
+    /// field the restored rows do not carry (#2730). Catching it here would leave the table
+    /// un-normalized while the run went on to report "normalization ON", which is a wrong
+    /// NUMBER rather than a missing table — the run has to stop. Every other failure is
+    /// per-table and is caught below. This summary used to say "never throws"; it was written
+    /// before the rule set existed and the two had drifted apart.
     /// </summary>
     private static void LoadOnDemand(object source, int tableId)
     {

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1400,6 +1400,34 @@ https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues.
     and the table is named on stderr with the reason; `--test-data`'s per-table outcome
     distinguishes "created during another table's hydration" from "never touched".
 
+  **Which company `--test-data` presents, and the one flag that changes it**
+  ([#2730](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2730)). The flag
+  restores the sandbox artifact's `BusinessCentral-W1.bak` **as shipped**. That is a valid BC
+  company, but it is not the company Microsoft's BaseApp test buckets were written against:
+  Microsoft generates theirs from scratch with the legacy DemoTool at pipeline time
+  ([#3429](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3429) has the
+  recipe and the field-by-field comparison). The differences measured so far:
+
+  | `General Ledger Setup` field | restored backup | Microsoft's DemoTool company |
+  |---|---|---|
+  | Additional Reporting Currency | `EUR` | `''` |
+  | Global Dimension 2 Code | `CUSTOMERGROUP` | `PROJECT` |
+  | Shortcut Dimension 3-6 Code | `''` | `CUSTOMERGROUP`, `AREA`, `BUSINESSGROUP`, `SALESCAMPAIGN` |
+
+  The Additional Reporting Currency is the one with a measured cost. Given an ACY, BC's own
+  residual rule **correctly** writes an extra G/L Entry, so every Microsoft test that counts
+  G/L Entries after a posting sees one more than it expects. Nothing in that chain is a runner
+  defect — the company is different. `--test-data-normalize-company` blanks that field after
+  the restore. It is **off by default**, and deliberately so: every pass/fail number recorded
+  in this repository was measured against the un-normalized restore, and a normalized run's
+  numbers are not comparable with them. When it is on, every rule reports what it changed, from
+  which value, in how many rows, and a rule that did not fire reports why.
+
+  The dimension rows are **not** normalized and must not be added as field writes: changing
+  Global Dimension 2 on a company that already has posted entries dimensioned by
+  `CUSTOMERGROUP` is not a field write in BC, and `PROJECT` does not exist as a `Dimension` in
+  the restored company at all.
+
   Measured on BC 28.1's W1 CRONUS backup with the Base Application / System Application /
   Business Foundation closure: **39,231 rows across 344 tables** hydrated; 12 refused,
   1 ambiguous by name, 293 companion columns dropped for apps outside the closure. All 12


### PR DESCRIPTION
Closes #2730
Closes #2290

Corpus-NA: this asserts nothing about Business Central. BC's residual-entry rule given an additional reporting currency is correct, and it is not what changes here — what changes is which COMPANY the tests run against, which is a property of the demo backup the runner restores and of the flag that rewrites it. There is no BC-behaviour claim for a service tier to adjudicate, so no corpus PR and no pin bump.

*(Filed by agent `coord-1`.)*

## What this is

`--test-data` restores the sandbox artifact's `BusinessCentral-W1.bak`, which presents `General Ledger Setup."Additional Reporting Currency"` as `EUR`. Microsoft does not build the company its BaseApp test buckets run against that way — it generates one from scratch with the legacy DemoTool at pipeline time, and `<AdditionalCurrency/>` is empty in all 25 `DemoDataConfig.xml` files, with `CreateGeneralLedgerSetup` writing the field only when it is non-empty (#3429 has the recipe and the field-by-field comparison). Our `EUR` is what Contoso codeunit 5627 produces on a GBP LCY.

Given an ACY, BC's own residual rule **correctly** writes an extra G/L Entry. So Microsoft's tests correctly report six where they expect five, and the runner is not wrong anywhere in that chain. The company is.

New flag **`--test-data-normalize-company`**, applying a named rule set to the restored rows. One rule today: `General Ledger Setup."Additional Reporting Currency" := ''`.

## It is opt-in and off by default

`--test-data` alone behaves exactly as it does today. Every pass/fail number recorded in this repository — the `running-ms-test-buckets` skill's 259/595 Tests-SMB figures, #3416's corpus counts, today's 727/1027 — was measured against the un-normalized restore. Making normalization the default would silently invalidate all of them.

The flag is folded into the install-baseline cache key (`TestDataOptions.BuildCacheIdentity`), for the same reason `--test-data` itself is: a baseline captured *without* normalization restored into a run that asked *for* it would proceed against un-normalized rows with no error anywhere. The rule-set version and rule count are part of that key, so adding or changing a rule invalidates baselines captured under the old set.

## It says what it changed

Per application, on stderr:

```
[test-data] NORMALIZED table 98 'General Ledger Setup'.'Additional Reporting Currency' := '' —
1 of 1 row(s) changed (was 'EUR'), 0 already matched. Why: Microsoft's DemoTool-built test
company has no additional reporting currency (<AdditionalCurrency/> is empty in all 25
DemoDataConfig.xml files); ...
```

And at the end of the run, whenever the flag is on — including when **no** rule fired:

```
[test-data] company normalization ON (--test-data-normalize-company, rule set v1, 1 rule(s)).
These numbers are NOT comparable with a run without it:
[test-data]   table 98 'General Ledger Setup'.'Additional Reporting Currency' := '':
1 row(s) changed (was 'EUR'), 0 already matched, over 1 load(s).
```

A rule that never fired reports `DID NOT APPLY — the run never touched that table`. A rule naming a field the loaded rows do not carry **throws** (`TestDataNormalizationException`) rather than being skipped: the alternative is a run reporting a normalization it did not perform. Confirmed absent from the un-normalized run's output — a default run prints nothing new.

## Where the rule is applied, and why there

On the reader's parsed JSON rows in `TestDataProvisioner.HydrateOne`, **before** `RecordPatches.HydrateTestDataTable` turns them into `NavValue`s. That single point covers both the rows that land in the live store and the `pristineRows` handed to `AppendBaselineTable`, so a value cannot be normalized in the store and un-normalized in the snapshot that replaces it at the next test boundary.

## The measurement

Measured on this box, BC 28.1, `--test-data` on both arms, everything else identical, separate private `--cache` per arm. Load average at each start: 1.2–2.4 on a 31 GB box — moderate, and shared with other agents' builds. **Counts are the result; treat the wall-clock figures as indicative only.**

| | without the flag | with it |
|---|---|---|
| **Tests-SMB** (1,028 discovered) | 727 pass / 286 fail / 15 error | **727 / 286 / 15 — zero delta** |
| **Tests-ERM `Codeunit134157`** in isolation | 3 pass / 3 fail | **6 pass / 0 fail** (exit 0) |
| Tests-SMB wall | 305.9s | 306.8s |

**The Tests-SMB delta is zero, and that is a real result rather than a failed task.** The rule fired in both bucket runs — `1 of 1 row(s) changed (was 'EUR')` — so this is not the flag failing to do anything. Tests-SMB simply carries no ACY-sensitive assertion; #2730's clusters are all in Tests-ERM (134157, 134880's four `Reverse…` tests, and the 16-test exchange-rate cluster). The `Codeunit134157` row is the direct reproduction of the measurement #3429 and the `running-ms-test-buckets` skill both record, and it is what says the mechanism works.

I did **not** run the full 40,530-test surface: a 32-bucket run was reported in flight and a second would contend for the box and corrupt both.

## Deliberate breaks — the tests are not vacuous

`.claude/rules/tdd.md`, and the seven-instance check-that-cannot-fail history. I broke the implementation twice and confirmed red both times:

| break | what it did | result |
|---|---|---|
| **1 — no-op** | `if (true) return rows;` at the top of `Apply`, after the `Enabled` check, so the flag turns on but nothing is rewritten | **5 failed / 12 passed.** The two central claims (`…IsBlankedOnARowThatArrivedAsEur`, `…TheAlValueBuiltFromTheNormalizedCellIsBlank`) both went red, along with the reporting and refusal tests |
| **2 — wrong value** | rule's `TargetJson` changed from `""` to `"USD"`, so the rewrite happens with the wrong target | **3 failed / 14 passed.** Both central claims went red again; the "no other field is touched" and "table nobody targets" tests correctly stayed green, because neither is about the value |
| **3 — call site drops the cache term** (reviewer's break) | fourth argument of `BuildCacheIdentity` at `TestDataOptions.CacheIdentity()` replaced with a `""` literal | **1 failed / 53 passed**, and the one failure is `NormalizedRun_AndUnnormalizedRun_DoNotShareAnInstallBaselineCacheKey`. The pure-function test stayed green, which is exactly the reviewer's point |

Restored and re-verified after each: 79/79 green across the five affected classes, 208/210 (2 pre-existing skips) across the reviewer's wider `InstallBaseline|CacheKey|CacheIdentity|TestData` filter, and 15/15 clean iterations.

### Break 3 is the one that mattered, and it is why a test moved file

The original `TheNormalizationFlagChangesTheInstallBaselineCacheKey` passed the normalization identity into `BuildCacheIdentity` **by hand**, so it proved that function is injective in its fourth parameter — a claim about a pure function that stays true even when the call site stops passing one. It is not the claim that matters. Would have been the eighth "check that cannot fail" in this repository.

`TestDataProvisioningTests.NormalizedRun_AndUnnormalizedRun_DoNotShareAnInstallBaselineCacheKey` now drives `TestExecutor.CurrentInstallBaselineCacheKey()` — the function that actually keys both the in-memory and the disk tier — on the model of the `#2258` sibling directly above it, whose own comment says the same thing. It lives in that class rather than beside the other normalization tests because that is where the `TestDataOptions` statics and the fake-reader fixture already are, and putting it elsewhere would have reintroduced the cross-class static race fixed below.

The regression this catches is durable: a normalized run served from a cache populated by an un-normalized one, or the reverse, across runs, with every number measured afterwards wrong and nothing indicating it.

## A flake found and fixed on the way

`TestDataOptions.ResetForTests()` cleared `TestDataNormalization.Enabled`. xunit runs test classes in parallel, so `TestDataProvisioningTests`' `Dispose` reached into state `TestDataCompanyNormalizationTests` was mid-assertion on — reproduced once, as `CacheIdentity()` returning `""` in a test that had just set `Enabled = true`. Fixed by decoupling the reset (each option class resets its own statics), not by serialising the two classes: `TestDataLazyHydrationTests` calls the same reset from two other collections, so a collection would only have hidden it from the classes that happened to be named. 20/20 clean iterations after, at ~68ms each — no per-iteration cost change, because the fix removes a call rather than adding synchronisation.

## Folded in: #2290

Same file, same block. `--help` promised `--test-data-company`'s "Default: the first company the backup reports"; the runner deliberately refuses to choose, and the shipped W1 backup holds two companies, so anyone following the help text on the default artifact got an `EXEC-FAIL`. The runtime behaviour is the intended one and is unchanged — the help text was documenting an earlier design. Corrected in `--help` and `--guide`, with its own RED → GREEN in `TestDataCompanyHelpTextTests`.

#2290 also asked whether the CLI drift test compares option *descriptions* or only *names*. **Only names** — `CliDocumentationTests.Help_DocumentsEveryRecognizedFlag` scrapes flag literals out of `Program.cs` and asserts `help.Contains(flag)`, which is exactly why a wrong description was invisible to it. I did **not** build a general description-level drift check: that is a project of its own with no obvious oracle, and guessing at one would produce a gate that nags or stays silent in the wrong places. What landed instead is a targeted assertion that this specific sentence cannot come back, plus the positive claim that replaced it.

## The three questions

1. **Same wrong pattern at another call site?** No. There is exactly one place backup rows become `NavValue`s (`HydrateTestDataTable`, reached only from `HydrateOne`), and the rule set is applied at that single point. Grepped for other writers into the hydration path; `AppendBaselineTable` consumes the same array.
2. **Sibling function making the same assumption?** The assumption being corrected — "the restored backup is the company Microsoft's tests expect" — is not made in code anywhere; it was an unstated property of the data. The place it *reads* as an assumption is documentation, which is why `docs/limitations.md` now states which company `--test-data` presents. That was #2730's own explicit ask.
3. **Two code paths writing the same state with different invariants?** Yes, and it is handled: the live store and the install-baseline snapshot are written from the same `built` array, so normalizing before that point keeps them equal by construction. Normalizing *after* hydration would have set the store and left the snapshot un-normalized, and the next test boundary would have restored `EUR` — the reason the rule set sits where it does.

## Not folded, and why

Open `area: test-data` issues sharing the subsystem but not the file:

- **#2833** — closed already; it is the `Codeunit134157` cluster this change measurably fixes (3/3 → 6/0). Nothing to fold.
- **#2273** (bare backup columns refused), **#2271** (TableFilter wire shape), **#2260** (BC system columns), **#2268/#2270** siblings — all in `RecordPatches.TestDataHydration.cs`'s codec, a different file, and each needs its own reasoning about a value type. Folding any of them would make this diff two unrelated reviews.
- **#2264** (same-named tables disambiguated by owning app) — `BuildPlan`/`ResolveCompany` in `TestDataProvisioner.cs`, so the same file, but it is a plan-construction change with no overlap with the hydration call site; a reviewer holding both would be holding two changes.
- **#2263** (talk to the reader over serve mode) — a transport change to `BackupReaderTool`, orthogonal.
- **#2277** (a setup singleton whose one row is blank is not explained) — `MissingTestDataDiagnosis.cs`. Worth noting for whoever takes it: this change makes blank setup singletons *slightly* more common by construction, since a normalized ACY is a blank field on an existing row. It does not make #2277 worse — that issue is about `Get()` succeeding on a blank row — but the two now interact.
- **#3429** stays open by design: it is the research issue, and the next rules it names (Global Dimension 2, shortcut dimensions 3-6, accounting-period anchoring) are master data, not field writes. A test in this PR asserts the rule set does not attempt them.

## Three smaller things the review asked for

- `TestDataOptions.CompanyOverride`'s doc comment still said *"Null means 'the first company the backup reports'"* — the same wrong sentence #2290 fixes in `--help`, left standing in code. Clause deleted, replaced with what actually happens. The `"<first>"` token inside `BuildCacheIdentity`'s hashed payload is left alone deliberately: it is an opaque placeholder for null, and renaming it would invalidate every existing `--test-data` baseline on every user's disk for no behavioural gain.
- `LoadOnDemand`'s summary said "Never throws", and `TestDataNormalizationException` escapes it. The exception is the correct half: a rule naming a field the rows do not carry is a wrong **number**, not a missing table, so catching it per-table would leave the run reporting "normalization ON" over un-normalized data. The summary was written before the rule set existed and now says which exception escapes and why.
- `TestDataNormalization.cs`'s header lost its first ~18 lines — the derivation of Microsoft's recipe, which is written in `docs/limitations.md` and #3429 — and now points at both. 54 → 45 lines.

## Where the prose went

`AlRunner/Infrastructure/TestDataNormalization.cs`'s header is over ten lines, and it stays in code: it is the file a person edits to add a rule, and the two things they would get wrong — making it default-on, and adding a dimension rule as a field write — are both edits to that file. The measurement tables went to `docs/limitations.md` and the skill, which are versioned and re-runnable; the derivation of Microsoft's recipe stays in #3429 and is cited, not reproduced.

## Tests run

- `TestDataCompanyNormalizationTests`, `TestDataCompanyHelpTextTests`, `TestDataProvisioningTests`, `TestDataLazyHydrationTests`, `CliDocumentationTests` — 79/79, and 15/15 clean iterations of the static-touching subset.
- The reviewer's wider filter `InstallBaseline|CacheKey|CacheIdentity|TestData` — 208 passed, 2 skipped (both pre-existing skips in `RecordPatchesWarmReloadInstallBaselineTests`).
- `CliDocumentationTests` + `ParallelFanOutFlagDriftTests` — 22/22 (this diff edits `CliText.cs`, `Program.cs` and the `BehaviorChangingFlags` list).
- Two Tests-SMB bucket runs and two `Codeunit134157` runs, as above.

I did not run the full `AlRunner.Tests` suite. The diff's blast radius is the `--test-data` option surface, the CLI text and one line in `Reporter.cs`; nothing touches the shared compile/dispatch path.

https://claude.ai/code/session_01F7HLDeNwiGQoLT5wFanqmH
