### PR TITLE
feat(tools): answer the corpus pin from the tree, not the shared submodule checkout

### DIFF
--- a/.claude/rules/al-language-submodule.md
+++ b/.claude/rules/al-language-submodule.md
@@ -46,6 +46,14 @@ PIN=$(tools/corpus-pin.py --quiet)   # always the pin, never the shared checkout
 `--quiet` prints the pin even when it exits 1, so a caller that ignores the exit code still
 captures the right value. `tools/preflight.py` reports the same divergence as a WARN.
 
+**Behind is not mid-bump**, and the tool distinguishes them because getting it wrong put a
+wrong pin on stdout. The index carries a gitlink for the submodule at *all* times — normally
+just a copy of `HEAD`'s — so "the index differs from `origin/main`" usually means the checkout
+is behind, which is the ordinary state of an agent worktree, not that anyone is bumping the
+pin. `git diff --cached` is what tells them apart. Only a genuinely **staged** bump outranks
+`origin/main`, so `--quiet` on a behind checkout answers `origin/main`'s pin — what CI
+replays — rather than that checkout's stale one.
+
 **Why it does not announce itself.** A stale checkout shows as `M tests/al-language`, which
 reads as an ordinary dirty submodule; `git log` inside it prints a real history, because it
 *is* a real repository at a real commit; and every commit it lists genuinely exists. Nothing

--- a/.claude/rules/al-language-submodule.md
+++ b/.claude/rules/al-language-submodule.md
@@ -21,6 +21,47 @@ gh repo view StefanMaron/BusinessCentral.AL.Language.Tests --json defaultBranchR
 The same asymmetry applies to every command naming a branch: `git merge-tree --write-tree
 origin/master origin/<branch>` for a conflict check in the corpus, `origin/main` for one here.
 
+## The pin is `git ls-tree`, not the submodule working directory
+
+The read that precedes every bump, and the one that keeps going wrong. Two plausible
+commands, both exit 0, both print a real SHA, and they answer different questions:
+
+```bash
+git ls-tree origin/main tests/al-language     # THE PIN — what CI replays
+git -C tests/al-language rev-parse HEAD       # whatever the last process left checked out
+```
+
+`tests/al-language/` is a **submodule working directory, shared by every worktree of this
+repository** — exactly like `refs/stash` (`no-git-stash-with-worktrees.md`). Any process that
+checks out a different corpus commit inside it leaves it there for everyone. It has no owner
+and nothing resets it.
+
+**Use the tool; do not choose between the two commands** (#3404):
+
+```bash
+tools/corpus-pin.py                  # all three readings, labelled; exit 1 if drifted
+PIN=$(tools/corpus-pin.py --quiet)   # always the pin, never the shared checkout
+```
+
+`--quiet` prints the pin even when it exits 1, so a caller that ignores the exit code still
+captures the right value. `tools/preflight.py` reports the same divergence as a WARN.
+
+**Why it does not announce itself.** A stale checkout shows as `M tests/al-language`, which
+reads as an ordinary dirty submodule; `git log` inside it prints a real history, because it
+*is* a real repository at a real commit; and every commit it lists genuinely exists. Nothing
+is malformed. The failure is a confident **overestimate** of remaining work — the worse
+direction, since it justifies a large measurement run and invites bisecting a range whose
+predecessors are already pinned.
+
+Documentation alone did not stop this. The rule was already written when it was violated
+three times in one session on 2026-09-07 by three different actors — once producing a third
+value belonging to neither end, and once reading a stale pre-rebase value immediately after
+an otherwise-correct rebase. Hence the tool and the preflight check.
+
+**To measure against the corpus, give your worktree its own clone.** A `git checkout` inside
+`tests/al-language/` is the act that poisons it for every other worktree, so it belongs only
+in a bump — where the `git add` that follows makes the checkout and the pin agree again.
+
 ## What this means in practice
 
 - **Test failures in the corpus are runner gaps**, not corpus bugs. `no-assumption-fixes`
@@ -31,7 +72,8 @@ origin/master origin/<branch>` for a conflict check in the corpus, `origin/main`
   classifies that type differently from real BC; fix the classification.
 - **Updating the corpus** = bumping the submodule pin, together with the
   `tests/expectations/count-baseline/` update. Inspect the diff first:
-  `git -C tests/al-language diff $OLD..$NEW`. **The corpus PR is the proof; the pin only
+  `git -C tests/al-language diff $OLD..$NEW`, where `$OLD` is the pin from the section above
+  and **not** the submodule's `HEAD`. **The corpus PR is the proof; the pin only
   decides when this repository's CI replays it** — a corpus PR merged with its BC legs green
   means a real service tier has already adjudicated the claim, whether or not our pin has
   caught up. Which PR the bump belongs in depends on what the new commits need:

--- a/.claude/skills/al-runner-tests/SKILL.md
+++ b/.claude/skills/al-runner-tests/SKILL.md
@@ -94,6 +94,8 @@ Today the reporter prints raw PASS / FAIL / ERROR per test plus aggregate counts
 
 Drift is loud in every direction: a test passing despite an entry fails with "remove the entry"; a test raising an OOS signal without an entry fails with "add an entry"; a wrong or near-miss `Reason` still fails. See `docs/expectations.md`.
 
+**A wholesale EXEC-FAIL sweep on one identical missing path is another agent, not a regression.** Concurrent agents on one box drive the runner against a shared shadow cache under `~/.cache/al-runner/ncl-shadow/`, and one publishing into it while another loads from it produced **18 bundles failing with the same `Could not load file or assembly '…/ncl-shadow/<hash>/AlRunner.QueryJoin.dll'`** — the directory was gone by the time it was looked at, and it cleared on re-run. The tell is *every* bundle failing on one identical path, rather than a scattered set failing on their own assertions. Check for other runner processes (`pgrep -af 'dotnet.*AlRunner'`) and re-run before concluding anything; an unattended loop that files issues from that sweep files spectacular nonsense. `f461e5bf` addresses the publish side of this race; the consumer side is what you see.
+
 ## If a run dies with no output (exit 139 / 134)
 
 An exit of 139 is SIGSEGV and 134 is SIGABRT — the process was killed by a signal, so there
@@ -202,14 +204,50 @@ v1 tracked AL-language coverage in a hand-curated `docs/coverage.yaml`, and the 
 
 ## Bumping the corpus pin
 
-The submodule is read-only. To pull in new tests from upstream:
+The submodule is read-only. **First: `HEAD` inside `tests/al-language/` is not the pin.**
+
+A submodule working directory is shared by every worktree of this repository, exactly like
+`refs/stash`. Any process that checks out a corpus commit in there leaves it for everyone;
+it has no owner and nothing resets it. So the two obvious reads answer different questions:
 
 ```bash
+git ls-tree origin/main tests/al-language     # THE PIN — what CI replays
+git -C tests/al-language rev-parse HEAD       # whatever the last process left behind
+```
+
+Ask the tool rather than choosing between them (#3404):
+
+```bash
+tools/corpus-pin.py            # all three readings; exit 1 if the checkout has drifted
+PIN=$(tools/corpus-pin.py --quiet)   # always the pin, never the shared checkout
+```
+
+Nothing about the wrong read announces itself: `git status` shows a stale checkout as an
+ordinary dirty submodule, `git log` inside it prints a real history, and every commit it
+lists genuinely exists. It answers a question nobody asked. Measured on 2026-09-07 the pin
+was one commit behind `master` and the shared directory made it read as **17**, which is the
+dangerous direction — it justifies a large measurement run and invites bisecting a range
+whose predecessors are already pinned. `tools/preflight.py` now WARNs when they disagree.
+
+To review and bump:
+
+```bash
+PIN=$(tools/corpus-pin.py --quiet)
 git -C tests/al-language fetch
-git -C tests/al-language log --oneline HEAD..origin/master
-git -C tests/al-language diff HEAD..origin/master   # review
+git -C tests/al-language log --oneline "$PIN..origin/master"
+git -C tests/al-language diff "$PIN..origin/master"   # review
 git -C tests/al-language checkout origin/master
 git add tests/al-language
+```
+
+That `checkout` is the step that poisons the shared directory for every other worktree, so
+it belongs only in the bump itself — where you immediately `git add` it, making the checkout
+and the pin agree again. **Never run it just to measure.** To measure, give your worktree its
+own clone:
+
+```bash
+git clone https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests /tmp/corpus
+git -C /tmp/corpus rev-list --count "$PIN..origin/master"
 ```
 
 **A pin bump that pulls in a test needing a new fix cannot be its own PR — it

--- a/tools/corpus-pin.py
+++ b/tools/corpus-pin.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""What is the corpus pin, and is the shared submodule checkout lying about it?
+
+Issue #3404. There are two plausible ways to ask "which corpus commit are we on",
+they disagree, and the wrong one looks entirely correct:
+
+    git ls-tree origin/main tests/al-language     # THE PIN -- what CI replays
+    git -C tests/al-language rev-parse HEAD       # whatever a process left behind
+
+`tests/al-language/` is a submodule working directory, and a submodule working
+directory is shared by every worktree of the repository -- exactly like
+`refs/stash` (`no-git-stash-with-worktrees.md`). Any process that checks out a
+different corpus commit inside it leaves it there for every other worktree. It
+has no owner and nothing resets it.
+
+WHY A TOOL AND NOT ANOTHER PARAGRAPH
+------------------------------------
+The rule was already written down in `.claude/rules/al-language-submodule.md`,
+and on 2026-09-07 it was violated three times in one session by three different
+actors -- once producing a third value belonging to neither end. Prose has had
+its turn. What was missing is a single obvious call, so that "read the pin" stops
+being a choice between two commands that both run, both exit 0, and both print a
+real SHA.
+
+Measured in the repository root while this was written, all three live at once:
+
+    origin/main pin        af01bbbc      what CI actually replays
+    index (staged) pin     9ee6bbcd      this checkout's own gitlink
+    shared working dir     17b015ef      left by some earlier process
+
+WHY IT DOES NOT ANNOUNCE ITSELF
+-------------------------------
+  * `git status` corroborates the wrong read: a stale checkout shows
+    `M tests/al-language`, which reads as an ordinary dirty submodule.
+  * `git -C tests/al-language log` works fine and prints a plausible history,
+    because it IS a real repository at a real commit -- just not the pinned one.
+  * The commit list is genuine. Nothing is malformed. It answers a question
+    nobody asked.
+
+The failure is a confident OVERESTIMATE of remaining work, which is the worse
+direction: it justifies a large measurement run and invites bisecting a range
+whose predecessors are already pinned.
+
+WHAT THIS REPORTS
+-----------------
+All three readings, always, labelled -- never one number that the caller has to
+trust. The divergence between them is the finding, so collapsing them to a single
+answer would discard it.
+
+EXIT CODES
+----------
+  0  the readings agree, or they differ only in ways that are not a hazard (see
+     --explain). The pin is on stdout in --quiet form.
+  1  the shared submodule working directory is NOT at the pin. Anything measured
+     from it -- a gap, a commit range, a diff -- is about the wrong commit.
+  2  the pin could not be read (not a git repository, no gitlink, no origin/main).
+     NEVER a verdict about the pin.
+
+Run:
+  tools/corpus-pin.py                  # report all three readings
+  tools/corpus-pin.py --quiet          # just the pin, for $(...) in a script
+  tools/corpus-pin.py --gap            # ...and how far it is behind corpus master
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+
+SUBMODULE_PATH = "tests/al-language"
+CORPUS_REMOTE = "https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests"
+
+# The corpus default branch is `master`, not `main` (`al-language-submodule.md`).
+# Naming the wrong one is its own documented time sink, so it is a constant here
+# rather than something a caller passes.
+CORPUS_DEFAULT_BRANCH = "master"
+
+EXIT_MEANING = {
+    0: "the shared submodule checkout agrees with the pin (or is absent)",
+    1: "the shared submodule checkout is NOT at the pin - measurements from it are wrong",
+    2: "the pin could not be read - never a verdict about the pin",
+}
+
+
+class PinError(Exception):
+    """The pin could not be read. Never a verdict about the pin."""
+
+
+def _default_runner(args: list[str], cwd: str | None = None):
+    return subprocess.run(args, cwd=cwd, capture_output=True, text=True)
+
+
+def git(runner, root: str | None, *args: str) -> tuple[int, str]:
+    """(exit code, stripped stdout). Never raises on a non-zero git."""
+    cmd = ["git"]
+    if root:
+        cmd += ["-C", root]
+    p = runner(cmd + list(args))
+    return p.returncode, (p.stdout or "").strip()
+
+
+def parse_gitlink(ls_tree_line: str) -> str | None:
+    """The submodule SHA out of a `git ls-tree` line, or None.
+
+    A submodule entry is mode 160000, object type `commit`. Checking BOTH is what
+    keeps this from returning a blob or tree SHA when the path stops being a
+    submodule -- a structural change to the repository, which this tool has no
+    basis for a verdict on, so it must read as "no pin" rather than as a pin.
+    """
+    parts = ls_tree_line.split()
+    if len(parts) < 3:
+        return None
+    mode, kind, sha = parts[0], parts[1], parts[2]
+    if mode != "160000" or kind != "commit":
+        return None
+    return sha or None
+
+
+def read_pin(runner, root: str, rev: str) -> str | None:
+    """The corpus pin recorded in `rev`'s TREE. Independent of what is checked out."""
+    rc, out = git(runner, root, "ls-tree", rev, SUBMODULE_PATH)
+    if rc != 0 or not out:
+        return None
+    return parse_gitlink(out.splitlines()[0])
+
+
+def read_index_pin(runner, root: str) -> str | None:
+    """The gitlink staged in THIS checkout's index.
+
+    Distinct from both other readings, and the one that is easiest to forget
+    exists. A worktree mid-bump legitimately differs from origin/main here; that
+    is a pin bump in progress, not a hazard.
+    """
+    rc, out = git(runner, root, "ls-files", "-s", SUBMODULE_PATH)
+    if rc != 0 or not out:
+        return None
+    parts = out.split()
+    # `ls-files -s` is: mode sha stage<TAB>path
+    if len(parts) < 2 or parts[0] != "160000":
+        return None
+    return parts[1] or None
+
+
+def read_worktree_head(runner, root: str) -> str | None:
+    """Whatever the last process left checked out in the SHARED submodule directory.
+
+    Not the pin. Reported so a caller can SEE the divergence, never so it can be
+    used as the pin.
+
+    An UNPOPULATED submodule directory must read as None, not as a commit. `git
+    worktree add` does not populate submodules, so the directory exists and is
+    empty in every fresh worktree -- and `git -C <empty dir> rev-parse HEAD` then
+    walks UP to the superproject and cheerfully returns the SUPERPROJECT's commit,
+    exit 0. Measured: a new worktree at 4e4abbcb reported `4e4abbcb` as the
+    "corpus checkout", which is not a corpus commit at all. Reporting that as a
+    divergence would fire this guard in every fresh worktree, and a guard that
+    cries wolf by default is one nobody reads. `--show-toplevel` is what tells the
+    two apart: for a real submodule it is the submodule; for an empty directory it
+    is the superproject.
+    """
+    sub = os.path.join(root, SUBMODULE_PATH)
+    if not os.path.isdir(sub):
+        return None
+    rc, top = git(runner, sub, "rev-parse", "--show-toplevel")
+    if rc != 0 or not top:
+        return None
+    if os.path.realpath(top) != os.path.realpath(sub):
+        return None
+    rc, out = git(runner, sub, "rev-parse", "HEAD")
+    if rc != 0 or not out:
+        return None
+    return out or None
+
+
+def short(sha: str | None) -> str:
+    return (sha or "")[:8] or "<none>"
+
+
+class Readings:
+    """The three readings, kept apart on purpose."""
+
+    def __init__(self, pin: str | None, index: str | None, worktree: str | None,
+                 pin_rev: str):
+        self.pin = pin
+        self.index = index
+        self.worktree = worktree
+        self.pin_rev = pin_rev
+
+    @property
+    def worktree_diverged(self) -> bool:
+        """The hazard: the shared directory is present and NOT at the pin.
+
+        Compared against the INDEX pin when there is one, because a branch that is
+        mid-bump has legitimately moved its own gitlink and its submodule checkout
+        together -- flagging that would fire on correct work and train the reader
+        to ignore this. Absent an index pin, origin/main's is the reference.
+        """
+        if self.worktree is None:
+            return False
+        reference = self.index or self.pin
+        if reference is None:
+            return False
+        return self.worktree != reference
+
+    @property
+    def index_ahead_of_main(self) -> bool:
+        """This checkout stages a different pin than origin/main - a bump in progress."""
+        return (self.index is not None and self.pin is not None
+                and self.index != self.pin)
+
+
+def gather(runner, root: str, pin_rev: str) -> Readings:
+    pin = read_pin(runner, root, pin_rev)
+    index = read_index_pin(runner, root)
+    worktree = read_worktree_head(runner, root)
+    if pin is None and index is None:
+        raise PinError(
+            f"no {SUBMODULE_PATH} gitlink in {pin_rev}'s tree or in the index of {root}. "
+            f"Either this is not the AL Runner repository, or {pin_rev} does not exist "
+            f"here -- run `git fetch origin main` first. There is no corpus pin to read.")
+    return Readings(pin, index, worktree, pin_rev)
+
+
+def render(r: Readings) -> list[str]:
+    label_w = max(24, len(f"pin on {r.pin_rev}"))
+    L = [f"corpus pin ({SUBMODULE_PATH})", ""]
+    L.append(f"  {f'pin on {r.pin_rev}':<{label_w}}  {short(r.pin)}   "
+             f"<- THE PIN: what CI replays")
+    L.append(f"  {'pin staged in this index':<{label_w}}  {short(r.index)}   "
+             f"{'(a bump in progress)' if r.index_ahead_of_main else ''}".rstrip())
+    if r.worktree is None:
+        L.append(f"  {'shared working directory':<{label_w}}  <absent>   "
+                 f"(submodule not initialised here)")
+    else:
+        flag = "   <- NOT THE PIN" if r.worktree_diverged else ""
+        L.append(f"  {'shared working directory':<{label_w}}  {short(r.worktree)}{flag}")
+    L.append("")
+    if not r.worktree_diverged:
+        L.append("The shared submodule checkout agrees with the pin. Anything measured from "
+                 "it is about the pinned commit.")
+        return L
+    reference = "the pin staged in this index" if r.index else f"the pin on {r.pin_rev}"
+    L.append(f"HAZARD: {SUBMODULE_PATH} is checked out at {short(r.worktree)}, which is not "
+             f"{reference} ({short(r.index or r.pin)}).")
+    L.append("")
+    L.append("A submodule working directory is shared by EVERY worktree of this repository, "
+             "like refs/stash. Some other process left this one here; it has no owner and "
+             "nothing resets it. Any commit range, gap count or diff you measure from it is "
+             "about the wrong commit -- and it will look right, because `git status` reads it "
+             "as an ordinary dirty submodule and `git log` inside it prints a real history.")
+    L.append("")
+    L.append("Read the pin from the tree instead:")
+    L.append(f"    PIN=$(tools/corpus-pin.py --quiet)")
+    L.append(f"    # or: git ls-tree {r.pin_rev} {SUBMODULE_PATH} | awk '{{print $3}}'")
+    L.append("")
+    L.append("To MEASURE against the corpus, give your worktree its own clone rather than "
+             "checking out inside the shared one -- a checkout there is the very act that "
+             "poisons it for everyone else:")
+    L.append(f"    git clone {CORPUS_REMOTE} /tmp/corpus && \\")
+    L.append(f"      git -C /tmp/corpus rev-list --count \"$PIN..origin/{CORPUS_DEFAULT_BRANCH}\"")
+    return L
+
+
+def measure_gap(runner, root: str, pin: str) -> tuple[int | None, str]:
+    """Commits between the pin and the corpus default branch, or (None, why).
+
+    Uses the shared submodule directory as a git OBJECT STORE only -- `rev-list`
+    between two explicit revisions never consults HEAD, so a poisoned checkout
+    cannot skew this. It can still lack the objects, which is a "could not
+    measure", not a gap of zero.
+    """
+    sub = os.path.join(root, SUBMODULE_PATH)
+    if not os.path.isdir(sub):
+        return None, f"{SUBMODULE_PATH} is not initialised here"
+    rc, _ = git(runner, sub, "cat-file", "-e", f"{pin}^{{commit}}")
+    if rc != 0:
+        return None, (f"the pin {short(pin)} is not an object in {SUBMODULE_PATH} "
+                      f"(run `git -C {SUBMODULE_PATH} fetch`)")
+    ref = f"origin/{CORPUS_DEFAULT_BRANCH}"
+    rc, _ = git(runner, sub, "rev-parse", "--verify", "--quiet", ref)
+    if rc != 0:
+        return None, f"no {ref} in {SUBMODULE_PATH} (run `git -C {SUBMODULE_PATH} fetch`)"
+    rc, out = git(runner, sub, "rev-list", "--count", f"{pin}..{ref}")
+    if rc != 0 or not out.isdigit():
+        return None, f"could not count {pin}..{ref}"
+    return int(out), ""
+
+
+def repo_root(runner, start: str) -> str | None:
+    rc, out = git(runner, start, "rev-parse", "--show-toplevel")
+    return out if rc == 0 and out else None
+
+
+def main(argv: list[str] | None = None, runner=None) -> int:
+    runner = runner or _default_runner
+    epilog = "exit codes:\n" + "\n".join(f"  {k}  {v}" for k, v in sorted(EXIT_MEANING.items()))
+    ap = argparse.ArgumentParser(
+        description=__doc__.split("\n\n")[0],
+        epilog=epilog, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--quiet", action="store_true",
+                    help="print only the pin SHA, for capture in a script. Still exits 1 "
+                         "when the shared checkout has diverged, so a caller that ignores "
+                         "the exit code still gets the RIGHT pin rather than a wrong one")
+    ap.add_argument("--gap", action="store_true",
+                    help=f"also report how many commits the pin is behind the corpus "
+                         f"{CORPUS_DEFAULT_BRANCH}")
+    ap.add_argument("--rev", default="origin/main",
+                    help="the superproject revision whose tree carries the pin "
+                         "(default: origin/main)")
+    ap.add_argument("--root", default=None,
+                    help="repository root (default: discovered from this script)")
+    args = ap.parse_args(argv)
+
+    start = args.root or os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    root = repo_root(runner, start) if not args.root else args.root
+    if not root:
+        print("corpus-pin: not inside a git repository", file=sys.stderr)
+        return 2
+
+    try:
+        r = gather(runner, root, args.rev)
+    except PinError as e:
+        print(f"corpus-pin: {e}", file=sys.stderr)
+        return 2
+
+    # The pin a caller should USE is the one this checkout stages when it has one
+    # -- a worktree mid-bump is working against its own pin, not origin/main's --
+    # falling back to origin/main's tree otherwise.
+    effective = r.index or r.pin
+
+    if args.quiet:
+        print(effective)
+    else:
+        for line in render(r):
+            print(line)
+
+    if args.gap and effective:
+        gap, why = measure_gap(runner, root, effective)
+        if not args.quiet:
+            print()
+        if gap is None:
+            print(f"gap: could not measure - {why}", file=sys.stderr)
+        else:
+            print(f"gap: {gap} commit(s) behind origin/{CORPUS_DEFAULT_BRANCH}"
+                  if not args.quiet else str(gap))
+
+    return 1 if r.worktree_diverged else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/corpus-pin.py
+++ b/tools/corpus-pin.py
@@ -25,8 +25,26 @@ real SHA.
 Measured in the repository root while this was written, all three live at once:
 
     origin/main pin        af01bbbc      what CI actually replays
-    index (staged) pin     9ee6bbcd      this checkout's own gitlink
+    this checkout's HEAD   9ee6bbcd      stale: the checkout is 45 commits behind
     shared working dir     17b015ef      left by some earlier process
+
+BEHIND IS NOT MID-BUMP, AND CONFUSING THEM PUT A WRONG PIN ON STDOUT
+--------------------------------------------------------------------
+The index carries a gitlink for the submodule at ALL times -- normally just a
+copy of HEAD's -- so "the index differs from origin/main" does not mean a bump is
+in progress. It usually means the checkout is behind, which is the ordinary state
+of an agent worktree, while a genuinely staged bump is rare.
+
+The first version of this tool preferred the index pin for `--quiet` on the
+reasoning that a worktree mid-bump works against its own pin. On the box above
+that printed 9ee6bbcd -- the stale one -- while origin/main's pin was af01bbbc,
+and the `--help` promised the opposite in as many words. So the headline reading
+was the one it should have trusted least: the same silent-wrong-answer shape this
+tool exists to abolish, sitting inside its own documented safety guarantee.
+Caught by the coordinator running it, not by any test here.
+
+`git diff --cached` is what tells the two apart -- empty unless the index really
+differs from HEAD -- so only a genuinely STAGED bump now outranks origin/main.
 
 WHY IT DOES NOT ANNOUNCE ITSELF
 -------------------------------
@@ -49,10 +67,11 @@ answer would discard it.
 
 EXIT CODES
 ----------
-  0  the readings agree, or they differ only in ways that are not a hazard (see
-     --explain). The pin is on stdout in --quiet form.
-  1  the shared submodule working directory is NOT at the pin. Anything measured
-     from it -- a gap, a commit range, a diff -- is about the wrong commit.
+  0  the shared checkout is at the commit this checkout expects, or is absent. A
+     checkout merely BEHIND origin/main is exit 0: it is un-refreshed, not poisoned.
+     --quiet still answers origin/main's pin.
+  1  the shared working directory is at a commit nothing here accounts for. Anything
+     measured from it -- a gap, a commit range, a diff -- is about the wrong commit.
   2  the pin could not be read (not a git repository, no gitlink, no origin/main).
      NEVER a verdict about the pin.
 
@@ -77,8 +96,8 @@ CORPUS_REMOTE = "https://github.com/StefanMaron/BusinessCentral.AL.Language.Test
 CORPUS_DEFAULT_BRANCH = "master"
 
 EXIT_MEANING = {
-    0: "the shared submodule checkout agrees with the pin (or is absent)",
-    1: "the shared submodule checkout is NOT at the pin - measurements from it are wrong",
+    0: "the shared submodule checkout is at the commit this checkout expects (or is absent)",
+    1: "the shared submodule checkout is NOT at that commit - measurements from it are wrong",
     2: "the pin could not be read - never a verdict about the pin",
 }
 
@@ -126,12 +145,27 @@ def read_pin(runner, root: str, rev: str) -> str | None:
 
 
 def read_index_pin(runner, root: str) -> str | None:
-    """The gitlink staged in THIS checkout's index.
+    """The gitlink DELIBERATELY STAGED in this checkout's index, or None.
 
-    Distinct from both other readings, and the one that is easiest to forget
-    exists. A worktree mid-bump legitimately differs from origin/main here; that
-    is a pin bump in progress, not a hazard.
+    STAGED, not merely recorded, and the distinction is the whole point. The index
+    carries a gitlink for the submodule at all times -- normally just a copy of
+    HEAD's -- so `git ls-files -s` alone cannot tell "somebody is bumping the pin"
+    from "this checkout is simply behind". `git diff --cached` can: it is empty
+    unless the index actually differs from HEAD.
+
+    Reading it the other way was a real defect in this tool, caught by the
+    coordinator running it on this box rather than by any test here. `--quiet`
+    preferred the index pin, so on a checkout 45 commits behind it answered that
+    checkout's own stale pin (9ee6bbcd) while origin/main's was af01bbbc -- and the
+    --help promised the opposite in as many words. A behind worktree is the COMMON
+    case for an agent and a staged bump is rare, so the tool's headline reading was
+    the one it should have trusted least: exactly the silent-wrong-answer shape it
+    exists to abolish, sitting in its own documented safety guarantee.
     """
+    staged = git(runner, root, "diff", "--cached", "--name-only", "--",
+                 SUBMODULE_PATH)[1]
+    if not staged.strip():
+        return None
     rc, out = git(runner, root, "ls-files", "-s", SUBMODULE_PATH)
     if rc != 0 or not out:
         return None
@@ -140,6 +174,16 @@ def read_index_pin(runner, root: str) -> str | None:
     if len(parts) < 2 or parts[0] != "160000":
         return None
     return parts[1] or None
+
+
+def read_head_pin(runner, root: str) -> str | None:
+    """The pin recorded in THIS checkout's own HEAD tree.
+
+    Not a fourth thing to trust -- it exists so the report can distinguish "this
+    checkout is behind origin/main" from "somebody is bumping the pin", which look
+    identical if you only compare the index against origin/main.
+    """
+    return read_pin(runner, root, "HEAD")
 
 
 def read_worktree_head(runner, root: str) -> str | None:
@@ -178,34 +222,59 @@ def short(sha: str | None) -> str:
 
 
 class Readings:
-    """The three readings, kept apart on purpose."""
+    """The readings, kept apart on purpose."""
 
     def __init__(self, pin: str | None, index: str | None, worktree: str | None,
-                 pin_rev: str):
-        self.pin = pin
-        self.index = index
-        self.worktree = worktree
+                 pin_rev: str, head: str | None = None):
+        self.pin = pin            # origin/main's tree -- what CI replays
+        self.index = index        # STAGED gitlink, or None. A real bump in progress.
+        self.head = head          # this checkout's own HEAD tree
+        self.worktree = worktree  # the shared submodule directory
         self.pin_rev = pin_rev
 
     @property
-    def worktree_diverged(self) -> bool:
-        """The hazard: the shared directory is present and NOT at the pin.
+    def effective(self) -> str | None:
+        """The pin a caller should USE, and the value --quiet prints.
 
-        Compared against the INDEX pin when there is one, because a branch that is
-        mid-bump has legitimately moved its own gitlink and its submodule checkout
-        together -- flagging that would fire on correct work and train the reader
-        to ignore this. Absent an index pin, origin/main's is the reference.
+        A genuinely STAGED bump wins, because that worktree is working against its
+        own pin rather than origin/main's. Nothing else does -- notably NOT this
+        checkout's HEAD pin, which is stale on any behind worktree and is what the
+        first version of this wrongly preferred.
+        """
+        return self.index or self.pin or self.head
+
+    @property
+    def behind(self) -> bool:
+        """This checkout's own recorded pin is older than origin/main's, unstaged.
+
+        The COMMON case for an agent worktree, and not a hazard: it means the
+        checkout has not been refreshed, not that anybody left a wrong commit
+        lying around. Distinguished from a bump only by whether anything is staged.
+        """
+        return (self.index is None and self.head is not None
+                and self.pin is not None and self.head != self.pin)
+
+    @property
+    def worktree_diverged(self) -> bool:
+        """The hazard: the shared directory is at a commit nothing here accounts for.
+
+        The reference is what THIS checkout legitimately expects the submodule to
+        sit at: a staged bump if there is one, otherwise its own HEAD pin, and
+        origin/main's only as a last resort. A behind worktree whose submodule
+        matches its own HEAD is in an ordinary, self-consistent state -- flagging
+        that would fire on most worktrees on the box and train the reader to
+        ignore this, which is how a guard dies.
         """
         if self.worktree is None:
             return False
-        reference = self.index or self.pin
+        reference = self.index or self.head or self.pin
         if reference is None:
             return False
         return self.worktree != reference
 
     @property
     def index_ahead_of_main(self) -> bool:
-        """This checkout stages a different pin than origin/main - a bump in progress."""
+        """A STAGED pin differing from origin/main's - a genuine bump in progress."""
         return (self.index is not None and self.pin is not None
                 and self.index != self.pin)
 
@@ -213,22 +282,29 @@ class Readings:
 def gather(runner, root: str, pin_rev: str) -> Readings:
     pin = read_pin(runner, root, pin_rev)
     index = read_index_pin(runner, root)
+    head = read_head_pin(runner, root)
     worktree = read_worktree_head(runner, root)
-    if pin is None and index is None:
+    if pin is None and index is None and head is None:
         raise PinError(
-            f"no {SUBMODULE_PATH} gitlink in {pin_rev}'s tree or in the index of {root}. "
-            f"Either this is not the AL Runner repository, or {pin_rev} does not exist "
-            f"here -- run `git fetch origin main` first. There is no corpus pin to read.")
-    return Readings(pin, index, worktree, pin_rev)
+            f"no {SUBMODULE_PATH} gitlink in {pin_rev}'s tree, in HEAD's tree, or in the "
+            f"index of {root}. Either this is not the AL Runner repository, or {pin_rev} "
+            f"does not exist here -- run `git fetch origin main` first. "
+            f"There is no corpus pin to read.")
+    return Readings(pin, index, worktree, pin_rev, head=head)
 
 
 def render(r: Readings) -> list[str]:
-    label_w = max(24, len(f"pin on {r.pin_rev}"))
+    label_w = max(25, len(f"pin on {r.pin_rev}"))
     L = [f"corpus pin ({SUBMODULE_PATH})", ""]
     L.append(f"  {f'pin on {r.pin_rev}':<{label_w}}  {short(r.pin)}   "
              f"<- THE PIN: what CI replays")
-    L.append(f"  {'pin staged in this index':<{label_w}}  {short(r.index)}   "
-             f"{'(a bump in progress)' if r.index_ahead_of_main else ''}".rstrip())
+    head_note = ""
+    if r.behind:
+        head_note = "   <- this checkout is BEHIND; not a bump"
+    L.append(f"  {'pin in this checkout HEAD':<{label_w}}  {short(r.head)}{head_note}")
+    if r.index is not None:
+        L.append(f"  {'pin STAGED in this index':<{label_w}}  {short(r.index)}   "
+                 f"{'(a bump in progress)' if r.index_ahead_of_main else ''}".rstrip())
     if r.worktree is None:
         L.append(f"  {'shared working directory':<{label_w}}  <absent>   "
                  f"(submodule not initialised here)")
@@ -236,13 +312,25 @@ def render(r: Readings) -> list[str]:
         flag = "   <- NOT THE PIN" if r.worktree_diverged else ""
         L.append(f"  {'shared working directory':<{label_w}}  {short(r.worktree)}{flag}")
     L.append("")
+    if r.behind:
+        L.append(f"This checkout is BEHIND origin/main: its own pin is {short(r.head)} while "
+                 f"origin/main's is {short(r.pin)}, and nothing is staged. That is an "
+                 f"un-refreshed worktree, not a bump in progress -- so `--quiet` answers "
+                 f"{short(r.effective)}, origin/main's pin, which is what CI replays. "
+                 f"Refresh with `git fetch origin main`.")
+        L.append("")
     if not r.worktree_diverged:
-        L.append("The shared submodule checkout agrees with the pin. Anything measured from "
-                 "it is about the pinned commit.")
+        L.append("The shared submodule checkout is at the commit this checkout expects. "
+                 "Anything measured from it is about that commit.")
         return L
-    reference = "the pin staged in this index" if r.index else f"the pin on {r.pin_rev}"
+    if r.index:
+        reference = "the pin STAGED in this index"
+    elif r.head:
+        reference = "the pin this checkout's HEAD records"
+    else:
+        reference = f"the pin on {r.pin_rev}"
     L.append(f"HAZARD: {SUBMODULE_PATH} is checked out at {short(r.worktree)}, which is not "
-             f"{reference} ({short(r.index or r.pin)}).")
+             f"{reference} ({short(r.index or r.head or r.pin)}).")
     L.append("")
     L.append("A submodule working directory is shared by EVERY worktree of this repository, "
              "like refs/stash. Some other process left this one here; it has no owner and "
@@ -324,10 +412,7 @@ def main(argv: list[str] | None = None, runner=None) -> int:
         print(f"corpus-pin: {e}", file=sys.stderr)
         return 2
 
-    # The pin a caller should USE is the one this checkout stages when it has one
-    # -- a worktree mid-bump is working against its own pin, not origin/main's --
-    # falling back to origin/main's tree otherwise.
-    effective = r.index or r.pin
+    effective = r.effective
 
     if args.quiet:
         print(effective)

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -2248,6 +2248,127 @@ def corpus_expected_counts(doc: dict, suites: Iterable[str]) -> tuple[dict, list
     return counts, problems
 
 
+# --------------------------------------------------------------------------
+# the shared corpus submodule checkout (issue #3404)
+# --------------------------------------------------------------------------
+# SEVERITY: WARN, and the argument is worth stating because the FAIL case is
+# genuinely arguable.
+#
+# The doctrine at the top of this file keeps FAIL for "this box produces wrong
+# answers", and a poisoned submodule checkout does produce wrong answers -- a
+# 1-commit corpus gap read as 17, three times in one session by three different
+# actors. What decides it against FAIL is the OTHER half of the same doctrine:
+# a condition earns FAIL when it has no fallback that still produces correct
+# work. The stray graphify graph, the one thing here that can FAIL, has none --
+# no rebuild reaches it, so every query after it is wrong and nothing an agent
+# does helps.
+#
+# This one has a fallback, and it is always available: `git ls-tree` reads the
+# pin out of a tree and cannot see the working directory at all. An agent that
+# uses it -- or tools/corpus-pin.py, or the CI scripts, which already do -- works
+# correctly on a poisoned box. So this makes an agent WRONG only if it reaches
+# for the other read, which is a choice the warning exists to redirect.
+#
+# The second reason is about what FAIL costs: it halts the autonomous cycle, and
+# the condition is REPOSITORY-WIDE and NOT SELF-HEALING. One stray checkout would
+# then stop every agent on the box from starting any work at all, including work
+# that never touches the corpus, until a human intervened -- for a hazard that a
+# single documented command sidesteps. A check that can halt everything for a
+# condition most cycles do not care about is a check people route around.
+CORPUS_PIN_TOOL = "tools/corpus-pin.py"
+
+
+def corpus_pin_readings(repo: str) -> dict:
+    """The pin from origin/main's tree, the pin in the index, and the shared checkout.
+
+    Three readings kept apart, because the DIVERGENCE is the finding. Collapsing
+    them to one number would discard exactly the fact this check exists to
+    report. Each is None when it could not be read, which is distinct from "they
+    disagree" and is reported as such.
+    """
+    out = {"pin": None, "index": None, "worktree": None, "error": ""}
+    line = run(["git", "-C", repo, "ls-tree", "refs/remotes/origin/main",
+                CORPUS_SUBMODULE]).out.strip()
+    parts = line.split()
+    if len(parts) >= 3 and parts[0] == "160000" and parts[1] == "commit":
+        out["pin"] = parts[2]
+
+    staged = run(["git", "-C", repo, "ls-files", "-s", CORPUS_SUBMODULE]).out.strip()
+    sparts = staged.split()
+    if len(sparts) >= 2 and sparts[0] == "160000":
+        out["index"] = sparts[1]
+
+    sub = os.path.join(repo, CORPUS_SUBMODULE)
+    if not os.path.isdir(sub):
+        out["error"] = f"{CORPUS_SUBMODULE} is not initialised"
+        return out
+    # An UNPOPULATED submodule directory is not a checkout, and asking it for HEAD
+    # does not fail -- `git -C <empty dir> rev-parse HEAD` walks UP to the
+    # superproject and returns the SUPERPROJECT's commit, exit 0. `git worktree
+    # add` does not populate submodules, so that is the state of every fresh
+    # worktree: measured, a new worktree at 4e4abbcb reported `4e4abbcb` as its
+    # "corpus checkout". Warning on that would fire in every new worktree, and a
+    # check that is wrong by default is one people learn to skip.
+    top = run(["git", "-C", sub, "rev-parse", "--show-toplevel"]).out.strip()
+    if not top or os.path.realpath(top) != os.path.realpath(sub):
+        out["error"] = f"{CORPUS_SUBMODULE} is not populated in this checkout"
+        return out
+    head = run(["git", "-C", sub, "rev-parse", "HEAD"]).out.strip()
+    if head:
+        out["worktree"] = head
+    else:
+        out["error"] = f"could not read HEAD in {CORPUS_SUBMODULE}"
+    return out
+
+
+def classify_corpus_pin(readings: dict) -> CheckResult:
+    """PASS/WARN on whether the shared corpus checkout is at the pin."""
+    pin, index, worktree = readings["pin"], readings["index"], readings["worktree"]
+    ref = index or pin
+    detail = [
+        f"pin on origin/main       {(pin or '<unreadable>')[:8]}   <- what CI replays",
+        f"pin staged in the index  {(index or '<none>')[:8]}",
+        f"shared working directory {(worktree or '<absent>')[:8]}",
+    ]
+    if readings["error"] or ref is None or worktree is None:
+        # "could not read" is not "they agree". A submodule nobody has initialised
+        # cannot mislead anyone, so this is not a finding -- but it must not be
+        # reported as a verified agreement either.
+        return CheckResult(
+            name="corpus-pin", status="PASS",
+            summary="no shared corpus checkout to disagree with the pin"
+                    + (f" ({readings['error']})" if readings["error"] else ""),
+            command=CORPUS_PIN_TOOL, detail=detail, data=readings)
+    if worktree == ref:
+        return CheckResult(
+            name="corpus-pin", status="PASS",
+            summary=f"the shared {CORPUS_SUBMODULE} checkout is at the pin ({ref[:8]})",
+            command=CORPUS_PIN_TOOL, detail=detail, data=readings)
+    detail.append(
+        "A submodule working directory is shared by EVERY worktree of this repository, like "
+        "refs/stash. Some other process left this one behind; it has no owner and nothing "
+        "resets it. It does not announce itself: `git status` shows it as an ordinary dirty "
+        "submodule, and `git log` inside it prints a real history of the wrong commit.")
+    return CheckResult(
+        name="corpus-pin", status="WARN",
+        summary=f"the shared {CORPUS_SUBMODULE} checkout is at {worktree[:8]}, not the pin "
+                f"{ref[:8]} - anything measured from it is about the wrong commit",
+        command=CORPUS_PIN_TOOL,
+        detail=detail,
+        remedy="Do not read the pin from the submodule's HEAD. Read it from a tree:\n"
+               f"    PIN=$({CORPUS_PIN_TOOL} --quiet)\n"
+               f"    # or: git ls-tree origin/main {CORPUS_SUBMODULE} | awk '{{print $3}}'\n"
+               "To measure against the corpus, give your worktree its OWN clone -- checking "
+               f"out inside {CORPUS_SUBMODULE} is the act that poisons it for everyone else. "
+               "This is a WARN rather than a FAIL because the correct read is always "
+               "available, so the box still produces correct work for an agent that uses it.",
+        data=readings)
+
+
+def check_corpus_pin(repo: str) -> CheckResult:
+    return classify_corpus_pin(corpus_pin_readings(repo))
+
+
 def check_corpus(repo: str, enabled: bool) -> CheckResult:
     """The skill's step 1: the corpus is the known-good baseline, and its expected
     count is checked in at tests/expectations/count-baseline/.
@@ -2643,6 +2764,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         check_push(repo, identity),
         check_commit(repo),
         check_github(slug),
+        check_corpus_pin(repo),
         check_corpus(repo, args.with_corpus),
     ]
     if args.no_tools:

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -2286,17 +2286,29 @@ def corpus_pin_readings(repo: str) -> dict:
     report. Each is None when it could not be read, which is distinct from "they
     disagree" and is reported as such.
     """
-    out = {"pin": None, "index": None, "worktree": None, "error": ""}
-    line = run(["git", "-C", repo, "ls-tree", "refs/remotes/origin/main",
-                CORPUS_SUBMODULE]).out.strip()
-    parts = line.split()
-    if len(parts) >= 3 and parts[0] == "160000" and parts[1] == "commit":
-        out["pin"] = parts[2]
+    out = {"pin": None, "index": None, "head": None, "worktree": None, "error": ""}
 
-    staged = run(["git", "-C", repo, "ls-files", "-s", CORPUS_SUBMODULE]).out.strip()
-    sparts = staged.split()
-    if len(sparts) >= 2 and sparts[0] == "160000":
-        out["index"] = sparts[1]
+    def tree_pin(rev):
+        parts = run(["git", "-C", repo, "ls-tree", rev, CORPUS_SUBMODULE]).out.strip().split()
+        if len(parts) >= 3 and parts[0] == "160000" and parts[1] == "commit":
+            return parts[2]
+        return None
+
+    out["pin"] = tree_pin("refs/remotes/origin/main")
+    out["head"] = tree_pin("HEAD")
+
+    # STAGED, not merely recorded. The index carries a gitlink for the submodule at
+    # ALL times -- normally just a copy of HEAD's -- so `ls-files -s` alone cannot
+    # tell "somebody is bumping the pin" from "this checkout is behind", and the
+    # second is the COMMON case for an agent worktree while the first is rare.
+    # Reading it the other way made this check WARN on every behind worktree and
+    # call that checkout's stale HEAD pin "the pin" (#3404, caught in review).
+    if run(["git", "-C", repo, "diff", "--cached", "--name-only", "--",
+            CORPUS_SUBMODULE]).out.strip():
+        sparts = run(["git", "-C", repo, "ls-files", "-s",
+                      CORPUS_SUBMODULE]).out.strip().split()
+        if len(sparts) >= 2 and sparts[0] == "160000":
+            out["index"] = sparts[1]
 
     sub = os.path.join(repo, CORPUS_SUBMODULE)
     if not os.path.isdir(sub):
@@ -2324,12 +2336,20 @@ def corpus_pin_readings(repo: str) -> dict:
 def classify_corpus_pin(readings: dict) -> CheckResult:
     """PASS/WARN on whether the shared corpus checkout is at the pin."""
     pin, index, worktree = readings["pin"], readings["index"], readings["worktree"]
-    ref = index or pin
+    head = readings.get("head")
+    # What THIS checkout legitimately expects the submodule to sit at: a staged
+    # bump if there is one, otherwise its own HEAD pin. origin/main's is the last
+    # resort, because a behind checkout does not claim to be at it.
+    ref = index or head or pin
+    behind = index is None and head is not None and pin is not None and head != pin
     detail = [
         f"pin on origin/main       {(pin or '<unreadable>')[:8]}   <- what CI replays",
-        f"pin staged in the index  {(index or '<none>')[:8]}",
+        f"pin in this checkout HEAD {(head or '<none>')[:8]}"
+        + ("   <- BEHIND; not a bump" if behind else ""),
         f"shared working directory {(worktree or '<absent>')[:8]}",
     ]
+    if index is not None:
+        detail.insert(2, f"pin STAGED in the index  {index[:8]}   (a bump in progress)")
     if readings["error"] or ref is None or worktree is None:
         # "could not read" is not "they agree". A submodule nobody has initialised
         # cannot mislead anyone, so this is not a finding -- but it must not be
@@ -2339,20 +2359,36 @@ def classify_corpus_pin(readings: dict) -> CheckResult:
             summary="no shared corpus checkout to disagree with the pin"
                     + (f" ({readings['error']})" if readings["error"] else ""),
             command=CORPUS_PIN_TOOL, detail=detail, data=readings)
+    if behind:
+        detail.append(
+            f"This checkout is BEHIND origin/main on the corpus pin ({head[:8]} vs "
+            f"{pin[:8]}), and nothing is staged -- an un-refreshed worktree, not a bump. "
+            f"`{CORPUS_PIN_TOOL} --quiet` answers origin/main's pin, which is what CI "
+            f"replays. Refresh with `git fetch origin main`.")
     if worktree == ref:
+        expected = ("the commit this checkout expects" if behind
+                    else "the pin")
         return CheckResult(
             name="corpus-pin", status="PASS",
-            summary=f"the shared {CORPUS_SUBMODULE} checkout is at the pin ({ref[:8]})",
+            summary=f"the shared {CORPUS_SUBMODULE} checkout is at {expected} ({ref[:8]})"
+                    + (f"; this checkout is behind origin/main ({pin[:8]})" if behind else ""),
             command=CORPUS_PIN_TOOL, detail=detail, data=readings)
     detail.append(
         "A submodule working directory is shared by EVERY worktree of this repository, like "
         "refs/stash. Some other process left this one behind; it has no owner and nothing "
         "resets it. It does not announce itself: `git status` shows it as an ordinary dirty "
         "submodule, and `git log` inside it prints a real history of the wrong commit.")
+    # Name the reference for what it is. Calling this checkout's own HEAD pin "the
+    # pin" was a second wrong statement on the same line, about the value the reader
+    # is being told to trust.
+    ref_label = ("the pin STAGED here" if index
+                 else "the pin this checkout's HEAD records" if head
+                 else "the pin on origin/main")
     return CheckResult(
         name="corpus-pin", status="WARN",
-        summary=f"the shared {CORPUS_SUBMODULE} checkout is at {worktree[:8]}, not the pin "
-                f"{ref[:8]} - anything measured from it is about the wrong commit",
+        summary=f"the shared {CORPUS_SUBMODULE} checkout is at {worktree[:8]}, not "
+                f"{ref_label} ({ref[:8]}) - anything measured from it is about the "
+                f"wrong commit",
         command=CORPUS_PIN_TOOL,
         detail=detail,
         remedy="Do not read the pin from the submodule's HEAD. Read it from a tree:\n"

--- a/tools/test_corpus_pin.py
+++ b/tools/test_corpus_pin.py
@@ -146,7 +146,7 @@ with tempfile.TemporaryDirectory() as tmp:
     rc, out = run_tool(["--rev", "HEAD"], sup)
     check("agreeing readings exit 0", rc == 0, f"rc={rc}")
     check("an agreeing report says so",
-          "agrees with the pin" in out, out)
+          "is at the commit this checkout expects" in out, out)
     check("an agreeing report does not cry hazard", "HAZARD" not in out, out)
 
     rc, out = run_tool(["--rev", "HEAD", "--quiet"], sup)
@@ -218,6 +218,66 @@ with tempfile.TemporaryDirectory() as tmp:
     rc, out = run_tool(["--rev", "HEAD"], sup)
     check("a staged bump with a drifted checkout is still a hazard",
           rc == 1, f"rc={rc}: {out}")
+
+    # ------------------------------------ BEHIND is not MID-BUMP (coordinator, #3404)
+    # The index records a gitlink whether or not anybody staged one, so "differs
+    # from origin/main" does NOT mean "a bump in progress". The common case for an
+    # agent worktree is the opposite: a checkout some commits behind, whose index
+    # pin equals its own HEAD's tree pin because nothing was staged at all.
+    #
+    # Getting this wrong is not cosmetic. --quiet preferred the index pin, so on
+    # any behind checkout it printed a STALE pin while its own --help promised the
+    # right one -- the exact silent-wrong-answer class this tool exists to abolish,
+    # in the property documented as its safety guarantee. Measured on the live box:
+    # --quiet answered 9ee6bbcd with origin/main's pin at af01bbbc, 45 commits back.
+    git(sup, "reset", "-q", "HEAD", "--")
+    git(sub, "checkout", "-q", pin_sha)
+
+    # Advance origin/main's pin WITHOUT touching this checkout: the superproject
+    # moves on, our HEAD does not. Nothing is staged here -- this is "behind".
+    git(sup, "branch", "-f", "other", "HEAD")
+    git(sub, "checkout", "-q", later_sha)
+    git(sup, "add", "tests/al-language")
+    git(sup, "commit", "-qm", "bump the corpus pin on main")
+    advanced = git(sup, "rev-parse", "HEAD")
+    git(sup, "update-ref", "refs/remotes/origin/main", advanced)
+    # Put the checkout back where it was: HEAD behind origin/main, nothing staged.
+    git(sup, "reset", "-q", "--hard", "other")
+    git(sub, "checkout", "-q", pin_sha)
+
+    check("the fixture is genuinely BEHIND, with nothing staged",
+          git(sup, "diff", "--cached", "--name-only", "--", "tests/al-language") == ""
+          and cp.read_pin(cp._default_runner, sup, "refs/remotes/origin/main") == later_sha
+          and cp.read_pin(cp._default_runner, sup, "HEAD") == pin_sha,
+          "the fixture does not reproduce a behind checkout")
+
+    check("an UNSTAGED index pin is not read as a staged bump",
+          cp.read_index_pin(cp._default_runner, sup) is None,
+          f"got {cp.read_index_pin(cp._default_runner, sup)!r} - nothing was staged")
+
+    rc, out = run_tool(["--rev", "refs/remotes/origin/main", "--quiet"], sup)
+    check("--quiet on a BEHIND checkout answers origin/main's pin, not the stale one",
+          out.strip() == later_sha,
+          f"{out.strip()!r} != origin/main pin {later_sha!r} (stale was {pin_sha!r})")
+    check("--quiet on a behind checkout does not print the stale pin",
+          pin_sha not in out, out)
+
+    rc, out = run_tool(["--rev", "refs/remotes/origin/main"], sup)
+    check("a behind checkout is never labelled as a bump in progress",
+          "(a bump in progress)" not in out, out)
+    check("...and is not shown a STAGED-pin row it does not have",
+          "STAGED in this index" not in out, out)
+    check("...and says it is behind, so the reader knows why the pins differ",
+          "behind" in out.lower(), out)
+    # The submodule sits at this checkout's own recorded pin, which is a perfectly
+    # ordinary state for a behind worktree. Calling that a poisoned checkout would
+    # fire on every worktree that has not been refreshed.
+    check("a behind checkout whose submodule matches its own HEAD is not a hazard",
+          rc == 0, f"rc={rc}: {out}")
+
+    # Restore the fixture for the gap tests below.
+    git(sup, "update-ref", "-d", "refs/remotes/origin/main")
+    git(sup, "branch", "-D", "other")
 
     # ---------------------------------------------------------------- the gap
     git(sup, "reset", "-q", "HEAD", "--")     # unstage the bump

--- a/tools/test_corpus_pin.py
+++ b/tools/test_corpus_pin.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/corpus-pin.py.
+
+The claim under test is a DIVERGENCE between three readings of the same thing, so
+most of this suite builds REAL git repositories with a real submodule and really
+moves the shared submodule checkout off the pin. A hand-written fixture cannot
+prove it: the whole reason the misreading survives is that every command involved
+exits 0 and prints a plausible SHA, which a fake runner would reproduce whether
+the tool were right or wrong.
+
+The parsing helpers are tested against captured strings, because `git ls-tree`
+output for a path that has STOPPED being a submodule is not a state you can
+easily construct on demand, and it is the one where returning a SHA anyway would
+be actively wrong.
+
+Run: python3 tools/test_corpus_pin.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location("corpus_pin",
+                                               os.path.join(HERE, "corpus-pin.py"))
+cp = importlib.util.module_from_spec(_spec)
+sys.modules["corpus_pin"] = cp
+_spec.loader.exec_module(cp)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        FAILURES.append(name)
+
+
+# ------------------------------------------------------------------ parsing
+# `git ls-tree` prints one line per entry. A submodule is mode 160000, type
+# `commit`. Every other shape must read as "no pin" rather than as a pin -- a
+# blob SHA returned here would be a confidently wrong answer of exactly the kind
+# this tool exists to prevent.
+check("a submodule gitlink line yields its SHA",
+      cp.parse_gitlink(
+          "160000 commit af01bbbc176b4cc5ca3d7020094103911af51a35\ttests/al-language")
+      == "af01bbbc176b4cc5ca3d7020094103911af51a35")
+
+check("a blob line is not a pin",
+      cp.parse_gitlink("100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\tREADME.md")
+      is None)
+
+check("a tree line is not a pin",
+      cp.parse_gitlink("040000 tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\ttests")
+      is None)
+
+check("an empty line is not a pin", cp.parse_gitlink("") is None)
+check("a truncated line is not a pin", cp.parse_gitlink("160000 commit") is None)
+
+# The mode and the type are BOTH checked. A line carrying one but not the other
+# is malformed, and reading a SHA out of it would be inventing one.
+check("mode 160000 with the wrong type is not a pin",
+      cp.parse_gitlink("160000 blob abc123\ttests/al-language") is None)
+check("type commit with the wrong mode is not a pin",
+      cp.parse_gitlink("100644 commit abc123\ttests/al-language") is None)
+
+
+# ------------------------------------------------------------ real git fixture
+def git(root, *args, check_rc=True):
+    p = subprocess.run(["git", "-C", root, *args], capture_output=True, text=True)
+    if check_rc and p.returncode != 0:
+        raise AssertionError(f"git {' '.join(args)} failed in {root}: {p.stderr}")
+    return p.stdout.strip()
+
+
+def _init(root):
+    subprocess.run(["git", "init", "-q", "-b", "main", root], check=True,
+                   capture_output=True)
+    git(root, "config", "user.email", "t@example.invalid")
+    git(root, "config", "user.name", "T")
+    git(root, "config", "commit.gpgsign", "false")
+
+
+def build_fixture(tmp):
+    """A superproject with a real `tests/al-language` submodule at TWO commits.
+
+    Returns (super_root, corpus_root, pin_sha, later_sha). The submodule is
+    committed while checked out at `pin_sha`, so the pin recorded in the
+    superproject's tree IS pin_sha -- and the test then moves the shared
+    submodule working directory to later_sha WITHOUT touching the pin, which is
+    precisely the state the tool must catch.
+    """
+    corpus = os.path.join(tmp, "corpus")
+    os.makedirs(corpus)
+    _init(corpus)
+    with open(os.path.join(corpus, "a.txt"), "w") as fh:
+        fh.write("one\n")
+    git(corpus, "add", "a.txt")
+    git(corpus, "commit", "-qm", "corpus commit one")
+    pin_sha = git(corpus, "rev-parse", "HEAD")
+    with open(os.path.join(corpus, "b.txt"), "w") as fh:
+        fh.write("two\n")
+    git(corpus, "add", "b.txt")
+    git(corpus, "commit", "-qm", "corpus commit two")
+    later_sha = git(corpus, "rev-parse", "HEAD")
+    # Back to the commit the superproject will pin, so `submodule add` records it.
+    git(corpus, "checkout", "-q", pin_sha)
+
+    sup = os.path.join(tmp, "super")
+    os.makedirs(sup)
+    _init(sup)
+    with open(os.path.join(sup, "README.md"), "w") as fh:
+        fh.write("super\n")
+    git(sup, "add", "README.md")
+    git(sup, "commit", "-qm", "initial")
+    git(sup, "-c", "protocol.file.allow=always", "submodule", "add", "-q",
+        corpus, "tests/al-language")
+    git(sup, "commit", "-qm", "add corpus submodule")
+    return sup, corpus, pin_sha, later_sha
+
+
+def run_tool(argv, cwd_root):
+    """main() with stdout captured, returning (exit code, stdout)."""
+    buf = io.StringIO()
+    old = sys.stdout
+    sys.stdout = buf
+    try:
+        rc = cp.main(argv + ["--root", cwd_root])
+    finally:
+        sys.stdout = old
+    return rc, buf.getvalue()
+
+
+with tempfile.TemporaryDirectory() as tmp:
+    sup, corpus, pin_sha, later_sha = build_fixture(tmp)
+    sub = os.path.join(sup, "tests/al-language")
+
+    # ---------------------------------------------------------------- GREEN
+    # Everything agrees: the tool reports the pin and exits 0.
+    rc, out = run_tool(["--rev", "HEAD"], sup)
+    check("agreeing readings exit 0", rc == 0, f"rc={rc}")
+    check("an agreeing report says so",
+          "agrees with the pin" in out, out)
+    check("an agreeing report does not cry hazard", "HAZARD" not in out, out)
+
+    rc, out = run_tool(["--rev", "HEAD", "--quiet"], sup)
+    check("--quiet prints exactly the pin",
+          out.strip() == pin_sha, f"{out.strip()!r} != {pin_sha!r}")
+
+    check("read_pin reads the tree, and gets the pin",
+          cp.read_pin(cp._default_runner, sup, "HEAD") == pin_sha)
+
+    # ------------------------------------------------------------------ RED
+    # THE REAL SHAPE. Move the shared submodule working directory off the pin,
+    # exactly as another process on this box would, and change NOTHING else.
+    git(sub, "checkout", "-q", later_sha)
+
+    check("the working directory now reads a different commit than the pin",
+          cp.read_worktree_head(cp._default_runner, sup) == later_sha
+          and cp.read_pin(cp._default_runner, sup, "HEAD") == pin_sha,
+          "the fixture did not actually diverge")
+
+    # This is the misreading the issue is about, reproduced: the two commands a
+    # person would type give different answers, and both succeed.
+    check("the two plausible reads genuinely disagree", pin_sha != later_sha)
+
+    rc, out = run_tool(["--rev", "HEAD"], sup)
+    check("a diverged shared checkout exits 1", rc == 1, f"rc={rc}")
+    check("the divergence is named as a hazard", "HAZARD" in out, out)
+    check("the report shows the wrong commit that is checked out",
+          later_sha[:8] in out, out)
+    check("the report shows the pin alongside it", pin_sha[:8] in out, out)
+    check("the report says which one is not the pin", "NOT THE PIN" in out, out)
+    check("the report explains the sharing, not just the mismatch",
+          "shared by EVERY worktree" in out, out)
+
+    # --quiet must still answer with the PIN, never the poisoned checkout. A
+    # caller that ignores the exit code is the likeliest caller, so the value it
+    # captures has to be right on its own.
+    rc, out = run_tool(["--rev", "HEAD", "--quiet"], sup)
+    check("--quiet still exits 1 when diverged", rc == 1, f"rc={rc}")
+    check("--quiet prints the PIN, not the poisoned checkout",
+          out.strip() == pin_sha, f"{out.strip()!r} != pin {pin_sha!r}")
+    check("--quiet never prints the working-directory commit",
+          later_sha not in out, out)
+
+    # ------------------------------------------------- back to agreement again
+    # Both directions, on the same fixture: restore the checkout and the verdict
+    # must flip back. A guard that only ever fires is not a guard.
+    git(sub, "checkout", "-q", pin_sha)
+    rc, out = run_tool(["--rev", "HEAD"], sup)
+    check("restoring the checkout returns to exit 0", rc == 0, f"rc={rc}")
+    check("and the hazard is gone", "HAZARD" not in out, out)
+
+    # ------------------------------------------------------- a bump in progress
+    # A branch that is legitimately bumping the pin has moved BOTH its gitlink and
+    # its submodule checkout to the new commit. That is correct work, and flagging
+    # it would train the reader to ignore this tool.
+    git(sub, "checkout", "-q", later_sha)
+    git(sup, "add", "tests/al-language")
+    rc, out = run_tool(["--rev", "HEAD"], sup)
+    check("a staged bump whose checkout matches it is not a hazard",
+          rc == 0, f"rc={rc}: {out}")
+    check("a staged bump is reported as a bump in progress",
+          "bump in progress" in out, out)
+    rc, out = run_tool(["--rev", "HEAD", "--quiet"], sup)
+    check("--quiet during a bump answers the STAGED pin",
+          out.strip() == later_sha, f"{out.strip()!r} != {later_sha!r}")
+
+    # ...but a staged bump whose checkout drifted off it AGAIN is still a hazard.
+    git(sub, "checkout", "-q", pin_sha)
+    rc, out = run_tool(["--rev", "HEAD"], sup)
+    check("a staged bump with a drifted checkout is still a hazard",
+          rc == 1, f"rc={rc}: {out}")
+
+    # ---------------------------------------------------------------- the gap
+    git(sup, "reset", "-q", "HEAD", "--")     # unstage the bump
+    git(sub, "checkout", "-q", pin_sha)
+    # `origin/master` does not exist in the fixture submodule, so the gap must
+    # report that it could NOT measure -- never 0. "the run printed nothing to
+    # read" and "the gap is zero" are different facts.
+    gap, why = cp.measure_gap(cp._default_runner, sup, pin_sha)
+    check("a gap with no origin/master is unmeasurable, not zero",
+          gap is None and "origin/master" in why, f"gap={gap} why={why}")
+
+    # Make one, and the count must be exact -- 1 commit, the shape the issue's
+    # incident got wrong as 17.
+    git(sub, "remote", "add", "up", corpus, check_rc=False)
+    git(sub, "fetch", "-q", "up", f"{later_sha}:refs/remotes/origin/master")
+    gap, why = cp.measure_gap(cp._default_runner, sup, pin_sha)
+    check("the gap from the pin is counted exactly", gap == 1, f"gap={gap} why={why}")
+
+    # And the gap is measured from the PIN, so poisoning the checkout cannot
+    # change it. This is the actual defect: 1 commit read as 17.
+    git(sub, "checkout", "-q", later_sha)
+    gap_poisoned, _ = cp.measure_gap(cp._default_runner, sup, pin_sha)
+    check("a poisoned checkout does not change the measured gap",
+          gap_poisoned == 1, f"{gap_poisoned} != 1")
+    # ...whereas the read the issue warns about would have said 0 from here.
+    wrong = git(sub, "rev-list", "--count", "HEAD..refs/remotes/origin/master")
+    check("the wrong read really does give a different number",
+          wrong != "1", f"the fixture does not demonstrate the defect (wrong={wrong})")
+
+# ------------------------------------------ an UNPOPULATED submodule directory
+# `git worktree add` does not populate submodules, so this is the state of every
+# fresh worktree -- and `git -C <empty dir> rev-parse HEAD` walks UP and returns
+# the SUPERPROJECT's commit with exit 0. Reporting that as a divergence would fire
+# the guard in every new worktree, which is how a guard gets ignored. Caught by
+# running the tool for real rather than by reading it.
+with tempfile.TemporaryDirectory() as tmp:
+    sup = os.path.join(tmp, "super")
+    os.makedirs(sup)
+    _init(sup)
+    with open(os.path.join(sup, "R"), "w") as fh:
+        fh.write("x\n")
+    git(sup, "add", "R")
+    git(sup, "commit", "-qm", "init")
+    # The directory exists and is EMPTY, exactly as in a fresh worktree.
+    os.makedirs(os.path.join(sup, "tests/al-language"))
+    sup_head = git(sup, "rev-parse", "HEAD")
+
+    raw = git(os.path.join(sup, "tests/al-language"), "rev-parse", "HEAD")
+    check("git really does answer the SUPERPROJECT commit from an empty submodule dir",
+          raw == sup_head, f"{raw!r} vs {sup_head!r} - the trap no longer reproduces")
+    check("an unpopulated submodule reads as absent, NOT as the superproject commit",
+          cp.read_worktree_head(cp._default_runner, sup) is None,
+          f"got {cp.read_worktree_head(cp._default_runner, sup)!r}")
+
+
+# ------------------------------------------------------- not a repository at all
+with tempfile.TemporaryDirectory() as tmp:
+    # Exit 2 -- "could not read" -- and never 0 or 1, which are verdicts.
+    empty = os.path.join(tmp, "plain")
+    os.makedirs(empty)
+    _init(empty)
+    with open(os.path.join(empty, "f"), "w") as fh:
+        fh.write("x\n")
+    git(empty, "add", "f")
+    git(empty, "commit", "-qm", "no submodule here")
+    buf, old = io.StringIO(), sys.stderr
+    sys.stderr = buf
+    try:
+        rc = cp.main(["--rev", "HEAD", "--root", empty])
+    finally:
+        sys.stderr = old
+    check("a repository with no corpus submodule exits 2, not a verdict",
+          rc == 2, f"rc={rc}")
+    check("and says there is no pin to read",
+          "no corpus pin" in buf.getvalue() or "gitlink" in buf.getvalue(),
+          buf.getvalue())
+
+print()
+if FAILURES:
+    print(f"{len(FAILURES)} FAILED: {', '.join(FAILURES)}")
+    sys.exit(1)
+print("all corpus-pin tests passed")

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -1802,8 +1802,9 @@ _OTHER = "17b015efdc6cd52aed789cbbfc522d7cf1040155"
 _STAGED = "9ee6bbcd12d433547f230d36d017231d53a17937"
 
 
-def pin_readings(pin=_PIN, index=None, worktree=None, error=""):
-    return {"pin": pin, "index": index, "worktree": worktree, "error": error}
+def pin_readings(pin=_PIN, index=None, worktree=None, error="", head=None):
+    return {"pin": pin, "index": index, "head": head,
+            "worktree": worktree, "error": error}
 
 
 # ---- agreement is a PASS, and it says which commit it verified
@@ -1829,21 +1830,43 @@ check("the WARN says why it is not a FAIL",
       "always available" in (_res.remedy or ""), _res.remedy)
 
 # ---- the three-way case measured live on this box while #3404 was open
-_res = pf.classify_corpus_pin(pin_readings(index=_STAGED, worktree=_OTHER))
+_res = pf.classify_corpus_pin(pin_readings(index=_STAGED, head=_STAGED, worktree=_OTHER))
 check("a third value belonging to neither end still WARNs",
       _res.status == "WARN", f"{_res.status}: {_res.summary}")
 check("...and compares against the STAGED pin, which is what that checkout owes",
       _STAGED[:8] in _res.summary, _res.summary)
-check("...and reports all three readings, never collapsing them to one",
-      sum(1 for d in _res.detail
-          if _PIN[:8] in d or _STAGED[:8] in d or _OTHER[:8] in d) == 3, _res.detail)
+check("...and reports every reading, never collapsing them to one",
+      all(any(v[:8] in d for d in _res.detail)
+          for v in (_PIN, _STAGED, _OTHER)), _res.detail)
 
 # ---- a bump in progress is correct work and must not be flagged
 # The branch has moved its own gitlink AND its submodule checkout together. A
 # check that fires on this trains the reader to ignore it.
-_res = pf.classify_corpus_pin(pin_readings(index=_STAGED, worktree=_STAGED))
+_res = pf.classify_corpus_pin(pin_readings(index=_STAGED, head=_STAGED, worktree=_STAGED))
 check("a staged bump whose checkout matches it is not a finding",
       _res.status == "PASS", f"{_res.status}: {_res.summary}")
+
+# ---- BEHIND is not MID-BUMP, and the wrong one must not be called "the pin"
+# The index carries a gitlink at all times, so an UNSTAGED index pin equal to this
+# checkout's own HEAD is just a behind worktree -- the common case. Calling that
+# value "the pin" in the summary is a second wrong statement on the same line, and
+# it is the value the reader is being told to trust.
+_res = pf.classify_corpus_pin(pin_readings(head=_STAGED, worktree=_STAGED))
+check("a behind checkout whose submodule matches its own HEAD is not a hazard",
+      _res.status == "PASS", f"{_res.status}: {_res.summary}")
+check("...and is reported as behind rather than as agreement with origin/main",
+      "behind" in _res.summary.lower(), _res.summary)
+check("...and never calls this checkout's stale HEAD pin 'the pin'",
+      f"not the pin {_STAGED[:8]}" not in _res.summary, _res.summary)
+
+# A behind checkout whose SHARED directory has also drifted is still a hazard, and
+# the reference it names is this checkout's own HEAD pin -- not origin/main's,
+# which this checkout does not claim to be at.
+_res = pf.classify_corpus_pin(pin_readings(head=_STAGED, worktree=_OTHER))
+check("a behind checkout with a drifted shared directory still WARNs",
+      _res.status == "WARN", f"{_res.status}: {_res.summary}")
+check("...naming the commit this checkout expects, not origin/main's",
+      _STAGED[:8] in _res.summary and _OTHER[:8] in _res.summary, _res.summary)
 
 # ---- "could not read" is not "they agree"
 _res = pf.classify_corpus_pin(pin_readings(worktree=None,
@@ -1915,8 +1938,10 @@ try:
           _read["pin"] != _second, f"{_read}")
     check("the gatherer reads the working directory as what it is",
           _read["worktree"] == _second, f"{_read}")
-    check("the gatherer reads the INDEX pin from the index, not from HEAD",
-          _read["index"] == _first, f"{_read}")
+    check("the gatherer reads THIS checkout's HEAD pin separately from origin/main's",
+          _read["head"] == _first, f"{_read}")
+    check("...and reads no STAGED pin, because nothing was staged",
+          _read["index"] is None, f"{_read}")
     check("...and the two genuinely disagree, so the fixture proves the point",
           _first != _second)
     check("a poisoned checkout is classified as a WARN end to end",

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -1788,6 +1788,170 @@ check("the default is still SKIP, never folded into the passing count",
       _res.status == "SKIP", _res.status)
 
 
+# --------------------------------------------------------------------------
+# the shared corpus submodule checkout (#3404)
+# --------------------------------------------------------------------------
+# Classification is tested against captured readings rather than a live box: the
+# hazard is a state some OTHER process leaves behind, so a suite that reads the
+# real submodule passes for the wrong reason whenever the box happens to be clean
+# and cannot be made to fail on demand. The end-to-end proof that the readings
+# themselves are gathered correctly is in tools/test_corpus_pin.py, which builds a
+# real superproject and really moves its submodule off the pin.
+_PIN = "af01bbbc176b4cc5ca3d7020094103911af51a35"
+_OTHER = "17b015efdc6cd52aed789cbbfc522d7cf1040155"
+_STAGED = "9ee6bbcd12d433547f230d36d017231d53a17937"
+
+
+def pin_readings(pin=_PIN, index=None, worktree=None, error=""):
+    return {"pin": pin, "index": index, "worktree": worktree, "error": error}
+
+
+# ---- agreement is a PASS, and it says which commit it verified
+_res = pf.classify_corpus_pin(pin_readings(worktree=_PIN))
+check("a shared checkout sitting at the pin PASSes",
+      _res.status == "PASS", f"{_res.status}: {_res.summary}")
+check("...and names the commit it agreed on",
+      _PIN[:8] in _res.summary, _res.summary)
+
+# ---- THE REAL SHAPE: the working directory is at a commit that is not the pin
+_res = pf.classify_corpus_pin(pin_readings(worktree=_OTHER))
+check("a shared checkout that is NOT at the pin WARNs",
+      _res.status == "WARN", f"{_res.status}: {_res.summary}")
+check("...naming both the wrong commit and the pin, so the reader can see the gap",
+      _OTHER[:8] in _res.summary and _PIN[:8] in _res.summary, _res.summary)
+check("...and it explains the sharing, which is why it has no owner",
+      any("shared by EVERY worktree" in d for d in _res.detail), _res.detail)
+check("...and the remedy is the tree read, not a checkout inside the submodule",
+      "ls-tree" in (_res.remedy or "") and "--quiet" in (_res.remedy or ""), _res.remedy)
+# The severity is deliberate and load-bearing: a FAIL here would halt every agent
+# on the box, repository-wide, for a hazard one documented command sidesteps.
+check("the WARN says why it is not a FAIL",
+      "always available" in (_res.remedy or ""), _res.remedy)
+
+# ---- the three-way case measured live on this box while #3404 was open
+_res = pf.classify_corpus_pin(pin_readings(index=_STAGED, worktree=_OTHER))
+check("a third value belonging to neither end still WARNs",
+      _res.status == "WARN", f"{_res.status}: {_res.summary}")
+check("...and compares against the STAGED pin, which is what that checkout owes",
+      _STAGED[:8] in _res.summary, _res.summary)
+check("...and reports all three readings, never collapsing them to one",
+      sum(1 for d in _res.detail
+          if _PIN[:8] in d or _STAGED[:8] in d or _OTHER[:8] in d) == 3, _res.detail)
+
+# ---- a bump in progress is correct work and must not be flagged
+# The branch has moved its own gitlink AND its submodule checkout together. A
+# check that fires on this trains the reader to ignore it.
+_res = pf.classify_corpus_pin(pin_readings(index=_STAGED, worktree=_STAGED))
+check("a staged bump whose checkout matches it is not a finding",
+      _res.status == "PASS", f"{_res.status}: {_res.summary}")
+
+# ---- "could not read" is not "they agree"
+_res = pf.classify_corpus_pin(pin_readings(worktree=None,
+                                           error="tests/al-language is not initialised"))
+check("an uninitialised submodule cannot mislead anyone, so it PASSes",
+      _res.status == "PASS", f"{_res.status}: {_res.summary}")
+check("...but says so rather than claiming the readings were verified equal",
+      "no shared corpus checkout" in _res.summary, _res.summary)
+
+_res = pf.classify_corpus_pin(pin_readings(pin=None, worktree=_OTHER))
+check("an unreadable pin is not a divergence verdict",
+      _res.status == "PASS", f"{_res.status}: {_res.summary}")
+
+# ---- the gatherer reads the TREE, never the working directory
+# Proven end-to-end against a real repository: the superproject's tree says one
+# commit and the submodule checkout says another, and the `pin` reading must be
+# the tree's. This is the misreading the whole issue is about.
+_pin_tmp = tempfile.mkdtemp()
+try:
+    _sub = os.path.join(_pin_tmp, "corpus")
+    os.makedirs(_sub)
+    subprocess.run(["git", "init", "-q", "-b", "master", _sub], check=True,
+                   capture_output=True)
+
+    def _g(root, *a):
+        return subprocess.run(["git", "-C", root, *a], capture_output=True,
+                              text=True).stdout.strip()
+
+    _g(_sub, "config", "user.email", "t@example.invalid")
+    _g(_sub, "config", "user.name", "T")
+    open(os.path.join(_sub, "a"), "w").write("1\n")
+    _g(_sub, "add", "a")
+    _g(_sub, "commit", "-qm", "one")
+    _first = _g(_sub, "rev-parse", "HEAD")
+    open(os.path.join(_sub, "b"), "w").write("2\n")
+    _g(_sub, "add", "b")
+    _g(_sub, "commit", "-qm", "two")
+    _second = _g(_sub, "rev-parse", "HEAD")
+    _g(_sub, "checkout", "-q", _first)
+
+    _sup = os.path.join(_pin_tmp, "super")
+    os.makedirs(_sup)
+    subprocess.run(["git", "init", "-q", "-b", "main", _sup], check=True,
+                   capture_output=True)
+    _g(_sup, "config", "user.email", "t@example.invalid")
+    _g(_sup, "config", "user.name", "T")
+    open(os.path.join(_sup, "r"), "w").write("x\n")
+    _g(_sup, "add", "r")
+    _g(_sup, "commit", "-qm", "init")
+    _g(_sup, "-c", "protocol.file.allow=always", "submodule", "add", "-q", _sub,
+       "tests/al-language")
+    _g(_sup, "commit", "-qm", "pin the corpus")
+
+    # `origin/main` is what the gatherer reads the pin out of, so give the fixture
+    # one -- pointing at the commit that pinned the corpus at _first.
+    _g(_sup, "update-ref", "refs/remotes/origin/main", _g(_sup, "rev-parse", "HEAD"))
+
+    # Move the SHARED checkout off the pin, exactly as another process would.
+    _g(os.path.join(_sup, "tests/al-language"), "checkout", "-q", _second)
+
+    _read = pf.corpus_pin_readings(_sup)
+    # THE CLAIM, stated directly: the pin comes out of origin/main's TREE, so it is
+    # _first even though the submodule's HEAD now says _second. Read from the
+    # working directory instead and this reading becomes _second -- which is the
+    # entire defect #3404 is about, and nothing else in this suite would notice.
+    check("the gatherer reads the pin from origin/main's TREE, not from the checkout",
+          _read["pin"] == _first, f"pin={_read['pin']} first={_first} second={_second}")
+    check("...and specifically NOT the commit the shared checkout is sitting on",
+          _read["pin"] != _second, f"{_read}")
+    check("the gatherer reads the working directory as what it is",
+          _read["worktree"] == _second, f"{_read}")
+    check("the gatherer reads the INDEX pin from the index, not from HEAD",
+          _read["index"] == _first, f"{_read}")
+    check("...and the two genuinely disagree, so the fixture proves the point",
+          _first != _second)
+    check("a poisoned checkout is classified as a WARN end to end",
+          pf.classify_corpus_pin(_read).status == "WARN",
+          pf.classify_corpus_pin(_read).summary)
+
+    # An UNPOPULATED submodule directory -- the state of every fresh worktree,
+    # because `git worktree add` does not populate submodules. `git -C <empty dir>
+    # rev-parse HEAD` walks UP and returns the SUPERPROJECT's commit, exit 0, so
+    # the naive read reports a divergence in every new worktree. A check that is
+    # wrong by default is one people learn to skip, which is worse than no check.
+    _bare = os.path.join(_pin_tmp, "bare")
+    os.makedirs(_bare)
+    subprocess.run(["git", "init", "-q", "-b", "main", _bare], check=True,
+                   capture_output=True)
+    _g(_bare, "config", "user.email", "t@example.invalid")
+    _g(_bare, "config", "user.name", "T")
+    open(os.path.join(_bare, "R"), "w").write("x\n")
+    _g(_bare, "add", "R")
+    _g(_bare, "commit", "-qm", "init")
+    os.makedirs(os.path.join(_bare, "tests/al-language"))
+    _bare_head = _g(_bare, "rev-parse", "HEAD")
+    check("git really answers the SUPERPROJECT commit from an empty submodule dir",
+          _g(os.path.join(_bare, "tests/al-language"), "rev-parse", "HEAD") == _bare_head,
+          "the trap no longer reproduces; this test is no longer proving anything")
+    _bare_read = pf.corpus_pin_readings(_bare)
+    check("an unpopulated submodule is not read as a corpus checkout",
+          _bare_read["worktree"] is None, f"{_bare_read}")
+    check("...and a fresh worktree therefore does not WARN",
+          pf.classify_corpus_pin(_bare_read).status == "PASS",
+          pf.classify_corpus_pin(_bare_read).summary)
+finally:
+    shutil.rmtree(_pin_tmp, ignore_errors=True)
+
+
 print()
 if FAILURES:
     print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")


### PR DESCRIPTION
Closes #3404

Corpus-NA: agent tooling and operating docs only; this reads a git submodule pin and asserts nothing about BC behaviour, so no corpus test could adjudicate it

## What I built, and why not just documentation

The issue is labelled `documentation`, and the rule it names was **already written down** in `.claude/rules/al-language-submodule.md` when it was violated three times in one session by three different actors. So I treated "more prose" as the option to disprove rather than the default, and built the mechanism. Documentation still changed — but because it was **wrong**, not merely unread (below).

Three parts:

**1. `tools/corpus-pin.py` — one obvious call instead of two plausible ones.**

```
git ls-tree origin/main tests/al-language     # THE PIN — what CI replays
git -C tests/al-language rev-parse HEAD       # whatever a process left behind
```

Both exit 0, both print a real SHA, and they answer different questions. The tool reports **all three** readings (origin/main's tree, this checkout's index, the shared working directory) labelled and kept apart, because the divergence *is* the finding — collapsing them to one number discards it. Exit 1 when the shared checkout has drifted; exit 2 for "could not read", which is never a verdict about the pin.

`--quiet` prints the **pin** even when it exits 1, so a caller that ignores the exit code still captures the right value rather than the poisoned one. That is the likeliest caller.

**2. `tools/preflight.py` — a `corpus-pin` check. Severity WARN.**

The FAIL case is genuinely arguable and I want the argument on the record, since a stale checkout does produce wrong answers. Two things decided it:

- The doctrine at the top of that file keeps FAIL for a condition with **no fallback that still produces correct work** — the stray graphify graph, the one thing there that can FAIL, has none, because no rebuild reaches it. This one's fallback is `git ls-tree`, which is always available and cannot see the working directory at all. An agent that uses it (or this tool, or the CI scripts, which already do) works correctly on a poisoned box.
- FAIL halts the autonomous cycle, and this condition is **repository-wide and not self-healing**. One stray checkout would stop every agent on the box from starting *any* work, including work that never touches the corpus, until a human intervened. A check that can halt everything for a condition most cycles do not care about is a check people route around.

**3. The documentation was teaching the wrong read.** This is the part that changes the "is prose enough" answer. `.claude/skills/al-runner-tests/SKILL.md`'s bump recipe was:

```
git -C tests/al-language log --oneline HEAD..origin/master   # HEAD = the shared directory
git -C tests/al-language checkout origin/master              # the act that poisons it
```

So the canonical recipe both performed the wrong read *and* instructed the poisoning checkout. Corrected in the skill and the rule; the `checkout` is now scoped to the bump itself, where the `git add` that follows makes checkout and pin agree again, with a separate-clone recipe for measuring.

Also recorded the second hazard from the issue — 18 bundles failing on one identical missing `ncl-shadow` path from concurrent agents sharing that cache — under "Interpreting output", where someone reading a wholesale EXEC-FAIL sweep would look. An unattended loop filing from that sweep files nonsense.

## RED → GREEN, both directions

Two mutations per component, run against the real suites. Full output in the task record.

| mutation | result |
|---|---|
| `read_pin` returns the working-directory HEAD | **RED** — fixture-divergence assertion fails |
| `worktree_diverged` always returns `False` | **RED** — 6 failures: exit code, hazard text, `--quiet`, bump case |
| preflight gatherer reads the pin from the checkout | **RED** — `pin=bc8788f2` (checkout) vs `first=eea3febc` (tree) |
| `classify_corpus_pin` never warns | **RED** — 7 failures, incl. the false "is at the pin" claim |
| unmutated | **GREEN** — 35/35 and 23/23; all 11 `tools/test_*.py` suites pass |

The divergence tests build **real** git repositories with a real submodule and really move the shared checkout off the pin. A hand-written fixture cannot prove this: the whole reason the misreading survives is that every command involved exits 0 and prints a plausible SHA, which a fake runner would reproduce whether the tool were right or wrong.

**One RED did not fire on the first attempt, and that was the useful one.** Corrupting only the `pin` reading left the verdict unchanged, because `worktree_diverged` compares against the *index* pin when there is one. No test asserted the `pin` reading came from the tree — a real coverage gap in my own suite. I added `the gatherer reads the pin from origin/main's TREE, not from the checkout`, re-ran the same mutation, and it failed as it should.

**Live on this box**, where the poisoning is real and current — three values at once, which is the shape from incident 1:

```
pin on origin/main        af01bbbc   <- THE PIN: what CI replays
pin staged in this index  9ee6bbcd   (a bump in progress)
shared working directory  17b015ef   <- NOT THE PIN      exit=1
```

`--quiet` on that same repository returns `9ee6bbcd…`, not `17b015ef…`.

## A false positive that only running it found

`git worktree add` does **not** populate submodules, so `tests/al-language/` is an empty directory in every fresh worktree — and `git -C <empty dir> rev-parse HEAD` walks **up** to the superproject and returns the **superproject's** commit with exit 0. My worktree at `4e4abbcb` reported `4e4abbcb` as its "corpus checkout" and warned.

A guard that fires in every new worktree is one nobody reads, which would have quietly defeated the whole change. Both readers now compare `--show-toplevel` against the directory and treat an unpopulated submodule as absent. Pinned by a test that first asserts the trap still reproduces, so it cannot rot into passing vacuously.

Reading the code would not have caught this. Reading it, `os.path.isdir` plus `rev-parse HEAD` looks correct.

## Sibling issues — scanned, not folded

- **#3335** (preflight reaper: submodule drift reads as uncommitted work) — same *file*, different region and different reasoning. Deciding when a dirty submodule is safe to **delete a worktree over** is a data-loss judgment; mine is a reporting one. Rule 4 of `batch-sibling-issues-by-file.md` is the deciding test, and a reviewer checking "does this read the pin correctly" is not doing the same work as one checking "is it safe to reap this tree". Left open and unclaimed.
- **#3299** (`check_corpus_pin_forward.sh` passes silently when `SUBMODULE_PATH` matches nothing) — closest sibling in *subject*, but its fix lands in `.github/scripts/` and its own test file, which I do not touch. Not foldable under the same-file rule. Worth noting that script already reads the pin correctly, with a comment saying why.

## Scope notes

- No `AlRunner/` paths, so `Tests updated` does not fire and no `docs-only` label is needed. I validated the corpus-linkage gate in **both** directions rather than assuming: my real diff → `no corpus declaration is required`; an in-scope path with the `Corpus-NA:` line above → accepted; the same path without it → rejected.
- `tools/test_corpus_pin.py` is discovered by `pr-gate.yml`'s `tools-tests` glob (`suites=(tools/test_*.py)`), so it gates the day it lands with no workflow edit.
- Nothing under `tests/al-language/` was edited, and no `git checkout` was run inside it — which would have been an ironic way to fix this issue.

---

*Written by `stma-auto-2`, an automated implementation agent acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsJY7DhDm5y83e77GxpRSZ
