### PR TITLE
fix(testpage): name a fault in BC's value evaluator instead of reporting BC's date refusal

### DIFF
--- a/AlRunner.Tests/TestPageEvaluatorFaultTests.cs
+++ b/AlRunner.Tests/TestPageEvaluatorFaultTests.cs
@@ -1,0 +1,104 @@
+// TestPageEvaluatorFaultTests - a fault on the BC-evaluator path is named, not reported as
+// BC refusing the value (issue #3444).
+//
+// TestPageTemporalValue asks BC's own NavValueEvaluator how this build reads a date, time or
+// datetime a test typed as text. It asks under DataError.TrapError, and the 28.1 Ncl decompile
+// of NavValueEvaluator`1.Evaluate settles what that mode means: a refusal returns false, and
+// the one refusal type raised from inside - NavNCLEvaluateException - is caught by BC itself
+// when dataError == 0, which DataError.TrapError is. So an exception escaping Evaluate is the
+// evaluator not completing, and answering false for it sends the caller back to the NavText
+// path where the AL author reads BC's date-format refusal for a value BC would have accepted.
+//
+// RED against main: every arm below that expects BcShapeGapException got `false` instead,
+// because the two catches at the call site returned false for any exception at all.
+using System;
+using System.Reflection;
+using AlRunner;
+using AlRunner.Infrastructure;
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+using Microsoft.Dynamics.Nav.Types.Exceptions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestPageEvaluatorFaultTests
+{
+    // Scenario 1 of the issue: unpopulated skeleton state NREs inside BC's evaluator, arrives
+    // wrapped by MethodBase.Invoke, and used to be indistinguishable from "BC said no".
+    [Fact]
+    public void InvokeEvaluate_WhenBcsEvaluatorFaults_RaisesAShapeGapNamingTheFault()
+    {
+        var gap = Assert.Throws<BcShapeGapException>(() => TestPageTemporalValue.InvokeEvaluate(
+            () => throw new TargetInvocationException(
+                new NullReferenceException("session.RegionalSettings was null"))));
+
+        Assert.Equal("NavValueEvaluator.Evaluate", gap.Member);
+        Assert.Contains("NullReferenceException", gap.Detail);
+        Assert.Contains("session.RegionalSettings was null", gap.Detail);
+        Assert.Contains("did not complete", gap.Detail);
+    }
+
+    // BcShapeGapException specifically, because that is the one an AL asserterror cannot
+    // absorb (NavMethodScope_AssertError rethrows only this type). A RunnerOutOfScopeException
+    // here would let `asserterror SetValue(...)` pass on a runner fault.
+    [Fact]
+    public void InvokeEvaluate_WhenBcsEvaluatorFaults_RaisesTheTypeAssertErrorCannotSwallow()
+    {
+        var thrown = Record.Exception(() => TestPageTemporalValue.InvokeEvaluate(
+            () => throw new TargetInvocationException(new InvalidOperationException("boom"))));
+
+        Assert.NotNull(thrown);
+        Assert.NotNull(BcShapeGapException.Find(thrown));
+        Assert.IsNotType<RunnerOutOfScopeException>(thrown);
+    }
+
+    // Scenario 2: an ArgumentException arrives UNWRAPPED, so it came from Invoke rather than
+    // from BC - the bound Evaluate does not take the arguments this call site passes.
+    [Fact]
+    public void InvokeEvaluate_WhenTheBoundEvaluateRefusesTheArguments_RaisesAVersionMismatch()
+    {
+        var gap = Assert.Throws<BcShapeGapException>(() => TestPageTemporalValue.InvokeEvaluate(
+            () => throw new ArgumentException("parameter count mismatch")));
+
+        Assert.Equal("NavValueEvaluator.Evaluate", gap.Member);
+        Assert.Contains("parameter count mismatch", gap.Detail);
+        Assert.Contains("version mismatch", gap.Detail);
+    }
+
+    // The one exception shape that IS a refusal. It cannot escape Evaluate under TrapError on
+    // the pinned build, but if a build raises it past the filter the answer is still "BC said
+    // no", and declining leaves BC's own message as the observable outcome.
+    [Fact]
+    public void InvokeEvaluate_WhenBcRaisesItsOwnEvaluateRefusal_DeclinesWithoutThrowing()
+    {
+        Assert.False(TestPageTemporalValue.InvokeEvaluate(
+            () => throw new TargetInvocationException(
+                new NavNCLEvaluateException("cannot be evaluated into type Date"))));
+    }
+
+    [Fact]
+    public void InvokeEvaluate_WhenTheEvaluatorAnswers_PassesThatAnswerThrough()
+    {
+        Assert.True(TestPageTemporalValue.InvokeEvaluate(() => true));
+        Assert.False(TestPageTemporalValue.InvokeEvaluate(() => false));
+    }
+
+    // The control the issue asked for: a genuine decline still reaches the NavText path.
+    //
+    // With the fix in place this is no longer ambiguous. Before it, a refusal and a fault both
+    // produced false here, so the assertion held either way and no reader could tell which had
+    // happened. Measured on this build while writing the fix: the session IS populated in the
+    // xunit process and BC's evaluator refuses '@@@' by RETURNING false, so nothing throws -
+    // which is why the assertion below and TestPageTemporalValueTests's own
+    // TryResolve_AnUnreadableSpelling_DeclinesRatherThanGuessing are now real controls.
+    [Fact]
+    public void TryResolve_AnUnreadableSpelling_IsRefusedByBcRatherThanFaulting()
+    {
+        _ = NavDate.Create(DateTime.SpecifyKind(new DateTime(2026, 1, 15), DateTimeKind.Local));
+        Assert.NotNull(BcRuntime.SkeletonSession);
+
+        Assert.False(TestPageTemporalValue.TryResolve(NavType.Date, "@@@", out var resolved));
+        Assert.Null(resolved);
+    }
+}

--- a/AlRunner.Tests/TestPageRefusalClaimTests.cs
+++ b/AlRunner.Tests/TestPageRefusalClaimTests.cs
@@ -401,7 +401,9 @@ public sealed class TestPageRefusalClaimTests
         var page = CodeOf("RunnerPageInstance.cs");
 
         Assert.Equal(10, Regex.Matches(mock, @"throw TestPageShapeGap\.").Count);
-        Assert.Equal(1, Regex.Matches(mock, @"throw new AlRunner\.Infrastructure\.BcShapeGapException\(").Count);
+        // 3: the SubPageLink FilterType site, plus the two evaluator-fault arms #3444 added -
+        // a fault inside BC's own NavValueEvaluator, and a signature mismatch against it.
+        Assert.Equal(3, Regex.Matches(mock, @"throw new AlRunner\.Infrastructure\.BcShapeGapException\(").Count);
 
         Assert.Equal(4, Regex.Matches(page, @"throw TestPageShapeGap\.").Count);
         Assert.Equal(1, Regex.Matches(page, @"throw new AlRunner\.Infrastructure\.BcShapeGapException\(").Count);

--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -804,6 +804,32 @@ public static partial class BcRuntime
         // NavException type lookup succeeds and CurrentMethodScope reflection is valid.
         if (_skeletonSession != null)
             AlRunner.Infrastructure.AlCallStackCapture.Initialize(_skeletonSession);
+
+        WarmSkeletonFormatSettings();
+    }
+
+    /// <summary>
+    /// Touch the skeleton session's <c>FormatSettings</c> once, here, while startup is still
+    /// single-threaded.
+    ///
+    /// <para>BC's <c>NavSession.SyncFormatSettings</c> lazily builds an instance
+    /// <c>Dictionary&lt;(int, int), FormatSettings&gt;</c> and <c>Add</c>s to it with no lock
+    /// (28.1 Ncl decompile). One skeleton session is shared, so two threads reaching it first
+    /// together get <c>ArgumentException: An item with the same key has already been added.
+    /// Key: (1033, 1033)</c> out of BC's own code — observed for real, see #3444. Completing
+    /// the lazy init before anything can share it removes the first-touch window.</para>
+    /// </summary>
+    private static void WarmSkeletonFormatSettings()
+    {
+        try
+        {
+            _ = (_skeletonSession as Microsoft.Dynamics.Nav.Runtime.NavSession)?.FormatSettings;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(
+                $"[BcRuntime] WARN: FormatSettings warm failed: {ex.GetType().Name}: {ex.Message}");
+        }
     }
 
     /// <summary>

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -3114,14 +3114,53 @@ internal static class TestPageTemporalValue
         // "no" so the caller keeps its NavText path, where BC raises the refusal AL is written
         // against. Throwing from here would replace that message with this one.
         var args = new object?[] { BcRuntime.SkeletonSession, _trapError, null, null, value, 0 };
-        bool ok;
-        try { ok = (bool)_evaluate!.Invoke(evaluator, args)!; }
-        catch (System.Reflection.TargetInvocationException) { return false; }
-        catch (System.ArgumentException) { return false; }
-
-        if (!ok) return false;
+        if (!InvokeEvaluate(() => (bool)_evaluate!.Invoke(evaluator, args)!)) return false;
         resolved = args[2] as NavValue;
         return resolved != null;
+    }
+
+    /// <summary>
+    /// Run BC's evaluator and answer what it answered - but only for an answer BC gave.
+    ///
+    /// <para>Under <c>DataError.TrapError</c> a refusal is not an exception: BC returns false and
+    /// traps its own <c>NavNCLEvaluateException</c> (28.1 Ncl, <c>NavValueEvaluator`1.Evaluate</c>:
+    /// <c>catch when (obj is NavNCLEvaluateException &amp;&amp; dataError == 0)</c>; TrapError is
+    /// 0). So anything else reaching here is the evaluator NOT COMPLETING, and answering false for
+    /// it shows the AL author BC's date-format refusal for a value BC would have taken (#3444).</para>
+    ///
+    /// <para><c>BcShapeGapException</c> because an <c>asserterror</c> can absorb a
+    /// <c>RunnerOutOfScopeException</c> and would then pass on a runner fault (#3062, #3428).</para>
+    /// </summary>
+    internal static bool InvokeEvaluate(Func<bool> invoke)
+    {
+        try { return invoke(); }
+        catch (System.Reflection.TargetInvocationException ex)
+            when (ex.InnerException is NavNCLEvaluateException)
+        {
+            // BC ran and said no, in the one shape that can still arrive as a throw.
+            return false;
+        }
+        catch (System.Reflection.TargetInvocationException ex)
+        {
+            var inner = ex.InnerException ?? ex;
+            throw new AlRunner.Infrastructure.BcShapeGapException(
+                "TestPage SetValue on a Date/DateTime/Time control",
+                "NavValueEvaluator.Evaluate",
+                $"BC's own value evaluator did not complete ({inner.GetType().Name}: "
+                + $"{inner.Message}), so the runner has no answer from BC about this spelling. "
+                + "This is a runner fault on the evaluate path, not a value BC rejected.");
+        }
+        catch (System.ArgumentException ex)
+        {
+            // Unwrapped, so it came from Invoke itself rather than from BC: the bound Evaluate
+            // does not take the arguments this call site passes.
+            throw new AlRunner.Infrastructure.BcShapeGapException(
+                "TestPage SetValue on a Date/DateTime/Time control",
+                "NavValueEvaluator.Evaluate",
+                $"the bound Evaluate refused this call's arguments ({ex.GetType().Name}: "
+                + $"{ex.Message}), so this BC build's evaluator is not the shape the runner "
+                + "reflects against. A runner/BC-version mismatch, not a rejected value.");
+        }
     }
 
     // Bound by reflection because NavValueEvaluator and NavNclType are internal to Ncl.dll. The

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -3172,9 +3172,22 @@ internal static class TestPageTemporalValue
     // leaves BC's own refusal as the observable outcome rather than a wrong value.
     private static bool TryBindEvaluator()
     {
-        if (_lookupDone) return _evaluate != null;
-        _lookupDone = true;
+        // Latched AFTER the work, under a gate: setting _lookupDone first let a second thread
+        // read "already bound" while _evaluate was still null, and EnsureEvaluatorBound then
+        // refused a BC build it had bound perfectly well, naming no reason (#3444, #3187's
+        // latch-before-work shape).
+        lock (BindGate)
+        {
+            if (_lookupDone) return _evaluate != null;
+            try { return BindEvaluatorCore(); }
+            finally { _lookupDone = true; }
+        }
+    }
 
+    private static readonly object BindGate = new();
+
+    private static bool BindEvaluatorCore()
+    {
         string? why = null;
         try
         {


### PR DESCRIPTION
Closes #3444

Corpus-NA: this is runner-side error attribution — which exception the runner raises when BC's own evaluator does not complete. No claim about what Business Central does changes, so a service tier has nothing to adjudicate. The BC-behaviour claim underneath this path is already upstream (corpus PR 263, codeunit 60670).

## What was wrong

`TestPageTemporalValue.TryEvaluateThroughBc` caught **every** exception out of `NavValueEvaluator.Evaluate` and answered `false`. `false` means one thing: BC ran and refused the text, so the caller keeps its `NavText` path where BC raises its own message. A fault on that path was reported to the AL author as BC's *"The format of the Date ... does not match your device's date settings"* for a value BC would have accepted.

## The decompile that settles it

`Microsoft.Dynamics.Nav.Ncl` 28.1, `NavValueEvaluator` 1 `.Evaluate`:

```csharp
try {
    bool num = InternalEvaluate(session, dataError, out value, metadata, source, number);
    if (!num && (int)dataError == 1) throw CreateEvaluateException(metadata, source);
    return num;
}
catch (object obj) when (obj is NavNCLEvaluateException && (int)dataError == 0) {
    value = GetDefaultValue(metadata); return false;
}
```

`DataError` is `{ TrapError, ThrowError }`, so `TrapError == 0`. Under the mode this call site passes, a refusal returns `false` and BC traps its own `NavNCLEvaluateException` itself. **Nothing BC raises as a refusal can reach the catch.** Anything that does reach it is the evaluator not completing.

## The fix

`InvokeEvaluate` classifies instead of swallowing:

| what arrives | answer |
|---|---|
| `false` / `true` | passed through |
| `TargetInvocationException` wrapping `NavNCLEvaluateException` | `false` — BC said no, in the one shape that can still arrive as a throw |
| `TargetInvocationException` wrapping anything else | `BcShapeGapException` naming the inner type and message |
| unwrapped `ArgumentException` (so: from `Invoke`, not from BC) | `BcShapeGapException` — the bound `Evaluate` does not take these arguments |

`BcShapeGapException`, not `RunnerOutOfScopeException`: `NavMethodScope_AssertError` rethrows only the shape-gap type, so an `asserterror SetValue(...)` would otherwise absorb a runner fault and pass (see 3062, and 3428's correction of the same shape).

## Two real faults the swallow was hiding

Making the path loud turned both up immediately in the xunit host. Neither is hypothetical and both are fixed here.

**1. `NavSession.SyncFormatSettings` is not thread-safe.** It lazily builds an instance `Dictionary<(int, int), FormatSettings>` and `Add`s with no lock. One skeleton session is shared, so two threads first-touching it together get `ArgumentException: An item with the same key has already been added. Key: (1033, 1033)` from inside BC — which `main` reports as "BC declined this date". Captured inner stack:

```
Dictionary`2.Add -> NavSession.SyncFormatSettings -> NavSession.get_FormatSettings
  -> NavSessionOrDefaultProvider.GetFormatSettings -> NavDateEvaluator.ClosingDateEvaluate
  -> NavDateEvaluator.InternalEvaluate -> NavValueEvaluator`1.Evaluate
```

Fixed by completing the lazy init once at startup, while it is still single-threaded (`BcRuntime.WarmSkeletonFormatSettings`). Not a `lock` at the evaluate site: every `FormatSettings` reader shares that dictionary, so the fix belongs at the shared object, not at one caller. **This is not a claim that production races** — `ParallelFanOut` is process-level, and it was observed in the xunit host (4 parallel collections). It removes the first-touch window for any two threads that do share the session.

**2. `TryBindEvaluator` latched before it worked.** `_lookupDone = true` was set on entry, so a second thread read "already bound" while `_evaluate` was still `null`, and `EnsureEvaluatorBound` refused a BC build it binds perfectly well — with `(reason not recorded)`, because `_bindFailure` was null too. Same latch-before-work shape as 3187. Now gated, latched in a `finally` after the work.

## This confirms the issue's open observation

3444 recorded that `TryResolve_AnUnreadableSpelling_DeclinesRatherThanGuessing` "cannot currently tell the two apart". It cannot: when it races, it passes **through the swallow** rather than through BC refusing `@@@`. Measured — 3 of 3 paired runs failed exactly one of the two racing tests once the swallow was removed. With this PR it is a real control, and `TestPageEvaluatorFaultTests.TryResolve_AnUnreadableSpelling_IsRefusedByBcRatherThanFaulting` states that explicitly (asserts the skeleton session is populated, then that BC refuses by returning, not by faulting).

## RED to GREEN

RED, with `InvokeEvaluate` extracted but still swallowing (assertion failures, not compile errors):

```
InvokeEvaluate_WhenTheBoundEvaluateRefusesTheArguments_RaisesAVersionMismatch [FAIL]
InvokeEvaluate_WhenBcsEvaluatorFaults_RaisesAShapeGapNamingTheFault           [FAIL]
InvokeEvaluate_WhenBcsEvaluatorFaults_RaisesTheTypeAssertErrorCannotSwallow   [FAIL]
   Assert.Throws() Failure: No exception was thrown
Failed! - Failed: 3, Passed: 3, Total: 6
```

GREEN, `TestPageEvaluatorFaultTests` + `TestPageTemporalValueTests` + `TestPageRefusalClaimTests`: `Passed! - Failed: 0, Passed: 110, Total: 110`.

Race evidence, the racing pair: **before** 3 of 3 runs failed one test; **after** both fixes, **25 of 25 clean** (about 30 ms each).

## Fixing the shape, not the reported line

1. **Same wrong pattern elsewhere?** `_getEvaluator!.Invoke(...)` two lines up has no catch at all. It needs none: `NavValueEvaluator.GetEvaluator(NavNclType)` decompiles to a single `switch` expression over the enum returning singleton `Instance`s with `_ => null`, so it has no throwing statement, and our `Enum.Parse` is guarded by the `Enum.IsDefined` immediately above it. Recorded rather than wrapped.
2. **Sibling making the same assumption?** Yes — `EnsureEvaluatorBound` refuses an unbindable BC build with `RunnerOutOfScopeException`, which an `asserterror` *can* swallow. Not folded in: a proving test has to provoke a bind failure, and the binding state is private static and latched for the process, so it needs a seam that does not exist. Filed as 3462.
3. **Two paths writing the same state?** The bind statics were exactly that, and the latch-before-work defect above is what it produced. Fixed.

**Open-issue scan.** Nothing folds. The open TestPage issues (3258, 3339, 3440, 3441, 3029, 3439, 2362, 3179, 2457) all land in `RunnerPageInstance` / the page-instance and action machinery, not in `TestPageTemporalValue` or the evaluator binding; none shares a line with this diff.

## Where the prose went

The derivation — the decompile walk, the captured inner stack, the iteration counts — is in this body. What stayed in code is the claim plus its citation: the `TrapError` semantics and the `NavValueEvaluator` catch-when, and one line on why the shape-gap type rather than the scope type.

## Also updated

`TestPageRefusalClaimTests.AllSixteenCorrectedRefusalsStillExist` counts raw `BcShapeGapException` constructions in `MockTestPage.cs`: 1 to 3, the two new evaluator-fault arms, with the reason in the test.

Implemented by agent fbk-1, an automated implementation agent acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPJecKgfS4YFcpXSQr2tqb
