### PR TITLE
fix(integer-vt): judge a half-open range against the base window, not the envelope-widened span

### DIFF
--- a/AlRunner.Tests/IntegerVirtualTableWindowGuardTests.cs
+++ b/AlRunner.Tests/IntegerVirtualTableWindowGuardTests.cs
@@ -36,6 +36,9 @@ public sealed class IntegerVirtualTableWindowGuardTests
     private static string FindInterceptSource => File.ReadAllText(
         Path.Combine(RepoRoot, "AlRunner", "Patches", "RecordPatches.FieldFindIntercept.cs"));
 
+    private static string IntegerVirtualTableSource => File.ReadAllText(
+        Path.Combine(RepoRoot, "AlRunner", "Patches", "RecordPatches.IntegerVirtualTable.cs"));
+
     // The three Cecil-prepended paths. The find path is wired differently — through the
     // DataAccess_IsManagedFindRequest predicate rather than a prepend of its own — and is
     // asserted separately below.
@@ -231,5 +234,30 @@ public sealed class IntegerVirtualTableWindowGuardTests
         Assert.True(capProp != null,
             "IntegerWindowMaxRows must be a property reading AL_RUNNER_INTEGER_WINDOW_MAX_ROWS: "
             + "the cap refusal tells the reader to raise it.");
+    }
+
+    [Fact]
+    public void TheHalfOpenRefusal_IsJudgedAgainstTheBaseWindow_NotTheEnvelopeWidenedSpan()
+    {
+        // Issue #3528, and the one claim in this file that AL genuinely cannot make. lowBound and
+        // highBound are the base window WIDENED by the filter's envelope, so comparing a half-open
+        // range's closed end against them lets a sibling range move the bar. No AL filter reaches
+        // that today -- BC's ToRangeList merges a sibling wide enough to widen the bound, because
+        // such a sibling overlaps the half-open range -- so codeunit 64591's two control arms pass
+        // either way and only the operand can be pinned. Asserted on the source, the way the
+        // wiring assertions above are, because EnsureIntegerWindowCoversRequest calls ToRangeList
+        // itself on BC runtime objects and no pre-merged range list can be handed to it without
+        // extracting the decision into a seam the Date side does not have either.
+        var source = IntegerVirtualTableSource;
+
+        Assert.Contains(
+            "if (openHigh && value > IntegerWindowMax) throw IntegerOpenEndedRefusal(value, openHigh: true);",
+            source, StringComparison.Ordinal);
+        Assert.Contains(
+            "if (!openHigh && value < IntegerWindowMin) throw IntegerOpenEndedRefusal(value, openHigh: false);",
+            source, StringComparison.Ordinal);
+
+        Assert.DoesNotContain("value > highBound", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("value < lowBound", source, StringComparison.Ordinal);
     }
 }

--- a/AlRunner/Patches/RecordPatches.IntegerVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.IntegerVirtualTable.cs
@@ -532,17 +532,24 @@ public static partial class RecordPatches
         var lowBound = closedLow is int cl && cl < IntegerWindowMin ? cl : IntegerWindowMin;
         var highBound = closedHigh is int ch && ch > IntegerWindowMax ? ch : IntegerWindowMax;
 
-        // The closed end of a half-open range sits outside the span we are about to materialise, so
-        // that range contributes no rows at all while BC answers it with up to a billion. Nothing
-        // here can be materialised honestly; say so.
+        // The closed end of a half-open range sits outside the span an open bound can be answered
+        // from, so that range contributes no rows at all while BC answers it with up to a billion.
+        // Nothing here can be materialised honestly; say so.
         //
         // Decided per RANGE, never from the envelope (#3471): `'1..50|200000..'` has its outermost
         // closed bounds at 1 and 50, both inside the window, and dropping the second range whole
         // is the same silent zero this refusal exists to remove.
+        //
+        // Compared against the base WINDOW, never against lowBound/highBound: those two are
+        // widened by the filter's envelope, so a sibling range would otherwise move the bar this
+        // range is judged against. No filter was found that actually reaches that -- BC's
+        // ToRangeList merges a sibling wide enough to widen the bound, because such a sibling
+        // overlaps the half-open range -- so what holds the invariant is the window, not that
+        // merge (#3528, the Integer half of #3483's follow-up).
         foreach (var (value, openHigh) in halfOpenEnds)
         {
-            if (openHigh && value > highBound) throw IntegerOpenEndedRefusal(value, openHigh: true);
-            if (!openHigh && value < lowBound) throw IntegerOpenEndedRefusal(value, openHigh: false);
+            if (openHigh && value > IntegerWindowMax) throw IntegerOpenEndedRefusal(value, openHigh: true);
+            if (!openHigh && value < IntegerWindowMin) throw IntegerOpenEndedRefusal(value, openHigh: false);
         }
 
         PopulateIntegerSpan(dataAccess, meta, lowBound, highBound);

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -1934,3 +1934,19 @@ after this PR merges.
 **Nothing else moved.** #285's rewrite changed no classification: the full three-app run at the
 new pin with CI's own invocation is **3124 total, 3124 pass, 0 fail**, and the expectation match
 audit reports all 23 entries matched a discovered test. Added by agent fbk-1.
+
+## runner-extras `integer-virtual-table-window` 14 -> 16 (#3528)
+
+Two arms on codeunit 64591, and both are **controls rather than RED -> GREEN**: they pass on
+`a3fb61d5` too, before this PR moved the half-open comparison off the envelope-widened
+`lowBound`/`highBound` and onto the base window. `'200000..|300000..300010'` and
+`'..-200000|-300010..-300000'` are the two shapes a sibling range could in principle use to
+move the bar the half-open range is judged against; BC's own `FilterExpression.ToRangeList`
+merges such a sibling into the half-open range, because a range wide enough to widen the
+bound necessarily overlaps it, so neither reaches the envelope comparison. What holds the
+invariant after this PR is the window, not that merge.
+
+Measured: `tests/runner-extras/integer-virtual-table-window` 16/16 before the fix and 16/16
+after; with the refusal loop deleted, 10/16 — both new arms among the six that fail, which is
+what makes them live controls rather than decoration. Full `runner-extras` 403/403 with the
+count baseline. Added by agent fbk-1.

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -28,7 +28,7 @@
         "http-egress-boundary-oos": { "tests": 4 },
         "install-trigger-seed": { "tests": 3 },
         "install-trigger-text-constant": { "tests": 2 },
-        "integer-virtual-table-window": { "tests": 14 },
+        "integer-virtual-table-window": { "tests": 16 },
         "manual-binding-dep": { "tests": 3, "absentOn": ["27.0", "27.3", "27.5"] },
         "microsoft-dependencies": { "tests": 26 },
         "microsoft-test-library": { "tests": 3, "absentOn": ["27.0", "27.3", "27.5"] },

--- a/tests/runner-extras/integer-virtual-table-window/IvtwTests.Codeunit.al
+++ b/tests/runner-extras/integer-virtual-table-window/IvtwTests.Codeunit.al
@@ -106,6 +106,9 @@ codeunit 64591 "Ivtw Tests"
         Assert.ExpectedError('out-of-scope: Integer (virtual table 2000000026)');
         Assert.ExpectedError('integer-virtual-table');
         Assert.ExpectedError('with its other end open');
+        // The bound itself, not just the fact of a refusal: a message naming a different
+        // number would mean the refusal came from the wrong end of the filter.
+        Assert.ExpectedError('249000');
     end;
 
     [Test]
@@ -121,6 +124,7 @@ codeunit 64591 "Ivtw Tests"
         Assert.ExpectedError('out-of-scope: Integer (virtual table 2000000026)');
         Assert.ExpectedError('integer-virtual-table');
         Assert.ExpectedError('with its other end open');
+        Assert.ExpectedError('-249000');
     end;
 
     [Test]

--- a/tests/runner-extras/integer-virtual-table-window/IvtwTests.Codeunit.al
+++ b/tests/runner-extras/integer-virtual-table-window/IvtwTests.Codeunit.al
@@ -51,6 +51,7 @@ codeunit 64591 "Ivtw Tests"
         // reads the short number as the real one.
         asserterror IntRec.FindSet();
         Assert.ExpectedError('out-of-scope: Integer (virtual table 2000000026)');
+        Assert.ExpectedError('integer-virtual-table');
         Assert.ExpectedError('row cap');
     end;
 
@@ -66,6 +67,7 @@ codeunit 64591 "Ivtw Tests"
 
         asserterror CountRows(IntRec);
         Assert.ExpectedError('out-of-scope: Integer (virtual table 2000000026)');
+        Assert.ExpectedError('integer-virtual-table');
         Assert.ExpectedError('row cap');
     end;
 
@@ -82,6 +84,7 @@ codeunit 64591 "Ivtw Tests"
 
         asserterror IsEmptyRows(IntRec);
         Assert.ExpectedError('out-of-scope: Integer (virtual table 2000000026)');
+        Assert.ExpectedError('integer-virtual-table');
         Assert.ExpectedError('row cap');
     end;
 
@@ -101,6 +104,7 @@ codeunit 64591 "Ivtw Tests"
 
         asserterror IntRec.FindSet();
         Assert.ExpectedError('out-of-scope: Integer (virtual table 2000000026)');
+        Assert.ExpectedError('integer-virtual-table');
         Assert.ExpectedError('with its other end open');
     end;
 
@@ -115,6 +119,7 @@ codeunit 64591 "Ivtw Tests"
 
         asserterror CountRows(IntRec);
         Assert.ExpectedError('out-of-scope: Integer (virtual table 2000000026)');
+        Assert.ExpectedError('integer-virtual-table');
         Assert.ExpectedError('with its other end open');
     end;
 
@@ -226,6 +231,7 @@ codeunit 64591 "Ivtw Tests"
 
         asserterror Reached := TryFindSet(IntRec);
         Assert.ExpectedError('out-of-scope: Integer (virtual table 2000000026)');
+        Assert.ExpectedError('integer-virtual-table');
         Assert.IsFalse(Reached, 'TryFindSet must not have completed.');
     end;
 
@@ -247,6 +253,7 @@ codeunit 64591 "Ivtw Tests"
 
         asserterror IntRec.FindSet();
         Assert.ExpectedError('out-of-scope: Integer (virtual table 2000000026)');
+        Assert.ExpectedError('integer-virtual-table');
         Assert.ExpectedError('with its other end open');
         Assert.ExpectedError('200000');
     end;
@@ -265,6 +272,7 @@ codeunit 64591 "Ivtw Tests"
 
         asserterror CountRows(IntRec);
         Assert.ExpectedError('out-of-scope: Integer (virtual table 2000000026)');
+        Assert.ExpectedError('integer-virtual-table');
         Assert.ExpectedError('with its other end open');
         Assert.ExpectedError('-200000');
     end;
@@ -307,6 +315,48 @@ codeunit 64591 "Ivtw Tests"
         Assert.IsTrue(IntRec.FindLast(), 'A closed multi-range filter reaching past the base window returned no last row.');
         Assert.AreEqual(200009, IntRec.Number, 'Expected the last row of 1..50|200000..200009 to be Number 200009.');
         Assert.IsTrue(IntRec.Get(200000), 'Number 200000 must be readable after the span was materialised.');
+    end;
+
+    [Test]
+    procedure Integer_HalfOpenRangeWithASiblingRangeFurtherOut_IsStillRefused()
+    var
+        IntRec: Record Integer;
+    begin
+        // Issue #3528, and a CONTROL rather than a RED -> GREEN: this arm is refused on
+        // a3fb61d5 too, before the comparison was moved onto the window. It pins that a sibling
+        // range cannot move the bar the half-open range is judged against. Two things hold that
+        // and only one of them is ours -- the refusal compares against the base window rather
+        // than against the envelope-widened span, and BC's own FilterExpression.ToRangeList
+        // merges this filter's second range into its first, because a range wide enough to widen
+        // the envelope's high bound past 200000 necessarily overlaps `200000..`.
+        IntRec.SetFilter(Number, '200000..|300000..300010');
+
+        // The bound is asserted, not just the fact of a refusal: a refusal naming 300000 or
+        // 300010 would mean the per-range decision landed on the wrong range.
+        asserterror CountRows(IntRec);
+        Assert.ExpectedError('out-of-scope: Integer (virtual table 2000000026)');
+        Assert.ExpectedError('integer-virtual-table');
+        Assert.ExpectedError('with its other end open');
+        Assert.ExpectedError('200000');
+    end;
+
+    [Test]
+    procedure Integer_HalfOpenLowRangeWithASiblingRangeFurtherOut_IsStillRefused()
+    var
+        IntRec: Record Integer;
+    begin
+        // The mirror, on the low side and on the find path. `..-200000|-300010..-300000` is open
+        // at the LOW end of its first range, and its sibling reaches further down still -- the
+        // shape that would widen lowBound below -200000 if the envelope were what this range was
+        // judged against. Refused on a3fb61d5 as well, for the merge reason above; what makes it
+        // hold without that merge is the window comparison.
+        IntRec.SetFilter(Number, '..-200000|-300010..-300000');
+
+        asserterror IntRec.FindSet();
+        Assert.ExpectedError('out-of-scope: Integer (virtual table 2000000026)');
+        Assert.ExpectedError('integer-virtual-table');
+        Assert.ExpectedError('with its other end open');
+        Assert.ExpectedError('-200000');
     end;
 
     local procedure CountRows(var IntRec: Record Integer): Integer


### PR DESCRIPTION
Closes #3528

`AlRunner/Patches/RecordPatches.IntegerVirtualTable.cs` compared each half-open range's closed
end against `lowBound` / `highBound` — the base window **widened by the filter's envelope** —
so in principle a closed sibling range could move the bar the half-open range is judged
against. That is the shape #3471 removed one level up, still present in what the comparison was
made against, and the identical shape PR #3511 fixed for the Date table. The comparison is now
against `IntegerWindowMin` / `IntegerWindowMax` directly. `lowBound` / `highBound` stay, because
`PopulateIntegerSpan` still needs them.

Corpus-NA: runner-side invariant; BC's ToRangeList merges the overlapping ranges so no new corpus arm can distinguish the two comparisons (see #3511 / #3528)

## There is no RED, and this says so plainly

The two AL control arms added here **pass on `a3fb61d5` as well**, before the fix. The issue
predicted this and the run confirms it: a closed sibling wide enough to push `closedHigh` past a
half-open range's low bound has to extend beyond that bound, so it lies inside the half-open
range, and BC's own `FilterExpression.ToRangeList` hands back the merged range instead of two.
No AL filter was found that reaches the envelope comparison. So this PR is an invariant
hardening with the arms as controls, not a RED to GREEN, and it is not presented as one.

What that leaves provable, and where each piece is proven:

| claim | proven by | RED? |
|---|---|---|
| the sibling shapes are refused, naming the right bound | `Ivtw` arms 15 and 16 (AL) | no — pass either way, by design |
| the refusal loop is what refuses them | mutation run below | — |
| the operand is the window, not the envelope | `TheHalfOpenRefusal_IsJudgedAgainstTheBaseWindow_NotTheEnvelopeWidenedSpan` (C#) | **yes** — `origin/main` still reads `value > highBound` |

The C# arm is the seam the brief allowed for: `EnsureIntegerWindowCoversRequest` calls
`ToRangeList` itself on BC runtime objects, so no pre-merged range list can be handed to it
without extracting the per-range decision into a pure function — a refactor the Date side did
not get, and "mirror #3511 exactly" argues against introducing it here. It is asserted on the
source text, which is how that file already pins the Cecil wiring three tests above it.

## Measurements

All on this box, BC 28.1, `--package-cache "$HOME/.al-runner/platform-apps"` plus `test-apps`.

| run | result |
|---|---|
| `integer-virtual-table-window`, arms added, **fix not yet applied** | 16 / 16 pass |
| same, **with the fix** | 16 / 16 pass |
| same, with the whole `foreach` refusal loop deleted (mutation) | **10 / 16** — both new arms among the six failures |
| full `tests/runner-extras` `--strict --count-baseline` | **403 / 403**, guard silent |
| `dotnet test AlRunner.Tests --filter FullyQualifiedName~IntegerVirtualTableWindowGuardTests` | 17 / 17 pass |

The mutation run is `tdd.md`'s "would this pass with a no-op" answered as a measurement: both
control arms are live, not decoration. The loop was restored and rebuilt before anything was
committed.

## Also in this diff

**Every refusal arm of codeunit 64591 now anchors `integer-virtual-table`**, not only the two
new ones. Eight assertions existed asserting the `out-of-scope: Integer (virtual table
2000000026)` prefix and none asserted the reason anchor, so nothing pinned it; it was already
emitted correctly (`IntegerShapeGap` passes it), and the arms now say so. Same follow-up #3511's
second pass made on the Date Year arm.

**Baseline:** `integer-virtual-table-window` 14 to 16, with an entry in
`tests/expectations/count-baseline/history.md` recording that the two arms are controls rather
than a RED, so the next reader is not left inferring a fix from a count.

## Fix the shape, not the reported line

1. **The same wrong pattern at another call site?** No. The envelope-vs-window comparison exists
   in exactly two places in the runner, `RecordPatches.DateVirtualTable.cs` and
   `RecordPatches.IntegerVirtualTable.cs`; the Date one was corrected by #3511 and this is the
   other. Nothing else in `AlRunner/Patches/` compares a per-item bound against an
   envelope-widened span.
2. **A sibling function making the same assumption?** `TryReadClosedNumberBounds` widens `low` /
   `high` across ranges the same way, but that is its job — it answers "does one span provably
   contain every row this filter selects", which is an envelope question. Its half-open list is
   already recorded per range and is not widened. `PopulateIntegerSpan` reads `lowBound` /
   `highBound` and must keep doing so.
3. **Two paths writing the same state with different invariants?** The Date and Integer paths do
   not share state; they share only this shape, and after this PR they share the corrected one.

**Same-file sibling scan of the open queue.** One other open issue lands in this file: **#3485**
— an open-ended range is answered from the base window or refused, never the way a service tier
answers it. Deliberately **not folded**: it questions whether the base-window answer for an
unbounded filter is right at all, which is a behavioural decision about materialising strategy
with an upstream corpus dimension, not the one-operand invariant here. Folding it would make
this diff two changes a reviewer has to hold separately.

## Not touched

`docs/limitations.md` — this change has no AL-observable behaviour, and the section's
description of the refusal is already correct. No corpus test, no pin bump, no `CHANGELOG.md`,
no workflow files.

Opened by agent fbk-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPJecKgfS4YFcpXSQr2tqb
