### PR TITLE
fix(codeunit-metadata): read a quoted Subtype as the identifier it is, and contain a refusal to its own row

### DIFF
--- a/AlRunner.Tests/CodeunitMetadataVirtualTableTests.cs
+++ b/AlRunner.Tests/CodeunitMetadataVirtualTableTests.cs
@@ -98,6 +98,14 @@ public sealed class CodeunitMetadataVirtualTableTests
             // string, not a hardcoded ordinal table.
             Assert.Contains(
                 "PASS  Codeunit60764.CodeunitMetadata_TestCodeunit_ReportsSubtypeTest", stdout);
+            // #3536: a quoted Subtype identifier is the same declaration as the bare one...
+            Assert.Contains(
+                "PASS  Codeunit60764.CodeunitMetadata_QuotedSubtype_IsReadAsTheIdentifierItIs", stdout);
+            // ...and a row the resolver cannot answer may not take the rest of the table with
+            // it. This one asserts the containment through the runner's real populate path,
+            // which is where the whole-table abort lived.
+            Assert.Contains(
+                "PASS  Codeunit60764.CodeunitMetadata_QuotedSubtypeCodeunit_DoesNotSuppressTheOtherRows", stdout);
             // Negative: an id no codeunit uses still answers false, not a silent success.
             Assert.Contains(
                 "PASS  Codeunit60764.CodeunitMetadata_UnknownCodeunitId_ReturnsFalse", stdout);

--- a/AlRunner.Tests/Fixtures/CodeunitMetadataVirtualTable/CmvFixtureTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/CodeunitMetadataVirtualTable/CmvFixtureTests.Codeunit.al
@@ -80,6 +80,40 @@ codeunit 60764 "CMV Fixture Tests"
     end;
 
     [Test]
+    procedure CodeunitMetadata_QuotedSubtype_IsReadAsTheIdentifierItIs()
+    var
+        CodeunitMetadata: Record "CodeUnit Metadata";
+    begin
+        // #3536. "CMV Quoted" declares Subtype = "Upgrade" — a quoted identifier, which AL
+        // accepts for Subtype = Upgrade. The runner used to hand the column the quote
+        // characters, which matched no member of its option string.
+        Assert.IsTrue(
+            CodeunitMetadata.Get(Codeunit::"CMV Quoted"),
+            'CodeUnit Metadata has no row for a codeunit declaring a quoted Subtype.');
+        Assert.AreEqual(
+            'Upgrade', Format(CodeunitMetadata.Subtype),
+            'A codeunit declaring Subtype = "Upgrade" must report Subtype::Upgrade.');
+    end;
+
+    [Test]
+    procedure CodeunitMetadata_QuotedSubtypeCodeunit_DoesNotSuppressTheOtherRows()
+    var
+        CodeunitMetadata: Record "CodeUnit Metadata";
+    begin
+        // The second half of #3536, and the one that hurt: resolving one row's Subtype used
+        // to happen while the table was being populated, so a row the resolver refused took
+        // the WHOLE table down — every other codeunit included, Company-Initialize's reads
+        // among them. A filter naming three codeunits of this bundle must select three rows
+        // even though one of them declares its Subtype the awkward way.
+        CodeunitMetadata.SetFilter(
+            ID, '%1|%2|%3', Codeunit::"CMV Quoted", Codeunit::"CMV Bound", Codeunit::"CMV Single");
+        Assert.AreEqual(
+            3, CodeunitMetadata.Count(),
+            'Every filtered codeunit must be served, including the one declaring a quoted Subtype.');
+        Assert.IsTrue(CodeunitMetadata.FindSet(), 'FindSet must succeed across the three rows.');
+    end;
+
+    [Test]
     procedure CodeunitMetadata_FilterOnId_DiscriminatesBetweenRows()
     var
         CodeunitMetadata: Record "CodeUnit Metadata";

--- a/AlRunner.Tests/Fixtures/CodeunitMetadataVirtualTable/CmvQuoted.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/CodeunitMetadataVirtualTable/CmvQuoted.Codeunit.al
@@ -1,0 +1,11 @@
+// Declares its Subtype as a QUOTED identifier — legal AL, and the same declaration as
+// `Subtype = Upgrade;`. #3536: the runner's source-decl parser used to carry the quote
+// characters through to the column resolver, which then matched no member and refused.
+codeunit 60765 "CMV Quoted"
+{
+    Subtype = "Upgrade";
+
+    trigger OnUpgradePerCompany()
+    begin
+    end;
+}

--- a/AlRunner.Tests/LoudDiagnosisReachesTheUserTests.cs
+++ b/AlRunner.Tests/LoudDiagnosisReachesTheUserTests.cs
@@ -170,6 +170,12 @@ public sealed class LoudDiagnosisReachesTheUserTests
         { "AlRunner/Patches/RecordPatches.UserSystemTable.cs", "exposes no user identity" },
         { "AlRunner/Patches/RecordPatches.UserSystemTable.cs", "was REFUSED and is NOT present" },
 
+        // #3536 — the same class again. A codeunit whose SubType this column cannot name is
+        // omitted from CodeUnit Metadata (2000000137) rather than taking the whole table down;
+        // the omission is silent at the read (Get() false, FindSet/Count one short, no error),
+        // so this line is the only account of it. See docs/limitations.md#codeunit-metadata-subtype.
+        { "AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs", "CodeUnit Metadata has NO ROW for codeunit" },
+
         // #2963, and named in #3068 as the same class: System Application module-ownership
         // checks silently decline for the whole run when this row set is not seeded.
         { "AlRunner/Patches/RecordPatches.PublishedApplicationSystemTable.cs", "Published Application rows" },

--- a/AlRunner.Tests/MetadataOptionColumnOrdinalTests.cs
+++ b/AlRunner.Tests/MetadataOptionColumnOrdinalTests.cs
@@ -310,6 +310,38 @@ public sealed class MetadataOptionColumnOrdinalTests
         Assert.Contains("'Install'", ex3.Message);
     }
 
+    [Fact]
+    public void RefusalNamesTheValueActuallyLookedUp_AndClaimsTheTranslationOnlyWhenItApplied()
+    {
+        // #3536. The refusal used to state the Install -> Normal translation unconditionally,
+        // so a declared subtype that had simply failed to match was reported as though the
+        // translation had been applied and had still missed. It read as an explanation and was
+        // one only by coincidence.
+        const string WithoutNormal = "Test,TestRunner,Upgrade";
+        var mapWithoutNormal = RecordPatches.BuildMetadataOptionOrdinals(WithoutNormal, null);
+
+        // Applied: declared Install IS looked up as Normal, and the message says so.
+        var translated = Assert.Throws<RunnerOutOfScopeException>(() =>
+            RecordPatches.ResolveCodeunitSubtypeOrdinal(
+                mapWithoutNormal, WithoutNormal, "Install", codeunitId: 60963));
+        Assert.Contains("declares Subtype = 'Install'", translated.Message);
+        Assert.Contains("looks up as 'Normal'", translated.Message);
+
+        // Not applied: a name that is not Install is looked up as itself, and the message must
+        // not offer the translation as the reason it missed.
+        var untranslated = Assert.Throws<RunnerOutOfScopeException>(() =>
+            RecordPatches.ResolveCodeunitSubtypeOrdinal(
+                SubTypeMap(), RealSubTypeOptions, "Wat", codeunitId: 60963));
+        Assert.Contains("declares Subtype = 'Wat'", untranslated.Message);
+        Assert.Contains(RealSubTypeOptions, untranslated.Message);
+        // The standing explanation stays (SubtypeTheColumnDoesNotName_IsRefusedNotDefaulted
+        // pins that it is there), but it may not be phrased as something that happened to
+        // THIS value: nothing was translated on the way to this refusal.
+        Assert.Contains("Install", untranslated.Message);
+        Assert.DoesNotContain("declares Subtype = 'Wat', which this resolver looks up as",
+            untranslated.Message);
+    }
+
     // ── The copies above, checked against the artifact this leg actually built with ──────
 
     /// <summary>BC's runtime enum behind CodeUnit Metadata's SubType column. Not a constant in

--- a/AlRunner.Tests/SiblingParserSyntaxTreeTests.cs
+++ b/AlRunner.Tests/SiblingParserSyntaxTreeTests.cs
@@ -291,6 +291,47 @@ public class SiblingParserSyntaxTreeTests
     }
 
     [Fact]
+    public void ObjectDecl_QuotedPropertyIdentifiers_ReachTheConsumerUnquoted()
+    {
+        // #3536. AL accepts `Subtype = "Install";` for `Subtype = Install;` — the quoting is
+        // lexical. The compiler agrees: SymbolReference.json inside a .app built from either
+        // spelling carries the bare name, so a parser that kept the quotes would make the two
+        // row sources of CodeUnit Metadata disagree about the same AL text.
+        var src = """
+            codeunit 61971 "Quoted Subtype Probe"
+            {
+                Subtype = "Install";
+                TestHttpRequestPolicy = "Allow";
+            }
+
+            codeunit 61972 "Bare Subtype Probe"
+            {
+                Subtype = Install;
+                TestHttpRequestPolicy = Allow;
+            }
+            """;
+        try
+        {
+            Parse("TryParseObjectDeclFile", src);
+
+            var quoted = Get("_parsedObjectDecls", ("Codeunit", 61971))!;
+            var bare = Get("_parsedObjectDecls", ("Codeunit", 61972))!;
+
+            // Concrete values, not merely "the two agree": a parser that dropped both
+            // properties would satisfy an equality-only assertion.
+            Assert.Equal("Install", Prop(quoted, "Subtype"));
+            Assert.Equal("Allow", Prop(quoted, "TestHttpRequestPolicy"));
+            Assert.Equal(Prop(bare, "Subtype"), Prop(quoted, "Subtype"));
+            Assert.Equal(Prop(bare, "TestHttpRequestPolicy"), Prop(quoted, "TestHttpRequestPolicy"));
+        }
+        finally
+        {
+            Dict("_parsedObjectDecls").Remove(("Codeunit", 61971));
+            Dict("_parsedObjectDecls").Remove(("Codeunit", 61972));
+        }
+    }
+
+    [Fact]
     public void ObjectCaption_ReadsTheObjectsOwnCaption_NotANestedOne()
     {
         // The nested `field`'s Caption must not become the table's. Absent Caption stays null

--- a/AlRunner/Patches/RecordPatches.AlObjectDeclParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlObjectDeclParser.cs
@@ -72,7 +72,12 @@ public static partial class RecordPatches
                     // AL's default is false; only an explicit `= true` sets it.
                     SingleInstance: PropIs(props, "SingleInstance", "true"),
                     // AL's default is Normal when the codeunit declares no Subtype.
-                    Subtype: PropValue(props, "Subtype")?.ToString()?.Trim(),
+                    // Unquoted: AL accepts `Subtype = "Install";` for `Subtype = Install;`,
+                    // and the compiler erases the difference before anything downstream sees
+                    // it — measured in the .app SymbolReference.json, which carries the bare
+                    // name for both spellings, so leaving the quotes on would make this source
+                    // path disagree with BcAppSymbolCache about the same AL text (#3536).
+                    Subtype: DeclaredIdentifierText(PropValue(props, "Subtype")),
                     // #2547. BC's AL->C# emit does not put this property on the generated
                     // type at all (measured: the emitted assembly carries NavCodeunitOptions
                     // and NavTestAttribute, and no trace of TestHttpRequestPolicy), and
@@ -81,12 +86,22 @@ public static partial class RecordPatches
                     // arrives through the XML object metadata the runner never loads for AL it
                     // compiles itself, so source is the only place it exists here.
                     // Null means "declares none", which the consumer reads as AL's default.
-                    TestHttpRequestPolicy: PropValue(props, "TestHttpRequestPolicy")?.ToString()?.Trim());
+                    TestHttpRequestPolicy: DeclaredIdentifierText(PropValue(props, "TestHttpRequestPolicy")));
                 continue;
             }
             _parsedObjectDecls[(kind, id)] = new ParsedAlObjectDecl(kind, id, name);
         }
     }
+
+    /// <summary>
+    /// The AL text of an identifier-valued object property, with any quoting removed —
+    /// `Subtype = "Install";` and `Subtype = Install;` state the same subtype, so they must
+    /// reach the consumer as the same string. `TableNo` needs no call here because
+    /// <c>LastNameSegment</c> already unquotes; the page parser makes the same call for
+    /// <c>PageType</c> and <c>SourceTable</c>.
+    /// </summary>
+    private static string? DeclaredIdentifierText(NavSyntax.PropertyValueSyntax? value)
+        => value?.ToString()?.Trim() is { } text ? Unquote(text) : null;
 
     /// <summary>Snapshot of every non-table/page/report/query/xmlport AL object declaration parsed from source.</summary>
     internal static IReadOnlyCollection<ParsedAlObjectDecl> ParsedObjectDecls => _parsedObjectDecls.Values;

--- a/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
@@ -105,6 +105,11 @@ public static partial class RecordPatches
     // field option string — same technique AllObj uses for its "Object Type" column.
     private static Dictionary<string, int>? _cmvSubtypeOrdinals;
 
+    // The same column's own OptionString, kept so the ordinal can be resolved BEFORE a row is
+    // handed to InsertVirtualRow — see PopulateCodeunitMetadataVirtualTable. Set in the same
+    // breath as _cmvSubtypeOrdinals and read only after it.
+    private static string? _cmvSubtypeOptionString;
+
     /// <summary>
     /// Populate the in-memory store behind CodeUnit Metadata (2000000137) with one row per
     /// codeunit the runner knows about. Idempotent per (provider, codeunit id); called on
@@ -125,9 +130,37 @@ public static partial class RecordPatches
         foreach (var row in EnumerateKnownCodeunitMetadata())
         {
             if (!done.TryAdd(row.Id, 0)) continue;
+
+            // Resolved HERE rather than from inside the per-field builder, so a subtype this
+            // column cannot name costs the one row it belongs to instead of the whole table
+            // (#3536). It used to throw out of InsertVirtualRow, which escapes
+            // GetDataAccessForTable — no row of the table was served, and because TryAdd above
+            // latches before the insert, the next handout omitted the offending codeunit
+            // silently. Codeunit 2 "Company-Initialize" reads this table, so one such codeunit
+            // anywhere in any loaded app left the company half-initialized.
+            //
+            // Still loud (loud-failures.md): the refusal's own message is printed, naming the
+            // codeunit and the reason, once per codeunit per provider — TryAdd has latched the
+            // id, so this row is not attempted again. What is contained is the blast radius,
+            // not the report.
+            int subtypeOrdinal;
+            try
+            {
+                subtypeOrdinal = ResolveCodeunitSubtypeOrdinal(
+                    subtypeOrdinals, _cmvSubtypeOptionString, row.Subtype, row.Id);
+            }
+            catch (RunnerOutOfScopeException ex)
+            {
+                Console.Error.WriteLine(
+                    $"[RecordPatches] CodeUnit Metadata: codeunit {row.Id} \"{row.Name}\" is NOT in the "
+                    + $"table — its SubType could not be resolved: {ex.Message}. Every other codeunit "
+                    + "is still reported; AL that reads this one's row will find none.");
+                continue;
+            }
+
             InsertVirtualRow(provider, metaTable,
                 new object[] { CodeunitMetadataVirtualTableId, row.Id, 0, 0 },
-                field => BuildCodeunitMetadataValue(field, row, subtypeOrdinals));
+                field => BuildCodeunitMetadataValue(field, row, subtypeOrdinal));
         }
     }
 
@@ -137,7 +170,7 @@ public static partial class RecordPatches
     /// rather than a hardcoded field-number table.
     /// </summary>
     private static object? BuildCodeunitMetadataValue(
-        NCLMetaField field, CodeunitMetaRow row, Dictionary<string, int> subtypeOrdinals)
+        NCLMetaField field, CodeunitMetaRow row, int subtypeOrdinal)
     {
         object? Text(string s) => _aovNavTextCreateTruncated!.Invoke(
             null, new object?[] { field.FieldDefinedLength, s ?? string.Empty });
@@ -153,11 +186,11 @@ public static partial class RecordPatches
             case "singleinstance":
                 return NavBoolean(row.SingleInstance);
             case "subtype":
+                // Already resolved by the caller, which is what keeps a refusal from escaping
+                // mid-insert and taking the whole table with it (#3536).
                 return _aovNavOptionCreate!.Invoke(null, new object?[]
                 {
-                    field.FieldOptionMetadata,
-                    ResolveCodeunitSubtypeOrdinal(
-                        subtypeOrdinals, field.FieldOptionMetadata?.OptionString, row.Subtype, row.Id)
+                    field.FieldOptionMetadata, subtypeOrdinal
                 });
             default:
                 return _aovGetDefaultNavValue!.Invoke(null, new object?[] { field, false });
@@ -258,12 +291,18 @@ public static partial class RecordPatches
         }
         if (ordinals.TryGetValue(NormalizeObjectTypeName(effectiveSubtype), out var ordinal))
             return ordinal;
+        // The message names the value that was LOOKED UP, and says so only when it differs
+        // from the declared one. Before #3536 it claimed the Install translation unconditionally,
+        // so a declared subtype that had merely failed to match — a quoted identifier, at the
+        // time — was reported as though the translation had been applied and had still missed.
+        var translated = !string.Equals(effectiveSubtype, declaredSubtype, StringComparison.Ordinal);
         throw CodeunitMetadataShapeGap(
-            $"codeunit {codeunitId} declares Subtype = '{declaredSubtype}', which is not a member of "
-            + $"that column's own option set ('{optionString}'). AL accepts one subtype the column "
-            + $"does not name — '{AlSubtypeTheCompilerDoesNotEmit}', which the compiler emits as "
-            + $"'{AlDefaultCodeunitSubtype}' and this resolver translates — so this is not an AL "
-            + "codeunit subtype at all");
+            $"codeunit {codeunitId} declares Subtype = '{declaredSubtype}'"
+            + (translated
+                ? $", which this resolver looks up as '{effectiveSubtype}' because the AL compiler "
+                  + $"emits '{AlSubtypeTheCompilerDoesNotEmit}' as '{AlDefaultCodeunitSubtype}', and that"
+                : ", which")
+            + $" is not a member of that column's own option set ('{optionString}')");
     }
 
     /// <summary>
@@ -379,6 +418,7 @@ public static partial class RecordPatches
         if (map.Count == 0)
             throw CodeunitMetadataShapeGap("\"Subtype\" option string is empty");
 
+        _cmvSubtypeOptionString = optionMetadata.OptionString;
         _cmvSubtypeOrdinals = map;
         return map;
     }

--- a/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
@@ -131,18 +131,10 @@ public static partial class RecordPatches
         {
             if (!done.TryAdd(row.Id, 0)) continue;
 
-            // Resolved HERE rather than from inside the per-field builder, so a subtype this
-            // column cannot name costs the one row it belongs to instead of the whole table
-            // (#3536). It used to throw out of InsertVirtualRow, which escapes
-            // GetDataAccessForTable — no row of the table was served, and because TryAdd above
-            // latches before the insert, the next handout omitted the offending codeunit
-            // silently. Codeunit 2 "Company-Initialize" reads this table, so one such codeunit
-            // anywhere in any loaded app left the company half-initialized.
-            //
-            // Still loud (loud-failures.md): the refusal's own message is printed, naming the
-            // codeunit and the reason, once per codeunit per provider — TryAdd has latched the
-            // id, so this row is not attempted again. What is contained is the blast radius,
-            // not the report.
+            // Keep this resolution OUT of the per-field builder: a throw from inside
+            // InsertVirtualRow escapes GetDataAccessForTable and no row of the table is served
+            // at all (#3536, docs/limitations.md#codeunit-metadata-subtype). The `[warn]` tag
+            // is load-bearing too — any other tag is dropped at default verbosity by Log.cs.
             int subtypeOrdinal;
             try
             {
@@ -152,9 +144,11 @@ public static partial class RecordPatches
             catch (RunnerOutOfScopeException ex)
             {
                 Console.Error.WriteLine(
-                    $"[RecordPatches] CodeUnit Metadata: codeunit {row.Id} \"{row.Name}\" is NOT in the "
-                    + $"table — its SubType could not be resolved: {ex.Message}. Every other codeunit "
-                    + "is still reported; AL that reads this one's row will find none.");
+                    $"[warn] RecordPatches: CodeUnit Metadata has NO ROW for codeunit {row.Id} "
+                    + $"\"{row.Name}\" — its SubType could not be resolved: {ex.Message}. Every other "
+                    + "codeunit is still reported, but AL asking for this one will fail to find "
+                    + "it: Get() answers false and a FindSet/Count is one row short, with no "
+                    + "error raised at the read.");
                 continue;
             }
 
@@ -291,10 +285,8 @@ public static partial class RecordPatches
         }
         if (ordinals.TryGetValue(NormalizeObjectTypeName(effectiveSubtype), out var ordinal))
             return ordinal;
-        // The message names the value that was LOOKED UP, and says so only when it differs
-        // from the declared one. Before #3536 it claimed the Install translation unconditionally,
-        // so a declared subtype that had merely failed to match — a quoted identifier, at the
-        // time — was reported as though the translation had been applied and had still missed.
+        // Name the value LOOKED UP, and only when it differs from the declared one: claiming
+        // the translation unconditionally makes the message false for a value it never touched.
         var translated = !string.Equals(effectiveSubtype, declaredSubtype, StringComparison.Ordinal);
         throw CodeunitMetadataShapeGap(
             $"codeunit {codeunitId} declares Subtype = '{declaredSubtype}'"
@@ -303,9 +295,8 @@ public static partial class RecordPatches
                   + $"emits '{AlSubtypeTheCompilerDoesNotEmit}' as '{AlDefaultCodeunitSubtype}', and that"
                 : ", which")
             + $" is not a member of that column's own option set ('{optionString}')"
-            // Why "not in the option string" is the right test for THIS column, when it is the
-            // wrong test for Page Metadata's PageType. Stated as the standing fact it is, not
-            // as something that happened to this value — see above.
+            // Why "not in the option string" is the right test for THIS column and the wrong
+            // one for Page Metadata's PageType. A standing fact, not an event.
             + (translated
                 ? string.Empty
                 : $". The one subtype AL accepts that this column does not name — "

--- a/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
@@ -302,7 +302,16 @@ public static partial class RecordPatches
                 ? $", which this resolver looks up as '{effectiveSubtype}' because the AL compiler "
                   + $"emits '{AlSubtypeTheCompilerDoesNotEmit}' as '{AlDefaultCodeunitSubtype}', and that"
                 : ", which")
-            + $" is not a member of that column's own option set ('{optionString}')");
+            + $" is not a member of that column's own option set ('{optionString}')"
+            // Why "not in the option string" is the right test for THIS column, when it is the
+            // wrong test for Page Metadata's PageType. Stated as the standing fact it is, not
+            // as something that happened to this value — see above.
+            + (translated
+                ? string.Empty
+                : $". The one subtype AL accepts that this column does not name — "
+                  + $"'{AlSubtypeTheCompilerDoesNotEmit}' — is looked up as "
+                  + $"'{AlDefaultCodeunitSubtype}' before it reaches here, so a miss is not an "
+                  + "AL codeunit subtype at all"));
     }
 
     /// <summary>

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1566,6 +1566,33 @@ https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues.
   and Windows Language have documented *divergences* as well — see their own sections above —
   and those are answers the runner gives on purpose, not refusals.
 
+  <a id="codeunit-metadata-subtype"></a>
+
+  **`CodeUnit Metadata` (2000000137) refuses per row, not per table**, and what a refusal
+  costs is worth stating exactly. The `SubType` column is resolved against that column's own
+  option string before the row is inserted, so a subtype the column cannot name loses **that
+  one row** and nothing else: `Get(<that id>)` answers `false`, a `FindSet`/`Count` over a
+  filter including it comes back one row short, and **no error is raised at the read** —
+  column values are materialised when the table is populated, so there is no per-read hook a
+  deferred throw could use. The refusal is reported instead, once per codeunit, as a `[warn]`
+  line naming the codeunit and the reason; that tag matters, because `AlRunner/Log.cs` drops
+  any other `[Tag]` prefix at default verbosity.
+
+  This replaced a whole-table failure. The resolution used to happen inside the per-field
+  builder, so the throw escaped `GetDataAccessForTable` and **no row of the table was served
+  to anybody** — and since the per-provider "already inserted" latch is set before the insert,
+  the offending codeunit then vanished silently from later handouts. Codeunit 2
+  `Company-Initialize` reads this table, so one such codeunit anywhere in any loaded app left
+  the company half-initialized and the run failed a long way from the cause
+  ([#3536](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3536)).
+
+  Note what can still reach the refusal: essentially nothing the AL compiler will produce. AL
+  accepts five codeunit subtypes; four are named by the column and the fifth, `Install`, is
+  translated to `Normal` in front of the lookup, in either spelling — `Subtype = Install;` and
+  `Subtype = "Install";` are the same declaration and now answer the same. So the contained
+  branch is **not covered by a test**: it is unreachable from compiling AL, and reaching it
+  would take an injected declaration carrying a subtype no compiler emits.
+
   `Date` and `Integer` refuse for a second, different reason on top of that one: both are
   computed per request on the service tier over a range too large to materialise, so a filter
   reaching past the window each one materialises is refused rather than answered short. See

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -1968,6 +1968,7 @@ at the new pin with CI's own invocation (`--show-pass --strict --expectations-re
 al-language-onprem + 0 al-language-internals-fixture.
 
 **Nothing else moved.** No expectation entry was added, removed or reclassified. Worth
-recording about the RED side: on `main` at this pin the three new tests fail *and so do two
-pre-existing 60962 tests*, because one refused row used to take the whole CodeUnit Metadata
-virtual table down with it — collateral damage, not a second regression. Added by agent fbk-2.
+recording about the RED side: on `main` at this pin the filtered run is 16 total, 9 pass,
+7 fail — the three new tests, **and four pre-existing ones** (two in codeunit 60962, two in
+60964), because one refused row used to take the whole CodeUnit Metadata virtual table down
+with it. Collateral damage, not a second regression. Added by agent fbk-2.

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -1950,3 +1950,24 @@ Measured: `tests/runner-extras/integer-virtual-table-window` 16/16 before the fi
 after; with the refusal loop deleted, 10/16 — both new arms among the six that fail, which is
 what makes them live controls rather than decoration. Full `runner-extras` 403/403 with the
 count baseline. Added by agent fbk-1.
+
+## al-language 3095 -> 3098, pin `84daa058` -> `eaba0b58` (#3536, corpus #287)
+
+One upstream corpus PR came in, StefanMaron/BusinessCentral.AL.Language.Tests#287 — the
+upstream half of #3536, a quoted `Subtype` identifier. It adds three tests to
+`Test Codeunit Metadata Virt T` (60962) and two fixtures, `ALT Quoted Install Probe` (60828)
+and `ALT Quoted Upgrade Probe` (60829): `Subtype = "Install";` reports what
+`Subtype = Install;` reports, `Subtype = "Upgrade";` reports Upgrade, and the table still
+enumerates every filtered codeunit when such a codeunit exists. Corpus history is linear and
+that PR is the only commit between the two pins.
+
+**3098 was measured, not computed.** This is the *fold* case — the bump alone is red, because
+the new tests fail without this PR's fix — so the number comes from a run of the fixed runner
+at the new pin with CI's own invocation (`--show-pass --strict --expectations-require-match
+--count-baseline`): **3127 total, 3127 pass, 0 fail, exit 0**, which is 3098 al-language + 29
+al-language-onprem + 0 al-language-internals-fixture.
+
+**Nothing else moved.** No expectation entry was added, removed or reclassified. Worth
+recording about the RED side: on `main` at this pin the three new tests fail *and so do two
+pre-existing 60962 tests*, because one refused row used to take the whole CodeUnit Metadata
+virtual table down with it — collateral damage, not a second regression. Added by agent fbk-2.

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Schema, semantics and how to bump: README.md in this directory. Per-bump rationale: history.md, never a prose line in here (#2485).",
   "suites": {
     "al-language": {
-      "tests": { "default": 3095 },
+      "tests": { "default": 3098 },
       "appGroups": { "default": 1 }
     },
     "al-language-internals-fixture": { "tests": { "default": 0 }, "appGroups": { "default": 1 } },


### PR DESCRIPTION
Closes #3536

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/287

That corpus PR is **merged** as `eaba0b58`, with its eight required BC legs green and execution verified per leg.

A codeunit may write its `Subtype` as a quoted identifier — `Subtype = "Install";` — which AL accepts and which states exactly what `Subtype = Install;` states. The runner read the declared value with its quote characters still attached, so `"Install"` matched no member of the CodeUnit Metadata (2000000137) SubType column's option string and the `Install` → `Normal` translation from #3080 never fired. That alone would be one wrong column. What made it a whole-run failure is that the refusal escaped while the table was being *populated*, so no row of the table was served to anybody — codeunit 2 `Company-Initialize` reads it, so one such codeunit anywhere in any loaded app left the company half-initialized and the run then failed a long way from the cause, with "cannot be found" / "must have a value" on setup tables.

## What changed

1. **`RecordPatches.AlObjectDeclParser.cs`** — `Subtype` (and the same-file sibling `TestHttpRequestPolicy`) go through a new `DeclaredIdentifierText`, which unquotes. This is the idiom the page parser already uses for `PageType` and `SourceTable`; `TableNo` needed nothing because `LastNameSegment` already unquotes.
2. **`RecordPatches.CodeunitMetadataVirtualTable.cs`** — the SubType ordinal is resolved **before** the row goes to `InsertVirtualRow`, so a refusal costs the one row it belongs to instead of the whole table. The refusal is still loud: its own message is printed to stderr naming the codeunit, exactly once (`done.TryAdd` has already latched the id), matching the `unresolvedTables` precedent a few lines up in the same file.
3. **The refusal message** no longer states the `Install` → `Normal` translation as something that happened to *this* value. It names the value actually looked up, and only when it differs from the declared one; the standing explanation of why "not in the option string" is the right test for this column (and the wrong one for `PageType`) is kept, phrased as the standing fact it is.

## Why the containment is not a new silent answer

`loud-failures.md` argues against swallowing. Two facts decide it here, and both are measured rather than reasoned:

- There is no per-read hook on this table — column values are materialized at populate time — so a *deferred* throw is not available. The choice is between failing the whole table and failing one row.
- The old code was already silently omitting the refused row, from the second handout onward: `done.TryAdd(row.Id, 0)` latches **before** the insert, so after the first throw the codeunit was simply absent. That is visible in the repro on `main` — the third arm reports `OBS codeunit 60103 not in CodeUnit Metadata` rather than any refusal. This change makes that omission loud and stops it taking every other row with it.

**What the reader actually sees**, stated exactly, because "contained" is not "harmless": the row is **absent**. `Get(<that id>)` answers `false`, a `FindSet`/`Count` over a filter including it comes back one row short, and **nothing is raised at the read**. The account of it is the `[warn]` line, which names the codeunit, the reason and that consequence. Same text in `docs/limitations.md#codeunit-metadata-subtype`.

**The `[warn]` tag is load-bearing, and the first version of this PR got it wrong.** `AlRunner/Log.cs` drops any `[Tag]`-prefixed line whose tag is not in its exemption list, so the line as originally written — `[RecordPatches] …` — only appeared under `--verbose`, and the "still loud" claim was false. It is now `[warn] RecordPatches: …` and pinned by `LoudDiagnosisReachesTheUserTests`, the suite #3068 created for exactly this defect; measured RED with the old tag (`RunFatalDiagnosis_SurvivesTheDefaultFilter` fails) and GREEN with the new one. Worth noting the `unresolvedTables` precedent cited above is silenced the same way — an existing instance of the same defect, not folded here because it is a different message on a different condition.

**The contained branch is not covered by a test, and that is stated rather than papered over.** After the parse fix it is unreachable from compiling AL: AL accepts five codeunit subtypes, the column names four, and the fifth (`Install`) is translated in front of the lookup in either spelling. Reaching the `catch` would take a declaration carrying a subtype no compiler emits — injected past the parser — and the populate path needs live BC metatable objects a unit test cannot construct, so there is no cheap route to it. What *is* tested is everything either side: the resolver's refusal (unit tests, both directions), the parse (unit test), the containment's observable effect through the real populate path (`CodeunitMetadata_QuotedSubtypeCodeunit_DoesNotSuppressTheOtherRows`), and the warning's visibility.

## Sibling scan

- Same file: `TestHttpRequestPolicy` had the identical shape and is fixed here with its own assertion. `TableNo` is safe (`LastNameSegment`), `SingleInstance` is a boolean literal that cannot be quoted.
- Other read sites: `RecordPatches.AlPageParser.cs:50,54` already unquote. Nothing else in the object-decl family reads an identifier-valued property raw.
- **The precompiled path was measured, not assumed, and needs no change.** Compiling the three-arm repro with `alc` 18.0.40.47373 and reading `SymbolReference.json` out of the `.app`: `60101 → 'Install'`, `60102 (quoted) → 'Install'`, `60103 (quoted) → 'Upgrade'`. The compiler erases the quoting, so `BcAppSymbolCache.cs:1091` already carried the bare name — the two row sources disagreed about the same AL text and now agree. `BcAppSymbolCache.cs` is deliberately not in this diff.
- **Open-issue queue scan** for this area (`CodeUnit Metadata`, `2000000137`, the decl parser, `Subtype`): #2326 and #3392 are AllObj/AllObjWithCaption `Object Subtype` — a different column in a different file, and #2326 already has PR #3391 open. Nothing else lands in either file, so nothing was folded.

## Not folded, filed separately

The reporter's third observation — the `[warn] CompanyInitializer … PARTIALLY initialized` line is printed but the run still exits green and the machine-readable summary says nothing — is a different mechanism in different files (`CompanyInitializer` and the summary writer, not these two). #3068 fixed the *visibility* of that line; whether a partial company initialization should reach the summary and the exit code is its own question. Filed as #3538 rather than folded here.

## RED → GREEN

| what | RED (`main` a3fb61d5) | GREEN (this branch) |
|---|---|---|
| 3-arm AL repro (unquoted Install / quoted Install / quoted Upgrade), from #3536 | 3 total, **0 pass, 3 fail** | 3 total, **3 pass** |
| corpus `--test Record_CodeunitMetadata` at the new pin | 16 total, **9 pass, 7 fail** | 16 total, **16 pass** |
| `MetadataOptionColumnOrdinalTests` + `SiblingParserSyntaxTreeTests` + `CodeunitMetadataVirtualTableTests` | 25 total, **3 fail** (exactly the three new ones) | 25 total, **25 pass** |
| the same three + `LoudDiagnosisReachesTheUserTests`, after the review fix | — | 59 total, **59 pass** |

The corpus RED is worth reading twice: 16 = 9 passing + 3 new + **4 pre-existing tests** that have nothing to do with quoting (two in codeunit 60962, two in 60964). Adding one quoted-subtype codeunit to the corpus app broke unrelated tests, which is the whole-table abort measured rather than argued. `history.md` states the same 4.

The RED baseline for the C# tests was taken by restoring both patched files from `origin/main` around a committed tree, then restoring them from a copy outside the repository and confirming `git diff HEAD` was empty before continuing.

## Real BC verdict

Before opening the corpus PR, an equivalent four-codeunit probe app was compiled, published and run against a live BC container (Test Runner 28.4.53241.0):

```
EXACT >>> bareInstall=0 quotedInstall=0 quotedUpgrade=3 bareUpgrade=3 enumerated=4 <<<
```

The quoted and bare spellings agree, and all four codeunits are enumerated. Corpus PR #287 then re-adjudicated it on all eight required legs.

## Pin bump

Folded here, per `al-language-submodule.md`'s *fold* case: corpus #287's three tests are red without this fix. `tests/al-language` 84daa058 → eaba0b58 (that PR is the only intervening commit; history is linear), and the al-language baseline 3095 → 3098 as a single-integer edit. The number is the one a run reported, not one computed: the full three-app run with CI's own invocation is **3127 total, 3127 pass, 0 fail, exit 0**. Rationale in `tests/expectations/count-baseline/history.md`.

## Prose placement

Everything above that is about *this diff* is here rather than in the code. What stayed in code is only what changes what the next person types: why the ordinal is resolved outside the per-field builder (moving it back re-creates the whole-table abort), why the `[warn]` tag cannot be changed, and why the parser unquotes. The history of the defect and the reader-visible effect moved to `docs/limitations.md#codeunit-metadata-subtype`, cited from the call site. No comment block over ten lines remains; the production diff is +14/-22 comment lines after the review pass.

<sub>Opened by agent `fbk-2`.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018eQEJqnKcAgqMbWgk4wdMa
