### PR TITLE
fix(metadata-loader): serve every captured kind from the seam, not four

### DIFF
--- a/AlRunner.Tests/MetadataLoaderKindCoverageTests.cs
+++ b/AlRunner.Tests/MetadataLoaderKindCoverageTests.cs
@@ -1,0 +1,121 @@
+// MetadataLoaderKindCoverageTests — #3599: RunnerXmlMetadataLoader.GetMetaObjectXmlMetadata
+// served four kinds (Report, Page, XmlPort, Table) and threw RunnerOutOfScopeException for
+// everything else, even when AlObjectMetadataRegistry (#3548) already held BC's own emitted
+// document for that exact (kind, id). This is a RUNNER-MECHANISM test: it calls the seam
+// directly, the same way BC's own MetaObjectCache / NCLObjectMetadataLoaderExtensions.GetMeta*
+// helpers call it (verified via bc-decompiler: NCLObjectMetadataLoaderExtensions.GetMetaCodeunit/
+// GetMetaQuery/GetMetaEnum all funnel through RetrieveRuntimeObject ->
+// loader.GetMetaObjectXmlMetadata(new ApplicationObjectId(objectType, id), appGroup)), without
+// needing the BC engine, a real bundle, or a subprocess spawn.
+//
+// ObjectType (Microsoft.Dynamics.Nav.Types.ObjectType) and the AL compiler's SymbolKind
+// (the string AlObjectMetadataRegistry is keyed by) are two different enums; RegistryKindByObjectType
+// in RunnerXmlMetadataLoader.cs carries the measured mapping between them. The one divergence:
+// ObjectType.CodeUnit vs SymbolKind's "Codeunit" — covered by CodeUnit_MapsToCodeunitRegistryKind
+// below so a future rename of either enum fails loudly here instead of silently losing the kind.
+using System.Xml;
+using AlRunner;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Microsoft.Dynamics.Nav.Types;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class MetadataLoaderKindCoverageTests : IDisposable
+{
+    public MetadataLoaderKindCoverageTests() => AlObjectMetadataRegistry.Clear();
+    public void Dispose() => AlObjectMetadataRegistry.Clear();
+
+    private static readonly RunnerXmlMetadataLoader Loader = new();
+
+    /// <summary>Every (ObjectType, registry kind) pair the fallback is supposed to serve,
+    /// excluding Report/Page/Table/XmlPort — those already have their own branches and their
+    /// own tests (TableMetadataFromBcDocumentTests and the report/page/xmlport registries).</summary>
+    public static IEnumerable<object[]> NewlyServedKinds()
+    {
+        yield return new object[] { ObjectType.CodeUnit, "Codeunit" };
+        yield return new object[] { ObjectType.Query, "Query" };
+        yield return new object[] { ObjectType.Enum, "Enum" };
+        yield return new object[] { ObjectType.EnumExtension, "EnumExtension" };
+        yield return new object[] { ObjectType.PermissionSet, "PermissionSet" };
+        yield return new object[] { ObjectType.PermissionSetExtension, "PermissionSetExtension" };
+        yield return new object[] { ObjectType.TableExtension, "TableExtension" };
+        yield return new object[] { ObjectType.PageExtension, "PageExtension" };
+        yield return new object[] { ObjectType.ReportExtension, "ReportExtension" };
+    }
+
+    // RED (pre-fix): every one of these ObjectTypes hit the final `throw` in
+    // GetMetaObjectXmlMetadata even though AlObjectMetadataRegistry held a document for the
+    // exact (kind, id) — confirmed by running this assembly against the pre-fix loader, where
+    // this test failed with RunnerOutOfScopeException rather than reaching the Assert.
+    [Theory]
+    [MemberData(nameof(NewlyServedKinds))]
+    public void PreviouslyThrowingKind_NowAnswersTheRegisteredBcDocument(ObjectType objectType, string registryKind)
+    {
+        const int id = 88010;
+        const string name = "MLKC Thing";
+        var xml = $"<{registryKind} Id=\"{id}\" Name=\"{name}\"><Marker>{registryKind}-{id}-payload</Marker></{registryKind}>";
+        AlObjectMetadataRegistry.Register(registryKind, id, name, xml);
+
+        var result = Loader.GetMetaObjectXmlMetadata(new ApplicationObjectId(objectType, id), appGroup: null!);
+
+        Assert.NotNull(result.Document.DocumentElement);
+        // A concrete value out of the registered document, not merely "did not throw": the
+        // marker text is unique per (kind, id) so a wrong-kind or wrong-id lookup would fail
+        // this assertion even though it returned SOME document.
+        Assert.Equal($"{registryKind}-{id}-payload", result.Document.DocumentElement!.SelectSingleNode("Marker")!.InnerText);
+    }
+
+    // Negative direction: an id the registry never saw for that kind still throws loudly —
+    // the fallback must never manufacture an empty/default document (loud-failures rule).
+    [Theory]
+    [MemberData(nameof(NewlyServedKinds))]
+    public void UnregisteredId_StillThrowsRunnerOutOfScopeException(ObjectType objectType, string registryKind)
+    {
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
+            () => Loader.GetMetaObjectXmlMetadata(new ApplicationObjectId(objectType, 88099), appGroup: null!));
+        Assert.Contains(objectType.ToString(), ex.Message);
+    }
+
+    // A kind the registry has never been taught about at all (per docs/object-metadata-capture.md,
+    // Profile never reaches AddApplicationObject with a non-empty document) must still refuse
+    // rather than silently answering something for it.
+    [Fact]
+    public void KindWithNoRegistryMapping_StillThrows()
+    {
+        AlObjectMetadataRegistry.Register("Profile", null, "MLKC Profile", "<Profile/>");
+
+        Assert.Throws<RunnerOutOfScopeException>(
+            () => Loader.GetMetaObjectXmlMetadata(new ApplicationObjectId(ObjectType.Profile, 0), appGroup: null!));
+    }
+
+    // The one spelling divergence between the two enums this mapping bridges, pinned so a
+    // future rename of either ObjectType.CodeUnit or SymbolKind.Codeunit is caught here rather
+    // than silently losing codeunit metadata to the fallback's final throw.
+    [Fact]
+    public void CodeUnit_MapsToCodeunitRegistryKind()
+    {
+        const int id = 88011;
+        AlObjectMetadataRegistry.Register("Codeunit", id, "MLKC Cu", "<Codeunit Id=\"88011\"><Marker>cu-marker</Marker></Codeunit>");
+
+        var result = Loader.GetMetaObjectXmlMetadata(new ApplicationObjectId(ObjectType.CodeUnit, id), appGroup: null!);
+
+        Assert.Equal("cu-marker", result.Document.DocumentElement!.SelectSingleNode("Marker")!.InnerText);
+    }
+
+    // Table keeps going through its own #3552 branch (RecordPatches.BcTableMetadataKind), not
+    // through the new fallback dictionary — this pins that the two routes do not collide, since
+    // both ultimately read the same registry.
+    [Fact]
+    public void Table_StillServedByItsOwnBranch_NotTheFallback()
+    {
+        const int id = 88012;
+        AlObjectMetadataRegistry.Register(RecordPatches.BcTableMetadataKind, id, "MLKC Table",
+            "<Table Id=\"88012\"><Marker>table-marker</Marker></Table>");
+
+        var result = Loader.GetMetaObjectXmlMetadata(new ApplicationObjectId(ObjectType.Table, id), appGroup: null!);
+
+        Assert.Equal("table-marker", result.Document.DocumentElement!.SelectSingleNode("Marker")!.InnerText);
+    }
+}

--- a/AlRunner/Patches/RunnerXmlMetadataLoader.cs
+++ b/AlRunner/Patches/RunnerXmlMetadataLoader.cs
@@ -30,11 +30,11 @@
 // the registry has no entry for (never compiled, or a non-report type) throw
 // loudly — never a silent empty/default document (loud-failures rule).
 //
-// Scope: this loader currently only serves ObjectType.Report — the runner's
-// AlReportMetadataRegistry is report-scoped. Page/query/xmlport source
-// metadata is a separate (currently unaddressed) gap; touching those members
-// throws RunnerOutOfScopeException rather than silently returning something
-// wrong.
+// Scope (#3599): report, page and xmlport keep their own per-kind registries above;
+// table (#3552) and every other kind AlObjectMetadataRegistry holds (#3548) are served
+// by the general fallback at the bottom of GetMetaObjectXmlMetadata. A kind neither
+// registry has an entry for still throws RunnerOutOfScopeException rather than
+// silently returning something wrong.
 //
 // Implemented directly (no runtime DispatchProxy — tried first, but produced
 // unexplained null returns from CreateEmptyNCLMetaReport's factory Invoke
@@ -49,10 +49,35 @@ using Microsoft.Dynamics.Nav.Types;
 namespace AlRunner.Patches;
 
 /// <summary>
-/// Real INCLObjectXmlMetadataLoader backed by AlReportMetadataRegistry.
+/// Real INCLObjectXmlMetadataLoader backed by BC's own emit-captured metadata:
+/// AlReportMetadataRegistry / AlPageMetadataRegistry / AlXmlPortMetadataRegistry per kind,
+/// AlObjectMetadataRegistry (#3548) for table and everything else it holds (#3599).
 /// </summary>
 public sealed class RunnerXmlMetadataLoader : INCLObjectXmlMetadataLoader
 {
+    // BC's runtime ObjectType (Microsoft.Dynamics.Nav.Types.ObjectType) and the AL compiler's
+    // SymbolKind (Microsoft.Dynamics.Nav.CodeAnalysis.SymbolKind — the string
+    // AlObjectMetadataRegistry is keyed by, via BcCompiler.CaptureOutputter.AddApplicationObject's
+    // `symbol.Kind.ToString()`) are two different enums. Measured by decompiling both
+    // (Microsoft.Dynamics.Nav.Types.dll / Microsoft.Dynamics.Nav.CodeAnalysis.dll, BC 28.1):
+    // every kind AlObjectMetadataRegistry captures (docs/object-metadata-capture.md) names
+    // identically in ObjectType, with exactly one spelling divergence — ObjectType.CodeUnit vs
+    // SymbolKind.Codeunit. Report/Page/Table/XmlPort are excluded here because the branches
+    // above already serve them from their own registries.
+    private static readonly System.Collections.Generic.IReadOnlyDictionary<ObjectType, string>
+        RegistryKindByObjectType = new System.Collections.Generic.Dictionary<ObjectType, string>
+        {
+            [ObjectType.CodeUnit] = "Codeunit",
+            [ObjectType.Query] = "Query",
+            [ObjectType.Enum] = "Enum",
+            [ObjectType.EnumExtension] = "EnumExtension",
+            [ObjectType.PermissionSet] = "PermissionSet",
+            [ObjectType.PermissionSetExtension] = "PermissionSetExtension",
+            [ObjectType.TableExtension] = "TableExtension",
+            [ObjectType.PageExtension] = "PageExtension",
+            [ObjectType.ReportExtension] = "ReportExtension",
+        };
+
     public NCLObjectXmlMetadata GetMetaObjectXmlMetadata(ApplicationObjectId objectId, NavAppGroup appGroup)
     {
         // MetadataHash is a cache-invalidation key only (the real
@@ -107,11 +132,20 @@ public sealed class RunnerXmlMetadataLoader : INCLObjectXmlMetadataLoader
             && RecordPatches.TryBuildDependencyReportMetadata(objectId.ObjectNumber) is { } depXml)
             return Wrap(depXml, $"runner-dep-report-{objectId.ObjectNumber}");
 
+        // Every other kind AlObjectMetadataRegistry holds (#3548, #3599): codeunit, query,
+        // enum(extension), permission set(extension), table extension, page extension, report
+        // extension. Same registry #3552 reads for tables, same shape — BC's own emitted
+        // document, keyed by (kind, id), served back to BC's own MetaObjectCache /
+        // NCLObjectMetadataLoaderExtensions so it builds the real MetaCodeunit / MetaQuery /
+        // MetaEnum / … instead of a runner-derived approximation.
+        if (RegistryKindByObjectType.TryGetValue(objectId.ObjectType, out var kind)
+            && AlObjectMetadataRegistry.TryGet(kind, objectId.ObjectNumber, out var kindXml))
+            return Wrap(kindXml, $"runner-{kind.ToLowerInvariant()}-{objectId.ObjectNumber}");
+
         throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
             $"INCLObjectXmlMetadataLoader.GetMetaObjectXmlMetadata({objectId.ObjectType} {objectId.ObjectNumber})",
             "not-yet-implemented — no metadata XML for this object: it was not source-compiled " +
-            "by the runner, and no loaded dependency .app declares it " +
-            "(only reports, pages and xmlports are served)");
+            "by the runner, and no loaded dependency .app declares it");
     }
 
     private static NCLObjectXmlMetadata Wrap(string xml, string metadataHash)
@@ -149,12 +183,12 @@ public sealed class RunnerMetaApplicationObjectLoader : INCLMetaApplicationObjec
     public INCLCodeLoader CodeLoader =>
         throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
             "INCLMetaApplicationObjectLoader.CodeLoader",
-            "not-yet-implemented — runner metadata loader only serves report metadata XML");
+            "not-yet-implemented — runner metadata loader only implements XmlMetadataLoader");
 
     public NCLMetadata MetadataCache =>
         throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
             "INCLMetaApplicationObjectLoader.MetadataCache",
-            "not-yet-implemented — runner metadata loader only serves report metadata XML");
+            "not-yet-implemented — runner metadata loader only implements XmlMetadataLoader");
 
     // BC's OWN MetaObjectCache, constructed over our XML loader. NCLMetaForm's page path
     // does NOT go through XmlMetadataLoader the way the report path does — it calls
@@ -196,7 +230,7 @@ public sealed class RunnerMetaApplicationObjectLoader : INCLMetaApplicationObjec
     public INavAppClrTypeRetriever AppClrTypeRetriever =>
         throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
             "INCLMetaApplicationObjectLoader.AppClrTypeRetriever",
-            "not-yet-implemented — runner metadata loader only serves report metadata XML");
+            "not-yet-implemented — runner metadata loader only implements XmlMetadataLoader");
 
     // Single shared instance. The XML loader half is stateless (every call re-resolves
     // against the registries, which are the source of truth); the MetaObjectCache half is


### PR DESCRIPTION
Closes #3599

Filed and implemented by an agent (Claude, identity `impl-1`).

## What changed

`RunnerXmlMetadataLoader.GetMetaObjectXmlMetadata` served four `ObjectType`s (Report, Page,
XmlPort, Table — the last added by #3552/#3584) and threw `RunnerOutOfScopeException` for
every other kind, even when `AlObjectMetadataRegistry` (#3548) already held BC's own emitted
document for that exact (kind, id). This adds a general fallback that maps BC's runtime
`ObjectType` to the AL compiler's `SymbolKind` string the registry is keyed by, and serves
nine more kinds from it: Codeunit, Query, Enum, EnumExtension, PermissionSet,
PermissionSetExtension, TableExtension, PageExtension, ReportExtension.

Also fixed the three stale `"only serves report metadata XML"` throw messages and the
header's stale `"only serves ObjectType.Report"` claim (issue's "Done when" item 4).

## The measured `ObjectType` -> kind mapping

Decompiled both enums directly (`bc-decompiler`, BC 28.1): `Microsoft.Dynamics.Nav.Types.ObjectType`
and `Microsoft.Dynamics.Nav.CodeAnalysis.SymbolKind` (the string
`BcCompiler.CaptureOutputter.AddApplicationObject` keys the registry with, via
`symbol.Kind.ToString()`). Every kind the registry captures (the thirteen in
`docs/object-metadata-capture.md`) names identically in `ObjectType`, with exactly one
spelling divergence:

| `ObjectType` member | registry kind string | served by |
|---|---|---|
| `Table` | `"Table"` | existing branch (#3552) |
| `Page` | `"Page"` | existing branch |
| `Report` | `"Report"` | existing branch |
| `XmlPort` | `"XmlPort"` | existing branch |
| `CodeUnit` | `"Codeunit"` | **new** (note the casing divergence) |
| `Query` | `"Query"` | **new** |
| `Enum` | `"Enum"` | **new** |
| `EnumExtension` | `"EnumExtension"` | **new** |
| `PermissionSet` | `"PermissionSet"` | **new** |
| `PermissionSetExtension` | `"PermissionSetExtension"` | **new** |
| `TableExtension` | `"TableExtension"` | **new** |
| `PageExtension` | `"PageExtension"` | **new** |
| `ReportExtension` | `"ReportExtension"` | **new** |

`ObjectType` members with no registry counterpart (never captured, per
`docs/object-metadata-capture.md`, because BC never hands them a document, or because the
runner never source-compiles them): `TableData`, `Form`, `Dataport`, `MenuSuite`, `System`,
`FieldNumber`, `LimitedUsageTableData`, `TablePage`, `Profile`, `ProfileExtension`,
`ExternalBusinessEvent`, `DynamicQuery`, `MovedObjectManifest`, `PackagedResourceManifest`,
`AnalysisViewManifest`.

`SymbolKind.Interface` has **no corresponding `ObjectType` member at all** — `ObjectType`
does not declare an `Interface` case. That is a stronger statement than "the capture drops
it" (which `docs/object-metadata-capture.md` already recorded): an interface never gets an
`ApplicationObjectId` with an `ObjectType` to look up in the first place, so it structurally
cannot reach this seam regardless of what the registry holds.

## Which kinds I left out, and why

None. Every kind `AlObjectMetadataRegistry` captures is now served. `Profile` is in the
dictionary of "no registry counterpart" above only because the registry itself never holds
a `Profile` document (measured in #3548/#3599 investigation) — not because I excluded it.

## RED -> GREEN

`AlRunner.Tests/MetadataLoaderKindCoverageTests.cs` calls the seam directly — the same way
BC's own `NCLObjectMetadataLoaderExtensions.GetMetaCodeunit` / `GetMetaQuery` / `GetMetaEnum`
call it (verified via `find_callers`/decompile: all three funnel through
`RetrieveRuntimeObject` -> `loader.GetMetaObjectXmlMetadata`) — without needing the BC engine,
a bundle, or a subprocess spawn. For each of the nine newly-served kinds it registers a
document with a distinguishing marker and asserts the seam returns that exact marker (not
merely "did not throw"), plus a negative case (unregistered id still throws) and a mapping
regression guard for the `CodeUnit`/`Codeunit` spelling divergence.

RED: temporarily disabled the new fallback branch and re-ran — 10 of 21 cases failed with
`RunnerOutOfScopeException` (the 9 positive cases + the dedicated `CodeUnit` mapping test).
GREEN: restored the fix, all 21 pass.

## The corpus run this issue's acceptance bar asks for

Ran the pinned `tests/al-language` corpus (commit `c9d5f656`, matching `origin/main`'s pin —
checked with `tools/corpus-pin.py`) from my own clone, never touching the shared submodule
checkout, before and after the fix:

| | total | pass | fail | error |
|---|---|---|---|---|
| before (fallback disabled) | 3112 | 3112 | 0 | 0 |
| after (this PR) | 3112 | 3112 | 0 | 0 |

Identical, including the `pass-oos`/`pass-known-gap`/`pass-divergence` breakdown (4/6/1 both
times). This is expected, not a null result: none of the runner's current runtime paths for
Codeunit, Query, Enum, TableExtension, PageExtension, PermissionSet(Extension) or
ReportExtension construct their `NCLMeta*` object by calling `LoadMetadata()` through this
seam — each has its own dedicated builder (`CodeunitPatches.MetaCodeunit.cs`'s
`CreateEmptyNCLMetaCodeunit` + manual field population for codeunits,
`RecordPatches.NclMetaQueryBuilder.cs`'s `CreateDynamicQuery` for queries, and so on) that
bypasses `LoadMetadata()` entirely, the same way Table/Page/Report/XmlPort did before their
own conversions wired them through this exact seam. So this PR is additive plumbing that
makes the seam *reachable* for every captured kind — the ground #3562's remaining per-kind
consumer conversions build on — not itself a behavior change for anything the corpus
currently exercises. A future conversion that makes one of these kinds' consumer actually
call through this seam owns its own before/after corpus measurement.

I also ran `tests/al-language-onprem` + `tests/runner-extras` locally for completeness. Five
`runner-extras` suites (microsoft-dependencies, dep-tableext-invoke-main and others needing
precompiled ISV/Microsoft-dependency `.app`s) hit `EMIT-ZERO`/`AL-DIAGNOSTIC-FAIL` — this is a
local package-cache provisioning gap (missing dependency `.app`s in this box's
`~/.al-runner/test-apps`), not caused by this change: those failures are AL **compile-time**
diagnostics, which happen entirely before any of this seam's runtime code ever executes.
CI's package cache differs from this box's.

## Batch-sibling scan (`.claude/rules/batch-sibling-issues-by-file.md`)

Scanned open issues for `RunnerXmlMetadataLoader`/`ObjectMetadataRegistry` and the
`area: metadata-conversion` label. No open issue lands in `RunnerXmlMetadataLoader.cs` — the
other open metadata-conversion issues (#3600, #3601, #3602, #3603, #3604) each land in a
different file (page metadata patches, table builder, DataClassification handling), so
nothing to fold here.

## Corpus linkage

Corpus-NA: this generalizes an existing runtime dispatch seam to reach a registry BC's own
emitter already populates (#3548); no BC-behavior claim changes for any object the corpus
currently exercises (measured: 3112/3112 pass before and after, identical breakdown) because
every newly-served kind's actual metadata construction today bypasses this seam via its own
dedicated builder. A future #3562 conversion that routes a kind's real consumer through this
seam is the one that owes its own corpus-observable claim and measurement.
