### PR TITLE
fix(tools): decode subprocess text as UTF-8, not the locale codec

### DIFF
--- a/tools/agent_self_freshness.py
+++ b/tools/agent_self_freshness.py
@@ -172,7 +172,10 @@ def make_runner(fn):
 
 def _default_runner(args: list[str], timeout: int | None = None):
     try:
-        p = subprocess.run(args, capture_output=True, text=True, timeout=timeout)
+        # UTF-8, never the locale codec (#3434): a commit subject or a path with a
+        # non-ASCII character would otherwise decode wrong, or raise, on Windows.
+        p = subprocess.run(args, capture_output=True, text=True, timeout=timeout,
+                           encoding="utf-8", errors="replace")
     except (OSError, subprocess.TimeoutExpired) as exc:
         return 128, "", str(exc)
     return p.returncode, p.stdout or "", p.stderr or ""

--- a/tools/ci-wait.py
+++ b/tools/ci-wait.py
@@ -165,7 +165,12 @@ def gh(args: list[str], attempts: int = 4) -> tuple[int, str]:
     """Run gh, retrying transient network failures. Returns (rc, stdout)."""
     last = ""
     for i in range(attempts):
-        p = subprocess.run(["gh", *args], capture_output=True, text=True)
+        # UTF-8, never the locale codec: a CI log or a JSON body decoded as
+        # cp1252 on Windows either mangles text or raises on an undefined byte,
+        # and a mangled log reads as "no matches" (#3434). errors="replace"
+        # because reading a verdict must not fail on one odd byte.
+        p = subprocess.run(["gh", *args], capture_output=True, text=True,
+                           encoding="utf-8", errors="replace")
         out = (p.stdout or "") + (p.stderr or "")
         # mise prints a banner on stdout; drop it so JSON parses.
         out = "\n".join(l for l in out.split("\n") if not l.startswith("mise "))

--- a/tools/context-pack.py
+++ b/tools/context-pack.py
@@ -46,6 +46,9 @@ def run_lsp(mode: str, symbol: str, timeout: int) -> tuple[int, str]:
         p = subprocess.run(
             [sys.executable, LSP_QUERY, mode, symbol],
             cwd=REPO, capture_output=True, text=True, timeout=timeout,
+            # UTF-8, never the locale codec (#3434): source excerpts carry
+            # non-ASCII characters, and cp1252 mangles or raises on them.
+            encoding="utf-8", errors="replace",
         )
     except subprocess.TimeoutExpired:
         return 2, f"(timed out after {timeout}s)"

--- a/tools/corpus-pass-count.py
+++ b/tools/corpus-pass-count.py
@@ -77,7 +77,12 @@ def gh(args: list[str], attempts: int = 4) -> tuple[int, str]:
     """Run gh, retrying transient network failures. Returns (rc, stdout)."""
     last = ""
     for i in range(attempts):
-        p = subprocess.run(["gh", *args], capture_output=True, text=True)
+        # UTF-8, never the locale codec: a CI log or a JSON body decoded as
+        # cp1252 on Windows either mangles text or raises on an undefined byte,
+        # and a mangled log reads as "no matches" (#3434). errors="replace"
+        # because reading a verdict must not fail on one odd byte.
+        p = subprocess.run(["gh", *args], capture_output=True, text=True,
+                           encoding="utf-8", errors="replace")
         out = (p.stdout or "") + (p.stderr or "")
         # mise prints a banner on stdout; drop it so JSON parses.
         out = "\n".join(l for l in out.split("\n") if not l.startswith("mise "))

--- a/tools/corpus-pin-advance.py
+++ b/tools/corpus-pin-advance.py
@@ -111,7 +111,9 @@ class MeasurementError(Exception):
 
 
 def git(corpus: str, *args: str, check: bool = True) -> str:
-    p = subprocess.run(["git", "-C", corpus, *args], capture_output=True, text=True)
+    # UTF-8, never the locale codec (#3434): git writes commit subjects as UTF-8.
+    p = subprocess.run(["git", "-C", corpus, *args], capture_output=True, text=True,
+                       encoding="utf-8", errors="replace")
     if check and p.returncode != 0:
         raise MeasurementError(
             f"git {' '.join(args)} failed in {corpus} (exit {p.returncode}): "

--- a/tools/corpus-pin.py
+++ b/tools/corpus-pin.py
@@ -107,7 +107,9 @@ class PinError(Exception):
 
 
 def _default_runner(args: list[str], cwd: str | None = None):
-    return subprocess.run(args, cwd=cwd, capture_output=True, text=True)
+    # UTF-8, never the locale codec (#3434): git writes commit subjects as UTF-8.
+    return subprocess.run(args, cwd=cwd, capture_output=True, text=True,
+                          encoding="utf-8", errors="replace")
 
 
 def git(runner, root: str | None, *args: str) -> tuple[int, str]:

--- a/tools/pr-body.py
+++ b/tools/pr-body.py
@@ -249,7 +249,11 @@ def gh(args: list[str], attempts: int = 4, sleep: Callable[[float], None] | None
     sleep = sleep or time.sleep
     last = ""
     for i in range(attempts):
-        p = subprocess.run(["gh", *args], capture_output=True, text=True)
+        # UTF-8 explicitly, never the locale codec: GitHub bodies are UTF-8, and
+        # under cp1252 an em dash comes back as three characters, so an anchor
+        # copied verbatim out of the body matches 0 times (#3434).
+        p = subprocess.run(["gh", *args], capture_output=True, text=True,
+                           encoding="utf-8", errors="strict")
         out = (p.stdout or "") + (p.stderr or "")
         # mise prints a banner on stdout; drop it so JSON parses.
         out = "\n".join(l for l in out.split("\n") if not l.startswith("mise "))
@@ -258,6 +262,17 @@ def gh(args: list[str], attempts: int = 4, sleep: Callable[[float], None] | None
         last = out
         sleep(3 * (i + 1))
     return 1, last.strip()
+
+
+def write_body_tempfile(text: str) -> str:
+    """Write `text` to a temp file for `gh --body-file`, and return its path."""
+    fd, path = tempfile.mkstemp(prefix="pr-body-", suffix=".md")
+    # `gh --body-file` reads UTF-8; encoding it as cp1252 would put bytes in the
+    # file that are not valid UTF-8, and re-reading through the same wrong codec
+    # would still compare equal, so the verify step could not see it (#3434).
+    with os.fdopen(fd, "w", encoding="utf-8", errors="strict") as f:
+        f.write(text + "\n")
+    return path
 
 
 class FetchError(Exception):
@@ -592,14 +607,14 @@ def collect_edits(args) -> list[Edit]:
 
 def build_new_body(orig: str, args, edits: list[Edit]) -> tuple[str, list[Result]]:
     if args.body_file:
-        with open(args.body_file) as f:
+        with open(args.body_file, encoding="utf-8", errors="strict") as f:
             return norm(f.read()), [Result("whole-body replacement", True, args.body_file)]
     new, results = apply_edits(orig, edits)
     tail = ""
     if args.append:
         tail += args.append
     if args.append_file:
-        with open(args.append_file) as f:
+        with open(args.append_file, encoding="utf-8", errors="strict") as f:
             tail += f.read()
     if tail:
         new = norm(new + "\n\n" + norm(tail))
@@ -738,10 +753,8 @@ def main(argv: list[str] | None = None) -> int:
     print(d)
 
     def writer(text: str) -> tuple[int, str]:
-        fd, path = tempfile.mkstemp(prefix="pr-body-", suffix=".md")
+        path = write_body_tempfile(text)
         try:
-            with os.fdopen(fd, "w") as f:
-                f.write(text + "\n")
             return gh(["pr", "edit", args.pr, "--repo", args.repo, "--body-file", path])
         finally:
             os.unlink(path)

--- a/tools/test_pr_body.py
+++ b/tools/test_pr_body.py
@@ -734,7 +734,7 @@ if enc.lower().replace("-", "") in ("utf8", "cp65001"):
     print(json.dumps({"skipped": enc})); raise SystemExit(0)
 spec = importlib.util.spec_from_file_location("pr_body", sys.argv[1])
 pb = importlib.util.module_from_spec(spec); spec.loader.exec_module(pb)
-payload = json.dumps({"body": "an em dash — here"}, ensure_ascii=False).encode("utf-8")
+payload = json.dumps({"body": "an em dash \u2014 here"}, ensure_ascii=False).encode("utf-8")
 real = subprocess.run
 pb.subprocess.run = lambda args, **kw: real(
     [sys.executable, "-c", "import sys;sys.stdout.buffer.write(%r)" % payload], **kw)
@@ -744,12 +744,16 @@ try:
 except Exception as e:
     out["read"] = "raised: %s" % type(e).__name__
 try:
-    p = pb.write_body_tempfile("an em dash — here")
+    p = pb.write_body_tempfile("an em dash \u2014 here")
     out["written"] = open(p, "rb").read().decode("utf-8", "replace"); os.unlink(p)
 except Exception as e:
     out["written"] = "raised: %s" % type(e).__name__
 sys.stdout.buffer.write(json.dumps(out).encode("utf-8"))
 '''
+# argv is decoded with the filesystem encoding, which under LC_ALL=C on Linux is
+# ASCII: a literal em dash here would reach the child as surrogates and raise
+# before it could report anything. The escape survives as source text instead.
+assert CHILD.isascii(), "CHILD must survive an ASCII argv"
 env = dict(os.environ, PYTHONUTF8="0", PYTHONCOERCECLOCALE="0", LC_ALL="C", LANG="C")
 env.pop("PYTHONIOENCODING", None)
 child = subprocess.run([sys.executable, "-c", CHILD, os.path.join(HERE, "pr-body.py")],

--- a/tools/test_pr_body.py
+++ b/tools/test_pr_body.py
@@ -666,7 +666,20 @@ def record_kwargs(store, real):
 
 
 calls: list[dict] = []
-_real_run, pb.subprocess.run = pb.subprocess.run, record_kwargs(calls, pb.subprocess.run)
+
+
+class _Done:
+    """What gh() reads off subprocess.run; no `gh` binary need exist."""
+
+    returncode, stdout, stderr = 0, "{}", ""
+
+
+def _spy(*a, **kw):
+    calls.append(kw)
+    return _Done()
+
+
+_real_run, pb.subprocess.run = pb.subprocess.run, _spy
 try:
     pb.gh(["--version"], attempts=1, sleep=lambda s: None)
 finally:

--- a/tools/test_pr_body.py
+++ b/tools/test_pr_body.py
@@ -452,7 +452,9 @@ class FakeGh:
         if args[:2] == ["pr", "edit"]:
             self.edits += 1
             path = args[args.index("--body-file") + 1]
-            with open(path) as f:
+            # UTF-8, because the real `gh` reads a --body-file as UTF-8; reading it
+            # with the locale codec would make this fake agree with a broken write.
+            with open(path, encoding="utf-8") as f:
                 text = f.read()
             if self.edit_lands:
                 self.body = pb.norm(text)
@@ -539,7 +541,9 @@ check("a write that reported failure but landed exits 0", rc == pb.EXIT_OK, f"rc
 # write goes through, which is the class of silent no-op this tool exists to
 # stop.
 _fd, _bodyfile = tempfile.mkstemp(prefix="pr-body-test-", suffix=".md")
-with os.fdopen(_fd, "w") as _f:
+# UTF-8, matching what the tool now reads and what any file an agent hands it
+# actually is; the payload below carries a non-ASCII character.
+with os.fdopen(_fd, "w", encoding="utf-8") as _f:
     _f.write(GOOD_BODY.replace("corpus 2500/2500", "corpus 2501/2501"))
 try:
     f = FakeGh()
@@ -627,6 +631,131 @@ else:
                       f"declared target(s): {' '.join(str(n) for n in declared)}" in p.stdout
                       or all(str(n) in p.stdout for n in declared),
                       p.stdout.strip()[:160])
+
+# --------------------------------------------------------------------------
+print("\ntext is UTF-8, never the locale codec (#3434)")
+# --------------------------------------------------------------------------
+# GitHub bodies are UTF-8 by definition. Every decode and encode in pr-body.py
+# must say so: on Windows the locale codec is cp1252, so an em dash read back
+# from `gh` becomes three mojibake characters and an anchor copied verbatim out
+# of the body matches 0 times, while the write path re-encodes it to a byte
+# `gh --body-file` cannot read as UTF-8. The verify-by-re-reading guard cannot
+# see that, because both sides decode wrong identically.
+#
+# The kwargs checks below are the ones that hold on any machine; the behavioural
+# checks under them only distinguish fixed from broken where the ambient codec
+# is not already UTF-8, which is why the child-interpreter run at the end forces
+# one that is not.
+
+EM = "an em dash — here"
+
+class _Args:
+    """The three attributes build_new_body reads off argparse's namespace."""
+
+    def __init__(self, body_file=None, append=None, append_file=None):
+        self.body_file, self.append, self.append_file = body_file, append, append_file
+
+
+
+
+def record_kwargs(store, real):
+    def spy(*a, **kw):
+        store.append(kw)
+        return real(*a, **kw)
+    return spy
+
+
+calls: list[dict] = []
+_real_run, pb.subprocess.run = pb.subprocess.run, record_kwargs(calls, pb.subprocess.run)
+try:
+    pb.gh(["--version"], attempts=1, sleep=lambda s: None)
+finally:
+    pb.subprocess.run = _real_run
+check("gh() decodes stdout as UTF-8",
+      bool(calls) and calls[0].get("encoding") == "utf-8", str(calls[:1]))
+check("gh() decodes strictly, so a bad byte is loud",
+      bool(calls) and calls[0].get("errors") == "strict", str(calls[:1]))
+
+fd_calls: list[dict] = []
+_real_fdopen, pb.os.fdopen = pb.os.fdopen, record_kwargs(fd_calls, pb.os.fdopen)
+try:
+    tmp = pb.write_body_tempfile(EM)
+finally:
+    pb.os.fdopen = _real_fdopen
+try:
+    written = open(tmp, "rb").read()
+finally:
+    os.unlink(tmp)
+check("write_body_tempfile encodes as UTF-8",
+      bool(fd_calls) and fd_calls[0].get("encoding") == "utf-8", str(fd_calls[:1]))
+check("write_body_tempfile writes UTF-8 bytes",
+      b"\xe2\x80\x94" in written and b"\x97" not in written, ascii(written))
+
+open_calls: list[dict] = []
+_real_open, pb.open = open, record_kwargs(open_calls, open)
+bf = os.path.join(tempfile.mkdtemp(), "body.md")
+with open(bf, "wb") as f:
+    f.write((EM + "\n").encode("utf-8"))
+try:
+    body, _ = pb.build_new_body("", _Args(body_file=bf), [])
+    open_calls_body = list(open_calls)
+    open_calls.clear()
+    appended, _ = pb.build_new_body("orig", _Args(append_file=bf), [])
+finally:
+    del pb.open
+check("--body-file is read as UTF-8",
+      bool(open_calls_body) and open_calls_body[0].get("encoding") == "utf-8",
+      str(open_calls_body[:1]))
+check("--append-file is read as UTF-8",
+      bool(open_calls) and open_calls[0].get("encoding") == "utf-8", str(open_calls[:1]))
+check("--body-file keeps the em dash", "—" in body, ascii(body))
+check("--append-file keeps the em dash", "—" in appended, ascii(appended))
+
+# The behavioural half, under a codec that is not UTF-8. A child interpreter is
+# the only portable lever: PYTHONIOENCODING reaches only sys.std*, and from
+# 3.11 the TextIOWrapper default is resolved in C, out of reach of a monkeypatch.
+CHILD = r'''
+import importlib.util, json, locale, os, subprocess, sys, tempfile
+enc = locale.getpreferredencoding(False)
+if enc.lower().replace("-", "") in ("utf8", "cp65001"):
+    print(json.dumps({"skipped": enc})); raise SystemExit(0)
+spec = importlib.util.spec_from_file_location("pr_body", sys.argv[1])
+pb = importlib.util.module_from_spec(spec); spec.loader.exec_module(pb)
+payload = json.dumps({"body": "an em dash — here"}, ensure_ascii=False).encode("utf-8")
+real = subprocess.run
+pb.subprocess.run = lambda args, **kw: real(
+    [sys.executable, "-c", "import sys;sys.stdout.buffer.write(%r)" % payload], **kw)
+out = {"encoding": enc}
+try:
+    out["read"] = pb.parse_body_json(*pb.gh(["pr", "view", "1", "--json", "body"]))
+except Exception as e:
+    out["read"] = "raised: %s" % type(e).__name__
+try:
+    p = pb.write_body_tempfile("an em dash — here")
+    out["written"] = open(p, "rb").read().decode("utf-8", "replace"); os.unlink(p)
+except Exception as e:
+    out["written"] = "raised: %s" % type(e).__name__
+sys.stdout.buffer.write(json.dumps(out).encode("utf-8"))
+'''
+env = dict(os.environ, PYTHONUTF8="0", PYTHONCOERCECLOCALE="0", LC_ALL="C", LANG="C")
+env.pop("PYTHONIOENCODING", None)
+child = subprocess.run([sys.executable, "-c", CHILD, os.path.join(HERE, "pr-body.py")],
+                       capture_output=True, env=env)
+try:
+    verdict = json.loads(child.stdout.decode("utf-8"))
+except Exception:
+    verdict = None
+if verdict is None:
+    check("non-UTF-8 locale: child ran", False,
+          ascii(child.stdout[-300:]) + ascii(child.stderr[-300:]))
+elif "skipped" in verdict:
+    print("  SKIP non-UTF-8 locale: this box gives %s even under LC_ALL=C "
+          "(NOT a pass -- the kwargs checks above are what gate here)" % verdict["skipped"])
+else:
+    check("non-UTF-8 locale (%s): gh output keeps the em dash" % verdict["encoding"],
+          verdict["read"] == EM, ascii(verdict["read"]))
+    check("non-UTF-8 locale (%s): the body file keeps the em dash" % verdict["encoding"],
+          verdict["written"].strip() == EM, ascii(verdict["written"]))
 
 print()
 if FAILURES:

--- a/tools/test_text_encoding.py
+++ b/tools/test_text_encoding.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Every subprocess text decode under tools/ names UTF-8 explicitly (#3434).
+
+`text=True` with no `encoding=` decodes with the locale codec. On Windows that
+is cp1252, so `gh`'s JSON and a BC CI log come back mangled -- a `pr-body.py`
+anchor carrying an em dash then matches 0 times, and a log grep reads as "no
+matches". The behavioural proof lives in test_pr_body.py; this is the shape
+guard, so the next tool added here cannot reintroduce it silently.
+
+Run: python3 tools/test_text_encoding.py [dir]
+"""
+from __future__ import annotations
+
+import ast
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = sys.argv[1] if len(sys.argv) > 1 else HERE
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        FAILURES.append(name)
+
+
+def text_mode(call: ast.Call) -> bool:
+    for kw in call.keywords:
+        if kw.arg in ("text", "universal_newlines"):
+            return not (isinstance(kw.value, ast.Constant) and kw.value.value is False)
+    return False
+
+
+def named(call: ast.Call) -> str:
+    f = call.func
+    return f"{getattr(f.value, 'id', '?')}.{f.attr}" if isinstance(f, ast.Attribute) else "?"
+
+
+print("subprocess text decodes under tools/ are UTF-8, not the locale codec")
+scanned = 0
+for fn in sorted(os.listdir(ROOT)):
+    # Test files drive real shell scripts whose output is ASCII by construction;
+    # the rule here is about the tools an agent's verdict depends on.
+    if not fn.endswith(".py") or fn.startswith("test_"):
+        continue
+    path = os.path.join(ROOT, fn)
+    with open(path, encoding="utf-8") as fh:
+        tree = ast.parse(fh.read(), filename=path)
+    scanned += 1
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or named(node) not in (
+                "subprocess.run", "subprocess.Popen", "subprocess.check_output"):
+            continue
+        if not text_mode(node):
+            continue
+        kwargs = {kw.arg for kw in node.keywords}
+        check(f"{fn}:{node.lineno} {named(node)} names an encoding",
+              "encoding" in kwargs, sorted(k for k in kwargs if k))
+
+check("something was scanned", scanned >= 5, f"{scanned} file(s)")
+
+print()
+if FAILURES:
+    print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")
+    sys.exit(1)
+print("all checks passed")


### PR DESCRIPTION
Closes #3434

`tools/pr-body.py` ran `gh` with `text=True` and no `encoding=`, so on Windows every
decode and encode used the locale codec (cp1252). Filed by `fbk-2` after hitting it on
PR #3381; agents have been working around it with `PYTHONUTF8=1` all day.

Corpus-NA: tools-only change, no `AlRunner/` path in the diff — nothing here changes what
AL observes, so there is no BC-behaviour claim for the corpus to adjudicate.
(`check_corpus_linkage.sh` does not trigger on `tools/` either; stated for the reviewer.)

## Measured on this Windows box, without `PYTHONUTF8` (cp1252, Python 3.14.7)

Driving the real code paths with a fake `gh` emitting the raw UTF-8 JSON that real `gh`
emits (Go does not escape non-ASCII):

| path | before | after |
|---|---|---|
| `gh pr view --json body` decode | `an em dash â€” here`, anchor found **0 times** | `an em dash — here`, found once |
| `os.fdopen(fd, "w")` for `--body-file` | `b'an em dash \x97 here'` — not valid UTF-8 | `b'an em dash \xe2\x80\x94 here'` |
| `--body-file` / `--append-file` read | UTF-8 file becomes mojibake in the new body | text preserved |

One correction to the issue's write-side claim, now that it is measured rather than read
off the code: text that *came back through* the broken read round-trips byte-identically
(cp1252 is symmetric on defined bytes, so `â€”` re-encodes to `E2 80 94`). The corruption
is confined to non-ASCII text the invocation *inserts* — `--append`, `--append-file`,
`--body-file`, a `--replace` replacement — which is exactly what an agent's edit is made of.

## The fix

`encoding="utf-8"` on every subprocess text decode and every file open in the tool.
`errors=` differs deliberately by role:

- **`pr-body.py` — `strict`.** It writes a PR body back; a byte it cannot decode must stop
  the write, not be replaced by U+FFFD and uploaded.
- **the log/verdict readers — `replace`.** Reading a CI verdict must not fail on one odd
  byte in a build log. A false zero from a mangled log is the failure mode
  `verify-execution-not-the-tick.md` is about; a crash instead of a verdict is a new one.

## Siblings — what was folded, what was not

`tools/test_text_encoding.py` (new) is the shape guard: it walks the AST of every
non-test `tools/*.py` and fails any `subprocess.run/Popen/check_output` in text mode with
no `encoding=`. It found one site nobody had listed — `context-pack.py`.

Folded (all one shape, all in `tools/`): `pr-body.py`, `ci-wait.py`,
`corpus-pass-count.py`, `agent_self_freshness.py`, `corpus-pin.py`, `corpus-pin-advance.py`,
`context-pack.py`.

Checked and left alone:

- **`tools/preflight.py`** — does not have the defect. It captures bytes and decodes with an
  explicit `p.stdout.decode("utf-8", "replace")` already. Its `open(baseline)` for a JSON
  file is a different shape (file read, ASCII content) and its own open-guard work is #3164.
- **`tools/agent-cost.py`, `comment-density.py`, `lsp-query.py`** — no subprocess text decode
  to fix; the guard confirms it rather than my reading of them.
- **`.github/scripts/*.py`** — outside `tools/`, so outside the same-file cluster. Not
  inspected for this defect; not claimed clean.
- **`FakeGh` in `test_pr_body.py`** — changed, not left: it read the body file with the
  locale codec, so it would have agreed with a broken write.

## RED → GREEN

- `tools/test_pr_body.py`, new section `text is UTF-8, never the locale codec (#3434)`:
  **10 checks, 10 passing on this branch.** The RED is louder than ten failures: run the
  new section against `origin/main`'s `tools/pr-body.py` and the suite *aborts* rather than
  reporting — `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb7 in position 366` out
  of `pr-body.py:745 writer` on Windows (the fixture now hands it a UTF-8 file, which the
  locale-codec write path corrupts), and `AttributeError: module 'pr_body' has no attribute
  'write_body_tempfile'` on Linux, since that helper is the extraction this PR makes. The
  10/10 count was measured against the intermediate state — helper extracted, encodings not
  yet added — which is the last point where every check can report. Four of the ten assert
  the kwargs (`encoding="utf-8"`, `errors="strict"`) and hold on any machine; four assert the
  text survives; two run the code in a **child interpreter** under
  `PYTHONUTF8=0 PYTHONCOERCECLOCALE=0 LC_ALL=C`, which is the only portable lever —
  `PYTHONIOENCODING` reaches only `sys.std*`, and from 3.11 the `TextIOWrapper` default is
  resolved in C, out of reach of a monkeypatch. That child prints a loud SKIP (never a pass)
  if the box gives UTF-8 anyway.
- `tools/test_text_encoding.py`: **7 failing** against `origin/main`'s `tools/`
  (`agent_self_freshness`, `ci-wait`, `context-pack`, `corpus-pass-count`, `corpus-pin`,
  `corpus-pin-advance`, `pr-body`), **all passing** on this branch.
- Also run green: `test_ci_wait`, `test_corpus_pin`, `test_corpus_pin_advance`,
  `test_corpus_pass_count`, `test_agent_self_freshness`, `test_line_endings`,
  `test_comment_density`, `test_doc_pointers`.
- `test_pr_body.py` still reports 7 failures on this box **before and after**, identical to
  the `origin/main` baseline: the `check_closing_reference.sh` parity block gets `sh_rc=127`
  because this shell mangles the Windows path it hands `bash`. Environment, not the change,
  and not touched by it.

## Gates

- **`Tests updated`** passes because the diff carries **no `^AlRunner/` path**, so
  `require-tests.yml` exits 0 with "No AlRunner/ source changes — test check skipped". It is
  *not* satisfied by the `tools/test_*.py` change; that check never looks at `tools/`.
- **`tools/ unit tests`** (`pr-gate.yml`) discovers suites by the glob `tools/test_*.py`, so
  the new file gates the day it lands, with no workflow edit.
- No `AlRunner.Tests` run: nothing in this diff is C#.

Filed and implemented by agent `fbk-2` (automated implementation agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018eQEJqnKcAgqMbWgk4wdMa
