### PR TITLE
fix(shadow): never prune an ncl-shadow dir a live process is running from, and refuse an incomplete one

### DIFF
--- a/AlRunner.Tests/LoudDiagnosisReachesTheUserTests.cs
+++ b/AlRunner.Tests/LoudDiagnosisReachesTheUserTests.cs
@@ -189,6 +189,11 @@ public sealed class LoudDiagnosisReachesTheUserTests
         // stated cause. See docs/partial-company-initialization.md.
         { "AlRunner/Program.cs", "every test in this run used a PARTIALLY initialized company" },
 
+        // #3559 — the only account of a shadow runtime dir being refused. Without it the run
+        // silently rebuilds a directory that a sibling emptied under a live process, and the
+        // next such directory takes a run down inside Roslyn twenty minutes later.
+        { "AlRunner/Infrastructure/NclShadowRuntime.cs", "is INCOMPLETE" },
+
         // #2963, and named in #3068 as the same class: System Application module-ownership
         // checks silently decline for the whole run when this row set is not seeded.
         { "AlRunner/Patches/RecordPatches.PublishedApplicationSystemTable.cs", "Published Application rows" },

--- a/AlRunner.Tests/NclShadowConcurrentStartupTests.cs
+++ b/AlRunner.Tests/NclShadowConcurrentStartupTests.cs
@@ -28,11 +28,14 @@ public sealed class NclShadowConcurrentStartupTests
     private static void WriteCompleteShadowDir(string dir, string origFull, byte[]? dllBytes = null)
     {
         Directory.CreateDirectory(dir);
-        File.WriteAllText(Path.Combine(dir, MarkerFileName), origFull);
         File.WriteAllBytes(Path.Combine(dir, EntryDllName), dllBytes ?? new byte[] { 1, 2, 3 });
         File.WriteAllBytes(Path.Combine(dir, NclFileName), new byte[] { 4, 5, 6 });
         File.WriteAllText(Path.Combine(dir, "al-runner.deps.json"), "{}");
         File.WriteAllText(Path.Combine(dir, "al-runner.runtimeconfig.json"), "{}");
+        // #3559: manifest then marker, last — the order a real build publishes in, and what
+        // makes this dir "complete" rather than merely launchable.
+        NclShadowRuntime.WriteManifest(dir);
+        File.WriteAllText(Path.Combine(dir, MarkerFileName), origFull);
     }
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/AlRunner.Tests/NclShadowInUseAndManifestTests.cs
+++ b/AlRunner.Tests/NclShadowInUseAndManifestTests.cs
@@ -123,9 +123,12 @@ public sealed class NclShadowInUseAndManifestTests
         finally { Directory.Delete(root, recursive: true); }
     }
 
-    /// <summary>A dangling symlink is a missing file (#2166's shape) — File.Exists says so,
-    /// and the manifest turns that into a refusal instead of a load failure hours later.</summary>
-    [Fact]
+    /// <summary>A dangling symlink is a missing file (#2166's shape), and the manifest must turn
+    /// it into a refusal instead of a load failure hours later. It is NOT enough to ask whether
+    /// the entry exists: measured on Linux (.NET 8), a dangling symlink answers File.Exists true
+    /// — the check has to resolve the link target. Skips, loudly, where symlink creation is
+    /// refused (Windows without Developer Mode), rather than passing having asserted nothing.</summary>
+    [SkippableFact]
     public void IsShadowDirComplete_ManifestEntryIsADanglingSymlink_Refuses()
     {
         var root = NewRoot("manifest-dangling");
@@ -139,7 +142,9 @@ public sealed class NclShadowInUseAndManifestTests
             try { File.CreateSymbolicLink(Path.Combine(shadow, "Linked.dll"), target); }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
             {
-                return; // symlinks refused on this box (the very condition #3559 was measured under)
+                throw new SkipException(
+                    $"cannot create a file symlink here ({ex.GetType().Name}: {ex.Message}) — this " +
+                    "box refuses symlinks, so the dangling-entry claim cannot be measured on it");
             }
             NclShadowRuntime.WriteManifest(shadow);
             Assert.True(NclShadowRuntime.IsShadowDirComplete(shadow, OrigFull));

--- a/AlRunner.Tests/NclShadowInUseAndManifestTests.cs
+++ b/AlRunner.Tests/NclShadowInUseAndManifestTests.cs
@@ -170,6 +170,35 @@ public sealed class NclShadowInUseAndManifestTests
         finally { Directory.Delete(root, recursive: true); }
     }
 
+    /// <summary>Acquiring the lock reclaims a dead process's lock file — otherwise a long-lived
+    /// shadow dir accumulates one entry per run — and leaves a live one alone, which is the half
+    /// that matters: reclaiming a held lock would defeat the prune guard entirely.</summary>
+    [Fact]
+    public void AcquireInUseLock_ReclaimsADeadLockFile_ButNeverAHeldOne()
+    {
+        var root = NewRoot("lock-cleanup");
+        FileStream? live = null;
+        try
+        {
+            var deadLock = Path.Combine(root, NclShadowRuntime.InUseLockPrefix + "999999");
+            File.WriteAllText(deadLock, "pid 999999");
+            var heldPath = Path.Combine(root, NclShadowRuntime.InUseLockPrefix + "999998");
+            live = new FileStream(heldPath, FileMode.Create, FileAccess.ReadWrite, FileShare.Read);
+
+            using var mine = NclShadowRuntime.AcquireInUseLock(root);
+            Assert.NotNull(mine);
+
+            Assert.False(File.Exists(deadLock), "an unheld lock file is a leftover and is reclaimed");
+            Assert.True(File.Exists(heldPath), "a lock another live process holds must survive");
+            Assert.True(File.Exists(Path.Combine(root, NclShadowRuntime.InUseLockPrefix + Environment.ProcessId)));
+        }
+        finally
+        {
+            live?.Dispose();
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
     /// <summary>The #3559 regression pin: the oldest dir is prune fodder by every rule the
     /// prune had, and is being executed from. It must survive with every file intact.</summary>
     [Fact]

--- a/AlRunner.Tests/NclShadowInUseAndManifestTests.cs
+++ b/AlRunner.Tests/NclShadowInUseAndManifestTests.cs
@@ -1,0 +1,330 @@
+// NclShadowInUseAndManifestTests — #3559.
+//
+// Measured mechanism (full account: docs/ncl-shadow-runtime.md). A sibling runner's
+// PruneStaleShadowDirs deleted a PUBLISHED shadow dir that another process was executing
+// from. On Windows the recursive delete removes every file the victim does not hold mapped
+// and leaves the rest, so the directory survives holding only its loaded assemblies — 22 of
+// 452 files in the field report — and the victim dies twenty minutes later on the first file
+// it opens by path (Roslyn, resolving a metadata reference).
+//
+// Two guards, pinned here: a published dir carries a manifest of its whole file set and is
+// refused when anything it lists is absent, and a dir whose in-use lock is held open is never
+// pruned.
+using System.Runtime.InteropServices;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class NclShadowInUseAndManifestTests
+{
+    private const string MarkerFileName = ".al-runner-shadow-source";
+    private const string ManifestFileName = ".al-runner-shadow-manifest";
+    private const string EntryDllName = "al-runner.dll";
+    private const string NclFileName = "Microsoft.Dynamics.Nav.Ncl.dll";
+    private const string OrigFull = @"C:\install\any";
+
+    private static string NewRoot(string label)
+    {
+        var dir = TestScratch.FlatDir($"ncl-shadow-3559-{label}-");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    /// <summary>A shadow dir as a completed mirror leaves it: the launch set, a handful of
+    /// ordinary dependency files including one in a nested directory, a manifest listing all
+    /// of them, and the marker last.</summary>
+    private static void WriteCompleteShadowDir(string dir)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllBytes(Path.Combine(dir, EntryDllName), new byte[] { 1, 2, 3 });
+        File.WriteAllBytes(Path.Combine(dir, NclFileName), new byte[] { 4, 5, 6 });
+        File.WriteAllText(Path.Combine(dir, "al-runner.deps.json"), "{}");
+        File.WriteAllText(Path.Combine(dir, "al-runner.runtimeconfig.json"), "{}");
+        File.WriteAllBytes(Path.Combine(dir, "Newtonsoft.Json.dll"), new byte[] { 7 });
+        Directory.CreateDirectory(Path.Combine(dir, "runtimes", "win", "lib", "net8.0"));
+        File.WriteAllBytes(Path.Combine(dir, "runtimes", "win", "lib", "net8.0", "System.Diagnostics.EventLog.Messages.dll"),
+            new byte[] { 9 });
+        NclShadowRuntime.WriteManifest(dir);
+        File.WriteAllText(Path.Combine(dir, MarkerFileName), OrigFull);
+    }
+
+    // ── The manifest ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Manifest_ListsEveryMirroredFile_AndNoBookkeepingFile()
+    {
+        var root = NewRoot("manifest-contents");
+        try
+        {
+            WriteCompleteShadowDir(root);
+            var entries = File.ReadAllLines(Path.Combine(root, ManifestFileName));
+
+            Assert.Contains(EntryDllName, entries);
+            Assert.Contains("Newtonsoft.Json.dll", entries);
+            Assert.Contains("runtimes/win/lib/net8.0/System.Diagnostics.EventLog.Messages.dll", entries);
+            Assert.DoesNotContain(ManifestFileName, entries);
+            Assert.DoesNotContain(MarkerFileName, entries);
+            Assert.Equal(6, entries.Length);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>The field case exactly: the launch set survives (mapped by the running
+    /// process) and an ordinary dependency file does not. Every pre-#3559 check passes on
+    /// this directory; the manifest is what refuses it, and it names the file.</summary>
+    [Fact]
+    public void IsShadowDirComplete_ManifestListsAnAbsentFile_RefusesAndNamesIt()
+    {
+        var root = NewRoot("manifest-missing-file");
+        try
+        {
+            WriteCompleteShadowDir(root);
+            var victim = Path.Combine(root, "runtimes", "win", "lib", "net8.0",
+                "System.Diagnostics.EventLog.Messages.dll");
+            File.Delete(victim);
+
+            Assert.False(NclShadowRuntime.IsShadowDirComplete(root, OrigFull),
+                "a dir missing a file its own manifest lists must not be offered to a run");
+
+            var missing = string.Join(", ", NclShadowRuntime.MissingRequiredNames(root, OrigFull));
+            Assert.Contains("runtimes/win/lib/net8.0/System.Diagnostics.EventLog.Messages.dll", missing);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    [Fact]
+    public void IsShadowDirComplete_NoManifest_Refuses()
+    {
+        var root = NewRoot("manifest-absent");
+        try
+        {
+            WriteCompleteShadowDir(root);
+            File.Delete(Path.Combine(root, ManifestFileName));
+
+            Assert.False(NclShadowRuntime.IsShadowDirComplete(root, OrigFull));
+            Assert.Contains("(no manifest)", string.Join(", ", NclShadowRuntime.MissingRequiredNames(root, OrigFull)));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>Positive control for the two negatives above — the same fixture, untouched,
+    /// is accepted. Without this the refusals could pass with a check that refuses everything.</summary>
+    [Fact]
+    public void IsShadowDirComplete_WholeDir_IsAccepted()
+    {
+        var root = NewRoot("manifest-complete");
+        try
+        {
+            WriteCompleteShadowDir(root);
+            Assert.True(NclShadowRuntime.IsShadowDirComplete(root, OrigFull));
+            Assert.Empty(NclShadowRuntime.MissingRequiredNames(root, OrigFull));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>A dangling symlink is a missing file (#2166's shape) — File.Exists says so,
+    /// and the manifest turns that into a refusal instead of a load failure hours later.</summary>
+    [Fact]
+    public void IsShadowDirComplete_ManifestEntryIsADanglingSymlink_Refuses()
+    {
+        var root = NewRoot("manifest-dangling");
+        var target = Path.Combine(root, "target.dll");
+        var shadow = Path.Combine(root, "shadow");
+        try
+        {
+            Directory.CreateDirectory(root);
+            File.WriteAllBytes(target, new byte[] { 1 });
+            WriteCompleteShadowDir(shadow);
+            try { File.CreateSymbolicLink(Path.Combine(shadow, "Linked.dll"), target); }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+            {
+                return; // symlinks refused on this box (the very condition #3559 was measured under)
+            }
+            NclShadowRuntime.WriteManifest(shadow);
+            Assert.True(NclShadowRuntime.IsShadowDirComplete(shadow, OrigFull));
+
+            File.Delete(target);
+            Assert.False(NclShadowRuntime.IsShadowDirComplete(shadow, OrigFull));
+            Assert.Contains("Linked.dll", string.Join(", ", NclShadowRuntime.MissingRequiredNames(shadow, OrigFull)));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    // ── The in-use lock ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void InUseLock_HeldMeansInUse_ReleasedMeansNot()
+    {
+        var root = NewRoot("lock-roundtrip");
+        try
+        {
+            Assert.False(NclShadowRuntime.IsInUse(root), "an empty dir is not in use");
+            var held = NclShadowRuntime.AcquireInUseLock(root);
+            Assert.NotNull(held);
+            Assert.True(NclShadowRuntime.IsInUse(root), "a held lock must read as in use");
+            held!.Dispose();
+            Assert.False(NclShadowRuntime.IsInUse(root),
+                "a lock file left behind by a dead process must not protect the dir forever");
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>The #3559 regression pin: the oldest dir is prune fodder by every rule the
+    /// prune had, and is being executed from. It must survive with every file intact.</summary>
+    [Fact]
+    public void PruneStaleShadowDirs_NeverDeletesADirWhoseInUseLockIsHeld()
+    {
+        var root = NewRoot("prune-skips-live");
+        FileStream? held = null;
+        try
+        {
+            var live = Path.Combine(root, "published-live");
+            WriteCompleteShadowDir(live);
+            Directory.SetLastWriteTimeUtc(live, DateTime.UtcNow.AddDays(-30));
+            held = NclShadowRuntime.AcquireInUseLock(live);
+            Assert.NotNull(held);
+
+            for (var i = 0; i < 3; i++)
+            {
+                var d = Path.Combine(root, $"published-{i}");
+                Directory.CreateDirectory(d);
+                Directory.SetLastWriteTimeUtc(d, DateTime.UtcNow.AddHours(-1 - i));
+            }
+            var protectedDir = Path.Combine(root, "protected");
+            Directory.CreateDirectory(protectedDir);
+
+            NclShadowRuntime.PruneStaleShadowDirs(root, protectedDir, keepNewest: 2);
+
+            Assert.True(Directory.Exists(live), "a shadow dir a live process is executing from must survive a prune");
+            Assert.True(File.Exists(Path.Combine(live, "runtimes", "win", "lib", "net8.0",
+                    "System.Diagnostics.EventLog.Messages.dll")),
+                "a partially-emptied survivor is the #3559 defect — the dir must be intact, not merely present");
+            Assert.True(NclShadowRuntime.IsShadowDirComplete(live, OrigFull));
+        }
+        finally
+        {
+            held?.Dispose();
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    /// <summary>Negative: the lock must not become "prune never deletes anything". An old dir
+    /// whose lock file is a leftover from a dead process is still reclaimed.</summary>
+    [Fact]
+    public void PruneStaleShadowDirs_StaleUnheldLockFile_StillPrunes()
+    {
+        var root = NewRoot("prune-stale-lock");
+        try
+        {
+            var stale = Path.Combine(root, "published-stale");
+            WriteCompleteShadowDir(stale);
+            File.WriteAllText(Path.Combine(stale, NclShadowRuntime.InUseLockPrefix + "999999"), "pid 999999");
+            Directory.SetLastWriteTimeUtc(stale, DateTime.UtcNow.AddDays(-30));
+
+            for (var i = 0; i < 3; i++)
+            {
+                var d = Path.Combine(root, $"published-{i}");
+                Directory.CreateDirectory(d);
+                Directory.SetLastWriteTimeUtc(d, DateTime.UtcNow.AddHours(-1 - i));
+            }
+            var protectedDir = Path.Combine(root, "protected");
+            Directory.CreateDirectory(protectedDir);
+
+            NclShadowRuntime.PruneStaleShadowDirs(root, protectedDir, keepNewest: 2);
+
+            Assert.False(Directory.Exists(stale),
+                "an unheld lock file is not a claim — the dir must still be reclaimable");
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>The age floor, the second guard: a freshly published dir is not pruned even
+    /// with no lock on it, which covers a process built before the lock existed.</summary>
+    [Fact]
+    public void PruneStaleShadowDirs_RecentlyPublishedDir_IsNotPruned()
+    {
+        var root = NewRoot("prune-age-floor");
+        try
+        {
+            var recent = Path.Combine(root, "published-recent");
+            WriteCompleteShadowDir(recent);
+            Directory.SetLastWriteTimeUtc(recent, DateTime.UtcNow - NclShadowRuntime.MinPruneAge + TimeSpan.FromMinutes(1));
+
+            for (var i = 0; i < 4; i++)
+            {
+                var d = Path.Combine(root, $"published-{i}");
+                Directory.CreateDirectory(d);
+                Directory.SetLastWriteTimeUtc(d, DateTime.UtcNow.AddMinutes(-5));
+            }
+            var protectedDir = Path.Combine(root, "protected");
+            Directory.CreateDirectory(protectedDir);
+
+            NclShadowRuntime.PruneStaleShadowDirs(root, protectedDir, keepNewest: 2);
+
+            Assert.True(Directory.Exists(recent));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>The Windows behaviour the whole issue rests on, measured rather than assumed:
+    /// a recursive delete over a directory with one open FileShare.Read handle throws, removes
+    /// every other file, and leaves the held one — the 22-of-452 signature. Windows-only; on
+    /// Linux unlink succeeds and the survivor set is empty, which is why the prune has to
+    /// probe before deleting instead of relying on the delete failing.</summary>
+    [Fact]
+    public void RecursiveDeleteOverAnOpenHandle_LeavesOnlyTheHeldFile_OnWindows()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        var root = NewRoot("delete-signature");
+        try
+        {
+            WriteCompleteShadowDir(root);
+            using (var held = File.Open(Path.Combine(root, EntryDllName), FileMode.Open, FileAccess.Read, FileShare.Read))
+            {
+                Assert.Throws<IOException>(() => Directory.Delete(root, recursive: true));
+                Assert.True(File.Exists(Path.Combine(root, EntryDllName)), "the mapped file survives");
+                Assert.False(File.Exists(Path.Combine(root, "Newtonsoft.Json.dll")), "everything unmapped is gone");
+                Assert.False(File.Exists(Path.Combine(root, MarkerFileName)));
+            }
+        }
+        finally { try { Directory.Delete(root, recursive: true); } catch (IOException) { } }
+    }
+
+    // ── The heal ────────────────────────────────────────────────────────────────
+
+    /// <summary>An emptied-but-live shadow dir is healed back to its whole file set, in place —
+    /// the four launch files the pre-#3559 heal copied cannot fill a hole this shape, and the
+    /// dir may not be renamed aside (#2489: a live process's AppContext.BaseDirectory).</summary>
+    [Fact]
+    public void PublishShadowDir_HealsEveryFileTheManifestLists_WithoutRenamingTheDir()
+    {
+        var root = NewRoot("heal-whole-set");
+        try
+        {
+            var shadowDir = Path.Combine(root, "key");
+            WriteCompleteShadowDir(shadowDir);
+            // What a prune under a live process leaves: the mapped entry assembly and Ncl.dll.
+            File.Delete(Path.Combine(shadowDir, "Newtonsoft.Json.dll"));
+            File.Delete(Path.Combine(shadowDir, "al-runner.deps.json"));
+            File.Delete(Path.Combine(shadowDir, "runtimes", "win", "lib", "net8.0",
+                "System.Diagnostics.EventLog.Messages.dll"));
+            File.Delete(Path.Combine(shadowDir, MarkerFileName));
+            Assert.False(NclShadowRuntime.IsShadowDirComplete(shadowDir, OrigFull));
+
+            var tempDir = Path.Combine(root, "key.building.x");
+            WriteCompleteShadowDir(tempDir);
+
+            var published = NclShadowRuntime.PublishShadowDir(tempDir, shadowDir, OrigFull);
+
+            Assert.Equal(shadowDir, published);
+            Assert.True(NclShadowRuntime.IsShadowDirComplete(shadowDir, OrigFull));
+            Assert.True(File.Exists(Path.Combine(shadowDir, "runtimes", "win", "lib", "net8.0",
+                "System.Diagnostics.EventLog.Messages.dll")));
+            Assert.True(File.Exists(Path.Combine(shadowDir, "Newtonsoft.Json.dll")));
+            Assert.DoesNotContain(Directory.GetDirectories(root),
+                d => Path.GetFileName(d).Contains(".stale.", StringComparison.OrdinalIgnoreCase));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+}

--- a/AlRunner.Tests/NclShadowInUseAndManifestTests.cs
+++ b/AlRunner.Tests/NclShadowInUseAndManifestTests.cs
@@ -181,9 +181,12 @@ public sealed class NclShadowInUseAndManifestTests
         {
             var live = Path.Combine(root, "published-live");
             WriteCompleteShadowDir(live);
-            Directory.SetLastWriteTimeUtc(live, DateTime.UtcNow.AddDays(-30));
             held = NclShadowRuntime.AcquireInUseLock(live);
             Assert.NotNull(held);
+            // Back-date AFTER taking the lock: writing the lock file bumps the dir's mtime,
+            // and a dir that looks young is protected by the age floor instead — which would
+            // let this test pass with the in-use probe removed entirely.
+            Directory.SetLastWriteTimeUtc(live, DateTime.UtcNow.AddDays(-30));
 
             for (var i = 0; i < 3; i++)
             {

--- a/AlRunner.Tests/NclShadowLockedSourcePublishTests.cs
+++ b/AlRunner.Tests/NclShadowLockedSourcePublishTests.cs
@@ -36,7 +36,8 @@ public sealed class NclShadowLockedSourcePublishTests
         File.WriteAllBytes(Path.Combine(dir, NclFileName), new byte[] { 4, 5, 6 });
         File.WriteAllText(Path.Combine(dir, "al-runner.deps.json"), "{}");
         File.WriteAllText(Path.Combine(dir, "al-runner.runtimeconfig.json"), "{}");
-        // Marker last, same invariant the real build holds.
+        // Manifest then marker, last — same invariant the real build holds (#3559).
+        NclShadowRuntime.WriteManifest(dir);
         File.WriteAllText(Path.Combine(dir, MarkerFileName), origFull);
     }
 

--- a/AlRunner.Tests/NclShadowPublishDiagnosisTests.cs
+++ b/AlRunner.Tests/NclShadowPublishDiagnosisTests.cs
@@ -50,7 +50,8 @@ public sealed class NclShadowPublishDiagnosisTests
         File.WriteAllBytes(Path.Combine(dir, NclFileName), new byte[] { 4, 5, 6 });
         File.WriteAllText(Path.Combine(dir, "al-runner.deps.json"), "{}");
         File.WriteAllText(Path.Combine(dir, "al-runner.runtimeconfig.json"), "{}");
-        // Marker last, same invariant the real build holds.
+        // Manifest then marker, last — same invariant the real build holds (#3559).
+        NclShadowRuntime.WriteManifest(dir);
         File.WriteAllText(Path.Combine(dir, MarkerFileName), origFull);
     }
 

--- a/AlRunner/Infrastructure/NclShadowRuntime.cs
+++ b/AlRunner/Infrastructure/NclShadowRuntime.cs
@@ -374,10 +374,30 @@ public static class NclShadowRuntime
         {
             if (rel.Length == 0) continue;
             var path = Path.Combine(dir, rel.Replace('/', Path.DirectorySeparatorChar).TrimEnd(Path.DirectorySeparatorChar));
-            var present = rel.EndsWith("/", StringComparison.Ordinal) ? Directory.Exists(path) : File.Exists(path);
-            if (!present) missing.Add(rel);
+            if (!EntryResolves(path, isDirectory: rel.EndsWith("/", StringComparison.Ordinal))) missing.Add(rel);
         }
         return missing;
+    }
+
+    /// <summary>
+    /// True when a manifest entry is really readable: present, and — when it is a symlink — its
+    /// target still exists. Measured on Linux (.NET 8), a DANGLING symlink answers
+    /// <c>File.Exists</c> true, <c>FileInfo.Exists</c> true, and is listed by
+    /// <c>Directory.EnumerateFiles</c>; only <c>ResolveLinkTarget(returnFinalTarget: true)</c>
+    /// reports it. On Windows <c>File.Exists</c> answers false for the same shape, so an
+    /// existence check alone passes there and lets the gap through on the legs that matter.
+    /// </summary>
+    internal static bool EntryResolves(string path, bool isDirectory)
+    {
+        try
+        {
+            FileSystemInfo info = isDirectory ? new DirectoryInfo(path) : new FileInfo(path);
+            if (!info.Exists) return false;
+            if (info.LinkTarget == null) return true;
+            return info.ResolveLinkTarget(returnFinalTarget: true)?.Exists == true;
+        }
+        catch (IOException) { return false; }              // cyclic or too many links
+        catch (UnauthorizedAccessException) { return false; }
     }
 
     /// <summary>

--- a/AlRunner/Infrastructure/NclShadowRuntime.cs
+++ b/AlRunner/Infrastructure/NclShadowRuntime.cs
@@ -235,8 +235,8 @@ public static class NclShadowRuntime
             if (why.Length > 0)
                 Console.Error.WriteLine(
                     $"[warn] Ncl shadow runtime: the published dir at {shadowDir} is INCOMPLETE " +
-                    $"(missing: {why}) - refusing to run from it and rebuilding it now. If this " +
-                    "repeats, a concurrent runner process pruned it while it was in use.");
+                    $"(missing: {why}) - this run will refuse it and rebuild it now. " +
+                    "See docs/ncl-shadow-runtime.md for the shapes that produce this.");
         }
 
         Console.Error.WriteLine($"[Cecil] Building Ncl shadow runtime dir at {shadowDir}");
@@ -891,14 +891,16 @@ public static class NclShadowRuntime
             // path. See docs/ncl-shadow-runtime.md.
             if (IsInUse(dir))
             {
-                Console.Error.WriteLine(
-                    $"[reexec] Not pruning shadow dir {dir}: another runner process is running from it");
+                if (AlRunner.Log.Verbose)
+                    Console.Error.WriteLine(
+                        $"[reexec] Not pruning shadow dir {dir}: another runner process is running from it");
                 continue;
             }
             if (IsYoungerThan(dir, MinPruneAge))
             {
-                Console.Error.WriteLine(
-                    $"[reexec] Not pruning shadow dir {dir}: published less than {MinPruneAge.TotalMinutes:0} minutes ago");
+                if (AlRunner.Log.Verbose)
+                    Console.Error.WriteLine(
+                        $"[reexec] Not pruning shadow dir {dir}: published less than {MinPruneAge.TotalMinutes:0} minutes ago");
                 continue;
             }
 

--- a/AlRunner/Infrastructure/NclShadowRuntime.cs
+++ b/AlRunner/Infrastructure/NclShadowRuntime.cs
@@ -388,6 +388,22 @@ public static class NclShadowRuntime
     /// </summary>
     internal static FileStream? AcquireInUseLock(string dir)
     {
+        // One lock file per pid would otherwise accumulate one entry per run, forever. A file
+        // that opens exclusively is held by nobody, so it belongs to a process that has exited.
+        foreach (var file in SafeEnumerateFiles(dir))
+        {
+            var name = Path.GetFileName(file);
+            if (!name.StartsWith(InUseLockPrefix, StringComparison.OrdinalIgnoreCase)) continue;
+            if (name.EndsWith("." + Environment.ProcessId, StringComparison.Ordinal)) continue;
+            try
+            {
+                using (var probe = new FileStream(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) { }
+                File.Delete(file);
+            }
+            catch (IOException) { /* held by a live process, or gone — leave it */ }
+            catch (UnauthorizedAccessException) { }
+        }
+
         try
         {
             var path = Path.Combine(dir, InUseLockPrefix + Environment.ProcessId);
@@ -431,6 +447,13 @@ public static class NclShadowRuntime
         catch (IOException) { return true; }
         catch (UnauthorizedAccessException) { return true; }
         return false;
+    }
+
+    private static IEnumerable<string> SafeEnumerateFiles(string dir)
+    {
+        try { return Directory.EnumerateFiles(dir).ToList(); }
+        catch (IOException) { return Array.Empty<string>(); }
+        catch (UnauthorizedAccessException) { return Array.Empty<string>(); }
     }
 
     /// <summary>

--- a/AlRunner/Infrastructure/NclShadowRuntime.cs
+++ b/AlRunner/Infrastructure/NclShadowRuntime.cs
@@ -49,6 +49,26 @@ public static class NclShadowRuntime
     private const string MarkerFileName = ".al-runner-shadow-source";
     private const string EntryDllName = "al-runner.dll";
 
+    // #3559. The manifest lists every entry a completed mirror produced, so completeness
+    // means "the whole file set", not "the five files a `dotnet exec` needs". The in-use
+    // lock is a file this process keeps an OPEN HANDLE on for its whole lifetime, so a
+    // sibling's prune can see that somebody is executing from here.
+    // See docs/ncl-shadow-runtime.md#completeness-and-in-use-locking.
+    private const string ManifestFileName = ".al-runner-shadow-manifest";
+    internal const string InUseLockPrefix = ".al-runner-shadow-inuse.";
+
+    /// <summary>Files this process's own bookkeeping writes into a shadow dir, so they are
+    /// never listed in the manifest (the marker is written after it, and the lock files come
+    /// and go per process).</summary>
+    private static bool IsBookkeepingName(string name) =>
+        name.Equals(ManifestFileName, StringComparison.OrdinalIgnoreCase)
+        || name.Equals(MarkerFileName, StringComparison.OrdinalIgnoreCase)
+        || name.StartsWith(InUseLockPrefix, StringComparison.OrdinalIgnoreCase);
+
+    // Held for the life of the process — see HoldInUseLock. A field, not a local, because
+    // closing the handle is exactly what makes the directory prunable again.
+    private static readonly List<FileStream> HeldInUseLocks = new();
+
     // The entry assembly and the small manifests hostfxr reads to launch it — these
     // must be real, independent files in the shadow dir, not symlinks. See the comment
     // at the call site in EnsureShadowDir for why.
@@ -195,8 +215,28 @@ public static class NclShadowRuntime
 
         if (reusable)
         {
-            Console.Error.WriteLine($"[Cecil] Reusing Ncl shadow runtime dir at {shadowDir}");
-            return shadowDll;
+            // Take the in-use lock BEFORE trusting the check: a sibling's prune can land
+            // between the two, and re-checking afterwards is what makes the lock the thing
+            // that decides (#3559).
+            HoldInUseLock(shadowDir);
+            if (IsShadowDirComplete(shadowDir, origFull))
+            {
+                Console.Error.WriteLine($"[Cecil] Reusing Ncl shadow runtime dir at {shadowDir}");
+                return shadowDll;
+            }
+        }
+
+        if (!forceFresh && Directory.Exists(shadowDir))
+        {
+            // #3559: say what was wrong with the directory we refused. Silence here is what
+            // turned a shadow dir emptied under a live process into a FileNotFoundException
+            // inside Roslyn twenty minutes later, with nothing naming the directory.
+            var why = string.Join(", ", MissingRequiredNames(shadowDir, origFull));
+            if (why.Length > 0)
+                Console.Error.WriteLine(
+                    $"[warn] Ncl shadow runtime: the published dir at {shadowDir} is INCOMPLETE " +
+                    $"(missing: {why}) - refusing to run from it and rebuilding it now. If this " +
+                    "repeats, a concurrent runner process pruned it while it was in use.");
         }
 
         Console.Error.WriteLine($"[Cecil] Building Ncl shadow runtime dir at {shadowDir}");
@@ -232,9 +272,10 @@ public static class NclShadowRuntime
             if (entrySource == null)
                 NclCecilRewrite.RewriteInPlace(bcServiceTierDir, Path.Combine(tempDir, NclFileName));
 
-            // Marker goes in LAST, inside the temp dir, so the invariant "marker present
-            // => fully built" survives the rename: nobody can observe a marker-bearing
-            // shadowDir that isn't complete.
+            // Manifest, then the marker, both LAST and inside the temp dir, so the invariant
+            // "marker present => fully built" survives the rename: nobody can observe a
+            // marker-bearing shadowDir that isn't complete.
+            WriteManifest(tempDir);
             File.WriteAllText(Path.Combine(tempDir, MarkerFileName), origFull);
 
             publishedDir = PublishShadowDir(tempDir, shadowDir, origFull);
@@ -247,6 +288,11 @@ public static class NclShadowRuntime
             if (!string.Equals(publishedDir, tempDir, StringComparison.OrdinalIgnoreCase))
                 try { if (Directory.Exists(tempDir)) Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
         }
+
+        // Held for this process's lifetime, and this process outlives the child it is about
+        // to re-exec into (TryShadowReexec waits on it) — so no sibling's prune can empty
+        // the directory the child is executing from (#3559).
+        HoldInUseLock(publishedDir);
 
         PruneStaleShadowDirs(shadowRoot, publishedDir, keepNewest: 4);
 
@@ -266,6 +312,126 @@ public static class NclShadowRuntime
     {
         "al-runner.deps.json", "al-runner.runtimeconfig.json",
     };
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // #3559 — completeness manifest, and the in-use lock that stops prune deleting
+    // a directory a live process is executing from.
+    // Mechanism and the field evidence: docs/ncl-shadow-runtime.md
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Every entry a completed mirror of a shadow dir holds, as paths relative to
+    /// <paramref name="dir"/> with '/' separators. A directory that is a symlink is
+    /// recorded as its own entry with a trailing '/' and not descended into (the link
+    /// target belongs to the install being mirrored, not to us); a real directory is
+    /// descended into; bookkeeping files are skipped.
+    /// </summary>
+    internal static IEnumerable<string> EnumerateManifestEntries(string dir, string prefix = "")
+    {
+        foreach (var entry in Directory.EnumerateFileSystemEntries(dir).OrderBy(e => e, StringComparer.Ordinal))
+        {
+            var name = Path.GetFileName(entry);
+            if (prefix.Length == 0 && IsBookkeepingName(name)) continue;
+            var rel = prefix + name;
+            var info = new DirectoryInfo(entry);
+            var isDir = (info.Attributes & FileAttributes.Directory) != 0;
+            var isLink = info.LinkTarget != null;
+            if (isDir && !isLink)
+            {
+                foreach (var nested in EnumerateManifestEntries(entry, rel + "/")) yield return nested;
+            }
+            else
+            {
+                yield return isDir ? rel + "/" : rel;
+            }
+        }
+    }
+
+    /// <summary>Writes the manifest of <paramref name="dir"/> into it. Called as the last
+    /// step before the marker, so "marker present" still implies "manifest present and
+    /// describes a finished mirror".</summary>
+    internal static void WriteManifest(string dir) =>
+        File.WriteAllLines(Path.Combine(dir, ManifestFileName), EnumerateManifestEntries(dir).ToList());
+
+    /// <summary>The manifest entries of <paramref name="dir"/> that are not on disk. Empty
+    /// when the dir is whole; a single "(no manifest)" pseudo-entry when the manifest is
+    /// absent, which is itself a refusal — a dir published without one cannot be
+    /// distinguished from one a prune emptied.</summary>
+    internal static IReadOnlyList<string> MissingManifestEntries(string dir)
+    {
+        var manifest = Path.Combine(dir, ManifestFileName);
+        string[] lines;
+        try
+        {
+            if (!File.Exists(manifest)) return new[] { "(no manifest)" };
+            lines = File.ReadAllLines(manifest);
+        }
+        catch (IOException) { return new[] { "(no manifest)" }; }
+        catch (UnauthorizedAccessException) { return new[] { "(no manifest)" }; }
+
+        var missing = new List<string>();
+        foreach (var rel in lines)
+        {
+            if (rel.Length == 0) continue;
+            var path = Path.Combine(dir, rel.Replace('/', Path.DirectorySeparatorChar).TrimEnd(Path.DirectorySeparatorChar));
+            var present = rel.EndsWith("/", StringComparison.Ordinal) ? Directory.Exists(path) : File.Exists(path);
+            if (!present) missing.Add(rel);
+        }
+        return missing;
+    }
+
+    /// <summary>
+    /// Opens this process's in-use lock inside <paramref name="dir"/> and returns the open
+    /// handle, or null when it could not be created. <c>FileShare.Read</c> is what makes it
+    /// a lock: a prune probing with <c>FileShare.None</c> is refused while it is open, and
+    /// on Windows <c>Directory.Delete(recursive: true)</c> is refused outright.
+    /// </summary>
+    internal static FileStream? AcquireInUseLock(string dir)
+    {
+        try
+        {
+            var path = Path.Combine(dir, InUseLockPrefix + Environment.ProcessId);
+            var fs = new FileStream(path, FileMode.Create, FileAccess.ReadWrite, FileShare.Read);
+            var stamp = Encoding.UTF8.GetBytes($"pid {Environment.ProcessId} since {DateTime.UtcNow:O}");
+            fs.Write(stamp, 0, stamp.Length);
+            fs.Flush(flushToDisk: false);
+            return fs;
+        }
+        catch (IOException) { return null; }
+        catch (UnauthorizedAccessException) { return null; }
+    }
+
+    /// <summary>Takes the in-use lock and never releases it — the handle lives as long as
+    /// this process does, which is precisely the window during which the directory must not
+    /// be pruned. The parent outlives the shadow child it re-execs (TryShadowReexec waits on
+    /// it), so the parent holding the lock covers the child's whole run.</summary>
+    internal static void HoldInUseLock(string dir)
+    {
+        var fs = AcquireInUseLock(dir);
+        if (fs == null) return;
+        lock (HeldInUseLocks) HeldInUseLocks.Add(fs);
+    }
+
+    /// <summary>True when any in-use lock in <paramref name="dir"/> is still held open —
+    /// i.e. some runner process is executing from it right now. A lock file left behind by a
+    /// crashed process opens cleanly and does not protect anything.</summary>
+    internal static bool IsInUse(string dir)
+    {
+        try
+        {
+            foreach (var file in Directory.EnumerateFiles(dir))
+            {
+                if (!Path.GetFileName(file).StartsWith(InUseLockPrefix, StringComparison.OrdinalIgnoreCase)) continue;
+                try { using var probe = new FileStream(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None); }
+                catch (IOException) { return true; }
+                catch (UnauthorizedAccessException) { return true; }
+            }
+        }
+        // Cannot read the directory: assume in use rather than delete something we cannot inspect.
+        catch (IOException) { return true; }
+        catch (UnauthorizedAccessException) { return true; }
+        return false;
+    }
 
     /// <summary>
     /// True when <paramref name="shadowDir"/> is a fully-built, reusable shadow dir for
@@ -287,7 +453,10 @@ public static class NclShadowRuntime
             if (!File.Exists(shadowDll) || !File.Exists(shadowNcl)) return false;
             foreach (var name in RequiredManifestNames)
                 if (!File.Exists(Path.Combine(shadowDir, name))) return false;
-            return true;
+            // #3559: the five names above are what `dotnet exec` needs to LAUNCH; the run
+            // then reads hundreds of further files off this directory by path, hours later.
+            // The manifest is the only check that covers those.
+            return MissingManifestEntries(shadowDir).Count == 0;
         }
         catch (IOException)
         {
@@ -308,6 +477,19 @@ public static class NclShadowRuntime
     {
         EntryDllName, NclFileName, "al-runner.deps.json", "al-runner.runtimeconfig.json",
     };
+
+    /// <summary>What an in-place heal copies out of a complete build: every entry that build's
+    /// manifest lists (#3559 — a prune that emptied a live dir leaves hundreds of holes, and
+    /// the four names above cannot fill them), falling back to those four names when the build
+    /// carries no manifest.</summary>
+    private static IEnumerable<string> HealableNames(string tempDir)
+    {
+        List<string> entries;
+        try { entries = EnumerateManifestEntries(tempDir).ToList(); }
+        catch (IOException) { return HealableFileNames; }
+        catch (UnauthorizedAccessException) { return HealableFileNames; }
+        return entries.Count > 0 ? entries : HealableFileNames;
+    }
 
     /// <summary>
     /// Publishes <paramref name="tempDir"/> (a fully-built shadow dir, marker written last)
@@ -429,14 +611,30 @@ public static class NclShadowRuntime
             // shadow dir itself, well past its own startup. A missing file has no
             // existing inode to corrupt, so creating it is safe regardless of who else
             // is running from this directory.
-            foreach (var name in HealableFileNames)
+            foreach (var name in HealableNames(tempDir))
             {
-                var dest = Path.Combine(shadowDir, name);
-                if (File.Exists(dest)) continue;
-                try { File.Copy(Path.Combine(tempDir, name), dest, overwrite: false); }
+                var isDir = name.EndsWith("/", StringComparison.Ordinal);
+                var rel = name.Replace('/', Path.DirectorySeparatorChar).TrimEnd(Path.DirectorySeparatorChar);
+                var dest = Path.Combine(shadowDir, rel);
+                var src = Path.Combine(tempDir, rel);
+                if (isDir ? Directory.Exists(dest) : File.Exists(dest)) continue;
+                try
+                {
+                    var destParent = Path.GetDirectoryName(dest);
+                    if (destParent != null) Directory.CreateDirectory(destParent);
+                    if (isDir) CopyDirectoryRecursive(src, dest);
+                    else File.Copy(src, dest, overwrite: false);
+                }
                 catch (IOException) { /* sibling created it (or is creating it) concurrently — fine either way */ }
                 catch (UnauthorizedAccessException) { /* same */ }
             }
+            // The manifest, then the marker, last — same invariant as the initial build:
+            // "marker matches origFull" only becomes true once every other required file is
+            // in place. Both are safe to overwrite (never mapped, never a load target).
+            try { File.Copy(Path.Combine(tempDir, ManifestFileName), Path.Combine(shadowDir, ManifestFileName), overwrite: true); }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+
             // Marker goes last, same invariant as the initial build: "marker matches
             // origFull" only becomes true once every other required file is in place.
             // The marker itself IS safe to overwrite unconditionally — nothing reads it
@@ -501,7 +699,7 @@ public static class NclShadowRuntime
     /// <summary>The required names <see cref="IsShadowDirComplete"/> did not find, so an
     /// error can say WHICH file is missing rather than only that something was. Same
     /// definition of "required" as that method, read from the same two lists.</summary>
-    private static IEnumerable<string> MissingRequiredNames(string dir, string origFull)
+    internal static IEnumerable<string> MissingRequiredNames(string dir, string origFull)
     {
         if (!Directory.Exists(dir)) { yield return "(the directory itself)"; yield break; }
         foreach (var name in new[] { EntryDllName, NclFileName }.Concat(RequiredManifestNames))
@@ -519,6 +717,14 @@ public static class NclShadowRuntime
             if (recorded != origFull)
                 yield return $"{MarkerFileName} (records '{recorded}', expected '{origFull}')";
         }
+
+        // #3559: the file set, summarised — a prune that emptied a live directory leaves
+        // hundreds missing, and printing all of them would bury the rest of the message.
+        var missingFromManifest = MissingManifestEntries(dir);
+        if (missingFromManifest.Count > 0)
+            yield return missingFromManifest.Count <= 5
+                ? string.Join(", ", missingFromManifest)
+                : $"{string.Join(", ", missingFromManifest.Take(5))} and {missingFromManifest.Count - 5} more file(s) listed in {ManifestFileName}";
     }
 
     /// <summary>
@@ -646,6 +852,18 @@ public static class NclShadowRuntime
     /// <see cref="PublishShadowDir"/> for the self-heal that recovers from that state
     /// once it's already happened, but the real fix is not deleting into it in the first
     /// place.</summary>
+    /// <summary>Second guard behind the in-use lock: a directory this new is plausibly serving
+    /// a process built before the lock existed, or one between its own publish and its lock.
+    /// It is a floor on age, not on count — a dir older than this is still ordinary prune fodder.</summary>
+    internal static readonly TimeSpan MinPruneAge = TimeSpan.FromMinutes(10);
+
+    private static bool IsYoungerThan(string dir, TimeSpan age)
+    {
+        try { return DateTime.UtcNow - Directory.GetLastWriteTimeUtc(dir) < age; }
+        catch (IOException) { return true; }
+        catch (UnauthorizedAccessException) { return true; }
+    }
+
     internal static void PruneStaleShadowDirs(string shadowRoot, string protectedDir, int keepNewest)
     {
         var protectedFull = Path.GetFullPath(protectedDir);
@@ -666,6 +884,24 @@ public static class NclShadowRuntime
 
         foreach (var dir in stale)
         {
+            // #3559: never delete a directory another runner process is executing from.
+            // Measured on Windows: Directory.Delete(recursive: true) over a live shadow dir
+            // deletes every file the process does not hold mapped and leaves the rest, so
+            // the victim keeps running and dies hours later on the first file it opens by
+            // path. See docs/ncl-shadow-runtime.md.
+            if (IsInUse(dir))
+            {
+                Console.Error.WriteLine(
+                    $"[reexec] Not pruning shadow dir {dir}: another runner process is running from it");
+                continue;
+            }
+            if (IsYoungerThan(dir, MinPruneAge))
+            {
+                Console.Error.WriteLine(
+                    $"[reexec] Not pruning shadow dir {dir}: published less than {MinPruneAge.TotalMinutes:0} minutes ago");
+                continue;
+            }
+
             // #2034 audit: same reasoning as the symlink-fallback WARN above — a real
             // failure during shadow-dir upkeep, not routine Cecil-rewrite diagnostics.
             try { Directory.Delete(dir, recursive: true); }

--- a/docs/ncl-shadow-runtime.md
+++ b/docs/ncl-shadow-runtime.md
@@ -63,10 +63,23 @@ deleting** rather than relying on the delete failing.
 
 ### Design notes
 
-- **The manifest lists names, not sizes.** The failure is a *missing* file. `File.Exists` on a
-  dangling symlink is false, so a name list also catches the #2166 shape (a symlink whose
-  target the original install lost), and a size read on a symlink means different things on
-  different platforms.
+- **The manifest lists names, not sizes.** The failure is a *missing* file, and a size read on a
+  symlink means different things on different platforms.
+- **Presence is not `File.Exists`.** A name list also catches the #2166 shape — a symlink whose
+  target the original install lost — but only if the check resolves the link. Measured on Linux
+  (.NET 8, WSL) against a dangling symlink:
+
+  | | intact | dangling |
+  |---|---|---|
+  | `File.Exists` / `FileInfo.Exists` | true | **true** |
+  | listed by `Directory.EnumerateFiles` | yes | yes |
+  | `ResolveLinkTarget(returnFinalTarget: true)?.Exists` | true | **false** |
+
+  On Windows `File.Exists` answers false for the same shape, so an existence check alone passes
+  there and lets the gap through on exactly the legs that matter. `EntryResolves` asks the third
+  row. This was caught by CI: PR #3596's first head was red on both unit legs with
+  `Assert.False() Failure, Actual: True`, on a Windows box where the test had skipped itself
+  because symlink creation is refused.
 - **Verification cost** is one `File.Exists` per entry, a few hundred stats, at startup and in
   the publish loop.
 - **The heal copies every manifest entry that is missing**, never overwriting one that exists.

--- a/docs/ncl-shadow-runtime.md
+++ b/docs/ncl-shadow-runtime.md
@@ -1,0 +1,93 @@
+# The Ncl shadow runtime directory
+
+The runner does not ship `Microsoft.Dynamics.Nav.Ncl.dll`. It mirrors its own install into a
+cached "shadow" directory under `<cache>/ncl-shadow/<key>`, puts a Cecil-rewritten Ncl.dll
+there, and re-execs into it, because CoreCLR fixes the trusted-platform-assemblies list from
+the on-disk contents of the base directory before any managed code runs.
+`AlRunner/Infrastructure/NclShadowRuntime.cs` has the class-level account of that design; this
+page covers what makes a published directory trustworthy, and what stopped it being so.
+
+## Completeness and in-use locking
+
+Two files are bookkeeping rather than mirror content:
+
+| file | written | meaning |
+|---|---|---|
+| `.al-runner-shadow-manifest` | last but one, in the `.building.*` temp dir | every entry a completed mirror produced, relative, `/`-separated, directories that are symlinks recorded with a trailing `/` |
+| `.al-runner-shadow-inuse.<pid>` | when a process adopts or publishes the dir | an open handle (`FileShare.Read`) the process holds until it exits |
+
+`IsShadowDirComplete` accepts a directory only when the marker matches the install, the launch
+set is present (`al-runner.dll`, `Ncl.dll`, `al-runner.deps.json`,
+`al-runner.runtimeconfig.json`), **and** nothing the manifest lists is absent.
+`PruneStaleShadowDirs` deletes a stale directory only when no in-use lock in it is held and it
+is older than `MinPruneAge` (10 minutes).
+
+### What went wrong (#3559)
+
+A run that had executed for ~20 minutes died in `BcAssembler.SharedMetadataReferences` →
+`MetadataReference.CreateFromFile` with `FileNotFoundException` on
+`…/ncl-shadow/7a4d…/runtimes/win/lib/net8.0/System.Diagnostics.EventLog.Messages.dll`. The
+directory existed and held **22 files** where a sibling published from the same install held
+**452**. Five runner processes from four builds were starting against one `~/.cache/al-runner`
+in the same half hour, and symlinks are refused on that box, so every mirror was a real copy.
+
+The 22 survivors decide the diagnosis. Every one is an assembly a running .NET process holds
+mapped:
+
+```
+al-runner.dll  Microsoft.Dynamics.Nav.Ncl.dll  AlRunner.QueryJoin.dll  AlRunner.Provisioning.dll
+Microsoft.CodeAnalysis[.CSharp].dll  Mono.Cecil.dll  Newtonsoft.Json.dll  Spectre.Console.dll
+System.Text.Json.dll  System.Reflection.Metadata.dll  System.Collections.Immutable.dll  …
+runtimes/win/lib/net8.0/System.Diagnostics.EventLog.dll
+```
+
+Nothing unmapped survived — not the marker, not `al-runner.deps.json`, not the 430 other DLLs,
+and not `EventLog.Messages.dll`, which is a resource-only assembly nothing loads. So the
+directory was not published incomplete: **it was built complete by the process that then
+crashed, and emptied underneath it by a sibling's `PruneStaleShadowDirs`.** The prune keeps the
+newest four and five keys existed, so the victim's own published directory was ordinary prune
+fodder — its `protectedDir` argument only ever protects the pruning process's own directory.
+
+Measured on Windows 11, .NET 8 (`tmp/probe3559/probe.ps1`): with one file of six held open
+`FileShare.Read`, `Directory.Delete(recursive: true)` throws
+`The process cannot access the file … because it is being used by another process`, deletes
+every other file, and leaves the held one. That is exactly the 22-of-452 shape, and it is why
+the victim keeps running — its already-open handles stay valid — until the first time it opens
+a file in that directory *by path*, which for this run was Roslyn resolving a metadata
+reference twenty minutes in.
+
+The same probe confirms the lock primitive: a holder with `FileShare.Read` refuses a prober's
+`FileShare.None` open, and the probe succeeds again the moment the holder disposes. On Linux
+the delete would succeed instead (unlink semantics), which is why the prune **probes before
+deleting** rather than relying on the delete failing.
+
+### Design notes
+
+- **The manifest lists names, not sizes.** The failure is a *missing* file. `File.Exists` on a
+  dangling symlink is false, so a name list also catches the #2166 shape (a symlink whose
+  target the original install lost), and a size read on a symlink means different things on
+  different platforms.
+- **Verification cost** is one `File.Exists` per entry, a few hundred stats, at startup and in
+  the publish loop.
+- **The heal copies every manifest entry that is missing**, never overwriting one that exists.
+  The four-file heal that predates this could not fill a 430-file hole. Overwriting is what is
+  unsafe (a sibling may have the file mapped) and renaming the directory aside is what #2489
+  forbids (a live process's `AppContext.BaseDirectory` is that exact path); creating a missing
+  file is safe under both.
+- **A legacy directory without a manifest is refused and rebuilt, once.** It costs nothing in
+  practice: the key already includes `RunnerFingerprint.ContentHash`, so a new runner build
+  never lands on an old build's directory.
+- **The 10-minute age floor is the second guard, not the first.** The lock is what decides. The
+  floor covers the window between a publish and its lock, and processes from builds that
+  predate the lock — those hold no lock, and nothing in a new build can make them.
+- **The lock is held by the parent, not the shadow child.** `TryShadowReexec` starts the child
+  and calls `WaitForExit`, so the parent outlives it; holding the lock in `EnsureShadowDir`
+  covers the child's whole run without touching the child's startup path.
+
+### Residual gaps
+
+- A process started from a build that predates this change holds no lock, so only the age floor
+  protects it. That resolves as installs update; it cannot be fixed from the new build.
+- A directory whose lock is held **and** whose file set is incomplete cannot be renamed aside,
+  so it is healed in place; if the heal cannot complete, `PublishShadowDir` falls back to
+  running from the `.building.*` temp dir, as it did before.


### PR DESCRIPTION
Closes #3559

Filed and implemented by an agent (Claude, `fbk-2`) on the account holder's behalf.

Corpus-NA: this is runner process/cache bookkeeping (shadow-dir publish, completeness, prune). Nothing about it is observable to AL, so no corpus test can express it.

## The mechanism, measured — and it is not the one the issue title states

The issue reads as "an incomplete directory is *offered to* a process". It is the other way
round: **the crashed process built that directory itself, and a sibling runner's
`PruneStaleShadowDirs` emptied it underneath the live process.**

What decides it is the survivor set. All 22 files left in `7a4d…` are assemblies a running
.NET process holds mapped — `al-runner.dll`, `Ncl.dll`, `AlRunner.QueryJoin.dll`, Roslyn,
Cecil, `Newtonsoft.Json`, `Spectre.Console`, `runtimes/win/lib/net8.0/System.Diagnostics.EventLog.dll`.
Nothing unmapped survived: not the marker, not `al-runner.deps.json`, not the other 430 DLLs,
and not `EventLog.Messages.dll`, which is resource-only and never loaded. None of the three
candidate mechanisms in the brief (partial publish, prune into a `.building.` dir, two
publishers racing one key) produces that shape; a recursive delete over a live process does.

Confirmed on this box (Windows 11, .NET 8, `tmp/probe3559/probe.ps1`): with one file of six
held open `FileShare.Read`, `Directory.Delete(recursive: true)` throws, deletes every other
file, and leaves the held one. Same probe confirms the lock primitive — a `FileShare.Read`
holder refuses a `FileShare.None` prober, and the prober succeeds the moment it is released.
On Linux the delete succeeds instead, which is why the prune **probes before deleting** rather
than relying on the delete failing.

The victim's own directory was ordinary prune fodder: `PruneStaleShadowDirs`'s `protectedDir`
only ever protects the *pruning* process's directory, and five keys existed against
`keepNewest: 4`.

## Process-level before/after (same harness, same conditions)

`tmp/harness3559.ps1`: one victim in `--server` mode (its stdin owned by the harness so it
cannot exit on EOF, stdout/stderr drained async so no pipe can fill), its published dir
back-dated so only the in-use guard — not the age floor — can save it, then five siblings run
from five *copies* of the same build (five distinct `origFull`, five distinct keys, so five
publishes and five prunes).

| arm | build | result |
|---|---|---|
| before | `origin/main` `eae442fd` | rep 1 **101 → 14 files**, victim still alive; rep 2 started from the broken 17-file dir and was handed it again (the pre-fix completeness check accepts it) — 2/2 incomplete |
| after | this branch | **103 → 103** and **103 → 104**, victim alive — 0/2 incomplete |

2 reps per arm, not N=10: the outcome is deterministic in both arms. `tmp/gap-repros/ncl-shadow-race/race.ps1`
was **not** run — it needs the packed global tool (out of bounds here) and it measures the
#2489 concurrent-publish race, which is not this mechanism.

## The fix — two guards, both loud

1. **A published shadow dir carries a manifest of its whole file set** (`.al-runner-shadow-manifest`,
   written as the step before the marker, inside the `.building.*` dir, so "marker present ⇒
   complete" still survives the rename). `IsShadowDirComplete` refuses a dir with no manifest or
   with any listed entry absent; the refusal is `[warn]`-tagged, names the directory and the
   missing entries (first five plus a count), and rebuilds. Names, not sizes — the failure is a
   *missing* file, `File.Exists` on a dangling symlink is false (so this also catches the #2166
   shape), and a size on a symlink means different things per platform.
2. **Prune never deletes a directory another runner process is executing from.** Each process
   opens `.al-runner-shadow-inuse.<pid>` with `FileShare.Read` and holds the handle for its
   lifetime; prune probes each such file with `FileShare.None` and skips the directory if any is
   held. A lock file from a crashed process opens cleanly, protects nothing, and is reclaimed the
   next time a process takes the lock there. A 10-minute age floor is the second guard, not the
   first.

The lock is taken by the **parent**: `TryShadowReexec` starts the shadow child and
`WaitForExit`s, so the parent outlives it, and `EnsureShadowDir` covers the child's whole run
without touching the child's startup path. On the reuse path the lock is taken *between* two
completeness checks, because a prune can land between the check and the lock.

The in-place heal now copies **every manifest entry that is missing** rather than four launch
files. It still never overwrites an existing file and never renames the directory aside —
#2489's reasoning (a live sibling's `AppContext.BaseDirectory` is that exact path) is untouched,
and `PublishShadowDir_SelfHeal_NeverRenamesShadowDirItself` still passes unchanged. #3385's
exec-ability refusal is unchanged.

Mechanism write-up, the field evidence and the design notes: `docs/ncl-shadow-runtime.md`
(pointed at from three call sites; `tools/test_doc_pointers.py` passes).

## RED → GREEN

New file `AlRunner.Tests/NclShadowInUseAndManifestTests.cs`, 12 tests. RED measured by
neutering each guard in production and re-running:

| probe | red |
|---|---|
| `IsShadowDirComplete` manifest check → `return true` | `IsShadowDirComplete_ManifestListsAnAbsentFile_RefusesAndNamesIt`, `IsShadowDirComplete_NoManifest_Refuses` |
| `IsInUse` → `return false` | `PruneStaleShadowDirs_NeverDeletesADirWhoseInUseLockIsHeld`, `InUseLock_HeldMeansInUse_ReleasedMeansNot` |

The prune test acquires the lock **then** back-dates the directory: writing the lock file bumps
the dir's mtime, so the other order would have been passed by the age floor with the lock
removed entirely. Negative cases carried: an unheld lock file is still reclaimed and its dir
still pruned; a recently published dir is not; a whole dir is accepted (positive control).
`RecursiveDeleteOverAnOpenHandle_LeavesOnlyTheHeldFile_OnWindows` pins the platform behaviour
the whole issue rests on, and returns early off Windows.

The `[warn]` refusal is registered in `AlRunner.Tests/LoudDiagnosisReachesTheUserTests.cs`
(anchor `is INCOMPLETE`), which is why the message says what stops working rather than guessing
a cause.

Ran locally: `--filter FullyQualifiedName~NclShadow|FullyQualifiedName~LoudDiagnosis` — 94
passed, 3 failed. The three are `NclShadowRuntimeTests.MirrorInstallDirectory_*` and are
**pre-existing on this box**: symlink creation is refused here (measured), so the mirror copies
instead of linking. Confirmed by running the same three on a clean `origin/main` `eae442fd`
worktree — identical 3 failures, and the diff does not touch `MirrorInstallDirectory` or
`LinkOrCopy`. They pass on the Linux legs.

Real-runner smoke (Release build, private `--cache`, `Fixtures/RecordTriggerXRec`): cold run
publishes, second run reuses with no `[warn]`, the published dir carries a manifest and a lock
file, and no `.building.*` is left behind — the check that a manifest over a *real* 104-file
layout verifies rather than self-refusing every start.

## The shape, not the reported line

- **Another call site with the same wrong pattern?** No other prune walks `ncl-shadow`.
- **A sibling making the same assumption?** The two other cross-process reapers in
  `AlRunner/Infrastructure/` — `PkgDedupCache.TryDeleteTree` and `ScratchDirs.DeleteTreeAndMarker`
  — already check owner liveness first, through a pid + start-ticks marker
  (`ScratchDirs.IsOwnerAlive`), and treat an unreadable claim as alive. The shadow prune was the
  one reaper with no liveness notion at all. I used a held handle rather than reusing the pid
  marker because it additionally makes Windows refuse the delete itself and needs no
  pid-reuse reasoning; the pid-marker siblings are not broken and are left alone.
- **Two paths writing one state with different invariants?** `NclCecilRewrite.PruneCacheFiles`
  (`keepNewest: 8`) prunes *files* in the ncl-cecil cache. A file another process has open cannot
  be deleted on Windows and the shadow dir holds its own copy of `Ncl.dll`, so it does not carry
  this exposure — checked, not changed.

**Not folded:** #2375 and #2374 are shadow-startup *cost* issues (a CLR start per invocation;
crossgen2 inside the shadow build). They touch the same subsystem but not this file's publish or
prune logic, and folding them would put performance work behind a correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018eQEJqnKcAgqMbWgk4wdMa
