### PR TITLE
fix(company-init): record a partially initialized company as a run-level result

### DIFF
--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -164,6 +164,15 @@ public sealed class CollectionCostOrderer : ITestCollectionOrderer
             // producing a 73s single-threaded tail (it is 3rd-heaviest at ~196s of serial
             // work; see the file header and issue #1887 for the measured timeline).
             ["InstallSeedDepCompanyCacheTests"] = 196,
+            // #3538: every arm spawns the runner, and two of them spawn it twice to get a
+            // cold-then-warm pair out of one private --cache. Measured 113.5 s on PR #3554's
+            // BC 27.5 / 28.4 legs (run 34230660996) and recorded rounded DOWN per the header —
+            // 113 is far above UnmeasuredWeightSeconds, so it changes dispatch order, which is
+            // the test that makes an entry worth having. The round of review that followed that
+            // measurement added one more spawn (the exit-1 arm re-runs with --output-json), so
+            // the true figure is a little higher; re-measure with scripts/trx-occupancy.py
+            // rather than trusting this line if the class changes shape again.
+            ["PartialCompanyInitializationTests"] = 113,
             // #2348: EmptySetupTable_Get/EmptySetupTable_TestField now call DeleteAll() on
             // "Source Code Setup" before asserting it's empty (fixing IncludeSender's
             // sender-position dispatch also fixed a latent install-time bug that used to

--- a/AlRunner.Tests/Fixtures/CompanyInitPartial/CipFixtureTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/CompanyInitPartial/CipFixtureTests.Codeunit.al
@@ -1,0 +1,22 @@
+// Fixture suite for PartialCompanyInitializationTests.cs (#3538).
+//
+// Deliberately trivial and deliberately GREEN. The condition under test is not something AL
+// can observe — the runner's own record of a company initialization that did not complete —
+// and the assertions in the C# test are about what happens to THIS result: it must still be
+// reported as a pass, in the totals and in every output document, while the run as a whole
+// stops being clean. A suite that failed here could not distinguish "the run is not clean
+// because the company is partial" from "the run is not clean because a test failed".
+codeunit 70680 "CIP Fixture Tests"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure ArithmeticStillRuns()
+    var
+        Sum: Integer;
+    begin
+        Sum := 2 + 40;
+        if Sum <> 42 then
+            Error('expected 42, got %1', Sum);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/CompanyInitPartial/app.json
+++ b/AlRunner.Tests/Fixtures/CompanyInitPartial/app.json
@@ -1,0 +1,24 @@
+{
+  "id": "a1b2c3d4-e5f6-4708-9a1b-2c3d4e5f6011",
+  "name": "Runner Tests Fixture - Company Init Partial",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "A bundle whose tests pass, used to prove a partially initialized company is a run-level result (#3538).",
+  "description": "The suite here is deliberately trivial and green: what PartialCompanyInitializationTests drives is the runner's reporting of a company initialization that did not complete, and the point of the assertions is that these passing results survive while the run stops being clean. No \"application\" dependency by design (.claude/rules/no-base-app-in-csharp-tests.md) — the abort is injected through AL_RUNNER_TEST_FAIL_COMPANY_INIT, so loading the Base Application floor would cost ~70s per invocation and prove nothing further about the reporting.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "idRanges": [
+    {
+      "from": 70680,
+      "to": 70699
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner.Tests/Fixtures/CompanyInitPartialFailing/CipFailingFixtureTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/CompanyInitPartialFailing/CipFailingFixtureTests.Codeunit.al
@@ -1,0 +1,19 @@
+// Fixture suite for PartialCompanyInitializationTests.DoesNotLowerAnEarnedExitCode (#3538).
+//
+// Deliberately RED. Its sibling fixture CompanyInitPartial is deliberately green, and the pair
+// is what separates the two exit codes: a clean run plus an abort must report 2, and a run that
+// has earned 1 by failing a test must keep 1 while still recording the abort.
+codeunit 70700 "CIP Failing Fixture Tests"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure ArithmeticIsWrongOnPurpose()
+    var
+        Sum: Integer;
+    begin
+        Sum := 2 + 40;
+        if Sum <> 41 then
+            Error('deliberate failure: expected 41, got %1', Sum);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/CompanyInitPartialFailing/app.json
+++ b/AlRunner.Tests/Fixtures/CompanyInitPartialFailing/app.json
@@ -1,0 +1,24 @@
+{
+  "id": "a1b2c3d4-e5f6-4708-9a1b-2c3d4e5f6012",
+  "name": "Runner Tests Fixture - Company Init Partial Failing",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "A bundle with one FAILING test, used to prove a company-init abort never lowers an earned exit code (#3538).",
+  "description": "The failing test is the point: the run has earned exit 1, a statement about the AL, and PartialCompanyInitializationTests asserts the partial-company notice does not overwrite that with 2 while still being recorded in the summary. No \"application\" dependency by design (.claude/rules/no-base-app-in-csharp-tests.md); the abort is injected through AL_RUNNER_TEST_FAIL_COMPANY_INIT.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "idRanges": [
+    {
+      "from": 70700,
+      "to": 70719
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner.Tests/LoudDiagnosisReachesTheUserTests.cs
+++ b/AlRunner.Tests/LoudDiagnosisReachesTheUserTests.cs
@@ -183,6 +183,12 @@ public sealed class LoudDiagnosisReachesTheUserTests
         // apart and nothing else in the run records which one it was.
         { "AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs", "could not be resolved to a table id" },
 
+        // #3538 — the end-of-run counterpart of the CompanyInitializer line above. It fires
+        // once, after the summary, and is the only thing that explains why a run whose every
+        // test passed did not exit 0; a reader who does not see it has an exit code with no
+        // stated cause. See docs/partial-company-initialization.md.
+        { "AlRunner/Program.cs", "every test in this run used a PARTIALLY initialized company" },
+
         // #2963, and named in #3068 as the same class: System Application module-ownership
         // checks silently decline for the whole run when this row set is not seeded.
         { "AlRunner/Patches/RecordPatches.PublishedApplicationSystemTable.cs", "Published Application rows" },

--- a/AlRunner.Tests/PartialCompanyInitializationTests.cs
+++ b/AlRunner.Tests/PartialCompanyInitializationTests.cs
@@ -236,16 +236,45 @@ public sealed class PartialCompanyInitializationTests
         TestArtifacts.SkipIfMissing();
 
         var cache = NewCacheDir();
-        var run = RunRunner(cache, injectAbort: true, bundles: new[] { FailingFixturePath });
+        var outPath = Path.Combine(cache, "classification.json");
+        var junitPath = Path.Combine(cache, "junit.xml");
+        var run = RunRunner(cache, injectAbort: true, outPath: outPath, junitPath: junitPath,
+            bundles: new[] { FailingFixturePath });
 
         Assert.True(run.Exit == 1,
             $"a failing test earns exit 1; the abort must not replace it with 2. "
             + $"exit={run.Exit}\n{run.Output}");
         Assert.Contains("fail:        1", run.Output);
-        // The condition is still recorded — it is not gated on the exit code.
+
+        // The condition is recorded on every surface — none of them is gated on the exit code,
+        // and a reader of any one of them has to be able to tell that the failing test ran
+        // against a company real BC could not produce.
         Assert.Contains("Company initialization: INCOMPLETE", run.Output);
         Assert.Contains(InjectedReason, run.Output);
-        // ...and the escalation line, which only explains a moved exit code, is not printed.
+
+        var companyInit = JsonDocument.Parse(File.ReadAllText(outPath)).RootElement
+            .GetProperty("all_failures").EnumerateArray()
+            .Where(f => f.GetProperty("kind").GetString() == "company-init")
+            .ToList();
+        Assert.Single(companyInit);
+        Assert.Equal(InjectedReason, companyInit[0].GetProperty("message").GetString());
+
+        var junit = File.ReadAllText(junitPath);
+        Assert.Contains("company initialization did NOT complete", junit);
+        Assert.Contains(InjectedReason, junit);
+
+        // --output-json is a separate invocation because it redirects everything else to stderr.
+        // Its exitCode field has to agree with the process — the #2403 rule this escalation sits
+        // next to — so it must read 1 here and not the 2 the abort would otherwise have set.
+        var jsonRun = RunRunner(cache, injectAbort: true, outputJson: true,
+            bundles: new[] { FailingFixturePath });
+        Assert.Equal(1, jsonRun.Exit);
+        var doc = JsonDocument.Parse(jsonRun.Output[jsonRun.Output.IndexOf('{')..]).RootElement;
+        Assert.Equal(1, doc.GetProperty("exitCode").GetInt32());
+        Assert.Equal(1, doc.GetProperty("failed").GetInt32());
+        Assert.Single(doc.GetProperty("companyInitFailures").EnumerateArray());
+
+        // ...and the escalation line, which only ever explains a MOVED exit code, is not printed.
         Assert.DoesNotContain("[warn] company-init:", run.Output);
     }
 

--- a/AlRunner.Tests/PartialCompanyInitializationTests.cs
+++ b/AlRunner.Tests/PartialCompanyInitializationTests.cs
@@ -41,6 +41,9 @@ public sealed class PartialCompanyInitializationTests
     private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
     private static readonly string FixturePath = Path.Combine(
         RepoRoot, "AlRunner.Tests", "Fixtures", "CompanyInitPartial");
+    // The same bundle with a deliberately failing test, so the run earns exit 1 on its own.
+    private static readonly string FailingFixturePath = Path.Combine(
+        RepoRoot, "AlRunner.Tests", "Fixtures", "CompanyInitPartialFailing");
 
     // The value the seam turns into the exception message, so every assertion below is against
     // text that could only have come through the real catch path.
@@ -49,7 +52,8 @@ public sealed class PartialCompanyInitializationTests
     private sealed record Run(string Output, int Exit);
 
     private static Run RunRunner(string cacheDir, bool injectAbort,
-        string? outPath = null, string? junitPath = null, bool outputJson = false)
+        string? outPath = null, string? junitPath = null, bool outputJson = false,
+        string[]? bundles = null, bool perfMarkers = false)
     {
         var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
         args.Append(TestBuildConfig.BcVersionArg);
@@ -57,7 +61,18 @@ public sealed class PartialCompanyInitializationTests
         if (outPath != null) args.Append($" --out \"{outPath}\"");
         if (junitPath != null) args.Append($" --output-junit \"{junitPath}\"");
         if (outputJson) args.Append(" --output-json");
-        args.Append($" \"{FixturePath}\"");
+        if (bundles != null)
+        {
+            // A generated closure compiles against the platform apps; without them on the
+            // package-cache path dependency resolution skips Microsoft/System and the bundle
+            // fails to compile at all (AL0185). Same reason as InstallSeedDepCompanyCacheTests.
+            args.Append(" --package-cache \"").Append(TestArtifacts.PlatformAppsDir()).Append('"');
+            foreach (var b in bundles) args.Append($" \"{b}\"");
+        }
+        else
+        {
+            args.Append($" \"{FixturePath}\"");
+        }
 
         var psi = new ProcessStartInfo
         {
@@ -67,6 +82,9 @@ public sealed class PartialCompanyInitializationTests
         };
         if (injectAbort) psi.Environment["AL_RUNNER_TEST_FAIL_COMPANY_INIT"] = InjectedReason;
         else psi.Environment.Remove("AL_RUNNER_TEST_FAIL_COMPANY_INIT");
+        // The DepCompanyCache MISS / HIT / DISK-HIT markers are PerfTrace lines, so the two
+        // cache tests below cannot see which tier answered without this.
+        if (perfMarkers) psi.Environment["AL_RUNNER_PERF"] = "1";
 
         var sb = new StringBuilder();
         using var p = Process.Start(psi)!;
@@ -81,7 +99,7 @@ public sealed class PartialCompanyInitializationTests
 
     private static string NewCacheDir()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-cip-" + Guid.NewGuid().ToString("N")[..12]);
+        var dir = TestScratch.Dir("al-runner-cip-cache");
         Directory.CreateDirectory(dir);
         return dir;
     }
@@ -206,28 +224,109 @@ public sealed class PartialCompanyInitializationTests
     }
 
     /// <summary>
-    /// The warm-cache arm. The dependency-company baseline is cached in memory and on disk, and
-    /// a HIT skips company initialization entirely — so a condition recorded only where the
-    /// codeunit actually ran would vanish on the second run and a repeat run would report a
-    /// clean database. That is precisely how the emit-exclusion loss came back green on a warm
-    /// cache (#3476). Both runs share one private `--cache` directory, so the second is a real
-    /// cross-process warm run.
+    /// The exit code is escalated from 0 and never from anything else. With a failing test in
+    /// the bundle the run has earned exit 1 — a statement about the AL — and the partial-company
+    /// notice must not overwrite it with 2, while every reporting surface still carries the
+    /// condition. Only the end-of-run `[warn] company-init:` line is gated on the run having
+    /// been otherwise clean, so its absence here is the assertion, not an omission.
     /// </summary>
     [SkippableFact]
-    public void PartialCompanyInit_SurvivesAWarmCache()
+    public void PartialCompanyInit_DoesNotLowerAnEarnedExitCode()
     {
         TestArtifacts.SkipIfMissing();
 
         var cache = NewCacheDir();
-        var cold = RunRunner(cache, injectAbort: true);
-        Assert.Equal(2, cold.Exit);
-        Assert.Contains("Company initialization: INCOMPLETE", cold.Output);
+        var run = RunRunner(cache, injectAbort: true, bundles: new[] { FailingFixturePath });
 
-        var warm = RunRunner(cache, injectAbort: true);
-        Assert.True(warm.Exit == 2,
-            $"the second run reuses the compiled output and may reuse the dependency baseline; "
-            + $"the company it runs against is still partial. exit={warm.Exit}\n{warm.Output}");
-        Assert.Contains("Company initialization: INCOMPLETE", warm.Output);
-        Assert.Contains(InjectedReason, warm.Output);
+        Assert.True(run.Exit == 1,
+            $"a failing test earns exit 1; the abort must not replace it with 2. "
+            + $"exit={run.Exit}\n{run.Output}");
+        Assert.Contains("fail:        1", run.Output);
+        // The condition is still recorded — it is not gated on the exit code.
+        Assert.Contains("Company initialization: INCOMPLETE", run.Output);
+        Assert.Contains(InjectedReason, run.Output);
+        // ...and the escalation line, which only explains a moved exit code, is not printed.
+        Assert.DoesNotContain("[warn] company-init:", run.Output);
+    }
+
+    /// <summary>
+    /// The disk lever. `EnsureCompanyInitialized` runs only on a dependency-company-baseline
+    /// MISS, so a snapshot persisted after an abort would be restored by the next PROCESS with
+    /// nothing left to report it — the run would come back clean on a company that is still
+    /// partial, which is the #3476 cache defect one cache over.
+    ///
+    /// <para>Both arms use <see cref="InstallSeedClosure"/>, whose dependency app writes rows in
+    /// its install trigger: without that the snapshot has zero DataAccessSources, the codec
+    /// refuses to persist it in either arm, and the whole question is unreachable. The clean arm
+    /// is the non-vacuity guard — it must reach DISK-HIT, so the abort arm's MISS is the
+    /// withhold rather than a fixture that never persists anything.</para>
+    /// </summary>
+    [SkippableFact]
+    public void PartialCompanyInit_IsWithheldFromTheDiskBaseline_SoTheNextProcessStillReportsIt()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = TestScratch.Dir("al-runner-cip-disk");
+        try
+        {
+            // Control: same fixture shape, no abort. Second process must reuse the persisted
+            // baseline, or the abort arm below proves nothing.
+            var cleanBundle = InstallSeedClosure.Write(root, "cipclean", 61980).BundleDir;
+            var cleanCache = NewCacheDir();
+            var cleanCold = RunRunner(cleanCache, injectAbort: false,
+                bundles: new[] { cleanBundle }, perfMarkers: true);
+            Assert.True(cleanCold.Exit == 0, $"control cold run failed. exit={cleanCold.Exit}\n{cleanCold.Output}");
+            var cleanWarm = RunRunner(cleanCache, injectAbort: false,
+                bundles: new[] { cleanBundle }, perfMarkers: true);
+            Assert.Contains("InstallBaseline.DepCompanyCache DISK-HIT", cleanWarm.Output);
+
+            // The arm under test: identical but for the injected abort.
+            var abortBundle = InstallSeedClosure.Write(root, "cipabort", 61995).BundleDir;
+            var abortCache = NewCacheDir();
+            var cold = RunRunner(abortCache, injectAbort: true,
+                bundles: new[] { abortBundle }, perfMarkers: true);
+            Assert.Equal(2, cold.Exit);
+            Assert.Contains("Company initialization: INCOMPLETE", cold.Output);
+
+            var warm = RunRunner(abortCache, injectAbort: true,
+                bundles: new[] { abortBundle }, perfMarkers: true);
+            Assert.DoesNotContain("InstallBaseline.DepCompanyCache DISK-HIT", warm.Output);
+            Assert.Contains("InstallBaseline.DepCompanyCache MISS", warm.Output);
+            Assert.True(warm.Exit == 2,
+                $"the second process must re-run company initialization and report the abort "
+                + $"again. exit={warm.Exit}\n{warm.Output}");
+            Assert.Contains("Company initialization: INCOMPLETE", warm.Output);
+            Assert.Contains(InjectedReason, warm.Output);
+        }
+        finally { try { Directory.Delete(root, true); } catch { } }
+    }
+
+    /// <summary>
+    /// The in-memory lever. Two app groups sharing one dependency closure resolve to the same
+    /// key, so the second gets a HIT and never calls `EnsureCompanyInitialized` — the snapshot
+    /// it restores IS the partial company the first group's abort left behind. Without the
+    /// carry, the second group runs its tests against that company and contributes nothing to
+    /// the record; with it, both groups are accounted for.
+    /// </summary>
+    [SkippableFact]
+    public void PartialCompanyInit_OnAnInMemoryCacheHit_IsReportedByTheSecondAppGroup()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = TestScratch.Dir("al-runner-cip-hit");
+        try
+        {
+            var (appA, appB, _) = InstallSeedClosure.WriteSharedClosure(root, "ciphit", 61960);
+            var run = RunRunner(NewCacheDir(), injectAbort: true,
+                bundles: new[] { appA, appB }, perfMarkers: true);
+
+            Assert.Equal(2, run.Exit);
+            // The HIT is what makes this test about the carry rather than about two aborts.
+            Assert.Contains("InstallBaseline.DepCompanyCache HIT", run.Output);
+            // One abort per app group: each ran its tests against the partial company, and the
+            // one that reused the snapshot has no other way to say so.
+            Assert.Contains("Company initialization: INCOMPLETE (2 abort(s))", run.Output);
+        }
+        finally { try { Directory.Delete(root, true); } catch { } }
     }
 }

--- a/AlRunner.Tests/PartialCompanyInitializationTests.cs
+++ b/AlRunner.Tests/PartialCompanyInitializationTests.cs
@@ -1,0 +1,233 @@
+// PartialCompanyInitializationTests — issue #3538.
+//
+// What is being pinned
+// --------------------
+// When Base App codeunit 2 "Company-Initialize" does not run to completion, the runner keeps
+// the rows it did write (CompanyInitializer's KNOWN INCOMPLETE note explains why: measured at
+// +5 tests over not running it at all) and the tests still run. Before #3538 that was ALL that
+// happened: a `[warn]` line on stderr, a summary that recorded nothing, `--output-json` /
+// `--out` / JUnit documents identical to a clean run's, and exit 0. The report that produced
+// this issue had ~2800 tests pass that way against a half-initialized database.
+//
+// Real BC cannot produce that state. Codeunit 2's OnRun commits exactly ONCE, at its end
+// (`src/Foundation/Company/CompanyInitialize.Codeunit.al` in Microsoft's Base Application app,
+// 28.1.49838.50256: one `Commit()` in 806 lines, the last statement of OnRun), so a service
+// tier either has the whole set of setup rows or the write that created them rolled back. A
+// run carrying a partial company is therefore a property of the RUN, not of any test — see
+// docs/partial-company-initialization.md for the decision and the exit-code rule.
+//
+// Why the abort is injected
+// -------------------------
+// Whether codeunit 2 aborts depends on the Base Application build: #3054 measured it aborting
+// on five of eight BC legs, and on the last green `main` matrix run (34216039259) it aborted on
+// none of them. So there is no fixture that reliably reproduces it, and reproducing it by
+// loading the Base Application floor would cost ~70s per runner invocation for a condition the
+// floor does not guarantee anyway (.claude/rules/no-base-app-in-csharp-tests.md). The seam
+// replaces the `NavCodeunit_RunCodeunit` call INSIDE the try block, so the catch path under
+// test — the exception unwrapping, the message, the accumulation, the cache carry — is the
+// real one, and the injected text is what the assertions below look for.
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using System.Xml.Linq;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PartialCompanyInitializationTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string FixturePath = Path.Combine(
+        RepoRoot, "AlRunner.Tests", "Fixtures", "CompanyInitPartial");
+
+    // The value the seam turns into the exception message, so every assertion below is against
+    // text that could only have come through the real catch path.
+    private const string InjectedReason = "CIP-INJECTED-ABORT: InitSourceCodeSetup did not finish";
+
+    private sealed record Run(string Output, int Exit);
+
+    private static Run RunRunner(string cacheDir, bool injectAbort,
+        string? outPath = null, string? junitPath = null, bool outputJson = false)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" --cache \"{cacheDir}\"");
+        if (outPath != null) args.Append($" --out \"{outPath}\"");
+        if (junitPath != null) args.Append($" --output-junit \"{junitPath}\"");
+        if (outputJson) args.Append(" --output-json");
+        args.Append($" \"{FixturePath}\"");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        if (injectAbort) psi.Environment["AL_RUNNER_TEST_FAIL_COMPANY_INIT"] = InjectedReason;
+        else psi.Environment.Remove("AL_RUNNER_TEST_FAIL_COMPANY_INIT");
+
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(240_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return new Run(sb.ToString(), p.ExitCode);
+    }
+
+    private static string NewCacheDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-cip-" + Guid.NewGuid().ToString("N")[..12]);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    /// <summary>
+    /// The positive case, everything a caller reading a single plain run can see: the tests
+    /// still ran and still passed, the summary names the abort and its cause, and the process
+    /// does not exit 0. `--out` carries it as its own record kind, and the JUnit document says
+    /// what the counts in it do not.
+    /// </summary>
+    [SkippableFact]
+    public void PartialCompanyInit_IsRecordedInEverySurface_AndTheRunIsNotClean()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var cache = NewCacheDir();
+        var outPath = Path.Combine(cache, "classification.json");
+        var junitPath = Path.Combine(cache, "junit.xml");
+        var run = RunRunner(cache, injectAbort: true, outPath: outPath, junitPath: junitPath);
+
+        // The results are NOT discarded — that is the half of the decision this test protects.
+        Assert.Contains("Tests:         1 total", run.Output);
+        Assert.Contains("pass:        1", run.Output);
+
+        // Exit 2 exactly: not 0 (the run is not clean), and not 1, which would say a test
+        // failed when none did.
+        Assert.True(run.Exit == 2,
+            $"a partially initialized company must exit 2 — nothing about the AL failed, the "
+            + $"database was not the one asked for. exit={run.Exit}\n{run.Output}");
+
+        // The summary block, next to the totals, naming the codeunit and the reason.
+        Assert.Contains("Company initialization: INCOMPLETE", run.Output);
+        Assert.Contains("codeunit 2 \"Company-Initialize\" did not complete", run.Output);
+        Assert.Contains(InjectedReason, run.Output);
+
+        // ...and the escalation line, which is what tells a scripted caller why the exit code
+        // moved without a single test failing.
+        Assert.Contains("[warn] company-init:", run.Output);
+
+        // --out: its own record kind, so a triage pass reading the file sees the condition
+        // before it starts chasing the failures it may explain.
+        var classification = JsonDocument.Parse(File.ReadAllText(outPath)).RootElement;
+        var companyInit = classification.GetProperty("all_failures").EnumerateArray()
+            .Where(f => f.GetProperty("kind").GetString() == "company-init")
+            .ToList();
+        Assert.Single(companyInit);
+        Assert.Equal(2, companyInit[0].GetProperty("codeunitId").GetInt32());
+        Assert.Equal("Company-Initialize", companyInit[0].GetProperty("codeunit").GetString());
+        Assert.Equal(InjectedReason, companyInit[0].GetProperty("message").GetString());
+
+        // JUnit: a comment, following the convention #2919 set for the sibling condition — the
+        // counts are whatever the tests earned and a synthetic suite would move them.
+        var junit = File.ReadAllText(junitPath);
+        Assert.Contains("company initialization did NOT complete", junit);
+        Assert.Contains(InjectedReason, junit);
+        // ...and it is still a well-formed document a consumer can parse.
+        Assert.Equal("testsuites", XDocument.Parse(junit).Root!.Name.LocalName);
+    }
+
+    /// <summary>
+    /// `--output-json` is the surface the issue named: a consumer reading only that document
+    /// could not tell this run from a clean one. The field is structured (codeunit id, type,
+    /// message), and `exitCode` in the document agrees with the process — the two disagreeing
+    /// is the defect #2403 fixed one condition over.
+    /// </summary>
+    [SkippableFact]
+    public void PartialCompanyInit_IsInTheOutputJsonDocument_WithTheRealExitCode()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var cache = NewCacheDir();
+        var run = RunRunner(cache, injectAbort: true, outputJson: true);
+        Assert.Equal(2, run.Exit);
+
+        var start = run.Output.IndexOf('{');
+        Assert.True(start >= 0, $"no JSON document on stdout:\n{run.Output}");
+        var doc = JsonDocument.Parse(run.Output[start..]).RootElement;
+
+        Assert.Equal(1, doc.GetProperty("passed").GetInt32());
+        Assert.Equal(0, doc.GetProperty("failed").GetInt32());
+        Assert.Equal(2, doc.GetProperty("exitCode").GetInt32());
+
+        var failures = doc.GetProperty("companyInitFailures").EnumerateArray().ToList();
+        Assert.Single(failures);
+        Assert.Equal(2, failures[0].GetProperty("codeunitId").GetInt32());
+        Assert.Equal("Company-Initialize", failures[0].GetProperty("codeunit").GetString());
+        Assert.Equal("InvalidOperationException", failures[0].GetProperty("exceptionType").GetString());
+        Assert.Equal(InjectedReason, failures[0].GetProperty("message").GetString());
+    }
+
+    /// <summary>
+    /// The negative control, and the one that makes every assertion above mean something: with
+    /// nothing injected, the same fixture in the same runner exits 0 and carries none of it.
+    /// A `companyInitFailures` field emitted unconditionally, or a summary block printed on
+    /// every run, would fail here.
+    /// </summary>
+    [SkippableFact]
+    public void CleanCompanyInit_CarriesNoneOfIt_AndExitsZero()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var cache = NewCacheDir();
+        var outPath = Path.Combine(cache, "classification.json");
+        var junitPath = Path.Combine(cache, "junit.xml");
+        var run = RunRunner(cache, injectAbort: false, outPath: outPath, junitPath: junitPath);
+
+        Assert.True(run.Exit == 0, $"a clean run must still exit 0. exit={run.Exit}\n{run.Output}");
+        Assert.DoesNotContain("Company initialization: INCOMPLETE", run.Output);
+        Assert.DoesNotContain("[warn] company-init:", run.Output);
+        Assert.DoesNotContain("did not complete", run.Output);
+
+        var classification = File.ReadAllText(outPath);
+        Assert.DoesNotContain("company-init", classification);
+        Assert.DoesNotContain("company initialization did NOT complete", File.ReadAllText(junitPath));
+
+        // And the JSON document omits the field entirely rather than carrying an empty array,
+        // so an existing consumer's document is unchanged.
+        var jsonRun = RunRunner(cache, injectAbort: false, outputJson: true);
+        Assert.Equal(0, jsonRun.Exit);
+        var doc = JsonDocument.Parse(jsonRun.Output[jsonRun.Output.IndexOf('{')..]).RootElement;
+        Assert.False(doc.TryGetProperty("companyInitFailures", out _));
+    }
+
+    /// <summary>
+    /// The warm-cache arm. The dependency-company baseline is cached in memory and on disk, and
+    /// a HIT skips company initialization entirely — so a condition recorded only where the
+    /// codeunit actually ran would vanish on the second run and a repeat run would report a
+    /// clean database. That is precisely how the emit-exclusion loss came back green on a warm
+    /// cache (#3476). Both runs share one private `--cache` directory, so the second is a real
+    /// cross-process warm run.
+    /// </summary>
+    [SkippableFact]
+    public void PartialCompanyInit_SurvivesAWarmCache()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var cache = NewCacheDir();
+        var cold = RunRunner(cache, injectAbort: true);
+        Assert.Equal(2, cold.Exit);
+        Assert.Contains("Company initialization: INCOMPLETE", cold.Output);
+
+        var warm = RunRunner(cache, injectAbort: true);
+        Assert.True(warm.Exit == 2,
+            $"the second run reuses the compiled output and may reuse the dependency baseline; "
+            + $"the company it runs against is still partial. exit={warm.Exit}\n{warm.Output}");
+        Assert.Contains("Company initialization: INCOMPLETE", warm.Output);
+        Assert.Contains(InjectedReason, warm.Output);
+    }
+}

--- a/AlRunner.Tests/ResumeCarryTests.cs
+++ b/AlRunner.Tests/ResumeCarryTests.cs
@@ -99,6 +99,56 @@ public sealed class ResumeCarryTests : IDisposable
     }
 
     [Fact]
+    public void RoundTrip_KeepsACompanyInitAbort()
+    {
+        // #3538. A company that did not finish initializing is a property of the RUN, and an
+        // attempt that recorded one hands it to the next process along with its results —
+        // otherwise the resumed run's summary, --out and --output-json describe tests that ran
+        // against a partial company and say nothing about it, which is the silent loss this
+        // field exists to stop, one process boundary over.
+        var path = Path.Combine(_dir, "attempt.json");
+        var bucket = Bucket() with
+        {
+            CompanyInitFailures = new[]
+            {
+                new CompanyInitFailure(2, "Company-Initialize", "NullReferenceException",
+                    "Object reference not set to an instance of an object."),
+            },
+        };
+
+        ResumeCarry.Write(path, new[] { bucket });
+        var back = Assert.Single(ResumeCarry.Read(new[] { path }, out var unreadable));
+
+        Assert.Equal(0, unreadable);
+        var f = Assert.Single(back.CompanyInitFailures!);
+        Assert.Equal(2, f.CodeunitId);
+        Assert.Equal("Company-Initialize", f.CodeunitName);
+        Assert.Equal("NullReferenceException", f.ExceptionType);
+        Assert.Equal("Object reference not set to an instance of an object.", f.Message);
+    }
+
+    [Fact]
+    public void ACarryFileWithoutTheField_ReadsAsNoAbort()
+    {
+        // The negative control, and the compatibility half: a file written by a runner build
+        // that predates #3538 has no companyInitFailures key at all. It must deserialise to
+        // null — "this attempt recorded no abort" — rather than failing the read, which would
+        // discard a whole attempt's results over a missing optional field.
+        var path = Path.Combine(_dir, "old-attempt.json");
+        File.WriteAllText(path,
+            """
+            [{"BucketPath":"/bundle/x","Stage":"Ran","CompileErrors":[],"ProcessError":null,
+              "Tests":[],"EmitTicks":0,"CompileTicks":0,"RunTicks":0,"RanGroupCount":1,
+              "ProvisionGaps":null}]
+            """);
+
+        var back = Assert.Single(ResumeCarry.Read(new[] { path }, out var unreadable));
+
+        Assert.Equal(0, unreadable);
+        Assert.Null(back.CompanyInitFailures);
+    }
+
+    [Fact]
     public void ManyFiles_AreConcatenatedInOrder()
     {
         // One file per attempt, so a chain of resumes reads back as the chain — never with an

--- a/AlRunner/CompanyInitializer.cs
+++ b/AlRunner/CompanyInitializer.cs
@@ -24,6 +24,11 @@
 //   keeps the partial result rather than rolling back — but it reports the failure loudly,
 //   because a half-initialized company is a real limitation a developer needs to know about
 //   when something downstream reads a setup table that codeunit 2 never got to.
+//
+//   #3538: the abort is also a RUN-LEVEL RESULT, not only a line on stderr. Real BC never
+//   presents a half-initialized company, so a run carrying one is in a state no service tier
+//   can produce, and every reporting surface says so — including the exit code. The decision,
+//   the BC citation and the exit-code rule are in docs/partial-company-initialization.md.
 using System.Reflection;
 
 namespace AlRunner;
@@ -33,10 +38,59 @@ internal static class CompanyInitializer
     // Codeunit 2 "Company-Initialize" (Base App). Absent in bundles that do not carry Base
     // App, which is not an error: those have no company-setup concept to initialize.
     private const int CompanyInitializeCodeunitId = 2;
+    private const string CompanyInitializeCodeunitName = "Company-Initialize";
+
+    // Test-only seam. Whether codeunit 2 aborts is a property of a particular Base Application
+    // on a particular BC build — #3054 measured it aborting on five of eight legs, and it
+    // aborts on none of them today — so the reporting path below has no other deterministic
+    // way to be driven. Same shape as AL_RUNNER_TEST_BARRIER_DIR: an env var no shipped code
+    // path sets. Its value becomes the exception message, so a test can assert its own text
+    // came through the formatting below rather than a fixed string.
+    private const string InjectFailureEnvVar = "AL_RUNNER_TEST_FAIL_COMPANY_INIT";
 
     private static bool _ranForThisBundle;
 
+    // Run-wide, NOT per app group: ResetForNewBundle runs once per app group and a bucket has
+    // several, so a single overwritten field would lose group 1's abort the moment group 2
+    // succeeded. Drained where Program.cs builds the bucket's BucketResult.
+    private static readonly List<CompanyInitFailure> _failures = new();
+    private static readonly object _failuresLock = new();
+
     internal static void ResetForNewBundle() => _ranForThisBundle = false;
+
+    /// <summary>Everything this run has recorded so far, removed from the accumulator.</summary>
+    internal static IReadOnlyList<CompanyInitFailure> DrainFailures()
+    {
+        lock (_failuresLock)
+        {
+            if (_failures.Count == 0) return Array.Empty<CompanyInitFailure>();
+            var drained = _failures.ToArray();
+            _failures.Clear();
+            return drained;
+        }
+    }
+
+    /// <summary>Discard what has been recorded. For tests that reuse one process.</summary>
+    internal static void ResetFailuresForTests()
+    {
+        lock (_failuresLock) _failures.Clear();
+        LastRecordedFailure = null;
+    }
+
+    /// <summary>
+    /// The failure recorded for the app group that just ran, or null. The dependency-baseline
+    /// cache stores this next to the snapshot it captured, so an app group reusing that
+    /// snapshot re-reports the abort instead of inheriting a silent partial company.
+    /// </summary>
+    internal static CompanyInitFailure? LastRecordedFailure { get; private set; }
+
+    /// <summary>
+    /// Re-report a failure carried on a cached dependency baseline. The snapshot restored on a
+    /// cache HIT IS the partial company, so the run is in exactly the state the original abort
+    /// left behind and has to say so. The emit-exclusion path had the mirror-image bug — a warm
+    /// run of a module missing objects came back byte-identical to a clean one (#3476).
+    /// </summary>
+    internal static void ReportCachedFailure(CompanyInitFailure failure) => Report(failure);
 
     /// <summary>
     /// Run BC's own company initialization once per bundle. Call after install triggers and
@@ -46,34 +100,57 @@ internal static class CompanyInitializer
     {
         if (_ranForThisBundle) return;
         _ranForThisBundle = true;
+        LastRecordedFailure = null;
 
-        if (BcRuntime.FindCodeunitTypePublic(CompanyInitializeCodeunitId) == null)
+        var injected = Environment.GetEnvironmentVariable(InjectFailureEnvVar);
+        // The exists-check is gated by the seam deliberately: the seam stands in for "codeunit
+        // 2 was found and threw", and whether Base App is loaded at all is upstream of
+        // everything this path reports. Gating it the other way would force every test of the
+        // reporting path to load the Base Application floor, which costs ~70s per runner
+        // invocation and proves nothing further about the reporting
+        // (.claude/rules/no-base-app-in-csharp-tests.md).
+        if (string.IsNullOrEmpty(injected)
+            && BcRuntime.FindCodeunitTypePublic(CompanyInitializeCodeunitId) == null)
             return; // no Base App in this bundle — nothing to initialize.
 
         try
         {
+            if (!string.IsNullOrEmpty(injected))
+                throw new InvalidOperationException(injected);
             BcRuntime.NavCodeunit_RunCodeunit(
                 Microsoft.Dynamics.Nav.Types.DataError.ThrowError, CompanyInitializeCodeunitId, null);
             PerfTrace.Log("CompanyInitializer: ran codeunit 2 Company-Initialize");
         }
         catch (Exception ex)
         {
-            // #3068: tagged `[warn]`, NOT `[CompanyInitializer]`. Log.cs drops any line starting
-            // with a `[Component]` tag at default verbosity, so for as long as this said
-            // `[CompanyInitializer]` the comment below was false — the line only reached the
-            // user under --verbose. Measured on BC 27.3: company initialisation aborted on every
-            // run and the runner said nothing, so the reader saw only the downstream
-            // "<Setup Table> does not exist" failures and a `[test-data]` hint pointing at the
-            // wrong remedy. `[warn]` is exempt from that filter by design (Log.cs: "a severity
-            // tag is never an internal diagnostic"), and the exemption list does not have to
-            // grow a component at a time. Do not re-tag this with a component name.
-            // Loud, never silent — see the KNOWN INCOMPLETE note above. Not fatal: the rows it
-            // did insert stay, and a bundle that never reads the rest still runs correctly.
             var inner = ex is TargetInvocationException tie && tie.InnerException != null ? tie.InnerException : ex;
-            Console.Error.WriteLine(
-                $"[warn] CompanyInitializer: codeunit 2 \"Company-Initialize\" did not complete: " +
-                $"{inner.GetType().Name}: {inner.Message} — the company is PARTIALLY initialized; " +
-                $"setup tables it had not reached yet are missing, and AL that reads them will fail.");
+            var failure = new CompanyInitFailure(
+                CompanyInitializeCodeunitId, CompanyInitializeCodeunitName,
+                inner.GetType().Name, inner.Message);
+            LastRecordedFailure = failure;
+            Report(failure);
         }
+    }
+
+    private static void Report(CompanyInitFailure failure)
+    {
+        lock (_failuresLock) _failures.Add(failure);
+        // #3068: tagged `[warn]`, NOT `[CompanyInitializer]`. Log.cs drops any line starting
+        // with a `[Component]` tag at default verbosity, so for as long as this said
+        // `[CompanyInitializer]` the comment below was false — the line only reached the
+        // user under --verbose. Measured on BC 27.3: company initialisation aborted on every
+        // run and the runner said nothing, so the reader saw only the downstream
+        // "<Setup Table> does not exist" failures and a `[test-data]` hint pointing at the
+        // wrong remedy. `[warn]` is exempt from that filter by design (Log.cs: "a severity
+        // tag is never an internal diagnostic"), and the exemption list does not have to
+        // grow a component at a time. Do not re-tag this with a component name.
+        // Loud, never silent — see the KNOWN INCOMPLETE note above. Not fatal at this point:
+        // the rows it did insert stay and the tests still run, but the run records the
+        // condition and will not exit 0 (#3538).
+        Console.Error.WriteLine(
+            $"[warn] CompanyInitializer: codeunit {failure.CodeunitId} \"{failure.CodeunitName}\" "
+            + $"did not complete: {failure.ExceptionType}: {failure.Message} — the company is "
+            + "PARTIALLY initialized; setup tables it had not reached yet are missing, and AL "
+            + "that reads them will fail.");
     }
 }

--- a/AlRunner/Infrastructure/ResumeCarry.cs
+++ b/AlRunner/Infrastructure/ResumeCarry.cs
@@ -48,7 +48,10 @@ public static class ResumeCarry
     public sealed record CarriedBucket(
         string BucketPath, BucketStage Stage, List<string> CompileErrors, string? ProcessError,
         List<CarriedTest> Tests, long EmitTicks, long CompileTicks, long RunTicks,
-        int RanGroupCount, List<string>? ProvisionGaps);
+        int RanGroupCount, List<string>? ProvisionGaps,
+        // #3538. Trailing and defaulted, so a carry file written by an earlier runner build
+        // deserialises unchanged and simply carries no abort.
+        List<CompanyInitFailure>? CompanyInitFailures = null);
 
     private static readonly JsonSerializerOptions Options = new()
     {
@@ -75,7 +78,8 @@ public static class ResumeCarry
             payload.Add(new CarriedBucket(
                 b.BucketPath, b.Stage, new List<string>(b.CompileErrors), b.ProcessError, tests,
                 b.EmitTime.Ticks, b.CompileTime.Ticks, b.RunTime.Ticks, b.RanGroupCount,
-                b.ProvisionGaps == null ? null : new List<string>(b.ProvisionGaps)));
+                b.ProvisionGaps == null ? null : new List<string>(b.ProvisionGaps),
+                b.CompanyInitFailures == null ? null : new List<CompanyInitFailure>(b.CompanyInitFailures)));
         }
         File.WriteAllText(path, JsonSerializer.Serialize(payload, Options));
     }
@@ -114,7 +118,12 @@ public static class ResumeCarry
                 all.Add(new BucketResult(
                     b.BucketPath, b.Stage, b.CompileErrors, b.ProcessError, tests,
                     TimeSpan.FromTicks(b.EmitTicks), TimeSpan.FromTicks(b.CompileTicks),
-                    TimeSpan.FromTicks(b.RunTicks), b.RanGroupCount, b.ProvisionGaps));
+                    TimeSpan.FromTicks(b.RunTicks), b.RanGroupCount, b.ProvisionGaps,
+                    // #3538: an abort recorded by an earlier attempt is carried forward with
+                    // that attempt's results. Dropping it here would be the same silent loss
+                    // this field exists to stop, one surface over — the resumed run's document
+                    // would describe tests that ran against a partial company and say nothing.
+                    b.CompanyInitFailures));
             }
         }
         return all;

--- a/AlRunner/JUnitReport.cs
+++ b/AlRunner/JUnitReport.cs
@@ -210,36 +210,6 @@ public static class JUnitReport
     /// synthetic suite would have to invent an <c>errors</c> count and so would move the very
     /// numbers a dashboard plots. It reports what did not run; it does not restate the run.</para>
     /// </summary>
-    /// <summary>
-    /// An XML comment per bucket whose company initialization aborted (#3538) — the JUnit
-    /// counterpart of <c>--output-json</c>'s <c>companyInitFailures</c> array.
-    ///
-    /// <para>Every test element in this document then describes a run against a company real BC
-    /// cannot produce, and nothing else in the XML says so: the counts are whatever the tests
-    /// earned, and a suite that happens not to read a missing setup row is wholly green. Same
-    /// shape and same reasoning as <see cref="WriteLostSuiteComments"/> — a comment rather than
-    /// a synthetic suite or a non-standard attribute, because it reports a condition about the
-    /// run without moving the numbers a dashboard plots.</para>
-    /// </summary>
-    private static void WriteCompanyInitComments(XmlWriter writer, IReadOnlyList<BucketResult> buckets)
-    {
-        foreach (var b in buckets)
-        {
-            var failures = b.CompanyInitFailures ?? Array.Empty<CompanyInitFailure>();
-            if (failures.Count == 0) continue;
-
-            var text = new StringBuilder();
-            text.Append($" company initialization did NOT complete for {b.BucketPath}: the tests "
-                + "in this report ran against a PARTIALLY initialized company, so setup rows are "
-                + "missing and a failure reading one is caused by this; ");
-            foreach (var f in failures)
-                text.Append($"[{Reporter.DescribeCompanyInitFailure(f)}] ");
-
-            // "--" cannot appear inside an XML comment, and a BC exception message can carry one.
-            writer.WriteComment(text.ToString().Replace("--", "- -"));
-        }
-    }
-
     private static void WriteLostSuiteComments(XmlWriter writer, IReadOnlyList<BucketResult> buckets)
     {
         foreach (var b in buckets)
@@ -261,6 +231,27 @@ public static class JUnitReport
             // "--" cannot appear inside an XML comment at all, so a compiler message carrying one
             // — `--package-cache`, a rule of dashes in a banner — would make the document
             // malformed rather than merely ugly. Same softening as the carried-file comment.
+            writer.WriteComment(text.ToString().Replace("--", "- -"));
+        }
+    }
+
+    // #3538 — see docs/partial-company-initialization.md for why a comment rather than a
+    // synthetic testsuite, which is WriteLostSuiteComments' reasoning above.
+    private static void WriteCompanyInitComments(XmlWriter writer, IReadOnlyList<BucketResult> buckets)
+    {
+        foreach (var b in buckets)
+        {
+            var failures = b.CompanyInitFailures ?? Array.Empty<CompanyInitFailure>();
+            if (failures.Count == 0) continue;
+
+            var text = new StringBuilder();
+            text.Append($" company initialization did NOT complete for {b.BucketPath}: the tests "
+                + "in this report ran against a PARTIALLY initialized company, so setup rows are "
+                + "missing and a failure reading one is caused by this; ");
+            foreach (var f in failures)
+                text.Append($"[{Reporter.DescribeCompanyInitFailure(f)}] ");
+
+            // "--" cannot appear inside an XML comment, and a BC exception message can carry one.
             writer.WriteComment(text.ToString().Replace("--", "- -"));
         }
     }

--- a/AlRunner/JUnitReport.cs
+++ b/AlRunner/JUnitReport.cs
@@ -101,6 +101,8 @@ public static class JUnitReport
             foreach (var cs in carriedSuites) cs.WriteTo(writer);
         }
 
+        WriteCompanyInitComments(writer, buckets);
+
         WriteLostSuiteComments(writer, buckets);
 
         foreach (var suite in suites)
@@ -208,6 +210,36 @@ public static class JUnitReport
     /// synthetic suite would have to invent an <c>errors</c> count and so would move the very
     /// numbers a dashboard plots. It reports what did not run; it does not restate the run.</para>
     /// </summary>
+    /// <summary>
+    /// An XML comment per bucket whose company initialization aborted (#3538) — the JUnit
+    /// counterpart of <c>--output-json</c>'s <c>companyInitFailures</c> array.
+    ///
+    /// <para>Every test element in this document then describes a run against a company real BC
+    /// cannot produce, and nothing else in the XML says so: the counts are whatever the tests
+    /// earned, and a suite that happens not to read a missing setup row is wholly green. Same
+    /// shape and same reasoning as <see cref="WriteLostSuiteComments"/> — a comment rather than
+    /// a synthetic suite or a non-standard attribute, because it reports a condition about the
+    /// run without moving the numbers a dashboard plots.</para>
+    /// </summary>
+    private static void WriteCompanyInitComments(XmlWriter writer, IReadOnlyList<BucketResult> buckets)
+    {
+        foreach (var b in buckets)
+        {
+            var failures = b.CompanyInitFailures ?? Array.Empty<CompanyInitFailure>();
+            if (failures.Count == 0) continue;
+
+            var text = new StringBuilder();
+            text.Append($" company initialization did NOT complete for {b.BucketPath}: the tests "
+                + "in this report ran against a PARTIALLY initialized company, so setup rows are "
+                + "missing and a failure reading one is caused by this; ");
+            foreach (var f in failures)
+                text.Append($"[{Reporter.DescribeCompanyInitFailure(f)}] ");
+
+            // "--" cannot appear inside an XML comment, and a BC exception message can carry one.
+            writer.WriteComment(text.ToString().Replace("--", "- -"));
+        }
+    }
+
     private static void WriteLostSuiteComments(XmlWriter writer, IReadOnlyList<BucketResult> buckets)
     {
         foreach (var b in buckets)

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3895,9 +3895,15 @@ foreach (var bundle in bundles)
     // existed.
     if (bundleTests.Count == 0 && bundleErrors.Count > 0)
         bundleStage = AlRunner.Infrastructure.BundleFailureStage.Classify(bundleErrors);
+    // #3538: drained here, once per bucket, because the accumulator is run-wide while
+    // CompanyInitializer.ResetForNewBundle runs once per APP GROUP — a bucket with several
+    // groups can abort in one and initialize cleanly in the next, and both facts belong to
+    // this bucket. Draining also means the next bucket starts empty rather than inheriting
+    // this one's condition.
     results.Add(new BucketResult(bundleAbs, bundleStage,
         bundleErrors, null, bundleTests,
-        bundleEmit, bundleComp, bundleRun, ranGroupCount, bundleProvisionGaps));
+        bundleEmit, bundleComp, bundleRun, ranGroupCount, bundleProvisionGaps,
+        CompanyInitializer.DrainFailures()));
     // Appended here, not buffered to process exit: a run that dies mid-way still
     // yields a row for every bundle it did finish. The row's wall clock covers this
     // whole loop turn, so wall − (emit+compile+run) is the per-bundle overhead
@@ -4485,6 +4491,27 @@ if (!serverMode && !watchMode && !dapMode
     && AlRunner.Infrastructure.ExecutionSchedulerShutdown.DisposeIfRealized()
         == AlRunner.Infrastructure.ExecutionSchedulerShutdown.Outcome.Disposed)
     Console.Error.WriteLine("[shutdown] disposed BC ExecutionScheduler that a BC-internal path realized during the run (#2704)");
+
+// #3538: company initialization did not finish, so every test above ran against a company
+// real BC cannot produce — codeunit 2 "Company-Initialize" commits exactly once, at the end of
+// its OnRun, so a service tier either has the whole set of setup rows or the company creation
+// failed. Ranked exactly like carryIncomplete and the lost output below, and for the same
+// reason: it says nothing about the AL, it says the DATABASE the AL ran against was not the one
+// asked for — so a consumer must not read it as "some tests failed", and equally must not read
+// a zero as "the company was initialized". Never RAISED above what the tests earned, so a
+// failing run still reports its own, more specific code, and --no-strict-exit still forces 0
+// for a consumer that wants the old behaviour.
+var companyInitFailures = Reporter.CompanyInitFailures(allResults);
+if (companyInitFailures.Count > 0 && computedExitCode == 0)
+{
+    Console.Error.WriteLine(
+        $"[warn] company-init: {companyInitFailures.Count} company initialization abort(s) — "
+        + "every test in this run used a PARTIALLY initialized company, so AL reading a setup "
+        + "row the codeunit never reached will fail for that reason and not its own; "
+        + "exiting 2 because the run is not clean. See the summary above, and "
+        + "docs/partial-company-initialization.md.");
+    computedExitCode = 2;
+}
 
 // #2403: an output file the caller asked for and did not get. Ranked exactly like
 // carryIncomplete above, and for the same reason: it says nothing about the AL, it says the

--- a/AlRunner/ProgramSupport/CliText.cs
+++ b/AlRunner/ProgramSupport/CliText.cs
@@ -664,7 +664,11 @@ internal static partial class ProgramSupport
         w.WriteLine("                            1  at least one test FAILED or ERRORED");
         w.WriteLine("                            2  a bundle could not execute (process-level error;");
         w.WriteLine("                               also a bad invocation — unknown flag, or a bundle");
-        w.WriteLine("                               path that does not exist)");
+        w.WriteLine("                               path that does not exist), an output file the run");
+        w.WriteLine("                               was asked for could not be written, or company");
+        w.WriteLine("                               initialization did not complete so the tests ran");
+        w.WriteLine("                               against a partially initialized company");
+        w.WriteLine("                               (docs/partial-company-initialization.md)");
         w.WriteLine("                            3  a bundle could not compile");
         w.WriteLine("                            4  --count-baseline: a suite's test or app-group count did");
         w.WriteLine("                               not exactly match its declared baseline (see --count-baseline)");

--- a/AlRunner/Reporter.cs
+++ b/AlRunner/Reporter.cs
@@ -7,6 +7,17 @@ namespace AlRunner;
 
 public enum BucketStage { CompileFailed, ExecuteFailed, Ran }
 
+/// <summary>
+/// Company initialization (Base App codeunit 2 "Company-Initialize") aborted part-way, so the
+/// company every test in this bucket ran against is missing whatever setup rows the codeunit
+/// had not reached. Real BC cannot produce that state — codeunit 2's OnRun commits exactly
+/// once, at the end — so this is a property of the RUN, not of any one test, and it is carried
+/// on the bucket rather than left on stderr (#3538). See
+/// docs/partial-company-initialization.md.
+/// </summary>
+public sealed record CompanyInitFailure(int CodeunitId, string CodeunitName,
+                                        string ExceptionType, string Message);
+
 public sealed record BucketResult(string BucketPath, BucketStage Stage,
                                    IReadOnlyList<string> CompileErrors,
                                    string? ProcessError,
@@ -30,7 +41,15 @@ public sealed record BucketResult(string BucketPath, BucketStage Stage,
                                    // PrintSummary repeats them at the end, where a scripted caller
                                    // and a human scrolling to the bottom actually look (#2587).
                                    // Optional/trailing for the same reason as RanGroupCount.
-                                   IReadOnlyList<string>? ProvisionGaps = null);
+                                   IReadOnlyList<string>? ProvisionGaps = null,
+                                   // #3538: company initialization aborted for one or more of
+                                   // this bucket's app groups, so its tests ran against a
+                                   // company real BC could not produce. Optional/trailing for
+                                   // the same reason as the two above; null and empty both mean
+                                   // "the company initialized cleanly", and every reporting
+                                   // surface omits the condition entirely in that case, so a
+                                   // clean run's output is byte-identical to before.
+                                   IReadOnlyList<CompanyInitFailure>? CompanyInitFailures = null);
 
 public static class Reporter
 {
@@ -79,6 +98,21 @@ public static class Reporter
     /// If it ever did, the failure mode is over-marking — the pre-review behaviour — not a real
     /// failure hidden.</para>
     /// </summary>
+    /// <summary>
+    /// Every company-initialization abort in the run, in bucket order (#3538). One place, so
+    /// the summary, --out, --output-json and the JUnit report cannot describe the same
+    /// condition differently — the reason IsSuspect exists one concept over.
+    /// </summary>
+    public static IReadOnlyList<CompanyInitFailure> CompanyInitFailures(IReadOnlyList<BucketResult> buckets)
+        => buckets
+            .SelectMany(b => b.CompanyInitFailures ?? Array.Empty<CompanyInitFailure>())
+            .ToList();
+
+    /// <summary>One abort, rendered the same way wherever it is printed.</summary>
+    public static string DescribeCompanyInitFailure(CompanyInitFailure f)
+        => $"codeunit {f.CodeunitId} \"{f.CodeunitName}\" did not complete: "
+            + $"{f.ExceptionType}: {f.Message}";
+
     internal static bool IsNamedCauseOfASuiteError(BucketResult b, TestResult t)
         => b.CompileErrors.Any(e =>
             Infrastructure.BundleFailureStage.AbortReasonNamesTest(e, t.Codeunit, t.Method));
@@ -330,6 +364,21 @@ public static class Reporter
                 foreach (var e in b.CompileErrors) w.WriteLine($"  {e}");
             }
         }
+        // #3538: a run-level condition, printed as its own block rather than folded into the
+        // counters above — none of them is about it. Every test below it ran against a company
+        // real BC never produces, so this has to be readable next to the totals, not only as a
+        // `[warn]` line thousands of lines earlier at the moment the codeunit aborted.
+        var companyInitFailures = CompanyInitFailures(buckets);
+        if (companyInitFailures.Count > 0)
+        {
+            w.WriteLine("-----------------------------------------------------------------");
+            w.WriteLine($"Company initialization: INCOMPLETE ({companyInitFailures.Count} abort(s)) — "
+                + "the tests above ran against a PARTIALLY initialized company.");
+            foreach (var f in companyInitFailures)
+                w.WriteLine($"  {DescribeCompanyInitFailure(f)}");
+            w.WriteLine("  → setup rows the codeunit had not reached are missing, so a failure "
+                + "reading one is caused by this, not by the AL under test.");
+        }
         var gaps = buckets
             .SelectMany(b => b.ProvisionGaps ?? Array.Empty<string>())
             .Distinct(StringComparer.Ordinal)
@@ -577,6 +626,8 @@ public static class Reporter
             .Select(b => new { file = b.BucketPath, errors = b.CompileErrors.ToList() })
             .ToList();
 
+        var companyInitFailures = CompanyInitFailures(buckets);
+
         var output = new
         {
             tests = tests.Select(x => new
@@ -618,6 +669,20 @@ public static class Reporter
             compilationErrors = compileErrors.Count > 0 ? compileErrors : null,
             executionErrors = executionErrors.Count > 0 ? executionErrors : null,
             suiteErrors = suiteErrors.Count > 0 ? suiteErrors : null,
+            // #3538: the condition a consumer could not previously see at all. It is not a test
+            // result and not a bucket stage, so it appeared in none of the arrays above while
+            // every test in the document had run against a half-initialized company. Additive
+            // and null-omitted, so a run whose company initialized cleanly serialises
+            // byte-identically to before.
+            companyInitFailures = companyInitFailures.Count > 0
+                ? companyInitFailures.Select(f => new
+                {
+                    codeunitId = f.CodeunitId,
+                    codeunit = f.CodeunitName,
+                    exceptionType = f.ExceptionType,
+                    message = f.Message,
+                }).ToList()
+                : null,
             // #1936: same "real wall clock, not just the measured phases" gap as the
             // `wall:` line in PrintSummary — see that comment. Additive field, so
             // existing consumers reading this JSON are unaffected.
@@ -665,6 +730,24 @@ public static class Reporter
             }
             else
             {
+                // #3538: same gap as #2762 one condition over. This file is the triage
+                // worklist, and every failing record under a bucket whose company did not
+                // finish initializing may be that condition rather than a runner gap worth
+                // chasing. Its own kind, ranked first so it is read before the records it may
+                // explain.
+                foreach (var f in b.CompanyInitFailures ?? Array.Empty<CompanyInitFailure>())
+                {
+                    failures.Add(new
+                    {
+                        bucket = b.BucketPath,
+                        kind = "company-init",
+                        codeunitId = f.CodeunitId,
+                        codeunit = f.CodeunitName,
+                        exceptionType = f.ExceptionType,
+                        message = f.Message,
+                        classification = "company-init/partial",
+                    });
+                }
                 // #2762: this branch walked only failing TESTS, so a bucket that lost a whole
                 // suite contributed zero records and the triage file said the run had nothing
                 // wrong with it. Its own kind, not "compile": the bucket ran, and the records

--- a/AlRunner/Reporter.cs
+++ b/AlRunner/Reporter.cs
@@ -98,6 +98,10 @@ public static class Reporter
     /// If it ever did, the failure mode is over-marking — the pre-review behaviour — not a real
     /// failure hidden.</para>
     /// </summary>
+    internal static bool IsNamedCauseOfASuiteError(BucketResult b, TestResult t)
+        => b.CompileErrors.Any(e =>
+            Infrastructure.BundleFailureStage.AbortReasonNamesTest(e, t.Codeunit, t.Method));
+
     /// <summary>
     /// Every company-initialization abort in the run, in bucket order (#3538). One place, so
     /// the summary, --out, --output-json and the JUnit report cannot describe the same
@@ -112,10 +116,6 @@ public static class Reporter
     public static string DescribeCompanyInitFailure(CompanyInitFailure f)
         => $"codeunit {f.CodeunitId} \"{f.CodeunitName}\" did not complete: "
             + $"{f.ExceptionType}: {f.Message}";
-
-    internal static bool IsNamedCauseOfASuiteError(BucketResult b, TestResult t)
-        => b.CompileErrors.Any(e =>
-            Infrastructure.BundleFailureStage.AbortReasonNamesTest(e, t.Codeunit, t.Method));
 
     /// <summary>Whether anything in this bucket is marked — i.e. whether the notes that
     /// introduce the marker have anything below them to introduce.</summary>

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -265,6 +265,13 @@ public sealed class TestExecutor
     // it was set to isolate.
     private static readonly Dictionary<string, AlRunner.Patches.RecordPatches.InstallBaselineSnapshot>
         _depCompanyBaselineCache = new();
+    // #3538: what codeunit 2 did while the snapshot beside it was being captured. A snapshot
+    // taken after an abort IS the partial company, so restoring it puts a later app group in
+    // exactly that state — and without this the abort was reported once, by whichever app group
+    // happened to MISS, and every group after it inherited a half-initialized company in
+    // silence. Same defect the emit-exclusion cache had (#3476), where a warm run of a module
+    // missing objects came back byte-identical to a clean one.
+    private static readonly Dictionary<string, CompanyInitFailure> _depCompanyBaselineInitFailure = new();
     private static readonly object _depCompanyBaselineCacheLock = new();
 
     // ── Second tier: the same snapshot, persisted across PROCESSES ──────────────────────
@@ -495,11 +502,15 @@ public sealed class TestExecutor
             // forces every lookup to MISS, as if the cache were never populated, so the
             // fresh-computation path can always be re-run on demand for diagnosis or to
             // re-verify the speedup without a patched rebuild.
+            CompanyInitFailure? cachedInitFailure = null;
             if (Environment.GetEnvironmentVariable("AL_RUNNER_NO_DEP_COMPANY_CACHE") == "1")
                 cached = null;
             else
                 lock (_depCompanyBaselineCacheLock)
+                {
                     _depCompanyBaselineCache.TryGetValue(depKey, out cached);
+                    _depCompanyBaselineInitFailure.TryGetValue(depKey, out cachedInitFailure);
+                }
             // #2710: this log token has to be an IDENTITY, and it was not. It used to be
             // depKey[..8] — and depKey opens with InstallTriggerRunner.CurrentDependencySetKey(),
             // whose first characters are the first dependency assembly's MVID, so every app
@@ -524,6 +535,10 @@ public sealed class TestExecutor
                 // group reused a prior computation instead of re-running dependency Install
                 // triggers + Company-Initialize. See InstallSeedDepCompanyCacheTests.
                 PerfTrace.Log($"InstallBaseline.DepCompanyCache HIT {shortKey}");
+                // #3538: the restored snapshot is the partial company the original abort left
+                // behind, so this app group is in that state too and the run says so again.
+                if (cachedInitFailure != null)
+                    CompanyInitializer.ReportCachedFailure(cachedInitFailure);
             }
             else
             {
@@ -575,15 +590,29 @@ public sealed class TestExecutor
                     AlRunner.Patches.RecordPatches.EnsurePublishedApplicationDependencyRowsSeeded();
                     InstallTriggerRunner.RunDependenciesOnly();
                     CompanyInitializer.EnsureCompanyInitialized();
+                    var initFailure = CompanyInitializer.LastRecordedFailure;
                     var snapshot = AlRunner.Patches.RecordPatches.CaptureInstallBaselineSnapshot();
                     lock (_depCompanyBaselineCacheLock)
+                    {
                         _depCompanyBaselineCache[depKey] = snapshot;
+                        if (initFailure != null) _depCompanyBaselineInitFailure[depKey] = initFailure;
+                        else _depCompanyBaselineInitFailure.Remove(depKey);
+                    }
                     AlRunner.Patches.RecordPatches.SetActiveDepCompanyBaseline(snapshot);
                     PerfTrace.Log($"InstallBaseline.DepCompanyCache MISS {shortKey}");
 
                     // Persist for the next process. Refusals are logged by the codec and cost
                     // only the persistence — this run already has its snapshot either way.
-                    if (diskKey != null)
+                    //
+                    // #3538: not when codeunit 2 aborted. The disk tier carries the snapshot
+                    // and nothing else, so a later PROCESS restoring it would get the partial
+                    // company with no record of how it got that way and would report a clean
+                    // run — the #3476 cache defect exactly, one cache over. Withholding the
+                    // entry costs that process the dependency baseline it would have reused
+                    // (seconds; it re-runs the triggers and codeunit 2 itself) and buys a run
+                    // that reports the condition every time, including after a runner fix has
+                    // made the abort stop happening.
+                    if (diskKey != null && initFailure == null)
                     {
                         var payload = AlRunner.Patches.RecordPatches.TrySerializeInstallBaselineSnapshot(
                             snapshot, diskKey);

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1584,7 +1584,12 @@ https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues.
   the offending codeunit then vanished silently from later handouts. Codeunit 2
   `Company-Initialize` reads this table, so one such codeunit anywhere in any loaded app left
   the company half-initialized and the run failed a long way from the cause
-  ([#3536](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3536)).
+  ([#3536](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3536)). A company
+  that half-initializes for any reason is now a run-level result rather than a `[warn]` line
+  beside a green exit — the summary, `--out`, `--output-json` and the JUnit document all carry
+  it, and the run exits 2 when it would otherwise have been clean. See
+  [`docs/partial-company-initialization.md`](partial-company-initialization.md)
+  ([#3538](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3538)).
 
   Note what can still reach the refusal: essentially nothing the AL compiler will produce. AL
   accepts five codeunit subtypes; four are named by the column and the fifth, `Install`, is

--- a/docs/partial-company-initialization.md
+++ b/docs/partial-company-initialization.md
@@ -94,6 +94,15 @@ Two levers, in `AlRunner/TestExecutor.cs`:
   — seconds, and it re-runs codeunit 2 itself — and gets a run that reports the condition, or a
   clean one once a runner fix has made the abort stop happening.
 
+Both are measured rather than reasoned, and the measurement needs a fixture whose dependency
+closure **writes rows**: with an empty snapshot the codec refuses to persist anything at all
+(`not persisting: snapshot has 0 DataAccessSource(s)`), no disk entry exists in either arm, and
+a warm run MISSes for a reason that has nothing to do with the withhold. So both tests build a
+closure with `AlRunner.Tests/InstallSeedClosure.cs`, and the disk test carries a control arm —
+the same fixture shape without an abort must reach `DISK-HIT` — so that the abort arm's `MISS`
+is the withhold and not a fixture that never persisted. Remove the two levers and both tests
+fail; that is what makes this section a claim about the code rather than about #3476.
+
 ## Where the code is
 
 - `AlRunner/CompanyInitializer.cs` — the catch path, the run-wide accumulator, and the
@@ -102,5 +111,7 @@ Two levers, in `AlRunner/TestExecutor.cs`:
 - `AlRunner/Program.cs` — draining the accumulator into the bucket's `BucketResult`, and the
   exit-code escalation
 - `AlRunner/Reporter.cs`, `AlRunner/JUnitReport.cs` — the four reporting surfaces
-- `AlRunner.Tests/PartialCompanyInitializationTests.cs` — the proving tests, including the
-  negative control and the cold-then-warm pair
+- `AlRunner/Infrastructure/ResumeCarry.cs` — the abort crosses the watchdog-resume process
+  boundary with the attempt's results
+- `AlRunner.Tests/PartialCompanyInitializationTests.cs` — the proving tests: the negative
+  control, the two cache levers, and the run that earns exit 1 on its own

--- a/docs/partial-company-initialization.md
+++ b/docs/partial-company-initialization.md
@@ -1,0 +1,106 @@
+# A company that did not finish initializing is a run-level result
+
+Base App codeunit 2 `"Company-Initialize"` is what gives the runner's company its setup rows —
+`Company Information`, `Source Code Setup`, the setup No. Series, `General Ledger Setup` and the
+rest. The runner runs BC's own codeunit rather than fabricating those rows
+(`AlRunner/CompanyInitializer.cs`). When it aborts part-way, the runner **keeps** what it wrote:
+that partial state is worth +5 tests over not running it at all, measured both ways, and the
+tests that never read a missing row are real results.
+
+What #3538 settled is what the run then **records**. Before it: a `[warn]` line on stderr at the
+moment of the abort, and nothing else — the summary, `--out`, `--output-json` and the JUnit
+document were byte-identical to a clean run's, and the process exited 0. The report behind the
+issue had roughly 2800 tests pass that way against a half-initialized database, with the few
+that did fail reporting plain "cannot be found" and "must have a value" errors a long way from
+the cause.
+
+## What real BC does, and why that makes it a run-level condition
+
+Codeunit 2's `OnRun` commits **once**, as its last statement, after `InitSetupTables()`,
+`InitSourceCodeSetup()`, `OnCompanyInitialize()` and the rest have all run. Measured on
+Microsoft's shipped `Microsoft_Base Application_28.1.49838.50256.app`,
+`src/Foundation/Company/CompanyInitialize.Codeunit.al`: **one `Commit()` in 806 lines**, and it
+is the final statement of the trigger.
+
+So on a service tier the outcome is all-or-nothing. An error anywhere inside that trigger rolls
+the write transaction back and the company does not acquire a subset of its setup rows; a
+company that exists has the whole set. The state the runner is in after an abort is one **no BC
+service tier can produce**, which is why it cannot be expressed as a per-test result — no test
+is wrong, the database every test read is.
+
+Two limits on that citation, stated rather than glossed: the subscribers on `OnBeforeOnRun` and
+`OnCompanyInitialize` (18 files in Base Application alone) were not audited for a `Commit` of
+their own, and the platform path that runs codeunit 2 during company creation lives in the
+service tier, not in AL, so what a *failed* company creation leaves behind on disk was not
+measured. Neither affects the conclusion drawn here, which rests on the single commit in the
+trigger the runner itself invokes.
+
+## The decision
+
+The run **records** the condition everywhere it reports, and **does not exit 0**. It does not
+refuse to run, and it does not discard results.
+
+| surface | what it carries |
+|---|---|
+| printed summary | a `Company initialization: INCOMPLETE (N abort(s))` block below the totals, one line per abort naming the codeunit, the exception type and the message |
+| `--output-json` | `companyInitFailures`: `codeunitId`, `codeunit`, `exceptionType`, `message`. Additive and null-omitted — a clean run's document is unchanged |
+| `--out` | a record with `"kind": "company-init"` and `"classification": "company-init/partial"`, ranked ahead of the test failures it may explain |
+| `--output-junit` | an XML comment per affected bucket, the same convention #2919 chose for a lost suite: a synthetic `testsuite` would have to invent counts, and this reports a condition without moving the numbers a dashboard plots |
+| exit code | **2**, and only when the run would otherwise have exited 0 |
+
+### Why exit 2, and why it is safe
+
+2 is the code `docs/cli-output-paths.md` already established for "this says nothing about the
+AL": a lost `--out` write, and a carried resume attempt that did not arrive. A partial company
+is the same kind of statement — the database the AL ran against was not the one asked for — so a
+consumer must not read it as "some tests failed", which is what 1 means. It is never *raised*
+above what the tests earned: a run with a failing test still reports 1, a compile failure still
+reports 3. `--no-strict-exit` still forces 0 for a consumer that wants the old behaviour, and
+`--output-json`'s `exitCode` field still reports the real outcome in that mode.
+
+The escalation was measured before it was chosen. On the last green `main` matrix run before
+#3538 (workflow run `34216039259`, all eight legs green), the string `CompanyInitializer` appears
+**zero times in all eight leg logs** — 1.1 MB per leg, covering the corpus run, `runner-extras`
+and the unit-test step. Codeunit 2 completes on every BC version the matrix builds, so nothing
+in CI trips this. #3054 measured it aborting on five of eight legs before #3067 fixed the cause,
+which is why the condition is worth reporting rather than assuming away.
+
+### What was rejected
+
+**Fail the run before any test executes.** The tests that do not read a missing setup row are
+real results — the report behind the issue had ~2800 of them — and `CompanyInitializer`'s own
+header records the measured decision to keep the partial state. Refusing to run would trade a
+silent wrong answer for no answer.
+
+**Record it and keep exiting 0.** That is the state the issue was filed about. The condition is
+machine-readable then, but every existing consumer — CI, a suite comparison, a person reading a
+shell's exit status — still reads the run as clean, and none of them opts in to a new field
+they do not know exists.
+
+## The warm-cache half
+
+`EnsureCompanyInitialized` runs only on a dependency-company-baseline cache MISS. On a HIT the
+snapshot restored **is** the partial company, and before #3538 nothing said so: the abort was
+reported once, by whichever app group missed, and every later group — and every later *process*,
+through the disk tier — inherited a half-initialized company in silence. That is the emit-exclusion
+cache defect exactly (#3476), where a warm run of a module missing objects came back
+byte-identical to a clean one.
+
+Two levers, in `AlRunner/TestExecutor.cs`:
+
+- the in-memory cache stores the failure next to the snapshot, and a HIT re-reports it;
+- the **disk** tier does not store an entry at all when the codeunit aborted, because that tier
+  carries the snapshot and nothing else. A later process pays for the dependency baseline again
+  — seconds, and it re-runs codeunit 2 itself — and gets a run that reports the condition, or a
+  clean one once a runner fix has made the abort stop happening.
+
+## Where the code is
+
+- `AlRunner/CompanyInitializer.cs` — the catch path, the run-wide accumulator, and the
+  `AL_RUNNER_TEST_FAIL_COMPANY_INIT` seam the proving tests drive it with
+- `AlRunner/TestExecutor.cs` — the cache carry and the withheld disk write
+- `AlRunner/Program.cs` — draining the accumulator into the bucket's `BucketResult`, and the
+  exit-code escalation
+- `AlRunner/Reporter.cs`, `AlRunner/JUnitReport.cs` — the four reporting surfaces
+- `AlRunner.Tests/PartialCompanyInitializationTests.cs` — the proving tests, including the
+  negative control and the cold-then-warm pair


### PR DESCRIPTION
Closes #3538

Corpus-NA: runner-only reporting mechanism — nothing about AL or BC semantics changes, so there is no assertion a service tier could adjudicate. The BC citation this rests on is a read of Microsoft's shipped Base Application source (below), not a new claim.

## What changed

Codeunit 2 `"Company-Initialize"` aborting used to produce one `[warn]` line on stderr and nothing else: the printed summary, `--out`, `--output-json` and the JUnit document were byte-identical to a clean run's, and the process exited 0. The report behind the issue had ~2800 tests pass that way against a half-initialized database.

Now the condition is a **run-level result**. Results are still kept and still reported — the tests that pass are real — but the run records the abort everywhere it reports, and does not exit 0.

| surface | what it carries |
|---|---|
| printed summary | `Company initialization: INCOMPLETE (N abort(s))` block below the totals, one line per abort |
| `--output-json` | `companyInitFailures`: `codeunitId`, `codeunit`, `exceptionType`, `message` — additive, null-omitted |
| `--out` | a record with `"kind": "company-init"`, `"classification": "company-init/partial"` |
| `--output-junit` | an XML comment per affected bucket (the convention #2919 chose for a lost suite) |
| exit code | **2**, and only when the run would otherwise have exited 0 |

## The BC citation (step 1 of the brief)

`src/Foundation/Company/CompanyInitialize.Codeunit.al`, inside Microsoft's shipped `Microsoft_Base Application_28.1.49838.50256.app`: **one `Commit()` in 806 lines**, and it is the last statement of `OnRun`, after `InitSetupTables()`, `InitSourceCodeSetup()`, `OnCompanyInitialize()` and the rest. So on a service tier company initialization is all-or-nothing — an error anywhere inside the trigger rolls the write transaction back, and a company that exists has the whole set of setup rows. The state the runner is in after an abort is one **no BC service tier can produce**, which is why it cannot be expressed as a per-test result.

Two limits, stated rather than glossed: the `OnBeforeOnRun` / `OnCompanyInitialize` subscribers (18 files in Base App alone) were not audited for a `Commit` of their own, and the platform path that runs codeunit 2 during company *creation* lives in the service tier, not in AL, so what a failed creation leaves on disk was not measured. Neither affects the conclusion, which rests on the single commit in the trigger the runner itself invokes.

## The option chosen, and why (step 2)

**(b) with the exit code moved**, i.e. the issue's candidate 2. Not (a) "fail before any test runs": `CompanyInitializer`'s own header records the measured decision to keep the partial state (+5 tests over not running codeunit 2 at all), and the issue explicitly rules out discarding results. Not candidate 1 (record it, keep exiting 0): that leaves every existing consumer — CI, a suite comparison, a shell exit status — reading the run as clean, which is the state the issue was filed about.

Exit **2** is the code `docs/cli-output-paths.md` already established for "this says nothing about the AL" (a lost `--out` write, a carried resume attempt that did not arrive). It is never raised above what the tests earned, and `--no-strict-exit` still forces 0.

**Measured before choosing, because (a) or an escalation could have broken CI.** On the last green `main` matrix run before this work (`34216039259`, all 8 legs green), `CompanyInitializer` appears **zero times in all eight leg logs** — 0.6-1.1 MB per leg, covering the corpus run, `runner-extras` and the unit-test step. Codeunit 2 completes on every BC version the matrix builds, so nothing in CI trips this today. #3054 measured it aborting on five of eight legs before #3067 fixed the cause, which is why it is worth reporting rather than assuming away.

Locally with the Base Application floor loaded: `EventSubscriberScanEquivalenceTests` passes with zero `CompanyInitializer` lines. `PlaceholderFloorProvisioningTests` fails on this box for an unrelated, pre-existing reason (both its tests assert a cold-cache provisioning refusal) — it fails identically on unmodified `origin/main`, and codeunit 2 never runs in it because the run is refused first.

## The warm-cache half (the blind spot this could have shipped with)

`EnsureCompanyInitialized` runs only on a dependency-company-baseline cache MISS. On a HIT the restored snapshot **is** the partial company, so a condition recorded only where the codeunit actually ran would vanish on the second app group and the second process — the emit-exclusion cache defect exactly (#3476), where a warm run of a module missing objects came back byte-identical to a clean one. Two levers in `TestExecutor.cs`: the in-memory cache stores the failure next to the snapshot and a HIT re-reports it; the **disk** tier withholds the entry entirely when the codeunit aborted, because that tier carries the snapshot and nothing else. Both levers are MEASURED, after review found the first version of this test could not fail: the fixture declared no dependencies, so the codec refused to persist the snapshot in either arm and the warm process reported only because the env seam re-fired. The two tests now build a row-writing closure with `InstallSeedClosure` (the #2364 pattern); the disk one carries a clean control arm that must reach `DISK-HIT`, and the in-memory one runs two app groups on one key. Levers removed: 2 failed, 4 passed. Levers restored: 6 passed.

## RED → GREEN

The fixture is `platform`-only and the abort is injected through `AL_RUNNER_TEST_FAIL_COMPANY_INIT`, a test-only env seam that replaces the `NavCodeunit_RunCodeunit` call **inside the `try`** — so the catch path under test is the real one, and no Base Application floor is loaded (`no-base-app-in-csharp-tests.md`; the floor costs ~70s per invocation and would not guarantee the abort anyway). No allowlist entry needed.

- **RED** — with the accumulation removed (pre-#3538 behaviour: warn only, nothing recorded), `dotnet test --filter FullyQualifiedName~PartialCompanyInitialization`: **3 failed, 1 passed**. The one pass is the negative control, which is what it should do.
- **GREEN** — with the change: **4 passed, 0 failed**.
- After rebasing onto `ecc7aa99` (#3541), `PartialCompanyInitialization` + `LoudDiagnosisReachesTheUser` + `BaseAppFloorFixtureGuard`: **60 passed, 0 failed**.
- **Review round 2 — the two cache levers.** With both removed (`if (diskKey != null)` restored, the `ReportCachedFailure` call deleted): **2 failed, 4 passed**. Restored: **6 passed**.
- **Review round 3 — the resume carry.** With `CompanyInitFailures` deleted from both the write and the read side of `ResumeCarry`: **1 failed, 7 passed** in `ResumeCarryTests`. Restored: **8 passed**.
- Targeted set at the round-3 head (`PartialCompanyInitialization`, `ResumeCarry`, `CollectionCost*`, `LoudDiagnosisReachesTheUser`, `BaseAppFloorFixtureGuard`, `JUnit*`): **115 passed, 0 failed**.
- Wider targeted sweep before the rebase (`LoudDiagnosis*`, `BaseAppFloorFixtureGuard*`, `JUnit*`, `Reporter*`, `Classification*`, `InstallSeedDepCompanyCache*`, `CliDocumentation*`): **152 passed, 1 failed** — `OutputPathPreparationTests.Cli_OutIntoAMissingDirectory_WritesTheClassificationAndExitsZero`, which asserts the literal `Classification → <path>` line in captured stdout. The line is printed (verified by hand: `Classification M-bM-^FM-^R <path>` under `cat -v`); the non-ASCII arrow does not survive this Windows box's process-capture encoding. `Program.cs:4422`, which prints it, is untouched by this diff.

**`tests/runner-extras` did not complete locally**: 66 suites, and two foreground attempts (cold and warm, private `--cache`) both hit the 570s ceiling I can hold a command open for on this box. So there is no local total for it to report, and I am not claiming one — CI's three BC legs run it in full.

## Sibling scan (nothing folded)

Open issues touching `CompanyInitializer.cs`, `Reporter.cs` or `JUnitReport.cs`: none. The closest by subject are #3361 (a preflight corpus check whose missing summary key reads as zero failures — same *shape*, but it lands in `tools/preflight.py`) and #3429 / #3236, which are about how the test company is built rather than how a failure to build it is reported. Nothing shares a file with this diff, so nothing folded.

## Where the prose went

The decision, the BC citation with its two stated limits, the rejected options, the measurement and the cache reasoning are in **`docs/partial-company-initialization.md`** (new). The code keeps short claims with pointers to it; `docs/limitations.md` gets a two-sentence pointer next to the #3536 entry it follows from, and `CliText.cs`'s exit-code list names the new cause of exit 2.

<sub>Implemented by agent `fbk-2`. Rebased onto `ecc7aa99` (#3541) after the coordinator flagged it; targeted tests re-run after the rebase, results above.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018eQEJqnKcAgqMbWgk4wdMa
