### PR TITLE
fix(allobj): answer the *extension kinds' Object Subtype with the target object's id

### DIFF
--- a/AlRunner.Tests/AllObjWithCaptionObjectSubtypeTests.cs
+++ b/AlRunner.Tests/AllObjWithCaptionObjectSubtypeTests.cs
@@ -166,4 +166,97 @@ public class AllObjWithCaptionObjectSubtypeTests
         Assert.Equal("NormalX", RecordPatches.ObjectSubtypeTextFor("Codeunit", "NormalX"));
         Assert.Equal("Abnormal", RecordPatches.ObjectSubtypeTextFor("Codeunit", "Abnormal"));
     }
+
+    // ----------------------------------------------------------------------------------
+    // Issue #3392 — the five *extension kinds, whose rule differs in KIND and not in value:
+    // BC answers the TARGET OBJECT'S ID as a decimal string, never a type name.
+    //
+    // The BC-behaviour claim is asserted upstream (corpus PR
+    // StefanMaron/BusinessCentral.AL.Language.Tests#291). What is pinned here is the
+    // runner-local mapping deciding WHICH id namespace each kind's target is resolved in.
+    // Getting that wrong does not fail loudly: AL gives every object kind its own id
+    // namespace, so resolving a pageextension's target among tables answers a plausible
+    // WRONG NUMBER rather than nothing — the hazard TryGetObjectNameOfKind exists for in
+    // the other direction (#2943), here in the direction nothing was guarding.
+    // ----------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("PageExtension", "Page")]
+    [InlineData("TableExtension", "Table")]
+    [InlineData("EnumExtension", "Enum")]
+    [InlineData("PermissionSetExtension", "PermissionSet")]
+    [InlineData("ReportExtension", "Report")]
+    public void ExtensionKind_ResolvesItsTargetInThatKindsOwnNamespace(string kind, string targetKind)
+    {
+        Assert.Equal(targetKind, RecordPatches.ExtensionTargetObjectKind(kind));
+    }
+
+    [Theory]
+    [InlineData("pageextension")]
+    [InlineData("PAGEEXTENSION")]
+    [InlineData("PageExtension")]
+    public void ExtensionKindMatch_IsSpellingInsensitive(string kind)
+    {
+        // Same NormalizeObjectTypeName route as the codeunit rule above. A spelling
+        // mismatch here would leave the column empty, which is indistinguishable from the
+        // pre-fix behaviour and so would pass every "is it non-empty" style check.
+        Assert.Equal("Page", RecordPatches.ExtensionTargetObjectKind(kind));
+    }
+
+    [Theory]
+    // NOT every kind whose name ends in "Extension". These two are the reason the mapping
+    // is an explicit list rather than a suffix test:
+    //   * QueryExtension is absent from BC's shared switch arm AND from
+    //     AllObjWithCaption's own "Object Type" option set.
+    //   * ProfileExtension IS in that option set but is NOT in the switch arm, so BC
+    //     leaves it on the initial `string.Empty`.
+    [InlineData("QueryExtension")]
+    [InlineData("ProfileExtension")]
+    // ...and the kinds that carry a real subtype must not be diverted into id resolution.
+    [InlineData("Table")]
+    [InlineData("Page")]
+    [InlineData("Query")]
+    [InlineData("Codeunit")]
+    [InlineData("Report")]
+    [InlineData("XMLport")]
+    [InlineData("Enum")]
+    public void KindsBcDoesNotAnswerWithATargetId_HaveNoTargetNamespace(string kind)
+    {
+        Assert.Null(RecordPatches.ExtensionTargetObjectKind(kind));
+    }
+
+    [Fact]
+    public void ExtensionWithAnUnresolvableTarget_IsEmptyRatherThanEchoingTheName()
+    {
+        // BC's arm ends in `?? string.Empty` — a target the app group cannot summarise
+        // yields the empty string. The runner must do the same rather than fall through to
+        // the non-extension path, which would put the target's NAME in a column whose value
+        // is documented to be an id. No object of any kind carries this name, so nothing
+        // resolves and the fallback is what is being read.
+        Assert.Equal(
+            string.Empty,
+            RecordPatches.ObjectSubtypeTextFor("TableExtension", "AXS No Such Object Anywhere"));
+    }
+
+    [Fact]
+    public void ExtensionDeclaringNoTarget_IsEmpty()
+    {
+        // Null and empty reach here from an extension whose target the parse could not read.
+        Assert.Equal(string.Empty, RecordPatches.ObjectSubtypeTextFor("PageExtension", null));
+        Assert.Equal(string.Empty, RecordPatches.ObjectSubtypeTextFor("PageExtension", string.Empty));
+    }
+
+    [Fact]
+    public void ExtensionKindDoesNotTakeTheCodeunitNormalRule()
+    {
+        // A tableextension over a table literally named "Normal" resolves as a name like any
+        // other. Written because the codeunit blanking test sits directly above this one and
+        // is the edit most likely to be widened by mistake; the empty answer here is the
+        // unresolvable-target fallback, NOT the Normal rule, which is why the assertion
+        // below distinguishes them.
+        Assert.Equal(string.Empty, RecordPatches.ObjectSubtypeTextFor("TableExtension", "Normal"));
+        // The codeunit rule, by contrast, blanks the WORD without consulting any inventory —
+        // so it still blanks it when an object of that name would have resolved.
+        Assert.Equal(string.Empty, RecordPatches.ObjectSubtypeTextFor("Codeunit", "Normal"));
+    }
 }

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -677,9 +677,14 @@ internal static partial class BcAppSymbolCache
     /// at their defaults — which is also what a codeunit declaring none of them means.
     /// <c>TableNo</c> is the reference AS WRITTEN (a bare id in text form, or a table name);
     /// resolving it to an id needs the run's table inventory, so the consumer does that.</para>
+    /// <para><c>TargetObjectName</c> is populated for the *extension kinds only — the object
+    /// the extension extends, module qualifier stripped, name AS STATED. AllObjWithCaption's
+    /// Object Subtype reports its ID for those kinds; see
+    /// docs/virtual-tables-allobj.md#object-subtype.</para>
     /// </summary>
     internal sealed record ObjectSymbol(string Kind, int Id, string Name, string? Caption = null,
-        string? TableNo = null, bool SingleInstance = false, string? Subtype = null);
+        string? TableNo = null, bool SingleInstance = false, string? Subtype = null,
+        string? TargetObjectName = null);
 
     // SymbolReference.json container name → the AllObj "Object Type" option name the
     // objects inside it map to. Matched against the live option string by name, so a
@@ -1099,7 +1104,8 @@ internal static partial class BcAppSymbolCache
                         Subtype: string.IsNullOrWhiteSpace(cuSubtype) ? null : cuSubtype.Trim()));
                     continue;
                 }
-                objects.TryAdd((kind, objId), new ObjectSymbol(kind, objId, objName, objCaption));
+                objects.TryAdd((kind, objId), new ObjectSymbol(kind, objId, objName, objCaption,
+                    TargetObjectName: ExtensionTargetName(kind, el)));
             }
         }
 
@@ -1322,6 +1328,30 @@ internal static partial class BcAppSymbolCache
 
         return new PageExtensionSymbol(extId, name!, StripModuleQualifierPrefix(target!),
             memberNames, actionRefTargets, runObjects);
+    }
+
+    /// <summary>
+    /// The object an *extension symbol extends, as the .app's SymbolReference.json states it,
+    /// with any <c>#&lt;appid&gt;#</c> module qualifier stripped. Null for a non-extension kind
+    /// and when the file states no target.
+    ///
+    /// <para>MEASURED against Base Application 28.1, because the compiler does NOT spell this
+    /// one element the same way in every container: <c>TableExtensions</c> (90),
+    /// <c>PageExtensions</c> (156), <c>EnumExtensionTypes</c> (39) and
+    /// <c>PermissionSetExtensions</c> (55) all carry <c>TargetObject</c> and every entry has
+    /// one — while all 14 <c>ReportExtensions</c> carry <c>Target</c> instead and NOT ONE
+    /// carries <c>TargetObject</c>. Reading only the first spelling leaves every
+    /// reportextension's target null, which reaches AllObjWithCaption as an empty Object
+    /// Subtype and looks exactly like the gap this exists to close. Both are NAMES; neither is
+    /// an id.</para>
+    /// </summary>
+    private static string? ExtensionTargetName(string kind, JsonElement el)
+    {
+        if (!kind.EndsWith("Extension", StringComparison.Ordinal)) return null;
+        var target = el.TryGetProperty("TargetObject", out var t) ? t.GetString() : null;
+        if (string.IsNullOrWhiteSpace(target))
+            target = el.TryGetProperty("Target", out var t2) ? t2.GetString() : null;
+        return string.IsNullOrWhiteSpace(target) ? null : StripModuleQualifierPrefix(target.Trim());
     }
 
     /// <summary>

--- a/AlRunner/Patches/RecordPatches.AlObjectDeclParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlObjectDeclParser.cs
@@ -89,7 +89,14 @@ public static partial class RecordPatches
                     TestHttpRequestPolicy: DeclaredIdentifierText(PropValue(props, "TestHttpRequestPolicy")));
                 continue;
             }
-            _parsedObjectDecls[(kind, id)] = new ParsedAlObjectDecl(kind, id, name);
+            // All five *extension kinds AL declares here derive from one syntax base carrying
+            // `BaseObject`, so the target is read once rather than per kind — a new extension
+            // kind is picked up without a further arm. AS WRITTEN: the id it names is resolved
+            // against the run's object inventory, which does not exist yet at parse time.
+            _parsedObjectDecls[(kind, id)] = new ParsedAlObjectDecl(kind, id, name,
+                BaseObjectName: obj is NavSyntax.ApplicationObjectExtensionSyntax ext
+                    ? LastNameSegment(ext.BaseObject?.ToString()?.Trim())
+                    : null);
         }
     }
 
@@ -125,8 +132,11 @@ public static partial class RecordPatches
 /// them means. <paramref name="TableNo"/> is the reference AS WRITTEN (a bare id in text form,
 /// or a table name) — resolving it to an id needs the run's table inventory, which does not
 /// exist yet at parse time.
+/// <para><paramref name="BaseObjectName"/> is the `extends` target of an *extension kind, also
+/// as WRITTEN and for the same reason; null for a non-extension. See
+/// docs/virtual-tables-allobj.md#object-subtype for what reads it.</para>
 /// </summary>
 internal record ParsedAlObjectDecl(
     string Kind, int Id, string Name,
     string? TableNo = null, bool SingleInstance = false, string? Subtype = null,
-    string? TestHttpRequestPolicy = null);
+    string? TestHttpRequestPolicy = null, string? BaseObjectName = null);

--- a/AlRunner/Patches/RecordPatches.AlReportParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlReportParser.cs
@@ -58,7 +58,13 @@ public static partial class RecordPatches
                 // (ProcessingOnly=true) into a layout-bound report → OOS at run.
                 case NavSyntax.ReportExtensionSyntax rx when ObjectIdOf(rx) is int extId:
                     _parsedReportExtensions[extId] = new ParsedReport(
-                        extId, IdentText(rx.Name), IsExtension: true, ProcessingOnly: false);
+                        extId, IdentText(rx.Name), IsExtension: true, ProcessingOnly: false)
+                    {
+                        // The `extends` target, AS WRITTEN — AllObjWithCaption's Object
+                        // Subtype reports its ID for a reportextension; see
+                        // docs/virtual-tables-allobj.md#object-subtype.
+                        BaseObjectName = LastNameSegment(rx.BaseObject?.ToString()?.Trim()),
+                    };
                     break;
             }
         }
@@ -137,6 +143,9 @@ internal record ParsedReport(int Id, string Name, bool IsExtension, bool Process
 
     /// <summary>Data-item tree, flattened in declaration order. Empty for processing-only reports.</summary>
     public List<ParsedReportDataItem> DataItems { get; init; } = new();
+
+    /// <summary>The object a reportextension extends, as written; null for a plain report.</summary>
+    public string? BaseObjectName { get; init; }
 }
 
 /// <summary>

--- a/AlRunner/Patches/RecordPatches.AllObjVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AllObjVirtualTable.cs
@@ -209,15 +209,19 @@ public static partial class RecordPatches
             // ParsedPage.PageType already carries AL's own default ("Card") for a page
             // declaring none, applied at parse time — the same value Page Metadata reports.
             yield return ("Page", p.Id, p.Name, SourceCaptionFor("Page", p.Id), p.PageType);
+        // The *extension kinds hand their `extends` TARGET NAME through the subtype slot;
+        // ObjectSubtypeTextFor resolves it to the id BC reports. See that method, and
+        // docs/virtual-tables-allobj.md#object-subtype.
         foreach (var p in _parsedPageExtensions.Values)
-            yield return ("PageExtension", p.Id, p.Name, SourceCaptionFor("PageExtension", p.Id), null);
+            yield return ("PageExtension", p.Id, p.Name, SourceCaptionFor("PageExtension", p.Id), p.BaseName);
         foreach (var r in _parsedReports.Values)
             // SourceCaptionFor("Report", …) reads r.Caption itself — AlReportParser is the
             // only pass that parses a report's Caption (#1714). Going through the same
             // accessor as every other kind is what keeps that single source uniform.
             yield return ("Report", r.Id, r.Name, SourceCaptionFor("Report", r.Id), null);
         foreach (var r in _parsedReportExtensions.Values)
-            yield return ("ReportExtension", r.Id, r.Name, SourceCaptionFor("ReportExtension", r.Id), null);
+            yield return ("ReportExtension", r.Id, r.Name, SourceCaptionFor("ReportExtension", r.Id),
+                r.BaseObjectName);
         foreach (var q in _parsedQueries.Values)
         {
             var kind = q.IsExtension ? "QueryExtension" : "Query";
@@ -227,9 +231,12 @@ public static partial class RecordPatches
             yield return ("XMLport", x.Id, x.Name, SourceCaptionFor("XMLport", x.Id), null);
         // Codeunits / enums / *extension kinds — see RecordPatches.AlObjectDeclParser.cs.
         // ParsedAlObjectDecl.Subtype is populated for Codeunit only and is null for a
-        // codeunit declaring none, which is exactly what BC blanks (Normal → empty).
+        // codeunit declaring none, which is exactly what BC blanks (Normal → empty);
+        // BaseObjectName for the *extension kinds only. The two never coexist on one
+        // declaration, so one slot carries whichever the kind has.
         foreach (var d in _parsedObjectDecls.Values)
-            yield return (d.Kind, d.Id, d.Name, SourceCaptionFor(d.Kind, d.Id), d.Subtype);
+            yield return (d.Kind, d.Id, d.Name, SourceCaptionFor(d.Kind, d.Id),
+                d.Subtype ?? d.BaseObjectName);
         // Enums registered by the emit pipeline and by dependency .app scans.
         foreach (var e in AlEnumMetadataRegistry.Snapshot())
             yield return ("Enum", e.Id, e.Name, SourceCaptionFor("Enum", e.Id), null);
@@ -270,7 +277,10 @@ public static partial class RecordPatches
             // ObjectSymbol.Subtype is populated for Codeunit only; null means the symbol file
             // stated none, which is Normal, which BC blanks.
             "codeunit" => o.Subtype,
-            _ => null,
+            // The *extension kinds: the TARGET NAME, which ObjectSubtypeTextFor resolves to
+            // the id BC reports. ObjectSymbol.TargetObjectName is populated for those kinds
+            // alone, so this arm needs no kind list of its own to keep in step with BC's.
+            _ => o.TargetObjectName,
         };
 
     // Table type by id across the registered dependency .apps. Built once per run: the walk

--- a/AlRunner/Patches/RecordPatches.AllObjWithCaptionVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AllObjWithCaptionVirtualTable.cs
@@ -157,14 +157,30 @@ public static partial class RecordPatches
     /// <para>Observably equivalent to AllObjWithCaptionDataProvider.GetCaptionAndSubtype: a
     /// per-kind switch answering the member name, except that a CODEUNIT whose subtype is
     /// <c>Normal</c> answers the empty string — a table or query whose type is Normal
-    /// answers the word. Editing this method without that asymmetry in hand gets it wrong in
-    /// two directions at once. Per-kind table, the decompiled bodies, why <c>Install</c>
-    /// lands on empty, and the five *extension kinds this deliberately leaves empty:
-    /// see docs/virtual-tables-allobj.md#object-subtype.</para>
+    /// answers the word — and the five *extension kinds answer the TARGET OBJECT'S ID as a
+    /// decimal string instead of any name at all. Editing this method without both of those
+    /// in hand gets it wrong in several directions at once. Per-kind table, the decompiled
+    /// bodies, and why <c>Install</c> lands on empty: see
+    /// docs/virtual-tables-allobj.md#object-subtype.</para>
     /// </summary>
     internal static string ObjectSubtypeTextFor(string kind, string? subtype)
     {
         if (string.IsNullOrEmpty(subtype)) return string.Empty;
+
+        // The *extension kinds: `subtype` is the TARGET NAME the inventory carried, not a
+        // subtype. BC reads TargetObjectId off the app group's object summary and renders it
+        // invariantly; the runner has no app-group summary, so it resolves the same target
+        // through the object inventory it does have. An unresolvable target answers the empty
+        // string, which is BC's own `?? string.Empty` on that arm rather than a runner
+        // invention.
+        if (ExtensionTargetObjectKind(kind) is string targetKind)
+        {
+            var targetId = ResolveObjectIdOfKindByName(targetKind, subtype);
+            return targetId > 0
+                ? targetId.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                : string.Empty;
+        }
+
         if (NormalizeObjectTypeName(kind) != "codeunit") return subtype;
 
         // What the COMPILER wrote, not what the author declared — the same translation, in
@@ -179,6 +195,102 @@ public static partial class RecordPatches
         return string.Equals(effective, AlDefaultCodeunitSubtype, StringComparison.OrdinalIgnoreCase)
             ? string.Empty
             : effective;
+    }
+
+    /// <summary>
+    /// For one of the five object kinds BC answers with a target id, the kind that target is
+    /// resolved in; null for every other kind.
+    ///
+    /// <para>The mapping is the point: AL gives every object kind its OWN id namespace, so a
+    /// pageextension's target must be looked up among PAGES and a tableextension's among
+    /// TABLES. Resolving by name alone answers whichever object happens to match first, which
+    /// is a plausible wrong number rather than a failure — the same hazard
+    /// TryGetObjectNameOfKind exists for in the other direction (#2943).</para>
+    /// <para>The set is BC's, taken from GetCaptionAndSubtype's shared switch arm, NOT
+    /// "every kind whose name ends in Extension": <c>QueryExtension</c> is absent from that
+    /// arm and from AllObjWithCaption's own Object Type option set, and
+    /// <c>ProfileExtension</c> is in the option set but not in the arm. Both therefore keep
+    /// the empty string.</para>
+    /// </summary>
+    internal static string? ExtensionTargetObjectKind(string kind)
+        => NormalizeObjectTypeName(kind) switch
+        {
+            "pageextension" => "Page",
+            "tableextension" => "Table",
+            "enumextension" => "Enum",
+            "permissionsetextension" => "PermissionSet",
+            "reportextension" => "Report",
+            _ => null,
+        };
+
+    /// <summary>
+    /// The id of the object named <paramref name="objectName"/> WITHIN the kind
+    /// <paramref name="kind"/>, or -1 when this run knows no such object.
+    ///
+    /// <para>Deliberately not <c>ResolveObjectIdByKindAndName</c>, which is otherwise the same
+    /// question: that one walks <see cref="EnumerateKnownAlObjects"/>, and every caller of this
+    /// method is ITSELF inside that walk — building an AllObjWithCaption row from an inventory
+    /// item. Re-entering a running iterator over the same dictionaries is what
+    /// <c>InvalidOperationException: Collection was modified</c> is made of, because
+    /// ResolveTableIdByName writes to <c>_parsedTables</c> when it faults a dependency table
+    /// in. So this reads the per-kind dictionaries directly and never the shared walk.</para>
+    /// <para>Name comparison is exact and case-insensitive, matching how the dependency page
+    /// index and BuildObjectIndexes compare — never the space-stripping NamesEqual, which
+    /// would let "Item Attribute" and a hypothetical "ItemAttribute" answer for each other.</para>
+    /// </summary>
+    private static int ResolveObjectIdOfKindByName(string kind, string objectName)
+    {
+        if (string.IsNullOrWhiteSpace(objectName)) return -1;
+
+        static bool Same(string? a, string b) => string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+
+        switch (NormalizeObjectTypeName(kind))
+        {
+            case "table":
+                foreach (var t in _parsedTables.Values)
+                    if (Same(t.TableName, objectName)) return t.TableId;
+                foreach (var t in EnumerateBcAppTableSymbols())
+                    if (Same(t.TableName, objectName)) return t.TableId;
+                return -1;
+            case "page":
+                foreach (var p in _parsedPages.Values)
+                    if (Same(p.Name, objectName)) return p.Id;
+                return ResolveDependencyObjectIdByName("Page", objectName);
+            case "report":
+                foreach (var r in _parsedReports.Values)
+                    if (Same(r.Name, objectName)) return r.Id;
+                return ResolveDependencyObjectIdByName("Report", objectName);
+            case "enum":
+                // AlEnumMetadataRegistry already merges this bundle's own enums with those
+                // scanned out of dependency .apps, so it needs no dependency fallback.
+                foreach (var e in AlEnumMetadataRegistry.Snapshot())
+                    if (Same(e.Name, objectName)) return e.Id;
+                return -1;
+            case "permissionset":
+                foreach (var d in _parsedObjectDecls.Values)
+                    if (NormalizeObjectTypeName(d.Kind) == "permissionset" && Same(d.Name, objectName))
+                        return d.Id;
+                return ResolveDependencyObjectIdByName("PermissionSet", objectName);
+            default:
+                return -1;
+        }
+    }
+
+    /// <summary>
+    /// The id of a precompiled dependency object of <paramref name="kind"/> named
+    /// <paramref name="objectName"/>, read off the registered .apps' flat object lists. -1
+    /// when none matches. Used only for the kinds with no dedicated per-kind dependency index.
+    /// </summary>
+    private static int ResolveDependencyObjectIdByName(string kind, string objectName)
+    {
+        var wanted = NormalizeObjectTypeName(kind);
+        foreach (var (_, symbols) in EnumerateRegisteredBcAppSymbols("extension target (AllObjWithCaption)"))
+            foreach (var o in symbols.Objects)
+                if (o.Id > 0
+                    && NormalizeObjectTypeName(o.Kind) == wanted
+                    && string.Equals(o.Name, objectName, StringComparison.OrdinalIgnoreCase))
+                    return o.Id;
+        return -1;
     }
 
     private static Dictionary<string, int>? _awcObjectTypeOrdinals;

--- a/docs/virtual-tables-allobj.md
+++ b/docs/virtual-tables-allobj.md
@@ -103,15 +103,55 @@ Both codeunit sources state the *declared* property, so `ObjectSubtypeTextFor` a
 A `null` from any of those means "declares none", which the AL defaults turn into `Normal`
 for a table or query and into the empty string for a codeunit — matching BC.
 
-### Known gap: the five *extension kinds
+### The five *extension kinds: the target object's id (#3392)
 
 BC answers a `PageExtension` / `TableExtension` / `EnumExtension` /
 `PermissionSetExtension` / `ReportExtension` row's Object Subtype with the **target
-object's id** as a decimal string, read from `NavAppGroup.GetObjectSummary`. The runner has
-no equivalent of that app-group object summary, so those kinds carry a null subtype through
-the inventory and land on the empty string — the value they had before #2326.
+object's id** as a decimal string, read from `NavAppGroup.GetObjectSummary`. This section
+described that as a known gap until #3392; it is now implemented, and what follows is how.
 
-This is deliberate rather than overlooked. The runner does resolve extension targets
-elsewhere, but that is a different fact reached a different way, and writing it into this
-column would put a value there that BC derives from a structure the runner does not model.
-Tracked separately; see the issue linked from the PR that added this document.
+The runner models no app-group object summary, so it cannot copy BC's route. What it does
+instead is resolve **the same target** through the object inventory it already has, in two
+steps that are deliberately separate:
+
+1. **The inventory carries the target NAME.** Every extension's `extends` target reaches
+   `EnumerateKnownAlObjects` through the same slot that carries a subtype for the other
+   kinds — the two never coexist on one object, so one slot serves both. Source-parsed
+   extensions read it off `ApplicationObjectExtensionSyntax.BaseObject`, which all five AL
+   extension node types derive from; precompiled ones read it off the `.app`'s
+   `SymbolReference.json` (see the spelling note below).
+2. **`ObjectSubtypeTextFor` resolves that name to an id**, in the target kind's **own id
+   namespace** — `ExtensionTargetObjectKind` is the mapping, and it is the part worth
+   reading before editing. AL gives every object kind a separate id namespace, so
+   resolving a pageextension's target among tables answers a plausible **wrong number**
+   rather than nothing.
+
+An unresolvable target answers the empty string, which is BC's own `?? string.Empty` on
+that arm rather than a runner invention.
+
+**The mapping is BC's list, not a suffix test.** `QueryExtension` is absent from BC's
+switch arm *and* from AllObjWithCaption's Object Type option set; `ProfileExtension` is in
+the option set but not in the arm. Both therefore keep the empty string, and
+`AllObjWithCaptionObjectSubtypeTests` pins both — a `kind.EndsWith("Extension")`
+simplification fails on exactly those two.
+
+#### One element the AL compiler does not spell consistently
+
+Measured against Base Application 28.1, because this is the trap that makes a
+reportextension look like an unfixed gap:
+
+| container | count | target element |
+|---|---|---|
+| `TableExtensions` | 90 | `TargetObject` |
+| `PageExtensions` | 156 | `TargetObject` |
+| `EnumExtensionTypes` | 39 | `TargetObject` |
+| `PermissionSetExtensions` | 55 | `TargetObject` |
+| **`ReportExtensions`** | **14** | **`Target`** — not one carries `TargetObject` |
+
+Both are names, neither is an id. `BcAppSymbolCache.ExtensionTargetName` reads
+`TargetObject` and falls back to `Target` for that reason; reading only the first spelling
+leaves every reportextension's target null, which reaches this column as an empty Object
+Subtype and is indistinguishable from the pre-fix behaviour.
+
+The BC-behaviour claim is adjudicated upstream in corpus codeunit 60802
+`"Test AllObj Virtual Table"`.


### PR DESCRIPTION
Closes #3392

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/291

`AllObjWithCaption` (2000000058) field 30 carried a real subtype for tables, pages, queries and codeunits after #3391, and stayed **empty for the five `*extension` kinds** — `PageExtension`, `TableExtension`, `EnumExtension`, `PermissionSetExtension`, `ReportExtension`. BC answers those with the **id of the object the extension extends**, as a decimal string: a rule that differs in *kind* from every other row on this table, not merely in value.

## The rule, and where the runner gets it from

From `AllObjWithCaptionDataProvider.GetCaptionAndSubtype` (Ncl.dll, BC 28.1), where all five share one switch arm reading `TargetObjectId` off `NavAppGroup.GetObjectSummary`.

The runner models no app-group object summary — that is exactly why #3391 left this out rather than guessing. So it resolves **the same target** through the object inventory it already has, in two deliberately separate steps:

1. **The inventory carries the target NAME**, through the same slot that carries a subtype for the other kinds; the two never coexist on one object. Source-parsed extensions read it off `ApplicationObjectExtensionSyntax.BaseObject` — all five AL extension node types derive from it, so a future extension kind needs no further arm — and precompiled ones read it off the `.app`'s `SymbolReference.json`.
2. **`ObjectSubtypeTextFor` resolves that name to an id in the target kind's OWN id namespace.** AL gives every object kind a separate namespace, so resolving a pageextension's target among tables answers a plausible **wrong number** rather than nothing — the hazard `TryGetObjectNameOfKind` exists for in the other direction (#2943), here in the direction nothing was guarding.

An unresolvable target answers the empty string, which is BC's own `?? string.Empty` on that arm rather than a runner invention.

## Two things pinned because a later tidy-up would remove either

**1. The kind mapping is BC's explicit list, not `kind.EndsWith("Extension")`.** `QueryExtension` is absent from BC's switch arm *and* from AllObjWithCaption's own Object Type option set; `ProfileExtension` is in the option set but not in the arm. Both keep the empty string. I wrote the suffix simplification and ran it: it fails four tests, including both of those.

**2. The AL compiler does not spell the target element consistently.** Measured on Base Application 28.1:

| container | count | target element |
|---|---|---|
| `TableExtensions` | 90 | `TargetObject` |
| `PageExtensions` | 156 | `TargetObject` |
| `EnumExtensionTypes` | 39 | `TargetObject` |
| `PermissionSetExtensions` | 55 | `TargetObject` |
| **`ReportExtensions`** | **14** | **`Target`** — not one carries `TargetObject` |

Both are names, neither is an id. Reading only the first spelling leaves every reportextension's target null, which reaches this column as an empty Object Subtype — **indistinguishable from the bug being fixed**, and green on every check that only asks "is it non-empty for some kind". `ExtensionTargetName` reads both.

`ObjectSymbol` gains `TargetObjectName`, a `CachePayload`-reachable member, so the structural `PayloadShape` fingerprint changes the cache key on its own. No `CacheVersion` bump: that integer is reserved for a parse change the shape cannot see.

## RED → GREEN

Both probes were taken against a **clean `origin/main` worktree that was actually built** — not `--no-build`, which silently reruns the previous binary and hands back a "baseline" identical to the branch.

**Probe A — a bundle declaring all five extension kinds** (two tableextensions over different tables, a pageextension, an enumextension, a reportextension, a permissionsetextension, plus a plain table and a plain report as controls):

- **RED: 2 pass / 6 fail.** Every failure `expected <NNNNN> but got <>`. The two that passed are the negative controls — a plain table still reports `Normal`, a plain report still empty — which is precisely what an always-empty implementation passes, and what makes the six failures proof.
- **GREEN: 8 pass / 0 fail.**

**Probe B — extensions whose target is in another app**, plus Base Application's *own* precompiled `tableextension 705` (→ 700) and `reportextension 929` (→ 302):

- **RED: 0 pass / 4 fail.** **GREEN: 4 pass / 0 fail.**

Probe B is the only one reaching the dependency-symbol arm, and its reportextension case is the only one reaching the `Target` spelling above.

**The mechanism test** (`AlRunner.Tests/AllObjWithCaptionObjectSubtypeTests.cs`, 26 → 46 tests) was RED-checked against the suffix-test implementation described above: **4 failed**, and the four were exactly `QueryExtension`, `ProfileExtension` and the two spelling-insensitivity cases. It does not pass against the plausible wrong version.

## Sibling scan

- **#3106** — the *same switch arm's* `guid` half (`App ID` / `App Runtime Package ID` on this table), same file, same `BuildAllObjWithCaptionValue`. **Not folded**, for the reason #3391 already declined it: its own body says three of its four questions are unanswered BC-behaviour questions needing a service tier first, and `App ID` has no counterpart in `AllObj` for the runner to copy. Folding it would mean guessing three values in the PR that exists to stop guessing one.
- **#2279** (one app group listing another's objects) concerns *which rows exist*; this changes only a column's value and adds no rows, so neither affects the other.
- **Call-site check:** `ObjectSubtypeTextFor` and `DependencyObjectSubtype` each have exactly one production call site, so there is no sibling site making the same assumption. The two row sources — source-parsed and dependency-symbol — now maintain the same invariant, which is the third question worth asking here: before this, only one of them could have carried a target at all.

## Corpus PR — already adjudicated on 8 legs

[StefanMaron/BusinessCentral.AL.Language.Tests#291](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/291), five tests on codeunit 60802, **no new fixtures**. All 16 legs green, and — because a green tick is not evidence that anything ran — `tools/corpus-pass-count.py 34231824621 AllObjWithCaption_` reports **14 distinct PASS on each of the eight required cloud legs** (9 pre-existing + 5 new, `0 had failures`), with the five new names read individually off the BC 28.4 job log. The eight OnPrem zeros are that leg's 29-test suite, the documented `not-run` case.

I also labelled it `run-nightly-windows`, so the official Microsoft Windows container adjudicates it too (run `34233312234`) — a signal, not a gate.

**This PR must not merge before that one.** The pin bump is not folded in here because the corpus PR has not merged yet; the proving test on this side is the runner-local mechanism test, which pins the runner's C# rule rather than restating the BC claim.

## What is still not answered

`PermissionSetExtension` and `ReportExtension` are implemented and covered by probe A/B, but **not** adjudicated upstream: the corpus app declares no fixture of either kind, so asserting a value for them there would have been a guess, and asserting the empty string would have encoded the pre-fix behaviour as the expectation. The implementation follows BC's shared switch arm, which treats all five identically; that is the evidence for those two, and it is weaker than the measurement backing the other three.

## Where the prose went

The derivation, the per-kind table and the `Target`/`TargetObject` measurement are in `docs/virtual-tables-allobj.md#object-subtype` (its "Known gap" section is rewritten into how it works). The code carries the namespace hazard at the line that would get it wrong, and a `see docs/...` pointer for the rest.

## Tests run

- `--filter FullyQualifiedName~AllObjWithCaptionObjectSubtypeTests` — **46/46**.
- `--filter` over `AllObj|BcAppSymbolCache|ObjectDecl|ReportMetadata|DependencySymbol|BcMatrixDocumentationDrift` — **135 passed, 0 failed**, 1 skipped. Re-run after the rebase onto `main`, not carried across it.
- `tests/runner-extras/object-metadata-system-table` + `object-system-table` + `report-precompiled-dep-metadata` — **11/11**.
- Both AL probes above, RED and GREEN, re-confirmed after the rebase.

Not run: the full `AlRunner.Tests` suite and the full corpus. Both are CI's job.

---

Written by agent `stma-auto-3`, an automated implementation agent acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsJY7DhDm5y83e77GxpRSZ
