### PR TITLE
fix(tests): cap the suite's heaviest collection at its modal timeout, and stop the message lying about it

### DIFF
--- a/AlRunner.Tests/BcVersionDefaultDocumentationTests.cs
+++ b/AlRunner.Tests/BcVersionDefaultDocumentationTests.cs
@@ -41,24 +41,10 @@ public sealed class BcVersionDefaultDocumentationTests
     /// <summary>
     /// Wall-clock cap for one spawned runner, in milliseconds.
     ///
-    /// This class is the HEAVIEST collection in the suite, and an xUnit collection is
-    /// strictly serial: on the BC 27.5 leg of run 34187276963 — a leg where every test
-    /// here PASSED — it summed 136.8s of runtime across 191.5s dispatched. Its spawns
-    /// include a cold, no-package-cache, two-bundle compile, which is close to the most
-    /// expensive thing any test here asks the runner to do.
-    ///
-    /// At the previous 120s that cap sat in the bottom sixth of the suite (18 spawns cap
-    /// at 120s; 132 of 152 cap at 180s or more) while doing more work than most, so what
-    /// it measured was how loaded the CI box was, not whether the runner works: issue
-    /// #3435 recorded the same test timing out on a different subset of legs on each run,
-    /// passing on 27.0 and 27.5 while failing on 28.4 within one run of one commit.
-    ///
-    /// 180s is the suite's modal cap (47 spawns), so this brings the heaviest collection
-    /// up to the value the rest of the suite already uses for ordinary work rather than
-    /// inventing a number. The claim under test is that the documented shape RUNS — a
-    /// correctness claim — so a cap only has to be loose enough that load cannot
-    /// masquerade as failure; it is not a performance budget, and nothing here asserts
-    /// that a run is fast. Startup cost is measured by its own tests.
+    /// 180s is the suite's modal cap, raised from 120s for issue #3435. The claim under
+    /// test is that the documented shape RUNS — a correctness claim — so this only has to
+    /// be loose enough that CI load cannot masquerade as failure. It is not a performance
+    /// budget: nothing here asserts a run is fast, and startup cost has its own tests.
     /// </summary>
     private const int SpawnTimeoutMs = 180_000;
 
@@ -268,11 +254,27 @@ public sealed class BcVersionDefaultDocumentationTests
         // And the source itself must derive the message from the constant rather than
         // reintroducing a literal — the defect above is invisible to the string check
         // whenever the hardcoded number happens to match the current cap.
+        //
+        // Anchored on the throw STATEMENT, not on the message text. The phrase "did not
+        // exit within" also appears in this file's comments and in the expected-value line
+        // above, so scanning for it and taking the FIRST hit would pass as soon as a doc
+        // line mentioning it moved above the throw site — a false negative that depends
+        // only on where the comments sit.
+        //
+        // The anchor is assembled below rather than written as one literal, so that this
+        // very comment — and any future prose quoting the throw site — cannot itself match
+        // it. Writing the anchor out in full here is what broke the first attempt.
         var source = File.ReadAllText(Path.Combine(
             RepoRoot, "AlRunner.Tests", "BcVersionDefaultDocumentationTests.cs"));
-        var throwIdx = source.IndexOf("did not exit within", StringComparison.Ordinal);
-        Assert.True(throwIdx >= 0, "expected the timeout message to still exist.");
-        var throwLine = source[throwIdx..source.IndexOf('\n', throwIdx)];
-        Assert.Contains("SpawnTimeoutMs", throwLine, StringComparison.Ordinal);
+        var ThrowAnchor = "throw new " + nameof(TimeoutException) + "(";
+        var throwIdx = source.IndexOf(ThrowAnchor, StringComparison.Ordinal);
+        Assert.True(throwIdx >= 0, "expected the timeout throw site to still exist.");
+        Assert.Equal(throwIdx, source.LastIndexOf(ThrowAnchor, StringComparison.Ordinal));
+
+        var stmtEnd = source.IndexOf(");", throwIdx, StringComparison.Ordinal);
+        Assert.True(stmtEnd > throwIdx, "expected the throw statement to terminate.");
+        var throwStmt = source[throwIdx..stmtEnd];
+        Assert.Contains("did not exit within", throwStmt, StringComparison.Ordinal);
+        Assert.Contains("SpawnTimeoutMs", throwStmt, StringComparison.Ordinal);
     }
 }

--- a/AlRunner.Tests/BcVersionDefaultDocumentationTests.cs
+++ b/AlRunner.Tests/BcVersionDefaultDocumentationTests.cs
@@ -38,6 +38,30 @@ public sealed class BcVersionDefaultDocumentationTests
     private static readonly string MinimalBundle =
         Path.Combine(RepoRoot, "tests", "runner-extras", "esm-xapp-table");
 
+    /// <summary>
+    /// Wall-clock cap for one spawned runner, in milliseconds.
+    ///
+    /// This class is the HEAVIEST collection in the suite, and an xUnit collection is
+    /// strictly serial: on the BC 27.5 leg of run 34187276963 — a leg where every test
+    /// here PASSED — it summed 136.8s of runtime across 191.5s dispatched. Its spawns
+    /// include a cold, no-package-cache, two-bundle compile, which is close to the most
+    /// expensive thing any test here asks the runner to do.
+    ///
+    /// At the previous 120s that cap sat in the bottom sixth of the suite (18 spawns cap
+    /// at 120s; 132 of 152 cap at 180s or more) while doing more work than most, so what
+    /// it measured was how loaded the CI box was, not whether the runner works: issue
+    /// #3435 recorded the same test timing out on a different subset of legs on each run,
+    /// passing on 27.0 and 27.5 while failing on 28.4 within one run of one commit.
+    ///
+    /// 180s is the suite's modal cap (47 spawns), so this brings the heaviest collection
+    /// up to the value the rest of the suite already uses for ordinary work rather than
+    /// inventing a number. The claim under test is that the documented shape RUNS — a
+    /// correctness claim — so a cap only has to be loose enough that load cannot
+    /// masquerade as failure; it is not a performance budget, and nothing here asserts
+    /// that a run is fast. Startup cost is measured by its own tests.
+    /// </summary>
+    private const int SpawnTimeoutMs = 180_000;
+
     private static (int ExitCode, string StdOut, string StdErr) Run(string? isolatedHome, params string[] args)
     {
         var sb = new StringBuilder(TestBuildConfig.RunArgs(Path.Combine(RepoRoot, "AlRunner")));
@@ -62,10 +86,11 @@ public sealed class BcVersionDefaultDocumentationTests
         proc.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (errSb) errSb.AppendLine(e.Data); };
         proc.BeginOutputReadLine();
         proc.BeginErrorReadLine();
-        if (!proc.WaitForExit(120_000))
+        if (!proc.WaitForExit(SpawnTimeoutMs))
         {
             try { proc.Kill(entireProcessTree: true); } catch { }
-            throw new TimeoutException($"al-runner did not exit within 120s for args: {string.Join(' ', args)}");
+            throw new TimeoutException(
+                $"al-runner did not exit within {SpawnTimeoutMs / 1000}s for args: {string.Join(' ', args)}");
         }
         proc.WaitForExit();
         lock (outSb) lock (errSb) return (proc.ExitCode, outSb.ToString(), errSb.ToString());
@@ -208,5 +233,46 @@ public sealed class BcVersionDefaultDocumentationTests
         var nextCommandMatch = Regex.Match(guide[shapeIdx..], @"al-runner[^\r\n]*");
         Assert.True(nextCommandMatch.Success, "expected an al-runner command line following the shape description.");
         Assert.DoesNotContain("--package-cache", nextCommandMatch.Value, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The timeout message must report the cap that was ACTUALLY applied, not a literal
+    /// that drifts from it.
+    ///
+    /// This is not hypothetical tidiness: while reproducing #3435, the cap was
+    /// temporarily squeezed to 3s to force the timeout path, and the failure still read
+    /// "did not exit within 120s" — the old message hardcoded the number the code no
+    /// longer used. A person diagnosing a CI timeout reads that sentence to decide
+    /// whether the cap is too tight, so a stale figure there sends them to the wrong
+    /// conclusion with nothing to warn them.
+    ///
+    /// Asserting the rendered text against <see cref="SpawnTimeoutMs"/> means re-hardcoding
+    /// the message, or changing the cap without the message following, fails here. The
+    /// assertion deliberately checks the derived SECONDS text rather than the constant's
+    /// presence, because that is the part a reader acts on.
+    /// </summary>
+    [Fact]
+    public void TimeoutMessage_ReportsTheCapThatWasActuallyApplied()
+    {
+        // Positive: the message renders the real cap, in seconds, as a reader will see it.
+        var rendered = $"al-runner did not exit within {SpawnTimeoutMs / 1000}s for args: <args>";
+        Assert.Contains($"within {SpawnTimeoutMs / 1000}s", rendered, StringComparison.Ordinal);
+
+        // Negative: a DIFFERENT cap must render a different sentence. Pinning the expected
+        // text to a literal 180 here would re-create the very coupling this test exists to
+        // forbid, so the wrong-figure check is expressed against a value the cap is not.
+        const int NotTheCap = 120_000;
+        Assert.NotEqual(NotTheCap, SpawnTimeoutMs);
+        Assert.DoesNotContain($"within {NotTheCap / 1000}s", rendered, StringComparison.Ordinal);
+
+        // And the source itself must derive the message from the constant rather than
+        // reintroducing a literal — the defect above is invisible to the string check
+        // whenever the hardcoded number happens to match the current cap.
+        var source = File.ReadAllText(Path.Combine(
+            RepoRoot, "AlRunner.Tests", "BcVersionDefaultDocumentationTests.cs"));
+        var throwIdx = source.IndexOf("did not exit within", StringComparison.Ordinal);
+        Assert.True(throwIdx >= 0, "expected the timeout message to still exist.");
+        var throwLine = source[throwIdx..source.IndexOf('\n', throwIdx)];
+        Assert.Contains("SpawnTimeoutMs", throwLine, StringComparison.Ordinal);
     }
 }

--- a/AlRunner.Tests/BcVersionDefaultDocumentationTests.cs
+++ b/AlRunner.Tests/BcVersionDefaultDocumentationTests.cs
@@ -21,6 +21,7 @@
 // docs) fails loud here instead of shipping silently a fourth time.
 using System.Diagnostics;
 using System.Text;
+using System.Linq;
 using System.Text.RegularExpressions;
 using AlRunner.Infrastructure;
 using Xunit;
@@ -276,5 +277,29 @@ public sealed class BcVersionDefaultDocumentationTests
         var throwStmt = source[throwIdx..stmtEnd];
         Assert.Contains("did not exit within", throwStmt, StringComparison.Ordinal);
         Assert.Contains("SpawnTimeoutMs", throwStmt, StringComparison.Ordinal);
+
+        // Co-occurrence is weaker than derivation, and the gap between them is reachable
+        // by accident: appending the constant to an otherwise-hardcoded message ("...within
+        // 180s... (cap {SpawnTimeoutMs})") satisfies both assertions above while the figure
+        // a reader acts on is still a literal. Nobody has to be trying to defeat the test
+        // to write that.
+        //
+        // So require that the statement carries NO standalone number other than the 1000
+        // that converts milliseconds to seconds. A hardcoded cap — in any spelling, at any
+        // position, interpolated or concatenated — is a digit run, and this refuses it.
+        // No trailing (?![\w.]) guard: the literal that matters is spelled "180s", glued to a
+        // letter, so requiring a non-word character after the digits would skip exactly the
+        // case being forbidden. Only a LEADING guard is needed — it is what keeps the digits
+        // inside identifiers like `Join`/`args` from matching.
+        //
+        // "1000" is the ms-to-seconds divisor; "0" and "1" are string.Format placeholders,
+        // which carry no cap and must not be read as one.
+        var digitRuns = Regex.Matches(throwStmt, @"(?<![\w.])\d+")
+            .Select(m => m.Value)
+            .Where(v => v is not ("1000" or "0" or "1"))
+            .ToArray();
+        Assert.True(digitRuns.Length == 0,
+            "the timeout message must DERIVE its figure from SpawnTimeoutMs, not carry a literal. " +
+            $"Unexpected number(s) in the throw statement: {string.Join(", ", digitRuns)}");
     }
 }


### PR DESCRIPTION
Closes #3435

**Corpus-NA:** this changes a C# test's own subprocess timeout and its failure message. It asserts nothing about what BC does — no AL behaviour is observed differently before or after — so there is no upstream claim for a service tier to adjudicate. The proving test is in `AlRunner.Tests` because the claim is about this repository's test harness.

## What the flake actually was

#3435 recorded the symptom (a failing-leg set that moves between runs) and offered two directions, calling the choice a maintainer's. The measurement below settles it without a judgement call, because the repository's own convention answers it.

`BcVersionDefaultDocumentationTests` is **the heaviest collection in the suite**, and an xUnit collection is strictly serial. From the per-class occupancy table on the BC 27.5 leg of run `34187276963` — a leg where every test in the class **passed**:

```
    summed  dispatched  class
    136.8s      191.5s  BcVersionDefaultDocumentationTests     <- this one
     97.3s       94.2s  CoverageTests
     81.2s      160.8s  AlOutputCacheDoNotCacheTests
```

Its spawns include a cold, no-package-cache, two-bundle compile. Yet its cap was **120s**, against the rest of the suite:

| cap | spawn sites |
|---|---|
| 5s–60s | 13 |
| **120s** | **18** |
| 180s | 47 (modal) |
| 240s | 26 |
| 300s | 20 |
| 600s | 10 |

103 of 134 spawn sites (77%) cap at 180s or more, and the rows above sum to 134. The heaviest collection was capped in the bottom sixth — 31 of 134 (23%) cap at 120s or less — so the cap was measuring how loaded the CI box was, not whether the runner works.

**Corrected after review.** This paragraph first read "132 of 152", which was wrong twice: 132 was the sum of *all* the rows rather than the ≥180s subset, and 152 had no derivation — there are 134 spawn sites. The gathering pattern also required the `_000` digit separator, missing `WaitForExit(10000)` twice in `Win32StubsLoudFailureTests.cs` (the 5s–60s row was 11, not 13). Re-derived: the two load-bearing figures — **18 sites at 120s, 47 at 180s (the mode)** — are unchanged, so the argument for 180s stands on corrected numbers. The same wrong arithmetic had been copied into the source tree and is deleted there in `7c99b0c7`.

The load-dependence is visible **within a single run of a single commit**: in `34187276963`, the same test passed on 27.0 and 27.5 and timed out on 28.4.

## Why 180s, and why this is not a performance regression

180s is the suite's **modal** cap, so this brings the heaviest collection up to what the rest of the suite already uses for ordinary work rather than inventing a number.

The claim under test is that the documented shape **runs** — a correctness claim. A cap only has to be loose enough that load cannot masquerade as failure. It is not a performance budget, and nothing here asserts a run is fast; startup cost has its own tests and its own issues (#2366, #2375). A green run is unaffected: the class takes the same time it always did.

`main` is unaffected either way — it has been consistently green, which also answers the issue's "not yet established" question: this shows on PR legs, not on `main`.

## The second defect, found while reproducing the first

To force the timeout path deterministically, I squeezed the cap to 3s. The failure still read:

```
System.TimeoutException : al-runner did not exit within 120s for args: ...
```

The message hardcoded `120s` while the applied cap was 3s. That sentence is exactly what a person diagnosing a CI timeout reads to decide whether the cap is too tight, so a stale figure there sends them to the wrong conclusion with nothing to warn them. It now derives from the constant.

## RED → GREEN

**RED** — cap squeezed to 3s, reproducing CI's failure with the identical exception and stack:

```
[FAIL] Guide_UsualShapeExample_ActuallyRunsWithoutPackageCache
   System.TimeoutException : al-runner did not exit within 120s for args: ...
Failed! - Failed: 1, Passed: 0
```

**GREEN** — at 180s, whole class: `Passed! - Failed: 0, Passed: 5`.
Wider sweep (this class + `CliDocumentationTests` + `CrossMajorNoteTests`): `Failed: 0, Passed: 31`.

**Mutation** — `TimeoutMessage_ReportsTheCapThatWasActuallyApplied` is checked against the defect it targets. Re-hardcoding the literal fails it **even when the literal matches the current cap**:

```
[FAIL] TimeoutMessage_ReportsTheCapThatWasActuallyApplied
   Assert.Contains() Failure: Sub-string not found
```

That case is the one a naive string assertion cannot catch, which is why the test also asserts the throw site derives its text from the constant. Its wrong-figure check is written against a value the cap is *not*, so the test does not re-create the hardcoding it forbids.

## Siblings considered and deliberately not folded

Five other spawn sites hardcode the figure in their message the same way (`CrossMajorNoteTests`, `CountryFlagTests`, `ArtifactsRootEnvOverrideTests` ×2, `HomeDirectoryMissingLoudFailureTests`). **None is folded in**, for two reasons: their literals currently *match* their caps, so they are latent rather than active defects; and none of them is the flake #3435 is about. Raising five more caps without evidence that any of them fails would be a speculative change across five files needing different reasoning to review — `batch-sibling-issues-by-file.md` point 4. Filed separately as the shape rather than fixed silently.

Open queue scanned for siblings landing in this file: #3446 is a workflow-level job timeout (different mechanism), #3459 is about `ci-verdicts.md` prose. Nothing folds.

---
*Filed by the `stma-auto-3` autonomous coordinator, an automated agent acting on the account holder's behalf. Every figure above is from the CI logs and a local run, not reconstructed from memory.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsJY7DhDm5y83e77GxpRSZ
