### PR TITLE
docs(testpage): drop a merge-order note whose two pull requests have both landed

### DIFF
--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -2946,16 +2946,6 @@ internal static class TestPageNumericValue
 /// <see cref="TestPageBooleanValue"/> and <see cref="TestPageOptionValue"/> already use, so
 /// neither binding shape can drift from the other — the corpus suite asserts both.</para>
 ///
-/// <para><b>Interaction with the WRITE side (#3384 / PR #3394), which lands in this same
-/// file.</b> That change reads a typed <c>SetValue</c> argument back through the spelling
-/// <c>ValueToString</c> produces. This one changes that spelling for a BLANK temporal only,
-/// from <c>01/01/0001 00:00:00</c> to <c>""</c> — and an empty string is not a value its
-/// round-trip branch is meant to parse, so it declines and falls through to BC's own evaluator,
-/// which is the correct outcome: writing a blank temporal is a separate question from rendering
-/// one, and neither change should silently answer the other's. Named
-/// <c>TestPageBlankTemporalValue</c> rather than <c>TestPageTemporalValue</c> so the two helpers
-/// can coexist in this file whichever merges first.</para>
-///
 /// <para>It must also be what <c>ValueToString</c> answers, for the reason spelled out in
 /// <see cref="TestPageBooleanValue"/>: <c>NavTestField.ALAssertEquals</c> converts the EXPECTED
 /// value through <c>ValueToString</c> and compares it ORDINALLY against the getter, so moving


### PR DESCRIPTION
Corpus-NA: comment-only; the diff is ten deleted /// lines and changes nothing AL can observe, so no service tier can adjudicate it.

No linked issue: comment-only cleanup of prose whose subject has already merged; no behaviour changes and nothing to track.

## What this removes

One `<para>` on `TestPageBlankTemporalValue` in `MockTestPage.cs`. It was written to tell a reviewer how two changes landing in the same file would interact **while both were still open**, and it ends:

> Named `TestPageBlankTemporalValue` rather than `TestPageTemporalValue` so the two helpers can coexist in this file whichever merges first.

## Why it goes now

Both subjects have landed:

| | state |
|---|---|
| PR #3394 (the WRITE side) | **merged**, `4e4c644e` |
| issue #3384 | **closed** |

So the question the paragraph answers — which of two in-flight pull requests merges first — can no longer be asked. What is left is the rationale for a naming decision already taken, and the type name carries that by itself.

The surrounding paragraphs stay. They explain things that are still true and still load-bearing: that both binding shapes are read through so neither can drift, and that `ValueToString` must agree with the getter because `ALAssertEquals` converts the expected value through it and compares **ordinally**. Neither depends on a merge order.

## What it does not touch

Comment-only. Ten lines removed, every one of them a `///` line; no code line changed. `dotnet build` reports **0 errors**, so the XML doc comment is still well-formed.

## A second instance in the same family, deliberately left

Review also flagged a paragraph in `testpage-same-value-modify` that duplicates in-code a derivation already in `docs/testpage-write-gate.md` — which the comment itself points at. That one sits inside PR #3427, still open, so editing it here would conflict with an in-flight branch for no benefit. It belongs in that PR or in a follow-up, not in this one.

## Where this came from

Surfaced by the review pass that merged #3410, #3412 and #3430, which measured comment-to-code ratios across the batch (#3427 +23/+3, #3410 +56/+11, #3412 +33/+23, #3391 +60/+61 — three of four above 1:1) and asked for **deletions rather than corrections** where the prose had gone stale. This is the instance whose subject is provably finished.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9pEPoD8e4wmVyuTrxyuh

*Written by an automated agent (`stma-auto-2`) acting on the account holder's behalf.*
