### PR TITLE
fix(release): tag the tested commit first, so a branch that moved cannot discard a green release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -579,12 +579,28 @@ jobs:
             # The tag is already on origin and this checkout IS that tag. Reuse its
             # CHANGELOG section rather than generating a second [x.y.z] heading — that
             # happened on 2026-08-05 (two duplicate v2.0.0 sections, cleaned up by hand).
-            echo "Reusing the CHANGELOG section already committed at $TAG."
-            SECTION=$(git show "$TAG:CHANGELOG.md" | awk -v ver="## [$VERSION]" '
-              $0 == ver { found=1 }
-              found && /^## \[/ && $0 != ver { exit }
-              found { print }
-            ')
+            # The tag points at the TESTED commit, which does not carry the release
+            # section (the CHANGELOG commit is pushed to the branch separately, below).
+            # So look on the branch first and fall back to the tag, which is where the
+            # section lived before this ordering changed. Refuse rather than ship empty
+            # notes if neither has it.
+            echo "Reusing the CHANGELOG section already recorded for $TAG."
+            git fetch --quiet origin "${{ needs.plan.outputs.branch }}" || true
+            read_section() {
+              git show "$1:CHANGELOG.md" 2>/dev/null | awk -v ver="## [$VERSION]" '
+                $0 == ver { found=1 }
+                found && /^## \[/ && $0 != ver { exit }
+                found { print }
+              '
+            }
+            SECTION=$(read_section "origin/${{ needs.plan.outputs.branch }}")
+            if [ -z "$SECTION" ]; then
+              SECTION=$(read_section "$TAG")
+            fi
+            if [ -z "$SECTION" ]; then
+              echo "::error::$TAG exists but no '## [$VERSION]' section was found on ${{ needs.plan.outputs.branch }} or at the tag. Refusing to publish a release with empty notes."
+              exit 1
+            fi
           else
             PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
             if [ -n "$PREV_TAG" ]; then
@@ -595,6 +611,16 @@ jobs:
 
             SECTION=$(VERSION="$VERSION" DATE="$(date +%Y-%m-%d)" COMMITS="$COMMITS" \
               python3 .github/scripts/generate_changelog.py)
+
+            # The commit the matrix, the build and the pack all ran against. THIS is
+            # what gets tagged: it is on the branch's history and stays reachable there
+            # after the branch moves, so the next release's
+            # `git describe --tags --abbrev=0` still finds it. Tagging the CHANGELOG
+            # commit instead would put the tag off-history the moment the retry path
+            # below regenerates onto a moved branch, and the NEXT release would then
+            # compute its commit range from the wrong baseline -- a failure that would
+            # not appear until one release later.
+            TESTED_SHA=$(git rev-parse HEAD)
 
             git add CHANGELOG.md
             git commit -m "chore: release v${VERSION}"
@@ -607,17 +633,59 @@ jobs:
               # to prevent, just self-inflicted during a test.
               echo "dry_run: skipping push of the release commit and tag to origin."
             else
-              # Push the release commit BEFORE creating the tag, and deliberately without
-              # --force, to the branch that was actually dispatched (needs.plan.outputs.branch
-              # — "main" for the ordinary path, a release branch for a patch release; #2060).
-              # HEAD is the commit build-and-pack just built plus a CHANGELOG-only diff, so
-              # this is a fast-forward exactly when that branch is still where the matrix
-              # found it. If someone pushed to it during the run this fails here — and NO
-              # tag is created, which is the whole point of #1978. Re-dispatch against the
-              # branch's new head.
-              git push origin HEAD:${{ needs.plan.outputs.branch }}
-              git tag "$TAG"
+              # WE RELEASE A COMMIT, NOT A BRANCH STATE (#3494).
+              #
+              # This used to push the CHANGELOG commit to the branch FIRST and create the
+              # tag only if that push was a fast-forward, so anything merging during the
+              # run killed the release outright. v2.11.0 died that way with all eight legs
+              # green, built, signed and packed: PRs #3484 and #3469 merged mid-run and the
+              # push was rejected as non-fast-forward, so no tag, no NuGet, no release.
+              #
+              # That guard was defended as "the whole point of #1978". It is not. #1978's
+              # property is NEVER TAG A COMMIT WHOSE TESTS DID NOT PASS, and that is
+              # satisfied by the matrix, the build and the pack all running before this
+              # step. "The branch has not moved" is a DIFFERENT property, and it says
+              # nothing about whether the commit being shipped is good. Commits merged
+              # after the tested one are, by definition, not in this release.
+              #
+              # So: the tag is the release, and it goes first. A tag push needs no
+              # fast-forward, so a branch that moved cannot block it.
+              git tag "$TAG" "$TESTED_SHA"
               git push origin "$TAG"
+
+              # The CHANGELOG commit is BOOKKEEPING. It goes to the branch afterwards, and
+              # failing to land it must not fail a release that is already tagged.
+              #
+              # Retry by REGENERATING onto the branch's current head, never by rebasing:
+              # $COMMITS is fixed to the tested commit's range, so regenerating replays the
+              # same section, whereas a rebase would drag in commits that merged after the
+              # release and put them under this version's heading.
+              #
+              # Emptying [Unreleased] here is correct and self-healing: the next ordinary
+              # push to the branch triggers sync-changelog-unreleased.yml, which recomputes
+              # it from the new tag forward and so restores anything that merged during the
+              # run. That workflow also refuses to run on this very commit, recognising it
+              # from its own "chore: release" message rather than from tag visibility, so
+              # pushing the tag before the commit does not disturb the #2109 race it guards.
+              CHANGELOG_PUSHED=false
+              for attempt in 1 2 3; do
+                if git push origin HEAD:${{ needs.plan.outputs.branch }}; then
+                  CHANGELOG_PUSHED=true
+                  break
+                fi
+                echo "::notice::${{ needs.plan.outputs.branch }} moved under the release commit; regenerating the section onto its new head (attempt $attempt)."
+                git fetch origin ${{ needs.plan.outputs.branch }}
+                git reset --hard "origin/${{ needs.plan.outputs.branch }}"
+                VERSION="$VERSION" DATE="$(date +%Y-%m-%d)" COMMITS="$COMMITS" \
+                  python3 .github/scripts/generate_changelog.py >/dev/null
+                git add CHANGELOG.md
+                git commit -m "chore: release v${VERSION}" || break
+              done
+
+              if [ "$CHANGELOG_PUSHED" != "true" ]; then
+                echo "::warning::$TAG is pushed and this release will publish, but the CHANGELOG commit could not be landed on ${{ needs.plan.outputs.branch }} after 3 attempts. The release is NOT affected -- add the '## [$VERSION]' section by hand or let the next sync run pick it up."
+              fi
+              echo "changelog-pushed=$CHANGELOG_PUSHED" >> "$GITHUB_OUTPUT"
             fi
           fi
 

--- a/AlRunner.Tests/PublishReleaseTagDecouplingTests.cs
+++ b/AlRunner.Tests/PublishReleaseTagDecouplingTests.cs
@@ -1,0 +1,115 @@
+// PublishReleaseOrderingTests — the release ships a COMMIT, not a branch state (#3494).
+//
+// WHAT WENT WRONG, AND WHY A TEST RATHER THAN A COMMENT
+//   publish.yml used to push the CHANGELOG commit to the branch FIRST and create the tag
+//   only if that push was a fast-forward. v2.11.0 ran all eight BC legs green, built,
+//   signed and packed, and then threw the lot away: PRs #3484 and #3469 merged during the
+//   run, the push was rejected as non-fast-forward, and no tag, no NuGet push and no
+//   GitHub Release followed. About fifty minutes of an account-wide Actions queue for
+//   nothing.
+//
+//   The old ordering was defended in a code comment as "the whole point of #1978". It is
+//   not. #1978's property is NEVER TAG A COMMIT WHOSE TESTS DID NOT PASS, and that is
+//   satisfied by the matrix, the build and the pack all running before the tag step.
+//   "The branch has not moved" is a separate property that says nothing about whether the
+//   commit being shipped is good — commits merged after the tested one are by definition
+//   not in the release.
+//
+//   A comment saying so is what was there before, pointing the other way. These assertions
+//   are what keep the ordering from being reverted by someone reading #1978 the same way.
+using System;
+using System.IO;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PublishReleaseTagDecouplingTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static string ReleaseStep() => WorkflowStep.BodyOf(
+        File.ReadAllText(Path.Combine(RepoRoot, ".github", "workflows", "publish.yml")),
+        "Generate CHANGELOG and push the release commit + tag");
+
+    /// <summary>
+    /// The tag push must come BEFORE the branch push. This is the assertion that fails on
+    /// the pre-#3494 file, where the order was the other way round and the branch push
+    /// gated the tag.
+    /// </summary>
+    [Fact]
+    public void TheTagIsPushed_BeforeTheChangelogCommit()
+    {
+        var body = ReleaseStep();
+
+        var tagPush = body.IndexOf("git push origin \"$TAG\"", StringComparison.Ordinal);
+        var branchPush = body.IndexOf("git push origin HEAD:", StringComparison.Ordinal);
+
+        Assert.True(tagPush >= 0, "the release step no longer pushes a tag at all");
+        Assert.True(branchPush >= 0, "the release step no longer pushes the CHANGELOG commit");
+        Assert.True(tagPush < branchPush,
+            "the tag must be pushed BEFORE the CHANGELOG commit. With the branch push first, a "
+            + "branch that moved during the run rejects it as non-fast-forward and NO TAG IS EVER "
+            + "CREATED — a fully tested, built and signed release is discarded because of commits "
+            + "that are not even in it (#3494). A tag push needs no fast-forward.");
+    }
+
+    /// <summary>
+    /// The tag must name the TESTED commit explicitly. A bare `git tag "$TAG"` tags whatever
+    /// HEAD is, which after the CHANGELOG commit is a commit that the regenerate-and-retry
+    /// path can leave off the branch's history — and then the NEXT release's
+    /// `git describe --tags --abbrev=0` does not find it and computes its range from the
+    /// wrong baseline. That breaks one release later, which is the worst time to find out.
+    /// </summary>
+    [Fact]
+    public void TheTag_NamesTheTestedCommit_NotWhateverHeadIs()
+    {
+        var body = ReleaseStep();
+
+        Assert.Contains("TESTED_SHA=$(git rev-parse HEAD)", body);
+        Assert.Contains("git tag \"$TAG\" \"$TESTED_SHA\"", body);
+        Assert.False(body.Contains("git tag \"$TAG\"\n", StringComparison.Ordinal),
+            "`git tag \"$TAG\"` with no commit argument tags HEAD, which by then is the CHANGELOG "
+            + "commit rather than the commit that was tested and built.");
+    }
+
+    /// <summary>
+    /// Failing to land the CHANGELOG commit must not fail a release that is already tagged
+    /// and about to publish. The push therefore has to sit inside a retry whose failure is
+    /// reported, not propagated.
+    /// </summary>
+    [Fact]
+    public void FailingToLandTheChangelog_DoesNotFailTheRelease()
+    {
+        var body = ReleaseStep();
+
+        Assert.Contains("CHANGELOG_PUSHED=false", body);
+        Assert.Contains("if git push origin HEAD:", body);
+        Assert.Contains("::warning::", body);
+
+        // The retry regenerates rather than rebases. $COMMITS is fixed to the tested range,
+        // so replaying it reproduces the same section; a rebase would drag commits that
+        // merged after the release under this version's heading.
+        Assert.Contains("git reset --hard \"origin/", body);
+        Assert.Contains("generate_changelog.py", body);
+        Assert.False(body.Contains("git rebase", StringComparison.Ordinal),
+            "the retry must regenerate the section onto the branch's new head, not rebase — a "
+            + "rebase would put commits that merged AFTER the tested commit under this release's "
+            + "heading.");
+    }
+
+    /// <summary>
+    /// The tag no longer carries the CHANGELOG commit, so the tag-exists reuse path cannot
+    /// read the section out of the tag alone. Left unchanged it would return nothing and the
+    /// release would publish with empty notes — a silent wrong answer rather than a failure.
+    /// </summary>
+    [Fact]
+    public void TheReusePath_ReadsTheSectionFromTheBranch_AndRefusesWhenItFindsNone()
+    {
+        var body = ReleaseStep();
+
+        Assert.Contains("read_section \"origin/", body);
+        Assert.Contains("::error::", body);
+        Assert.Contains("Refusing to publish a release with empty notes", body);
+    }
+}


### PR DESCRIPTION
> Opened by an agent (`agent: coord-1`) on the account holder's behalf. The merge decision remains his.

Closes #3494

Corpus-NA: release-workflow plumbing; asserts nothing about BC's behavior and touches no runner code.

> **Scope narrowed after review.** This PR originally carried a second change — skipping the BC matrix
> when the dispatched commit already held a green eight-leg verdict. A review found two blocking
> defects in it, the worse of which broke the release *only when the optimization worked*, so it has
> been removed and re-filed as **#3534** with the findings and the parts worth keeping. What remains
> is the tag decoupling, which the same review confirmed on all five of its points.

## What happened

Run [`34191500610`](https://github.com/StefanMaron/BusinessCentral.AL.Runner/actions/runs/34191500610)
ran all eight BC legs green, built, signed and packed — then discarded it:

```
[detached HEAD a4ffdadc] chore: release v2.11.0
 ! [rejected]          HEAD -> main (non-fast-forward)
```

PRs #3484 and #3469 merged during the run. No tag, no NuGet push, no GitHub Release.

## The reasoning error this corrects

The step pushed the CHANGELOG commit to the branch first and created the tag only if that push was a
fast-forward. Its own comment defended that:

> If someone pushed to it during the run this fails here — and NO tag is created, which is the whole
> point of #1978.

That conflates two properties. #1978's is **never tag a commit whose tests did not pass**, and it is
satisfied by the matrix, the build and the pack all running before this step. **The branch has not
moved** is a different property and says nothing about whether the commit being shipped is good. We
release a specific commit; anything merged after it is by definition not in that release.

## What changes

- **The tag goes first, naming the tested commit explicitly.** A tag push needs no fast-forward, so a
  moved branch cannot block it. It still precedes the NuGet push, so NuGet keeps an immutable ref for
  provenance.
- **The CHANGELOG commit follows as bookkeeping.** Failing to land it warns; it does not fail a
  release that is already tagged and publishing.
- **The retry regenerates onto the branch's new head rather than rebasing.** `$COMMITS` is fixed to
  the tested range, so replaying it reproduces the same section — a rebase would put commits that
  merged *after* the release under this version's heading.

## Two things that would have broken one release later

**The tag names the tested commit, not the CHANGELOG commit.** The tested commit stays on the
branch's history; the CHANGELOG commit does not, once the retry regenerates onto a moved branch.
Tagging the latter would leave the next release's `git describe --tags --abbrev=0` unable to find it,
and it would compute `PREV_TAG..HEAD` from the wrong baseline — a wrong changelog on the *following*
release, with nothing failing in between.

**The `tag-exists` reuse path read the section out of the tag** via `git show "$TAG:CHANGELOG.md"`.
The tag no longer carries it, so it now reads from the branch, falls back to the tag, and **refuses**
rather than publishing a release with empty notes.

## Why reversing the order is safe for the #2109 sync race

`sync-changelog-unreleased.yml`'s header warns that publish.yml pushes the commit before the tag, so
a sync run could see the release commit while the tag is not yet visible. Its mitigation does not
depend on that order: `update_unreleased()` recognises a release commit from its own message via
`RELEASE_COMMIT_RE` and returns early. Its docstring says so —

> it doesn't matter whether the tag has propagated, because the check never looks at tags at all when
> HEAD is the release commit itself

With the tag pushed first the race is if anything easier. Emptying `[Unreleased]` on the retry path is
self-healing: the next ordinary push triggers the sync workflow, which recomputes from the new tag
forward.

A reviewer also checked something I had not: the tag moving to the tested commit puts
`chore: release vX` inside the next `PREV_TAG..HEAD` range, but `generate_changelog.py` drops `chore`
— no regression.

## RED → GREEN

`AlRunner.Tests/PublishReleaseTagDecouplingTests.cs`, four assertions. Verified against the
pre-change `publish.yml`, restored with `git show HEAD:...` rather than a checkout so the index was
never touched:

```
Failed!  - Failed: 4, Passed: 0, Skipped: 0, Total: 4
```

and with the change in place:

```
Passed!  - Failed: 0, Passed: 4, Skipped: 0, Total: 4
```

The whole publish-workflow set — these 4 plus the 10 already in `PublishReleaseOrderingTests` — is
**14 passed, 0 failed**. `ReleaseJob_...BeforeItPushesTheCommitAndTag_...` asserts step-level order
and is unaffected, because this change is entirely inside one step whose name did not change.

## Known and not addressed here

Two prose sites now contradict the shipped ordering and are not in this diff:
`.github/scripts/generate_changelog.py:68` and `.github/workflows/sync-changelog-unreleased.yml:23-25`.
Both describe the old commit-then-tag sequence. Worth a follow-up; neither changes behaviour.

https://claude.ai/code/session_01F7HLDeNwiGQoLT5wFanqmH
