### PR TITLE
fix(table-metadata): build a compiled table's metadata from BC's own document, not from parsed AL

### DIFF
--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -152,6 +152,12 @@ public sealed class CollectionCostOrderer : ITestCollectionOrderer
             // the 60s freshness threshold, so rounding down to the low end would satisfy the
             // gate while leaving dispatch order at the fallback and the tail in place.
             ["InstallBaselineVirtualTableExclusionTests"] = 61,
+            // #3552: the table-metadata document route. 84.9s on the BC 28.4 leg on its
+            // first CI run -- one leg, so that figure is the ceiling of the claim rather
+            // than a settled average. Recorded at 84, rounded down: far enough above
+            // UnmeasuredWeightSeconds (30) that the rounding cannot put it back in the
+            // #1887 single-threaded tail this table exists to prevent.
+            ["TableMetadataFromBcDocumentTests"] = 84,
             ["ServerCancelTests"] = 285,
             // perf/boot-overhead: 37.8s measured on the same run; below the 60s freshness
             // threshold, listed so it is dispatched by measured cost, not by the fallback.

--- a/AlRunner.Tests/Fixtures/TableMetadataFromBcDocument/Objects.al
+++ b/AlRunner.Tests/Fixtures/TableMetadataFromBcDocument/Objects.al
@@ -1,0 +1,44 @@
+// Every declaration here is a non-default value that BC's emitted metadata document carries
+// and the runner's AL-source derivation did not reproduce, so each is a distinguishable
+// assertion rather than a coincidence with a default:
+//
+//   field 2  Editable = false          — the derivation left every field editable
+//   field 2  EndUserIdentifiableInformation, field 3 SystemMetadata
+//                                      — the derivation gave every field the TABLE's value
+//   field 3  Enum "TMD Kind"           — the derivation left EnumTypeId 0 / EnumTypeName empty
+//
+// Field 1 declares none of the three, so it is the control: it must stay editable and take
+// the table's CustomerContent.
+
+enum 70680 "TMD Kind"
+{
+    Extensible = true;
+
+    value(0; Plain) { Caption = 'Plain'; }
+    value(5; Fancy) { Caption = 'Fancy'; }
+}
+
+table 70680 "TMD Thing"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; Description; Text[50])
+        {
+            DataClassification = EndUserIdentifiableInformation;
+            Editable = false;
+        }
+        field(3; Kind; Enum "TMD Kind")
+        {
+            DataClassification = SystemMetadata;
+        }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.") { Clustered = true; }
+        key(ByDescription; Description) { }
+    }
+}

--- a/AlRunner.Tests/Fixtures/TableMetadataFromBcDocument/Tests.al
+++ b/AlRunner.Tests/Fixtures/TableMetadataFromBcDocument/Tests.al
@@ -1,0 +1,18 @@
+codeunit 70680 "TMD Tests"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure ThingRoundTrips()
+    var
+        Thing: Record "TMD Thing";
+    begin
+        Thing.Init();
+        Thing."Entry No." := 7;
+        Thing.Insert();
+
+        Thing.Get(7);
+        if Thing."Entry No." <> 7 then
+            Error('Expected entry 7, got %1', Thing."Entry No.");
+    end;
+}

--- a/AlRunner.Tests/Fixtures/TableMetadataFromBcDocument/app.json
+++ b/AlRunner.Tests/Fixtures/TableMetadataFromBcDocument/app.json
@@ -1,0 +1,23 @@
+{
+  "id": "a3000000-0000-4000-8000-000000000049",
+  "name": "Runner Tests Fixture - Table Metadata From BC Document",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "#3552: a compiled table's NCLMetaTable must come from BC's own emitted metadata document, so the per-field values only that document carries survive to the runtime metadata.",
+  "description": "Used by AlRunner.Tests' TableMetadataFromBcDocumentTests. One table whose fields declare non-default Editable and DataClassification and one enum-typed field, so each assertion names a concrete value rather than a count. Deliberately declares no 'application' dependency (see .claude/rules/no-base-app-in-csharp-tests.md).",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "idRanges": [
+    {
+      "from": 70680,
+      "to": 70699
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner.Tests/TableMetadataFromBcDocumentTests.cs
+++ b/AlRunner.Tests/TableMetadataFromBcDocumentTests.cs
@@ -242,6 +242,270 @@ public class TableMetadataFromBcDocumentTests
         """);
     }
 
+    /// <summary>
+    /// A table in a source-compiled DEPENDENCY takes BC's document too, cold and across the
+    /// dependency's own compile-cache HIT.
+    ///
+    /// <c>AlObjectMetadataRegistry</c> is keyed <c>(kind, id)</c> with no notion of which app
+    /// compiled the object, so coverage was never limited to the app under test — but the
+    /// replay path is different and could fail on its own: a dependency served from
+    /// <c>compiled-deps</c> skips its own Emit, and its documents reach the run only through
+    /// <c>DependencyLoader</c>'s <c>.object-metadata.json</c> sidecar. Losing that would show
+    /// up on the second run only, with the first one green. Same two-process shape as
+    /// <see cref="ObjectMetadataCaptureTests"/>'s dependency case, which is where it comes
+    /// from.
+    ///
+    /// What is NOT covered by this, and is #3549: a dependency shipped as a precompiled
+    /// <c>.app</c>, which never compiles here and so has no document at all.
+    /// </summary>
+    [SkippableFact]
+    public void SourceCompiledDependencyTable_TakesBcsDocument_AcrossItsOwnCacheHit()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var scratch = TestScratch.Dir("al-runner-table-metadata-dep");
+        var depDir = Path.Combine(scratch, "dep-app");
+        var testsDir = Path.Combine(scratch, "tests-app");
+        var alCacheDir = Path.Combine(scratch, "al-out");
+        Directory.CreateDirectory(depDir);
+        Directory.CreateDirectory(testsDir);
+
+        var depId = Guid.NewGuid();
+        var testsId = Guid.NewGuid();
+        const int DepTableId = 70670;
+        const int DepEnumId = 70670;
+
+        File.WriteAllText(Path.Combine(depDir, "app.json"), $$"""
+        {
+          "id": "{{depId}}",
+          "name": "TMDep App",
+          "publisher": "TMDep",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 70670, "to": 70674 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(depDir, "Dep.al"), """
+        enum 70670 "TMDep Kind"
+        {
+            Extensible = true;
+            value(0; Plain) { }
+            value(5; Fancy) { }
+        }
+
+        table 70670 "TMDep Thing"
+        {
+            DataClassification = CustomerContent;
+            fields
+            {
+                field(1; "Entry No."; Integer) { }
+                field(2; Description; Text[50])
+                {
+                    DataClassification = EndUserIdentifiableInformation;
+                    Editable = false;
+                }
+                field(3; Kind; Enum "TMDep Kind") { DataClassification = SystemMetadata; }
+            }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(testsDir, "app.json"), $$"""
+        {
+          "id": "{{testsId}}",
+          "name": "TMDep Tests",
+          "publisher": "TMDep",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{depId}}", "name": "TMDep App", "publisher": "TMDep", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 70675, "to": 70679 } ],
+          "runtime": "14.0"
+        }
+        """);
+        var testsAlPath = Path.Combine(testsDir, "Tests.al");
+        File.WriteAllText(testsAlPath, """
+        codeunit 70675 "TMDep Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure DepThingRoundTrips()
+            var
+                Thing: Record "TMDep Thing";
+            begin
+                Thing.Init();
+                Thing."Entry No." := 1;
+                Thing.Insert();
+                Thing.Get(1);
+            end;
+        }
+        """);
+
+        void AssertDepTableCameFromBcDocument(string output, string phase)
+        {
+            Assert.True(output.Contains($"[table-metadata] {DepTableId} source=bc-document"),
+                $"{phase}: dependency table {DepTableId} did not take BC's document.\n{output}");
+
+            var lines = output.Split('\n').Select(l => l.TrimEnd('\r')).ToArray();
+            string Field(int no) => lines.LastOrDefault(
+                l => l.StartsWith($"[table-metadata] {DepTableId} field={no} ", StringComparison.Ordinal))
+                ?? throw new Xunit.Sdk.XunitException(
+                    $"{phase}: no trace line for dependency field {no}.\n{output}");
+
+            Assert.True(Field(2).Contains(" editable=False")
+                        && Field(2).Contains(" dataClassification=EndUserIdentifiableInformation"),
+                $"{phase}: the dependency's field 2 declares Editable = false and "
+                + "EndUserIdentifiableInformation.\n" + Field(2));
+            Assert.True(Field(3).Contains($" enumTypeId={DepEnumId} enumTypeName=TMDep Kind"),
+                $"{phase}: the dependency's field 3 is Enum \"TMDep Kind\".\n" + Field(3));
+        }
+
+        var (run1, exit1) = RunRunner(testsDir, alCacheDir);
+        Assert.True(exit1 == 0 && run1.Contains("1P/0F/0E"), $"run 1 (all cold) must pass:\n{run1}");
+        AssertDepTableCameFromBcDocument(run1, "run 1 (cold)");
+
+        // Touch the tests bundle only: its key changes (bundle MISS) while the dep's
+        // synthesized .app stays byte-identical, so the dep is served from compiled-deps and
+        // its Emit never runs.
+        File.AppendAllText(testsAlPath, "\n// touched\n");
+
+        var (run2, exit2) = RunRunner(testsDir, alCacheDir);
+        Assert.True(exit2 == 0 && run2.Contains("1P/0F/0E"), $"run 2 (dep HIT) must pass:\n{run2}");
+        Assert.Contains("source-cache HIT", run2);
+        AssertDepTableCameFromBcDocument(run2, "run 2 (dependency compile-cache HIT)");
+    }
+
+    /// <summary>
+    /// A base table extended by a KEY-ONLY tableextension in another app keeps the derivation.
+    ///
+    /// This is the case the merged-field count could not see. Fields and keys reach
+    /// <c>MergeExtensionFields</c> through separate channels (#3216), and a key-only —
+    /// or <c>modify(...)</c>-only — extension contributes no fields, so
+    /// <c>_parsedExtensionFields</c> stays empty. A count-based guard therefore passed, the
+    /// base app's own document won, and the extension's key vanished: measured on this
+    /// fixture, <c>RecordRef.KeyCount()</c> answered 3 instead of 4, exit 0, no diagnostic.
+    ///
+    /// The claim is about a KEY the runner merges at runtime, so the count is the assertion
+    /// and the trace line is the mechanism behind it — both are checked, because either alone
+    /// can be satisfied by the wrong thing: the count alone would pass if the key came back by
+    /// some other route, and the route alone says nothing about the key surviving.
+    ///
+    /// Cross-app on purpose. A same-app extension is merged into the emitting app's own
+    /// document by BC's compiler; one contributed by a DIFFERENT app is runtime-merged state
+    /// that no per-app document can express, which is the whole distinction the guard encodes.
+    /// </summary>
+    [SkippableFact]
+    public void BaseTableWithAKeyOnlyExtensionInAnotherApp_KeepsTheDerivation()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var scratch = TestScratch.Dir("al-runner-table-metadata-keyonly");
+        var depDir = Path.Combine(scratch, "dep-app");
+        var testsDir = Path.Combine(scratch, "tests-app");
+        Directory.CreateDirectory(depDir);
+        Directory.CreateDirectory(testsDir);
+
+        var depId = Guid.NewGuid();
+        var testsId = Guid.NewGuid();
+        const int DepTableId = 70670;
+
+        File.WriteAllText(Path.Combine(depDir, "app.json"), $$"""
+        {
+          "id": "{{depId}}",
+          "name": "TMK Dep App",
+          "publisher": "TMK",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 70670, "to": 70674 } ],
+          "runtime": "14.0"
+        }
+        """);
+        // Two declared keys, so the count below distinguishes "the extension's key is missing"
+        // from "keys are missing altogether".
+        File.WriteAllText(Path.Combine(depDir, "Dep.al"), """
+        table 70670 "TMK Dep Thing"
+        {
+            fields
+            {
+                field(1; "Entry No."; Integer) { }
+                field(2; Description; Text[50]) { }
+                field(3; Rank; Integer) { }
+            }
+            keys
+            {
+                key(PK; "Entry No.") { Clustered = true; }
+                key(ByDescription; Description) { }
+            }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(testsDir, "app.json"), $$"""
+        {
+          "id": "{{testsId}}",
+          "name": "TMK Tests",
+          "publisher": "TMK",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{depId}}", "name": "TMK Dep App", "publisher": "TMK", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 70675, "to": 70679 } ],
+          "runtime": "14.0"
+        }
+        """);
+        // Keys only — no fields block at all, which is what leaves _parsedExtensionFields empty.
+        File.WriteAllText(Path.Combine(testsDir, "Tests.al"), """
+        tableextension 70675 "TMK Key Only Ext" extends "TMK Dep Thing"
+        {
+            keys
+            {
+                key(ByRank; Rank) { }
+            }
+        }
+
+        codeunit 70675 "TMK Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure ExtensionKeyIsStillThere()
+            var
+                RRef: RecordRef;
+                KRef: KeyRef;
+                FRef: FieldRef;
+            begin
+                RRef.Open(70670);
+                if RRef.KeyCount() <> 4 then
+                    Error('KeyCount=%1, expected 4 (PK, ByDescription, ByRank, and the ' +
+                          'platform key). A lower count means the extension''s key was dropped.',
+                          RRef.KeyCount());
+
+                // Name the key by the field it starts on: a count alone would be satisfied by
+                // any third key at all.
+                KRef := RRef.KeyIndex(3);
+                FRef := KRef.FieldIndex(1);
+                if FRef.Number() <> 3 then
+                    Error('Key 3 starts on field %1, expected 3 (Rank) — the extension''s key.',
+                          FRef.Number());
+                RRef.Close();
+            end;
+        }
+        """);
+
+        var (output, exit) = RunRunner(testsDir, Path.Combine(scratch, "al-out"));
+        Assert.True(exit == 0 && output.Contains("1P/0F/0E"),
+            $"the extension's key must survive:\n{output}");
+
+        // ...and it survived because the table kept the derivation, not by some other route.
+        Assert.Contains($"[table-metadata] {DepTableId} source=derived", output);
+        Assert.DoesNotContain($"[table-metadata] {DepTableId} source=bc-document", output);
+    }
+
     [SkippableFact]
     public void TableWithNoCapturedDocument_KeepsTheDerivation()
     {

--- a/AlRunner.Tests/TableMetadataFromBcDocumentTests.cs
+++ b/AlRunner.Tests/TableMetadataFromBcDocumentTests.cs
@@ -1,0 +1,263 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #3552 — a table the runner COMPILED gets its NCLMetaTable from BC's own emitted metadata
+/// document (captured by #3548) instead of from the runner's AL-source derivation, and a table
+/// with no document keeps the derivation.
+///
+/// The four values asserted here are the ones the derivation got wrong, and none of them is
+/// reachable from AL: <c>Editable</c> and the enum type live on
+/// <c>Types.Metadata.MetaField</c> and no AL surface exposes either for a table field, while
+/// <c>DataClassification</c> reaches AL only through the Field virtual table, which needs the
+/// Base Application floor this fixture may not declare
+/// (<c>.claude/rules/no-base-app-in-csharp-tests.md</c>). The AL-observable half of the same
+/// change — per-field DataClassification, the relation columns and SystemCreatedBy's
+/// relation — is adjudicated by a real service tier in corpus PR #292, not here.
+///
+/// Observed through <c>AL_RUNNER_TRACE_TABLE_METADATA_SOURCE=2</c>, the same shape
+/// <see cref="ObjectMetadataCaptureTests"/> uses for the capture it pins: the two construction
+/// routes produce the same TYPE, so nothing downstream can be asked which one ran.
+///
+/// Warm assertions are identical to the cold ones and run against the same cache directory
+/// (<c>.claude/rules/local-test-scope.md</c>): BC's Emit runs only on a compile-cache MISS, so
+/// a warm run that lost the document would silently fall back to the derivation while the run
+/// stayed green.
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips when absent.
+/// </summary>
+public class TableMetadataFromBcDocumentTests
+{
+    private const int TableId = 70680;
+    private const int EnumId = 70680;
+
+    /// <summary>The Field system virtual table. The runner never compiles it, so no document
+    /// exists for it and it must keep the derivation — the fallback direction, asserted
+    /// against a real table rather than a contrived one.</summary>
+    private const int FieldVirtualTableId = 2000000041;
+
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string FixtureRoot = Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TableMetadataFromBcDocument"));
+
+    private static void CopyDir(string src, string dst)
+    {
+        Directory.CreateDirectory(dst);
+        foreach (var f in Directory.GetFiles(src))
+            File.Copy(f, Path.Combine(dst, Path.GetFileName(f)), overwrite: true);
+    }
+
+    private static (string output, int exit) RunRunner(string bundleDir, string alCacheDir)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" \"{bundleDir}\"");
+        args.Append($" --cache \"{alCacheDir}\"");
+        args.Append(" --verbose");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = args.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        psi.Environment["AL_RUNNER_TRACE_TABLE_METADATA_SOURCE"] = "2";
+        var platformApps = TestArtifacts.PlatformAppsDir();
+        if (Directory.Exists(platformApps))
+            psi.Arguments += $" --package-cache \"{platformApps}\"";
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(300_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>The last trace line for one field of the compiled table — the last, because the
+    /// derivation traces the same field first and the assertion is about the state the run
+    /// ends up serving.</summary>
+    private static string FieldLine(string output, int fieldNo)
+    {
+        var prefix = $"[table-metadata] {TableId} field={fieldNo} ";
+        var hit = output.Split('\n')
+            .Select(l => l.TrimEnd('\r'))
+            .LastOrDefault(l => l.StartsWith(prefix, StringComparison.Ordinal));
+        Assert.True(hit != null,
+            $"no trace line for field {fieldNo} of table {TableId}. "
+            + $"AL_RUNNER_TRACE_TABLE_METADATA_SOURCE=2 emits one per field per build.\n{output}");
+        return hit!;
+    }
+
+    private static void AssertCompiledTableCameFromBcDocument(string output, string phase)
+    {
+        Assert.True(output.Contains($"[table-metadata] {TableId} source=bc-document"),
+            $"{phase}: table {TableId} was not built from BC's metadata document. "
+            + $"It is compiled by this bundle, so #3548 captures one for it.\n{output}");
+
+        // Field 2 declares BOTH non-default values. Editable is the shape #3545 names: the
+        // derivation defaulted it to true, which is a plausible answer, so a test asserting
+        // "some value" would pass on the defect.
+        var f2 = FieldLine(output, 2);
+        Assert.True(f2.Contains(" editable=False"),
+            $"{phase}: field 2 declares Editable = false.\n{f2}");
+        Assert.True(f2.Contains(" dataClassification=EndUserIdentifiableInformation"),
+            $"{phase}: field 2 declares DataClassification = EndUserIdentifiableInformation, "
+            + "not the table's CustomerContent.\n" + f2);
+
+        // Field 3 pins the enum type and a THIRD DataClassification value, so no single
+        // constant satisfies fields 1, 2 and 3 at once.
+        var f3 = FieldLine(output, 3);
+        Assert.True(f3.Contains($" enumTypeId={EnumId} enumTypeName=TMD Kind"),
+            $"{phase}: field 3 is Enum \"TMD Kind\", so the metadata must name enum {EnumId} "
+            + "rather than answer 0 / empty.\n" + f3);
+        Assert.True(f3.Contains(" dataClassification=SystemMetadata"),
+            $"{phase}: field 3 declares DataClassification = SystemMetadata.\n{f3}");
+
+        // Field 1 declares none of the three: the control. If it came back editable=False or
+        // carried an enum type, the values above would be coming from somewhere other than
+        // each field's own declaration.
+        var f1 = FieldLine(output, 1);
+        Assert.True(f1.Contains(" editable=True"),
+            $"{phase}: field 1 declares no Editable, so it stays editable.\n{f1}");
+        Assert.True(f1.Contains(" dataClassification=CustomerContent"),
+            $"{phase}: field 1 declares none, so it takes the table's CustomerContent.\n{f1}");
+        Assert.True(f1.Contains(" enumTypeId=0"),
+            $"{phase}: field 1 is an Integer, so it names no enum.\n{f1}");
+    }
+
+    [SkippableFact]
+    public void CompiledTable_IsBuiltFromBcsMetadataDocument_ColdAndOnAWarmCacheHit()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var scratch = TestScratch.Dir("al-runner-table-metadata-from-bc");
+        var bundle = Path.Combine(scratch, "bundle");
+        var alCacheDir = Path.Combine(scratch, "al-out");
+        CopyDir(FixtureRoot, bundle);
+
+        var (cold, coldExit) = RunRunner(bundle, alCacheDir);
+        Assert.True(coldExit == 0 && cold.Contains("1P/0F/0E"), $"cold run must pass:\n{cold}");
+        AssertCompiledTableCameFromBcDocument(cold, "cold run");
+
+        // Same sources, same cache directory: the AL-output cache HITs and Emit never runs,
+        // so the document reaches this run only through the replayed sidecar.
+        var (warm, warmExit) = RunRunner(bundle, alCacheDir);
+        Assert.True(warmExit == 0 && warm.Contains("1P/0F/0E"), $"warm run must pass:\n{warm}");
+        Assert.Contains("[cache] HIT", warm);
+        AssertCompiledTableCameFromBcDocument(warm, "warm run (AL-output cache HIT)");
+    }
+
+    /// <summary>
+    /// Each table takes BC's document exactly ONCE per run, however many apps the bundle path
+    /// holds.
+    ///
+    /// <c>BcRuntime.SetTestAssembly</c> runs once per emitted assembly, and the sweep that
+    /// applies the document hangs off it, so a sweep with no ledger reloads every eligible
+    /// table again on each call. That is not idempotent: BC's <c>AssignFromMetaTable</c>
+    /// rebuilds the field array, and a data provider already open over the table then raises
+    /// <c>NavObjectDefinitionChangedException</c>. Measured on <c>tests/runner-extras</c>
+    /// before the fix — table 60710 reloaded eight times, one suite lost to EXEC-FAIL and an
+    /// unrelated query test failing as collateral.
+    ///
+    /// Two sibling apps under one path is the smallest bundle that emits two assemblies, and
+    /// it is the shape <c>tests/runner-extras</c> has. Measured on this fixture with the
+    /// ledger removed: 4 loads for the first table and 3 for the second — so the count of one
+    /// is a claim about the ledger, not an accident of there being nothing to repeat.
+    /// </summary>
+    [SkippableFact]
+    public void EachTable_TakesBcsDocumentOnce_AcrossASiblingAppBundle()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var scratch = TestScratch.Dir("al-runner-table-metadata-once");
+        const int TableA = 70690;
+        const int TableB = 70695;
+
+        WriteSiblingApp(Path.Combine(scratch, "app-a"), "TMA", TableA, 70694);
+        WriteSiblingApp(Path.Combine(scratch, "app-b"), "TMB", TableB, 70699);
+
+        var (output, exit) = RunRunner(scratch, Path.Combine(scratch, "al-out"));
+        Assert.True(exit == 0 && output.Contains("2P/0F/0E"), $"run must pass:\n{output}");
+
+        foreach (var id in new[] { TableA, TableB })
+        {
+            var loads = output.Split('\n')
+                .Count(l => l.TrimEnd('\r') == $"[table-metadata] {id} source=bc-document");
+            Assert.True(loads == 1,
+                $"table {id} must take BC's document exactly once; saw {loads}. "
+                + "More than one means the sweep is running per assembly.\n" + output);
+        }
+    }
+
+    /// <summary>One self-contained app: a table, and a test that writes a row to it so the
+    /// table really is materialised rather than merely declared.</summary>
+    private static void WriteSiblingApp(string dir, string prefix, int idFrom, int idTo)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{Guid.NewGuid()}}",
+          "name": "{{prefix}} App",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": {{idFrom}}, "to": {{idTo}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Objects.al"), $$"""
+        table {{idFrom}} "{{prefix}} Thing"
+        {
+            fields { field(1; "Entry No."; Integer) { } }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+
+        codeunit {{idFrom}} "{{prefix}} Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure ThingRoundTrips()
+            var
+                Thing: Record "{{prefix}} Thing";
+            begin
+                Thing.Init();
+                Thing."Entry No." := 1;
+                Thing.Insert();
+                Thing.Get(1);
+            end;
+        }
+        """);
+    }
+
+    [SkippableFact]
+    public void TableWithNoCapturedDocument_KeepsTheDerivation()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var scratch = TestScratch.Dir("al-runner-table-metadata-fallback");
+        var bundle = Path.Combine(scratch, "bundle");
+        CopyDir(FixtureRoot, bundle);
+
+        var (output, exit) = RunRunner(bundle, Path.Combine(scratch, "al-out"));
+        Assert.True(exit == 0 && output.Contains("1P/0F/0E"), $"run must pass:\n{output}");
+
+        // The Field virtual table is built during this same run and the runner never compiles
+        // it, so no document exists for it. Availability is what decides the route, so it must
+        // report the derivation — and must never report the other one.
+        Assert.Contains($"[table-metadata] {FieldVirtualTableId} source=derived", output);
+        Assert.DoesNotContain($"[table-metadata] {FieldVirtualTableId} source=bc-document", output);
+    }
+}

--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -520,6 +520,15 @@ public static partial class BcRuntime
         HookXmlPortInitializeComponents(asm);
         AlRunner.PerfTrace.Log($"SetTestAssembly.HookXmlPortInitializeComponents {sw.ElapsedMilliseconds}ms");
 
+        // #3552 — BC's own metadata document for a compiled table is registered by Emit,
+        // which runs AFTER the AddSourceDir pass that first built the table. Rebuild those
+        // through BC's loader now the documents exist; a table first touched after this
+        // point takes that route on its single build. Ahead of the two wiring passes below,
+        // which must run against the tables that will actually serve the run.
+        sw.Restart();
+        AlRunner.Patches.RecordPatches.RebuildTablesFromBcMetadataAll();
+        AlRunner.PerfTrace.Log($"SetTestAssembly.RebuildTablesFromBcMetadataAll {sw.ElapsedMilliseconds}ms");
+
         // Field-level OnValidate/OnLookup wiring. NCLMetaField.EventTriggerDataValue
         // must point at the AL-emitted [FieldTriggerHandler] methods on the Record CLR
         // class. The NCLMetaTable was built during AddSourceDir (before AL emit), so

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -138,6 +138,21 @@ public static partial class RecordPatches
 
         try
         {
+            // #3552 — when BC's emitter handed the runner its own metadata document for this
+            // table (#3548), let BC construct the NCLMetaTable from it rather than deriving one
+            // below. AVAILABILITY decides the route; a failure past this point propagates
+            // rather than dropping to the derivation, because a weaker answer under a green
+            // build is what .claude/rules/loud-failures.md exists to prevent. What each step
+            // supplies, and which tables are deliberately left on the derivation:
+            // docs/object-metadata-from-bc.md#the-seam.
+            if (ShouldBuildTableFromBcDocument(tableId, parsed))
+            {
+                var fromBc = BuildNCLMetaTableFromBcDocument(tableId, ResolveNavAppBaseGroup());
+                ApplyRunnerFieldWiring(fromBc, parsed, Array.Empty<ParsedField>(), parsed.Fields);
+                TraceTableMetadataSource(tableId, "bc-document", fromBc);
+                return fromBc;
+            }
+
             // Build MetaField[] — include a synthetic timestamp field (id=0, BigInteger)
             // and the BC system fields: SystemId (2000000000), SystemCreatedAt (2000000001),
             // SystemCreatedBy (2000000002), SystemModifiedAt (2000000003), SystemModifiedBy
@@ -223,14 +238,7 @@ public static partial class RecordPatches
                 parsed.TableTypeName);
             if (defaultMetaTable == null) return null;
 
-            // NavAppGroup.BaseGroup
-            var nclAsm = AppDomain.CurrentDomain.GetAssemblies()
-                .First(a => a.GetName().Name == "Microsoft.Dynamics.Nav.Ncl");
-            var tAppGroup = nclAsm.GetType("Microsoft.Dynamics.Nav.Runtime.Apps.NavAppGroup")!;
-            var baseGroup = tAppGroup.GetProperty("BaseGroup",
-                BindingFlags.Public | BindingFlags.Static)?.GetValue(null)
-                ?? tAppGroup.GetField("BaseGroup",
-                    BindingFlags.Public | BindingFlags.Static)?.GetValue(null);
+            var baseGroup = ResolveNavAppBaseGroup();
 
             var built = (NCLMetaTable?)_mCreateFromMetaTable.Invoke(null,
                 new object?[] { defaultMetaTable, baseGroup });
@@ -260,21 +268,6 @@ public static partial class RecordPatches
                 if (_fNCLMetaAppObjMetadataLoaded != null)
                     AlRunner.Infrastructure.FieldPoke.SetInstance(_fNCLMetaAppObjMetadataLoaded, built, true);
 
-                // W-8b A-prime: poke a real NavTableTriggerEventHandler into the
-                // tableTriggerEventHandler field. NCLMetaTable.TableTriggerEventHandler /
-                // TriggerEventHandler are simple field-getter properties — even when their
-                // call sites are R2R-inlined into NavRecord.InsertAsync, the inlined code
-                // reads our field. EventSubscriberPatches.InjectAll later attaches per-event
-                // NavEventSubscription objects to its NavEventScope.registeredSubscriptions.
-                var triggerHandler = AlRunner.Patches.EventSubscriberPatches
-                    .CreateTableTriggerEventHandler();
-                if (triggerHandler != null)
-                {
-                    var f = built.GetType().GetField("tableTriggerEventHandler",
-                        BindingFlags.NonPublic | BindingFlags.Instance);
-                    if (f != null)
-                        AlRunner.Infrastructure.FieldPoke.SetInstance(f, built, triggerHandler);
-                }
                 // NOTE: table-level trigger-subscriber injection (EventSubscriberPatches
                 // .InjectTriggerSubsForTable) is deliberately NOT called here. This method runs
                 // INSIDE _metaTableCache.GetOrAdd(tableId, BuildNCLMetaTable) — the cache entry for
@@ -292,28 +285,9 @@ public static partial class RecordPatches
                 // AppDomain yet at NCLMetaTable build time (build runs during
                 // AddSourceDir, before AL emit). See WireFieldTriggerHandlersAll().
 
-                // For AL `Enum "X"`-typed fields the upstream BC factory builds
-                // either a plain NCLOptionMetadataWithCaptions (when EnumTypeId==0)
-                // or an NCLFieldEnumMetadata that chains to NavGlobal.MetadataProvider
-                // (NREs on skeleton). Both paths produce wrong results for
-                // `FieldRef.GetEnumValueCaption/NameFromOrdinalValue(ordinal)` on
-                // sparse AL enums (e.g. value(0), value(5), value(10)) because the
-                // base GetCaptionFromIndex/GetOptionFromIndex treats the AL ordinal
-                // as a 0..Count-1 array index. We swap in AlEnumOptionMetadata which
-                // mirrors NCLEnumMetadata semantics (search indexes[] for matching
-                // ordinal) using data captured by BcCompiler at AL emit time.
-                FixupEnumFieldOptionMetadata(built, parsed, extFields);
-
-                // Register any AutoIncrement fields so NavRecord_ALInsertAsync3 assigns
-                // counters. `allParsed` rather than `parsed.Fields`: a tableextension may
-                // declare the AutoIncrement field, and since #1711 that property survives the
-                // parse. Registering only base-table fields would be the silent half-fix —
-                // the NCLMetaField would say autoIncrement=true while no counter ever
-                // advanced, so every Insert left the field at 0 and the second row collided.
-                foreach (var f in allParsed)
-                    if (f.IsAutoIncrement)
-                        AlRunner.BcRuntime.RegisterAutoIncrementField(tableId, f.FieldId);
+                ApplyRunnerFieldWiring(built, parsed, extFields, allParsed);
             }
+            TraceTableMetadataSource(tableId, "derived", built);
             return built;
         }
         catch (Exception ex)

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -140,10 +140,12 @@ public static partial class RecordPatches
         {
             // #3552 — when BC's emitter handed the runner its own metadata document for this
             // table (#3548), let BC construct the NCLMetaTable from it rather than deriving one
-            // below. AVAILABILITY decides the route; a failure past this point propagates
-            // rather than dropping to the derivation, because a weaker answer under a green
-            // build is what .claude/rules/loud-failures.md exists to prevent. What each step
-            // supplies, and which tables are deliberately left on the derivation:
+            // below. AVAILABILITY decides the route, and a failure is never re-routed to the
+            // derivation: a weaker answer substituted on error is what
+            // .claude/rules/loud-failures.md exists to prevent. It is not LOUD here, though —
+            // this site is inside the catch below, which swallows any throw into `return null`
+            // for both routes alike (pre-existing, #3590). What each step supplies, and which
+            // tables are deliberately left on the derivation:
             // docs/object-metadata-from-bc.md#the-seam.
             if (ShouldBuildTableFromBcDocument(tableId, parsed))
             {

--- a/AlRunner/Patches/RecordPatches.NclMetaTableFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableFromBcDocument.cs
@@ -1,0 +1,315 @@
+// RecordPatches.NclMetaTableFromBcDocument — build a compiled table's NCLMetaTable by
+// letting BC construct it from BC's own emitted metadata document, instead of deriving
+// one by hand (issue #3552, first conversion of the chain #3562 tracks).
+//
+// THE SEAM
+//   NCLMetaTable has no public constructor and no conversion from Types.Metadata.MetaTable;
+//   it builds itself FROM A LOADER. NCLMetaApplicationObject.Populate() calls
+//   NCLMetaTable.LoadMetadata(), which reaches
+//   ObjectLoader.MetaObjectCache.GetMetaTable(objectId, appGroup) →
+//   INCLObjectXmlMetadataLoader.GetMetaObjectXmlMetadata(...) →
+//   MetaTable.CreateMetaTableFromXml(document, appGroup.GroupId), and then does the
+//   AssignFromMetaTable / metadataAppGroupMetaTable / RuntimeInfo work itself.
+//   RunnerXmlMetadataLoader already implements that interface for reports, pages and
+//   xmlports; answering ObjectType.Table out of AlObjectMetadataRegistry (#3548) is what
+//   makes this path reachable for a table the runner compiled.
+//   See docs/object-metadata-from-bc.md for the decompiled chain and what each step supplies.
+//
+// AVAILABILITY DECIDES, FAILURE DOES NOT
+//   The route is taken only when a document is registered for (Table, id). Anything that
+//   goes wrong AFTER that decision propagates: dropping to the hand-derivation on error
+//   would answer a subtly different table under a green build, which is the failure mode
+//   .claude/rules/loud-failures.md exists to prevent.
+using System.Reflection;
+using Microsoft.Dynamics.Nav.Runtime;
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    internal const string BcTableMetadataKind = "Table";
+
+    /// <summary>
+    /// Table ids whose live NCLMetaTable already carries BC's document. Reloading one a second
+    /// time is not idempotent from BC's side: <c>AssignFromMetaTable</c> rebuilds the
+    /// NCLMetaField array, and a data provider already open over that table then raises
+    /// <c>NavObjectDefinitionChangedException</c> ("the definition of the … field has
+    /// changed"). That is not hypothetical — <c>SetTestAssembly</c> runs once per emitted
+    /// assembly, so a consolidated bundle reloaded table 60710 eight times and lost a whole
+    /// suite to it. Cleared with <c>_metaTableCache</c> in ResetForReload, because a
+    /// --watch/--server cycle replaces the instances this is asserting about.
+    /// </summary>
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<int, byte>
+        _bcDocumentBackedTables = new();
+
+    internal static void ClearBcDocumentBackedTables() => _bcDocumentBackedTables.Clear();
+
+    private static MethodInfo? _mCreateEmptyNCLMetaTable;
+    private static MethodInfo? _mNclMetaTableLoadMetadata;
+    private static readonly object _bcDocumentShapeLock = new();
+
+    /// <summary>
+    /// True when BC's emitter handed the runner a metadata document for this table id, so
+    /// <see cref="BuildNCLMetaTableFromBcDocument"/> can construct it through BC's own loader.
+    /// A table with no document — a precompiled dependency's, a virtual system table, or one
+    /// served from a cache written before #3548 — answers false and keeps the derivation.
+    /// </summary>
+    internal static bool HasBcTableMetadataDocument(int tableId)
+        => AlObjectMetadataRegistry.TryGet(BcTableMetadataKind, tableId, out var xml)
+           && !string.IsNullOrEmpty(xml);
+
+    /// <summary>
+    /// The one predicate both routes into BC's document consult — the cold build in
+    /// <c>BuildNCLMetaTable</c> and the post-emit reload in
+    /// <see cref="RebuildTablesFromBcMetadataAll"/>. It is a single method rather than the same
+    /// two conditions written twice because the two paths write the same state: a table that
+    /// took one route and not the other would carry half of each answer.
+    ///
+    /// The extension clause is scope, not caution. BC merges a <c>tableextension</c> through
+    /// NavAppGroup's own extension registry, which the runner does not populate, so BC's
+    /// document for the BASE table alone would silently drop the extension's fields and keys —
+    /// the derivation already merges them (<c>_parsedExtensionFields</c>), so it stays in
+    /// charge of those tables until TableExtension is converted too (#3562).
+    /// </summary>
+    internal static bool ShouldBuildTableFromBcDocument(int tableId, ParsedTable parsed)
+        => HasBcTableMetadataDocument(tableId)
+           && !(_parsedExtensionFields.TryGetValue(parsed.TableName.ToLowerInvariant(), out var ext)
+                && ext.Count > 0);
+
+    /// <summary>
+    /// Construct the table through BC: an empty NCLMetaTable bound to
+    /// <see cref="RunnerMetaApplicationObjectLoader"/>, then the load call that parses the
+    /// document and assigns every field, key, relation and caption.
+    /// Never called unless <see cref="HasBcTableMetadataDocument"/> is true.
+    /// </summary>
+    private static NCLMetaTable BuildNCLMetaTableFromBcDocument(int tableId, object? baseGroup)
+    {
+        EnsureBcDocumentShape();
+
+        var built = (NCLMetaTable?)_mCreateEmptyNCLMetaTable!.Invoke(null, new object?[]
+        {
+            RunnerMetaApplicationObjectLoader.Instance, tableId, baseGroup, -1, string.Empty,
+        }) ?? throw new BcShapeGapException(
+            "AL table metadata construction",
+            "NCLMetaTable.CreateEmptyNCLMetaTable",
+            $"BC's factory returned null for table {tableId}");
+
+        // LoadMetadata(), NOT Populate(). Populate() is the natural entry point and BC's own
+        // callers use it, but this runner Cecil-rewrites NCLMetaApplicationObject.Populate()
+        // to a void no-op (NclCecilRewrite.Runtime.cs) because it NREs on the hand-built
+        // skeleton metas the derivation produces. Calling it here therefore builds an EMPTY
+        // table in silence — measured: TableName "", Fields null, and the first record access
+        // NREs in NCLMetaTable.get_PrimaryKey. LoadMetadata is what Populate would have
+        // called; NCLMetaApplicationObject.LoadMetadata (the base call it starts with) has an
+        // empty body, so nothing is skipped by entering one level down.
+        _mNclMetaTableLoadMetadata!.Invoke(built, Array.Empty<object?>());
+
+        // The two bookkeeping assignments Populate() makes around LoadMetadata. metadataLoaded
+        // is what stops NCLMetadata.GetMetaApplicationObjectInternal calling the no-op'd
+        // Populate later and concluding the table still needs loading.
+        EnsureCachePopulatorReflection();
+        if (_fNCLMetaAppObjMetadataLoaded != null)
+            AlRunner.Infrastructure.FieldPoke.SetInstance(_fNCLMetaAppObjMetadataLoaded, built, true);
+
+        _bcDocumentBackedTables[tableId] = 1;
+        return built;
+    }
+
+    /// <summary>
+    /// One line per built table naming which of the two routes produced it. Off unless
+    /// <c>AL_RUNNER_TRACE_TABLE_METADATA_SOURCE=1</c>, and the only place the choice is
+    /// observable — the two routes produce the same TYPE, so nothing downstream can be asked
+    /// which one ran. Same shape and rationale as
+    /// <c>AL_RUNNER_TRACE_OBJECT_METADATA</c> (docs/object-metadata-capture.md).
+    /// </summary>
+    private static void TraceTableMetadataSource(int tableId, string source, NCLMetaTable? built = null)
+    {
+        var level = Environment.GetEnvironmentVariable("AL_RUNNER_TRACE_TABLE_METADATA_SOURCE");
+        if (level != "1" && level != "2") return;
+        Console.Out.WriteLine($"[table-metadata] {tableId} source={source}");
+        if (level != "2" || built == null) return;
+
+        // Per-field Editable / DataClassification / EnumTypeId / EnumTypeName. All four live
+        // on Types.Metadata.MetaField, reachable only through the ORIGINAL MetaTable the
+        // NCLMetaTable was built from: NCLMetaField carries DataClassification but neither
+        // Editable nor the enum type, and no AL surface exposes any of them for a table field.
+        // So this trace is where those values are observable at all — see
+        // docs/object-metadata-from-bc.md#reading-the-values-back.
+        foreach (var line in DescribeMetaFields(built))
+            Console.Out.WriteLine($"[table-metadata] {tableId} {line}");
+    }
+
+    private static IEnumerable<string> DescribeMetaFields(NCLMetaTable built)
+    {
+        var original = built.GetType()
+            .GetField("metadataAppGroupMetaTable", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?.GetValue(built);
+        var metaTable = original?.GetType()
+            .GetProperty("Item", BindingFlags.Public | BindingFlags.Instance)?.GetValue(original);
+        if (metaTable == null) yield break;
+
+        var fields = metaTable.GetType()
+            .GetProperty("Fields", BindingFlags.Public | BindingFlags.Instance)?.GetValue(metaTable);
+        if (fields is not System.Collections.IEnumerable seq) yield break;
+
+        foreach (var f in seq)
+        {
+            if (f == null) continue;
+            var t = f.GetType();
+            string Read(string name) =>
+                t.GetProperty(name, BindingFlags.Public | BindingFlags.Instance)
+                    ?.GetValue(f)?.ToString() ?? "<none>";
+            yield return $"field={Read("Id")} name={Read("Name")}"
+                       + $" editable={Read("Editable")}"
+                       + $" dataClassification={Read("DataClassification")}"
+                       + $" enumTypeId={Read("EnumTypeId")} enumTypeName={Read("EnumTypeName")}";
+        }
+    }
+
+    /// <summary>
+    /// Rebuild every already-cached table for which BC's document has since arrived.
+    ///
+    /// Ordering, and the reason this method exists: <c>BuildNCLMetaTable</c> first runs during
+    /// AddSourceDir, and <c>Emit</c> — which is what registers the documents — runs after it.
+    /// So the first build of a compiled table sees an EMPTY registry and takes the derivation
+    /// even though a document is about to exist. Measured on a three-field fixture: one
+    /// <c>BuildNCLMetaTable(72282331)</c> call, with <c>AlObjectMetadataRegistry.Count == 0</c>.
+    /// Called from <c>BcRuntime.SetTestAssembly</c>, the same post-emit point
+    /// <c>FixupEnumFieldOptionMetadataAll</c> and <c>WireFieldTriggerHandlersAll</c> use for
+    /// exactly this reason. A table first touched AFTER emit needs nothing from here — its
+    /// single build already finds the document.
+    /// </summary>
+    public static void RebuildTablesFromBcMetadataAll()
+    {
+        foreach (var kvp in _metaTableCache)
+        {
+            if (kvp.Value is not NCLMetaTable built) continue;
+            // Once, per table, per bundle — see _bcDocumentBackedTables.
+            if (_bcDocumentBackedTables.ContainsKey(kvp.Key)) continue;
+            if (!_parsedTables.TryGetValue(kvp.Key, out var parsed)) continue;
+            if (!ShouldBuildTableFromBcDocument(kvp.Key, parsed)) continue;
+
+            ReloadFromBcDocumentInPlace(built);
+            ApplyRunnerFieldWiring(built, parsed, Array.Empty<ParsedField>(), parsed.Fields);
+            _bcDocumentBackedTables[kvp.Key] = 1;
+            TraceTableMetadataSource(kvp.Key, "bc-document", built);
+        }
+    }
+
+    /// <summary>
+    /// Re-run BC's own load against the CACHED instance rather than replacing it.
+    ///
+    /// Evicting and rebuilding was tried first, and produced three runner-extras regressions
+    /// against a clean baseline: a [ConfirmHandler] that stopped firing, a source-field
+    /// OnLookup trigger that stopped being found, and a cross-app OnAfterValidate mutation
+    /// that stopped propagating — each one a consumer still holding the instance the table had
+    /// been cached as. Preserving the identity and reassigning only the metadata is what
+    /// BC's own AssignFromMetaTable does anyway.
+    ///
+    /// The loader is supplied first because the derivation built this instance without one —
+    /// CreateFromMetaTable passes null — and LoadMetadata dereferences it to reach
+    /// MetaObjectCache.
+    /// </summary>
+    private static void ReloadFromBcDocumentInPlace(NCLMetaTable built)
+    {
+        EnsureBcDocumentShape();
+        AlRunner.Infrastructure.FieldPoke.SetInstance(
+            RequireObjectLoaderBackingField(built.GetType()),
+            built, RunnerMetaApplicationObjectLoader.Instance);
+        _mNclMetaTableLoadMetadata!.Invoke(built, Array.Empty<object?>());
+    }
+
+    private static FieldInfo? _fNclMetaAppObjObjectLoader;
+
+    private static FieldInfo RequireObjectLoaderBackingField(Type nclMetaTableType)
+        => _fNclMetaAppObjObjectLoader ??= BcShape.RequiredField(
+            nclMetaTableType, "<ObjectLoader>k__BackingField",
+            "AL table metadata construction",
+            "the auto-property backing field NCLMetaApplicationObject.ObjectLoader reads, which "
+            + "LoadMetadata dereferences to reach MetaObjectCache");
+
+    /// <summary>
+    /// <c>NavAppGroup.BaseGroup</c> — the metadata app group every runner-built table belongs
+    /// to, and the one BC's loader path resolves the object's owner against.
+    /// </summary>
+    private static object? ResolveNavAppBaseGroup()
+    {
+        var nclAsm = AppDomain.CurrentDomain.GetAssemblies()
+            .First(a => a.GetName().Name == "Microsoft.Dynamics.Nav.Ncl");
+        var tAppGroup = nclAsm.GetType("Microsoft.Dynamics.Nav.Runtime.Apps.NavAppGroup")!;
+        return tAppGroup.GetProperty("BaseGroup", BindingFlags.Public | BindingFlags.Static)
+                   ?.GetValue(null)
+               ?? tAppGroup.GetField("BaseGroup", BindingFlags.Public | BindingFlags.Static)
+                   ?.GetValue(null);
+    }
+
+    /// <summary>
+    /// The runner's own wiring onto a freshly built NCLMetaTable, shared by both construction
+    /// routes because neither BC nor the derivation supplies it: the table-trigger event
+    /// handler, enum-field option metadata, and AutoIncrement registration. Everything BC
+    /// *can* state about the table comes from whichever route built it.
+    /// </summary>
+    private static void ApplyRunnerFieldWiring(
+        NCLMetaTable built, ParsedTable parsed,
+        IEnumerable<ParsedField> extFields, IEnumerable<ParsedField> autoIncrementCandidates)
+    {
+        // W-8b A-prime: poke a real NavTableTriggerEventHandler into the
+        // tableTriggerEventHandler field. NCLMetaTable.TableTriggerEventHandler /
+        // TriggerEventHandler are simple field-getter properties — even when their call
+        // sites are R2R-inlined into NavRecord.InsertAsync, the inlined code reads our
+        // field. EventSubscriberPatches.InjectAll later attaches per-event
+        // NavEventSubscription objects to its NavEventScope.registeredSubscriptions.
+        var triggerHandler = EventSubscriberPatches.CreateTableTriggerEventHandler();
+        if (triggerHandler != null)
+        {
+            var f = built.GetType().GetField("tableTriggerEventHandler",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            if (f != null)
+                AlRunner.Infrastructure.FieldPoke.SetInstance(f, built, triggerHandler);
+        }
+
+        // For AL `Enum "X"`-typed fields the upstream BC factory builds either a plain
+        // NCLOptionMetadataWithCaptions (when EnumTypeId==0) or an NCLFieldEnumMetadata that
+        // chains to NavGlobal.MetadataProvider (NREs on skeleton). Both paths produce wrong
+        // results for `FieldRef.GetEnumValueCaption/NameFromOrdinalValue(ordinal)` on sparse
+        // AL enums (e.g. value(0), value(5), value(10)) because the base
+        // GetCaptionFromIndex/GetOptionFromIndex treats the AL ordinal as a 0..Count-1 array
+        // index. We swap in AlEnumOptionMetadata which mirrors NCLEnumMetadata semantics
+        // (search indexes[] for matching ordinal) using data captured by BcCompiler at AL
+        // emit time. This applies to the BC-document route too: the document states a real
+        // EnumTypeId, so BC builds the chaining NCLFieldEnumMetadata rather than the plain
+        // one, and the provider it chains to is the skeleton's.
+        FixupEnumFieldOptionMetadata(built, parsed, extFields);
+
+        // Register any AutoIncrement fields so NavRecord_ALInsertAsync3 assigns counters.
+        // A tableextension may declare the AutoIncrement field, and since #1711 that
+        // property survives the parse. Registering only base-table fields would be the
+        // silent half-fix — the NCLMetaField would say autoIncrement=true while no counter
+        // ever advanced, so every Insert left the field at 0 and the second row collided.
+        foreach (var f in autoIncrementCandidates)
+            if (f.IsAutoIncrement)
+                AlRunner.BcRuntime.RegisterAutoIncrementField(parsed.TableId, f.FieldId);
+    }
+
+    private static void EnsureBcDocumentShape()
+    {
+        if (_mCreateEmptyNCLMetaTable != null && _mNclMetaTableLoadMetadata != null) return;
+        lock (_bcDocumentShapeLock)
+        {
+            _mCreateEmptyNCLMetaTable ??= BcShape.RequiredMethod(
+                typeof(NCLMetaTable), "CreateEmptyNCLMetaTable",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                "AL table metadata construction", "NCLMetaTable.CreateEmptyNCLMetaTable",
+                "BC's own factory for a loader-backed NCLMetaTable — see docs/object-metadata-from-bc.md");
+
+            _mNclMetaTableLoadMetadata ??= BcShape.RequiredMethod(
+                typeof(NCLMetaTable), "LoadMetadata",
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                "AL table metadata construction", "NCLMetaTable.LoadMetadata",
+                "the call that parses the loader's document into this table — entered directly "
+                + "because Populate() is a Cecil no-op here",
+                types: Type.EmptyTypes);
+        }
+    }
+}

--- a/AlRunner/Patches/RecordPatches.NclMetaTableFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableFromBcDocument.cs
@@ -15,11 +15,19 @@
 //   makes this path reachable for a table the runner compiled.
 //   See docs/object-metadata-from-bc.md for the decompiled chain and what each step supplies.
 //
-// AVAILABILITY DECIDES, FAILURE DOES NOT
-//   The route is taken only when a document is registered for (Table, id). Anything that
-//   goes wrong AFTER that decision propagates: dropping to the hand-derivation on error
-//   would answer a subtly different table under a green build, which is the failure mode
+// AVAILABILITY DECIDES THE ROUTE, AND A FAILURE IS NEVER RE-ROUTED
+//   The route is taken only when a document is registered for (Table, id), and nothing here
+//   catches a failure and tries the derivation instead: a weaker answer substituted on error
+//   would be wrong metadata under a green build, which is what
 //   .claude/rules/loud-failures.md exists to prevent.
+//
+//   How far a failure then travels differs by call site, and only one of the two is loud:
+//   the post-emit sweep (RebuildTablesFromBcMetadataAll ← BcRuntime.SetTestAssembly) has no
+//   handler over it, so a throw there aborts bundle load naming the member; the cold build
+//   sits inside BuildNCLMetaTable's pre-existing `catch → Console.Error → return null`, which
+//   swallows it into "no metatable" exactly as it does for a derivation failure. That swallow
+//   predates this change and is #3590 — do not read the paragraph above as a claim that the
+//   cold path tears through, because it does not.
 using System.Reflection;
 using Microsoft.Dynamics.Nav.Runtime;
 using AlRunner.Infrastructure;
@@ -63,19 +71,36 @@ public static partial class RecordPatches
     /// The one predicate both routes into BC's document consult — the cold build in
     /// <c>BuildNCLMetaTable</c> and the post-emit reload in
     /// <see cref="RebuildTablesFromBcMetadataAll"/>. It is a single method rather than the same
-    /// two conditions written twice because the two paths write the same state: a table that
-    /// took one route and not the other would carry half of each answer.
+    /// conditions written twice because the two paths write the same state: a table that took
+    /// one route and not the other would carry half of each answer.
     ///
-    /// The extension clause is scope, not caution. BC merges a <c>tableextension</c> through
-    /// NavAppGroup's own extension registry, which the runner does not populate, so BC's
-    /// document for the BASE table alone would silently drop the extension's fields and keys —
-    /// the derivation already merges them (<c>_parsedExtensionFields</c>), so it stays in
-    /// charge of those tables until TableExtension is converted too (#3562).
+    /// <para><b>The extension clause is about BUILD-TIME versus RUNTIME-MERGED state, and that
+    /// is why it is not a field count.</b> BC's document for a table is what ONE app's compiler
+    /// emitted for it. A <c>tableextension</c> in another app contributes fields AND keys that
+    /// the service tier merges at publish time through NavAppGroup's extension registry, which
+    /// the runner does not populate — so no per-app document can express them, whichever app
+    /// emitted it. The runner's derivation does merge them, so an extended base table stays on
+    /// the derivation until TableExtension is converted too (#3562).</para>
+    ///
+    /// <para><b>Gate on the extension INDEX, never on the merged field count.</b> Fields and
+    /// keys travel separate channels into <see cref="MergeExtensionFields"/>, and a
+    /// <c>modify(...)</c>-only or key-only extension contributes no fields at all — measured:
+    /// a cross-app key-only tableextension left <c>_parsedExtensionFields</c> empty, the
+    /// count-based guard passed, the base app's own document won, and
+    /// <c>RecordRef.KeyCount()</c> silently answered 2 where the derivation answers 3. Exit 0,
+    /// no diagnostic. <c>_extensionIdsByBaseTable</c> records EVERY extension, so it is the
+    /// signal that another app has contributed anything at all; the two collections beside it
+    /// are belt-and-braces for a writer that ever registers one without an id.</para>
     /// </summary>
     internal static bool ShouldBuildTableFromBcDocument(int tableId, ParsedTable parsed)
-        => HasBcTableMetadataDocument(tableId)
-           && !(_parsedExtensionFields.TryGetValue(parsed.TableName.ToLowerInvariant(), out var ext)
-                && ext.Count > 0);
+    {
+        if (!HasBcTableMetadataDocument(tableId)) return false;
+        var key = parsed.TableName.ToLowerInvariant();
+        if (_extensionIdsByBaseTable.TryGetValue(key, out var extIds) && extIds.Count > 0) return false;
+        if (_parsedExtensionFields.TryGetValue(key, out var extFields) && extFields.Count > 0) return false;
+        if (_parsedExtensionKeys.TryGetValue(key, out var extKeys) && extKeys.Count > 0) return false;
+        return true;
+    }
 
     /// <summary>
     /// Construct the table through BC: an empty NCLMetaTable bound to

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -263,6 +263,10 @@ public static partial class RecordPatches
     public static void ResetForReload()
     {
         _metaTableCache.Clear();
+        // #3552 — the ledger names LIVE NCLMetaTable instances as already carrying BC's
+        // document, so it is meaningless the moment the line above drops them, and leaving it
+        // populated would make the next cycle's tables keep the derivation in silence.
+        ClearBcDocumentBackedTables();
         // #3121: every table is rebuilt from scratch below, so carrying the previous bundle's
         // pending CalcFormula rebuilds forward only buys a wasted repopulate pass on the next
         // .app registration.

--- a/AlRunner/Patches/RunnerXmlMetadataLoader.cs
+++ b/AlRunner/Patches/RunnerXmlMetadataLoader.cs
@@ -88,6 +88,16 @@ public sealed class RunnerXmlMetadataLoader : INCLObjectXmlMetadataLoader
             && AlXmlPortMetadataRegistry.TryGet(objectId.ObjectNumber, out var xmlPortXml))
             return Wrap(xmlPortXml, $"runner-xmlport-{objectId.ObjectNumber}");
 
+        // Tables: BC's own emitted metadata document, kept per (kind, id) by #3548. This is
+        // the entry point for NCLMetaTable.LoadMetadata() — MetaObjectCache.GetMetaTable
+        // hands what we return here to MetaTable.CreateMetaTableFromXml, so BC constructs
+        // the table's fields, keys, relations and captions from its own bytes instead of
+        // the runner deriving them (#3552).
+        if (objectId.ObjectType == ObjectType.Table
+            && AlObjectMetadataRegistry.TryGet(
+                RecordPatches.BcTableMetadataKind, objectId.ObjectNumber, out var tableXml))
+            return Wrap(tableXml, $"runner-table-{objectId.ObjectNumber}");
+
         // Reports living in a PRECOMPILED dependency .app: never source-compiled, so the
         // emit registry above will never hold them. Their shape is still fully stated by
         // the .app itself (SymbolReference.json + the embedded AL source), so reconstruct

--- a/docs/object-metadata-capture.md
+++ b/docs/object-metadata-capture.md
@@ -8,8 +8,10 @@ object id).
 
 Three older registries keep one kind each and are unchanged: `AlReportMetadataRegistry`,
 `AlPageMetadataRegistry`, `AlXmlPortMetadataRegistry`. The general registry overlaps them
-on purpose — it is additive, and nothing reads it yet (issue #3548, step 2). Converting a
-consumer to read from it is a separate change, per kind, with its own RED → GREEN.
+on purpose — it is additive. Converting a consumer to read from it is a separate change, per
+kind, with its own RED → GREEN; the first is tables, in
+[`docs/object-metadata-from-bc.md`](object-metadata-from-bc.md) (#3552), and #3562 tracks the
+rest.
 
 <a id="which-kinds-arrive"></a>
 

--- a/docs/object-metadata-from-bc.md
+++ b/docs/object-metadata-from-bc.md
@@ -1,0 +1,135 @@
+# Building a table's metadata from BC's own document
+
+[`docs/object-metadata-capture.md`](object-metadata-capture.md) covers the capture: BC's
+emitter hands the runner a metadata document for every object it emits, and
+`AlObjectMetadataRegistry` keeps them all. This file covers the first **consumer** — a table
+the runner compiled gets its `NCLMetaTable` built by BC from that document, instead of by the
+runner's AL-source derivation (issue #3552; issue #3562 tracks the remaining kinds).
+
+<a id="the-seam"></a>
+
+## The seam, and why it is not `CreateMetaTableFromXml`
+
+`MetaTable.CreateMetaTableFromXml` is the obvious entry point and it is the wrong level.
+`Types.Metadata.MetaTable` and `Runtime.NCLMetaTable` are different types in different
+assemblies; there is no conversion between them, and `NCLMetaTable`'s only constructor is
+protected and takes a **loader**, not a `MetaTable`. BC builds the runtime object from bytes
+itself, through this chain (decompiled from `Microsoft.Dynamics.Nav.Ncl.dll`, 28.1):
+
+| step | what it adds |
+|---|---|
+| `NCLMetaApplicationObject.Populate()` | calls `LoadMetadata()`, then sets `metadataLoaded` |
+| `NCLMetaTable.LoadMetadata()` | `AssignFromMetaTable`, `metadataAppGroupMetaTable`, `InherentPermissionsAndEntitlements`, `RuntimeInfo` |
+| `NCLMetaTable.LoadTableMetadata()` | `GetStaticTableMetadata` for BC's built-in system tables, otherwise `ObjectLoader.MetaObjectCache.GetMetaTable(objectId, appGroup)` |
+| `MetaObjectCache.GetMetaTable` | `INCLObjectXmlMetadataLoader.GetMetaObjectXmlMetadata`, then `MetaTable.CreateMetaTableFromXml(document, appGroup.GroupId)` |
+
+The runner already implements that interface — `RunnerXmlMetadataLoader` — for reports, pages
+and xmlports. Answering `ObjectType.Table` out of `AlObjectMetadataRegistry` is the whole of
+what makes the chain reachable for a compiled table; BC does the construction.
+
+<a id="populate-is-a-no-op-here"></a>
+
+## `Populate()` is a Cecil no-op in this runner, so the entry point is `LoadMetadata()`
+
+`NclCecilRewrite.Runtime.cs` replaces `NCLMetaApplicationObject.Populate()` with a void `ret`,
+because it NREs on the hand-built skeleton metas the derivation produces. Calling it therefore
+builds an **empty** table in silence. Measured while implementing this: `TableName` `""`,
+`Fields` null, and the first record access NREs in `NCLMetaTable.get_PrimaryKey` — a failure
+several layers away from its cause.
+
+`LoadMetadata()` is what `Populate()` would have called and is not rewritten;
+`NCLMetaApplicationObject.LoadMetadata`, the base call it starts with, has an empty body, so
+entering one level down skips nothing. The runner sets `metadataLoaded` itself, which is the
+other thing `Populate()` did.
+
+<a id="reload-in-place"></a>
+
+## The cached instance is reloaded, not replaced
+
+`BuildNCLMetaTable` first runs during `AddSourceDir`, and `Emit` — which registers the
+documents — runs after it. So a compiled table's first build sees an empty registry and takes
+the derivation even though a document is about to exist.
+`RecordPatches.RebuildTablesFromBcMetadataAll`, called from `BcRuntime.SetTestAssembly`
+alongside the two wiring passes that exist for the same ordering reason, closes that gap.
+
+It reloads **the cached instance**: supply the loader (the derivation's instance has none —
+`CreateFromMetaTable` passes null), then call `LoadMetadata()` on it.
+
+### Once per table, per bundle
+
+`SetTestAssembly` runs **once per emitted assembly**, not once per run, so a sweep that reloads
+every eligible table on every call reloads each one as many times as the bundle has assemblies.
+That is not idempotent from BC's side: `AssignFromMetaTable` rebuilds the `NCLMetaField` array,
+and a data provider already open over the table then raises
+`NavObjectDefinitionChangedException` — *"the definition of the Descr field has changed; old
+type: Integer, new type: Text"*, naming a field of a different table entirely.
+
+Measured on `tests/runner-extras` before the ledger: table 60710 reloaded **eight** times, one
+suite lost to `EXEC-FAIL`, and a query test in an unrelated suite failing as collateral. It
+reproduced only on a warm shared cache root, and not cold, not on an isolated `--cache`, not
+across builds, and not for that suite run alone — so a fresh-cache run cannot see it and
+neither could CI.
+
+`_bcDocumentBackedTables` records the ids already carrying the document and the sweep skips
+them. Pinned by `EachTable_TakesBcsDocumentOnce_AcrossASiblingAppBundle`, over two sibling apps
+under one path — the smallest bundle that emits two assemblies, and the shape
+`tests/runner-extras` has. With the ledger removed that fixture loads its two tables 4 and 3
+times. It is cleared in `RecordPatches.ResetForReload` alongside `_metaTableCache`, because it
+names live instances that a `--watch` / `--server` cycle replaces.
+
+Evicting and rebuilding was tried first and produced three `tests/runner-extras` regressions
+against a clean `origin/main` baseline — a `[ConfirmHandler]` that stopped firing, a
+source-field `OnLookup` trigger that stopped being found, and a cross-app `OnAfterValidate`
+mutation that stopped propagating. Each was a consumer still holding the instance the table had
+been cached as. Preserving the identity and reassigning only the metadata is what BC's own
+`AssignFromMetaTable` does anyway.
+
+<a id="what-it-changes"></a>
+
+## What it changes, measured
+
+Both routes trace in the same run, so this is one measurement rather than two. Fixture
+`AlRunner.Tests/Fixtures/TableMetadataFromBcDocument`, BC 28.1:
+
+| field | declared | derived | from BC's document |
+|---|---|---|---|
+| 1 `Entry No.` | nothing | `editable=True dataClassification=CustomerContent enumTypeId=0` | same |
+| 2 `Description` | `Editable = false`, `EndUserIdentifiableInformation` | `editable=True dataClassification=CustomerContent` | `editable=False dataClassification=EndUserIdentifiableInformation` |
+| 3 `Kind` | `Enum "TMD Kind"`, `SystemMetadata` | `dataClassification=CustomerContent enumTypeId=0 enumTypeName=` | `dataClassification=SystemMetadata enumTypeId=70680 enumTypeName=TMD Kind` |
+
+AL-observable on the same shape: `FieldRef.Relation()` for `SystemCreatedBy` answered `0` and
+now answers `2000000120`. That claim is adjudicated by a real service tier in corpus PR #292,
+not here.
+
+Across the pinned corpus (`19560bd3`), 172 of its 178 own tables take the document route and
+the whole suite stays green. The six that do not are the scope boundary below.
+
+<a id="scope"></a>
+
+## What still takes the derivation, and why
+
+- **A base table a `tableextension` extends.** BC merges an extension through `NavAppGroup`'s
+  own extension registry, which the runner does not populate, so BC's document for the *base*
+  table alone would silently drop the extension's fields and keys. Those tables keep the
+  derivation until `TableExtension` is converted too (#3562). Measured: 6 of the corpus's 178.
+- **Every table with no captured document** — a precompiled dependency's (#3549), a virtual
+  system table, or a bundle served from an AL-output cache written before #3548. Availability
+  decides the route; a *failure* after that decision propagates rather than falling back, so a
+  document that cannot be loaded is loud (`.claude/rules/loud-failures.md`).
+
+<a id="reading-the-values-back"></a>
+
+## Seeing which route ran, and what it produced
+
+```
+AL_RUNNER_TRACE_TABLE_METADATA_SOURCE=1   # one line per built table: id, route
+AL_RUNNER_TRACE_TABLE_METADATA_SOURCE=2   # ...and one line per field
+```
+
+Level 2 prints `Editable`, `DataClassification`, `EnumTypeId` and `EnumTypeName`. All four live
+on `Types.Metadata.MetaField`, reachable only through the original `MetaTable` the
+`NCLMetaTable` was built from: `NCLMetaField` carries `DataClassification` but neither
+`Editable` nor the enum type, and no AL surface exposes any of them for a table field. So this
+trace is where those values are observable at all, which is why
+`AlRunner.Tests/TableMetadataFromBcDocumentTests.cs` asserts through it — the two routes
+produce the same *type*, so nothing downstream can be asked which one ran.

--- a/docs/object-metadata-from-bc.md
+++ b/docs/object-metadata-from-bc.md
@@ -101,21 +101,54 @@ AL-observable on the same shape: `FieldRef.Relation()` for `SystemCreatedBy` ans
 now answers `2000000120`. That claim is adjudicated by a real service tier in corpus PR #292,
 not here.
 
-Across the pinned corpus (`19560bd3`), 172 of its 178 own tables take the document route and
-the whole suite stays green. The six that do not are the scope boundary below.
+**Wherever a compile happened, the document wins — including a dependency's.**
+`AlObjectMetadataRegistry` is keyed `(kind, id)` with no notion of which app compiled the
+object, so a source-compiled dependency's table takes this route exactly like the app under
+test's. Measured on a dependency shipping source and no DLL: table 70670 reported
+`source=bc-document` with `editable=False`, `dataClassification=EndUserIdentifiableInformation`
+and `enumTypeId=70670` — cold, and again across the dependency's own `source-cache HIT`, which
+is the separate replay path (`DependencyLoader`'s `.object-metadata.json` sidecar) that could
+have failed on its own. On the pinned corpus, three of the 175 tables taking the route are
+outside the corpus app's own id range for the same reason.
+
+What is still out of reach is a dependency shipped as a **precompiled `.app`**: it never
+compiles here, so no document exists for it at all. That is #3549.
+
+Across the pinned corpus (`19560bd3`), 172 of the corpus app's own 178 tables take the document
+route and the whole suite stays green. The six that do not are the scope boundary below.
 
 <a id="scope"></a>
 
 ## What still takes the derivation, and why
 
-- **A base table a `tableextension` extends.** BC merges an extension through `NavAppGroup`'s
-  own extension registry, which the runner does not populate, so BC's document for the *base*
-  table alone would silently drop the extension's fields and keys. Those tables keep the
-  derivation until `TableExtension` is converted too (#3562). Measured: 6 of the corpus's 178.
+- **A base table any `tableextension` extends.** BC's document for a table is what **one**
+  app's compiler emitted. An extension in another app contributes fields *and keys* that the
+  service tier merges at publish time through `NavAppGroup`'s extension registry, which the
+  runner does not populate — build-time state versus runtime-merged state, and no per-app
+  document can express the second. The derivation does merge it, so an extended base table
+  keeps the derivation until `TableExtension` is converted too (#3562). Measured: 6 of the
+  corpus's 178.
+
+  **The gate is `_extensionIdsByBaseTable`, never the merged field count.** Fields and keys
+  reach `MergeExtensionFields` through separate channels (#3216), and a key-only — or
+  `modify(...)`-only — extension contributes no fields, so a count-based guard passes on it.
+  Measured on a cross-app key-only extension over a source-compiled dependency's table:
+  `RecordRef.KeyCount()` answered **3 where the derivation answers 4**, exit 0, no diagnostic,
+  the extension's key simply gone. Nothing existing could have caught it — at corpus pin
+  `19560bd3` all eight `tableextension` declarations add fields, so neither the corpus nor a
+  same-app fixture reaches the branch. Pinned by
+  `BaseTableWithAKeyOnlyExtensionInAnotherApp_KeepsTheDerivation`.
 - **Every table with no captured document** — a precompiled dependency's (#3549), a virtual
-  system table, or a bundle served from an AL-output cache written before #3548. Availability
-  decides the route; a *failure* after that decision propagates rather than falling back, so a
-  document that cannot be loaded is loud (`.claude/rules/loud-failures.md`).
+  system table, or a bundle served from an AL-output cache written before #3548.
+
+Availability decides the route, and a failure is never re-routed to the derivation: a weaker
+answer substituted on error is what `.claude/rules/loud-failures.md` exists to prevent. **How
+far that failure travels differs by call site, and only one of the two is loud.** The post-emit
+sweep has no handler over it and aborts bundle load naming the member. The cold build sits
+inside `BuildNCLMetaTable`'s pre-existing `catch → Console.Error → return null`, which swallows
+it into "no metatable" exactly as it does a derivation failure — and that write is
+`[RecordPatches]`-tagged, so the default log filter drops it. That swallow predates this work
+and is tracked as **#3590**; it is not a claim this page makes about the cold path.
 
 <a id="reading-the-values-back"></a>
 


### PR DESCRIPTION
Closes #3552

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/292

Opened by an agent (Claude, impl-1). First conversion of the chain **#3562** tracks — tables
only, and a proof of concept rather than the finish line.

A table the runner **compiles** now gets its `NCLMetaTable` built by BC from the metadata
document BC's own emitter produced for it (#3548), instead of from the runner's AL-source
derivation. **Nothing is deleted** — retiring the derivation is step 4, per kind, with its own
proof.

## The seam is the loader, not `CreateMetaTableFromXml`

`Types.Metadata.MetaTable` and `Runtime.NCLMetaTable` are different types in different
assemblies with no conversion between them; `NCLMetaTable`'s only constructor is protected and
takes a **loader**. BC builds the runtime object itself:

`Populate()` → `LoadMetadata()` → `LoadTableMetadata()` →
`ObjectLoader.MetaObjectCache.GetMetaTable` → `INCLObjectXmlMetadataLoader.GetMetaObjectXmlMetadata`
→ `MetaTable.CreateMetaTableFromXml(document, appGroup.GroupId)`.

`RunnerXmlMetadataLoader` already implements that interface for reports, pages and xmlports.
Answering `ObjectType.Table` out of `AlObjectMetadataRegistry` is the whole of what makes the
chain reachable. Three things only running it could find, all in
`docs/object-metadata-from-bc.md` and cited rather than copied into the code:

1. **`Populate()` is a Cecil no-op here** (`NclCecilRewrite.Runtime.cs`). Calling it builds an
   **empty** table in silence — `TableName ""`, `Fields` null, NRE later in `get_PrimaryKey`.
   `LoadMetadata()` is the working entry point.
2. **The cached instance is reloaded, not replaced.** Evicting cost three `runner-extras`
   regressions against a clean baseline, each a consumer still holding the old instance.
3. **Once per table, per run.** `SetTestAssembly` runs once per emitted *assembly*; without a
   ledger every table reloads once per assembly, and `AssignFromMetaTable` then makes an open
   data provider raise `NavObjectDefinitionChangedException`. Table 60710 reloaded eight times
   and lost a whole suite. Reproduced only on a warm shared cache root — not cold, not
   isolated, not cross-build, not `--no-cache`.

## Coverage: wherever a compile happened, the document wins

`AlObjectMetadataRegistry` is keyed `(kind, id)` with no notion of which app compiled the
object, so **a source-compiled dependency's tables take this route too** — an earlier draft of
this body said "172 of the corpus's 178 own tables" and understated it. Verified on a
dependency shipping source and no DLL: table 70670 reports `source=bc-document` with
`editable=False`, `dataClassification=EndUserIdentifiableInformation`, `enumTypeId=70670` —
cold, and again across the dependency's own `source-cache HIT`, which is a separate replay path
(`DependencyLoader`'s `.object-metadata.json` sidecar). Three of the 175 tables taking the route
on the corpus are outside the corpus app's own id range for the same reason.

Still out of reach: a dependency shipped as a **precompiled `.app`**, which never compiles here
and has no document at all. That is #3549.

## What actually moved, measured

Both routes trace in the same run, so this is one measurement rather than a before/after pair.
Fixture `AlRunner.Tests/Fixtures/TableMetadataFromBcDocument`, BC 28.1:

| field | declared | derived | from BC's document |
|---|---|---|---|
| 1 `Entry No.` | nothing | `editable=True dataClassification=CustomerContent enumTypeId=0` | same |
| 2 `Description` | `Editable = false`, `EndUserIdentifiableInformation` | `editable=True dataClassification=CustomerContent` | `editable=False dataClassification=EndUserIdentifiableInformation` |
| 3 `Kind` | `Enum "TMD Kind"`, `SystemMetadata` | `dataClassification=CustomerContent enumTypeId=0 enumTypeName=` | `dataClassification=SystemMetadata enumTypeId=70680 enumTypeName=TMD Kind` |

AL-observable, adjudicated on a real service tier by corpus #292: `FieldRef.Relation()` for
`SystemCreatedBy` **0 → 2000000120**, and per-field `DataClassification` **table default → each
field's own**. Two of #292's seven went FAIL → PASS.

**The key count did not move**, and the issue predicted it would — that `2 vs 3` was measured
with the subject app as a *dependency*, which is #3549. Corpus #292 pins the secondary key by
the field number it starts on instead.

## The extension gate is `_extensionIdsByBaseTable`, not a field count

From review, and it was a **silent behaviour regression**: fields and keys reach
`MergeExtensionFields` through separate channels (#3216), so a key-only — or `modify(...)`-only
— tableextension leaves `_parsedExtensionFields` empty and a count-based guard passes on it.
BC's per-app document cannot carry a key another app contributed, so it vanished. Reproduced
here on a cross-app key-only extension over a source-compiled dependency's table:

| | field-count gate | index gate |
|---|---|---|
| `RecordRef.KeyCount()` | **3** | 4 |
| route taken | `bc-document` | `derived` |

Exit 0, no diagnostic, either way. Nothing existing reaches it: at both pins every corpus
`tableextension` adds fields. Now pinned by
`BaseTableWithAKeyOnlyExtensionInAnotherApp_KeepsTheDerivation`, which RED-checks at
*"KeyCount=3, expected 4"*.

The guard says in one place why it is a **build-time versus runtime-merged** distinction rather
than a fields question, so it does not get re-narrowed.

## Correction: "a failure propagates" was too strong

A failure is never *re-routed* to the derivation — that part holds. But only the post-emit
sweep is loud; the cold build sits inside `BuildNCLMetaTable`'s pre-existing
`catch → Console.Error → return null`, whose write is `[RecordPatches]`-tagged and dropped by
the default log filter. Both comments and the doc now say which site is which. The swallow
predates this change and is filed as **#3590**.

## Tests

`AlRunner.Tests/TableMetadataFromBcDocumentTests.cs`, five:

- `CompiledTable_IsBuiltFromBcsMetadataDocument_ColdAndOnAWarmCacheHit` — the four values as
  concrete values, cold and on a cache HIT, with field 1 as the control declaring none of them.
- `SourceCompiledDependencyTable_TakesBcsDocument_AcrossItsOwnCacheHit` — the dependency claim
  above, including the dependency sidecar replay, which could fail on its own.
- `BaseTableWithAKeyOnlyExtensionInAnotherApp_KeepsTheDerivation` — the regression this review
  caught.
- `EachTable_TakesBcsDocumentOnce_AcrossASiblingAppBundle` — RED without the ledger: *"saw 4."*
- `TableWithNoCapturedDocument_KeepsTheDerivation` — the Field virtual table (2000000041).

`Editable` and the enum type are asserted here rather than upstream because no AL surface
exposes either for a table field; `AL_RUNNER_TRACE_TABLE_METADATA_SOURCE=2` is where they are
observable at all, the same shape `ObjectMetadataCaptureTests` uses for #3548.

## The pin is NOT bumped here, and what holds the remainder

Corpus #292 merged as `3ad4c340`. It is **not** pinned in this PR: `main` is pinned at
`23a9e869` (#290), and a pin cannot name a commit without its predecessors, so folding #292
would drag in two corpus commits that have nothing to do with this change. Measured at
`3ad4c340` against this head, so the state is known rather than assumed:

| corpus commit | | at this head |
|---|---|---|
| `c9d5f65` #291 | AllObjWithCaption's Object Subtype for the *extension kinds | **green** — all 20 of `Codeunit60802` pass; PR #3563 fixed it and merged before this branch's base |
| `26b0434` #293 | report / xmlport import / page field validate under `TransactionModel::None` | **3 of 4** — Test11, Test13a and Test13 pass; `Test12_AnXmlPortImportMayWriteUnderNone` fails |
| `3ad4c34` #292 | this PR's own seven | **7 of 7** |

The one red test is **#3580** — filed before this PR, open, `runner-gap`, not mine: under
`TransactionModel::None` real BC lets an `XmlPort.Import` write and the runner refuses. It
could be absorbed with an `expect-fail-known-gap` entry, and this repo has precedent for
exactly that on a pin bump, but that would put someone else's gap classification inside a PR
that did not produce it — so the bump lands later as a catch-up instead, once #3580 is fixed or
someone decides to classify it. **The corpus PR is the proof and it has merged**; the pin only
decides when this repository replays it.

Measured either way, so the choice costs nothing to reverse: at `3ad4c340` with a known-gap
entry for that one method the suite is 3123/3123 with `--strict --count-baseline` (baseline
3107 → 3123), and at the current pin `23a9e869` it is 3107/3107, exit 0. Note **#3588** is
another loop's catch-up bump to `c9d5f656`; a later bump from here must be strictly ahead of
whatever lands first.

## Run locally

| | result |
|---|---|
| corpus at the pinned commit `23a9e869`, `--strict --count-baseline` | 3107/3107, exit 0 |
| corpus at `3ad4c340` (this PR's own seven included, not pinned) | 3123/3123 with one known-gap entry for #3580 |
| `tests/runner-extras` | 407/407 — shared cache root, cold, warm and cross-build |
| `AlRunner.Tests` filtered — `TableMetadataFromBcDocument`, `ObjectMetadataCapture`, `Tdd`, `ServerMode`, `Watch` | 75/75 |

One unrelated failure in an earlier wider filtered run is **not** from this change:
`TestPageTemporalValueTests.TryResolve_RoundTripSpelling_ForADateTimeControl_KeepsTheTimeOfDay`
fails on `origin/main` too, on any non-UTC box once `tools/engine-test-bootstrap.sh` has run.
Filed as **#3567**.

## Queue scan — nothing folded, and why

Every open issue in this area is a different **kind** (which #3562 owns and the brief says not
to widen into) or a different **code path**: **#3549** dependencies-as-precompiled-apps,
**#3545** / **#3533** the `SymbolReference` reader (#3533 claimed by another agent), the
`blocked-by: metadata-emitter` cluster (**#3546**, **#3228**, **#2417**, **#3499**, **#3502**,
**#3367**, **#3503**, **#2279**, **#2267**, **#2789**), and **#3556**, which touches the same
file but is about `Is<Trigger>Defined` for a table with a `tableextension` — the case this
change excludes.

https://claude.ai/code/session_01F7HLDeNwiGQoLT5wFanqmH
