### PR TITLE
fix(page-metadata): answer eleven defaulted Properties-derived columns from BC's own document

### DIFF
--- a/AlRunner.Tests/PageMetadataPropertiesTests.cs
+++ b/AlRunner.Tests/PageMetadataPropertiesTests.cs
@@ -1,0 +1,86 @@
+// PageMetadataPropertiesTests — pins the runner-only half of issue #3601: what
+// RecordPatches.GetPageProperties/FormatInherentMask do independently of any single page's
+// declared values.
+//
+// What this proves, and what it deliberately does NOT
+// -----------------------------------------------------
+// The BC-observable claim — that Page Metadata (2000000138) reports a page's declared
+// RefreshOnActivate/APIPublisher/APIGroup/APIVersion/EntitySetName/EntityName/
+// DataCaptionExpr./ChangeTrackingAllowed/InherentPermissions/InherentEntitlements/AL
+// Namespace rather than each column's type default — is plain BC behaviour and belongs
+// upstream against a real service tier (.claude/rules/bc-behavior-tests-go-upstream.md). It
+// is proved there, in corpus codeunit 60904 "Test Page Metadata Properties" (corpus PR #298,
+// merged, all eight cloud legs green — run 34275562528).
+//
+// This file pins two narrower runner-only claims underneath it:
+//
+//   1. When the runner has no loadable page metadata for a page, GetPageProperties must
+//      REFUSE rather than quietly answer BC's default — same policy, and same shape of
+//      test, as PageMetadataSourceObjectRefusalTests pins for the sibling <SourceObject>
+//      columns.
+//   2. FormatInherentMask actually reaches BC's own runtime-engine
+//      PermissionDefinition.ExpandDirectPermissionToIndirect and
+//      MetadataDataProvider.CreatePermissionMaskString and renders their result correctly.
+//      No service tier can adjudicate THIS — it is a question about whether this runner
+//      BUILD's reflection resolves those two BC members and calls them in the right order,
+//      not about what a page's declared mask means.
+
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class PageMetadataPropertiesTests
+{
+    // An id no fixture, no dependency .app and no corpus page declares, so
+    // EnsureRealPageMetadata genuinely has nothing to load for it. Deliberately distinct from
+    // PageMetadataSourceObjectRefusalTests' own PageNoRunnerMetadataFor (77451903), and far
+    // from the 88123xxx block DependencyPageMetadataXmlTests uses and from every 6xxxx corpus
+    // range.
+    private const int PageNoRunnerMetadataFor = 77451904;
+
+    [Fact]
+    public void GetPageProperties_PageWithNoLoadableMetadata_ThrowsInsteadOfAnsweringBcDefaults()
+    {
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
+            () => RecordPatches.GetPageProperties(PageNoRunnerMetadataFor));
+
+        // The page has to be named, or the refusal cannot be acted on.
+        Assert.Contains(PageNoRunnerMetadataFor.ToString(), ex.Message);
+
+        // The refusal must say the surface is unimplemented, NOT permanently out of scope —
+        // ApplicationObjectBasePatches.IsPermanentOutOfScope treats any reason that does not
+        // start with "not-yet-implemented" as permanent, and an AL [TryFunction] over a
+        // permanent refusal yields `false`, restoring the silent wrong answer this change
+        // removes.
+        Assert.StartsWith("not-yet-implemented", ex.Reason);
+        Assert.Contains("page-metadata-virtual-table", ex.Reason);
+
+        // And it must name enough of the eleven columns that the reader knows the whole
+        // group is affected, not just one.
+        Assert.Contains("RefreshOnActivate", ex.Message);
+        Assert.Contains("InherentPermissions", ex.Message);
+        Assert.Contains("InherentEntitlements", ex.Message);
+        Assert.Contains("AL Namespace", ex.Message);
+    }
+
+    [Theory]
+    // PermissionMask.None formats to NavText.Empty — the one legitimate default in this
+    // file, for a page declaring neither InherentPermissions nor InherentEntitlements.
+    [InlineData(0, "")]
+    // PermissionMask.Execute (bit 4, value 16) is the ONLY value a page may ever declare —
+    // the AL compiler rejects anything else on a page with AL0195 (see
+    // docs/page-metadata-properties.md). Formats to the single uppercase letter "X".
+    [InlineData(16, "X")]
+    // A multi-bit mask a TABLE can declare (Read|Insert|Modify|Delete|Execute = 1+2+4+8+16),
+    // which no page can produce but which the SAME reflection call must still render
+    // correctly, since FormatInherentMask does not know or care which object kind called it.
+    // Proves the wiring reaches BC's real formatter rather than a page-specific shortcut.
+    [InlineData(31, "RIMDX")]
+    public void FormatInherentMask_ReachesBcsOwnFormatterAndRendersItsLetterCode(int declaredMask, string expected)
+    {
+        var actual = RecordPatches.FormatInherentMask(declaredMask, pageId: 1, column: "InherentPermissions");
+        Assert.Equal(expected, actual);
+    }
+}

--- a/AlRunner/Patches/RecordPatches.PageMetadataProperties.cs
+++ b/AlRunner/Patches/RecordPatches.PageMetadataProperties.cs
@@ -1,0 +1,262 @@
+// RecordPatches.PageMetadataProperties — the eleven "Page Metadata" (2000000138) columns
+// that come off a page's <Properties> element (ten of them) or the page definition itself
+// (ALNamespace), read from BC's OWN parsed metadata (#3601).
+//
+// ── THE DEFECT ───────────────────────────────────────────────────────────────────────────
+//   BuildPageMetadataValue's switch fell through eleven of its columns to
+//   NavValue.GetDefaultNavValue — a hardcoded default, never the page's own declaration.
+//   Measured at main 9a0dd368 (issue #3601): eleven of the twelve defaulted columns are
+//   stated outright in BC's own emitted <Properties> document — RefreshOnActivate in 236 of
+//   236 pages, ALNamespace in 236 of 236, InherentEntitlements in 94, InherentPermissions in
+//   92, APIVersion in 39 on Base App, DataCaptionExpr. in 32, EntityName/EntitySetName in 10,
+//   APIPublisher/APIGroup in 8, ChangeTrackingAllowed in 2.
+//
+// ── WHERE THE VALUES COME FROM, AND WHY NOT FROM THE TWO OBVIOUS PLACES ──────────────────
+//   #3063 established the pattern one element down, on <SourceObject>: BOTH page origins —
+//   a page this run source-compiled, and a page declared by a precompiled dependency .app —
+//   already converge on ONE object, BC's own MetaPageDefinition, loaded through
+//   EnsureRealPageMetadata's NCLMetaForm.LoadMetadata(). This file reads the same object one
+//   layer up: MetaPageDefinition.Properties (a MetaPageProperties) for ten of the eleven, and
+//   MetaPageDefinition.ALNamespace itself for the eleventh — verified against BC 28.1's real
+//   PageDataProvider.<GetValuesWithinRangeForKeyField>d__3.MoveNext() (decompiled): it reads
+//   `properties.RefreshOnActivate` / `.APIPublisher` / `.APIGroup` / `.APIVersion` /
+//   `.EntitySetName` / `.EntityName` / `.DataCaptionExpr` / `.ChangeTrackingAllowed` and
+//   `item.ALNamespace` (via `GetNormalizedNamespace`, which is `NavText.Create(fieldValue)` —
+//   no further transform) directly off this same object, so there is nothing left for either
+//   row source (ParsedPage / BcAppSymbolCache.PageSymbol) to add.
+//
+// ── InherentPermissions / InherentEntitlements ARE NOT A DIRECT FIELD READ ───────────────
+//   BC's real column value is NOT `properties.InherentPermissions` printed as text — it is
+//   that raw declared mask, expanded and formatted through two of BC's OWN runtime-engine
+//   methods, reused here rather than reimplemented (precompiled-dll-respect.md):
+//     PermissionDefinition.ExpandDirectPermissionToIndirect(PermissionMask) — sets the
+//       matching INDIRECT bit for every DIRECT bit a page declares (NCLMetaForm.LoadMetadata
+//       does exactly this before storing InherentPermissionsAndEntitlements);
+//     MetadataDataProvider.CreatePermissionMaskString(PermissionMask) — renders the mask as
+//       the letters columns 30/31 carry: uppercase for a DIRECT bit, lowercase for an
+//       INDIRECT-only one, empty for PermissionMask.None.
+//   Both are internal members of internal-but-loadable types in Ncl.dll, resolved by
+//   reflection the same way PageDataProvider.GenerateSourceTableViewString is in
+//   RecordPatches.PageMetadataSourceObject.cs. A PAGE can only ever declare `X` (Execute) for
+//   either property — the AL compiler rejects `rimd` on a page with "Invalid permission kind.
+//   Expected: 'X'" — so the expand step never changes the OBSERVABLE letters for a page (a
+//   direct bit always wins the uppercase branch before its own indirect twin is checked), but
+//   it is still BC's real call graph, not a shortcut that happens to agree with it today.
+//
+// ── DataCaptionExpr. IS A FIXED PLACEHOLDER, NOT THE AL SOURCE TEXT ──────────────────────
+//   Measured against the real AL compiler (BC 28.1): a page declaring
+//   `DataCaptionExpression = 'Probe Page Fixture';` and one declaring
+//   `DataCaptionExpression = 'Some Other Totally Different Text Value XYZ';` both compile to
+//   the identical <Properties DataCaptionExpr="DataCaptionExprCode" .../> — BC compiles the
+//   expression to a generated method and the document merely names that there is one, not
+//   what it evaluates to. properties.DataCaptionExpr is exactly that fixed string, so reading
+//   it verbatim is correct; there is no formatting step to reproduce.
+//
+// ── WHAT IS REFUSED RATHER THAN DEFAULTED (loud-failures.md) ─────────────────────────────
+//   Same policy as the sibling <SourceObject> file: a page whose real metadata will not load
+//   gets a named refusal naming the column, never BC's default. Unlike <SourceObject>,
+//   MetaPageDefinition.Properties itself is not null for any page shape the compiler
+//   produces — verified against every corpus page BC 28.1 compiles — so a null there is
+//   refused as a BC-shape gap rather than treated as a real, if unusual, answer.
+//
+// ── AppID IS DELIBERATELY NOT HERE ────────────────────────────────────────────────────────
+//   BC's real column reads MetadataDataProvider.GetAppId(metaFormById), computed from the
+//   page's owning app-identity/app-group, not from <Properties> at all — the one column of
+//   the twelve the issue's own measurement found unstated on the document. Left on
+//   NavValue.GetDefaultNavValue in RecordPatches.PageMetadataVirtualTable.cs, unchanged.
+//
+// ── PRECOMPILED-DLL RESPECT ──────────────────────────────────────────────────────────────
+//   Runtime-engine and metadata types only (NCLMetaForm, MetaPageDefinition,
+//   MetaPageProperties, PermissionDefinition, MetadataDataProvider — all reached the same way
+//   the sibling <SourceObject> file reaches PageDataProvider). No AL business-logic body is
+//   touched, and nothing here re-implements a BC behaviour BC itself is present to perform.
+
+using System.Reflection;
+using AlRunner.Infrastructure;
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    /// <summary>
+    /// A refusal for a Page Metadata column this file could not answer from BC's own parsed
+    /// metadata. Category (2) of RecordPatches.VirtualTableShapeGap.cs — same policy as
+    /// <see cref="PageMetadataSourceObjectGap"/>.
+    /// </summary>
+    internal static RunnerOutOfScopeException PageMetadataPropertiesGap(int pageId, string column, string detail)
+        => PageMetadataShapeGap(
+            $"page {pageId} column \"{column}\": {detail} — refusing rather than answering "
+            + "BC's default, which would be a plausible wrong value for a property the page declares");
+
+    /// <summary>
+    /// The eleven <c>&lt;Properties&gt;</c>-derived Page Metadata columns for one page.
+    /// <see cref="InherentPermissions"/> and <see cref="InherentEntitlements"/> are already
+    /// formatted through BC's own letter-code renderer (empty for a page declaring neither).
+    /// </summary>
+    internal sealed record PagePropertiesInfo(
+        bool RefreshOnActivate,
+        string ALNamespace,
+        string InherentPermissions,
+        string InherentEntitlements,
+        string APIVersion,
+        string DataCaptionExpr,
+        string EntityName,
+        string EntitySetName,
+        string APIPublisher,
+        string APIGroup,
+        bool ChangeTrackingAllowed);
+
+    private static MethodInfo? _pmvExpandDirectPermissionToIndirect;
+    private static MethodInfo? _pmvCreatePermissionMaskString;
+    private static bool _pmvPermissionFormatterResolved;
+    private static readonly object _pmvPermissionFormatterLock = new();
+
+    /// <summary>
+    /// BC's own <c>PermissionDefinition.ExpandDirectPermissionToIndirect</c> and
+    /// <c>MetadataDataProvider.CreatePermissionMaskString</c> — the two methods
+    /// <c>NCLMetaForm.LoadMetadata()</c> and BC's real <c>PageDataProvider</c> chain to turn a
+    /// page's declared InherentPermissions/InherentEntitlements int into the letter-code text
+    /// columns 30/31 carry. Null when either could not be resolved, which
+    /// <see cref="FormatInherentMask"/> turns into a refusal rather than a guessed format.
+    /// </summary>
+    private static (MethodInfo Expand, MethodInfo Format)? ResolvePermissionFormatter()
+    {
+        if (_pmvPermissionFormatterResolved)
+            return _pmvExpandDirectPermissionToIndirect != null && _pmvCreatePermissionMaskString != null
+                ? (_pmvExpandDirectPermissionToIndirect, _pmvCreatePermissionMaskString) : null;
+        lock (_pmvPermissionFormatterLock)
+        {
+            if (_pmvPermissionFormatterResolved)
+                return _pmvExpandDirectPermissionToIndirect != null && _pmvCreatePermissionMaskString != null
+                    ? (_pmvExpandDirectPermissionToIndirect, _pmvCreatePermissionMaskString) : null;
+
+            var nclAssembly = typeof(NCLMetadata).Assembly;
+            var permissionDefinitionType = nclAssembly.GetType("Microsoft.Dynamics.Nav.Runtime.PermissionDefinition");
+            var metadataDataProviderType = nclAssembly.GetType("Microsoft.Dynamics.Nav.Runtime.MetadataDataProvider");
+
+            _pmvExpandDirectPermissionToIndirect = permissionDefinitionType == null ? null : BcShape.FindMethod(
+                permissionDefinitionType, "ExpandDirectPermissionToIndirect",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                "Page Metadata (virtual table 2000000138)", "PermissionDefinition.ExpandDirectPermissionToIndirect",
+                "it expands a page's declared DIRECT InherentPermissions/InherentEntitlements bits to "
+                + "their matching INDIRECT bits, exactly as BC's own NCLMetaForm.LoadMetadata does before "
+                + "formatting them, so the runner cannot skip it on the page's behalf",
+                new[] { typeof(PermissionMask) });
+
+            _pmvCreatePermissionMaskString = metadataDataProviderType == null ? null : BcShape.FindMethod(
+                metadataDataProviderType, "CreatePermissionMaskString",
+                BindingFlags.Public | BindingFlags.Static,
+                "Page Metadata (virtual table 2000000138)", "MetadataDataProvider.CreatePermissionMaskString",
+                "it renders a PermissionMask into the letter-code text these two columns carry "
+                + "(uppercase direct, lowercase indirect-only), and the runner cannot re-derive that "
+                + "case rule on the page's behalf",
+                new[] { typeof(PermissionMask) });
+
+            _pmvPermissionFormatterResolved = true;
+            return _pmvExpandDirectPermissionToIndirect != null && _pmvCreatePermissionMaskString != null
+                ? (_pmvExpandDirectPermissionToIndirect, _pmvCreatePermissionMaskString) : null;
+        }
+    }
+
+    /// <summary>
+    /// <paramref name="declaredMask"/> (a page's raw declared InherentPermissions or
+    /// InherentEntitlements int) rendered exactly as BC's own
+    /// InherentObjectPermissionAndEntitlementsHelper/MetadataDataProvider chain renders it —
+    /// empty for a page declaring neither (PermissionMask.None formats to NavText.Empty).
+    /// </summary>
+    private static string FormatInherentMask(int declaredMask, int pageId, string column)
+    {
+        var formatter = ResolvePermissionFormatter()
+            ?? throw PageMetadataPropertiesGap(pageId, column,
+                "BC's own PermissionDefinition.ExpandDirectPermissionToIndirect or "
+                + "MetadataDataProvider.CreatePermissionMaskString could not be resolved");
+        try
+        {
+            var direct = (PermissionMask)checked((ushort)declaredMask);
+            var expanded = (PermissionMask)formatter.Expand.Invoke(null, new object?[] { direct })!;
+            var formatted = (NavText)formatter.Format.Invoke(null, new object?[] { expanded })!;
+            return formatted.Value ?? string.Empty;
+        }
+        catch (Exception ex)
+        {
+            var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
+            throw PageMetadataPropertiesGap(
+                pageId, column,
+                $"BC's own permission-mask formatter could not render the declared value {declaredMask} "
+                + $"({inner.GetType().Name}: {inner.Message})");
+        }
+    }
+
+    /// <summary>
+    /// The eleven <c>&lt;Properties&gt;</c>-derived columns for <paramref name="pageId"/>,
+    /// read off BC's own parsed page metadata — the same <c>MetaPageProperties</c>/
+    /// <c>MetaPageDefinition.ALNamespace</c> BC's real <c>PageDataProvider</c> reads them off.
+    ///
+    /// <para>Throws rather than defaulting when the page's real metadata will not load, since
+    /// a default here is a plausible wrong answer for a property the page declares. Unlike
+    /// <see cref="GetPageSourceObject"/>'s <c>SourceObject</c>, <c>Properties</c> itself is
+    /// never null for a page BC's compiler produces, so a null one is a BC-shape gap rather
+    /// than a real answer to default to.</para>
+    /// </summary>
+    internal static PagePropertiesInfo GetPageProperties(int pageId)
+    {
+        var meta = EnsureRealPageMetadata(pageId)
+            ?? throw PageMetadataPropertiesGap(
+                pageId, "Properties",
+                "the runner has no loadable page metadata for this page, so its declared "
+                + "RefreshOnActivate/APIPublisher/APIGroup/APIVersion/EntitySetName/EntityName/"
+                + "DataCaptionExpr./ChangeTrackingAllowed/InherentPermissions/InherentEntitlements/"
+                + "AL Namespace cannot be read");
+
+        return TryGetPageProperties(meta, pageId);
+    }
+
+    /// <summary>
+    /// Read the eleven columns off an already-loaded <c>NCLMetaForm</c>. Split out from
+    /// <see cref="GetPageProperties"/> so the metadata-load half and the read half fail
+    /// separately and say which of the two failed — same shape as
+    /// <see cref="TryGetPageSourceObject"/>.
+    /// </summary>
+    private static PagePropertiesInfo TryGetPageProperties(object meta, int pageId)
+    {
+        Microsoft.Dynamics.Nav.Types.Metadata.MetaPageDefinition? definition;
+        try
+        {
+            definition = (meta as NCLMetaForm)
+                ?.GetFrozenPageDefinitionWithExtensionWithoutMergedMultiLanguage().Item;
+        }
+        catch (Exception ex)
+        {
+            throw PageMetadataPropertiesGap(
+                pageId, "Properties",
+                $"BC's own page definition could not be read ({ex.GetType().Name}: {ex.Message})");
+        }
+
+        if (definition == null)
+            throw PageMetadataPropertiesGap(
+                pageId, "Properties",
+                "BC's own page definition is null even though the page's metadata loaded");
+
+        var properties = definition.Properties
+            ?? throw PageMetadataPropertiesGap(
+                pageId, "Properties",
+                "BC's own page properties are null even though the page's metadata loaded — "
+                + "every page shape the compiler produces carries one, so this is a BC-shape gap, "
+                + "not a page declaring none of the eleven");
+
+        return new PagePropertiesInfo(
+            RefreshOnActivate: properties.RefreshOnActivate,
+            ALNamespace: definition.ALNamespace ?? string.Empty,
+            InherentPermissions: FormatInherentMask(properties.InherentPermissions, pageId, "InherentPermissions"),
+            InherentEntitlements: FormatInherentMask(properties.InherentEntitlements, pageId, "InherentEntitlements"),
+            APIVersion: properties.APIVersion ?? string.Empty,
+            DataCaptionExpr: properties.DataCaptionExpr ?? string.Empty,
+            EntityName: properties.EntityName ?? string.Empty,
+            EntitySetName: properties.EntitySetName ?? string.Empty,
+            APIPublisher: properties.APIPublisher ?? string.Empty,
+            APIGroup: properties.APIGroup ?? string.Empty,
+            ChangeTrackingAllowed: properties.ChangeTrackingAllowed);
+    }
+}

--- a/AlRunner/Patches/RecordPatches.PageMetadataProperties.cs
+++ b/AlRunner/Patches/RecordPatches.PageMetadataProperties.cs
@@ -1,75 +1,49 @@
 // RecordPatches.PageMetadataProperties — the eleven "Page Metadata" (2000000138) columns
 // that come off a page's <Properties> element (ten of them) or the page definition itself
-// (ALNamespace), read from BC's OWN parsed metadata (#3601).
+// (ALNamespace), read from BC's OWN parsed metadata (#3601). Full derivation — the census
+// that motivated this, why one object serves both page origins, and the AL-compiler probes
+// behind the two non-obvious claims below — is in docs/page-metadata-properties.md.
 //
-// ── THE DEFECT ───────────────────────────────────────────────────────────────────────────
-//   BuildPageMetadataValue's switch fell through eleven of its columns to
-//   NavValue.GetDefaultNavValue — a hardcoded default, never the page's own declaration.
-//   Measured at main 9a0dd368 (issue #3601): eleven of the twelve defaulted columns are
-//   stated outright in BC's own emitted <Properties> document — RefreshOnActivate in 236 of
-//   236 pages, ALNamespace in 236 of 236, InherentEntitlements in 94, InherentPermissions in
-//   92, APIVersion in 39 on Base App, DataCaptionExpr. in 32, EntityName/EntitySetName in 10,
-//   APIPublisher/APIGroup in 8, ChangeTrackingAllowed in 2.
+// CLAIM: all eleven are stated on the SAME MetaPageDefinition/MetaPageProperties object
+// EnsureRealPageMetadata already loads for the nine <SourceObject> columns one element down
+// (#3063), and reading it here is faithful to BC's own PageDataProvider — verified against
+// BC 28.1's decompiled PageDataProvider.<GetValuesWithinRangeForKeyField>d__3.MoveNext(),
+// which reads every one of them off this same object. See docs/page-metadata-properties.md
+// §"one object not two".
 //
-// ── WHERE THE VALUES COME FROM, AND WHY NOT FROM THE TWO OBVIOUS PLACES ──────────────────
-//   #3063 established the pattern one element down, on <SourceObject>: BOTH page origins —
-//   a page this run source-compiled, and a page declared by a precompiled dependency .app —
-//   already converge on ONE object, BC's own MetaPageDefinition, loaded through
-//   EnsureRealPageMetadata's NCLMetaForm.LoadMetadata(). This file reads the same object one
-//   layer up: MetaPageDefinition.Properties (a MetaPageProperties) for ten of the eleven, and
-//   MetaPageDefinition.ALNamespace itself for the eleventh — verified against BC 28.1's real
-//   PageDataProvider.<GetValuesWithinRangeForKeyField>d__3.MoveNext() (decompiled): it reads
-//   `properties.RefreshOnActivate` / `.APIPublisher` / `.APIGroup` / `.APIVersion` /
-//   `.EntitySetName` / `.EntityName` / `.DataCaptionExpr` / `.ChangeTrackingAllowed` and
-//   `item.ALNamespace` (via `GetNormalizedNamespace`, which is `NavText.Create(fieldValue)` —
-//   no further transform) directly off this same object, so there is nothing left for either
-//   row source (ParsedPage / BcAppSymbolCache.PageSymbol) to add.
+// CLAIM: InherentPermissions/InherentEntitlements are rendered through BC's OWN
+// PermissionDefinition.ExpandDirectPermissionToIndirect and
+// MetadataDataProvider.CreatePermissionMaskString (reflection, same pattern as
+// PageDataProvider.GenerateSourceTableViewString in the sibling <SourceObject> file), not
+// reimplemented (precompiled-dll-respect.md). TRAP: a page can only ever declare `X`
+// (Execute) for either — the AL compiler rejects anything else with AL0195 — so do not
+// "simplify" this to a literal-string special case; the call graph is what makes it correct
+// if BC ever allows more. See docs/page-metadata-properties.md §"InherentPermissions".
 //
-// ── InherentPermissions / InherentEntitlements ARE NOT A DIRECT FIELD READ ───────────────
-//   BC's real column value is NOT `properties.InherentPermissions` printed as text — it is
-//   that raw declared mask, expanded and formatted through two of BC's OWN runtime-engine
-//   methods, reused here rather than reimplemented (precompiled-dll-respect.md):
-//     PermissionDefinition.ExpandDirectPermissionToIndirect(PermissionMask) — sets the
-//       matching INDIRECT bit for every DIRECT bit a page declares (NCLMetaForm.LoadMetadata
-//       does exactly this before storing InherentPermissionsAndEntitlements);
-//     MetadataDataProvider.CreatePermissionMaskString(PermissionMask) — renders the mask as
-//       the letters columns 30/31 carry: uppercase for a DIRECT bit, lowercase for an
-//       INDIRECT-only one, empty for PermissionMask.None.
-//   Both are internal members of internal-but-loadable types in Ncl.dll, resolved by
-//   reflection the same way PageDataProvider.GenerateSourceTableViewString is in
-//   RecordPatches.PageMetadataSourceObject.cs. A PAGE can only ever declare `X` (Execute) for
-//   either property — the AL compiler rejects `rimd` on a page with "Invalid permission kind.
-//   Expected: 'X'" — so the expand step never changes the OBSERVABLE letters for a page (a
-//   direct bit always wins the uppercase branch before its own indirect twin is checked), but
-//   it is still BC's real call graph, not a shortcut that happens to agree with it today.
+// CLAIM: DataCaptionExpr. is BC's fixed placeholder "DataCaptionExprCode", never the AL
+// source text — confirmed with two different declared expressions producing the identical
+// column value, and adjudicated on a real service tier by corpus PR #298 (merged, 8/8 cloud
+// legs green). See docs/page-metadata-properties.md §"data-caption-expr".
 //
-// ── DataCaptionExpr. IS A FIXED PLACEHOLDER, NOT THE AL SOURCE TEXT ──────────────────────
-//   Measured against the real AL compiler (BC 28.1): a page declaring
-//   `DataCaptionExpression = 'Probe Page Fixture';` and one declaring
-//   `DataCaptionExpression = 'Some Other Totally Different Text Value XYZ';` both compile to
-//   the identical <Properties DataCaptionExpr="DataCaptionExprCode" .../> — BC compiles the
-//   expression to a generated method and the document merely names that there is one, not
-//   what it evaluates to. properties.DataCaptionExpr is exactly that fixed string, so reading
-//   it verbatim is correct; there is no formatting step to reproduce.
+// TRAP: APIVersion's "declares none" default is the literal "beta", not "", per
+// MetaPageProperties.APIVersion's own [DefaultValue("beta")] — needs no code here since it
+// falls out of reading the property directly, but do not "correct" a future refactor's
+// default to "" for this one column. See docs/page-metadata-properties.md §"api-version-default".
 //
-// ── WHAT IS REFUSED RATHER THAN DEFAULTED (loud-failures.md) ─────────────────────────────
-//   Same policy as the sibling <SourceObject> file: a page whose real metadata will not load
-//   gets a named refusal naming the column, never BC's default. Unlike <SourceObject>,
-//   MetaPageDefinition.Properties itself is not null for any page shape the compiler
-//   produces — verified against every corpus page BC 28.1 compiles — so a null there is
-//   refused as a BC-shape gap rather than treated as a real, if unusual, answer.
+// REFUSAL POLICY (loud-failures.md): same as the sibling <SourceObject> file — a page whose
+// real metadata will not load gets a named refusal, never BC's default. Unlike
+// <SourceObject>, MetaPageDefinition.Properties is never null for any page shape the
+// compiler produces, so a null one here is refused as a BC-shape gap, not treated as a real
+// answer.
 //
-// ── AppID IS DELIBERATELY NOT HERE ────────────────────────────────────────────────────────
-//   BC's real column reads MetadataDataProvider.GetAppId(metaFormById), computed from the
-//   page's owning app-identity/app-group, not from <Properties> at all — the one column of
-//   the twelve the issue's own measurement found unstated on the document. Left on
-//   NavValue.GetDefaultNavValue in RecordPatches.PageMetadataVirtualTable.cs, unchanged.
+// AppID is deliberately NOT here — BC reads it from MetadataDataProvider.GetAppId, an
+// app-identity surface unrelated to <Properties>. See
+// docs/page-metadata-properties.md §"app-id".
 //
-// ── PRECOMPILED-DLL RESPECT ──────────────────────────────────────────────────────────────
-//   Runtime-engine and metadata types only (NCLMetaForm, MetaPageDefinition,
-//   MetaPageProperties, PermissionDefinition, MetadataDataProvider — all reached the same way
-//   the sibling <SourceObject> file reaches PageDataProvider). No AL business-logic body is
-//   touched, and nothing here re-implements a BC behaviour BC itself is present to perform.
+// PRECOMPILED-DLL RESPECT: runtime-engine and metadata types only (NCLMetaForm,
+// MetaPageDefinition, MetaPageProperties, PermissionDefinition, MetadataDataProvider — all
+// reached the same way the sibling file reaches PageDataProvider). No AL business-logic
+// body is touched.
 
 using System.Reflection;
 using AlRunner.Infrastructure;
@@ -165,8 +139,12 @@ public static partial class RecordPatches
     /// InherentEntitlements int) rendered exactly as BC's own
     /// InherentObjectPermissionAndEntitlementsHelper/MetadataDataProvider chain renders it —
     /// empty for a page declaring neither (PermissionMask.None formats to NavText.Empty).
+    /// Internal rather than private so <c>PageMetadataPropertiesFormattingTests</c> can pin
+    /// this reflection call reaching BC's own runtime-engine formatter without needing a
+    /// compiled page: the BC-behaviour claim (what a page's declared mask MEANS) is
+    /// adjudicated upstream by corpus PR #298; this is the runner-side wiring underneath it.
     /// </summary>
-    private static string FormatInherentMask(int declaredMask, int pageId, string column)
+    internal static string FormatInherentMask(int declaredMask, int pageId, string column)
     {
         var formatter = ResolvePermissionFormatter()
             ?? throw PageMetadataPropertiesGap(pageId, column,

--- a/AlRunner/Patches/RecordPatches.PageMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.PageMetadataVirtualTable.cs
@@ -49,25 +49,24 @@
 //   disagree about which pages exist.
 //
 // COLUMNS NOT IMPLEMENTED
-//   Twenty of the table's 32 columns are answered here. Eleven come off PageMetaRow
+//   Thirty-one of the table's 32 columns are answered here. Eleven come off PageMetaRow
 //   (Id/Name/Caption/SourceTable/PageType/Editable/InsertAllowed/ModifyAllowed/
 //   DeleteAllowed/SourceTableTemporary/CardPageID); the nine <SourceObject> ones
 //   (SourceTableView/DelayedInsert/ShowFilter/MultipleNewLines/SaveValues/AutoSplitKey/
 //   DataCaptionFields/LinksAllowed/PopulateAllFields) were added by #3063 and are read from
 //   BC's OWN parsed page metadata — see RecordPatches.PageMetadataSourceObject.cs, which is
-//   also where the refusal policy for them lives.
+//   also where the refusal policy for them lives. Eleven more — DataCaptionExpr.,
+//   RefreshOnActivate, APIPublisher, APIGroup, APIVersion, EntitySetName, EntityName,
+//   ChangeTrackingAllowed, InherentPermissions, InherentEntitlements and "AL Namespace" —
+//   were added by #3601 and are read from that SAME parsed page metadata, one element up:
+//   BC's own <Properties> (ten of them) and the page definition itself (ALNamespace). See
+//   RecordPatches.PageMetadataProperties.cs.
 //
-//   The remaining twelve still get BC's own NavValue.GetDefaultNavValue for the column's
-//   type — the same "declares none of them" default a real row carries for a page that
-//   states nothing about them. They are DataCaptionExpr., RefreshOnActivate, APIPublisher,
-//   APIGroup, APIVersion, EntitySetName, EntityName, ChangeTrackingAllowed, AppID,
-//   InherentPermissions, InherentEntitlements and Namespace. Unlike the nine above, none of
-//   these has a value sitting parsed and unused in the process today: the API* / Entity* /
-//   DataCaptionExpr. / RefreshOnActivate / ChangeTrackingAllowed group is <Properties>-level
-//   rather than <SourceObject>-level and is not carried on either row source, and the last
-//   four are computed by BC from an app-identity and permission-mask surface the runner does
-//   not populate at all. Each is therefore a separate piece of work, not a fall-through this
-//   file could close by widening its switch.
+//   Only AppID (29) is still answered by NavValue.GetDefaultNavValue, and it stays that way
+//   deliberately: BC computes it from an app-identity surface — MetadataDataProvider.GetAppId
+//   reading the page's owning NCLMetaForm/app-group identity — that has nothing to do with
+//   either <Properties> or <SourceObject> and that the runner does not populate. It is a
+//   separate piece of work, not a fall-through either of the two files above could close.
 //
 // PRECOMPILED-DLL RESPECT
 //   Runtime-engine types only (VirtualDataProvider, NCLMetaTable, NavValue,
@@ -159,15 +158,24 @@ public static partial class RecordPatches
             PageSourceObjectInfo? sourceObject = null;
             PageSourceObjectInfo SourceObjectFor(PageMetaRow r) => sourceObject ??= GetPageSourceObject(r.Id);
 
+            // Same shape, one element up (#3601): a second lazy slot for the eleven
+            // <Properties>-derived columns, shared the same way and independent of the one
+            // above — BC's own GetFrozenPageDefinitionWithExtensionWithoutMergedMultiLanguage
+            // memoizes on the NCLMetaForm instance itself (verified by decompile), so the two
+            // slots each triggering it costs nothing beyond the first call either one makes.
+            PagePropertiesInfo? properties = null;
+            PagePropertiesInfo PropertiesFor(PageMetaRow r) => properties ??= GetPageProperties(r.Id);
+
             InsertVirtualRow(provider, metaTable,
                 new object[] { PageMetadataVirtualTableId, row.Id, 0, 0 },
-                field => BuildPageMetadataValue(field, row, pageTypeOrdinals, SourceObjectFor));
+                field => BuildPageMetadataValue(field, row, pageTypeOrdinals, SourceObjectFor, PropertiesFor));
         }
     }
 
     private static object? BuildPageMetadataValue(
         NCLMetaField field, PageMetaRow row, Dictionary<string, int> pageTypeOrdinals,
-        Func<PageMetaRow, PageSourceObjectInfo> SourceObjectFor)
+        Func<PageMetaRow, PageSourceObjectInfo> SourceObjectFor,
+        Func<PageMetaRow, PagePropertiesInfo> PropertiesFor)
     {
         object? Text(string s) => _aovNavTextCreateTruncated!.Invoke(null, new object?[] { field.FieldDefinedLength, s ?? string.Empty });
 
@@ -229,6 +237,35 @@ public static partial class RecordPatches
                 return NavBoolean(SourceObjectFor(row).LinksAllowed);
             case "populateallfields":
                 return NavBoolean(SourceObjectFor(row).PopulateAllFields);
+
+            // The eleven <Properties>-derived Page Metadata columns (#3601). Read from BC's
+            // own parsed page metadata one element up from the nine above — the same
+            // MetaPageProperties BC's real PageDataProvider reads them off — so a
+            // source-compiled page and a page from a dependency .app cannot answer
+            // differently. See RecordPatches.PageMetadataProperties.cs, which also states
+            // which one (AppID) is deliberately NOT here and why.
+            case "refreshonactivate":
+                return NavBoolean(PropertiesFor(row).RefreshOnActivate);
+            case "alnamespace":
+                return Text(PropertiesFor(row).ALNamespace);
+            case "inherentpermissions":
+                return Text(PropertiesFor(row).InherentPermissions);
+            case "inherententitlements":
+                return Text(PropertiesFor(row).InherentEntitlements);
+            case "apiversion":
+                return Text(PropertiesFor(row).APIVersion);
+            case "datacaptionexpr.":
+                return Text(PropertiesFor(row).DataCaptionExpr);
+            case "entityname":
+                return Text(PropertiesFor(row).EntityName);
+            case "entitysetname":
+                return Text(PropertiesFor(row).EntitySetName);
+            case "apipublisher":
+                return Text(PropertiesFor(row).APIPublisher);
+            case "apigroup":
+                return Text(PropertiesFor(row).APIGroup);
+            case "changetrackingallowed":
+                return NavBoolean(PropertiesFor(row).ChangeTrackingAllowed);
 
             default:
                 return _aovGetDefaultNavValue!.Invoke(null, new object?[] { field, false });

--- a/docs/page-metadata-properties.md
+++ b/docs/page-metadata-properties.md
@@ -1,0 +1,101 @@
+# Page Metadata's eleven `<Properties>`-derived columns
+
+`AlRunner/Patches/RecordPatches.PageMetadataProperties.cs` answers eleven columns of the
+"Page Metadata" (2000000138) virtual table from BC's own compiled page document, rather than
+from `NavValue.GetDefaultNavValue` (issue #3601). This is the derivation behind the claims in
+that file's header; the file itself carries only the claim and a pointer here.
+
+<a id="the-measurement"></a>
+
+## The measurement that motivated the fix
+
+Measured at `main` `9a0dd368` (issue #3562's tracking comment): eleven of the table's twelve
+defaulted columns are stated outright in BC's own emitted `<Properties>` document —
+`RefreshOnActivate` in 236 of 236 pages, `ALNamespace` in 236 of 236, `InherentEntitlements`
+in 94, `InherentPermissions` in 92, `APIVersion` in 39 on Base App, `DataCaptionExpr.` in 32,
+`EntityName`/`EntitySetName` in 10, `APIPublisher`/`APIGroup` in 8, `ChangeTrackingAllowed`
+in 2. `AppID` is the twelfth and is not stated on the document at all — see below.
+
+<a id="one-object-not-two"></a>
+
+## Why one object serves both page origins, and why not the two obvious places
+
+#3063 established the pattern one element down, on `<SourceObject>`: a page this run
+source-compiled and a page declared by a precompiled dependency `.app` already converge on
+ONE object, BC's own `MetaPageDefinition`, loaded through `EnsureRealPageMetadata`'s
+`NCLMetaForm.LoadMetadata()`. This file reads the same object one layer up —
+`MetaPageDefinition.Properties` (a `MetaPageProperties`) for ten of the eleven, and
+`MetaPageDefinition.ALNamespace` itself for the eleventh.
+
+Verified against BC 28.1's decompiled
+`PageDataProvider.<GetValuesWithinRangeForKeyField>d__3.MoveNext()`: it reads
+`properties.RefreshOnActivate` / `.APIPublisher` / `.APIGroup` / `.APIVersion` /
+`.EntitySetName` / `.EntityName` / `.DataCaptionExpr` / `.ChangeTrackingAllowed` and
+`item.ALNamespace` (via `GetNormalizedNamespace`, which is `NavText.Create(fieldValue)` — no
+further transform) directly off this same object. So there is nothing left for either of the
+two row sources `EnumerateKnownPageMetadata` already walks (`ParsedPage` for a source-compiled
+page, `BcAppSymbolCache.PageSymbol` for a dependency `.app`) to add — feeding the two
+independently would make "the table answers differently depending on where a page came from"
+the default outcome, which is the failure mode #3063 already rejected for the nine
+`<SourceObject>` columns.
+
+<a id="inherent-permissions"></a>
+
+## `InherentPermissions` / `InherentEntitlements` are not a direct field read
+
+BC's real column value is not `properties.InherentPermissions` printed as text — it is that
+raw declared mask, expanded and formatted through two of BC's own runtime-engine methods:
+
+- `PermissionDefinition.ExpandDirectPermissionToIndirect(PermissionMask)` — sets the matching
+  INDIRECT bit for every DIRECT bit a page declares. `NCLMetaForm.LoadMetadata()` does exactly
+  this before storing `InherentPermissionsAndEntitlements`.
+- `MetadataDataProvider.CreatePermissionMaskString(PermissionMask)` — renders the mask as the
+  letters columns 30/31 carry: uppercase for a DIRECT bit, lowercase for an INDIRECT-only one,
+  empty for `PermissionMask.None`.
+
+Both are internal members of internal-but-loadable types in `Ncl.dll`, resolved by reflection
+the same way `PageDataProvider.GenerateSourceTableViewString` is in
+`RecordPatches.PageMetadataSourceObject.cs`.
+
+A page can only ever declare `X` (Execute) for either property — verified against the real AL
+compiler: `InherentPermissions = rimd;` on a page is rejected with `AL0195: Invalid permission
+kind. Expected: 'X'`, while the identical declaration compiles on a table. So the expand step
+never changes the *observable* letters for a page (a direct bit always wins the uppercase
+branch before its own indirect twin is checked) — it is still BC's real call graph, not a
+shortcut that happens to agree with it today, and the day BC allows more than `X` on a page
+this stops being a coincidence.
+
+<a id="data-caption-expr"></a>
+
+## `DataCaptionExpr.` is a fixed placeholder, not the AL source text
+
+Measured against the real AL compiler (BC 28.1): a page declaring `DataCaptionExpression =
+'Probe Page Fixture';` and one declaring `DataCaptionExpression = 'Some Other Totally
+Different Text Value XYZ';` both compile to the identical `<Properties
+DataCaptionExpr="DataCaptionExprCode" .../>`. BC compiles the expression to a generated method
+and the document merely names that there is one, not what it evaluates to.
+`properties.DataCaptionExpr` is exactly that fixed string, so reading it verbatim is correct;
+there is no formatting step to reproduce. Corpus PR #298 pins this on a real service tier
+(merged, all eight cloud legs green — see the runner PR body for the run).
+
+<a id="api-version-default"></a>
+
+## `APIVersion`'s "declares none" default is `"beta"`, not empty
+
+`Microsoft.Dynamics.Nav.Types.MetaPageProperties.APIVersion`'s own getter (decompiled, BC
+28.1) carries `[DefaultValue("beta")]` and returns the literal `"beta"` when the backing field
+is null — every other string column on this type returns `""` or a raw possibly-null field.
+Confirmed against a live AL-compiler probe: a page declaring no `APIVersion` attribute at all
+still reads `"beta"` through this property. `RecordPatches.PageMetadataProperties.cs` needs no
+special case for this — it falls out of reading `properties.APIVersion` directly — but a test
+asserting the "declares none" default as empty would be wrong for this one column. Corpus PR
+#298's negative control pins `"beta"`, adjudicated on a real service tier.
+
+<a id="app-id"></a>
+
+## `AppID` is deliberately not here
+
+BC's real column reads `MetadataDataProvider.GetAppId(metaFormById)`, computed from the
+page's owning app-identity/app-group, not from `<Properties>` at all — the one column of the
+twelve the measurement above found unstated on the document. It stays on
+`NavValue.GetDefaultNavValue` in `RecordPatches.PageMetadataVirtualTable.cs`, unchanged.


### PR DESCRIPTION
Closes #3601

## What changed

Page Metadata (2000000138) fell through eleven columns to `NavValue.GetDefaultNavValue` —
a hardcoded default rather than the page's real value. All eleven are stated on BC's own
emitted `<Properties>` element (or, for `ALNamespace`, on the page definition itself), which
#3063 already reads through `EnsureRealPageMetadata` for the table's nine `<SourceObject>`
columns. `RecordPatches.PageMetadataProperties.cs` reads them off that same
`MetaPageDefinition`/`MetaPageProperties` object BC's real `PageDataProvider` reads, verified
against BC 28.1's decompiled `PageDataProvider.<GetValuesWithinRangeForKeyField>d__3.MoveNext()`.

Columns now answering from BC's document: `RefreshOnActivate`, `AL Namespace`,
`InherentPermissions`, `InherentEntitlements`, `APIVersion`, `DataCaptionExpr.`,
`EntityName`, `EntitySetName`, `APIPublisher`, `APIGroup`, `ChangeTrackingAllowed`.

`InherentPermissions`/`InherentEntitlements` are rendered through BC's own
`PermissionDefinition.ExpandDirectPermissionToIndirect` and
`MetadataDataProvider.CreatePermissionMaskString`, reused via reflection (same pattern as
`PageDataProvider.GenerateSourceTableViewString` in the sibling `<SourceObject>` file) rather
than reimplemented.

`AppID` is left exactly as it was — BC computes it from an app-identity surface
(`MetadataDataProvider.GetAppId`) that has nothing to do with `<Properties>` and that the
runner does not populate; it is the one column of the twelve the issue's own measurement
found unstated on the document.

The out-of-date comment in `PageMetadataVirtualTable.cs` claiming these columns are "not
carried on either row source" is corrected to name the third source (BC's own compiled
document) and point at the new file.

## Proof (RED → GREEN)

Verified against a real corpus run (my own clone of the al-language corpus at the pinned
commit, not the runner's own submodule checkout), targeting the three new test methods below:

- RED (before this fix): `Record_PageMetadata_PropertiesPage_ReportsDeclaredPropertiesColumns`
  and `Record_PageMetadata_ApiPage_ReportsDeclaredApiAndEntityColumns` FAIL — e.g.
  `RefreshOnActivate` read `No` instead of the declared `Yes`, `APIPublisher` read empty
  instead of `altpublisher`. `Record_PageMetadata_PageDeclaringNoPropertiesColumns_ReportsDefaults`
  (the negative control) already PASSED, which is expected — the defect *is* the default.
- GREEN (after this fix): all three PASS.

Fixture pages and the test codeunit are in the corpus PR below, since this is a claim about
BC's own behavior.

## Corpus counts unchanged

Ran the pinned runner submodule corpus (`tests/al-language/tests/al-language`, pin `c9d5f656`)
with `--count-baseline tests/expectations/count-baseline/test-count-baseline.json`: **3112
total, 3112 pass, 0 fail** — matches the existing baseline exactly, since none of the pinned
corpus's existing tests assert on these eleven columns (they were all silently defaulted
before). Also ran `tests/runner-extras` (401/401 pass) and a filtered `AlRunner.Tests --filter
FullyQualifiedName~PageMetadata` (44 passed, 3 skipped unrelated, 0 failed).

## A genuine finding along the way

`MetaPageProperties.APIVersion`'s own getter returns the literal `"beta"`, not an empty
string, when the field is unset (`[DefaultValue("beta")]` on the real BC type — decompiled,
and confirmed against the real AL compiler with a page declaring no `APIVersion` attribute at
all). My first draft of the corpus negative control asserted an empty string and failed after
the fix — the fix was right, my assumption about "empty is always the default" was not. The
corpus test now pins `'beta'` for that one column.

## Batch-sibling scan

Scanned the open-issue queue for anything else landing in `PageMetadataVirtualTable.cs` or
`PageMetadataProperties.cs` before starting. Two open issues touch the Page Metadata /
dependency-page-metadata area but land in different files and are not folded here:

- #2460 (dependency page metadata action tree / `Enabled` reconstruction) — a different
  consumer (`RunnerPageInstance`/action-tree reconstruction), not this virtual table's column
  build.
- #2325 (Tenant Profile Page Metadata cascade on profile rename) — a different table
  (`Tenant Profile Page Metadata`) and a different mechanism (rename cascade), not this file.

Nothing else in the open-issue queue lands in either file touched by this PR.

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/298


## Update: corpus PR #298 merged; pin bump measured and NOT folded

Corpus PR #298 merged (`b90177f`), all eight cloud legs green, execution confirmed per test
name (`corpus-pass-count.py`, run 34275562528) — the eleven-column claim is now adjudicated on
a real service tier.

Measured whether the runner's `tests/al-language` pin could advance from `c9d5f656` to that
tip before folding the bump in here, per-commit (7 commits, all against my own scratch clone,
never the shared submodule checkout):

| corpus commit | corpus PR | new failures |
|---|---|---|
| control `c9d5f656` | — | 0 |
| `26b0434` | #293 | +1 |
| `3ad4c34` | #292 | +0 |
| `123d6dd` | #273 | +6 |
| `bd16835` | #272 | +2 |
| `c7af700` | #294 | +3 |
| `11bc2fe` | #295 | +0 |
| `b90177f` (tip, #298) | #298 | +0 |

**Red at the tip: 12 pre-existing failures, none touching Page Metadata.** Per
`al-language-submodule.md`'s blocked-by-an-intervening-commit case, the bump does not fold
into this PR. Four of the five gap classes were already tracked (#3586, #2943, #3593, #3506);
the fifth — a FlowField over the `Integer` virtual table crashing with `ArgumentException` —
is newly filed as #3622. Full attribution table posted on #3416, refreshing a record flagged
as stale.

Added `AlRunner.Tests/PageMetadataPropertiesTests.cs` to satisfy `Tests updated` instead: it
pins the refusal policy and the InherentPermissions/InherentEntitlements reflection wiring —
runner-side questions no service tier can adjudicate, since corpus #298 already settled what
BC's document means.

Also trimmed `RecordPatches.PageMetadataProperties.cs`'s header per
`loud-failures.md`'s audit-justification form — moved the census/derivation/probe walk to
`docs/page-metadata-properties.md`, kept a claim + citation per section in the code.
