### PR TITLE
fix(symbols): read Editable and a field's effective DataClassification from the symbol file

### DIFF
--- a/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
+++ b/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
@@ -186,15 +186,17 @@ public sealed class MetadataEquivalenceHarnessTests
         // build moves is worse than no pin, because it reads as covered.
         //
         // The fix is not to choose which way that fails. The counts genuinely move with the
-        // build (System Application's DataClassification is 661 / 663 / 617 across 28.1 / 28.4
-        // / 27.5, and its table count 138 / 138 / 127), so ANY key is either too tight and goes
-        // inert or too loose and asserts a number that held once. The SHAPE does not move: the
-        // reader answers a constant, which is what the defect IS. Measured on all three builds,
-        // BC says False on 87 of 87 Editable differences and the runner says True on 87 of 87;
-        // the runner says CustomerContent on 620-666 of 620-666 DataClassification differences
-        // and 0 on every EnumTypeId one. Asserting the constant is both stronger than a count
-        // and incapable of going inert. The counts themselves are recorded in
-        // docs/metadata-equivalence.md, where a measurement belongs.
+        // build, so ANY key is either too tight and goes inert or too loose and asserts a
+        // number that held once. The SHAPE does not move: where the reader is still wrong it
+        // answers a CONSTANT, which is what the defect IS, and where it has been fixed it
+        // answers BC exactly. Both are asserted here, and neither can go inert. The counts
+        // themselves are recorded in docs/metadata-equivalence.md, where a measurement belongs.
+        //
+        // The three members #3545 fixed — Editable, DataClassification, EnumTypeId — moved
+        // from the first list to the second in that change, and their allowlist entries were
+        // deleted with it. Their agreement is re-asserted below rather than left to
+        // Every_difference_is_declared_with_a_reason, which would report a regression as an
+        // undeclared member and say nothing about which reader rule broke.
         foreach (var report in RunAll())
         {
             int MissingRelation(int fieldId) => report.Differences
@@ -212,12 +214,21 @@ public sealed class MetadataEquivalenceHarnessTests
             MetadataDifference[] Declared(string signature) => report.Differences
                 .Where(d => d.Signature == signature && IsDeclaredField(d.Path)).ToArray();
 
-            AssertConstantAnswer(report, Declared("MetaField.Editable"), "MetaField.Editable",
-                bc: "False", runner: "True");
-            AssertConstantAnswer(report, Declared("MetaField.DataClassification"),
-                "MetaField.DataClassification", bc: null, runner: "CustomerContent");
-            AssertConstantAnswer(report, Declared("MetaField.EnumTypeId"), "MetaField.EnumTypeId",
-                bc: null, runner: "0");
+            // Still wrong, and wrong the same way on every build: the reader falls back to a
+            // constant. Tracked on #3568.
+            AssertConstantAnswer(report, Declared("MetaField.ClrType"), "MetaField.ClrType",
+                bc: null, runner: "<empty>");
+            AssertConstantAnswer(report, Declared("MetaField.ExtendedDatatype"),
+                "MetaField.ExtendedDatatype", bc: "Undefined", runner: "None");
+            AssertConstantAnswer(report, Declared("MetaField.CaptionML." + MetadataObjectDiff.PresenceMember),
+                "MetaField.CaptionML", bc: "present", runner: MetadataObjectDiff.Null);
+
+            // Fixed by #3545, and asserted over EVERY field rather than only the declared
+            // ones: the same change corrected BC's six platform-added fields, whose Editable
+            // and DataClassification come from SystemFieldsHelper's boilerplate.
+            AssertReaderAgrees(report, "MetaField.Editable");
+            AssertReaderAgrees(report, "MetaField.DataClassification");
+            AssertReaderAgrees(report, "MetaField.EnumTypeId");
         }
     }
 
@@ -247,6 +258,23 @@ public sealed class MetadataEquivalenceHarnessTests
         Assert.True(bcAnswers.Length == 1 && bcAnswers[0] == bc,
             $"{report.Bundle.Label}: {signature} — BC should answer '{bc}' on all " +
             $"{differences.Length} differences. It answers: " + string.Join(", ", bcAnswers.Take(10)));
+    }
+
+    /// <summary>
+    /// The reader answers exactly what BC answers on <paramref name="signature"/>, everywhere.
+    /// This is the GREEN half of the test above, and it is not vacuous: a regression in any of
+    /// the three reader rules #3545 landed puts differences straight back here, and the
+    /// message names the member rather than leaving the allowlist to report it as undeclared.
+    /// </summary>
+    private static void AssertReaderAgrees(MetadataEquivalenceReport report, string signature)
+    {
+        var differences = report.Differences.Where(d => d.Signature == signature).ToArray();
+        Assert.True(differences.Length == 0,
+            $"{report.Bundle.Label}: {signature} was fixed by #3545 and its allowlist entry " +
+            $"deleted with it, so any difference here is a regression in the reader rule. " +
+            $"{differences.Length} difference(s), first {Math.Min(5, differences.Length)}:" +
+            Environment.NewLine +
+            string.Join(Environment.NewLine, differences.Take(5).Select(d => "  " + d)));
     }
 
     [SkippableFact]

--- a/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
+++ b/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
@@ -192,9 +192,11 @@ public sealed class MetadataEquivalenceHarnessTests
         // answers BC exactly. Both are asserted here, and neither can go inert. The counts
         // themselves are recorded in docs/metadata-equivalence.md, where a measurement belongs.
         //
-        // The three members #3545 fixed — Editable, DataClassification, EnumTypeId — moved
-        // from the first list to the second in that change, and their allowlist entries were
-        // deleted with it. Their agreement is re-asserted below rather than left to
+        // The two members #3545 fixed — Editable and DataClassification — moved from the first
+        // list to the second in that change, and their allowlist entries were deleted with it.
+        // EnumTypeId did NOT move and is still asserted as a defect below: the value is
+        // readable and stating it is what is blocked, on #3594. Their agreement is re-asserted
+        // rather than left to
         // Every_difference_is_declared_with_a_reason, which would report a regression as an
         // undeclared member and say nothing about which reader rule broke.
         foreach (var report in RunAll())
@@ -223,12 +225,16 @@ public sealed class MetadataEquivalenceHarnessTests
             AssertConstantAnswer(report, Declared("MetaField.CaptionML." + MetadataObjectDiff.PresenceMember),
                 "MetaField.CaptionML", bc: "present", runner: MetadataObjectDiff.Null);
 
+            // Still wrong for a reason that is not a reading defect: the id is known and
+            // stating it needs a metadata object BC can resolve (#3594).
+            AssertConstantAnswer(report, Declared("MetaField.EnumTypeId"), "MetaField.EnumTypeId",
+                bc: null, runner: "0");
+
             // Fixed by #3545, and asserted over EVERY field rather than only the declared
             // ones: the same change corrected BC's six platform-added fields, whose Editable
             // and DataClassification come from SystemFieldsHelper's boilerplate.
             AssertReaderAgrees(report, "MetaField.Editable");
             AssertReaderAgrees(report, "MetaField.DataClassification");
-            AssertReaderAgrees(report, "MetaField.EnumTypeId");
         }
     }
 

--- a/AlRunner/Patches/BcAppSymbolCache.TableExtensions.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.TableExtensions.cs
@@ -285,12 +285,34 @@ internal static partial class BcAppSymbolCache
                     : null;
                 var relationValidate = !(props.TryGetValue("ValidateTableRelation", out var vtr)
                     && (vtr == "0" || vtr.Equals("false", StringComparison.OrdinalIgnoreCase)));
+                // #3545 — read exactly as the base-table loop reads them, for the same reason
+                // the TableRelation gate above gives: the two loops must not disagree about
+                // the same JSON. An extension field's DataClassification inherits the EXTENDED
+                // table's when it declares none, which is resolved in BuildMetaField where the
+                // base table is in hand.
+                var editable = SymbolEditable(props);
+                props.TryGetValue("DataClassification", out var fieldDataClassification);
+                var (enumTypeId, enumTypeName) = SymbolEnumType(
+                    field.TryGetProperty("TypeDefinition", out var td2) ? td2 : default);
                 fields.Add(new ParsedField(fieldId, fieldName, typeName, SymbolTypeLength(typeName), isFlowField, null,
                     optionMembers, initValue, isAutoIncrement, IsFlowFilter: isFlowFilter,
                     RelationArms: relationArms, RelationValidate: relationValidate,
-                    MinValue: minValue, MaxValue: maxValue));
+                    MinValue: minValue, MaxValue: maxValue,
+                    Editable: editable,
+                    DataClassificationName: string.IsNullOrWhiteSpace(fieldDataClassification)
+                        ? null : fieldDataClassification.Trim(),
+                    EnumTypeId: enumTypeId, EnumTypeName: enumTypeName));
             }
         }
+        // #3545 — an extension field with no DataClassification takes the TABLEEXTENSION's,
+        // NOT the extended table's. Measured: System Application's `tableextension ... extends
+        // "User Details"` declares none and its six fields declare none, and BC's emitter
+        // answers CustomerContent for all six while the extended table declares
+        // SystemMetadata. Inheriting from the extended table would answer SystemMetadata on
+        // every one of them.
+        RecordPatches.ApplyOwnerDataClassification(fields,
+            SymbolProperties(ext).TryGetValue("DataClassification", out var extDataClassification)
+                ? extDataClassification : null);
         // #3216 — the extension's own keys. Same JSON shape the base-table reader consumes in
         // BcAppSymbolCache.cs (Keys[].Name + Keys[].FieldNames), minus the "first key is the
         // PK" split, which does not apply to a tableextension. Names are passed through

--- a/AlRunner/Patches/BcAppSymbolCache.TableExtensions.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.TableExtensions.cs
@@ -287,9 +287,9 @@ internal static partial class BcAppSymbolCache
                     && (vtr == "0" || vtr.Equals("false", StringComparison.OrdinalIgnoreCase)));
                 // #3545 — read exactly as the base-table loop reads them, for the same reason
                 // the TableRelation gate above gives: the two loops must not disagree about
-                // the same JSON. An extension field's DataClassification inherits the EXTENDED
-                // table's when it declares none, which is resolved in BuildMetaField where the
-                // base table is in hand.
+                // the same JSON. DataClassificationName is the field's OWN declaration here;
+                // ApplyOwnerDataClassification below resolves the effective value, and which
+                // object counts as the owner is the thing to read there before changing it.
                 var editable = SymbolEditable(props);
                 props.TryGetValue("DataClassification", out var fieldDataClassification);
                 var (enumTypeId, enumTypeName) = SymbolEnumType(

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -207,7 +207,17 @@ internal static partial class BcAppSymbolCache
     // test never finishes. A wrong answer replayed from cache rather than a cache miss.
     // Since #3485 that end is BC's own [-1000000000..1000000000] rather than a materialised
     // window of 101,001 rows, so the loop no longer terminates in any useful time at all.
-    private const int CacheVersion = 34;
+    // v35: ParsedField gained Editable / DataClassificationName / EnumTypeId / EnumTypeName
+    // (#3545) — three properties the symbol file states on every field and this reader threw
+    // away. Both halves of the rule above hold at once. The record's SHAPE changed, so
+    // PayloadShape keys a fresh payload on its own; and the PARSE changed twice over, because
+    // DataClassificationName is stored EFFECTIVE rather than declared — a field silent about
+    // it takes its owner's, which is a different value read out of unchanged bytes. That
+    // second half is what needs the integer: it was measured here, where a payload written by
+    // an earlier build of this same change (declared-only, same shape) was replayed warm and
+    // put 154 of System Application's fields back on CustomerContent while the harness said
+    // the reader had been fixed. A wrong answer from cache, wearing a green build.
+    private const int CacheVersion = 35;
     private static readonly ConcurrentDictionary<string, AppSymbols> ProcessCache = new(StringComparer.OrdinalIgnoreCase);
     // Issue #1820's path -> content-hash memo now lives in
     // RunnerFingerprint._fileContentHashes (#2955), because AppLoader's persisted r2r-chunks
@@ -2126,10 +2136,22 @@ internal static partial class BcAppSymbolCache
                     : null;
                 var relationValidate = !(props.TryGetValue("ValidateTableRelation", out var vtr)
                     && (vtr == "0" || vtr.Equals("false", StringComparison.OrdinalIgnoreCase)));
+                // #3545 — Editable / DataClassification / the enum type. All three are stated
+                // in the symbol file and all three were dropped here; see
+                // docs/metadata-equivalence.md#three-symbol-properties-the-reader-dropped for
+                // what each one costs AL and how the rules were measured.
+                var editable = SymbolEditable(props);
+                props.TryGetValue("DataClassification", out var fieldDataClassification);
+                var (enumTypeId, enumTypeName) = SymbolEnumType(
+                    field.TryGetProperty("TypeDefinition", out var td2) ? td2 : default);
                 fields.Add(new ParsedField(fieldId, fieldName, typeName, SymbolTypeLength(typeName), isFlowField, calcFormula,
                     optionMembers, initValue, isAutoIncrement, IsFlowFilter: isFlowFilter,
                     RelationArms: relationArms, RelationValidate: relationValidate,
-                    MinValue: minValue, MaxValue: maxValue));
+                    MinValue: minValue, MaxValue: maxValue,
+                    Editable: editable,
+                    DataClassificationName: string.IsNullOrWhiteSpace(fieldDataClassification)
+                        ? null : fieldDataClassification.Trim(),
+                    EnumTypeId: enumTypeId, EnumTypeName: enumTypeName));
             }
         }
 
@@ -2186,6 +2208,10 @@ internal static partial class BcAppSymbolCache
         // CustomerContent, 61 SystemMetadata, 2 OrganizationIdentifiableInformation) and 61
         // state ExternalName ("CDS BC Table Relation" -> dyn365bc_syntheticrelation).
         tableProps.TryGetValue("DataClassification", out var dataClassification);
+        // #3545 — a field that declares no DataClassification takes the TABLE's. Done here,
+        // after the table's own property is in hand, so ParsedField.DataClassificationName is
+        // the value BC's emitter states rather than only what the field wrote.
+        RecordPatches.ApplyOwnerDataClassification(fields, dataClassification);
         tableProps.TryGetValue("ExternalName", out var externalName);
         // DataPerCompany was hardcoded true here while the SOURCE-parsed path read the declared
         // property — the two paths writing the same column disagreed, so every precompiled table
@@ -2297,6 +2323,43 @@ internal static partial class BcAppSymbolCache
             && subtype.TryGetProperty("Name", out var enumNameProp))
             return $"Enum \"{enumNameProp.GetString() ?? string.Empty}\"";
         return name;
+    }
+
+    /// <summary>
+    /// The field's declared <c>Editable</c>, or null when the symbol file states none — which
+    /// AL reads as true (#3545). Measured over 3,848 field observations on four BC builds:
+    /// the symbol file states <c>Editable</c> only where it is <c>0</c>, and BC's own emitter
+    /// answers <c>1</c> or nothing everywhere it is silent, with zero disagreements. So the
+    /// only value worth carrying is the false, and null is passed on unchanged so
+    /// MetaField's own null default decides — not a true this reader made up.
+    /// </summary>
+    private static bool? SymbolEditable(Dictionary<string, string> props)
+    {
+        if (!props.TryGetValue("Editable", out var v) || string.IsNullOrWhiteSpace(v)) return null;
+        if (v == "0" || v.Equals("false", StringComparison.OrdinalIgnoreCase)) return false;
+        if (v == "1" || v.Equals("true", StringComparison.OrdinalIgnoreCase)) return true;
+        return null;
+    }
+
+    /// <summary>
+    /// The enum object a field's <c>TypeDefinition</c> names — <c>(id, name)</c> when
+    /// <c>TypeDefinition.Name == "Enum"</c>, <c>(0, null)</c> otherwise. Measured: the
+    /// presence of <c>Subtype.Id</c> and the presence of BC's own emitted
+    /// <c>EnumTypeId</c> agree on 3,848 of 3,848 field observations, and the values agree
+    /// wherever both are present (#3545).
+    /// </summary>
+    private static (int Id, string? Name) SymbolEnumType(JsonElement typeDefinition)
+    {
+        if (typeDefinition.ValueKind != JsonValueKind.Object) return (0, null);
+        if (!typeDefinition.TryGetProperty("Name", out var nameProp)
+            || !string.Equals(nameProp.GetString(), "Enum", StringComparison.OrdinalIgnoreCase))
+            return (0, null);
+        if (!typeDefinition.TryGetProperty("Subtype", out var subtype)
+            || subtype.ValueKind != JsonValueKind.Object)
+            return (0, null);
+        var id = subtype.TryGetProperty("Id", out var idProp) && idProp.TryGetInt32(out var i) ? i : 0;
+        var name = subtype.TryGetProperty("Name", out var snProp) ? snProp.GetString() : null;
+        return (id, string.IsNullOrEmpty(name) ? null : name);
     }
 
     private static int SymbolTypeLength(string typeName)

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -1535,8 +1535,10 @@ internal record ParsedRelationArm(string TableName, string? FieldName, List<Pars
 /// hand, so consumers never re-derive it; that method carries the rule and its two exceptions.
 /// See docs/metadata-equivalence.md#field-dataclassification-inherits-its-owner (#3545).</param>
 /// <param name="EnumTypeId">The object id of the enum an <c>Enum "X"</c>-typed field names, or
-/// 0 when the field is not enum-typed. <c>MetaField.EnumTypeId</c> is what resolves such a
-/// field back to its enum object (#3545).</param>
+/// 0 when the field is not enum-typed. Read from the symbol file and NOT yet passed to
+/// <c>MetaField.enumTypeId</c> — BC then resolves the id through NCLMetadata and the runner
+/// registers no metadata object for a precompiled app's enum (#3594). Carried here so the
+/// reading is in place when it is.</param>
 /// <param name="EnumTypeName">The enum's name, paired with <see cref="EnumTypeId"/>; null when
 /// the field is not enum-typed.</param>
 internal record ParsedField(int FieldId, string FieldName, string TypeName, int Length, bool IsFlowField = false, ParsedCalcFormula? CalcFormula = null, string? OptionMembers = null, string? InitValueText = null, bool IsAutoIncrement = false, string? Caption = null, List<ParsedRelationArm>? RelationArms = null, bool RelationValidate = true, bool IsFlowFilter = false, string ObsoleteState = "No", string? ObsoleteReason = null, string? MinValue = null, string? MaxValue = null, bool? Editable = null, string? DataClassificationName = null, int EnumTypeId = 0, string? EnumTypeName = null);

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -484,10 +484,23 @@ public static partial class RecordPatches
         var minValue = PropValue(props, "MinValue")?.ToString()?.Trim();
         var maxValue = PropValue(props, "MaxValue")?.ToString()?.Trim();
 
+        // #3545 — Editable and DataClassification, read here as well as on the symbol path so
+        // the two paths answer the same MetaField for the same declaration. Only the explicit
+        // `Editable = false` is carried: AL's default is true and MetaField's own null default
+        // already resolves to it, so asserting a true here would claim a reading never made.
+        // EnumTypeId/EnumTypeName are deliberately NOT set from AL source — the enum's OBJECT
+        // ID is not in the type text, and half of that pair is worse than none of it; see
+        // docs/metadata-equivalence.md#three-symbol-properties-the-reader-dropped.
+        bool? editable = PropIs(props, "Editable", "false") ? false : null;
+        var fieldDataClassification = PropValue(props, "DataClassification")?.ToString()?.Trim();
+
         return new ParsedField(fid, fname, ftype, length, isFlowField, calcFormula,
             optionMembers, initValueText, isAutoIncrement, caption,
             relationArms, relationValidate, isFlowFilter, obsoleteState, obsoleteReason,
-            minValue, maxValue);
+            minValue, maxValue,
+            Editable: editable,
+            DataClassificationName: string.IsNullOrWhiteSpace(fieldDataClassification)
+                ? null : fieldDataClassification);
     }
 
     /// <summary>
@@ -852,6 +865,9 @@ public static partial class RecordPatches
             // this value is not; neither would have caught it. DataClassification above is an
             // identifier, not a literal, so it needs none of this.
             var externalName = AlStringLiteralText(PropValue(table.PropertyList, "ExternalName"));
+            // #3545 — a field that declares no DataClassification takes the TABLE's, exactly
+            // as the symbol-read path resolves it.
+            ApplyOwnerDataClassification(fields, dataClassification);
             _parsedTables[tableId] = new ParsedTable(tableId, tableName, fields, pkFieldIds,
                 secondaryKeys, isTableTypeTemporary, dataPerCompany, lookupPage, drillDownPage,
                 TableTypeName: string.IsNullOrWhiteSpace(tableTypeName) ? null : tableTypeName.Trim(),
@@ -902,6 +918,11 @@ public static partial class RecordPatches
                         extKeys.Add(new ParsedExtensionKey(keyName, keyFieldNames));
                 }
             }
+
+            // #3545 — the owner of an extension field is the TABLEEXTENSION, not the table it
+            // extends; see ApplyOwnerDataClassification for the measurement that settled it.
+            ApplyOwnerDataClassification(fields,
+                PropValue(ext.PropertyList, "DataClassification")?.ToString()?.Trim());
 
             Console.Error.WriteLine($"[TableExt] parsed extension {extId} '{extName}' extends '{baseName}' with {fields.Count} fields, {extKeys.Count} keys");
 
@@ -1503,7 +1524,22 @@ internal record ParsedRelationArm(string TableName, string? FieldName, List<Pars
 /// undeclared. Passed through to MetaField.minValue (a string) unparsed — NCL's own field
 /// validation on TestPage SetValue is what evaluates and formats it (#2495).</param>
 /// <param name="MaxValue">Same shape as <see cref="MinValue"/>, for MaxValue.</param>
-internal record ParsedField(int FieldId, string FieldName, string TypeName, int Length, bool IsFlowField = false, ParsedCalcFormula? CalcFormula = null, string? OptionMembers = null, string? InitValueText = null, bool IsAutoIncrement = false, string? Caption = null, List<ParsedRelationArm>? RelationArms = null, bool RelationValidate = true, bool IsFlowFilter = false, string ObsoleteState = "No", string? ObsoleteReason = null, string? MinValue = null, string? MaxValue = null);
+/// <param name="Editable">The declared <c>Editable</c>, or null when the field declares none —
+/// which AL reads as true (#3545). Null and true are therefore the same answer; what the null
+/// preserves is "nothing was declared", so the builder passes MetaField's own null default
+/// through rather than asserting a value it did not read.</param>
+/// <param name="DataClassificationName">The <c>DataClassification</c> BC's own emitter states
+/// for the field: the field's own when it declares one, otherwise its OWNER's — the table, or
+/// the tableextension for a field an extension adds. Every reader resolves this through
+/// <c>RecordPatches.ApplyOwnerDataClassification</c> as soon as the owner's declaration is in
+/// hand, so consumers never re-derive it; that method carries the rule and its two exceptions.
+/// See docs/metadata-equivalence.md#field-dataclassification-inherits-its-owner (#3545).</param>
+/// <param name="EnumTypeId">The object id of the enum an <c>Enum "X"</c>-typed field names, or
+/// 0 when the field is not enum-typed. <c>MetaField.EnumTypeId</c> is what resolves such a
+/// field back to its enum object (#3545).</param>
+/// <param name="EnumTypeName">The enum's name, paired with <see cref="EnumTypeId"/>; null when
+/// the field is not enum-typed.</param>
+internal record ParsedField(int FieldId, string FieldName, string TypeName, int Length, bool IsFlowField = false, ParsedCalcFormula? CalcFormula = null, string? OptionMembers = null, string? InitValueText = null, bool IsAutoIncrement = false, string? Caption = null, List<ParsedRelationArm>? RelationArms = null, bool RelationValidate = true, bool IsFlowFilter = false, string ObsoleteState = "No", string? ObsoleteReason = null, string? MinValue = null, string? MaxValue = null, bool? Editable = null, string? DataClassificationName = null, int EnumTypeId = 0, string? EnumTypeName = null);
 internal record ParsedKey(string Name, List<int> FieldIds);
 
 /// <summary>A key declared by a <c>tableextension</c> on the table it extends (#3216).

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -566,15 +566,16 @@ public static partial class RecordPatches
                 args[i] = dcVal;
                 continue;
             }
-            // #3545 — the enum object an `Enum "X"`-typed field names. Both halves come from
-            // the symbol file's TypeDefinition.Subtype and are passed together or not at all:
-            // an id with no name (or the reverse) is a shape BC never produces.
-            if (p.Name == "enumTypeId" && f.EnumTypeId != 0) { args[i] = f.EnumTypeId; continue; }
-            if (p.Name == "enumTypeName" && f.EnumTypeId != 0 && !string.IsNullOrEmpty(f.EnumTypeName))
-            {
-                args[i] = f.EnumTypeName;
-                continue;
-            }
+            // The enum object an `Enum "X"`-typed field names is deliberately NOT passed, even
+            // though ParsedField now carries it. Passing enumTypeId makes BC's own
+            // FieldDataProvider.GetFieldRecordBuffer resolve that id through NCLMetadata, and
+            // for a PRECOMPILED app's enum the runner registers no metadata object for it —
+            // measured on the corpus: every read of the Field virtual table (2000000041) for
+            // Base Application table 1366 then threw NavMetadataNotFoundException("Enum 8889"),
+            // which aborted codeunit 2 Company-Initialize and took the whole corpus app's
+            // 2,900 tests with it. Reading the id is the easy half; making it resolvable is
+            // the work, and it is tracked on #3594 with MetaField.EnumTypeId still declared in
+            // the metadata-equivalence allowlist.
             if (p.Name == "fieldClass" && _tFieldClass != null && (f.IsFlowField || f.IsFlowFilter))
             {
                 // #1716 — FlowFilter must reach the metadata as FlowFilter. NCLMetaTable

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -142,7 +142,10 @@ public static partial class RecordPatches
             // and the BC system fields: SystemId (2000000000), SystemCreatedAt (2000000001),
             // SystemCreatedBy (2000000002), SystemModifiedAt (2000000003), SystemModifiedBy
             // (2000000004). These are required for system-field access via FieldRef and RecordRef.
-            var timestampParsed       = new ParsedField(0,          "timestamp",         "BigInteger", 0);
+            // Editable / DataClassification per BC's own boilerplate — see
+            // SystemParsedFields' doc comment for the citation (#3545).
+            var timestampParsed       = new ParsedField(0,          "timestamp",         "BigInteger", 0,
+                Editable: false, DataClassificationName: "SystemMetadata");
             // Merge any tableextension fields for this base table.
             // De-duplicate by field id: precompiled .app SymbolReference.json sometimes lists
             // extension fields both in the base table's Tables[].Fields entry AND in
@@ -549,6 +552,29 @@ public static partial class RecordPatches
                 if (ml != null) { args[i] = ml; continue; }
             }
             if (p.Name == "enabled") { args[i] = (bool?)true; continue; }
+            // #3545 — Editable. AL's default is true and MetaField's own null default already
+            // resolves to it, so only the declared false is passed; a true here would assert a
+            // value the reader may never have seen. Proved by deleting the MetaField.Editable
+            // entry from tests/expectations/metadata-equivalence/allowlist.json.
+            if (p.Name == "editable" && f.Editable == false) { args[i] = (bool?)false; continue; }
+            // #3545 — DataClassification. ParsedField already carries the EFFECTIVE value
+            // (ApplyOwnerDataClassification), so nothing is resolved here.
+            if (p.Name == "dataClassification" && _tALDataClassification != null
+                && !string.IsNullOrWhiteSpace(f.DataClassificationName)
+                && Enum.TryParse(_tALDataClassification, f.DataClassificationName, ignoreCase: true, out var dcVal))
+            {
+                args[i] = dcVal;
+                continue;
+            }
+            // #3545 — the enum object an `Enum "X"`-typed field names. Both halves come from
+            // the symbol file's TypeDefinition.Subtype and are passed together or not at all:
+            // an id with no name (or the reverse) is a shape BC never produces.
+            if (p.Name == "enumTypeId" && f.EnumTypeId != 0) { args[i] = f.EnumTypeId; continue; }
+            if (p.Name == "enumTypeName" && f.EnumTypeId != 0 && !string.IsNullOrEmpty(f.EnumTypeName))
+            {
+                args[i] = f.EnumTypeName;
+                continue;
+            }
             if (p.Name == "fieldClass" && _tFieldClass != null && (f.IsFlowField || f.IsFlowFilter))
             {
                 // #1716 — FlowFilter must reach the metadata as FlowFilter. NCLMetaTable
@@ -1037,6 +1063,39 @@ public static partial class RecordPatches
     }
 
     /// <summary>
+    /// Rewrite each field's <see cref="ParsedField.DataClassificationName"/> from the value it
+    /// DECLARES to the value BC's metadata emitter states for it, given the declaration of the
+    /// object that owns it — the <c>table</c>, or the <c>tableextension</c> for a field an
+    /// extension adds. Called once per parsed object, by every reader.
+    ///
+    /// <para>Three rules, measured against BC's own emitted metadata for Business Foundation
+    /// and System Application on four BC builds (3,848 field observations, zero
+    /// counterexamples) plus the six extension fields on table 774 that first showed the owner
+    /// is the extension and not the extended table. The two exceptions are not cosmetic:
+    /// eleven fields sit on tables declaring <c>SystemMetadata</c>, so inheriting
+    /// unconditionally answers <c>SystemMetadata</c> where BC answers <c>CustomerContent</c> —
+    /// trading one wrong answer for another. Derivation and per-build counts:
+    /// docs/metadata-equivalence.md#field-dataclassification-inherits-its-owner.</para>
+    /// </summary>
+    internal static void ApplyOwnerDataClassification(List<ParsedField> fields, string? ownerDeclared)
+    {
+        var owner = string.IsNullOrWhiteSpace(ownerDeclared) ? null : ownerDeclared!.Trim();
+        for (int i = 0; i < fields.Count; i++)
+        {
+            var f = fields[i];
+            if (!string.IsNullOrWhiteSpace(f.DataClassificationName)) continue;
+            if (owner == null) continue;
+            // A FlowField/FlowFilter is not stored, and BC classifies nothing it does not
+            // store. Blob is the one stored type it also leaves unclassified when the field
+            // itself is silent.
+            if (f.IsFlowField || f.IsFlowFilter) continue;
+            if ((f.TypeName ?? string.Empty).TrimStart().StartsWith("Blob", StringComparison.OrdinalIgnoreCase))
+                continue;
+            fields[i] = f with { DataClassificationName = owner };
+        }
+    }
+
+    /// <summary>
     /// The BC system fields every table carries, in the id order BC itself uses. They are
     /// appended to every metatable the runner builds but are NOT part of
     /// <c>ParsedTable.Fields</c>, because no AL source declares them — the platform does.
@@ -1056,14 +1115,27 @@ public static partial class RecordPatches
     /// array twice and corrupt the field layout R2R-precompiled BC code holds offsets for.
     /// It is resolvable but not appended, which is why the two sets are now read through
     /// separate members rather than through this one.</para>
+    ///
+    /// <para><c>Editable</c> and <c>DataClassification</c> are BC's own, not this runner's
+    /// choice: <c>SystemFieldsHelper</c> in <c>Microsoft.Dynamics.Nav.Types</c> builds these
+    /// six fields by parsing boilerplate XML that states <c>Editable="0"</c> for all six, and
+    /// <c>DataClassification="EndUserPseudonymousIdentifiers"</c> for <c>$systemId</c>,
+    /// <c>SystemCreatedBy</c> and <c>SystemModifiedBy</c> against <c>"SystemMetadata"</c> for
+    /// <c>timestamp</c>, <c>SystemCreatedAt</c> and <c>SystemModifiedAt</c>. The metadata
+    /// equivalence harness measured the same split independently on 150 tables (#3545).</para>
     /// </summary>
     private static readonly ParsedField[] SystemParsedFields = new[]
     {
-        new ParsedField(2000000000, "SystemId",         "Guid",     0),
-        new ParsedField(2000000001, "SystemCreatedAt",  "DateTime", 0),
-        new ParsedField(2000000002, "SystemCreatedBy",  "Guid",     0),
-        new ParsedField(2000000003, "SystemModifiedAt", "DateTime", 0),
-        new ParsedField(2000000004, "SystemModifiedBy", "Guid",     0),
+        new ParsedField(2000000000, "SystemId",         "Guid",     0,
+            Editable: false, DataClassificationName: "EndUserPseudonymousIdentifiers"),
+        new ParsedField(2000000001, "SystemCreatedAt",  "DateTime", 0,
+            Editable: false, DataClassificationName: "SystemMetadata"),
+        new ParsedField(2000000002, "SystemCreatedBy",  "Guid",     0,
+            Editable: false, DataClassificationName: "EndUserPseudonymousIdentifiers"),
+        new ParsedField(2000000003, "SystemModifiedAt", "DateTime", 0,
+            Editable: false, DataClassificationName: "SystemMetadata"),
+        new ParsedField(2000000004, "SystemModifiedBy", "Guid",     0,
+            Editable: false, DataClassificationName: "EndUserPseudonymousIdentifiers"),
     };
 
     /// <summary>
@@ -1107,7 +1179,8 @@ public static partial class RecordPatches
     /// set already contains.</para>
     /// </summary>
     private static readonly ParsedField SystemRowVersionParsedField =
-        new ParsedField(0, "SystemRowVersion", "BigInteger", 0);
+        new ParsedField(0, "SystemRowVersion", "BigInteger", 0,
+            Editable: false, DataClassificationName: "SystemMetadata");
 
     /// <summary>
     /// Resolve a field NAME that a CalcFormula or a TableRelation states, on

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -33,6 +33,10 @@ public static partial class RecordPatches
     // Microsoft.Dynamics.Nav.Types.Metadata.ObsoleteState — MetaField's obsoleteState ctor
     // param type (#1780). Bound in Register() alongside the other MetaField-adjacent types.
     private static Type? _tObsoleteState;
+    // Microsoft.Dynamics.Nav.Types.Metadata.ALDataClassification — MetaField's
+    // dataClassification ctor param type (#3545). Member 0 is CustomerContent, which is what
+    // MetaField answers when nothing is passed.
+    private static Type? _tALDataClassification;
     private static Type? _tMetaCalcFormula;
     private static Type? _tMetaFilter;
     private static Type? _tMetaCondition;
@@ -595,6 +599,7 @@ public static partial class RecordPatches
         _tNavType   = typesAsm.GetType("Microsoft.Dynamics.Nav.Types.NavType")!;
         _tFieldClass = typesAsm.GetType("Microsoft.Dynamics.Nav.Types.Metadata.FieldClass")!;
         _tObsoleteState = typesAsm.GetType("Microsoft.Dynamics.Nav.Types.Metadata.ObsoleteState")!;
+        _tALDataClassification = typesAsm.GetType("Microsoft.Dynamics.Nav.Types.Metadata.ALDataClassification")!;
         _tMetaCalcFormula = typesAsm.GetType("Microsoft.Dynamics.Nav.Types.Metadata.MetaCalcFormula")!;
         _tMetaFilter  = typesAsm.GetType("Microsoft.Dynamics.Nav.Types.Metadata.MetaFilter")!;
         _tMetaCondition = typesAsm.GetType("Microsoft.Dynamics.Nav.Types.Metadata.MetaCondition")!;

--- a/docs/metadata-equivalence.md
+++ b/docs/metadata-equivalence.md
@@ -197,6 +197,16 @@ all stated in `SymbolReference.json`, and the reader read none of them. Together
 classification the Field and Table Metadata virtual tables report, and whether an enum-typed
 field can be resolved back to its enum object at all.
 
+**Two of the three landed.** The enum id did not, and the reason is the useful part: reading it
+was never the problem. Stating `enumTypeId` on the `MetaField` makes BC's own
+`FieldDataProvider.GetFieldRecordBuffer` resolve that id through `NCLMetadata`, and the runner
+registers no metadata object for a **precompiled** app's enum — so every read of the Field
+virtual table for Base Application table 1366 threw `NavMetadataNotFoundException("Enum 8889")`,
+which aborted codeunit 2 `Company-Initialize` and reported the corpus app as `EXEC-FAIL` with 0
+of ~2,900 tests run. Registering the metadata is the work, and it is #3594; `MetaField.EnumTypeId`
+stays declared in the allowlist until then, with the measurement below recorded on it so nobody
+re-derives it.
+
 The rules below are measurements, not readings of the AL documentation. Each was checked by
 joining every field of Business Foundation and System Application in `SymbolReference.json`
 to the same field in BC's own emitted metadata, on four BC builds — **3,848 field
@@ -204,22 +214,15 @@ observations, zero counterexamples for all three rules**.
 
 | | rule |
 |---|---|
-| `Editable` | stated only where it is `0`; silence means true. So only the false is carried, and `MetaField`'s own null default decides the rest. |
-| `EnumTypeId` / `EnumTypeName` | `TypeDefinition.Subtype.Id` and `.Name`, when `TypeDefinition.Name == "Enum"`. Presence of the subtype and presence of BC's emitted `EnumTypeId` agree on every observation. |
-| field `DataClassification` | see the next section — it is the one with exceptions. |
+| `Editable` | stated only where it is `0`; silence means true. So only the false is carried, and `MetaField`'s own null default decides the rest. **Landed.** |
+| field `DataClassification` | see the next section — it is the one with exceptions. **Landed.** |
+| `EnumTypeId` / `EnumTypeName` | `TypeDefinition.Subtype.Id` and `.Name`, when `TypeDefinition.Name == "Enum"`. Presence of the subtype and presence of BC's emitted `EnumTypeId` agree on every observation. **Read, not stated — #3594.** |
 
-Two things deliberately not done.
-
-**`EnumTypeId`/`EnumTypeName` are not read from AL source.** The enum's OBJECT ID is not in the
-type text, and the name alone would produce a pair BC never emits — an id of 0 beside a real
-name. A source-compiled enum field is served by `FixupEnumFieldOptionMetadata`, a different
-mechanism, and half of this pair is worse than none of it.
-
-**`MetaField.EnumTypeName` stays declared in the allowlist**, down from 1,888 to 1,811. What
-remains is not this defect: it is BC answering `null` where the runner answers the empty
-string on the ~1,800 fields that are not enum-typed at all, the same null-versus-empty shape
-twenty other `MetaField` members carry. That is #3568's, and folding it in here would have
-let a real difference ride out under a fixed member's name.
+**`EnumTypeId`/`EnumTypeName` are not read from AL source either**, independently of #3594. The
+enum's OBJECT ID is not in the type text, and the name alone would produce a pair BC never emits
+— an id of 0 beside a real name. A source-compiled enum field is served by
+`FixupEnumFieldOptionMetadata`, a different mechanism, and half of this pair is worse than none
+of it.
 
 <a id="field-dataclassification-inherits-its-owner"></a>
 ## A field's DataClassification inherits its OWNER, with two exceptions
@@ -259,12 +262,12 @@ builds them by parsing boilerplate XML: `Editable="0"` on all six, and
 
 | | before | after |
 |---|---:|---:|
-| differences | 70,728 | 68,023 |
-| members differing | 74 | 71 |
+| differences | 70,728 | 68,177 |
+| members differing | 74 | 72 |
 | `MetaField.Editable` | 987 | **0** |
 | `MetaField.DataClassification` | 1,564 | **0** |
-| `MetaField.EnumTypeId` | 77 | **0** |
-| `MetaField.EnumTypeName` | 1,888 | 1,811 |
+| `MetaField.EnumTypeId` | 77 | 77 (#3594) |
+| `MetaField.EnumTypeName` | 1,888 | 1,888 (#3568) |
 
 No other member moved in either direction, and no new member appeared.
 

--- a/docs/metadata-equivalence.md
+++ b/docs/metadata-equivalence.md
@@ -167,7 +167,7 @@ Two consequences worth meeting before a non-empty diff is:
   holds after deltas are applied — which is not obtainable without a tier. That is the ceiling on
   how empty this diff can ever get.
 
-Verified across four BC builds: the same 74 entries cover every difference on all four, with none
+Verified across four BC builds: the same entries cover every difference on all four, with none
 stale. The membership does not move; the counts do, which is the whole reason nothing asserts one.
 
 | BC build | differences | members | System App tables | `Editable` | `DataClassification` | `EnumTypeId` |
@@ -177,13 +177,104 @@ stale. The membership does not move; the counts do, which is the whole reason no
 | 28.1.49838.54044 | 70,728 | 74 | 138 | 78 | 661 | 76 |
 | 28.4.53241.53989 | 70,836 | 74 | 138 | 78 | 663 | 76 |
 
-The last three columns are System Application's own declared fields. They are recorded here and
-asserted nowhere — see the next section.
+The last three columns are System Application's own declared fields. **They are the pre-#3545
+measurement and are all zero now** — kept because they are what the four-build verification was
+run against, and because the first two columns are the baseline the section below reports
+against. They are recorded here and asserted nowhere; see "Three symbol properties the reader
+dropped" for the post-fix figures.
 
 `maxOccurrences` is unused in the current file. The mechanism is right for a difference whose
 count is bounded independently of the build; a count measured on one BC build and one set of apps
 is not that, because the unit legs run 27.5 and 28.4 while the current numbers were measured on
 28.1.
+
+<a id="three-symbol-properties-the-reader-dropped"></a>
+## Three symbol properties the reader dropped (#3545)
+
+`Editable`, a field's `DataClassification` and the enum an `Enum "X"`-typed field names are
+all stated in `SymbolReference.json`, and the reader read none of them. Together they were
+2,628 of the 70,728 differences, and all three are AL-observable: a field's editability, the
+classification the Field and Table Metadata virtual tables report, and whether an enum-typed
+field can be resolved back to its enum object at all.
+
+The rules below are measurements, not readings of the AL documentation. Each was checked by
+joining every field of Business Foundation and System Application in `SymbolReference.json`
+to the same field in BC's own emitted metadata, on four BC builds — **3,848 field
+observations, zero counterexamples for all three rules**.
+
+| | rule |
+|---|---|
+| `Editable` | stated only where it is `0`; silence means true. So only the false is carried, and `MetaField`'s own null default decides the rest. |
+| `EnumTypeId` / `EnumTypeName` | `TypeDefinition.Subtype.Id` and `.Name`, when `TypeDefinition.Name == "Enum"`. Presence of the subtype and presence of BC's emitted `EnumTypeId` agree on every observation. |
+| field `DataClassification` | see the next section — it is the one with exceptions. |
+
+Two things deliberately not done.
+
+**`EnumTypeId`/`EnumTypeName` are not read from AL source.** The enum's OBJECT ID is not in the
+type text, and the name alone would produce a pair BC never emits — an id of 0 beside a real
+name. A source-compiled enum field is served by `FixupEnumFieldOptionMetadata`, a different
+mechanism, and half of this pair is worse than none of it.
+
+**`MetaField.EnumTypeName` stays declared in the allowlist**, down from 1,888 to 1,811. What
+remains is not this defect: it is BC answering `null` where the runner answers the empty
+string on the ~1,800 fields that are not enum-typed at all, the same null-versus-empty shape
+twenty other `MetaField` members carry. That is #3568's, and folding it in here would have
+let a real difference ride out under a fixed member's name.
+
+<a id="field-dataclassification-inherits-its-owner"></a>
+## A field's DataClassification inherits its OWNER, with two exceptions
+
+BC's emitter states the *effective* classification on each field, not the declared one. The
+rule, and both exceptions, are load-bearing:
+
+1. The field's own `DataClassification`, when it states one — 613 of 978 fields on BC
+   28.1, agreeing with BC on 613 of 613.
+2. Otherwise the **owning object's**: the `table` for a field the table declares, the
+   **`tableextension`** for a field an extension adds. Not the extended table — System
+   Application's extension of `User Details` declares no classification and neither do its
+   six fields, and BC answers `CustomerContent` for all six while the extended table declares
+   `SystemMetadata`. Inheriting from the extended table answers `SystemMetadata` on every one
+   of them, which is how this was found: the first attempt cleared 1,558 differences and
+   created 6.
+3. Otherwise `CustomerContent`, which is `ALDataClassification`'s member 0 and therefore what
+   `MetaField` answers when nothing is passed.
+
+**The exceptions.** A `FlowField`/`FlowFilter` and a `Blob` field that are silent about
+`DataClassification` inherit nothing — BC emits no attribute for them, so they land on
+`CustomerContent` however the owner is classified. This is not cosmetic: 11 such fields sit on
+tables declaring `SystemMetadata`, so inheriting unconditionally trades one wrong answer for
+another rather than fixing anything. Verbatim from System Application's table 9131, whose
+table line reads `DataClassification = SystemMetadata`: field 1 `Id` (`Text[250]`, silent) is
+emitted `SystemMetadata`, and field 8 `FieldsJson` (`Blob`, silent) is emitted with no
+`DataClassification` at all.
+
+**BC's six platform-added fields** were wrong on both members and are fixed with them. Their
+values are BC's own, read out of `SystemFieldsHelper` in `Microsoft.Dynamics.Nav.Types`, which
+builds them by parsing boilerplate XML: `Editable="0"` on all six, and
+`DataClassification="EndUserPseudonymousIdentifiers"` for `$systemId`, `SystemCreatedBy` and
+`SystemModifiedBy` against `"SystemMetadata"` for `timestamp`, `SystemCreatedAt` and
+`SystemModifiedAt`. The harness measured the same split independently across 150 tables.
+
+**What this cost, measured on BC 28.1.49838.53910** over the same two apps:
+
+| | before | after |
+|---|---:|---:|
+| differences | 70,728 | 68,023 |
+| members differing | 74 | 71 |
+| `MetaField.Editable` | 987 | **0** |
+| `MetaField.DataClassification` | 1,564 | **0** |
+| `MetaField.EnumTypeId` | 77 | **0** |
+| `MetaField.EnumTypeName` | 1,888 | 1,811 |
+
+No other member moved in either direction, and no new member appeared.
+
+**The symbol cache replays a parse, so this needed a `CacheVersion` bump** (34 → 35), and the
+reason is worth keeping. `DataClassificationName` is stored *effective* rather than declared,
+which is a different value read out of unchanged bytes with no change of shape — exactly what
+`BcAppSymbolCache`'s structural payload hash cannot see. Measured here rather than reasoned
+about: a payload written by an earlier build of this same change was replayed warm and put 154
+of System Application's fields back on `CustomerContent` while the build was green and the
+harness reported the reader as fixed.
 
 <a id="a-check-that-cannot-fail-reads-like-a-check-that-passed"></a>
 ## A check that cannot fail reads exactly like a check that passed

--- a/tests/expectations/metadata-equivalence/allowlist.json
+++ b/tests/expectations/metadata-equivalence/allowlist.json
@@ -300,6 +300,11 @@
       "issue": 3568
     },
     {
+      "member": "MetaField.EnumTypeId",
+      "reason": "BC resolves the enum object's id; the runner answers 0. The AL-observable consequence is that an enum-typed field cannot be resolved back to its enum object. #3545 established WHERE the value is \u2014 TypeDefinition.Subtype.Id, agreeing with BC on 3,848 of 3,848 field observations across four builds \u2014 and did not land it: passing enumTypeId makes BC's own FieldDataProvider.GetFieldRecordBuffer resolve that id through NCLMetadata, and the runner registers no metadata object for a precompiled app's enum, so every read of the Field virtual table for Base Application table 1366 threw NavMetadataNotFoundException(\"Enum 8889\") and aborted the corpus app. Registering the metadata is the work; see #3594.",
+      "issue": 3594
+    },
+    {
       "member": "MetaField.Access",
       "reason": "BC states Internal on fields whose AL declares it; the runner answers Public. The symbol file carries Access.",
       "issue": 3568

--- a/tests/expectations/metadata-equivalence/allowlist.json
+++ b/tests/expectations/metadata-equivalence/allowlist.json
@@ -172,11 +172,6 @@
       "issue": 3568
     },
     {
-      "member": "MetaField.DataClassification",
-      "reason": "A field with no DataClassification inherits the TABLE's, which the symbol file does carry. On 439 of 439 measured fields the emitted value equals the table's.",
-      "issue": 3545
-    },
-    {
       "member": "MetaField.ALNamespace",
       "reason": "BC states the object's AL namespace on every field; the runner states the empty string. The symbol file has no ALNamespace attribute, but its Namespaces nesting is exactly what the attribute names.",
       "issue": 3568
@@ -191,11 +186,6 @@
       "member": "MetaField.ExtendedDatatype",
       "reason": "BC answers Undefined where nothing is declared; the runner answers None, a different member of the same enum. An encoded-default disagreement, not a missing read.",
       "issue": 3568
-    },
-    {
-      "member": "MetaField.Editable",
-      "reason": "An absent Editable in the symbol file means true; the reader takes the constructor default instead. Measured over 1,540 ISV fields: 271 stated, 1,269 silent-and-default, zero silent-and-non-default.",
-      "issue": 3545
     },
     {
       "member": "MetaField.TestRelations",
@@ -307,11 +297,6 @@
     {
       "member": "MetaKey.KeyName",
       "reason": "The same naming disagreement as MetaKey.Name, on the second of the two name properties.",
-      "issue": 3568
-    },
-    {
-      "member": "MetaField.EnumTypeId",
-      "reason": "BC resolves the enum object's id; the runner answers 0. The AL-observable consequence is that an enum-typed field cannot be resolved back to its enum object.",
       "issue": 3568
     },
     {


### PR DESCRIPTION
Closes #3545

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/295

The SymbolReference reader dropped three properties the symbol file states on every field.
The #3533 harness measures them against BC's own metadata emitter, and they were 2,628 of
its 70,728 differences.

**Two of the three landed. The third is a finding, not a fix**, and that is the part worth
reading first.

## What the harness says

| | before | after |
|---|---:|---:|
| differences | 70,728 | **68,177** |
| members differing | 74 | **72** |
| `MetaField.Editable` | 987 | **0** |
| `MetaField.DataClassification` | 1,564 | **0** |
| `MetaField.EnumTypeId` | 77 | 77 — #3594 |

No other member moved in either direction and no new member appeared. The two allowlist
entries carrying `"issue": 3545` are deleted, which is the proof: the harness fails on a
stale entry, so an entry cannot be removed without the behaviour actually changing.

Both runs on BC 28.1.49838.53910, Business Foundation (12 tables) + System Application (138).

## The rules, and how they were measured

Not read off the documentation. Every **table-declared** field of both apps in
`SymbolReference.json` was joined to the same field in BC's own emitted metadata, on four BC
builds — **3,848 field observations, zero counterexamples**.

**Corrected after the fact (#3603, PR #3651).** This paragraph originally said "every field of
both apps", which overstated the population: the four bundles carry 3,888 declared fields, and
the 3,848 measured here are the table-declared ones. The remaining 40 are the **extension-added**
fields — 10 per build across the four builds — and the rule was subsequently measured to hold for
them too, with zero counterexamples. Only 10 of the 125 extension-added fields are observable at
all, because `ObsoleteState = Moved` removes a field from BC's emitted metadata entirely while
`Removed` leaves it in.

- **`Editable`** is stated only where it is `0`; silence means true. So only the false is
  carried, and `MetaField`'s own null default decides the rest. Asserting a `true` would claim
  a reading that was never made.
- **A field's `DataClassification`** is the *effective* value: its own when it states one, else
  its **owner's** — the table, or the **tableextension** for a field an extension adds — else
  `CustomerContent`. A silent `FlowField`/`FlowFilter` or `Blob` field inherits nothing.
- **`EnumTypeId`/`EnumTypeName`** are `TypeDefinition.Subtype.Id` and `.Name`. Read, and
  deliberately not stated — below.

Two parts of that were found by being wrong first, and both are in `docs/`:

**The owner is the tableextension, not the extended table.** The first attempt inherited from
the extended table, cleared 1,558 differences and **created 6**: System Application's extension
of `User Details` declares no classification and neither do its six fields, and BC answers
`CustomerContent` for all six while the extended table declares `SystemMetadata`.

**The FlowField/Blob exception is not cosmetic.** Eleven such fields sit on tables declaring
`SystemMetadata`, so inheriting unconditionally trades one wrong answer for another. Verbatim
from System Application's table 9131, whose table line reads `DataClassification =
SystemMetadata`: field 1 `Id` (`Text[250]`, silent) is emitted `SystemMetadata`, field 8
`FieldsJson` (`Blob`, silent) is emitted with no `DataClassification` at all.

**BC's six platform-added fields** were wrong on both members and are fixed with them. Those
values are BC's own, read out of `SystemFieldsHelper` in `Microsoft.Dynamics.Nav.Types`, which
builds the six by parsing boilerplate XML stating `Editable="0"` for all of them and
`EndUserPseudonymousIdentifiers` for `$systemId` / `SystemCreatedBy` / `SystemModifiedBy`
against `SystemMetadata` for `timestamp` / `SystemCreatedAt` / `SystemModifiedAt`. The harness
measured the same split independently across 150 tables. Fixing them is what let the two
allowlist entries go: 87 of the `Editable` differences were on declared fields and **900 were
on these six**.

## The third one: `EnumTypeId` is read and not stated (#3594)

Reading it was never the problem — 3,848 of 3,848. **Stating it broke the corpus outright.**
Passing `enumTypeId` makes BC's own `FieldDataProvider.GetFieldRecordBuffer` resolve that id
through `NCLMetadata`, and the runner registers no metadata object for a *precompiled* app's
enum:

```
GetFieldRecordBuffer threw for table 1366 field: NavMetadataNotFoundException:
  The metadata object Enum 8889 was not found.
```

Measured: that aborted codeunit 2 `Company-Initialize` and the corpus app reported `EXEC-FAIL`
with **0 of ~2,900 tests run**. So the id is only safe to state once the object it names can be
found — which is #3594, filed with the measurement on it, and `MetaField.EnumTypeId` goes back
into the allowlist against it rather than under #3568's generic entry.

This is the reason the branch has two commits: the second one takes the enum half back out.

## `CacheVersion` 34 -> 35

`DataClassificationName` is stored *effective* rather than declared — a different value read
out of unchanged bytes with **no change of shape**, which is exactly what
`BcAppSymbolCache`'s structural payload hash cannot see. Measured rather than reasoned about: a
payload written by an earlier build of this same change was replayed warm and put 154 of System
Application's fields back on `CustomerContent` **while the build was green and the harness
reported the reader as fixed**.

## The shape, not the reported line

- **Another call site with the same wrong pattern?** Yes — the tableextension reader
  (`BcAppSymbolCache.TableExtensions.cs`) read the same JSON and dropped the same three
  properties. Fixed, and it is where the owner rule came from.
- **A sibling making the same assumption?** Yes — the AL-source parser
  (`RecordPatches.AlSourceParser.cs`) also read neither `Editable` nor a field's
  `DataClassification`. Fixed, so the two paths answer the same `MetaField` for the same
  declaration; that invariant is stated in these files already and was not holding.
- **Two paths writing one invariant?** The resolution now lives in one place,
  `RecordPatches.ApplyOwnerDataClassification`, called by all four readers at the moment their
  owner's declaration is in hand — rather than in `BuildMetaField`, which cannot tell a
  table's field from an extension's.

## Open issues in the same area that I did NOT fold in

Scanned the queue for this file cluster. Nothing else lands in it:

- **#3568** — the other 71 harness members. Three of its members are touched here and none is
  closed: `MetaField.EnumTypeId` moves to #3594 with a measurement, `MetaField.EnumTypeName`
  keeps its entry unchanged (what remains on it is BC `null` versus runner empty string on the
  ~1,800 fields that are not enum-typed — a different defect from twenty other members' shape),
  and `MetaTable.DataClassification` is the table-level member, untouched.
- **#3552 / PR #3584** — builds a *compiled* table's metadata from BC's own document instead of
  parsed AL. Adjacent subject, disjoint files (`RecordPatches.NclMetaTableFromBcDocument.cs`,
  `RunnerXmlMetadataLoader.cs`), and it does not touch the symbol reader this fixes. Folding
  would have produced a diff nobody could hold.

## Corpus

`Corpus-PR:` above adds four tests: a silent field, a field with its own value, a silent `Blob`
and a `FlowField`, all on one table declaring `SystemMetadata`. Corpus #292 already pins the
two easy rows on a `CustomerContent` table, where the inherited value and the default are the
same word and cannot be told apart; these come apart.

Writing them found a fifth thing, which is why the FlowField row asserts what it does:
**`NCLMetaField.DataClassification`'s getter returns `SystemMetadata` for any field whose
`FieldClass` is not `Normal`**, whatever the metadata says. So the FlowField half of the
exception above is invisible to AL and matters only to `MetaField` equivalence — my first
version of that test asserted `CustomerContent` and failed against the runner, which is how it
was found rather than shipped as a wrong claim.

## What was run

- `MetadataEquivalenceHarnessTests` — 7/7. `The_current_reader_reproduces_the_known_defect_shapes`
  is updated in this commit, as #3545 requires: the two fixed members move to a
  zero-difference assertion, `EnumTypeId` stays a constant-answer defect, and three still-broken
  members (`ClrType`, `ExtendedDatatype`, `CaptionML`) keep the property that this test can fail.
- Filtered `AlRunner.Tests` over the surface — 144 passed, 1 skipped, 0 failed
  (`MetadataEquivalence*`, `MetadataDifferenceAllowlist*`, `BcInternalsNullForgivingGuard*`,
  `FieldTriggerShapeGapCallSite*`, `BcShapeMethodLookup*`, `*SymbolCache*`,
  `ProseRelocationPointer*`, `*DocumentationDrift*`).
- All 32 glob-discovered suites: `tools/test_*.py`, `.github/scripts/test_*.{py,sh}`,
  `scripts/tests/*.test.py` — all pass.
- **The pinned al-language corpus, in the CI configuration** (`--strict
  --expectations-require-match --count-baseline`): **3,112 / 3,112 pass, 0 fail**. This is what
  caught the enum defect, and it is the check that says an AL-observable metadata change did not
  move anything else.

## Where the prose went

Two `docs/metadata-equivalence.md` sections — "Three symbol properties the reader dropped" and
"A field's DataClassification inherits its OWNER, with two exceptions" — carry the derivations,
the per-build counts and the verbatim examples. The code keeps the claim and a pointer.

https://claude.ai/code/session_01F7HLDeNwiGQoLT5wFanqmH
