### PR TITLE
fix(transactions): end the write transaction at the test-method boundary BC ends it at

### DIFF
--- a/AlRunner.Tests/TransactionModelCommitRefusalTests.cs
+++ b/AlRunner.Tests/TransactionModelCommitRefusalTests.cs
@@ -131,30 +131,6 @@ public class TransactionModelCommitRefusalTests
                 Helpers: Codeunit "TXM Helpers";
                 RefusalTxt: Label 'Tests cannot call the Commit function if TransactionModel property is set to AutoRollback.', Locked = true;
 
-            // The guard is BC's, and BC writes it into ALDatabase.ALCommit only. A guarded
-            // Codeunit.Run ends its nested transaction through EndTransactionWorldAndTransaction
-            // instead, which is not an AL Commit() statement and is not refused — so the runner
-            // must not route that internal commit through the refusal.
-            [Test]
-            [TransactionModel(TransactionModel::AutoRollback)]
-            procedure AutoRollback_GuardedCodeunitRunIsNotRefused()
-            var
-                Runnable: Codeunit "TXM Runnable";
-                Probe: Record "TXM Probe";
-            begin
-                // DECLARED FIRST ON PURPOSE, and do not reorder: AlRunner#3468 — the runner's
-                // write-transaction flag survives a test-method boundary, so any arm below that
-                // writes without committing leaves this guarded Codeunit.Run refused with "the
-                // transaction is stopped" instead of measuring what it is here to measure. It
-                // also writes nothing itself, for the same reason within the method (corpus
-                // TestCodeunitRunWriteTransaction). Entry 20 is used here and nowhere else.
-                if not Runnable.Run() then
-                    Error('TXM7 FAIL: a guarded Codeunit.Run inside an AutoRollback test must succeed, got [%1]', GetLastErrorText());
-
-                if not Probe.Get(20) then
-                    Error('TXM7 FAIL: the run codeunit''s row must be visible after a successful guarded run');
-            end;
-
             // Arm (a): the refusal itself.
             [Test]
             [TransactionModel(TransactionModel::AutoRollback)]
@@ -222,6 +198,33 @@ public class TransactionModelCommitRefusalTests
 
                 if Probe.Get(11) then
                     Error('TXM4 FAIL: an ignored Commit() must not move the rollback boundary, so the unrelated error must undo the Insert');
+            end;
+
+            // The guard is BC's, and BC writes it into ALDatabase.ALCommit only. A guarded
+            // Codeunit.Run ends its nested transaction through EndTransactionWorldAndTransaction
+            // instead, which is not an AL Commit() statement and is not refused — so the runner
+            // must not route that internal commit through the refusal.
+            //
+            // DECLARED HERE ON PURPOSE (AlRunner#3468), directly behind the arm above, which
+            // ends with an Insert that is rolled back and never committed. Until #3468 this arm
+            // had to be declared FIRST in the codeunit: the runner's write-transaction flag
+            // survived the test-method boundary, so the guarded Codeunit.Run was refused with
+            // "the transaction is stopped" before it could measure anything. Sitting behind a
+            // pending write is now the point — a regression in the boundary reset fails here as
+            // well as in WriteTransactionTestBoundaryTests. Entry 20 is used here and nowhere
+            // else.
+            [Test]
+            [TransactionModel(TransactionModel::AutoRollback)]
+            procedure AutoRollback_GuardedCodeunitRunIsNotRefused()
+            var
+                Runnable: Codeunit "TXM Runnable";
+                Probe: Record "TXM Probe";
+            begin
+                if not Runnable.Run() then
+                    Error('TXM7 FAIL: a guarded Codeunit.Run inside an AutoRollback test must succeed, got [%1]', GetLastErrorText());
+
+                if not Probe.Get(20) then
+                    Error('TXM7 FAIL: the run codeunit''s row must be visible after a successful guarded run');
             end;
 
             // Arm (e): both guards apply, and the TransactionModel one is evaluated first, so

--- a/AlRunner.Tests/WriteTransactionTestBoundaryTests.cs
+++ b/AlRunner.Tests/WriteTransactionTestBoundaryTests.cs
@@ -11,7 +11,7 @@ namespace AlRunner.Tests;
 /// uncommitted.
 ///
 /// The BEHAVIOURAL claim is plain BC behaviour and lives upstream (see the PR body's
-/// <c>Corpus-PR:</c> line, codeunit 60898 "Test Write Tx Test Boundary"), per
+/// <c>Corpus-PR:</c> line, codeunit 60878 "Test Write Tx Test Boundary"), per
 /// .claude/rules/bc-behavior-tests-go-upstream.md. This test spawns the real runner against a
 /// synthetic bundle so a regression in the runner's own boundary handling fails loudly here
 /// without depending on the submodule pin having moved.

--- a/AlRunner.Tests/WriteTransactionTestBoundaryTests.cs
+++ b/AlRunner.Tests/WriteTransactionTestBoundaryTests.cs
@@ -1,0 +1,210 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Runner-mechanism test for issue #3468: the write-transaction flag behind
+/// <c>Database.IsInWriteTransaction()</c> must not survive a test-method boundary, so a later
+/// test's guarded <c>Codeunit.Run</c> is not refused by a write the PREVIOUS test left
+/// uncommitted.
+///
+/// The BEHAVIOURAL claim is plain BC behaviour and lives upstream (see the PR body's
+/// <c>Corpus-PR:</c> line, codeunit 60898 "Test Write Tx Test Boundary"), per
+/// .claude/rules/bc-behavior-tests-go-upstream.md. This test spawns the real runner against a
+/// synthetic bundle so a regression in the runner's own boundary handling fails loudly here
+/// without depending on the submodule pin having moved.
+///
+/// No Base Application dependency (.claude/rules/no-base-app-in-csharp-tests.md): each AL test
+/// raises its own Error() carrying the observed state, and the runner's PASS/FAIL output is the
+/// assertion surface.
+/// </summary>
+public class WriteTransactionTestBoundaryTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunRunner(params string[] bundles)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        foreach (var b in bundles) args.Append(" \"").Append(b).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    [SkippableFact]
+    public void UncommittedWriteInAnEarlierTest_DoesNotLeaveTheNextTestInAWriteTransaction()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = TestScratch.Dir("al-runner-writetx-boundary-3468");
+        Directory.CreateDirectory(root);
+
+        File.WriteAllText(Path.Combine(root, "app.json"), """
+        {
+          "id": "b3468000-0000-4000-8000-000000003468",
+          "name": "WriteTxBoundary3468",
+          "publisher": "Repro3468",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62470, "to": 62479 } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(root, "TxbProbe.al"), """
+        table 62470 "TXB Probe"
+        {
+            DataClassification = SystemMetadata;
+
+            fields
+            {
+                field(1; "Entry No."; Integer) { }
+            }
+
+            keys
+            {
+                key(PK; "Entry No.") { Clustered = true; }
+            }
+        }
+
+        codeunit 62472 "TXB Runnable"
+        {
+            trigger OnRun()
+            var
+                Probe: Record "TXB Probe";
+            begin
+                Probe."Entry No." := 90;
+                Probe.Insert();
+            end;
+        }
+
+        // A second runnable with its own key, because a successful guarded Codeunit.Run
+        // COMMITS its own transaction (corpus TestCodeunitRunWriteTransaction), so the row
+        // codeunit 62472 writes is still there when the later test runs — re-running 62472
+        // would fail on a duplicate key instead of measuring the boundary.
+        codeunit 62473 "TXB Runnable Two"
+        {
+            trigger OnRun()
+            var
+                Probe: Record "TXB Probe";
+            begin
+                Probe."Entry No." := 93;
+                Probe.Insert();
+            end;
+        }
+
+        codeunit 62470 "TXB Tests"
+        {
+            Subtype = Test;
+            TestPermissions = Disabled;
+
+            // Declaration order IS the fixture. Each writing test below deliberately does not
+            // Commit(), and the guarded-run test that follows it asserts the platform ended
+            // that write transaction at the test-method boundary.
+
+            [Test]
+            [TransactionModel(TransactionModel::AutoRollback)]
+            procedure A_AutoRollbackTestWritesWithoutCommitting()
+            var
+                Probe: Record "TXB Probe";
+            begin
+                Probe."Entry No." := 91;
+                Probe.Insert();
+
+                if not Database.IsInWriteTransaction() then
+                    Error('TXB1 FAIL: an uncommitted Insert must open a write transaction inside the test that made it');
+            end;
+
+            [Test]
+            [TransactionModel(TransactionModel::AutoRollback)]
+            procedure B_WritesNothingAtAll()
+            begin
+                if Database.IsInWriteTransaction() then
+                    Error('TXB2 FAIL: a test that writes nothing must not start inside a write transaction left by the previous test');
+            end;
+
+            [Test]
+            [TransactionModel(TransactionModel::AutoRollback)]
+            procedure C_GuardedCodeunitRunIsAllowed()
+            var
+                Runnable: Codeunit "TXB Runnable";
+                Probe: Record "TXB Probe";
+            begin
+                if Database.IsInWriteTransaction() then
+                    Error('TXB3 FAIL: no write transaction may be pending at the start of this test');
+
+                if not Runnable.Run() then
+                    Error('TXB3 FAIL: a guarded Codeunit.Run must be allowed here, got [%1]', GetLastErrorText());
+
+                if not Probe.Get(90) then
+                    Error('TXB3 FAIL: the run codeunit''s row must be visible after a successful guarded run');
+            end;
+
+            // The same claim for the DEFAULT transaction model, where BC ends the transaction
+            // by committing rather than by rolling back.
+            [Test]
+            procedure D_DefaultModelTestWritesWithoutCommitting()
+            var
+                Probe: Record "TXB Probe";
+            begin
+                Probe."Entry No." := 92;
+                Probe.Insert();
+
+                if not Database.IsInWriteTransaction() then
+                    Error('TXB4 FAIL: an uncommitted Insert must open a write transaction inside the test that made it');
+            end;
+
+            [Test]
+            procedure E_GuardedCodeunitRunIsStillAllowed()
+            var
+                Runnable: Codeunit "TXB Runnable Two";
+                Probe: Record "TXB Probe";
+            begin
+                if Database.IsInWriteTransaction() then
+                    Error('TXB5 FAIL: the previous test''s uncommitted write must have been committed at the test-method boundary');
+
+                if not Runnable.Run() then
+                    Error('TXB5 FAIL: a guarded Codeunit.Run must be allowed here, got [%1]', GetLastErrorText());
+
+                if not Probe.Get(93) then
+                    Error('TXB5 FAIL: the run codeunit''s row must be visible after a successful guarded run');
+
+                // The previous test ran under the default model, so BC COMMITTED its write —
+                // the row is still there. This is the negative direction of the same boundary:
+                // ending the transaction must not mean discarding the rows.
+                if not Probe.Get(92) then
+                    Error('TXB5 FAIL: a default-model test''s write is committed at the boundary, so the row must still be visible');
+            end;
+        }
+        """);
+
+        var (output, exitCode) = RunRunner(root);
+
+        Assert.True(exitCode == 0,
+            $"Expected all five tests to pass (exit 0); got exit {exitCode}.\n{output}");
+        Assert.DoesNotContain("FAIL", output);
+        Assert.Contains("PASS  Codeunit62470.A_AutoRollbackTestWritesWithoutCommitting", output);
+        Assert.Contains("PASS  Codeunit62470.B_WritesNothingAtAll", output);
+        Assert.Contains("PASS  Codeunit62470.C_GuardedCodeunitRunIsAllowed", output);
+        Assert.Contains("PASS  Codeunit62470.D_DefaultModelTestWritesWithoutCommitting", output);
+        Assert.Contains("PASS  Codeunit62470.E_GuardedCodeunitRunIsStillAllowed", output);
+    }
+}

--- a/AlRunner/Patches/ALDatabasePatches.cs
+++ b/AlRunner/Patches/ALDatabasePatches.cs
@@ -481,14 +481,11 @@ public static class ALDatabasePatches
     }
 
     /// <summary>
-    /// End the session's write transaction at a TEST-METHOD boundary, the way BC's
-    /// NavTestCodeunit.ExecuteTestMethodAsync does — <c>case TestTransactionModel.AutoCommit:
-    /// activeSession.Commit();</c>, <c>case TestTransactionModel.AutoRollback:
-    /// activeSession.Rollback();</c>, and the surrounding <c>catch (Exception) { if
-    /// (activeSession.IsTransactionActive()) activeSession.Rollback(); }</c> when the method
-    /// threw (decompiled Ncl.dll 28.4.53241.54039). All three end the transaction, so the next
-    /// [Test] in the codeunit starts with nothing pending for
-    /// <see cref="ThrowIfWriteTransactionStarted"/> to fire on. AlRunner#3468.
+    /// End the session's write transaction at a TEST-METHOD boundary. BC does it in every arm
+    /// of NavTestCodeunit.ExecuteTestMethodAsync (Ncl.dll 28.4.53241.54039) except None —
+    /// commit, rollback, or rollback from the catch — so the next [Test] in the codeunit
+    /// starts with nothing pending for <see cref="ThrowIfWriteTransactionStarted"/> to fire
+    /// on. AlRunner#3468; the arm-by-arm reading is in that PR's body.
     ///
     /// <para>Flag only — deliberately NOT a commit point, and deliberately not a rollback.
     /// Which rows survive is decided separately by TestExecutor.ApplyTestTransactionModel

--- a/AlRunner/Patches/ALDatabasePatches.cs
+++ b/AlRunner/Patches/ALDatabasePatches.cs
@@ -45,7 +45,9 @@ public static class ALDatabasePatches
     // committed". BC opens the write transaction on the first write of the AL call and
     // ends it at Commit (or when the invocation unwinds). That is exactly what this flag
     // models — set from the same AL write entry points that move the row-version clock,
-    // cleared by Commit and at the per-test isolation boundary.
+    // cleared by Commit, at the end of every test METHOD (see
+    // TestExecutor.ApplyTestTransactionModel and EndWriteTransactionAtTestBoundary below),
+    // and at the per-test-CODEUNIT isolation boundary (ResetWriteTransactionState).
     //
     // NOT faithful for: rollback semantics (the runner's store has none — see
     // docs/limitations.md) and nested/explicit transaction scopes.
@@ -477,6 +479,25 @@ public static class ALDatabasePatches
                 + $"(runner could not build BC's own message: {ex.GetType().Name})");
         }
     }
+
+    /// <summary>
+    /// End the session's write transaction at a TEST-METHOD boundary, the way BC's
+    /// NavTestCodeunit.ExecuteTestMethodAsync does — <c>case TestTransactionModel.AutoCommit:
+    /// activeSession.Commit();</c>, <c>case TestTransactionModel.AutoRollback:
+    /// activeSession.Rollback();</c>, and the surrounding <c>catch (Exception) { if
+    /// (activeSession.IsTransactionActive()) activeSession.Rollback(); }</c> when the method
+    /// threw (decompiled Ncl.dll 28.4.53241.54039). All three end the transaction, so the next
+    /// [Test] in the codeunit starts with nothing pending for
+    /// <see cref="ThrowIfWriteTransactionStarted"/> to fire on. AlRunner#3468.
+    ///
+    /// <para>Flag only — deliberately NOT a commit point, and deliberately not a rollback.
+    /// Which rows survive is decided separately by TestExecutor.ApplyTestTransactionModel
+    /// (rollback on AutoRollback/threw) and by RunOne's own MarkCommitPoint() at the start of
+    /// the next test; folding either into this method would change row visibility, which the
+    /// corpus pins independently ("Test Isolation Rollback Scope", 60897).</para>
+    /// </summary>
+    public static void EndWriteTransactionAtTestBoundary()
+        => System.Threading.Volatile.Write(ref _inWriteTransaction, false);
 
     /// <summary>Clear write-transaction state at the per-test isolation boundary, so one
     /// test's uncommitted write cannot make the next test start "in a transaction".</summary>

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -1573,9 +1573,10 @@ public sealed class TestExecutor
         _testAttrCache = new();
 
     /// <summary>
-    /// Roll the row store back to this test's own commit point (RunOne's own MarkCommitPoint()
-    /// call, right before m.Invoke) in the two cases BC's own
-    /// NavTestCodeunit.ExecuteTestMethodAsync does.
+    /// Apply what BC's own NavTestCodeunit.ExecuteTestMethodAsync does at the END of a test
+    /// method: roll the row store back to this test's own commit point (RunOne's own
+    /// MarkCommitPoint() call, right before m.Invoke) in the two cases BC does, and end the
+    /// session's write transaction in every arm BC ends it (#3468 — see the inline comment).
     ///
     /// <para>1. <paramref name="m"/> carries [TransactionModel(TransactionModel::AutoRollback)]
     /// — the `case TestTransactionModel.AutoRollback: activeSession.Rollback();` arm on the
@@ -1611,6 +1612,20 @@ public sealed class TestExecutor
     {
         if (threw || IsAutoRollback(m))
             AlRunner.Patches.RecordPatches.RollbackToCommitPoint(BcRuntime.SkeletonSession);
+
+        // #3468: whichever of those arms BC takes, it ENDS the session's transaction here —
+        // Commit() under AutoCommit, Rollback() under AutoRollback, Rollback() from the catch
+        // when the method threw. So the next [Test] in this codeunit starts with no write
+        // transaction pending and its guarded Codeunit.Run is allowed. The runner's flag is
+        // separate from the row store, so ending it is its own call.
+        //
+        // TransactionModel::None is the one arm that does NOT end it: BC's switch has no None
+        // case, and the transaction handling None does get (`while (IsTransactionActive())
+        // EndTransaction(commit: false)`) runs BEFORE the method body, not after it. The
+        // runner does not model that pre-body loop, so leaving the flag alone here is the
+        // honest answer rather than a half-modelled one.
+        if (threw || TransactionModelName(m) != "None")
+            AlRunner.Patches.ALDatabasePatches.EndWriteTransactionAtTestBoundary();
     }
 
     /// <summary>
@@ -1625,20 +1640,28 @@ public sealed class TestExecutor
     /// in-process engine bootstrap ApplyTestTransactionModel's own RollbackToCommitPoint call
     /// requires.
     /// </summary>
-    internal static bool IsAutoRollback(MethodInfo m)
+    internal static bool IsAutoRollback(MethodInfo m) => TransactionModelName(m) == "AutoRollback";
+
+    /// <summary>
+    /// <paramref name="m"/>'s declared TransactionModel as its enum member NAME
+    /// (<c>AutoCommit</c> / <c>AutoRollback</c> / <c>None</c>), or <c>null</c> when the method
+    /// carries no [Test] attribute at all. A [Test] with no explicit model answers
+    /// <c>AutoCommit</c>, which is the attribute's own default and BC's.
+    ///
+    /// TestTransactionModel.AutoRollback = 1 (AutoCommit=0, AutoRollback=1, None=2) — read by
+    /// NAME, not by casting to the real enum type, for the same assembly-load-context reason
+    /// as the attribute-name lookup (a multi-bundle run can have more than one Ncl loaded).
+    /// </summary>
+    internal static string? TransactionModelName(MethodInfo m)
     {
         var attr = _testAttrCache.GetOrAdd(m, static mi =>
             mi.GetCustomAttributes(inherit: false)
               .FirstOrDefault(a => a.GetType().Name is "NavTestAttribute" or "TestAttribute"));
-        if (attr == null) return false;
+        if (attr == null) return null;
 
         var prop = attr.GetType().GetProperty("TransactionModel",
             BindingFlags.Public | BindingFlags.Instance);
-        var value = prop?.GetValue(attr);
-        // TestTransactionModel.AutoRollback = 1 (AutoCommit=0, AutoRollback=1, None=2) —
-        // compared by NAME, not by casting to the real enum type, for the same
-        // assembly-load-context reason as the attribute-name lookup above.
-        return value != null && value.ToString() == "AutoRollback";
+        return prop?.GetValue(attr)?.ToString();
     }
 
     // Issue #2070 root cause: this watchdog's clock is WALL-CLOCK time on the AL

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -1778,3 +1778,35 @@ this fix adds no corpus test, it makes two existing ones pass and deletes their 
 entries.
 
 Written by the fbk-1 agent.
+
+## 2026-09-08 — al-language 3077 → 3089 (pin `af01bbbc` → `24106565`, two commits)
+
+Issue #3468. The pin advances across two corpus commits, and the second is the one this PR
+needs; the first cannot be skipped, because a pin cannot name a commit without its
+predecessors.
+
+* `466dd46` (corpus #277) — six tests in a new `autoformat/` area, codeunit 60605 "ALT
+  AutoFormat Tests", asking what a `TestPage` reads from a Decimal control carrying
+  `AutoFormatType` and `DecimalPlaces`. **Not this PR's work** — it is the maintainer's
+  `stma-auto-2` for issue #3406.
+* `2410656` (corpus #279) — six tests, codeunit 60878 "Test Write Tx Test Boundary", asking
+  whether a write transaction survives a test-METHOD boundary under both transaction models.
+  Red without the runner fix in this PR (3/6), which is why the bump is folded here rather
+  than landing as a catch-up.
+
+3089 is the guard's own printed actual (`[count-baseline] GROWTH: suite 'al-language' tests
+count: expected 3077, actual 3089 (BC 28.1)`), not a computed number.
+
+Five of `466dd46`'s six tests fail at this pin and are declared in the new
+`tests/expectations/known-gaps-testpage-autoformat.json` against **#3406, which stays open
+after this PR merges**. They are pulled in by the bump, not caused by it: the runner rewrites
+`NavForm.GetAutoFormatStringAsync` to return `""` unconditionally, so a Decimal control reads
+through a hardcoded two-decimal default. The runner fix for that is PR #3469, and that PR is
+what deletes the known-gaps file. The sixth test of `466dd46` passes.
+
+Codeunit 60878 is **6/6 in the full three-app run** with CI's own invocation and both package
+caches — not under a `--test` filter, which matters here because #3468 is precisely about a
+codeunit's neighbours in the run being observable. Full run at this pin: `3118 total, 3113
+pass, 5 fail, 0 error`, the five being the declared known gaps above.
+
+Written by the fbk-1 agent.

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Schema, semantics and how to bump: README.md in this directory. Per-bump rationale: history.md, never a prose line in here (#2485).",
   "suites": {
     "al-language": {
-      "tests": { "default": 3077 },
+      "tests": { "default": 3089 },
       "appGroups": { "default": 1 }
     },
     "al-language-internals-fixture": { "tests": { "default": 0 }, "appGroups": { "default": 1 } },

--- a/tests/expectations/known-gaps-testpage-autoformat.json
+++ b/tests/expectations/known-gaps-testpage-autoformat.json
@@ -1,0 +1,42 @@
+[
+  {
+    "codeunitId": 60605,
+    "CodeunitName": "ALT AutoFormat Tests",
+    "Method": "AutoFormat_PlainControl_FallsToTheTwoDecimalDefault",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3406",
+    "Note": "Expected 1,234.50, got 1234.50 -- the thousands separator is missing. Pulled in by this PR's submodule pin bump, NOT caused by it: corpus commit 466dd46 (upstream #277) arrived between the old pin af01bbbc and this PR's own corpus commit 24106565, and a pin cannot skip its predecessor. The runner rewrites NavForm.GetAutoFormatStringAsync to return \"\" unconditionally, so a TestPage reads a Decimal control through the hardcoded two-decimal default instead of the control's own format. Tracked as #3406, which is OPEN at the time of writing; its fix is PR #3477's sibling PR https://github.com/StefanMaron/BusinessCentral.AL.Runner/pull/3469, and THAT PR deletes this file. This PR does not close #3406."
+  },
+  {
+    "codeunitId": 60605,
+    "CodeunitName": "ALT AutoFormat Tests",
+    "Method": "AutoFormat_DecimalPlacesControl_ReadsThreeDecimals",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3406",
+    "Note": "Expected 1,234.500, got 1234.50 -- neither DecimalPlaces = 3 : 3 nor the separator is applied. Pulled in by this PR's submodule pin bump, NOT caused by it: corpus commit 466dd46 (upstream #277) arrived between the old pin af01bbbc and this PR's own corpus commit 24106565, and a pin cannot skip its predecessor. The runner rewrites NavForm.GetAutoFormatStringAsync to return \"\" unconditionally, so a TestPage reads a Decimal control through the hardcoded two-decimal default instead of the control's own format. Tracked as #3406, which is OPEN at the time of writing; its fix is PR #3477's sibling PR https://github.com/StefanMaron/BusinessCentral.AL.Runner/pull/3469, and THAT PR deletes this file. This PR does not close #3406."
+  },
+  {
+    "codeunitId": 60605,
+    "CodeunitName": "ALT AutoFormat Tests",
+    "Method": "AutoFormat_CustomExpressionControl_HonoursTheFormatString",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3406",
+    "Note": "Expected 1,234.500, got 1234.50 -- AutoFormatType = 11's AutoFormatExpression is not applied. Pulled in by this PR's submodule pin bump, NOT caused by it: corpus commit 466dd46 (upstream #277) arrived between the old pin af01bbbc and this PR's own corpus commit 24106565, and a pin cannot skip its predecessor. The runner rewrites NavForm.GetAutoFormatStringAsync to return \"\" unconditionally, so a TestPage reads a Decimal control through the hardcoded two-decimal default instead of the control's own format. Tracked as #3406, which is OPEN at the time of writing; its fix is PR #3477's sibling PR https://github.com/StefanMaron/BusinessCentral.AL.Runner/pull/3469, and THAT PR deletes this file. This PR does not close #3406."
+  },
+  {
+    "codeunitId": 60605,
+    "CodeunitName": "ALT AutoFormat Tests",
+    "Method": "AutoFormat_CurrencyControl_WithACurrencyCode",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3406",
+    "Note": "Expected 1,234.50, got 1234.50 -- the thousands separator is missing. Pulled in by this PR's submodule pin bump, NOT caused by it: corpus commit 466dd46 (upstream #277) arrived between the old pin af01bbbc and this PR's own corpus commit 24106565, and a pin cannot skip its predecessor. The runner rewrites NavForm.GetAutoFormatStringAsync to return \"\" unconditionally, so a TestPage reads a Decimal control through the hardcoded two-decimal default instead of the control's own format. Tracked as #3406, which is OPEN at the time of writing; its fix is PR #3477's sibling PR https://github.com/StefanMaron/BusinessCentral.AL.Runner/pull/3469, and THAT PR deletes this file. This PR does not close #3406."
+  },
+  {
+    "codeunitId": 60605,
+    "CodeunitName": "ALT AutoFormat Tests",
+    "Method": "AutoFormat_CurrencyControl_WithABlankExpression",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3406",
+    "Note": "Expected 1,234.50, got 1234.50 -- the thousands separator is missing. Pulled in by this PR's submodule pin bump, NOT caused by it: corpus commit 466dd46 (upstream #277) arrived between the old pin af01bbbc and this PR's own corpus commit 24106565, and a pin cannot skip its predecessor. The runner rewrites NavForm.GetAutoFormatStringAsync to return \"\" unconditionally, so a TestPage reads a Decimal control through the hardcoded two-decimal default instead of the control's own format. Tracked as #3406, which is OPEN at the time of writing; its fix is PR #3477's sibling PR https://github.com/StefanMaron/BusinessCentral.AL.Runner/pull/3469, and THAT PR deletes this file. This PR does not close #3406."
+  }
+]


### PR DESCRIPTION
Closes #3468

Opened by the **fbk-1 agent**.

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/279

## The defect

`ALDatabasePatches._inWriteTransaction` is set by every AL write and cleared by `Commit()` and by `ResetWriteTransactionState()`. The only caller of that reset is `RecordPatches.ResetPerTestState()`, reached from `RestoreInstallBaseline()` — which under the default `TestIsolation = Codeunit` fires at the **codeunit** boundary. `TestExecutor.RunOne` moves the row store's commit point per test **method** and never touched the flag.

So a test method ending with an uncommitted write left the next test method in the same codeunit believing a write transaction was still open, and `ThrowIfWriteTransactionStarted` refused its guarded `Codeunit.Run` with `An error occurred and the transaction is stopped.`

## The boundary I chose, and why

BC ends the session's transaction at the **end of the test method**, in `NavTestCodeunit.ExecuteTestMethodAsync` (decompiled from `Microsoft.Dynamics.Nav.Ncl.dll` 28.4.53241.54039). Three arms, all of which end it:

```csharp
switch (transactionModel)
{
case TestTransactionModel.AutoCommit:  activeSession.Commit();   break;
case TestTransactionModel.AutoRollback: activeSession.Rollback(); break;
}
...
catch (Exception ex)
{
    if (activeSession.IsTransactionActive()) activeSession.Rollback();
    MarkExceptions(ex);
}
```

That is exactly where `TestExecutor.ApplyTestTransactionModel` already mirrors BC's rollback arms (#2400, #2523), so the flag clear goes there rather than at an arbitrary point — one new call, `ALDatabasePatches.EndWriteTransactionAtTestBoundary()`.

**`TransactionModel::None` is the one arm BC does not end at this point**, and I checked it before choosing placement rather than after. Its handling is a `while (activeSession.IsTransactionActive()) activeSession.EndTransaction(commit: false);` loop that runs **before** the method body, not after it, and the `switch` has no `None` case. The runner does not model that pre-body loop, so the fix leaves the flag alone for `None` instead of half-modelling it. `IsAutoRollback` was generalised into `TransactionModelName(MethodInfo)` to express that; `IsAutoRollback` is now one line over it and behaves identically.

The new method is flag-only — deliberately not a commit point and not a rollback. Row visibility is decided separately by `ApplyTestTransactionModel`'s rollback and by `RunOne`'s own `MarkCommitPoint()`, and the corpus pins it independently (60897). `ResetWriteTransactionState` keeps its `MarkCommitPoint()` call, which `TestPageOpenIsNotACommitPointTests` asserts.

## Is this BC-observable? Yes, and a service tier has now been asked

Corpus PR 279 adds codeunit 60878 "Test Write Tx Test Boundary" — six declaration-ordered tests covering both models. **Container-verified on a real BC 28.4.53241.0 service tier** before opening it, as a standalone probe app with its own table and `Library Assert`: all six green.

The first probe shape I ran was wrong in a way worth recording, because it fails looking like something else. A `Commit()` inside an AutoRollback test is refused (`Tests cannot call the Commit function if TransactionModel property is set to AutoRollback` — that is #3451's guard), and that refusal also reaches a codeunit such a test *runs*, so using a committing run target made the guarded run return `false` for a reason unrelated to the transaction boundary. The final shape clears the fixture in a default-model test and uses the non-committing run target under AutoRollback.

Existing corpus coverage that does **not** answer this: 60254 asks the guarded/statement `Codeunit.Run` question within one test method, and every one of its tests opens with a `Commit`-carrying `Initialize`. 60897 answers the neighbouring **row** question. Test06 of the new codeunit asserts both at once — the previous test's row is still visible *and* no write transaction is pending — which is what makes it not a restatement of 60897.

**The pin is folded in.** Corpus PR 279 merged as `24106565`; `tests/al-language` advances from `af01bbbc` across two commits, because a pin cannot skip its predecessor:

* `466dd46` (upstream #277) — six tests, codeunit 60605 "ALT AutoFormat Tests". **Not this PR's work**, the maintainer's `stma-auto-2` for issue #3406. Five of the six fail at this pin and are declared in the new `tests/expectations/known-gaps-testpage-autoformat.json` against **#3406, which stays open after this PR merges**; PR #3469 is the runner fix for it and is what deletes that file. The sixth passes. Pulled in by the bump, not caused by it.
* `24106565` (upstream #279) — codeunit 60878, this PR's proving test.

Baseline `al-language` 3077 → **3089**, the guard's own printed actual (`[count-baseline] GROWTH: suite 'al-language' tests count: expected 3077, actual 3089 (BC 28.1)`), with a `history.md` entry covering both commits.

## RED → GREEN

**New — `AlRunner.Tests/WriteTransactionTestBoundaryTests.cs`** (runner-mechanism test, spawns the real runner against a synthetic bundle with no Base App floor). Five AL tests mirroring the corpus shape.

RED on `origin/main`, 2P/3F:

```
PASS  Codeunit62470.A_AutoRollbackTestWritesWithoutCommitting
FAIL  Codeunit62470.B_WritesNothingAtAll
      TXB2 FAIL: a test that writes nothing must not start inside a write transaction left by the previous test
FAIL  Codeunit62470.C_GuardedCodeunitRunIsAllowed
      TXB3 FAIL: no write transaction may be pending at the start of this test
PASS  Codeunit62470.D_DefaultModelTestWritesWithoutCommitting
FAIL  Codeunit62470.E_GuardedCodeunitRunIsStillAllowed
      TXB5 FAIL: the previous test's uncommitted write must have been committed at the test-method boundary
```

GREEN after: 5/5.

**Changed — `AlRunner.Tests/TransactionModelCommitRefusalTests.cs`.** The `AutoRollback_GuardedCodeunitRunIsNotRefused` arm carried a "DECLARED FIRST ON PURPOSE, and do not reorder" note pointing at #3468. The note is gone and the arm now sits directly behind `AutoRollback_CommitBehaviorIgnoreIsExempt`, which ends with an `Insert` that is rolled back and never committed.

Note on where I put it: moving the arm to the *very end* of the codeunit does **not** reproduce, because the arm before the end (`Unattributed_ExplicitCommitIsAllowed`) closes with `Commit()`. I checked that, found it green on `origin/main`, and repositioned rather than report a RED I had not actually observed. Behind the Ignore arm it reproduces exactly the reported error:

```
FAIL  Codeunit62460.AutoRollback_GuardedCodeunitRunIsNotRefused
      NavCSideException: An error occurred and the transaction is stopped. Contact your administrator or partner for further assistance.
```

GREEN after: 7/7.

**The corpus codeunit itself, run against this branch.** Not just the C# mirror — the runner was pointed at my corpus clone with `--test Codeunit60878 --strict`:

| | Test01 | Test02 | Test03 | Test04 | Test05 | Test06 |
|---|---|---|---|---|---|---|
| `origin/main` | PASS | PASS | **FAIL** | **FAIL** | PASS | **FAIL** |
| this branch | PASS | PASS | PASS | PASS | PASS | PASS |

3/6 to 6/6. That measurement was taken against a clone before the pin moved; **60878 is now 6/6 in the full three-app run** at the folded pin, which is the number that matters — #3468 is precisely about a codeunit's neighbours in the run being observable, so a `--test`-filtered green would not have settled it.

## Fixing the shape, not the reported line

- **Another call site with the same wrong pattern?** No. `_inWriteTransaction` has exactly three writers (`NoteRecordWrite`, `NoteRecordInsertWrite`, `CommitWithoutTestExecutionGuard`) and two resets, and I read all of them. The codeunit boundary was already covered through `ResetPerTestState`; the test-method boundary was the only one missing.
- **A sibling function making the same assumption?** `RunOne`'s `MarkCommitPoint()` at the start of each test is the row-store half of this boundary and was already there — the flag was the half that had no counterpart. That asymmetry is the bug.
- **Two paths writing the same state with different invariants?** Yes, and that is what this fixes: the codeunit boundary reset both the rows and the flag, the method boundary reset only the rows.
- **`TransactionModel::None` at the START of a test is a known residue, filed as #3480.** The reviewer confirmed the end-of-method exclusion is faithful — BC's `None` loop is pre-body and the enclosing `finally` re-opens the transactions it ended. What is not modelled is the pre-body loop itself: at the start of a `None` test BC holds no transaction and allows a guarded `Codeunit.Run`, and the runner still refuses it. Worth stating plainly: **no arm of any other model distinguishes "clear at the end of test N" from "clear at the start of test N+1"** — for `AutoCommit` and `AutoRollback` the two are observationally identical, so only a `None` arm can tell them apart, and that is the proving test #3480 needs. It also needs a service-tier measurement first; nothing here rests on it.
- **The `timedOut` path is deliberately untouched.** `RunOne` skips `ApplyTestTransactionModel` on a timeout because the abandoned thread may still be writing to the row store, so a timed-out test still leaks the flag to its successor. Clearing a bool would not race, but it would also not help: that thread's next write sets it again. Stating it rather than silently half-fixing it.

## Open-queue scan (same file)

- **#3217** — `OrderTestCodeunitsByObjectId` tie-breaking, also in `TestExecutor.cs`, no open PR. **Not folded**: it is a different reasoning (undefined `Assembly.GetTypes()` ordering across codeunits with equal ids) that a reviewer would have to hold separately from the transaction boundary, and it needs its own diagnosis. Adjacent in effect only — the tests here depend on method order *within* one codeunit, which `GetMethods()` decides, not on codeunit order.
- **#2184** — asks whether BC refuses a value-consuming `XmlPort.Import` / `Report.RunModal` inside a write transaction. Same guard (`ThrowIfWriteTransactionStarted`), different files (the XmlPort/Report patches), and it is an unmeasured BC question needing its own corpus measurement first.
- Nothing else in the open queue lands in `TestExecutor.cs` or `ALDatabasePatches.cs`.

## What I ran

- `dotnet test AlRunner.Tests --filter` over `WriteTransactionTestBoundaryTests`, `TransactionModelCommitRefusalTests`, `CodeunitRunWriteTransactionRefusalTests`, `TestTransactionModelDetectionTests`, `RecordBulkWriteNotesTransactionTests`, `TestPageOpenIsNotACommitPointTests` — 19/21.
  The 2 failures are `RecordBulkWriteNotesTransactionTests.{DeleteAll,ModifyAll}Async_NonTemporaryRecord_NotesWriteBeforeOriginalBodyRuns`, and they are **pre-existing on `origin/main`**: I reverted both changed source files to `origin/main` and re-ran that class alone — same 2 failures, same messages. Not touched by this change.
- Full corpus at the folded pin, CI's three-app invocation with `--strict --expectations-require-match --count-baseline`: **3118/3118, exit 0** (`pass-known-gap: 22` — 17 pre-existing plus the 5 new AutoFormat entries, so every declared entry matched a real failure and none went stale).
- `tests/runner-extras` with `--strict --count-baseline`: **391/391, exit 0**.
- Prose: no comment block over ten lines added to `AlRunner/`. Per review, the quoted `switch`/`catch` decompile on `EndWriteTransactionAtTestBoundary` is now a one-line citation (member name plus Ncl version); the arm-by-arm reading, the `None` reasoning and the probe history live here in the PR body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPJecKgfS4YFcpXSQr2tqb
