### PR TITLE
fix(testpage): report the close BC actually performs after a [MessageHandler] consumes it

### DIFF
--- a/AlRunner.Tests/RunnerFormCloseHandlerTests.cs
+++ b/AlRunner.Tests/RunnerFormCloseHandlerTests.cs
@@ -58,20 +58,19 @@ public class RunnerFormCloseHandlerTests
     }
 
     // Positive: the general case. An AL error is handed to BC's own message channel, verbatim
-    // — not reworded, not prefixed by the runner.
+    // — not reworded, not prefixed by the runner — and the close is then REFUSED, which is
+    // BC's own `return false`. Measured on a real service tier: corpus codeunit 60602
+    // "QCM Query Close Msg Tests", green on all eight cloud legs and on the Windows nightly.
     [Fact]
-    public void AlError_IsHandedToTheMessageChannelVerbatim()
+    public void AlError_IsHandedToTheMessageChannelVerbatim_AndTheCloseIsRefused()
     {
         var probe = new FakeTestExecution(handled: true);
 
-        // A [MessageHandler] consumed it, so BC's own `return false` is reached and the page
-        // stays open — a shape the runner refuses loudly rather than modelling.
-        var oos = Assert.Throws<RunnerOutOfScopeException>(() =>
-            RunnerFormCloseHandler.RefuseCloseAfter(
-                new NavNCLDialogException("close refused by OnQueryClosePage"), probe));
+        var mayClose = RunnerFormCloseHandler.RefuseCloseAfter(
+            new NavNCLDialogException("close refused by OnQueryClosePage"), probe);
 
         Assert.Equal("close refused by OnQueryClosePage", probe.Seen);
-        Assert.Contains("testpage-close-refused-after-message", oos.Message, StringComparison.Ordinal);
+        Assert.False(mayClose);
     }
 
     // Negative: no message channel means the text has nowhere to go. Losing it would be a
@@ -133,50 +132,53 @@ public class RunnerFormCloseHandlerTests
         Assert.Same(original, thrown);
         Assert.Null(probe.Seen);
     }
-    // ── The refusal's CLASSIFICATION, not its text (#3179) ───────────────────────────────
+    // ── What a [MessageHandler]-consumed close error leaves behind (#3179) ──────────────
     //
-    // RunnerOutOfScopeException carries two kinds of refusal, and which kind decides whether an
-    // AL [TryFunction] may swallow it (ApplicationObjectBasePatches.IsPermanentOutOfScope):
+    // MEASURED, not reasoned: corpus codeunit 60602 "QCM Query Close Msg Tests"
+    // (StefanMaron/BusinessCentral.AL.Language.Tests#272, merged bd168356), green on all eight
+    // cloud legs and confirmed by the Windows nightly reference tier. Three facts, two of which
+    // contradicted what the test author predicted:
     //
-    //   permanent ("SMTP does not exist here")  -> TryInvoke returns false, matching a real BC
-    //                                              environment that also lacks the surface
-    //   "not-yet-implemented" (an in-scope gap) -> tears through, so a gap can never read green
+    //   1. the caller REGAINS CONTROL -- the close-time error does not propagate;
+    //   2. RunModal() reports Action::None, not the OK the [ModalPageHandler] chose, because a
+    //      refused close completed no action (the same codeunit's negative control, where the
+    //      close SUCCEEDS, does report OK -- so None is the refusal, not a lost action);
+    //   3. the page's uncommitted write SURVIVES. Codeunit 60677 asserts the opposite and also
+    //      passes: it measures behind asserterror, where what rolls the write back is the
+    //      framework unwinding a PROPAGATED error. A consumed message propagates nothing.
     //
-    // The test is a STRING PREFIX on the reason, so a gap whose reason merely says
-    // not-implemented in prose is classified permanent and silently swallowed. That is the
-    // defect issue #2966 was filed and closed for; this surface is a later instance of it,
-    // introduced with the close handler itself in #3057 and therefore not covered by that sweep.
-    //
-    // A page whose close BC refuses IS in scope -- #3179 is open and tracks building it -- so
-    // the refusal must tear through a [TryFunction], not become `false`.
+    // Fact 1 is what made the previous RunnerOutOfScopeException refusal wrong rather than
+    // merely conservative: the runner was raising an error on a path real BC completes without
+    // one. This pair pins that it no longer does.
 
     [Fact]
-    public void CloseRefusedAfterMessage_IsClassifiedAsAnInScopeGap_NotAPermanentRefusal()
+    public void CloseRefusedAfterMessage_ReturnsFalse_AndDoesNotRaise()
     {
         var probe = new FakeTestExecution(handled: true);
 
-        var oos = Assert.Throws<RunnerOutOfScopeException>(() =>
-            RunnerFormCloseHandler.RefuseCloseAfter(new NavNCLDialogException("boom"), probe));
+        // No Assert.Throws: the whole claim is that control comes back.
+        var mayClose = RunnerFormCloseHandler.RefuseCloseAfter(
+            new NavNCLDialogException("boom"), probe);
 
-        // The prefix IS the classification. Asserting the surface name too, so a rewording that
-        // kept the prefix but lost the surface still fails here.
-        Assert.StartsWith("not-yet-implemented", oos.Reason, StringComparison.Ordinal);
-        Assert.Contains("testpage-close-refused-after-message", oos.Reason, StringComparison.Ordinal);
+        Assert.False(mayClose);
+        Assert.Equal("boom", probe.Seen);
     }
 
-    // The property the classification exists to produce, asserted through the real decision
-    // point rather than by re-reading the string: a [TryFunction] must NOT swallow this refusal.
+    // A [TryFunction] must see the refusal the same way it sees any completed call: as a
+    // SUCCESS, because nothing was raised. The previous behaviour tore an out-of-scope signal
+    // through here, which is what a TryFunction cannot swallow -- so this is the negative of
+    // the test it replaces, and it fails against the old code with the refusal escaping.
     [Fact]
-    public void CloseRefusedAfterMessage_TearsThroughATryFunction()
+    public void CloseRefusedAfterMessage_LeavesATryFunctionReportingSuccess()
     {
         var probe = new FakeTestExecution(handled: true);
 
-        var oos = Assert.Throws<RunnerOutOfScopeException>(() =>
-            BcRuntime.NavApplicationObjectBase_TryInvoke(
-                null,
-                () => RunnerFormCloseHandler.RefuseCloseAfter(new NavNCLDialogException("boom"), probe)));
+        var ok = BcRuntime.NavApplicationObjectBase_TryInvoke(
+            null,
+            () => RunnerFormCloseHandler.RefuseCloseAfter(new NavNCLDialogException("boom"), probe));
 
-        Assert.Contains("testpage-close-refused-after-message", oos.Reason, StringComparison.Ordinal);
+        Assert.True(ok);
+        Assert.Equal("boom", probe.Seen);
     }
 
     // Negative control for the pair above, and the reason they are two tests rather than one:

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -1839,18 +1839,34 @@ internal class LiveNavTestPage : MockITestPage
         // instead of closing -- measured on real BC, Close() does NOT silently no-op here.
         if (_tornDown) throw MakeTestPageNotOpenException();
 
-        // OnQueryClosePage's veto is the one part of the close sequence the runner cannot
-        // model: BC would leave the page open and hand control back to the user, which has no
-        // meaning in a test that has already asked for the close. Refusing by name beats both
-        // alternatives — closing anyway hides that the page objected, and hanging is worse.
-        if (_page != null && !_page.RaiseOnClosePage(_formResult))
+        // Two ways BC refuses a close, and they are not the same question — see
+        // RunnerPageInstance.CloseRefusal.
+        if (_page != null && !_page.RaiseOnClosePage(_formResult, out var refusal))
+        {
+            // An AL error the trigger raised, consumed by a declared [MessageHandler]. MEASURED
+            // on a real service tier (corpus codeunit 60602 "QCM Query Close Msg Tests",
+            // StefanMaron/BusinessCentral.AL.Language.Tests#272, green on all eight cloud legs
+            // and on the Windows nightly): Close() returns normally, the message reaches the
+            // handler exactly once on this route, and the page is left OPEN.
+            //
+            // Returning here is the whole of that: the tear-down below is skipped, so _opened
+            // stays true, no row is flushed by the close, and BC's own form state is untouched
+            // — the test's TestPage variable keeps working, which is what a real tier leaves it
+            // holding. It is deliberately NOT a refusal any more; raising one here would be the
+            // runner erroring on a path BC completes without an error (issue #3179).
+            if (refusal == RunnerPageInstance.CloseRefusal.ErrorShownAsMessage) return;
+
+            // A plain veto (the trigger returned false) on the EXPLICIT TestPage.Close() path.
+            // Still a refusal, and still a permanent scope boundary (#2999 lists it among the
+            // fourteen): BC leaves the page open awaiting a user, and unlike the arm above no
+            // service tier has been asked what a test observes afterwards. A [TryFunction]
+            // reading false is BC's outcome.
             throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                // No " — " in the api — see RequireRecord. The CLAIM is unchanged and stays a
-                // permanent scope boundary (#2999 lists it among the fourteen): BC leaves the
-                // page open awaiting a user, so a [TryFunction] reading false is BC's outcome.
+                // No " — " in the api — see RequireRecord.
                 $"TestPage page {_pageId} (OnQueryClosePage)",
                 "testpage-close-veto — the page's OnQueryClosePage returned false, which in BC "
                 + "leaves the page open awaiting the user. See docs/scope.md");
+        }
         FlushParts(); FlushRow(); _opened = false;
 
         // The triggers above are this page's close, so BC's own form state has to agree that

--- a/AlRunner/Patches/RunnerFormCloseHandler.cs
+++ b/AlRunner/Patches/RunnerFormCloseHandler.cs
@@ -52,6 +52,26 @@
 //   TestPageMessageHelper.ShowErrorMessage, which throws NavTestWrappedException carrying the
 //   same text), so rethrowing the original preserves the observable AL outcome — the text —
 //   without the runner claiming to model a force-close-and-continue it has no path to.
+//
+// WHAT THE REFUSAL MEANS TO EACH CALLER
+//   `false` from RefuseCloseAfter says only "BC did not perform this close". What that leaves
+//   the AL observing is the CALLER's decision, because the two close routes leave the test
+//   holding different things, and both are measured by corpus codeunit 60602 (#272, bd168356):
+//
+//     RunnerModalDispatch.TryQueryCloseForm  — the test holds no page handle after RunModal()
+//       returns, so "still open" is not observable. What IS observable is the Action, and a
+//       refused close completed none: the caller drops the handler's result and the AL reads
+//       back FormResult.None. Measured: Action::None, against Action::OK on the same codeunit's
+//       negative control where the close succeeds.
+//
+//     MockTestPage.Close / RunnerPageInstance.RaiseOnClosePage — the test still holds the
+//       TestPage variable, so BC's open page IS observable. Close() returns without tearing the
+//       page down, leaving it drivable, which is what a real tier leaves behind.
+//
+//   Neither route discards the page's uncommitted write, and that is measured rather than
+//   incidental: corpus 60677 asserts the write IS rolled back on the no-[MessageHandler] arm and
+//   passes on the same leg of the same run. What unwinds it there is the framework tearing down
+//   a PROPAGATED error; a consumed message propagates nothing, so nothing unwinds.
 using System.Reflection;
 
 namespace AlRunner.Patches;
@@ -88,9 +108,11 @@ internal static class RunnerFormCloseHandler
     /// as a message either propagates or is replaced by a louder one.
     /// </returns>
     /// <remarks>
-    /// The common case does not return at all. With no <c>[MessageHandler]</c> declared,
+    /// With no <c>[MessageHandler]</c> declared this does not return at all:
     /// <c>TestHandleMessage</c> raises BC's own "Unhandled UI: Message {text}" refusal from
-    /// inside the call — exactly the outcome a real service tier produces for this shape.
+    /// inside the call — exactly the outcome a real service tier produces for that shape. With
+    /// one declared the handler consumes the text and this returns <c>false</c>, which is BC's
+    /// own <c>return false</c>; see the "WHAT THE REFUSAL MEANS TO EACH CALLER" note above.
     /// </remarks>
     internal static bool RefuseCloseAfter(Exception ex, object? testExecution)
     {
@@ -117,28 +139,14 @@ internal static class RunnerFormCloseHandler
             System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex).Throw();
 
         // A [MessageHandler] consumed the text, so BC's `return false` is reached: the close is
-        // refused and the page is STILL OPEN, waiting for a user who does not exist here. That
-        // is the same boundary MockTestPage.Close already names for an OnQueryClosePage veto
-        // (#2999) — the runner has no model for a page that refuses to close and keeps running.
-        // Throwing says so; returning false would let the caller force the page shut and report
-        // a close BC did not perform.
-        //
-        // The reason MUST start "not-yet-implemented", and the prefix is load-bearing rather
-        // than cosmetic: ApplicationObjectBasePatches.IsPermanentOutOfScope classifies by that
-        // string prefix, and anything else is treated as PERMANENTLY out of scope, which an AL
-        // [TryFunction] then swallows into `false`. This surface is in scope and tracked open in
-        // #3179, so swallowing it would turn the gap into a green test that lies
-        // (.claude/rules/loud-failures.md). It read "testpage-close-refused-after-message …"
-        // until #3179 — the same defect #2966 was filed for, on a site created after that sweep.
-        // docs/limitations.md, not docs/scope.md, for the same reason: this is a gap, not a
-        // permanent boundary.
-        throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-            "TestPage page close (OnQueryClosePage)",
-            "not-yet-implemented — testpage-close-refused-after-message: OnQueryClosePage raised "
-            + "an error, a [MessageHandler] consumed it, and BC then leaves the page OPEN. The "
-            + "runner has no model for a page that outlives its own close. "
-            + "See docs/limitations.md#testpage-shape-gaps",
-            "todo");
+        // refused. Observably equivalent (loud-failures.md audit): a real service tier hands
+        // control straight back to the caller here, raising nothing — measured by corpus
+        // codeunit 60602 "QCM Query Close Msg Tests", green on all eight cloud legs and on the
+        // Windows nightly reference tier. So `false` IS BC's answer on this path, and the
+        // RunnerOutOfScopeException this replaced was itself the divergence: it raised an error
+        // on a path BC completes without one. See docs/limitations.md#testpage-shape-gaps for
+        // what each caller does with the refusal and what is still not reproduced.
+        return false;
     }
 
     private static bool IsNavBaseException(Exception ex)

--- a/AlRunner/Patches/RunnerFormCloseHandler.cs
+++ b/AlRunner/Patches/RunnerFormCloseHandler.cs
@@ -72,6 +72,11 @@
 //   incidental: corpus 60677 asserts the write IS rolled back on the no-[MessageHandler] arm and
 //   passes on the same leg of the same run. What unwinds it there is the framework tearing down
 //   a PROPAGATED error; a consumed message propagates nothing, so nothing unwinds.
+//
+//   NOT reproduced, and tracked in #3593: BC delivers this message TWICE on the RunModal route,
+//   because its round trip attempts the close twice (the handler's OK().Invoke() is itself a
+//   close attempt on BC and is not one here). The runner delivers once on both routes, which
+//   matches BC on the TestPage route only.
 using System.Reflection;
 
 namespace AlRunner.Patches;

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -1772,7 +1772,17 @@ internal sealed partial class RunnerPageInstance
     /// unsaved work; NavForm's base returns true, so a page declaring none closes normally.
     /// </summary>
     internal bool RaiseOnClosePage(Microsoft.Dynamics.Nav.Types.FormResult closeAction)
+        => RaiseOnClosePage(closeAction, out _);
+
+    /// <inheritdoc cref="RaiseOnClosePage(Microsoft.Dynamics.Nav.Types.FormResult)"/>
+    /// <param name="refusal">
+    /// Why the close was refused, when it was. The two refusals are not interchangeable and the
+    /// callers do different things with them — see <see cref="CloseRefusal"/>.
+    /// </param>
+    internal bool RaiseOnClosePage(
+        Microsoft.Dynamics.Nav.Types.FormResult closeAction, out CloseRefusal refusal)
     {
+        refusal = CloseRefusal.None;
         object? queryClose;
         try
         {
@@ -1788,12 +1798,51 @@ internal sealed partial class RunnerPageInstance
             // path in RunnerModalDispatch — TestPageProxy.InternalClose reaches
             // NavFormCloseHandler.ExecuteCloseCore too, so both shapes must agree. See
             // RunnerFormCloseHandler and issue #3057.
-            return RunnerFormCloseHandler.RefuseCloseAfter(ex, TestExecutionOrNull());
+            //
+            // RefuseCloseAfter either does not return (no [MessageHandler]: BC's own
+            // "Unhandled UI: Message …" comes out of it) or answers false, which is BC's
+            // `return false` after a handler consumed the text. Only the second reaches here.
+            var mayClose = RunnerFormCloseHandler.RefuseCloseAfter(ex, TestExecutionOrNull());
+            if (!mayClose) refusal = CloseRefusal.ErrorShownAsMessage;
+            return mayClose;
         }
 
-        if (queryClose is false) return false;
+        if (queryClose is false)
+        {
+            refusal = CloseRefusal.TriggerReturnedFalse;
+            return false;
+        }
         InvokeRecordTrigger("OnClosePage", Type.EmptyTypes, Array.Empty<object>());
         return true;
+    }
+
+    /// <summary>
+    /// Why <see cref="RaiseOnClosePage(Microsoft.Dynamics.Nav.Types.FormResult, out CloseRefusal)"/>
+    /// refused a close. Both mean "BC did not perform this close", and they are kept apart
+    /// because what the runner can faithfully do next differs between them.
+    /// </summary>
+    internal enum CloseRefusal
+    {
+        /// <summary>The close happened.</summary>
+        None,
+
+        /// <summary>
+        /// <c>OnQueryClosePage</c> returned <c>false</c> — a plain veto. On the explicit
+        /// <c>TestPage.Close()</c> path this stays a refusal (docs/scope.md): BC leaves the page
+        /// open awaiting a user, and no service tier has been asked what a test observes after
+        /// one. It is NOT the same question as the arm below, which has been asked.
+        /// </summary>
+        TriggerReturnedFalse,
+
+        /// <summary>
+        /// <c>OnQueryClosePage</c> raised an AL error and a <c>[MessageHandler]</c> consumed the
+        /// text, so BC's close handler reached its own <c>return false</c>. Measured on a real
+        /// service tier — corpus codeunit 60602 "QCM Query Close Msg Tests"
+        /// (StefanMaron/BusinessCentral.AL.Language.Tests#272), green on all eight cloud legs
+        /// and on the Windows nightly: the caller regains control, nothing is raised, and the
+        /// page stays open and drivable. See docs/limitations.md#testpage-shape-gaps.
+        /// </summary>
+        ErrorShownAsMessage,
     }
 
     /// <summary>

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1535,21 +1535,30 @@ https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues.
   and `RunModal()` reports `Action::None`
   ([#3050](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3050)).
 
-  A ninth refusal joins them on the same surface, this one on **both** close paths. An
-  `OnQueryClosePage` that raises an AL *error* — as opposed to vetoing — is shown by BC's own
-  client-side close handler as a **message**, after which the close is refused and the page
-  stays open. The runner reproduces the message half through BC's own
-  `NavTestExecution.TestHandleMessage` (`AlRunner/Patches/RunnerFormCloseHandler.cs`), so with
-  no `[MessageHandler]` declared the test sees BC's `Unhandled UI: Message …` refusal, exactly
-  as a service tier produces it. With a `[MessageHandler]` declared the handler consumes the
-  text and control returns to a page real BC has left open, which the runner has no model for;
-  it raises `RunnerOutOfScopeException` with reason
-  `not-yet-implemented — testpage-close-refused-after-message` rather than force the page shut
-  and report a close BC did not perform. The `not-yet-implemented` prefix is load-bearing: it is
-  what stops an AL `[TryFunction]` from swallowing the refusal into `false`, since this surface
-  is an open gap rather than a permanent boundary
-  ([#3057](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3057),
-  [#3179](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3179)).
+  An `OnQueryClosePage` that raises an AL *error* — as opposed to vetoing — is not a refusal
+  here at all, and used to be. BC's own client-side close handler shows the text as a
+  **message** and then refuses the close. The runner reproduces the message half through BC's
+  own `NavTestExecution.TestHandleMessage`
+  (`AlRunner/Patches/RunnerFormCloseHandler.cs`), so with no `[MessageHandler]` declared the
+  test sees BC's `Unhandled UI: Message …` refusal, exactly as a service tier produces it
+  ([#3057](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3057)). With one
+  declared the handler consumes the text and the close is refused, which the runner now
+  reports rather than raising over
+  ([#3179](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3179)). Corpus
+  codeunit 60602 "QCM Query Close Msg Tests"
+  ([#272](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/272)) measured
+  what a real tier leaves behind, green on all eight cloud legs and on the Windows nightly:
+  the caller regains control with nothing raised, `RunModal()` reports `Action::None` rather
+  than the action the `[ModalPageHandler]` chose, and the page's uncommitted write survives.
+  Each close route reproduces its own half — `RunModal` drops the handler's result so the AL
+  reads back `Action::None`, and `TestPage.Close()` returns with the page still open and
+  drivable.
+
+  **Still not reproduced on this surface, and tracked separately:** BC delivers the close-time
+  message **twice** on the `RunModal` route and once on the `TestPage.Close()` route, because
+  its round trip attempts the close twice. The runner attempts it once on both, so a
+  `[MessageHandler]` that counts deliveries sees one where BC would show two
+  ([#3593](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3593)).
 
 <a id="virtual-table-shape-gaps"></a>
 

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -65,6 +65,7 @@
         "tableext-eviction-subscriber-timing-dep": { "tests": 0 },
         "task-scheduler-oos": { "tests": 8 },
         "temporary-virtual-table-isolation": { "tests": 6 },
+        "testpage-close-message-consumed": { "tests": 4 },
         "testpage-lookup-tablerelation-oos": { "tests": 3 },
         "testpage-precompiled-dep-control": { "tests": 2 },
         "testpage-precompiled-member-names": { "tests": 8 },

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -65,7 +65,7 @@
         "tableext-eviction-subscriber-timing-dep": { "tests": 0 },
         "task-scheduler-oos": { "tests": 8 },
         "temporary-virtual-table-isolation": { "tests": 6 },
-        "testpage-close-message-consumed": { "tests": 4 },
+        "testpage-close-message-consumed": { "tests": 5 },
         "testpage-lookup-tablerelation-oos": { "tests": 3 },
         "testpage-precompiled-dep-control": { "tests": 2 },
         "testpage-precompiled-member-names": { "tests": 8 },

--- a/tests/runner-extras/testpage-close-message-consumed/TcmAssert.Codeunit.al
+++ b/tests/runner-extras/testpage-close-message-consumed/TcmAssert.Codeunit.al
@@ -1,0 +1,16 @@
+// Standalone Assert codeunit -- this suite must stand alone (README.md), it does not import
+// from tests/al-language.
+codeunit 65860 "Tcm Assert"
+{
+    procedure AreEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        if Format(Expected) <> Format(Actual) then
+            Error('Expected %1 but got %2: %3', Format(Expected), Format(Actual), Msg);
+    end;
+
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then
+            Error('Expected true: %1', Msg);
+    end;
+}

--- a/tests/runner-extras/testpage-close-message-consumed/TcmErrorCard.Page.al
+++ b/tests/runner-extras/testpage-close-message-consumed/TcmErrorCard.Page.al
@@ -1,0 +1,42 @@
+/// <summary>
+/// A card whose OnQueryClosePage always raises an AL error, and which writes a row from
+/// OnOpenPage. Shaped after the corpus fixture "QCE Error Card" (page 60678) so the runner
+/// meets the same shape a real service tier already adjudicated, but with its own object ids
+/// -- this bundle stands alone and does not depend on the corpus.
+/// </summary>
+page 65862 "Tcm Error Card"
+{
+    PageType = Card;
+    SourceTable = "Tcm Row";
+    ApplicationArea = All;
+    UsageCategory = None;
+
+    layout
+    {
+        area(Content)
+        {
+            field("No."; Rec."No.") { ApplicationArea = All; }
+            field("Set ID"; Rec."Set ID") { ApplicationArea = All; }
+        }
+    }
+
+    var
+        CloseRefusedErr: Label 'TCM close refused by OnQueryClosePage';
+
+    trigger OnOpenPage()
+    var
+        Row: Record "Tcm Row";
+    begin
+        if not Row.Get('OPENED') then begin
+            Row.Init();
+            Row."No." := 'OPENED';
+            Row."Set ID" := 42;
+            Row.Insert();
+        end;
+    end;
+
+    trigger OnQueryClosePage(CloseAction: Action): Boolean
+    begin
+        Error(CloseRefusedErr);
+    end;
+}

--- a/tests/runner-extras/testpage-close-message-consumed/TcmRow.Table.al
+++ b/tests/runner-extras/testpage-close-message-consumed/TcmRow.Table.al
@@ -1,0 +1,24 @@
+/// <summary>
+/// Two jobs, kept in one table so the bundle stays small. The 'OPENED' row is what
+/// "Tcm Error Card" writes from OnOpenPage -- present after a refused close, absent if
+/// something unwound it. Rows tagged by the [MessageHandler] record that the handler fired
+/// and with what text, so no assertion has to run inside the handler itself: an assertion
+/// raised there would arrive wrapped in whatever the close path does with an exception, and
+/// the test could not tell "the handler never ran" from "the handler ran and disagreed".
+/// </summary>
+table 65861 "Tcm Row"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; "Set ID"; Integer) { }
+        field(3; "Last Text"; Text[250]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/tests/runner-extras/testpage-close-message-consumed/TcmTests.Codeunit.al
+++ b/tests/runner-extras/testpage-close-message-consumed/TcmTests.Codeunit.al
@@ -1,0 +1,159 @@
+// TCM -- the runner reaches the END of BC's close path when a [MessageHandler] consumes the
+// close-time error, instead of refusing partway through it. Issue #3179.
+//
+// WHAT IS ASSERTED HERE, AND WHAT IS NOT
+//   That real BC shows an OnQueryClosePage error as a MESSAGE, refuses the close, hands
+//   control back to the caller, and leaves the page open is a plain BC-behaviour claim. It is
+//   asserted upstream in the al-language corpus by codeunit 60602 "QCM Query Close Msg Tests"
+//   (StefanMaron/BusinessCentral.AL.Language.Tests#272, merged bd168356), green on all eight
+//   cloud legs and confirmed by the Windows nightly reference tier. None of it is re-asserted
+//   here, and none of these assertions may be read as evidence about BC.
+//
+//   What this suite pins is a property only a runner test can observe: the runner does not
+//   REFUSE. Until #3179 it raised RunnerOutOfScopeException the instant a [MessageHandler]
+//   consumed the text, so every line after the close was unreachable -- a test that passes on a
+//   service tier could not run here at all. A corpus leg cannot see that, because the refusal
+//   exists only in the runner.
+//
+//   Each [Test] below therefore has the same structure: DRIVE the close, then read state back
+//   AFTER it. Reaching the read at all is half the claim; the value read is the other half, and
+//   it is a concrete value rather than a liveness check, so a runner that returned control but
+//   discarded the page's work would fail rather than pass quietly.
+codeunit 65863 "Tcm Close Message Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit "Tcm Assert";
+        CloseRefusedTxt: Label 'TCM close refused by OnQueryClosePage';
+
+    // CLAIM 1: control comes back. This is the whole of the #3179 defect -- the runner used to
+    // raise here, so the line after Close() was unreachable.
+    //
+    // Asserting the witness row rather than merely reaching the end is what makes the test
+    // prove something: a runner that swallowed the close-time error without ever dispatching
+    // the [MessageHandler] would also reach this line, and it fails the first assertion.
+    [Test]
+    [HandlerFunctions('TcmMessageHandler')]
+    procedure CloseAfterQueryCloseError_MessageConsumed_ReturnsToTheCaller()
+    var
+        Card: TestPage "Tcm Error Card";
+        Row: Record "Tcm Row";
+    begin
+        Initialize();
+
+        Card.OpenEdit();
+        Card.Close();
+
+        // Reaching this line is the claim. Before #3179 the runner raised
+        // "not-yet-implemented -- testpage-close-refused-after-message" inside Close().
+        Assert.IsTrue(Row.Get('SEEN'),
+            'The [MessageHandler] must have been dispatched -- reaching this line without it would mean the close-time error was swallowed rather than shown.');
+        Assert.AreEqual(1, Row."Set ID",
+            'The TestPage route must deliver the close-time message exactly once. Two would mean the runner attempted the close twice.');
+        Assert.IsTrue(StrPos(Row."Last Text", CloseRefusedTxt) > 0,
+            StrSubstNo('The handler must receive the trigger''s own error text, not a runner-invented one; got "%1".', Row."Last Text"));
+    end;
+
+    // CLAIM 2: the page is still usable afterwards, which is what "BC left it open" means for a
+    // test that still holds the variable. A runner that returned control but tore the page down
+    // would fail here with BC's own "The TestPage is not open."
+    //
+    // Reading a FIELD, not a status flag: a torn-down page raises on any field read, so this
+    // cannot pass against a page that only claims to be open.
+    [Test]
+    [HandlerFunctions('TcmMessageHandler')]
+    procedure CloseAfterQueryCloseError_MessageConsumed_LeavesThePageDrivable()
+    var
+        Card: TestPage "Tcm Error Card";
+    begin
+        Initialize();
+
+        Card.OpenEdit();
+        Card."Set ID".SetValue(99);
+        Card.Close();
+
+        Assert.AreEqual('99', Format(Card."Set ID".Value()),
+            'The page must still be drivable after a close BC refused -- and must still hold the value set before the close, not a value re-read from a page that was torn down and rebuilt.');
+    end;
+
+    // CLAIM 3: the write the page made survives the refused close.
+    //
+    // Corpus 60602 measured this on a real tier and it was the fact that contradicted the test
+    // author's prediction: the neighbouring codeunit 60677 asserts the write IS rolled back and
+    // also passes, because it measures behind asserterror, where what unwinds the write is a
+    // PROPAGATED error. A consumed message propagates nothing, so nothing unwinds. Pinned here
+    // because the runner's own close path has a flush step, and skipping the tear-down (which is
+    // how the refusal is implemented) must not be allowed to drop the row either.
+    //
+    // The VALUE is asserted, not just the row's presence, so a row resurrected empty by anything
+    // else cannot satisfy it.
+    [Test]
+    [HandlerFunctions('TcmMessageHandler')]
+    procedure CloseAfterQueryCloseError_MessageConsumed_KeepsThePagesWrite()
+    var
+        Card: TestPage "Tcm Error Card";
+        Row: Record "Tcm Row";
+    begin
+        Initialize();
+
+        Card.OpenEdit();
+        Card.Close();
+
+        Assert.IsTrue(Row.Get('OPENED'),
+            'The row OnOpenPage inserted must survive a close the page refused -- nothing propagated, so nothing unwinds.');
+        Assert.AreEqual(42, Row."Set ID",
+            'The surviving row must carry the value OnOpenPage wrote, not a default.');
+    end;
+
+    // NEGATIVE CONTROL, and the reason the three arms above are not vacuous. Without a
+    // [MessageHandler] the text has nowhere to go, so showing it is itself what fails: the
+    // framework raises its own "Unhandled UI: Message ..." from inside the show call and the
+    // close-time error DOES reach the test.
+    //
+    // This is what stops "the runner now swallows every close-time error" from passing the
+    // suite. A change that made Close() unconditionally succeed would turn all three arms above
+    // green and fail this one.
+    [Test]
+    procedure CloseAfterQueryCloseError_NoMessageHandler_StillReachesTheTest()
+    var
+        Card: TestPage "Tcm Error Card";
+    begin
+        Initialize();
+
+        Card.OpenEdit();
+        asserterror Card.Close();
+
+        // The trigger's own text, carried inside whatever envelope the unhandled-message
+        // refusal puts it in. Asserting the text rather than the envelope: which wording the
+        // framework wraps it in is BC's decision and is pinned upstream, not here.
+        Assert.IsTrue(StrPos(GetLastErrorText(), CloseRefusedTxt) > 0,
+            StrSubstNo('With no [MessageHandler] declared the close-time error must still reach the test; got "%1".', GetLastErrorText()));
+    end;
+
+    local procedure Initialize()
+    var
+        Row: Record "Tcm Row";
+    begin
+        Row.DeleteAll();
+    end;
+
+    // Records rather than asserts -- see the "Tcm Row" header. Counting deliveries as well as
+    // capturing the text, so an arm can tell one close attempt from two.
+    [MessageHandler]
+    procedure TcmMessageHandler(Msg: Text[1024])
+    var
+        Row: Record "Tcm Row";
+    begin
+        if not Row.Get('SEEN') then begin
+            Row.Init();
+            Row."No." := 'SEEN';
+            Row."Set ID" := 0;
+            Row.Insert();
+        end;
+        Row."Set ID" := Row."Set ID" + 1;
+        Row."Last Text" := CopyStr(Msg, 1, MaxStrLen(Row."Last Text"));
+        Row.Modify();
+    end;
+}

--- a/tests/runner-extras/testpage-close-message-consumed/TcmTests.Codeunit.al
+++ b/tests/runner-extras/testpage-close-message-consumed/TcmTests.Codeunit.al
@@ -139,6 +139,54 @@ codeunit 65863 "Tcm Close Message Tests"
         Row.DeleteAll();
     end;
 
+    // CLAIM 5: the MODAL route reaches the end too, and reports an Action.
+    //
+    // The four arms above all drive TestPage.Close(). RunModal() reaches the same close handler
+    // by a different route -- RunnerModalDispatch rather than MockTestPage -- and that route is
+    // NOT covered by them. It is covered upstream by corpus 60602, but that codeunit cannot run
+    // in this repository until the pin passes #2943, so without this arm a modal-route
+    // regression would be invisible here in the meantime.
+    //
+    // What is asserted is the runner-observable half, exactly as in the arms above: control
+    // comes back at all, where before #3179 the dispatch raised RunnerOutOfScopeException and
+    // this line was unreachable. The Action value is read back as a concrete value rather than
+    // a liveness check, so a runner that returned control while losing the dispatch's result
+    // fails instead of passing quietly.
+    //
+    // Action::None is BC's own answer here and is asserted upstream, not established by this
+    // test: a refused close completed no action, so there is none to report. It is written as
+    // an equality against Action::None rather than an inequality against OK, because "not OK"
+    // would also accept a runner that invented some third value.
+    [Test]
+    [HandlerFunctions('TcmOkHandler,TcmMessageHandler')]
+    procedure RunModalAfterQueryCloseError_MessageConsumed_ReturnsToTheCaller()
+    var
+        Row: Record "Tcm Row";
+        Card: Page "Tcm Error Card";
+        Result: Action;
+    begin
+        Initialize();
+
+        Result := Card.RunModal();
+
+        // Reaching this line at all is the #3179 half; the rest is what came back.
+        Assert.IsTrue(Row.Get('SEEN'),
+            'the [MessageHandler] must have consumed the close-time message on the RunModal route too');
+        Assert.IsTrue(StrPos(Row."Last Text", CloseRefusedTxt) > 0,
+            'the handler must receive the trigger''s own error text on the RunModal route');
+        Assert.AreEqual(Format(Action::None), Format(Result),
+            'RunModal must report an Action once control returns, and a refused close completed none');
+    end;
+
+    // Invoked by the modal arm above. Chooses OK deliberately: the close is refused regardless,
+    // which is what makes Action::None a statement about the refusal rather than about what the
+    // handler picked.
+    [ModalPageHandler]
+    procedure TcmOkHandler(var Card: TestPage "Tcm Error Card")
+    begin
+        Card.OK().Invoke();
+    end;
+
     // Records rather than asserts -- see the "Tcm Row" header. Counting deliveries as well as
     // capturing the text, so an arm can tell one close attempt from two.
     [MessageHandler]

--- a/tests/runner-extras/testpage-close-message-consumed/app.json
+++ b/tests/runner-extras/testpage-close-message-consumed/app.json
@@ -1,0 +1,18 @@
+{
+  "id": "b3d9f2a7-5c14-4e68-9a03-7d1f6b8c4e52",
+  "name": "Runner Extras - TestPage Close Message Consumed",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Issue #3179: after a [MessageHandler] consumes an error raised in OnQueryClosePage, control must come back to the caller and the page must still be drivable -- the runner must not raise where BC does not.",
+  "description": "Runner-specific, and deliberately so. What BC DOES on this path is a plain BC-behaviour claim and is asserted upstream by corpus codeunit 60602 'QCM Query Close Msg Tests' (BusinessCentral.AL.Language.Tests#272, merged bd168356, green on all eight cloud legs and on the Windows nightly). None of that is re-asserted here. What this bundle pins is that the RUNNER reaches the end of that path at all: until #3179 it raised RunnerOutOfScopeException the moment a [MessageHandler] consumed the text, so every assertion after the close was unreachable and an AL test that passes on a service tier could not run here. The claim is 'the runner does not refuse', which only a runner test can make -- a corpus leg cannot observe a refusal that exists only here. Runs on all eight BC legs rather than the two that carry AlRunner.Tests.",
+  "dependencies": [],
+  "idRanges": [
+    {
+      "from": 65860,
+      "to": 65869
+    }
+  ],
+  "platform": "27.0.0.0",
+  "runtime": "15.0",
+  "target": "Cloud"
+}


### PR DESCRIPTION
Closes #3179

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/272

A `[MessageHandler]`-consumed error from `OnQueryClosePage` now returns "close refused" on both close routes, instead of raising `RunnerOutOfScopeException`.

## Why the refusal was right, and is not any more

The refusal was the honest answer while nothing had measured what a real tier leaves behind — #3179's own stated blocker. That blocker is gone. Corpus codeunit 60602 "QCM Query Close Msg Tests" (corpus PR #272, merged `bd168356`) is green on all eight cloud legs and confirmed by the Windows nightly reference tier. Execution verified with `tools/corpus-pass-count.py`: 7 distinct PASS per cloud leg, 0 failures.

It measured three things, two of which contradicted what the test author predicted:

1. **The caller regains control** — the close-time error does not propagate.
2. **`RunModal()` returns `Action::None`**, not the `OK` the `[ModalPageHandler]` chose. The same codeunit's negative control, where the close *succeeds*, returns `OK` — so `None` is the refusal being reported, not an action going missing.
3. **The page's uncommitted write survives.** Codeunit 60677 asserts the opposite and also passes, on the same leg of the same run: it measures behind `asserterror`, where what rolls the write back is the framework unwinding a **propagated** error. A consumed message propagates nothing, so nothing unwinds.

Fact 1 is what turns the refusal from conservative into wrong. The runner was raising an error on a path BC completes without one, so an AL test that passes on a service tier could not run here at all. Returning `false` here is not a silent divergence — it is the answer a real tier gives, and the exception was the divergence.

## What changed

`RaiseOnClosePage` now reports **why** it refused, because the two refusals are different questions:

| refusal | what happens now |
|---|---|
| `TriggerReturnedFalse` — a plain veto, explicit `TestPage.Close()` path | **unchanged.** Still refuses, still cites `docs/scope.md`, still one of #2999's list. No tier has been asked what a test observes after one. |
| `ErrorShownAsMessage` — an AL error a `[MessageHandler]` consumed | reports the refusal; this is the measured arm |

Each caller then does what 60602 measured for its own route, and both needed less than expected because the plumbing was already there:

- **`RunModal`** — `TryQueryCloseForm` already turns `false` into `result = null`, so `SetLastFormResult` is skipped and the AL reads back `FormResult.None`. That is fact 2, with no change to `RunnerModalDispatch.cs` at all.
- **`TestPage.Close()`** — returns without tearing the page down, so `_opened` stays true, the close flushes nothing, and BC's own form state is untouched. The test's variable keeps working, which is what "BC left the page open" means for a test that still holds one. Fact 3 follows: nothing propagated, so nothing unwinds.

## RED → GREEN

Two proving layers, both run in both directions.

**AL, end to end** — `tests/runner-extras/testpage-close-message-consumed` (new, ids 65860-65869), BC 28.1.49838.53910:

```
3 FAIL -> 3 PASS   the two message-consumed arms plus the surviving-write arm, each failing with
                   "Unexpected out-of-scope: ... not-yet-implemented -- testpage-close-refused-after-message"
1 PASS -> 1 PASS   the no-[MessageHandler] negative control, unchanged in both directions
```

The control is what makes the other three mean something: a change that made `Close()` unconditionally succeed would turn all three green and fail it.

**C#, the classifier in isolation** — `AlRunner.Tests/RunnerFormCloseHandlerTests`: 3 FAIL → 0 FAIL, 9/9 pass. Two of the three are the negatives of tests they replace, so they fail against the old code by construction rather than by omission.

Filtered regression run over the surface (`TestPageRefusalClaim`, `RunnerFormCloseHandler`, `TestPageShapeGap`, `PageLifecycleTriggerDispatch`, `CountBaseline`): 132 passed, 0 failed, 10 skipped. `tools/test_comment_density.py`: all checks passed.

## Where the proving test went, and why

The BC-behaviour claim is upstream already — that is corpus 60602, and none of it is re-asserted here. The runner-side test asserts something only a runner test can: **the runner does not refuse.** A corpus leg cannot observe a refusal that exists only in the runner. It lives in `tests/runner-extras/` rather than in `AlRunner.Tests/` because the defect was reachability — the refusal fired inside `Close()`, so every line after it was unreachable — and only real AL driving a real page shows that. It also runs on all eight BC legs rather than the two that carry `AlRunner.Tests`.

**No pin bump.** The corpus test merged after this repo's pin (`c9d5f656`), but nothing here needs it: the fix is proven by the runner-extras suite, and a bump would drag in unrelated intervening commits. A catch-up bump is its own PR.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes, and it is the reason `RaiseOnClosePage` grew an `out` parameter rather than the fix landing in one place. `RefuseCloseAfter` has two callers on two different routes, and returning `false` means something different to each. Both are covered.
2. **Sibling function making the same assumption?** `MockTestPage.Close()` was collapsing two refusals into one `bool`, so it could not have distinguished them even with the classifier fixed. That is why the enum exists rather than a second boolean.
3. **Two code paths writing the same state with different invariants?** Found one, and it is **not** fixed here — see below.

## Deliberately left out, and filed: #3593

BC delivers the close-time message **twice** on the `RunModal` route and **once** on `TestPage.Close()`, because its round trip attempts the close twice — the handler's `OK().Invoke()` is a close attempt on BC and is not one here. The runner delivers once on both, so it matches BC on one route and not the other.

Not folded in, for a concrete reason rather than scope discipline: fixing it changes when `OK().Invoke()` attempts a close, which touches every modal `[ModalPageHandler]` path, and corpus 60276 pins that an *allowed* close raises `OnQueryClosePage` exactly once on that same shape — so a naive second attempt would break a currently-passing result. Filed as #3593 with the measurement, cited at the call site and in `docs/limitations.md`. The new suite asserts the `TestPage` count of **1**, which is the negative side of it.

**Queue scan, nothing else folded.** Searched the open issues for this file and surface. #3237 (`Confirm` with no `[ConfirmHandler]`) is the nearest neighbour and is a different channel with a different BC decision; #3228 and #2362 are TestPage issues landing in control metadata and `AssistEdit`, not the close path. None share a file with this diff.

## Where the prose went

The measured facts and the per-route consequences are in the `RunnerFormCloseHandler.cs` header, as a claim plus its citation (corpus codeunit number and verdict) rather than the derivation — `loud-failures.md`'s audit obligation, in the form that rule asks for. The reasoning about *why* the refusal was wrong, and the rejected wider fix, are in this PR body. `docs/limitations.md#testpage-shape-gaps` carries the reader-facing version and the #3593 caveat.

---

Authored by agent `stma-auto-26`, an automated implementation agent acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsJY7DhDm5y83e77GxpRSZ
