### PR TITLE
feat(ms-buckets): let a workflow ask for the prepared company, so the comparison can be measured

### DIFF
--- a/.claude/skills/running-ms-test-buckets/SKILL.md
+++ b/.claude/skills/running-ms-test-buckets/SKILL.md
@@ -94,6 +94,14 @@ Tests-SMB has no ACY-sensitive assertion; #2730's clusters are in Tests-ERM. Do 
 flat Tests-SMB row as the flag not working — the run reported `1 of 1 row(s) changed (was
 'EUR')` in both cases.
 
+**To measure it across the surface, dispatch `ms-surface.yml` with `normalize-company: true`**
+(#3450). It hands the switch down to `ms-bucket.yml`, which appends
+`--test-data-normalize-company` to the runner's argument array. The input defaults to **false**
+on every path — `ms-surface.yml`, `ms-bucket.yml`'s two trigger blocks, and the nightly, which
+passes nothing and inherits it — so a run that leaves the field alone is still comparable with
+every number here. The nightly deliberately never turns it on: it is the trend line, and each
+point on it was measured un-normalized.
+
 #### The triage rule
 
 When a Microsoft bucket test fails, ask **"is this a data-recipe failure?" before treating it

--- a/.github/workflows/ms-bucket-nightly.yml
+++ b/.github/workflows/ms-bucket-nightly.yml
@@ -132,6 +132,12 @@ jobs:
     # and the surface's would come to differ, which would make their numbers incomparable —
     # exactly the failure this whole file exists to avoid.
     #
+    # Company normalization is NOT passed either, for the same reason and one more: the
+    # nightly is the trend line, and every point on it so far was measured against the
+    # un-normalized restore. Inheriting ms-bucket.yml's OFF default keeps the series
+    # comparable with itself; the prepared-company number is a surface dispatch, not a
+    # silent change of what the nightly measures (#3450).
+    #
     # bc-version is left EMPTY on purpose: ms-bucket.yml resolves that to the newest prefix in
     # .github/bc-versions.txt, which is the version the matrix marks required. Pinning a
     # version here is the thing this nightly must not do.

--- a/.github/workflows/ms-bucket.yml
+++ b/.github/workflows/ms-bucket.yml
@@ -59,6 +59,10 @@ name: MS bucket (manual)
 #     legitimate tests here (#3431). Do NOT remove the watchdog to fix that: it is what turns
 #     an unbounded loop into a diagnosable abort instead of a job grinding to the 360-minute
 #     ceiling.
+#   * --test-data-normalize-company, from the `normalize-company` input, default OFF (#3450).
+#     Leave the default off: every number recorded in this repository was measured against the
+#     un-normalized restore, so turning it on by default would make all of them uncomparable
+#     without announcing it.
 #
 # Reading the number — two known ways it can be wrong until their fixes land, both surfaced
 # verbatim in the summary by scripts/ms-bucket-summary.py:
@@ -153,6 +157,14 @@ on:
         type: number
         required: false
         default: 300
+      normalize-company:
+        description: >-
+          Prepare the restored company the way Microsoft prepares its own test company
+          (--test-data-normalize-company, #2730). Off by default: every number in this
+          repository was measured without it, so the two are not comparable.
+        type: boolean
+        required: false
+        default: false
   workflow_dispatch:
     inputs:
       bucket:
@@ -209,6 +221,15 @@ on:
         type: number
         required: false
         default: 300
+      normalize-company:
+        description: >-
+          Blank General Ledger Setup."Additional Reporting Currency" on the restored company,
+          so it matches what Microsoft's own test company has
+          (--test-data-normalize-company, #2730). Turn it on to measure the prepared-company
+          number; leave it off to stay comparable with every number recorded so far.
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -437,6 +458,11 @@ jobs:
           # dropping the flag would leave the timeout working and MsBucketWorkflowTests could
           # no longer tell.
           TEST_TIMEOUT_SEC: ${{ inputs.test-timeout }}
+          # Appended as a bare switch below when it is "true". It carries no value on purpose:
+          # --test-data-normalize-company takes none, so `--test-data-normalize-company false`
+          # would leave `false` as a positional argument and the runner would read it as a
+          # bundle directory (Program.cs's flag loop falls through to bundles.Add).
+          NORMALIZE_COMPANY: ${{ inputs.normalize-company }}
         run: |
           set +e
           mapfile -t BUCKET_LIST < "$RUNNER_TEMP/buckets.txt"
@@ -475,6 +501,13 @@ jobs:
               # SQL form of the company name: trailing underscore. With a period the run fails
               # loudly and lists both companies.
               args+=( "--test-data=$bak" --test-data-company "CRONUS International Ltd_" )
+              # Nested rather than a sibling: the flag rewrites rows on their way out of the
+              # backup, so without --test-data it changes nothing while still printing
+              # "company normalization ON", which reads like data was prepared when none was
+              # restored.
+              if [ "$NORMALIZE_COMPANY" = "true" ]; then
+                args+=( --test-data-normalize-company )
+              fi
             fi
             echo "::group::[$i/$total] $bucket"
             start=$SECONDS

--- a/.github/workflows/ms-surface.yml
+++ b/.github/workflows/ms-surface.yml
@@ -82,6 +82,15 @@ on:
         type: number
         required: false
         default: 300
+      normalize-company:
+        description: >-
+          Prepare the restored company the way Microsoft prepares its own, handed down to
+          ms-bucket.yml, which puts the switch on the runner's command line (#2730). OFF is
+          the surface as every recorded number measured it; ON is the second number the
+          comparison needs. Must match ms-bucket.yml's default.
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -105,6 +114,7 @@ jobs:
       bc-version: ${{ inputs.bc-version }}
       test-data: ${{ inputs.test-data }}
       test-timeout: ${{ inputs.test-timeout }}
+      normalize-company: ${{ inputs.normalize-company }}
       # Tests-ERM (9,496) and Tests-SCM (8,524) lead deliberately: 44% of the 40,530 between
       # them, measured on the 28.1.49838.53507 artifact (#3409), so if anything is lost to the
       # 360-minute ceiling it should not be the two buckets everything else is compared

--- a/AlRunner.Tests/MsBucketWorkflowTests.cs
+++ b/AlRunner.Tests/MsBucketWorkflowTests.cs
@@ -93,24 +93,77 @@ internal static class WorkflowInputDefaults
 internal static class BashArrayLiteral
 {
     /// <summary>
-    /// The inside of a bash array literal <c>name=( … )</c>, matched by counting parentheses
-    /// rather than by looking for a terminator string. An assertion about what the runner is
-    /// invoked WITH has to be scoped to the array it is invoked with — a flag mentioned in a
-    /// comment, an <c>echo</c>, or a sibling <c>args+=(</c> guarded by an <c>if</c> is not the
-    /// same claim. Empty when the array is absent.
+    /// The inside of EVERY bash array literal <c>name=( … )</c> in the script, newline-joined
+    /// and parenthesis-matched rather than terminated by a string. An assertion about what the
+    /// runner is invoked WITH has to be scoped to the arrays it is invoked with — a flag named
+    /// in a comment, an <c>echo</c>, or a sibling <c>args+=(</c> guarded by an <c>if</c> is not
+    /// the same claim. Empty when there is no such literal.
+    ///
+    /// It reads every literal, not the first, because a NEGATIVE reading is load-bearing here:
+    /// "the flag must not be in the unconditional array" is what keeps the input's <c>false</c>
+    /// default from being decorative. A first-match reader supports a positive claim perfectly
+    /// well — #3443 asserted <c>--test-timeout</c> IS present and was right — but scoped to a
+    /// subset it silently PERMITS what a negative claim forbids everywhere else. Reviewed on
+    /// #3453: keeping the conditional append exactly as shipped and adding a second literal,
+    /// <c>args=( "${args[@]}" --test-data-normalize-company )</c>, turns the flag on for every
+    /// caller including the nightly and left the whole pinned suite green.
     /// </summary>
     internal static string Of(string script, string name)
     {
-        var open = script.IndexOf(name + "=(", StringComparison.Ordinal);
-        if (open < 0) return string.Empty;
-        var i = open + name.Length + 1;      // at the '('
-        var depth = 0;
-        for (var j = i; j < script.Length; j++)
+        var marker = name + "=(";
+        var bodies = new List<string>();
+        for (var open = script.IndexOf(marker, StringComparison.Ordinal); open >= 0;
+             open = script.IndexOf(marker, open + marker.Length, StringComparison.Ordinal))
         {
-            if (script[j] == '(') depth++;
-            else if (script[j] == ')' && --depth == 0) return script[(i + 1)..j];
+            // `MY_args=(` is a different array from `args=(`, and matching it would let a
+            // negative assertion fail on text it does not govern.
+            if (open > 0 && (char.IsLetterOrDigit(script[open - 1]) || script[open - 1] == '_'))
+                continue;
+            var i = open + name.Length + 1;      // at the '('
+            var depth = 0;
+            for (var j = i; j < script.Length; j++)
+            {
+                if (script[j] == '(') depth++;
+                else if (script[j] == ')' && --depth == 0) { bodies.Add(script[(i + 1)..j]); break; }
+            }
+            // An unbalanced literal contributes nothing — the caller's assertion says so.
         }
-        return string.Empty;                 // unbalanced — the caller's assertion says so
+        return string.Join('\n', bodies);
+    }
+}
+
+internal static class BashIfBlock
+{
+    /// <summary>
+    /// The body of <c>if &lt;condition&gt;; then … fi</c>, up to the <c>fi</c> that closes it
+    /// rather than the first one seen, so a nested <c>if</c> does not end the block early.
+    /// Empty when no such block exists.
+    ///
+    /// An index comparison is NOT this claim. <c>Assert.True(inner &gt; outer)</c> is satisfied
+    /// by text sitting after the block's closing <c>fi</c>, so it pins ORDER and reads like it
+    /// pins NESTING — reviewed on #3453, where moving the append out of the block with its
+    /// guard and body unchanged left the suite green.
+    /// </summary>
+    internal static string BodyOf(string script, string condition)
+    {
+        var lines = script.Replace("\r\n", "\n").Split('\n');
+        var opener = "if " + condition + "; then";
+        var start = -1;
+        var depth = 0;
+        var body = new List<string>();
+        for (var k = 0; k < lines.Length; k++)
+        {
+            var line = lines[k].Trim();
+            if (start < 0)
+            {
+                if (line == opener) { start = k; depth = 1; }
+                continue;
+            }
+            if (line.StartsWith("if ", StringComparison.Ordinal)) depth++;
+            else if (line == "fi" && --depth == 0) return string.Join('\n', body);
+            body.Add(lines[k]);
+        }
+        return string.Empty;                 // absent, or never closed
     }
 }
 
@@ -275,6 +328,64 @@ public sealed class MsBucketWorkflowTests
         Assert.DoesNotContain("echo", array, StringComparison.Ordinal);
         Assert.DoesNotContain("--test-data-company", array, StringComparison.Ordinal);
         Assert.Equal(string.Empty, BashArrayLiteral.Of(script, "nosuch"));
+    }
+
+    /// <summary>
+    /// The property a NEGATIVE assertion needs and a first-match reader cannot give it: every
+    /// literal is read, so "this flag is in no unconditional array" covers all of them. The
+    /// second literal below is the reviewer's break on #3453 — the conditional append left
+    /// exactly as shipped, plus one more <c>args=( … )</c> that turns the flag on for everyone.
+    /// </summary>
+    [Fact]
+    public void BashArrayLiteral_ReadsEveryLiteral_NotOnlyTheFirst()
+    {
+        const string script = """
+            args=( "$BUNDLE" --cache "$C" )
+            if [ "$NORMALIZE_COMPANY" = "true" ]; then
+              args+=( --test-data-normalize-company )
+            fi
+            args=( "${args[@]}" --test-data-normalize-company )
+            """;
+
+        var all = BashArrayLiteral.Of(script, "args");
+        Assert.Contains("--cache \"$C\"", all, StringComparison.Ordinal);
+        Assert.Contains("--test-data-normalize-company", all, StringComparison.Ordinal);
+        // The conditional append is still NOT a literal — that separation is what makes the
+        // shipped workflow's own assertion mean something.
+        Assert.Single(BashConditionalAppend.Of(script, "args"));
+
+        // A different array whose name merely ends in the one asked for is not this array.
+        Assert.Equal("--quiet", BashArrayLiteral.Of("MY_args=( --loud )\nargs=( --quiet )", "args").Trim());
+    }
+
+    /// <summary>
+    /// <see cref="BashIfBlock.BodyOf"/> ends at the <c>fi</c> that closes the block it was
+    /// asked for, not the first one it meets, and text after that <c>fi</c> is outside. That
+    /// second half is the whole point: an index comparison would call it inside.
+    /// </summary>
+    [Fact]
+    public void BashIfBlock_EndsAtItsOwnFi_AndExcludesWhatFollows()
+    {
+        const string script = """
+            if [ "$WITH_TEST_DATA" = "true" ]; then
+              args+=( --test-data-company "CRONUS International Ltd_" )
+              if [ "$NORMALIZE_COMPANY" = "true" ]; then
+                args+=( --test-data-normalize-company )
+              fi
+            fi
+            args+=( --after-the-block )
+            """;
+
+        var body = BashIfBlock.BodyOf(script, "[ \"$WITH_TEST_DATA\" = \"true\" ]");
+        Assert.Contains("--test-data-normalize-company", body, StringComparison.Ordinal);
+        Assert.Contains("--test-data-company", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("--after-the-block", body, StringComparison.Ordinal);
+
+        // The inner block is addressable on its own terms, and an absent condition is empty
+        // rather than "everything from here on".
+        Assert.Equal("args+=( --test-data-normalize-company )",
+            BashIfBlock.BodyOf(script, "[ \"$NORMALIZE_COMPANY\" = \"true\" ]").Trim());
+        Assert.Equal(string.Empty, BashIfBlock.BodyOf(script, "[ \"$NOPE\" = \"true\" ]"));
     }
 
     [Fact]
@@ -629,22 +740,28 @@ public sealed class MsBucketWorkflowTests
         Assert.Equal(TestDataNormalization.FlagName, normalize.Body);
         Assert.Equal("[ \"$NORMALIZE_COMPANY\" = \"true\" ]", normalize.Condition);
 
+        // In NO unconditional literal — BashArrayLiteral.Of reads every `args=( … )` in the
+        // step, because this negative claim is what keeps the input's false default from being
+        // decorative and a claim scoped to one literal permits the flag in the next one.
         Assert.DoesNotContain(TestDataNormalization.FlagName,
             BashArrayLiteral.Of(runStep, "args"), StringComparison.Ordinal);
 
         Assert.Contains("/al-runner\" \"${args[@]}\"", runStep, StringComparison.Ordinal);
 
-        // Nested inside the --test-data block, not beside it. The rule rewrites rows on their
-        // way out of the backup, so with --test-data off the flag changes nothing while the
-        // runner still prints "company normalization ON" — a line that reads like data was
-        // prepared when none was restored.
-        var testData = runStep.IndexOf("if [ \"$WITH_TEST_DATA\" = \"true\" ]; then",
-            StringComparison.Ordinal);
-        var switchIndex = runStep.IndexOf("if [ \"$NORMALIZE_COMPANY\" = \"true\" ]; then",
-            StringComparison.Ordinal);
-        Assert.True(testData >= 0 && switchIndex > testData,
-            "the normalization switch must sit inside the --test-data block, not before it");
-        Assert.True(switchIndex < runStep.IndexOf("\"${args[@]}\"", StringComparison.Ordinal),
+        // Nested INSIDE the --test-data block, which is a containment claim and not an
+        // ordering one: the rule rewrites rows on their way out of the backup, so outside the
+        // block the flag changes nothing while the runner still prints "company normalization
+        // ON" — a line that reads like data was prepared when none was restored.
+        var withTestData = BashIfBlock.BodyOf(runStep, "[ \"$WITH_TEST_DATA\" = \"true\" ]");
+        Assert.False(string.IsNullOrWhiteSpace(withTestData),
+            "the --test-data block is gone from the \"Run the bucket(s)\" step");
+        Assert.Contains(TestDataNormalization.FlagName, withTestData, StringComparison.Ordinal);
+        Assert.Equal(TestDataNormalization.FlagName,
+            Assert.Single(BashConditionalAppend.Of(withTestData, "args")
+                .Where(a => a.Body.Contains(TestDataNormalization.FlagName, StringComparison.Ordinal))).Body);
+
+        Assert.True(runStep.IndexOf("if [ \"$WITH_TEST_DATA\" = \"true\" ]; then", StringComparison.Ordinal)
+                < runStep.IndexOf("\"${args[@]}\"", StringComparison.Ordinal),
             "the switch must be appended before the runner is invoked");
     }
 

--- a/AlRunner.Tests/MsBucketWorkflowTests.cs
+++ b/AlRunner.Tests/MsBucketWorkflowTests.cs
@@ -114,6 +114,58 @@ internal static class BashArrayLiteral
     }
 }
 
+internal static class BashConditionalAppend
+{
+    /// <summary>
+    /// Every <c>name+=( … )</c> in a script, paired with the condition of the nearest
+    /// <c>if …; then</c> above it — parenthesis-matched for the same reason
+    /// <see cref="BashArrayLiteral.Of"/> is: a flag named in a comment, an <c>echo</c> or an
+    /// input's own description is not the claim "the runner is invoked with it".
+    ///
+    /// A SWITCH cannot be asserted with <see cref="BashArrayLiteral.Of"/> at all. It carries no
+    /// value, so it has to be appended under a condition rather than sit in the unconditional
+    /// literal — and that literal is precisely what <c>Of</c> reads and a conditional append is
+    /// precisely what it excludes. Pairing the append with its guard is what makes "turning the
+    /// input on is what puts the flag on the command line" a falsifiable claim rather than a
+    /// substring search that a comment would satisfy.
+    /// </summary>
+    internal static IReadOnlyList<(string Condition, string Body)> Of(string script, string name)
+    {
+        var found = new List<(string, string)>();
+        var marker = name + "+=(";
+        for (var open = script.IndexOf(marker, StringComparison.Ordinal); open >= 0;
+             open = script.IndexOf(marker, open + marker.Length, StringComparison.Ordinal))
+        {
+            var i = open + marker.Length - 1;    // at the '('
+            var depth = 0;
+            var body = string.Empty;
+            for (var j = i; j < script.Length; j++)
+            {
+                if (script[j] == '(') depth++;
+                else if (script[j] == ')' && --depth == 0) { body = script[(i + 1)..j]; break; }
+            }
+            found.Add((ConditionAbove(script, open), body.Trim()));
+        }
+        return found;
+    }
+
+    /// <summary>The nearest <c>if …; then</c> line above <paramref name="index"/>, stripped to
+    /// its condition. Empty when there is none, so an unconditional append is distinguishable
+    /// from a guarded one instead of both reading the same.</summary>
+    private static string ConditionAbove(string script, int index)
+    {
+        var lines = script[..index].Replace("\r\n", "\n").Split('\n');
+        for (var k = lines.Length - 1; k >= 0; k--)
+        {
+            var line = lines[k].Trim();
+            if (!line.StartsWith("if ", StringComparison.Ordinal)) continue;
+            var then = line.LastIndexOf("; then", StringComparison.Ordinal);
+            return (then < 0 ? line[3..] : line[3..then]).Trim();
+        }
+        return string.Empty;
+    }
+}
+
 public sealed class MsBucketWorkflowTests
 {
     private static readonly string RepoRoot = Path.GetFullPath(
@@ -223,6 +275,40 @@ public sealed class MsBucketWorkflowTests
         Assert.DoesNotContain("echo", array, StringComparison.Ordinal);
         Assert.DoesNotContain("--test-data-company", array, StringComparison.Ordinal);
         Assert.Equal(string.Empty, BashArrayLiteral.Of(script, "nosuch"));
+    }
+
+    [Fact]
+    public void BashConditionalAppend_PairsEachAppendWithItsGuard_AndIgnoresProseNamingTheFlag()
+    {
+        const string script = """
+            # --test-data-normalize-company belongs in a comment and must not count as an append.
+            echo "would run with --test-data-normalize-company"
+            args=( "$BUNDLE" --cache "$C" )
+            if [ "$WITH_TEST_DATA" = "true" ]; then
+              args+=( "--test-data=$bak" --test-data-company "CRONUS International Ltd_" )
+              if [ "$NORMALIZE_COMPANY" = "true" ]; then
+                args+=( --test-data-normalize-company )
+              fi
+            fi
+            """;
+
+        var appends = BashConditionalAppend.Of(script, "args");
+        Assert.Equal(2, appends.Count);
+        Assert.Equal("[ \"$WITH_TEST_DATA\" = \"true\" ]", appends[0].Condition);
+        Assert.Contains("--test-data-company", appends[0].Body, StringComparison.Ordinal);
+        Assert.Equal("[ \"$NORMALIZE_COMPANY\" = \"true\" ]", appends[1].Condition);
+        Assert.Equal("--test-data-normalize-company", appends[1].Body);
+
+        // The comment and the echo name the same flag and are not appends; the unconditional
+        // literal is a different claim again and holds neither flag.
+        Assert.DoesNotContain(appends, a => a.Body.Contains("echo", StringComparison.Ordinal));
+        Assert.DoesNotContain("--test-data-normalize-company", BashArrayLiteral.Of(script, "args"),
+            StringComparison.Ordinal);
+        Assert.Empty(BashConditionalAppend.Of(script, "nosuch"));
+
+        // An append with no `if` above it reports an empty condition rather than borrowing one.
+        Assert.Equal(string.Empty,
+            Assert.Single(BashConditionalAppend.Of("args+=( --quiet )", "args")).Condition);
     }
 
     // ---- wired to the real files ------------------------------------------------------
@@ -504,6 +590,99 @@ public sealed class MsBucketWorkflowTests
         // And the thing it inherits is real: ms-bucket.yml declares the input with a default,
         // so "passes nothing" means 300 s, not nothing.
         Assert.NotEmpty(WorkflowInputDefaults.Of(Read(Path.Combine("workflows", Workflow)), "test-timeout"));
+    }
+
+    // ---- company normalization (#3450, the flag from #2730) ----------------------------
+
+    /// <summary>
+    /// #3450: <c>--test-data-normalize-company</c> shipped on the runner (#2730) with no way
+    /// for any workflow to pass it, so the comparison it was built for could not be run in CI.
+    ///
+    /// The claim is that the flag ARRIVES, which is four separate links — checking any one of
+    /// them alone passes on the defect this exists to catch:
+    ///
+    ///   1. the INPUT reaches a shell variable, so a caller's override goes somewhere;
+    ///   2. the variable GUARDS an append, so the input is what decides;
+    ///   3. the APPENDED text is the flag the runner's own parser accepts, spelled from
+    ///      <see cref="TestDataNormalization.FlagName"/> rather than typed a second time, and
+    ///      carries no value — <c>--test-data-normalize-company false</c> would leave
+    ///      <c>false</c> as a positional argument, which Program.cs adds to the bundle list;
+    ///   4. that array is what the runner is invoked with.
+    ///
+    /// And the negative that keeps every recorded number valid: the flag is NOT in the
+    /// unconditional <c>args=( … )</c> literal. There it would be on for every caller,
+    /// including the nightly, and the input's <c>false</c> default would be decorative.
+    /// </summary>
+    [Fact]
+    public void MsBucketWorkflow_PutsCompanyNormalizationOnTheRunnersArgumentArray_OnlyWhenAskedTo()
+    {
+        var code = CodeOnly(Read(Path.Combine("workflows", Workflow)));
+        var runStep = WorkflowStep.BodyOf(code, "Run the bucket(s)");
+
+        Assert.Contains("NORMALIZE_COMPANY: ${{ inputs.normalize-company }}", runStep,
+            StringComparison.Ordinal);
+
+        var appends = BashConditionalAppend.Of(runStep, "args");
+        var normalize = Assert.Single(appends.Where(
+            a => a.Body.Contains(TestDataNormalization.FlagName, StringComparison.Ordinal)));
+
+        Assert.Equal(TestDataNormalization.FlagName, normalize.Body);
+        Assert.Equal("[ \"$NORMALIZE_COMPANY\" = \"true\" ]", normalize.Condition);
+
+        Assert.DoesNotContain(TestDataNormalization.FlagName,
+            BashArrayLiteral.Of(runStep, "args"), StringComparison.Ordinal);
+
+        Assert.Contains("/al-runner\" \"${args[@]}\"", runStep, StringComparison.Ordinal);
+
+        // Nested inside the --test-data block, not beside it. The rule rewrites rows on their
+        // way out of the backup, so with --test-data off the flag changes nothing while the
+        // runner still prints "company normalization ON" — a line that reads like data was
+        // prepared when none was restored.
+        var testData = runStep.IndexOf("if [ \"$WITH_TEST_DATA\" = \"true\" ]; then",
+            StringComparison.Ordinal);
+        var switchIndex = runStep.IndexOf("if [ \"$NORMALIZE_COMPANY\" = \"true\" ]; then",
+            StringComparison.Ordinal);
+        Assert.True(testData >= 0 && switchIndex > testData,
+            "the normalization switch must sit inside the --test-data block, not before it");
+        Assert.True(switchIndex < runStep.IndexOf("\"${args[@]}\"", StringComparison.Ordinal),
+            "the switch must be appended before the runner is invoked");
+    }
+
+    /// <summary>
+    /// The default is OFF on BOTH trigger blocks, and it is the same word on each. Every
+    /// pass/fail number recorded in this repository — the running-ms-test-buckets skill's
+    /// 259/595 for Tests-SMB, #3416's corpus counts, the full-surface runs — was measured
+    /// against the un-normalized restore. A default of <c>true</c> would make all of them
+    /// uncomparable and nothing would announce it; a default on only one trigger would make
+    /// the two spellings disagree, which is the same failure one dispatch at a time.
+    /// </summary>
+    [Fact]
+    public void MsBucketWorkflow_DefaultsCompanyNormalizationOff_OnBothTriggers()
+    {
+        var defaults = WorkflowInputDefaults.Of(
+            Read(Path.Combine("workflows", Workflow)), "normalize-company");
+
+        Assert.Equal(2, defaults.Count);
+        Assert.Equal(new[] { "false", "false" }, defaults);
+    }
+
+    /// <summary>
+    /// The nightly inherits the OFF default by passing nothing. It is the trend line, and every
+    /// point on it so far was measured un-normalized — a second spelling here is both how two
+    /// configurations drift apart (#1976, one input down) and how a series quietly stops being
+    /// comparable with itself.
+    /// </summary>
+    [Fact]
+    public void NightlyWorkflow_InheritsCompanyNormalization_RatherThanSpellingItAgain()
+    {
+        var code = CodeOnly(Read(Path.Combine("workflows", Nightly)));
+
+        Assert.DoesNotContain("normalize-company", code, StringComparison.Ordinal);
+        Assert.Contains("uses: ./.github/workflows/ms-bucket.yml", code, StringComparison.Ordinal);
+        // And what it inherits is real: ms-bucket.yml declares the input with a default, so
+        // "passes nothing" means OFF rather than an empty string.
+        Assert.NotEmpty(WorkflowInputDefaults.Of(
+            Read(Path.Combine("workflows", Workflow)), "normalize-company"));
     }
 
     [Fact]

--- a/AlRunner.Tests/MsSurfaceWorkflowTests.cs
+++ b/AlRunner.Tests/MsSurfaceWorkflowTests.cs
@@ -283,6 +283,7 @@ public sealed class MsSurfaceWorkflowTests
                      "--package-cache", "READER_TAG", "--test-data-company",
                      "CRONUS International Ltd_", "AL_RUNNER_EMIT_TIMEOUT_SEC",
                      "provision-bc", "al-runner", "--test-timeout",
+                     "--test-data-normalize-company",
                  })
             Assert.DoesNotContain(owned, code, StringComparison.Ordinal);
     }
@@ -310,6 +311,31 @@ public sealed class MsSurfaceWorkflowTests
         Assert.Single(surface);
         Assert.NotEmpty(bucket);
         Assert.Equal(bucket.Distinct(StringComparer.Ordinal).Single(), surface[0]);
+    }
+
+    /// <summary>
+    /// #3450: the surface is where the prepared-company comparison gets run, so it needs the
+    /// knob — passed THROUGH, at the same default, for the same two reasons the timeout is.
+    ///
+    /// The default is asserted to be <c>false</c> by name here rather than only "equal to
+    /// ms-bucket.yml's". Equality alone would survive both files being flipped to <c>true</c>
+    /// together, and that is the change that silently invalidates every number this repository
+    /// has recorded: the skill's 259/595 for Tests-SMB, #3416's corpus counts, and the
+    /// full-surface runs were all measured against the un-normalized restore. Turning it on is
+    /// a dispatch-time decision, never a default.
+    /// </summary>
+    [Fact]
+    public void SurfaceWorkflow_PassesCompanyNormalizationThrough_AtTheSameDefault_Off()
+    {
+        Assert.Contains("normalize-company: ${{ inputs.normalize-company }}",
+            CodeOnly(Read(SurfaceWorkflow)), StringComparison.Ordinal);
+
+        var surface = WorkflowInputDefaults.Of(Read(SurfaceWorkflow), "normalize-company");
+        var bucket = WorkflowInputDefaults.Of(Read(BucketWorkflow), "normalize-company");
+
+        Assert.Equal("false", Assert.Single(surface));
+        Assert.NotEmpty(bucket);
+        Assert.Equal("false", bucket.Distinct(StringComparer.Ordinal).Single());
     }
 
     // ---- what the surface needs from ms-bucket.yml -------------------------------------

--- a/AlRunner/Infrastructure/TestDataNormalization.cs
+++ b/AlRunner/Infrastructure/TestDataNormalization.cs
@@ -108,11 +108,20 @@ internal static class TestDataNormalization
         lock (_gate) _outcomes.Clear();
     }
 
+    /// <summary>
+    /// The CLI spelling, as a constant so a caller that has to REPRODUCE it — ms-bucket.yml,
+    /// pinned by MsBucketWorkflowTests — binds to the parser rather than to a second copy of
+    /// the string. A switch, taking no value: <c>--test-data-normalize-company false</c> leaves
+    /// <c>false</c> as a positional argument, which Program.cs's flag loop adds to the bundle
+    /// list.
+    /// </summary>
+    internal const string FlagName = "--test-data-normalize-company";
+
     /// <summary>Parse one argument. False when it is not this flag, so the caller's flag loop
     /// is unchanged for everything else.</summary>
     internal static bool TryParseArg(string arg)
     {
-        if (arg != "--test-data-normalize-company") return false;
+        if (arg != FlagName) return false;
         Enabled = true;
         return true;
     }


### PR DESCRIPTION
Closes #3450

Corpus-NA: a workflow input reaching a command line. Nothing here asserts BC behaviour — no AL is compiled or executed differently by this diff, and a real service tier has nothing to adjudicate about a GitHub Actions `inputs:` block.

#3432 landed `--test-data-normalize-company` on the runner, off by default. No workflow could pass it, so the prepared-company comparison it was built for could not be run in CI.

## What changed

- `ms-bucket.yml` — a `normalize-company` boolean input on **both** trigger blocks, default `false`, bound to a `NORMALIZE_COMPANY` env var and appended to the runner's argument array.
- `ms-surface.yml` — the same input at the same default, passed through rather than re-spelled.
- `ms-bucket-nightly.yml` — passes nothing and inherits. It is the trend line, and every point on it so far was measured against the un-normalized restore; a second spelling here is how two configurations drift apart and stop being comparable.
- `TestDataNormalization.FlagName` — the CLI spelling as a constant, so the workflow test binds to the parser instead of to a second copy of the string. A British-spelling typo in the workflow now fails a unit test rather than a three-hour dispatch.

## The one way this differs from #3443

`test-timeout` carries a value; this is a **switch**. I read `Program.cs`'s flag loop before choosing the shape: `TestDataNormalization.TryParseArg` matches the bare flag and consumes nothing, and the loop's fall-through is `bundles.Add(args[i])`. So `--test-data-normalize-company false` would leave `false` as a positional argument and the runner would treat it as a bundle directory — failing in a way that reads like a bundle problem. It is therefore appended conditionally:

```bash
if [ "$WITH_TEST_DATA" = "true" ]; then
  args+=( "--test-data=$bak" --test-data-company "CRONUS International Ltd_" )
  if [ "$NORMALIZE_COMPANY" = "true" ]; then
    args+=( --test-data-normalize-company )
  fi
fi
```

Nested inside the `--test-data` block rather than beside it: the rule rewrites rows on their way out of the backup, so without `--test-data` the flag changes nothing while the runner still prints `[test-data] company normalization ON` — a line that reads like data was prepared when none was restored.

## The proving test, and what each deliberate break did

`BashArrayLiteral.Of` reads every unconditional `args=( … )` literal and deliberately excludes a conditional `args+=( … )`, so it cannot see a switch at all. `BashConditionalAppend.Of` is its counterpart: every `args+=( … )` paren-matched, paired with the nearest `if …; then` above it. That pairing is what makes "turning the input on is what puts the flag on the command line" falsifiable rather than a substring search a comment would satisfy. It has its own self-test on constructed text, including a comment and an `echo` naming the same flag.

Ten breaks, run against the real files with the tests unchanged. Two of them (H and I) are the reviewer's, and both were GREEN on the first push — see "What review caught" below.

| break | what I did | result |
|---|---|---|
| **A (mandated)** | removed `args+=( --test-data-normalize-company )`, leaving the input, the default, the env binding and every comment mention in place | **RED** — `Assert.Single() Failure: The collection was empty` |
| B | replaced the conditional append with the flag hardcoded in the unconditional `args=( … )` | **RED** — same `Assert.Single` |
| B2 | kept the conditional append **and** also put the flag in `args=( … )`, i.e. always on with the input still reading `false` | **RED** — `Assert.DoesNotContain() Failure: Sub-string found` |
| C | changed the guard to `[ "$WITH_TEST_DATA" = "true" ]`, so the append fires without the input | **RED** — condition `Assert.Equal` |
| D | gave the switch a value: `args+=( --test-data-normalize-company "$NORMALIZE_COMPANY" )` | **RED** — body `Assert.Equal` |
| E | flipped both defaults to `true`, keeping them equal to each other | **RED** — twice, once per file |
| F | declared the input on `workflow_dispatch` only | **RED** — the both-triggers count |
| G | British spelling `--test-data-normalise-company` on the array | **RED** — `Assert.Single`, via `FlagName` |
| **H (reviewer)** | conditional append untouched, plus a **second** literal `args=( "${args[@]}" --test-data-normalize-company )` | **RED** — `Assert.DoesNotContain(): Sub-string found` |
| **I (reviewer)** | append moved **outside** the `--test-data` block, guard and body unchanged | **RED** — `Assert.Contains(): Sub-string not found` |

E is the one worth naming separately. The surface-side test asserts the default is `"false"` **by name**, not merely equal to `ms-bucket.yml`'s: equality alone survives both files being flipped together, and that is exactly the change that silently invalidates every number this repository has recorded.

## Default false is the constraint that matters

The `running-ms-test-buckets` skill's 259/595 for Tests-SMB, #3416's corpus counts and the two full-surface runs currently on CI were all measured against the un-normalized restore. A default of `true` would make all of them uncomparable and nothing would announce it. Four assertions hold it: both of `ms-bucket.yml`'s triggers, `ms-surface.yml`'s, and the nightly not mentioning it at all.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site?** `ms-bucket.yml` is the only place the runner's argument array is built for a Microsoft bucket; `bc-tests.yml` and the release path do not run buckets. Nothing found.
2. **A sibling making the same assumption?** `--test-data-company` is the only other `--test-data`-family flag on that array, and it is already input-driven through `WITH_TEST_DATA`. `--test-data` itself has an input. No third flag is stranded the way this one was.
3. **Two paths writing the same state?** Three callers reach `ms-bucket.yml` — the surface, the nightly and a direct dispatch. All three now resolve `normalize-company` through one declaration with one default, which is what the nightly's "pass nothing" is for. The pattern that would break it is a caller re-spelling the default, and `NightlyWorkflow_InheritsCompanyNormalization_RatherThanSpellingItAgain` plus the surface's equality assertion are what refuse it.

**Open-issue queue:** no other open issue's fix lands in `ms-bucket.yml`, `ms-surface.yml`, `ms-bucket-nightly.yml` or either workflow test file, and no open PR touches them. Nothing to fold.

## What I ran, and what I deliberately did not

Filtered: `MsBucketWorkflowTests`, `MsSurfaceWorkflowTests`, `TestDataCompanyNormalizationTests`, `TestDataCompanyHelpTextTests`, `CliDocumentationTests` — 100 passed, 0 failed. Plus the other suites that read these workflow files (`ArtifactDownloaderMsBucketTests`, `MainVerdictFloorWorkflowTests`, `BundleFailureStageTests`, `BackupReaderFailureReportingTests`) — 67 passed. Every assertion #3443 added hours ago still passes; I ran them rather than assuming. The three workflows parse under `yaml.safe_load` and the run step passes `bash -n`.

I did **not** run the Microsoft buckets: two full-surface runs are in flight on CI and a local run would contend for nothing useful. This diff cannot change a test result — it can only change whether a flag reaches the command line, which is what the tests above measure.

## Prose

The one paragraph that would otherwise have gone in a comment block — how to actually dispatch the comparison — went to `.claude/skills/running-ms-test-buckets/SKILL.md`, next to the measured with/without table it belongs beside.

Filed and implemented by an agent (`coord-1`).

https://claude.ai/code/session_01F7HLDeNwiGQoLT5wFanqmH


## What review caught, and why it is a new variant

The shipped YAML was correct in both cases. **Two of my assertions were not**, and each was green on exactly the defect it existed to forbid.

**1. `BashArrayLiteral.Of` was a single `IndexOf`, so it read only the first literal.** Keeping the conditional append exactly as shipped and adding a second literal, `args=( "${args[@]}" --test-data-normalize-company )`, turns the flag on for every caller including the nightly, with the input still reading `false` — and left the whole pinned suite green. The helper now reads **every** literal and joins them, and ignores a match whose array name merely ends in the one asked for. Fixed in the helper rather than at my call site, so #3443's `--test-timeout` assertions keep working and any future negative use is safe.

**2. The nesting was not pinned — only the ordering was.** `Assert.True(switchIndex > testData)` compares string indexes, so it is satisfied by the append sitting *below* the block's closing `fi`. Moving it out with guard and body unchanged left the suite green. New `BashIfBlock.BodyOf` extracts the block up to the `fi` that closes it, counting nested `if`s, and the assertion is containment rather than order. The nesting is what matters: outside the block the runner still prints `company normalization ON` over a run that normalized nothing.

Both helpers now carry a self-test on constructed text with the reviewer's break as its case.

**The general point.** This repository's dominant failure mode has been a *positive* assertion that cannot fail. These two are **negative** assertions — "the flag must not appear unconditionally", "the flag must not sit outside the block" — and the arithmetic is different. A positive assertion scoped to a subset is merely incomplete; it still proves something. A negative one scoped to a subset is **wrong**: it silently permits the thing it forbids everywhere outside that subset, and reads identically to a correct one. `BashArrayLiteral.Of` was written for #3443's positive reading, where first-match is perfectly sound; #3453 is the first PR where the negative reading is load-bearing. When you assert something is absent, the reader has to cover every place it could be present.

## Not fixed here, filed separately

`test-data: false` with `normalize-company: true` silently drops the request — no warning, nothing in the summary. The same run step already fails loudly up front on a bad `test-timeout`, so a matching guard would be idiomatic. Out of scope for this PR; the coordinator is filing it.
