### PR TITLE
fix(ms-surface): coerce the per-test timeout, so GitHub will create the run at all

### DIFF
--- a/.github/workflows/ms-surface.yml
+++ b/.github/workflows/ms-surface.yml
@@ -113,7 +113,11 @@ jobs:
       expected-tests: 40530
       bc-version: ${{ inputs.bc-version }}
       test-data: ${{ inputs.test-data }}
-      test-timeout: ${{ inputs.test-timeout }}
+      # fromJSON is load-bearing, not decoration: a workflow_dispatch input reaches the
+      # inputs context as a STRING whatever its declared type, and a string handed to a
+      # workflow_call input declared `type: number` makes GitHub refuse to create the run —
+      # zero jobs, no log, no annotation (#3456). Booleans coerce; numbers do not.
+      test-timeout: ${{ fromJSON(inputs.test-timeout) }}
       normalize-company: ${{ inputs.normalize-company }}
       # Tests-ERM (9,496) and Tests-SCM (8,524) lead deliberately: 44% of the 40,530 between
       # them, measured on the 28.1.49838.53507 artifact (#3409), so if anything is lost to the

--- a/AlRunner.Tests/MsBucketWorkflowTests.cs
+++ b/AlRunner.Tests/MsBucketWorkflowTests.cs
@@ -64,7 +64,18 @@ internal static class WorkflowInputDefaults
     /// them resolves to the empty string on the other trigger. Empty when the input is absent,
     /// so callers must assert a COUNT before comparing values.
     /// </summary>
-    internal static IReadOnlyList<string> Of(string workflowText, string inputName)
+    internal static IReadOnlyList<string> Of(string workflowText, string inputName) =>
+        WorkflowInputDeclarations.Of(workflowText, inputName, "default:");
+}
+
+internal static class WorkflowInputDeclarations
+{
+    /// <summary>
+    /// Every value of one property (<c>default:</c>, <c>type:</c>, …) declared for an input of
+    /// the given name, one entry per declaration. Empty when the input — or the property — is
+    /// absent, so callers must assert a COUNT before comparing values.
+    /// </summary>
+    internal static IReadOnlyList<string> Of(string workflowText, string inputName, string property)
     {
         var lines = workflowText.Replace("\r\n", "\n").Split('\n');
         var found = new List<string>();
@@ -83,8 +94,8 @@ internal static class WorkflowInputDefaults
                 continue;
             }
             if (indent <= keyIndent) { keyIndent = trimmed == inputName + ":" ? indent : -1; continue; }
-            if (trimmed.StartsWith("default:", StringComparison.Ordinal))
-                found.Add(trimmed["default:".Length..].Trim());
+            if (trimmed.StartsWith(property, StringComparison.Ordinal))
+                found.Add(trimmed[property.Length..].Trim());
         }
         return found;
     }

--- a/AlRunner.Tests/MsSurfaceWorkflowTests.cs
+++ b/AlRunner.Tests/MsSurfaceWorkflowTests.cs
@@ -87,6 +87,65 @@ internal static class WorkflowStep
     }
 }
 
+internal static class ReusableCallInputs
+{
+    /// <summary>
+    /// The <c>with:</c> mapping a caller hands to a reusable workflow: one entry per key
+    /// declared directly under it, value as written. A <c>key: |</c> block scalar yields
+    /// <c>"|"</c> — its lines sit deeper and are not keys. Empty when the job has no
+    /// <c>with:</c>, so callers must assert a COUNT before iterating.
+    /// </summary>
+    internal static IReadOnlyList<(string Name, string Value)> Of(string code)
+    {
+        var lines = code.Replace("\r\n", "\n").Split('\n');
+        var found = new List<(string, string)>();
+        var withIndent = -1;
+        var keyIndent = -1;
+        foreach (var raw in lines)
+        {
+            var line = raw.TrimEnd();
+            if (line.Length == 0) continue;
+            var trimmed = line.TrimStart();
+            if (trimmed.StartsWith('#')) continue;
+            var indent = line.Length - trimmed.Length;
+
+            if (withIndent < 0)
+            {
+                if (trimmed == "with:") withIndent = indent;
+                continue;
+            }
+            if (indent <= withIndent) { withIndent = trimmed == "with:" ? indent : -1; keyIndent = -1; continue; }
+            if (keyIndent < 0) keyIndent = indent;
+            if (indent != keyIndent) continue;
+            var colon = trimmed.IndexOf(':');
+            if (colon <= 0) continue;
+            found.Add((trimmed[..colon], trimmed[(colon + 1)..].Trim()));
+        }
+        return found;
+    }
+}
+
+internal static class ReusableCallTypeCoercion
+{
+    /// <summary>
+    /// The inputs a caller hands down as a bare <c>${{ … }}</c> expression while the called
+    /// workflow declares them <c>type: number</c> — the shape that makes GitHub refuse to
+    /// create the run at all (#3456). A literal is fine; <c>fromJSON(…)</c> is the coercion.
+    /// </summary>
+    internal static IReadOnlyList<string> UncoercedNumberInputs(string callerCode, string calleeText)
+    {
+        var bad = new List<string>();
+        foreach (var (name, value) in ReusableCallInputs.Of(callerCode))
+        {
+            if (!value.Contains("${{", StringComparison.Ordinal)) continue;
+            if (value.Contains("fromJSON(", StringComparison.Ordinal)) continue;
+            if (!WorkflowInputDeclarations.Of(calleeText, name, "type:").Contains("number")) continue;
+            bad.Add(name);
+        }
+        return bad;
+    }
+}
+
 public sealed class MsSurfaceWorkflowTests
 {
     private static readonly string RepoRoot = Path.GetFullPath(
@@ -96,6 +155,7 @@ public sealed class MsSurfaceWorkflowTests
 
     private const string SurfaceWorkflow = "workflows/ms-surface.yml";
     private const string BucketWorkflow = "workflows/ms-bucket.yml";
+    private const string NightlyWorkflow = "workflows/ms-bucket-nightly.yml";
 
     /// <summary>
     /// The 35 <c>*.Source.zip</c> entries under <c>Applications/BaseApp/Test/</c>, measured —
@@ -289,6 +349,118 @@ public sealed class MsSurfaceWorkflowTests
     }
 
     /// <summary>
+    /// #3456: every dispatch of ms-surface.yml failed in three seconds with ZERO jobs, no log
+    /// and no annotation, from the moment #3443 added <c>test-timeout: ${{ inputs.test-timeout }}</c>.
+    ///
+    /// A <c>workflow_dispatch</c> input reaches the <c>inputs</c> context as a STRING whatever
+    /// its declared type says, and handing a string to a <c>workflow_call</c> input declared
+    /// <c>type: number</c> makes GitHub refuse to create the run — before any job exists, so
+    /// there is nothing to read afterwards. Booleans are NOT affected: <c>test-data</c> and
+    /// <c>normalize-company</c> pass through bare and the run starts (measured, run
+    /// 34166606192). So the rule is number-typed inputs only, and the coercion is
+    /// <c>fromJSON()</c>.
+    ///
+    /// Checked over every caller of ms-bucket.yml rather than over the one input that broke:
+    /// <c>expected-tests</c> is number-typed too and is a literal today, so the same edit is
+    /// one passthrough away from being made again. What no test in this repository can cover
+    /// is whether GitHub ACCEPTS the file — that is a property of GitHub's schema, not of the
+    /// text, and only a dispatch answers it.
+    /// </summary>
+    [Fact]
+    public void EveryCallerOfTheBucketWorkflow_CoercesTheNumberTypedInputsItHandsDown()
+    {
+        var callee = Read(BucketWorkflow);
+
+        foreach (var caller in new[] { SurfaceWorkflow, NightlyWorkflow })
+        {
+            var handedDown = ReusableCallInputs.Of(CodeOnly(Read(caller)));
+            Assert.NotEmpty(handedDown);
+
+            var uncoerced = ReusableCallTypeCoercion.UncoercedNumberInputs(CodeOnly(Read(caller)), callee);
+            Assert.True(uncoerced.Count == 0,
+                $"{caller} hands ms-bucket.yml a bare ${{{{ … }}}} expression for the number-typed "
+                + $"input(s) {string.Join(", ", uncoerced)}. GitHub refuses to create the run — zero "
+                + "jobs, no log — so wrap the value in fromJSON() or pass a literal (#3456).");
+        }
+
+        // Non-vacuous in both directions: the machinery resolved a real number-typed input on
+        // the callee side, and the surface really does hand that input down.
+        Assert.Contains("number", WorkflowInputDeclarations.Of(callee, "test-timeout", "type:"));
+        Assert.Contains(ReusableCallInputs.Of(CodeOnly(Read(SurfaceWorkflow))),
+            i => i.Name == "test-timeout");
+    }
+
+    // ---- the with-block reader and the coercion rule, proven on constructed text ---------
+
+    [Fact]
+    public void ReusableCallInputs_ReadsOnlyTheWithBlocksOwnKeys()
+    {
+        const string code = """
+            jobs:
+              surface:
+                uses: ./.github/workflows/ms-bucket.yml
+                with:
+                  label: surface
+                  expected-tests: 40530
+                  test-timeout: ${{ inputs.test-timeout }}
+                  buckets: |
+                    Tests-ERM
+                    Tests-SCM
+            """;
+
+        var inputs = ReusableCallInputs.Of(code);
+
+        Assert.Equal(new[] { "label", "expected-tests", "test-timeout", "buckets" },
+            inputs.Select(i => i.Name));
+        Assert.Equal("40530", inputs.Single(i => i.Name == "expected-tests").Value);
+        Assert.Equal("${{ inputs.test-timeout }}", inputs.Single(i => i.Name == "test-timeout").Value);
+        // A block scalar's lines are deeper than the keys and are not keys themselves.
+        Assert.Equal("|", inputs.Single(i => i.Name == "buckets").Value);
+        Assert.DoesNotContain(inputs, i => i.Name == "uses");
+        Assert.Empty(ReusableCallInputs.Of("jobs:\n  surface:\n    uses: ./x.yml\n"));
+    }
+
+    [Fact]
+    public void UncoercedNumberInputs_NamesTheBareExpressionAndNothingElse()
+    {
+        const string callee = """
+            on:
+              workflow_call:
+                inputs:
+                  test-timeout:
+                    type: number
+                    default: 300
+                  expected-tests:
+                    type: number
+                    default: 0
+                  test-data:
+                    type: boolean
+                    default: true
+                  bc-version:
+                    type: string
+                    default: ''
+            """;
+
+        const string broken = """
+            jobs:
+              surface:
+                with:
+                  test-timeout: ${{ inputs.test-timeout }}
+                  expected-tests: 40530
+                  test-data: ${{ inputs.test-data }}
+                  bc-version: ${{ inputs.bc-version }}
+            """;
+
+        // The number-typed passthrough is named; the number LITERAL, the boolean passthrough
+        // and the string passthrough are not — booleans and strings coerce, numbers do not.
+        Assert.Equal(new[] { "test-timeout" },
+            ReusableCallTypeCoercion.UncoercedNumberInputs(broken, callee));
+
+        var fixedUp = broken.Replace("${{ inputs.test-timeout }}", "${{ fromJSON(inputs.test-timeout) }}");
+        Assert.Empty(ReusableCallTypeCoercion.UncoercedNumberInputs(fixedUp, callee));
+    }
+
+    /// <summary>
     /// #3431: the surface ran with the runner's 60 s wall-clock default per-test watchdog on a
     /// hosted runner, so tests that finish comfortably inside it locally were cut off.
     ///
@@ -302,7 +474,7 @@ public sealed class MsSurfaceWorkflowTests
     [Fact]
     public void SurfaceWorkflow_PassesThePerTestTimeoutThrough_AtTheSameDefault()
     {
-        Assert.Contains("test-timeout: ${{ inputs.test-timeout }}",
+        Assert.Contains("test-timeout: ${{ fromJSON(inputs.test-timeout) }}",
             CodeOnly(Read(SurfaceWorkflow)), StringComparison.Ordinal);
 
         var surface = WorkflowInputDefaults.Of(Read(SurfaceWorkflow), "test-timeout");


### PR DESCRIPTION
Closes #3456

`ms-surface.yml` has been undispatchable since #3443 merged: every attempt failed in about
three seconds with zero jobs, no log and no annotation, which blocked the full-surface
measurement that #3409 and #3443 exist to produce.

## The mechanism, measured rather than reasoned

A `workflow_dispatch` input reaches the `inputs` context as a **string**, whatever its
declared `type` says. Handing that string to a `workflow_call` input declared `type: number`
makes GitHub refuse to create the run. The refusal happens before any job exists, so there is
nothing to read afterwards — no job, no log, no annotation, and `conclusion: failure` rather
than `startup_failure`.

Four dispatches against `agent/coord-1/issue-3456`, changing one line between them:

| run | shape of the passthrough | jobs | result |
|---|---|---|---|
| [`34166554045`](https://github.com/StefanMaron/BusinessCentral.AL.Runner/actions/runs/34166554045) | `test-timeout: ${{ inputs.test-timeout }}` (the file as merged) | **0** | failure in 3s |
| [`34166606192`](https://github.com/StefanMaron/BusinessCentral.AL.Runner/actions/runs/34166606192) | `test-timeout: ${{ fromJSON(inputs.test-timeout) }}` | **1** | started, cancelled at once |
| [`34166705750`](https://github.com/StefanMaron/BusinessCentral.AL.Runner/actions/runs/34166705750) | the fix, dispatched with `test-timeout=abc` | **0** | failure in 3s |
| [`34167032229`](https://github.com/StefanMaron/BusinessCentral.AL.Runner/actions/runs/34167032229) | this PR's exact commit `925a17b7` | **1** | started, cancelled at once |

Every run started this way was cancelled immediately; none ran a bucket.

Three things fall out of those four dispatches that the issue could only hypothesize:

- **The hypothesis in #3456 is confirmed**, and confirmed by the `abc` run specifically:
  `fromJSON` parsed it, so the value really does arrive as a string. `type: number` on a
  `workflow_dispatch` input therefore validates nothing — GitHub accepted `abc` without a 422.
- **Booleans are not affected.** Run `34166606192` differs from `34166554045` only in the
  `test-timeout` line: `test-data` and `normalize-company` still pass through bare, and it
  started. So `normalize-company`, which merged in #3453 and was the other thing worth
  checking, has no exposure here — measured, not assumed. Neither does the string-typed
  `bc-version`.
- **The fault really was the caller.** `ms-bucket.yml` and `ms-bucket-nightly.yml` are
  untouched by this PR and unaffected.

## What changed

One line of YAML — `test-timeout: ${{ fromJSON(inputs.test-timeout) }}` — with a four-line
comment above it, because the next person to read that line would otherwise simplify it back
and get the same silent failure.

The 300-second timeout is unchanged and still explicit. `fromJSON('300')` is the number 300,
`ms-bucket.yml` puts it on `TEST_TIMEOUT_SEC` and then on `--test-timeout`, and #3443's tests
that pin the argument array and the equal defaults on both files pass untouched.

## Fixing the shape, not the reported line

The new test checks **every caller of `ms-bucket.yml`**, not the one input that broke: no
input the callee declares `type: number` may be handed down as a bare `${{ … }}` expression;
a literal or a `fromJSON(…)` wrapper is required. `expected-tests` is number-typed too and is
a literal today, one edit away from reproducing this exact failure, and the nightly is checked
by the same loop so a passthrough added there is caught as well.

RED → GREEN, run locally with the filter `MsSurfaceWorkflowTests|MsBucketWorkflowTests`:

- **RED**, with the YAML reverted to the merged shape: 1 failed, 39 passed —
  `workflows/ms-surface.yml hands ms-bucket.yml a bare ${{ … }} expression for the
  number-typed input(s) test-timeout.`
- **GREEN**, with the fix: 40 passed.

The rule is also proven on constructed text in both directions, so it is not just an
assertion about today's file: a number-typed passthrough is named, and a number literal, a
boolean passthrough and a string passthrough are not. `MainVerdictFloorWorkflowTests` and
`ArtifactDownloaderMsBucketTests` (35 tests) pass alongside.

`WorkflowInputDefaults.Of` is generalized into `WorkflowInputDeclarations.Of(text, input,
property)` so the type can be read with the scanner that already reads defaults, rather than a
second copy of it. `WorkflowInputDefaults.Of` keeps its name and its meaning and now delegates.

## The coverage gap, which no test in this repository closes

`MsSurfaceWorkflowTests` and `MsBucketWorkflowTests` read the YAML and assert names, defaults,
wiring and the runner's argument array. All of that was **correct** while the workflow was
undispatchable — the file was exactly what #3443 intended. What broke is whether GitHub will
**accept** the workflow, which is a property of GitHub's schema and not of the file's text, and
nothing short of a dispatch answers it. The test added here narrows the gap to one known shape;
it does not close it.

A cheap guard is possible and is **not** built here, because the blocker matters more: a
`pr-gate.yml` job that, on a PR touching `ms-surface.yml` or `ms-bucket.yml`, dispatches
`ms-surface.yml` against the PR's head ref, asserts the run has at least one job, and cancels
it. That is roughly the four commands used above, it costs a few seconds of runner time, and
`--ref` reading the workflow definition from the branch is what makes it work — proven by the
four runs in the table, all of which read this branch rather than `main`. It wants its own
issue: it needs `actions: write` on a PR-triggered workflow, which is a permissions decision
rather than a test.

## Open issues in the same area that are deliberately NOT folded in

- **#3454** — `normalize-company` with `test-data: false` is silently dropped. Same workflow
  family, but the fix is in `ms-bucket.yml`'s "Run the bucket(s)" shell, not in
  `ms-surface.yml`'s `with:` block, and it needs different reasoning to review.
- **#3446** — `bc-tests.yml` runs with the runner's 60s default timeout. Same shape as #3431,
  a different workflow file entirely.

Neither shares a file with this change, so folding them in would trade a one-line unblocking
fix for a diff a reviewer has to hold three arguments in their head for.

Corpus-NA: a workflow input reaching a command line asserts nothing about BC behaviour — the
failure is GitHub refusing to create a workflow run, and no service tier can adjudicate it.

---

Opened by an agent (`coord-1`). The four dispatch outcomes above are measured on this branch;
every run that started was cancelled immediately.

https://claude.ai/code/session_01F7HLDeNwiGQoLT5wFanqmH
