### PR TITLE
fix(codeunit-metadata): make the unresolved-TableNo warning survive the default log filter

### DIFF
--- a/AlRunner.Tests/LoudDiagnosisReachesTheUserTests.cs
+++ b/AlRunner.Tests/LoudDiagnosisReachesTheUserTests.cs
@@ -176,6 +176,13 @@ public sealed class LoudDiagnosisReachesTheUserTests
         // so this line is the only account of it. See docs/limitations.md#codeunit-metadata-subtype.
         { "AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs", "CodeUnit Metadata has NO ROW for codeunit" },
 
+        // #3540 — the sibling condition in the same file, and the only account of a column
+        // value the runner answers WRONG on purpose. A declared TableNo the resolver cannot
+        // turn into a table id makes that row answer TableNo = 0, which is also the truthful
+        // answer for a codeunit declaring no TableNo at all — so the read cannot tell the two
+        // apart and nothing else in the run records which one it was.
+        { "AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs", "could not be resolved to a table id" },
+
         // #2963, and named in #3068 as the same class: System Application module-ownership
         // checks silently decline for the whole run when this row set is not seeded.
         { "AlRunner/Patches/RecordPatches.PublishedApplicationSystemTable.cs", "Published Application rows" },
@@ -220,6 +227,29 @@ public sealed class LoudDiagnosisReachesTheUserTests
             || message.Contains("will refuse", StringComparison.OrdinalIgnoreCase)
             || message.Contains("will decline", StringComparison.OrdinalIgnoreCase),
             $"{relativePath} (\"{anchor}\") no longer tells the reader what stops working: {message}");
+    }
+
+    /// <summary>
+    /// #3540, the wording rather than the tag. `RunFatalDiagnosis_NamesTheConsequence` accepts
+    /// any of three verbs, so it cannot pin WHICH consequence this line names. This one does:
+    /// the message has to say the affected rows answer TableNo = 0, and that this is the same
+    /// value a codeunit declaring no TableNo answers — without both halves the reader is told
+    /// a resolution failed but not that a column now carries a value they cannot interpret.
+    /// Read out of the production source, never typed here, for the reason at the top of this
+    /// file.
+    /// </summary>
+    [Fact]
+    public void UnresolvedTableNo_NamesTheValueTheRowsAnswer_AndWhyItIsAmbiguous()
+    {
+        var message = ExtractEmittedMessage(
+            "AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs",
+            "could not be resolved to a table id");
+
+        Assert.StartsWith("[warn] ", message);
+        Assert.Contains("TableNo = 0", message);
+        Assert.Contains("declares no TableNo", message);
+        // And it still survives the real filter with that wording.
+        Assert.Contains(message, FilterOnce(message, verbose: false));
     }
 
     /// <summary>

--- a/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
@@ -356,10 +356,18 @@ public static partial class RecordPatches
                     symbol.Subtype ?? "Normal");
             }
 
+            // Loud, never silent (#3540). This is the runner answering a column WRONG on
+            // purpose, not progress: the row's TableNo reads 0, which is also the truthful
+            // answer for a codeunit declaring none, so the read cannot tell the two apart and
+            // nothing else in the run records which one it was. `[warn]` is the severity shape
+            // Log.cs exempts by design; `[RecordPatches]` is dropped at default verbosity along
+            // with its 379 lines of ordinary chatter, which is where this sentence used to go.
             if (unresolvedTables.Count > 0)
                 Console.Error.WriteLine(
-                    $"[RecordPatches] CodeUnit Metadata: {unresolvedTables.Count} declared TableNo reference(s) "
-                    + "could not be resolved to a table id and are reported as 0: "
+                    $"[warn] RecordPatches: CodeUnit Metadata: {unresolvedTables.Count} declared TableNo "
+                    + "reference(s) could not be resolved to a table id, so those rows answer TableNo = 0 — "
+                    + "the same value a codeunit that declares no TableNo answers, and AL branching on "
+                    + "TableNo will fail to tell the two apart: "
                     + string.Join("; ", unresolvedTables.Take(10))
                     + (unresolvedTables.Count > 10 ? $" (+{unresolvedTables.Count - 10} more)" : string.Empty));
 


### PR DESCRIPTION
Closes #3540

Corpus-NA: runner-only diagnostic visibility and wording — no AL-observable value changes (the same `TableNo = 0` is answered before and after), and real BC emits no equivalent stderr line for a corpus test to assert on.

## What was wrong

`EnumerateKnownCodeunitMetadata` reports every codeunit whose declared `TableNo` it could not resolve to a table id, and says those rows answer `0`. The line carried the `[RecordPatches]` tag, which `AlRunner/Log.cs`'s default filter drops — by design, since that tag carries 379 lines of ordinary chatter on one healthy run (measured for #3068). So the only account of the runner answering a column **wrong on purpose** reached the terminal only under `--verbose`, and `TableNo = 0` is also the truthful answer for a codeunit declaring none. The two are indistinguishable at the read.

## The change

Two files, the same two-step #3068 established and #3539 applied to the sibling refusal message a few lines above:

1. Re-tagged to `[warn] RecordPatches: …`, the severity shape `Log.cs` exempts by design, and reworded so the sentence names the value the affected rows answer and why it cannot be interpreted: *"…so those rows answer TableNo = 0 — the same value a codeunit that declares no TableNo answers, and AL branching on TableNo will fail to tell the two apart: …"*.
2. Registered the call site in `LoudDiagnosisReachesTheUserTests.DiagnosisCallSites`, which extracts the **real** production statement out of the source file and pushes it through the **real** filter, so re-tagging it back goes red.

`Log.cs` is untouched — its allowlist and the negative control (`[RecordPatches]`, `[Cecil]`, `[Subscribers]`, `[BcRuntime]`, `[Dispatch]`, `[deps]` still suppressed) are unchanged and still green.

## RED → GREEN

`dotnet test AlRunner.Tests --filter FullyQualifiedName~LoudDiagnosisReachesTheUserTests`

- **RED** (test entry added, production untouched): **Failed 3, Passed 35, Total 38.** The three are exactly the ones the shape predicts — `RunFatalDiagnosis_SurvivesTheDefaultFilter` (filter output empty), `RunFatalDiagnosis_NamesTheConsequence` (old wording names no consequence), and the new `UnresolvedTableNo_NamesTheValueTheRowsAnswer_AndWhyItIsAmbiguous`. `RunFatalDiagnosis_AlsoSurvivesVerbose` and the negative control were green throughout, so the failure is the default filter, not the extraction.
- **GREEN** (after the retag + reword): **Failed 0, Passed 38, Total 38.**

The new `[Fact]` is not redundant with the theory: `NamesTheConsequence` accepts any of three verbs and cannot pin *which* consequence, so the direct test asserts the message contains `TableNo = 0` and `declares no TableNo` — read out of the production source, never typed into the test.

Also run:

- `--filter FullyQualifiedName~CodeunitMetadataVirtualTableTests|…LogUserFacingTagsTests|…CleanRunStartupVerbosityTests` — 19 passed, 2 failed, both in `CleanRunStartupVerbosityTests` and both **environment, not this change**: the runner re-exec refuses to create the `al-runner.exe` symlink on this un-elevated Windows box (`"[reexec] Symlink for 'al-runner.exe' refu…"` is the whole captured output), so the banner assertions have nothing to match. The two suites that could see this change — `CodeunitMetadataVirtualTableTests`, `LogUserFacingTagsTests` — are green.
- `tests/runner-extras/object-metadata-system-table` with `--package-cache ~/.al-runner/platform-apps` — 6/6 pass, 1 bucket, no compile or exec failures.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — three, and they are deliberately **not** in this PR. `RecordPatches.AllProfileVirtualTable.cs:257` (declared RoleCenter → page id), `RecordPatches.PageMetadataVirtualTable.cs:344` (declared CardPageId → page id) and `RecordPatches.TableMetadataVirtualTable.cs:406` (declared page reference → page id) each emit a near-verbatim `[RecordPatches] … could not be resolved to a … id and are reported as 0` on the same condition, and each is dropped by the same filter. Three separate files, so `batch-sibling-issues-by-file.md`'s same-file test fails, and #3540 states its own scope as the one line. They are listed on #2221 as a comment rather than fixed here.
2. **Does a sibling function make the same assumption?** Within this file, no. Both row sources — source-parsed `_parsedObjectDecls` and precompiled `EnumerateBcAppCodeunitSymbols` — funnel through the single `ResolveTableNo` local, so the ledger and the one diagnostic already cover both and there is no second path to keep in step.
3. **Two paths writing the same state with different invariants?** No. `ResolveTableNo` is the only writer of `unresolvedTables` and the only producer of a `CodeunitMetaRow.TableNo`.

**Open-issue scan** for this file / `TableNo` / the `reported as 0` shape found nothing foldable: #3512 is a different defect (virtual `Field` table `DeleteAll` re-find), and #2221 is the general design issue — the filter's default is backwards — which this is one instance of and which stays open. Nothing else in the queue lands in `RecordPatches.CodeunitMetadataVirtualTable.cs`.

Related: #2221 (general form, deliberately not folded), #3068 (the same defect at five call sites, and where this test suite comes from), #3536 / #3539 (the sibling line in this file, fixed there, which is where #3540 was spotted).

<sub>Implemented by agent `fbk-3`.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018eQEJqnKcAgqMbWgk4wdMa
