### PR TITLE
feat(metadata): keep BC's own metadata document for every object it emits, not three kinds

### DIFF
--- a/AlRunner.Tests/AlCacheWriterDependencyCacheOrderingTests.cs
+++ b/AlRunner.Tests/AlCacheWriterDependencyCacheOrderingTests.cs
@@ -48,11 +48,12 @@ public sealed class AlCacheWriterDependencyCacheOrderingTests
             var pageMetadataSidecar = Path.Combine(dir, key + ".page-metadata.json");
             var xmlPortMetadataSidecar = Path.Combine(dir, key + ".xmlport-metadata.json");
             var enumRegistrySidecar = Path.Combine(dir, key + ".enum-registry.json");
+            var objectMetadataSidecar = Path.Combine(dir, key + ".object-metadata.json");
             var cachedDll = Path.Combine(dir, key + ".dll");
             var sidecarPaths = new[]
             {
                 reportSidecar, reportLayoutSidecar, pageMetadataSidecar,
-                xmlPortMetadataSidecar, enumRegistrySidecar,
+                xmlPortMetadataSidecar, enumRegistrySidecar, objectMetadataSidecar,
             };
 
             // Empty id sets everywhere — this test's claim is about ordering/atomicity of
@@ -66,7 +67,8 @@ public sealed class AlCacheWriterDependencyCacheOrderingTests
                 reportLayoutSidecar,
                 pageMetadataSidecar, Array.Empty<int>(),
                 xmlPortMetadataSidecar, Array.Empty<int>(),
-                enumRegistrySidecar, Array.Empty<int>());
+                enumRegistrySidecar, Array.Empty<int>(),
+                objectMetadataSidecar, Array.Empty<string>());
 
             Assert.Equal(0, sidecarCount);
             Assert.Equal(0, enumSidecarCount);
@@ -78,7 +80,7 @@ public sealed class AlCacheWriterDependencyCacheOrderingTests
             Assert.True(File.Exists(cachedDll));
             Assert.Equal(new byte[] { 1, 2, 3, 4 }, File.ReadAllBytes(cachedDll));
 
-            // No leftover .tmp artifacts from any of the six AtomicPublish calls.
+            // No leftover .tmp artifacts from any of the seven AtomicPublish calls.
             var leftovers = Directory.GetFiles(dir)
                 .Where(f => !sidecarPaths.Contains(f) && !string.Equals(f, cachedDll))
                 .ToArray();
@@ -90,7 +92,7 @@ public sealed class AlCacheWriterDependencyCacheOrderingTests
     // Deterministic proof of the DLL-last ORDERING invariant (not just the end state):
     // uses PublishSourceDependencyCache's onSidecarsPublishedBeforeDll test seam to
     // observe filesystem state at the EXACT point a concurrent reader gated on
-    // `File.Exists(cachedDll)` (LoadOne) could land — after all five sidecars are
+    // `File.Exists(cachedDll)` (LoadOne) could land — after all six sidecars are
     // committed, before the DLL is. No polling/timing race required: the seam runs
     // synchronously on the same call stack, between the last sidecar's AtomicPublish and
     // the DLL's.
@@ -106,11 +108,12 @@ public sealed class AlCacheWriterDependencyCacheOrderingTests
             var pageMetadataSidecar = Path.Combine(dir, key + ".page-metadata.json");
             var xmlPortMetadataSidecar = Path.Combine(dir, key + ".xmlport-metadata.json");
             var enumRegistrySidecar = Path.Combine(dir, key + ".enum-registry.json");
+            var objectMetadataSidecar = Path.Combine(dir, key + ".object-metadata.json");
             var cachedDll = Path.Combine(dir, key + ".dll");
 
             var hookRan = false;
             bool dllExistedAtHookTime = true; // start "true" so a no-op hook can't fake a pass
-            bool[] sidecarsExistedAtHookTime = new bool[5];
+            bool[] sidecarsExistedAtHookTime = new bool[6];
 
             DependencyLoader.PublishSourceDependencyCache(
                 cachedDll, new byte[] { 9 },
@@ -119,6 +122,7 @@ public sealed class AlCacheWriterDependencyCacheOrderingTests
                 pageMetadataSidecar, Array.Empty<int>(),
                 xmlPortMetadataSidecar, Array.Empty<int>(),
                 enumRegistrySidecar, Array.Empty<int>(),
+                objectMetadataSidecar, Array.Empty<string>(),
                 onSidecarsPublishedBeforeDll: () =>
                 {
                     hookRan = true;
@@ -128,6 +132,7 @@ public sealed class AlCacheWriterDependencyCacheOrderingTests
                     sidecarsExistedAtHookTime[2] = File.Exists(pageMetadataSidecar);
                     sidecarsExistedAtHookTime[3] = File.Exists(xmlPortMetadataSidecar);
                     sidecarsExistedAtHookTime[4] = File.Exists(enumRegistrySidecar);
+                    sidecarsExistedAtHookTime[5] = File.Exists(objectMetadataSidecar);
                 });
 
             Assert.True(hookRan);

--- a/AlRunner.Tests/Fixtures/ObjectMetadataCapture/Objects.al
+++ b/AlRunner.Tests/Fixtures/ObjectMetadataCapture/Objects.al
@@ -1,0 +1,139 @@
+// One object of each kind BC's emitter produces a metadata document for.
+//
+// Table, page, codeunit, enum, report and xmlport all deliberately carry the SAME
+// numeric id (70660). AL allows that — ids are unique per object type — and it is the
+// point of the fixture: a metadata registry keyed on the id alone collapses six
+// documents into one, and a per-kind assertion is the only thing that notices.
+
+table 70660 "OMR Thing"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Entry No."; Integer) { DataClassification = CustomerContent; }
+        field(2; Description; Text[50]) { DataClassification = CustomerContent; Editable = false; }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.") { Clustered = true; }
+        key(ByDescription; Description) { }
+    }
+}
+
+page 70660 "OMR Thing List"
+{
+    PageType = List;
+    SourceTable = "OMR Thing";
+    ApplicationArea = All;
+    UsageCategory = Lists;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Rows)
+            {
+                field("Entry No."; Rec."Entry No.") { ApplicationArea = All; }
+                field(Description; Rec.Description) { ApplicationArea = All; }
+            }
+        }
+    }
+}
+
+enum 70660 "OMR Kind"
+{
+    Extensible = true;
+
+    value(0; Plain) { Caption = 'Plain kind'; }
+    value(1; Fancy) { Caption = 'Fancy kind'; }
+}
+
+interface "OMR IThing"
+{
+    procedure Describe(): Text;
+}
+
+report 70660 "OMR Report"
+{
+    ProcessingOnly = true;
+    UseRequestPage = false;
+
+    dataset
+    {
+        dataitem(Thing; "OMR Thing")
+        {
+            column(EntryNo; "Entry No.") { }
+        }
+    }
+}
+
+xmlport 70660 "OMR Port"
+{
+    Format = Xml;
+    Direction = Export;
+
+    schema
+    {
+        textelement(Root)
+        {
+            tableelement(Thing; "OMR Thing")
+            {
+                fieldelement(EntryNo; Thing."Entry No.") { }
+            }
+        }
+    }
+}
+
+permissionset 70661 "OMR PS"
+{
+    Assignable = true;
+    Caption = 'OMR base permissions';
+    Permissions = tabledata "OMR Thing" = RIMD;
+}
+
+tableextension 70662 "OMR Thing Ext" extends "OMR Thing"
+{
+    fields
+    {
+        field(50; "Extra Note"; Text[30]) { DataClassification = CustomerContent; }
+    }
+}
+
+pageextension 70663 "OMR Thing List Ext" extends "OMR Thing List"
+{
+    layout
+    {
+        addlast(Content)
+        {
+            field("Extra Note"; Rec."Extra Note") { ApplicationArea = All; }
+        }
+    }
+}
+
+enumextension 70664 "OMR Kind Ext" extends "OMR Kind"
+{
+    value(2; Extended) { Caption = 'Extended kind'; }
+}
+
+permissionsetextension 70665 "OMR PS Ext" extends "OMR PS"
+{
+    Permissions = tabledata "OMR Thing" = RIMD;
+}
+
+// A query carries a metadata document too, and the issue's own table of twelve kinds
+// does not list it — which is the point of capturing on "the metadata string is
+// non-empty" rather than on a list of kinds someone remembered to write down.
+query 70660 "OMR Query"
+{
+    QueryType = Normal;
+
+    elements
+    {
+        dataitem(Thing; "OMR Thing")
+        {
+            column(EntryNo; "Entry No.") { }
+        }
+    }
+}

--- a/AlRunner.Tests/Fixtures/ObjectMetadataCapture/Tests.al
+++ b/AlRunner.Tests/Fixtures/ObjectMetadataCapture/Tests.al
@@ -1,0 +1,18 @@
+codeunit 70660 "OMR Capture Tests"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure ThingRoundTrips()
+    var
+        Thing: Record "OMR Thing";
+    begin
+        Thing.Init();
+        Thing."Entry No." := 42;
+        Thing.Insert();
+
+        Thing.Get(42);
+        if Thing."Entry No." <> 42 then
+            Error('Expected entry 42, got %1', Thing."Entry No.");
+    end;
+}

--- a/AlRunner.Tests/Fixtures/ObjectMetadataCapture/app.json
+++ b/AlRunner.Tests/Fixtures/ObjectMetadataCapture/app.json
@@ -1,0 +1,23 @@
+{
+  "id": "a3000000-0000-4000-8000-000000000048",
+  "name": "Runner Tests Fixture - Object Metadata Capture",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "#3548: BC's emitter hands CaptureOutputter a metadata document for every application object it emits; the general registry must hold one per (kind, id).",
+  "description": "Used by AlRunner.Tests' ObjectMetadataCaptureTests. Declares one object of each kind BC emits metadata for, reusing the SAME numeric id 70660 across table/page/codeunit/enum/report/xmlport so a registry keyed on the id alone would collapse them into one entry. Deliberately declares no 'application' dependency (see .claude/rules/no-base-app-in-csharp-tests.md).",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "idRanges": [
+    {
+      "from": 70660,
+      "to": 70679
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner.Tests/ObjectMetadataCaptureTests.cs
+++ b/AlRunner.Tests/ObjectMetadataCaptureTests.cs
@@ -1,0 +1,262 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #3548 step 2 — BC's own emitter hands
+/// <c>CaptureOutputter.AddApplicationObject</c> a metadata document for every
+/// application object it emits, and the runner used to keep three kinds (report,
+/// page, xmlport) and drop the rest. <see cref="AlObjectMetadataRegistry"/> keeps all
+/// of them, keyed by (kind, id).
+///
+/// Two claims, and the second is the one the issue says will sink this work if it is
+/// missed: BC's Emit runs only on a compile-cache MISS, so a registry fed from there
+/// alone is empty on every warm run and every consumer silently takes its not-found
+/// branch. The warm assertions below are identical to the cold ones and run against
+/// the same cache directory, per .claude/rules/local-test-scope.md.
+///
+/// Observed through <c>AL_RUNNER_TRACE_OBJECT_METADATA=1</c>'s per-entry line rather
+/// than through AL, because this PR deliberately converts no consumer — nothing reads
+/// the registry yet, so there is no AL-observable behaviour to assert on. The trace
+/// line is emitted by Register itself, which is the single funnel both the emit path
+/// and the sidecar-replay path go through.
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips when absent.
+/// </summary>
+public class ObjectMetadataCaptureTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string FixtureRoot = Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "ObjectMetadataCapture"));
+
+    /// <summary>
+    /// The (kind, id) pairs the fixture declares, as the trace spells them. Table,
+    /// page, codeunit, enum, report, xmlport and query all share id 70660 on purpose —
+    /// a registry keyed on the id alone answers seven of these with one document, and
+    /// only a per-kind assertion notices.
+    ///
+    /// Query is here and Interface is not, which is the measurement rather than a
+    /// guess: see docs/object-metadata-capture.md#which-kinds-arrive.
+    /// </summary>
+    private static readonly (string Kind, int Id)[] Expected =
+    {
+        ("Table", 70660),
+        ("Page", 70660),
+        ("Codeunit", 70660),
+        ("Enum", 70660),
+        ("Report", 70660),
+        ("XmlPort", 70660),
+        ("Query", 70660),
+        ("PermissionSet", 70661),
+        ("TableExtension", 70662),
+        ("PageExtension", 70663),
+        ("EnumExtension", 70664),
+        ("PermissionSetExtension", 70665),
+    };
+
+    private static void CopyDir(string src, string dst)
+    {
+        Directory.CreateDirectory(dst);
+        foreach (var f in Directory.GetFiles(src))
+            File.Copy(f, Path.Combine(dst, Path.GetFileName(f)), overwrite: true);
+    }
+
+    private static (string output, int exit) RunRunner(string bundleDir, string alCacheDir)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" \"{bundleDir}\"");
+        args.Append($" --cache \"{alCacheDir}\"");
+        args.Append(" --verbose");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = args.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        psi.Environment["AL_RUNNER_TRACE_OBJECT_METADATA"] = "1";
+        var platformApps = TestArtifacts.PlatformAppsDir();
+        if (Directory.Exists(platformApps))
+            psi.Arguments += $" --package-cache \"{platformApps}\"";
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(300_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    private static void AssertEveryKindCaptured(string output, string phase)
+    {
+        foreach (var (kind, id) in Expected)
+        {
+            Assert.True(
+                output.Contains($"[object-metadata] registered {kind} {id} "),
+                $"{phase}: no metadata document captured for {kind} {id}. "
+                + "BC's emitter produces one for every object it emits; a missing kind means "
+                + $"AddApplicationObject dropped it.\n{output}");
+        }
+
+        // Negative direction, and the reason the fixture reuses one id across six kinds:
+        // 70660 is a table, a page, a codeunit, an enum, a report and an xmlport, and is
+        // NOT a tableextension. A registry keyed on the id alone — or one that answered
+        // any kind for a known id — passes every positive assertion above and fails here.
+        Assert.DoesNotContain("[object-metadata] registered TableExtension 70660 ", output);
+        // Nothing in the fixture declares 70670; a capture that registered a document
+        // under an id it invented would show up here.
+        Assert.DoesNotContain(" 70670 ", output);
+    }
+
+    [SkippableFact]
+    public void EveryEmittedObjectKind_IsCaptured_ColdAndOnAWarmCacheHit()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var scratch = TestScratch.Dir("al-runner-object-metadata-capture");
+        var bundle = Path.Combine(scratch, "bundle");
+        var alCacheDir = Path.Combine(scratch, "al-out");
+        CopyDir(FixtureRoot, bundle);
+
+        // Run 1 — cold. The AL-output cache is empty, so BC's Emit runs and
+        // CaptureOutputter sees every object.
+        var (cold, coldExit) = RunRunner(bundle, alCacheDir);
+        Assert.True(coldExit == 0 && cold.Contains("1P/0F/0E"), $"cold run must pass:\n{cold}");
+        AssertEveryKindCaptured(cold, "cold run");
+
+        // Run 2 — same sources, same cache directory, so the AL-output cache HITs and
+        // Emit never runs. Without a replayed sidecar the registry is empty here and
+        // every assertion below fails while the run itself stays green: exactly the
+        // failure the source-text parser in RecordPatches.AlObjectDeclParser.cs was
+        // written to avoid.
+        var (warm, warmExit) = RunRunner(bundle, alCacheDir);
+        Assert.True(warmExit == 0 && warm.Contains("1P/0F/0E"), $"warm run must pass:\n{warm}");
+        Assert.Contains("[cache] HIT", warm);
+        AssertEveryKindCaptured(warm, "warm run (AL-output cache HIT)");
+    }
+
+    /// <summary>
+    /// The third replay path: a source-compiled DEPENDENCY served from the
+    /// `compiled-deps` cache skips its own Emit, so its objects are captured only if
+    /// the dependency's own `.object-metadata.json` sidecar is written and replayed.
+    /// Same two-process "dep HIT + bundle MISS" sequence as
+    /// <see cref="SourceDepCacheEnumMetadataTests"/>, which is where that shape and its
+    /// fresh-AppId reasoning come from.
+    /// </summary>
+    [SkippableFact]
+    public void DependencyObjects_AreCaptured_AcrossASourceDepCacheHit()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var scratch = TestScratch.Dir("al-runner-object-metadata-dep");
+        var depDir = Path.Combine(scratch, "dep-app");
+        var testsDir = Path.Combine(scratch, "tests-app");
+        var alCacheDir = Path.Combine(scratch, "al-out");
+        Directory.CreateDirectory(depDir);
+        Directory.CreateDirectory(testsDir);
+
+        // Fresh identities: the dep's Tier-3 cache key has never been seen, so run 1 is
+        // unconditionally a dep MISS and run 2 an unconditional dep HIT.
+        var depId = Guid.NewGuid();
+        var testsId = Guid.NewGuid();
+
+        File.WriteAllText(Path.Combine(depDir, "app.json"), $$"""
+        {
+          "id": "{{depId}}",
+          "name": "OMR Dep App",
+          "publisher": "OMR",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 70670, "to": 70674 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(depDir, "Dep.al"), """
+        table 70670 "OMR Dep Thing"
+        {
+            DataClassification = CustomerContent;
+            fields { field(1; "Entry No."; Integer) { DataClassification = CustomerContent; } }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+
+        codeunit 70670 "OMR Dep Service"
+        {
+            procedure Answer(): Integer
+            begin
+                exit(7);
+            end;
+        }
+
+        enum 70670 "OMR Dep Kind"
+        {
+            Extensible = true;
+            value(0; Plain) { Caption = 'Plain'; }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(testsDir, "app.json"), $$"""
+        {
+          "id": "{{testsId}}",
+          "name": "OMR Dep Tests",
+          "publisher": "OMR",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{depId}}", "name": "OMR Dep App", "publisher": "OMR", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 70675, "to": 70679 } ],
+          "runtime": "14.0"
+        }
+        """);
+        var testsAlPath = Path.Combine(testsDir, "Tests.al");
+        File.WriteAllText(testsAlPath, """
+        codeunit 70675 "OMR Dep Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure DepAnswers()
+            var
+                Service: Codeunit "OMR Dep Service";
+            begin
+                if Service.Answer() <> 7 then
+                    Error('Expected 7, got %1', Service.Answer());
+            end;
+        }
+        """);
+
+        (string Kind, int Id)[] depObjects =
+        {
+            ("Table", 70670), ("Codeunit", 70670), ("Enum", 70670),
+        };
+
+        var (run1, exit1) = RunRunner(testsDir, alCacheDir);
+        Assert.True(exit1 == 0 && run1.Contains("1P/0F/0E"), $"run 1 (all cold) must pass:\n{run1}");
+        foreach (var (kind, id) in depObjects)
+            Assert.True(run1.Contains($"[object-metadata] registered {kind} {id} "),
+                $"run 1: dependency object {kind} {id} was not captured.\n{run1}");
+
+        // Touch the tests bundle only: its cache key changes (bundle MISS) while the
+        // dep's synthesized .app stays byte-identical (dep HIT).
+        File.AppendAllText(testsAlPath, "\n// touched\n");
+
+        var (run2, exit2) = RunRunner(testsDir, alCacheDir);
+        Assert.True(exit2 == 0 && run2.Contains("1P/0F/0E"), $"run 2 (dep HIT) must pass:\n{run2}");
+        Assert.Contains("source-cache HIT", run2);
+        foreach (var (kind, id) in depObjects)
+            Assert.True(run2.Contains($"[object-metadata] registered {kind} {id} "),
+                $"run 2: dependency object {kind} {id} lost its metadata when the dependency "
+                + $"was served from the compiled-deps cache.\n{run2}");
+    }
+}

--- a/AlRunner.Tests/ObjectMetadataRegistryTests.cs
+++ b/AlRunner.Tests/ObjectMetadataRegistryTests.cs
@@ -1,0 +1,132 @@
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #3548 — <see cref="AlObjectMetadataRegistry"/>'s own contract, without spawning the
+/// runner: (kind, id) is the identity, not the id; an id-less kind is addressable by
+/// name; and the sidecar round-trips every entry, because the sidecar is the only thing
+/// standing between the capture and an empty registry on every warm run.
+///
+/// Serialized against the other tests that touch this static registry — see
+/// <see cref="ObjectMetadataRegistrySerialCollection"/>.
+/// </summary>
+[Collection("object-metadata-registry")]
+public class ObjectMetadataRegistryTests : IDisposable
+{
+    public ObjectMetadataRegistryTests() => AlObjectMetadataRegistry.Clear();
+    public void Dispose() => AlObjectMetadataRegistry.Clear();
+
+    [Fact]
+    public void SameId_DifferentKinds_AreDifferentEntries()
+    {
+        AlObjectMetadataRegistry.Register("Table", 70660, "OMR Thing", "<MetaTable ID=\"70660\" />");
+        AlObjectMetadataRegistry.Register("Page", 70660, "OMR Thing List", "<PageDefinition ID=\"70660\" />");
+
+        Assert.Equal(2, AlObjectMetadataRegistry.Count);
+
+        Assert.True(AlObjectMetadataRegistry.TryGet("Table", 70660, out var table));
+        Assert.Equal("<MetaTable ID=\"70660\" />", table);
+
+        Assert.True(AlObjectMetadataRegistry.TryGet("Page", 70660, out var page));
+        Assert.Equal("<PageDefinition ID=\"70660\" />", page);
+
+        // Negative direction: a kind that was never registered under this id must not
+        // resolve to the table's or the page's document just because the id is known.
+        Assert.False(AlObjectMetadataRegistry.TryGet("Codeunit", 70660, out var codeunit));
+        Assert.Equal(string.Empty, codeunit);
+        // And an id nothing registered stays unknown for a kind that IS known.
+        Assert.False(AlObjectMetadataRegistry.TryGet("Table", 70661, out _));
+    }
+
+    [Fact]
+    public void RegisteringTheSameIdentityTwice_ReplacesRatherThanDuplicates()
+    {
+        AlObjectMetadataRegistry.Register("Table", 70660, "OMR Thing", "<MetaTable Access=\"Internal\" />");
+        AlObjectMetadataRegistry.Register("Table", 70660, "OMR Thing", "<MetaTable Access=\"Public\" />");
+
+        Assert.Equal(1, AlObjectMetadataRegistry.Count);
+        Assert.True(AlObjectMetadataRegistry.TryGet("Table", 70660, out var xml));
+        Assert.Equal("<MetaTable Access=\"Public\" />", xml);
+    }
+
+    [Fact]
+    public void IdlessKind_IsAddressableByName_AndAnEmptyDocumentIsRefused()
+    {
+        AlObjectMetadataRegistry.Register("Profile", null, "OMR Profile", "<Profile ProfileID=\"OMR Profile\" />");
+
+        Assert.True(AlObjectMetadataRegistry.TryGetByName("Profile", "OMR Profile", out var xml));
+        Assert.Equal("<Profile ProfileID=\"OMR Profile\" />", xml);
+        Assert.False(AlObjectMetadataRegistry.TryGetByName("Profile", "Some Other Profile", out _));
+
+        // A symbol arriving with no metadata document is not an entry with an empty
+        // document — a consumer must be able to tell "BC said nothing" from "BC said
+        // nothing about this object" (.claude/rules/loud-failures.md).
+        AlObjectMetadataRegistry.Register("Table", 70662, "Empty", "");
+        Assert.False(AlObjectMetadataRegistry.TryGet("Table", 70662, out _));
+        // Neither is an identity-less registration.
+        AlObjectMetadataRegistry.Register("Profile", null, "", "<Profile />");
+        Assert.Equal(1, AlObjectMetadataRegistry.Count);
+    }
+
+    [Fact]
+    public void Sidecar_RoundTripsEveryEntry_AndScopesToTheKeysAsked()
+    {
+        AlObjectMetadataRegistry.Register("Table", 70660, "OMR Thing", "<MetaTable ID=\"70660\" />");
+        AlObjectMetadataRegistry.Register("Page", 70660, "OMR Thing List", "<PageDefinition ID=\"70660\" />");
+        AlObjectMetadataRegistry.Register("Profile", null, "OMR Profile", "<Profile />");
+        // A sibling app's entry, which this dependency's sidecar must NOT carry.
+        AlObjectMetadataRegistry.Register("Table", 79999, "Foreign Thing", "<MetaTable ID=\"79999\" />");
+
+        var dir = TestScratch.Dir("al-runner-objmeta-sidecar");
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, "dep.object-metadata.json");
+        var mine = new[]
+        {
+            AlObjectMetadataRegistry.KeyFor("Table", 70660, "OMR Thing"),
+            AlObjectMetadataRegistry.KeyFor("Page", 70660, "OMR Thing List"),
+            AlObjectMetadataRegistry.KeyFor("Profile", null, "OMR Profile"),
+        };
+        Assert.Equal(3, AlObjectMetadataRegistry.SaveSidecar(path, mine));
+
+        AlObjectMetadataRegistry.Clear();
+        Assert.Equal(0, AlObjectMetadataRegistry.Count);
+
+        Assert.Equal(3, AlObjectMetadataRegistry.LoadSidecar(path));
+        Assert.True(AlObjectMetadataRegistry.TryGet("Table", 70660, out var table));
+        Assert.Equal("<MetaTable ID=\"70660\" />", table);
+        Assert.True(AlObjectMetadataRegistry.TryGet("Page", 70660, out var page));
+        Assert.Equal("<PageDefinition ID=\"70660\" />", page);
+        Assert.True(AlObjectMetadataRegistry.TryGetByName("Profile", "OMR Profile", out _));
+        // The scoping is the claim: the sibling app's entry was never written.
+        Assert.False(AlObjectMetadataRegistry.TryGet("Table", 79999, out _));
+
+        // Names survive too — the dependency sidecar's own scoping diff keys on
+        // (kind, id-or-name), so a lost name makes an id-less entry unaddressable.
+        Assert.Equal("OMR Thing List", AlObjectMetadataRegistry.Snapshot()
+            .Single(e => e.Kind == "Page" && e.Id == 70660).Name);
+    }
+
+    [Fact]
+    public void Sidecar_CorruptJson_Throws_SoCallersCanFallThroughToAMiss()
+    {
+        var dir = TestScratch.Dir("al-runner-objmeta-sidecar-bad");
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, "bad.object-metadata.json");
+
+        File.WriteAllText(path, "{ not json");
+        Assert.ThrowsAny<Exception>(() => AlObjectMetadataRegistry.LoadSidecar(path));
+
+        // Well-formed JSON without the array is just as unusable, and silently replaying
+        // zero entries is the failure this whole registry exists to avoid.
+        File.WriteAllText(path, "{ \"somethingElse\": [] }");
+        Assert.Throws<InvalidDataException>(() => AlObjectMetadataRegistry.LoadSidecar(path));
+
+        Assert.Equal(0, AlObjectMetadataRegistry.Count);
+    }
+}
+
+[CollectionDefinition("object-metadata-registry", DisableParallelization = true)]
+public class ObjectMetadataRegistrySerialCollection { }

--- a/AlRunner.Tests/RadObjectMetadataSnapshotReloadTests.cs
+++ b/AlRunner.Tests/RadObjectMetadataSnapshotReloadTests.cs
@@ -1,0 +1,298 @@
+// RadObjectMetadataSnapshotReloadTests — the fourth replay path for #3548's general
+// (kind, id) object-metadata capture: the --watch / --server RAD shadow snapshot.
+//
+// Three of the four paths that keep AlObjectMetadataRegistry populated across a warm run
+// are covered by ObjectMetadataCaptureTests (cold emit, bundle AL-output cache HIT,
+// source-dependency cache HIT). This is the fourth, and it is the one where the runner
+// actively DESTROYS the registry: BcRuntime.ResetForNewBundleReload() calls
+// AlObjectMetadataRegistry.Clear() at the top of every reload cycle, and the per-module
+// shadow snapshot on the BcCompiler instance is the only thing that puts back an object
+// the next cycle's partial (or skipped) Emit never re-registers.
+//
+// So the Clear() is a regression on its own, and the snapshot is what makes it safe. That
+// pairing is what this file pins, in both directions:
+//
+//   survives   Table 90410 / Page 90410 / Codeunit 90413 are never touched between the two
+//              cycles, so a delta compile emits nothing for them — after the Clear they can
+//              only come back from the snapshot.
+//   vacated    Codeunit 90411's file is DELETED, so it must NOT be answerable afterwards.
+//              This is the half the snapshot can get wrong in the other direction: replaying
+//              a stale entry resurrects an object the bundle no longer declares.
+//   changed    Table 90412 gains a field, so it must answer the NEW document, not the one
+//              captured on cycle 1.
+//
+// Every assertion names (kind, id) and compares document CONTENT. A count would pass against
+// a snapshot holding the wrong documents, and — because table 90410 and page 90410 share an
+// id on purpose — so would anything keyed on the id alone.
+//
+// ── Why in-process rather than a spawned `--watch` subprocess ────────────────────────────
+//
+// #3548 steps 1 and 2 convert no consumer, so nothing reads this registry yet and there is
+// no AL-observable behaviour a subprocess could assert on — only the
+// AL_RUNNER_TRACE_OBJECT_METADATA trace text, which shows registrations rather than what the
+// registry answers, and cannot express "this (kind, id) is NOT answerable". Driving the same
+// two calls --watch drives (BcRuntime.ResetForNewBundleReload, then
+// BcCompiler.TryEmitIncremental) reads the registry directly and states the claim exactly.
+// Same reasoning, and the same shape, as RadQuerySymbolsSnapshotModuleScopeTests, which
+// reaches BcCompiler's private RAD snapshot for the neighbouring #2939 property.
+//
+// The fast-path assertion below is load-bearing for that: if TryEmitIncremental returns null
+// the caller falls back to a whole-module Emit, which repopulates the registry by itself and
+// would make every assertion here pass with no snapshot at all.
+using Xunit;
+using AlRunner;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class RadObjectMetadataSnapshotReloadTests : IDisposable
+{
+    private const string Module = "RadObjMetaModule";
+
+    // Table and page deliberately SHARE id 90410 — AL allows it, and it is what makes the
+    // per-(kind, id) claim testable: a snapshot keyed on the id alone answers both with one
+    // document and passes every positive assertion below.
+    private const int SharedId = 90410;
+    private const int VacatedCodeunitId = 90411;
+    private const int ChangedTableId = 90412;
+    private const int KeptCodeunitId = 90413;
+
+    // Only ever present in the post-edit table, so "answered the new document" cannot be
+    // satisfied by the cycle-1 one.
+    private const string AddedFieldMarker = "ZebraMarkerBeta";
+
+    private readonly string _root;
+    private readonly BcEngineFixture _engine;
+
+    public RadObjectMetadataSnapshotReloadTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = TestScratch.Dir("al-runner-rad-objmeta-reload");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        // Process-global state this test writes into. The collection is serial, but leaving a
+        // scratch bundle's objects registered would still be visible to whatever runs next.
+        try { AlObjectMetadataRegistry.Clear(); } catch { /* best-effort */ }
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort */ }
+    }
+
+    // The RAD fast path requires exactly one object per file, so every object gets its own.
+    private void WriteAl(string fileName, string content) => File.WriteAllText(Path.Combine(_root, fileName), content);
+
+    private const string RowTable = """
+        table 90410 "Rad Obj Row"
+        {
+            DataClassification = CustomerContent;
+            fields
+            {
+                field(1; "Entry No."; Integer) { DataClassification = CustomerContent; }
+            }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+        """;
+
+    private const string RowPage = """
+        page 90410 "Rad Obj Page"
+        {
+            PageType = Card;
+            SourceTable = "Rad Obj Row";
+            layout
+            {
+                area(Content)
+                {
+                    group(General) { field("Entry No."; Rec."Entry No.") { ApplicationArea = All; } }
+                }
+            }
+        }
+        """;
+
+    /// <summary>The object whose file is deleted on cycle 2. Referenced by nothing, so its
+    /// removal is a clean vacate rather than a delta-compile error.</summary>
+    private const string GoneCodeunit = """
+        codeunit 90411 "Rad Obj Gone"
+        {
+            procedure Vanishes(): Integer
+            begin
+                exit(11);
+            end;
+        }
+        """;
+
+    /// <summary>The control for the vacated assertion: a codeunit that is NOT deleted. Without
+    /// it, "Codeunit 90411 does not answer" is also satisfied by a snapshot that drops every
+    /// codeunit, or captures none in the first place.</summary>
+    private const string KeptCodeunit = """
+        codeunit 90413 "Rad Obj Keep"
+        {
+            procedure Stays(): Integer
+            begin
+                exit(13);
+            end;
+        }
+        """;
+
+    private const string ChangedTableBefore = """
+        table 90412 "Rad Obj Changed"
+        {
+            DataClassification = CustomerContent;
+            fields
+            {
+                field(1; "Entry No."; Integer) { DataClassification = CustomerContent; }
+            }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+        """;
+
+    private const string ChangedTableAfter = """
+        table 90412 "Rad Obj Changed"
+        {
+            DataClassification = CustomerContent;
+            fields
+            {
+                field(1; "Entry No."; Integer) { DataClassification = CustomerContent; }
+                field(2; ZebraMarkerBeta; Text[30]) { DataClassification = CustomerContent; }
+            }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+        """;
+
+    private static string Doc(string kind, int id)
+    {
+        Assert.True(
+            AlObjectMetadataRegistry.TryGet(kind, id, out var xml),
+            $"no metadata document is answerable for {kind} {id}.");
+        return xml;
+    }
+
+    /// <summary>
+    /// One reload cycle, exactly as --watch runs it: Emit + baseline, then
+    /// ResetForNewBundleReload, then TryEmitIncremental. Asserts the registry really is empty
+    /// between the two — the whole point of the snapshot is that it survives a Clear() that
+    /// actually happened, and every later assertion is vacuous if it did not.
+    /// </summary>
+    [SkippableFact]
+    public void RadReload_KeepsEveryUntouchedObjectsDocumentPerKindAndId()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        WriteAl("Row.Table.al", RowTable);
+        WriteAl("Row.Page.al", RowPage);
+        WriteAl("Gone.Codeunit.al", GoneCodeunit);
+        WriteAl("Keep.Codeunit.al", KeptCodeunit);
+        WriteAl("Changed.Table.al", ChangedTableBefore);
+
+        // ── cycle 1: the cold compile that populates the registry and the shadow snapshot ──
+        var compiler = new BcCompiler();
+        var cold = compiler.Emit(new[] { _root }, Module, trackIncrementalBaseline: true);
+        Assert.Empty(cold.Diagnostics);
+
+        var tableDocBefore = Doc("Table", SharedId);
+        var pageDocBefore = Doc("Page", SharedId);
+        var keptDocBefore = Doc("Codeunit", KeptCodeunitId);
+        var changedDocBefore = Doc("Table", ChangedTableId);
+        Assert.True(AlObjectMetadataRegistry.TryGet("Codeunit", VacatedCodeunitId, out _),
+            $"Codeunit {VacatedCodeunitId} must be captured on cycle 1 — otherwise 'it is gone after "
+            + "cycle 2' is satisfied by it never having been there.");
+
+        // Fixture guard: table 90410 and page 90410 really are two entries carrying different
+        // documents. Everything per-(kind, id) below rests on this.
+        Assert.NotEqual(tableDocBefore, pageDocBefore);
+        Assert.Contains("Rad Obj Row", tableDocBefore, StringComparison.Ordinal);
+        Assert.Contains("Rad Obj Page", pageDocBefore, StringComparison.Ordinal);
+        Assert.DoesNotContain(AddedFieldMarker, changedDocBefore, StringComparison.Ordinal);
+
+        // ── the edit: one object vacated, one changed, three untouched ──
+        File.Delete(Path.Combine(_root, "Gone.Codeunit.al"));
+        WriteAl("Changed.Table.al", ChangedTableAfter);
+
+        // ── cycle 2, first half: the reload's own Clear() ──
+        BcRuntime.ResetForNewBundleReload();
+        Assert.False(AlObjectMetadataRegistry.TryGet("Table", SharedId, out _),
+            "the reload did not clear AlObjectMetadataRegistry, so nothing below measures the shadow "
+            + "snapshot: every document would still be there because it was never removed.");
+        Assert.Equal(0, AlObjectMetadataRegistry.Count);
+
+        // ── cycle 2, second half: the RAD delta ──
+        var delta = compiler.TryEmitIncremental(new[] { _root }, Module, appRootDir: null, out var fallbackReason);
+        Assert.True(delta != null,
+            "the incremental path fell back to a whole-module Emit, which repopulates the registry by "
+            + "itself — so this test would pass with no shadow snapshot at all and prove nothing. "
+            + $"fallbackReason: {fallbackReason}");
+
+        // 1. Untouched objects. A delta compile emits nothing for these, so after the Clear the
+        //    snapshot replay is the only thing that can answer them — and it must answer with the
+        //    SAME document BC produced on cycle 1, not merely with something.
+        Assert.Equal(tableDocBefore, Doc("Table", SharedId));
+        Assert.Equal(pageDocBefore, Doc("Page", SharedId));
+        Assert.Equal(keptDocBefore, Doc("Codeunit", KeptCodeunitId));
+
+        // 2. Per (kind, id), not per id: the two 90410 entries must still be distinct after the
+        //    round trip through the snapshot.
+        Assert.NotEqual(Doc("Table", SharedId), Doc("Page", SharedId));
+
+        // 3. The destructive half. Codeunit 90411's file is gone, so the snapshot must have
+        //    dropped it — replaying it would resurrect an object the bundle no longer declares.
+        Assert.False(AlObjectMetadataRegistry.TryGet("Codeunit", VacatedCodeunitId, out var resurrected),
+            $"Codeunit {VacatedCodeunitId}'s source file was deleted before this cycle, but the RAD "
+            + "shadow snapshot still answered for it — UpdateRadMetadataSnapshotDelta did not drop the "
+            + $"vacated identity, so the replay put a retired object back. Document ({resurrected.Length} "
+            + "chars) begins: " + resurrected[..Math.Min(200, resurrected.Length)]);
+
+        // 4. The changed object answers the NEW document. Without this a snapshot that replayed
+        //    cycle 1 verbatim over the delta's own fresh registration would look correct.
+        var changedDocAfter = Doc("Table", ChangedTableId);
+        Assert.Contains(AddedFieldMarker, changedDocAfter, StringComparison.Ordinal);
+        Assert.NotEqual(changedDocBefore, changedDocAfter);
+
+        // 5. Nothing was invented: a kind this bundle never declares under a known id, and an id
+        //    it never declares at all, must both stay unanswerable.
+        Assert.False(AlObjectMetadataRegistry.TryGet("TableExtension", SharedId, out _),
+            $"{SharedId} is a table and a page here, and no tableextension — a registry answering any "
+            + "kind for a known id passes every positive assertion above.");
+        Assert.False(AlObjectMetadataRegistry.TryGet("Table", 90419, out _));
+    }
+
+    /// <summary>
+    /// The zero-work cycle: --watch re-runs with no edit at all (a save that changed no bytes,
+    /// or a sibling bundle's edit). TryEmitIncremental returns the previous output verbatim
+    /// without calling Emit anywhere, so EVERY document in the registry comes from the replay —
+    /// which makes this the sharpest statement of the property, and the cheapest way for the
+    /// snapshot to be silently missing.
+    /// </summary>
+    [SkippableFact]
+    public void RadReload_WithNoEditAtAll_StillAnswersEveryObjectItAnsweredBefore()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        WriteAl("Row.Table.al", RowTable);
+        WriteAl("Row.Page.al", RowPage);
+        WriteAl("Keep.Codeunit.al", KeptCodeunit);
+
+        var compiler = new BcCompiler();
+        Assert.Empty(compiler.Emit(new[] { _root }, Module, trackIncrementalBaseline: true).Diagnostics);
+
+        var before = AlObjectMetadataRegistry.Snapshot()
+            .ToDictionary(e => AlObjectMetadataRegistry.KeyFor(e.Kind, e.Id, e.Name), e => e.Xml, StringComparer.Ordinal);
+        Assert.Equal(3, before.Count);
+
+        BcRuntime.ResetForNewBundleReload();
+        Assert.Equal(0, AlObjectMetadataRegistry.Count);
+
+        var delta = compiler.TryEmitIncremental(new[] { _root }, Module, appRootDir: null, out var fallbackReason);
+        Assert.True(delta != null, $"a no-edit cycle must take the fast path. fallbackReason: {fallbackReason}");
+
+        var after = AlObjectMetadataRegistry.Snapshot()
+            .ToDictionary(e => AlObjectMetadataRegistry.KeyFor(e.Kind, e.Id, e.Name), e => e.Xml, StringComparer.Ordinal);
+
+        // Key set AND document per key. Comparing the dictionaries rather than the counts is
+        // what stops a snapshot that replays three of the wrong documents from passing.
+        Assert.Equal(
+            before.Keys.OrderBy(k => k, StringComparer.Ordinal),
+            after.Keys.OrderBy(k => k, StringComparer.Ordinal));
+        foreach (var (key, xml) in before)
+            Assert.Equal(xml, after[key]);
+    }
+}

--- a/AlRunner/BcCompiler.Incremental.cs
+++ b/AlRunner/BcCompiler.Incremental.cs
@@ -230,6 +230,13 @@ public sealed partial class BcCompiler
     private readonly Dictionary<string, Dictionary<int, string>> _radXmlPortMetadataByModule =
         new(StringComparer.Ordinal);
 
+    // #3548 — the same shadow copy for the general (kind, id) capture, which
+    // ResetForNewBundleReload clears alongside the two above. Keyed by
+    // AlObjectMetadataRegistry identity key rather than by id, because ids repeat across
+    // kinds: table 70660 and page 70660 are two entries, not one.
+    private readonly Dictionary<string, Dictionary<string, AlObjectMetadataEntry>> _radObjectMetadataByModule =
+        new(StringComparer.Ordinal);
+
     // #2939, and the same mechanism as the two dictionaries above. RecordPatches'
     // _bcQuerySymbolJsonPaths — the loose SymbolReference.json files a bundle's own compiled
     // queries are read from — is a REGISTERED list, and since #2939 the per-bundle reload path
@@ -260,9 +267,22 @@ public sealed partial class BcCompiler
     {
         var pages = new Dictionary<int, string>();
         var xmlPorts = new Dictionary<int, string>();
+        var objects = new Dictionary<string, AlObjectMetadataEntry>(StringComparer.Ordinal);
         foreach (var sym in declared)
         {
             var id = (sym as NavCA.ISymbolWithId)?.Id;
+            // #3548 — the general capture covers every kind, including the id-less ones the
+            // two id-keyed snapshots below cannot represent, so it is taken first and does
+            // not share their `id == null` bail-out. It reads the process-wide registry
+            // exactly as they do, which carries #3282's known call-site asymmetry: on the
+            // EmitDepSymbols(trackIncrementalBaseline: true) path no outputter ran, so a
+            // colliding object id can capture another module's document. Deliberately kept
+            // consistent with its two neighbours rather than diverging — see
+            // docs/object-metadata-capture.md#surviving-a-warm-run.
+            var objKey = AlObjectMetadataRegistry.KeyFor(
+                sym.Kind.ToString(), IdlessSymbolKinds.Contains(sym.Kind) ? null : id, sym.Name);
+            if (AlObjectMetadataRegistry.TryGetByKey(objKey, out var objEntry))
+                objects[objKey] = objEntry;
             if (id == null) continue;
             if (sym.Kind == NavCA.SymbolKind.Page && AlPageMetadataRegistry.TryGet(id.Value, out var pageXml))
                 pages[id.Value] = pageXml;
@@ -271,6 +291,7 @@ public sealed partial class BcCompiler
         }
         _radPageMetadataByModule[moduleName] = pages;
         _radXmlPortMetadataByModule[moduleName] = xmlPorts;
+        _radObjectMetadataByModule[moduleName] = objects;
 
         // #2939: the query-symbol source file THIS module's own full compile just wrote, or
         // null when it wrote none (it declares no query, or it is not the bundle-emit path at
@@ -316,15 +337,22 @@ public sealed partial class BcCompiler
             _radPageMetadataByModule[moduleName] = pages = new Dictionary<int, string>();
         if (!_radXmlPortMetadataByModule.TryGetValue(moduleName, out var xmlPorts))
             _radXmlPortMetadataByModule[moduleName] = xmlPorts = new Dictionary<int, string>();
+        if (!_radObjectMetadataByModule.TryGetValue(moduleName, out var objects))
+            _radObjectMetadataByModule[moduleName] = objects =
+                new Dictionary<string, AlObjectMetadataEntry>(StringComparer.Ordinal);
 
         foreach (var v in vacatedIds)
         {
+            objects.Remove(RadObjectMetadataKey(v));
             if (v.Id is not { } id) continue;
             if (v.Kind == NavCA.SymbolKind.Page) pages.Remove(id);
             else if (v.Kind == NavCA.SymbolKind.XmlPort) xmlPorts.Remove(id);
         }
         foreach (var c in changedIds)
         {
+            var objKey = RadObjectMetadataKey(c);
+            if (AlObjectMetadataRegistry.TryGetByKey(objKey, out var objEntry))
+                objects[objKey] = objEntry;
             if (c.Id is not { } id) continue;
             if (c.Kind == NavCA.SymbolKind.Page && AlPageMetadataRegistry.TryGet(id, out var pageXml))
                 pages[id] = pageXml;
@@ -341,6 +369,9 @@ public sealed partial class BcCompiler
             foreach (var (id, xml) in pages) AlPageMetadataRegistry.Register(id, xml);
         if (_radXmlPortMetadataByModule.TryGetValue(moduleName, out var xmlPorts))
             foreach (var (id, xml) in xmlPorts) AlXmlPortMetadataRegistry.Register(id, xml);
+        if (_radObjectMetadataByModule.TryGetValue(moduleName, out var objects))
+            foreach (var e in objects.Values)
+                AlObjectMetadataRegistry.Register(e.Kind, e.Id, e.Name, e.Xml);
         // #2939. RegisterBundleQuerySymbolsJson is itself idempotent AND always invalidates the
         // derived index (the file is rewritten in place by each full Emit), so replaying an
         // already-registered path is correct rather than merely harmless.
@@ -362,6 +393,15 @@ public sealed partial class BcCompiler
     };
 
     private static string RadObjKey(NavCA.SymbolKind kind, int id) => $"{kind}:{id}";
+
+    /// <summary>The <see cref="AlObjectMetadataRegistry"/> identity of a RAD object
+    /// identity — id-bearing kinds by id, id-less kinds by name, exactly as the capture in
+    /// CaptureOutputter.AddApplicationObject keyed it.</summary>
+    private static string RadObjectMetadataKey(RadObjectIdentity identity)
+        => AlObjectMetadataRegistry.KeyFor(
+            identity.Kind.ToString(),
+            IdlessSymbolKinds.Contains(identity.Kind) ? null : identity.Id,
+            identity.Name ?? string.Empty);
 
     /// <summary>Stable (Kind,Id-or-Name) key used to match a "vacated" identity against an "appeared" one across paths.</summary>
     private static string IdentityKey(RadObjectIdentity id) => $"{id.Kind}|{(id.Id.HasValue ? "id:" + id.Id.Value : "name:" + id.Name)}";

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -3044,6 +3044,22 @@ public sealed partial class BcCompiler
             if (symbol is NavCA.IXmlPortTypeSymbol xmlPortSym && !string.IsNullOrEmpty(metadata))
                 AlXmlPortMetadataRegistry.Register(xmlPortSym.Id, metadata);
 
+            // General capture (#3548). BC hands us its own metadata document for every
+            // object it emits and the three branches above keep three kinds; the rest was
+            // discarded and then rebuilt from SymbolReference.json, AL source text or
+            // symbol properties. Keep all of it, keyed by (kind, id), so a kind BC adds
+            // later is covered without a fourteenth branch. Additive — the registries
+            // above stay, with their consumers unchanged.
+            if (!string.IsNullOrEmpty(metadata))
+            {
+                var idless = IdlessSymbolKinds.Contains(symbol.Kind);
+                AlObjectMetadataRegistry.Register(
+                    symbol.Kind.ToString(),
+                    idless ? null : (symbol as NavCA.ISymbolWithId)?.Id,
+                    symbol.Name,
+                    metadata);
+            }
+
             if (Environment.GetEnvironmentVariable("BCCOMPILER_TRACE") == "1")
                 Console.Error.WriteLine($"  emit[{AddCalls}]: {symbol.Name} kind={symbol.GetType().Name} metaLen={metadata?.Length ?? -1}");
             // #2967 — SCRATCH-DIR CLASSIFICATION: a DOCUMENTED TRADE-OFF that stays as it is.

--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -630,6 +630,11 @@ public static partial class BcRuntime
         AlReportLayoutRegistry.Clear();
         AlPageMetadataRegistry.Clear();
         AlXmlPortMetadataRegistry.Clear();
+        // #3548 — same lifecycle as the four registries above: bundle-derived, so a
+        // reload must drop it, and the --watch RAD shadow snapshot in
+        // BcCompiler.Incremental.cs is what puts back the entries the next cycle's
+        // partial (or skipped) Emit does not re-register.
+        AlObjectMetadataRegistry.Clear();
         NavReportSync.ResetMetadataCache();
         // Sibling patch classes with their own bundle-derived state.
         AlRunner.Patches.RecordPatches.ResetForReload();

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -563,6 +563,10 @@ public sealed class DependencyLoader
         // enum then failed with a blank enum name / empty option list. Mirrors the
         // bundle-level `.enum-registry.json` sidecar (Program.cs SaveEnumRegistrySidecar).
         var enumRegistrySidecar = Path.Combine(cacheDir, cacheKey + ".enum-registry.json");
+        // #3548 — the general capture: BC's own metadata document for every object this
+        // dep emitted, keyed by (kind, id). Same cache-HIT hazard as the four sidecars
+        // above, and the same shape of fix.
+        var objectMetadataSidecar = Path.Combine(cacheDir, cacheKey + ".object-metadata.json");
         if (File.Exists(cachedDll))
         {
             try
@@ -579,6 +583,8 @@ public sealed class DependencyLoader
                     AlPageMetadataRegistry.LoadSidecar(pageMetadataSidecar);
                 if (File.Exists(xmlPortMetadataSidecar))
                     AlXmlPortMetadataRegistry.LoadSidecar(xmlPortMetadataSidecar);
+                if (File.Exists(objectMetadataSidecar))
+                    AlObjectMetadataRegistry.LoadSidecar(objectMetadataSidecar);
                 int replayedEnums = 0;
                 if (File.Exists(enumRegistrySidecar))
                     replayedEnums = AlEnumMetadataRegistry.LoadSidecar(enumRegistrySidecar);
@@ -633,6 +639,7 @@ public sealed class DependencyLoader
         var pageIdsBeforeEmit = new HashSet<int>(AlPageMetadataRegistry.Ids);
         var xmlPortIdsBeforeEmit = new HashSet<int>(AlXmlPortMetadataRegistry.Ids);
         var enumIdsBeforeEmit = new HashSet<int>(AlEnumMetadataRegistry.Ids);
+        var objectKeysBeforeEmit = new HashSet<string>(AlObjectMetadataRegistry.Keys, StringComparer.Ordinal);
         // Scope _currentAppId to the dep's own identity for the duration of this compile.
         // GetSharedReferences uses _currentAppId to exclude the "current app" from its
         // reference specs. Without this, the dep's resolved spec (from _resolvedDeps of
@@ -690,7 +697,9 @@ public sealed class DependencyLoader
                 xmlPortMetadataSidecar,
                 AlXmlPortMetadataRegistry.Ids.Where(i => !xmlPortIdsBeforeEmit.Contains(i)).ToArray(),
                 enumRegistrySidecar,
-                AlEnumMetadataRegistry.Ids.Where(i => !enumIdsBeforeEmit.Contains(i)));
+                AlEnumMetadataRegistry.Ids.Where(i => !enumIdsBeforeEmit.Contains(i)),
+                objectMetadataSidecar,
+                AlObjectMetadataRegistry.Keys.Where(k => !objectKeysBeforeEmit.Contains(k)).ToArray());
             Console.Error.WriteLine(
                 $"[deps] source-cache WROTE: {m.Name} v{m.Version} key={cacheKey[..12]} ({compile.AssemblyBytes!.Length} bytes, {sidecarCount} report-metadata entries, {enumSidecarCount} enum-registry entries)");
         }
@@ -709,8 +718,8 @@ public sealed class DependencyLoader
     }
 
     /// <summary>
-    /// Publishes the six on-disk artifacts of a compiled source-dependency cache entry
-    /// (five metadata sidecars + the DLL). Extracted out of <see cref="LoadOne"/> so
+    /// Publishes the seven on-disk artifacts of a compiled source-dependency cache entry
+    /// (six metadata sidecars + the DLL). Extracted out of <see cref="LoadOne"/> so
     /// AlRunner.Tests can pin the write-ordering/atomicity contract directly —
     /// see AlCacheWriterDependencyCacheOrderingTests.
     ///
@@ -733,10 +742,10 @@ public sealed class DependencyLoader
     /// ordering guarantee AlCacheWriterTests.
     /// SequencedPublish_SidecarThenDll_DllNeverVisibleBeforeSidecar pins for the
     /// AL-output cache; this mirrors it for the dependency-compile cache's larger
-    /// 5-sidecars-then-1-DLL shape.
+    /// 6-sidecars-then-1-DLL shape.
     /// </summary>
     ///
-    /// <param name="onSidecarsPublishedBeforeDll">Test-only seam: invoked after all five
+    /// <param name="onSidecarsPublishedBeforeDll">Test-only seam: invoked after all six
     /// sidecars are committed but before the DLL is published, so a test can assert the
     /// DLL-not-yet-visible ordering deterministically instead of racing a polling thread
     /// against the filesystem. Null in production and in every test that doesn't need it
@@ -749,6 +758,7 @@ public sealed class DependencyLoader
         string pageMetadataSidecar, int[] ownPageIds,
         string xmlPortMetadataSidecar, int[] ownXmlPortIds,
         string enumRegistrySidecar, IEnumerable<int> ownEnumIds,
+        string objectMetadataSidecar, IEnumerable<string> ownObjectKeys,
         Action? onSidecarsPublishedBeforeDll = null)
     {
         int sidecarCount = AlCacheWriter.AtomicPublish(reportSidecar,
@@ -761,6 +771,8 @@ public sealed class DependencyLoader
             tmp => AlXmlPortMetadataRegistry.SaveSidecar(tmp, ownXmlPortIds));
         int enumSidecarCount = AlCacheWriter.AtomicPublish(enumRegistrySidecar,
             tmp => AlEnumMetadataRegistry.SaveSidecar(tmp, ownEnumIds));
+        AlCacheWriter.AtomicPublish(objectMetadataSidecar,
+            tmp => AlObjectMetadataRegistry.SaveSidecar(tmp, ownObjectKeys));
         onSidecarsPublishedBeforeDll?.Invoke();
         AlCacheWriter.AtomicPublish(cachedDll, tmp => File.WriteAllBytes(tmp, assemblyBytes));
         return (sidecarCount, enumSidecarCount);
@@ -787,8 +799,11 @@ public sealed class DependencyLoader
         var pageMetadataSidecar = Path.Combine(cacheDir, cacheKey + ".page-metadata.json");
         var xmlPortMetadataSidecar = Path.Combine(cacheDir, cacheKey + ".xmlport-metadata.json");
         var enumRegistrySidecar = Path.Combine(cacheDir, cacheKey + ".enum-registry.json");
+        var objectMetadataSidecar = Path.Combine(cacheDir, cacheKey + ".object-metadata.json");
         try
         {
+            if (File.Exists(objectMetadataSidecar))
+                AlObjectMetadataRegistry.LoadSidecar(objectMetadataSidecar);
             int replayedReports = File.Exists(reportSidecar) ? AlReportMetadataRegistry.LoadSidecar(reportSidecar) : 0;
             if (File.Exists(reportLayoutSidecar))
                 AlReportLayoutRegistry.LoadSidecar(reportLayoutSidecar);

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -178,7 +178,7 @@ public sealed class DependencyLoader
                 {
                     // #2593/#2579: this dependency's Assembly is being reused without calling
                     // LoadOne again — but LoadOne is the ONLY place that replays this dependency's
-                    // Tier-3 metadata sidecars (report/report-layout/page/xmlport/enum) into the
+                    // Tier-3 metadata sidecars (report/report-layout/page/xmlport/enum/object) into the
                     // process-wide registries. Those registries get reset every reload cycle
                     // (BcRuntime.ResetForNewBundleReload), so on the SECOND and every later
                     // --watch/--server cycle that resolves this same AppId as a dependency, skipping
@@ -802,14 +802,23 @@ public sealed class DependencyLoader
         var objectMetadataSidecar = Path.Combine(cacheDir, cacheKey + ".object-metadata.json");
         try
         {
-            if (File.Exists(objectMetadataSidecar))
-                AlObjectMetadataRegistry.LoadSidecar(objectMetadataSidecar);
             int replayedReports = File.Exists(reportSidecar) ? AlReportMetadataRegistry.LoadSidecar(reportSidecar) : 0;
             if (File.Exists(reportLayoutSidecar))
                 AlReportLayoutRegistry.LoadSidecar(reportLayoutSidecar);
             int replayedPages = File.Exists(pageMetadataSidecar) ? AlPageMetadataRegistry.LoadSidecar(pageMetadataSidecar) : 0;
             int replayedXmlPorts = File.Exists(xmlPortMetadataSidecar) ? AlXmlPortMetadataRegistry.LoadSidecar(xmlPortMetadataSidecar) : 0;
             int replayedEnums = File.Exists(enumRegistrySidecar) ? AlEnumMetadataRegistry.LoadSidecar(enumRegistrySidecar) : 0;
+            // LAST, deliberately. This catch logs and RETURNS -- the module is already
+            // loaded, so there is no rebuild behind it. Loading the object registry first put a
+            // new throw source ahead of the five sidecars that have live consumers, so a corrupt
+            // or future-shaped .object-metadata.json would take report, report-layout, page,
+            // xmlport and enum metadata down with it, silently, on a reused module. Nothing reads
+            // the object registry yet, so it is the one that can afford to fail. Keep it last
+            // until step 3 gives it a consumer, then it needs its own error handling rather than
+            // this position. LoadOne's HIT branch is different: its catch falls through to a full
+            // rebuild, so the call is safe anywhere in that block.
+            if (File.Exists(objectMetadataSidecar))
+                AlObjectMetadataRegistry.LoadSidecar(objectMetadataSidecar);
             if (replayedReports + replayedPages + replayedXmlPorts + replayedEnums > 0)
                 Console.Error.WriteLine(
                     $"[deps] metadata sidecar replay (reused module): {m.Name} v{m.Version} — " +
@@ -824,7 +833,7 @@ public sealed class DependencyLoader
 
     /// <summary>
     /// The Tier-3 source-compile cache key for one dependency package — the NAME of
-    /// <c>compiled-deps/&lt;key&gt;.dll</c> and its five metadata sidecars, so this string's
+    /// <c>compiled-deps/&lt;key&gt;.dll</c> and its six metadata sidecars, so this string's
     /// VALUE is persisted, shared across processes, and read by later runs. Changing what it
     /// computes for unchanged inputs orphans every existing entry on every machine; #3043's
     /// whole difficulty is that the obvious refactor does exactly that.

--- a/AlRunner/Patches/ObjectMetadataRegistry.cs
+++ b/AlRunner/Patches/ObjectMetadataRegistry.cs
@@ -1,0 +1,165 @@
+// AlObjectMetadataRegistry — BC's own metadata document for EVERY application object
+// the emitter hands to CaptureOutputter, keyed by (object kind, object id).
+//
+// The three registries next to this one (report, page, xmlport) each keep one kind.
+// Everything else BC emits was discarded and then rebuilt from SymbolReference.json,
+// from AL source text, or from symbol properties. This registry keeps the emitter's
+// own answer for all of it. It is additive: nothing reads it yet, and the three
+// per-kind registries keep their consumers unchanged (issue #3548, step 2).
+//
+// KEYING
+//   Every kind that reaches AddApplicationObject with a non-empty metadata document is
+//   id-bearing, and ids repeat across kinds — table 70660 and page 70660 are different
+//   objects with different documents. So the key is (kind, id), never the id alone.
+//   `id` is nullable anyway: an id-less kind (profile, controladdin, …) does not reach
+//   this outputter today, and if one ever does it is keyed by name rather than dropped.
+//   See docs/object-metadata-capture.md for which kinds arrive and which do not.
+//
+// CACHE-HIT SAFETY
+//   Emit runs only on a compile-cache MISS, so anything captured here and not persisted
+//   is gone on the next warm run — silently, with every consumer taking its not-found
+//   branch. This registry is replayed by the same three mechanisms the page registry
+//   uses: the bundle's `.enum-registry.json` sidecar (ProgramSupport.Save/Load
+//   EnumRegistrySidecar), the dependency compile cache's `.object-metadata.json`
+//   sidecar (DependencyLoader), and the --watch RAD shadow snapshot
+//   (BcCompiler.Incremental.cs). Any suite exercising it must be run twice.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace AlRunner;
+
+/// <summary>One emitted object's metadata document, as BC produced it.</summary>
+/// <param name="Kind">The AL compiler's own <c>SymbolKind</c> name — "Table", "Page",
+/// "PermissionSetExtension", … Carried as a string so a kind BC adds later flows
+/// through the capture, the sidecar and back without a code change.</param>
+/// <param name="Id">The object's AL id, or null for a kind that has none.</param>
+public sealed record AlObjectMetadataEntry(string Kind, int? Id, string Name, string Xml);
+
+public static class AlObjectMetadataRegistry
+{
+    private static readonly ConcurrentDictionary<string, AlObjectMetadataEntry> _byKey =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The identity a document is stored under. Mirrors BcCompiler.Incremental's
+    /// IdentityKey: id-bearing kinds key by id, id-less kinds by name.
+    /// </summary>
+    public static string KeyFor(string kind, int? id, string name)
+        => id.HasValue ? $"{kind}|id:{id.Value}" : $"{kind}|name:{name}";
+
+    public static void Register(string kind, int? id, string name, string metadataXml)
+    {
+        if (string.IsNullOrEmpty(kind) || string.IsNullOrEmpty(metadataXml)) return;
+        // An id-less registration needs a name to be addressable at all; without either
+        // there is no identity to store it under.
+        if (!id.HasValue && string.IsNullOrEmpty(name)) return;
+        var key = KeyFor(kind, id, name);
+        _byKey[key] = new AlObjectMetadataEntry(kind, id, name ?? string.Empty, metadataXml);
+
+        var trace = Environment.GetEnvironmentVariable("AL_RUNNER_TRACE_OBJECT_METADATA");
+        if (trace == "1" || trace == "2")
+            Console.Out.WriteLine(id.HasValue
+                ? $"[object-metadata] registered {kind} {id.Value} '{name}' ({metadataXml.Length} chars)"
+                : $"[object-metadata] registered {kind} name '{name}' ({metadataXml.Length} chars)");
+        // "2" dumps the document itself — the only way to see what BC's emitter actually
+        // says about a property, as opposed to what the runner's own derivation says.
+        if (trace == "2")
+            Console.Out.WriteLine($"[object-metadata] {key} XML:\n{metadataXml}");
+    }
+
+    public static bool TryGet(string kind, int id, out string metadataXml)
+    {
+        if (_byKey.TryGetValue(KeyFor(kind, id, string.Empty), out var e))
+        {
+            metadataXml = e.Xml;
+            return true;
+        }
+        metadataXml = string.Empty;
+        return false;
+    }
+
+    public static bool TryGetByName(string kind, string name, out string metadataXml)
+    {
+        if (_byKey.TryGetValue(KeyFor(kind, null, name), out var e))
+        {
+            metadataXml = e.Xml;
+            return true;
+        }
+        metadataXml = string.Empty;
+        return false;
+    }
+
+    public static int Count => _byKey.Count;
+
+    public static void Clear() => _byKey.Clear();
+
+    /// <summary>Identity keys currently held — the unit both sidecar scoping and the
+    /// --watch shadow snapshot diff on.</summary>
+    public static string[] Keys => _byKey.Keys.ToArray();
+
+    public static bool TryGetByKey(string key, out AlObjectMetadataEntry entry)
+        => _byKey.TryGetValue(key, out entry!);
+
+    /// <summary>Every entry, ordered so two snapshots of the same state serialize
+    /// byte-identically.</summary>
+    public static IReadOnlyList<AlObjectMetadataEntry> Snapshot()
+        => _byKey.Values
+            .OrderBy(e => e.Kind, StringComparer.Ordinal)
+            .ThenBy(e => e.Id ?? int.MinValue)
+            .ThenBy(e => e.Name, StringComparer.Ordinal)
+            .ToArray();
+
+    /// <summary>
+    /// Serialize only the given identity keys — a dependency's own sidecar must not
+    /// carry a sibling app's entries. Returns the number written.
+    /// </summary>
+    public static int SaveSidecar(string path, IEnumerable<string> onlyKeys)
+    {
+        var wanted = new HashSet<string>(onlyKeys, StringComparer.Ordinal);
+        var entries = Snapshot()
+            .Where(e => wanted.Contains(KeyFor(e.Kind, e.Id, e.Name)))
+            .Select(e => new { kind = e.Kind, id = e.Id, name = e.Name, xml = e.Xml })
+            .ToArray();
+        File.WriteAllText(path, System.Text.Json.JsonSerializer.Serialize(new { objects = entries }));
+        return entries.Length;
+    }
+
+    /// <summary>
+    /// Replay entries from a sidecar file. Throws on corrupt JSON — callers treat that
+    /// as a cache MISS. Returns the replayed entry count.
+    /// </summary>
+    public static int LoadSidecar(string path)
+    {
+        using var doc = System.Text.Json.JsonDocument.Parse(File.ReadAllText(path));
+        if (!doc.RootElement.TryGetProperty("objects", out var arr)
+            || arr.ValueKind != System.Text.Json.JsonValueKind.Array)
+            throw new InvalidDataException("object-metadata.json: missing 'objects' array");
+        return LoadFromJsonArray(arr);
+    }
+
+    /// <summary>Replay an <c>objects</c> array, wherever it is embedded — the bundle's
+    /// AL-output cache folds it into the enum-registry sidecar rather than writing a
+    /// second file.</summary>
+    public static int LoadFromJsonArray(System.Text.Json.JsonElement arr)
+    {
+        int count = 0;
+        foreach (var e in arr.EnumerateArray())
+        {
+            int? id = e.TryGetProperty("id", out var idEl)
+                && idEl.ValueKind == System.Text.Json.JsonValueKind.Number
+                    ? idEl.GetInt32()
+                    : null;
+            Register(
+                e.GetProperty("kind").GetString() ?? string.Empty,
+                id,
+                e.TryGetProperty("name", out var nameEl) ? nameEl.GetString() ?? string.Empty : string.Empty,
+                e.GetProperty("xml").GetString() ?? string.Empty);
+            count++;
+        }
+        return count;
+    }
+}

--- a/AlRunner/ProgramSupport/Dependencies.cs
+++ b/AlRunner/ProgramSupport/Dependencies.cs
@@ -449,7 +449,15 @@ internal static partial class ProgramSupport
         //        code. A v12 entry and a v13 entry are not interchangeable in EITHER
         //        direction (v13 HITs where v12 MISSed, for a byte-identical package with a
         //        fresh mtime), so v12 entries must not be served under the new shape.
-        WriteLine("schema:v13");
+        //    v14 (issue #3548): the sidecar also carries `objectMetadata` — BC's own
+        //        metadata document for EVERY object the emitter produced, keyed by (kind,
+        //        id). A v13 entry has no such array, so a HIT served under the old key
+        //        shape would leave AlObjectMetadataRegistry empty on warm runs only, which
+        //        is the silent-empty-registry failure the capture exists to avoid. (The
+        //        runner fingerprint on the next line already forces a miss across a runner
+        //        rebuild; this line is what makes the sidecar-shape change explicit rather
+        //        than incidental.)
+        WriteLine("schema:v14");
         WriteLine($"tdd:{(AlRunner.BcCompiler.IsTddMode() ? "1" : "0")}");
 
         // 1. Runner assembly fingerprint (content hash, not mtime — see v10 note above) +

--- a/AlRunner/ProgramSupport/Suites.cs
+++ b/AlRunner/ProgramSupport/Suites.cs
@@ -69,6 +69,14 @@ internal static partial class ProgramSupport
                     id = i,
                     xml = AlXmlPortMetadataRegistry.TryGet(i, out var x) ? x : string.Empty,
                 }).ToArray(),
+            // v14 (#3548): BC's own metadata document for EVERY object it emitted, keyed
+            // by (kind, id). Overlaps the three arrays above on purpose — those keep their
+            // consumers, this one is the general capture. Same emit-only hazard: without
+            // it a cache HIT leaves the registry empty and every future consumer takes its
+            // not-found branch on warm runs only.
+            objectMetadata = AlObjectMetadataRegistry.Snapshot()
+                .Select(e => new { kind = e.Kind, id = e.Id, name = e.Name, xml = e.Xml })
+                .ToArray(),
         };
         var json = System.Text.Json.JsonSerializer.Serialize(dto, new System.Text.Json.JsonSerializerOptions
         {
@@ -199,6 +207,12 @@ internal static partial class ProgramSupport
                     e.GetProperty("id").GetInt32(),
                     e.GetProperty("xml").GetString() ?? string.Empty);
             }
+        }
+        // v14: replay the general per-object metadata capture (#3548).
+        if (doc.RootElement.TryGetProperty("objectMetadata", out var objArr)
+            && objArr.ValueKind == System.Text.Json.JsonValueKind.Array)
+        {
+            AlObjectMetadataRegistry.LoadFromJsonArray(objArr);
         }
         return count;
     }

--- a/docs/object-metadata-capture.md
+++ b/docs/object-metadata-capture.md
@@ -36,8 +36,11 @@ Two things that a list of kinds written by hand would have got wrong:
 - **`Interface` is in that table and does NOT arrive.** A runtime package ships `INT`
   documents; this outputter never sees them. Re-measured with an implementing codeunit
   present, in case an unimplemented interface were being elided — still absent. The same
-  goes for `Profile`: a runtime package ships a `PROFILE` document, and the fixture's
-  profile produces no `AddApplicationObject` call.
+  goes for `Profile`: a runtime package ships a `PROFILE` document, and a profile declared
+  in a scratch copy of the fixture produced no `AddApplicationObject` call. The checked-in
+  fixture declares no profile, so that half is a measurement made outside the tree rather
+  than something this repository pins -- add a profile and a role-center page to the fixture
+  if you want a future BC that starts emitting `PROFILE` to show up as a new trace line.
 
 So this path covers eleven of the issue's twelve kinds plus one it did not know about.
 Interface and profile metadata are only available from a runtime package (#3537) or from

--- a/docs/object-metadata-capture.md
+++ b/docs/object-metadata-capture.md
@@ -71,6 +71,13 @@ registry uses the same three rather than inventing a fourth.
 | source-dependency compile cache HIT | `AlObjectMetadataRegistry.LoadSidecar` replays `<key>.object-metadata.json`; written by `PublishSourceDependencyCache`, scoped to the keys that dependency's own emit added | `AlRunner/DependencyLoader.cs` |
 | `--watch` / `--server` RAD fast path | `BcRuntime.ResetForNewBundleReload` clears the registry each cycle; the per-module shadow snapshot survives the reset and is replayed on every fast-path return | `AlRunner/BcCompiler.Incremental.cs` |
 
+The first two are pinned by `AlRunner.Tests/ObjectMetadataCaptureTests.cs`; the RAD one by
+`AlRunner.Tests/RadObjectMetadataSnapshotReloadTests.cs`, which drives the two calls `--watch`
+drives (`ResetForNewBundleReload`, then `TryEmitIncremental`) and reads the registry back per
+(kind, id). It covers the destructive direction too — an object whose file is deleted between
+cycles must stop being answerable, and one whose source changed must answer the new document
+rather than the snapshot's.
+
 Consequences worth knowing before changing any of this:
 
 - The bundle sidecar's shape is part of the AL-output cache key (`schema:v14`,

--- a/docs/object-metadata-capture.md
+++ b/docs/object-metadata-capture.md
@@ -1,0 +1,96 @@
+# Capturing BC's own object metadata
+
+BC's `Compilation.Emit` hands the runner's `CodeModuleOutputter` a metadata document for
+every application object it emits — the same XML the service tier stores in Application
+Object Metadata at publish time. `AlObjectMetadataRegistry`
+(`AlRunner/Patches/ObjectMetadataRegistry.cs`) keeps all of them, keyed by (object kind,
+object id).
+
+Three older registries keep one kind each and are unchanged: `AlReportMetadataRegistry`,
+`AlPageMetadataRegistry`, `AlXmlPortMetadataRegistry`. The general registry overlaps them
+on purpose — it is additive, and nothing reads it yet (issue #3548, step 2). Converting a
+consumer to read from it is a separate change, per kind, with its own RED → GREEN.
+
+<a id="which-kinds-arrive"></a>
+
+## Which kinds reach `AddApplicationObject`
+
+Measured on the `ObjectMetadataCapture` fixture (`AlRunner.Tests/Fixtures/`), BC 28.1,
+`BCCOMPILER_TRACE=1`. Twelve kinds arrive with a non-empty metadata document:
+
+| kind (`SymbolKind`) | | kind (`SymbolKind`) | |
+|---|---|---|---|
+| `Table` | ✓ | `Enum` | ✓ |
+| `Page` | ✓ | `EnumExtension` | ✓ |
+| `Codeunit` | ✓ | `PermissionSet` | ✓ |
+| `Report` | ✓ | `PermissionSetExtension` | ✓ |
+| `XmlPort` | ✓ | `TableExtension` | ✓ |
+| `Query` | ✓ | `PageExtension` | ✓ |
+
+Two things that a list of kinds written by hand would have got wrong:
+
+- **`Query` is not in issue #3548's own table of twelve** — that table was measured from
+  runtime packages of twelve ISV apps, none of which declares a query. It arrives here
+  (1,489 characters on the fixture's one query). This is why the capture keys off "the
+  metadata string is non-empty" rather than off a list of kinds.
+- **`Interface` is in that table and does NOT arrive.** A runtime package ships `INT`
+  documents; this outputter never sees them. Re-measured with an implementing codeunit
+  present, in case an unimplemented interface were being elided — still absent. The same
+  goes for `Profile`: a runtime package ships a `PROFILE` document, and the fixture's
+  profile produces no `AddApplicationObject` call.
+
+So this path covers eleven of the issue's twelve kinds plus one it did not know about.
+Interface and profile metadata are only available from a runtime package (#3537) or from
+`SymbolReference.json` (#3533, #3545).
+
+Every kind that does arrive is id-bearing, and ids repeat across kinds — the fixture
+deliberately declares a table, a page, a codeunit, an enum, a report, an xmlport and a
+query all numbered 70660. A registry keyed on the id alone answers seven objects with one
+document. The registry still accepts an id-less registration and keys it by name, so a
+kind BC starts delivering later is stored rather than dropped.
+
+<a id="surviving-a-warm-run"></a>
+
+## Surviving a warm run
+
+`Emit` runs only on a compile-cache **MISS**. Anything captured there and not persisted is
+gone on the next run, silently: the registry is simply empty and every consumer takes its
+not-found branch while the run stays green. `AlRunner/Patches/RecordPatches.AlObjectDeclParser.cs`
+exists because of exactly that, and its header names this hazard as the reason it parses AL
+source text instead.
+
+Three mechanisms already solve it for the page and report registries, and the general
+registry uses the same three rather than inventing a fourth.
+
+| path | what runs | where |
+|---|---|---|
+| bundle AL-output cache HIT | `ProgramSupport.LoadEnumRegistrySidecar` replays the `objectMetadata` array out of `<key>.enum-registry.json` (one file, not one per registry) | `AlRunner/ProgramSupport/Suites.cs`, called from `AlRunner/Program.cs` |
+| source-dependency compile cache HIT | `AlObjectMetadataRegistry.LoadSidecar` replays `<key>.object-metadata.json`; written by `PublishSourceDependencyCache`, scoped to the keys that dependency's own emit added | `AlRunner/DependencyLoader.cs` |
+| `--watch` / `--server` RAD fast path | `BcRuntime.ResetForNewBundleReload` clears the registry each cycle; the per-module shadow snapshot survives the reset and is replayed on every fast-path return | `AlRunner/BcCompiler.Incremental.cs` |
+
+Consequences worth knowing before changing any of this:
+
+- The bundle sidecar's shape is part of the AL-output cache key (`schema:v14`,
+  `AlRunner/ProgramSupport/Dependencies.cs`). A cache entry written under an older schema
+  carries no `objectMetadata` array, and serving it would produce an empty registry on warm
+  runs only.
+- The dependency sidecar is scoped by identity key, not by id, because ids repeat across
+  kinds. Scoping is what stops one dependency's sidecar carrying a sibling app's entries.
+- `CaptureRadMetadataSnapshotFull` reads the process-wide registry, which is correct on the
+  `Emit` call site and is the known asymmetry issue **#3282** describes for the
+  page/xmlport snapshots on the `EmitDepSymbols(trackIncrementalBaseline: true)` one. The
+  object snapshot is deliberately consistent with its two neighbours rather than diverging;
+  #3282's fix should cover all three together.
+- Report and report-layout metadata have no RAD shadow snapshot at all — issue **#2655**.
+
+## Seeing what BC actually said
+
+```
+AL_RUNNER_TRACE_OBJECT_METADATA=1   # one line per registered entry: kind, id, name, length
+AL_RUNNER_TRACE_OBJECT_METADATA=2   # ...and the document itself
+```
+
+The trace comes from `Register`, which is the single funnel both the emit path and all
+three replay paths go through, so the same lines appear on a cold run and on a warm one.
+That is what `AlRunner.Tests/ObjectMetadataCaptureTests.cs` asserts, twice, against one
+cache directory.


### PR DESCRIPTION
Closes #3548

Opened by an agent (impl-1) on the account holder's behalf.

Corpus-NA: capture-only change with no AL-observable behaviour — nothing reads the new registry yet, and "what BC's emitter hands the runner's CodeModuleOutputter" is not something a service tier can be asked about from AL. Step 3 (converting a consumer per kind) is where the BC-behaviour claims start, and each of those owes an upstream corpus test.

**Steps 1 and 2 of #3548 only.** Steps 3 and 4 — converting consumers per object kind and retiring the derivations that become redundant — are separate PRs and are not here. This PR changes no observable metadata behaviour: it establishes the capture and proves it is populated per (kind, id) and survives a warm run.

## Step 1 first: how the existing registries survive a warm run

`AlRunner/Patches/RecordPatches.AlObjectDeclParser.cs:12` says a registry fed from `CaptureOutputter` "would be empty on every warm run", and that is the thing most likely to make this work worthless. It is true of the capture on its own, and three mechanisms already solve it for the page and report registries. The new registry uses those same three rather than inventing a fourth.

| path | what runs | where |
|---|---|---|
| **cold compile** | `CaptureOutputter.AddApplicationObject` registers as a side effect of BC's `Compilation.Emit` | `AlRunner/BcCompiler.cs` |
| **bundle AL-output cache HIT** | `ProgramSupport.LoadEnumRegistrySidecar` replays arrays out of one `<key>.enum-registry.json`. Despite the name that file is not enum-only — it already carries `reportMetadata`, `reportLayouts`, `pageMetadata` and `xmlPortMetadata`, and its shape is versioned into the cache key (`schema:v13` → now `v14`) | `AlRunner/ProgramSupport/Suites.cs`, `AlRunner/ProgramSupport/Dependencies.cs` |
| **source-dependency compile cache HIT** | one sidecar file per registry (`<key>.page-metadata.json`, …), written by `PublishSourceDependencyCache` scoped to the ids that dependency's own emit added, and replayed from **two** call sites — `LoadOne`'s HIT branch and `ReplayDependencyMetadataSidecars` for a module reused across a bundle reload | `AlRunner/DependencyLoader.cs` |
| **`--watch` / `--server` RAD fast path** | `BcRuntime.ResetForNewBundleReload` clears the registries every cycle; a per-module shadow snapshot on the `BcCompiler` instance survives the reset and is replayed on every fast-path return (#2593, #2939) | `AlRunner/BcCompiler.Incremental.cs` |

The fourth path is the one that is easy to miss, and it is not optional: without a shadow snapshot, adding the `Clear()` call that the reload correctly needs *is* the regression.

**A precompiled dependency is a fifth path and is not a replay of this capture at all.** `DependencyPageMetadataXml.cs` and `DependencyReportMetadata.cs` reconstruct metadata from `SymbolReference.json` for an app that was never source-compiled here. Nothing was captured, so there is nothing to replay; that path is #3533/#3545's subject, not this one's.

All of this is written up at `docs/object-metadata-capture.md`.

## What this adds

`AlObjectMetadataRegistry` (`AlRunner/Patches/ObjectMetadataRegistry.cs`), keyed by (object kind, object id), populated in `AddApplicationObject` for **every** symbol arriving with a non-empty `metadata` string. The kind is carried as the AL compiler's own `SymbolKind` name, so a kind BC adds later flows through the capture, the sidecar and back with no code change — there is no list of kinds anywhere in the path.

Wired into all four paths above, plus `AlObjectMetadataRegistry.Clear()` in `ResetForNewBundleReload`. Additive throughout: the three per-kind registries and every one of their consumers are untouched.

## Two measurements that a hand-written list of kinds would have got wrong

Measured on the new fixture with `BCCOMPILER_TRACE=1`, BC 28.1:

- **`Query` arrives, and is not in #3548's table of twelve.** That table was measured from runtime packages of twelve ISV apps, none of which declares a query. The fixture's one query produces a 1,489-character document. This is exactly why the capture keys off "the metadata string is non-empty".
- **`Interface` is in that table and does not arrive.** A runtime package ships `INT` documents; this outputter never sees one. Re-measured with an implementing codeunit present in case an unreferenced interface were being elided — still absent. Same for `Profile`, which a runtime package also ships.

So the source-compile path covers eleven of the issue's twelve kinds plus one it did not know about. Interface and profile metadata are reachable only from a runtime package (#3537) or from `SymbolReference.json` (#3533, #3545) — worth knowing before step 3 plans a conversion for either.

Every kind that does arrive is id-bearing. The registry still accepts and addresses an id-less registration by name, so a kind BC starts delivering later is stored rather than dropped.

## RED → GREEN

Both directions were run, not reasoned about.

**RED, bundle warm path.** Fixture, cold run: 12 documents captured. Second run against the same `--cache` directory:

```
  [cache] HIT  key=377df52d… (19456 bytes, 15 enum entries replayed) — skipping Emit+Compile
  → 1P/0F/0E across 1 tests, 0 suite errors (0.2s)
```

Zero `[object-metadata]` lines. Green run, empty registry — the exact silent failure the AL-source parser exists to avoid.

**RED, dependency path.** Same two-process "dep HIT + bundle MISS" sequence as `SourceDepCacheEnumMetadataTests`, with the dependency's `.object-metadata.json` removed between the runs to reproduce the pre-fix on-disk state:

```
[deps] source-cache HIT: OMR Dep App v1.0.0.0 key=38a3f6be306f (12800 bytes, …)
  → 1P/0F/0E across 1 tests, 0 suite errors (3.6s)
```

Zero entries for the dependency's table, codeunit and enum.

**GREEN.** Both runs now register all 12 / all 3, with identical document lengths cold and warm.

## Proving tests

`AlRunner.Tests/ObjectMetadataCaptureTests.cs` (spawns the real runner):

- `EveryEmittedObjectKind_IsCaptured_ColdAndOnAWarmCacheHit` — asserts a document **per kind and id**, never a total, cold and then warm against one cache directory with `[cache] HIT` asserted so a silent MISS cannot fake the second half.
- `DependencyObjects_AreCaptured_AcrossASourceDepCacheHit` — the dependency path, asserting `source-cache HIT`.

The fixture declares a table, page, codeunit, enum, report, xmlport **and query all numbered 70660**, which AL permits and a registry keyed on the id alone cannot represent: it answers seven objects with one document and passes every positive assertion. The negative assertions are built on that — `TableExtension 70660` must **not** resolve (70660 is six other kinds, not that one), and no id the fixture never declares may appear.

`AlRunner.Tests/ObjectMetadataRegistryTests.cs` (no subprocess) covers the registry contract in both directions: same id under two kinds stays two entries; an unregistered kind under a known id returns false; re-registering an identity replaces rather than duplicates; an id-less kind is addressable by name; an empty metadata document is refused rather than stored as an empty entry; the sidecar round-trips every field and carries only the keys it was asked for; corrupt and array-less JSON both throw so callers fall through to a MISS.

`AlCacheWriterDependencyCacheOrderingTests` is extended to the sixth sidecar — that test pins "the DLL becomes visible only after every sidecar it depends on", and a new sidecar outside its list would leave the invariant asserted over a stale set.

## Cost

The bundle sidecar grows because the general capture deliberately overlaps the three per-kind arrays rather than coupling to them. On the al-language corpus (1,070 documents): **2.82 MB → 7.69 MB**. Warm corpus wall over three runs each, same machine: **55.4 / 44.0 / 43.7 s** with the array against **58.6 / 46.6 / 43.6 s** without — not distinguishable from noise, since the ~40 s test run dominates. The duplication goes away in step 3, when the per-kind arrays' consumers move onto the general registry.

## Local results

- Corpus, matching CI's invocation: **3098/3098 pass**, 0 fail, 0 error.
- `tests/runner-extras`: **403/403 pass**.
- `dotnet test AlRunner.Tests --filter` over the cache / dependency / watch / object-metadata surface (`AlCacheWriter*`, `SourceDepCache*`, `AlOutputCache*`, `WatchPageMetadataReload*`, `WatchQuerySymbols*`, `RadQuerySymbols*`, `EnumExtensionSidecar*`, `ObjectMetadata*`): **69 passed, 2 skipped** (the two skips are environment-gated and skip on `main` too), then **44 passed** on a final `~ObjectMetadata` re-run.

The full `AlRunner.Tests` suite was **not** run — `.claude/rules/local-test-scope.md`. The corpus and runner-extras runs are the wide check for the shared compile path.

## Fixing the shape, and what I deliberately did not fold in

**Another call site with the same pattern?** The dependency sidecars are replayed from two places, `LoadOne`'s HIT branch and `ReplayDependencyMetadataSidecars`. Both now replay the new sidecar; wiring only the first would have left a module reused across a bundle reload silently empty.

**A sibling making the same assumption?** Yes, and it is already filed: **#2655** — the report and report-layout registries have no RAD shadow snapshot, so an unchanged app group's report metadata is lost across a `--watch` cycle by the same mechanism as #2593. Not folded in: it lands in the same file but needs its own `--watch` fixture and its own RED, and it is an existing defect rather than one this PR introduces.

**Two paths writing the same state with different invariants?** The new RAD shadow capture reads the process-wide registry exactly as the page and xmlport snapshots do, which carries **#3282**'s known call-site asymmetry (on the `EmitDepSymbols(trackIncrementalBaseline: true)` path no outputter ran, so a colliding object id can capture another module's document). I kept it consistent with its two neighbours rather than diverging, and said so in a comment at the site: #3282 is `status: blocked` and its fix should cover all three snapshots together. Diverging here would make that fix harder, not easier.

**Open-issue queue scan** for the files this lands in — `BcCompiler*`, `DependencyLoader`, the metadata registries:

| issue | why not folded |
|---|---|
| #3546 codeunit `TableNo` = 0, #3447 page trigger flags, #3510 xmlport metadata, #3228 pageextension control | all step 3 — each converts one consumer to read from this registry, each needs its own RED → GREEN, and #3548 says explicitly they are separate PRs |
| #3549 dependency metadata from the emitter | the precompiled-dependency path, which captures nothing; different mechanism |
| #3282 RAD snapshot reads the process-wide registry | `status: blocked`; see above |
| #2655 report/report-layout RAD snapshot | see above |
| #3533, #3545, #3491 `SymbolReference` fallback | the other half of the problem by construction — the path taken when no compile is possible |

Nothing in that list shares a change with this one; the fold set is empty and this is one coherent diff.

## Where the prose went

`docs/object-metadata-capture.md` — which kinds arrive and which do not, the four replay paths, the sidecar-shape/cache-key coupling, and the trace flags. The code carries pointers to it rather than a second copy, at the registry header and at the RAD capture site.

https://claude.ai/code/session_01F7HLDeNwiGQoLT5wFanqmH
