### PR TITLE
test(corpus): advance the pin to 98eec278, the one of nine commits not held by an open fix PR

### DIFF
--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -1586,3 +1586,45 @@ revision of this branch carried are gone, and neither was deleted on a guess:
   the "remove the entry" direction.
 
 Written by the fbk-1 agent.
+
+### 3008 -> 3011 (pin 69ae7598 -> 98eec278, +3)
+
+A **catch-up** bump: PR #3393, the runner fix these three tests need, merged earlier today, so
+this bump closes no issue and stands on its own.
+
+ONE corpus commit of the nine available: #265 `98eec27`, which pins how far the Integer virtual
+table reaches and that an open-ended filter is answered rather than refused.
+
+**3011 is the guard's own printed `actual`**, read by running with a deliberately impossible
+baseline so the guard had to state the number it measured -- not `3008 + 3`. `al-language-onprem`
+stayed at 29 and `al-language-internals-fixture` at 0.
+
+**Why the pin stops here rather than at corpus master `ccc10f12`.** Corpus history is linear and
+`98eec27` is the oldest of the nine commits master is ahead by. Each of the remaining eight was
+measured individually, cumulatively, on this branch's build; failures are strictly monotonic, so
+the attribution below is a partition rather than an estimate:
+
+| corpus commit | corpus PR | +new failures | codeunit | held by |
+|---|---|---|---|---|
+| `98eec27` | #265 | 2 | `Codeunit60368` Integer window | **#3438** -- declared here |
+| `ce2c3af` | #270 | 1 | `Codeunit60035` recursion depth | PR #3412 (`Closes #3405`) |
+| `8678dc2` | #263 | 5 | `Codeunit60670` temporal SetValue | PR #3394 (`Closes #3384`) |
+| `7153eb5` | #267 | 1 | `Codeunit60662` blank temporal | PR #3410 (`Closes #2361`) |
+| `5f4b254` | #266 | 5 | `Codeunit60358` part OnNewRecord | PR #3414 (`Closes #3029`) |
+| `9bb602a` | #268 | **0** | -- passes already | nothing |
+| `c5b8123` | #269 | 4 | `Codeunit60702` effective permissions | PR #3413 (`Closes #2382`) |
+| `2a89f13` | #271 | 1 | `Codeunit60411` same-value SetValue | PR #3427 (`Closes #3055`) |
+| `ccc10f12` | #274 | 9 | `Codeunit60636` page trigger events | #3436, #3441, #3440 (no PR) |
+
+Every one of those eight is held by an open runner PR **created today and still unmerged**, or
+by an open issue with no PR. Declaring known-gap entries for them would produce entries that go
+stale the day each PR merges -- the failure mode that once produced 20 bogus entries -- so they
+are left for the fold bumps their own PRs will carry.
+
+`98eec27` is the exception, and that is why it is the one commit taken: its blocker **#3438** is
+open, unassigned and carries no fix PR, so the two entries declared in
+`known-gaps-integer-virtual-table-window.json` describe a durable gap rather than a race with a
+merge queue. #3393 implemented the *guard* (closing #2350) and deliberately left the window's
+*width* as the in-scope remainder; #3438 is that remainder.
+
+Written by agent `stma-auto-49`, an automated agent acting on the account holder's behalf.

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Schema, semantics and how to bump: README.md in this directory. Per-bump rationale: history.md, never a prose line in here (#2485).",
   "suites": {
     "al-language": {
-      "tests": { "default": 3008 },
+      "tests": { "default": 3011 },
       "appGroups": { "default": 1 }
     },
     "al-language-internals-fixture": { "tests": { "default": 0 }, "appGroups": { "default": 1 } },

--- a/tests/expectations/known-gaps-integer-virtual-table-window.json
+++ b/tests/expectations/known-gaps-integer-virtual-table-window.json
@@ -1,0 +1,18 @@
+[
+  {
+    "codeunitId": 60368,
+    "CodeunitName": "Test Integer Virtual Table",
+    "Method": "Record_Integer_RangeFarAboveAnySeededWindow_YieldsTheWholeRange",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3438",
+    "Note": "Pulled in by this catch-up pin bump to corpus 98eec27 (StefanMaron/BusinessCentral.AL.Language.Tests#265), NOT caused by it. The test reads Number 250000, an ordinary row on a real service tier: #3393 established from the Ncl decompile that IntegerDataProvider clamps to [-1000000000..1000000000], so BC serves it. The runner materialises [-1000..100000] eagerly and, since #3393, refuses a closed bound outside that window loudly rather than truncating it silently -- so the refusal here is the guard working as designed, and the residual gap is the window's width, not the guard. Tracked as #3438, which is open, unassigned, carries no fix PR, and stays open after this PR merges; widening the window to BC's range removes this entry."
+  },
+  {
+    "codeunitId": 60368,
+    "CodeunitName": "Test Integer Virtual Table",
+    "Method": "Record_Integer_RangeFarBelowZero_YieldsTheWholeRange",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3438",
+    "Note": "The same gap at the other end of the window: the test reads Number -250000, which real BC serves within its [-1000000000..1000000000] clamp and which sits below the runner's materialised floor of -1000. See the sibling entry above for why the refusal is #3393's guard behaving correctly rather than a regression. Tracked as #3438, which stays open after this PR merges."
+  }
+]


### PR DESCRIPTION
No linked issue: a catch-up submodule pin bump. PR #3393, the runner fix the newly-pinned tests need, merged earlier today, so this bump is green on its own and closes nothing.

Advances `tests/al-language` **`69ae7598` -> `98eec278`** (corpus PR #265), and updates `tests/expectations/count-baseline/` alongside it.

## The measurement

Corpus `master` (`ccc10f12`) is **nine** commits ahead of the old pin. I measured every candidate prefix rather than reasoning about it: the runner built from this branch, run the way `bc-tests.yml` does — all three apps via `scripts/corpus-app-dirs.py`, `--strict --expectations-require-match --count-baseline` — on BC 28.1, in a worktree with its **own** corpus clone so the shared submodule directory could not contaminate the reading (#3404).

**The control is clean in both cache states**, which is what makes every failure below attributable to the bump rather than to the box:

| pin | AL emit | tests | pass | fail | exit |
|---|---|---|---|---|---|
| control `69ae7598`, cold | 4.9s | 3037 | 3037 | **0** | 0 |
| control `69ae7598`, warm (cache HIT) | 0.0s | 3037 | 3037 | **0** | 0 |
| **new pin `98eec278`, cold (`--no-cache`)** | 3.5s | 3040 | **3040** | **0** | **0** |
| **new pin `98eec278`, warm (cache HIT)** | 0.0s | 3040 | **3040** | **0** | **0** |

The warm runs were genuine compile-cache hits (AL emit and C# compile both 0.0s against 3.5s / 11.6s cold) and produced identical counts, so nothing here is cache-sensitive — the case `local-test-scope.md` asks for.

`exec-fail` was **0** and `ran` was **3** on all eleven runs, so none of this is the concurrent-agent `ncl-shadow` EXEC-FAIL sweep.

## Why the pin stops at the first of nine

Corpus history is linear, so a commit cannot be taken without its predecessors. Each of the nine was measured individually and cumulatively. Failures accumulate **strictly monotonically** — no failure ever disappears — so this is a partition, not an estimate:

| corpus commit | corpus PR | +new failures | codeunit | held by |
|---|---|---|---|---|
| **`98eec27`** | **#265** | **2** | `Codeunit60368` Integer window | **#3438 — declared here** |
| `ce2c3af` | #270 | 1 | `Codeunit60035` recursion depth | PR #3412 (declares #3405 as its target) |
| `8678dc2` | #263 | 5 | `Codeunit60670` temporal SetValue | PR #3394 (declares #3384 as its target) |
| `7153eb5` | #267 | 1 | `Codeunit60662` blank temporal | PR #3410 (declares #2361 as its target) |
| `5f4b254` | #266 | 5 | `Codeunit60358` part OnNewRecord | PR #3414 (declares #3029 as its target) |
| `9bb602a` | #268 | **0** | — passes already | nothing |
| `c5b8123` | #269 | 4 | `Codeunit60702` effective permissions | PR #3413 (declares #2382 as its target) |
| `2a89f13` | #271 | 1 | `Codeunit60411` same-value SetValue | PR #3427 (declares #3055 as its target) |
| `ccc10f12` | #274 | 9 | `Codeunit60636` page trigger events | #3436, #3441, #3440 (no PR) |

Every one of those eight is held by a runner PR **created today and still unmerged**, or by an open issue with no PR at all. Writing `expect-fail-known-gap` entries for them would create entries that go stale the day each PR merges — the failure mode that once produced 20 bogus entries — so they are left for the *fold* bumps their own PRs will carry. That is `al-language-submodule.md`'s blocked-by-an-intervening-commit case: pin the newest commit whose predecessors are all satisfied, name what holds the rest.

`9bb602a` (#268, NAV App Installed App) adds **zero** failures and would be free, but it sits behind four blocked predecessors and cannot be taken alone.

## Why `98eec278` is the exception

Its two failures are the only ones whose blocker is **durable**. #3393 implemented the Integer window *guard* (the fix for #2350) and deliberately left the window's *width* as the in-scope remainder; that remainder is **#3438**, which is open, unassigned and carries no fix PR. So the entries in `known-gaps-integer-virtual-table-window.json` describe a gap that stays tracked after this merges, rather than racing a merge queue.

The classification is not a guess about BC. #3393 established from the `Ncl.dll` decompile that `IntegerDataProvider` clamps to `[-1000000000..1000000000]`, so `Number = 250000` and `-250000` are ordinary rows a service tier serves — and corpus #265 is green on real BC. The runner materialises `[-1000..100000]` **eagerly**, so widening it to BC's range is not a config change, which is exactly why #3438 exists as work rather than a setting. The runner's own refusal message names the surface, the window and the requested bound.

## Counts

`al-language` **3008 -> 3011**, and `pass-known-gap` **15 -> 17** — the two entries added, nothing else reclassified.

**3011 is the count-baseline guard's own printed `actual`**, not `3008 + 3`. I read it by running against a deliberately impossible baseline so the guard had to state the number it measured:

```
[count-baseline] DROP: suite 'al-language' tests count: expected 999999, actual 3011 (BC 28.1)
```

The same probe against the control printed `actual 3008`, matching the baseline on disk — which also proves the guard was live rather than silently skipping, so the green control is evidence rather than an answer that could not have come out otherwise. `al-language-onprem` stayed at 29 and `al-language-internals-fixture` at 0.

## Note on #3416

**#3416's stated chain is now stale** and I have said so on the issue. It records `29042fc` (AllObj, PR #3391) as the first of five blockers; `29042fc` is now an **ancestor of the old pin** (`git merge-base --is-ancestor` confirms), and four of its five PRs — #3360, #3381, #3379, #3393 — have merged. Its remaining live claim is that the blocker sits on the *oldest* held-out commit, which this measurement independently reproduces against a different set of nine commits.

**#3391 is not a blocker for this bump.** Its corpus commit `29042fc` is already pinned, and its four AllObj tests are classified by `known-gaps-allobj-subtype.json`, already on `main` — which is why the control run is green.

---

Written by agent `stma-auto-49`, an automated agent acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9pEPoD8e4wmVyuTrxyuh
