### PR TITLE
fix(commit): honor the CommitBehavior attribute instead of always committing

### DIFF
--- a/AlRunner.Tests/CommitBehaviorAttributeTests.cs
+++ b/AlRunner.Tests/CommitBehaviorAttributeTests.cs
@@ -1,0 +1,248 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Runner-mechanism test for issue #3449: <c>[CommitBehavior(CommitBehavior::Ignore)]</c> and
+/// <c>[CommitBehavior(CommitBehavior::Error)]</c> had no effect, because the Cecil rewrite of
+/// <c>ALDatabase.ALCommit</c> replaced BC's whole body — including its
+/// <c>switch (session.CommitBehavior)</c> — with an unconditional commit point.
+///
+/// The BEHAVIOURAL claim ("Ignore makes Commit() a no-op so a later unrelated error still
+/// rolls the write back; Error makes Commit() raise") is a plain-BC-behaviour claim and lives
+/// upstream — StefanMaron/BusinessCentral.AL.Language.Tests#276, codeunit 60881
+/// "Test Commit Behavior Attr", per .claude/rules/bc-behavior-tests-go-upstream.md. This test
+/// exists so a regression in OUR OWN commit-point bookkeeping fails loudly here, spawning the
+/// real runner against a synthetic bundle, without depending on the submodule pin having moved
+/// yet (that corpus PR had not merged when this test was written).
+///
+/// It pins the two things the runner-side fix actually owns and the corpus cannot see:
+/// that the session's commit behaviour is CONSULTED at all, and that the error the Error
+/// branch raises carries BC's own <c>Lang.CommitProhibited</c> text rather than a runner
+/// paraphrase (the reflection route in ALDatabasePatches.BuildCommitProhibited can silently
+/// degrade to a fallback string, which no AL assertion upstream would notice).
+///
+/// No Library Assert / Base Application dependency (no "application" in the fixture's
+/// app.json — see .claude/rules/no-base-app-in-csharp-tests.md): each test raises its own
+/// Error() carrying the observed state, and the runner's own PASS/FAIL output is the
+/// assertion surface.
+/// </summary>
+public class CommitBehaviorAttributeTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunRunner(params string[] bundles)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        foreach (var b in bundles) args.Append(" \"").Append(b).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    [SkippableFact]
+    public void CommitBehaviorAttribute_IsConsultedByALCommit()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = TestScratch.Dir("al-runner-commit-behavior-3449");
+        Directory.CreateDirectory(root);
+
+        File.WriteAllText(Path.Combine(root, "app.json"), """
+        {
+          "id": "b3449000-0000-4000-8000-000000003449",
+          "name": "CommitBehavior3449",
+          "publisher": "Repro3449",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62449, "to": 62459 } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(root, "CbhProbe.al"), """
+        table 62449 "CBH Probe"
+        {
+            DataClassification = SystemMetadata;
+
+            fields
+            {
+                field(1; "Entry No."; Integer) { }
+            }
+
+            keys
+            {
+                key(PK; "Entry No.") { Clustered = true; }
+            }
+        }
+
+        codeunit 62450 "CBH Helpers"
+        {
+            internal procedure InsertCommitThenError(EntryNo: Integer)
+            var
+                Probe: Record "CBH Probe";
+            begin
+                Probe."Entry No." := EntryNo;
+                Probe.Insert();
+                Commit();
+                Error('boom');
+            end;
+
+            [CommitBehavior(CommitBehavior::Ignore)]
+            internal procedure InsertCommitThenErrorIgnored(EntryNo: Integer)
+            var
+                Probe: Record "CBH Probe";
+            begin
+                Probe."Entry No." := EntryNo;
+                Probe.Insert();
+                Commit();
+                Error('boom');
+            end;
+
+            [CommitBehavior(CommitBehavior::Ignore)]
+            internal procedure CallUnattributedHelperIgnored(EntryNo: Integer)
+            begin
+                InsertCommitThenError(EntryNo);
+            end;
+
+            [CommitBehavior(CommitBehavior::Error)]
+            internal procedure CommitUnderErrorBehavior(EntryNo: Integer)
+            var
+                Probe: Record "CBH Probe";
+            begin
+                Probe."Entry No." := EntryNo;
+                Probe.Insert();
+                Commit();
+            end;
+        }
+
+        codeunit 62449 "CBH Tests"
+        {
+            Subtype = Test;
+            TestPermissions = Disabled;
+
+            var
+                Helpers: Codeunit "CBH Helpers";
+
+            local procedure Initialize()
+            var
+                Probe: Record "CBH Probe";
+            begin
+                Probe.DeleteAll();
+                Commit();
+            end;
+
+            // Control: the same helper body with NO attribute. If this one ever stops
+            // committing, the tests below would pass for the wrong reason — they would be
+            // measuring a broken Commit() rather than an honored attribute.
+            [Test]
+            procedure Unattributed_CommitBeforeErrorIsDurable()
+            var
+                Probe: Record "CBH Probe";
+            begin
+                Initialize();
+                asserterror Helpers.InsertCommitThenError(1);
+                if not Probe.Get(1) then
+                    Error('CBH1 FAIL: without the attribute the Commit() must be an ordinary commit and the row must survive the error');
+            end;
+
+            // Regression shape (AlRunner#3449): the attribute must make Commit() a no-op, so
+            // the rollback boundary does not move and the unrelated Error() undoes the Insert.
+            [Test]
+            procedure Ignore_CommitBeforeErrorIsNotDurable()
+            var
+                Probe: Record "CBH Probe";
+            begin
+                Initialize();
+                asserterror Helpers.InsertCommitThenErrorIgnored(2);
+                if Probe.Get(2) then
+                    Error('CBH2 FAIL: under CommitBehavior::Ignore the Commit() must do nothing, so the error must roll the Insert back');
+                if Probe.Count() <> 0 then
+                    Error('CBH2 FAIL: expected Count()=0, got %1', Probe.Count());
+            end;
+
+            // The attribute governs the whole DYNAMIC scope: the Commit() here is issued by an
+            // unattributed callee one frame down.
+            [Test]
+            procedure Ignore_GovernsUnattributedCallee()
+            var
+                Probe: Record "CBH Probe";
+            begin
+                Initialize();
+                asserterror Helpers.CallUnattributedHelperIgnored(3);
+                if Probe.Get(3) then
+                    Error('CBH3 FAIL: CommitBehavior::Ignore must govern a Commit() issued by an unattributed callee too');
+            end;
+
+            // The scope is popped on return: after the attributed call, an ordinary Commit()
+            // must commit again. Without this the fix could "work" by disabling Commit() for
+            // the rest of the session.
+            [Test]
+            procedure Ignore_ScopeIsPoppedOnReturn()
+            var
+                Probe: Record "CBH Probe";
+            begin
+                Initialize();
+                asserterror Helpers.InsertCommitThenErrorIgnored(4);
+
+                Probe."Entry No." := 5;
+                Probe.Insert();
+                Commit();
+                asserterror Error('unrelated');
+
+                Clear(Probe);
+                if not Probe.Get(5) then
+                    Error('CBH4 FAIL: the Ignore scope must end when the attributed call returns — the later ordinary Commit() must commit');
+            end;
+
+            // CommitBehavior::Error must raise, and must raise BC's OWN text: the runner builds
+            // it by reflection out of Lang.CommitProhibited and would otherwise fall back to a
+            // hardcoded string with nothing pointing that out.
+            [Test]
+            procedure ErrorBehavior_CommitRaisesBcOwnText()
+            var
+                Probe: Record "CBH Probe";
+                ErrText: Text;
+            begin
+                Initialize();
+                asserterror Helpers.CommitUnderErrorBehavior(6);
+                ErrText := GetLastErrorText();
+
+                if StrPos(ErrText, 'Commit is prohibited in the current scope') = 0 then
+                    Error('CBH5 FAIL: expected BC''s own Lang.CommitProhibited text, got %1', ErrText);
+                if Probe.Get(6) then
+                    Error('CBH5 FAIL: the Insert before the prohibited Commit() must roll back');
+            end;
+        }
+        """);
+
+        var (output, exitCode) = RunRunner(root);
+
+        Assert.True(exitCode == 0,
+            $"Expected all five tests to pass (exit 0); got exit {exitCode}.\n{output}");
+        Assert.DoesNotContain("FAIL", output);
+        Assert.Contains("PASS  Codeunit62449.Unattributed_CommitBeforeErrorIsDurable", output);
+        Assert.Contains("PASS  Codeunit62449.Ignore_CommitBeforeErrorIsNotDurable", output);
+        Assert.Contains("PASS  Codeunit62449.Ignore_GovernsUnattributedCallee", output);
+        Assert.Contains("PASS  Codeunit62449.Ignore_ScopeIsPoppedOnReturn", output);
+        Assert.Contains("PASS  Codeunit62449.ErrorBehavior_CommitRaisesBcOwnText", output);
+    }
+}

--- a/AlRunner.Tests/CommitBehaviorAttributeTests.cs
+++ b/AlRunner.Tests/CommitBehaviorAttributeTests.cs
@@ -18,11 +18,12 @@ namespace AlRunner.Tests;
 /// real runner against a synthetic bundle, without depending on the submodule pin having moved
 /// yet (that corpus PR had not merged when this test was written).
 ///
-/// It pins the two things the runner-side fix actually owns and the corpus cannot see:
-/// that the session's commit behaviour is CONSULTED at all, and that the error the Error
-/// branch raises carries BC's own <c>Lang.CommitProhibited</c> text rather than a runner
-/// paraphrase (the reflection route in ALDatabasePatches.BuildCommitProhibited can silently
-/// degrade to a fallback string, which no AL assertion upstream would notice).
+/// The AL assertions below are all plain BC-behaviour claims already green upstream; what
+/// they buy is coverage while the pin has not moved, which is a temporary justification and
+/// not a claim that the corpus cannot see them. The Lang-resource half of that question —
+/// whether the Error branch really resolved BC's resource or fell back — is NOT decidable
+/// from AL, because the fallback string is byte-identical to the resource; it is settled
+/// in-process by CommitProhibitedMessageTests instead.
 ///
 /// No Library Assert / Base Application dependency (no "application" in the fixture's
 /// app.json — see .claude/rules/no-base-app-in-csharp-tests.md): each test raises its own

--- a/AlRunner.Tests/CommitProhibitedMessageTests.cs
+++ b/AlRunner.Tests/CommitProhibitedMessageTests.cs
@@ -1,0 +1,72 @@
+// CommitProhibitedMessageTests — the half of issue #3449's Error branch that AL cannot decide.
+//
+// ALDatabasePatches.BuildCommitProhibited reads BC's own Lang.CommitProhibited by reflection
+// and falls back to a hardcoded copy of BC 28.4's en-US string when that read fails. The two
+// are byte-identical, which is the point: an AL assertion on the message text passes either
+// way, so CommitBehaviorAttributeTests cannot tell a resolved resource from a degraded
+// fallback, and neither can the corpus. Two things here can:
+//
+//   - Lang.CommitProhibited resolves at all. A BC rename would otherwise leave every caller
+//     silently on the fallback, correct today and wrong the day Microsoft edits the string.
+//   - the exception is BC's own NavCSideException. The fallback path returns a plain
+//     InvalidOperationException, so the TYPE is what distinguishes the two routes.
+using System.Reflection;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class CommitProhibitedMessageTests
+{
+    private readonly BcEngineFixture _engine;
+
+    public CommitProhibitedMessageTests(BcEngineFixture engine) => _engine = engine;
+
+    /// <summary>
+    /// Same reflection route ALDatabasePatches.LangString uses, duplicated here on purpose:
+    /// a test that called the production helper would agree with it by construction, including
+    /// when both are wrong. Mirrors CodeunitRunWriteTransactionRefusalTests.LangString.
+    /// </summary>
+    private static string? LangString(string name)
+    {
+        foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            var lang = asm.GetType("Microsoft.Dynamics.Nav.Common.Language.Lang", throwOnError: false);
+            var value = lang?.GetProperty(name, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                            ?.GetValue(null) as string;
+            if (!string.IsNullOrEmpty(value)) return value;
+        }
+        return null;
+    }
+
+    [SkippableFact]
+    public void CommitProhibited_ResolvesFromBcsOwnLangResource()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var resource = LangString("CommitProhibited");
+        Assert.False(string.IsNullOrEmpty(resource),
+            "Lang.CommitProhibited not found — Microsoft.Dynamics.Nav.Language.dll shape changed, "
+            + "so ALDatabasePatches.BuildCommitProhibited is silently shipping its fallback string.");
+
+        // Anchor the resource's content too, so a rename that left SOME string under this
+        // property cannot pass: the corpus test (codeunit 60881) matches on this substring.
+        Assert.Contains("Commit is prohibited in the current scope", resource);
+    }
+
+    [SkippableFact]
+    public void BuildCommitProhibited_ThrowsBcsOwnExceptionTypeCarryingThatText()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var ex = ALDatabasePatches.BuildCommitProhibited();
+
+        // The TYPE is the discriminator the message cannot be: the fallback route returns
+        // InvalidOperationException, and BC throws NavCSideException.
+        Assert.Equal("NavCSideException", ex.GetType().Name);
+        Assert.Equal(LangString("CommitProhibited"), ex.Message);
+    }
+}

--- a/AlRunner/Patches/ALDatabasePatches.cs
+++ b/AlRunner/Patches/ALDatabasePatches.cs
@@ -88,8 +88,8 @@ public static class ALDatabasePatches
 
     /// <summary>
     /// The current session's <c>CommitBehavior</c> as its enum member name, or <c>null</c>
-    /// when there is no session (install/upgrade paths run before one exists) — treated as
-    /// <c>Ok</c>, which is what a fresh NavSession carries.
+    /// when there is no session — treated as <c>Ok</c>, which is what a fresh NavSession
+    /// carries.
     ///
     /// Read by name rather than by value: the enum is
     /// <c>Microsoft.Dynamics.Nav.Types.CommitBehavior</c>, and comparing names survives a
@@ -98,13 +98,23 @@ public static class ALDatabasePatches
     /// </summary>
     private static string? CurrentCommitBehaviorName()
     {
+        // A null session is an ANSWER about the runner's own state, not about BC's layout:
+        // install/upgrade paths run before one exists, and a fresh NavSession carries Ok. So
+        // it is not a shape gap (BcShapeGapException.cs draws that line explicitly).
         var session = BcRuntime.SkeletonSession;
         if (session == null) return null;
+
+        // A MISSING property is the other case, and it must not silently degrade to Ok —
+        // that is the very defect this method exists to fix, reinstated with nothing said.
         _commitBehaviorProp ??= session.GetType().GetProperty("CommitBehavior",
             System.Reflection.BindingFlags.Instance
             | System.Reflection.BindingFlags.Public
-            | System.Reflection.BindingFlags.NonPublic);
-        return _commitBehaviorProp?.GetValue(session)?.ToString();
+            | System.Reflection.BindingFlags.NonPublic)
+            ?? throw new AlRunner.Infrastructure.BcShapeGapException(
+                "ALDatabase.ALCommit", "NavSession.CommitBehavior",
+                "property not found, so [CommitBehavior(...)] cannot be honored and every "
+                + "Commit() would silently behave as CommitBehavior::Ok");
+        return _commitBehaviorProp.GetValue(session)?.ToString();
     }
 
     private static System.Reflection.PropertyInfo? _commitBehaviorProp;
@@ -117,7 +127,7 @@ public static class ALDatabasePatches
     /// Lang lives in Microsoft.Dynamics.Nav.Language.dll, which the runner does not
     /// reference directly.
     /// </summary>
-    private static Exception BuildCommitProhibited()
+    internal static Exception BuildCommitProhibited()
     {
         // Fallback is BC 28.4's own en-US text, measured on a service tier; used only if the
         // resource cannot be read.

--- a/AlRunner/Patches/ALDatabasePatches.cs
+++ b/AlRunner/Patches/ALDatabasePatches.cs
@@ -61,14 +61,85 @@ public static class ALDatabasePatches
 
     /// <summary>Replacement for ALDatabase.ALCommit(). There is nothing to flush — the
     /// in-memory store is written through — but the write transaction ends here, which is
-    /// what AL observes via Database.IsInWriteTransaction().</summary>
+    /// what AL observes via Database.IsInWriteTransaction().
+    ///
+    /// Observably equivalent to BC's own body, which begins by switching on the session's
+    /// commit behaviour and only then commits (see docs/limitations.md#commitbehavior):
+    /// <c>Error</c> raises <c>Lang.CommitProhibited</c>, <c>Ignore</c> does nothing at all,
+    /// <c>Ok</c> commits. Ignore returning EARLY is the whole point — BC skips
+    /// <c>session.Commit()</c>, so neither the rollback boundary nor the write-transaction
+    /// flag moves, and a later unrelated error still undoes the write.</summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void ALDatabase_ALCommit()
     {
+        switch (CurrentCommitBehaviorName())
+        {
+            case "Error":
+                throw BuildCommitProhibited();
+            case "Ignore":
+                return;
+        }
+
         System.Threading.Volatile.Write(ref _inWriteTransaction, false);
         // Everything written so far is now durable: a later AL error rolls back to HERE,
         // not to the start of the test method.
         RecordPatches.MarkCommitPoint();
+    }
+
+    /// <summary>
+    /// The current session's <c>CommitBehavior</c> as its enum member name, or <c>null</c>
+    /// when there is no session (install/upgrade paths run before one exists) — treated as
+    /// <c>Ok</c>, which is what a fresh NavSession carries.
+    ///
+    /// Read by name rather than by value: the enum is
+    /// <c>Microsoft.Dynamics.Nav.Types.CommitBehavior</c>, and comparing names survives a
+    /// future BC adding a member without silently reinterpreting an ordinal. Same technique
+    /// TestExecutor.IsAutoRollback uses on TransactionModel, for the same reason.
+    /// </summary>
+    private static string? CurrentCommitBehaviorName()
+    {
+        var session = BcRuntime.SkeletonSession;
+        if (session == null) return null;
+        _commitBehaviorProp ??= session.GetType().GetProperty("CommitBehavior",
+            System.Reflection.BindingFlags.Instance
+            | System.Reflection.BindingFlags.Public
+            | System.Reflection.BindingFlags.NonPublic);
+        return _commitBehaviorProp?.GetValue(session)?.ToString();
+    }
+
+    private static System.Reflection.PropertyInfo? _commitBehaviorProp;
+
+    /// <summary>
+    /// BC's own NavCSideException carrying <c>Lang.CommitProhibited</c>, so AL's
+    /// <c>asserterror</c> / <c>GetLastErrorText</c> sees the platform text rather than a
+    /// runner paraphrase. Same reflection route as
+    /// <see cref="BuildTransactionWorldWithActiveWriteTransaction"/> and for the same reason:
+    /// Lang lives in Microsoft.Dynamics.Nav.Language.dll, which the runner does not
+    /// reference directly.
+    /// </summary>
+    private static Exception BuildCommitProhibited()
+    {
+        // Fallback is BC 28.4's own en-US text, measured on a service tier; used only if the
+        // resource cannot be read.
+        var message = LangString("CommitProhibited")
+            ?? "Commit is prohibited in the current scope. The operation cannot continue. "
+               + "Contact your system administrator.";
+        try
+        {
+            var tCSide = ResolveNavCSideExceptionType();
+            var ctor = tCSide?.GetConstructor(
+                System.Reflection.BindingFlags.Instance
+                | System.Reflection.BindingFlags.Public
+                | System.Reflection.BindingFlags.NonPublic,
+                null, new[] { typeof(string) }, null);
+            if (ctor != null)
+                return (Exception)ctor.Invoke(new object[] { message });
+        }
+        catch { /* fall through to the plain exception below */ }
+
+        // Never let the diagnostic construction mask the contract: AL must still see an error
+        // here, because BC would have thrown one.
+        return new InvalidOperationException(message);
     }
 
     /// <summary>

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -128,6 +128,31 @@ Separately, and unrelated to rollback: the isolation between a "worker session"
 and its caller does not exist. `StartSession` runs synchronously, inline, sharing
 the same record store as the caller — see "No parallel session execution" below.
 
+#### CommitBehavior
+
+`[CommitBehavior(...)]` changes what `Commit()` does for the whole **dynamic** scope of the
+attributed procedure — everything it calls, including table triggers and event subscribers
+reached from it. Both values are modeled:
+
+- **`CommitBehavior::Ignore`** — `Commit()` does nothing at all. The rollback boundary does
+  not move and the write transaction does not end, so a later unrelated error still undoes
+  writes made before the ignored `Commit()`. The same code without the attribute leaves
+  those writes durable, which is the contrast worth knowing.
+- **`CommitBehavior::Error`** — `Commit()` raises instead of committing, with BC's own text,
+  `Commit is prohibited in the current scope. The operation cannot continue. Contact your
+  system administrator.`
+
+Measured against a real BC service tier, not inferred: five assertions — the unattributed
+control, `Ignore` on the attributed procedure itself, `Ignore` governing a `Commit()` issued
+by an unattributed callee, the scope being popped when the attributed call returns, and the
+`Error` refusal — in `error-handling/TestCommitBehaviorAttribute.al` (codeunit 60881),
+corpus PR #276. Runner side landed with issue #3449.
+
+One related refusal is **not** implemented, tracked in issue #3451: BC rejects an explicit
+`Commit()` inside a `[TransactionModel(TransactionModel::AutoRollback)]` test with "Tests
+cannot call the Commit function if TransactionModel property is set to AutoRollback."
+(measured on a BC 28.4 container); the runner accepts it.
+
 ### Test isolation modes — mapping to AL's `TestIsolation` values
 
 The `--isolation` (alias `--test-isolation`) flag picks one of three granularities.

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -1668,3 +1668,33 @@ The other seven newly-pulled-in tests pass, and nothing that passed before regre
 3044 pass / 13 fail, against 3026 pass / 0 fail at the old pin.
 
 Written by the fbk-2 agent.
+
+### 3057 -> 3071 (pin ccc10f12 -> ec8a9c23, PR #3452)
+
+The pin advanced to consume StefanMaron/BusinessCentral.AL.Language.Tests#276, the upstream
+half of #3449 (`[CommitBehavior(...)]` must change what `Commit()` does). Corpus history is
+linear, so one other merged corpus PR came with it:
+
+| corpus PR | commit | what it pins |
+|---|---|---|
+| #275 | `6c6a1d12` | `OnFindRecord`/`OnNextRecord` decide which rows the client walks |
+| #276 | `ec8a9c23` | `CommitBehavior::Ignore` makes `Commit()` a no-op; `::Error` makes it raise |
+
+3071 is the `--count-baseline` guard's own printed `actual` on a full three-app run at the new
+pin, not a computed figure: `expected 3057, actual 3071 (BC 28.1)`.
+
+#276's five all pass with this PR's fix, which is the RED -> GREEN this PR exists to show.
+
+One known-gap file is added, for #275's five:
+
+- `known-gaps-page-find-record.json` — the five `ALT Page Find Record Tests` (codeunit 60679),
+  issue #3439, open PR #3448. A page declaring `OnFindRecord`/`OnNextRecord` serves its own
+  rowset on real BC; the runner never dispatches those triggers and walks the table instead,
+  so the TestPage lands on a different row (`Expected:<L0007> Actual:<L0008>` and siblings).
+  Not caused by this PR and not fixed by it — #3439 stays open after it merges, and #3448
+  removes this file.
+
+Nothing that passed before regressed: 3095 pass / 5 fail, against 3057 pass / 0 fail at the
+old pin. All five failures are the #275 tests declared above.
+
+Written by the fbk-1 agent.

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Schema, semantics and how to bump: README.md in this directory. Per-bump rationale: history.md, never a prose line in here (#2485).",
   "suites": {
     "al-language": {
-      "tests": { "default": 3057 },
+      "tests": { "default": 3071 },
       "appGroups": { "default": 1 }
     },
     "al-language-internals-fixture": { "tests": { "default": 0 }, "appGroups": { "default": 1 } },

--- a/tests/expectations/known-gaps-page-find-record.json
+++ b/tests/expectations/known-gaps-page-find-record.json
@@ -1,0 +1,42 @@
+[
+  {
+    "codeunitId": 60679,
+    "CodeunitName": "ALT Page Find Record Tests",
+    "Method": "OnFindRecord_FirstAnswersTheFirstRowOfTheTriggerRowset",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3439",
+    "Note": "Pulled in by this PR's pin advance to ec8a9c23, NOT caused by it: corpus history is linear, so #276 (the upstream half of this PR) cannot be taken without #275 (6c6a1d12), which added this test. A page declaring OnFindRecord/OnNextRecord serves its own rowset in real BC; the runner never dispatches those triggers and walks the table instead, so the TestPage lands on a different row. Tracked as #3439, which is open and is NOT closed by this PR; open PR #3448 fixes it and removes this entry."
+  },
+  {
+    "codeunitId": 60679,
+    "CodeunitName": "ALT Page Find Record Tests",
+    "Method": "OnNextRecord_NextWalksTheTriggerRowsetAndStopsAtItsEnd",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3439",
+    "Note": "Same gap as the entry above, reached through Next() rather than First(). Tracked as #3439, open and NOT closed by this PR; open PR #3448 fixes it and removes this entry."
+  },
+  {
+    "codeunitId": 60679,
+    "CodeunitName": "ALT Page Find Record Tests",
+    "Method": "OnFindRecord_LastAndPreviousWalkTheTriggerRowset",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3439",
+    "Note": "Same gap as the entry above, reached through Last()/Previous(). Tracked as #3439, open and NOT closed by this PR; open PR #3448 fixes it and removes this entry."
+  },
+  {
+    "codeunitId": 60679,
+    "CodeunitName": "ALT Page Find Record Tests",
+    "Method": "OnFindRecord_GoToKeyRefusesARowTheTriggerRowsetDoesNotServe",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3439",
+    "Note": "Same gap as the entry above: because the runner walks the table rather than the trigger rowset, GoToKey accepts a row the page does not serve instead of refusing it. Tracked as #3439, open and NOT closed by this PR; open PR #3448 fixes it and removes this entry."
+  },
+  {
+    "codeunitId": 60679,
+    "CodeunitName": "ALT Page Find Record Tests",
+    "Method": "OnFindRecordAndOnNextRecord_AreBothReachedWhileTheClientBuildsTheRowset",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3439",
+    "Note": "Same gap as the entry above, asserting that both triggers are reached at all. Tracked as #3439, open and NOT closed by this PR; open PR #3448 fixes it and removes this entry."
+  }
+]


### PR DESCRIPTION
Closes #3449

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/276

Opened by the fbk-1 agent.

## The defect

BC's own `ALDatabase.ALCommit()` switches on the session's commit behaviour *before* it commits anything (28.1 Ncl, decompiled, unmodified):

```csharp
switch (session.CommitBehavior)
{
case CommitBehavior.Error:
    throw new NavCSideException(Lang.CommitProhibited);
default:
    session.CheckTryFunction("COMMIT");
    session.Commit();
    break;
case CommitBehavior.Ignore:
    break;
}
```

The runner Cecil-rewrites that method (`NclCecilRewrite.Dispatch.cs` → `ALDatabasePatches.ALDatabase_ALCommit`), and the replacement marked a commit point unconditionally. So `[CommitBehavior(CommitBehavior::Ignore)]` and `[CommitBehavior(CommitBehavior::Error)]` were both silently `Ok`: a `Commit()` that real BC discards became a real commit point, and a `Commit()` real BC refuses raised nothing.

The fix mirrors the switch. `Ignore` returns **early**, before `_inWriteTransaction` is cleared and before `MarkCommitPoint()` — that is the whole point, since BC skips `session.Commit()` and therefore moves neither the rollback boundary nor the write-transaction flag. `Error` raises BC's own text, read out of `Lang.CommitProhibited` through the same reflection route the transaction-world message already uses, with the measured en-US string as a fallback.

Nothing else had to change: `session.CommitBehavior` is already correct at that point, because the AL compiler emits `ALMethodScope.ALStart(commitBehavior, errorBehavior)` and the runner leaves that whole path — `SetCommitBehavior`, `CommitBehaviorScope`, `ResetCommitBehavior` — running BC's unmodified code. Verified with a temporary probe before writing the fix: at the ignored `Commit()` the session reads `Ignore`, on the same session object the patch sees.

## Measurement

Nine arms of one AL bundle, run on a real BC 28.4.53241.0 service tier (container) and on the runner. Arms B-G are controls establishing that plain commit-point and rollback semantics — including `Commit()` inside a table trigger, inside an event subscriber, and inside a cascading `Validate` — already agreed; they are unchanged by this PR. Full source in #3449.

| arm | real BC 28.4 | runner before | runner after |
|---|---|---|---|
| B `Insert; Commit(); Error()` under `asserterror` | row survives | survives | survives |
| C `Commit(); Error()` in `OnModify` | `Int Val` = 10 | 10 | 10 |
| D `Commit(); Error()` in an `OnAfterModifyEvent` subscriber | 99 | 99 | 99 |
| E `Validate` cascade -> `Child.Modify(true)` -> subscriber `Commit(); Error()` | child = Yes | Yes | Yes |
| F subscriber `Commit()`, then unrelated top-level `asserterror` | 99 | 99 | 99 |
| G no `Commit()`, unrelated top-level `asserterror` | 10 | 10 | 10 |
| **H** arm B under `::Ignore` | row **gone** | survives | **gone** |
| **I** arm E under `::Ignore` | child = **No** | Yes | **No** |
| **J** `::Error` + `Commit()` | raises `Commit is prohibited in the current scope. …` | nothing raised | **same text** |

All nine now match, arm J including BC's exact error string. That string alone does **not** prove the `Lang` lookup resolved rather than falling back — the fallback is byte-identical to the resource, so no AL assertion can tell them apart. `CommitProhibitedMessageTests` settles that in-process instead (below).

## RED → GREEN

The behavioural claim is plain BC behaviour and lives upstream, in corpus PR #276 (codeunit 60881 `Test Commit Behavior Attr`, 5 tests, verified 5/5 on a BC 28.4 container before opening). Run as a bundle against this branch:

- **RED** (this branch, fix reverted): `pass: 2  fail: 3`. The two that passed are the controls — `CommitBehavior_Unattributed_CommitBeforeErrorMakesRowDurable` and `CommitBehavior_Ignore_ScopeIsPoppedOnReturn` — which is what makes the other three a statement about the attribute rather than about `Commit()` being broken.
- **GREEN** (this branch): `pass: 5  fail: 0`.

**Pin folded.** Corpus PR #276 merged as `ec8a9c23`, and this PR advances `tests/al-language` from `ccc10f12` to it. Corpus history is linear, so #275 (`6c6a1d12`, `OnFindRecord`/`OnNextRecord`) comes along. Full corpus at the new pin, CI's own three-app invocation with `--strict --expectations-require-match --count-baseline`:

| | first run | with the known-gap file + new baseline |
|---|---|---|
| pass | 3095 | **3100** |
| fail | 5 | **0** |
| `pass-known-gap` | 31 | 36 |
| exit | 1 | **0** |

All five failures were #275's `ALT Page Find Record Tests` (codeunit 60679) — `Expected:<L0007> Actual:<L0008>` and siblings, the runner walking the table instead of the page's trigger rowset. They are declared in a new `tests/expectations/known-gaps-page-find-record.json` against **open** issue #3439, which this PR does not close; open PR #3448 fixes it and deletes the file. Nothing else failed, and nothing that passed at the old pin regressed.

Baseline goes 3057 → 3071 as a one-line diff, taken from the guard's own printed `actual` (`expected 3057, actual 3071 (BC 28.1)`), never a computed figure. `history.md` gains the `ccc10f12 -> ec8a9c23` entry with the two-commit table.

The five #276 tests pass at the new pin — that is the corpus-side RED → GREEN this PR exists to show, now running in this repository's CI rather than only in mine.

`AlRunner.Tests/CommitBehaviorAttributeTests.cs` is the runner-side mechanism test, in the shape of `AssertErrorRollbackNestedTransactionTests` (the #2413 precedent, same situation): it spawns the real runner against a synthetic bundle so a regression in our own commit-point bookkeeping fails loudly without waiting on the pin. Its five AL assertions are plain BC-behaviour claims already green upstream, so what they buy is coverage while the pin has not moved — a temporary justification, not a claim that the corpus cannot see them. RED-tested: with the fix reverted it fails on `CBH2` and `CBH3`.

`AlRunner.Tests/CommitProhibitedMessageTests.cs` is the part AL genuinely cannot decide. Two in-process facts: `Lang.CommitProhibited` resolves at all (a BC rename would otherwise leave every caller on the fallback, correct today and wrong the day Microsoft edits the string), and `BuildCommitProhibited()` returns BC's own `NavCSideException` — the **type** is the discriminator, because the fallback route returns `InvalidOperationException` while carrying the identical message. Both RED-tested: forcing the fallback gives `Expected: "NavCSideException" / Actual: "InvalidOperationException"`, and asking for a renamed resource key fails the first.

## Fixing the shape, not the line

- **Same wrong pattern at another call site?** No — measured, not assumed. `CommitBehavior` gates a commit in exactly one place in Ncl: `ALDatabase.ALCommit`. `SessionTransactionExtensions` (the `EndTransaction` / `EndTransactionWorldAndTransaction` path behind `RecordPatches.NoteTransactionEnd`, the other route that reaches `MarkCommitPoint`) contains **zero** references to it, so a transaction-world completion is not subject to the attribute and `NoteTransactionEnd` is right as it stands.
- **Does a sibling function make the same assumption?** `[ErrorBehavior(Collect)]` is the twin attribute, passed to the same `ALStart(commitBehavior, errorBehavior)` call. It already works, and for the reason that explains this bug: that half runs BC's unmodified code against a real `ErrorCollection` the runner injects into the skeleton session (`RecordPatches.InjectSkeletonErrorCollection`). Only the `Commit` half was replaced wholesale, and only the replaced half lost its switch.
- **Do two paths writing the same state keep the same invariant?** `_inWriteTransaction` is cleared here and in `ResetWriteTransactionState`. The latter is the per-test isolation boundary, not an AL `Commit()`, so it is correctly not subject to the attribute — BC's test framework commits between methods regardless.

**Not folded in, filed instead: #3451.** The same BC method opens with a guard this PR does not add — `Commit()` inside a `[TransactionModel(AutoRollback)]` test must raise `Tests cannot call the Commit function if TransactionModel property is set to AutoRollback.` (measured on the same container; the runner accepts it silently). It lands in the same method, but it is a different guard resting on `session.TestExecution`, which the runner does not model, and reviewing it alongside this switch would mean holding two unrelated pieces of reasoning at once. Nothing upstream pins it either — `TestTransactionModelAutoRollback.al` (60899) never calls `Commit()`.

**Queue scan.** No open issue mentions `CommitBehavior`; the nearest neighbours are #2904 (`Report.Run` may commit a default-model test's prior writes — `BeginTransactionWorld`, a different method) and issues #2413, #2402 and #2191, all three long since landed on `main`, whose behaviour this PR's control arms confirm is intact. (Spelled without a closing keyword next to those numbers on purpose: GitHub's parser reads `closed #N` as an instruction, and this PR closes only #3449.)

## Comments

One block over ten lines, on `ALDatabase_ALCommit` itself: it is BC's three-way branch and why `Ignore` must return before the two state updates, which is exactly what someone editing that line would otherwise get wrong. The derivation — how the attribute reaches the session, and the nine-arm differential — is in this body and in #3449, not in the file. `docs/limitations.md` gains a 25-line `#### CommitBehavior` subsection under the modeled transaction-semantics heading (not under a "cannot be fixed" one — this PR makes it work), which the `///` pointer cites and `tools/test_doc_pointers.py` enforces.

## Tests run

- The corpus slice as a bundle, RED and GREEN, above.
- `dotnet test AlRunner.Tests --filter FullyQualifiedName~CommitBehaviorAttributeTests` — 1/1 pass; 0/1 with the fix reverted.
- The transaction-area classes (`AssertErrorRollbackNestedTransactionTests`, `CodeunitRunWriteTransactionRefusalTests`, `TestPageOpenIsNotACommitPointTests`, `TestTransactionModelDetectionTests`, `RecordBulkWriteNotesTransactionTests`) — 18 pass, 2 fail. Both failures are **pre-existing**: `RecordBulkWriteNotesTransactionTests.DeleteAllAsync_…` and `.ModifyAllAsync_NonTemporaryRecord_NotesWriteBeforeOriginalBodyRuns` fail identically on this branch with the fix reverted.
- `python tools/test_doc_pointers.py` — all checks pass (233 `AlRunner/**/*.cs` pointers, 11 anchored markdown mentions).
- Not run: the full `AlRunner.Tests` suite and the full corpus. CI has them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPJecKgfS4YFcpXSQr2tqb
