### PR TITLE
test(corpus): advance the pin to 7195a4ba, where the count goes up by one

### DIFF
--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -1716,3 +1716,44 @@ and the five appearing as plain `PASS`. Codeunit 60680's two `Copy`-onto-tempora
 here and passed before the fix as well; they pin behaviour rather than record a gap.
 
 Written by the fbk-3 agent.
+### 3071 -> 3072 (pin ec8a9c23 -> 7195a4ba, catch-up bump)
+
+Two upstream commits, both merged before this PR was opened, so a bump alone is green rather
+than red by construction — the **catch-up** case in `.claude/rules/al-language-submodule.md`.
+
+| corpus PR | commit | what it pins |
+|---|---|---|
+| [#257](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/257) | `2549e353` | `Encrypt()` does not return its plaintext input, and `Decrypt()` reverses it exactly |
+| [#258](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/258) | `7195a4ba` | the error text a non-rendering tier reports when `Report.SaveAs(Pdf)` refuses |
+
+Only #257 moves the count. It reinstates
+`Codeunit60378.IsolatedStorage_EncryptDecrypt_RoundTripsAndIsNotPlaintext`, removed while
+bc-linux's tenant encryption key was a pass-through fake that structurally could not satisfy
+the "ciphertext differs from plaintext" half; MsDyn365Bc.On.Linux#72 turned that fake off, so
+the test came back unchanged in what it claims.
+
+#258 adds **no test procedure**. It restores an `Assert.ExpectedError` inside the existing
+`Codeunit60774.Report_SaveAs_Pdf_ReturnValueAgreesWithTheBytesInTheStream`, in the arm taken
+only by a tier that refuses to render. It changes nothing here: that test is declared
+`expect-oos` in `tests/expectations/oos-reports.json`, so the runner raises
+`report-rendering-external` before AL reaches the new assertion, and it still classifies
+`PASS (oos)` across the bump.
+
+**3072 is the number the guard itself printed**, not 3071 plus one. Measured on BC
+28.1.49838.53910 on a real three-app run: with the pin moved and the baseline still at 3071
+the run exited 4 with
+`GROWTH: suite 'al-language' tests count: expected 3071, actual 3072 (BC 28.1)`, and 3072 is
+that `actual`. Re-run after the bump: **3101 tests total, 3101 pass, 0 fail, exit 0**, of which
+`al-language-onprem` contributes 29 and `al-language-internals-fixture` 0 — both unchanged,
+neither reporting a mismatch, so only the one key moved.
+
+A control run at the **old** pin, same runner build and same baseline file, exited 0 with 3100
+total. So the +1 is the bump's own effect and not a property of this machine.
+
+**No manifest drift, in either direction.** The classification split is identical across the
+bump — 3 `pass-oos`, 36 `pass-known-gap`, 1 `pass-divergence`, 0 FAIL — and
+`--expectations-require-match` reported `all 40 entries matched a discovered test` on both
+sides. Nothing declared `expect-fail-known-gap` started passing, and nothing undeclared
+started throwing out-of-scope.
+
+Written by agent stma-auto-2 (automated implementation agent).

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Schema, semantics and how to bump: README.md in this directory. Per-bump rationale: history.md, never a prose line in here (#2485).",
   "suites": {
     "al-language": {
-      "tests": { "default": 3071 },
+      "tests": { "default": 3072 },
       "appGroups": { "default": 1 }
     },
     "al-language-internals-fixture": { "tests": { "default": 0 }, "appGroups": { "default": 1 } },


### PR DESCRIPTION
No linked issue: a corpus pin catch-up bump. Both upstream corpus PRs were already merged before this PR was opened, so there is no runner-side issue for it to close.

## What this is

The **catch-up** case in `.claude/rules/al-language-submodule.md`: the fixes have already merged upstream, so a bump alone is expected to be green rather than red by construction.

Both ends measured with `git ls-tree origin/main tests/al-language` and `git ls-remote`, never by reading the shared submodule working directory — that directory read `17b015ef` at the time, a third value belonging to neither end (#3404).

| | commit |
|---|---|
| pin at `origin/main` | `ec8a9c23` |
| corpus `master` tip | `7195a4ba` |
| pin set here | `7195a4ba` |

Two commits, both merged upstream:

| corpus PR | commit | what it pins |
|---|---|---|
| [#257](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/257) | `2549e353` | `Encrypt()` does not return its plaintext input, and `Decrypt()` reverses it exactly |
| [#258](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/258) | `7195a4ba` | the error text a non-rendering tier reports when `Report.SaveAs(Pdf)` refuses |

## The baseline number is the guard's own printed `actual`

`tests/expectations/count-baseline/test-count-baseline.json`, one line:

```
-      "tests": { "default": 3071 },
+      "tests": { "default": 3072 },
```

3072 is **not** 3071 plus one. With the pin moved and the baseline still at 3071, a full three-app run on BC 28.1.49838.53910 exited 4 with the guard printing:

```
[count-baseline] GROWTH: suite 'al-language' tests count: expected 3071, actual 3072 (BC 28.1)
```

3072 is that `actual`. It was the only mismatch the guard reported, so only that one key moved — `al-language-onprem` (29) and `al-language-internals-fixture` (0) were both silent, and the `runner-extras` group counts are untouched.

## RED → GREEN, with a control

| run | pin | baseline | exit | totals |
|---|---|---|---|---|
| control | `ec8a9c23` (old) | 3071 | 0 | 3100 total, 3100 pass, 0 fail |
| RED | `7195a4ba` (new) | 3071 | **4** (count mismatch) | 3101 total, 3101 pass, 0 fail |
| GREEN | `7195a4ba` (new) | 3072 | **0** | 3101 total, 3101 pass, 0 fail |

Same runner build across all three, `dotnet run --no-build --project AlRunner -c Release --framework net8.0` with both package caches, `--strict --expectations-require-match --count-baseline`. The control is what makes the +1 the bump's own effect rather than a property of this machine.

## Only #257 moves the count

The reinstated test executed and passed here as a genuine `PASS`, not a `PASS (known-gap)`:

```
PASS  Codeunit60378.IsolatedStorage_EncryptDecrypt_RoundTripsAndIsNotPlaintext (3ms)
```

**#258 adds no test procedure.** It restores an `Assert.ExpectedError` *inside* the existing `Codeunit60774.Report_SaveAs_Pdf_ReturnValueAgreesWithTheBytesInTheStream`, in the arm taken only by a tier that refuses to render. That changes nothing here: the test is declared `expect-oos` in `tests/expectations/oos-reports.json`, so the runner raises `report-rendering-external` before AL ever reaches the new assertion, and it still classifies `PASS (oos)` on both sides of the bump.

## No manifest drift, in either direction

The classification split is identical across the bump — 3 `pass-oos`, 36 `pass-known-gap`, 1 `pass-divergence`, 0 `FAIL` lines — and `--expectations-require-match` reported `all 40 entries matched a discovered test` on both the old and the new pin. Nothing declared `expect-fail-known-gap` started passing (which would fail the run with "Remove the entry"), and nothing undeclared started throwing out-of-scope. No expectations file is touched by this PR.

## Notes

- `tests/expectations/count-baseline/history.md` gets one appended section, following the file's existing format, newest last. It is an append-append conflict magnet; if it conflicts, keep both blocks with `main`'s first.
- No file under `tests/al-language/` is edited — only the gitlink moves.
- The diff touches nothing under `AlRunner/`, so `require-tests.yml`'s gate does not fire.

---

Written by **stma-auto-2**, an automated implementation agent acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9pEPoD8e4wmVyuTrxyuh