### PR TITLE
fix(table-metadata): relax the tableextension guard for same-app add-only extensions

### DIFF
--- a/AlRunner.Tests/ActionRefTargetParserTests.cs
+++ b/AlRunner.Tests/ActionRefTargetParserTests.cs
@@ -42,7 +42,7 @@ public class ActionRefTargetParserTests
 
     private static void Parse(string method, string source) =>
         RP.GetMethod(method, BindingFlags.NonPublic | BindingFlags.Static)!
-          .Invoke(null, new object[] { source });
+          .InvokeStatic(source);
 
     private static System.Collections.IDictionary Dict(string field) =>
         (System.Collections.IDictionary)RP

--- a/AlRunner.Tests/AlSourceParserCommentTests.cs
+++ b/AlRunner.Tests/AlSourceParserCommentTests.cs
@@ -47,7 +47,7 @@ public class AlSourceParserCommentTests
 
         try
         {
-            parse.Invoke(null, new object[] { source });
+            parse.InvokeStatic(source);
             Assert.True(tables.Contains(TableId), $"table {TableId} was not parsed at all");
             var table = tables[TableId]!;
             var fields = (System.Collections.IEnumerable)table.GetType()
@@ -147,7 +147,7 @@ public class AlSourceParserCommentTests
             .GetValue(null)!;
         try
         {
-            parse.Invoke(null, new object[] { source });
+            parse.InvokeStatic(source);
             var table = tables[TableId]!;
             var ids = ((System.Collections.IEnumerable)table.GetType()
                     .GetProperty("Fields")!.GetValue(table)!)

--- a/AlRunner.Tests/AlSourceParserSyntaxTreeTests.cs
+++ b/AlRunner.Tests/AlSourceParserSyntaxTreeTests.cs
@@ -44,7 +44,7 @@ public class AlSourceParserSyntaxTreeTests
     {
         var parse = RecordPatchesType.GetMethod("TryParseTableFile",
             BindingFlags.NonPublic | BindingFlags.Static)!;
-        parse.Invoke(null, new object[] { source });
+        parse.InvokeStatic(source);
         Assert.True(ParsedTables.Contains(TableId), $"table {TableId} was not parsed at all");
         var table = ParsedTables[TableId]!;
         foreach (var f in (System.Collections.IEnumerable)table.GetType()
@@ -177,7 +177,7 @@ public class AlSourceParserSyntaxTreeTests
         {
             var parse = RecordPatchesType.GetMethod("TryParseTableFile",
                 BindingFlags.NonPublic | BindingFlags.Static)!;
-            parse.Invoke(null, new object[] { source });
+            parse.InvokeStatic(source);
 
             var table = ParsedTables[TableId]!;
             var ids = ((System.Collections.IEnumerable)table.GetType()
@@ -291,9 +291,9 @@ public class AlSourceParserSyntaxTreeTests
         var parse = RecordPatchesType.GetMethod("TryParseTableFile",
             BindingFlags.NonPublic | BindingFlags.Static)!;
 
-        parse.Invoke(null, new object[] { "this is not AL at all { { {" });
-        parse.Invoke(null, new object[] { "" });
-        parse.Invoke(null, new object[] { "page 50100 P { layout { area(content) { } } }" });
+        parse.InvokeStatic("this is not AL at all { { {");
+        parse.InvokeStatic("");
+        parse.InvokeStatic("page 50100 P { layout { area(content) { } } }");
 
         Assert.False(ParsedTables.Contains(TableId));
     }

--- a/AlRunner.Tests/CalcFormulaExtensionFieldWiringTests.cs
+++ b/AlRunner.Tests/CalcFormulaExtensionFieldWiringTests.cs
@@ -253,7 +253,7 @@ public sealed class CalcFormulaExtensionFieldWiringTests : IDisposable
                     BindingFlags.NonPublic | BindingFlags.Static)
                 ?? throw new InvalidOperationException(
                     "RecordPatches.MergeExtensionFields not found — this test drives it.");
-        m.Invoke(null, new object?[] { baseTableName, extensionId, fields, null });
+        m.InvokeStatic(baseTableName, extensionId, fields, null);
     }
 
     /// <summary>Assign the metadata reflection statics RecordPatches.Register() would, from the

--- a/AlRunner.Tests/CalcFormulaSyntaxTests.cs
+++ b/AlRunner.Tests/CalcFormulaSyntaxTests.cs
@@ -73,7 +73,7 @@ public class CalcFormulaSyntaxTests
     {
         var parse = RecordPatchesType.GetMethod("TryParseTableFile",
             BindingFlags.NonPublic | BindingFlags.Static)!;
-        parse.Invoke(null, new object[] { Table(calcFormula) });
+        parse.InvokeStatic(Table(calcFormula));
         Assert.True(ParsedTables.Contains(TableId), $"table {TableId} was not parsed at all");
         var table = (ParsedTable)ParsedTables[TableId]!;
         var field = table.Fields.Single(f => f.FieldId == 2);

--- a/AlRunner.Tests/ObsoleteStateFieldParsingTests.cs
+++ b/AlRunner.Tests/ObsoleteStateFieldParsingTests.cs
@@ -36,7 +36,7 @@ public class ObsoleteStateFieldParsingTests
     {
         var parse = RecordPatchesType.GetMethod("TryParseTableFile",
             BindingFlags.NonPublic | BindingFlags.Static)!;
-        parse.Invoke(null, new object[] { source });
+        parse.InvokeStatic(source);
         Assert.True(ParsedTables.Contains(TableId), $"table {TableId} was not parsed at all");
         var table = ParsedTables[TableId]!;
         foreach (var f in (System.Collections.IEnumerable)table.GetType()
@@ -178,7 +178,7 @@ public class ObsoleteStateFieldParsingTests
         {
             var parse = RecordPatchesType.GetMethod("TryParseTableFile",
                 BindingFlags.NonPublic | BindingFlags.Static)!;
-            parse.Invoke(null, new object[] { source });
+            parse.InvokeStatic(source);
 
             var live = ParseTableAndGetField(source, fieldId: 2);
             var gone = ParseTableAndGetField(source, fieldId: 3);

--- a/AlRunner.Tests/PageControlExtensionFieldBindingTests.cs
+++ b/AlRunner.Tests/PageControlExtensionFieldBindingTests.cs
@@ -46,7 +46,7 @@ public class PageControlExtensionFieldBindingTests
 
     private static void InvokeParser(string methodName, string source)
         => RecordPatchesType.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static)!
-            .Invoke(null, new object[] { source });
+            .InvokeStatic(source);
 
     [Fact]
     public void GetPageControlFieldMap_ControlBoundToTableExtensionField_Resolves()

--- a/AlRunner.Tests/PageExtensionParserTests.cs
+++ b/AlRunner.Tests/PageExtensionParserTests.cs
@@ -49,7 +49,7 @@ public class PageExtensionParserTests
 
     private static void Parse(string method, string source) =>
         RP.GetMethod(method, BindingFlags.NonPublic | BindingFlags.Static)!
-          .Invoke(null, new object[] { source });
+          .InvokeStatic(source);
 
     private static System.Collections.IDictionary Dict(string field) =>
         (System.Collections.IDictionary)RP

--- a/AlRunner.Tests/RecordPatchesParseOnceTests.cs
+++ b/AlRunner.Tests/RecordPatchesParseOnceTests.cs
@@ -74,7 +74,7 @@ public sealed class RecordPatchesParseOnceTests : IDisposable
     private static void InvokeTryParse(string methodName, string text)
     {
         var method = RecordPatchesType.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static)!;
-        method.Invoke(null, new object[] { text });
+        method.InvokeStatic(text);
     }
 
     private static Dictionary<int, ParsedTable> ParsedTables =>

--- a/AlRunner.Tests/ReflectiveParserInvoke.cs
+++ b/AlRunner.Tests/ReflectiveParserInvoke.cs
@@ -1,0 +1,33 @@
+// ReflectiveParserInvoke — a shared, arity-tolerant call for the RecordPatches parser
+// statics this suite drives by reflection (TryParseTableFile, TryParseTableExtensionFile,
+// MergeExtensionFields, ...).
+//
+// #3600/#3615: a C# optional parameter is a call-site convenience the compiler fills in;
+// MethodInfo.Invoke matches the argument array length exactly and does not, so adding one
+// to TryParseTableFile/TryParseTableExtensionFile threw TargetParameterCountException at
+// every reflective call site still passing the old count — see PR #3615 for the count and
+// the classes. InvokeStatic pads any parameter a call site doesn't know about with its
+// declared default (or null), so a future optional parameter does not repeat that failure.
+using System;
+using System.Reflection;
+
+namespace AlRunner.Tests;
+
+internal static class ReflectiveParserInvoke
+{
+    internal static object? InvokeStatic(this MethodInfo method, params object?[] knownArgs)
+    {
+        var parameters = method.GetParameters();
+        if (knownArgs.Length > parameters.Length)
+            throw new ArgumentException(
+                $"{method.Name} takes {parameters.Length} parameter(s); {knownArgs.Length} supplied.");
+        if (knownArgs.Length == parameters.Length)
+            return method.Invoke(null, knownArgs);
+
+        var args = new object?[parameters.Length];
+        knownArgs.CopyTo(args, 0);
+        for (var i = knownArgs.Length; i < parameters.Length; i++)
+            args[i] = parameters[i].HasDefaultValue ? parameters[i].DefaultValue : null;
+        return method.Invoke(null, args);
+    }
+}

--- a/AlRunner.Tests/TableMetadataFromBcDocumentTests.cs
+++ b/AlRunner.Tests/TableMetadataFromBcDocumentTests.cs
@@ -506,6 +506,223 @@ public class TableMetadataFromBcDocumentTests
         Assert.DoesNotContain($"[table-metadata] {DepTableId} source=bc-document", output);
     }
 
+    /// <summary>
+    /// #3600 — a SAME-app, add-only tableextension no longer forces the derivation: BC's
+    /// compiler already folded its field AND its key into the base table's own document, so
+    /// excluding it was sending a table the document already answered correctly through the
+    /// hand-derivation. Measured on <c>ObjectMetadataCapture</c> (see the issue): 5 of the
+    /// al-language corpus's 6 previously-excluded tables are exactly this shape.
+    ///
+    /// Both halves are asserted, not just the route: a route-only check would also pass if the
+    /// field or the key had silently vanished on the way to the document, which is the exact
+    /// failure this guard exists to avoid (see the key-only regression test above). The field's
+    /// Editable/DataClassification are set to NON-default values for the same reason
+    /// <see cref="AssertCompiledTableCameFromBcDocument"/> does it: a default-valued assertion
+    /// would still pass if the field came from nowhere at all.
+    /// </summary>
+    [SkippableFact]
+    public void SameAppAddOnlyExtension_TakesBcsDocument_WithItsFieldAndKeyIntact()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var scratch = TestScratch.Dir("al-runner-table-metadata-sameapp-addonly");
+        var appDir = Path.Combine(scratch, "app");
+        Directory.CreateDirectory(appDir);
+        const int TableId = 70681;
+
+        File.WriteAllText(Path.Combine(appDir, "app.json"), $$"""
+        {
+          "id": "{{Guid.NewGuid()}}",
+          "name": "TME App",
+          "publisher": "TME",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 70681, "to": 70689 } ],
+          "runtime": "14.0"
+        }
+        """);
+        // Table and tableextension in the SAME app.json — the shape that must now relax.
+        File.WriteAllText(Path.Combine(appDir, "Objects.al"), """
+        table 70681 "TME Base Thing"
+        {
+            DataClassification = CustomerContent;
+            fields
+            {
+                field(1; "Entry No."; Integer) { }
+                field(2; Description; Text[50]) { }
+            }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+
+        tableextension 70682 "TME Add Only Ext" extends "TME Base Thing"
+        {
+            fields
+            {
+                field(50; "Extra Note"; Text[30])
+                {
+                    DataClassification = EndUserIdentifiableInformation;
+                    Editable = false;
+                }
+            }
+            keys
+            {
+                key(ByExtraNote; "Extra Note") { }
+            }
+        }
+
+        codeunit 70681 "TME Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure ExtensionFieldAndKeySurviveViaBcsDocument()
+            var
+                Thing: Record "TME Base Thing";
+                RRef: RecordRef;
+                KRef: KeyRef;
+                FRef: FieldRef;
+            begin
+                Thing.Init();
+                Thing."Entry No." := 1;
+                Thing."Extra Note" := 'Hello';
+                Thing.Insert();
+                Thing.Get(1);
+                if Thing."Extra Note" <> 'Hello' then
+                    Error('Extra Note=%1, expected Hello — the extension field did not round-trip.',
+                          Thing."Extra Note");
+
+                RRef.Open(70681);
+                if RRef.KeyCount() <> 3 then
+                    Error('KeyCount=%1, expected 3 (PK, ByExtraNote, and the platform key). ' +
+                          'A lower count means the extension''s key was dropped.', RRef.KeyCount());
+                KRef := RRef.KeyIndex(2);
+                FRef := KRef.FieldIndex(1);
+                if FRef.Number() <> 50 then
+                    Error('Key 2 starts on field %1, expected 50 (Extra Note) — the extension''s key.',
+                          FRef.Number());
+                RRef.Close();
+            end;
+        }
+        """);
+
+        var (output, exit) = RunRunner(appDir, Path.Combine(scratch, "al-out"));
+        Assert.True(exit == 0 && output.Contains("1P/0F/0E"), $"run must pass:\n{output}");
+
+        // NOT DoesNotContain(source=derived): the FIRST build of every compiled table runs
+        // during AddSourceDir, before Emit has registered any document (see
+        // RebuildTablesFromBcMetadataAll's own header), so a "derived" trace line is emitted
+        // for this table regardless of the eventual route. The claim is about where the run
+        // ENDS UP, which is what the field/key assertions below (read from the LAST matching
+        // trace line, exactly like AssertCompiledTableCameFromBcDocument does) actually pin.
+        Assert.Contains($"[table-metadata] {TableId} source=bc-document", output);
+
+        var lines = output.Split('\n').Select(l => l.TrimEnd('\r')).ToArray();
+        var field50 = lines.LastOrDefault(
+            l => l.StartsWith($"[table-metadata] {TableId} field=50 ", StringComparison.Ordinal))
+            ?? throw new Xunit.Sdk.XunitException($"no trace line for the extension's field 50.\n{output}");
+        Assert.True(field50.Contains(" editable=False") && field50.Contains(" dataClassification=EndUserIdentifiableInformation"),
+            $"the extension's field 50 must carry its own declared Editable/DataClassification, " +
+            $"read straight off BC's document — not defaults.\n{field50}");
+    }
+
+    /// <summary>
+    /// #3600's other half: a tableextension declaring <c>modify(...)</c> keeps the table on the
+    /// derivation even though it is same-app and even though it also ADDS a field — a mixed
+    /// extension is not "mostly safe", because <c>modify(...)</c>'s <c>&lt;FieldChange&gt;</c>
+    /// only ever lands in the extension's own delta document, never in the base table's.
+    ///
+    /// What this does NOT claim: that the runner applies <c>modify(...)</c>'s property change
+    /// (here, Description's ToolTip) at all — it does not, on either route, before
+    /// or after this change; nothing in the AL-source parser keeps a
+    /// <c>FieldModificationSyntax</c>'s property list past detecting its PRESENCE (see
+    /// <c>TryParseTableExtensionFile</c>). That is a separate, pre-existing gap, filed
+    /// separately. What this test proves is narrower and is the thing #3600 could get wrong:
+    /// that detecting the modify(...) still routes to the derivation, and that doing so does not
+    /// cost the extension's OTHER, legitimately-applied content — its added field.
+    /// </summary>
+    [SkippableFact]
+    public void SameAppExtensionDeclaringModify_StillTakesTheDerivation_AndKeepsItsAddedField()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var scratch = TestScratch.Dir("al-runner-table-metadata-sameapp-modify");
+        var appDir = Path.Combine(scratch, "app");
+        Directory.CreateDirectory(appDir);
+        const int TableId = 70691;
+
+        File.WriteAllText(Path.Combine(appDir, "app.json"), $$"""
+        {
+          "id": "{{Guid.NewGuid()}}",
+          "name": "TMM App",
+          "publisher": "TMM",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 70691, "to": 70699 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(appDir, "Objects.al"), """
+        table 70691 "TMM Base Thing"
+        {
+            DataClassification = CustomerContent;
+            fields
+            {
+                field(1; "Entry No."; Integer) { }
+                field(2; Description; Text[50]) { }
+            }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+
+        tableextension 70692 "TMM Modify Ext" extends "TMM Base Thing"
+        {
+            fields
+            {
+                field(50; "Extra Flag"; Boolean) { }
+                modify(Description)
+                {
+                    ToolTip = 'Changed by the extension.';
+                }
+            }
+        }
+
+        codeunit 70691 "TMM Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure AddedFieldSurvivesAlongsideAModifyBlock()
+            var
+                Thing: Record "TMM Base Thing";
+            begin
+                Thing.Init();
+                Thing."Entry No." := 1;
+                Thing."Extra Flag" := true;
+                Thing.Insert();
+                Thing.Get(1);
+                if not Thing."Extra Flag" then
+                    Error('Extra Flag did not round-trip — the extension''s added field was lost.');
+            end;
+        }
+        """);
+
+        var (output, exit) = RunRunner(appDir, Path.Combine(scratch, "al-out"));
+        Assert.True(exit == 0 && output.Contains("1P/0F/0E"), $"run must pass:\n{output}");
+
+        // The modify(...) block is what must keep this on the derivation, not the lack of a
+        // document: table 70691 IS compiled by this run, so #3548 captures one for it — the
+        // guard has to actively exclude it.
+        Assert.Contains($"[table-metadata] {TableId} source=derived", output);
+        Assert.DoesNotContain($"[table-metadata] {TableId} source=bc-document", output);
+
+        var lines = output.Split('\n').Select(l => l.TrimEnd('\r')).ToArray();
+        var field50 = lines.LastOrDefault(
+            l => l.StartsWith($"[table-metadata] {TableId} field=50 ", StringComparison.Ordinal))
+            ?? throw new Xunit.Sdk.XunitException($"no trace line for the extension's field 50.\n{output}");
+        Assert.Contains(" dataClassification=CustomerContent", field50);
+    }
+
     [SkippableFact]
     public void TableWithNoCapturedDocument_KeepsTheDerivation()
     {

--- a/AlRunner.Tests/TableMetadataFromBcDocumentTests.cs
+++ b/AlRunner.Tests/TableMetadataFromBcDocumentTests.cs
@@ -606,24 +606,36 @@ public class TableMetadataFromBcDocumentTests
         }
         """);
 
-        var (output, exit) = RunRunner(appDir, Path.Combine(scratch, "al-out"));
-        Assert.True(exit == 0 && output.Contains("1P/0F/0E"), $"run must pass:\n{output}");
+        // Cold, then warm on the SAME --cache dir: Emit (which registers the document) runs
+        // only on a compile-cache MISS, and DependencyLoader/AL-output-cache replay is a
+        // separate path from the cold Emit one — see TableMetadataFromBcDocumentTests's own
+        // header. A warm-only assertion would miss a replay that silently lost the extension's
+        // field/key; a cold-only one would miss a replay that silently lost the ROUTE.
+        void AssertExtensionSurvivesViaBcsDocument(string output, string phase)
+        {
+            Assert.True(output.Contains($"[table-metadata] {TableId} source=bc-document"),
+                $"{phase}: table {TableId} was not built from BC's document.\n{output}");
 
-        // NOT DoesNotContain(source=derived): the FIRST build of every compiled table runs
-        // during AddSourceDir, before Emit has registered any document (see
-        // RebuildTablesFromBcMetadataAll's own header), so a "derived" trace line is emitted
-        // for this table regardless of the eventual route. The claim is about where the run
-        // ENDS UP, which is what the field/key assertions below (read from the LAST matching
-        // trace line, exactly like AssertCompiledTableCameFromBcDocument does) actually pin.
-        Assert.Contains($"[table-metadata] {TableId} source=bc-document", output);
+            var lines = output.Split('\n').Select(l => l.TrimEnd('\r')).ToArray();
+            var field50 = lines.LastOrDefault(
+                l => l.StartsWith($"[table-metadata] {TableId} field=50 ", StringComparison.Ordinal))
+                ?? throw new Xunit.Sdk.XunitException(
+                    $"{phase}: no trace line for the extension's field 50.\n{output}");
+            Assert.True(
+                field50.Contains(" editable=False") && field50.Contains(" dataClassification=EndUserIdentifiableInformation"),
+                $"{phase}: the extension's field 50 must carry its own declared "
+                + $"Editable/DataClassification, read straight off BC's document.\n{field50}");
+        }
 
-        var lines = output.Split('\n').Select(l => l.TrimEnd('\r')).ToArray();
-        var field50 = lines.LastOrDefault(
-            l => l.StartsWith($"[table-metadata] {TableId} field=50 ", StringComparison.Ordinal))
-            ?? throw new Xunit.Sdk.XunitException($"no trace line for the extension's field 50.\n{output}");
-        Assert.True(field50.Contains(" editable=False") && field50.Contains(" dataClassification=EndUserIdentifiableInformation"),
-            $"the extension's field 50 must carry its own declared Editable/DataClassification, " +
-            $"read straight off BC's document — not defaults.\n{field50}");
+        var alCacheDir = Path.Combine(scratch, "al-out");
+        var (cold, coldExit) = RunRunner(appDir, alCacheDir);
+        Assert.True(coldExit == 0 && cold.Contains("1P/0F/0E"), $"cold run must pass:\n{cold}");
+        AssertExtensionSurvivesViaBcsDocument(cold, "cold run");
+
+        var (warm, warmExit) = RunRunner(appDir, alCacheDir);
+        Assert.True(warmExit == 0 && warm.Contains("1P/0F/0E"), $"warm run must pass:\n{warm}");
+        Assert.Contains("[cache] HIT", warm);
+        AssertExtensionSurvivesViaBcsDocument(warm, "warm run (AL-output cache HIT)");
     }
 
     /// <summary>

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -788,7 +788,7 @@ public static partial class RecordPatches
         return parts.Count > 0 ? parts[^1] : Unquote(fallbackText?.Trim() ?? "");
     }
 
-    private static void TryParseTableFile(string text)
+    private static void TryParseTableFile(string text, string? filePath = null)
     {
         foreach (var obj in ParseAlObjects(text))
         {
@@ -872,11 +872,12 @@ public static partial class RecordPatches
                 secondaryKeys, isTableTypeTemporary, dataPerCompany, lookupPage, drillDownPage,
                 TableTypeName: string.IsNullOrWhiteSpace(tableTypeName) ? null : tableTypeName.Trim(),
                 DataClassificationName: string.IsNullOrWhiteSpace(dataClassification) ? null : dataClassification,
-                ExternalName: string.IsNullOrWhiteSpace(externalName) ? null : externalName);
+                ExternalName: string.IsNullOrWhiteSpace(externalName) ? null : externalName,
+                OwningAppId: filePath != null ? ResolveOwningApp(filePath)?.AppId : null);
         }
     }
 
-    private static void TryParseTableExtensionFile(string text)
+    private static void TryParseTableExtensionFile(string text, string? filePath = null)
     {
         foreach (var obj in ParseAlObjects(text))
         {
@@ -889,12 +890,23 @@ public static partial class RecordPatches
             // ParseFieldSyntax for what they used to lose (#1711).
             var fields = new List<ParsedField>();
             // OfType<FieldSyntax>: a tableextension's field list also holds `modify(...)`
-            // entries, which declare no new field. The regex only ever matched
-            // `field(N; Name; Type)` either, so this keeps the same set.
+            // entries (NavSyntax.FieldModificationSyntax), which declare no new field. The
+            // regex only ever matched `field(N; Name; Type)` either, so this keeps the same
+            // set. #3600 reads that same list a second time below for the OPPOSITE purpose —
+            // not to skip modify(...), but to know one is there.
             if (ext.Fields != null)
                 foreach (var f in ext.Fields.Fields.OfType<NavSyntax.FieldSyntax>())
                     if (ParseFieldSyntax(f) is { } pf)
                         fields.Add(pf);
+
+            // #3600 — a modify(...) block changes an existing field's properties only in the
+            // extension's OWN delta document (BC's <FieldChange>), never in the base table's
+            // document; see RecordExtensionSource / ShouldBuildTableFromBcDocument. True even
+            // for a mixed extension that ALSO adds fields, because the field list above cannot
+            // tell "no modify" from "modify, but this extractor discards it" — it has to be
+            // asked directly.
+            var hasModify = ext.Fields != null
+                && ext.Fields.Fields.OfType<NavSyntax.FieldModificationSyntax>().Any();
 
             // #3216 — the keys a tableextension declares. Every one is a SECONDARY key on the
             // extended table: a tableextension cannot restate the primary key, so unlike
@@ -935,6 +947,15 @@ public static partial class RecordPatches
             // shared helper so a second writer (RecordPatches.BcAppFallback.cs's
             // EnsureBcSymbolExtensionIndex) can't repeat this file's own former omission of it.
             MergeExtensionFields(baseName, extId, fields, extKeys);
+
+            // #3600 — the declaring app (from this file's own app.json, walked up from
+            // filePath) plus whether this extension declares modify(...). Recorded even for
+            // an extension that contributes no field and no key (a modify-only, or a
+            // key-only, extension) — see BaseTableWithAKeyOnlyExtensionInAnotherApp_Keeps-
+            // TheDerivation in AlRunner.Tests/TableMetadataFromBcDocumentTests.cs for why that
+            // case cannot be read off _parsedExtensionFields/_parsedExtensionKeys alone.
+            RecordExtensionSource(baseName,
+                filePath != null ? ResolveOwningApp(filePath)?.AppId : null, hasModify);
         }
     }
 
@@ -1597,9 +1618,16 @@ internal record ParsedColumnFilter(string FieldName, ParsedColumnFilterKind Kind
 /// Application 28.1's 1523 tables state one, e.g. "CDS BC Table Relation" ->
 /// <c>dyn365bc_syntheticrelation</c>). Null when the table declares none, which is the blank
 /// the Table Metadata column must then report (#2938).</param>
+/// <param name="OwningAppId">The <c>id</c> of the <c>app.json</c> that owns the file this table
+/// was declared in, or null when the file's path was not supplied (a precompiled-.app
+/// source-text reparse, or a --tdd in-memory regeneration — see the callers of
+/// <c>TryParseTableFile</c>) or no app.json was found above it. #3600's table-metadata-source
+/// guard uses this to tell a same-app tableextension from a cross-app one; see
+/// <see cref="RecordPatches._extensionSourceInfo"/>.</param>
 internal record ParsedTable(int TableId, string TableName,
     List<ParsedField> Fields, List<int> PkFieldIds, List<ParsedKey>? SecondaryKeys = null,
     bool IsTableTypeTemporary = false, bool DataPerCompany = true,
     string? LookupPageName = null, string? DrillDownPageName = null,
     string? TableTypeName = null,
-    string? DataClassificationName = null, string? ExternalName = null);
+    string? DataClassificationName = null, string? ExternalName = null,
+    Guid? OwningAppId = null);

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -901,7 +901,7 @@ public static partial class RecordPatches
 
             // #3600 — a modify(...) block changes an existing field's properties only in the
             // extension's OWN delta document (BC's <FieldChange>), never in the base table's
-            // document; see RecordExtensionSource / ShouldBuildTableFromBcDocument. True even
+            // document; see MergeExtensionFields / ShouldBuildTableFromBcDocument. True even
             // for a mixed extension that ALSO adds fields, because the field list above cannot
             // tell "no modify" from "modify, but this extractor discards it" — it has to be
             // asked directly.
@@ -941,21 +941,15 @@ public static partial class RecordPatches
             // Merge into _parsedExtensionFields, record the extension id (so its emitted
             // TableExtension{extId} CLR type can be instantiated and registered on each
             // record of the base table — record-level triggers + field-validate dispatch),
-            // and evict any already-built NCLMetaTable for the base table so a rebuild picks
-            // up these fields. All three steps — including the eviction, whose necessity is
-            // explained on MergeExtensionFields itself (#2126) — happen atomically in the
-            // shared helper so a second writer (RecordPatches.BcAppFallback.cs's
-            // EnsureBcSymbolExtensionIndex) can't repeat this file's own former omission of it.
-            MergeExtensionFields(baseName, extId, fields, extKeys);
-
-            // #3600 — the declaring app (from this file's own app.json, walked up from
-            // filePath) plus whether this extension declares modify(...). Recorded even for
-            // an extension that contributes no field and no key (a modify-only, or a
-            // key-only, extension) — see BaseTableWithAKeyOnlyExtensionInAnotherApp_Keeps-
-            // TheDerivation in AlRunner.Tests/TableMetadataFromBcDocumentTests.cs for why that
-            // case cannot be read off _parsedExtensionFields/_parsedExtensionKeys alone.
-            RecordExtensionSource(baseName,
-                filePath != null ? ResolveOwningApp(filePath)?.AppId : null, hasModify);
+            // record this extension's declaring app (from this file's own app.json, walked up
+            // from filePath) and whether it declares modify(...) (#3600), and evict any
+            // already-built NCLMetaTable for the base table so a rebuild picks up these
+            // fields. All these steps happen atomically in the shared helper so a second
+            // writer (RecordPatches.BcAppFallback.cs's EnsureBcSymbolExtensionIndex) can't
+            // repeat this file's own former omission of the eviction (#2126).
+            MergeExtensionFields(baseName, extId, fields, extKeys,
+                owningAppId: filePath != null ? ResolveOwningApp(filePath)?.AppId : null,
+                hasModify: hasModify);
         }
     }
 

--- a/AlRunner/Patches/RecordPatches.BcAppFallback.cs
+++ b/AlRunner/Patches/RecordPatches.BcAppFallback.cs
@@ -1082,19 +1082,17 @@ public static partial class RecordPatches
                 // extended table's key list even though its fields were merged. The fields still
                 // go through ResolveExtensionCalcFormulas (#3121), which parses the CalcFormula
                 // text the symbol read carried along.
+                //
+                // #3600 — owningAppId: null (never equal to any real app id) because a
+                // PRECOMPILED .app's extension is, by construction, never in the same app as a
+                // table this runner holds a document for: HasBcTableMetadataDocument is only
+                // ever true for a table WE compiled from source, and a table living in a
+                // precompiled .app never gets a document at all — so this extension's base
+                // table was compiled by a DIFFERENT app than this one, cross-app,
+                // unconditionally, without needing this .app's own identity.
                 MergeExtensionFields(ext.TargetTableName, ext.ExtensionId,
-                    ResolveExtensionCalcFormulas(ext), ext.Keys);
-
-                // #3600 — a PRECOMPILED .app's extension is, by construction, never in the
-                // same app as a table this runner holds a document for: HasBcTableMetadataDocument
-                // is only ever true for a table WE compiled from source (the bundle under test
-                // or a source-compiled dependency — see AlObjectMetadataRegistry's writers), and
-                // a table living in a precompiled .app never gets a document at all. So this
-                // extension's base table, whenever ShouldBuildTableFromBcDocument asks, was
-                // compiled by a DIFFERENT app than this one — cross-app, unconditionally. Recording
-                // owningAppId as null (never equal to any real app id) encodes exactly that,
-                // without needing this .app's own identity.
-                RecordExtensionSource(ext.TargetTableName, owningAppId: null, hasModify: false);
+                    ResolveExtensionCalcFormulas(ext), ext.Keys,
+                    owningAppId: null, hasModify: false);
                 merged++;
             }
         }

--- a/AlRunner/Patches/RecordPatches.BcAppFallback.cs
+++ b/AlRunner/Patches/RecordPatches.BcAppFallback.cs
@@ -1084,6 +1084,17 @@ public static partial class RecordPatches
                 // text the symbol read carried along.
                 MergeExtensionFields(ext.TargetTableName, ext.ExtensionId,
                     ResolveExtensionCalcFormulas(ext), ext.Keys);
+
+                // #3600 — a PRECOMPILED .app's extension is, by construction, never in the
+                // same app as a table this runner holds a document for: HasBcTableMetadataDocument
+                // is only ever true for a table WE compiled from source (the bundle under test
+                // or a source-compiled dependency — see AlObjectMetadataRegistry's writers), and
+                // a table living in a precompiled .app never gets a document at all. So this
+                // extension's base table, whenever ShouldBuildTableFromBcDocument asks, was
+                // compiled by a DIFFERENT app than this one — cross-app, unconditionally. Recording
+                // owningAppId as null (never equal to any real app id) encodes exactly that,
+                // without needing this .app's own identity.
+                RecordExtensionSource(ext.TargetTableName, owningAppId: null, hasModify: false);
                 merged++;
             }
         }

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -138,16 +138,11 @@ public static partial class RecordPatches
 
         try
         {
-            // Merge any tableextension fields for this base table. Read ONCE, ahead of the
-            // route choice below, because #3600 needs it on BOTH routes now: a same-app
-            // add-only extension's fields are already inside BC's document (nothing to splice
-            // into the field ARRAY), but ApplyRunnerFieldWiring still needs the PARSE-TIME
-            // ParsedField (TypeName for the enum fixup, IsAutoIncrement for counter
-            // registration) for those same fields — neither is recoverable from the built
-            // NCLMetaTable. Before #3600 no bc-document-routed table ever had an extension
-            // (any extension forced the derivation), so this gap was unreachable; passing
-            // Array.Empty<ParsedField>() here silently dropped both for the first extension
-            // relaxation ever lets through.
+            // #3600 — read once, ahead of the route choice below, and fed to
+            // ApplyRunnerFieldWiring on BOTH routes: a same-app add-only extension's fields
+            // are already inside BC's document, so bc-document needs nothing spliced into the
+            // field ARRAY, but the enum-type-name / AutoIncrement side info those fields carry
+            // lives only in this parse-time ParsedField list, not on the built NCLMetaTable.
             //
             // De-duplicate by field id: precompiled .app SymbolReference.json sometimes lists
             // extension fields both in the base table's Tables[].Fields entry AND in

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -138,6 +138,26 @@ public static partial class RecordPatches
 
         try
         {
+            // Merge any tableextension fields for this base table. Read ONCE, ahead of the
+            // route choice below, because #3600 needs it on BOTH routes now: a same-app
+            // add-only extension's fields are already inside BC's document (nothing to splice
+            // into the field ARRAY), but ApplyRunnerFieldWiring still needs the PARSE-TIME
+            // ParsedField (TypeName for the enum fixup, IsAutoIncrement for counter
+            // registration) for those same fields — neither is recoverable from the built
+            // NCLMetaTable. Before #3600 no bc-document-routed table ever had an extension
+            // (any extension forced the derivation), so this gap was unreachable; passing
+            // Array.Empty<ParsedField>() here silently dropped both for the first extension
+            // relaxation ever lets through.
+            //
+            // De-duplicate by field id: precompiled .app SymbolReference.json sometimes lists
+            // extension fields both in the base table's Tables[].Fields entry AND in
+            // TableExtensions[].Fields (e.g. BC BaseApp table 242 "Source Code Setup" already
+            // carries its extension fields in Tables[]). Duplicating them corrupts the
+            // NCLMetaTable field layout that R2R-precompiled BC code has baked offsets for.
+            // Only append ext fields whose id is NOT already present in the base table's own list.
+            var extFields = _parsedExtensionFields.TryGetValue(parsed.TableName.ToLowerInvariant(), out var ef)
+                ? ef : Enumerable.Empty<ParsedField>();
+
             // #3552 — when BC's emitter handed the runner its own metadata document for this
             // table (#3548), let BC construct the NCLMetaTable from it rather than deriving one
             // below. AVAILABILITY decides the route, and a failure is never re-routed to the
@@ -150,7 +170,7 @@ public static partial class RecordPatches
             if (ShouldBuildTableFromBcDocument(tableId, parsed))
             {
                 var fromBc = BuildNCLMetaTableFromBcDocument(tableId, ResolveNavAppBaseGroup());
-                ApplyRunnerFieldWiring(fromBc, parsed, Array.Empty<ParsedField>(), parsed.Fields);
+                ApplyRunnerFieldWiring(fromBc, parsed, extFields, parsed.Fields.Concat(extFields));
                 TraceTableMetadataSource(tableId, "bc-document", fromBc);
                 return fromBc;
             }
@@ -163,15 +183,6 @@ public static partial class RecordPatches
             // SystemParsedFields' doc comment for the citation (#3545).
             var timestampParsed       = new ParsedField(0,          "timestamp",         "BigInteger", 0,
                 Editable: false, DataClassificationName: "SystemMetadata");
-            // Merge any tableextension fields for this base table.
-            // De-duplicate by field id: precompiled .app SymbolReference.json sometimes lists
-            // extension fields both in the base table's Tables[].Fields entry AND in
-            // TableExtensions[].Fields (e.g. BC BaseApp table 242 "Source Code Setup" already
-            // carries its extension fields in Tables[]). Duplicating them corrupts the
-            // NCLMetaTable field layout that R2R-precompiled BC code has baked offsets for.
-            // Only append ext fields whose id is NOT already present in the base table's own list.
-            var extFields = _parsedExtensionFields.TryGetValue(parsed.TableName.ToLowerInvariant(), out var ef)
-                ? ef : Enumerable.Empty<ParsedField>();
             var baseFieldIds = new HashSet<int>(parsed.Fields.Select(f => f.FieldId));
             var extFieldsNew = extFields.Where(f => !baseFieldIds.Contains(f.FieldId));
             var allParsed = new[] { timestampParsed }.Concat(parsed.Fields)

--- a/AlRunner/Patches/RecordPatches.NclMetaTableFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableFromBcDocument.cs
@@ -71,41 +71,22 @@ public static partial class RecordPatches
     /// <summary>
     /// The one predicate both routes into BC's document consult — the cold build in
     /// <c>BuildNCLMetaTable</c> and the post-emit reload in
-    /// <see cref="RebuildTablesFromBcMetadataAll"/>. It is a single method rather than the same
-    /// conditions written twice because the two paths write the same state: a table that took
-    /// one route and not the other would carry half of each answer.
+    /// <see cref="RebuildTablesFromBcMetadataAll"/>. One method, not the same conditions
+    /// written twice, because a table that took one route and not the other would carry half
+    /// of each answer.
     ///
-    /// <para><b>#3600 narrowed this from "any tableextension names the table" to the two cases
-    /// BC genuinely does not fold.</b> Measured on the <c>ObjectMetadataCapture</c> fixture: a
-    /// same-app, add-only tableextension's fields AND keys are already in the base table's own
-    /// <c>&lt;MetaTable&gt;</c> — BC's compiler folds them in at compile time — so excluding
-    /// those tables sent 5 of the al-language corpus's 6 excluded tables to a hand-derivation
-    /// the document already answered. What is genuinely NOT folded: a <c>modify(...)</c> block,
-    /// which lands only in the extension's own delta (<c>&lt;FieldChange&gt;</c>); and a
-    /// cross-app extension, whose <c>FieldAdd</c> delta the base table's own document — emitted
-    /// by ITS app's compile, before or independently of the extending app's — cannot see. See
-    /// the issue comment thread for the measurement and docs/object-metadata-from-bc.md.</para>
+    /// Relaxed by #3600 from "any tableextension names the table" to only a
+    /// <c>modify(...)</c>-declaring or cross-app one; see docs/object-metadata-from-bc.md#scope
+    /// for the measurement, including the corpus's own cross-app case.
     ///
-    /// <para><b>Gate on <see cref="_extensionSourceInfo"/>, never on the merged field/key
-    /// count.</b> Fields and keys travel separate channels into
-    /// <see cref="MergeExtensionFields"/>, and a <c>modify(...)</c>-only or key-only extension
-    /// contributes no fields at all — measured: a cross-app key-only tableextension left
-    /// <c>_parsedExtensionFields</c> empty, a COUNT-based guard passed, the base app's own
-    /// document won, and <c>RecordRef.KeyCount()</c> silently answered 2 where the derivation
-    /// answers 3. Exit 0, no diagnostic (pinned by
-    /// <c>BaseTableWithAKeyOnlyExtensionInAnotherApp_KeepsTheDerivation</c> in
-    /// AlRunner.Tests/TableMetadataFromBcDocumentTests.cs). <see cref="_extensionSourceInfo"/>
-    /// records one entry per
-    /// extension REGARDLESS of whether it contributed any field or key, which is what keeps a
-    /// modify-only or key-only extension visible here even though the other three collections
-    /// beside it would show nothing for it.</para>
-    ///
-    /// <para><b>Unknown reads as cross-app, not as same-app.</b> A precompiled <c>.app</c>'s
-    /// extension always carries <c>OwningAppId = null</c> (see
-    /// <c>RecordPatches.BcAppFallback.EnsureBcSymbolExtensionIndex</c>), and an AL-source
-    /// extension or table whose app.json could not be resolved also carries null. Two nulls are
-    /// never treated as matching — only two RESOLVED, EQUAL app ids relax the guard — so an
-    /// unresolvable boundary keeps the table on the derivation instead of guessing it is safe.</para>
+    /// <b>Gate on <see cref="_extensionSourceInfo"/>, never the merged field/key count</b> — a
+    /// <c>modify(...)</c>-only or key-only extension contributes no field at all, so a
+    /// count-based guard cannot see it (the KeyCount 3→2 regression #3600 fixed;
+    /// <c>BaseTableWithAKeyOnlyExtensionInAnotherApp_KeepsTheDerivation</c> pins it).
+    /// <see cref="_extensionSourceInfo"/> records one entry per extension regardless. And
+    /// unknown never reads as same-app: a precompiled <c>.app</c> extension or an unresolvable
+    /// <c>app.json</c> both carry <c>OwningAppId = null</c>, which never matches — only two
+    /// RESOLVED, EQUAL ids relax the guard.
     /// </summary>
     internal static bool ShouldBuildTableFromBcDocument(int tableId, ParsedTable parsed)
     {
@@ -239,11 +220,12 @@ public static partial class RecordPatches
             if (!ShouldBuildTableFromBcDocument(kvp.Key, parsed)) continue;
 
             ReloadFromBcDocumentInPlace(built);
-            // #3600 — same reasoning as BuildNCLMetaTable's cold-build call: a same-app
-            // add-only extension's fields are already inside the document BC just (re)loaded,
-            // but the enum-type-name / AutoIncrement side information ApplyRunnerFieldWiring
-            // needs for THOSE fields lives only in the parse-time ParsedField, not on the
-            // built NCLMetaTable.
+            // #3600 — feeds ApplyRunnerFieldWiring's AutoIncrement registration for a
+            // same-app add-only extension's field; the enum-type-name fixup this also
+            // recomputes is reapplied again, moments later, by BcRuntime.SetTestAssembly's
+            // own FixupEnumFieldOptionMetadataAll call (BcRuntime.cs), which recomputes
+            // extFields itself for every cached table regardless of route — so passing it
+            // here too is redundant for enums, not wrong, and kept for AutoIncrement's sake.
             var extFields = _parsedExtensionFields.TryGetValue(parsed.TableName.ToLowerInvariant(), out var ef)
                 ? ef : Enumerable.Empty<ParsedField>();
             ApplyRunnerFieldWiring(built, parsed, extFields, parsed.Fields.Concat(extFields));

--- a/AlRunner/Patches/RecordPatches.NclMetaTableFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableFromBcDocument.cs
@@ -28,6 +28,7 @@
 //   swallows it into "no metatable" exactly as it does for a derivation failure. That swallow
 //   predates this change and is #3590 — do not read the paragraph above as a claim that the
 //   cold path tears through, because it does not.
+using System.Linq;
 using System.Reflection;
 using Microsoft.Dynamics.Nav.Runtime;
 using AlRunner.Infrastructure;
@@ -74,31 +75,53 @@ public static partial class RecordPatches
     /// conditions written twice because the two paths write the same state: a table that took
     /// one route and not the other would carry half of each answer.
     ///
-    /// <para><b>The extension clause is about BUILD-TIME versus RUNTIME-MERGED state, and that
-    /// is why it is not a field count.</b> BC's document for a table is what ONE app's compiler
-    /// emitted for it. A <c>tableextension</c> in another app contributes fields AND keys that
-    /// the service tier merges at publish time through NavAppGroup's extension registry, which
-    /// the runner does not populate — so no per-app document can express them, whichever app
-    /// emitted it. The runner's derivation does merge them, so an extended base table stays on
-    /// the derivation until TableExtension is converted too (#3562).</para>
+    /// <para><b>#3600 narrowed this from "any tableextension names the table" to the two cases
+    /// BC genuinely does not fold.</b> Measured on the <c>ObjectMetadataCapture</c> fixture: a
+    /// same-app, add-only tableextension's fields AND keys are already in the base table's own
+    /// <c>&lt;MetaTable&gt;</c> — BC's compiler folds them in at compile time — so excluding
+    /// those tables sent 5 of the al-language corpus's 6 excluded tables to a hand-derivation
+    /// the document already answered. What is genuinely NOT folded: a <c>modify(...)</c> block,
+    /// which lands only in the extension's own delta (<c>&lt;FieldChange&gt;</c>); and a
+    /// cross-app extension, whose <c>FieldAdd</c> delta the base table's own document — emitted
+    /// by ITS app's compile, before or independently of the extending app's — cannot see. See
+    /// the issue comment thread for the measurement and docs/object-metadata-from-bc.md.</para>
     ///
-    /// <para><b>Gate on the extension INDEX, never on the merged field count.</b> Fields and
-    /// keys travel separate channels into <see cref="MergeExtensionFields"/>, and a
-    /// <c>modify(...)</c>-only or key-only extension contributes no fields at all — measured:
-    /// a cross-app key-only tableextension left <c>_parsedExtensionFields</c> empty, the
-    /// count-based guard passed, the base app's own document won, and
-    /// <c>RecordRef.KeyCount()</c> silently answered 2 where the derivation answers 3. Exit 0,
-    /// no diagnostic. <c>_extensionIdsByBaseTable</c> records EVERY extension, so it is the
-    /// signal that another app has contributed anything at all; the two collections beside it
-    /// are belt-and-braces for a writer that ever registers one without an id.</para>
+    /// <para><b>Gate on <see cref="_extensionSourceInfo"/>, never on the merged field/key
+    /// count.</b> Fields and keys travel separate channels into
+    /// <see cref="MergeExtensionFields"/>, and a <c>modify(...)</c>-only or key-only extension
+    /// contributes no fields at all — measured: a cross-app key-only tableextension left
+    /// <c>_parsedExtensionFields</c> empty, a COUNT-based guard passed, the base app's own
+    /// document won, and <c>RecordRef.KeyCount()</c> silently answered 2 where the derivation
+    /// answers 3. Exit 0, no diagnostic (pinned by
+    /// <c>BaseTableWithAKeyOnlyExtensionInAnotherApp_KeepsTheDerivation</c> in
+    /// AlRunner.Tests/TableMetadataFromBcDocumentTests.cs). <see cref="_extensionSourceInfo"/>
+    /// records one entry per
+    /// extension REGARDLESS of whether it contributed any field or key, which is what keeps a
+    /// modify-only or key-only extension visible here even though the other three collections
+    /// beside it would show nothing for it.</para>
+    ///
+    /// <para><b>Unknown reads as cross-app, not as same-app.</b> A precompiled <c>.app</c>'s
+    /// extension always carries <c>OwningAppId = null</c> (see
+    /// <c>RecordPatches.BcAppFallback.EnsureBcSymbolExtensionIndex</c>), and an AL-source
+    /// extension or table whose app.json could not be resolved also carries null. Two nulls are
+    /// never treated as matching — only two RESOLVED, EQUAL app ids relax the guard — so an
+    /// unresolvable boundary keeps the table on the derivation instead of guessing it is safe.</para>
     /// </summary>
     internal static bool ShouldBuildTableFromBcDocument(int tableId, ParsedTable parsed)
     {
         if (!HasBcTableMetadataDocument(tableId)) return false;
         var key = parsed.TableName.ToLowerInvariant();
-        if (_extensionIdsByBaseTable.TryGetValue(key, out var extIds) && extIds.Count > 0) return false;
-        if (_parsedExtensionFields.TryGetValue(key, out var extFields) && extFields.Count > 0) return false;
-        if (_parsedExtensionKeys.TryGetValue(key, out var extKeys) && extKeys.Count > 0) return false;
+        if (!_extensionSourceInfo.TryGetValue(key, out var extensions) || extensions.Count == 0)
+            return true;
+
+        foreach (var (owningAppId, hasModify) in extensions)
+        {
+            if (hasModify) return false;
+            if (owningAppId is not { } extApp
+                || parsed.OwningAppId is not { } tableApp
+                || extApp != tableApp)
+                return false;
+        }
         return true;
     }
 
@@ -216,7 +239,14 @@ public static partial class RecordPatches
             if (!ShouldBuildTableFromBcDocument(kvp.Key, parsed)) continue;
 
             ReloadFromBcDocumentInPlace(built);
-            ApplyRunnerFieldWiring(built, parsed, Array.Empty<ParsedField>(), parsed.Fields);
+            // #3600 — same reasoning as BuildNCLMetaTable's cold-build call: a same-app
+            // add-only extension's fields are already inside the document BC just (re)loaded,
+            // but the enum-type-name / AutoIncrement side information ApplyRunnerFieldWiring
+            // needs for THOSE fields lives only in the parse-time ParsedField, not on the
+            // built NCLMetaTable.
+            var extFields = _parsedExtensionFields.TryGetValue(parsed.TableName.ToLowerInvariant(), out var ef)
+                ? ef : Enumerable.Empty<ParsedField>();
+            ApplyRunnerFieldWiring(built, parsed, extFields, parsed.Fields.Concat(extFields));
             _bcDocumentBackedTables[kvp.Key] = 1;
             TraceTableMetadataSource(kvp.Key, "bc-document", built);
         }

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -154,6 +154,35 @@ public static partial class RecordPatches
     internal static readonly Dictionary<string, List<int>> _extensionIdsByBaseTable = new();
 
     /// <summary>
+    /// #3600 — one entry per tableextension merged onto a base table, recording what
+    /// <see cref="RecordPatches.NclMetaTableFromBcDocument.ShouldBuildTableFromBcDocument"/>
+    /// needs to decide whether BC's OWN document for the base table already carries this
+    /// extension (same app, add-only — BC folds it at compile time) or must be excluded in
+    /// favor of the derivation (a <c>modify(...)</c> block, which lands only in the delta
+    /// document; or a different declaring app, whose <c>FieldAdd</c> delta the base table's
+    /// own document — emitted by ITS app's compile — cannot see). <c>OwningAppId</c> is null
+    /// for a precompiled <c>.app</c> dependency's extension (never resolvable to an app.json
+    /// this runner reads) and for any AL-source extension whose declaring app.json could not
+    /// be found; either reads as "does not match" against the base table's own app, which is
+    /// the conservative direction on unknown input.
+    /// </summary>
+    internal static readonly Dictionary<string, List<(Guid? OwningAppId, bool HasModify)>>
+        _extensionSourceInfo = new();
+
+    /// <summary>Record one tableextension's source signal for <see cref="_extensionSourceInfo"/>.
+    /// Called once per merged extension by both writers that funnel through
+    /// <see cref="MergeExtensionFields"/> — see that method's own header for why there are
+    /// exactly two.</summary>
+    internal static void RecordExtensionSource(string baseTableName, Guid? owningAppId, bool hasModify)
+    {
+        if (string.IsNullOrEmpty(baseTableName)) return;
+        var key = baseTableName.ToLowerInvariant();
+        if (!_extensionSourceInfo.TryGetValue(key, out var list))
+            _extensionSourceInfo[key] = list = new();
+        list.Add((owningAppId, hasModify));
+    }
+
+    /// <summary>
     /// Merge <paramref name="fields"/> into <c>_parsedExtensionFields[baseTableName]</c>,
     /// record <paramref name="extensionId"/> in <c>_extensionIdsByBaseTable</c>, and evict
     /// any already-built NCLMetaTable for the base table so the next lookup rebuilds it with
@@ -301,6 +330,9 @@ public static partial class RecordPatches
         // bundle's extension keys to the next bundle's tables.
         _parsedExtensionKeys.Clear();
         _extensionIdsByBaseTable.Clear();
+        // #3600 — cleared alongside the two above for the same reason: a stale entry here
+        // would attribute the PREVIOUS bundle's app boundaries to the next one's tables.
+        _extensionSourceInfo.Clear();
         // #2478: must invalidate _bcSymbolTableIndex too, not just _bcSymbolExtensionIndexBuilt —
         // EnsureBcSymbolExtensionIndex's only call site is inside EnsureBcSymbolTableIndex, gated
         // by `_bcSymbolTableIndex != null`. Leaving that index populated made the flag reset above
@@ -479,8 +511,13 @@ public static partial class RecordPatches
     /// </summary>
     private static void ParseSourceFileIntoAllExtractors(string text, string? filePath = null)
     {
-        TryParseTableFile(text);
-        TryParseTableExtensionFile(text);
+        // Table and tableextension need the file PATH too, same reason as the profile/
+        // permission-set calls below: #3600's table-metadata-source guard has to tell a
+        // same-app tableextension (BC folds its fields/keys into the base table's own
+        // document) from a cross-app one (it cannot), and "same app" is only knowable from
+        // the app.json that owns each file.
+        TryParseTableFile(text, filePath);
+        TryParseTableExtensionFile(text, filePath);
         TryParsePageFile(text);
         TryParseReportFile(text);
         TryParseQueryFile(text);

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -154,56 +154,40 @@ public static partial class RecordPatches
     internal static readonly Dictionary<string, List<int>> _extensionIdsByBaseTable = new();
 
     /// <summary>
-    /// #3600 — one entry per tableextension merged onto a base table, recording what
-    /// <see cref="RecordPatches.NclMetaTableFromBcDocument.ShouldBuildTableFromBcDocument"/>
-    /// needs to decide whether BC's OWN document for the base table already carries this
-    /// extension (same app, add-only — BC folds it at compile time) or must be excluded in
-    /// favor of the derivation (a <c>modify(...)</c> block, which lands only in the delta
-    /// document; or a different declaring app, whose <c>FieldAdd</c> delta the base table's
-    /// own document — emitted by ITS app's compile — cannot see). <c>OwningAppId</c> is null
-    /// for a precompiled <c>.app</c> dependency's extension (never resolvable to an app.json
-    /// this runner reads) and for any AL-source extension whose declaring app.json could not
-    /// be found; either reads as "does not match" against the base table's own app, which is
-    /// the conservative direction on unknown input.
+    /// #3600 — one entry per tableextension merged onto a base table: its declaring app id
+    /// (null for a precompiled <c>.app</c>'s extension or an unresolvable <c>app.json</c> —
+    /// reads as "does not match", the conservative direction) and whether it declares
+    /// <c>modify(...)</c>. Feeds
+    /// <see cref="RecordPatches.NclMetaTableFromBcDocument.ShouldBuildTableFromBcDocument"/>;
+    /// see docs/object-metadata-from-bc.md#scope for what each case means. Written only from
+    /// inside <see cref="MergeExtensionFields"/>, never at a call site.
     /// </summary>
     internal static readonly Dictionary<string, List<(Guid? OwningAppId, bool HasModify)>>
         _extensionSourceInfo = new();
 
-    /// <summary>Record one tableextension's source signal for <see cref="_extensionSourceInfo"/>.
-    /// Called once per merged extension by both writers that funnel through
-    /// <see cref="MergeExtensionFields"/> — see that method's own header for why there are
-    /// exactly two.</summary>
-    internal static void RecordExtensionSource(string baseTableName, Guid? owningAppId, bool hasModify)
-    {
-        if (string.IsNullOrEmpty(baseTableName)) return;
-        var key = baseTableName.ToLowerInvariant();
-        if (!_extensionSourceInfo.TryGetValue(key, out var list))
-            _extensionSourceInfo[key] = list = new();
-        list.Add((owningAppId, hasModify));
-    }
-
     /// <summary>
-    /// Merge <paramref name="fields"/> into <c>_parsedExtensionFields[baseTableName]</c>,
-    /// record <paramref name="extensionId"/> in <c>_extensionIdsByBaseTable</c>, and evict
-    /// any already-built NCLMetaTable for the base table so the next lookup rebuilds it with
-    /// these fields merged in.
+    /// Merge <paramref name="fields"/>/<paramref name="keys"/> into
+    /// <c>_parsedExtensionFields</c>/<c>_parsedExtensionKeys</c>, record
+    /// <paramref name="extensionId"/> in <c>_extensionIdsByBaseTable</c> and this extension's
+    /// app/modify signal in <see cref="_extensionSourceInfo"/> (#3600), and evict any
+    /// already-built NCLMetaTable for the base table so the next lookup rebuilds it.
     ///
-    /// This is the single writer both tableextension-field sources funnel through — the
-    /// AL-source parser (<c>TryParseTableExtensionFile</c> in
-    /// RecordPatches.AlSourceParser.cs) and the precompiled-.app symbol merge
-    /// (<c>EnsureBcSymbolExtensionIndex</c> in RecordPatches.BcAppFallback.cs) — so the
-    /// eviction happens exactly once, in one place, and any future third writer inherits it
-    /// automatically instead of needing to remember to call it. See #2126: before this,
-    /// only the AL-source path evicted, so a base table whose NCLMetaTable had already been
-    /// materialized (e.g. referenced by AL source parsed earlier in the dependency graph)
-    /// before EnsureBcSymbolExtensionIndex ran stayed frozen forever without the precompiled
-    /// extension's fields.
+    /// The single writer both tableextension-field sources — the AL-source parser
+    /// (<c>TryParseTableExtensionFile</c>) and the precompiled-.app symbol merge
+    /// (<c>EnsureBcSymbolExtensionIndex</c>) — funnel through, so a future third writer
+    /// inherits the eviction (#2126) and the source recording (#3600) automatically instead
+    /// of needing to remember either. <paramref name="owningAppId"/>/<paramref name="hasModify"/>
+    /// are recorded HERE rather than through a second call a writer could forget.
     /// </summary>
     private static void MergeExtensionFields(string baseTableName, int extensionId, IEnumerable<ParsedField> fields,
-        IEnumerable<ParsedExtensionKey>? keys = null)
+        IEnumerable<ParsedExtensionKey>? keys = null, Guid? owningAppId = null, bool hasModify = false)
     {
         if (string.IsNullOrEmpty(baseTableName)) return;
         var key = baseTableName.ToLowerInvariant();
+
+        if (!_extensionSourceInfo.TryGetValue(key, out var sourceInfo))
+            _extensionSourceInfo[key] = sourceInfo = new();
+        sourceInfo.Add((owningAppId, hasModify));
 
         // De-dup by field id: the same extension can legitimately be scanned/merged more than
         // once (a dependency app's source dir registered both by its own suite AND by

--- a/docs/object-metadata-from-bc.md
+++ b/docs/object-metadata-from-bc.md
@@ -115,29 +115,49 @@ What is still out of reach is a dependency shipped as a **precompiled `.app`**: 
 compiles here, so no document exists for it at all. That is #3549.
 
 Across the pinned corpus (`19560bd3`), 172 of the corpus app's own 178 tables take the document
-route and the whole suite stays green. The six that do not are the scope boundary below.
+route and the whole suite stays green. The six that did not, at that pin, are the scope
+boundary below — narrowed by #3600, which is what most of them now clear.
 
 <a id="scope"></a>
 
 ## What still takes the derivation, and why
 
-- **A base table any `tableextension` extends.** BC's document for a table is what **one**
-  app's compiler emitted. An extension in another app contributes fields *and keys* that the
-  service tier merges at publish time through `NavAppGroup`'s extension registry, which the
-  runner does not populate — build-time state versus runtime-merged state, and no per-app
-  document can express the second. The derivation does merge it, so an extended base table
-  keeps the derivation until `TableExtension` is converted too (#3562). Measured: 6 of the
-  corpus's 178.
+- **A base table a `tableextension` extends with a `modify(...)` block, or from a DIFFERENT
+  app than the base table's own.** BC's document for a table is what **one** app's compiler
+  emitted. A `modify(...)` block changes an existing field's properties only in the
+  extension's own delta document (`<FieldChange>`), never in the base table's — the derivation
+  applies neither today, so nothing regresses, but nothing is gained either (a separate,
+  still-open gap: #3614 [modify(...) property changes are silently dropped by BOTH routes]). A
+  cross-app extension's `<FieldAdd>` delta likewise never reaches a base document emitted by a
+  DIFFERENT (and possibly earlier, possibly precompiled) compile — the service tier only
+  merges it at publish time through `NavAppGroup`'s extension registry, which the runner does
+  not populate. **A same-app, add-only extension has neither problem**: BC's compiler folds
+  its fields AND keys straight into the base table's own document, so #3600 relaxed the guard
+  for exactly that case, measured on the `ObjectMetadataCapture` fixture and confirmed on the
+  pinned corpus itself — of its six `tableextension` declarations touching the corpus's own
+  tables, four (60000 "ALT Universal", 60006 "ALT Keyed", 60809 "TXC Parent", 60819 "TXC Line")
+  now take the document; two do not, one for each of the reasons above: 60002 "ALT Triggered"
+  is modified by 60024's `modify("Watched Field")`, and 61001 "ALT Internal Table" (declared in
+  the `al-language-internals-fixture` app) is extended cross-app by 60205 "ALT Internal Table
+  Ext" (declared in the main corpus app) — a real cross-app case already living in the corpus,
+  not a synthetic one.
 
-  **The gate is `_extensionIdsByBaseTable`, never the merged field count.** Fields and keys
-  reach `MergeExtensionFields` through separate channels (#3216), and a key-only — or
-  `modify(...)`-only — extension contributes no fields, so a count-based guard passes on it.
-  Measured on a cross-app key-only extension over a source-compiled dependency's table:
-  `RecordRef.KeyCount()` answered **3 where the derivation answers 4**, exit 0, no diagnostic,
-  the extension's key simply gone. Nothing existing could have caught it — at corpus pin
-  `19560bd3` all eight `tableextension` declarations add fields, so neither the corpus nor a
-  same-app fixture reaches the branch. Pinned by
-  `BaseTableWithAKeyOnlyExtensionInAnotherApp_KeepsTheDerivation`.
+  **The gate is per-extension source info (`RecordPatches._extensionSourceInfo`: the
+  declaring app id plus whether it declares `modify(...)`), never the merged field count.**
+  Fields and keys reach `MergeExtensionFields` through separate channels (#3216), and a
+  key-only — or `modify(...)`-only — extension contributes no fields, so a count-based guard
+  passes on it. Measured on a cross-app key-only extension over a source-compiled dependency's
+  table: `RecordRef.KeyCount()` answered **3 where the derivation answers 4**, exit 0, no
+  diagnostic, the extension's key simply gone. Nothing existing could have caught it — at
+  corpus pin `19560bd3` all eight `tableextension` declarations add fields, so neither the
+  corpus nor a same-app fixture reaches the branch. Pinned by
+  `BaseTableWithAKeyOnlyExtensionInAnotherApp_KeepsTheDerivation`, and #3600 kept that test
+  green while relaxing the same-app add-only case — see
+  `SameAppAddOnlyExtension_TakesBcsDocument_WithItsFieldAndKeyIntact` and
+  `SameAppExtensionDeclaringModify_StillTakesTheDerivation_AndKeepsItsAddedField` in
+  `AlRunner.Tests/TableMetadataFromBcDocumentTests.cs`. An app boundary that cannot be resolved
+  (a precompiled `.app`'s extension, or an AL-source extension/table whose `app.json` cannot
+  be found) reads as non-matching, i.e. stays on the derivation, rather than being guessed safe.
 - **Every table with no captured document** — a precompiled dependency's (#3549), a virtual
   system table, or a bundle served from an AL-output cache written before #3548.
 


### PR DESCRIPTION
Closes #3600

## What changed

`ShouldBuildTableFromBcDocument` narrows from "any tableextension names this table" to the
two cases BC genuinely does not fold into the base table's own metadata document: a
`modify(...)` block (delta-only `<FieldChange>`), and a cross-app extension (the base
document, emitted by its own app's compile, cannot see a `<FieldAdd>` from a different app).
A same-app, add-only extension's fields AND keys are already inside BC's document, so those
tables now take it instead of the hand-derivation.

Tracked per extension in a new `RecordPatches._extensionSourceInfo` (declaring app id,
resolved from the nearest `app.json`; whether it declares `modify(...)`), recorded regardless
of whether the extension contributes any field or key — the same discipline the prior
count-based guard was missing, which is what let a key-only cross-app extension slip through
(the regression test this PR keeps green). An unresolvable app boundary (a precompiled
`.app`'s extension, or an AL-source extension/table whose `app.json` can't be found) reads as
non-matching, so the guard stays conservative rather than guessing.

Also fixes both bc-document call sites (`BuildNCLMetaTable`'s cold build and
`RebuildTablesFromBcMetadataAll`'s post-emit sweep), which previously passed
`Array.Empty<ParsedField>()` for a bc-document-routed table's extension fields
unconditionally — correct while no such table ever had one, but this PR is the first case
where it can, and the enum-type-name fixup / AutoIncrement registration need the parse-time
`ParsedField` for those fields regardless of which route built the table.

## Cross-app case: measured, not guessed

`ObjectMetadataCapture`'s reference bundles only contain same-app extensions (noted as an
open question on #3562). The corpus itself settles the cross-app case: `tableextension 60205
"ALT Internal Table Ext"` (declared in the main corpus app) extends `"ALT Internal Table"`
(table 61001, declared in the `al-language-internals-fixture` app, id range 61000-61099) — a
real cross-app extension already exercised by the corpus (`TestTableExtCrossApp.al`), not a
synthetic one. It correctly stays on the derivation both before and after this change.

## Corpus measurement

Ran the pinned corpus (`c9d5f656`) and `tests/runner-extras` with `--no-cache` (a private
clone, per the coordinator's note that the shared submodule checkout was stale) before and
after this change, both with `AL_RUNNER_TRACE_TABLE_METADATA_SOURCE=1`:

| | corpus (tests/al-language) | runner-extras |
|---|---|---|
| before | 3112/3112 pass, exit 0 | 401/401 pass, exit 0 |
| after | 3112/3112 pass, exit 0 | 401/401 pass, exit 0 |

Identical pass counts, `--count-baseline` green on both. Per-table final metadata source,
diffed between the two runs: **4 tables changed**, all `derived` -> `bc-document`:

- 60000 "ALT Universal" (extended by 60025, add-only)
- 60006 "ALT Keyed" (extended by 60330, add-only)
- 60809 "TXC Parent" (extended by 60798, add-only)
- 60819 "TXC Line" (extended by 60799, add-only)

Two of the corpus's six `tableextension` declarations targeting the corpus's own tables did
NOT change source, each for a stated reason: 60002 "ALT Triggered" (extended by 60024, which
declares `modify("Watched Field")`) and 61001 "ALT Internal Table" (the cross-app case
above). No table changed in `tests/runner-extras`.

(An earlier pass of the corpus run, using the shared default `~/.al-runner/al-out` cache
instead of `--no-cache`, showed a handful of unrelated failures that varied between two runs
of the SAME reverted tree — load-dependent contamination from other agents' concurrent runs
against that shared cache, not a defect in either guard version; `--no-cache` runs came back
clean both before and after.)

## TDD

- RED -> GREEN: `SameAppAddOnlyExtension_TakesBcsDocument_WithItsFieldAndKeyIntact` — a
  same-app add-only tableextension now takes `source=bc-document`, and its added field AND
  key are both answered with concrete, non-default values (Editable/DataClassification off
  the trace; a RecordRef key lookup by field number).
- RED -> GREEN: `SameAppExtensionDeclaringModify_StillTakesTheDerivation_AndKeepsItsAddedField`
  — a `modify(...)`-declaring extension still takes `source=derived`, and the SAME
  extension's added field survives the derivation. Verified the `hasModify` check is
  load-bearing by disabling it locally and confirming this test fails (source flips to
  bc-document) before restoring it.
- `BaseTableWithAKeyOnlyExtensionInAnotherApp_KeepsTheDerivation` (the existing regression
  test for the count-based-guard defect) stays green — a cross-app key-only extension is now
  caught by the app-id mismatch rather than by the removed field/key-count checks.

## What I did not fix here

Filed #3614: a tableextension's `modify(...)` property changes (`ToolTip`, `NotBlank`, ...)
are silently discarded on BOTH metadata routes today — the AL-source parser drops
`FieldModificationSyntax`'s property list entirely, and BC's document delta
(`GetExtensionDeltasForAppObject`) is never read. This PR correctly keeps a
modify(...)-declaring extension on the derivation (so it isn't newly served from an
incomplete bc-document), but does not implement applying the modify(...) itself — that gap
predates this PR and is unaffected by it either way. The corpus's own `modify(...)` block
(60024, "Watched Field") only adds triggers, not property changes, so it doesn't exercise
this gap.

Corpus-NA: the underlying claim — that BC's own document correctly represents a compiled
table's fields and keys, including ones a same-app tableextension adds — is the SAME
mechanism corpus PR #292 already adjudicated for #3552/#3584 (Corpus-PR on that PR). #3600
only widens WHICH tables take that already-adjudicated route; it introduces no new BC
behavior for a service tier to test, which is why re-running the corpus (3112/3112
unchanged before/after, per-table source diffed above) is this PR's own verification rather
than a new corpus PR.

https://claude.ai/code/session_01F7HLDeNwiGQoLT5wFanqmH
