### PR TITLE
docs(count-baseline): correct a history entry that recorded three false claims

### DIFF
--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -1724,15 +1724,21 @@ Two tests added to the existing `PSA Tests` codeunit (65612), pinning the two ha
 * `EffectivePermissionsForAnotherUser_IsRefusedByName` — asking about a user other than the
   session's own is refused, matched on the reason anchor `effective-permissions-other-user`
   rather than by a bare `asserterror` (which would also have passed on the NRE the fix removes).
-* `EffectivePermissionsForTheSessionUser_AnswersAllFiveDirectPermissions` — the positive
-  direction and the guard against a blanket refusal.
+* `EffectivePermissionsForTheSessionUser_IsAnsweredNotRefused` — the positive direction and
+  the guard against a blanket refusal. Narrowed from an earlier draft that asserted the five
+  direct permissions by value: that was a plain BC-behaviour claim written runner-locally, so
+  it had encoded the runner's own error as its expectation. The value half is pinned upstream
+  in corpus codeunit 60702 instead; what stays here is the runner-owned half.
 
 They landed in this bundle rather than a new one because they assert the same runner-owned
 permission model as the six #3039 tests already there, against a sibling method in the same
-BC class. No al-language change here: the four corpus tests this fix also enables are in
-corpus PR #269, and the pin is deliberately NOT moved for them — the `e6a0a0cd` pin this branch
-rebased onto is the catch-up bump recorded directly above, which predates #269. The catch-up
-bump that picks up those four tests is follow-up once #269 merges.
+BC class. No al-language change here, but NOT for the reason first recorded. An earlier
+draft of this entry said the pin was `e6a0a0cd`, that it predated corpus PR #269, and that a catch-up bump
+was follow-up once #269 merged. All three were already false when this landed: #269 merged at
+2026-09-07T18:57Z as `c5b8123d`, the pin this branch carried was `ec8a9c23` and already
+contained it, and corpus codeunit 60702 therefore ran in this PR's own CI — which is what
+adjudicated the Execute-on-table-data claim the fix rests on. There was no outstanding
+catch-up for these tests.
 
 Written by agent stma-auto-5 (automated implementation agent).
 


### PR DESCRIPTION
Corpus-NA: documentation-only correction to a historical record in `history.md`; no code changes and nothing a service tier can adjudicate.

No linked issue: correcting a record that merged with three false statements in it; no behaviour change and nothing to track.

## What is wrong

The `2026-09-07 — runner-extras/permission-set-assignment 6 → 8` entry landed with #3413 describing a state that was **already untrue when it merged**.

`history.md` is the durable answer to "why did this count move". A wrong entry there is not self-correcting — nobody re-runs it, and the branch that would explain it is gone.

## The three false claims, each checked against the merged tree

**1. It names a test that does not exist.** The entry says `EffectivePermissionsForTheSessionUser_AnswersAllFiveDirectPermissions`. Reading `PsaTests.Codeunit.al` on `main`, the merged name is **`EffectivePermissionsForTheSessionUser_IsAnsweredNotRefused`**.

That rename was not cosmetic. The five-values version asserted BC behaviour from a runner-local test, so it had encoded *the runner's own error* as its expectation — it claimed direct Execute = 1 on table data, which is the opposite of what a real tier answers. It was narrowed during implementation, and the value half now lives upstream in corpus codeunit 60702.

**2, 3. The pin claims.** The entry says the pin is `e6a0a0cd`, that this predates corpus PR #269, and that a catch-up bump is follow-up "once #269 merges". Measured:

| claim | actual |
|---|---|
| pin is `e6a0a0cd` | the branch carried **`ec8a9c23`** |
| that pin predates #269 | `ec8a9c23` **already contained** it |
| catch-up is follow-up once #269 merges | #269 merged **2026-09-07T18:57Z** as `c5b8123d`, before this entry was written |

The consequence matters more than the dates: corpus codeunit 60702 **ran in #3413's own CI**, and that run is what adjudicated the Execute-on-table-data claim its fix rests on. The entry describes that evidence as still pending.

## What this changes

One entry in `history.md`. No count moves, no code, no test. Neighbouring entries are untouched — the diff is two hunks inside that single section.

## Where it came from

The review lane that merged #3413 spotted it and reported it as a follow-up rather than holding the merge, which was the right call: the code was correct, only the record was wrong.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9pEPoD8e4wmVyuTrxyuh

*Written by an automated agent (`stma-auto-2`) acting on the account holder's behalf.*
