### PR TITLE
fix(testpage): a temporal bind failure and an unwrapped Invoke fault must not be swallowable by asserterror

### DIFF
--- a/AlRunner.Tests/SkeletonFormatSettingsWarmTests.cs
+++ b/AlRunner.Tests/SkeletonFormatSettingsWarmTests.cs
@@ -1,0 +1,59 @@
+// SkeletonFormatSettingsWarmTests - the FormatSettings warm says when it did not warm (#3462).
+//
+// BcRuntime.WarmSkeletonFormatSettings closes the first-touch race on NavSession's lazily
+// built, unlocked FormatSettings dictionary (#3444). Its catch writes a stderr warning, but
+// the body is `(_skeletonSession as NavSession)?.FormatSettings` - so when the skeleton
+// session is null, or is not a NavSession, the null-conditional skipped the warm and NOTHING
+// was written anywhere. The window the warm exists to close was then still open and no output
+// said so. RED against main: the writer is empty on both skip arms.
+using System;
+using System.IO;
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class SkeletonFormatSettingsWarmTests
+{
+    private static string Warm(object? session)
+    {
+        var err = new StringWriter();
+        BcRuntime.WarmSkeletonFormatSettings(session, err);
+        return err.ToString();
+    }
+
+    [Fact]
+    public void Warm_WithNoSkeletonSession_SaysSoRatherThanSkippingSilently()
+    {
+        var written = Warm(null);
+
+        Assert.Contains("FormatSettings warm skipped", written);
+        Assert.Contains("no skeleton session", written);
+    }
+
+    [Fact]
+    public void Warm_WithASessionThatIsNotANavSession_NamesTheTypeItGotInstead()
+    {
+        var written = Warm(new StringBuilderStandIn());
+
+        Assert.Contains("FormatSettings warm skipped", written);
+        Assert.Contains("NavSession", written);
+        Assert.Contains(nameof(StringBuilderStandIn), written);
+    }
+
+    // The control arm. Without it "it always writes something" would satisfy both assertions
+    // above and prove nothing: a warm that actually ran must stay silent, because this runs at
+    // every runner start and a line on the happy path is noise on every single run.
+    [Fact]
+    public void Warm_WithTheRealSkeletonSession_WarmsAndWritesNothing()
+    {
+        // Same trigger TestPageEvaluatorFaultTests uses to make sure the runtime is up.
+        _ = Microsoft.Dynamics.Nav.Runtime.NavDate.Create(
+            DateTime.SpecifyKind(new DateTime(2026, 1, 15), DateTimeKind.Local));
+        Assert.NotNull(BcRuntime.SkeletonSession);
+
+        Assert.Equal(string.Empty, Warm(BcRuntime.SkeletonSession));
+    }
+
+    private sealed class StringBuilderStandIn { }
+}

--- a/AlRunner.Tests/TestPageEvaluatorFaultTests.cs
+++ b/AlRunner.Tests/TestPageEvaluatorFaultTests.cs
@@ -12,6 +12,7 @@
 // RED against main: every arm below that expects BcShapeGapException got `false` instead,
 // because the two catches at the call site returned false for any exception at all.
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using AlRunner;
 using AlRunner.Infrastructure;
@@ -59,11 +60,114 @@ public sealed class TestPageEvaluatorFaultTests
     public void InvokeEvaluate_WhenTheBoundEvaluateRefusesTheArguments_RaisesAVersionMismatch()
     {
         var gap = Assert.Throws<BcShapeGapException>(() => TestPageTemporalValue.InvokeEvaluate(
-            () => throw new ArgumentException("parameter count mismatch")));
+            () => throw new ArgumentException("the argument is of the wrong type")));
 
         Assert.Equal("NavValueEvaluator.Evaluate", gap.Member);
-        Assert.Contains("parameter count mismatch", gap.Detail);
+        Assert.Contains("the argument is of the wrong type", gap.Detail);
         Assert.Contains("version mismatch", gap.Detail);
+    }
+
+    // The two shapes MethodBase.Invoke raises UNWRAPPED that the ArgumentException arm above
+    // does not cover: both derive from ApplicationException, not from ArgumentException, so on
+    // main they propagated raw past every arm (#3462). RED against main: BcShapeGapException
+    // was not thrown - the raw exception came out instead.
+    public static IEnumerable<object[]> UnwrappedInvokeFaults() => new[]
+    {
+        new object[] { new TargetParameterCountException("Parameter count mismatch.") },
+        new object[] { new TargetException("Object does not match target type.") },
+    };
+
+    [Theory]
+    [MemberData(nameof(UnwrappedInvokeFaults))]
+    public void InvokeEvaluate_WhenInvokeItselfRefusesTheCall_RaisesAVersionMismatch(Exception injected)
+    {
+        var gap = Assert.Throws<BcShapeGapException>(
+            () => TestPageTemporalValue.InvokeEvaluate(() => throw injected));
+
+        Assert.Equal("NavValueEvaluator.Evaluate", gap.Member);
+        Assert.Contains(injected.GetType().Name, gap.Detail);
+        Assert.Contains("version mismatch", gap.Detail);
+    }
+
+    // ...and the consequence, on the seam that INVERTS a result. An asserterror around a
+    // SetValue that hits one of these must still fail; before the fix NavMethodScope_AssertError
+    // absorbed the raw exception on its catch-all and the asserterror PASSED.
+    [Theory]
+    [MemberData(nameof(UnwrappedInvokeFaults))]
+    public void InvokeEvaluate_WhenInvokeItselfRefusesTheCall_IsNotSwallowedByAssertError(Exception injected)
+    {
+        var gap = Assert.Throws<BcShapeGapException>(() => BcRuntime.NavMethodScope_AssertError(
+            null!, () => TestPageTemporalValue.InvokeEvaluate(() => throw injected)));
+
+        Assert.Equal("NavValueEvaluator.Evaluate", gap.Member);
+    }
+
+    // ══ The bind path two frames up (#3462) ══════════════════════════════════════════════
+    //
+    // A bind failure means the runner could not ask THIS BC build how it reads a date at all -
+    // a runner/BC-version mismatch, which BcShapeGapException is the type for. It refused with
+    // RunnerOutOfScopeException, which an asserterror absorbs, so `asserterror SetValue(...)`
+    // on a temporal control passed green having measured nothing.
+    //
+    // The bind result latches once per process, so these drive the refusal through the
+    // ForceBindFailure seam rather than by breaking the real binding for the rest of the run.
+
+    [Fact]
+    public void EnsureEvaluatorBound_WhenTheBindFailed_RaisesAShapeGapNamingTheReason()
+    {
+        using (TestPageTemporalValue.ForceBindFailure("NavValueEvaluator not found"))
+        {
+            var gap = Assert.Throws<BcShapeGapException>(TestPageTemporalValue.EnsureEvaluatorBound);
+
+            Assert.Equal("NavValueEvaluator.Evaluate", gap.Member);
+            Assert.Contains("NavValueEvaluator not found", gap.Detail);
+            Assert.Contains("version mismatch", gap.Detail);
+        }
+    }
+
+    [Fact]
+    public void EnsureEvaluatorBound_WhenTheBindFailed_IsNotSwallowedByAssertError()
+    {
+        // RED against main: NavMethodScope_AssertError rethrows only BcShapeGapException and
+        // absorbed the RunnerOutOfScopeException on its catch-all, so this returned normally
+        // and the AL asserterror it stands for passed on a runner fault.
+        using (TestPageTemporalValue.ForceBindFailure("NavValueEvaluator.Evaluate not found"))
+        {
+            var gap = Assert.Throws<BcShapeGapException>(() => BcRuntime.NavMethodScope_AssertError(
+                null!, TestPageTemporalValue.EnsureEvaluatorBound));
+
+            Assert.Equal("TestPage SetValue on a Date/DateTime/Time control", gap.Surface);
+        }
+    }
+
+    [Fact]
+    public void EnsureEvaluatorBound_WhenTheBindFailed_IsNotAbsorbableAsAnOutOfScopeSignal()
+    {
+        // The other half: anything carrying a RunnerOutOfScopeException can be declared away by
+        // an `expect-oos` manifest entry, and which BC build is on disk must never be
+        // declarable as an expected scope boundary.
+        using (TestPageTemporalValue.ForceBindFailure("DataError.TrapError not found"))
+        {
+            var thrown = Record.Exception(TestPageTemporalValue.EnsureEvaluatorBound);
+
+            Assert.NotNull(thrown);
+            Assert.IsNotType<RunnerOutOfScopeException>(thrown);
+            Assert.Null(OutOfScopeMessage.FromException(thrown));
+        }
+    }
+
+    // The seam is a seam, not a switch: with nothing forced, the real bind still decides. On
+    // this build it succeeds, so EnsureEvaluatorBound returns - which is also what makes the
+    // three arms above statements about the refusal rather than about the seam.
+    [Fact]
+    public void EnsureEvaluatorBound_WithNothingForced_StillBindsThisBuildsEvaluator()
+    {
+        using (TestPageTemporalValue.ForceBindFailure("probe")) { }
+
+        TestPageTemporalValue.EnsureEvaluatorBound();
+        Assert.True(TestPageTemporalValue.TryResolve(
+            NavType.Date, "01/15/2026 00:00:00", out var resolved));
+        Assert.NotNull(resolved);
     }
 
     // The one exception shape that IS a refusal. It cannot escape Evaluate under TrapError on

--- a/AlRunner.Tests/TestPageRefusalClaimTests.cs
+++ b/AlRunner.Tests/TestPageRefusalClaimTests.cs
@@ -401,9 +401,11 @@ public sealed class TestPageRefusalClaimTests
         var page = CodeOf("RunnerPageInstance.cs");
 
         Assert.Equal(10, Regex.Matches(mock, @"throw TestPageShapeGap\.").Count);
-        // 3: the SubPageLink FilterType site, plus the two evaluator-fault arms #3444 added -
-        // a fault inside BC's own NavValueEvaluator, and a signature mismatch against it.
-        Assert.Equal(3, Regex.Matches(mock, @"throw new AlRunner\.Infrastructure\.BcShapeGapException\(").Count);
+        // 4: the SubPageLink FilterType site, the two evaluator-fault arms #3444 added - a
+        // fault inside BC's own NavValueEvaluator, and a signature mismatch against it - and
+        // #3462's bind refusal, which claimed testpage-temporal-evaluator under
+        // RunnerOutOfScopeException and was therefore swallowable by an AL asserterror.
+        Assert.Equal(4, Regex.Matches(mock, @"throw new AlRunner\.Infrastructure\.BcShapeGapException\(").Count);
 
         Assert.Equal(4, Regex.Matches(page, @"throw TestPageShapeGap\.").Count);
         Assert.Equal(1, Regex.Matches(page, @"throw new AlRunner\.Infrastructure\.BcShapeGapException\(").Count);

--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -827,7 +827,22 @@ public static partial class BcRuntime
     {
         try
         {
-            _ = (session as Microsoft.Dynamics.Nav.Runtime.NavSession)?.FormatSettings;
+            // Not `(session as NavSession)?.FormatSettings`: the null-conditional made both skip
+            // arms silent, so the first-touch window the warm exists to close stayed open with
+            // nothing saying so (#3462). Stderr rather than a throw — `session` is only null
+            // when the Ncl types were not found, where ApplyAllPatches has already failed and
+            // throwing here would report the symptom instead of the cause.
+            if (session is Microsoft.Dynamics.Nav.Runtime.NavSession navSession)
+            {
+                _ = navSession.FormatSettings;
+                return;
+            }
+
+            err.WriteLine("[BcRuntime] WARN: FormatSettings warm skipped: "
+                + (session == null
+                    ? "no skeleton session, so NavSession.SyncFormatSettings is still unwarmed"
+                    : $"the skeleton session is a {session.GetType().Name}, not a NavSession, "
+                      + "so NavSession.SyncFormatSettings is still unwarmed"));
         }
         catch (Exception ex)
         {

--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -820,14 +820,18 @@ public static partial class BcRuntime
     /// the lazy init before anything can share it removes the first-touch window.</para>
     /// </summary>
     private static void WarmSkeletonFormatSettings()
+        => WarmSkeletonFormatSettings(_skeletonSession, Console.Error);
+
+    /// <summary>The warm itself, taking its session and its output so a test can drive both.</summary>
+    internal static void WarmSkeletonFormatSettings(object? session, System.IO.TextWriter err)
     {
         try
         {
-            _ = (_skeletonSession as Microsoft.Dynamics.Nav.Runtime.NavSession)?.FormatSettings;
+            _ = (session as Microsoft.Dynamics.Nav.Runtime.NavSession)?.FormatSettings;
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine(
+            err.WriteLine(
                 $"[BcRuntime] WARN: FormatSettings warm failed: {ex.GetType().Name}: {ex.Message}");
         }
     }

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -3445,6 +3445,27 @@ internal static class TestPageTemporalValue
 
     private static string? _bindFailure;
 
+    // TEST SEAM (#3462). The bind result latches once per process, so a test cannot provoke a
+    // real bind failure without destroying the binding for every other test in the run. This
+    // makes EnsureEvaluatorBound refuse as though the bind had failed, without touching the
+    // latch. AsyncLocal, not a plain static: xunit runs test classes in parallel and the
+    // temporal suites drive this path concurrently.
+    private static readonly System.Threading.AsyncLocal<string?> ForcedBindFailure = new();
+
+    internal static IDisposable ForceBindFailure(string reason)
+    {
+        var previous = ForcedBindFailure.Value;
+        ForcedBindFailure.Value = reason;
+        return new ForcedBindFailureScope(previous);
+    }
+
+    private sealed class ForcedBindFailureScope : IDisposable
+    {
+        private readonly string? _previous;
+        internal ForcedBindFailureScope(string? previous) => _previous = previous;
+        public void Dispose() => ForcedBindFailure.Value = _previous;
+    }
+
     /// <summary>
     /// Bind BC's evaluator, or THROW.
     ///
@@ -3459,12 +3480,13 @@ internal static class TestPageTemporalValue
     /// </summary>
     internal static void EnsureEvaluatorBound()
     {
-        if (TryBindEvaluator()) return;
+        var forced = ForcedBindFailure.Value;
+        if (forced == null && TryBindEvaluator()) return;
 
         throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
             "TestPage SetValue on a Date/DateTime/Time control",
             "testpage-temporal-evaluator — could not bind BC's own NavValueEvaluator ("
-            + (_bindFailure ?? "reason not recorded") + "), so the runner cannot ask this BC "
+            + (forced ?? _bindFailure ?? "reason not recorded") + "), so the runner cannot ask this BC "
             + "build how it reads a date, time or datetime a test typed as text. This is a "
             + "runner/BC-version mismatch, not a rejected value.");
     }

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -3348,10 +3348,14 @@ internal static class TestPageTemporalValue
                 + $"{inner.Message}), so the runner has no answer from BC about this spelling. "
                 + "This is a runner fault on the evaluate path, not a value BC rejected.");
         }
-        catch (System.ArgumentException ex)
+        catch (Exception ex) when (ex is System.ArgumentException
+                                or System.Reflection.TargetParameterCountException
+                                or System.Reflection.TargetException)
         {
             // Unwrapped, so it came from Invoke itself rather than from BC: the bound Evaluate
-            // does not take the arguments this call site passes.
+            // does not take the arguments this call site passes. The two reflection types are
+            // not ArgumentExceptions — both derive from ApplicationException — so before #3462
+            // they propagated raw past every arm here and an asserterror absorbed them.
             throw new AlRunner.Infrastructure.BcShapeGapException(
                 "TestPage SetValue on a Date/DateTime/Time control",
                 "NavValueEvaluator.Evaluate",
@@ -3467,25 +3471,23 @@ internal static class TestPageTemporalValue
     }
 
     /// <summary>
-    /// Bind BC's evaluator, or THROW.
-    ///
-    /// <para>Not a decline. Declining is what happens when the evaluator runs and BC refuses the
-    /// text, and that is correct — the caller then falls through to its NavText path and BC
-    /// raises its own refusal. A failure to BIND is a different thing entirely: it means this
-    /// runner cannot ask BC at all, on a BC build whose shape it does not recognise. Left as a
-    /// decline it would be invisible, because the typed-argument path keeps working through
-    /// <see cref="TryResolveRoundTrip"/> and only text spellings quietly revert to the
-    /// pre-#3384 refusal — a silent downgrade of exactly the kind loud-failures.md forbids.
-    /// </para>
+    /// Bind BC's evaluator, or THROW — a failure to BIND means the runner cannot ask THIS BC
+    /// build how it reads a date, which is a shape gap and not a decline. Declining would be
+    /// invisible: the typed-argument path keeps working through <see cref="TryResolveRoundTrip"/>
+    /// and only text spellings quietly revert to the pre-#3384 refusal.
     /// </summary>
     internal static void EnsureEvaluatorBound()
     {
         var forced = ForcedBindFailure.Value;
         if (forced == null && TryBindEvaluator()) return;
 
-        throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+        // BcShapeGapException, not RunnerOutOfScopeException: an AL asserterror absorbs the
+        // latter (NavMethodScope_AssertError rethrows only this type), so `asserterror
+        // SetValue(<temporal>)` passed green on a runner that could not ask BC anything (#3462).
+        throw new AlRunner.Infrastructure.BcShapeGapException(
             "TestPage SetValue on a Date/DateTime/Time control",
-            "testpage-temporal-evaluator — could not bind BC's own NavValueEvaluator ("
+            "NavValueEvaluator.Evaluate",
+            "could not bind BC's own NavValueEvaluator ("
             + (forced ?? _bindFailure ?? "reason not recorded") + "), so the runner cannot ask this BC "
             + "build how it reads a date, time or datetime a test typed as text. This is a "
             + "runner/BC-version mismatch, not a rejected value.");


### PR DESCRIPTION
Closes #3462

Corpus-NA: runner fault attribution on a bind failure; no AL-observable BC behaviour changes

Three refusals on the TestPage temporal path attributed a **runner** fault as something an AL
`asserterror` absorbs. `NavMethodScope_AssertError` rethrows only `BcShapeGapException` and
catches everything else, so `asserterror TestPage.MyDateField.SetValue('...')` passed green on a
runner that could not ask BC how this build reads a date - the result is not hidden, it is
inverted.

## What changed

1. **`EnsureEvaluatorBound` (`AlRunner/Patches/MockTestPage.cs`)** - the issue's subject. A
   failure to *bind* `NavValueEvaluator` is a runner/BC-version mismatch, not a scope boundary,
   so it now raises `BcShapeGapException("TestPage SetValue on a Date/DateTime/Time control",
   "NavValueEvaluator.Evaluate", ...)` instead of `RunnerOutOfScopeException`. The reason string
   is unchanged; only the type and the member attribution move.
2. **`InvokeEvaluate`'s unwrapped arm** (reviewer finding (a)) - it caught `ArgumentException`
   only. `MethodBase.Invoke` also raises `TargetParameterCountException` and `TargetException`
   unwrapped, and both derive from `ApplicationException`, so they propagated raw past all three
   arms into the `asserterror` catch-all. One merged filter now covers all three.
3. **`WarmSkeletonFormatSettings` (`AlRunner/BcRuntime.cs`)** (reviewer finding (b)) - the
   null-conditional `(_skeletonSession as NavSession)?.FormatSettings` skipped the warm silently
   on both non-`NavSession` arms, leaving the `SyncFormatSettings` first-touch window that #3444 sealed
   open again with nothing saying so. It now writes one stderr line naming *which* of the
   two. Stderr and not a throw: `_skeletonSession` is only null when `ApplyAllPatches` could not
   find the Ncl types, where the runner has already failed, and throwing here would report the
   symptom instead of the cause. Line 805's existing `AlCallStackCapture.Initialize` guard
   tolerates null on the same path for the same reason.

The existing `InvokeEvaluate_WhenTheBoundEvaluateRefusesTheArguments_RaisesAVersionMismatch`
injected `ArgumentException("parameter count mismatch")`, naming a condition .NET signals with
`TargetParameterCountException`. Its message now names what an `ArgumentException` from `Invoke`
actually is; the parameter-count condition has its own arm.

## The seam, and why one was needed

The issue notes a proving test needs a seam into private latched bind state. `_lookupDone` /
`_evaluate` / `_bindFailure` latch once per process, so a test that provoked a real bind failure
would destroy the binding for every other test in the run.
`TestPageTemporalValue.ForceBindFailure(reason)` returns an `IDisposable` scope that makes
`EnsureEvaluatorBound` refuse as though the bind had failed, without touching the latch. It is an
`AsyncLocal<string?>`, not a plain static, because xunit runs test classes in parallel and the
temporal suites drive `TryResolve` into `EnsureEvaluatorBound` concurrently.

`EnsureEvaluatorBound_WithNothingForced_StillBindsThisBuildsEvaluator` is the control: with
nothing forced the real bind still decides and still succeeds on this build, which is what makes
the other arms statements about the refusal rather than about the seam.
`Warm_WithTheRealSkeletonSession_WarmsAndWritesNothing` is the same control for (3) - a warm that
actually ran must stay silent, since this runs at every runner start.

## RED to GREEN

`dotnet test AlRunner.Tests --filter FullyQualifiedName~TestPageEvaluatorFaultTests|FullyQualifiedName~SkeletonFormatSettingsWarmTests`
against the seams-only commit (`91e47cd5`, behaviour unchanged): **9 failed, 8 passed**, the nine
being exactly the new arms.

- bind path (3 arms) - `RunnerOutOfScopeException` thrown where `BcShapeGapException` was
  expected; the `asserterror`-shaped arm ran the refusal through
  `BcRuntime.NavMethodScope_AssertError(null!, ...)` and it was absorbed.
- unwrapped `Invoke` faults (4 arms, `TargetParameterCountException` and `TargetException` by
  direct and by asserterror) - `Assert.Throws() Failure: Actual: typeof(System.Reflection.TargetParameterCountException)`,
  i.e. the raw exception came out.
- warm skip (2 arms) - the writer was empty on both null and wrong-type sessions.

After the fix, on `b34f357d`: **168 passed, 0 failed** across `TestPageEvaluatorFaultTests`,
`SkeletonFormatSettingsWarmTests`, `TestPageTemporalValueTests`, `TestPageRefusalClaimTests`,
`TestPageBlankTemporalValueTests`, `AssertErrorOutOfScopeCatchabilityTests` and
`BcShapeGapConventionTests`.

`TestPageRefusalClaimTests.AllSixteenCorrectedRefusalsStillExist_...` counts
`throw new AlRunner.Infrastructure.BcShapeGapException(` occurrences in `MockTestPage.cs` and
went 3 to 4; the count is updated with the reason recorded next to it, as that test's own comment
requires. The `docs/scope.md` citation count is untouched - the corrected refusal never cited it.

## Corpus at the pin (`19560bd3`), on this branch

The other session's #3542 (merged `4a72612b`) changed `FlushPendingNewRow` and xRec snapshots in
`MockTestPage.cs` and `RunnerPageInstance*.cs`, so the two codeunits it touches were run here as
well as the temporal one - no interaction:

| codeunit | result |
|---|---|
| `Codeunit60636` "Test Page Trigger Events" | 9/9 PASS, exit 0 |
| `Codeunit60844` "TRT Tests" | 9/9 PASS, exit 0 |
| `Codeunit60670` "Test TestPage Temporal Value" | 10/10 PASS, exit 0 |

Also green: `tools/test_doc_pointers.py`, `tools/test_comment_density.py`.

## Shape questions

**Another call site with the same wrong pattern?** `BindEvaluatorCore`'s `catch (Exception ex)`
downgrades whatever it catches - including a `BcShapeGapException` raised by
`BcShape.FindMethod` - into a `why` string. That is no longer a defect after this change: the
string is rebuilt as a `BcShapeGapException` by `EnsureEvaluatorBound`, so the type survives to
the caller. Before it, the ambiguity guard's own shape gap was demoted to a swallowable refusal.

**A sibling making the same assumption?** Two in `TryEvaluateThroughBc`:
`if (!Enum.IsDefined(_navNclType!, member)) return false` and `if (evaluator == null) return
false`. Both are silent declines on what is really a version gap - BC's `NavNclType` lacking
`NavDate`, or `GetEvaluator` answering null for a type it defines. **Not folded**: neither is
reachable through the `ForceBindFailure` seam, both would need their own, and neither has an
issue. Flagged here rather than corrected untested.

**Two paths writing the same state, one guard?** `EnsureEvaluatorBound` and `InvokeEvaluate` are
the only two refusal paths on this surface and they now agree on type, surface and member.

**Open-issue queue for this file.** #3479 (`TryGetControlFormat`'s bare catch) is the closest
shape - same "silent skip is indistinguishable from a legitimate empty answer" family - but it
lands in `RunnerPageInstance.cs`, not `MockTestPage.cs`, and is untriaged. Not folded. #3339,
#3029, #3504, #3518, #3179 and #2457 all touch `MockTestPage.cs`'s surface but each needs
materially different reasoning (action lookup, `OnNewRecord` double-fire, `Editable()`,
TableRelation lookup) - separate diffs. **#2871 is deliberately untouched**: this argues one
specific refusal is misclassified, not that `RunnerOutOfScopeException` should stop being
catchable, and `PermanentTestPageRefusal_IsStillCatchableByAssertError` still pins that row.

**Where the prose went.** No comment block over ten lines was added. `EnsureEvaluatorBound`'s
12-line doc comment was cut to four; what it explained about the decline-vs-throw distinction is
in "What changed" above.

Implementation agent fbk-1, an automated agent acting on the account holder's behalf.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPJecKgfS4YFcpXSQr2tqb
