### PR TITLE
fix(query): build a compiled query's MetaQuery from BC's own document, not four constants

### DIFF
--- a/AlRunner.Tests/Fixtures/QueryMetadataFromBcDocument/Objects.al
+++ b/AlRunner.Tests/Fixtures/QueryMetadataFromBcDocument/Objects.al
@@ -1,0 +1,71 @@
+table 70720 "QMD Head"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Amount; Decimal) { }
+    }
+    keys { key(PK; "No.") { Clustered = true; } }
+}
+
+table 70721 "QMD Line"
+{
+    fields
+    {
+        field(1; "Head No."; Code[20]) { }
+        field(2; "Line No."; Integer) { }
+        field(3; Qty; Decimal) { }
+    }
+    keys { key(PK; "Head No.", "Line No.") { Clustered = true; } }
+}
+
+// Declares a DIFFERENT value for every constant the runner used to hardcode, so a run that
+// still hardcodes them cannot produce this query's trace line. The nested dataitem omits
+// SqlJoinType, which is the one with AL-observable consequences.
+query 70720 "QMD Divergent"
+{
+    QueryType = API;
+    APIPublisher = 'alrunner';
+    APIGroup = 'qmd';
+    APIVersion = 'v1.0';
+    EntityName = 'qmdDivergent';
+    EntitySetName = 'qmdDivergents';
+    ReadState = ReadShared;
+    TopNumberOfRows = 5;
+    QueryCategory = 'Lists';
+
+    elements
+    {
+        dataitem(Head; "QMD Head")
+        {
+            column(HeadNo; "No.") { }
+            column(TotalAmount; Amount)
+            {
+                Method = Sum;
+            }
+
+            dataitem(Line; "QMD Line")
+            {
+                DataItemLink = "Head No." = Head."No.";
+
+                column(LineQty; Qty) { }
+            }
+        }
+    }
+}
+
+// Declares NONE of them: the control. Its trace line must carry the defaults, so no single
+// constant can satisfy this query and 70720 at once.
+query 70721 "QMD Plain"
+{
+    QueryType = Normal;
+
+    elements
+    {
+        dataitem(H; "QMD Head")
+        {
+            filter(HFilterNo; "No.") { }
+            column(HAmount; Amount) { }
+        }
+    }
+}

--- a/AlRunner.Tests/Fixtures/QueryMetadataFromBcDocument/Tests.al
+++ b/AlRunner.Tests/Fixtures/QueryMetadataFromBcDocument/Tests.al
@@ -1,0 +1,20 @@
+codeunit 70720 "QMD Tests"
+{
+    Subtype = Test;
+
+    // Opening each query is what forces its MetaQuery design to be built, which is what the
+    // trace this fixture exists for reports on. The join behaviour itself is adjudicated on a
+    // real service tier by corpus PR #297, not here.
+    [Test]
+    procedure OpensBothQueries()
+    var
+        Divergent: Query "QMD Divergent";
+        Plain: Query "QMD Plain";
+    begin
+        Divergent.Open();
+        Divergent.Close();
+
+        Plain.Open();
+        Plain.Close();
+    end;
+}

--- a/AlRunner.Tests/Fixtures/QueryMetadataFromBcDocument/app.json
+++ b/AlRunner.Tests/Fixtures/QueryMetadataFromBcDocument/app.json
@@ -1,0 +1,23 @@
+{
+  "id": "a3000000-0000-4000-8000-000000000050",
+  "name": "Runner Tests Fixture - Query Metadata From BC Document",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "#3608: a compiled query's MetaQuery design must come from BC's own emitted metadata document, so the values the runner used to hardcode answer what the query actually declares.",
+  "description": "Used by AlRunner.Tests' QueryMetadataFromBcDocumentTests. One query declares a value DIFFERING from each hardcode the runner used to supply (ReadState ReadShared not ReadUncommitted, QueryType API not Normal, TopNumberOfRows 5 not 0, QueryCategory Lists not empty) plus a Sum column whose ColumnType only the document states; a second declares none of them, so no single constant satisfies both. Deliberately declares no 'application' dependency (see .claude/rules/no-base-app-in-csharp-tests.md).",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "idRanges": [
+    {
+      "from": 70720,
+      "to": 70739
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner.Tests/QueryMetadataFromBcDocumentTests.cs
+++ b/AlRunner.Tests/QueryMetadataFromBcDocumentTests.cs
@@ -1,0 +1,221 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #3608 — a query the runner COMPILED gets its <c>MetaQuery</c> design object from BC's own
+/// emitted metadata document (captured by #3548) instead of from the SymbolReference sidecar
+/// plus four hardcoded constants.
+///
+/// <para>Every value asserted here is one the runner used to supply from a constant, and
+/// <c>QMD Divergent</c> declares a value DIFFERING from each — <c>ReadShared</c> against the
+/// hardcoded <c>ReadUncommitted</c>, <c>API</c> against the defaulted <c>Normal</c>, top 5
+/// against 0, <c>Lists</c> against empty. A query that happened to agree with a hardcode could
+/// not distinguish a fix from a no-op, which is why <c>QMD Plain</c> is here as well: it
+/// declares none of them, so no single constant satisfies both trace lines at once.</para>
+///
+/// <para>None of the four reaches AL. There is no AL surface that reads a query's
+/// <c>ReadState</c>, its design-time <c>TopNumberOfRows</c>, its <c>QueryCategory</c> or a
+/// dataitem's <c>Distinct</c> — <c>AllObjWithCaption</c>'s Object Subtype reports
+/// <c>QueryType</c>, but from the parsed-query registry, a different consumer this change does
+/// not touch. So this is a runner-mechanism test observing
+/// <c>AL_RUNNER_TRACE_QUERY_METADATA_SOURCE=1</c>, the same shape
+/// <see cref="TableMetadataFromBcDocumentTests"/> uses and for the same reason: the two
+/// construction routes produce the same TYPE, so nothing downstream can be asked which one ran.
+/// The AL-observable half of the change — an omitted <c>SqlJoinType</c> joining as
+/// <c>LeftOuterJoin</c> — is adjudicated by a real service tier in corpus PR #297.</para>
+///
+/// <para>Warm assertions are identical to the cold ones and run against the same cache
+/// directory (<c>.claude/rules/local-test-scope.md</c>): BC's Emit runs only on a compile-cache
+/// MISS, so a warm run that lost the document would silently fall back to the derivation while
+/// the run stayed green.</para>
+///
+/// <para>Spawns the real runner; needs the BC artifact cache. Skips when absent.</para>
+/// </summary>
+public class QueryMetadataFromBcDocumentTests
+{
+    private const int DivergentQueryId = 70720;
+    private const int PlainQueryId = 70721;
+
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string FixtureRoot = Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "QueryMetadataFromBcDocument"));
+
+    private static void CopyDir(string src, string dst)
+    {
+        Directory.CreateDirectory(dst);
+        foreach (var f in Directory.GetFiles(src))
+            File.Copy(f, Path.Combine(dst, Path.GetFileName(f)), overwrite: true);
+    }
+
+    private static (string output, int exit) RunRunner(string bundleDir, string alCacheDir)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" \"{bundleDir}\"");
+        args.Append($" --cache \"{alCacheDir}\"");
+        args.Append(" --verbose");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = args.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        psi.Environment["AL_RUNNER_TRACE_QUERY_METADATA_SOURCE"] = "1";
+        var platformApps = TestArtifacts.PlatformAppsDir();
+        if (Directory.Exists(platformApps))
+            psi.Arguments += $" --package-cache \"{platformApps}\"";
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(300_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>The last trace line for one query whose text starts with the given suffix after
+    /// the id — the last, because a query built more than once traces each build and the
+    /// assertion is about the state the run ends up serving.</summary>
+    private static string TraceLine(string output, int queryId, string discriminator)
+    {
+        var prefix = $"[query-metadata] {queryId} ";
+        var hit = output.Split('\n')
+            .Select(l => l.TrimEnd('\r'))
+            .LastOrDefault(l => l.StartsWith(prefix, StringComparison.Ordinal)
+                                && l.Contains(discriminator, StringComparison.Ordinal));
+        Assert.True(hit != null,
+            $"no '{discriminator}' trace line for query {queryId}. "
+            + $"AL_RUNNER_TRACE_QUERY_METADATA_SOURCE=1 emits one per built query.\n{output}");
+        return hit!;
+    }
+
+    private static void AssertBothQueriesCameFromBcDocument(string output, string phase)
+    {
+        foreach (var id in new[] { DivergentQueryId, PlainQueryId })
+            Assert.True(output.Contains($"[query-metadata] {id} source=bc-document"),
+                $"{phase}: query {id} was not built from BC's metadata document. "
+                + $"It is compiled by this bundle, so #3548 captures one for it.\n{output}");
+
+        // Query 70720 declares a value differing from EVERY hardcode the derivation supplied.
+        // A run still hardcoding them produces readState=ReadUncommitted and queryCategory=''
+        // on this same line, so this single assertion cannot pass on the pre-fix build.
+        var divergent = TraceLine(output, DivergentQueryId, "readState=");
+        Assert.True(divergent.Contains("readState=ReadShared"),
+            $"{phase}: query {DivergentQueryId} declares ReadState = ReadShared, not the "
+            + "hardcoded ReadUncommitted.\n" + divergent);
+        Assert.True(divergent.Contains("queryType=API"),
+            $"{phase}: query {DivergentQueryId} declares QueryType = API, not the default Normal.\n"
+            + divergent);
+        Assert.True(divergent.Contains("top=5"),
+            $"{phase}: query {DivergentQueryId} declares TopNumberOfRows = 5.\n" + divergent);
+        Assert.True(divergent.Contains("queryCategory='Lists'"),
+            $"{phase}: query {DivergentQueryId} declares QueryCategory = 'Lists'; the derivation "
+            + "carried no QueryCategory at all.\n" + divergent);
+
+        // Query 70721 declares NONE of them: the control. If it came back ReadShared or API,
+        // the values above would be coming from somewhere other than each query's own
+        // declaration, and no single constant could satisfy both lines.
+        var plain = TraceLine(output, PlainQueryId, "readState=");
+        Assert.True(plain.Contains("readState=ReadUncommitted"),
+            $"{phase}: query {PlainQueryId} declares no ReadState, so it takes BC's default.\n"
+            + plain);
+        Assert.True(plain.Contains("queryType=Normal"),
+            $"{phase}: query {PlainQueryId} declares QueryType = Normal.\n" + plain);
+        Assert.True(plain.Contains("top=0"),
+            $"{phase}: query {PlainQueryId} declares no TopNumberOfRows.\n" + plain);
+        Assert.True(plain.Contains("queryCategory=''"),
+            $"{phase}: query {PlainQueryId} declares no QueryCategory.\n" + plain);
+
+        // The compiler-assigned columns. ColumnType is the one nothing but the document can
+        // supply — the SymbolReference sidecar names the source FIELD, never the AL type the
+        // compiler resolved it to, so the derivation left it at the design object's None.
+        var totalAmount = TraceLine(output, DivergentQueryId, "column=TotalAmount");
+        Assert.True(totalAmount.Contains("columnType=Decimal"),
+            $"{phase}: column TotalAmount sums a Decimal field, so BC's document types it "
+            + "Decimal; the derivation could only answer None.\n" + totalAmount);
+        Assert.True(totalAmount.Contains("totalingMethod=Sum"),
+            $"{phase}: column TotalAmount declares Method = Sum.\n" + totalAmount);
+        Assert.True(totalAmount.Contains("index=1"),
+            $"{phase}: TotalAmount is the second result column of the query.\n" + totalAmount);
+
+        // A filter-only column takes QueryColumnIndex -1, not the design object's default 0 —
+        // 0 is a real result slot, so the default would have it claim the first column's.
+        var filterColumn = TraceLine(output, PlainQueryId, "column=HFilterNo");
+        Assert.True(filterColumn.Contains("index=-1"),
+            $"{phase}: HFilterNo is a filter(...) element, so it holds no result slot.\n"
+            + filterColumn);
+        Assert.True(filterColumn.Contains("filterOnly=True"),
+            $"{phase}: HFilterNo is filter-only.\n" + filterColumn);
+
+        // The nested dataitem of 70720 declares NO SqlJoinType. BC's document states
+        // Left Outer Join for it; the derivation defaulted to InnerJoin, which dropped every
+        // parent row with no matching child. Corpus PR #297 adjudicates that on real BC.
+        var nested = TraceLine(output, DivergentQueryId, "dataItem=Line");
+        Assert.True(nested.Contains("linkType=LeftOuterJoin"),
+            $"{phase}: the nested dataitem declares no SqlJoinType, and AL defaults it to "
+            + "LeftOuterJoin — not the InnerJoin the derivation assumed.\n" + nested);
+    }
+
+    [SkippableFact]
+    public void CompiledQuery_IsBuiltFromBcsMetadataDocument_ColdAndOnAWarmCacheHit()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var scratch = TestScratch.Dir("al-runner-query-metadata-from-bc");
+        var bundle = Path.Combine(scratch, "bundle");
+        var alCacheDir = Path.Combine(scratch, "al-out");
+        CopyDir(FixtureRoot, bundle);
+
+        var (cold, coldExit) = RunRunner(bundle, alCacheDir);
+        Assert.True(coldExit == 0 && cold.Contains("1P/0F/0E"), $"cold run must pass:\n{cold}");
+        AssertBothQueriesCameFromBcDocument(cold, "cold run");
+
+        // Same sources, same cache directory: the AL-output cache HITs and Emit never runs, so
+        // the document reaches this run only through the replayed sidecar. Without that replay
+        // both queries fall back to the derivation and every assertion above flips.
+        var (warm, warmExit) = RunRunner(bundle, alCacheDir);
+        Assert.True(warmExit == 0 && warm.Contains("1P/0F/0E"), $"warm run must pass:\n{warm}");
+        Assert.Contains("[cache] HIT", warm);
+        AssertBothQueriesCameFromBcDocument(warm, "warm run (AL-output cache HIT)");
+    }
+
+    /// <summary>
+    /// The route is chosen on AVAILABILITY, so a query with no document keeps the derivation
+    /// rather than failing. Nothing in this fixture can produce that state — every query here
+    /// is compiled — so the claim is made against the predicate itself, which is what both
+    /// call sites consult.
+    /// </summary>
+    [Fact]
+    public void QueryWithNoRegisteredDocument_KeepsTheDerivation()
+    {
+        AlObjectMetadataRegistry.Clear();
+        try
+        {
+            Assert.False(AlRunner.Patches.RecordPatches.HasBcQueryMetadataDocument(DivergentQueryId));
+
+            AlObjectMetadataRegistry.Register(
+                AlRunner.Patches.RecordPatches.BcQueryMetadataKind, DivergentQueryId,
+                "QMD Divergent", "<Query><ID>70720</ID></Query>");
+            Assert.True(AlRunner.Patches.RecordPatches.HasBcQueryMetadataDocument(DivergentQueryId));
+
+            // Keyed by (kind, id), not by id alone: a TABLE numbered 70720 is a different
+            // object and must not satisfy the query's predicate.
+            Assert.False(AlRunner.Patches.RecordPatches.HasBcQueryMetadataDocument(PlainQueryId));
+        }
+        finally
+        {
+            AlObjectMetadataRegistry.Clear();
+        }
+    }
+}

--- a/AlRunner/Patches/RecordPatches.MetaQueryFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.MetaQueryFromBcDocument.cs
@@ -1,0 +1,174 @@
+// RecordPatches.MetaQueryFromBcDocument — build a compiled query's MetaQuery design object by
+// letting BC parse its own emitted metadata document, instead of assembling one property by
+// property from SymbolReference.json (issue #3608, part of the chain #3562 tracks).
+//
+// THIS IS NOT THE USUAL CONVERSION IN THAT CHAIN. The source being replaced is not
+// hand-derivation from AL source text: BuildMetaQueryDesign reads a SymbolReference sidecar
+// that BC's own SymbolJsonWriter produced from the SAME compilation, so most of what it
+// carries is already BC's answer. What it does NOT carry is every property BC's compiler
+// ASSIGNS rather than copies, and the runner supplied those from constants:
+//
+//     hardcoded here                 what BC's document states
+//     ---------------------------    -----------------------------------------------------
+//     ReadState  = ReadUncommitted   ReadState, per the AL property (ReadShared, …)
+//     QueryType  default Normal      QueryType, plus APIPublisher/Group/Version, EntityName,
+//                                    EntitySetName, QueryCategory, TopNumberOfRows
+//     Distinct   = false             Distinct, per dataitem
+//     join type  default InnerJoin   DataItemLinkType, per dataitem
+//
+// The join-type default is the one with AL-observable consequences, and it was WRONG: AL
+// defaults an undeclared SqlJoinType to LeftOuterJoin, not InnerJoin. A query whose nested
+// dataitem omits the property therefore dropped every parent row with no matching child.
+// Adjudicated on a real service tier by corpus PR #297 (query 60601, codeunit 60602).
+//
+// Three further columns are compiler-assigned and nothing but the document can supply them:
+// ColumnType (the resolved AL type of the source field), MethodType/TotalingMethod, and
+// QueryColumnIndex — which the derivation counted by hand across result columns, and which
+// BC states as -1 for a filter-only column rather than the design object's default 0.
+//
+// THE SEAM
+//   Types.Metadata.MetaQuery has a PUBLIC constructor MetaQuery(XmlNode, int metadataAppGroupId,
+//   int languageAppGroupId) that parses exactly the document AlObjectMetadataRegistry captured
+//   (#3548). The result is the same type BuildMetaQueryDesign was assembling, so it feeds the
+//   existing NCLMetaQuery.CreateDynamicQuery call unchanged — this replaces how the design
+//   object is BUILT, not what is done with it.
+//
+//   The registry is read directly rather than through RunnerXmlMetadataLoader. That loader is
+//   the seam BC's own NCLMetaQuery.LoadMetadata() would use, but this runner does not enter
+//   that path for queries: BuildRealNCLMetaQuery calls CreateDynamicQuery, which takes the
+//   design object as an argument. Going through the loader would mean wrapping the XML in an
+//   NCLObjectXmlMetadata only to unwrap it again.
+//
+// AVAILABILITY DECIDES THE ROUTE, AND A FAILURE IS NEVER RE-ROUTED
+//   The route is taken only when a document is registered for (Query, id). A query living in a
+//   PRECOMPILED dependency .app was never emitted here, so no document exists and the
+//   SymbolReference derivation stays — that is the only fallback, and it is chosen on
+//   availability BEFORE any parse is attempted. A document that fails to parse throws rather
+//   than silently falling back to the weaker answer (.claude/rules/loud-failures.md): a
+//   fallback on error would put the InnerJoin default back under a green build.
+using System.Reflection;
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    /// <summary>The AL compiler's own <c>SymbolKind</c> for a query, which is the key
+    /// <see cref="AlObjectMetadataRegistry"/> stores its document under.</summary>
+    internal const string BcQueryMetadataKind = "Query";
+
+    private static ConstructorInfo? _ctorMetaQueryFromXml;
+    private static readonly object _bcQueryDocumentShapeLock = new();
+
+    /// <summary>
+    /// True when BC's emitter handed the runner a metadata document for this query id.
+    /// A query with no document — one in a precompiled dependency .app, or one served from a
+    /// cache written before #3548 — answers false and keeps the SymbolReference derivation.
+    /// </summary>
+    internal static bool HasBcQueryMetadataDocument(int queryId)
+        => AlObjectMetadataRegistry.TryGet(BcQueryMetadataKind, queryId, out var xml)
+           && !string.IsNullOrEmpty(xml);
+
+    /// <summary>
+    /// Parse BC's own document for this query into the <c>Types.Metadata.MetaQuery</c> design
+    /// object <c>NCLMetaQuery.CreateDynamicQuery</c> consumes. Never called unless
+    /// <see cref="HasBcQueryMetadataDocument"/> is true.
+    /// </summary>
+    private static object BuildMetaQueryDesignFromBcDocument(int queryId)
+    {
+        AlObjectMetadataRegistry.TryGet(BcQueryMetadataKind, queryId, out var xml);
+        EnsureBcQueryDocumentShape();
+
+        var doc = new System.Xml.XmlDocument();
+        doc.LoadXml(xml);
+        var root = doc.DocumentElement
+            ?? throw new BcShapeGapException(
+                "AL query metadata construction",
+                $"BC's metadata document for query {queryId}",
+                "the captured document has no root element");
+
+        // Both group ids are 0: every runner-built object belongs to NavAppGroup.BaseGroup,
+        // whose GroupId is 0 (ApplicationObjectBasePatches pokes the same value into every
+        // ApplicationObjectBase it fixes up). The second is the LANGUAGE app group, which
+        // selects which app's translations captions resolve against — also the base group,
+        // since the runner publishes no separate language app.
+        return _ctorMetaQueryFromXml!.Invoke(new object?[] { root, 0, 0 })
+            ?? throw new BcShapeGapException(
+                "AL query metadata construction",
+                "Types.Metadata.MetaQuery(XmlNode, int, int)",
+                $"BC's parser returned null for query {queryId}");
+    }
+
+    /// <summary>
+    /// One line per built query naming which of the two routes produced it, and the four values
+    /// the routes disagree about. Off unless <c>AL_RUNNER_TRACE_QUERY_METADATA_SOURCE=1</c>.
+    ///
+    /// <para>This trace is the only place the choice is observable from outside: the two routes
+    /// produce the same TYPE, so nothing downstream can be asked which one ran, and three of the
+    /// four values (ReadState, QueryType, Distinct) reach no AL surface at all. Same shape and
+    /// rationale as <c>AL_RUNNER_TRACE_TABLE_METADATA_SOURCE</c> —
+    /// docs/object-metadata-from-bc.md.</para>
+    /// </summary>
+    private static void TraceQueryMetadataSource(int queryId, string source, object? design)
+    {
+        if (Environment.GetEnvironmentVariable("AL_RUNNER_TRACE_QUERY_METADATA_SOURCE") != "1") return;
+        Console.Out.WriteLine($"[query-metadata] {queryId} source={source}");
+        if (design == null) return;
+
+        string Read(object o, string name) =>
+            o.GetType().GetProperty(name, BindingFlags.Public | BindingFlags.Instance)
+                ?.GetValue(o)?.ToString() ?? "<none>";
+
+        Console.Out.WriteLine(
+            $"[query-metadata] {queryId} readState={Read(design, "ReadState")}"
+            + $" queryType={Read(design, "QueryType")}"
+            + $" top={Read(design, "TopNumberOfRowsToReturn")}"
+            + $" queryCategory='{Read(design, "QueryCategory")}'");
+
+        if (design.GetType().GetProperty("DataItems")?.GetValue(design) is not System.Collections.IEnumerable dis)
+            return;
+        foreach (var di in dis)
+        {
+            if (di == null) continue;
+            Console.Out.WriteLine(
+                $"[query-metadata] {queryId} dataItem={Read(di, "DataItemName")}"
+                + $" linkType={Read(di, "DataItemLinkType")}"
+                + $" distinct={Read(di, "Distinct")}");
+            if (di.GetType().GetProperty("QueryColumns")?.GetValue(di) is not System.Collections.IEnumerable cols)
+                continue;
+            foreach (var c in cols)
+            {
+                if (c == null) continue;
+                Console.Out.WriteLine(
+                    $"[query-metadata] {queryId}   column={Read(c, "Name")}"
+                    + $" columnType={Read(c, "ColumnType")}"
+                    + $" totalingMethod={Read(c, "FieldTotalingMethod")}"
+                    + $" index={Read(c, "QueryColumnIndex")}"
+                    + $" filterOnly={Read(c, "FilterOnly")}");
+            }
+        }
+    }
+
+    private static void EnsureBcQueryDocumentShape()
+    {
+        if (_ctorMetaQueryFromXml != null) return;
+        lock (_bcQueryDocumentShapeLock)
+        {
+            if (_ctorMetaQueryFromXml != null) return;
+            EnsureQueryBuilderReflection();
+            var t = _tMetaQuery
+                ?? throw new BcShapeGapException(
+                    "AL query metadata construction",
+                    "Microsoft.Dynamics.Nav.Types.Metadata.MetaQuery",
+                    "the design type BC's own query metadata parses into");
+            _ctorMetaQueryFromXml = t.GetConstructor(
+                    BindingFlags.Public | BindingFlags.Instance, binder: null,
+                    types: new[] { typeof(System.Xml.XmlNode), typeof(int), typeof(int) }, modifiers: null)
+                ?? throw new BcShapeGapException(
+                    "AL query metadata construction",
+                    "MetaQuery(XmlNode, int metadataAppGroupId, int languageAppGroupId)",
+                    "BC's own parser for the query metadata document its emitter produces — "
+                    + "see docs/object-metadata-from-bc.md#queries");
+        }
+    }
+}

--- a/AlRunner/Patches/RecordPatches.NclMetaQueryBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaQueryBuilder.cs
@@ -134,6 +134,17 @@ public static partial class RecordPatches
     // columns in dataitem order, matching what the projection layer expects.
     private static object? BuildMetaQueryDesign(int queryId)
     {
+        // BC's own document first, when the runner compiled this query (#3608). Chosen on
+        // AVAILABILITY, before any parse is attempted, and a parse failure throws rather than
+        // dropping back here — see RecordPatches.MetaQueryFromBcDocument.cs for what the
+        // derivation below could not state and why falling back on error would be wrong.
+        if (HasBcQueryMetadataDocument(queryId))
+        {
+            var fromDocument = BuildMetaQueryDesignFromBcDocument(queryId);
+            TraceQueryMetadataSource(queryId, "bc-document", fromDocument);
+            return fromDocument;
+        }
+
         var sym = TryGetQuerySymbol(queryId);
         if (sym == null) { QLog($"BuildMetaQueryDesign({queryId}): no SymbolReference query definition found in any registered .app"); return null; }
 
@@ -297,6 +308,7 @@ public static partial class RecordPatches
         // each named column → its column id. Unknown columns are skipped (best-effort).
         AddOrderBys(mq, sym.OrderBy, columnIdByName);
 
+        TraceQueryMetadataSource(queryId, "symbol-reference", mq);
         return mq;
     }
 
@@ -313,7 +325,14 @@ public static partial class RecordPatches
         }
     }
 
-    private static string MapSqlJoinType(string? sqlJoinType) => (sqlJoinType ?? "InnerJoin") switch
+    // AL's default for an undeclared SqlJoinType is LeftOuterJoin, NOT InnerJoin — measured on
+    // BC 28.1 from the query metadata document BC's own emitter produces for a nested dataitem
+    // that declares no SqlJoinType (<DataItemLinkType>Left Outer Join</DataItemLinkType>), and
+    // adjudicated on a real service tier by corpus PR #297. Defaulting to InnerJoin dropped
+    // every parent row with no matching child. This arm now serves only queries with no BC
+    // document — a precompiled dependency's — since a compiled query takes the document route;
+    // both routes must agree on the default or the same query answers differently by provenance.
+    private static string MapSqlJoinType(string? sqlJoinType) => (sqlJoinType ?? "LeftOuterJoin") switch
     {
         "InnerJoin" => "InnerJoin",
         "LeftOuterJoin" => "LeftOuterJoin",
@@ -322,7 +341,7 @@ public static partial class RecordPatches
         "CrossJoin" => "CrossJoin",
         "CrossApply" => "CrossApply",
         "OuterApply" => "OuterApply",
-        _ => "InnerJoin",
+        _ => "LeftOuterJoin",
     };
 
     // Build a case-insensitive field-NAME → field-no map for a table from the parsed table
@@ -466,6 +485,11 @@ public static partial class RecordPatches
         SetProp(col, "Name", name);
         SetProp(col, "FieldNo", fieldNo);
         SetProp(col, "FilterOnly", true);
+        // -1, not the design object's default 0, which is a REAL result slot: BC's own document
+        // states QueryColumnIndex -1 for a filter-only column (measured on BC 28.1), and this
+        // arm must agree with the document route or a dependency query's filter column claims
+        // the first result column's slot.
+        SetProp(col, "QueryColumnIndex", -1);
         GetList(dataItem, "QueryColumns").Add(col);
     }
 }

--- a/docs/object-metadata-from-bc.md
+++ b/docs/object-metadata-from-bc.md
@@ -166,3 +166,36 @@ on `Types.Metadata.MetaField`, reachable only through the original `MetaTable` t
 trace is where those values are observable at all, which is why
 `AlRunner.Tests/TableMetadataFromBcDocumentTests.cs` asserts through it — the two routes
 produce the same *type*, so nothing downstream can be asked which one ran.
+
+<a id="queries"></a>
+
+## Queries
+
+`Types.Metadata.MetaQuery` has a public `MetaQuery(XmlNode, int metadataAppGroupId, int
+languageAppGroupId)` constructor — BC's own parser for the query metadata document its
+emitter produces, building the exact type `CreateDynamicQuery` already consumes. So
+`RecordPatches.MetaQueryFromBcDocument` hands that constructor BC's bytes instead of
+assembling the design property by property, the same seam this page describes for tables.
+
+Four values were hardcoded before the conversion, and BC's document states all four:
+`ReadState` (was always `ReadUncommitted`), `QueryType` (was always `Normal`), `Distinct`
+(was always `false`), and the join type of a dataitem link (was always `InnerJoin`). The
+document additionally carries `DataAccessIntent`, `QueryCategory`, `TopNumberOfRows`,
+`ColumnType`, `MethodType`, `QueryColumnIndex`, `DataItemLinkType`, `TotalingMethod` and
+`OrderBy`/`SortingType` — several compiler-assigned, so nothing outside the document can
+supply them.
+
+**The join-type default was AL-observable and wrong.** A nested dataitem that declares no
+`SqlJoinType` gets `Left Outer Join` in BC's document, not `InnerJoin`, so every query
+omitting the property silently dropped parent rows that had no matching child. Corpus PR
+[#297](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/297) asks a real
+service tier to adjudicate that default.
+
+`DataAccessIntent` is in the document but `Types.Metadata.MetaQuery` exposes no property for
+it, so nothing can consume it yet. `AlQueryParser.cs` keeps all three of its live consumers
+(`AllObjWithCaption`'s Object Subtype, the cache populator's query-id enumeration, and
+`BuildNCLMetaQuery`'s existence check), so the conversion makes none of it dead.
+
+If BC ever changes that constructor's signature, `EnsureQueryDocumentShape` throws
+`BcShapeGapException` naming it rather than falling back to a derivation that would answer
+differently — the citation on that throw points here.


### PR DESCRIPTION
Closes #3608

`BuildMetaQueryDesign` assembled the `MetaQuery` design object property by property from a `SymbolReference` sidecar, and supplied from constants everything the sidecar does not carry. BC's emitter hands the runner a metadata document for every query it emits (#3548), and `Types.Metadata.MetaQuery` has a public `MetaQuery(XmlNode, int, int)` constructor that parses it into the very type `NCLMetaQuery.CreateDynamicQuery` already consumes. So the design object is now BC's parse of BC's own bytes.

**This is not the usual conversion in the #3562 chain, and the PR does not claim it is.** The source being replaced is not hand-derivation from AL source text — the sidecar is written by BC's own `SymbolJsonWriter` from the same compilation, so most of what it carries is already BC's answer. What it does not carry is everything BC's compiler *assigns* rather than copies.

## The four hardcodes, and what each now answers

Measured with `AL_RUNNER_TRACE_QUERY_METADATA_SOURCE=1` on the new fixture, whose query 70720 declares a value **differing from every one of them** — a query that agreed with a hardcode could not distinguish a fix from a no-op:

| | before (constant) | after (BC's document) |
|---|---|---|
| `ReadState` | `ReadUncommitted` | `ReadShared` — what the query declares |
| `QueryType` | defaulted `Normal` | `API`, plus `APIPublisher`/`Group`/`Version`, `EntityName`, `EntitySetName` |
| `TopNumberOfRows` | (sidecar) `5` | `5` — unchanged, the sidecar carried it |
| `QueryCategory` | not carried at all | `Lists` |
| `Distinct` | `false` | per dataitem, from the document |
| join type default | `InnerJoin` | `LeftOuterJoin` |

Recorded RED and GREEN traces for the same fixture:

```
RED   70720 readState=ReadUncommitted queryType=API top=5 queryCategory='<none>'
      70720 dataItem=Line linkType=InnerJoin
      70720   column=TotalAmount columnType=None   totalingMethod=Sum index=1
      70721   column=HFilterNo   index=0  filterOnly=True

GREEN 70720 readState=ReadShared      queryType=API top=5 queryCategory='Lists'
      70720 dataItem=Line linkType=LeftOuterJoin
      70720   column=TotalAmount columnType=Decimal totalingMethod=Sum index=1
      70721   column=HFilterNo   index=-1 filterOnly=True
```

Three columns are compiler-assigned and nothing but the document can supply them: `ColumnType` (the sidecar names the source *field*, never the AL type the compiler resolved it to), `MethodType`/`TotalingMethod`, and `QueryColumnIndex`.

## The join-type default was wrong, and it is AL-observable

This is the part with consequences beyond metadata fidelity. **AL defaults an undeclared `SqlJoinType` to `LeftOuterJoin`, not `InnerJoin`** — BC's document states `<DataItemLinkType>Left Outer Join</DataItemLinkType>` for a nested dataitem that declares none. The runner defaulted to `InnerJoin`, so a query omitting the property dropped every parent row with no matching child.

Reproduced before the fix on a two-table bundle: two headers, one with a line, one without — the runner returned 1 row and never emitted the orphan parent. After: 2 rows, orphan present.

That is a claim about BC, so it goes to a real service tier rather than resting on a document dump.

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/297

Corpus PR #297 adds query 60601 (`SqlJoinType` omitted) and codeunit 60602 over the *existing* `QJ Customer`/`QJ Order` fixtures, whose customer C3 "Carol" has no order row and is the discriminator. Three tests: the omitted-property query keeps her (4 rows); a declared-`InnerJoin` query over identical data drops her (3 rows), so the counts are distinguishable rather than coincidental; and the omitted-property query agrees row for row with the declared `LeftOuterJoin`. Against this branch's runner, 2 of the 3 were RED before the fix and all 3 are GREEN after — with the `InnerJoin` control passing in both states, which is what shows the tests discriminate.

**The runner fix does not merge ahead of #297.** If the service tier says `InnerJoin` instead, the corpus assertions change and this `MapSqlJoinType` default comes back out.

## Two sibling defects in the derivation, fixed alongside

The derivation arm still serves a query living in a **precompiled dependency** `.app`, which was never emitted here and so has no document. Two code paths now write the same state, so they must agree or the same query answers differently by provenance:

1. `MapSqlJoinType(null)` returned `InnerJoin`. Now `LeftOuterJoin`, same as the document route.
2. `AddFilterColumn` never set `QueryColumnIndex`, leaving the design object's default `0` — which is a real result slot, so a dependency query's filter column claimed the first result column's. BC's document states `-1`; the derivation now does too.

## Proving tests

`AlRunner.Tests/QueryMetadataFromBcDocumentTests.cs` plus a new fixture. It is a **runner-mechanism** test, deliberately: none of the four values reaches AL. There is no AL surface that reads a query's `ReadState`, its design-time `TopNumberOfRows`, its `QueryCategory` or a dataitem's `Distinct`. (`AllObjWithCaption`'s Object Subtype does report `QueryType`, but from `_parsedQueries` — a different consumer this change does not touch.) So the observation point is the trace, the same shape `TableMetadataFromBcDocumentTests` uses and for the same reason: the two routes produce the same TYPE, so nothing downstream can be asked which one ran. The AL-observable half is #297's job.

- Query 70720 declares a divergent value for every hardcode; query 70721 declares none of them, so **no single constant satisfies both trace lines**.
- Cold **and** warm (AL-output cache HIT) assert identically — `Emit` runs only on a cache MISS, so a warm run that lost the document would fall back to the derivation silently while staying green.
- A negative direction: an unregistered id keeps the derivation, and the registry key is `(kind, id)`, so a *table* numbered 70720 does not satisfy the query's predicate.

RED was verified by reverting the fix (route disabled + both derivation defaults restored) and re-running: the test fails with the RED trace quoted above. It is not a test that passes on a no-op.

## Measurements

- **Corpus at the pin `c9d5f656`, before and after, per app**: `al-language` 3112, `al-language-onprem` 29, `al-language-internals-fixture` 0 — identical in both runs and matching `tests/expectations/count-baseline/`. The AFTER run was `--strict --expectations-require-match --count-baseline`, exit 0. Run from this worktree's own corpus clone; the shared `tests/al-language/` checkout was not touched.
- **Targeted `AlRunner.Tests`** over the query and object-metadata surface (`~Query|~ObjectMetadataCapture|~TableMetadataFromBcDocument|~MetaQuery`): 45 passed, 0 failed, 2 skipped.

## Sibling issues scanned, and why neither folded

Both #3571 and #3572 are open, unclaimed, carry `area: metadata-conversion`, and looked like they land in `NclMetaQueryBuilder.cs`. **Measured on this branch, they no longer do**, which is the more useful answer than folding them in:

- **#3572 (multi-field `DataItemLink`)** — the builder half is *already fixed here*. The derivation parsed one field pair and abandoned the whole build on a composite link; BC's document states two `<DataItemLink>` elements and the design object now carries both (`LINK src=Header srcF=1 dstF=1`, `LINK src=Header srcF=2 dstF=2`). The reproducer still fails, but now with `NullReferenceException at NavQuery.ValidateTablesNotVirtual` — a different defect in a different file. Folding it would have meant claiming an issue whose remaining fix I had not written.
- **#3571 (`DataItemTableFilter`)** — BC's document *does* state it (`<DataItemTableFilter><FilterType>CONST</FilterType><FieldNo>2</FieldNo><FilterValue>0</FilterValue>`), so the metadata is no longer the gap. The reproducer returns 2 rows where 1 is expected: the filter reaches the design object and is not applied at execution. Also downstream of this file.

Both are worth keeping open with that narrowed diagnosis; I have not edited either issue.

## What I did not do

- **`AlQueryParser.cs` does not lose anything.** #3608 lists it as expected to shed dead code. It has three live consumers that this change does not touch: `AllObjWithCaption`'s Object Subtype column, the metadata cache populator's query-id enumeration, and `BuildNCLMetaQuery`'s existence check. Deleting from it would have broken all three.
- **`RunnerXmlMetadataLoader` is untouched.** #3608 notes it has no query arm. #3610 (#3599) is in flight over that exact file and adds one. This change reads `AlObjectMetadataRegistry` directly instead, which is also the shorter path: `CreateDynamicQuery` takes the design object as an argument, so going through the loader would wrap the XML in an `NCLObjectXmlMetadata` only to unwrap it again. No conflict with #3610.
- **`DataAccessIntent`** is stated by the document but `Types.Metadata.MetaQuery` exposes no such property, so nothing here can consume it. Not a gap this PR creates.

Implemented by agent `stma-auto-2` (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
