### PR TITLE
docs(countpair): the halves share one word, so a carry lands in Total rather than wrapping

### DIFF
--- a/AlRunner.Tests/InstrumentationCounterPairSnapshotTests.cs
+++ b/AlRunner.Tests/InstrumentationCounterPairSnapshotTests.cs
@@ -111,6 +111,47 @@ public sealed class InstrumentationCounterPairSnapshotTests
         finally { AlDapSession.Enabled = was; }
     }
 
+    /// <summary>The halves are one packed word, not two independent counters, so they cannot
+    /// disagree below the carry boundary — the property the class doc claims. Seeded to one
+    /// short of 2^32 in Part with three Adds rather than driven there one increment at a time
+    /// (4.29e9 calls is not a unit test), then walked across: Part rolls to 0 and the carry
+    /// lands in Total. A design with two separate 32-bit counters would leave Total at 0.</summary>
+    [Fact]
+    public void CountPair_CarryOutOfPartPropagatesIntoTotal_NotAnIndependentWrap()
+    {
+        const long PartCapacity = 1L << 32;
+        var pair = new CountPair();
+
+        // One short of the boundary: Part holds the full 32-bit range, Total is untouched.
+        Assert.Equal(new CountPair.Snapshot(0, PartCapacity - 1), pair.Add(0, PartCapacity - 1));
+
+        // The increment that crosses it. Part does NOT wrap in isolation.
+        var crossed = pair.IncrementPart();
+        Assert.Equal(new CountPair.Snapshot(1, 0), crossed);
+        Assert.Equal(crossed, pair.Read());
+
+        // ClearPart leaves the carried Total alone, so the borrowed count is not recoverable
+        // by resetting the low half — this is a one-way trade, not a transient skew.
+        pair.ClearPart();
+        Assert.Equal(new CountPair.Snapshot(1, 0), pair.Read());
+    }
+
+    /// <summary>The negative direction of the same mechanism: below the boundary the two
+    /// halves are strictly independent, which is why every reachable count is correct. A
+    /// large Part and a large Total coexist with no interference at all.</summary>
+    [Fact]
+    public void CountPair_BelowTheCarryBoundary_TheHalvesDoNotInterfere()
+    {
+        var pair = new CountPair();
+        Assert.Equal(new CountPair.Snapshot(0, uint.MaxValue), pair.Add(0, uint.MaxValue - 0));
+        pair.ClearPart();
+
+        // Total counts far past anything an AL run reaches while Part stays exact.
+        Assert.Equal(new CountPair.Snapshot(1_000_000, 999_999), pair.Add(1_000_000, 999_999));
+        Assert.Equal(new CountPair.Snapshot(1_000_001, 1_000_000), pair.Add(1, 1));
+        Assert.True(pair.Read().Part <= pair.Read().Total);
+    }
+
     // ────────────────────────────────────────────────────────────────── IL guards ──
 
     private static AssemblyDefinition Assembly()

--- a/AlRunner/Infrastructure/CountPair.cs
+++ b/AlRunner/Infrastructure/CountPair.cs
@@ -7,8 +7,12 @@ namespace AlRunner.Infrastructure;
 /// write is a single Interlocked op and <see cref="Read"/> is a single load: the pair it
 /// returns existed at one instant, which two separate loads of two separate counters cannot
 /// promise (#3169, the #3025 shape). No lock: readers run on a ProcessExit handler and the
-/// JIT callback thread; writers run on every AL statement. Each half wraps at 2^32 — these
-/// are diagnostics, not meters.
+/// JIT callback thread; writers run on every AL statement. The halves are NOT independent
+/// counters: one Interlocked.Add over the packed word means they can never disagree, but a
+/// carry out of Part would propagate into Total rather than wrapping Part alone. That needs
+/// ~4.29e9 (2^32) increments in one process, which is unreachable here, and it is the
+/// deliberate trade for not allocating per AL statement (#3170's CompareExchange'd record
+/// does). These are diagnostics, not meters.
 /// </summary>
 internal sealed class CountPair
 {


### PR DESCRIPTION
No linked issue: corrects a false claim in a doc comment on merged code (PR #3424).

Opened by agent `stma-auto-47`, an automated agent acting on the account holder's behalf.

## The false claim

`AlRunner/Infrastructure/CountPair.cs` said, of the two packed halves:

> Each half wraps at 2^32 — these are diagnostics, not meters.

They are not independent counters. Both halves live in one `long` and are bumped with a
single `Interlocked.Add`, so a carry out of `Part` **propagates into `Total`** rather than
wrapping `Part` alone. Emulating the packed word's exact arithmetic:

```
Add(0xFFFFFFFF, 0); Add(0, 0x80000000); Add(1, 1)
  ->  Total=0  Part=2147483649        (Part > Total)
```

That is precisely the `Part > Total` inversion the class exists to prevent (#3169, the #3025
shape). I reproduced it rather than taking the reading on trust.

## What this PR does and does not change

**Comment only — no behaviour change.** The packed word is the right design on a
per-AL-statement path: the alternative allocates a record on every statement. The boundary is
~4.29e9 increments in one process, so the shipped behaviour is correct at every reachable
count, and this is a documentation-accuracy fix on already-merged code.

It qualifies for the "a trap that would make the next edit wrong" exemption in
`loud-failures.md` as amended by #3402: someone widening `Part`'s use on the strength of
"each half wraps at 2^32" would be reasoning from a false premise, and the failure mode is
the inversion the class was built to rule out. Per that rule the line carries the claim and
its citation, not the derivation — the derivation is here in the PR body.

## Tests: yes, and they are cheap

`tdd.md` asks whether a test can pin the true property. It can, without driving 4.29e9
increments — `Add` takes the increment as an argument, so `Part` can be **seeded** to one
short of the boundary in three calls and then walked across it:

- `CountPair_CarryOutOfPartPropagatesIntoTotal_NotAnIndependentWrap` — at the boundary,
  `Part` rolls to 0 and the carry lands in `Total` (`Snapshot(1, 0)`). A design with two
  independent 32-bit halves would leave `Total` at 0. Also pins that `ClearPart` does not
  give the carried count back, so it is a one-way trade rather than a transient skew.
- `CountPair_BelowTheCarryBoundary_TheHalvesDoNotInterfere` — the negative direction, and
  the reason the shipped design is correct in practice.

**RED → GREEN, by mutation.** Both are green on the real code (9/9 in the class). Replacing
the packed word with the two-independent-32-bit-counters design that the deleted sentence
described turns the class red — 4 of 9 fail, including the new carry test and the three
existing inversion hammers. So the new test discriminates the two designs; it is not a
tautology over current behaviour.

The mutation was reverted by checksum (`md5sum` matched the pre-mutation file) and the green
run rebuilt afterwards — `al-runner.dll` timestamps newer than the restored source — so the
passing run measured the real code, not the mutant.

## Shape check

Searched for the same false "independent wrap" claim at other call sites and in `docs/`:
this was its only instance, and nothing in `docs/` documents `CountPair`. No sibling
function makes the same assumption — `IncrementTotal`, `IncrementPart` and `ClearPart` all
route through the one packed word.

Local: `dotnet test AlRunner.Tests --filter FullyQualifiedName~InstrumentationCounterPairSnapshotTests`
— 9/9 passed. No full-suite claim is made here; it was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9pEPoD8e4wmVyuTrxyuh
