### PR TITLE
docs(rules): label a corpus PR to get a Windows verdict, rather than dispatching it

### DIFF
--- a/.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md
+++ b/.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md
@@ -62,30 +62,17 @@ since corpus issue #213:
 
 So: **a Windows failure is a real failure. A Linux-only failure is an image bug.**
 
-**On a corpus PR, label it — do not `workflow_dispatch` it:**
+**On a corpus PR, label it:**
 
 ```bash
 gh pr edit <N> --repo StefanMaron/BusinessCentral.AL.Language.Tests \
   --add-label run-nightly-windows
 ```
 
-The label is the mechanism the workflow was built for, and its own header says so: it fires on
-`pull_request: [labeled]` and the gate job requires exactly `run-nightly-windows`, so an
-ordinary PR never spends a ~2h Windows run by accident.
-
-**It also runs the right workflow, which a dispatch does not.** `workflow_dispatch` executes
-the workflow **as it exists on the ref**, so a branch that predates a fix to the nightly keeps
-running the broken version indefinitely. A `pull_request` event runs it from the **base
-branch**, so labelling picks up whatever `master` has.
-
-Measured 2026-09-08: two dispatches against corpus PRs #272 and #273 both died in the
-tenant-encryption-key step before running a test, because neither branch contained corpus
-`7195a4ba` — the commit that fixed exactly that step. The same PR labelled instead passed the
-gate and reached the Windows container. The failure looked environmental and was not; it was
-old CI, faithfully re-run.
-
-For a ref that is **not** a PR — `master`, or a branch with no pull request — the dispatch is
-still the only route, and the same staleness caveat applies to it:
+A `pull_request` event runs the workflow from the **base branch**, so the label always gets
+`master`'s copy. `workflow_dispatch` runs it **as it exists on the ref**, so on a branch that
+predates a fix to the nightly it re-runs the broken version and the failure looks like a tier
+fault. Dispatch only for a ref with no pull request:
 
 ```bash
 gh workflow run 351779742 --repo StefanMaron/BusinessCentral.AL.Language.Tests \

--- a/.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md
+++ b/.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md
@@ -69,10 +69,11 @@ gh pr edit <N> --repo StefanMaron/BusinessCentral.AL.Language.Tests \
   --add-label run-nightly-windows
 ```
 
-A `pull_request` event runs the workflow from the **base branch**, so the label always gets
-`master`'s copy. `workflow_dispatch` runs it **as it exists on the ref**, so on a branch that
-predates a fix to the nightly it re-runs the broken version and the failure looks like a tier
-fault. Dispatch only for a ref with no pull request:
+A `pull_request` event reads the workflow **file** from the base branch and runs it against
+**your PR's merge commit** — so the label adjudicates your tests using `master`'s CI.
+`workflow_dispatch` takes both from the ref, so on a branch that predates a fix to the nightly
+it re-runs the broken version and the failure looks like a tier fault. Dispatch only for a ref
+with no pull request:
 
 ```bash
 gh workflow run 351779742 --repo StefanMaron/BusinessCentral.AL.Language.Tests \

--- a/.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md
+++ b/.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md
@@ -62,6 +62,31 @@ since corpus issue #213:
 
 So: **a Windows failure is a real failure. A Linux-only failure is an image bug.**
 
+**On a corpus PR, label it — do not `workflow_dispatch` it:**
+
+```bash
+gh pr edit <N> --repo StefanMaron/BusinessCentral.AL.Language.Tests \
+  --add-label run-nightly-windows
+```
+
+The label is the mechanism the workflow was built for, and its own header says so: it fires on
+`pull_request: [labeled]` and the gate job requires exactly `run-nightly-windows`, so an
+ordinary PR never spends a ~2h Windows run by accident.
+
+**It also runs the right workflow, which a dispatch does not.** `workflow_dispatch` executes
+the workflow **as it exists on the ref**, so a branch that predates a fix to the nightly keeps
+running the broken version indefinitely. A `pull_request` event runs it from the **base
+branch**, so labelling picks up whatever `master` has.
+
+Measured 2026-09-08: two dispatches against corpus PRs #272 and #273 both died in the
+tenant-encryption-key step before running a test, because neither branch contained corpus
+`7195a4ba` — the commit that fixed exactly that step. The same PR labelled instead passed the
+gate and reached the Windows container. The failure looked environmental and was not; it was
+old CI, faithfully re-run.
+
+For a ref that is **not** a PR — `master`, or a branch with no pull request — the dispatch is
+still the only route, and the same staleness caveat applies to it:
+
 ```bash
 gh workflow run 351779742 --repo StefanMaron/BusinessCentral.AL.Language.Tests \
   --ref <branch> -f bc_version=28.4 -f artifact_type=sandbox -f country=w1


### PR DESCRIPTION
No linked issue: a rules correction. The recipe this rule shipped with was the wrong mechanism on a pull request.

## The change

`.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md` told an agent to get a Windows verdict with `workflow_dispatch`. On a corpus PR the mechanism is the **`run-nightly-windows` label**, and the rule now says so in 12 lines: the label's name, the repo to apply it on, and why to prefer it.

A `pull_request` event runs the workflow from the **base branch**, so the label always gets `master`'s copy. `workflow_dispatch` runs it **as it exists on the ref** — so on a branch that predates a fix to the nightly it re-runs the broken version, and the failure looks like a tier fault rather than an old branch. The dispatch stays documented for a ref with no pull request, which is the one case it is still needed for.

## Why the diff is small

An earlier revision of this PR was 25 lines and carried the incident that found the label — two named PRs, the commit that fixed the nightly, which step died, what the successful run did differently. That has been cut.

An agent following the pointer finds all of it by looking, and prose they have to read past to reach the instruction makes the instruction *less* likely to be followed. The incident lives on corpus #288 for anyone who wants it.

## Verification

Docs-only. `tools/test_doc_pointers.py` passes; the full `tools/test_*.py` suite exits 0.

The label name, workflow id and trigger were read from `master`'s `nightly-windows.yml` rather than recalled.

---
*Filed by the `stma-auto-3` autonomous coordinator, an automated agent acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsJY7DhDm5y83e77GxpRSZ
