### PR TITLE
fix(transactions): let a report and a page field validate write under TransactionModel::None

### DIFF
--- a/AlRunner.Tests/WriteTransactionTestBoundaryTests.cs
+++ b/AlRunner.Tests/WriteTransactionTestBoundaryTests.cs
@@ -384,4 +384,230 @@ public class WriteTransactionTestBoundaryTests
         Assert.Contains("PASS  Codeunit62481.I_ARunCodeunitMayWriteUnderNone", output);
         Assert.Contains("PASS  Codeunit62481.J_ADefaultModelTestAfterANoneTestCanStillWrite", output);
     }
+    /// <summary>
+    /// Issue #3543, the sibling surfaces. <c>Codeunit.Run</c> is not the only AL construct
+    /// that begins a transaction, so the #3480 scope above refused writes BC allows: a report's
+    /// dataitem trigger and a page field's <c>OnValidate</c> both run inside a transaction the
+    /// construct itself begins.
+    ///
+    /// BC's own bodies, decompiled: <c>NavReport.RunReportInternalCoreAsync</c> calls
+    /// <c>Session.BeginTransaction()</c> immediately before <c>GetReportRecords()</c> and
+    /// <c>Session.EndTransaction(...)</c> after the data-item iterator;
+    /// <c>NavRecord.ValidateFieldsAsync</c> opens one per field around
+    /// <c>ValidateAsync</c>; <c>NavForm.ModifyAsync</c> the same around the page's Modify.
+    ///
+    /// The BC claim is pinned upstream (corpus 60878 Test11 and Test13, PR body's
+    /// <c>Corpus-PR:</c> line). This pins the runner's own brackets.
+    ///
+    /// The negative arm is the one that makes this prove something: <c>K_</c> shows the test
+    /// BODY is still refused. Without it every assertion here would also pass if the brackets
+    /// simply disabled the no-transaction scope outright.
+    /// </summary>
+    [SkippableFact]
+    public void UnderTransactionModelNone_AReportAndAPageFieldValidateMayWrite()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = TestScratch.Dir("al-runner-writetx-none-surfaces-3543");
+        Directory.CreateDirectory(root);
+
+        File.WriteAllText(Path.Combine(root, "app.json"), """
+        {
+          "id": "b3543000-0000-4000-8000-000000003543",
+          "name": "WriteTxNoneSurfaces3543",
+          "publisher": "Repro3543",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62540, "to": 62549 } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(root, "TxnSurfaces.al"), """
+        table 62540 "TXS Probe"
+        {
+            DataClassification = SystemMetadata;
+
+            fields
+            {
+                field(1; "Entry No."; Integer) { }
+                field(2; "Text Field"; Text[100])
+                {
+                    // Writes a DIFFERENT row from the one the page sits on, so "did the write
+                    // land" cannot be satisfied by the page's own Modify of the current record.
+                    trigger OnValidate()
+                    var
+                        Marker: Record "TXS Probe";
+                    begin
+                        if Rec."Entry No." <> 9414 then begin
+                            Marker."Entry No." := 9414;
+                            Marker.Insert();
+                        end;
+                    end;
+                }
+            }
+
+            keys
+            {
+                key(PK; "Entry No.") { Clustered = true; }
+            }
+        }
+
+        report 62541 "TXS Report Inserter"
+        {
+            ProcessingOnly = true;
+            UseRequestPage = false;
+
+            dataset
+            {
+                dataitem(Loop; Integer)
+                {
+                    DataItemTableView = sorting(Number) where(Number = const(1));
+
+                    trigger OnAfterGetRecord()
+                    var
+                        Probe: Record "TXS Probe";
+                    begin
+                        Probe."Entry No." := 9412;
+                        Probe.Insert();
+                    end;
+                }
+            }
+        }
+
+        page 62543 "TXS Card"
+        {
+            PageType = Card;
+            SourceTable = "TXS Probe";
+            ApplicationArea = All;
+
+            layout
+            {
+                area(Content)
+                {
+                    group(General)
+                    {
+                        field("Entry No."; Rec."Entry No.") { ApplicationArea = All; }
+                        field("Text Field"; Rec."Text Field") { ApplicationArea = All; }
+                    }
+                }
+            }
+        }
+
+        codeunit 62544 "TXS Tests"
+        {
+            Subtype = Test;
+            TestPermissions = Disabled;
+
+            // Declaration order IS the fixture.
+
+            local procedure MarkerCount(EntryNo: Integer): Integer
+            var
+                Probe: Record "TXS Probe";
+            begin
+                Probe.Reset();
+                Probe.SetRange("Entry No.", EntryNo);
+                exit(Probe.Count());
+            end;
+
+            [Test]
+            [TransactionModel(TransactionModel::None)]
+            procedure A_ReportMayWriteUnderNone()
+            var
+                Rep: Report "TXS Report Inserter";
+            begin
+                if MarkerCount(9412) <> 0 then
+                    Error('TXS1 FAIL: the report marker must not exist before the report runs');
+
+                Rep.UseRequestPage(false);
+                Rep.RunModal();
+
+                if MarkerCount(9412) <> 1 then
+                    Error('TXS1 FAIL: a report run from a None test must be able to write; got %1 row(s)', MarkerCount(9412));
+                if Database.IsInWriteTransaction() then
+                    Error('TXS1 FAIL: the transaction the report began must end with the report');
+            end;
+
+            // The page arm needs a row to open on, and a None body cannot write one for itself
+            // (#3480). A default-model test writes it; the platform commits it at this boundary.
+            [Test]
+            procedure B_SeedsTheRowThePageOpensOn()
+            var
+                Probe: Record "TXS Probe";
+            begin
+                Probe."Entry No." := 9415;
+                Probe.Insert();
+
+                if not Database.IsInWriteTransaction() then
+                    Error('TXS2 FAIL: an uncommitted Insert must open a write transaction inside the test that made it');
+            end;
+
+            [Test]
+            [TransactionModel(TransactionModel::None)]
+            procedure C_PageFieldValidateMayWriteUnderNone()
+            var
+                Probe: Record "TXS Probe";
+                Card: TestPage "TXS Card";
+            begin
+                if MarkerCount(9414) <> 0 then
+                    Error('TXS3 FAIL: the OnValidate marker must not exist before the edit');
+                if not Probe.Get(9415) then
+                    Error('TXS3 FAIL: the previous default-model test''s seed row must be visible here');
+
+                Card.OpenEdit();
+                Card.GoToKey(9415);
+                Card."Text Field".SetValue('EDITED-UNDER-NONE');
+                Card.Close();
+
+                if MarkerCount(9414) <> 1 then
+                    Error('TXS3 FAIL: a page field''s OnValidate driven from a None test must be able to write; got %1 row(s)', MarkerCount(9414));
+                if Database.IsInWriteTransaction() then
+                    Error('TXS3 FAIL: the transaction the page began must end with the page');
+            end;
+
+            // The negative arm, and the reason the three above prove anything: the brackets must
+            // make a write legal INSIDE those constructs WITHOUT reopening the test body itself.
+            // Delete either bracket's Exit and this test starts passing writes BC refuses.
+            [Test]
+            [TransactionModel(TransactionModel::None)]
+            procedure D_TheTestBodyItselfIsStillRefused()
+            var
+                Probe: Record "TXS Probe";
+            begin
+                Probe."Entry No." := 9416;
+                asserterror Probe.Insert();
+
+                if GetLastErrorText() <> 'A transaction must be started before changes can be made to the database.' then
+                    Error('TXS4 FAIL: expected BC''s no-transaction refusal, got [%1]', GetLastErrorText());
+                if MarkerCount(9416) <> 0 then
+                    Error('TXS4 FAIL: a refused write must not have written a row');
+            end;
+
+            // And the scope must not outlive the None tests that opened it.
+            [Test]
+            procedure E_ADefaultModelTestAfterwardsCanStillWrite()
+            var
+                Probe: Record "TXS Probe";
+            begin
+                Probe."Entry No." := 9417;
+                Probe.Insert();
+
+                if not Database.IsInWriteTransaction() then
+                    Error('TXS5 FAIL: a default-model test after the None tests must still be able to write');
+            end;
+        }
+        """);
+
+        var (output, exitCode) = RunRunner(root);
+
+        Assert.True(exitCode == 0,
+            $"Expected all five tests to pass (exit 0); got exit {exitCode}.\n{output}");
+        Assert.DoesNotContain("FAIL", output);
+        Assert.Contains("PASS  Codeunit62544.A_ReportMayWriteUnderNone", output);
+        Assert.Contains("PASS  Codeunit62544.B_SeedsTheRowThePageOpensOn", output);
+        Assert.Contains("PASS  Codeunit62544.C_PageFieldValidateMayWriteUnderNone", output);
+        Assert.Contains("PASS  Codeunit62544.D_TheTestBodyItselfIsStillRefused", output);
+        Assert.Contains("PASS  Codeunit62544.E_ADefaultModelTestAfterwardsCanStillWrite", output);
+    }
 }

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -3757,18 +3757,37 @@ internal sealed class LiveNavTestField : ITestField
         // again, so the assignment must not outlive this one validate call.
         var previousCurrFieldNo = _record.CurrFieldNo;
         _record.CurrFieldNo = _fieldNo;
+        // #3543: BC brackets a page-driven field validate in a transaction of its own —
+        // NavRecord.ValidateFieldsAsync opens Session.BeginTransaction() per field and closes
+        // it with Session.EndTransaction(commit) in a finally, and NavForm.ModifyAsync does
+        // the same around the page's own Modify. So an OnValidate that writes is legal even
+        // when the CALLER holds no transaction, which under TransactionModel::None is the
+        // whole test body (#3480). Without this bracket the runner refused a write BC allows.
+        //
+        // Observably equivalent: the counter grants a write nothing outside a None scope,
+        // where ThrowIfNoTransactionForWrite returns before it is read at all, and it changes
+        // no commit point — which is a separate question, tracked by NoteTransactionEnd and
+        // deliberately left alone here (#2413 measured that conflating the two is wrong).
+        AlRunner.Patches.ALDatabasePatches.EnterRunTransaction();
         try
         {
-            _record.ALValidateAsync(_fieldNo, navValue, null).GetAwaiter().GetResult();
+            try
+            {
+                _record.ALValidateAsync(_fieldNo, navValue, null).GetAwaiter().GetResult();
+            }
+            finally
+            {
+                _record.CurrFieldNo = previousCurrFieldNo;
+            }
+
+            // Then the control's own OnValidate, which is a second and independent trigger: the
+            // table field's runs first, the page's after it.
+            if (_page != null && _controlId != 0) _page.RaiseOnValidate(_controlId);
         }
         finally
         {
-            _record.CurrFieldNo = previousCurrFieldNo;
+            AlRunner.Patches.ALDatabasePatches.ExitRunTransaction();
         }
-
-        // Then the control's own OnValidate, which is a second and independent trigger: the
-        // table field's runs first, the page's after it.
-        if (_page != null && _controlId != 0) _page.RaiseOnValidate(_controlId);
 
         _onEdited?.Invoke();
     }

--- a/AlRunner/Patches/NavReportSync.cs
+++ b/AlRunner/Patches/NavReportSync.cs
@@ -681,9 +681,32 @@ public static partial class NavReportSync
             // ResultSetProcessor.RequireDataColumnEval and NREs on a null one. Installing it
             // inside InvokeDataItems, as this used to, put it one step too late.
             var datasetProcessor = EnsureResultSetProcessor(navReport, FindDataItemIteratorType(navReport));
-            RunOnPreTrigger(navReport, navReportBase);
-            bool datasetWritten = InvokeDataItems(navReport, datasetProcessor);
-            RunLifecycleTrigger(navReport, navReportBase, "OnPostReport");
+
+            // #3543: BC's RunReportInternalCoreAsync calls Session.BeginTransaction()
+            // immediately before GetReportRecords() and Session.EndTransaction(...) after the
+            // data-item iterator returns, so a report's triggers run inside a transaction the
+            // report itself began. That is what makes a write from a report legal inside a
+            // TransactionModel::None test body, whose own writes are refused (#3480).
+            //
+            // Bracketed from here rather than from the top of the method to match where BC
+            // puts it: the request page above runs OUTSIDE this transaction, which is BC's
+            // own ordering and not an approximation.
+            //
+            // Observably equivalent: the counter only makes a write legal that BC also makes
+            // legal. It grants nothing outside a None scope, where ThrowIfNoTransactionForWrite
+            // returns before reading it at all.
+            AlRunner.Patches.ALDatabasePatches.EnterRunTransaction();
+            bool datasetWritten;
+            try
+            {
+                RunOnPreTrigger(navReport, navReportBase);
+                datasetWritten = InvokeDataItems(navReport, datasetProcessor);
+                RunLifecycleTrigger(navReport, navReportBase, "OnPostReport");
+            }
+            finally
+            {
+                AlRunner.Patches.ALDatabasePatches.ExitRunTransaction();
+            }
 
             // Strict AL semantics: when the report declares `ProcessingOnly =
             // false` (the AL default) — in its own AL source, or in the symbol


### PR DESCRIPTION
Closes #3543

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/293

PR #3541 gave a `TransactionModel::None` test body the transaction-less world BC gives it, and
bracketed only `Codeunit.Run`. `Codeunit.Run` is not the only AL construct that begins a
transaction, so the runner refused writes BC allows.

## The measurement came first, and it decided the scope

The issue was explicit that whether BC allows a write through each surface had to come from a
service tier, one arm per surface, before any bracket was added. So corpus PR #293 went up
first, shaped like codeunit 60878's Test10, and **all three arms passed on a real BC service
tier**:

| arm | corpus test | verdict |
|---|---|---|
| `Report.RunModal` | `WriteTxBoundary_Test11_AReportMayWriteUnderNone` | PASS |
| `XmlPort.Import` | `WriteTxBoundary_Test12_AnXmlPortImportMayWriteUnderNone` | PASS |
| page field `OnValidate` via `TestPage` | `WriteTxBoundary_Test13_APageFieldValidateMayWriteUnderNone` | PASS |

Five cloud legs ran the codeunit (27.0, 27.3, 27.5, 28.0, 28.4), **0 failures**. Verified with
`tools/corpus-pass-count.py 34241787233` rather than read off a green tick — three legs' logs
were still unavailable and the eight OnPrem legs correctly report `not-run`, which is exactly
the false-zero shape `verify-execution-not-the-tick.md` exists to catch. Four more cloud legs
and the Windows reference leg were still running when this PR was opened.

So no surface turned out to be "correct as-is": all three refusals are divergences.

## What this PR fixes: two of the three

Both brackets go where BC itself puts one, using the existing
`ALDatabasePatches.EnterRunTransaction()` / `ExitRunTransaction()` counter #3541 added.

**Report** — `NavReportSync.TryRunOrControlFlow`, around the pre-report trigger, the data-item
loop and `OnPostReport`. BC's `NavReport.RunReportInternalCoreAsync` calls
`Session.BeginTransaction()` immediately before `GetReportRecords()` and
`Session.EndTransaction(transactionResult)` after the iterator returns, so the request page
stays **outside** the bracket — BC's own ordering, not an approximation. Covers both spellings:
`SyncStaticRun` funnels into `SyncRun`.

**Page field validate** — `MockTestPage`'s Rec-bound `SetValue`, around `ALValidateAsync` and
the control's own `OnValidate`. BC's `NavRecord.ValidateFieldsAsync` opens a transaction per
field around `ValidateAsync` and closes it in a `finally`; `NavForm.ModifyAsync` does the same
around the page's `Modify`. The existing `CurrFieldNo` try/finally is nested inside the new one
so its restore still runs first.

## What this PR does NOT fix, and why it is filed rather than forced

**`XmlPort.Import` — #3580.** `XmlPortPatches.cs` deliberately leaves the instance
`Export`/`Import`/`SetTableView` to **BC's real, unpatched body**, and that decision is right:
the runner must not re-implement an import. The consequence is that the runner owns no seam on
that path at all — `rg` over `AlRunner/` finds nothing on it. Bracketing it needs one of:

1. a new Cecil try/finally wrapper (`PrependStaticCall` can only prepend;
   `ReplaceBodyWithHelper` would discard BC's body), or
2. a prepend onto `SessionTransactionExtensions.BeginTransaction`/`EndTransaction`, which pair
   exactly — but `BeginTransaction` has **73 callers** spanning `NavSession`, `NavTenant`,
   `UserManagement`, `NavForm`, `NavQuery`, `TaskRunner` and the app installer, and
   `NclCecilRewrite.Forms.cs` §8g records #2413, where a wide hook on the plain `EndTransaction`
   wrongly turned `Query.Open` and statement-form `XmlPort.Import` into commit points.

Either is a materially different change needing its own reasoning to review, which is the split
signal in `batch-sibling-issues-by-file.md` point 4. The upstream proving test already exists
and is already green, so #3580 needs no new corpus work.

## RED → GREEN

Taken in a **clean `origin/main` worktree**, built from source — not `--no-build`, which would
silently have re-run this branch's binary:

```
RED  (origin/main a3685ee3):  5 tests, 3 pass, 2 fail
       FAIL A_ReportMayWriteUnderNone
       FAIL C_PageFieldValidateMayWriteUnderNone
GREEN (this branch):          5 tests, 5 pass
```

**The three tests that already passed on `origin/main` are what make this prove something.**
`D_TheTestBodyItselfIsStillRefused` asserts the test body is *still* refused with BC's exact
message, and `E_ADefaultModelTestAfterwardsCanStillWrite` that the scope does not outlive the
`None` tests. Delete either bracket's `ExitRunTransaction` and D starts passing writes BC
refuses; disable the `None` scope outright and both fail. A no-op implementation cannot make
this test green.

## Where the proving test lives

The BC claim is upstream (corpus 60878 Test11/Test12/Test13) per
`bc-behavior-tests-go-upstream.md`. What is here is a runner **mechanism** test —
`AlRunner.Tests/WriteTransactionTestBoundaryTests.cs`, alongside #3468's and #3480's, same file
and same shape — pinning the runner's own brackets without depending on the submodule pin
having moved. No Base Application dependency, per `no-base-app-in-csharp-tests.md`.

**The corpus pin is deliberately not bumped here.** Corpus #293 has since **merged** as `26b0434f`,
but the bump still does not belong in this PR: advancing past it brings `Test12`, the xmlport arm,
which the runner fails until #3580 lands. So the pin on this branch stays at `main`'s `19560bd3`, and
the bump goes with the #3580 fix — or with an `expect-fail-known-gap` entry linking it, whichever
comes first. Recorded on #3580 so whoever advances the pin meets it deliberately.

## Fixing the shape, not the reported line

- **Same wrong pattern at another call site?** Yes — that is the whole issue, and the answer is
  the table above. `EnterRunTransaction` had exactly two call sites before this
  (`CodeunitPatches.cs:171` and `:229`, both `Codeunit.Run`); it now has four.
- **Does a sibling function make the same assumption?** `MockTestPage`'s page-variable-bound
  setter (`RunnerPageInstance.SetValue` + `RaiseOnValidate`, ~line 3983) has the same shape.
  Left alone deliberately: a page-global control stages no row edit, so it has no `Modify`
  path, and no corpus arm measures it. Naming it here rather than bracketing it on a guess.
- **Two code paths writing the same state maintaining the same invariant?** `_runTransactionDepth`
  is only ever moved by the Enter/Exit pair, and `ExitNoTransactionScope` resets it to 0
  unconditionally for every test, so an unbalanced Enter cannot leak past a test boundary. Both
  new brackets put their `Exit` in a `finally`.
- **Open-issue queue scanned** for this file and subsystem: #2904 (report transaction world
  unhooked) and #2184 (value-consuming forms in a write transaction) are neighbouring but land
  elsewhere and ask different questions — named in the issue as explicitly not this one. #3580
  is the piece split out.

## Prose placement

Both new comment blocks are under ten lines of rationale each and sit at the line a reader would
otherwise get wrong — which BC method they mirror, and the `observably equivalent` justification
`loud-failures.md` requires. The comparative reasoning about the two xmlport mechanisms lives in
#3580 and in this PR body, not in the code.

## Testing

- `dotnet test AlRunner.Tests --filter FullyQualifiedName~WriteTransactionTestBoundaryTests` —
  3 passed, 0 failed (13s), including #3468's and #3480's existing tests.
- The RED → GREEN above, both arms built from source.

Opened by agent stma-auto-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsJY7DhDm5y83e77GxpRSZ
