### PR TITLE
fix(ms-buckets): give the Microsoft bucket workflows a per-test timeout above the hosted runner's speed

### DIFF
--- a/.github/workflows/ms-bucket-nightly.yml
+++ b/.github/workflows/ms-bucket-nightly.yml
@@ -126,6 +126,12 @@ jobs:
     # watchdog behaviour. A second spelling of any of that is how bc-tests.yml's provisioning
     # drifted four times and failed two releases (#1976).
     #
+    # test-timeout is deliberately NOT passed: this runs on the same hosted runner as every
+    # other caller, so it wants the same watchdog, and ms-bucket.yml's 300 s default (#3431)
+    # is where that number lives. Spelling it again here is how the nightly's configuration
+    # and the surface's would come to differ, which would make their numbers incomparable —
+    # exactly the failure this whole file exists to avoid.
+    #
     # bc-version is left EMPTY on purpose: ms-bucket.yml resolves that to the newest prefix in
     # .github/bc-versions.txt, which is the version the matrix marks required. Pinning a
     # version here is the thing this nightly must not do.

--- a/.github/workflows/ms-bucket.yml
+++ b/.github/workflows/ms-bucket.yml
@@ -54,27 +54,11 @@ name: MS bucket (manual)
 #   * AL_RUNNER_EMIT_TIMEOUT_SEC far above the 120 s default (Tests-ERM's emit alone is
 #     minutes);
 #   * a private --cache root, never the shared default;
-#   * --test-timeout, from the `test-timeout` input, default 300 s. See below for why the
-#     runner's own 60 s default is wrong here specifically.
-#
-# THE PER-TEST WATCHDOG IS WALL CLOCK, AND THIS RUNNER IS SLOW (#3431)
-#   The runner's default is 60 s, which is a developer-box number: every local measurement in
-#   this repository was taken on a much faster machine than a hosted 4-vCPU one. Run
-#   34150530633 cut off Codeunit134043.CloseFiscalYearWithAdditionalCurrencyRounding at
-#   `60001ms` — the watchdog firing one millisecond past the limit on a test still making
-#   progress — where the same bucket on a 12-core box ran 9,496 of 9,496 with zero aborts.
-#
-#   That is not one lost test. An abort ends the process, the resume machinery restarts, and
-#   past --resume-aborts (default 5) the rest of the bucket goes with it. The number the run
-#   produces is then wrong by an amount that depends on how fast the machine was, which is
-#   the one property a measurement must not have.
-#
-#   The watchdog is NOT removed, and must not be: it is what turns an unbounded loop into a
-#   diagnosable abort instead of a job grinding to the 360-minute ceiling. 300 s keeps that
-#   while covering the slowdown — the #3374 MaxIteration defect produced loops that completed
-#   at no timeout at all (one ran 1,300 s through 87,313 of ~101,001 iterations of the first
-#   of two passes), so raising the ceiling does not hide that class. Worst case cost is
-#   bounded at about 25 minutes: five aborts at 300 s rather than at 60 s.
+#   * --test-timeout, from the `test-timeout` input, default 300 s. The watchdog is wall
+#     clock, and the runner's own 60 s default is a developer-box number that aborts
+#     legitimate tests here (#3431). Do NOT remove the watchdog to fix that: it is what turns
+#     an unbounded loop into a diagnosable abort instead of a job grinding to the 360-minute
+#     ceiling.
 #
 # Reading the number — two known ways it can be wrong until their fixes land, both surfaced
 # verbatim in the summary by scripts/ms-bucket-summary.py:
@@ -219,10 +203,9 @@ on:
         default: true
       test-timeout:
         description: >-
-          Per-test watchdog in seconds (--test-timeout). 300 covers the hosted runner's
-          slowdown against the developer boxes every local number was measured on; the
-          runner's own 60 s default does not, and an abort takes its bucket's remaining
-          suites with it (#3431). Lower it only to reproduce a specific abort.
+          Per-test watchdog in seconds (--test-timeout). The runner's own 60 s default is a
+          developer-box number and aborts legitimate tests on a hosted runner (#3431). Lower
+          it only to reproduce a specific abort.
         type: number
         required: false
         default: 300
@@ -449,20 +432,20 @@ jobs:
           BC_VERSION: ${{ steps.bc.outputs.version }}
           WITH_TEST_DATA: ${{ inputs.test-data }}
           READER: ${{ steps.reader.outputs.tag }}
-          # The per-test watchdog, handed to --test-timeout on the runner's argument array
-          # below. Deliberately NOT named AL_RUNNER_TEST_TIMEOUT_SEC, which the runner reads
-          # by itself: with that name, dropping the flag from the array would leave the
-          # timeout working anyway and nothing here could tell. This name reaches the runner
-          # only through the flag, so losing the flag reverts to the 60 s default and the
-          # guard in MsBucketWorkflowTests goes red.
+          # Handed to --test-timeout on the argument array below. Do NOT rename this to
+          # AL_RUNNER_TEST_TIMEOUT_SEC, which the runner reads by itself: under that name,
+          # dropping the flag would leave the timeout working and MsBucketWorkflowTests could
+          # no longer tell.
           TEST_TIMEOUT_SEC: ${{ inputs.test-timeout }}
         run: |
           set +e
           mapfile -t BUCKET_LIST < "$RUNNER_TEMP/buckets.txt"
           total=${#BUCKET_LIST[@]}
-          # An empty value would make --test-timeout swallow the next argument instead of
-          # failing, so it is refused here rather than producing a run configured differently
-          # from the one that was asked for.
+          # Fails once, up front, before provisioning. The runner rejects a bad value itself
+          # -- the flag's value is quoted on the array, so an empty one arrives as an empty
+          # argument and Program.cs exits 2 rather than swallowing the next flag -- but it
+          # does so only after this job has paid provisioning and each bucket's setup, once
+          # per invocation.
           if ! printf '%s' "$TEST_TIMEOUT_SEC" | grep -Eq '^[1-9][0-9]*$'; then
             echo "::error::test-timeout must be a positive whole number of seconds, got '$TEST_TIMEOUT_SEC'"
             exit 1

--- a/.github/workflows/ms-bucket.yml
+++ b/.github/workflows/ms-bucket.yml
@@ -53,7 +53,28 @@ name: MS bucket (manual)
 #   * both --package-cache directories;
 #   * AL_RUNNER_EMIT_TIMEOUT_SEC far above the 120 s default (Tests-ERM's emit alone is
 #     minutes);
-#   * a private --cache root, never the shared default.
+#   * a private --cache root, never the shared default;
+#   * --test-timeout, from the `test-timeout` input, default 300 s. See below for why the
+#     runner's own 60 s default is wrong here specifically.
+#
+# THE PER-TEST WATCHDOG IS WALL CLOCK, AND THIS RUNNER IS SLOW (#3431)
+#   The runner's default is 60 s, which is a developer-box number: every local measurement in
+#   this repository was taken on a much faster machine than a hosted 4-vCPU one. Run
+#   34150530633 cut off Codeunit134043.CloseFiscalYearWithAdditionalCurrencyRounding at
+#   `60001ms` — the watchdog firing one millisecond past the limit on a test still making
+#   progress — where the same bucket on a 12-core box ran 9,496 of 9,496 with zero aborts.
+#
+#   That is not one lost test. An abort ends the process, the resume machinery restarts, and
+#   past --resume-aborts (default 5) the rest of the bucket goes with it. The number the run
+#   produces is then wrong by an amount that depends on how fast the machine was, which is
+#   the one property a measurement must not have.
+#
+#   The watchdog is NOT removed, and must not be: it is what turns an unbounded loop into a
+#   diagnosable abort instead of a job grinding to the 360-minute ceiling. 300 s keeps that
+#   while covering the slowdown — the #3374 MaxIteration defect produced loops that completed
+#   at no timeout at all (one ran 1,300 s through 87,313 of ~101,001 iterations of the first
+#   of two passes), so raising the ceiling does not hide that class. Worst case cost is
+#   bounded at about 25 minutes: five aborts at 300 s rather than at 60 s.
 #
 # Reading the number — two known ways it can be wrong until their fixes land, both surfaced
 # verbatim in the summary by scripts/ms-bucket-summary.py:
@@ -141,6 +162,13 @@ on:
         type: boolean
         required: false
         default: true
+      test-timeout:
+        description: >-
+          Per-test watchdog in seconds (--test-timeout). The runner's 60 s default is a
+          developer-box number and cuts legitimate tests off on a hosted runner (#3431).
+        type: number
+        required: false
+        default: 300
   workflow_dispatch:
     inputs:
       bucket:
@@ -189,6 +217,15 @@ on:
         type: boolean
         required: false
         default: true
+      test-timeout:
+        description: >-
+          Per-test watchdog in seconds (--test-timeout). 300 covers the hosted runner's
+          slowdown against the developer boxes every local number was measured on; the
+          runner's own 60 s default does not, and an abort takes its bucket's remaining
+          suites with it (#3431). Lower it only to reproduce a specific abort.
+        type: number
+        required: false
+        default: 300
 
 permissions:
   contents: read
@@ -412,10 +449,24 @@ jobs:
           BC_VERSION: ${{ steps.bc.outputs.version }}
           WITH_TEST_DATA: ${{ inputs.test-data }}
           READER: ${{ steps.reader.outputs.tag }}
+          # The per-test watchdog, handed to --test-timeout on the runner's argument array
+          # below. Deliberately NOT named AL_RUNNER_TEST_TIMEOUT_SEC, which the runner reads
+          # by itself: with that name, dropping the flag from the array would leave the
+          # timeout working anyway and nothing here could tell. This name reaches the runner
+          # only through the flag, so losing the flag reverts to the 60 s default and the
+          # guard in MsBucketWorkflowTests goes red.
+          TEST_TIMEOUT_SEC: ${{ inputs.test-timeout }}
         run: |
           set +e
           mapfile -t BUCKET_LIST < "$RUNNER_TEMP/buckets.txt"
           total=${#BUCKET_LIST[@]}
+          # An empty value would make --test-timeout swallow the next argument instead of
+          # failing, so it is refused here rather than producing a run configured differently
+          # from the one that was asked for.
+          if ! printf '%s' "$TEST_TIMEOUT_SEC" | grep -Eq '^[1-9][0-9]*$'; then
+            echo "::error::test-timeout must be a positive whole number of seconds, got '$TEST_TIMEOUT_SEC'"
+            exit 1
+          fi
           bak="$HOME/.al-runner/test-data/$BC_VERSION/BusinessCentral-W1.bak"
           # cwd OUTSIDE the checkout: the runner auto-probes ./tests/expectations from cwd as
           # a fallback (ExpectationsDirectoryResolution.cs), and the corpus manifest has no
@@ -433,6 +484,7 @@ jobs:
                    --package-cache "$HOME/.al-runner/platform-apps"
                    --package-cache "$HOME/.al-runner/test-apps"
                    --cache "$RUNNER_TEMP/al-runner-cache"
+                   --test-timeout "$TEST_TIMEOUT_SEC"
                    --output-junit "$out/junit.xml"
                    --out "$out/results.json"
                    --quiet )

--- a/.github/workflows/ms-surface.yml
+++ b/.github/workflows/ms-surface.yml
@@ -74,6 +74,16 @@ on:
         type: boolean
         required: false
         default: true
+      test-timeout:
+        description: >-
+          Per-test watchdog in seconds, handed down to ms-bucket.yml, which is what puts it on
+          the runner's command line. The runner's own 60 s default is a developer-box number:
+          it cuts legitimate tests off on a hosted runner, and an abort takes its bucket's
+          remaining suites with it (#3431). Must match ms-bucket.yml's default —
+          MsSurfaceWorkflowTests holds the two equal.
+        type: number
+        required: false
+        default: 300
 
 permissions:
   contents: read
@@ -96,6 +106,7 @@ jobs:
       expected-tests: 40530
       bc-version: ${{ inputs.bc-version }}
       test-data: ${{ inputs.test-data }}
+      test-timeout: ${{ inputs.test-timeout }}
       # Tests-ERM (9,496) and Tests-SCM (8,524) lead deliberately: 44% of the 40,530 between
       # them, measured on the 28.1.49838.53507 artifact (#3409), so if anything is lost to the
       # 360-minute ceiling it should not be the two buckets everything else is compared

--- a/.github/workflows/ms-surface.yml
+++ b/.github/workflows/ms-surface.yml
@@ -76,11 +76,9 @@ on:
         default: true
       test-timeout:
         description: >-
-          Per-test watchdog in seconds, handed down to ms-bucket.yml, which is what puts it on
-          the runner's command line. The runner's own 60 s default is a developer-box number:
-          it cuts legitimate tests off on a hosted runner, and an abort takes its bucket's
-          remaining suites with it (#3431). Must match ms-bucket.yml's default —
-          MsSurfaceWorkflowTests holds the two equal.
+          Per-test watchdog in seconds, handed down to ms-bucket.yml, which puts it on the
+          runner's command line. The runner's own 60 s default aborts legitimate tests on a
+          hosted runner (#3431). Must match ms-bucket.yml's default.
         type: number
         required: false
         default: 300

--- a/AlRunner.Tests/MsBucketWorkflowTests.cs
+++ b/AlRunner.Tests/MsBucketWorkflowTests.cs
@@ -16,6 +16,8 @@
 //
 // Split like ReleaseTestParityTests: WorkflowTriggers.TriggersOf is a pure function proven
 // on constructed text; the rest wires it (and the marker checks) to the real files on disk.
+using System.Globalization;
+using AlRunner.Infrastructure;
 using Xunit;
 
 namespace AlRunner.Tests;
@@ -53,6 +55,65 @@ internal static class WorkflowTriggers
     }
 }
 
+internal static class WorkflowInputDefaults
+{
+    /// <summary>
+    /// Every <c>default:</c> declared for an input of the given name, one entry per
+    /// declaration — a workflow that offers both <c>workflow_call</c> and
+    /// <c>workflow_dispatch</c> declares its inputs twice, and an input added to only one of
+    /// them resolves to the empty string on the other trigger. Empty when the input is absent,
+    /// so callers must assert a COUNT before comparing values.
+    /// </summary>
+    internal static IReadOnlyList<string> Of(string workflowText, string inputName)
+    {
+        var lines = workflowText.Replace("\r\n", "\n").Split('\n');
+        var found = new List<string>();
+        var keyIndent = -1;
+        foreach (var raw in lines)
+        {
+            var line = raw.TrimEnd();
+            if (line.Length == 0) continue;
+            var trimmed = line.TrimStart();
+            if (trimmed.StartsWith('#')) continue;
+            var indent = line.Length - trimmed.Length;
+
+            if (keyIndent < 0)
+            {
+                if (trimmed == inputName + ":") keyIndent = indent;
+                continue;
+            }
+            if (indent <= keyIndent) { keyIndent = trimmed == inputName + ":" ? indent : -1; continue; }
+            if (trimmed.StartsWith("default:", StringComparison.Ordinal))
+                found.Add(trimmed["default:".Length..].Trim());
+        }
+        return found;
+    }
+}
+
+internal static class BashArrayLiteral
+{
+    /// <summary>
+    /// The inside of a bash array literal <c>name=( … )</c>, matched by counting parentheses
+    /// rather than by looking for a terminator string. An assertion about what the runner is
+    /// invoked WITH has to be scoped to the array it is invoked with — a flag mentioned in a
+    /// comment, an <c>echo</c>, or a sibling <c>args+=(</c> guarded by an <c>if</c> is not the
+    /// same claim. Empty when the array is absent.
+    /// </summary>
+    internal static string Of(string script, string name)
+    {
+        var open = script.IndexOf(name + "=(", StringComparison.Ordinal);
+        if (open < 0) return string.Empty;
+        var i = open + name.Length + 1;      // at the '('
+        var depth = 0;
+        for (var j = i; j < script.Length; j++)
+        {
+            if (script[j] == '(') depth++;
+            else if (script[j] == ')' && --depth == 0) return script[(i + 1)..j];
+        }
+        return string.Empty;                 // unbalanced — the caller's assertion says so
+    }
+}
+
 public sealed class MsBucketWorkflowTests
 {
     private static readonly string RepoRoot = Path.GetFullPath(
@@ -65,6 +126,16 @@ public sealed class MsBucketWorkflowTests
     private const string SharedMatrix = "bc-tests.yml";
     private const string ProvisionAction = "actions/provision-bc/action.yml";
     private const string ProvisionMarker = "uses: ./.github/actions/provision-bc";
+
+    /// <summary>
+    /// The per-test watchdog these workflows run with, in seconds (#3431). A constant, so
+    /// changing the number is a deliberate edit here with a reason, rather than a value that
+    /// drifted. 300 covers the hosted runner's slowdown against the developer boxes every
+    /// local number was measured on, and still catches the unbounded-loop class the watchdog
+    /// exists for — #3374's MaxIteration defect produced loops that finished at no timeout at
+    /// all. Worst case cost is five aborts at 300 s instead of at 60 s, about 25 minutes.
+    /// </summary>
+    private const int WorkflowTestTimeoutSeconds = 300;
 
     private static string Read(string relative)
     {
@@ -106,6 +177,54 @@ public sealed class MsBucketWorkflowTests
         Assert.Empty(WorkflowTriggers.TriggersOf("name: X\njobs:\n  run:\n    runs-on: ubuntu-latest\n"));
         Assert.Equal(new[] { "workflow_dispatch" },
             WorkflowTriggers.TriggersOf("on:\n  # push: would be wrong here\n  workflow_dispatch:\n"));
+    }
+
+    [Fact]
+    public void InputDefaults_FindsEveryDeclarationOfOneInput_AndNothingElses()
+    {
+        const string wf = """
+            on:
+              workflow_call:
+                inputs:
+                  test-timeout:
+                    type: number
+                    default: 300
+                  test-data:
+                    type: boolean
+                    default: true
+              workflow_dispatch:
+                inputs:
+                  test-timeout:
+                    description: >-
+                      Two declarations of one input is normal, and they can disagree.
+                    type: number
+                    default: 120
+            """;
+
+        Assert.Equal(new[] { "300", "120" }, WorkflowInputDefaults.Of(wf, "test-timeout"));
+        Assert.Equal(new[] { "true" }, WorkflowInputDefaults.Of(wf, "test-data"));
+        Assert.Empty(WorkflowInputDefaults.Of(wf, "bc-version"));
+    }
+
+    [Fact]
+    public void BashArrayLiteral_ReadsOnlyTheArraysOwnContents()
+    {
+        const string script = """
+            echo "--test-timeout is not set here"
+            args=( "$BUNDLE"
+                   --cache "$C"
+                   --test-timeout "$T" )
+            if [ "$X" = "true" ]; then
+              args+=( --test-data-company "CRONUS International Ltd_" )
+            fi
+            """;
+
+        var array = BashArrayLiteral.Of(script, "args");
+        Assert.Contains("--test-timeout \"$T\"", array, StringComparison.Ordinal);
+        // The echo above it and the conditional append below it are NOT the array.
+        Assert.DoesNotContain("echo", array, StringComparison.Ordinal);
+        Assert.DoesNotContain("--test-data-company", array, StringComparison.Ordinal);
+        Assert.Equal(string.Empty, BashArrayLiteral.Of(script, "nosuch"));
     }
 
     // ---- wired to the real files ------------------------------------------------------
@@ -292,6 +411,106 @@ public sealed class MsBucketWorkflowTests
         Assert.DoesNotContain("gh release view", code, StringComparison.Ordinal);
         // The download still uses the tag, so pinning cannot silently stop pinning.
         Assert.Contains("gh release download \"$tag\"", code, StringComparison.Ordinal);
+    }
+
+    // ---- the per-test watchdog (#3431) -------------------------------------------------
+
+    /// <summary>
+    /// #3431: the workflow set no timeout at all, so the runner's 60 s default applied on a
+    /// hosted 4-vCPU runner. The watchdog is WALL CLOCK and every local number in this
+    /// repository was measured on a much faster box, so run 34150530633 cut
+    /// <c>CloseFiscalYearWithAdditionalCurrencyRounding</c> off at <c>60001ms</c> — one
+    /// millisecond past the limit, on a test still making progress — where the same bucket on
+    /// a 12-core box ran 9,496 of 9,496 with no aborts. An abort is not one lost test: it ends
+    /// the process, and past <c>--resume-aborts</c> it takes the bucket's remaining suites.
+    ///
+    /// Three links, asserted separately, because checking any one of them alone passes on the
+    /// defect this test exists to catch:
+    ///
+    ///   1. the INPUT reaches a shell variable. Bound to a literal instead, the input would be
+    ///      decorative and a caller's override would go nowhere.
+    ///   2. that variable is INSIDE the runner's argument array — not in a comment, an
+    ///      <c>echo</c>, or the conditional <c>args+=( … )</c> that a false <c>test-data</c>
+    ///      skips. This is the link that fails when the flag is dropped while the input stays,
+    ///      which is precisely the "a check that cannot fail" shape: an input that exists and
+    ///      reaches nothing.
+    ///   3. that array is what the runner is invoked with.
+    ///
+    /// The shell variable is deliberately NOT called <c>AL_RUNNER_TEST_TIMEOUT_SEC</c>, which
+    /// the runner reads on its own: under that name link 2 could be deleted and the timeout
+    /// would still apply, so nothing here could tell the difference. That the flag itself
+    /// works is <c>TestTimeoutFlagTests</c>'s claim, proven against the runner; this file's
+    /// claim is only that the workflow supplies it.
+    /// </summary>
+    [Fact]
+    public void MsBucketWorkflow_PutsThePerTestTimeoutOnTheRunnersArgumentArray()
+    {
+        var code = CodeOnly(Read(Path.Combine("workflows", Workflow)));
+        var runStep = WorkflowStep.BodyOf(code, "Run the bucket(s)");
+
+        Assert.Contains("TEST_TIMEOUT_SEC: ${{ inputs.test-timeout }}", runStep, StringComparison.Ordinal);
+
+        var args = BashArrayLiteral.Of(runStep, "args");
+        Assert.False(string.IsNullOrWhiteSpace(args),
+            "the runner's `args=( … )` array is gone from the \"Run the bucket(s)\" step");
+        Assert.Contains("--test-timeout \"$TEST_TIMEOUT_SEC\"", args, StringComparison.Ordinal);
+
+        Assert.Contains("/al-runner\" \"${args[@]}\"", runStep, StringComparison.Ordinal);
+
+        // An empty value would make --test-timeout swallow the next argument rather than fail,
+        // producing a run configured differently from the one that was asked for. Both halves:
+        // the guard is there, and it runs BEFORE the bucket loop it protects.
+        var guard = runStep.IndexOf("::error::test-timeout must be a positive whole number",
+            StringComparison.Ordinal);
+        Assert.True(guard >= 0, "the empty/non-numeric test-timeout guard is gone");
+        Assert.True(guard < runStep.IndexOf("for bucket in \"${BUCKET_LIST[@]}\"", StringComparison.Ordinal),
+            "the test-timeout guard must run before the bucket loop, not inside it");
+    }
+
+    /// <summary>
+    /// The default has to be declared on BOTH trigger blocks and has to be the same number.
+    /// On <c>workflow_call</c> only, a manual dispatch resolves <c>inputs.test-timeout</c> to
+    /// the empty string and the guard above fails the job; on <c>workflow_dispatch</c> only,
+    /// ms-surface.yml and the nightly get nothing. Either way the run is wrong, and a PR check
+    /// is a far cheaper place to find that than a three-hour dispatch.
+    ///
+    /// It is compared against the runner's OWN default rather than a second copy of 60, so the
+    /// relationship stays true if that default ever moves.
+    /// </summary>
+    [Fact]
+    public void MsBucketWorkflow_DefaultsThePerTestTimeoutAboveTheRunnersOwn()
+    {
+        var defaults = WorkflowInputDefaults.Of(Read(Path.Combine("workflows", Workflow)), "test-timeout");
+
+        Assert.Equal(2, defaults.Count);
+        Assert.Single(defaults.Distinct(StringComparer.Ordinal));
+
+        Assert.True(int.TryParse(defaults[0], NumberStyles.None, CultureInfo.InvariantCulture, out var seconds),
+            $"test-timeout's default must be a whole number of seconds, not '{defaults[0]}'");
+        Assert.Equal(WorkflowTestTimeoutSeconds, seconds);
+        Assert.True(seconds > ParallelFanOut.DefaultTestTimeoutSec,
+            $"the workflow's per-test timeout ({seconds}s) must exceed the runner's own default "
+            + $"({ParallelFanOut.DefaultTestTimeoutSec}s) — at or below it the input changes nothing "
+            + "and #3431 is back");
+    }
+
+    /// <summary>
+    /// The nightly runs on the same hosted runner as every other caller, so it wants the same
+    /// watchdog — and gets it by passing nothing and inheriting ms-bucket.yml's default. A
+    /// second spelling of the number here is how the nightly's configuration and the surface's
+    /// would come to differ, which makes their numbers incomparable: the same failure mode as
+    /// the provisioning copy that drifted four times (#1976), one input down.
+    /// </summary>
+    [Fact]
+    public void NightlyWorkflow_InheritsThePerTestTimeout_RatherThanSpellingItAgain()
+    {
+        var code = CodeOnly(Read(Path.Combine("workflows", Nightly)));
+
+        Assert.DoesNotContain("test-timeout", code, StringComparison.Ordinal);
+        Assert.Contains("uses: ./.github/workflows/ms-bucket.yml", code, StringComparison.Ordinal);
+        // And the thing it inherits is real: ms-bucket.yml declares the input with a default,
+        // so "passes nothing" means 300 s, not nothing.
+        Assert.NotEmpty(WorkflowInputDefaults.Of(Read(Path.Combine("workflows", Workflow)), "test-timeout"));
     }
 
     [Fact]

--- a/AlRunner.Tests/MsBucketWorkflowTests.cs
+++ b/AlRunner.Tests/MsBucketWorkflowTests.cs
@@ -130,10 +130,8 @@ public sealed class MsBucketWorkflowTests
     /// <summary>
     /// The per-test watchdog these workflows run with, in seconds (#3431). A constant, so
     /// changing the number is a deliberate edit here with a reason, rather than a value that
-    /// drifted. 300 covers the hosted runner's slowdown against the developer boxes every
-    /// local number was measured on, and still catches the unbounded-loop class the watchdog
-    /// exists for — #3374's MaxIteration defect produced loops that finished at no timeout at
-    /// all. Worst case cost is five aborts at 300 s instead of at 60 s, about 25 minutes.
+    /// drifted. 300 covers the hosted runner's slowdown and still catches the unbounded-loop
+    /// class the watchdog exists for: #3374's MaxIteration loops finished at no timeout at all.
     /// </summary>
     private const int WorkflowTestTimeoutSeconds = 300;
 
@@ -416,13 +414,8 @@ public sealed class MsBucketWorkflowTests
     // ---- the per-test watchdog (#3431) -------------------------------------------------
 
     /// <summary>
-    /// #3431: the workflow set no timeout at all, so the runner's 60 s default applied on a
-    /// hosted 4-vCPU runner. The watchdog is WALL CLOCK and every local number in this
-    /// repository was measured on a much faster box, so run 34150530633 cut
-    /// <c>CloseFiscalYearWithAdditionalCurrencyRounding</c> off at <c>60001ms</c> — one
-    /// millisecond past the limit, on a test still making progress — where the same bucket on
-    /// a 12-core box ran 9,496 of 9,496 with no aborts. An abort is not one lost test: it ends
-    /// the process, and past <c>--resume-aborts</c> it takes the bucket's remaining suites.
+    /// #3431: the workflow set no timeout at all, so the runner's 60 s wall-clock default
+    /// applied on a hosted runner and aborted tests that finish comfortably inside it locally.
     ///
     /// Three links, asserted separately, because checking any one of them alone passes on the
     /// defect this test exists to catch:
@@ -457,9 +450,9 @@ public sealed class MsBucketWorkflowTests
 
         Assert.Contains("/al-runner\" \"${args[@]}\"", runStep, StringComparison.Ordinal);
 
-        // An empty value would make --test-timeout swallow the next argument rather than fail,
-        // producing a run configured differently from the one that was asked for. Both halves:
-        // the guard is there, and it runs BEFORE the bucket loop it protects.
+        // The guard fails the job once, up front. The runner rejects a bad value itself, but
+        // only after provisioning and each bucket's setup have been paid, once per
+        // invocation. Both halves: the guard is there, and it runs BEFORE the bucket loop.
         var guard = runStep.IndexOf("::error::test-timeout must be a positive whole number",
             StringComparison.Ordinal);
         Assert.True(guard >= 0, "the empty/non-numeric test-timeout guard is gone");

--- a/AlRunner.Tests/MsSurfaceWorkflowTests.cs
+++ b/AlRunner.Tests/MsSurfaceWorkflowTests.cs
@@ -288,11 +288,8 @@ public sealed class MsSurfaceWorkflowTests
     }
 
     /// <summary>
-    /// #3431: the surface ran with the runner's 60 s default per-test watchdog on a hosted
-    /// 4-vCPU runner, so tests that finish comfortably inside it locally were cut off — and an
-    /// abort ends the process and past <c>--resume-aborts</c> takes its bucket's remaining
-    /// suites, which understates the total by an amount that depends on how fast the machine
-    /// was.
+    /// #3431: the surface ran with the runner's 60 s wall-clock default per-test watchdog on a
+    /// hosted runner, so tests that finish comfortably inside it locally were cut off.
     ///
     /// The surface owns the POLICY knob and ms-bucket.yml owns putting it on the command line.
     /// So two things: the value is PASSED THROUGH rather than re-spelled — a hardcoded number

--- a/AlRunner.Tests/MsSurfaceWorkflowTests.cs
+++ b/AlRunner.Tests/MsSurfaceWorkflowTests.cs
@@ -69,6 +69,24 @@ internal static class WorkflowBlockScalar
     }
 }
 
+internal static class WorkflowStep
+{
+    /// <summary>
+    /// One named step's text, from its <c>- name:</c> line to the next step's. Assertions
+    /// about ORDER need this: <c>ms-bucket.yml</c> has two <c>for bucket in …</c> loops, so an
+    /// index taken over the whole file answers a question about the FETCH loop while reading
+    /// like a question about the run loop.
+    /// </summary>
+    internal static string BodyOf(string code, string stepName)
+    {
+        const string marker = "      - name: ";
+        var start = code.IndexOf(marker + stepName, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"no step named \"{stepName}\" in the workflow");
+        var next = code.IndexOf(marker, start + marker.Length, StringComparison.Ordinal);
+        return next < 0 ? code[start..] : code[start..next];
+    }
+}
+
 public sealed class MsSurfaceWorkflowTests
 {
     private static readonly string RepoRoot = Path.GetFullPath(
@@ -122,20 +140,9 @@ public sealed class MsSurfaceWorkflowTests
     private static string CodeOnly(string text) =>
         string.Join('\n', text.Split('\n').Where(l => !l.TrimStart().StartsWith('#')));
 
-    /// <summary>
-    /// One named step's text, from its <c>- name:</c> line to the next step's. Assertions
-    /// about ORDER need this: <c>ms-bucket.yml</c> has two <c>for bucket in …</c> loops, so an
-    /// index taken over the whole file answers a question about the FETCH loop while reading
-    /// like a question about the run loop.
-    /// </summary>
-    private static string StepBody(string code, string stepName)
-    {
-        const string marker = "      - name: ";
-        var start = code.IndexOf(marker + stepName, StringComparison.Ordinal);
-        Assert.True(start >= 0, $"no step named \"{stepName}\" in the workflow");
-        var next = code.IndexOf(marker, start + marker.Length, StringComparison.Ordinal);
-        return next < 0 ? code[start..] : code[start..next];
-    }
+    /// <summary>See <see cref="WorkflowStep.BodyOf"/>; MsBucketWorkflowTests slices the same
+    /// run step for the per-test timeout, so the slicer is shared rather than spelled twice.</summary>
+    private static string StepBody(string code, string stepName) => WorkflowStep.BodyOf(code, stepName);
 
     private static IReadOnlyList<string> SurfaceBuckets() =>
         WorkflowBlockScalar.Of(CodeOnly(Read(SurfaceWorkflow)), "buckets");
@@ -275,9 +282,37 @@ public sealed class MsSurfaceWorkflowTests
                  {
                      "--package-cache", "READER_TAG", "--test-data-company",
                      "CRONUS International Ltd_", "AL_RUNNER_EMIT_TIMEOUT_SEC",
-                     "provision-bc", "al-runner",
+                     "provision-bc", "al-runner", "--test-timeout",
                  })
             Assert.DoesNotContain(owned, code, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// #3431: the surface ran with the runner's 60 s default per-test watchdog on a hosted
+    /// 4-vCPU runner, so tests that finish comfortably inside it locally were cut off — and an
+    /// abort ends the process and past <c>--resume-aborts</c> takes its bucket's remaining
+    /// suites, which understates the total by an amount that depends on how fast the machine
+    /// was.
+    ///
+    /// The surface owns the POLICY knob and ms-bucket.yml owns putting it on the command line.
+    /// So two things: the value is PASSED THROUGH rather than re-spelled — a hardcoded number
+    /// here would silently stop tracking an override — and the two files' defaults are equal,
+    /// so a dispatch that leaves the field untouched measures under the same watchdog as the
+    /// nightly, which passes nothing at all. Without that equality the three callers drift and
+    /// their numbers stop being comparable, which is the one property this measurement needs.
+    /// </summary>
+    [Fact]
+    public void SurfaceWorkflow_PassesThePerTestTimeoutThrough_AtTheSameDefault()
+    {
+        Assert.Contains("test-timeout: ${{ inputs.test-timeout }}",
+            CodeOnly(Read(SurfaceWorkflow)), StringComparison.Ordinal);
+
+        var surface = WorkflowInputDefaults.Of(Read(SurfaceWorkflow), "test-timeout");
+        var bucket = WorkflowInputDefaults.Of(Read(BucketWorkflow), "test-timeout");
+
+        Assert.Single(surface);
+        Assert.NotEmpty(bucket);
+        Assert.Equal(bucket.Distinct(StringComparer.Ordinal).Single(), surface[0]);
     }
 
     // ---- what the surface needs from ms-bucket.yml -------------------------------------


### PR DESCRIPTION
Closes #3431

Filed and implemented by an agent (`coord-1`).

## The defect

`ms-surface.yml` and `ms-bucket.yml` set no `--test-timeout` and no
`AL_RUNNER_TEST_TIMEOUT_SEC`, so the runner's 60-second default applied on a hosted 4-vCPU
runner. The per-test watchdog is wall clock, and every local number in this repository was
measured on a much faster box, so run `34150530633` cut
`Codeunit134043.CloseFiscalYearWithAdditionalCurrencyRounding` off at `60001ms` — one
millisecond past the limit, on a test that was still making progress. The same bucket on a
12-core box ran 9,496 of 9,496 with zero aborts.

An abort is not one lost test. It ends the process, the resume machinery restarts, and past
`--resume-aborts` (default 5) it takes the bucket's remaining suites. So the number the run
produces is wrong by an amount that depends on how fast the machine was, which is the one
property a measurement must not have.

## The change

- `ms-bucket.yml` grows a `test-timeout` input on **both** trigger blocks, default 300 s,
  bound to `TEST_TIMEOUT_SEC` in the run step's `env` and put on the runner's `args` array as
  `--test-timeout "$TEST_TIMEOUT_SEC"`. A guard before the bucket loop refuses an empty or
  non-numeric value, so the job fails **once, up front, before provisioning**. The runner
  would reject a bad value itself, but only after this job has paid provisioning and each
  bucket's setup, once per invocation.
- `ms-surface.yml` declares the same input at the same default and passes it through.
- `ms-bucket-nightly.yml` passes nothing and inherits it.

The watchdog is **not** removed. It is what turns an unbounded loop into a diagnosable abort
instead of a job grinding to the 360-minute ceiling.

### Why 300

It covers the hosted runner's slowdown against the developer boxes with margin for the
slowest legitimate tests, and it still catches a genuine hang: #3374's `MaxIteration` defect
produced loops that completed at **no** timeout at all — one ran 1,300 s having finished
87,313 of ~101,001 iterations of the first of two passes — so raising the ceiling does not
hide that class.

**On cost, correcting my own earlier claim.** I first wrote that the worst case was bounded at
about 25 minutes, five aborts at 300 s instead of 60 s. That bound does not hold.
`AbortResume.DefaultBudget` is 5 per *runner invocation*, and the run step invokes the runner
once per bucket, so the budget resets each time — it is per bucket, and `ms-surface.yml` sends
32 buckets into one job under the 360-minute ceiling. The expected effect is still **fewer**
aborts, not more, since a test that used to be killed at 60 s now finishes; so this is a
wording correction, not a design change. I am not putting a replacement number here, because I
have not measured one.

### The two paths you asked me to check

- **The singular `bucket` input.** Covered, and not by a second edit: both the singular and
  the list path run through the same loop and the same `args` array, so there is one place the
  flag goes. The proving test asserts on that array, so it covers both by construction.
- **`ms-bucket-nightly.yml`.** Same hosted runner, same exposure, and it gets the fix by
  **inheriting** ms-bucket.yml's default rather than declaring its own. Spelling the number
  again there is how the nightly's configuration and the surface's would come to differ,
  which would make their numbers incomparable — the same failure as the provisioning copy
  that drifted four times (#1976), one input down. `NightlyWorkflow_InheritsThePerTestTimeout_RatherThanSpellingItAgain`
  pins both halves: the nightly does not mention it, and the thing it inherits actually exists.

## The proving test, and what breaking it did

The weak version of this test is "the input is declared", which passes while the value reaches
nothing. So the assertion is a three-link chain, sliced to the run step with #3411's
`StepBody` (promoted to a shared `WorkflowStep.BodyOf` — `MsBucketWorkflowTests` now slices
the same step): the **input** reaches a shell variable, that variable is **inside the runner's
argument array** by paren matching rather than by appearing somewhere in the step, and that
array is **what the runner is invoked with**. Two new pure helpers, `WorkflowInputDefaults`
and `BashArrayLiteral`, are each proven on constructed text first.

One deliberate detail: the shell variable is **not** named `AL_RUNNER_TEST_TIMEOUT_SEC`, which
the runner reads on its own. Under that name, deleting the flag would leave the timeout working
and nothing here could tell — the test would have been unfalsifiable by construction.

Six deliberate breaks, each restored, filtered run of both classes (30 tests):

| break | result |
|---|---|
| **drop `--test-timeout` from the args array, leave the input declared** (the one you asked for) | 1 red — `PutsThePerTestTimeoutOnTheRunnersArgumentArray`. The input and default tests stayed **green**, which is exactly the shape being guarded against |
| both workflows exactly as `origin/main` has them (the real pre-fix baseline) | 4 red — every wired test; the two pure-function tests stay green, correctly |
| default lowered to 60, the runner's own | 2 red — the input reaches the runner but changes nothing |
| declared on `workflow_call` only | 1 red — a manual dispatch would resolve it to `''` |
| surface hardcodes `300` instead of passing the input through | 1 red |
| surface default drifts to 120 while ms-bucket stays at 300 | 1 red |

## Correction after review

The reviewer and the coordinator caught a comment next to the guard that stated a mechanism
that does not exist: that an empty `test-timeout` would make `--test-timeout` swallow the next
argument. It would not — the value is quoted on the args array, so an empty one arrives as an
empty argv element and `Program.cs` rejects it (`'' is not a positive integer` → exit 2).
Measured in bash: quoted gives 7 argv elements with an empty one preserved, unquoted gives 6
with `--output-junit` consumed as the value. An *unquoted* expansion would swallow; the code is
quoted.

The guard stays, with the real reason, which is the better one: it fails once, up front, before
provisioning, instead of after every bucket's setup work. The same sentence had been duplicated
into the test's doc comment and is corrected there too.

Worth stating plainly, because it is the same class of defect this PR exists to fix one level
up: a comment asserting a mechanism nobody checked is exactly the failure the proving test
guards against in the workflow. I wrote the sentence from what quoting *usually* costs you in
shell, without testing it against this line.

I also cut the `ms-bucket.yml` header down to the single line that changes what the next person
types — the watchdog must not be removed — and dropped the forensics, which live here and in
#3431. `.github/workflows/` is now +24 comment lines against +37 before, and `60001ms` no
longer appears in any source file.

## Sibling scan

Nothing folded. No other open issue's fix lands in these three files. The nearest neighbours
and why they are separate: **#3433** (local reader v0.1.0 vs the v0.1.2 CI pins) is about the
local install, not `READER_TAG`, which is already correct here; **#3374** and **#2414** are
timeout-shaped but land in the runner's report code; **#3435** is a CI-load timeout inside
`AlRunner.Tests`, a different mechanism.

## Tests run

`dotnet test AlRunner.Tests --filter` over `MsBucketWorkflowTests`, `MsSurfaceWorkflowTests`
and the wider set of classes that read workflow YAML (`BcLegRerunWorkflowTests`,
`MainVerdictFloorWorkflowTests`, `PullRequestMatrixScopeTests`,
`BackupReaderFailureReportingTests`, `ArtifactDownloaderMsBucketTests`,
`BundleFailureStageTests`): **110 passed, 0 failed, 1 skipped**. All three workflows re-parse
as YAML and resolve to 300 on every path. I did not run the Microsoft buckets — a surface run
is in flight on CI.

Corpus-NA: this changes a GitHub Actions workflow input and the runner's command line, not
runner behaviour under AL; the diff touches no `AlRunner/` code and asserts nothing about BC.

https://claude.ai/code/session_01F7HLDeNwiGQoLT5wFanqmH
