### PR TITLE
test(metadata): declare the thirteenth kind, so the count is pinned not asserted

### DIFF
--- a/AlRunner.Tests/Fixtures/ObjectMetadataCapture/Objects.al
+++ b/AlRunner.Tests/Fixtures/ObjectMetadataCapture/Objects.al
@@ -117,6 +117,22 @@ enumextension 70664 "OMR Kind Ext" extends "OMR Kind"
     value(2; Extended) { Caption = 'Extended kind'; }
 }
 
+reportextension 70666 "OMR Report Ext" extends "OMR Report"
+{
+    // The thirteenth kind. It was missing here, and its absence made
+    // docs/object-metadata-capture.md report twelve kinds arriving when thirteen do --
+    // the doc was describing this fixture rather than the compiler. Base Application
+    // emits 14 ReportExtension documents, so the kind was always arriving; nothing here
+    // could see it.
+    dataset
+    {
+        add(Thing)
+        {
+            column(DescriptionExt; Description) { }
+        }
+    }
+}
+
 permissionsetextension 70665 "OMR PS Ext" extends "OMR PS"
 {
     Permissions = tabledata "OMR Thing" = RIMD;

--- a/AlRunner.Tests/ObjectMetadataCaptureTests.cs
+++ b/AlRunner.Tests/ObjectMetadataCaptureTests.cs
@@ -56,6 +56,7 @@ public class ObjectMetadataCaptureTests
         ("PageExtension", 70663),
         ("EnumExtension", 70664),
         ("PermissionSetExtension", 70665),
+        ("ReportExtension", 70666),
     };
 
     private static void CopyDir(string src, string dst)

--- a/docs/object-metadata-capture.md
+++ b/docs/object-metadata-capture.md
@@ -26,8 +26,9 @@ Measured on the `ObjectMetadataCapture` fixture (`AlRunner.Tests/Fixtures/`), BC
 | `Report` | ✓ | `PermissionSetExtension` | ✓ |
 | `XmlPort` | ✓ | `TableExtension` | ✓ |
 | `Query` | ✓ | `PageExtension` | ✓ |
+| `ReportExtension` | ✓ | | |
 
-Two things that a list of kinds written by hand would have got wrong:
+Three things that a list of kinds written by hand would have got wrong:
 
 - **`Query` is not in issue #3548's own table of twelve** — that table was measured from
   runtime packages of twelve ISV apps, none of which declares a query. It arrives here
@@ -42,9 +43,20 @@ Two things that a list of kinds written by hand would have got wrong:
   than something this repository pins -- add a profile and a role-center page to the fixture
   if you want a future BC that starts emitting `PROFILE` to show up as a new trace line.
 
-So this path covers eleven of the issue's twelve kinds plus one it did not know about.
-Interface and profile metadata are only available from a runtime package (#3537) or from
-`SymbolReference.json` (#3533, #3545).
+- **`ReportExtension` arrives and was missing from this document**, because the fixture
+  declared none. The doc was describing the fixture rather than the compiler. Base
+  Application emits **14** `ReportExtension` documents, so the kind was always arriving and
+  nothing here could see it. The fixture now declares one, so the count is pinned rather
+  than asserted -- which is the only reason the other rows in this table are worth trusting.
+
+So **thirteen** kinds arrive. `Interface` and `Profile` do not, and their metadata is
+available only from a runtime package (#3537) or from `SymbolReference.json` (#3533, #3545).
+
+A caution for anyone extending this table: the metadata document's **root element is not the
+`SymbolKind`**. `MetadataRuntimeDeltas` is the root emitted for `TableExtension`,
+`PageExtension` and `PermissionSetExtension` alike, and `<Enum>` covers both `Enum` and
+`EnumExtension`. Counting root elements produces kinds that do not exist -- it is what put a
+non-existent `MetadataRuntimeDeltas` kind into #3562's first table.
 
 Every kind that does arrive is id-bearing, and ids repeat across kinds — the fixture
 deliberately declares a table, a page, a codeunit, an enum, a report, an xmlport and a


### PR DESCRIPTION
`docs/object-metadata-capture.md`, merged an hour ago with #3551, said **twelve** object kinds reach `CaptureOutputter.AddApplicationObject`. **Thirteen do.**

The cause matters more than the fact: the document was describing **the test fixture**, not the compiler. `Objects.al` declares one object of every kind its author knew about and declares no `reportextension` — so nothing in the repository could observe that kind arriving, and the doc recorded the fixture's blind spot as a property of BC. Base Application emits **14** `ReportExtension` documents; the kind was always there.

## What changed

- `Objects.al` declares `reportextension 70666 "OMR Report Ext"`.
- `ObjectMetadataCaptureTests.Expected` gains `("ReportExtension", 70666)`, so the count is **pinned by a test** rather than asserted in prose.
- The doc is corrected to thirteen, and gains the caution below.

## RED → GREEN, measured

Adding the `Expected` entry alone: `Failed: 1, Passed: 1`. Adding the fixture object: `Passed: 2`. The fixture arm is load-bearing, not decorative.

## The caution added to the doc

The metadata document's **root element is not the `SymbolKind`**, and counting root elements invents kinds that do not exist. `MetadataRuntimeDeltas` is the root emitted for `TableExtension`, `PageExtension` and `PermissionSetExtension` alike — Base App 156 + 90 + 55 = 301, exactly its document count — and `<Enum>` covers both `Enum` (566) and `EnumExtension` (39). That error put a non-existent `MetadataRuntimeDeltas` "kind" into #3562's first table.

## Runs

`~ObjectMetadata` 44 passed / 2 skipped. Documentation and doc-pointer tests 31 passed / 1 skipped. Full `AlRunner.Tests` not run.

Corpus-NA: test fixture and documentation only; no runner behaviour changes, so no AL-observable claim reaches a service tier.

Closes #3564

https://claude.ai/code/session_01F7HLDeNwiGQoLT5wFanqmH
