### PR TITLE
docs(rules): add GitHub's owner/repo#N shorthand to the rejected Corpus-PR forms

### DIFF
--- a/.claude/rules/bc-behavior-tests-go-upstream.md
+++ b/.claude/rules/bc-behavior-tests-go-upstream.md
@@ -80,6 +80,7 @@ one day (#3330), each pinned in `test_check_corpus_linkage.sh`:
 | `Corpus-PR:` on one line, the URL on the next | the marker and the URL must share a line — a brief saying "a bare full URL on its own line" produces this |
 | `**Corpus-PR:** https://…/pull/226` | bold markers break the marker |
 | `Corpus-PR: <https://…/pull/226>` | angle-bracket autolinks break the URL |
+| `Corpus-PR: StefanMaron/BusinessCentral.AL.Language.Tests#293` | GitHub's own cross-repo shorthand renders as a link and reads correctly, but it is not a URL |
 
 A `Corpus-PR:` line that fails the regex is reported as *malformed*, not absent, so the log
 says which of the two you have. Check before pushing — the script takes the body and the

--- a/.github/scripts/test_check_corpus_linkage.sh
+++ b/.github/scripts/test_check_corpus_linkage.sh
@@ -201,6 +201,11 @@ assert_exit "a bold marker is not the marker" 1 \
 assert_exit "an autolink in angle brackets does not count" 1 \
   "AlRunner/Patches/MockTestPage.cs" \
   "Corpus-PR: <$CORPUS_URL>"
+# GitHub's own cross-repo shorthand renders as a working link and reads correctly to a
+# human, which is what makes it the shape an agent reaches for -- it went red on PR #3582.
+assert_exit "GitHub's owner/repo#N shorthand is not a URL" 1 \
+  "AlRunner/Patches/MockTestPage.cs" \
+  "Corpus-PR: StefanMaron/BusinessCentral.AL.Language.Tests#293"
 
 # --- Extraction mode, used by the advisory half in pr-check.yml --------------
 # The parsing lives here, under test; only the gh call that resolves the URL is


### PR DESCRIPTION
No linked issue: a rules correction, found by hitting it. The `Corpus-PR:` rejected-forms table did not list the shape an agent actually reaches for.

## The shape

PR #3582 wrote its trailer as GitHub's own cross-repo reference:

```
Corpus-PR: StefanMaron/BusinessCentral.AL.Language.Tests#293
```

That **renders as a working link**, reads correctly to a human, and names the right PR. The checker rejects it, because the regex requires a full `https://…/pull/<N>` URL — so the PR went red on an advisory check while being substantively correct.

That combination is what makes it worth listing. The five shapes already in the table look wrong on the page — a markdown link, bold markers, angle brackets, a bare `#226`, the marker and URL on separate lines. This one looks right.

## Why the rule was not at fault

`bc-behavior-tests-go-upstream.md` is thorough here: it states the regex in prose, lists five rejected shapes, and says each is pinned in `test_check_corpus_linkage.sh`. Nothing was wrong or missing.

It was a list built from incidents, which is exactly its limit — it covers what someone had already tried. This adds the sixth, from the sixth incident.

## Pinned, and mutation-checked

Added to the test alongside the others, as the rule promises:

```bash
assert_exit "GitHub's owner/repo#N shorthand is not a URL" 1 \
  "AlRunner/Patches/MockTestPage.cs" \
  "Corpus-PR: StefanMaron/BusinessCentral.AL.Language.Tests#293"
```

Verified it tests something rather than passing vacuously — widening `CORPUS_REPO_URL` to also accept the shorthand takes the suite from **70 pass** to **69 pass / 1 fail**, and the failure is this assertion. Restored, suite green.

## Verification

```
.github/scripts/test_check_corpus_linkage.sh   passed: 70, failed: 0
tools/test_doc_pointers.py                     all checks passed
```

---
*Filed by the `stma-auto-3` autonomous coordinator, an automated agent acting on the account holder's behalf, after this trailer cost a red tick on an otherwise-green PR for the second time.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsJY7DhDm5y83e77GxpRSZ
