### PR TITLE
feat(metadata): a total equivalence harness for the SymbolReference derivation

### DIFF
--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -462,6 +462,26 @@ jobs:
           </RunSettings>
           EOF
 
+      - name: Generate BC metadata ground truth (metadata-equivalence harness)
+        if: ${{ matrix.target.unit-tests }}
+        run: |
+          # Issue #3533. MetadataEquivalenceHarnessTests compares BC's OWN metadata-emitter
+          # output against the runner's SymbolReference derivation, member for member. The
+          # emitter output is the ground truth and it has to be produced by compiling a
+          # Microsoft app with BC's own compiler — Business Foundation ~3s, System Application
+          # ~14s on this leg's already-provisioned artifacts.
+          #
+          # It is regenerated here rather than checked into the repository. Two reasons, and
+          # both matter: it is Microsoft's compiler output over Microsoft's source, which is not
+          # ours to redistribute; and it belongs to one exact BC build, so a checked-in copy
+          # would either churn on every Microsoft release or go stale silently — which is the
+          # failure mode this whole harness exists to remove.
+          #
+          # NOT continue-on-error. If this step fails, the harness must report the app as
+          # uncovered and fail, not compare less of it quietly.
+          tools/gen-metadata-ground-truth.sh \
+            --artifacts "$HOME/.local/share/al-runner/artifacts/${{ matrix.target.bc-version }}"
+
       # Issue #1825: AL_RUNNER_PHASE_LOG makes each runner subprocess append one JSONL
       # record per app group / bundle / process to a shared file. The 76 spawns' stdout
       # is captured into strings and discarded by the tests (and several assert on it

--- a/AlRunner.Tests/BcEngineCollection.cs
+++ b/AlRunner.Tests/BcEngineCollection.cs
@@ -25,7 +25,7 @@
 //
 // Members: BcCompilerEmitRetryTests, BcCompilerProfileEmitCrashTests,
 // SkeletonSharedObjectContainerLeakTests, RecordBulkWriteNotesTransactionTests,
-// CodeunitRunWriteTransactionRefusalTests.
+// CodeunitRunWriteTransactionRefusalTests, MetadataEquivalenceHarnessTests.
 // Any NEW test that loads Microsoft.Dynamics.Nav.* types in-process belongs here too.
 
 using System.Runtime.CompilerServices;

--- a/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
+++ b/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
@@ -36,8 +36,12 @@
 //                      .NET surface does not move under a BC update. 7.
 //     FrameworkTuple   `Item1` / `Item2` on a ValueTuple or Tuple<,>. The tuple is BC's, the
 //                      MEMBER is the framework's, so a BC update cannot move it. 8.
-//     Listed           ten sites the three rules above cannot classify structurally, each with
-//                      its own reason below. 10.
+//     Listed           fifteen sites the three rules above cannot classify structurally, each
+//                      with its own reason below. 15. 10 → 15 in the #3533 metadata-equivalence
+//                      PR: the differ walks an arbitrary object graph reflectively, so it reads
+//                      the C# enumerator pattern (MoveNext/Current) and KeyValuePair<,>'s
+//                      Key/Value off locals. Four entries cover five sites — two ask for
+//                      "Value" — and none is a BC-layout read.
 //
 //   So the assertion is two-directional. An unclassified site fails ("account for it or
 //   convert it"), and a change in any category's count fails too — removing a site is as loud
@@ -94,6 +98,35 @@ public sealed class BcInternalsNullForgivingGuardTests
         { ("AlRunner/Patches/RecordPatches.cs", "stackType", "\"Push\""),
           "Stack<T>.Push — BCL" },
 
+        // The C# ENUMERATOR PATTERN and KeyValuePair<,>, in the metadata differ. The receiver is
+        // a local in every case, so `typeof(...)` cannot be read off the text, but none of the
+        // four members belongs to a BC type whose layout Microsoft can move:
+        //
+        //   MoveNext / Current — `e` is whatever GetEnumerator() returned on the line above, so
+        //     it IS an enumerator, and those two names are the C# foreach contract rather than a
+        //     layout choice. An enumerator that renamed them would stop being one and BC's own
+        //     `foreach` over it would stop compiling. Same shape as FrameworkTuple above: the
+        //     enumerator may be BC's, the MEMBERS are the language's.
+        //   Key / Value — guarded on the immediately preceding line by
+        //     `t.GetGenericTypeDefinition() == typeof(KeyValuePair<,>)`, so the declaring type is
+        //     proven BCL before the lookup runs.
+        //
+        // Converting these to BcShape would be wrong in the other direction: a
+        // BcShapeGapException claims BC's layout moved, which none of these could ever show.
+        // Independently, #3051's inversion needs an AL-entered path — the NRE is swallowed by
+        // NavMethodScope_AssertError's catch and `asserterror` then passes — and nothing calls
+        // MetadataObjectDiff from AL; its only caller is MetadataEquivalenceHarness in the test
+        // assembly. That is a second reason, not the primary one, because callers can change and
+        // the four members still cannot.
+        { ("AlRunner/Metadata/MetadataObjectDiff.cs", "e.GetType()", "\"MoveNext\""),
+          "IEnumerator.MoveNext — the C# foreach contract, not a BC member" },
+        { ("AlRunner/Metadata/MetadataObjectDiff.cs", "e.GetType()", "\"Current\""),
+          "IEnumerator.Current — the C# foreach contract, not a BC member" },
+        { ("AlRunner/Metadata/MetadataObjectDiff.cs", "t", "\"Key\""),
+          "KeyValuePair<,>.Key — BCL, and the generic type definition is checked on the line above" },
+        { ("AlRunner/Metadata/MetadataObjectDiff.cs", "t", "\"Value\""),
+          "KeyValuePair<,>.Value — BCL, checked the same way; two sites share this key" },
+
         // The runner's own artifacts, not BC's.
         { ("AlRunner/Program.cs", "target", "\"OnRun\""),
           "OnRun on a codeunit THIS runner emitted — absence is an emit defect, not BC's layout" },
@@ -106,7 +139,7 @@ public sealed class BcInternalsNullForgivingGuardTests
         [Cat.RunnerOwnMember] = 38,
         [Cat.Bcl] = 7,
         [Cat.FrameworkTuple] = 8,
-        [Cat.Listed] = 10,
+        [Cat.Listed] = 15,
     };
 
     /// <summary>Receivers of the form <c>typeof(X…)</c> that name a type in this repository.</summary>

--- a/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
+++ b/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
@@ -36,12 +36,11 @@
 //                      .NET surface does not move under a BC update. 7.
 //     FrameworkTuple   `Item1` / `Item2` on a ValueTuple or Tuple<,>. The tuple is BC's, the
 //                      MEMBER is the framework's, so a BC update cannot move it. 8.
-//     Listed           fifteen sites the three rules above cannot classify structurally, each
-//                      with its own reason below. 15. 10 → 15 in the #3533 metadata-equivalence
+//     Listed           thirteen sites the three rules above cannot classify structurally, each
+//                      with its own reason below. 13. 10 → 13 in the #3533 metadata-equivalence
 //                      PR: the differ walks an arbitrary object graph reflectively, so it reads
-//                      the C# enumerator pattern (MoveNext/Current) and KeyValuePair<,>'s
-//                      Key/Value off locals. Four entries cover five sites — two ask for
-//                      "Value" — and none is a BC-layout read.
+//                      KeyValuePair<,>'s Key and Value off a local. Two entries cover three
+//                      sites — two ask for "Value" — and neither is a BC-layout read.
 //
 //   So the assertion is two-directional. An unclassified site fails ("account for it or
 //   convert it"), and a change in any category's count fails too — removing a site is as loud
@@ -98,15 +97,10 @@ public sealed class BcInternalsNullForgivingGuardTests
         { ("AlRunner/Patches/RecordPatches.cs", "stackType", "\"Push\""),
           "Stack<T>.Push — BCL" },
 
-        // The C# ENUMERATOR PATTERN and KeyValuePair<,>, in the metadata differ. The receiver is
-        // a local in every case, so `typeof(...)` cannot be read off the text, but none of the
-        // four members belongs to a BC type whose layout Microsoft can move:
+        // KeyValuePair<,> in the metadata differ. The receiver is a local, so `typeof(...)`
+        // cannot be read off the text, but neither member belongs to a BC type whose layout
+        // Microsoft can move:
         //
-        //   MoveNext / Current — `e` is whatever GetEnumerator() returned on the line above, so
-        //     it IS an enumerator, and those two names are the C# foreach contract rather than a
-        //     layout choice. An enumerator that renamed them would stop being one and BC's own
-        //     `foreach` over it would stop compiling. Same shape as FrameworkTuple above: the
-        //     enumerator may be BC's, the MEMBERS are the language's.
         //   Key / Value — guarded on the immediately preceding line by
         //     `t.GetGenericTypeDefinition() == typeof(KeyValuePair<,>)`, so the declaring type is
         //     proven BCL before the lookup runs.
@@ -118,10 +112,6 @@ public sealed class BcInternalsNullForgivingGuardTests
         // MetadataObjectDiff from AL; its only caller is MetadataEquivalenceHarness in the test
         // assembly. That is a second reason, not the primary one, because callers can change and
         // the four members still cannot.
-        { ("AlRunner/Metadata/MetadataObjectDiff.cs", "e.GetType()", "\"MoveNext\""),
-          "IEnumerator.MoveNext — the C# foreach contract, not a BC member" },
-        { ("AlRunner/Metadata/MetadataObjectDiff.cs", "e.GetType()", "\"Current\""),
-          "IEnumerator.Current — the C# foreach contract, not a BC member" },
         { ("AlRunner/Metadata/MetadataObjectDiff.cs", "t", "\"Key\""),
           "KeyValuePair<,>.Key — BCL, and the generic type definition is checked on the line above" },
         { ("AlRunner/Metadata/MetadataObjectDiff.cs", "t", "\"Value\""),
@@ -139,7 +129,7 @@ public sealed class BcInternalsNullForgivingGuardTests
         [Cat.RunnerOwnMember] = 38,
         [Cat.Bcl] = 7,
         [Cat.FrameworkTuple] = 8,
-        [Cat.Listed] = 15,
+        [Cat.Listed] = 13,
     };
 
     /// <summary>Receivers of the form <c>typeof(X…)</c> that name a type in this repository.</summary>

--- a/AlRunner.Tests/MetadataDifferenceAllowlistTests.cs
+++ b/AlRunner.Tests/MetadataDifferenceAllowlistTests.cs
@@ -103,11 +103,28 @@ public sealed class MetadataDifferenceAllowlistTests
     }
 
     [Fact]
-    public void A_tolerated_defect_with_no_issue_is_refused()
+    public void An_entry_that_says_nothing_about_WHY_is_refused()
     {
         var ex = Assert.Throws<InvalidDataException>(() => new MetadataDifferenceAllowlist(
             new[] { new MetadataAllowlistEntry { Member = "MetaField.Editable", Reason = "we think it is fine" } }));
-        Assert.Contains("names no issue", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("says nothing about WHY", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void An_entry_claiming_two_kinds_of_reason_is_refused()
+    {
+        // The four kinds need different evidence, so an entry hedging between them has
+        // established none of them.
+        var ex = Assert.Throws<InvalidDataException>(() => new MetadataDifferenceAllowlist(
+            new[]
+            {
+                new MetadataAllowlistEntry
+                {
+                    Member = "TranslationKey.#Id1", Reason = "both, somehow",
+                    Issue = 3568, CannotExpress = true,
+                },
+            }));
+        Assert.Contains("more than one kind of reason", ex.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -117,13 +134,76 @@ public sealed class MetadataDifferenceAllowlistTests
         {
             new MetadataAllowlistEntry
             {
-                Member = "TranslationKey.#Id1",
-                Reason = "translation keys are assigned by the compiler and are not in SymbolReference.json",
+                Member = "SomeType.SomeMember",
+                Reason = "not in the symbol file and not derivable from anything in it",
                 CannotExpress = true,
             },
         });
 
+        Assert.True(list.Classify(new[] { Diff("SomeType", "SomeMember") }).Ok);
+    }
+
+    [Fact]
+    public void A_scope_or_oracle_boundary_without_a_Doc_pointer_is_refused()
+    {
+        // Both are PERMANENT licences to differ, unlike a tracked defect, so the claim has to
+        // be somewhere a reviewer can find and disagree with. test_doc_pointers.py then keeps
+        // the pointer resolving.
+        foreach (var entry in new[]
+                 {
+                     new MetadataAllowlistEntry { Member = "TranslationKey.#Id1", Reason = "the runner reads no translation files", OutOfScope = true },
+                     new MetadataAllowlistEntry { Member = "MetaTable.Fields.<presence>", Reason = "runtime-merged versus build-time emit", OracleLimitation = true },
+                 })
+        {
+            var ex = Assert.Throws<InvalidDataException>(
+                () => new MetadataDifferenceAllowlist(new[] { entry }));
+            Assert.Contains("no 'Doc' pointer", ex.Message, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void A_scope_boundary_with_a_Doc_pointer_covers_its_difference()
+    {
+        var list = new MetadataDifferenceAllowlist(new[]
+        {
+            new MetadataAllowlistEntry
+            {
+                Member = "TranslationKey.#Id1",
+                Reason = "the runner reads no translation files, so no AL test can observe this",
+                OutOfScope = true,
+                Doc = "docs/metadata-equivalence.md#translation-keys-are-out-of-scope",
+            },
+        });
+
         Assert.True(list.Classify(new[] { Diff("TranslationKey", "#Id1") }).Ok);
+    }
+
+    [Fact]
+    public void The_checked_in_allowlist_claims_no_permanent_symbol_file_limit()
+    {
+        // Not decoration. 36% of the diff was declared cannotExpress on evidence that turned
+        // out to be about storage rather than derivability, and both TranslationKey and
+        // ClrType proved recoverable. If a future entry claims one, it should have to change
+        // this test and say why in the same commit.
+        var list = MetadataDifferenceAllowlist.Load(MetadataEquivalencePaths.AllowlistFile());
+
+        Assert.Empty(list.Entries.Where(e => e.CannotExpress).Select(e => e.Member));
+    }
+
+    [Fact]
+    public void Every_scope_and_oracle_entry_in_the_checked_in_allowlist_points_at_docs()
+    {
+        var list = MetadataDifferenceAllowlist.Load(MetadataEquivalencePaths.AllowlistFile());
+
+        foreach (var e in list.Entries.Where(e => e.OutOfScope || e.OracleLimitation))
+        {
+            Assert.StartsWith("docs/", e.Doc!, StringComparison.Ordinal);
+            Assert.Contains('#', e.Doc!);
+            Assert.True(File.Exists(Path.Combine(
+                    Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..")),
+                    e.Doc!.Split('#')[0])),
+                $"{e.Member} points at '{e.Doc}', which does not exist.");
+        }
     }
 
     [Fact]

--- a/AlRunner.Tests/MetadataDifferenceAllowlistTests.cs
+++ b/AlRunner.Tests/MetadataDifferenceAllowlistTests.cs
@@ -16,8 +16,8 @@ public sealed class MetadataDifferenceAllowlistTests
     private static MetadataDifference Diff(string type, string member, string objectKey = "Table 5")
         => new(objectKey, member, type, member, "bc", "ours");
 
-    private static MetadataAllowlistEntry Entry(string member, int? max = null, string? objectKey = null)
-        => new() { Member = member, Reason = "measured; tracked", Issue = 3545, MaxOccurrences = max, ObjectKey = objectKey };
+    private static MetadataAllowlistEntry Entry(string member, string? objectKey = null)
+        => new() { Member = member, Reason = "measured; tracked", Issue = 3545, ObjectKey = objectKey };
 
     [Fact]
     public void An_undeclared_difference_is_undeclared()
@@ -54,33 +54,106 @@ public sealed class MetadataDifferenceAllowlistTests
     }
 
     [Fact]
-    public void Exceeding_a_declared_occurrence_cap_fails()
+    public void A_runner_only_entry_does_not_cover_the_BC_only_direction()
     {
-        var list = new MetadataDifferenceAllowlist(new[] { Entry("MetaField.Editable", max: 1) });
-
-        var verdict = list.Classify(new[]
+        // The blocking defect this fixes. The three merged-runtime entries are a permanent,
+        // uncapped licence written for "the runner has a field BC's per-app emit does not".
+        // Undirected they also covered the reverse — BC emitted a field and the runner built
+        // none — which is a hard reader defect on every table.
+        var list = new MetadataDifferenceAllowlist(new[]
         {
-            Diff("MetaField", "Editable", "Table 5"),
-            Diff("MetaField", "Editable", "Table 6"),
+            new MetadataAllowlistEntry
+            {
+                Member = "MetaTable.Fields.<presence>", Reason = "runtime-merged versus build-time emit",
+                OracleLimitation = true, Direction = MetadataAllowlistEntry.RunnerOnly,
+                Doc = "docs/metadata-equivalence.md#the-oracle-is-build-time-per-app-metadata",
+            },
         });
 
-        Assert.Empty(verdict.Undeclared);
-        Assert.Contains("2 occurrences, declared max 1", Assert.Single(verdict.ExceededEntries), StringComparison.Ordinal);
-        Assert.False(verdict.Ok);
+        var runnerOnly = new MetadataDifference("Table 242", "Fields[id=10]",
+            "MetaTable", "Fields.<presence>", MetadataObjectDiff.Absent, "present");
+        var bcOnly = new MetadataDifference("Table 242", "Fields[id=10]",
+            "MetaTable", "Fields.<presence>", "present", MetadataObjectDiff.Absent);
+
+        Assert.Empty(list.Classify(new[] { runnerOnly }).Undeclared);
+
+        var undeclared = Assert.Single(list.Classify(new[] { runnerOnly, bcOnly }).Undeclared);
+        Assert.Equal("present", undeclared.Expected);
+        Assert.Equal(MetadataObjectDiff.Absent, undeclared.Actual);
     }
 
     [Fact]
-    public void Staying_within_a_declared_occurrence_cap_passes()
+    public void A_bc_only_entry_does_not_cover_the_runner_only_direction()
     {
-        var list = new MetadataDifferenceAllowlist(new[] { Entry("MetaField.Editable", max: 2) });
+        var list = new MetadataDifferenceAllowlist(new[]
+        {
+            new MetadataAllowlistEntry
+            {
+                Member = "MetaField.Relations.<presence>", Reason = "BC relates SystemCreatedBy to User; the runner does not",
+                Issue = 3568, Direction = MetadataAllowlistEntry.BcOnly,
+            },
+        });
 
-        Assert.True(list.Classify(new[] { Diff("MetaField", "Editable") }).Ok);
+        var bcOnly = new MetadataDifference("Table 5", "Fields[id=2000000002].Relations[0]",
+            "MetaField", "Relations.<presence>", "present", MetadataObjectDiff.Absent);
+        var runnerInvented = new MetadataDifference("Table 5", "Fields[id=7].Relations[0]",
+            "MetaField", "Relations.<presence>", MetadataObjectDiff.Absent, "present");
+
+        Assert.Empty(list.Classify(new[] { bcOnly }).Undeclared);
+        Assert.Single(list.Classify(new[] { bcOnly, runnerInvented }).Undeclared);
+    }
+
+    [Fact]
+    public void An_unknown_direction_is_refused()
+    {
+        var ex = Assert.Throws<InvalidDataException>(() => new MetadataDifferenceAllowlist(
+            new[]
+            {
+                new MetadataAllowlistEntry
+                {
+                    Member = "MetaField.Editable", Reason = "measured; tracked",
+                    Issue = 3545, Direction = "sideways",
+                },
+            }));
+        Assert.Contains("direction 'sideways'", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("MetaTable.Fields.<presence>", "Fields[id=10]")]
+    [InlineData("MetaTable.FieldsById.<presence>", "FieldsById[key=10]")]
+    [InlineData("MetaTable.#fieldsById.<presence>", "#fieldsById[key=10]")]
+    public void The_CHECKED_IN_allowlist_leaves_a_missing_field_undeclared(string signature, string path)
+    {
+        // Against the real file, not a constructed one. "BC emitted this field and the runner
+        // built none" must still fail on the very members whose permanent licence covers the
+        // opposite direction — that is the whole point of scoping them.
+        var list = MetadataDifferenceAllowlist.Load(MetadataEquivalencePaths.AllowlistFile());
+        var i = signature.IndexOf('.', StringComparison.Ordinal);
+
+        var runnerBuiltNothing = new MetadataDifference(
+            "Table 242", path, signature[..i], signature[(i + 1)..],
+            Expected: "present", Actual: MetadataObjectDiff.Absent);
+
+        var undeclared = Assert.Single(list.Classify(new[] { runnerBuiltNothing }).Undeclared);
+        Assert.Equal(signature, undeclared.Signature);
+    }
+
+    [Fact]
+    public void Every_permanent_licence_in_the_checked_in_allowlist_is_direction_scoped()
+    {
+        // outOfScope and oracleLimitation never expire, so an undirected one licenses a defect
+        // in the direction its reason says nothing about. The TranslationKey entries are a
+        // value difference in both directions at once and are exempt.
+        var list = MetadataDifferenceAllowlist.Load(MetadataEquivalencePaths.AllowlistFile());
+
+        foreach (var e in list.Entries.Where(e => e.OracleLimitation))
+            Assert.Equal(MetadataAllowlistEntry.RunnerOnly, e.Direction);
     }
 
     [Fact]
     public void An_entry_narrowed_to_one_object_does_not_cover_another()
     {
-        var list = new MetadataDifferenceAllowlist(new[] { Entry("MetaField.Editable", objectKey: "Table 5") });
+        var list = new MetadataDifferenceAllowlist(new[] { Entry("MetaField.Editable", "Table 5") });
 
         var verdict = list.Classify(new[]
         {

--- a/AlRunner.Tests/MetadataDifferenceAllowlistTests.cs
+++ b/AlRunner.Tests/MetadataDifferenceAllowlistTests.cs
@@ -1,0 +1,151 @@
+// MetadataDifferenceAllowlistTests — the allowlist's own contract.
+//
+// The allowlist is the only thing standing between "a difference we have decided about" and
+// "a difference nobody has looked at". Three properties make it that rather than a mute:
+// an undeclared difference fails; an entry that stops matching fails (so a landed fix must
+// shrink the list instead of leaving cover behind); and an entry may cap its occurrences, so
+// a declared defect getting WORSE still fails.
+
+using AlRunner.Metadata;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class MetadataDifferenceAllowlistTests
+{
+    private static MetadataDifference Diff(string type, string member, string objectKey = "Table 5")
+        => new(objectKey, member, type, member, "bc", "ours");
+
+    private static MetadataAllowlistEntry Entry(string member, int? max = null, string? objectKey = null)
+        => new() { Member = member, Reason = "measured; tracked", Issue = 3545, MaxOccurrences = max, ObjectKey = objectKey };
+
+    [Fact]
+    public void An_undeclared_difference_is_undeclared()
+    {
+        var list = new MetadataDifferenceAllowlist(new[] { Entry("MetaField.Editable") });
+
+        var verdict = list.Classify(new[] { Diff("MetaField", "Editable"), Diff("MetaField", "EnumTypeId") });
+
+        var undeclared = Assert.Single(verdict.Undeclared);
+        Assert.Equal("MetaField.EnumTypeId", undeclared.Signature);
+        Assert.False(verdict.Ok);
+    }
+
+    [Fact]
+    public void A_fully_declared_difference_set_is_ok()
+    {
+        var list = new MetadataDifferenceAllowlist(new[] { Entry("MetaField.Editable") });
+
+        var verdict = list.Classify(new[] { Diff("MetaField", "Editable") });
+
+        Assert.True(verdict.Ok);
+        Assert.Equal(1, verdict.OccurrencesByEntry["MetaField.Editable"]);
+    }
+
+    [Fact]
+    public void An_entry_that_matches_nothing_is_reported_so_a_landed_fix_must_remove_it()
+    {
+        var list = new MetadataDifferenceAllowlist(new[] { Entry("MetaField.Editable"), Entry("MetaField.Lookup") });
+
+        var verdict = list.Classify(new[] { Diff("MetaField", "Editable") });
+
+        Assert.Equal("MetaField.Lookup", Assert.Single(verdict.UnusedEntries));
+        Assert.False(verdict.Ok);
+    }
+
+    [Fact]
+    public void Exceeding_a_declared_occurrence_cap_fails()
+    {
+        var list = new MetadataDifferenceAllowlist(new[] { Entry("MetaField.Editable", max: 1) });
+
+        var verdict = list.Classify(new[]
+        {
+            Diff("MetaField", "Editable", "Table 5"),
+            Diff("MetaField", "Editable", "Table 6"),
+        });
+
+        Assert.Empty(verdict.Undeclared);
+        Assert.Contains("2 occurrences, declared max 1", Assert.Single(verdict.ExceededEntries), StringComparison.Ordinal);
+        Assert.False(verdict.Ok);
+    }
+
+    [Fact]
+    public void Staying_within_a_declared_occurrence_cap_passes()
+    {
+        var list = new MetadataDifferenceAllowlist(new[] { Entry("MetaField.Editable", max: 2) });
+
+        Assert.True(list.Classify(new[] { Diff("MetaField", "Editable") }).Ok);
+    }
+
+    [Fact]
+    public void An_entry_narrowed_to_one_object_does_not_cover_another()
+    {
+        var list = new MetadataDifferenceAllowlist(new[] { Entry("MetaField.Editable", objectKey: "Table 5") });
+
+        var verdict = list.Classify(new[]
+        {
+            Diff("MetaField", "Editable", "Table 5"),
+            Diff("MetaField", "Editable", "Table 6"),
+        });
+
+        Assert.Equal("Table 6", Assert.Single(verdict.Undeclared).ObjectKey);
+    }
+
+    [Fact]
+    public void A_placeholder_reason_is_refused_at_construction()
+    {
+        foreach (var placeholder in new[] { "", "  ", "n/a", "TBD", "none", "-" })
+        {
+            var ex = Assert.Throws<InvalidDataException>(() => new MetadataDifferenceAllowlist(
+                new[] { new MetadataAllowlistEntry { Member = "MetaField.Editable", Reason = placeholder, Issue = 1 } }));
+            Assert.Contains("placeholder reason", ex.Message, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void A_tolerated_defect_with_no_issue_is_refused()
+    {
+        var ex = Assert.Throws<InvalidDataException>(() => new MetadataDifferenceAllowlist(
+            new[] { new MetadataAllowlistEntry { Member = "MetaField.Editable", Reason = "we think it is fine" } }));
+        Assert.Contains("names no issue", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_permanent_symbol_file_limit_needs_no_issue()
+    {
+        var list = new MetadataDifferenceAllowlist(new[]
+        {
+            new MetadataAllowlistEntry
+            {
+                Member = "TranslationKey.#Id1",
+                Reason = "translation keys are assigned by the compiler and are not in SymbolReference.json",
+                CannotExpress = true,
+            },
+        });
+
+        Assert.True(list.Classify(new[] { Diff("TranslationKey", "#Id1") }).Ok);
+    }
+
+    [Fact]
+    public void The_empty_allowlist_declares_nothing()
+    {
+        var verdict = MetadataDifferenceAllowlist.None.Classify(new[] { Diff("MetaField", "Editable") });
+        Assert.Single(verdict.Undeclared);
+        Assert.Empty(verdict.UnusedEntries);
+    }
+
+    [Fact]
+    public void The_checked_in_allowlist_loads_and_every_entry_is_well_formed()
+    {
+        // Loading IS the validation: the constructor refuses a placeholder reason and a
+        // tolerated defect with no issue. A malformed entry therefore fails the build rather
+        // than sitting in the file granting cover nobody reviewed.
+        var path = MetadataEquivalencePaths.AllowlistFile();
+        Assert.True(File.Exists(path), $"the checked-in allowlist is missing at {path}");
+
+        var list = MetadataDifferenceAllowlist.Load(path);
+
+        Assert.NotEmpty(list.Entries);
+        Assert.All(list.Entries, e => Assert.Contains('.', e.Member));
+    }
+}

--- a/AlRunner.Tests/MetadataEquivalenceHarness.cs
+++ b/AlRunner.Tests/MetadataEquivalenceHarness.cs
@@ -1,0 +1,223 @@
+// MetadataEquivalenceHarness — drives the total comparison of BC's own metadata emitter
+// against the runner's SymbolReference-derived metadata, for one ground-truth bundle.
+//
+// Issue #3533. The standard: the derivation is acceptable only if it builds the SAME objects
+// BC's emitter builds, member for member, with every difference declared.
+//
+// The two sides, and why they are the same TYPE
+// ---------------------------------------------
+//   BC's:  MetaTable.CreateMetaTableFromXml(<the emitter's own document>)
+//   ours:  RecordPatches.GetOrBuildNCLMetaTable(id).GetMetaTableOriginal()
+//
+// The runner builds a Types.Metadata.MetaTable and hands it to NCLMetaTable.CreateFromMetaTable;
+// GetMetaTableOriginal() hands that same MetaTable back. So both sides are
+// Microsoft.Dynamics.Nav.Types.Metadata.MetaTable and the comparison is member-for-member on
+// one type, not a translation between two shapes.
+//
+// Why the bundle is not checked in: see docs/metadata-equivalence.md § "Where the ground
+// truth lives".
+
+using System.Reflection;
+using System.Text.Json;
+using System.Xml;
+using AlRunner.Metadata;
+using AlRunner.Patches;
+
+namespace AlRunner.Tests;
+
+/// <summary>One object in a ground-truth bundle, as its manifest describes it.</summary>
+internal sealed record GroundTruthObject(string Kind, int Id, string Name, string File, string Sha256);
+
+internal sealed record GroundTruthBundle(
+    string Directory,
+    int Schema,
+    Guid AppId,
+    string AppName,
+    string AppPublisher,
+    string AppVersion,
+    string BcBuild,
+    IReadOnlyDictionary<string, int> Census,
+    IReadOnlyList<GroundTruthObject> Objects)
+{
+    public string Label => $"{AppPublisher}_{AppName} {AppVersion}";
+}
+
+/// <summary>What one bundle's comparison found, including what it did NOT cover.</summary>
+internal sealed record MetadataEquivalenceReport(
+    GroundTruthBundle Bundle,
+    IReadOnlyList<string> KindsCompared,
+    IReadOnlyList<string> KindsNotCompared,
+    int ObjectsCompared,
+    IReadOnlyList<string> Unbuildable,
+    IReadOnlyList<MetadataDifference> Differences)
+{
+    public string Summary =>
+        $"{Bundle.Label} (BC {Bundle.BcBuild}): compared {ObjectsCompared} object(s) of kind(s) " +
+        $"[{string.Join(", ", KindsCompared)}]; NOT compared: [{string.Join(", ", KindsNotCompared)}]; " +
+        $"{Differences.Count} difference(s) across {Differences.Select(d => d.Signature).Distinct().Count()} member(s)";
+}
+
+internal static class MetadataEquivalencePaths
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    public static string ExpectationsDir()
+        => Path.Combine(RepoRoot, "tests", "expectations", "metadata-equivalence");
+
+    public static string AllowlistFile() => Path.Combine(ExpectationsDir(), "allowlist.json");
+
+    public static string AppsFile() => Path.Combine(ExpectationsDir(), "apps.json");
+
+    /// <summary>
+    /// Where the generator writes bundles. A sibling of the artifacts root, because a bundle
+    /// belongs to the BC build it was generated from and is regenerated when that moves.
+    /// </summary>
+    public static string GroundTruthRoot()
+    {
+        var explicitRoot = Environment.GetEnvironmentVariable("AL_RUNNER_METADATA_GROUND_TRUTH");
+        if (!string.IsNullOrEmpty(explicitRoot)) return explicitRoot;
+        var artifacts = AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir;
+        return Path.Combine(Path.GetDirectoryName(Path.TrimEndingDirectorySeparator(artifacts))
+                            ?? artifacts, "metadata-ground-truth");
+    }
+}
+
+internal static class MetadataEquivalenceHarness
+{
+    /// <summary>Bundle schema this harness understands. See tools/metadata-ground-truth.</summary>
+    private const int SupportedSchema = 1;
+
+    /// <summary>
+    /// The object kinds this harness compares today. Everything else in a bundle is reported
+    /// as NOT compared rather than dropped — covering less has to be visible, or the harness
+    /// becomes the silent-partial-answer it was built to prevent.
+    /// </summary>
+    private static readonly string[] ComparedKinds = { "MetaTable" };
+
+    public static IReadOnlyList<GroundTruthBundle> LoadBundles(string root)
+    {
+        if (!Directory.Exists(root)) return Array.Empty<GroundTruthBundle>();
+        var bundles = new List<GroundTruthBundle>();
+        foreach (var manifestPath in Directory.EnumerateFiles(root, "manifest.json", SearchOption.AllDirectories)
+                     .OrderBy(p => p, StringComparer.Ordinal))
+            bundles.Add(ReadManifest(manifestPath));
+        return bundles;
+    }
+
+    private static GroundTruthBundle ReadManifest(string manifestPath)
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(manifestPath));
+        var root = doc.RootElement;
+        var schema = root.GetProperty("schema").GetInt32();
+        if (schema != SupportedSchema)
+            throw new InvalidDataException(
+                $"{manifestPath}: bundle schema {schema}, this harness understands {SupportedSchema}. " +
+                "Regenerate with tools/metadata-ground-truth rather than reading fields that may have moved.");
+
+        var app = root.GetProperty("app");
+        var census = new SortedDictionary<string, int>(StringComparer.Ordinal);
+        foreach (var kv in root.GetProperty("census").EnumerateObject())
+            census[kv.Name] = kv.Value.GetInt32();
+
+        var objects = root.GetProperty("objects").EnumerateArray()
+            .Select(o => new GroundTruthObject(
+                o.GetProperty("Kind").GetString()!,
+                o.GetProperty("Id").GetInt32(),
+                o.GetProperty("Name").GetString()!,
+                o.GetProperty("File").GetString()!,
+                o.GetProperty("Sha256").GetString()!))
+            .ToArray();
+
+        return new GroundTruthBundle(
+            Path.GetDirectoryName(manifestPath)!, schema,
+            app.GetProperty("Id").GetGuid(), app.GetProperty("Name").GetString()!,
+            app.GetProperty("Publisher").GetString()!, app.GetProperty("Version").GetString()!,
+            root.GetProperty("bcBuild").GetString()!, census, objects);
+    }
+
+    /// <summary>
+    /// Compare one bundle. <paramref name="appPackagePath"/> is the very .app the bundle was
+    /// generated from — the runner reads its SymbolReference.json, so a different build of the
+    /// same app would compare two things that were never meant to agree.
+    /// </summary>
+    public static MetadataEquivalenceReport Compare(GroundTruthBundle bundle, string appPackagePath)
+    {
+        RecordPatches.AddBcAppPath(appPackagePath);
+
+        var getOriginal = Type.GetType("Microsoft.Dynamics.Nav.Runtime.NCLMetaTable, Microsoft.Dynamics.Nav.Ncl")
+            ?.GetMethod("GetMetaTableOriginal", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException(
+                "NCLMetaTable.GetMetaTableOriginal is not reachable. Without it there is no way to " +
+                "read back the MetaTable the runner built, and the comparison would silently " +
+                "become NCLMetaTable-vs-MetaTable — two different types.");
+
+        var fromXml = Type.GetType("Microsoft.Dynamics.Nav.Types.Metadata.MetaTable, Microsoft.Dynamics.Nav.Types")
+            ?.GetMethod("CreateMetaTableFromXml", BindingFlags.Public | BindingFlags.Static)
+            ?? throw new InvalidOperationException("MetaTable.CreateMetaTableFromXml is not reachable.");
+
+        var differences = new List<MetadataDifference>();
+        var unbuildable = new List<string>();
+        int compared = 0;
+
+        foreach (var obj in bundle.Objects.Where(o => ComparedKinds.Contains(o.Kind, StringComparer.Ordinal))
+                     .OrderBy(o => o.Id))
+        {
+            var xmlPath = Path.Combine(bundle.Directory, obj.File);
+            var document = new XmlDocument();
+            document.Load(xmlPath);
+
+            var expected = fromXml.Invoke(null, new object?[] { document.DocumentElement, 0 });
+            if (expected is null)
+            {
+                unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': BC's own CreateMetaTableFromXml returned null");
+                continue;
+            }
+
+            object? actual = null;
+            try
+            {
+                var ncl = RecordPatches.GetOrBuildNCLMetaTable(obj.Id);
+                if (ncl is not null) actual = getOriginal.Invoke(ncl, null);
+            }
+            catch (Exception ex)
+            {
+                unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': the runner threw — " +
+                                $"{(ex.InnerException ?? ex).GetType().Name}: {(ex.InnerException ?? ex).Message}");
+                continue;
+            }
+
+            if (actual is null)
+            {
+                unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': the runner built no metadata at all");
+                continue;
+            }
+
+            compared++;
+            differences.AddRange(MetadataObjectDiff.Compare(expected, actual, $"Table {obj.Id}"));
+        }
+
+        var kindsPresent = bundle.Census.Keys.ToArray();
+        return new MetadataEquivalenceReport(
+            bundle,
+            kindsPresent.Where(k => ComparedKinds.Contains(k, StringComparer.Ordinal)).ToArray(),
+            kindsPresent.Where(k => !ComparedKinds.Contains(k, StringComparer.Ordinal)).ToArray(),
+            compared, unbuildable, differences);
+    }
+
+    /// <summary>
+    /// The .app a bundle was generated from, located by identity rather than by a path baked
+    /// into the manifest. Returns null when this box has no such package — which the caller
+    /// must report, never absorb.
+    /// </summary>
+    public static string? FindAppPackage(GroundTruthBundle bundle)
+    {
+        var artifacts = AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir;
+        var wanted = $"{bundle.AppPublisher}_{bundle.AppName}_{bundle.AppVersion}.app";
+        if (!Directory.Exists(artifacts)) return null;
+        foreach (var candidate in Directory.EnumerateFiles(artifacts, "*.app", SearchOption.AllDirectories))
+            if (string.Equals(Path.GetFileName(candidate), wanted, StringComparison.Ordinal))
+                return candidate;
+        return null;
+    }
+}

--- a/AlRunner.Tests/MetadataEquivalenceHarness.cs
+++ b/AlRunner.Tests/MetadataEquivalenceHarness.cs
@@ -81,6 +81,21 @@ internal static class MetadataEquivalencePaths
         return Path.Combine(Path.GetDirectoryName(Path.TrimEndingDirectorySeparator(artifacts))
                             ?? artifacts, "metadata-ground-truth");
     }
+
+    /// <summary>
+    /// Bundles for the BC build this process actually loaded — never the whole root.
+    ///
+    /// A dev box accumulates one directory per build it has generated, and every one of them
+    /// holds a System Application bundle with the same table ids. Registering two of those
+    /// packages into RecordPatches' process-global state makes the second table id lose to the
+    /// first, and the comparison then measures one app's metadata against another app's
+    /// symbols — a wrong answer, arrived at silently, of exactly the kind this harness exists
+    /// to catch. CI has one build so it would never have shown up there.
+    /// </summary>
+    public static string GroundTruthDirForThisBuild()
+        => Path.Combine(GroundTruthRoot(),
+            Path.GetFileName(Path.TrimEndingDirectorySeparator(
+                AlRunner.Infrastructure.BcArtifacts.ServiceTierDir)));
 }
 
 internal static class MetadataEquivalenceHarness
@@ -212,7 +227,12 @@ internal static class MetadataEquivalenceHarness
     /// </summary>
     public static string? FindAppPackage(GroundTruthBundle bundle)
     {
-        var artifacts = AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir;
+        // Scoped to the build's own artifact directory rather than the whole root, for the
+        // same reason GroundTruthDirForThisBuild is: several builds of one app are on a dev
+        // box, they carry the same object ids, and picking the wrong one is not detectable
+        // downstream.
+        var artifacts = Path.Combine(
+            AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, bundle.BcBuild);
         var wanted = $"{bundle.AppPublisher}_{bundle.AppName}_{bundle.AppVersion}.app";
         if (!Directory.Exists(artifacts)) return null;
         foreach (var candidate in Directory.EnumerateFiles(artifacts, "*.app", SearchOption.AllDirectories))

--- a/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
+++ b/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
@@ -245,6 +245,99 @@ public sealed class MetadataEquivalenceHarnessTests
         Assert.Equal(pinned.Tables, systemApp.ObjectsCompared);
     }
 
+    [SkippableFact]
+    public void TranslationKeysAreDerivable_NotAPermanentLimit()
+    {
+        // Why this test exists rather than a sentence in the allowlist.
+        //
+        // Seven TranslationKey entries account for 25,721 of the 70,728 differences, and they
+        // were first declared as a PERMANENT limit of the symbol file on the evidence that
+        // SymbolReference.json contains the string "TranslationKey" zero times. That
+        // observation is true and the conclusion drawn from it was wrong: the key is COMPUTED
+        // from names, not stored, so "nothing is stored" says nothing about whether anything
+        // can be derived. A permanent-limit reason is a licence to differ forever, so the
+        // claim underneath it is pinned here instead of asserted in prose.
+        //
+        // The algorithm is BC's own LanguageKeyHelper.ConstructObjectHash:
+        //     (uint)(FNV-1a-32 over the UTF-16LE bytes of the name + int.MaxValue)
+        // and a key is "<Kind> <hash>" components joined by " - ", ending in the property.
+        //
+        // This is evidence, not an implementation. The reader fix (#3568) is where it lands.
+        var bundles = MetadataEquivalenceHarness.LoadBundles(
+            MetadataEquivalencePaths.GroundTruthDirForThisBuild());
+        Skip.If(bundles.Count == 0, "no metadata ground-truth bundle for this BC build.");
+
+        Assert.Equal(2879900210u, TranslationKeyHash("Caption"));
+        Assert.Equal(1295455071u, TranslationKeyHash("ToolTip"));
+        Assert.Equal(62802879u, TranslationKeyHash("OptionCaption"));
+
+        int attempted = 0, reproduced = 0, tables = 0;
+        var counterExamples = new List<string>();
+        foreach (var bundle in bundles)
+            foreach (var obj in bundle.Objects.Where(o => o.Kind == "MetaTable"))
+            {
+                var doc = new System.Xml.XmlDocument();
+                doc.Load(Path.Combine(bundle.Directory, obj.File));
+                var table = doc.DocumentElement!;
+                var tableName = table.GetAttribute("Name");
+                tables++;
+
+                Check(table.GetAttribute("CaptionTranslationKey"), tableName, null);
+                foreach (System.Xml.XmlNode field in table.GetElementsByTagName("Field"))
+                {
+                    var e = (System.Xml.XmlElement)field;
+                    var fieldName = e.GetAttribute("Name");
+                    foreach (var attr in new[]
+                             { "CaptionTranslationKey", "ToolTipTranslationKey", "OptionCaptionTranslationKey" })
+                        Check(e.GetAttribute(attr), tableName, fieldName);
+                }
+
+                void Check(string emitted, string owner, string? field)
+                {
+                    if (string.IsNullOrEmpty(emitted)) return;
+                    attempted++;
+                    var parts = emitted.Split(" - ", StringSplitOptions.None);
+                    var expected = new List<string> { "Table " + TranslationKeyHash(owner) };
+                    if (field is not null) expected.Add("Field " + TranslationKeyHash(field));
+
+                    var prefixMatches = parts.Length == expected.Count + 1
+                        && expected.Zip(parts).All(p => p.First == p.Second)
+                        && parts[^1].StartsWith("Property ", StringComparison.Ordinal);
+                    if (prefixMatches) reproduced++;
+                    else if (counterExamples.Count < 5)
+                        counterExamples.Add($"{obj.Name}: emitted '{emitted}', derived '{string.Join(" - ", expected)} - Property …'");
+                }
+            }
+
+        Assert.True(counterExamples.Count == 0,
+            "the translation-key derivation does not reproduce BC's own keys, so declaring them " +
+            "recoverable is wrong and the allowlist reasons must say so:" + Environment.NewLine +
+            string.Join(Environment.NewLine, counterExamples));
+        // Non-vacuity, measured rather than guessed. An earlier version asserted a flat
+        // `> 2000`, which was a number nobody had measured: 27.5's System Application has 127
+        // tables against 28.x's 138, so it carries 1,964 keys and the test failed on a run
+        // where the derivation had in fact reproduced every single one. The floor now comes
+        // from the bundle itself — every table document carries a CaptionTranslationKey, so
+        // fewer keys than tables means this stopped finding them.
+        Assert.Equal(attempted, reproduced);
+        Assert.True(attempted >= tables && tables > 0,
+            $"only {attempted} translation keys were found across {tables} table document(s); " +
+            "every table carries a CaptionTranslationKey, so this test has stopped measuring " +
+            "what it claims to.");
+    }
+
+    /// <summary>
+    /// BC's <c>LanguageKeyHelper.ConstructObjectHash</c>: FNV-1a-32 over the name's UTF-16LE
+    /// bytes, plus <see cref="int.MaxValue"/>, wrapped to <see cref="uint"/>.
+    /// </summary>
+    private static uint TranslationKeyHash(string name)
+    {
+        uint hash = 2166136261;
+        foreach (var b in System.Text.Encoding.Unicode.GetBytes(name))
+            hash = unchecked((hash ^ b) * 16777619);
+        return unchecked(hash + int.MaxValue);
+    }
+
     private static bool IsDeclaredField(string path)
     {
         const string marker = "Fields[id=";

--- a/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
+++ b/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
@@ -1,0 +1,271 @@
+// MetadataEquivalenceHarnessTests — the gate for issue #3533.
+//
+// What it asserts, in the order the issue asks for it:
+//   1. every app tests/expectations/metadata-equivalence/apps.json declares is actually
+//      covered, so the harness cannot quietly measure less than it claims;
+//   2. every difference between BC's emitter and the runner's derivation is declared in the
+//      allowlist, with a reason — anything else fails;
+//   3. no allowlist entry has gone stale, so a landed reader fix must shrink the file;
+//   4. the CURRENT reader reproduces four independently-predicted defect counts. That is the
+//      test that shows this harness can fail: a harness green against a reader with 5,241
+//      wrong Editable values would be proving nothing.
+//
+// (4) is deliberately expressed as exact values, not "greater than zero". It fails if the
+// differ stops reporting, if it starts reporting more, and if the reader changes — which is
+// the point: when #3545 lands, this test is the thing that must be updated, in the same
+// commit, with the new measurement.
+//
+// Set AL_RUNNER_METADATA_EQUIVALENCE_REPORT=<path> to dump the full per-member diff; that
+// dump is the working specification for the reader fix.
+
+using AlRunner.Metadata;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class MetadataEquivalenceHarnessTests
+{
+    private readonly BcEngineFixture _engine;
+
+    public MetadataEquivalenceHarnessTests(BcEngineFixture engine) => _engine = engine;
+
+    private sealed record DeclaredApp(string Publisher, string Name, string Reason);
+
+    private static IReadOnlyList<DeclaredApp> DeclaredApps()
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(MetadataEquivalencePaths.AppsFile()));
+        return doc.RootElement.GetProperty("apps").EnumerateArray()
+            .Select(a => new DeclaredApp(
+                a.GetProperty("publisher").GetString()!,
+                a.GetProperty("name").GetString()!,
+                a.GetProperty("reason").GetString()!))
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Every bundle on this box, compared. Skips locally when nothing has been generated;
+    /// FAILS on CI, where the generator runs by construction — a leg where every bundle is
+    /// absent would otherwise report green having measured nothing, which is the exact defect
+    /// this harness exists to remove (same reasoning as TestArtifacts.SkipIfMissingIn).
+    /// </summary>
+    private IReadOnlyList<MetadataEquivalenceReport> RunAll()
+    {
+        Skip.IfNot(_engine.Ready, _engine.SkipReason);
+
+        var root = MetadataEquivalencePaths.GroundTruthRoot();
+        var bundles = MetadataEquivalenceHarness.LoadBundles(root);
+        if (bundles.Count == 0)
+        {
+            var reason =
+                $"no metadata ground-truth bundle under '{root}'. Generate one with " +
+                "tools/gen-metadata-ground-truth.sh (Business Foundation is ~3s, System " +
+                "Application ~14s), or set AL_RUNNER_METADATA_GROUND_TRUTH.";
+            if (TestArtifacts.RunningOnCi)
+                Assert.Fail(
+                    "On a CI leg the ground truth is generated before `dotnet test` (see the " +
+                    "'Generate BC metadata ground truth' step in .github/workflows/bc-tests.yml), " +
+                    "so its absence is a workflow regression, not a legitimate skip. Skipping here " +
+                    "would leave the metadata-equivalence gate reporting green while measuring " +
+                    "nothing. " + reason);
+            throw new SkipException(reason);
+        }
+
+        var reports = new List<MetadataEquivalenceReport>();
+        foreach (var bundle in bundles)
+        {
+            var app = MetadataEquivalenceHarness.FindAppPackage(bundle);
+            Assert.True(app is not null,
+                $"ground truth exists for {bundle.Label} but its .app is not on this box. The " +
+                "runner derives its side from that package's SymbolReference.json, so comparing " +
+                "against a different build would compare two things never meant to agree. " +
+                "Regenerate the bundle from the artifacts now present.");
+            reports.Add(MetadataEquivalenceHarness.Compare(bundle, app!));
+        }
+
+        WriteReportIfAsked(reports);
+        return reports;
+    }
+
+    [SkippableFact]
+    public void Every_declared_app_is_actually_covered()
+    {
+        var reports = RunAll();
+
+        foreach (var declared in DeclaredApps())
+        {
+            var hit = reports.FirstOrDefault(r =>
+                r.Bundle.AppName == declared.Name && r.Bundle.AppPublisher == declared.Publisher);
+            Assert.True(hit is not null,
+                $"apps.json declares '{declared.Publisher}_{declared.Name}' must be covered " +
+                $"({declared.Reason}), and no ground-truth bundle for it was found. Covered: " +
+                string.Join(", ", reports.Select(r => r.Bundle.Label)));
+            Assert.True(hit!.ObjectsCompared > 0,
+                $"{hit.Bundle.Label}: a bundle exists but NOTHING was compared. " + hit.Summary);
+        }
+    }
+
+    [SkippableFact]
+    public void Every_object_in_a_compared_kind_really_was_compared()
+    {
+        // The bundle's own census is the denominator, so a table the runner cannot build is a
+        // failure rather than a quietly smaller comparison.
+        foreach (var report in RunAll())
+        {
+            Assert.True(report.Unbuildable.Count == 0,
+                $"{report.Bundle.Label}: the runner produced no comparable metadata for " +
+                $"{report.Unbuildable.Count} object(s):{Environment.NewLine}" +
+                string.Join(Environment.NewLine, report.Unbuildable.Take(20)));
+
+            foreach (var kind in report.KindsCompared)
+                Assert.Equal(report.Bundle.Census[kind],
+                    report.Bundle.Objects.Count(o => o.Kind == kind));
+        }
+    }
+
+    [SkippableFact]
+    public void Every_difference_is_declared_with_a_reason()
+    {
+        var allowlist = MetadataDifferenceAllowlist.Load(MetadataEquivalencePaths.AllowlistFile());
+        var differences = RunAll().SelectMany(r => r.Differences).ToArray();
+
+        var verdict = allowlist.Classify(differences);
+
+        Assert.True(verdict.Undeclared.Count == 0, Undeclared(verdict));
+    }
+
+    [SkippableFact]
+    public void No_allowlist_entry_has_gone_stale()
+    {
+        var allowlist = MetadataDifferenceAllowlist.Load(MetadataEquivalencePaths.AllowlistFile());
+        var verdict = allowlist.Classify(RunAll().SelectMany(r => r.Differences).ToArray());
+
+        Assert.True(verdict.UnusedEntries.Count == 0,
+            "these allowlist entries no longer match any difference — the derivation now agrees " +
+            "with BC on them, so remove the entries (leaving them grants cover nobody reviewed):" +
+            Environment.NewLine + string.Join(Environment.NewLine, verdict.UnusedEntries));
+
+        Assert.True(verdict.ExceededEntries.Count == 0,
+            "these declared differences occur more often than the allowlist says — the defect got " +
+            "WORSE, which a membership-only allowlist would have hidden:" + Environment.NewLine +
+            string.Join(Environment.NewLine, verdict.ExceededEntries));
+    }
+
+    [SkippableFact]
+    public void The_harness_states_which_kinds_it_does_not_compare()
+    {
+        // Not decoration. A bundle carries every kind BC emitted; this harness compares
+        // tables. If that set silently widened or narrowed, "no differences" would mean
+        // something different from run to run.
+        foreach (var report in RunAll())
+        {
+            Assert.Equal(new[] { "MetaTable" }, report.KindsCompared);
+            Assert.NotEmpty(report.KindsNotCompared);
+            Assert.DoesNotContain("MetaTable", report.KindsNotCompared);
+        }
+    }
+
+    /// <summary>
+    /// Counts measured on one exact app build. Pinned per build because they MOVE with it: the
+    /// app's own AL changes between BC releases, so a number measured on 28.1 is not a
+    /// prediction about 28.4. A build that is not in here still gets the version-portable
+    /// assertions below; adding one is a measurement, not a guess.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, (int Editable, int DataClassification, int EnumTypeId, int Tables)>
+        PinnedSystemApplicationCounts = new Dictionary<string, (int, int, int, int)>(StringComparer.Ordinal)
+        {
+            ["28.1.49838.54044"] = (78, 661, 76, 138),
+        };
+
+    [SkippableFact]
+    public void The_current_reader_reproduces_the_known_defect_shapes()
+    {
+        // This is the test that shows the harness can FAIL. A metadata gate that was green
+        // against a reader answering 5,241 wrong Editable values would be proving nothing, so
+        // the first thing to establish about this harness is that it sees those defects.
+        //
+        // Two tiers, deliberately. The portable claims hold on every BC build and are exact —
+        // "on EVERY table", not "on some" — so they cannot be satisfied by a differ that has
+        // started reporting almost nothing. The pinned counts are the sharper claim and apply
+        // only on the build they were measured on.
+        var reports = RunAll();
+
+        foreach (var report in reports)
+        {
+            int MissingRelation(int fieldId) => report.Differences
+                .Where(d => d.Member == "Relations." + MetadataObjectDiff.PresenceMember
+                            && d.Path.StartsWith($"Fields[id={fieldId}].Relations[", StringComparison.Ordinal)
+                            && d.Actual == MetadataObjectDiff.Absent)
+                .Select(d => d.ObjectKey).Distinct().Count();
+
+            // BC gives both of these a TableRelation to User (2000000120) and the runner gives
+            // them none — on every table, in every app, which is why this is expressed against
+            // the number of tables compared rather than as a constant.
+            Assert.Equal(report.ObjectsCompared, MissingRelation(2000000002));
+            Assert.Equal(report.ObjectsCompared, MissingRelation(2000000004));
+
+            int Declared(string signature) => report.Differences
+                .Count(d => d.Signature == signature && IsDeclaredField(d.Path));
+
+            Assert.True(Declared("MetaField.Editable") > 0,
+                $"{report.Bundle.Label}: the reader now agrees with BC on Editable for every " +
+                "declared field. If #3545 landed, update this test with the new measurement; " +
+                "if it did not, the harness has stopped seeing a defect it used to see.");
+            Assert.True(Declared("MetaField.DataClassification") > 0,
+                $"{report.Bundle.Label}: the reader now agrees with BC on field DataClassification.");
+        }
+
+        var systemApp = reports.FirstOrDefault(r => r.Bundle.AppName == "System Application");
+        Skip.If(systemApp is null, "no System Application ground truth on this box.");
+        if (!PinnedSystemApplicationCounts.TryGetValue(systemApp!.Bundle.AppVersion, out var pinned))
+            return;   // a build nobody has measured; the portable claims above still ran
+
+        int DeclaredIn(string signature) => systemApp.Differences
+            .Count(d => d.Signature == signature && IsDeclaredField(d.Path));
+
+        Assert.Equal(pinned.Editable, DeclaredIn("MetaField.Editable"));
+        Assert.Equal(pinned.DataClassification, DeclaredIn("MetaField.DataClassification"));
+        Assert.Equal(pinned.EnumTypeId, DeclaredIn("MetaField.EnumTypeId"));
+        Assert.Equal(pinned.Tables, systemApp.ObjectsCompared);
+    }
+
+    private static bool IsDeclaredField(string path)
+    {
+        const string marker = "Fields[id=";
+        var i = path.IndexOf(marker, StringComparison.Ordinal);
+        if (i < 0) return false;
+        var j = path.IndexOf(']', i);
+        return j > 0
+               && int.TryParse(path.AsSpan(i + marker.Length, j - i - marker.Length), out var id)
+               && id > 0 && id < 2000000000;
+    }
+
+    private static string Undeclared(MetadataAllowlistVerdict verdict)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("BC's metadata emitter and the runner's SymbolReference derivation disagree on " +
+                      $"{verdict.Undeclared.Count} member(s) that nothing declares. Each is either a " +
+                      "reader defect to fix or a difference to declare in " +
+                      "tests/expectations/metadata-equivalence/allowlist.json with a reason.");
+        foreach (var g in verdict.Undeclared.GroupBy(d => d.Signature)
+                     .OrderByDescending(g => g.Count()).Take(40))
+            sb.AppendLine($"  {g.Key,-48} x{g.Count(),-6} e.g. {g.First()}");
+        return sb.ToString();
+    }
+
+    private static void WriteReportIfAsked(IReadOnlyList<MetadataEquivalenceReport> reports)
+    {
+        var path = Environment.GetEnvironmentVariable("AL_RUNNER_METADATA_EQUIVALENCE_REPORT");
+        if (string.IsNullOrEmpty(path)) return;
+        var sb = new StringBuilder();
+        foreach (var r in reports)
+        {
+            sb.AppendLine("# " + r.Summary);
+            foreach (var d in r.Differences)
+                sb.AppendLine($"{r.Bundle.AppName}\t{d.ObjectKey}\t{d.Path}\t{d.Signature}\t{d.Expected}\t{d.Actual}");
+        }
+        File.WriteAllText(path, sb.ToString());
+    }
+}

--- a/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
+++ b/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
@@ -55,14 +55,22 @@ public sealed class MetadataEquivalenceHarnessTests
     {
         Skip.IfNot(_engine.Ready, _engine.SkipReason);
 
-        var root = MetadataEquivalencePaths.GroundTruthRoot();
+        var root = MetadataEquivalencePaths.GroundTruthDirForThisBuild();
         var bundles = MetadataEquivalenceHarness.LoadBundles(root);
         if (bundles.Count == 0)
         {
+            // Names the exact --artifacts to pass. A dev box holds several BC builds and the
+            // generator's own default is the NEWEST one, while this process loaded whichever
+            // build the runner was compiled against — so "just run the generator" is not
+            // actionable on its own and has already cost one round trip.
             var reason =
-                $"no metadata ground-truth bundle under '{root}'. Generate one with " +
-                "tools/gen-metadata-ground-truth.sh (Business Foundation is ~3s, System " +
-                "Application ~14s), or set AL_RUNNER_METADATA_GROUND_TRUTH.";
+                $"no metadata ground-truth bundle under '{root}'. This test process loaded BC " +
+                $"from '{AlRunner.Infrastructure.BcArtifacts.ServiceTierDir}', so generate for " +
+                $"that build:{Environment.NewLine}" +
+                $"  tools/gen-metadata-ground-truth.sh --artifacts " +
+                $"\"{AlRunner.Infrastructure.BcArtifacts.ServiceTierDir}\"{Environment.NewLine}" +
+                "Business Foundation is ~3s and System Application ~14s. " +
+                "AL_RUNNER_METADATA_GROUND_TRUTH overrides where bundles are read from.";
             if (TestArtifacts.RunningOnCi)
                 Assert.Fail(
                     "On a CI leg the ground truth is generated before `dotnet test` (see the " +
@@ -176,7 +184,13 @@ public sealed class MetadataEquivalenceHarnessTests
     private static readonly IReadOnlyDictionary<string, (int Editable, int DataClassification, int EnumTypeId, int Tables)>
         PinnedSystemApplicationCounts = new Dictionary<string, (int, int, int, int)>(StringComparer.Ordinal)
         {
+            // Measured by running this harness on each build. They MOVE — DataClassification
+            // is 661 / 663 / 617 and EnumTypeId 76 / 76 / 75 across the three below — which is
+            // why they are pinned per build rather than asserted as constants.
+            ["28.1.49838.53910"] = (78, 661, 76, 138),
             ["28.1.49838.54044"] = (78, 661, 76, 138),
+            ["28.4.53241.53989"] = (78, 663, 76, 138),
+            ["27.5.46862.53931"] = (78, 617, 75, 127),
         };
 
     [SkippableFact]

--- a/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
+++ b/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
@@ -152,13 +152,10 @@ public sealed class MetadataEquivalenceHarnessTests
 
         Assert.True(verdict.UnusedEntries.Count == 0,
             "these allowlist entries no longer match any difference — the derivation now agrees " +
-            "with BC on them, so remove the entries (leaving them grants cover nobody reviewed):" +
+            "with BC on them, so remove the entries (leaving them grants cover nobody reviewed). " +
+            "A direction-scoped entry also lands here when every difference has flipped to the " +
+            "direction it does NOT cover, which is a finding rather than a tidy-up:" +
             Environment.NewLine + string.Join(Environment.NewLine, verdict.UnusedEntries));
-
-        Assert.True(verdict.ExceededEntries.Count == 0,
-            "these declared differences occur more often than the allowlist says — the defect got " +
-            "WORSE, which a membership-only allowlist would have hidden:" + Environment.NewLine +
-            string.Join(Environment.NewLine, verdict.ExceededEntries));
     }
 
     [SkippableFact]
@@ -175,38 +172,30 @@ public sealed class MetadataEquivalenceHarnessTests
         }
     }
 
-    /// <summary>
-    /// Counts measured on one exact app build. Pinned per build because they MOVE with it: the
-    /// app's own AL changes between BC releases, so a number measured on 28.1 is not a
-    /// prediction about 28.4. A build that is not in here still gets the version-portable
-    /// assertions below; adding one is a measurement, not a guess.
-    /// </summary>
-    private static readonly IReadOnlyDictionary<string, (int Editable, int DataClassification, int EnumTypeId, int Tables)>
-        PinnedSystemApplicationCounts = new Dictionary<string, (int, int, int, int)>(StringComparer.Ordinal)
-        {
-            // Measured by running this harness on each build. They MOVE — DataClassification
-            // is 661 / 663 / 617 and EnumTypeId 76 / 76 / 75 across the three below — which is
-            // why they are pinned per build rather than asserted as constants.
-            ["28.1.49838.53910"] = (78, 661, 76, 138),
-            ["28.1.49838.54044"] = (78, 661, 76, 138),
-            ["28.4.53241.53989"] = (78, 663, 76, 138),
-            ["27.5.46862.53931"] = (78, 617, 75, 127),
-        };
-
     [SkippableFact]
     public void The_current_reader_reproduces_the_known_defect_shapes()
     {
         // This is the test that shows the harness can FAIL. A metadata gate that was green
-        // against a reader answering 5,241 wrong Editable values would be proving nothing, so
-        // the first thing to establish about this harness is that it sees those defects.
+        // against a reader answering 5,241 wrong Editable values would be proving nothing.
         //
-        // Two tiers, deliberately. The portable claims hold on every BC build and are exact —
-        // "on EVERY table", not "on some" — so they cannot be satisfied by a differ that has
-        // started reporting almost nothing. The pinned counts are the sharper claim and apply
-        // only on the build they were measured on.
-        var reports = RunAll();
-
-        foreach (var report in reports)
+        // Every claim here is exact AND build-independent, and that combination is deliberate.
+        // An earlier version pinned the COUNTS per four-part BC build (78 / 661 / 76 / 138 on
+        // 28.1.49838.54044) and returned silently on a build it did not know. CI resolves
+        // 28.4 to a build that moves, so the lookup missed and all four numbers went unasserted
+        // — green, with nothing to say it had checked nothing. A pin that disappears when the
+        // build moves is worse than no pin, because it reads as covered.
+        //
+        // The fix is not to choose which way that fails. The counts genuinely move with the
+        // build (System Application's DataClassification is 661 / 663 / 617 across 28.1 / 28.4
+        // / 27.5, and its table count 138 / 138 / 127), so ANY key is either too tight and goes
+        // inert or too loose and asserts a number that held once. The SHAPE does not move: the
+        // reader answers a constant, which is what the defect IS. Measured on all three builds,
+        // BC says False on 87 of 87 Editable differences and the runner says True on 87 of 87;
+        // the runner says CustomerContent on 620-666 of 620-666 DataClassification differences
+        // and 0 on every EnumTypeId one. Asserting the constant is both stronger than a count
+        // and incapable of going inert. The counts themselves are recorded in
+        // docs/metadata-equivalence.md, where a measurement belongs.
+        foreach (var report in RunAll())
         {
             int MissingRelation(int fieldId) => report.Differences
                 .Where(d => d.Member == "Relations." + MetadataObjectDiff.PresenceMember
@@ -214,35 +203,50 @@ public sealed class MetadataEquivalenceHarnessTests
                             && d.Actual == MetadataObjectDiff.Absent)
                 .Select(d => d.ObjectKey).Distinct().Count();
 
-            // BC gives both of these a TableRelation to User (2000000120) and the runner gives
-            // them none — on every table, in every app, which is why this is expressed against
-            // the number of tables compared rather than as a constant.
+            // BC gives both a TableRelation to User (2000000120) and the runner gives them
+            // none — on EVERY table, which is why this is against the number compared rather
+            // than a constant.
             Assert.Equal(report.ObjectsCompared, MissingRelation(2000000002));
             Assert.Equal(report.ObjectsCompared, MissingRelation(2000000004));
 
-            int Declared(string signature) => report.Differences
-                .Count(d => d.Signature == signature && IsDeclaredField(d.Path));
+            MetadataDifference[] Declared(string signature) => report.Differences
+                .Where(d => d.Signature == signature && IsDeclaredField(d.Path)).ToArray();
 
-            Assert.True(Declared("MetaField.Editable") > 0,
-                $"{report.Bundle.Label}: the reader now agrees with BC on Editable for every " +
-                "declared field. If #3545 landed, update this test with the new measurement; " +
-                "if it did not, the harness has stopped seeing a defect it used to see.");
-            Assert.True(Declared("MetaField.DataClassification") > 0,
-                $"{report.Bundle.Label}: the reader now agrees with BC on field DataClassification.");
+            AssertConstantAnswer(report, Declared("MetaField.Editable"), "MetaField.Editable",
+                bc: "False", runner: "True");
+            AssertConstantAnswer(report, Declared("MetaField.DataClassification"),
+                "MetaField.DataClassification", bc: null, runner: "CustomerContent");
+            AssertConstantAnswer(report, Declared("MetaField.EnumTypeId"), "MetaField.EnumTypeId",
+                bc: null, runner: "0");
         }
+    }
 
-        var systemApp = reports.FirstOrDefault(r => r.Bundle.AppName == "System Application");
-        Skip.If(systemApp is null, "no System Application ground truth on this box.");
-        if (!PinnedSystemApplicationCounts.TryGetValue(systemApp!.Bundle.AppVersion, out var pinned))
-            return;   // a build nobody has measured; the portable claims above still ran
+    /// <summary>
+    /// Every difference on <paramref name="signature"/> answers the same constant on the
+    /// runner's side (and optionally on BC's), and there is at least one. Non-emptiness is half
+    /// the assertion: "all zero of them agree" is how this would pass having checked nothing.
+    /// </summary>
+    private static void AssertConstantAnswer(
+        MetadataEquivalenceReport report, MetadataDifference[] differences,
+        string signature, string? bc, string runner)
+    {
+        Assert.True(differences.Length > 0,
+            $"{report.Bundle.Label}: the reader now agrees with BC on {signature} for every " +
+            "declared field. If the reader fix landed, this test is what must be updated in the " +
+            "same change; if it did not, the harness has stopped seeing a defect it used to see.");
 
-        int DeclaredIn(string signature) => systemApp.Differences
-            .Count(d => d.Signature == signature && IsDeclaredField(d.Path));
+        var runnerAnswers = differences.Select(d => d.Actual).Distinct().ToArray();
+        Assert.True(runnerAnswers.Length == 1 && runnerAnswers[0] == runner,
+            $"{report.Bundle.Label}: {signature} — the runner should answer the constant " +
+            $"'{runner}' on all {differences.Length} differences (that constant IS the defect: " +
+            "it is the value the reader falls back to). It answers: " +
+            string.Join(", ", runnerAnswers.Take(10)));
 
-        Assert.Equal(pinned.Editable, DeclaredIn("MetaField.Editable"));
-        Assert.Equal(pinned.DataClassification, DeclaredIn("MetaField.DataClassification"));
-        Assert.Equal(pinned.EnumTypeId, DeclaredIn("MetaField.EnumTypeId"));
-        Assert.Equal(pinned.Tables, systemApp.ObjectsCompared);
+        if (bc is null) return;
+        var bcAnswers = differences.Select(d => d.Expected).Distinct().ToArray();
+        Assert.True(bcAnswers.Length == 1 && bcAnswers[0] == bc,
+            $"{report.Bundle.Label}: {signature} — BC should answer '{bc}' on all " +
+            $"{differences.Length} differences. It answers: " + string.Join(", ", bcAnswers.Take(10)));
     }
 
     [SkippableFact]

--- a/AlRunner.Tests/MetadataObjectDiffTests.cs
+++ b/AlRunner.Tests/MetadataObjectDiffTests.cs
@@ -1,0 +1,373 @@
+// MetadataObjectDiffTests — the differ's own contract, provable with plain C# fixtures and
+// no BC service tier.
+//
+// The claim under test is TOTALITY: the differ must report a member it was never told about.
+// So the fixtures below deliberately carry properties with names nothing in the differ (or in
+// these tests' assertions) mentions, and the assertions are made against the SET of reported
+// paths rather than against a hand-written list of members — a test that named the members
+// would have exactly the blind spot this differ exists to remove.
+//
+// The real end-to-end measurement, against BC's own emitter output, is
+// MetadataEquivalenceHarnessTests; it needs the in-process engine and a ground-truth bundle.
+
+using AlRunner.Metadata;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class MetadataObjectDiffTests
+{
+    // Namespace-prefixed so the differ's default recursion rule treats these as metadata
+    // objects. The prefix is the only thing that matters; the shapes are ours.
+    private const string Prefix = "AlRunner.Tests";
+
+    private static MetadataObjectDiffOptions Opts(params string[] pairById) => new()
+    {
+        RecurseNamespacePrefixes = new[] { Prefix },
+        PairByIdMembers = new HashSet<string>(pairById.Length == 0
+            ? new[] { "FakeTable.Fields" } : pairById, StringComparer.Ordinal),
+    };
+
+    private sealed class FakeField
+    {
+        public int Id { get; init; }
+        public string? Name { get; init; }
+        public bool Editable { get; init; } = true;
+        public string? Classification { get; init; }
+        public FakeRelation? Relation { get; init; }
+    }
+
+    private sealed class FakeRelation
+    {
+        public int TargetTable { get; init; }
+        public string? Condition { get; init; }
+    }
+
+    private sealed class FakeTable
+    {
+        public int Id { get; init; }
+        public string? Caption { get; init; }
+        public Scope Scope { get; init; }
+        public List<FakeField> Fields { get; init; } = new();
+        public List<string> CaptionFields { get; init; } = new();
+    }
+
+    private enum Scope { Cloud, OnPrem }
+
+    private sealed class Node
+    {
+        public string? Name { get; set; }
+        public Node? Next { get; set; }
+    }
+
+    private static FakeTable Table(params FakeField[] fields)
+        => new() { Id = 5, Caption = "T", Fields = fields.ToList() };
+
+    // ---- totality ----------------------------------------------------------------------
+
+    [Fact]
+    public void Compare_reports_a_member_the_caller_never_named()
+    {
+        // `Classification` appears in no argument to Compare and in no option. If the differ
+        // only looked at members it was told about, this would come back empty.
+        var left = Table(new FakeField { Id = 1, Name = "No.", Classification = "SystemMetadata" });
+        var right = Table(new FakeField { Id = 1, Name = "No.", Classification = "CustomerContent" });
+
+        var diff = MetadataObjectDiff.Compare(left, right, "Table 5", Opts());
+
+        var d = Assert.Single(diff);
+        Assert.Equal("Fields[id=1].Classification", d.Path);
+        Assert.Equal("FakeField.Classification", d.Signature);
+        Assert.Equal("SystemMetadata", d.Expected);
+        Assert.Equal("CustomerContent", d.Actual);
+    }
+
+    [Fact]
+    public void Compare_reports_nothing_when_every_member_agrees()
+    {
+        var left = Table(new FakeField { Id = 1, Name = "No.", Classification = "X" });
+        var right = Table(new FakeField { Id = 1, Name = "No.", Classification = "X" });
+
+        Assert.Empty(MetadataObjectDiff.Compare(left, right, "Table 5", Opts()));
+    }
+
+    [Fact]
+    public void Compare_walks_into_a_nested_metadata_object()
+    {
+        var left = Table(new FakeField { Id = 1, Relation = new FakeRelation { TargetTable = 2000000120 } });
+        var right = Table(new FakeField { Id = 1, Relation = new FakeRelation { TargetTable = 0 } });
+
+        var d = Assert.Single(MetadataObjectDiff.Compare(left, right, "Table 5", Opts()));
+        Assert.Equal("Fields[id=1].Relation.TargetTable", d.Path);
+        Assert.Equal("2000000120", d.Expected);
+        Assert.Equal("0", d.Actual);
+    }
+
+    // ---- both directions ---------------------------------------------------------------
+
+    [Fact]
+    public void Compare_reports_a_value_the_RIGHT_side_states_and_the_left_does_not()
+    {
+        // The direction that is easy to miss and is real here: the runner carries a table
+        // Caption where BC's is null (50 System Application tables).
+        var left = new FakeTable { Id = 5, Caption = null };
+        var right = new FakeTable { Id = 5, Caption = "Data Subjects" };
+
+        var d = Assert.Single(MetadataObjectDiff.Compare(left, right, "Table 5", Opts()));
+        Assert.Equal("Caption", d.Path);
+        Assert.Equal(MetadataObjectDiff.Null, d.Expected);
+        Assert.Equal("Data Subjects", d.Actual);
+    }
+
+    [Fact]
+    public void Compare_reports_an_element_only_the_RIGHT_side_has()
+    {
+        var left = Table(new FakeField { Id = 1 });
+        var right = Table(new FakeField { Id = 1 }, new FakeField { Id = 2000000000, Name = "SystemId" });
+
+        var d = Assert.Single(MetadataObjectDiff.Compare(left, right, "Table 5", Opts()));
+        Assert.Equal("Fields[id=2000000000]", d.Path);
+        // The presence difference names the COLLECTION member, so an allowlist entry can cover
+        // extra Fields without also covering missing FieldGroups.
+        Assert.Equal("FakeTable.Fields." + MetadataObjectDiff.PresenceMember, d.Signature);
+        Assert.Equal(MetadataObjectDiff.Absent, d.Expected);
+        Assert.Equal("present", d.Actual);
+    }
+
+    [Fact]
+    public void Compare_reports_an_element_only_the_LEFT_side_has()
+    {
+        var left = Table(new FakeField { Id = 1 }, new FakeField { Id = 7 });
+        var right = Table(new FakeField { Id = 1 });
+
+        var d = Assert.Single(MetadataObjectDiff.Compare(left, right, "Table 5", Opts()));
+        Assert.Equal("Fields[id=7]", d.Path);
+        Assert.Equal("present", d.Expected);
+        Assert.Equal(MetadataObjectDiff.Absent, d.Actual);
+    }
+
+    // ---- pairing -----------------------------------------------------------------------
+
+    [Fact]
+    public void Fields_pair_by_id_so_an_extra_element_does_not_cascade()
+    {
+        // Positionally these two lists disagree on every element from index 0. Paired by id
+        // there is exactly one difference: the element that is missing.
+        var left = Table(new FakeField { Id = 1, Name = "a" }, new FakeField { Id = 2, Name = "b" });
+        var right = Table(new FakeField { Id = 2, Name = "b" });
+
+        var d = Assert.Single(MetadataObjectDiff.Compare(left, right, "Table 5", Opts()));
+        Assert.Equal("Fields[id=1]", d.Path);
+    }
+
+    [Fact]
+    public void Id_paired_elements_still_report_a_reordering()
+    {
+        // Pairing by id would otherwise HIDE order, and order is meaningful in AL.
+        var left = Table(new FakeField { Id = 1 }, new FakeField { Id = 2 });
+        var right = Table(new FakeField { Id = 2 }, new FakeField { Id = 1 });
+
+        var diff = MetadataObjectDiff.Compare(left, right, "Table 5", Opts());
+        Assert.Equal(2, diff.Count);
+        Assert.All(diff, d => Assert.Equal("#Ordinal", d.Member));
+        Assert.Contains(diff, d => d.Path == "Fields[id=1].#Ordinal" && d.Expected == "0" && d.Actual == "1");
+        Assert.Contains(diff, d => d.Path == "Fields[id=2].#Ordinal" && d.Expected == "1" && d.Actual == "0");
+    }
+
+    [Fact]
+    public void A_collection_not_declared_id_paired_is_compared_by_position()
+    {
+        var left = Table(new FakeField { Id = 1 });
+        var right = Table(new FakeField { Id = 1 });
+        left.CaptionFields.AddRange(new[] { "a", "b" });
+        right.CaptionFields.AddRange(new[] { "a" });
+
+        var d = Assert.Single(MetadataObjectDiff.Compare(left, right, "Table 5", Opts()));
+        Assert.Equal("CaptionFields", d.Path);
+        Assert.Equal("[a,b]", d.Expected);
+        Assert.Equal("[a]", d.Actual);
+    }
+
+    // ---- rendering -----------------------------------------------------------------------
+
+    [Fact]
+    public void An_enum_is_a_leaf_reported_against_the_property_that_holds_it()
+    {
+        // Regression: recursing into an enum reported this as `Scope.#value__` — against the
+        // ENUM type, not the property — so an allowlist could not name `FakeTable.Scope`, and
+        // one entry would have covered every property sharing that enum type.
+        var left = new FakeTable { Id = 5, Scope = Scope.OnPrem };
+        var right = new FakeTable { Id = 5, Scope = Scope.Cloud };
+
+        var d = Assert.Single(MetadataObjectDiff.Compare(left, right, "Table 5", Opts()));
+        Assert.Equal("Scope", d.Path);
+        Assert.Equal("FakeTable.Scope", d.Signature);
+        Assert.Equal("OnPrem", d.Expected);
+        Assert.Equal("Cloud", d.Actual);
+    }
+
+    [Fact]
+    public void Null_and_empty_string_are_distinguishable()
+    {
+        var left = new FakeTable { Id = 5, Caption = null };
+        var right = new FakeTable { Id = 5, Caption = "" };
+
+        var d = Assert.Single(MetadataObjectDiff.Compare(left, right, "Table 5", Opts()));
+        Assert.Equal(MetadataObjectDiff.Null, d.Expected);
+        Assert.Equal("<empty>", d.Actual);
+    }
+
+    // ---- termination ---------------------------------------------------------------------
+
+    [Fact]
+    public void A_cycle_terminates_and_still_reports_the_difference_inside_it()
+    {
+        var left = new Node { Name = "a" };
+        left.Next = left;
+        var right = new Node { Name = "b" };
+        right.Next = right;
+
+        var d = Assert.Single(MetadataObjectDiff.Compare(left, right, "Node", Opts()));
+        Assert.Equal("Name", d.Path);
+    }
+
+    [Fact]
+    public void Exceeding_the_depth_limit_is_REPORTED_not_silently_truncated()
+    {
+        // A walk that quietly stops short is the same class of wrong answer as a test that
+        // names its properties: it reports "no differences" for a region it never looked at.
+        static Node Chain(int depth, string leaf)
+        {
+            var head = new Node { Name = "n" };
+            var cur = head;
+            for (int i = 0; i < depth; i++) { cur.Next = new Node { Name = "n" }; cur = cur.Next; }
+            cur.Name = leaf;
+            return head;
+        }
+
+        var diff = MetadataObjectDiff.Compare(
+            Chain(6, "left"), Chain(6, "right"), "Node",
+            new MetadataObjectDiffOptions { MaxDepth = 3, RecurseNamespacePrefixes = new[] { Prefix } });
+
+        var d = Assert.Single(diff);
+        Assert.Equal(MetadataObjectDiff.DepthMember, d.Member);
+        Assert.Contains("depth", d.Expected, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_getter_that_throws_on_one_side_only_is_reported()
+    {
+        var left = new Throwing { Explode = false };
+        var right = new Throwing { Explode = true };
+
+        var diff = MetadataObjectDiff.Compare(left, right, "Throwing", Opts());
+        var d = Assert.Single(diff, x => x.Path == "Value");
+        Assert.Equal("ok", d.Expected);
+        Assert.StartsWith("<throw:", d.Actual, StringComparison.Ordinal);
+    }
+
+    private sealed class Throwing
+    {
+        public bool Explode { get; init; }
+        public string Value => Explode ? throw new InvalidOperationException("boom") : "ok";
+    }
+
+    [Fact]
+    public void A_private_field_with_no_property_is_still_compared()
+    {
+        // MetaTable.fieldsById is exactly this shape: real state reachable only as a field.
+        var left = new WithPrivateField(1);
+        var right = new WithPrivateField(2);
+
+        var d = Assert.Single(MetadataObjectDiff.Compare(left, right, "WithPrivateField", Opts()));
+        Assert.Equal("#_hidden", d.Path);
+        Assert.Equal("1", d.Expected);
+        Assert.Equal("2", d.Actual);
+    }
+
+    private sealed class WithPrivateField
+    {
+#pragma warning disable CS0414 // read reflectively; that IS the subject of the test
+        private readonly int _hidden;
+#pragma warning restore CS0414
+        public WithPrivateField(int hidden) => _hidden = hidden;
+    }
+
+    [Fact]
+    public void An_auto_property_is_reported_once_not_twice()
+    {
+        // Auto-property backing fields are skipped precisely so a single disagreement does
+        // not arrive as two, which would double every count the allowlist ratchets on.
+        var left = new FakeTable { Id = 5, Caption = "a" };
+        var right = new FakeTable { Id = 5, Caption = "b" };
+
+        Assert.Single(MetadataObjectDiff.Compare(left, right, "Table 5", Opts()));
+    }
+
+    [Fact]
+    public void Two_collection_members_on_one_type_get_DIFFERENT_presence_signatures()
+    {
+        // Regression: both used to arrive as `FakeTwo.<presence>`, so one allowlist entry
+        // covered both — declaring one difference would have silently declared the other.
+        var left = new FakeTwo { A = { new FakeField { Id = 1 } }, B = { new FakeField { Id = 2 } } };
+        var right = new FakeTwo();
+
+        var diff = MetadataObjectDiff.Compare(left, right, "Two",
+            new MetadataObjectDiffOptions { RecurseNamespacePrefixes = new[] { Prefix } });
+
+        Assert.Equal(2, diff.Count);
+        Assert.Contains(diff, d => d.Signature == "FakeTwo.A.<presence>");
+        Assert.Contains(diff, d => d.Signature == "FakeTwo.B.<presence>");
+    }
+
+    private sealed class FakeTwo
+    {
+        public List<FakeField> A { get; } = new();
+        public List<FakeField> B { get; } = new();
+    }
+
+    [Fact]
+    public void A_nested_member_present_on_one_side_only_names_the_MEMBER_not_its_type()
+    {
+        // Regression: reported as `FakeRelation.<presence>`, which cannot distinguish two
+        // members of the same type on the same object.
+        var left = Table(new FakeField { Id = 1, Relation = new FakeRelation { TargetTable = 7 } });
+        var right = Table(new FakeField { Id = 1, Relation = null });
+
+        var d = Assert.Single(MetadataObjectDiff.Compare(left, right, "Table 5", Opts()));
+        Assert.Equal("FakeField.Relation.<presence>", d.Signature);
+        Assert.Equal("present", d.Expected);
+        Assert.Equal(MetadataObjectDiff.Null, d.Actual);
+    }
+
+    [Fact]
+    public void A_dictionary_is_paired_by_KEY_not_by_position()
+    {
+        // Regression: MetaTable.FieldsById enumerates in insertion order, which differs
+        // between the two sides, and positional pairing turned that into 74 fabricated
+        // differences on Business Foundation alone.
+        var left = new FakeDict { ById = { [2] = "b", [1] = "a" } };
+        var right = new FakeDict { ById = { [1] = "a", [2] = "b" } };
+
+        Assert.Empty(MetadataObjectDiff.Compare(left, right, "Dict",
+            new MetadataObjectDiffOptions { RecurseNamespacePrefixes = new[] { Prefix } }));
+    }
+
+    [Fact]
+    public void A_dictionary_key_present_on_one_side_only_is_reported()
+    {
+        var left = new FakeDict { ById = { [1] = "a" } };
+        var right = new FakeDict { ById = { [1] = "a", [2] = "b" } };
+
+        var d = Assert.Single(MetadataObjectDiff.Compare(left, right, "Dict",
+            new MetadataObjectDiffOptions { RecurseNamespacePrefixes = new[] { Prefix } }));
+        Assert.Equal("ById[key=2]", d.Path);
+        Assert.Equal("FakeDict.ById.<presence>", d.Signature);
+        Assert.Equal(MetadataObjectDiff.Absent, d.Expected);
+    }
+
+    private sealed class FakeDict
+    {
+        public Dictionary<int, string> ById { get; } = new();
+    }
+}

--- a/AlRunner/Metadata/MetadataDifferenceAllowlist.cs
+++ b/AlRunner/Metadata/MetadataDifferenceAllowlist.cs
@@ -8,8 +8,15 @@
 //     runner deliberately does not implement, or a limitation of the oracle itself;
 //   * an entry that stops matching anything is an ERROR, not a tidy-up — that is how a
 //     landed fix forces the allowlist to shrink instead of leaving stale cover behind;
-//   * an entry may cap how many differences it covers, so a defect getting WORSE fails even
-//     though its shape is declared.
+//   * an entry may narrow itself to ONE direction, so a reason that justifies "the runner
+//     states something BC does not" cannot also license the reverse.
+//
+// There is deliberately no occurrence CAP. One was implemented and never used, which made the
+// PR claim a ratchet the code did not keep. No entry here has a bound that survives a rebuild:
+// the counts move with the BC build and with which apps are bundled (System Application's
+// DataClassification is 661 / 663 / 617 across 28.1 / 28.4 / 27.5), so any cap would be a
+// number nobody measured. `direction` narrows CATEGORICALLY instead, which is build-independent
+// and checkable per difference.
 //
 // The four kinds are separate because they need DIFFERENT evidence, and conflating them is
 // how a recoverable difference gets a permanent licence. Seven TranslationKey entries — 36%
@@ -64,32 +71,57 @@ public sealed class MetadataAllowlistEntry
     /// </summary>
     [JsonPropertyName("Doc")] public string? Doc { get; init; }
 
+    /// <summary>
+    /// Narrow the entry to ONE direction, so a reason that justifies one does not license the
+    /// other. <c>runner-only</c> covers a difference where BC's side is absent or null and the
+    /// runner states something; <c>bc-only</c> is the reverse. Null covers both.
+    ///
+    /// This is why it exists. The three merged-runtime entries are a permanent, uncapped
+    /// licence, and every difference they were written for is BC-absent / runner-present. Left
+    /// undirected they also covered "BC emitted a field and the runner built none" — a hard
+    /// reader defect, on every table, and the single class of defect the #3545 rewrite is most
+    /// likely to introduce. A check that cannot fail reads exactly like a check that passed.
+    /// </summary>
+    [JsonPropertyName("direction")] public string? Direction { get; init; }
+
     /// <summary>Only cover differences on this object, e.g. <c>Table 2000000120</c>.</summary>
     [JsonPropertyName("objectKey")] public string? ObjectKey { get; init; }
 
     /// <summary>Only cover differences whose path starts with this.</summary>
     [JsonPropertyName("pathPrefix")] public string? PathPrefix { get; init; }
 
-    /// <summary>Fail if more than this many differences match. Null means uncapped.</summary>
-    [JsonPropertyName("maxOccurrences")] public int? MaxOccurrences { get; init; }
+    public const string RunnerOnly = "runner-only";
+    public const string BcOnly = "bc-only";
 
     public bool Covers(MetadataDifference d)
         => string.Equals(Member, d.Signature, StringComparison.Ordinal)
            && (ObjectKey is null || string.Equals(ObjectKey, d.ObjectKey, StringComparison.Ordinal))
-           && (PathPrefix is null || d.Path.StartsWith(PathPrefix, StringComparison.Ordinal));
+           && (PathPrefix is null || d.Path.StartsWith(PathPrefix, StringComparison.Ordinal))
+           && DirectionCovers(d);
+
+    private bool DirectionCovers(MetadataDifference d) => Direction switch
+    {
+        null => true,
+        RunnerOnly => IsAbsentOrNull(d.Expected),
+        BcOnly => IsAbsentOrNull(d.Actual),
+        _ => false,   // unreachable: the constructor refuses an unknown direction
+    };
+
+    private static bool IsAbsentOrNull(string value)
+        => value == MetadataObjectDiff.Absent || value == MetadataObjectDiff.Null;
 
     public string Describe()
-        => Member + (ObjectKey is null ? "" : $" @{ObjectKey}") + (PathPrefix is null ? "" : $" ~{PathPrefix}");
+        => Member + (Direction is null ? "" : $" [{Direction}]")
+           + (ObjectKey is null ? "" : $" @{ObjectKey}") + (PathPrefix is null ? "" : $" ~{PathPrefix}");
 }
 
 /// <summary>What the allowlist made of one comparison.</summary>
 public sealed record MetadataAllowlistVerdict(
     IReadOnlyList<MetadataDifference> Undeclared,
     IReadOnlyList<string> UnusedEntries,
-    IReadOnlyList<string> ExceededEntries,
     IReadOnlyDictionary<string, int> OccurrencesByEntry)
 {
-    public bool Ok => Undeclared.Count == 0 && UnusedEntries.Count == 0 && ExceededEntries.Count == 0;
+    public bool Ok => Undeclared.Count == 0 && UnusedEntries.Count == 0;
 }
 
 public sealed class MetadataDifferenceAllowlist
@@ -122,6 +154,13 @@ public sealed class MetadataDifferenceAllowlist
                 throw new InvalidDataException(
                     $"metadata allowlist: entry '{e.Member}' claims more than one kind of reason. " +
                     "They need different evidence, so exactly one applies.");
+            if (e.Direction is not null
+                && e.Direction != MetadataAllowlistEntry.RunnerOnly
+                && e.Direction != MetadataAllowlistEntry.BcOnly)
+                throw new InvalidDataException(
+                    $"metadata allowlist: entry '{e.Member}' has direction '{e.Direction}'. " +
+                    $"Use '{MetadataAllowlistEntry.RunnerOnly}' or '{MetadataAllowlistEntry.BcOnly}', " +
+                    "or omit it to cover both.");
             if ((e.OutOfScope || e.OracleLimitation) && string.IsNullOrWhiteSpace(e.Doc))
                 throw new InvalidDataException(
                     $"metadata allowlist: entry '{e.Member}' declares a scope or oracle boundary " +
@@ -163,11 +202,7 @@ public sealed class MetadataDifferenceAllowlist
 
         var unused = Entries.Where(e => counts[e.Describe()] == 0)
             .Select(e => e.Describe()).ToArray();
-        var exceeded = Entries
-            .Where(e => e.MaxOccurrences is int cap && counts[e.Describe()] > cap)
-            .Select(e => $"{e.Describe()}: {counts[e.Describe()]} occurrences, declared max {e.MaxOccurrences}")
-            .ToArray();
 
-        return new MetadataAllowlistVerdict(undeclared, unused, exceeded, counts);
+        return new MetadataAllowlistVerdict(undeclared, unused, counts);
     }
 }

--- a/AlRunner/Metadata/MetadataDifferenceAllowlist.cs
+++ b/AlRunner/Metadata/MetadataDifferenceAllowlist.cs
@@ -3,12 +3,20 @@
 // difference from failing the run.
 //
 // The contract (issue #3533):
-//   * every declared difference carries a reason and, where it is a defect rather than a
-//     permanent limit, the issue tracking it;
+//   * every declared difference carries a reason AND says which KIND of reason it is —
+//     exactly one of: a tracked defect, a permanent limit of the symbol file, a surface the
+//     runner deliberately does not implement, or a limitation of the oracle itself;
 //   * an entry that stops matching anything is an ERROR, not a tidy-up — that is how a
 //     landed fix forces the allowlist to shrink instead of leaving stale cover behind;
 //   * an entry may cap how many differences it covers, so a defect getting WORSE fails even
 //     though its shape is declared.
+//
+// The four kinds are separate because they need DIFFERENT evidence, and conflating them is
+// how a recoverable difference gets a permanent licence. Seven TranslationKey entries — 36%
+// of the whole diff — were first declared a permanent limit of the symbol file on the
+// evidence that it stores no translation keys. True, and the wrong conclusion: the key is
+// computed from names rather than stored, and the computation reproduces all 2,153 of them.
+// "Nothing is stored" is evidence about storage, never about derivability.
 //
 // Drift is loud in both directions, the same way tests/expectations/ already works for
 // out-of-scope corpus tests (docs/expectations.md).
@@ -31,10 +39,30 @@ public sealed class MetadataAllowlistEntry
     [JsonPropertyName("issue")] public int? Issue { get; init; }
 
     /// <summary>
-    /// True when the difference is a permanent limit of the symbol file rather than a defect —
-    /// the "cannot express" set. Such an entry needs no issue.
+    /// The symbol file genuinely cannot express this and it cannot be derived either. Needs
+    /// evidence about DERIVABILITY, not merely that nothing is stored.
     /// </summary>
     [JsonPropertyName("cannotExpress")] public bool CannotExpress { get; init; }
+
+    /// <summary>
+    /// The runner deliberately does not implement the surface this member serves, so no AL
+    /// test can observe it. A scope declaration, not a capability limit — it says nothing
+    /// about whether the value could be produced. Requires <see cref="Doc"/>.
+    /// </summary>
+    [JsonPropertyName("outOfScope")] public bool OutOfScope { get; init; }
+
+    /// <summary>
+    /// The GROUND TRUTH is the wrong shape for this member, so the difference is expected by
+    /// construction and is not evidence about the runner at all. Requires <see cref="Doc"/>.
+    /// </summary>
+    [JsonPropertyName("oracleLimitation")] public bool OracleLimitation { get; init; }
+
+    /// <summary>
+    /// Where the claim is written down, as <c>docs/&lt;file&gt;.md#anchor</c>. Named
+    /// <c>Doc</c> so tools/test_doc_pointers.py validates the path AND the anchor — the same
+    /// convention the out-of-scope corpus expectations use.
+    /// </summary>
+    [JsonPropertyName("Doc")] public string? Doc { get; init; }
 
     /// <summary>Only cover differences on this object, e.g. <c>Table 2000000120</c>.</summary>
     [JsonPropertyName("objectKey")] public string? ObjectKey { get; init; }
@@ -81,11 +109,25 @@ public sealed class MetadataDifferenceAllowlist
                 throw new InvalidDataException(
                     $"metadata allowlist: entry '{e.Member}' has a placeholder reason " +
                     $"('{e.Reason}'). Every declared difference states why it is tolerated.");
-            if (e.Issue is null && !e.CannotExpress)
+            var kinds = (e.Issue is not null ? 1 : 0) + (e.CannotExpress ? 1 : 0)
+                        + (e.OutOfScope ? 1 : 0) + (e.OracleLimitation ? 1 : 0);
+            if (kinds == 0)
                 throw new InvalidDataException(
-                    $"metadata allowlist: entry '{e.Member}' names no issue and is not marked " +
-                    "'cannotExpress'. A tolerated DEFECT is tracked; only a permanent limit of " +
-                    "the symbol file is not.");
+                    $"metadata allowlist: entry '{e.Member}' says nothing about WHY it is " +
+                    "tolerated. Set exactly one of: 'issue' (a tracked defect), 'cannotExpress' " +
+                    "(the symbol file cannot express it and it cannot be derived), 'outOfScope' " +
+                    "(the runner does not implement the surface, so no AL test can see it), or " +
+                    "'oracleLimitation' (the ground truth is the wrong shape for it).");
+            if (kinds > 1)
+                throw new InvalidDataException(
+                    $"metadata allowlist: entry '{e.Member}' claims more than one kind of reason. " +
+                    "They need different evidence, so exactly one applies.");
+            if ((e.OutOfScope || e.OracleLimitation) && string.IsNullOrWhiteSpace(e.Doc))
+                throw new InvalidDataException(
+                    $"metadata allowlist: entry '{e.Member}' declares a scope or oracle boundary " +
+                    "with no 'Doc' pointer. Those two are permanent licences to differ, so the " +
+                    "claim has to be written down somewhere a reader can find and a reviewer can " +
+                    "disagree with — tools/test_doc_pointers.py checks the pointer resolves.");
         }
     }
 

--- a/AlRunner/Metadata/MetadataDifferenceAllowlist.cs
+++ b/AlRunner/Metadata/MetadataDifferenceAllowlist.cs
@@ -1,0 +1,131 @@
+// MetadataDifferenceAllowlist — the declared differences between BC's own metadata emitter
+// and the runner's SymbolReference-derived derivation, and the ONLY thing that keeps a
+// difference from failing the run.
+//
+// The contract (issue #3533):
+//   * every declared difference carries a reason and, where it is a defect rather than a
+//     permanent limit, the issue tracking it;
+//   * an entry that stops matching anything is an ERROR, not a tidy-up — that is how a
+//     landed fix forces the allowlist to shrink instead of leaving stale cover behind;
+//   * an entry may cap how many differences it covers, so a defect getting WORSE fails even
+//     though its shape is declared.
+//
+// Drift is loud in both directions, the same way tests/expectations/ already works for
+// out-of-scope corpus tests (docs/expectations.md).
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AlRunner.Metadata;
+
+/// <summary>One declared difference. Matching is on <see cref="Member"/>, optionally narrowed.</summary>
+public sealed class MetadataAllowlistEntry
+{
+    /// <summary><c>DeclaringType.Member</c>, e.g. <c>MetaField.Editable</c>.</summary>
+    [JsonPropertyName("member")] public string Member { get; init; } = "";
+
+    /// <summary>Why this difference is tolerated. Free text; a placeholder is refused.</summary>
+    [JsonPropertyName("reason")] public string Reason { get; init; } = "";
+
+    /// <summary>The issue tracking the fix, for a difference that is a defect.</summary>
+    [JsonPropertyName("issue")] public int? Issue { get; init; }
+
+    /// <summary>
+    /// True when the difference is a permanent limit of the symbol file rather than a defect —
+    /// the "cannot express" set. Such an entry needs no issue.
+    /// </summary>
+    [JsonPropertyName("cannotExpress")] public bool CannotExpress { get; init; }
+
+    /// <summary>Only cover differences on this object, e.g. <c>Table 2000000120</c>.</summary>
+    [JsonPropertyName("objectKey")] public string? ObjectKey { get; init; }
+
+    /// <summary>Only cover differences whose path starts with this.</summary>
+    [JsonPropertyName("pathPrefix")] public string? PathPrefix { get; init; }
+
+    /// <summary>Fail if more than this many differences match. Null means uncapped.</summary>
+    [JsonPropertyName("maxOccurrences")] public int? MaxOccurrences { get; init; }
+
+    public bool Covers(MetadataDifference d)
+        => string.Equals(Member, d.Signature, StringComparison.Ordinal)
+           && (ObjectKey is null || string.Equals(ObjectKey, d.ObjectKey, StringComparison.Ordinal))
+           && (PathPrefix is null || d.Path.StartsWith(PathPrefix, StringComparison.Ordinal));
+
+    public string Describe()
+        => Member + (ObjectKey is null ? "" : $" @{ObjectKey}") + (PathPrefix is null ? "" : $" ~{PathPrefix}");
+}
+
+/// <summary>What the allowlist made of one comparison.</summary>
+public sealed record MetadataAllowlistVerdict(
+    IReadOnlyList<MetadataDifference> Undeclared,
+    IReadOnlyList<string> UnusedEntries,
+    IReadOnlyList<string> ExceededEntries,
+    IReadOnlyDictionary<string, int> OccurrencesByEntry)
+{
+    public bool Ok => Undeclared.Count == 0 && UnusedEntries.Count == 0 && ExceededEntries.Count == 0;
+}
+
+public sealed class MetadataDifferenceAllowlist
+{
+    private static readonly string[] Placeholders = { "", "-", "n/a", "na", "none", "tbd", "todo", "?" };
+
+    public IReadOnlyList<MetadataAllowlistEntry> Entries { get; }
+
+    public MetadataDifferenceAllowlist(IEnumerable<MetadataAllowlistEntry> entries)
+    {
+        Entries = entries.ToArray();
+        foreach (var e in Entries)
+        {
+            if (string.IsNullOrWhiteSpace(e.Member))
+                throw new InvalidDataException("metadata allowlist: an entry has no 'member'.");
+            if (Placeholders.Contains(e.Reason.Trim().ToLowerInvariant()))
+                throw new InvalidDataException(
+                    $"metadata allowlist: entry '{e.Member}' has a placeholder reason " +
+                    $"('{e.Reason}'). Every declared difference states why it is tolerated.");
+            if (e.Issue is null && !e.CannotExpress)
+                throw new InvalidDataException(
+                    $"metadata allowlist: entry '{e.Member}' names no issue and is not marked " +
+                    "'cannotExpress'. A tolerated DEFECT is tracked; only a permanent limit of " +
+                    "the symbol file is not.");
+        }
+    }
+
+    public static MetadataDifferenceAllowlist Load(string path)
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        if (!doc.RootElement.TryGetProperty("differences", out var arr)
+            || arr.ValueKind != JsonValueKind.Array)
+            throw new InvalidDataException($"{path}: missing 'differences' array.");
+        var entries = JsonSerializer.Deserialize<MetadataAllowlistEntry[]>(arr.GetRawText())
+                      ?? Array.Empty<MetadataAllowlistEntry>();
+        return new MetadataDifferenceAllowlist(entries);
+    }
+
+    /// <summary>Empty allowlist — every difference is undeclared. Used to measure the raw diff.</summary>
+    public static MetadataDifferenceAllowlist None { get; } =
+        new(Array.Empty<MetadataAllowlistEntry>());
+
+    public MetadataAllowlistVerdict Classify(IReadOnlyList<MetadataDifference> differences)
+    {
+        var counts = Entries.ToDictionary(e => e.Describe(), _ => 0, StringComparer.Ordinal);
+        var undeclared = new List<MetadataDifference>();
+
+        foreach (var d in differences)
+        {
+            // First entry wins, so a narrowed entry must be listed before a broad one that
+            // would otherwise swallow it — and the unused-entry check below is what makes a
+            // shadowed entry visible rather than silently inert.
+            var hit = Entries.FirstOrDefault(e => e.Covers(d));
+            if (hit is null) { undeclared.Add(d); continue; }
+            counts[hit.Describe()]++;
+        }
+
+        var unused = Entries.Where(e => counts[e.Describe()] == 0)
+            .Select(e => e.Describe()).ToArray();
+        var exceeded = Entries
+            .Where(e => e.MaxOccurrences is int cap && counts[e.Describe()] > cap)
+            .Select(e => $"{e.Describe()}: {counts[e.Describe()]} occurrences, declared max {e.MaxOccurrences}")
+            .ToArray();
+
+        return new MetadataAllowlistVerdict(undeclared, unused, exceeded, counts);
+    }
+}

--- a/AlRunner/Metadata/MetadataObjectDiff.cs
+++ b/AlRunner/Metadata/MetadataObjectDiff.cs
@@ -1,0 +1,474 @@
+// MetadataObjectDiff — a TOTAL, reflective comparison of two BC metadata objects.
+//
+// The point of "total": this walks every readable instance member the type has, found by
+// reflection at run time, rather than a list of members someone chose to check. A test that
+// names its properties cannot fail on the property nobody thought about, which is exactly how
+// the runner shipped 5,241 wrong `Editable` values and 3,760 wrong `DataClassification`
+// values while every metadata test was green (issue #3533).
+//
+// So: no member allowlist HERE. What is known-different is declared once, with a reason, in
+// MetadataDifferenceAllowlist, and everything else is a failure. A BC version that adds a
+// property therefore surfaces as a new, undeclared difference.
+//
+// Nothing about this file is BC-specific in its types — it takes `object` and reflects — so
+// it is unit-testable with plain C# fixtures and no service tier. See
+// docs/metadata-equivalence.md for how it is driven and what the ground truth is.
+
+using System.Collections;
+using System.Globalization;
+using System.Reflection;
+using System.Text;
+
+namespace AlRunner.Metadata;
+
+/// <summary>One member on which the two sides disagree.</summary>
+/// <param name="ObjectKey">The object being compared, e.g. <c>Table 1180</c>.</param>
+/// <param name="Path">Where in the object graph, e.g. <c>Fields[id=7].Editable</c>.</param>
+/// <param name="DeclaringType">Simple name of the type declaring the member, e.g. <c>MetaField</c>.</param>
+/// <param name="Member">The member's own name, or <see cref="MetadataObjectDiff.PresenceMember"/>.</param>
+/// <param name="Expected">Ground truth — what BC's emitter produced.</param>
+/// <param name="Actual">What the runner derived.</param>
+public sealed record MetadataDifference(
+    string ObjectKey,
+    string Path,
+    string DeclaringType,
+    string Member,
+    string Expected,
+    string Actual)
+{
+    /// <summary>The <c>Type.Member</c> pair an allowlist entry declares.</summary>
+    public string Signature => DeclaringType + "." + Member;
+
+    public override string ToString()
+        => $"{ObjectKey} {Path}: expected '{Expected}', got '{Actual}'";
+}
+
+public sealed class MetadataObjectDiffOptions
+{
+    /// <summary>
+    /// How deep the walk may go before it stops. Exceeding it is REPORTED as a difference
+    /// rather than silently truncating — a walk that quietly stops short is the same class of
+    /// wrong answer this whole harness exists to prevent.
+    /// </summary>
+    public int MaxDepth { get; init; } = 12;
+
+    /// <summary>
+    /// Namespace prefixes whose objects are walked member-by-member. Anything else is a leaf
+    /// rendered through <c>ToString()</c>. Defaults to BC's own metadata assemblies.
+    /// </summary>
+    public IReadOnlyList<string> RecurseNamespacePrefixes { get; init; } =
+        new[] { "Microsoft.Dynamics.Nav." };
+
+    /// <summary>
+    /// Collection members whose elements are paired by an <c>Id</c> property instead of by
+    /// position, given as <c>DeclaringType.Member</c>. Position is the default because element
+    /// ORDER is meaningful in AL (a table's keys, a key's fields); an id-paired member also
+    /// gets a synthetic <c>#Ordinal</c> comparison so a reordering is still caught.
+    /// </summary>
+    public IReadOnlySet<string> PairByIdMembers { get; init; } =
+        new HashSet<string>(StringComparer.Ordinal) { "MetaTable.Fields" };
+}
+
+public static class MetadataObjectDiff
+{
+    /// <summary>Member name used when an element exists on one side only.</summary>
+    public const string PresenceMember = "<presence>";
+
+    /// <summary>Member name used when the walk hit <see cref="MetadataObjectDiffOptions.MaxDepth"/>.</summary>
+    public const string DepthMember = "<depth-limit>";
+
+    public const string Absent = "<absent>";
+    public const string Null = "<null>";
+
+    public static IReadOnlyList<MetadataDifference> Compare(
+        object? expected, object? actual, string objectKey, MetadataObjectDiffOptions? options = null)
+    {
+        var opts = options ?? new MetadataObjectDiffOptions();
+        var acc = new List<MetadataDifference>();
+        var comparedPairs = new HashSet<(object, object)>(PairComparer.Instance);
+        Walk(expected, actual, objectKey, path: "", depth: 0, opts, acc, comparedPairs);
+        return acc;
+    }
+
+    private static void Walk(
+        object? expected, object? actual, string objectKey, string path, int depth,
+        MetadataObjectDiffOptions opts, List<MetadataDifference> acc,
+        HashSet<(object, object)> comparedPairs)
+    {
+        if (expected is null && actual is null) return;
+        if (expected is null || actual is null)
+        {
+            Add(acc, objectKey, path, TypeNameOf(expected ?? actual), PresenceMember,
+                expected is null ? Null : "present", actual is null ? Null : "present");
+            return;
+        }
+
+        // A pair already compared elsewhere in the graph adds nothing on a second visit, and
+        // stopping here is what terminates cycles (MetaTable.FieldsById holds the very
+        // MetaField instances MetaTable.Fields holds).
+        if (!comparedPairs.Add((expected, actual))) return;
+
+        if (depth > opts.MaxDepth)
+        {
+            Add(acc, objectKey, path, TypeNameOf(expected), DepthMember,
+                $"walk stopped at depth {depth}", $"walk stopped at depth {depth}");
+            return;
+        }
+
+        var type = expected.GetType();
+        if (actual.GetType() != type)
+        {
+            Add(acc, objectKey, path, type.Name, "<type>", type.FullName ?? type.Name,
+                actual.GetType().FullName ?? actual.GetType().Name);
+            return;
+        }
+
+        foreach (var (name, get) in ReadableMembers(type))
+        {
+            var memberPath = path.Length == 0 ? name : path + "." + name;
+            object? ev, av;
+            string? ethrow = null, athrow = null;
+            try { ev = get(expected); } catch (Exception ex) { ev = null; ethrow = Throw(ex); }
+            try { av = get(actual); } catch (Exception ex) { av = null; athrow = Throw(ex); }
+
+            if (ethrow != null || athrow != null)
+            {
+                if (ethrow != athrow)
+                    Add(acc, objectKey, memberPath, type.Name, name,
+                        ethrow ?? Render(ev, opts), athrow ?? Render(av, opts));
+                continue;
+            }
+
+            if (IsCollection(ev, opts) || IsCollection(av, opts))
+            {
+                CompareCollection(ev, av, objectKey, memberPath, type.Name + "." + name,
+                    depth, opts, acc, comparedPairs);
+                continue;
+            }
+
+            if (ShouldRecurse(ev, opts) || ShouldRecurse(av, opts))
+            {
+                // Attributed HERE, where the member is known. Left to Walk's own null branch
+                // it would be reported against the VALUE's type — `MultiLanguage.<presence>`
+                // for both CaptionML and OptionCaptionML — and one allowlist entry would then
+                // cover two unrelated members.
+                if (ev is null || av is null)
+                    Add(acc, objectKey, memberPath, type.Name, name + "." + PresenceMember,
+                        ev is null ? Null : "present", av is null ? Null : "present");
+                else
+                    Walk(ev, av, objectKey, memberPath, depth + 1, opts, acc, comparedPairs);
+                continue;
+            }
+
+            var es = Render(ev, opts);
+            var @as = Render(av, opts);
+            if (!string.Equals(es, @as, StringComparison.Ordinal))
+                Add(acc, objectKey, memberPath, type.Name, name, es, @as);
+        }
+    }
+
+    private static void CompareCollection(
+        object? expected, object? actual, string objectKey, string path, string memberSignature,
+        int depth, MetadataObjectDiffOptions opts, List<MetadataDifference> acc,
+        HashSet<(object, object)> comparedPairs)
+    {
+        // A DICTIONARY has no order, so pairing its entries by position compares whichever
+        // entries happen to sit at the same index and reports every one of them as different.
+        // Measured before this branch existed: MetaTable.FieldsById produced 20 `MetaField.Id`,
+        // 20 `DataColumnName`, 13 `Type`, 13 `IsSystemField` and 8 `Length` "differences" on
+        // Business Foundation alone, none of them real — the two sides simply insert in
+        // different orders. Paired by key they reduce to the entries that genuinely differ,
+        // and the values themselves were already compared under Fields[], so the pair-visited
+        // set short-circuits them.
+        if (TryMaterializeKeyed(expected, out var ke) && TryMaterializeKeyed(actual, out var ka))
+        {
+            foreach (var key in ke.Keys.Concat(ka.Keys).Distinct(StringComparer.Ordinal)
+                         .OrderBy(k => k, StringComparer.Ordinal))
+            {
+                var entryPath = $"{path}[key={key}]";
+                var hasE = ke.TryGetValue(key, out var ev);
+                var hasA = ka.TryGetValue(key, out var av);
+                if (!hasE || !hasA)
+                {
+                    Add(acc, objectKey, entryPath, SplitType(memberSignature), PresenceFor(memberSignature),
+                        hasE ? Describe(ev, opts) : Absent, hasA ? Describe(av, opts) : Absent);
+                    continue;
+                }
+                Walk(ev, av, objectKey, entryPath, depth + 1, opts, acc, comparedPairs);
+            }
+            return;
+        }
+
+        var e = Materialize(expected);
+        var a = Materialize(actual);
+
+        // A collection of scalars is a value, not a structure: rendering it whole says more in
+        // one line than N positional differences would.
+        if (e.All(x => IsScalar(x, opts)) && a.All(x => IsScalar(x, opts)))
+        {
+            var es = "[" + string.Join(",", e.Select(x => Render(x, opts))) + "]";
+            var @as = "[" + string.Join(",", a.Select(x => Render(x, opts))) + "]";
+            if (!string.Equals(es, @as, StringComparison.Ordinal))
+                Add(acc, objectKey, path, SplitType(memberSignature), SplitMember(memberSignature), es, @as);
+            return;
+        }
+
+        if (opts.PairByIdMembers.Contains(memberSignature)
+            && TryPairById(e, a, out var byId))
+        {
+            // Ordinals are only meaningful while both sides hold the SAME set of ids. One
+            // side missing an element shifts every ordinal after it, and reporting that
+            // cascade would bury the one difference that caused it — the exact noise
+            // id-pairing exists to remove.
+            var sameIdSet = byId.All(x => x.E is not null && x.A is not null);
+            foreach (var (id, ei, ai, eo, ao) in byId)
+            {
+                var elemPath = $"{path}[id={id}]";
+                if (ei is null || ai is null)
+                {
+                    Add(acc, objectKey, elemPath, SplitType(memberSignature), PresenceFor(memberSignature),
+                        ei is null ? Absent : "present", ai is null ? Absent : "present");
+                    continue;
+                }
+                if (sameIdSet && eo != ao)
+                    Add(acc, objectKey, elemPath + ".#Ordinal", TypeNameOf(ei), "#Ordinal",
+                        eo.ToString(CultureInfo.InvariantCulture), ao.ToString(CultureInfo.InvariantCulture));
+                Walk(ei, ai, objectKey, elemPath, depth + 1, opts, acc, comparedPairs);
+            }
+            return;
+        }
+
+        for (int i = 0; i < Math.Max(e.Count, a.Count); i++)
+        {
+            var elemPath = $"{path}[{i}]";
+            var ei = i < e.Count ? e[i] : null;
+            var ai = i < a.Count ? a[i] : null;
+            if (ei is null || ai is null)
+            {
+                Add(acc, objectKey, elemPath, SplitType(memberSignature), PresenceFor(memberSignature),
+                    ei is null ? Absent : Describe(ei, opts), ai is null ? Absent : Describe(ai, opts));
+                continue;
+            }
+            Walk(ei, ai, objectKey, elemPath, depth + 1, opts, acc, comparedPairs);
+        }
+    }
+
+    private static bool TryPairById(
+        IReadOnlyList<object?> e, IReadOnlyList<object?> a,
+        out List<(string Id, object? E, object? A, int EOrd, int AOrd)> paired)
+    {
+        paired = new List<(string, object?, object?, int, int)>();
+        var ek = new Dictionary<string, (object Obj, int Ord)>(StringComparer.Ordinal);
+        var ak = new Dictionary<string, (object Obj, int Ord)>(StringComparer.Ordinal);
+        if (!Index(e, ek) || !Index(a, ak)) return false;
+
+        foreach (var key in ek.Keys.Concat(ak.Keys).Distinct(StringComparer.Ordinal)
+                     .OrderBy(k => k, StringComparer.Ordinal))
+        {
+            ek.TryGetValue(key, out var ev);
+            ak.TryGetValue(key, out var av);
+            paired.Add((key, ev.Obj, av.Obj, ev.Ord, av.Ord));
+        }
+        return true;
+
+        static bool Index(IReadOnlyList<object?> src, Dictionary<string, (object, int)> into)
+        {
+            for (int i = 0; i < src.Count; i++)
+            {
+                var o = src[i];
+                if (o is null) return false;
+                var p = o.GetType().GetProperty("Id", BindingFlags.Public | BindingFlags.Instance);
+                if (p is null || p.PropertyType != typeof(int)) return false;
+                var key = Convert.ToString(p.GetValue(o), CultureInfo.InvariantCulture) ?? "";
+                if (!into.TryAdd(key, (o, i))) return false;   // duplicate ids: fall back to position
+            }
+            return true;
+        }
+    }
+
+    // ---- member enumeration -------------------------------------------------------------
+
+    private static readonly Dictionary<Type, (string Name, Func<object, object?> Get)[]> _members = new();
+
+    /// <summary>
+    /// Every readable instance member of a type: public and non-public properties without index
+    /// parameters, plus non-public fields that are NOT auto-property backing fields (those are
+    /// already covered by their property, and reading both would double every difference).
+    /// A field with no property is real state and IS compared — <c>MetaTable.fieldsById</c> is one.
+    /// </summary>
+    internal static (string Name, Func<object, object?> Get)[] ReadableMembers(Type type)
+    {
+        lock (_members)
+        {
+            if (_members.TryGetValue(type, out var cached)) return cached;
+
+            const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+            var list = new List<(string, Func<object, object?>)>();
+
+            foreach (var p in type.GetProperties(flags)
+                         .Where(p => p.CanRead && p.GetIndexParameters().Length == 0)
+                         .OrderBy(p => p.Name, StringComparer.Ordinal))
+            {
+                var pi = p;
+                list.Add((pi.Name, o => pi.GetValue(o)));
+            }
+
+            foreach (var f in type.GetFields(flags)
+                         .Where(f => !f.Name.Contains('<'))
+                         .OrderBy(f => f.Name, StringComparer.Ordinal))
+            {
+                var fi = f;
+                list.Add(("#" + fi.Name, o => fi.GetValue(o)));
+            }
+
+            var arr = list.ToArray();
+            _members[type] = arr;
+            return arr;
+        }
+    }
+
+    // ---- value classification ----------------------------------------------------------
+
+    private static bool ShouldRecurse(object? v, MetadataObjectDiffOptions opts)
+    {
+        if (v is null || v is string) return false;
+        var t = v.GetType();
+        // An enum is a VALUE, not a structure. Without this it recurses into the enum's own
+        // `#value__` storage field, and every enum-valued difference is then reported against
+        // the enum type — `CompilationTarget.#value__` instead of `MetaTable.Scope` — so the
+        // allowlist cannot name the member that actually differs and one entry would cover
+        // every property sharing that enum type.
+        if (t.IsEnum) return false;
+        var full = t.FullName ?? "";
+        return opts.RecurseNamespacePrefixes.Any(p => full.StartsWith(p, StringComparison.Ordinal));
+    }
+
+    private static bool IsScalar(object? v, MetadataObjectDiffOptions opts)
+        => v is null || v is string || v.GetType().IsPrimitive || v.GetType().IsEnum
+           || v is decimal || v is Guid || v is DateTime || v is TimeSpan;
+
+    private static bool IsCollection(object? v, MetadataObjectDiffOptions opts)
+    {
+        if (v is null || v is string) return false;
+        if (v is IEnumerable) return true;
+        // ImmutableArray<T> is a struct that implements IEnumerable only through its
+        // generic interfaces, so `is IEnumerable` alone would miss it.
+        var t = v.GetType();
+        return t.IsGenericType
+               && t.GetInterfaces().Any(i => i.IsGenericType
+                    && i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+    }
+
+    private static List<object?> Materialize(object? v)
+    {
+        var list = new List<object?>();
+        if (v is null) return list;
+        if (v is IEnumerable en && v is not string)
+        {
+            foreach (var it in en) list.Add(Unwrap(it));
+            return list;
+        }
+        // ImmutableArray<T> / any generic-only enumerable.
+        var m = v.GetType().GetMethod("GetEnumerator", BindingFlags.Public | BindingFlags.Instance);
+        if (m is not null)
+        {
+            var e = m.Invoke(v, null);
+            if (e is not null)
+            {
+                var moveNext = e.GetType().GetMethod("MoveNext")!;
+                var current = e.GetType().GetProperty("Current")!;
+                while ((bool)(moveNext.Invoke(e, null) ?? false)) list.Add(Unwrap(current.GetValue(e)));
+            }
+        }
+        return list;
+    }
+
+    /// <summary>A dictionary enumerates as KeyValuePair; the value is what gets compared.</summary>
+    private static object? Unwrap(object? it)
+    {
+        if (it is null) return null;
+        var t = it.GetType();
+        if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
+            return t.GetProperty("Value")!.GetValue(it);
+        return it;
+    }
+
+    /// <summary>
+    /// True when every element is a KeyValuePair — i.e. this is a dictionary — with the
+    /// entries indexed by their key rendered as a string. A duplicate rendered key gives up
+    /// rather than silently dropping an entry.
+    /// </summary>
+    private static bool TryMaterializeKeyed(object? v, out Dictionary<string, object?> keyed)
+    {
+        keyed = new Dictionary<string, object?>(StringComparer.Ordinal);
+        if (v is null) return false;
+        var raw = new List<object?>();
+        if (v is IEnumerable en && v is not string) { foreach (var it in en) raw.Add(it); }
+        else return false;
+        if (raw.Count == 0) return false;
+
+        foreach (var it in raw)
+        {
+            if (it is null) return false;
+            var t = it.GetType();
+            if (!t.IsGenericType || t.GetGenericTypeDefinition() != typeof(KeyValuePair<,>)) return false;
+            var key = Convert.ToString(t.GetProperty("Key")!.GetValue(it), CultureInfo.InvariantCulture) ?? "";
+            if (!keyed.TryAdd(key, t.GetProperty("Value")!.GetValue(it))) return false;
+        }
+        return true;
+    }
+
+    private static string Render(object? v, MetadataObjectDiffOptions opts)
+    {
+        if (v is null) return Null;
+        if (v is string s) return s.Length == 0 ? "<empty>" : s;
+        if (v is bool b) return b ? "True" : "False";
+        if (v.GetType().IsEnum) return v.ToString() ?? "";
+        if (v is IFormattable f) return f.ToString(null, CultureInfo.InvariantCulture);
+        return v.ToString() ?? "";
+    }
+
+    private static string Describe(object? v, MetadataObjectDiffOptions opts)
+    {
+        if (v is null) return Null;
+        var id = v.GetType().GetProperty("Id", BindingFlags.Public | BindingFlags.Instance);
+        var name = v.GetType().GetProperty("Name", BindingFlags.Public | BindingFlags.Instance);
+        var sb = new StringBuilder(v.GetType().Name);
+        if (id is not null) sb.Append(" Id=").Append(Render(SafeGet(id, v), opts));
+        if (name is not null) sb.Append(" Name=").Append(Render(SafeGet(name, v), opts));
+        return sb.ToString();
+    }
+
+    private static object? SafeGet(PropertyInfo p, object o)
+    { try { return p.GetValue(o); } catch { return null; } }
+
+    private static string Throw(Exception ex)
+        => "<throw:" + (ex.InnerException ?? ex).GetType().Name + ">";
+
+    private static string TypeNameOf(object? o) => o?.GetType().Name ?? "<null>";
+    private static string SplitType(string sig) => sig.Split('.')[0];
+    private static string SplitMember(string sig) => sig[(sig.IndexOf('.') + 1)..];
+
+    /// <summary>
+    /// The member name a presence difference is attributed to — <c>Fields.&lt;presence&gt;</c>
+    /// rather than a bare <c>&lt;presence&gt;</c>, so an allowlist entry can cover the runner's
+    /// extra FIELDS without also covering its missing FIELD GROUPS. Both used to arrive as
+    /// <c>MetaTable.&lt;presence&gt;</c>.
+    /// </summary>
+    private static string PresenceFor(string memberSignature)
+        => SplitMember(memberSignature) + "." + PresenceMember;
+
+    private static void Add(List<MetadataDifference> acc, string objectKey, string path,
+        string declaringType, string member, string expected, string actual)
+        => acc.Add(new MetadataDifference(objectKey, path, declaringType, member, expected, actual));
+
+    private sealed class PairComparer : IEqualityComparer<(object, object)>
+    {
+        internal static readonly PairComparer Instance = new();
+        public bool Equals((object, object) x, (object, object) y)
+            => ReferenceEquals(x.Item1, y.Item1) && ReferenceEquals(x.Item2, y.Item2);
+        public int GetHashCode((object, object) o)
+            => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(o.Item1) * 397
+               ^ System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(o.Item2);
+    }
+}

--- a/AlRunner/Metadata/MetadataObjectDiff.cs
+++ b/AlRunner/Metadata/MetadataObjectDiff.cs
@@ -364,23 +364,18 @@ public static class MetadataObjectDiff
         var list = new List<object?>();
         if (v is null) return list;
         if (v is IEnumerable en && v is not string)
-        {
             foreach (var it in en) list.Add(Unwrap(it));
-            return list;
-        }
-        // ImmutableArray<T> / any generic-only enumerable.
-        var m = v.GetType().GetMethod("GetEnumerator", BindingFlags.Public | BindingFlags.Instance);
-        if (m is not null)
-        {
-            var e = m.Invoke(v, null);
-            if (e is not null)
-            {
-                var moveNext = e.GetType().GetMethod("MoveNext")!;
-                var current = e.GetType().GetProperty("Current")!;
-                while ((bool)(moveNext.Invoke(e, null) ?? false)) list.Add(Unwrap(current.GetValue(e)));
-            }
-        }
         return list;
+
+        // There used to be a reflective GetEnumerator/MoveNext/Current fallback here for
+        // "ImmutableArray<T> / any generic-only enumerable". It could not run: IEnumerable<T>
+        // DERIVES from IEnumerable, so every value IsCollection accepts satisfies the branch
+        // above — including ImmutableArray<T>, whose boxed struct implements both. Probed to be
+        // certain rather than reasoned alone: instrumented, it was reached zero times across the
+        // whole MetaTable graph of 150 tables. And a value that is genuinely not enumerable
+        // cannot reach here for a same-typed member anyway, because both sides are the same
+        // MetaTable member and MetaTable's collection members are all ImmutableArray or
+        // ImmutableDictionary; Walk reports a runtime-type mismatch before this is called.
     }
 
     /// <summary>A dictionary enumerates as KeyValuePair; the value is what gets compared.</summary>

--- a/docs/metadata-equivalence.md
+++ b/docs/metadata-equivalence.md
@@ -82,10 +82,78 @@ make it that:
 | an entry that matches nothing | fails — so a landed fix must delete its entries |
 | an entry exceeding its `maxOccurrences` | fails — so a declared defect getting worse still fails |
 
-Every entry states a reason. An entry tolerating a **defect** names the issue tracking it; only a
-permanent limit of the symbol file may set `cannotExpress` instead and skip the issue. Both rules
-are enforced at load time by `MetadataDifferenceAllowlist`, so a malformed entry fails the run
-rather than sitting in the file granting cover nobody reviewed.
+Every entry states a reason **and exactly one kind of reason**, because the four kinds need
+different evidence and conflating them is how a recoverable difference gets a permanent licence:
+
+| kind | means | needs |
+|---|---|---|
+| `issue: N` | a defect, tracked, expected to go away | the issue |
+| `outOfScope: true` | the runner does not implement the surface, so no AL test can observe it | a `Doc` pointer |
+| `oracleLimitation: true` | the ground truth is the wrong shape for this member | a `Doc` pointer |
+| `cannotExpress: true` | the symbol file cannot express it **and** it cannot be derived | evidence about derivability |
+
+Enforced at load by `MetadataDifferenceAllowlist`, so a malformed entry fails the run rather than
+sitting in the file granting cover nobody reviewed. `Doc` is spelled that way on purpose:
+`tools/test_doc_pointers.py` already validates every `Doc` value under `tests/expectations`,
+path and anchor, so a scope claim cannot point at a section that has been renamed away.
+
+**No entry currently claims `cannotExpress`**, and the way that changed is the reason the
+distinction exists. The seven `TranslationKey` entries — 25,721 of the 70,728 differences, 36% of
+the diff — were first declared a permanent limit of the symbol file, on the evidence that
+`SymbolReference.json` contains the string `TranslationKey` zero times in both packages. That
+observation is true. The conclusion drawn from it was wrong twice over, and both corrections are
+below. **"Nothing is stored" is evidence about storage, never about derivability.**
+
+<a id="translation-keys-are-out-of-scope"></a>
+## Translation keys are out of scope, and separately are derivable
+
+A `CaptionTranslationKey` is a lookup id into a translation file. It means something only to
+something that reads those files, and **the runner reads none**: there is no `.xlf` or
+`Translations/` handling anywhere in `AlRunner/`, and `docs/limitations.md` already records that
+the runner installs no BC translation resources. So no AL test can observe this member, and the
+honest declaration is a scope boundary. What would invalidate it is the runner gaining
+translation support — not anything about BC.
+
+It is also **derivable**, which matters because it means the entry can never become a permanent
+limit. BC's own `LanguageKeyHelper.ConstructObjectHash` is
+
+```
+(uint)(FNV-1a-32 over the UTF-16LE bytes of the name + int.MaxValue)
+```
+
+and a key is `<Kind> <hash>` components joined by `" - "`, ending in the property. Measured
+against the ground truth: **2,153 of 2,153 keys reproduced exactly**, with the property component
+decomposing to `Caption` (1,138), `ToolTip` (988) and `OptionCaption` (27) and nothing left
+unexplained. `MetadataEquivalenceHarnessTests.TranslationKeysAreDerivable_NotAPermanentLimit`
+pins that, so the claim under the allowlist reason is checked rather than asserted.
+
+**`CaptionML` is a different member and is not covered by any of this.** It is the caption
+*text*, it is AL-observable — `Format()` on an option with an `OptionCaption`, field captions in
+error messages — and `MetaField.CaptionML.<presence>` (988) is declared separately as a tracked
+defect. The two must not be folded together: doing so would license a real difference behind a
+scope declaration that does not apply to it.
+
+<a id="the-oracle-is-build-time-per-app-metadata"></a>
+## The oracle is build-time per-app metadata, not runtime merged metadata
+
+The ground truth is what BC's compiler emits **for one app at build time**. A running BC system
+holds something else: metadata with every installed app's tableextension deltas applied. The
+runner models the second, because that is the state AL actually executes against.
+
+So where the runner shows a merged view, a difference is **expected by construction and is not
+evidence about the runner**. Measured: 115 fields on four Business Foundation tables (230, 242,
+308, 6635), which are tableextension fields other registered apps contribute. In BC 29 everything
+is merged at database level anyway, which makes the runner's merged view the forward-looking one
+rather than a deviation.
+
+Two consequences worth meeting before a non-empty diff is:
+
+- **A multi-app bundle can never produce an empty diff.** That is a limitation of this oracle, not
+  a wart in the runner. Do not read the residue as normal noise, and do not read it as a bug —
+  read the three `oracleLimitation` entries and check the difference is one of them.
+- **The faithful comparison would need BC's post-publish runtime metadata** — what a service tier
+  holds after deltas are applied — which is not obtainable without a tier. That is the ceiling on
+  how empty this diff can ever get.
 
 Verified across BC 27.5.46862.53931, 28.1.49838.53910, 28.1.49838.54044 and 28.4.53241.53989:
 the same 74 entries cover every difference on all four, with none stale. The counts move

--- a/docs/metadata-equivalence.md
+++ b/docs/metadata-equivalence.md
@@ -1,0 +1,131 @@
+# Metadata equivalence: proving the SymbolReference derivation equals BC's emitter
+
+The runner gets a precompiled app's table metadata by reading its `SymbolReference.json` and
+building a `MetaTable` by hand — about 3,800 lines across `BcAppSymbolCache.cs`,
+`BcAppSymbolCache.TableExtensions.cs` and `RecordPatches.BcAppFallback.cs`. That derivation is
+acceptable only if it produces the same objects BC's own metadata emitter produces for the same
+app, and the proof has to be total rather than a list of properties someone thought to check.
+
+Issue #3533 sets that standard. This document is how it is enforced.
+
+<a id="the-two-sides"></a>
+## The two sides, and why they are the same type
+
+```
+ground truth   MetaTable.CreateMetaTableFromXml(<BC's own emitted document>)
+the runner     RecordPatches.GetOrBuildNCLMetaTable(id).GetMetaTableOriginal()
+```
+
+The runner builds a `Microsoft.Dynamics.Nav.Types.Metadata.MetaTable` and hands it to
+`NCLMetaTable.CreateFromMetaTable`; `GetMetaTableOriginal()` hands that same instance back. So
+both sides are one type, and the comparison is member-for-member rather than a translation
+between two shapes.
+
+`AlRunner/Metadata/MetadataObjectDiff.cs` walks every readable instance member found by
+reflection: public and non-public properties, plus non-public fields that are not auto-property
+backing storage (`MetaTable.fieldsById` is real state reachable only as a field). It recurses
+into nested BC metadata objects, pairs `Fields` by id and everything else by position, pairs
+dictionary entries by key, and terminates on a pair it has already compared.
+
+There is no member allowlist in the differ. What is known-different is declared once, with a
+reason, in `tests/expectations/metadata-equivalence/allowlist.json`.
+
+<a id="where-the-ground-truth-lives"></a>
+## Where the ground truth lives, and why it is not in the repository
+
+`tools/metadata-ground-truth` compiles a Microsoft app's shipped AL source with BC's own
+compiler and keeps every document the emitter produced. `tools/gen-metadata-ground-truth.sh`
+runs it for the apps `tests/expectations/metadata-equivalence/apps.json` declares, into
+`<artifacts-root>/../metadata-ground-truth/<bc-build>/<publisher>_<app>_<version>/`.
+
+Measured on BC 28.1.49838.54044: Business Foundation 3.2 s and 70 documents, System Application
+15.2 s and 1,218 documents. Gzipped the two bundles are 35 KB and 656 KB.
+
+Small enough to check in, and it is deliberately not checked in:
+
+- It is **Microsoft's compiler output over Microsoft's source.** Everything else the runner
+  consumes from Microsoft is provisioned by the user from Microsoft; redistributing this in a
+  public repository is a licensing decision, not a technical one.
+- It belongs to **one exact BC build.** A checked-in copy would either churn on every Microsoft
+  release or go stale silently — and going stale silently is the failure mode this whole harness
+  exists to remove.
+- Regenerating is cheap and needs nothing the box does not already have. CI regenerates it in
+  the `Generate BC metadata ground truth` step of `bc-tests.yml`, on the two unit-test legs.
+
+What IS checked in is the part that carries judgement: the app list, the allowlist, the
+generator and the differ.
+
+One consequence worth stating plainly: because the bundle is generated on the same box from the
+same artifacts, the `.app` the runner reads and the emitter output it is compared against always
+come from one build. There is no staleness question to get wrong.
+
+<a id="the-allowlist"></a>
+## The allowlist
+
+`tests/expectations/metadata-equivalence/allowlist.json` is the only thing standing between "a
+difference someone has decided about" and "a difference nobody has looked at". Three properties
+make it that:
+
+| | |
+|---|---|
+| a difference not listed | fails |
+| an entry that matches nothing | fails — so a landed fix must delete its entries |
+| an entry exceeding its `maxOccurrences` | fails — so a declared defect getting worse still fails |
+
+Every entry states a reason. An entry tolerating a **defect** names the issue tracking it; only a
+permanent limit of the symbol file may set `cannotExpress` instead and skip the issue. Both rules
+are enforced at load time by `MetadataDifferenceAllowlist`, so a malformed entry fails the run
+rather than sitting in the file granting cover nobody reviewed.
+
+`maxOccurrences` is unused in the current file. The mechanism is right for a difference whose
+count is bounded independently of the build; a count measured on one BC build and one set of apps
+is not that, because the unit legs run 27.5 and 28.4 while the current numbers were measured on
+28.1.
+
+<a id="what-is-compared"></a>
+## What is compared, and what is not
+
+The harness compares `MetaTable` documents. A bundle carries every kind BC emitted — codeunits,
+pages, enums, permission sets, queries, reports, xmlports, and the `MetadataRuntimeDeltas`
+documents that cover table, page and permission-set extensions — and
+`MetadataEquivalenceHarnessTests` asserts the set it compares AND the set it does not, so
+covering less cannot happen quietly.
+
+**Base Application is not covered.** Its emit needs a `PublicKeyToken=null` copy of
+`Microsoft.AspNetCore.StaticFiles` that no BC artifact ships, and without it BC's emitter
+produces zero objects for the whole app (#3549). The generator treats a zero-object emit as a
+failure rather than writing an empty bundle, and `apps.json` says why Base Application is absent
+rather than listing it and failing every leg.
+
+<a id="running-it"></a>
+## Running it
+
+```bash
+tools/gen-metadata-ground-truth.sh              # once per BC build
+tools/engine-test-bootstrap.sh                  # the bc-engine-serial collection needs this
+AL_RUNNER_METADATA_EQUIVALENCE_REPORT=/tmp/diff.tsv \
+  dotnet test AlRunner.Tests -c Release --no-build --settings engine.runsettings \
+    --filter FullyQualifiedName~MetadataEquivalenceHarnessTests
+```
+
+The dump is one line per differing member per object: app, object, path, `Type.Member`, BC's
+value, the runner's. It is the working specification for the reader work.
+
+`AL_RUNNER_METADATA_GROUND_TRUTH` overrides where bundles are read from and written to.
+
+<a id="a-single-unresolved-dotnet-reference-costs-the-whole-app"></a>
+## A single unresolved .NET reference costs the whole app
+
+Worth knowing before adding an app to `apps.json`. BC's emitter is atomic per module: one AL
+error anywhere produces **zero** objects for the entire app, not a smaller set. Two instances:
+
+- System Application's `SamplingPerfProfilerImpl` calls
+  `JsonSerializer.Deserialize(TextReader, Type)`. The service tier ships the net6.0 build of
+  Newtonsoft.Json, whose `TextReader` parameter is typed against `System.Runtime 6.0.0.0`, and no
+  .NET 6 reference assemblies exist on a net8 or net10 box — so AL0133, and no ground truth at
+  all. The generator ships the netstandard2.0 build of the same Newtonsoft version in a
+  `dotnet-shims` directory at the head of its probing paths; see the csproj.
+- Base Application's `Microsoft.AspNetCore.StaticFiles`, above, which has no such fix yet.
+
+So an app that "almost compiles" produces nothing, and the generator says so loudly instead of
+writing a bundle.

--- a/docs/metadata-equivalence.md
+++ b/docs/metadata-equivalence.md
@@ -92,6 +92,18 @@ different evidence and conflating them is how a recoverable difference gets a pe
 | `oracleLimitation: true` | the ground truth is the wrong shape for this member | a `Doc` pointer |
 | `cannotExpress: true` | the symbol file cannot express it **and** it cannot be derived | evidence about derivability |
 
+An entry may also set `direction` to `runner-only` or `bc-only`, and ten do. An entry covers both
+directions unless it says otherwise, and **a reason that justifies one direction must not license
+the other**. All three `oracleLimitation` entries are `runner-only`: they exist because the runner
+shows a merged runtime view, so BC-absent / runner-present is what they justify — while the
+reverse, BC emitting a field the runner never builds, is a hard reader defect that must still
+fail. Undirected, that defect was covered on every table by a permanent, uncapped licence.
+
+There is deliberately **no occurrence cap**. One was implemented and used by nothing, which is a
+ratchet nobody turns. No entry here has a bound that survives a rebuild — the counts move with the
+BC build and with which apps are bundled — so any cap would be a number nobody measured. Direction
+narrows *categorically* instead, which is build-independent and checkable per difference.
+
 Enforced at load by `MetadataDifferenceAllowlist`, so a malformed entry fails the run rather than
 sitting in the file granting cover nobody reviewed. `Doc` is spelled that way on purpose:
 `tools/test_doc_pointers.py` already validates every `Doc` value under `tests/expectations`,
@@ -155,15 +167,53 @@ Two consequences worth meeting before a non-empty diff is:
   holds after deltas are applied — which is not obtainable without a tier. That is the ceiling on
   how empty this diff can ever get.
 
-Verified across BC 27.5.46862.53931, 28.1.49838.53910, 28.1.49838.54044 and 28.4.53241.53989:
-the same 74 entries cover every difference on all four, with none stale. The counts move
-(System Application `DataClassification` is 661 / 661 / 663 / 617 and `EnumTypeId` 76 / 76 / 76 /
-75), the membership does not.
+Verified across four BC builds: the same 74 entries cover every difference on all four, with none
+stale. The membership does not move; the counts do, which is the whole reason nothing asserts one.
+
+| BC build | differences | members | System App tables | `Editable` | `DataClassification` | `EnumTypeId` |
+|---|---:|---:|---:|---:|---:|---:|
+| 27.5.46862.53931 | 65,505 | 74 | 127 | 78 | 617 | 75 |
+| 28.1.49838.53910 | 70,728 | 74 | 138 | 78 | 661 | 76 |
+| 28.1.49838.54044 | 70,728 | 74 | 138 | 78 | 661 | 76 |
+| 28.4.53241.53989 | 70,836 | 74 | 138 | 78 | 663 | 76 |
+
+The last three columns are System Application's own declared fields. They are recorded here and
+asserted nowhere — see the next section.
 
 `maxOccurrences` is unused in the current file. The mechanism is right for a difference whose
 count is bounded independently of the build; a count measured on one BC build and one set of apps
 is not that, because the unit legs run 27.5 and 28.4 while the current numbers were measured on
 28.1.
+
+<a id="a-check-that-cannot-fail-reads-like-a-check-that-passed"></a>
+## A check that cannot fail reads exactly like a check that passed
+
+Three defects in this harness have now had the same shape, and it is the shape to watch for in
+anything added to it.
+
+1. **A reason category that could not be wrong.** Seven `TranslationKey` entries claimed a
+   permanent limit of the symbol file — 36% of the diff — on evidence about *storage*, which says
+   nothing about *derivability*. Fixed by making the kind of reason an explicit field with its own
+   evidence requirement.
+2. **A licence that covered both directions.** The three merged-runtime entries were written for
+   "the runner has a field BC's build-time emit does not", and silently also covered "BC emitted a
+   field and the runner built none" — a hard reader defect, on every table, permanently. Fixed by
+   `direction`.
+3. **An assertion that went inert when the build moved.** The known-defect counts were pinned per
+   four-part BC build. CI resolves 28.4 to a build that moves, so the lookup missed, the four
+   numbers went unasserted, and the test passed green having checked nothing.
+
+The third is worth dwelling on, because the fix was not to pick a failure mode. Pinning tighter
+goes inert; pinning looser asserts a number that held once. **The counts move and the shape does
+not**, so the test asserts the shape: the reader answers a *constant* — `Editable` `True` where BC
+says `False`, `DataClassification` `CustomerContent`, `EnumTypeId` `0` — on every occurrence, on
+every build measured. That is stronger than a count (a count passes if the reader answers a
+different constant) and it cannot disappear. The counts live in the table above, where a
+measurement belongs.
+
+The general rule: **an answer a check could not have failed to give is not evidence.** When adding
+an assertion here, ask what would have to be true for it to fail, and make sure that state is
+reachable.
 
 <a id="what-is-compared"></a>
 ## What is compared, and what is not

--- a/docs/metadata-equivalence.md
+++ b/docs/metadata-equivalence.md
@@ -59,6 +59,16 @@ One consequence worth stating plainly: because the bundle is generated on the sa
 same artifacts, the `.app` the runner reads and the emitter output it is compared against always
 come from one build. There is no staleness question to get wrong.
 
+The harness enforces that rather than assuming it: it reads only
+`<ground-truth-root>/<the build this process loaded>/`, and it finds each bundle's `.app` inside
+that build's own artifact directory. A dev box accumulates a directory per build, every one of
+them holding a System Application bundle with the same table ids, and registering two of those
+packages into `RecordPatches`' process-global state makes the second id lose to the first — one
+app's metadata measured against another app's symbols, silently. CI has one build, so this would
+never have surfaced there. When no bundle exists for the loaded build the skip message names the
+exact `--artifacts` to pass, because the generator's own default is the NEWEST build and the test
+host loads whichever build the runner was compiled against.
+
 <a id="the-allowlist"></a>
 ## The allowlist
 
@@ -76,6 +86,11 @@ Every entry states a reason. An entry tolerating a **defect** names the issue tr
 permanent limit of the symbol file may set `cannotExpress` instead and skip the issue. Both rules
 are enforced at load time by `MetadataDifferenceAllowlist`, so a malformed entry fails the run
 rather than sitting in the file granting cover nobody reviewed.
+
+Verified across BC 27.5.46862.53931, 28.1.49838.53910, 28.1.49838.54044 and 28.4.53241.53989:
+the same 74 entries cover every difference on all four, with none stale. The counts move
+(System Application `DataClassification` is 661 / 661 / 663 / 617 and `EnumTypeId` 76 / 76 / 76 /
+75), the membership does not.
 
 `maxOccurrences` is unused in the current file. The mechanism is right for a difference whose
 count is bounded independently of the build; a count measured on one BC build and one set of apps

--- a/tests/expectations/metadata-equivalence/README.md
+++ b/tests/expectations/metadata-equivalence/README.md
@@ -1,0 +1,13 @@
+# metadata-equivalence
+
+The declared state of the total comparison between BC's own metadata emitter and the runner's
+`SymbolReference.json`-derived metadata. Issue #3533.
+
+| file | what it decides |
+|---|---|
+| `apps.json` | which Microsoft apps the harness MUST cover. Declaring an app makes covering it mandatory: the harness fails if no ground-truth bundle for it is present. |
+| `allowlist.json` | which member differences are tolerated, and why. Anything not listed fails; an entry that matches nothing also fails. |
+
+The ground truth itself is not here — it is regenerated per BC build by
+`tools/gen-metadata-ground-truth.sh`. [`docs/metadata-equivalence.md`](../../../docs/metadata-equivalence.md)
+has the full picture, including why it is not checked in.

--- a/tests/expectations/metadata-equivalence/allowlist.json
+++ b/tests/expectations/metadata-equivalence/allowlist.json
@@ -23,11 +23,16 @@
     "reproduced), and the runner reads no translation files anyway, so it is out of scope rather",
     "than impossible. 'Nothing is stored' is evidence about storage, never about derivability.",
     "",
-    "No entry sets maxOccurrences. The mechanism exists (see MetadataDifferenceAllowlist) and",
-    "is worth using for a difference whose count is bounded independently of the build, but a",
-    "count measured on one BC build and one set of apps is not that: the unit legs run 27.5 and",
-    "28.4 while these numbers were measured on 28.1, and the totals move with both the BC build",
-    "and which apps have a ground-truth bundle.",
+    "Ten entries are DIRECTION-SCOPED. An entry covers both directions unless it says otherwise,",
+    "and a reason that justifies one direction must not license the other. All three",
+    "oracleLimitation entries are runner-only: they exist because the runner shows a merged",
+    "runtime view, so BC-absent / runner-present is what they justify \u2014 while the reverse, BC",
+    "emitting a field the runner never builds, is a hard reader defect that must still fail.",
+    "",
+    "There is deliberately NO occurrence cap. One was implemented and used by nothing, which made",
+    "the PR claim a ratchet the code did not keep. No entry here has a bound that survives a",
+    "rebuild \u2014 the counts move with the BC build and with which apps are bundled \u2014 so any cap",
+    "would be a number nobody measured. Direction narrows categorically instead.",
     "",
     "Measured on BC 28.1.49838.54044 over Business Foundation (12 tables) and System Application",
     "(138 tables): 70,728 differences across 74 members. Per-member counts and examples are on",
@@ -178,8 +183,9 @@
     },
     {
       "member": "MetaField.CaptionML.<presence>",
-      "reason": "BC builds a MultiLanguage caption for the field; the runner builds none. The symbol file carries Caption (2,743 occurrences in System Application) \u2014 the MultiLanguage object is its runtime form.",
-      "issue": 3568
+      "reason": "BC builds a MultiLanguage caption for the field; the runner builds none. The symbol file carries Caption (2,743 occurrences in System Application) \u2014 the MultiLanguage object is its runtime form. Direction-scoped to BC-present / runner-absent; the runner inventing a caption BC does not have is a different defect.",
+      "issue": 3568,
+      "direction": "bc-only"
     },
     {
       "member": "MetaField.ExtendedDatatype",
@@ -208,8 +214,9 @@
     },
     {
       "member": "MetaField.Relations.<presence>",
-      "reason": "BC gives SystemCreatedBy and SystemModifiedBy a TableRelation to User (2000000120); the runner gives them none. This is the difference already observable from plain AL as FieldRef.Relation() answering 0 \u2014 see #3549.",
-      "issue": 3568
+      "reason": "BC gives SystemCreatedBy and SystemModifiedBy a TableRelation to User (2000000120); the runner gives them none. This is the difference already observable from plain AL as FieldRef.Relation() answering 0 \u2014 see #3549. Direction-scoped to BC-present / runner-absent; the runner inventing a relation BC does not have would be a different defect and is not covered.",
+      "issue": 3568,
+      "direction": "bc-only"
     },
     {
       "member": "MetaField.ValidateRelation",
@@ -275,19 +282,22 @@
       "member": "MetaTable.#fieldsById.<presence>",
       "reason": "The private backing storage behind MetaTable.FieldsById, holding the same merged tableextension fields as MetaTable.Fields.<presence>; same runtime-merged-versus-build-time-emit boundary, same consequence for an empty diff.",
       "oracleLimitation": true,
-      "Doc": "docs/metadata-equivalence.md#the-oracle-is-build-time-per-app-metadata"
+      "Doc": "docs/metadata-equivalence.md#the-oracle-is-build-time-per-app-metadata",
+      "direction": "runner-only"
     },
     {
       "member": "MetaTable.Fields.<presence>",
-      "reason": "The runner models the MERGED RUNTIME state a running system has \u2014 every registered app's tableextension fields present on the base table. The ground truth is BC's BUILD-TIME per-app emit, which by construction sees only the app being compiled. Two different things, so this is a limitation of the oracle and not evidence about the runner: 115 fields on four Business Foundation tables (230, 242, 308, 6635). In BC 29 everything is merged at database level anyway, which makes the runner's merged view the forward-looking one. CONSEQUENCE: a multi-app bundle can never produce an empty diff, so a non-empty diff here is expected and must not be read as noise or as a bug.",
+      "reason": "The runner models the MERGED RUNTIME state a running system has \u2014 every registered app's tableextension fields present on the base table. The ground truth is BC's BUILD-TIME per-app emit, which by construction sees only the app being compiled. Two different things, so this is a limitation of the oracle and not evidence about the runner: 115 fields on four Business Foundation tables (230, 242, 308, 6635). In BC 29 everything is merged at database level anyway, which makes the runner's merged view the forward-looking one. CONSEQUENCE: a multi-app bundle can never produce an empty diff, so a non-empty diff here is expected and must not be read as noise or as a bug. DIRECTION-SCOPED: covers only BC-absent / runner-present, which is the merged-runtime direction this reason justifies. The reverse \u2014 BC emitted a field and the runner built none \u2014 is a hard reader defect and is NOT covered.",
       "oracleLimitation": true,
-      "Doc": "docs/metadata-equivalence.md#the-oracle-is-build-time-per-app-metadata"
+      "Doc": "docs/metadata-equivalence.md#the-oracle-is-build-time-per-app-metadata",
+      "direction": "runner-only"
     },
     {
       "member": "MetaTable.FieldsById.<presence>",
       "reason": "The by-id index of the same merged tableextension fields as MetaTable.Fields.<presence>; same runtime-merged-versus-build-time-emit boundary, same consequence for an empty diff.",
       "oracleLimitation": true,
-      "Doc": "docs/metadata-equivalence.md#the-oracle-is-build-time-per-app-metadata"
+      "Doc": "docs/metadata-equivalence.md#the-oracle-is-build-time-per-app-metadata",
+      "direction": "runner-only"
     },
     {
       "member": "MetaTable.ReplicateData",
@@ -321,13 +331,15 @@
     },
     {
       "member": "MetaTable.Caption",
-      "reason": "The reverse direction: BC's table Caption is null and the runner carries a real caption. The runner resolves it from AL and BC leaves the runtime object's Caption unset, answering through CaptionML instead.",
-      "issue": 3568
+      "reason": "The reverse direction: BC's table Caption is null and the runner carries a real caption. The runner resolves it from AL and BC leaves the runtime object's Caption unset, answering through CaptionML instead. Direction-scoped to BC-null / runner-present, which is the direction this reason describes; BC stating a caption the runner drops is not covered.",
+      "issue": 3568,
+      "direction": "runner-only"
     },
     {
       "member": "MetaTable.CaptionOriginal",
-      "reason": "The CaptionOriginal half of MetaTable.Caption, same cause.",
-      "issue": 3568
+      "reason": "The CaptionOriginal half of MetaTable.Caption, same cause. Direction-scoped to BC-null / runner-present, which is the direction this reason describes; BC stating a caption the runner drops is not covered.",
+      "issue": 3568,
+      "direction": "runner-only"
     },
     {
       "member": "MetaTable.DataClassification",
@@ -341,8 +353,9 @@
     },
     {
       "member": "MetaField.OptionCaptionML.<presence>",
-      "reason": "The option-caption half of MetaField.CaptionML.<presence>.",
-      "issue": 3568
+      "reason": "The option-caption half of MetaField.CaptionML.<presence>. Direction-scoped to BC-present / runner-absent.",
+      "issue": 3568,
+      "direction": "bc-only"
     },
     {
       "member": "MetaField.NotBlank",
@@ -351,8 +364,9 @@
     },
     {
       "member": "MetaTable.FieldGroups.<presence>",
-      "reason": "BC builds the declared field groups (Brick, DropDown); the runner builds none anywhere. The symbol file carries FieldGroups.",
-      "issue": 3568
+      "reason": "BC builds the declared field groups (Brick, DropDown); the runner builds none anywhere. The symbol file carries FieldGroups. Direction-scoped to BC-present / runner-absent.",
+      "issue": 3568,
+      "direction": "bc-only"
     },
     {
       "member": "MetaKey.Clustered",
@@ -361,8 +375,9 @@
     },
     {
       "member": "MetaKey.SumIndexFields.<presence>",
-      "reason": "BC builds the declared SumIndexFields; the runner builds none.",
-      "issue": 3568
+      "reason": "BC builds the declared SumIndexFields; the runner builds none. Direction-scoped to BC-present / runner-absent.",
+      "issue": 3568,
+      "direction": "bc-only"
     },
     {
       "member": "MetaField.Lookup",

--- a/tests/expectations/metadata-equivalence/allowlist.json
+++ b/tests/expectations/metadata-equivalence/allowlist.json
@@ -1,0 +1,396 @@
+{
+  "comment": [
+    "Declared differences between BC's own metadata emitter and the runner's",
+    "SymbolReference-derived MetaTable. Issue #3533.",
+    "",
+    "This file IS the allowlist: MetadataEquivalenceHarnessTests fails on any difference not",
+    "listed here, and equally on any entry here that no longer matches anything. So a reader",
+    "fix must delete its entries in the same change, and a BC version that introduces a new",
+    "property surfaces as a new undeclared difference rather than passing silently.",
+    "",
+    "Every entry carries a reason. An entry that tolerates a DEFECT names the issue tracking",
+    "it; only a permanent limit of the symbol file may set cannotExpress instead.",
+    "",
+    "No entry sets maxOccurrences. The mechanism exists (see MetadataDifferenceAllowlist) and",
+    "is worth using for a difference whose count is bounded independently of the build, but a",
+    "count measured on one BC build and one set of apps is not that: the unit legs run 27.5 and",
+    "28.4 while these numbers were measured on 28.1, and the totals move with both the BC build",
+    "and which apps have a ground-truth bundle.",
+    "",
+    "Measured on BC 28.1.49838.54044 over Business Foundation (12 tables) and System Application",
+    "(138 tables): 70,728 differences across 73 members. Per-member counts and examples are on",
+    "issue #3568."
+  ],
+  "differences": [
+    {
+      "member": "TranslationKey.#Id2",
+      "reason": "Same as TranslationKey.#Id1: the symbol file records no translation keys at all.",
+      "cannotExpress": true
+    },
+    {
+      "member": "TranslationKey.#NavSymbolKind1",
+      "reason": "The symbol-kind half of a translation key the symbol file does not carry.",
+      "cannotExpress": true
+    },
+    {
+      "member": "TranslationKey.#NavSymbolKind2",
+      "reason": "The symbol-kind half of a translation key the symbol file does not carry.",
+      "cannotExpress": true
+    },
+    {
+      "member": "TranslationKey.#NavSymbolKind3",
+      "reason": "The symbol-kind half of a translation key the symbol file does not carry.",
+      "cannotExpress": true
+    },
+    {
+      "member": "TranslationKey.#NavSymbolKind4",
+      "reason": "The symbol-kind half of a translation key the symbol file does not carry.",
+      "cannotExpress": true
+    },
+    {
+      "member": "TranslationKey.#Id3",
+      "reason": "Same as TranslationKey.#Id1: the symbol file records no translation keys at all.",
+      "cannotExpress": true
+    },
+    {
+      "member": "TranslationKey.#Id1",
+      "reason": "Translation keys are hashes the AL compiler assigns at compile time. SymbolReference.json contains the string 'TranslationKey' zero times in either measured package, so there is nothing to read and nothing to derive.",
+      "cannotExpress": true
+    },
+    {
+      "member": "MetaField.Caption",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.CaptionClass",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.CaptionOriginal",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.CharAllowed",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.ClrType",
+      "reason": "BC states the field's real CLR type (System.Int64, System.Guid, System.String, ...); the runner states the empty string on every field. Not in the symbol file under that name, but derivable from the declared field type.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.EnumTypeName",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.ExternalName",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.ExternalType",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.ObsoleteReason",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.OptionCaption",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.OptionCaptionOriginal",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.ToolTip",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.ToolTipOriginal",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.ValuesAllowed",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.MaxValue",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.MinValue",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.OptionString",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.InitValue",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.DataClassification",
+      "reason": "A field with no DataClassification inherits the TABLE's, which the symbol file does carry. On 439 of 439 measured fields the emitted value equals the table's.",
+      "issue": 3545
+    },
+    {
+      "member": "MetaField.ALNamespace",
+      "reason": "BC states the object's AL namespace on every field; the runner states the empty string. The symbol file has no ALNamespace attribute, but its Namespaces nesting is exactly what the attribute names.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.CaptionML.<presence>",
+      "reason": "BC builds a MultiLanguage caption for the field; the runner builds none. The symbol file carries Caption (2,743 occurrences in System Application) \u2014 the MultiLanguage object is its runtime form.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.ExtendedDatatype",
+      "reason": "BC answers Undefined where nothing is declared; the runner answers None, a different member of the same enum. An encoded-default disagreement, not a missing read.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.Editable",
+      "reason": "An absent Editable in the symbol file means true; the reader takes the constructor default instead. Measured over 1,540 ISV fields: 271 stated, 1,269 silent-and-default, zero silent-and-non-default.",
+      "issue": 3545
+    },
+    {
+      "member": "MetaField.TestRelations",
+      "reason": "BC answers true on a field with no declared TestTableRelation; the runner answers false. AL's real default, not the constructor's.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.AllowInCustomizations",
+      "reason": "BC answers AsReadOnly where the runner answers ToBeClassified. The symbol file states AllowInCustomizations only where it is non-default, so this is the AL default being wrong rather than a value being lost.",
+      "issue": 3568
+    },
+    {
+      "member": "FieldMetadataRelation.Name",
+      "reason": "BC names each field a key refers to; the runner leaves the name null and carries the id alone.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.Relations.<presence>",
+      "reason": "BC gives SystemCreatedBy and SystemModifiedBy a TableRelation to User (2000000120); the runner gives them none. This is the difference already observable from plain AL as FieldRef.Relation() answering 0 \u2014 see #3549.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.ValidateRelation",
+      "reason": "BC answers false on the platform-added system fields; the runner answers true. Restricted to the fields BC adds, not to declared ones.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaKey.ALNamespace",
+      "reason": "Same gap as MetaField.ALNamespace, on keys, where the runner answers null.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaKey.DebuggerDisplay",
+      "reason": "Derived from MetaKey.Name and the key's field names, so it differs wherever those do. Not separately fixable.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaKey.Name",
+      "reason": "BC's key name is the SQL key spec it generates (Field1); the runner's is the AL key name (PK). Two different naming schemes, so this is not a value being lost.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaKey.ObsoleteReason",
+      "reason": "The same null-versus-empty-string shape as the MetaField entries, running the other way: BC states the empty string and the runner states null.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.Name",
+      "reason": "BC names the platform-added system fields $systemId, $systemCreatedAt and so on; the runner uses the AL spelling (SystemId). BC policy for the fields IT adds, which the runner adds itself.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaTable.ALNamespace",
+      "reason": "Same gap as MetaField.ALNamespace, on the table itself.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaTable.PlatformDefinedFieldsAdded",
+      "reason": "BC marks every table as having had its platform fields added; the runner leaves the flag false even though it adds those fields.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaTable.Scope",
+      "reason": "BC answers Personalization where the runner answers Cloud. The symbol file carries Scope.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.Validation",
+      "reason": "BC answers true where the runner answers false, on fields whose AL declares an OnValidate trigger.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaTable.InherentEntitlements",
+      "reason": "BC states the declared inherent entitlements; the runner answers None. The symbol file carries InherentEntitlements (687 occurrences in System Application).",
+      "issue": 3568
+    },
+    {
+      "member": "MetaTable.InherentPermissions",
+      "reason": "The permissions half of MetaTable.InherentEntitlements, same shape and same source.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaTable.#fieldsById.<presence>",
+      "reason": "The private backing storage behind MetaTable.FieldsById, carrying the same merged fields.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaTable.Fields.<presence>",
+      "reason": "The runner merges every REGISTERED app's tableextension fields into the base table; BC's emit sees only the app being compiled. 115 fields on four Business Foundation tables. A difference in what is being asked rather than a value being wrong, and it cannot be empty while another app is loaded.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaTable.FieldsById.<presence>",
+      "reason": "The by-id index of the same merged tableextension fields as MetaTable.Fields.<presence>.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaTable.ReplicateData",
+      "reason": "BC answers true unless AL declares otherwise; the runner answers false. The symbol file states ReplicateData only when non-default.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaKey.KeyName",
+      "reason": "The same naming disagreement as MetaKey.Name, on the second of the two name properties.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.EnumTypeId",
+      "reason": "BC resolves the enum object's id; the runner answers 0. The AL-observable consequence is that an enum-typed field cannot be resolved back to its enum object.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.Access",
+      "reason": "BC states Internal on fields whose AL declares it; the runner answers Public. The symbol file carries Access.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaTable.Access",
+      "reason": "Same as MetaField.Access, on the table.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaCalcFormula.FlowFieldType",
+      "reason": "A case disagreement: BC answers Lookup, the runner answers LOOKUP. The runner is echoing the AL source text rather than mapping it to BC's enum spelling.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaTable.Caption",
+      "reason": "The reverse direction: BC's table Caption is null and the runner carries a real caption. The runner resolves it from AL and BC leaves the runtime object's Caption unset, answering through CaptionML instead.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaTable.CaptionOriginal",
+      "reason": "The CaptionOriginal half of MetaTable.Caption, same cause.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaTable.DataClassification",
+      "reason": "The table-level value, distinct from the field-level inheritance #3545 covers: BC states SystemMetadata where the runner answers CustomerContent.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaFilter.FilterValue",
+      "reason": "Where a CalcFormula filter compares against an enum or a boolean, BC stores the ordinal (0, 1) and the runner stores the source text (System, true).",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.OptionCaptionML.<presence>",
+      "reason": "The option-caption half of MetaField.CaptionML.<presence>.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.NotBlank",
+      "reason": "BC states NotBlank where AL declares it; the runner answers false. The symbol file carries NotBlank.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaTable.FieldGroups.<presence>",
+      "reason": "BC builds the declared field groups (Brick, DropDown); the runner builds none anywhere. The symbol file carries FieldGroups.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaKey.Clustered",
+      "reason": "BC answers false on a key AL does not declare clustered; the runner answers true. The symbol file carries Clustered.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaKey.SumIndexFields.<presence>",
+      "reason": "BC builds the declared SumIndexFields; the runner builds none.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.Lookup",
+      "reason": "BC states Lookup where AL declares it; the runner answers false.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaTable.ObsoleteReason",
+      "reason": "BC states the declared obsolete reason; the runner answers null.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaTable.ObsoleteState",
+      "reason": "BC states Pending on an obsoleted table; the runner answers No.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.ObsoleteState",
+      "reason": "BC states Pending on an obsoleted field; the runner answers No.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaTable.DrillDownFormId",
+      "reason": "BC resolves the declared DrillDownPageId to a page id; the runner answers 0.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaCondition.ConditionValue",
+      "reason": "The same ordinal-versus-source-text disagreement as MetaFilter.FilterValue, on a conditional TableRelation.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.BlankZero",
+      "reason": "BC states BlankZero where AL declares it; the runner answers false.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaKey.Unique",
+      "reason": "BC states Unique where AL declares it; the runner answers false.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaTable.DataCaptionFields",
+      "reason": "BC states the declared DataCaptionFields; the runner states an empty array. The symbol file carries DataCaptionFields.",
+      "issue": 3568
+    },
+    {
+      "member": "MetaField.BlobSubType",
+      "reason": "BC states the declared BLOB subtype (Bitmap); the runner answers UserDefined.",
+      "issue": 3568
+    }
+  ]
+}

--- a/tests/expectations/metadata-equivalence/allowlist.json
+++ b/tests/expectations/metadata-equivalence/allowlist.json
@@ -8,8 +8,20 @@
     "fix must delete its entries in the same change, and a BC version that introduces a new",
     "property surfaces as a new undeclared difference rather than passing silently.",
     "",
-    "Every entry carries a reason. An entry that tolerates a DEFECT names the issue tracking",
-    "it; only a permanent limit of the symbol file may set cannotExpress instead.",
+    "Every entry carries a reason AND exactly one KIND of reason, because the four kinds need",
+    "different evidence:",
+    "  issue            a defect, tracked, expected to go away",
+    "  outOfScope       the runner does not implement the surface, so no AL test can see it",
+    "                   (needs a Doc pointer)",
+    "  oracleLimitation the ground truth is the wrong shape for this member, so the difference",
+    "                   says nothing about the runner (needs a Doc pointer)",
+    "  cannotExpress    the symbol file cannot express it AND it cannot be derived",
+    "",
+    "NO ENTRY CURRENTLY CLAIMS cannotExpress. Seven TranslationKey entries did, on the evidence",
+    "that SymbolReference.json stores no translation keys. That was true and the conclusion was",
+    "wrong twice over: the key is COMPUTED from names rather than stored (2,153 of 2,153",
+    "reproduced), and the runner reads no translation files anyway, so it is out of scope rather",
+    "than impossible. 'Nothing is stored' is evidence about storage, never about derivability.",
     "",
     "No entry sets maxOccurrences. The mechanism exists (see MetadataDifferenceAllowlist) and",
     "is worth using for a difference whose count is bounded independently of the build, but a",
@@ -18,44 +30,51 @@
     "and which apps have a ground-truth bundle.",
     "",
     "Measured on BC 28.1.49838.54044 over Business Foundation (12 tables) and System Application",
-    "(138 tables): 70,728 differences across 73 members. Per-member counts and examples are on",
+    "(138 tables): 70,728 differences across 74 members. Per-member counts and examples are on",
     "issue #3568."
   ],
   "differences": [
     {
       "member": "TranslationKey.#Id2",
-      "reason": "Same as TranslationKey.#Id1: the symbol file records no translation keys at all.",
-      "cannotExpress": true
+      "reason": "The field-name or property-name component of a translation-file lookup id. A translation key only means anything to something that reads translation files. Measured: the runner has no .xlf or Translations/ handling anywhere \u2014 zero references in AlRunner/ \u2014 and docs/limitations.md already records that it installs no BC translation resources. Separately, the key IS derivable: (uint)(FNV-1a-32 over the UTF-16LE bytes of the name + int.MaxValue) reproduces 2,153 of 2,153 keys in the ground truth (TranslationKeysAreDerivable_NotAPermanentLimit). So this is a scope boundary, never a permanent limit \u2014 the runner gaining translation support is what invalidates this entry. NOT to be confused with MetaField.CaptionML, which is the caption TEXT, is AL-observable, and is declared separately as a defect.",
+      "outOfScope": true,
+      "Doc": "docs/metadata-equivalence.md#translation-keys-are-out-of-scope"
     },
     {
       "member": "TranslationKey.#NavSymbolKind1",
-      "reason": "The symbol-kind half of a translation key the symbol file does not carry.",
-      "cannotExpress": true
+      "reason": "The symbol kind of a translation key's first component (BC: Table, runner: Module). A translation key only means anything to something that reads translation files. Measured: the runner has no .xlf or Translations/ handling anywhere \u2014 zero references in AlRunner/ \u2014 and docs/limitations.md already records that it installs no BC translation resources. Separately, the key IS derivable: (uint)(FNV-1a-32 over the UTF-16LE bytes of the name + int.MaxValue) reproduces 2,153 of 2,153 keys in the ground truth (TranslationKeysAreDerivable_NotAPermanentLimit). So this is a scope boundary, never a permanent limit \u2014 the runner gaining translation support is what invalidates this entry. NOT to be confused with MetaField.CaptionML, which is the caption TEXT, is AL-observable, and is declared separately as a defect.",
+      "outOfScope": true,
+      "Doc": "docs/metadata-equivalence.md#translation-keys-are-out-of-scope"
     },
     {
       "member": "TranslationKey.#NavSymbolKind2",
-      "reason": "The symbol-kind half of a translation key the symbol file does not carry.",
-      "cannotExpress": true
+      "reason": "The symbol kind of a translation key's second component. A translation key only means anything to something that reads translation files. Measured: the runner has no .xlf or Translations/ handling anywhere \u2014 zero references in AlRunner/ \u2014 and docs/limitations.md already records that it installs no BC translation resources. Separately, the key IS derivable: (uint)(FNV-1a-32 over the UTF-16LE bytes of the name + int.MaxValue) reproduces 2,153 of 2,153 keys in the ground truth (TranslationKeysAreDerivable_NotAPermanentLimit). So this is a scope boundary, never a permanent limit \u2014 the runner gaining translation support is what invalidates this entry. NOT to be confused with MetaField.CaptionML, which is the caption TEXT, is AL-observable, and is declared separately as a defect.",
+      "outOfScope": true,
+      "Doc": "docs/metadata-equivalence.md#translation-keys-are-out-of-scope"
     },
     {
       "member": "TranslationKey.#NavSymbolKind3",
-      "reason": "The symbol-kind half of a translation key the symbol file does not carry.",
-      "cannotExpress": true
+      "reason": "The symbol kind of a translation key's third component. A translation key only means anything to something that reads translation files. Measured: the runner has no .xlf or Translations/ handling anywhere \u2014 zero references in AlRunner/ \u2014 and docs/limitations.md already records that it installs no BC translation resources. Separately, the key IS derivable: (uint)(FNV-1a-32 over the UTF-16LE bytes of the name + int.MaxValue) reproduces 2,153 of 2,153 keys in the ground truth (TranslationKeysAreDerivable_NotAPermanentLimit). So this is a scope boundary, never a permanent limit \u2014 the runner gaining translation support is what invalidates this entry. NOT to be confused with MetaField.CaptionML, which is the caption TEXT, is AL-observable, and is declared separately as a defect.",
+      "outOfScope": true,
+      "Doc": "docs/metadata-equivalence.md#translation-keys-are-out-of-scope"
     },
     {
       "member": "TranslationKey.#NavSymbolKind4",
-      "reason": "The symbol-kind half of a translation key the symbol file does not carry.",
-      "cannotExpress": true
+      "reason": "The symbol kind of a translation key's fourth component. A translation key only means anything to something that reads translation files. Measured: the runner has no .xlf or Translations/ handling anywhere \u2014 zero references in AlRunner/ \u2014 and docs/limitations.md already records that it installs no BC translation resources. Separately, the key IS derivable: (uint)(FNV-1a-32 over the UTF-16LE bytes of the name + int.MaxValue) reproduces 2,153 of 2,153 keys in the ground truth (TranslationKeysAreDerivable_NotAPermanentLimit). So this is a scope boundary, never a permanent limit \u2014 the runner gaining translation support is what invalidates this entry. NOT to be confused with MetaField.CaptionML, which is the caption TEXT, is AL-observable, and is declared separately as a defect.",
+      "outOfScope": true,
+      "Doc": "docs/metadata-equivalence.md#translation-keys-are-out-of-scope"
     },
     {
       "member": "TranslationKey.#Id3",
-      "reason": "Same as TranslationKey.#Id1: the symbol file records no translation keys at all.",
-      "cannotExpress": true
+      "reason": "The property-name component of a field's translation-file lookup id. A translation key only means anything to something that reads translation files. Measured: the runner has no .xlf or Translations/ handling anywhere \u2014 zero references in AlRunner/ \u2014 and docs/limitations.md already records that it installs no BC translation resources. Separately, the key IS derivable: (uint)(FNV-1a-32 over the UTF-16LE bytes of the name + int.MaxValue) reproduces 2,153 of 2,153 keys in the ground truth (TranslationKeysAreDerivable_NotAPermanentLimit). So this is a scope boundary, never a permanent limit \u2014 the runner gaining translation support is what invalidates this entry. NOT to be confused with MetaField.CaptionML, which is the caption TEXT, is AL-observable, and is declared separately as a defect.",
+      "outOfScope": true,
+      "Doc": "docs/metadata-equivalence.md#translation-keys-are-out-of-scope"
     },
     {
       "member": "TranslationKey.#Id1",
-      "reason": "Translation keys are hashes the AL compiler assigns at compile time. SymbolReference.json contains the string 'TranslationKey' zero times in either measured package, so there is nothing to read and nothing to derive.",
-      "cannotExpress": true
+      "reason": "The object-name component of a translation-file lookup id. A translation key only means anything to something that reads translation files. Measured: the runner has no .xlf or Translations/ handling anywhere \u2014 zero references in AlRunner/ \u2014 and docs/limitations.md already records that it installs no BC translation resources. Separately, the key IS derivable: (uint)(FNV-1a-32 over the UTF-16LE bytes of the name + int.MaxValue) reproduces 2,153 of 2,153 keys in the ground truth (TranslationKeysAreDerivable_NotAPermanentLimit). So this is a scope boundary, never a permanent limit \u2014 the runner gaining translation support is what invalidates this entry. NOT to be confused with MetaField.CaptionML, which is the caption TEXT, is AL-observable, and is declared separately as a defect.",
+      "outOfScope": true,
+      "Doc": "docs/metadata-equivalence.md#translation-keys-are-out-of-scope"
     },
     {
       "member": "MetaField.Caption",
@@ -79,7 +98,7 @@
     },
     {
       "member": "MetaField.ClrType",
-      "reason": "BC states the field's real CLR type (System.Int64, System.Guid, System.String, ...); the runner states the empty string on every field. Not in the symbol file under that name, but derivable from the declared field type.",
+      "reason": "BC states the field's real CLR type and the runner states the empty string on all 1,888 fields. ClrType is not an XML attribute at all \u2014 BC derives it itself \u2014 and it is a PURE FUNCTION of Datatype, which the symbol file does carry and the runner already reads: measured over 988 observations, all 16 Datatypes map to exactly one ClrType each (BigInteger->System.Int64, GUID->System.Guid, Code/Text/DateFormula->System.String, Option/Integer->System.Int32, BLOB/RecordID->System.Byte[], Media->NSMediaWrapper, and so on). Recoverable with no app data.",
       "issue": 3568
     },
     {
@@ -254,18 +273,21 @@
     },
     {
       "member": "MetaTable.#fieldsById.<presence>",
-      "reason": "The private backing storage behind MetaTable.FieldsById, carrying the same merged fields.",
-      "issue": 3568
+      "reason": "The private backing storage behind MetaTable.FieldsById, holding the same merged tableextension fields as MetaTable.Fields.<presence>; same runtime-merged-versus-build-time-emit boundary, same consequence for an empty diff.",
+      "oracleLimitation": true,
+      "Doc": "docs/metadata-equivalence.md#the-oracle-is-build-time-per-app-metadata"
     },
     {
       "member": "MetaTable.Fields.<presence>",
-      "reason": "The runner merges every REGISTERED app's tableextension fields into the base table; BC's emit sees only the app being compiled. 115 fields on four Business Foundation tables. A difference in what is being asked rather than a value being wrong, and it cannot be empty while another app is loaded.",
-      "issue": 3568
+      "reason": "The runner models the MERGED RUNTIME state a running system has \u2014 every registered app's tableextension fields present on the base table. The ground truth is BC's BUILD-TIME per-app emit, which by construction sees only the app being compiled. Two different things, so this is a limitation of the oracle and not evidence about the runner: 115 fields on four Business Foundation tables (230, 242, 308, 6635). In BC 29 everything is merged at database level anyway, which makes the runner's merged view the forward-looking one. CONSEQUENCE: a multi-app bundle can never produce an empty diff, so a non-empty diff here is expected and must not be read as noise or as a bug.",
+      "oracleLimitation": true,
+      "Doc": "docs/metadata-equivalence.md#the-oracle-is-build-time-per-app-metadata"
     },
     {
       "member": "MetaTable.FieldsById.<presence>",
-      "reason": "The by-id index of the same merged tableextension fields as MetaTable.Fields.<presence>.",
-      "issue": 3568
+      "reason": "The by-id index of the same merged tableextension fields as MetaTable.Fields.<presence>; same runtime-merged-versus-build-time-emit boundary, same consequence for an empty diff.",
+      "oracleLimitation": true,
+      "Doc": "docs/metadata-equivalence.md#the-oracle-is-build-time-per-app-metadata"
     },
     {
       "member": "MetaTable.ReplicateData",

--- a/tests/expectations/metadata-equivalence/apps.json
+++ b/tests/expectations/metadata-equivalence/apps.json
@@ -1,0 +1,26 @@
+{
+  "comment": [
+    "Which Microsoft apps the metadata-equivalence harness must cover (issue #3533).",
+    "Declaring an app here makes covering it mandatory: MetadataEquivalenceHarnessTests fails",
+    "if no ground-truth bundle for it is present, so the harness cannot quietly measure less",
+    "than it claims. Add an app only once tools/gen-metadata-ground-truth.sh produces a bundle",
+    "for it on a clean box.",
+    "",
+    "Base Application is deliberately ABSENT. Its emit needs a PublicKeyToken=null copy of",
+    "Microsoft.AspNetCore.StaticFiles that no BC artifact ships, and without it the emitter",
+    "produces ZERO objects (issue #3549). Listing it here would fail every leg; leaving it out",
+    "and saying so is the honest state."
+  ],
+  "apps": [
+    {
+      "publisher": "Microsoft",
+      "name": "Business Foundation",
+      "reason": "96 AL files, 12 tables, compiles clean headless in ~3s with no reference-set workaround at all — the app that proves the harness runs anywhere the artifacts do."
+    },
+    {
+      "publisher": "Microsoft",
+      "name": "System Application",
+      "reason": "1,319 AL files, 138 tables, ~14s. The app the known defect counts were measured on, and large enough that a reader regression has somewhere to hide."
+    }
+  ]
+}

--- a/tools/gen-metadata-ground-truth.sh
+++ b/tools/gen-metadata-ground-truth.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# gen-metadata-ground-truth.sh — produce the ground truth the metadata-equivalence harness
+# measures against: BC's OWN metadata-emitter output for the Microsoft apps listed in
+# tests/expectations/metadata-equivalence/apps.json. Issue #3533.
+#
+# Runs once per BC build. Business Foundation is ~3s, System Application ~14s, so this is a
+# provisioning cost, not a per-run one. Re-running is cheap and idempotent; a bundle is keyed
+# on the BC build so a new artifact gets its own directory rather than overwriting.
+#
+# Usage:
+#   tools/gen-metadata-ground-truth.sh                       # every app in apps.json
+#   tools/gen-metadata-ground-truth.sh --artifacts <dir>     # a specific BC build
+#   tools/gen-metadata-ground-truth.sh --out <dir>           # somewhere other than the default
+#   tools/gen-metadata-ground-truth.sh --app "System Application"
+#
+# Exit codes: 0 every requested app produced a bundle; 1 at least one did not (and says which).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ARTIFACTS=""
+OUT="${AL_RUNNER_METADATA_GROUND_TRUTH:-}"
+ONLY=""
+CONFIG=Release
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --artifacts) ARTIFACTS="$2"; shift 2 ;;
+    --out) OUT="$2"; shift 2 ;;
+    --app) ONLY="$2"; shift 2 ;;
+    -c|--configuration) CONFIG="$2"; shift 2 ;;
+    -h|--help) sed -n '2,20p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) echo "unknown argument '$1'" >&2; exit 2 ;;
+  esac
+done
+
+ARTIFACTS_ROOT="${AL_RUNNER_ARTIFACTS_ROOT:-$HOME/.local/share/al-runner/artifacts}"
+
+if [ -z "$ARTIFACTS" ]; then
+  # Newest cached build. The runner's own default selection is per-major; here any single
+  # build is a legitimate subject, because a bundle records the build it came from and the
+  # harness compares each bundle against the very .app it was generated from.
+  ARTIFACTS="$(ls -d "$ARTIFACTS_ROOT"/*/ 2>/dev/null | sort -V | tail -1 || true)"
+  ARTIFACTS="${ARTIFACTS%/}"
+fi
+if [ -z "$ARTIFACTS" ] || [ ! -d "$ARTIFACTS" ]; then
+  echo "no BC artifacts found under $ARTIFACTS_ROOT — provision one first (al-runner provision)." >&2
+  exit 1
+fi
+BC_BUILD="$(basename "$ARTIFACTS")"
+
+if [ -z "$OUT" ]; then
+  OUT="$(dirname "$ARTIFACTS_ROOT")/metadata-ground-truth"
+fi
+
+echo "[ground-truth] BC build $BC_BUILD -> $OUT/$BC_BUILD"
+
+dotnet build "$REPO_ROOT/tools/metadata-ground-truth/MetadataGroundTruth.csproj" \
+  -c "$CONFIG" -p:ServiceTierPath="$ARTIFACTS" --nologo -v quiet
+TOOL="$REPO_ROOT/tools/metadata-ground-truth/bin/$CONFIG/net8.0/metadata-ground-truth.dll"
+
+failed=0
+covered=0
+APPS="$(python3 -c '
+import json, sys
+for a in json.load(open(sys.argv[1]))["apps"]:
+    print(a["publisher"] + "\t" + a["name"])
+' "$REPO_ROOT/tests/expectations/metadata-equivalence/apps.json")"
+
+while IFS=$'\t' read -r publisher name; do
+  [ -n "$name" ] || continue
+  if [ -n "$ONLY" ] && [ "$ONLY" != "$name" ]; then continue; fi
+
+  pkg="$(find "$ARTIFACTS" -name "${publisher}_${name}_*.app" -print -quit 2>/dev/null || true)"
+  if [ -z "$pkg" ]; then
+    echo "::error::no ${publisher}_${name} package under $ARTIFACTS" >&2
+    failed=1
+    continue
+  fi
+  version="$(basename "$pkg" .app)"
+  version="${version##*_}"
+  dest="$OUT/$BC_BUILD/${publisher}_${name}_${version}"
+  mkdir -p "$dest"
+
+  args=(--app "$pkg" --out "$dest" --artifacts "$ARTIFACTS")
+
+  echo "[ground-truth] $publisher $name $version"
+  if dotnet "$TOOL" "${args[@]}"; then
+    covered=$((covered + 1))
+  else
+    echo "::error::ground truth generation FAILED for ${publisher}_${name} — the harness will " \
+         "report this app as uncovered rather than compare less of it" >&2
+    rm -rf "$dest"
+    failed=1
+  fi
+done <<< "$APPS"
+
+echo "[ground-truth] $covered app(s) bundled under $OUT/$BC_BUILD"
+exit $failed

--- a/tools/metadata-ground-truth/AppCompilation.cs
+++ b/tools/metadata-ground-truth/AppCompilation.cs
@@ -1,0 +1,187 @@
+// Configuring BC's own compiler over a shipped Microsoft app's source, the way BC's publish
+// step does. Every knob here exists because omitting it changes the emitted metadata or stops
+// the compile outright; each is noted at its line.
+
+using NavCA = Microsoft.Dynamics.Nav.CodeAnalysis;
+
+namespace AlRunner.Tools.MetadataGroundTruth;
+
+internal static class AppCompilation
+{
+    public static NavCA.Compilation Create(
+        AppIdentity identity, string packageRoot, string srcRoot, string serviceTierDir, string appPath,
+        IReadOnlyList<string>? dotnetFirst = null)
+    {
+        var features = NavCA.CompilerFeatures.None;
+        foreach (var f in identity.Features)
+            if (Enum.TryParse<NavCA.CompilerFeatures>(f, ignoreCase: true, out var parsed))
+                features |= parsed;
+
+        if (!Enum.TryParse<NavCA.CompilationTarget>(identity.Target, ignoreCase: true, out var target))
+            target = NavCA.CompilationTarget.OnPrem;
+
+        var parseOptions = identity.PreprocessorSymbols.Count > 0
+            ? NavCA.ParseOptions.Default.WithPreprocessorSymbols(identity.PreprocessorSymbols)
+            : NavCA.ParseOptions.Default;
+
+        var files = Directory.GetFiles(srcRoot, "*.al", SearchOption.AllDirectories);
+        Console.WriteLine($"[src] {files.Length} .al files");
+        var trees = files.AsParallel()
+            .Select(f => NavCA.Syntax.SyntaxTree.ParseObjectText(
+                LayoutPaths.Normalize(File.ReadAllText(f)), path: f, encoding: null, parseOptions, default))
+            .ToArray();
+
+        var options = new NavCA.CompilationOptions(
+            continueBuildOnError: true,
+            target: target,
+            // Code | Navigation is what publish asks for. Metadata is emitted alongside code
+            // and is not separately selectable, so asking for less than Code yields no
+            // metadata documents at all.
+            generateOptions: NavCA.CompilationGenerationOptions.Code | NavCA.CompilationGenerationOptions.Navigation,
+            compilerFeatures: features,
+            contextSensitiveHelpUrl: string.IsNullOrEmpty(identity.ContextSensitiveHelpUrl)
+                ? null : identity.ContextSensitiveHelpUrl);
+
+        var comp = NavCA.Compilation.Create(
+            moduleName: identity.Name, publisher: identity.Publisher, version: identity.Version,
+            appId: identity.Id, syntaxTrees: trees, options: options);
+
+        comp = comp.WithFileSystem(new LayeredFileSystem(ResourceRoots(packageRoot)));
+        comp = WithReferences(comp, identity, serviceTierDir, appPath);
+        comp = comp.WithDotNetResolverFactory(
+            new NavCA.DotNet.DotNetResolverFactory(
+                new NavCA.DotNet.AssemblyLocator(DotNetProbingPaths(serviceTierDir, dotnetFirst))));
+        return comp;
+    }
+
+    /// <summary>
+    /// Resource lookups resolve relative to the package root, to each directory it ships, and
+    /// to addin/src — a control add-in's files sit under the last of those and nowhere the
+    /// package root alone would find them.
+    /// </summary>
+    private static IEnumerable<string> ResourceRoots(string packageRoot)
+    {
+        yield return packageRoot;
+        foreach (var sub in Directory.GetDirectories(packageRoot)) yield return sub;
+        yield return Path.Combine(packageRoot, "addin", "src");
+    }
+
+    private static NavCA.Compilation WithReferences(
+        NavCA.Compilation comp, AppIdentity identity, string serviceTierDir, string appPath)
+    {
+        // Every reference is resolved from .app packages sitting beside the subject app, plus
+        // the platform's own System.app. An app declaring no <Dependencies> still depends on
+        // the platform — System Application is exactly that case — so the platform app is
+        // added unconditionally rather than only when the manifest mentions it.
+        var appDir = Path.GetDirectoryName(Path.GetFullPath(appPath))!;
+        var searchDirs = new List<string> { appDir };
+        foreach (var name in new[] { "platform-apps", "platform-apps-us", "Applications", "Extensions" })
+        {
+            var d = Path.Combine(serviceTierDir, name);
+            if (Directory.Exists(d) && !searchDirs.Contains(d)) searchDirs.Add(d);
+        }
+
+        var wanted = new List<(Guid Id, string Name, string Publisher, Version Version)>(identity.Dependencies);
+        var specs = new List<NavCA.SymbolReferenceSpecification>();
+        var resolved = new List<string>();
+        var refDir = Directory.CreateTempSubdirectory("al-runner-groundtruth-refs-");
+
+        foreach (var candidate in searchDirs.SelectMany(d => Directory.GetFiles(d, "*.app")))
+        {
+            if (string.Equals(Path.GetFullPath(candidate), Path.GetFullPath(appPath), StringComparison.Ordinal))
+                continue;
+            AppIdentity id;
+            try { id = NavxPackage.ReadIdentity(candidate); }
+            catch { continue; }   // not a readable .app; the reference loader would reject it too
+
+            var isPlatform = string.Equals(id.Name, "System", StringComparison.OrdinalIgnoreCase);
+            var isDeclared = wanted.Any(w => w.Id == id.Id);
+            if (!isPlatform && !isDeclared) continue;
+
+            var staged = Path.Combine(refDir.FullName, Path.GetFileName(candidate));
+            if (File.Exists(staged)) continue;
+            File.Copy(candidate, staged);
+            specs.Add(new NavCA.SymbolReferenceSpecification(
+                id.Name, id.Publisher, id.Version, false, id.Id));
+            resolved.Add($"{id.Name} {id.Version}");
+        }
+
+        if (specs.Count == 0)
+            throw new InvalidOperationException(
+                $"no reference packages found for {identity.Name}. Looked in: {string.Join(", ", searchDirs)}. " +
+                "Without the platform's System.app the compile produces thousands of AL0185s and " +
+                "no metadata, which would otherwise look like an app-specific failure.");
+
+        Console.WriteLine($"[refs] {specs.Count}: " + string.Join(", ", resolved));
+        var loader = NavCA.SymbolReference.ReferenceLoaderFactory
+            .CreateReferenceLoader(new[] { refDir.FullName });
+        return comp.WithReferenceLoader(loader).AddReferences(specs.ToArray());
+    }
+
+    /// <summary>
+    /// The same order the runner's own compiler setup uses: .NET REFERENCE packs first (real
+    /// TypeDefinitions rather than forwarder facades), then the service tier, then its
+    /// Add-ins, then the shared framework LAST. Putting the shared framework first resolves
+    /// facades and the AL DotNet declarations fail to bind.
+    /// </summary>
+    private static List<string> DotNetProbingPaths(string serviceTierDir, IReadOnlyList<string>? dotnetFirst)
+    {
+        var probing = new List<string>();
+        // Shipped beside this tool by the CopyDotNetShims target; see the csproj for what is in
+        // it and why it has to come first.
+        var shims = Path.Combine(AppContext.BaseDirectory, "dotnet-shims");
+        if (Directory.Exists(shims)) probing.Add(shims);
+        foreach (var d in dotnetFirst ?? Array.Empty<string>())
+            if (Directory.Exists(d)) probing.Add(d);
+        var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        var idx = runtimeDir.Replace('\\', '/').IndexOf("/shared/", StringComparison.OrdinalIgnoreCase);
+        var dotnetRoot = idx > 0 ? runtimeDir[..idx] : null;
+
+        if (dotnetRoot is not null && Directory.Exists(Path.Combine(dotnetRoot, "packs")))
+        {
+            var packs = Path.Combine(dotnetRoot, "packs");
+            int? runtimeMajor = Version.TryParse(Path.GetFileName(runtimeDir.TrimEnd('/')), out var v) ? v.Major : null;
+            AddRefPack(probing, Path.Combine(packs, "Microsoft.NETCore.App.Ref"), runtimeMajor);
+            AddRefPack(probing, Path.Combine(packs, "NETStandard.Library.Ref"), null);
+        }
+
+        probing.Add(serviceTierDir);
+        var addins = Path.Combine(serviceTierDir, "Add-ins");
+        if (Directory.Exists(addins))
+            probing.AddRange(Directory.GetDirectories(addins, "*", SearchOption.AllDirectories));
+        var webClient = Path.Combine(serviceTierDir, "platform", "WebClient");
+        if (Directory.Exists(webClient))
+            probing.AddRange(Directory.GetDirectories(webClient, "*", SearchOption.AllDirectories)
+                .Where(d => Path.GetFileName(d) == "refs"));
+        probing.Add(runtimeDir);
+        return probing;
+    }
+
+    private static void AddRefPack(List<string> probing, string packRoot, int? preferMajor)
+    {
+        if (!Directory.Exists(packRoot)) return;
+        var candidates = Directory.EnumerateDirectories(packRoot)
+            .Select(d => (Dir: d, Ver: Version.TryParse(Path.GetFileName(d), out var v) ? v : null))
+            .Where(t => t.Ver is not null).ToList();
+        var best = candidates.Where(t => preferMajor is null || t.Ver!.Major == preferMajor.Value)
+                       .OrderByDescending(t => t.Ver).Select(t => t.Dir).FirstOrDefault()
+                   ?? candidates.OrderByDescending(t => t.Ver).Select(t => t.Dir).FirstOrDefault();
+        if (best is null) return;
+        var refDir = Path.Combine(best, "ref");
+        if (Directory.Exists(refDir)) probing.AddRange(Directory.EnumerateDirectories(refDir));
+    }
+}
+
+/// <summary>
+/// Layout property values ship with Windows separators in some Microsoft apps and raise AL0363
+/// on Linux. Normalizing them in the source text is what the runner's own compile path does.
+/// </summary>
+internal static class LayoutPaths
+{
+    private static readonly System.Text.RegularExpressions.Regex Rx = new(
+        @"(?im)^(\s*(?:LayoutFile|RDLCLayout|WordLayout|ExcelLayout)\s*=\s*')([^']*)(')");
+
+    public static string Normalize(string text)
+        => text.IndexOf('\\') < 0 ? text : Rx.Replace(text, m =>
+            m.Groups[1].Value + m.Groups[2].Value.Replace('\\', '/') + m.Groups[3].Value);
+}

--- a/tools/metadata-ground-truth/BcHost.cs
+++ b/tools/metadata-ground-truth/BcHost.cs
@@ -1,0 +1,68 @@
+// Standing BC's compiler assemblies up in a plain console process: resolve them out of the
+// service-tier directory, and satisfy their Win32 P/Invokes from the runner's stub library.
+//
+// The runner does the same two things through DependencyLoader and Win32Stubs. This tool
+// deliberately does not reference the runner (no build-order dependency on the thing it
+// checks), so it repeats the small part it needs and nothing else.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace AlRunner.Tools.MetadataGroundTruth;
+
+internal static class BcHost
+{
+    private static readonly HashSet<string> Win32 = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "kernel32", "kernel32.dll", "user32", "user32.dll", "wintrust", "wintrust.dll",
+        "nclcsrts", "nclcsrts.dll", "advapi32", "advapi32.dll", "secur32", "secur32.dll",
+        "iphlpapi", "iphlpapi.dll", "psapi", "psapi.dll", "ws2_32", "ws2_32.dll",
+        "shlwapi", "shlwapi.dll", "netapi32", "netapi32.dll", "userenv", "userenv.dll",
+        "wtsapi32", "wtsapi32.dll", "dhcpcsvc", "dhcpcsvc.dll", "ntdsapi", "ntdsapi.dll",
+    };
+
+    public static void Install(string serviceTierDir)
+    {
+        AppDomain.CurrentDomain.AssemblyResolve += (_, e) =>
+        {
+            var file = new AssemblyName(e.Name).Name + ".dll";
+            var path = Path.Combine(serviceTierDir, file);
+            return File.Exists(path) ? Assembly.LoadFrom(path) : null;
+        };
+
+        var stub = FindStubs();
+        if (stub is null)
+        {
+            // Not fatal by itself — say so rather than let the first P/Invoke fail with a
+            // DllNotFoundException naming kernel32, which reads as a broken machine.
+            Console.Error.WriteLine(
+                "[warn] Win32 stub library not found; BC assemblies that P/Invoke kernel32 and " +
+                "friends will fail. Build it with AlRunner/Win32Stubs/build-prebuilt.sh, or set " +
+                "AL_RUNNER_WIN32_STUBS to its path.");
+            return;
+        }
+
+        var handle = NativeLibrary.Load(stub);
+        DllImportResolver resolver = (name, _, _) => Win32.Contains(name) ? handle : IntPtr.Zero;
+        AppDomain.CurrentDomain.AssemblyLoad += (_, e) =>
+        { try { NativeLibrary.SetDllImportResolver(e.LoadedAssembly, resolver); } catch { } };
+        foreach (var a in AppDomain.CurrentDomain.GetAssemblies())
+            try { NativeLibrary.SetDllImportResolver(a, resolver); } catch { }
+    }
+
+    private static string? FindStubs()
+    {
+        var explicitPath = Environment.GetEnvironmentVariable("AL_RUNNER_WIN32_STUBS");
+        if (!string.IsNullOrEmpty(explicitPath) && File.Exists(explicitPath)) return explicitPath;
+
+        // Walk up from this assembly to the repository root — this tool lives in tools/, so
+        // the runner's prebuilt stub is a known relative distance away.
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        for (int i = 0; dir is not null && i < 10; i++, dir = dir.Parent)
+        {
+            var candidate = Path.Combine(dir.FullName, "AlRunner", "Win32Stubs", "libwin32_stubs.linux-x64.so");
+            if (File.Exists(candidate)) return candidate;
+        }
+        return null;
+    }
+}

--- a/tools/metadata-ground-truth/LayeredFileSystem.cs
+++ b/tools/metadata-ground-truth/LayeredFileSystem.cs
@@ -1,0 +1,117 @@
+// The IFileSystem BC's compiler resolves an app's resources through: ordered roots, so an
+// overlay such as addin/src sits beside the package root, plus '\' -> '/', URL-decoding and
+// case-folded lookup applied unconditionally. Microsoft's own apps rely on all three.
+
+using NavCA = Microsoft.Dynamics.Nav.CodeAnalysis;
+
+namespace AlRunner.Tools.MetadataGroundTruth;
+
+internal sealed class LayeredFileSystem : NavCA.IFileSystem
+{
+    private readonly string[] _roots;
+    private readonly Dictionary<string, string> _caseFolded = new(StringComparer.OrdinalIgnoreCase);
+
+    public LayeredFileSystem(IEnumerable<string> roots)
+    {
+        _roots = roots.Where(Directory.Exists).Select(Path.GetFullPath).Distinct().ToArray();
+        foreach (var root in _roots)
+            foreach (var file in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+            {
+                var rel = Path.GetRelativePath(root, file).Replace('\\', '/');
+                _caseFolded.TryAdd(rel, file);
+            }
+    }
+
+    public string Root => _roots.Length > 0 ? _roots[0] : "";
+
+    private string Resolve(string path)
+    {
+        if (string.IsNullOrEmpty(path)) return path;
+        if (Path.IsPathRooted(path) && File.Exists(path)) return path;
+        foreach (var variant in Variants(path))
+        {
+            foreach (var root in _roots)
+            {
+                var candidate = Path.Combine(root, variant);
+                if (File.Exists(candidate)) return candidate;
+            }
+            if (_caseFolded.TryGetValue(variant, out var folded)) return folded;
+        }
+        return _roots.Length > 0 ? Path.Combine(_roots[0], path.Replace('\\', '/')) : path;
+    }
+
+    private static IEnumerable<string> Variants(string path)
+    {
+        var normalized = (path ?? "").Replace('\\', '/').TrimStart('.', '/');
+        yield return normalized;
+        string decoded = normalized;
+        try { decoded = Uri.UnescapeDataString(normalized); } catch { /* not a URL-escaped path */ }
+        if (decoded != normalized) yield return decoded;
+    }
+
+    // BC calls GetFiles(searchPattern) with a whole path, which for a control add-in can be a
+    // CDN URL. Real BC tolerates that, so enumerate defensively rather than throw.
+    private static List<string> Safe(string dir, string pattern, SearchOption option)
+    {
+        try
+        {
+            return Directory.Exists(dir)
+                ? Directory.EnumerateFiles(dir, pattern, option).ToList()
+                : new List<string>();
+        }
+        catch { return new List<string>(); }
+    }
+
+    public byte[] ReadBytes(string path) => File.ReadAllBytes(Resolve(path));
+
+    public byte[] ReadBytes(string path, int count)
+    {
+        using var s = File.OpenRead(Resolve(path));
+        var buffer = new byte[count];
+        var read = s.Read(buffer, 0, count);
+        if (read == count) return buffer;
+        Array.Resize(ref buffer, read);
+        return buffer;
+    }
+
+    public void WriteBytes(string path, byte[] content) => File.WriteAllBytes(Resolve(path), content);
+    public bool Exists(string path) => File.Exists(Resolve(path));
+    public bool DirectoryExistsForFile(string path) => Directory.Exists(Path.GetDirectoryName(Resolve(path)));
+
+    public bool DirectoryExists(string directory)
+        => _roots.Any(r => Directory.Exists(Path.Combine(r, (directory ?? "").Replace('\\', '/'))))
+           || Directory.Exists(directory ?? "");
+
+    public string GetAbsolutePath(string relativePath) => Resolve(relativePath);
+
+    public IEnumerable<string> GetFiles(string searchPattern)
+    {
+        var sp = (searchPattern ?? "").Replace('\\', '/');
+        var slash = sp.LastIndexOf('/');
+        var dir = slash >= 0 ? sp[..slash] : "";
+        var pattern = slash >= 0 ? sp[(slash + 1)..] : sp;
+        if (pattern.Length == 0) pattern = "*";
+        return _roots.SelectMany(r => Safe(Path.Combine(r, dir), pattern, SearchOption.TopDirectoryOnly));
+    }
+
+    public IEnumerable<string> GetFiles(string directory, string searchPattern)
+        => _roots.SelectMany(r => Safe(Path.Combine(r, (directory ?? "").Replace('\\', '/')),
+            searchPattern ?? "*", SearchOption.TopDirectoryOnly));
+
+    public IEnumerable<string> GetFilesRecursively(string directory)
+        => _roots.SelectMany(r => Safe(Path.Combine(r, (directory ?? "").Replace('\\', '/')),
+            "*", SearchOption.AllDirectories));
+
+    public string GetDirectoryPath() => Root;
+    public void CreateDirectoryForFile(string path) => Directory.CreateDirectory(Path.GetDirectoryName(Resolve(path))!);
+    public Stream CreateFile(string path) => File.Create(Resolve(path));
+    public Stream OpenRead(string path) => File.OpenRead(Resolve(path));
+    public Stream OpenWrite(string path) => File.OpenWrite(Resolve(path));
+
+    public Stream OpenFile(string filePath, FileMode mode, FileAccess access, FileShare share,
+        int bufferSize, FileOptions options)
+        => new FileStream(Resolve(filePath), mode, access, share, bufferSize, options);
+
+    public void DeleteFile(string path) => File.Delete(Resolve(path));
+    public long GetFileSize(string path) => new FileInfo(Resolve(path)).Length;
+}

--- a/tools/metadata-ground-truth/MetadataGroundTruth.csproj
+++ b/tools/metadata-ground-truth/MetadataGroundTruth.csproj
@@ -1,0 +1,69 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Generates the GROUND TRUTH the metadata-equivalence harness measures against:
+       BC's own ObjectMetadataEmitter output for a Microsoft app, produced by compiling
+       that app's shipped AL source with BC's own compiler. Issue #3533.
+
+       Deliberately NOT in AlRunner.slnx. It is a per-BC-version provisioning tool, not
+       part of the runner, and adding it to the solution would put a compile of a
+       Microsoft app on every `dotnet build`. -->
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>metadata-ground-truth</AssemblyName>
+    <RootNamespace>AlRunner.Tools.MetadataGroundTruth</RootNamespace>
+    <NoWarn>$(NoWarn);CS0618;MSB3277</NoWarn>
+  </PropertyGroup>
+
+  <!-- Same ServiceTierPath resolution AlRunner.csproj uses, so a dev's already-downloaded
+       artifacts serve this tool too. -->
+  <PropertyGroup Condition="'$(ServiceTierPath)' == ''">
+    <ServiceTierPath>$(_ArtifactsRoot)$(_BCVersion)</ServiceTierPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="10.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.0" />
+
+    <!-- Referenced for its FILE, never linked (ExcludeAssets=all). See the DotNetShims target
+         below for why the netstandard2.0 build specifically. -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3"
+                      GeneratePathProperty="true" ExcludeAssets="all" />
+  </ItemGroup>
+
+  <!-- .NET assemblies BC's AL binder must see BEFORE the service tier's own copies.
+       Program.cs puts this directory at the head of the probing paths automatically.
+
+       Today that is one file, and it earns its place. System Application's
+       SamplingPerfProfilerImpl calls JsonSerializer.Deserialize(TextReader, Type). The service
+       tier ships the net6.0 build of Newtonsoft.Json, whose TextReader parameter is typed
+       against System.Runtime 6.0.0.0; no .NET 6 reference assemblies exist on a net8 or net10
+       box, so that parameter type never resolves and the call raises AL0133. BC's emitter then
+       produces ZERO objects for the WHOLE app rather than skipping the one codeunit — the same
+       shape as the Base Application blocker in #3549 — so a single unresolvable .NET reference
+       costs the entire ground truth. The netstandard2.0 build of the SAME Newtonsoft version
+       binds against netstandard, which does resolve.
+
+       Deliberately a package reference rather than a path into ~/.nuget: a CI leg has no reason
+       to have that package cached, and probing for one would make the generator's success
+       depend on what happened to be on the machine. -->
+  <Target Name="CopyDotNetShims" AfterTargets="Build">
+    <Copy SourceFiles="$(PkgNewtonsoft_Json)/lib/netstandard2.0/Newtonsoft.Json.dll"
+          DestinationFolder="$(OutDir)dotnet-shims" SkipUnchangedFiles="true" />
+  </Target>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.Dynamics.Nav.CodeAnalysis">
+      <HintPath>$(ServiceTierPath)/Microsoft.Dynamics.Nav.CodeAnalysis.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.Dynamics.Nav.Types">
+      <HintPath>$(ServiceTierPath)/Microsoft.Dynamics.Nav.Types.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/tools/metadata-ground-truth/NavxPackage.cs
+++ b/tools/metadata-ground-truth/NavxPackage.cs
@@ -1,0 +1,124 @@
+// Reading a .app: the NAVX header, the outer/inner zip nesting, and the manifest fields the
+// compiler needs back. Standalone rather than calling into AlRunner, so this tool has no
+// build-order dependency on the runner it exists to check.
+
+using System.IO.Compression;
+using System.Xml;
+
+namespace AlRunner.Tools.MetadataGroundTruth;
+
+internal sealed record AppIdentity(
+    Guid Id, string Name, string Publisher, Version Version, string Platform,
+    string Target, string ContextSensitiveHelpUrl,
+    IReadOnlyList<string> Features, IReadOnlyList<string> PreprocessorSymbols,
+    IReadOnlyList<(Guid Id, string Name, string Publisher, Version Version)> Dependencies);
+
+internal static class NavxPackage
+{
+    private const string Ns = "http://schemas.microsoft.com/navx/2015/manifest";
+
+    /// <summary>Extract a .app to <paramref name="destination"/>, unwrapping the R2R nesting.</summary>
+    /// <remarks>
+    /// A shipped Microsoft app is a NAVX-prefixed zip whose only real entry is ANOTHER
+    /// NAVX-prefixed zip (`&lt;guid&gt;_&lt;version&gt;_&lt;plat&gt;_&lt;build&gt;.app`), and the
+    /// inner one holds src/, SymbolReference.json and the resources. Stopping at the outer
+    /// layer yields a directory with no NavxManifest.xml, which reads as "this app has no
+    /// source" rather than as an unfinished extraction.
+    /// </remarks>
+    public static void ExtractTo(string appPath, string destination)
+    {
+        Directory.CreateDirectory(destination);
+        var bytes = File.ReadAllBytes(appPath);
+        ExtractBytes(bytes, destination, depth: 0);
+    }
+
+    private static void ExtractBytes(byte[] bytes, string destination, int depth)
+    {
+        using var zip = OpenNavx(bytes);
+        var inner = zip.Entries.FirstOrDefault(e =>
+            e.FullName.EndsWith(".app", StringComparison.OrdinalIgnoreCase) && !e.FullName.Contains('/'));
+        if (inner is not null && depth < 4)
+        {
+            using var s = inner.Open();
+            using var ms = new MemoryStream();
+            s.CopyTo(ms);
+            ExtractBytes(ms.ToArray(), destination, depth + 1);
+            return;
+        }
+
+        foreach (var e in zip.Entries)
+        {
+            if (e.FullName.EndsWith("/")) continue;
+            var target = Path.GetFullPath(Path.Combine(destination, e.FullName.Replace('\\', '/')));
+            if (!target.StartsWith(Path.GetFullPath(destination), StringComparison.Ordinal)) continue;
+            Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+            using var src = e.Open();
+            using var dst = File.Create(target);
+            src.CopyTo(dst);
+        }
+    }
+
+    private static ZipArchive OpenNavx(byte[] bytes)
+    {
+        var offset = bytes.Length >= 8 && bytes[0] == (byte)'N' && bytes[1] == (byte)'A'
+                     && bytes[2] == (byte)'V' && bytes[3] == (byte)'X'
+            ? (int)BitConverter.ToUInt32(bytes, 4)
+            : 0;
+        return new ZipArchive(new MemoryStream(bytes, offset, bytes.Length - offset, writable: false),
+            ZipArchiveMode.Read);
+    }
+
+    /// <summary>Read a manifest out of a .app without extracting the whole package.</summary>
+    public static AppIdentity ReadIdentity(string appPath)
+    {
+        var bytes = File.ReadAllBytes(appPath);
+        var xml = ReadManifestXml(bytes, depth: 0)
+                  ?? throw new InvalidDataException($"{appPath}: no NavxManifest.xml in the package.");
+        return ParseIdentity(xml);
+    }
+
+    private static string? ReadManifestXml(byte[] bytes, int depth)
+    {
+        using var zip = OpenNavx(bytes);
+        var manifest = zip.GetEntry("NavxManifest.xml");
+        if (manifest is not null)
+        {
+            using var r = new StreamReader(manifest.Open());
+            return r.ReadToEnd();
+        }
+        var inner = zip.Entries.FirstOrDefault(e =>
+            e.FullName.EndsWith(".app", StringComparison.OrdinalIgnoreCase) && !e.FullName.Contains('/'));
+        if (inner is null || depth >= 4) return null;
+        using var s = inner.Open();
+        using var ms = new MemoryStream();
+        s.CopyTo(ms);
+        return ReadManifestXml(ms.ToArray(), depth + 1);
+    }
+
+    public static AppIdentity ParseIdentity(string manifestXml)
+    {
+        var doc = new XmlDocument();
+        doc.LoadXml(manifestXml);
+        var ns = new XmlNamespaceManager(doc.NameTable);
+        ns.AddNamespace("m", Ns);
+        var app = (XmlElement?)doc.SelectSingleNode("//m:App", ns)
+                  ?? throw new InvalidDataException("NavxManifest.xml has no <App> element.");
+
+        var deps = new List<(Guid, string, string, Version)>();
+        foreach (XmlElement d in doc.SelectNodes("//m:Dependencies/m:Dependency", ns)!)
+            deps.Add((Guid.Parse(d.GetAttribute("Id")), d.GetAttribute("Name"),
+                d.GetAttribute("Publisher"), Version.Parse(d.GetAttribute("MinVersion"))));
+
+        return new AppIdentity(
+            Guid.Parse(app.GetAttribute("Id")),
+            app.GetAttribute("Name"),
+            app.GetAttribute("Publisher"),
+            Version.Parse(app.GetAttribute("Version")),
+            app.GetAttribute("Platform"),
+            app.GetAttribute("Target"),
+            app.GetAttribute("ContextSensitiveHelpUrl"),
+            doc.SelectNodes("//m:Features/m:Feature", ns)!.Cast<XmlNode>().Select(n => n.InnerText).ToArray(),
+            doc.SelectNodes("//m:PreprocessorSymbols/m:PreprocessorSymbol", ns)!.Cast<XmlNode>().Select(n => n.InnerText).ToArray(),
+            deps);
+    }
+}

--- a/tools/metadata-ground-truth/Program.cs
+++ b/tools/metadata-ground-truth/Program.cs
@@ -1,0 +1,274 @@
+// metadata-ground-truth — compile a Microsoft app with BC's OWN compiler and keep what BC's
+// ObjectMetadataEmitter produced, as the ground truth the equivalence harness measures the
+// runner's SymbolReference derivation against (issue #3533).
+//
+// Ground truth is BC's emitter, not a fixture. Nothing here writes an expected value, edits
+// one, or defaults one: every byte in the bundle came out of `Compilation.Emit` on Microsoft's
+// own source.
+//
+// Cost is why this is a separate tool rather than something a test does: Business Foundation
+// is ~2s, System Application ~14s, Base Application ~116s and ~7GB. Per BC version that is
+// affordable; per pull request it is not. So this runs once per (app, BC build), writes a
+// bundle, and the harness reads the bundle.
+//
+// See docs/metadata-equivalence.md.
+
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Xml;
+using NavCA = Microsoft.Dynamics.Nav.CodeAnalysis;
+using NavEmit = Microsoft.Dynamics.Nav.CodeAnalysis.Emit;
+
+namespace AlRunner.Tools.MetadataGroundTruth;
+
+internal static class Program
+{
+    /// <summary>
+    /// Bumped whenever the bundle's shape changes. The harness refuses a bundle written by a
+    /// different version rather than reading fields that may have moved.
+    /// </summary>
+    internal const int BundleSchema = 1;
+
+    private static int Main(string[] args)
+    {
+        string? appPath = null, outDir = null, artifacts = null;
+        bool declOnly = false;
+        var dotnetFirst = new List<string>();
+        for (int i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--app": appPath = args[++i]; break;
+                case "--out": outDir = args[++i]; break;
+                case "--artifacts": artifacts = args[++i]; break;
+                case "--decl-only": declOnly = true; break;
+                case "--dotnet-first": dotnetFirst.Add(args[++i]); break;
+                case "-h" or "--help": Usage(); return 0;
+                default: Console.Error.WriteLine($"unknown argument '{args[i]}'"); Usage(); return 2;
+            }
+        }
+        if (appPath is null || outDir is null) { Usage(); return 2; }
+
+        artifacts ??= Environment.GetEnvironmentVariable("AL_RUNNER_SERVICE_TIER");
+        if (string.IsNullOrEmpty(artifacts))
+        {
+            Console.Error.WriteLine("--artifacts (or AL_RUNNER_SERVICE_TIER) must name the BC service-tier directory.");
+            return 2;
+        }
+
+        BcHost.Install(artifacts);
+        try { return Generate(appPath, outDir, artifacts, declOnly, dotnetFirst); }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine("metadata-ground-truth FAILED: " + ex);
+            return 1;
+        }
+    }
+
+    private static void Usage() => Console.Error.WriteLine("""
+        metadata-ground-truth --app <path-to.app> --out <bundle-dir> [--artifacts <service-tier-dir>]
+
+          Compiles the app's shipped AL source with BC's own compiler and writes every
+          metadata document the emitter produced into <bundle-dir>, with a manifest.
+
+          --decl-only   stop after declaration diagnostics; reports whether the app WOULD
+                        compile without paying for the emit.
+        """);
+
+    private static int Generate(string appPath, string outDir, string artifacts, bool declOnly,
+        IReadOnlyList<string> dotnetFirst)
+    {
+        var swTotal = Stopwatch.StartNew();
+        var identity = NavxPackage.ReadIdentity(appPath);
+        Console.WriteLine($"[app] {identity.Publisher}_{identity.Name} {identity.Version} " +
+                          $"id={identity.Id} target={identity.Target} platform={identity.Platform}");
+
+        var work = Directory.CreateTempSubdirectory("al-runner-groundtruth-");
+        try
+        {
+            NavxPackage.ExtractTo(appPath, work.FullName);
+            var srcRoot = Path.Combine(work.FullName, "src");
+            if (!Directory.Exists(srcRoot))
+                throw new InvalidOperationException(
+                    $"{Path.GetFileName(appPath)} ships no src/ — its ResourceExposurePolicy " +
+                    "excludes source, so BC's emitter cannot be run over it here. A runtime " +
+                    "package is the other route to this app's metadata (issue #3537).");
+
+            var comp = AppCompilation.Create(identity, work.FullName, srcRoot, artifacts, appPath, dotnetFirst);
+
+            var sw = Stopwatch.StartNew();
+            var declErrors = comp.GetDeclarationDiagnostics()
+                .Where(d => d.Severity == NavCA.Diagnostics.DiagnosticSeverity.Error).ToList();
+            Console.WriteLine($"[decl] {sw.ElapsedMilliseconds}ms  errors={declErrors.Count}");
+            foreach (var g in declErrors.GroupBy(d => d.Id).OrderByDescending(g => g.Count()).Take(10))
+                Console.WriteLine($"   [{g.Key}] x{g.Count()} :: {g.First().GetMessage()} @ {g.First().Location}");
+            if (declOnly) return declErrors.Count == 0 ? 0 : 1;
+
+            var capture = new CaptureOutputter();
+            sw.Restart();
+            var result = comp.Emit(NavCA.EmitOptions.Default, capture);
+            var emitMs = sw.ElapsedMilliseconds;
+            var emitErrors = result.Diagnostics
+                .Where(d => d.Severity == NavCA.Diagnostics.DiagnosticSeverity.Error).ToList();
+            Console.WriteLine($"[emit] {emitMs}ms success={result.Success} " +
+                              $"objects={capture.Items.Count} errors={emitErrors.Count}");
+            foreach (var g in emitErrors.GroupBy(d => d.Id).OrderByDescending(g => g.Count()).Take(10))
+                Console.WriteLine($"   [{g.Key}] x{g.Count()} :: {g.First().GetMessage()} @ {g.First().Location}");
+
+            // Loud, not smaller. An app that emits nothing is the #3549 shape — Base
+            // Application emitting ZERO objects because one .NET reference could not be
+            // resolved — and writing an empty bundle would turn that into a harness that
+            // silently measures nothing while still reporting a bundle.
+            if (capture.Items.Count == 0)
+                throw new InvalidOperationException(
+                    "the emitter produced NO objects. That is a compile failure, not an empty " +
+                    "app; writing a bundle here would leave the harness measuring nothing. " +
+                    "See the diagnostics above and issue #3549.");
+
+            return Write(outDir, appPath, identity, artifacts, capture, result.Success,
+                emitErrors.Count, emitMs, swTotal);
+        }
+        finally
+        {
+            try { work.Delete(recursive: true); } catch { /* temp dir cleanup is best effort */ }
+        }
+    }
+
+    private static int Write(
+        string outDir, string appPath, AppIdentity identity, string artifacts,
+        CaptureOutputter capture, bool emitSuccess, int emitErrors, long emitMs, Stopwatch swTotal)
+    {
+        var metaDir = Path.Combine(outDir, "metadata");
+        if (Directory.Exists(metaDir)) Directory.Delete(metaDir, recursive: true);
+        Directory.CreateDirectory(metaDir);
+
+        var objects = new List<BundleObject>();
+        var census = new SortedDictionary<string, int>(StringComparer.Ordinal);
+        var used = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var item in capture.Items)
+        {
+            var (kind, id) = ClassifyDocument(item.Metadata, item.SymbolKind);
+            census[kind] = census.GetValueOrDefault(kind) + 1;
+            if (string.IsNullOrEmpty(item.Metadata)) continue;
+
+            // Collision-free by construction. An earlier dump keyed files on kind+id alone;
+            // Report, Query, XmlPort and ReportExtension carry their id in a CHILD element,
+            // so every one of them landed on id=0 and collapsed onto a single file per kind.
+            // The name disambiguates, and a residual clash still gets a suffix rather than
+            // overwriting — silently losing a document is the failure this whole harness is
+            // meant to make impossible.
+            var stem = $"{kind}-{id}-{Sanitize(item.Name)}";
+            var file = stem;
+            for (int n = 2; !used.Add(file); n++) file = $"{stem}~{n}";
+
+            var rel = "metadata/" + file + ".xml";
+            File.WriteAllText(Path.Combine(outDir, rel), item.Metadata);
+            objects.Add(new BundleObject(kind, id, item.Name, rel, Sha256(item.Metadata)));
+        }
+
+        var duplicateTableIds = objects.Where(o => o.Kind == "MetaTable")
+            .GroupBy(o => o.Id).Where(g => g.Count() > 1).Select(g => g.Key).ToArray();
+        if (duplicateTableIds.Length > 0)
+            throw new InvalidOperationException(
+                "two MetaTable documents share an id: " + string.Join(",", duplicateTableIds) +
+                ". The harness keys tables by id, so this would silently compare one and drop the other.");
+
+        var manifest = new BundleManifest(
+            BundleSchema,
+            new BundleApp(identity.Id, identity.Name, identity.Publisher, identity.Version.ToString()),
+            Path.GetFileName(Path.TrimEndingDirectorySeparator(artifacts)),
+            Path.GetFileName(appPath),
+            DateTime.UtcNow.ToString("O"),
+            new BundleEmit(emitSuccess, capture.Items.Count, objects.Count, emitErrors, emitMs),
+            census,
+            objects.OrderBy(o => o.Kind, StringComparer.Ordinal).ThenBy(o => o.Id).ThenBy(o => o.Name, StringComparer.Ordinal).ToArray());
+
+        Directory.CreateDirectory(outDir);
+        File.WriteAllText(Path.Combine(outDir, "manifest.json"),
+            JsonSerializer.Serialize(manifest, new JsonSerializerOptions { WriteIndented = true }));
+
+        Console.WriteLine($"[bundle] {objects.Count} document(s) -> {outDir}");
+        foreach (var kv in census) Console.WriteLine($"   {kv.Key,-24} {kv.Value,6}");
+        Console.WriteLine($"[total] {swTotal.Elapsed.TotalSeconds:F1}s");
+        return emitErrors == 0 ? 0 : 1;
+    }
+
+    /// <summary>
+    /// The document's OWN root element decides the kind, never the compiler's SymbolKind.
+    /// They disagree: MetadataRuntimeDeltas is the root for TableExtension, PageExtension AND
+    /// PermissionSetExtension, and one &lt;Enum&gt; root covers both Enum and EnumExtension.
+    /// Keying on SymbolKind would split documents that BC treats as one shape.
+    /// </summary>
+    private static (string Kind, int Id) ClassifyDocument(string? metadata, string symbolKind)
+    {
+        if (string.IsNullOrEmpty(metadata)) return ("<no-metadata>" + symbolKind, 0);
+        try
+        {
+            var doc = new XmlDocument();
+            doc.LoadXml(metadata);
+            var root = doc.DocumentElement!;
+            var idText = root.GetAttribute("ID");
+            if (string.IsNullOrEmpty(idText)) idText = root.GetAttribute("Id");
+            int.TryParse(idText, out var id);
+            return (root.Name, id);
+        }
+        catch (XmlException ex)
+        {
+            return ("<unparseable:" + ex.GetType().Name + ">", 0);
+        }
+    }
+
+    private static string Sanitize(string name)
+    {
+        var chars = name.Select(c => char.IsLetterOrDigit(c) ? c : '_').ToArray();
+        var s = new string(chars).Trim('_');
+        return s.Length > 60 ? s[..60] : (s.Length == 0 ? "unnamed" : s);
+    }
+
+    internal static string Sha256(string text)
+        => Convert.ToHexString(SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(text))).ToLowerInvariant();
+}
+
+internal sealed record BundleApp(Guid Id, string Name, string Publisher, string Version);
+internal sealed record BundleEmit(bool Success, int Objects, int WithMetadata, int Errors, long EmitMs);
+internal sealed record BundleObject(string Kind, int Id, string Name, string File, string Sha256);
+
+internal sealed record BundleManifest(
+    [property: JsonPropertyName("schema")] int Schema,
+    [property: JsonPropertyName("app")] BundleApp App,
+    [property: JsonPropertyName("bcBuild")] string BcBuild,
+    [property: JsonPropertyName("sourcePackage")] string SourcePackage,
+    [property: JsonPropertyName("generatedAtUtc")] string GeneratedAtUtc,
+    [property: JsonPropertyName("emit")] BundleEmit Emit,
+    [property: JsonPropertyName("census")] IReadOnlyDictionary<string, int> Census,
+    [property: JsonPropertyName("objects")] IReadOnlyList<BundleObject> Objects);
+
+/// <summary>
+/// Keeps every application object the emitter hands over, with the metadata document BC
+/// produced for it. Nothing is filtered here: what a document is FOR is the harness's
+/// question, and dropping a kind at capture time would decide it silently.
+/// </summary>
+internal sealed class CaptureOutputter : NavEmit.CodeModuleOutputter
+{
+    internal readonly List<(string Name, string SymbolKind, string? Metadata, int CodeLength)> Items = new();
+
+    public CaptureOutputter() : base(NavCA.EmitOptions.Default) { }
+
+    public override void InitializeModule(NavCA.IModuleSymbol m) { }
+
+    public override void AddApplicationObject(
+        NavCA.IApplicationObjectTypeSymbol s, byte[] code, string metadata, string debugCode)
+        => Items.Add((s.Name, s.GetType().Name, metadata, code?.Length ?? 0));
+
+    public override void AddProfileObject(NavCA.ISymbol s, byte[] code, string metadata, string debugCode) { }
+    public override void AddNavigationObject(string s) { }
+    public override void AddExternalBusinessEvent(string s) { }
+    public override void AddMovedObjects(string s) { }
+    public override void FinalizeModule() { }
+
+    public override System.Collections.Immutable.ImmutableArray<NavCA.Diagnostics.Diagnostic> GetDiagnostics()
+        => System.Collections.Immutable.ImmutableArray<NavCA.Diagnostics.Diagnostic>.Empty;
+}


### PR DESCRIPTION
Closes #3533

Corpus-NA: nothing in this diff changes what AL observes — it adds a comparison harness, a ground-truth generator and tests, and no runner output moves.

Opened by an agent (`agent: impl-2`).

## What this is

A total equivalence harness proving that the metadata the runner derives by hand from
`SymbolReference.json` equals what BC's own metadata emitter produces for the same app. Not a
list of properties someone chose — every member of the built object, found by reflection.

It gates the reader fix (#3545). The reader lands against this, not before it.

## Ground truth is BC's emitter

`tools/metadata-ground-truth` compiles a Microsoft app's shipped AL source with BC's own
compiler and keeps every document `CaptureOutputter` receives. Nothing here writes an expected
value, edits one, or defaults one.

The two sides are the same type, so the comparison is member-for-member rather than a
translation between two shapes:

```
ground truth   MetaTable.CreateMetaTableFromXml(<BC's own emitted document>)
the runner     RecordPatches.GetOrBuildNCLMetaTable(id).GetMetaTableOriginal()
```

## It fails against the current reader, with the predicted numbers

The point of building this first is that a harness green against a reader with thousands of
wrong values would be proving nothing. Run against the reader as it is today, on System
Application:

| | predicted | measured |
|---|---:|---:|
| `MetaField.Editable`, declared fields | 78 | **78** |
| `MetaField.DataClassification`, declared fields | 661 | **661** |
| `MetaField.EnumTypeId` | 76 | **76** |
| tables with no `SystemCreatedBy` relation | 138 of 138 | **138 of 138** |

Four independently-predicted numbers, four exact matches. Over both bundled apps the total is
**70,728 differences across 74 members**, on 150 tables.

Both directions are real and both are covered. 60 tables where BC's `Caption` is `null` and the
runner carries one; 1,888 fields where BC is `null` and the runner is `""`; and 115 fields on
four Business Foundation tables that the runner has and BC's per-app emit does not.

I also confirmed the gate bites, in both directions, by breaking it deliberately:

- deleting the `MetaField.EnumTypeId` entry → `Every_difference_is_declared_with_a_reason`
  fails, naming 77 occurrences and an example;
- adding an entry for a member that does not differ → `No_allowlist_entry_has_gone_stale`
  fails, naming it.

## The allowlist is the declaration, and it is not a mute

`tests/expectations/metadata-equivalence/allowlist.json`, 74 entries, each with a reason.

- A difference not listed fails.
- An entry that matches nothing fails — so a landed reader fix must delete its entries in the
  same change rather than leave cover behind.
- Every entry declares exactly one KIND of reason, and the two permanent kinds each need a `Doc`
  pointer. Enforced at load, so a malformed entry fails the run instead of quietly granting
  cover. The table below has the four kinds and the counts.
- There is deliberately **no occurrence cap**. One was implemented and used by nothing, which is
  a ratchet nobody turns; it is removed. No entry has a bound that survives a rebuild —
  `DataClassification` is 617 / 661 / 663 across 27.5 / 28.1 / 28.4 — so any cap would be a
  number nobody measured. `direction` narrows *categorically* instead, which is build-independent.

**No entry claims `cannotExpress`, and how that changed is the most important thing in this PR.**

Seven `TranslationKey` entries — 25,721 differences, 36% of the diff — were first declared a
permanent limit of the symbol file, on the evidence that `SymbolReference.json` contains the
string `TranslationKey` zero times in both packages. The observation is true. The conclusion was
wrong twice over, and I got it wrong; the coordinator caught it.

1. **The key is computed, not stored.** BC's own `LanguageKeyHelper.ConstructObjectHash` is
   `(uint)(FNV-1a-32 over the UTF-16LE bytes of the name + int.MaxValue)`. Tested against my own
   ground truth rather than taking it on report: **2,153 of 2,153 keys reproduced exactly**, with
   the property component decomposing to `Caption` (1,138), `ToolTip` (988) and `OptionCaption`
   (27) and nothing left unexplained. Pinned by
   `TranslationKeysAreDerivable_NotAPermanentLimit` so the claim is checked, not asserted.
2. **The runner reads no translation files at all** — zero `.xlf` or `Translations/` references in
   `AlRunner/`, and `docs/limitations.md` already records that it installs no BC translation
   resources. So the member is unobservable from AL, and the honest reason is a *scope* boundary:
   what invalidates it is the runner gaining translation support, not anything about BC.

**"Nothing is stored" is evidence about storage, never about derivability.** So an entry now
declares which KIND of reason it is claiming, because the four need different evidence:

| kind | means | needs |
|---|---|---|
| `issue: N` | a tracked defect | the issue |
| `outOfScope` | the runner does not implement the surface, so no AL test can see it | a `Doc` pointer |
| `oracleLimitation` | the ground truth is the wrong shape for this member | a `Doc` pointer |
| `cannotExpress` | not expressible **and** not derivable | evidence about derivability |

An entry may also narrow to one `direction`, and ten do — see the review-fix section below.

64 / 7 / 3 / **0**. `Doc` is spelled that way deliberately: `tools/test_doc_pointers.py` already
validates every `Doc` value under `tests/expectations` for path and anchor, so a scope claim
cannot point at a section renamed away. A test holds that nothing claims `cannotExpress`.

`MetaField.CaptionML` is deliberately **not** covered by any of that. It is the caption *text*, it
is AL-observable, and it stays a tracked defect — folding it in with `TranslationKey` would
license a real difference behind a scope declaration that does not apply to it. Both the allowlist
entry and the docs say so.

`ClrType` was the same shape and is now measured rather than described: not an XML attribute at
all (BC derives it itself), and a pure function of `Datatype` — all 16 Datatypes map to exactly
one CLR type each over 988 observations. Recoverable with no app data.

## Cost, and where the ground truth lives

Generating needs a compile, so it runs once per BC build rather than per PR. Business Foundation
3.2 s / 70 documents; System Application 15.2 s / 1,218 documents. Gzipped the two bundles are
35 KB and 656 KB.

**Small enough to check in, and deliberately not checked in.** It is Microsoft's compiler output
over Microsoft's source, and redistributing that in a public repository is a licensing decision
rather than a technical one; and it belongs to one exact BC build, so a checked-in copy would
either churn on every Microsoft release or go stale silently — the failure mode this harness
exists to remove. CI regenerates it in a new `bc-tests.yml` step on the two unit-test legs, from
artifacts those legs already have. What is checked in is the part carrying judgement: the app
list, the allowlist, the generator and the differ.

That choice also removes a whole class of error: the `.app` the runner reads and the emitter
output it is compared against always come from one build, by construction.

## Verified on four BC builds

The same 74 entries cover every difference on 27.5.46862.53931, 28.1.49838.53910,
28.1.49838.54044 and 28.4.53241.53989, with none stale. 27.5 and 28.4 are the two unit-test
legs, so this is the configuration CI will actually run. Each was a real rebuild
(`-p:_BCVersion=…`) plus `tools/engine-test-bootstrap.sh` plus the filtered suite, not an
inference from 28.1.

## Fixing the shape, not just the reported line

The first run of the harness reported differences that were artifacts of the differ rather than
disagreements, and each was a shape rather than an instance:

- **Enums were being recursed into**, so `MetaTable.Scope` arrived as `CompilationTarget.#value__`
  — attributed to the enum type, where one allowlist entry would have covered every property
  sharing it.
- **`MetaTable.FieldsById` is a dictionary and was paired by position.** The two sides insert in
  different orders, which fabricated 74 differences on Business Foundation alone across five
  members. Dictionaries now pair by key.
- **Presence differences were attributed to the value's type**, so `MetaTable.Fields`,
  `MetaTable.FieldGroups` and `MetaTable.FieldsById` all arrived as `MetaTable.<presence>`, and
  `MetaField.CaptionML` and `MetaField.OptionCaptionML` both as `MultiLanguage.<presence>`.
  Declaring one would silently have declared the others.
- **Id-paired ordinals cascaded** after a missing element, burying the one difference that
  caused them.

Each has a regression test in `MetadataObjectDiffTests`.

**Scanned the open-issue queue for this area and folded in nothing.** #3545 (the two absent-property
meanings), #3549 (dependency metadata from the emitter) and #3491 (the derivation) all land in
`BcAppSymbolCache.cs` / `RecordPatches.BcAppFallback.cs`, and this PR touches neither — by
design, since the whole point is to build the oracle before the fix. #3568 is the record of the
71 members #3545 does not cover; I filed it from this measurement rather than leaving them in an
allowlist pointing at an issue that will close without them.

## Also filed

- **#3568** — the full per-member table with counts and examples, and what
  `SymbolReference.json` measurably does and does not carry. That table is the working
  specification for the reader work.

## Review fixes — two more ways the gate passed silently

Both are the shape I had already fixed once here, which is the thing worth taking from this PR:
**a check that cannot fail reads exactly like a check that passed.**

**1. Entries licensed both directions.** `Covers` matched on member and path and never read
`Expected`/`Actual`. All 115 merged-runtime differences are BC-absent / runner-present — the
direction those three permanent, uncapped entries were written for. Undirected they also covered
the reverse, *BC emitted a field and the runner built none*: a hard reader defect, on every table,
and the class the #3545 rewrite is most likely to introduce.

Entries now take `direction`. I measured every member first rather than fixing only the three
flagged: **all eight `<presence>` members are unidirectional on every build**, so all eight are
scoped, plus `MetaTable.Caption`/`CaptionOriginal` whose reasons already said "the reverse
direction" — ten in total. Three tests hold it, including a `[Theory]` that classifies a
wrong-direction difference against the **checked-in** allowlist and asserts it comes back
undeclared.

**2. The pinned counts were already inert on a gating leg.** They keyed on the four-part build and
held `28.4.53241.53989`. CI resolves 28.4 to **`28.4.53241.54407`** — I confirmed that with
`tools/DownloadArtifacts resolve-version` — so the lookup missed, `return;` fired, and all four
numbers went unasserted while the test reported green.

I could not simply record the new build: the sandbox has no route to the BC CDN, so provisioning
`54407` to measure it fails. That turned out to be useful, because the fix should not have been to
record a number anyway. **Pinning tighter goes inert; pinning looser asserts a number that held
once.** So I looked for something exact that does not move, and there is one:

| | 27.5 | 28.1 | 28.4 |
|---|---|---|---|
| `Editable` count | 78 | 78 | 78 |
| `DataClassification` count | 617 | 661 | 663 |
| `EnumTypeId` count | 75 | 76 | 76 |
| **BC's answer on every `Editable` difference** | `False` | `False` | `False` |
| **the runner's answer, every difference** | `True` | `True` | `True` |
| **the runner's `DataClassification`, every difference** | `CustomerContent` | `CustomerContent` | `CustomerContent` |
| **the runner's `EnumTypeId`, every difference** | `0` | `0` | `0` |

The counts move; the shape does not, because *the reader answering a constant is what the defect
is*. The test now asserts the constant on every occurrence, plus non-emptiness. That is **stronger
than a count** — a count still passes if the reader starts answering a different constant — and it
cannot go inert. The counts are recorded in `docs/metadata-equivalence.md`, where a measurement
belongs.

**Re-derived on all four builds after the change, not assumed unchanged:** 74 members on each,
none stale, all green. The diff itself is unchanged (65,505 / 70,728 / 70,728 / 70,836) — the
direction fix narrows what is *covered*, not what is *found*, which is exactly what it should do.

`docs/metadata-equivalence.md` now has a section on this failure family, since a gate whose value
is that nothing hides should say plainly how it has hidden things three times.

## Things worth a reviewer's attention

- **Base Application is not covered, and `apps.json` says so** rather than listing it and failing
  every leg. Its emit needs a `PublicKeyToken=null` copy of `Microsoft.AspNetCore.StaticFiles`
  that no BC artifact ships (#3549). The generator treats a zero-object emit as a failure, so it
  cannot write an empty bundle and call it covered.
- **System Application needs one .NET shim to compile at all.** BC's emitter is atomic per
  module: one AL error yields zero objects for the whole app. The service tier ships the net6.0
  build of Newtonsoft.Json, whose `TextReader` is typed against `System.Runtime 6.0.0.0`, and no
  .NET 6 reference assemblies exist on a net8 or net10 box. The generator ships the
  netstandard2.0 build of the same Newtonsoft version in a `dotnet-shims` directory at the head
  of its probing paths — a `PackageReference`, deliberately not a probe into `~/.nuget`, so the
  result does not depend on what happened to be cached.
- **The 115 extra Business Foundation fields are a property of the oracle, not of the runner.**
  The runner models the merged runtime state a running system has; the ground truth is a
  build-time per-app emit that only ever sees the app being compiled. Two different things, and
  in BC 29 everything is merged at database level anyway, which makes the runner's view the
  forward-looking one. Declared as `oracleLimitation` with that reason. **The consequence is
  stated in `docs/metadata-equivalence.md`: a multi-app bundle can never produce an empty diff**,
  so nobody later reads the residue as normal noise or as a bug. The faithful comparison would
  need a service tier's post-publish metadata, which is the ceiling on how empty this can get.
- **The harness compares `MetaTable` only.** A bundle carries every kind BC emitted, and the
  tests assert the set compared AND the set not compared, so widening it is a visible change
  rather than a silent one.

## Prose

Three new files carry a header block over ten lines: `MetadataObjectDiff.cs`,
`MetadataDifferenceAllowlist.cs` and `AlRunner.Tests/MetadataEquivalenceHarness.cs`. Each states
the contract and ends with a pointer to `docs/metadata-equivalence.md`, which is where the cost
figures, the storage decision, the emitter's atomicity and the reproduction recipe live. New
product code under `AlRunner/Metadata/` is 22.3% comment against the repository's 46%.

## Tests run

- `MetadataObjectDiffTests` — 20, pure, no BC, 52 ms.
- `MetadataDifferenceAllowlistTests` — 21, including that the checked-in allowlist loads, claims
  no permanent limit, direction-scopes every oracle entry, points every scope/oracle entry at a
  doc section that exists, and leaves a wrong-direction difference undeclared.
- `MetadataEquivalenceHarnessTests` — 7, in `bc-engine-serial`, against real bundles.
- **All 48 green on each of four BC builds** — 27.5.46862.53931, 28.1.49838.53910,
  28.1.49838.54044, 28.4.53241.53989 — each a real rebuild plus engine bootstrap.
- `TestArtifactsGate`, `BcEngineSkipAttribution`, `BcEngineReadinessGuard`,
  `BaseAppFloorFixtureGuard`, `ProseRelocationPointer` — 65 green.
- The expectations scanners (`Expectation*`, `BcShapeGapConvention`, `CountBaseline`) — 133
  green, so the new `tests/expectations/` subdirectory does not disturb them.
- The workflow drift set (`Workflow`, `BcMatrix`, `Documentation`, `PullRequestMatrixScope`) —
  119 green, 1 pre-existing corpus-submodule skip.
- `tools/test_doc_pointers.py`, `tools/test_line_endings.py` — pass.

**And the whole `AlRunner.Tests` suite, twice** — 4,429 tests, ~14 minutes each. That is not
routine and it is why this PR needed a third fix: my filtered runs could not see the repo-wide
scanners. The full run caught `BcShapeMethodLookupTests.NameOnlyBcTypedMethodLookups_HaveNotIncreased`
(74 against a recorded 72), which neither of the two guards I was pointed at covers.

Its constant is documented "it may never rise", so bumping it was not available and gaming it
with an explicit signature would have been worse. The honest fix was to ask whether the code
needed to exist: `Materialize`'s reflective `GetEnumerator`/`MoveNext`/`Current` fallback,
written for "ImmutableArray<T> / any generic-only enumerable", is **unreachable** —
`IEnumerable<T>` derives from `IEnumerable`, so every value `IsCollection` accepts is handled by
the branch above it. Probed rather than only reasoned: instrumented, it was reached **zero times**
across the whole MetaTable graph of 150 tables. Deleting it removes both `GetMethod` sites (72
stays 72) and two of the five `!` sites, so `Listed` is 13 rather than 15 and only
`KeyValuePair<,>`'s `Key`/`Value` remain.

Final state: 4,428 of 4,429 pass. The one failure is
`TestPageTemporalValueTests.TryResolve_RoundTripSpelling_ForADateTimeControl_KeepsTheTimeOfDay`,
which is **pre-existing and not mine**: it fails by exactly one hour under `Europe/Warsaw` and
passes under `TZ=UTC`, which is what CI runs. Filed as #3592 rather than left for the next person
to rediscover.

The diff the harness produces is **byte-identical on all four builds before and after** the
dead-code removal (65,505 / 70,728 / 70,728 / 70,836), which is the check that it really was
dead.

### The fourth scanner, and why the branch is rebased

`tools/ unit tests` then went red on `test_agent_self_freshness.py` — a **Python** suite CI
discovers by glob (`suites=(tools/test_*.py)`), so neither full `dotnet test` run could see it.
That is the same scoping gap one suite further out.

It was not the new `tools/metadata-ground-truth/` content and not a network flake. The tool's own
note named the cause: `origin/main` moved `tools/agent_self_freshness.py` in `eae442fd` (#3587)
**after this branch's merge base**, so this checkout's copy predated a published change to itself,
the tool refused to vouch for its own freshness, and all four failing checks fell out of that one
refusal. `ci-verdicts.md` documents exactly this — *"a wave of exit-3 refusals right after a merge
is the guard working exactly as designed; the fix is `git fetch origin main` in each worktree"*.

So the branch is **rebased onto `origin/main`** (`eae442fd`), which also carries main's corpus-pin
bump from `19560bd3` to `23a9e869` — main's change, not one this PR makes; the diff against
`origin/main` touches no submodule.

Re-run after the rebase rather than carried across it:

- **every suite in all three globs CI discovers** — `tools/test_*.py` (12),
  `.github/scripts/test_*.{py,sh}` (14), `scripts/tests/*.test.py` (6). All green. Two of those
  print `::error` lines that are asserted output from an error-path test, not failures; confirmed
  by exit code rather than by reading the text.
- **the full `AlRunner.Tests` suite, a third time**, under `TZ=UTC` as CI runs:
  **4,448 passed, 0 failed**, 1 pre-existing corpus-submodule skip. The count rose from 4,429
  because the rebase brought in 20 tests from main.
- the harness on 27.5, 28.1 and 28.4 again — diffs **identical to pre-rebase** on all three.

https://claude.ai/code/session_01F7HLDeNwiGQoLT5wFanqmH
