### PR TITLE
docs(rules): name the Windows nightly as the tier the corpus pins, and say what to do when Linux is in doubt

### DIFF
--- a/.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md
+++ b/.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md
@@ -67,7 +67,7 @@ gh workflow run 351779742 --repo StefanMaron/BusinessCentral.AL.Language.Tests \
   --ref <branch> -f bc_version=28.4 -f artifact_type=sandbox -f country=w1
 ```
 
-Three outcomes, and only the first two need anyone to do anything:
+Four outcomes, and only the first two need anyone to do anything here:
 
 | Windows | meaning | fix goes |
 |---|---|---|

--- a/.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md
+++ b/.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md
@@ -32,10 +32,77 @@ A corpus test green on a real service tier beats, in this order, every one of:
 3. Microsoft's documentation,
 4. the name of a BC codeunit, or a comment naming one.
 
+**And one thing outranks the corpus CI itself: the Windows nightly.** The eight cloud legs
+run on `MsDyn365Bc.On.Linux`, which is one particular patched container rather than Business
+Central; the nightly runs an official Microsoft container on Windows. Where the two disagree,
+Windows is right by definition and the Linux result is an image bug — see the next section
+for the dispatch and the three outcomes.
+
 **One qualifier on that ranking**, and it is not a footnote: the tier is patched. On a
 surface an unfaithful patch covers, a corpus result measures the patch, not BC — read
 "The tier is patched, so check before quoting it on a UI surface" below before resting a
 UI-side claim on a corpus result.
+
+## When the Linux tier is the thing in doubt, ask Windows — do not reason about it
+
+The qualifier above says a corpus result can be measuring the patch rather than BC. It does
+not say what to do about it, and the answer is not more reading: **dispatch the Windows
+nightly against the branch and let it adjudicate.**
+
+The ordering, which is the repository owner's standing instruction:
+
+> **The corpus pins what the Windows pipeline says. `MsDyn365Bc.On.Linux` and AL Runner
+> follow it — never the reverse.**
+
+This is not new policy. `.github/workflows/nightly-windows.yml`'s own header has carried it
+since corpus issue #213:
+
+> any test that fails on windows needs to be first fixed on
+> https://github.com/StefanMaron/MsDyn365Bc.On.Linux
+
+So: **a Windows failure is a real failure. A Linux-only failure is an image bug.**
+
+```bash
+gh workflow run 351779742 --repo StefanMaron/BusinessCentral.AL.Language.Tests \
+  --ref <branch> -f bc_version=28.4 -f artifact_type=sandbox -f country=w1
+```
+
+Three outcomes, and only the first two need anyone to do anything:
+
+| Windows | meaning | fix goes |
+|---|---|---|
+| fails too | the assertion does not match BC | **the corpus test** — change the assertion |
+| passes, Linux fails | Linux-only ⇒ image bug | **`MsDyn365Bc.On.Linux`** — the assertion stands, the PR waits |
+| passes, Linux passes | settled | merge |
+
+None of those rows is a judgement call. Which is the point: a red corpus leg on a
+UI-adjacent surface looks like it needs analysis, and it usually needs a dispatch.
+
+**It adjudicates; it does not gate.** The nightly takes 1-2 hours and is deliberately not a
+required status context — a nightly that gates merges stalls the repository. The eight
+`BC <ver> / test` legs remain the merge gate, so a PR stays blocked on those either way.
+
+**Do not adjust a corpus assertion to match the Linux tier, and never to match the runner.**
+The second is the more tempting error, because it turns a red leg green and looks like
+progress; it is how the corpus stops being evidence about BC at all.
+
+### The cost of not reaching for this first
+
+Measured 2026-09-08. Two corpus PRs (#272, #273) sat red on their cloud legs. A Linux tier
+defect had just been fixed upstream (`2b0d91f8`, forcing `CommunicationBroker.Async = false`
+and so disabling BC's own notification coalescing), and the failures matched its shape
+closely — one of them read `Expected:<1> Actual:<2>`, a message delivered twice, which is
+exactly what disabled coalescing produces.
+
+The inference was written up on both PRs as a hypothesis, with single-leg re-runs attached.
+Both re-runs failed **identically** on the fixed tier, and the hypothesis was retracted.
+
+The reasoning was sound and the conclusion was wrong: **a symptom matching a mechanism is not
+evidence that mechanism produced it.** What made it recoverable was attaching the check to the
+claim rather than publishing a finding. What would have avoided it entirely was dispatching
+Windows first — one command, against a documented authority, instead of an argument about
+which tier to believe.
+
 
 ## The two incidents this rule is made of
 

--- a/.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md
+++ b/.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md
@@ -74,9 +74,32 @@ Three outcomes, and only the first two need anyone to do anything:
 | fails too | the assertion does not match BC | **the corpus test** — change the assertion |
 | passes, Linux fails | Linux-only ⇒ image bug | **`MsDyn365Bc.On.Linux`** — the assertion stands, the PR waits |
 | passes, Linux passes | settled | merge |
+| **errored before running tests** | **no verdict at all** | **nothing here — the tier is broken; file it** |
 
-None of those rows is a judgement call. Which is the point: a red corpus leg on a
+None of the first three rows is a judgement call. Which is the point: a red corpus leg on a
 UI-adjacent surface looks like it needs analysis, and it usually needs a dispatch.
+
+**The fourth row is the one that will bite, and it bit on this rule's first use.** A run that
+dies before executing a test still reports `conclusion: failure`. Read that as a verdict and
+you land on row 1 — *change the corpus assertion* — which is precisely what the last paragraph
+of this section forbids, arrived at by following the table. So the conclusion is not the thing
+to read:
+
+```
+##[error]parsed 0 tests from the supplied XUnit files. That is not a green run -- it means the
+         tests never executed, or the result file never got written. Refusing to report a verdict.
+```
+
+That refusal is the signal. **A `failure` with zero tests parsed is not Windows disagreeing
+with you; it is Windows not having been asked.** Measured 2026-09-08: two dispatches against
+corpus PRs #272 and #273 both died in the nightly's tenant-encryption-key step, before any test
+ran (corpus #288). Three runs earlier the same day had succeeded, so this is a thing that
+happens to a working workflow, not a permanent state — which is exactly why it has to be
+recognised rather than assumed away.
+
+Do not re-dispatch to see whether it clears: two runs twelve minutes apart failing identically
+is a deterministic fault, and another attempt spends an hour of the account's shared Actions
+queue reproducing it.
 
 **It adjudicates; it does not gate.** The nightly takes 1-2 hours and is deliberately not a
 required status context — a nightly that gates merges stalls the repository. The eight
@@ -103,8 +126,7 @@ claim rather than publishing a finding. What would have avoided it entirely was 
 Windows first — one command, against a documented authority, instead of an argument about
 which tier to believe.
 
-
-## The two incidents this rule is made of
+## The incidents this rule is made of
 
 **#2144 — the container differential lost, and a self-inflicted failure got classified
 instead of reverted.** The differential said `TestIsolation = Codeunit` rolls the database
@@ -160,6 +182,9 @@ worked case, what remains out of reach, and the `SingleInstance`-probe technique
 observable a rollback would otherwise destroy.
 
 ## When no verdict is available
+
+This covers the fourth row of the table above — a reference-tier run that errored before
+executing anything is *no verdict*, not a negative one, and the rules here apply unchanged.
 
 Say so plainly, name what would settle it, and land the runner change with whatever coverage
 is legitimately available — the escape hatch in `bc-behavior-tests-go-upstream.md` applies


### PR DESCRIPTION
Writes down an ordering that was already policy but was not where an agent would read it before forming a theory.

No linked issue: a rules correction, prompted by the repository owner restating an ordering that was already policy and by an incident where I applied it wrongly. No defect is being fixed and no behaviour changes.

## The ordering

> **The corpus pins what the Windows pipeline says. `MsDyn365Bc.On.Linux` and AL Runner follow it — never the reverse.**

This is not new. The corpus's own `.github/workflows/nightly-windows.yml` header has carried it since corpus issue #213:

> any test that fails on windows needs to be first fixed on https://github.com/StefanMaron/MsDyn365Bc.On.Linux

So a **Windows failure is a real failure**, and a **Linux-only failure is an image bug**. What was missing is that `ask-the-corpus-before-claiming-bc-behavior.md` — the rule an agent consults before acting on a belief about BC — topped its ranking out at "a corpus test green on a real service tier", with a footnote that the tier is patched and may be measuring the patch rather than BC.

That footnote says what can go wrong. It does not say what to do, so the natural next move looks like analysis. It is a dispatch.

## What the change adds

- **Windows above the corpus CI in the ranking**, with why: the eight cloud legs run on one particular patched container; the nightly runs an official Microsoft container.
- **The dispatch command**, so it is one copy-paste rather than a workflow hunt.
- **The three outcomes**, none of which is a judgement call:

| Windows | meaning | fix goes |
|---|---|---|
| fails too | the assertion does not match BC | the corpus test |
| passes, Linux fails | Linux-only ⇒ image bug | `MsDyn365Bc.On.Linux`; assertion stands |
| passes, Linux passes | settled | merge |

- **That it adjudicates but does not gate** — 1–2 hours, deliberately not a required context, because a nightly that gates merges stalls the repository.
- **The error to guard hardest against: never adjust a corpus assertion to match the runner.** It turns a red leg green and looks like progress, and it is how the corpus stops being evidence about BC at all.

## The incident it records

Two corpus PRs (#272, #273) sat red on their cloud legs. A Linux tier defect had just been fixed upstream (`2b0d91f8` — it forced `CommunicationBroker.Async = false`, disabling BC's own notification coalescing), and the failures matched its shape closely. One read `Expected:<1> Actual:<2>` — a message delivered twice, which is exactly what disabled coalescing produces.

I wrote the inference up on both PRs **as a hypothesis with single-leg re-runs attached**. Both re-runs failed identically on a tier that provably carried the fix (jobs started 07:08Z and 07:09Z; fix committed 07:03:50Z), and I retracted it on both threads with the measurement.

The reasoning was sound and the conclusion was wrong: **a symptom matching a mechanism is not evidence that mechanism produced it.** Attaching the check to the claim is what made it recoverable in ten minutes rather than becoming a confident wrong diagnosis on two PRs. Dispatching Windows first is what would have avoided it entirely — one command against a documented authority, instead of an argument about which tier to believe.

Both PRs now have that dispatch running.

## Verification

Docs-only; no code paths touched.

```
tools/test_doc_pointers.py    all doc-pointer checks passed (34 links, 13 anchors, 5 Doc values)
tools/test_line_endings.py    PASS (3283 tracked files)
.github/scripts/test_docs_only.py   all checks passed
```

The workflow filename and id cited in the rule were verified against the corpus repo's API rather than recalled: `.github/workflows/nightly-windows.yml`, id `351779742`.

---
*Filed by the `stma-auto-3` autonomous coordinator, an automated agent acting on the account holder's behalf, at their instruction that the Windows pipeline is the reference the corpus pins.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsJY7DhDm5y83e77GxpRSZ
