### PR TITLE
feat(codeunit-metadata): answer four CodeUnit Metadata columns from BC's own document instead of defaulting them

### DIFF
--- a/AlRunner.Tests/CodeunitMetadataDocumentColumnTests.cs
+++ b/AlRunner.Tests/CodeunitMetadataDocumentColumnTests.cs
@@ -1,0 +1,262 @@
+// CodeunitMetadataDocumentColumnTests — how four CodeUnit Metadata (2000000137) columns are
+// read out of BC's own emitted metadata document, and what happens to a document that states
+// something the runner cannot spell (#3606).
+//
+// WHY THIS IS A RUNNER-SIDE MECHANISM TEST AND NOT (ONLY) AN AL BUNDLE
+// -------------------------------------------------------------------
+// The BC-behaviour claims are upstream, in corpus PR 296 — a TestRunner reporting each
+// declared TestIsolation, a Subtype = Test codeunit reporting None where an ordinary one
+// reports Disabled, an X-declaring codeunit reporting 'X' while its sibling column stays
+// empty, and a namespaced codeunit reporting its full dotted namespace. Nothing here restates
+// them; the same four assertions run there against eight real service tiers.
+//
+// What this file pins is what no AL assertion can reach. An AL test observes only the
+// documents the AL compiler chose to emit for the bundle it ran on, so it cannot present:
+//
+//   * a TestIsolation value the column's own option string does not name — AL0223 stops the
+//     property on anything but a TestRunner, and the compiler writes only members the column
+//     has, so the refusal path has no AL spelling at all;
+//   * a permission mask other than X — AL0195 rejects every other kind on a codeunit, so the
+//     R/I/M/D letters and the lowercase indirect half are unreachable from AL even though the
+//     same two columns exist on Table and Page Metadata where the mask is not restricted;
+//   * a malformed document, which is a BC emitter shape change rather than anything AL can
+//     declare;
+//   * an ABSENT ALNamespace attribute as distinct from one stated as the empty string. BC
+//     emits ALNamespace="" for an un-namespaced object, so the two are the same answer on any
+//     real bundle and a test written against one cannot tell which the runner read.
+//
+// The permission spelling asserted below is BC's own, read out of Ncl.dll:
+// MetadataDataProvider.permissions decodes to R,I,M,D,X and CreatePermissionMaskString
+// lowercases the letter for the indirect bit at n+5. See
+// AlRunner/Patches/RecordPatches.CodeunitMetadataFromBcDocument.cs.
+
+using System.Collections.Generic;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class CodeunitMetadataDocumentColumnTests
+{
+    // BC 28.1.49838.53910's own OptionMembers for the RequiredTestIsolation column, read out
+    // of System.app's CodeUnitMetadata.Table.al. Matches Types.TestCodeunitRequiredTestIsolation
+    // member for member, unlike the SubType column beside it — see
+    // MetadataOptionColumnOrdinalTests for that contrast.
+    private const string RealIsolationOptions = "None,Disabled,Codeunit,Function";
+
+    private static Dictionary<string, int> IsolationMap(string optionString = RealIsolationOptions)
+        => RecordPatches.BuildMetadataOptionOrdinals(optionString, bcRuntimeEnum: null);
+
+    /// <summary>A document with exactly the attributes named, in BC's own emitted shape.</summary>
+    private static string Document(string attributes) =>
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+        + $"<CodeUnit MetadataVersion=\"130000\" ID=\"60963\" Name=\"ALT Codeunit Meta Probe\" {attributes} "
+        + "EventSubscriberInstance=\"StaticAutomatic\" SingleInstance=\"0\" "
+        + "xmlns=\"urn:schemas-microsoft-com:dynamics:NAV:MetaObjects\" />";
+
+    private static RecordPatches.BcCodeunitDocumentValues Parse(
+        string attributes, string optionString = RealIsolationOptions)
+        => RecordPatches.ParseCodeunitMetadataDocument(
+            Document(attributes), codeunitId: 60963, IsolationMap(optionString));
+
+    // ── RequiredTestIsolation: the ordinal comes from the COLUMN, not from a constant ──────
+
+    [Fact]
+    public void EachDeclaredTestIsolation_ResolvesItsOwnMemberOrdinal()
+    {
+        // The compiler writes the member name; the ordinal has to come from the column's own
+        // option string. Asserting all three, and that they differ, is what a resolver
+        // answering one constant cannot satisfy.
+        Assert.Equal(1, Parse("TestIsolation=\"Disabled\"").RequiredTestIsolationOrdinal);
+        Assert.Equal(2, Parse("TestIsolation=\"Codeunit\"").RequiredTestIsolationOrdinal);
+        Assert.Equal(3, Parse("TestIsolation=\"Function\"").RequiredTestIsolationOrdinal);
+    }
+
+    [Fact]
+    public void DeclaredTestIsolation_IsLookedUpByName_NotByPosition()
+    {
+        // On the real column Disabled sits at 1, so "resolved the Disabled member" and
+        // "returned 1" are indistinguishable there. Reordered they are not — and no artifact
+        // can present a reordered column, which is why this case only exists here.
+        const string Reordered = "Function,None,Codeunit,Disabled";
+        Assert.Equal(3, Parse("TestIsolation=\"Disabled\"", Reordered).RequiredTestIsolationOrdinal);
+        Assert.Equal(0, Parse("TestIsolation=\"Function\"", Reordered).RequiredTestIsolationOrdinal);
+    }
+
+    [Fact]
+    public void AbsentTestIsolation_IsLeftToBcsDefault_NotMappedOntoAMember()
+    {
+        // -1 is this parse's "the document states nothing this column can carry", and the row
+        // builder turns it into NavValue.GetDefaultNavValue. It is NOT 0: answering 0 here
+        // would be the runner deciding the column's value rather than leaving it to BC, and
+        // the two are indistinguishable downstream on a column whose default happens to be 0.
+        Assert.Equal(-1, Parse("").RequiredTestIsolationOrdinal);
+        Assert.Equal(-1, Parse("TestIsolation=\"\"").RequiredTestIsolationOrdinal);
+
+        // The absent case is the Subtype = Test one — the compiler omits the attribute for a
+        // test codeunit and supplies Disabled for everything else — so this is the branch
+        // 32 of Base Application's 1,690 codeunit documents take.
+        Assert.NotEqual(
+            Parse("TestIsolation=\"Disabled\"").RequiredTestIsolationOrdinal,
+            Parse("").RequiredTestIsolationOrdinal);
+    }
+
+    [Fact]
+    public void TestIsolationTheColumnDoesNotName_IsRefused_NotDefaulted()
+    {
+        // A member the column has no ordinal for is refused rather than silently written as 0,
+        // which would read exactly like a codeunit that declares nothing. Same rule
+        // ResolveCodeunitSubtypeOrdinal applies to SubType (#3080).
+        //
+        // Unreachable from AL: the compiler only ever writes members this column names. It
+        // becomes reachable the day BC adds an isolation mode, and then the runner says so
+        // instead of quietly answering None.
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
+            () => Parse("TestIsolation=\"PerTest\""));
+        Assert.Contains("PerTest", ex.Message);
+        Assert.Contains("60963", ex.Message);
+    }
+
+    [Fact]
+    public void NoIsolationOrdinalsAvailable_LeavesTheColumnToBcsDefault_RatherThanThrowing()
+    {
+        // An artifact whose CodeUnit Metadata has no RequiredTestIsolation column at all: the
+        // value has nowhere to go, and the other three columns are still answerable. Refusing
+        // here would cost the whole row for a column that does not exist.
+        var parsed = RecordPatches.ParseCodeunitMetadataDocument(
+            Document("TestIsolation=\"Codeunit\" ALNamespace=\"A.B\""), 60963, isolationOrdinals: null);
+        Assert.Equal(-1, parsed.RequiredTestIsolationOrdinal);
+        Assert.Equal("A.B", parsed.AlNamespace);
+    }
+
+    // ── The two permission columns: BC's own spelling, and they never bleed into each other ──
+
+    [Fact]
+    public void ExecuteMask_SpellsX_AndTheColumnTheCodeunitDidNotDeclareStaysEmpty()
+    {
+        // 16 is PermissionMask.Execute, the only kind AL accepts on a codeunit (AL0195), and
+        // the only value observed on Base Application. The empty sibling is the half that
+        // proves the two attributes are read independently rather than one being echoed.
+        var permOnly = Parse("InherentPermissions=\"16\"");
+        Assert.Equal("X", permOnly.InherentPermissions);
+        Assert.Equal("", permOnly.InherentEntitlements);
+
+        var entOnly = Parse("InherentEntitlements=\"16\"");
+        Assert.Equal("X", entOnly.InherentEntitlements);
+        Assert.Equal("", entOnly.InherentPermissions);
+    }
+
+    [Fact]
+    public void EveryDirectPermissionBit_GetsItsOwnLetter_InBcsOwnOrder()
+    {
+        // R,I,M,D,X at bits 0..4 — MetadataDataProvider.permissions, decoded from Ncl.dll.
+        // Unreachable from AL on a codeunit, and the reason to pin it anyway is that the same
+        // two columns exist on Table and Page Metadata, where the mask is not restricted: a
+        // half-implementation here is what the next conversion would copy.
+        Assert.Equal("R", Parse("InherentPermissions=\"1\"").InherentPermissions);
+        Assert.Equal("I", Parse("InherentPermissions=\"2\"").InherentPermissions);
+        Assert.Equal("M", Parse("InherentPermissions=\"4\"").InherentPermissions);
+        Assert.Equal("D", Parse("InherentPermissions=\"8\"").InherentPermissions);
+        Assert.Equal("X", Parse("InherentPermissions=\"16\"").InherentPermissions);
+
+        // Combined, in bit order and not in the order the bits were set.
+        Assert.Equal("RIMD", Parse("InherentPermissions=\"15\"").InherentPermissions);
+        Assert.Equal("RIMDX", Parse("InherentPermissions=\"31\"").InherentPermissions);
+    }
+
+    [Fact]
+    public void IndirectPermissionBits_LowercaseTheirLetter_AndTheDirectBitWins()
+    {
+        // Bits 5..9 are the indirect half; BC emits permissions[n] + 32, the lowercase letter.
+        Assert.Equal("r", Parse("InherentPermissions=\"32\"").InherentPermissions);
+        Assert.Equal("x", Parse("InherentPermissions=\"512\"").InherentPermissions);
+        Assert.Equal("ri", Parse("InherentPermissions=\"96\"").InherentPermissions);
+
+        // With both bits set for one permission, the direct one is the answer — one character
+        // per permission, never two. BC reaches the same result by sizing its buffer with
+        // PopCount((num >> 5) | (num & 0x1F)), which cannot hold both either.
+        Assert.Equal("R", Parse("InherentPermissions=\"33\"").InherentPermissions);
+        Assert.Equal("Ri", Parse("InherentPermissions=\"65\"").InherentPermissions);
+    }
+
+    [Fact]
+    public void NoMask_AndAnExplicitZeroMask_BothSpellTheEmptyString()
+    {
+        // PermissionMask.None is NavText.Empty in BC's own CreatePermissionMaskString, and an
+        // absent attribute is the same answer — which is correct, because a codeunit declaring
+        // no permission and one declaring an empty mask are the same codeunit.
+        Assert.Equal("", Parse("").InherentPermissions);
+        Assert.Equal("", Parse("InherentPermissions=\"0\"").InherentPermissions);
+        Assert.Equal("", Parse("InherentPermissions=\"None\"").InherentPermissions);
+    }
+
+    [Fact]
+    public void MemberNameSpelledMask_IsAcceptedAlongsideTheNumericOne()
+    {
+        // BC's own MetaCodeunit ctor parses this attribute with Enum.Parse(PermissionMask, …),
+        // which takes both a numeric string and a member name. The compiler writes the number,
+        // so the name form is unreachable from AL — accepted here because BC accepts it.
+        Assert.Equal("X", Parse("InherentPermissions=\"Execute\"").InherentPermissions);
+        Assert.Equal("RI", Parse("InherentPermissions=\"Read, Insert\"").InherentPermissions);
+        Assert.Equal("r", Parse("InherentPermissions=\"IndirectRead\"").InherentPermissions);
+    }
+
+    [Fact]
+    public void MaskTheRunnerCannotSpell_IsRefused_NotAnsweredAsEmpty()
+    {
+        // An empty answer would be indistinguishable from a codeunit declaring no permission,
+        // so a mask that is neither numeric nor a name this file knows is refused instead.
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
+            () => Parse("InherentPermissions=\"Superuser\""));
+        Assert.Contains("Superuser", ex.Message);
+        Assert.Contains("InherentPermissions", ex.Message);
+    }
+
+    // ── AL Namespace: stated-empty and absent are the same answer, and that is deliberate ──
+
+    [Fact]
+    public void StatedNamespace_IsReportedInFull_NotOneSegmentOfIt()
+    {
+        Assert.Equal(
+            "ALLanguage.Coverage.MetadataProbes",
+            Parse("ALNamespace=\"ALLanguage.Coverage.MetadataProbes\"").AlNamespace);
+    }
+
+    [Fact]
+    public void AbsentAndStatedEmptyNamespace_BothAnswerTheEmptyString()
+    {
+        // BC emits ALNamespace="" for an object whose file states no namespace, so on any real
+        // bundle the two are the same case and no AL test can separate them. Pinned here
+        // because the runner must not treat an absent attribute as a reason to answer
+        // something other than empty.
+        Assert.Equal("", Parse("ALNamespace=\"\"").AlNamespace);
+        Assert.Equal("", Parse("").AlNamespace);
+    }
+
+    // ── A document that is not a document ───────────────────────────────────────────────────
+
+    [Fact]
+    public void MalformedDocument_IsRefused_RatherThanFallingBackToTheOldDefaults()
+    {
+        // A registered but unparseable document means BC's emitter changed shape. Answering
+        // the pre-#3606 defaults would hide that behind a green run, which is what
+        // .claude/rules/loud-failures.md exists to prevent.
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
+            () => RecordPatches.ParseCodeunitMetadataDocument(
+                "<CodeUnit ID=\"60963\"", codeunitId: 60963, IsolationMap()));
+        Assert.Contains("60963", ex.Message);
+        Assert.Contains("well-formed", ex.Message);
+    }
+
+    [Fact]
+    public void UnregisteredCodeunit_ReadsAsNoDocument_RatherThanAnEmptyOne()
+    {
+        // Every codeunit in a precompiled dependency takes this branch: the .app ships no
+        // metadata XML, so there is nothing to read and the four columns keep BC's defaults.
+        // null and a document whose four attributes are all absent are different states — the
+        // second is a document that says the values are empty, the first is no answer at all.
+        Assert.Null(RecordPatches.TryReadCodeunitMetadataDocument(
+            codeunitId: 2147483600, IsolationMap()));
+    }
+}

--- a/AlRunner.Tests/CodeunitMetadataDocumentColumnTests.cs
+++ b/AlRunner.Tests/CodeunitMetadataDocumentColumnTests.cs
@@ -1,21 +1,16 @@
-// CodeunitMetadataDocumentColumnTests — how four CodeUnit Metadata (2000000137) columns are
+// CodeunitMetadataDocumentColumnTests — how three CodeUnit Metadata (2000000137) columns are
 // read out of BC's own emitted metadata document, and what happens to a document that states
 // something the runner cannot spell (#3606).
 //
 // WHY THIS IS A RUNNER-SIDE MECHANISM TEST AND NOT (ONLY) AN AL BUNDLE
 // -------------------------------------------------------------------
-// The BC-behaviour claims are upstream, in corpus PR 296 — a TestRunner reporting each
-// declared TestIsolation, a Subtype = Test codeunit reporting None where an ordinary one
-// reports Disabled, an X-declaring codeunit reporting 'X' while its sibling column stays
-// empty, and a namespaced codeunit reporting its full dotted namespace. Nothing here restates
-// them; the same four assertions run there against eight real service tiers.
+// The BC-behaviour claims are upstream, in corpus PR 296 — an X-declaring codeunit reporting
+// 'X' while its sibling column stays empty, and a namespaced codeunit reporting its full
+// dotted namespace. Both are green on eight real service tiers. Nothing here restates them.
 //
 // What this file pins is what no AL assertion can reach. An AL test observes only the
 // documents the AL compiler chose to emit for the bundle it ran on, so it cannot present:
 //
-//   * a TestIsolation value the column's own option string does not name — AL0223 stops the
-//     property on anything but a TestRunner, and the compiler writes only members the column
-//     has, so the refusal path has no AL spelling at all;
 //   * a permission mask other than X — AL0195 rejects every other kind on a codeunit, so the
 //     R/I/M/D letters and the lowercase indirect half are unreachable from AL even though the
 //     same two columns exist on Table and Page Metadata where the mask is not restricted;
@@ -25,12 +20,21 @@
 //     emits ALNamespace="" for an un-namespaced object, so the two are the same answer on any
 //     real bundle and a test written against one cannot tell which the runner read.
 //
+// NO RequiredTestIsolation HERE, AND THAT IS THE POINT
+// ---------------------------------------------------
+// An earlier draft of this file read that column out of the document's TestIsolation
+// attribute and pinned the mapping. Corpus PR 296 put the claim in front of eight cloud legs
+// and every one refuted it: a real tier answers None for EVERY codeunit, including one
+// declaring TestIsolation = Disabled. The conversion and its tests were removed rather than
+// adjusted, and the column went back to BC's own default, which is the faithful answer.
+// docs/codeunit-metadata-from-bc.md#requiredtestisolation has the tier evidence and the
+// mechanism in Ncl.dll.
+//
 // The permission spelling asserted below is BC's own, read out of Ncl.dll:
 // MetadataDataProvider.permissions decodes to R,I,M,D,X and CreatePermissionMaskString
 // lowercases the letter for the indirect bit at n+5. See
 // AlRunner/Patches/RecordPatches.CodeunitMetadataFromBcDocument.cs.
 
-using System.Collections.Generic;
 using AlRunner.Infrastructure;
 using AlRunner.Patches;
 using Xunit;
@@ -39,15 +43,6 @@ namespace AlRunner.Tests;
 
 public sealed class CodeunitMetadataDocumentColumnTests
 {
-    // BC 28.1.49838.53910's own OptionMembers for the RequiredTestIsolation column, read out
-    // of System.app's CodeUnitMetadata.Table.al. Matches Types.TestCodeunitRequiredTestIsolation
-    // member for member, unlike the SubType column beside it — see
-    // MetadataOptionColumnOrdinalTests for that contrast.
-    private const string RealIsolationOptions = "None,Disabled,Codeunit,Function";
-
-    private static Dictionary<string, int> IsolationMap(string optionString = RealIsolationOptions)
-        => RecordPatches.BuildMetadataOptionOrdinals(optionString, bcRuntimeEnum: null);
-
     /// <summary>A document with exactly the attributes named, in BC's own emitted shape.</summary>
     private static string Document(string attributes) =>
         "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
@@ -55,80 +50,8 @@ public sealed class CodeunitMetadataDocumentColumnTests
         + "EventSubscriberInstance=\"StaticAutomatic\" SingleInstance=\"0\" "
         + "xmlns=\"urn:schemas-microsoft-com:dynamics:NAV:MetaObjects\" />";
 
-    private static RecordPatches.BcCodeunitDocumentValues Parse(
-        string attributes, string optionString = RealIsolationOptions)
-        => RecordPatches.ParseCodeunitMetadataDocument(
-            Document(attributes), codeunitId: 60963, IsolationMap(optionString));
-
-    // ── RequiredTestIsolation: the ordinal comes from the COLUMN, not from a constant ──────
-
-    [Fact]
-    public void EachDeclaredTestIsolation_ResolvesItsOwnMemberOrdinal()
-    {
-        // The compiler writes the member name; the ordinal has to come from the column's own
-        // option string. Asserting all three, and that they differ, is what a resolver
-        // answering one constant cannot satisfy.
-        Assert.Equal(1, Parse("TestIsolation=\"Disabled\"").RequiredTestIsolationOrdinal);
-        Assert.Equal(2, Parse("TestIsolation=\"Codeunit\"").RequiredTestIsolationOrdinal);
-        Assert.Equal(3, Parse("TestIsolation=\"Function\"").RequiredTestIsolationOrdinal);
-    }
-
-    [Fact]
-    public void DeclaredTestIsolation_IsLookedUpByName_NotByPosition()
-    {
-        // On the real column Disabled sits at 1, so "resolved the Disabled member" and
-        // "returned 1" are indistinguishable there. Reordered they are not — and no artifact
-        // can present a reordered column, which is why this case only exists here.
-        const string Reordered = "Function,None,Codeunit,Disabled";
-        Assert.Equal(3, Parse("TestIsolation=\"Disabled\"", Reordered).RequiredTestIsolationOrdinal);
-        Assert.Equal(0, Parse("TestIsolation=\"Function\"", Reordered).RequiredTestIsolationOrdinal);
-    }
-
-    [Fact]
-    public void AbsentTestIsolation_IsLeftToBcsDefault_NotMappedOntoAMember()
-    {
-        // -1 is this parse's "the document states nothing this column can carry", and the row
-        // builder turns it into NavValue.GetDefaultNavValue. It is NOT 0: answering 0 here
-        // would be the runner deciding the column's value rather than leaving it to BC, and
-        // the two are indistinguishable downstream on a column whose default happens to be 0.
-        Assert.Equal(-1, Parse("").RequiredTestIsolationOrdinal);
-        Assert.Equal(-1, Parse("TestIsolation=\"\"").RequiredTestIsolationOrdinal);
-
-        // The absent case is the Subtype = Test one — the compiler omits the attribute for a
-        // test codeunit and supplies Disabled for everything else — so this is the branch
-        // 32 of Base Application's 1,690 codeunit documents take.
-        Assert.NotEqual(
-            Parse("TestIsolation=\"Disabled\"").RequiredTestIsolationOrdinal,
-            Parse("").RequiredTestIsolationOrdinal);
-    }
-
-    [Fact]
-    public void TestIsolationTheColumnDoesNotName_IsRefused_NotDefaulted()
-    {
-        // A member the column has no ordinal for is refused rather than silently written as 0,
-        // which would read exactly like a codeunit that declares nothing. Same rule
-        // ResolveCodeunitSubtypeOrdinal applies to SubType (#3080).
-        //
-        // Unreachable from AL: the compiler only ever writes members this column names. It
-        // becomes reachable the day BC adds an isolation mode, and then the runner says so
-        // instead of quietly answering None.
-        var ex = Assert.Throws<RunnerOutOfScopeException>(
-            () => Parse("TestIsolation=\"PerTest\""));
-        Assert.Contains("PerTest", ex.Message);
-        Assert.Contains("60963", ex.Message);
-    }
-
-    [Fact]
-    public void NoIsolationOrdinalsAvailable_LeavesTheColumnToBcsDefault_RatherThanThrowing()
-    {
-        // An artifact whose CodeUnit Metadata has no RequiredTestIsolation column at all: the
-        // value has nowhere to go, and the other three columns are still answerable. Refusing
-        // here would cost the whole row for a column that does not exist.
-        var parsed = RecordPatches.ParseCodeunitMetadataDocument(
-            Document("TestIsolation=\"Codeunit\" ALNamespace=\"A.B\""), 60963, isolationOrdinals: null);
-        Assert.Equal(-1, parsed.RequiredTestIsolationOrdinal);
-        Assert.Equal("A.B", parsed.AlNamespace);
-    }
+    private static RecordPatches.BcCodeunitDocumentValues Parse(string attributes)
+        => RecordPatches.ParseCodeunitMetadataDocument(Document(attributes), codeunitId: 60963);
 
     // ── The two permission columns: BC's own spelling, and they never bleed into each other ──
 
@@ -244,7 +167,7 @@ public sealed class CodeunitMetadataDocumentColumnTests
         // .claude/rules/loud-failures.md exists to prevent.
         var ex = Assert.Throws<RunnerOutOfScopeException>(
             () => RecordPatches.ParseCodeunitMetadataDocument(
-                "<CodeUnit ID=\"60963\"", codeunitId: 60963, IsolationMap()));
+                "<CodeUnit ID=\"60963\"", codeunitId: 60963));
         Assert.Contains("60963", ex.Message);
         Assert.Contains("well-formed", ex.Message);
     }
@@ -253,10 +176,9 @@ public sealed class CodeunitMetadataDocumentColumnTests
     public void UnregisteredCodeunit_ReadsAsNoDocument_RatherThanAnEmptyOne()
     {
         // Every codeunit in a precompiled dependency takes this branch: the .app ships no
-        // metadata XML, so there is nothing to read and the four columns keep BC's defaults.
-        // null and a document whose four attributes are all absent are different states — the
+        // metadata XML, so there is nothing to read and the three columns keep BC's defaults.
+        // null and a document whose three attributes are all absent are different states — the
         // second is a document that says the values are empty, the first is no answer at all.
-        Assert.Null(RecordPatches.TryReadCodeunitMetadataDocument(
-            codeunitId: 2147483600, IsolationMap()));
+        Assert.Null(RecordPatches.TryReadCodeunitMetadataDocument(codeunitId: 2147483600));
     }
 }

--- a/AlRunner/Patches/RecordPatches.CodeunitMetadataFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.CodeunitMetadataFromBcDocument.cs
@@ -1,11 +1,11 @@
-// RecordPatches.CodeunitMetadataFromBcDocument — four CodeUnit Metadata (2000000137)
+// RecordPatches.CodeunitMetadataFromBcDocument — three CodeUnit Metadata (2000000137)
 // columns read out of BC's own emitted metadata document instead of being defaulted
 // (issue #3606, one conversion of the chain #3562 tracks).
 //
 // THE ROUTE
 //   BC's emitter hands CaptureOutputter a metadata document per object;
 //   AlObjectMetadataRegistry keeps it keyed (kind, id) — "Codeunit" here, the AL
-//   compiler's own SymbolKind name. This file reads four attributes off that document's
+//   compiler's own SymbolKind name. This file reads three attributes off that document's
 //   root <CodeUnit> element. It does NOT go through RunnerXmlMetadataLoader: that seam
 //   serves BC's own NCLMeta* loaders, and nothing in this provider builds an NCLMetaCodeunit.
 //   Reaching the registry directly is the same shape RecordPatches.NclMetaTableFromBcDocument
@@ -14,16 +14,15 @@
 // WHY BC'S DOCUMENT IS NOT PARSED BY BC HERE
 //   Types.Metadata.MetaCodeunit(XmlNode) would parse the same document, but its output is a
 //   MetaCodeunit, and this provider needs NavValues in a ReadOnlyRecordBuffer keyed by the
-//   live metatable's own field names. Nothing converts one to the other, so the four
+//   live metatable's own field names. Nothing converts one to the other, so the three
 //   attributes are read directly. Which attributes and how they are typed comes FROM that
 //   ctor, not from a guess — see the per-column notes.
 //
-// ATTRIBUTE-NAME TRAP: the compiler emits TestIsolation, BC's parser reads RequiredTestIsolation
-//   BC's own MetaCodeunit(XmlNode) matches "RequiredTestIsolation", which the compiler never
-//   writes, so its parse leaves the property at None for everything. This file reads the name
-//   the COMPILER writes, because that is what a service tier's row reflects — the tier reads
-//   an NCLMetaCodeunit built from the compiled attribute, not from this document. Adjudicated
-//   by corpus PR 296; derivation in docs/codeunit-metadata-from-bc.md#the-attribute-name-trap.
+// WHY RequiredTestIsolation IS NOT ONE OF THEM
+//   The document states TestIsolation, and converting the column from it is wrong: a real
+//   service tier answers None for EVERY codeunit, including one declaring
+//   TestIsolation = Disabled. Measured on eight cloud legs by corpus PR 296, and the
+//   mechanism is in Ncl.dll — docs/codeunit-metadata-from-bc.md#requiredtestisolation.
 using System.Xml.Linq;
 using AlRunner.Infrastructure;
 using Microsoft.Dynamics.Nav.Runtime;
@@ -37,7 +36,7 @@ public static partial class RecordPatches
     internal const string BcCodeunitMetadataKind = "Codeunit";
 
     /// <summary>
-    /// The four columns of CodeUnit Metadata that BC's emitted document states, as read off
+    /// The three columns of CodeUnit Metadata that BC's emitted document states, as read off
     /// one codeunit's document. A codeunit with no document — every codeunit in a precompiled
     /// dependency, and every codeunit on a compile-cache HIT with no replayed sidecar — has no
     /// <see cref="BcCodeunitDocumentValues"/> at all, and its row keeps BC's own column
@@ -49,34 +48,29 @@ public static partial class RecordPatches
     /// <param name="InherentPermissions">The permission-mask string BC's provider builds from
     /// the mask, e.g. "X". Empty when the codeunit declares none.</param>
     /// <param name="InherentEntitlements">Same, for the entitlement mask.</param>
-    /// <param name="RequiredTestIsolationOrdinal">The ordinal of the column's own option set,
-    /// already resolved. -1 when the document states nothing this column can carry.</param>
     internal sealed record BcCodeunitDocumentValues(
         string AlNamespace,
         string InherentPermissions,
-        string InherentEntitlements,
-        int RequiredTestIsolationOrdinal);
+        string InherentEntitlements);
 
     /// <summary>
-    /// BC's document for one codeunit, parsed into the four column values, or null when no
+    /// BC's document for one codeunit, parsed into the three column values, or null when no
     /// document is registered for that id.
     /// </summary>
-    internal static BcCodeunitDocumentValues? TryReadCodeunitMetadataDocument(
-        int codeunitId, IReadOnlyDictionary<string, int>? isolationOrdinals)
+    internal static BcCodeunitDocumentValues? TryReadCodeunitMetadataDocument(int codeunitId)
         => AlObjectMetadataRegistry.TryGet(BcCodeunitMetadataKind, codeunitId, out var xml)
            && !string.IsNullOrEmpty(xml)
-            ? ParseCodeunitMetadataDocument(xml, codeunitId, isolationOrdinals)
+            ? ParseCodeunitMetadataDocument(xml, codeunitId)
             : null;
 
     /// <summary>
-    /// The parse itself, split from the registry lookup so the four column values can be
-    /// driven with a document the caller chooses. The cases that matter — an isolation member
-    /// the column does not name, a permission mask no codeunit can legally declare, a
-    /// namespace that is stated versus one that is absent — are ones no single compiled
-    /// bundle can present at once.
+    /// The parse itself, split from the registry lookup so the three column values can be
+    /// driven with a document the caller chooses. The cases that matter — a permission mask
+    /// no codeunit can legally declare, a namespace that is stated versus one that is absent
+    /// — are ones no single compiled bundle can present at once.
     /// </summary>
     internal static BcCodeunitDocumentValues ParseCodeunitMetadataDocument(
-        string xml, int codeunitId, IReadOnlyDictionary<string, int>? isolationOrdinals)
+        string xml, int codeunitId)
     {
         XElement root;
         try
@@ -97,8 +91,7 @@ public static partial class RecordPatches
         return new BcCodeunitDocumentValues(
             Attr(root, "ALNamespace") ?? string.Empty,
             ReadPermissionMaskString(root, "InherentPermissions", codeunitId),
-            ReadPermissionMaskString(root, "InherentEntitlements", codeunitId),
-            ReadRequiredTestIsolationOrdinal(root, isolationOrdinals, codeunitId));
+            ReadPermissionMaskString(root, "InherentEntitlements", codeunitId));
     }
 
     /// <summary>Attribute value ignoring the document's default namespace, which BC sets to
@@ -193,74 +186,4 @@ public static partial class RecordPatches
         }
         return true;
     }
-
-    /// <summary>
-    /// The RequiredTestIsolation column's ordinal for one codeunit, or -1 when BC's document
-    /// states nothing this column can carry.
-    ///
-    /// <para><b>The attribute name read here is the COMPILER's</b> — <c>TestIsolation</c> — not
-    /// the one BC's own document parser matches, <c>RequiredTestIsolation</c>. That is
-    /// deliberate: a service tier's row comes from an <c>NCLMetaCodeunit</c> built from the
-    /// compiled attribute rather than from this document, so reading the compiler's name is
-    /// what makes the runner track the DECLARATION, which is what the tier reports. Adjudicated
-    /// by corpus PR 296 on eight service tiers; if a tier ever disagrees, the corpus is right
-    /// and this method changes. docs/codeunit-metadata-from-bc.md#the-attribute-name-trap.</para>
-    ///
-    /// <para><b>The absent case is left to BC's default, never mapped to a member.</b> -1 means
-    /// the document states nothing this column can carry, and the row builder then keeps
-    /// <c>NavValue.GetDefaultNavValue</c>. The compiler omits the attribute for exactly one
-    /// shape — a <c>Subtype = Test</c> codeunit, the 32-of-1,690 group on Base Application —
-    /// and supplies <c>Disabled</c> for every other, including a TestRunner that declares
-    /// nothing. Mapping the absent case onto Disabled here would therefore be wrong twice
-    /// over: docs/codeunit-metadata-from-bc.md#what-the-compiler-emits.</para>
-    /// </summary>
-    private static int ReadRequiredTestIsolationOrdinal(
-        XElement root, IReadOnlyDictionary<string, int>? ordinals, int codeunitId)
-    {
-        var raw = Attr(root, "TestIsolation");
-        if (string.IsNullOrWhiteSpace(raw) || ordinals == null) return -1;
-
-        if (ordinals.TryGetValue(NormalizeObjectTypeName(raw), out var ordinal)) return ordinal;
-
-        // A member the column's own option string does not name is refused, not defaulted —
-        // the same rule ResolveCodeunitSubtypeOrdinal applies to SubType (#3080). Defaulting
-        // would write ordinal 0 (None) for a codeunit that declares an isolation mode, which
-        // reads exactly like a codeunit declaring nothing.
-        throw CodeunitMetadataShapeGap(
-            $"codeunit {codeunitId} states TestIsolation = '{raw}' in BC's metadata document, "
-            + "which is not a member of that column's own option set");
-    }
-
-    /// <summary>
-    /// The RequiredTestIsolation column's own option ordinals, by member name, read off the
-    /// live metatable exactly the way <see cref="EnsureCodeunitSubtypeOrdinals"/> reads
-    /// SubType's — never a hardcoded table, so the mapping tracks whatever the System package
-    /// in the resolved artifact declares.
-    /// <para>Deliberately no runtime-enum overlay. The column names four members
-    /// (None,Disabled,Codeunit,Function) and <c>Types.TestCodeunitRequiredTestIsolation</c>
-    /// carries the same four at the same ordinals, so an overlay would add nothing and would
-    /// introduce the failure mode <see cref="EnsureCodeunitSubtypeOrdinals"/> documents for
-    /// SubType, where the enum reaches one member further than the column.</para>
-    /// <para>Answers null rather than throwing when the column is absent: an artifact whose
-    /// CodeUnit Metadata has no such column is one where the value has nowhere to go, and the
-    /// other three columns are still answerable. <see cref="BuildCodeunitMetadataValue"/>
-    /// never asks for an ordinal it has no column for.</para>
-    /// </summary>
-    private static Dictionary<string, int>? EnsureCodeunitTestIsolationOrdinals(NCLMetaTable metaTable)
-    {
-        if (_cmvIsolationOrdinals != null) return _cmvIsolationOrdinals;
-
-        var field = (GetAllFields(metaTable) ?? Enumerable.Empty<NCLMetaField>())
-            .FirstOrDefault(f => NormalizeObjectTypeName(f.FieldName ?? string.Empty) == "requiredtestisolation");
-        var optionString = field?.FieldOptionMetadata?.OptionString;
-        if (string.IsNullOrEmpty(optionString)) return null;
-
-        var map = BuildMetadataOptionOrdinals(optionString, bcRuntimeEnum: null);
-        if (map.Count == 0) return null;
-
-        _cmvIsolationOrdinals = map;
-        return map;
-    }
-
-    private static Dictionary<string, int>? _cmvIsolationOrdinals;
 }

--- a/AlRunner/Patches/RecordPatches.CodeunitMetadataFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.CodeunitMetadataFromBcDocument.cs
@@ -19,12 +19,11 @@
 //   ctor, not from a guess — see the per-column notes.
 //
 // ATTRIBUTE-NAME TRAP: the compiler emits TestIsolation, BC's parser reads RequiredTestIsolation
-//   The compiler writes TestIsolation="Disabled". MetaCodeunit's ctor switches on attribute
-//   name and matches the string "RequiredTestIsolation" — a different name, so its own parse
-//   never assigns the property and leaves it at 0 (None). This file reads the name the
-//   COMPILER writes, because that is the value the declaration states; see the note on
-//   ReadRequiredTestIsolationOrdinal for why that is the faithful answer and what would
-//   settle it if BC ever changed either name.
+//   BC's own MetaCodeunit(XmlNode) matches "RequiredTestIsolation", which the compiler never
+//   writes, so its parse leaves the property at None for everything. This file reads the name
+//   the COMPILER writes, because that is what a service tier's row reflects — the tier reads
+//   an NCLMetaCodeunit built from the compiled attribute, not from this document. Adjudicated
+//   by corpus PR 296; derivation in docs/codeunit-metadata-from-bc.md#the-attribute-name-trap.
 using System.Xml.Linq;
 using AlRunner.Infrastructure;
 using Microsoft.Dynamics.Nav.Runtime;
@@ -64,11 +63,21 @@ public static partial class RecordPatches
     /// </summary>
     internal static BcCodeunitDocumentValues? TryReadCodeunitMetadataDocument(
         int codeunitId, IReadOnlyDictionary<string, int>? isolationOrdinals)
-    {
-        if (!AlObjectMetadataRegistry.TryGet(BcCodeunitMetadataKind, codeunitId, out var xml)
-            || string.IsNullOrEmpty(xml))
-            return null;
+        => AlObjectMetadataRegistry.TryGet(BcCodeunitMetadataKind, codeunitId, out var xml)
+           && !string.IsNullOrEmpty(xml)
+            ? ParseCodeunitMetadataDocument(xml, codeunitId, isolationOrdinals)
+            : null;
 
+    /// <summary>
+    /// The parse itself, split from the registry lookup so the four column values can be
+    /// driven with a document the caller chooses. The cases that matter — an isolation member
+    /// the column does not name, a permission mask no codeunit can legally declare, a
+    /// namespace that is stated versus one that is absent — are ones no single compiled
+    /// bundle can present at once.
+    /// </summary>
+    internal static BcCodeunitDocumentValues ParseCodeunitMetadataDocument(
+        string xml, int codeunitId, IReadOnlyDictionary<string, int>? isolationOrdinals)
+    {
         XElement root;
         try
         {
@@ -99,13 +108,10 @@ public static partial class RecordPatches
 
     /// <summary>
     /// The five permission characters CodeUnit Metadata's two Text[5] mask columns are spelled
-    /// with, in bit order: bit 0 Read, 1 Insert, 2 Modify, 3 Delete, 4 Execute. The indirect
-    /// half of the mask (bits 5..9) uses the same letters lowercased.
-    /// <para>Read out of Ncl.dll rather than assumed: <c>MetadataDataProvider.permissions</c> is
-    /// a static <c>char[5]</c> whose initializer blob decodes to R, I, M, D, X (BC 28.1,
-    /// 52 00 49 00 4D 00 44 00 58 00). <c>CreatePermissionMaskString</c> walks bits 0..4 and
-    /// emits <c>permissions[n]</c> for a direct bit or <c>permissions[n] + 32</c> — the
-    /// lowercase letter — for the matching indirect bit at n+5.</para>
+    /// with, in bit order: bit 0 Read, 1 Insert, 2 Modify, 3 Delete, 4 Execute; the indirect
+    /// half (bits 5..9) uses the same letters lowercased. Read out of Ncl.dll's own
+    /// <c>MetadataDataProvider.permissions</c> rather than assumed — see
+    /// docs/codeunit-metadata-from-bc.md#permission-mask-spelling.
     /// </summary>
     private const string PermissionMaskLetters = "RIMDX";
 
@@ -113,23 +119,17 @@ public static partial class RecordPatches
     /// One inherent-permission column, spelled the way BC's own provider spells it.
     ///
     /// <para><b>Observably equivalent</b> to <c>MetadataDataProvider.CreatePermissionMaskString</c>,
-    /// which is what fills these two columns on a service tier: it returns
-    /// <c>NavText.Empty</c> for <c>PermissionMask.None</c>, and otherwise one character per set
-    /// bit in 0..4, uppercase for the direct bit and lowercase for the indirect bit at n+5. The
-    /// loop below is that method's shape, over the same letters read out of its own static
-    /// array. What it does NOT reproduce is the ORDER-INDEPENDENT part of BC's implementation —
-    /// BC sizes a stack buffer with <c>PopCount((num &gt;&gt; 5) | (num &amp; 0x1F))</c> and
-    /// fills it in bit order, so direct and indirect bits for the same permission cannot both
-    /// appear; this walks the same bits in the same order and takes the direct bit first, which
-    /// is the same choice.</para>
+    /// which is what fills these two columns on a service tier: empty for
+    /// <c>PermissionMask.None</c>, otherwise one character per set bit in 0..4, uppercase for
+    /// the direct bit and lowercase for the indirect bit at n+5, in bit order — so one
+    /// permission never contributes two characters. Both the numeric and the member-name
+    /// spelling are accepted because BC's own parser uses <c>Enum.Parse</c>, which takes
+    /// either. See docs/codeunit-metadata-from-bc.md#permission-mask-spelling.</para>
     ///
-    /// <para>The attribute BC emits is the mask's NUMERIC value ("16"), and BC's own document
-    /// parser reads it with <c>Enum.Parse(typeof(PermissionMask), value)</c>, which accepts
-    /// both a numeric string and a member name. Both spellings are accepted here for the same
-    /// reason. On a codeunit AL only permits X (Execute, 16) for either property — anything
-    /// else is AL0195 — so 16 is the only value observed in practice; the full walk is written
-    /// out anyway because the same two columns exist on Table and Page Metadata, where the
-    /// mask is not restricted, and a half-implementation here would be the wrong thing to copy.</para>
+    /// <para>On a codeunit AL permits only X for either property (AL0195), so 16 is the only
+    /// value reachable from AL. The full bit walk is written out anyway because the same two
+    /// columns exist on Table and Page Metadata, where the mask is not restricted — a
+    /// half-implementation here is what the next conversion would copy.</para>
     /// </summary>
     private static string ReadPermissionMaskString(XElement root, string attributeName, int codeunitId)
     {
@@ -198,38 +198,21 @@ public static partial class RecordPatches
     /// The RequiredTestIsolation column's ordinal for one codeunit, or -1 when BC's document
     /// states nothing this column can carry.
     ///
-    /// <para><b>The attribute name is the compiler's, not BC's parser's, and that is deliberate.</b>
-    /// The AL compiler emits <c>TestIsolation="Disabled"</c>; BC's own
-    /// <c>Types.Metadata.MetaCodeunit(XmlNode)</c> switches on attribute name and compares
-    /// against the string <c>"RequiredTestIsolation"</c>, which the compiler never writes. So
-    /// BC's document parse leaves <c>MetaCodeunit.RequiredTestIsolation</c> at its field
-    /// initializer, 0 = None, for every codeunit — including one that declares
-    /// <c>TestIsolation = Codeunit</c>.</para>
+    /// <para><b>The attribute name read here is the COMPILER's</b> — <c>TestIsolation</c> — not
+    /// the one BC's own document parser matches, <c>RequiredTestIsolation</c>. That is
+    /// deliberate: a service tier's row comes from an <c>NCLMetaCodeunit</c> built from the
+    /// compiled attribute rather than from this document, so reading the compiler's name is
+    /// what makes the runner track the DECLARATION, which is what the tier reports. Adjudicated
+    /// by corpus PR 296 on eight service tiers; if a tier ever disagrees, the corpus is right
+    /// and this method changes. docs/codeunit-metadata-from-bc.md#the-attribute-name-trap.</para>
     ///
-    /// <para>That is a fact about BC's XML path, which is not the path a service tier's
-    /// CodeUnit Metadata row travels: <c>CodeUnitDataProvider</c> reads
-    /// <c>NclMetadata.GetMetaCodeunitById(...).RequiredTestIsolation</c>, an
-    /// <c>NCLMetaCodeunit</c> built from the published app's compiled attribute rather than
-    /// from this document — the same asymmetry <see cref="AlSubtypeTheCompilerDoesNotEmit"/>
-    /// records for SubType. Reading the compiler's own attribute is what makes the runner's
-    /// answer track the DECLARATION, which is what the tier reports.</para>
-    ///
-    /// <para>Corpus PR 296 puts that claim in front of eight real service tiers:
-    /// <c>Record_CodeunitMetadata_Get_TestRunnerCodeunits_ReportEachDeclaredTestIsolation</c>
-    /// asserts a TestRunner declaring each of Disabled / Codeunit / Function reports the
-    /// matching member, and
-    /// <c>Record_CodeunitMetadata_Get_CodeunitStatingNoTestIsolation_ReportsTheUnstatedValue</c>
-    /// asserts that a codeunit stating none reports something DIFFERENT from an explicit
-    /// Disabled. If a tier disagrees, the corpus is right and this method is what changes.</para>
-    ///
-    /// <para><b>The absent case is left to BC's default, never mapped to a member.</b> AL
-    /// permits TestIsolation only on Subtype = TestRunner (AL0223), so the compiler omits the
-    /// attribute for every ordinary codeunit — and for a Subtype = Test codeunit, which is the
-    /// 32-of-1690 group on Base Application. Returning -1 here means the column keeps
-    /// <c>NavValue.GetDefaultNavValue</c>, ordinal 0, which is the member the column names
-    /// None and the value BC's own field initializer holds. Substituting Disabled instead —
-    /// the value BC emits for a plain codeunit's document — would make a declared Disabled and
-    /// an unstated property indistinguishable.</para>
+    /// <para><b>The absent case is left to BC's default, never mapped to a member.</b> -1 means
+    /// the document states nothing this column can carry, and the row builder then keeps
+    /// <c>NavValue.GetDefaultNavValue</c>. The compiler omits the attribute for exactly one
+    /// shape — a <c>Subtype = Test</c> codeunit, the 32-of-1,690 group on Base Application —
+    /// and supplies <c>Disabled</c> for every other, including a TestRunner that declares
+    /// nothing. Mapping the absent case onto Disabled here would therefore be wrong twice
+    /// over: docs/codeunit-metadata-from-bc.md#what-the-compiler-emits.</para>
     /// </summary>
     private static int ReadRequiredTestIsolationOrdinal(
         XElement root, IReadOnlyDictionary<string, int>? ordinals, int codeunitId)

--- a/AlRunner/Patches/RecordPatches.CodeunitMetadataFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.CodeunitMetadataFromBcDocument.cs
@@ -1,0 +1,283 @@
+// RecordPatches.CodeunitMetadataFromBcDocument — four CodeUnit Metadata (2000000137)
+// columns read out of BC's own emitted metadata document instead of being defaulted
+// (issue #3606, one conversion of the chain #3562 tracks).
+//
+// THE ROUTE
+//   BC's emitter hands CaptureOutputter a metadata document per object;
+//   AlObjectMetadataRegistry keeps it keyed (kind, id) — "Codeunit" here, the AL
+//   compiler's own SymbolKind name. This file reads four attributes off that document's
+//   root <CodeUnit> element. It does NOT go through RunnerXmlMetadataLoader: that seam
+//   serves BC's own NCLMeta* loaders, and nothing in this provider builds an NCLMetaCodeunit.
+//   Reaching the registry directly is the same shape RecordPatches.NclMetaTableFromBcDocument
+//   uses. See docs/codeunit-metadata-from-bc.md for the measurement behind every claim below.
+//
+// WHY BC'S DOCUMENT IS NOT PARSED BY BC HERE
+//   Types.Metadata.MetaCodeunit(XmlNode) would parse the same document, but its output is a
+//   MetaCodeunit, and this provider needs NavValues in a ReadOnlyRecordBuffer keyed by the
+//   live metatable's own field names. Nothing converts one to the other, so the four
+//   attributes are read directly. Which attributes and how they are typed comes FROM that
+//   ctor, not from a guess — see the per-column notes.
+//
+// ATTRIBUTE-NAME TRAP: the compiler emits TestIsolation, BC's parser reads RequiredTestIsolation
+//   The compiler writes TestIsolation="Disabled". MetaCodeunit's ctor switches on attribute
+//   name and matches the string "RequiredTestIsolation" — a different name, so its own parse
+//   never assigns the property and leaves it at 0 (None). This file reads the name the
+//   COMPILER writes, because that is the value the declaration states; see the note on
+//   ReadRequiredTestIsolationOrdinal for why that is the faithful answer and what would
+//   settle it if BC ever changed either name.
+using System.Xml.Linq;
+using AlRunner.Infrastructure;
+using Microsoft.Dynamics.Nav.Runtime;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    /// <summary>The AL compiler's own <c>SymbolKind</c> name for a codeunit, which is the
+    /// kind half of <see cref="AlObjectMetadataRegistry"/>'s key.</summary>
+    internal const string BcCodeunitMetadataKind = "Codeunit";
+
+    /// <summary>
+    /// The four columns of CodeUnit Metadata that BC's emitted document states, as read off
+    /// one codeunit's document. A codeunit with no document — every codeunit in a precompiled
+    /// dependency, and every codeunit on a compile-cache HIT with no replayed sidecar — has no
+    /// <see cref="BcCodeunitDocumentValues"/> at all, and its row keeps BC's own column
+    /// defaults rather than a value invented here.
+    /// </summary>
+    /// <param name="AlNamespace">The declaring file's namespace, or the empty string when it
+    /// states none. BC emits the attribute either way, so an empty value is a stated empty
+    /// rather than an absent attribute.</param>
+    /// <param name="InherentPermissions">The permission-mask string BC's provider builds from
+    /// the mask, e.g. "X". Empty when the codeunit declares none.</param>
+    /// <param name="InherentEntitlements">Same, for the entitlement mask.</param>
+    /// <param name="RequiredTestIsolationOrdinal">The ordinal of the column's own option set,
+    /// already resolved. -1 when the document states nothing this column can carry.</param>
+    internal sealed record BcCodeunitDocumentValues(
+        string AlNamespace,
+        string InherentPermissions,
+        string InherentEntitlements,
+        int RequiredTestIsolationOrdinal);
+
+    /// <summary>
+    /// BC's document for one codeunit, parsed into the four column values, or null when no
+    /// document is registered for that id.
+    /// </summary>
+    internal static BcCodeunitDocumentValues? TryReadCodeunitMetadataDocument(
+        int codeunitId, IReadOnlyDictionary<string, int>? isolationOrdinals)
+    {
+        if (!AlObjectMetadataRegistry.TryGet(BcCodeunitMetadataKind, codeunitId, out var xml)
+            || string.IsNullOrEmpty(xml))
+            return null;
+
+        XElement root;
+        try
+        {
+            root = XDocument.Parse(xml).Root
+                   ?? throw CodeunitMetadataShapeGap(
+                       $"BC's metadata document for codeunit {codeunitId} has no root element");
+        }
+        catch (System.Xml.XmlException ex)
+        {
+            // Refuse rather than fall back to the defaults. A document that is registered but
+            // unparseable is a shape change in BC's emitter, and silently answering the old
+            // defaults would hide it behind a green run (.claude/rules/loud-failures.md).
+            throw CodeunitMetadataShapeGap(
+                $"BC's metadata document for codeunit {codeunitId} is not well-formed XML: {ex.Message}");
+        }
+
+        return new BcCodeunitDocumentValues(
+            Attr(root, "ALNamespace") ?? string.Empty,
+            ReadPermissionMaskString(root, "InherentPermissions", codeunitId),
+            ReadPermissionMaskString(root, "InherentEntitlements", codeunitId),
+            ReadRequiredTestIsolationOrdinal(root, isolationOrdinals, codeunitId));
+    }
+
+    /// <summary>Attribute value ignoring the document's default namespace, which BC sets to
+    /// <c>urn:schemas-microsoft-com:dynamics:NAV:MetaObjects</c> — an XML default namespace
+    /// does not apply to attributes, so an unqualified name is the right lookup.</summary>
+    private static string? Attr(XElement root, string name) => root.Attribute(name)?.Value;
+
+    /// <summary>
+    /// The five permission characters CodeUnit Metadata's two Text[5] mask columns are spelled
+    /// with, in bit order: bit 0 Read, 1 Insert, 2 Modify, 3 Delete, 4 Execute. The indirect
+    /// half of the mask (bits 5..9) uses the same letters lowercased.
+    /// <para>Read out of Ncl.dll rather than assumed: <c>MetadataDataProvider.permissions</c> is
+    /// a static <c>char[5]</c> whose initializer blob decodes to R, I, M, D, X (BC 28.1,
+    /// 52 00 49 00 4D 00 44 00 58 00). <c>CreatePermissionMaskString</c> walks bits 0..4 and
+    /// emits <c>permissions[n]</c> for a direct bit or <c>permissions[n] + 32</c> — the
+    /// lowercase letter — for the matching indirect bit at n+5.</para>
+    /// </summary>
+    private const string PermissionMaskLetters = "RIMDX";
+
+    /// <summary>
+    /// One inherent-permission column, spelled the way BC's own provider spells it.
+    ///
+    /// <para><b>Observably equivalent</b> to <c>MetadataDataProvider.CreatePermissionMaskString</c>,
+    /// which is what fills these two columns on a service tier: it returns
+    /// <c>NavText.Empty</c> for <c>PermissionMask.None</c>, and otherwise one character per set
+    /// bit in 0..4, uppercase for the direct bit and lowercase for the indirect bit at n+5. The
+    /// loop below is that method's shape, over the same letters read out of its own static
+    /// array. What it does NOT reproduce is the ORDER-INDEPENDENT part of BC's implementation —
+    /// BC sizes a stack buffer with <c>PopCount((num &gt;&gt; 5) | (num &amp; 0x1F))</c> and
+    /// fills it in bit order, so direct and indirect bits for the same permission cannot both
+    /// appear; this walks the same bits in the same order and takes the direct bit first, which
+    /// is the same choice.</para>
+    ///
+    /// <para>The attribute BC emits is the mask's NUMERIC value ("16"), and BC's own document
+    /// parser reads it with <c>Enum.Parse(typeof(PermissionMask), value)</c>, which accepts
+    /// both a numeric string and a member name. Both spellings are accepted here for the same
+    /// reason. On a codeunit AL only permits X (Execute, 16) for either property — anything
+    /// else is AL0195 — so 16 is the only value observed in practice; the full walk is written
+    /// out anyway because the same two columns exist on Table and Page Metadata, where the
+    /// mask is not restricted, and a half-implementation here would be the wrong thing to copy.</para>
+    /// </summary>
+    private static string ReadPermissionMaskString(XElement root, string attributeName, int codeunitId)
+    {
+        var raw = Attr(root, attributeName);
+        if (string.IsNullOrWhiteSpace(raw)) return string.Empty;
+
+        int mask;
+        if (!int.TryParse(raw, System.Globalization.NumberStyles.Integer,
+                          System.Globalization.CultureInfo.InvariantCulture, out mask))
+        {
+            if (!TryParsePermissionMaskNames(raw, out mask))
+                throw CodeunitMetadataShapeGap(
+                    $"codeunit {codeunitId} states {attributeName}='{raw}' in BC's metadata document, "
+                    + "which is neither a numeric PermissionMask nor a comma-separated list of its "
+                    + "member names — the runner cannot spell a mask it cannot read, and answering "
+                    + "an empty string would be indistinguishable from a codeunit declaring none");
+        }
+
+        if (mask == 0) return string.Empty;
+
+        var sb = new System.Text.StringBuilder(PermissionMaskLetters.Length);
+        for (int bit = 0; bit < PermissionMaskLetters.Length; bit++)
+        {
+            if ((mask & (1 << bit)) != 0) sb.Append(PermissionMaskLetters[bit]);
+            else if ((mask & (1 << (bit + PermissionMaskLetters.Length))) != 0)
+                sb.Append(char.ToLowerInvariant(PermissionMaskLetters[bit]));
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// The member-name spelling of a PermissionMask, e.g. "Execute" or "Read, Insert" — what
+    /// <c>Enum.Parse</c> accepts alongside the numeric form BC actually emits. Resolved against
+    /// the letters this file already knows rather than against the runtime enum, so a member
+    /// BC adds outside the five permission bits (the mask's HasExpDate / IgnoreWildcard flags,
+    /// which no permission column spells) cannot silently become a letter.
+    /// </summary>
+    private static bool TryParsePermissionMaskNames(string raw, out int mask)
+    {
+        mask = 0;
+        foreach (var part in raw.Split(',', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var name = part.Trim();
+            var bit = name.ToLowerInvariant() switch
+            {
+                "none" => -1,
+                "read" => 0,
+                "insert" => 1,
+                "modify" => 2,
+                "delete" => 3,
+                "execute" => 4,
+                "indirectread" => 5,
+                "indirectinsert" => 6,
+                "indirectmodify" => 7,
+                "indirectdelete" => 8,
+                "indirectexecute" => 9,
+                _ => -2,
+            };
+            if (bit == -2) return false;
+            if (bit >= 0) mask |= 1 << bit;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// The RequiredTestIsolation column's ordinal for one codeunit, or -1 when BC's document
+    /// states nothing this column can carry.
+    ///
+    /// <para><b>The attribute name is the compiler's, not BC's parser's, and that is deliberate.</b>
+    /// The AL compiler emits <c>TestIsolation="Disabled"</c>; BC's own
+    /// <c>Types.Metadata.MetaCodeunit(XmlNode)</c> switches on attribute name and compares
+    /// against the string <c>"RequiredTestIsolation"</c>, which the compiler never writes. So
+    /// BC's document parse leaves <c>MetaCodeunit.RequiredTestIsolation</c> at its field
+    /// initializer, 0 = None, for every codeunit — including one that declares
+    /// <c>TestIsolation = Codeunit</c>.</para>
+    ///
+    /// <para>That is a fact about BC's XML path, which is not the path a service tier's
+    /// CodeUnit Metadata row travels: <c>CodeUnitDataProvider</c> reads
+    /// <c>NclMetadata.GetMetaCodeunitById(...).RequiredTestIsolation</c>, an
+    /// <c>NCLMetaCodeunit</c> built from the published app's compiled attribute rather than
+    /// from this document — the same asymmetry <see cref="AlSubtypeTheCompilerDoesNotEmit"/>
+    /// records for SubType. Reading the compiler's own attribute is what makes the runner's
+    /// answer track the DECLARATION, which is what the tier reports.</para>
+    ///
+    /// <para>Corpus PR 296 puts that claim in front of eight real service tiers:
+    /// <c>Record_CodeunitMetadata_Get_TestRunnerCodeunits_ReportEachDeclaredTestIsolation</c>
+    /// asserts a TestRunner declaring each of Disabled / Codeunit / Function reports the
+    /// matching member, and
+    /// <c>Record_CodeunitMetadata_Get_CodeunitStatingNoTestIsolation_ReportsTheUnstatedValue</c>
+    /// asserts that a codeunit stating none reports something DIFFERENT from an explicit
+    /// Disabled. If a tier disagrees, the corpus is right and this method is what changes.</para>
+    ///
+    /// <para><b>The absent case is left to BC's default, never mapped to a member.</b> AL
+    /// permits TestIsolation only on Subtype = TestRunner (AL0223), so the compiler omits the
+    /// attribute for every ordinary codeunit — and for a Subtype = Test codeunit, which is the
+    /// 32-of-1690 group on Base Application. Returning -1 here means the column keeps
+    /// <c>NavValue.GetDefaultNavValue</c>, ordinal 0, which is the member the column names
+    /// None and the value BC's own field initializer holds. Substituting Disabled instead —
+    /// the value BC emits for a plain codeunit's document — would make a declared Disabled and
+    /// an unstated property indistinguishable.</para>
+    /// </summary>
+    private static int ReadRequiredTestIsolationOrdinal(
+        XElement root, IReadOnlyDictionary<string, int>? ordinals, int codeunitId)
+    {
+        var raw = Attr(root, "TestIsolation");
+        if (string.IsNullOrWhiteSpace(raw) || ordinals == null) return -1;
+
+        if (ordinals.TryGetValue(NormalizeObjectTypeName(raw), out var ordinal)) return ordinal;
+
+        // A member the column's own option string does not name is refused, not defaulted —
+        // the same rule ResolveCodeunitSubtypeOrdinal applies to SubType (#3080). Defaulting
+        // would write ordinal 0 (None) for a codeunit that declares an isolation mode, which
+        // reads exactly like a codeunit declaring nothing.
+        throw CodeunitMetadataShapeGap(
+            $"codeunit {codeunitId} states TestIsolation = '{raw}' in BC's metadata document, "
+            + "which is not a member of that column's own option set");
+    }
+
+    /// <summary>
+    /// The RequiredTestIsolation column's own option ordinals, by member name, read off the
+    /// live metatable exactly the way <see cref="EnsureCodeunitSubtypeOrdinals"/> reads
+    /// SubType's — never a hardcoded table, so the mapping tracks whatever the System package
+    /// in the resolved artifact declares.
+    /// <para>Deliberately no runtime-enum overlay. The column names four members
+    /// (None,Disabled,Codeunit,Function) and <c>Types.TestCodeunitRequiredTestIsolation</c>
+    /// carries the same four at the same ordinals, so an overlay would add nothing and would
+    /// introduce the failure mode <see cref="EnsureCodeunitSubtypeOrdinals"/> documents for
+    /// SubType, where the enum reaches one member further than the column.</para>
+    /// <para>Answers null rather than throwing when the column is absent: an artifact whose
+    /// CodeUnit Metadata has no such column is one where the value has nowhere to go, and the
+    /// other three columns are still answerable. <see cref="BuildCodeunitMetadataValue"/>
+    /// never asks for an ordinal it has no column for.</para>
+    /// </summary>
+    private static Dictionary<string, int>? EnsureCodeunitTestIsolationOrdinals(NCLMetaTable metaTable)
+    {
+        if (_cmvIsolationOrdinals != null) return _cmvIsolationOrdinals;
+
+        var field = (GetAllFields(metaTable) ?? Enumerable.Empty<NCLMetaField>())
+            .FirstOrDefault(f => NormalizeObjectTypeName(f.FieldName ?? string.Empty) == "requiredtestisolation");
+        var optionString = field?.FieldOptionMetadata?.OptionString;
+        if (string.IsNullOrEmpty(optionString)) return null;
+
+        var map = BuildMetadataOptionOrdinals(optionString, bcRuntimeEnum: null);
+        if (map.Count == 0) return null;
+
+        _cmvIsolationOrdinals = map;
+        return map;
+    }
+
+    private static Dictionary<string, int>? _cmvIsolationOrdinals;
+}

--- a/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
@@ -36,14 +36,33 @@
 //   shared inventory AllObj reads, so AllObj and CodeUnit Metadata cannot disagree about
 //   which codeunits exist.
 //
-// COLUMNS NOT IMPLEMENTED
-//   Everything outside ID / Name / TableNo / SingleInstance / Subtype — the owning app id,
-//   the two permission-mask strings, TestType, RequiredTestIsolation, Namespace — gets BC's
-//   own NavValue.GetDefaultNavValue for that column's type, which is also what a real row
-//   carries for a codeunit that declares none of them. Filling them needs sources the
-//   runner does not have yet (the app-id column needs per-object app attribution, which is
-//   the same data issue #2326 tracks for AllObj's "Object Subtype"); inventing a value
-//   would be a silent wrong answer, so they are left at BC's default and named here.
+// COLUMNS FROM BC'S OWN METADATA DOCUMENT (#3606)
+//   AL Namespace, InherentPermissions, InherentEntitlements and RequiredTestIsolation are
+//   read off the document BC's emitter produced for the codeunit — see
+//   RecordPatches.CodeunitMetadataFromBcDocument.cs. A codeunit with no document keeps BC's
+//   default for all four; that is every codeunit in a precompiled dependency, whose .app
+//   ships no metadata XML, and every codeunit on a compile-cache HIT with no replayed
+//   sidecar.
+//
+// COLUMNS STILL NOT IMPLEMENTED, AND WHY THESE TWO ARE DIFFERENT FROM THE FOUR ABOVE
+//   App ID and TestType get BC's own NavValue.GetDefaultNavValue, and neither is waiting on
+//   the conversion above, because neither is in the document to convert:
+//
+//     * App ID is not an object property at all. BC's provider fills it with
+//       MetadataDataProvider.GetAppId(metaCodeunit) — the id of the app the object was
+//       PUBLISHED from, which is per-run state and not something a compiler can emit.
+//       Answering it needs per-object app attribution, the same data #2326 tracks for
+//       AllObj's "Object Subtype".
+//     * TestType is emitted 0 times in Base Application's 1,690 codeunit documents (#3606's
+//       measurement, re-confirmed here on a source-compiled Subtype = Test codeunit: the
+//       document carries Subtype="Test" and no TestType attribute). BC does not read it from
+//       the document either — Types.Metadata.MetaCodeunit's ctor DERIVES it, setting
+//       TestType = UnitTest when SubType == Test and TestType is still 0. Reproducing that
+//       derivation is a separate claim about BC, needing its own corpus test, and is not
+//       part of #3606.
+//
+//   Inventing a value for either would be a silent wrong answer, so they stay at BC's
+//   default and are named here.
 //
 // PRECOMPILED-DLL RESPECT
 //   Runtime-engine types only (NCLMetaTable, NCLMetaField, NavValue, ReadOnlyRecordBuffer,
@@ -121,6 +140,7 @@ public static partial class RecordPatches
         EnsureReportMetadataReflection(metaTable);   // NavBoolean.Create(bool)
         EnsureDataAccessProviderReflection(dataAccess);
         var subtypeOrdinals = EnsureCodeunitSubtypeOrdinals(metaTable);
+        var isolationOrdinals = EnsureCodeunitTestIsolationOrdinals(metaTable);
 
         var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
             ?? throw CodeunitMetadataShapeGap("data access has no in-memory provider");
@@ -131,21 +151,26 @@ public static partial class RecordPatches
         {
             if (!done.TryAdd(row.Id, 0)) continue;
 
-            // Keep this resolution OUT of the per-field builder: a throw from inside
+            // Keep BOTH resolutions OUT of the per-field builder: a throw from inside
             // InsertVirtualRow escapes GetDataAccessForTable and no row of the table is served
-            // at all (#3536, docs/limitations.md#codeunit-metadata-subtype). The `[warn]` tag
-            // is load-bearing too — any other tag is dropped at default verbosity by Log.cs.
+            // at all (#3536, docs/limitations.md#codeunit-metadata-subtype). The document read
+            // joins the subtype resolution here for exactly that reason — it refuses on a
+            // malformed document and on an isolation member the column does not name, and
+            // either would otherwise take the whole table down. The `[warn]` tag is
+            // load-bearing too — any other tag is dropped at default verbosity by Log.cs.
             int subtypeOrdinal;
+            BcCodeunitDocumentValues? document;
             try
             {
                 subtypeOrdinal = ResolveCodeunitSubtypeOrdinal(
                     subtypeOrdinals, _cmvSubtypeOptionString, row.Subtype, row.Id);
+                document = TryReadCodeunitMetadataDocument(row.Id, isolationOrdinals);
             }
             catch (RunnerOutOfScopeException ex)
             {
                 Console.Error.WriteLine(
                     $"[warn] RecordPatches: CodeUnit Metadata has NO ROW for codeunit {row.Id} "
-                    + $"\"{row.Name}\" — its SubType could not be resolved: {ex.Message}. Every other "
+                    + $"\"{row.Name}\" — {ex.Message}. Every other "
                     + "codeunit is still reported, but AL asking for this one will fail to find "
                     + "it: Get() answers false and a FindSet/Count is one row short, with no "
                     + "error raised at the read.");
@@ -154,7 +179,7 @@ public static partial class RecordPatches
 
             InsertVirtualRow(provider, metaTable,
                 new object[] { CodeunitMetadataVirtualTableId, row.Id, 0, 0 },
-                field => BuildCodeunitMetadataValue(field, row, subtypeOrdinal));
+                field => BuildCodeunitMetadataValue(field, row, subtypeOrdinal, document));
         }
     }
 
@@ -163,11 +188,17 @@ public static partial class RecordPatches
     /// the mapping tracks whatever the System package in the resolved artifact declares
     /// rather than a hardcoded field-number table.
     /// </summary>
+    /// <param name="document">BC's own metadata document for this codeunit, already parsed, or
+    /// null when none is registered for it. The four columns it states fall through to BC's
+    /// default when it is null, which is the honest answer for a codeunit whose .app ships no
+    /// metadata XML — never a value derived from something else.</param>
     private static object? BuildCodeunitMetadataValue(
-        NCLMetaField field, CodeunitMetaRow row, int subtypeOrdinal)
+        NCLMetaField field, CodeunitMetaRow row, int subtypeOrdinal,
+        BcCodeunitDocumentValues? document)
     {
         object? Text(string s) => _aovNavTextCreateTruncated!.Invoke(
             null, new object?[] { field.FieldDefinedLength, s ?? string.Empty });
+        object? Default() => _aovGetDefaultNavValue!.Invoke(null, new object?[] { field, false });
 
         switch (NormalizeObjectTypeName(field.FieldName ?? string.Empty))
         {
@@ -186,8 +217,25 @@ public static partial class RecordPatches
                 {
                     field.FieldOptionMetadata, subtypeOrdinal
                 });
+            case "alnamespace":
+                return document == null ? Default() : Text(document.AlNamespace);
+            case "inherentpermissions":
+                return document == null ? Default() : Text(document.InherentPermissions);
+            case "inherententitlements":
+                return document == null ? Default() : Text(document.InherentEntitlements);
+            case "requiredtestisolation":
+                // -1 means BC's document states nothing this column can carry, which is every
+                // codeunit AL forbids the property on. BC's default is ordinal 0 = None, the
+                // same value MetaCodeunit's field initializer holds — see
+                // ReadRequiredTestIsolationOrdinal for why it is not mapped onto Disabled.
+                return document == null || document.RequiredTestIsolationOrdinal < 0
+                    ? Default()
+                    : _aovNavOptionCreate!.Invoke(null, new object?[]
+                    {
+                        field.FieldOptionMetadata, document.RequiredTestIsolationOrdinal
+                    });
             default:
-                return _aovGetDefaultNavValue!.Invoke(null, new object?[] { field, false });
+                return Default();
         }
     }
 

--- a/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
@@ -44,25 +44,14 @@
 //   ships no metadata XML, and every codeunit on a compile-cache HIT with no replayed
 //   sidecar.
 //
-// COLUMNS STILL NOT IMPLEMENTED, AND WHY THESE TWO ARE DIFFERENT FROM THE FOUR ABOVE
-//   App ID and TestType get BC's own NavValue.GetDefaultNavValue, and neither is waiting on
-//   the conversion above, because neither is in the document to convert:
-//
-//     * App ID is not an object property at all. BC's provider fills it with
-//       MetadataDataProvider.GetAppId(metaCodeunit) — the id of the app the object was
-//       PUBLISHED from, which is per-run state and not something a compiler can emit.
-//       Answering it needs per-object app attribution, the same data #2326 tracks for
-//       AllObj's "Object Subtype".
-//     * TestType is emitted 0 times in Base Application's 1,690 codeunit documents (#3606's
-//       measurement, re-confirmed here on a source-compiled Subtype = Test codeunit: the
-//       document carries Subtype="Test" and no TestType attribute). BC does not read it from
-//       the document either — Types.Metadata.MetaCodeunit's ctor DERIVES it, setting
-//       TestType = UnitTest when SubType == Test and TestType is still 0. Reproducing that
-//       derivation is a separate claim about BC, needing its own corpus test, and is not
-//       part of #3606.
-//
-//   Inventing a value for either would be a silent wrong answer, so they stay at BC's
-//   default and are named here.
+// COLUMNS STILL NOT IMPLEMENTED, AND WHY NEITHER IS WAITING ON THE CONVERSION ABOVE
+//   App ID and TestType get BC's own NavValue.GetDefaultNavValue, because neither is in the
+//   document to convert: App ID is not an object property at all (BC fills it from the
+//   PUBLISHING app, per-run state a compiler cannot emit — the same data #2326 tracks for
+//   AllObj), and TestType is emitted 0 times in Base Application's 1,690 codeunit documents
+//   because BC DERIVES it rather than reading it. Deriving it is a separate claim about BC
+//   needing its own corpus test. Inventing a value for either would be a silent wrong answer.
+//   docs/codeunit-metadata-from-bc.md#the-two-columns-left-at-bcs-default.
 //
 // PRECOMPILED-DLL RESPECT
 //   Runtime-engine types only (NCLMetaTable, NCLMetaField, NavValue, ReadOnlyRecordBuffer,

--- a/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
@@ -37,21 +37,24 @@
 //   which codeunits exist.
 //
 // COLUMNS FROM BC'S OWN METADATA DOCUMENT (#3606)
-//   AL Namespace, InherentPermissions, InherentEntitlements and RequiredTestIsolation are
-//   read off the document BC's emitter produced for the codeunit — see
+//   AL Namespace, InherentPermissions and InherentEntitlements are read off the document
+//   BC's emitter produced for the codeunit — see
 //   RecordPatches.CodeunitMetadataFromBcDocument.cs. A codeunit with no document keeps BC's
-//   default for all four; that is every codeunit in a precompiled dependency, whose .app
+//   default for all three; that is every codeunit in a precompiled dependency, whose .app
 //   ships no metadata XML, and every codeunit on a compile-cache HIT with no replayed
 //   sidecar.
 //
-// COLUMNS STILL NOT IMPLEMENTED, AND WHY NEITHER IS WAITING ON THE CONVERSION ABOVE
-//   App ID and TestType get BC's own NavValue.GetDefaultNavValue, because neither is in the
-//   document to convert: App ID is not an object property at all (BC fills it from the
-//   PUBLISHING app, per-run state a compiler cannot emit — the same data #2326 tracks for
-//   AllObj), and TestType is emitted 0 times in Base Application's 1,690 codeunit documents
-//   because BC DERIVES it rather than reading it. Deriving it is a separate claim about BC
-//   needing its own corpus test. Inventing a value for either would be a silent wrong answer.
-//   docs/codeunit-metadata-from-bc.md#the-two-columns-left-at-bcs-default.
+// COLUMNS STILL NOT IMPLEMENTED, AND WHY NONE IS WAITING ON THE CONVERSION ABOVE
+//   App ID, TestType and RequiredTestIsolation get BC's own NavValue.GetDefaultNavValue.
+//   App ID is not an object property at all (BC fills it from the PUBLISHING app, per-run
+//   state a compiler cannot emit — the same data #2326 tracks for AllObj). TestType is
+//   emitted 0 times in Base Application's 1,690 codeunit documents because BC DERIVES it
+//   rather than reading it; deriving it is a separate claim about BC needing its own corpus
+//   test. RequiredTestIsolation IS stated in the document, as TestIsolation — and reading it
+//   is WRONG: a real service tier answers None for every codeunit, so BC's default is the
+//   faithful answer and the document value is not. Eight cloud legs measured that (corpus PR
+//   296) and Ncl.dll says why: the property BC's row builder reads is never assigned.
+//   docs/codeunit-metadata-from-bc.md#requiredtestisolation.
 //
 // PRECOMPILED-DLL RESPECT
 //   Runtime-engine types only (NCLMetaTable, NCLMetaField, NavValue, ReadOnlyRecordBuffer,
@@ -129,7 +132,6 @@ public static partial class RecordPatches
         EnsureReportMetadataReflection(metaTable);   // NavBoolean.Create(bool)
         EnsureDataAccessProviderReflection(dataAccess);
         var subtypeOrdinals = EnsureCodeunitSubtypeOrdinals(metaTable);
-        var isolationOrdinals = EnsureCodeunitTestIsolationOrdinals(metaTable);
 
         var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
             ?? throw CodeunitMetadataShapeGap("data access has no in-memory provider");
@@ -144,8 +146,8 @@ public static partial class RecordPatches
             // InsertVirtualRow escapes GetDataAccessForTable and no row of the table is served
             // at all (#3536, docs/limitations.md#codeunit-metadata-subtype). The document read
             // joins the subtype resolution here for exactly that reason — it refuses on a
-            // malformed document and on an isolation member the column does not name, and
-            // either would otherwise take the whole table down. The `[warn]` tag is
+            // malformed document and on a permission mask it cannot read, either of which
+            // would otherwise take the whole table down. The `[warn]` tag is
             // load-bearing too — any other tag is dropped at default verbosity by Log.cs.
             int subtypeOrdinal;
             BcCodeunitDocumentValues? document;
@@ -153,7 +155,7 @@ public static partial class RecordPatches
             {
                 subtypeOrdinal = ResolveCodeunitSubtypeOrdinal(
                     subtypeOrdinals, _cmvSubtypeOptionString, row.Subtype, row.Id);
-                document = TryReadCodeunitMetadataDocument(row.Id, isolationOrdinals);
+                document = TryReadCodeunitMetadataDocument(row.Id);
             }
             catch (RunnerOutOfScopeException ex)
             {
@@ -178,7 +180,7 @@ public static partial class RecordPatches
     /// rather than a hardcoded field-number table.
     /// </summary>
     /// <param name="document">BC's own metadata document for this codeunit, already parsed, or
-    /// null when none is registered for it. The four columns it states fall through to BC's
+    /// null when none is registered for it. The three columns it states fall through to BC's
     /// default when it is null, which is the honest answer for a codeunit whose .app ships no
     /// metadata XML — never a value derived from something else.</param>
     private static object? BuildCodeunitMetadataValue(
@@ -212,17 +214,6 @@ public static partial class RecordPatches
                 return document == null ? Default() : Text(document.InherentPermissions);
             case "inherententitlements":
                 return document == null ? Default() : Text(document.InherentEntitlements);
-            case "requiredtestisolation":
-                // -1 means BC's document states nothing this column can carry, which is every
-                // codeunit AL forbids the property on. BC's default is ordinal 0 = None, the
-                // same value MetaCodeunit's field initializer holds — see
-                // ReadRequiredTestIsolationOrdinal for why it is not mapped onto Disabled.
-                return document == null || document.RequiredTestIsolationOrdinal < 0
-                    ? Default()
-                    : _aovNavOptionCreate!.Invoke(null, new object?[]
-                    {
-                        field.FieldOptionMetadata, document.RequiredTestIsolationOrdinal
-                    });
             default:
                 return Default();
         }

--- a/docs/codeunit-metadata-from-bc.md
+++ b/docs/codeunit-metadata-from-bc.md
@@ -1,0 +1,153 @@
+# CodeUnit Metadata columns from BC's own document
+
+`CodeUnit Metadata` (2000000137) has 11 columns. Five are built from the runner's own object
+inventory; four are read from the metadata document BC's emitter produces for each codeunit
+(#3606); two are left at BC's default, for reasons that are not "not implemented yet".
+
+The code is `AlRunner/Patches/RecordPatches.CodeunitMetadataFromBcDocument.cs`, wired into the
+row builder in `RecordPatches.CodeunitMetadataVirtualTable.cs`. This document holds the
+measurements behind it, and the two facts that are easy to get backwards.
+
+<a id="the-eleven-columns"></a>
+
+## The eleven columns and where each comes from
+
+BC's own row builder is `Microsoft.Dynamics.Nav.Runtime.CodeUnitDataProvider.GetValuesWithinRangeForKeyField`
+(Ncl.dll), which fills an eleven-slot buffer in this order:
+
+| # | column | AL name | BC fills it from | runner |
+|---|---|---|---|---|
+| 1 | ID | `ID` | the object number | inventory |
+| 2 | Name | `Name` | the object name | inventory |
+| 3 | TableNo | `TableNo` | `NCLMetaCodeunit.TableId` | inventory (#3546 is open against it) |
+| 4 | SingleInstance | `SingleInstance` | `IsSingleInstance \|\| id == 1` | inventory |
+| 5 | SubType | `SubType` | `GetOptionValue(5, (int)Subtype)` | inventory + option string (#3080) |
+| 6 | App ID | `App ID` | `MetadataDataProvider.GetAppId(metaCodeunit)` | **BC's default** |
+| 7 | InherentPermissions | `InherentPermissions` | `CreatePermissionMaskString(…Permissions)` | **BC's document** |
+| 8 | InherentEntitlements | `InherentEntitlements` | `CreatePermissionMaskString(…Entitlements)` | **BC's document** |
+| 9 | TestType | `TestType` | `GetOptionValue(9, (int)TestType)` | **BC's default** |
+| 10 | RequiredTestIsolation | `RequiredTestIsolation` | `GetOptionValue(10, (int)RequiredTestIsolation)` | **BC's document** |
+| 11 | AL Namespace | `AL Namespace` | `GetNormalizedNamespace(11, …ALNamespace)` | **BC's document** |
+
+`GetNormalizedNamespace` is `NavText.Create(fieldValue)` — a passthrough despite the name.
+
+<a id="the-attribute-name-trap"></a>
+
+## The attribute-name trap: `TestIsolation` versus `RequiredTestIsolation`
+
+The AL compiler emits `TestIsolation="Disabled"`. BC's own document parser,
+`Microsoft.Dynamics.Nav.Types.Metadata.MetaCodeunit(XmlNode)`, switches on attribute name and
+compares against the string **`RequiredTestIsolation`** — a name the compiler never writes. So
+BC's XML path leaves `MetaCodeunit.RequiredTestIsolation` at its field initializer, `0` /
+`None`, for every codeunit, including one that declares `TestIsolation = Codeunit`.
+
+That is a fact about BC's XML path, and it is **not** the path a service tier's row travels.
+`CodeUnitDataProvider` reads `NclMetadata.GetMetaCodeunitById(id).RequiredTestIsolation` — an
+`NCLMetaCodeunit` built from the published app's compiled attribute, not from this document.
+The runner therefore reads the name the **compiler** writes, so its answer tracks the
+declaration, which is what the tier reports.
+
+This is the same asymmetry `SubType` has, where the value reaching the column is what the
+compiler wrote rather than what the AL author declared —
+`RecordPatches.CodeunitMetadataVirtualTable.cs`'s `AlSubtypeTheCompilerDoesNotEmit` records
+that one.
+
+If BC ever renames either attribute, corpus PR 296's `RequiredTestIsolation` tests go red on
+that version, and `ReadRequiredTestIsolationOrdinal` is what changes.
+
+<a id="what-the-compiler-emits"></a>
+
+## What the compiler actually emits, per declaration shape
+
+Measured on BC 28.1.49838.53910 by compiling one codeunit of each shape and dumping the
+captured document with `AL_RUNNER_TRACE_OBJECT_METADATA=2`:
+
+| declaration | `TestIsolation` attribute |
+|---|---|
+| `Subtype = Normal`, property absent | `"Disabled"` |
+| `Subtype = TestRunner`, property absent | `"Disabled"` |
+| `Subtype = TestRunner`, property declared | the declared member |
+| `Subtype = Test` | **absent** |
+
+So `Disabled` is supplied for everything except a `Subtype = Test` codeunit, and it is the
+**Test subtype**, not an omitted property, that reaches the column's `None` member.
+
+That identifies #3606's "stated for 1,658 of 1,690" figure: the 32 Base Application documents
+with no `TestIsolation` attribute are the test codeunits. It also falsifies the obvious
+reading of that figure — that the 32 are codeunits which "declined to state" a property others
+stated — which is the assumption the first draft of the corpus test was written against and
+which a service tier would have rejected.
+
+**Two AL constraints make most of this unreachable from AL**, which is why the runner-side
+mechanism tests in `AlRunner.Tests/CodeunitMetadataDocumentColumnTests.cs` exist alongside the
+corpus tests:
+
+- `AL0223` — `TestIsolation` is accepted only when `Subtype = TestRunner`.
+- `AL0195` — on a codeunit, `InherentPermissions` and `InherentEntitlements` accept only `X`.
+
+<a id="permission-mask-spelling"></a>
+
+## How a permission mask is spelled
+
+`MetadataDataProvider.CreatePermissionMaskString` (Ncl.dll) returns `NavText.Empty` for
+`PermissionMask.None`; otherwise it walks bits 0..4 and emits `permissions[n]` for a direct
+bit, or `permissions[n] + 32` — the lowercase letter — for the matching indirect bit at `n+5`.
+It sizes its stack buffer with `PopCount((num >> 5) | (num & 0x1F))`, so one permission never
+contributes two characters.
+
+`permissions` is a static `char[5]` initialized from a blob. Decoded from BC 28.1's
+`<PrivateImplementationDetails>`:
+
+```
+52 00 49 00 4D 00 44 00 58 00   ->  'R' 'I' 'M' 'D' 'X'
+```
+
+`PermissionMask` itself (Types.dll) numbers `Read=1, Insert=2, Modify=4, Delete=8,
+Execute=16`, then `IndirectRead=32` … `IndirectExecute=512`, plus flags above that
+(`HasExpDate=4096`, `IgnoreWildcard=32768`) which no permission column spells.
+
+The attribute BC emits is the mask's **numeric** value — `InherentPermissions="16"` for
+`InherentPermissions = X` — and BC's own parser reads it with
+`Enum.Parse(typeof(PermissionMask), value)`, which accepts a numeric string or a member name.
+The runner accepts both for the same reason, and refuses anything it cannot read rather than
+answering the empty string, which would be indistinguishable from a codeunit declaring no
+permission.
+
+<a id="the-two-columns-left-at-bcs-default"></a>
+
+## The two columns left at BC's default
+
+Neither is waiting on this conversion; neither is in the document to convert.
+
+**`App ID`** is not an object property. BC fills it with
+`MetadataDataProvider.GetAppId(metaCodeunit)` — the id of the app the object was *published*
+from, which is per-run state a compiler cannot emit. Answering it needs per-object app
+attribution, the same data #2326 tracks for `AllObj`'s "Object Subtype".
+
+**`TestType`** is emitted **0 times** in Base Application's 1,690 codeunit documents, and BC
+does not read it from the document either. `MetaCodeunit`'s ctor **derives** it, in a tail
+block after the attribute loop:
+
+```
+if (SubType == CodeunitSubType.Test && TestType == 0)
+    TestType = TestCodeunitTestType.UnitTest;      // i.e. 1
+```
+
+So a service tier reports `UnitTest` for a test codeunit that declares nothing, which is a
+derivation rather than a stated value. Reproducing it is a separate claim about BC needing its
+own corpus test, and is deliberately not part of #3606.
+
+<a id="what-adjudicated-this"></a>
+
+## What adjudicated this
+
+Corpus PR 296 (`StefanMaron/BusinessCentral.AL.Language.Tests`) adds four tests and seven
+fixtures to `record/TestCodeunitMetadataVirtualTable.al`:
+
+- `Record_CodeunitMetadata_Get_TestRunnerCodeunits_ReportEachDeclaredTestIsolation`
+- `Record_CodeunitMetadata_Get_TestSubtypeCodeunit_ReportsADifferentTestIsolationFromAPlainOne`
+- `Record_CodeunitMetadata_Get_InherentPermissionsAndEntitlements_ReadIndependently`
+- `Record_CodeunitMetadata_Get_ALNamespace_ReportsTheDeclaringFilesNamespace`
+
+All four fail against the runner as it stood before #3606, with concrete wrong values: `None`
+where `Disabled` is declared, `''` where `X` is declared, `''` where a namespace is declared.

--- a/docs/codeunit-metadata-from-bc.md
+++ b/docs/codeunit-metadata-from-bc.md
@@ -1,8 +1,12 @@
 # CodeUnit Metadata columns from BC's own document
 
 `CodeUnit Metadata` (2000000137) has 11 columns. Five are built from the runner's own object
-inventory; four are read from the metadata document BC's emitter produces for each codeunit
-(#3606); two are left at BC's default, for reasons that are not "not implemented yet".
+inventory; three are read from the metadata document BC's emitter produces for each codeunit
+(#3606); three are left at BC's default, for reasons that are not "not implemented yet".
+
+One of those three — `RequiredTestIsolation` — **is** stated in the document, and reading it
+is wrong. A real service tier answers `None` for every codeunit. That is the section worth
+reading first, because the obvious implementation is the incorrect one.
 
 The code is `AlRunner/Patches/RecordPatches.CodeunitMetadataFromBcDocument.cs`, wired into the
 row builder in `RecordPatches.CodeunitMetadataVirtualTable.cs`. This document holds the
@@ -26,38 +30,95 @@ BC's own row builder is `Microsoft.Dynamics.Nav.Runtime.CodeUnitDataProvider.Get
 | 7 | InherentPermissions | `InherentPermissions` | `CreatePermissionMaskString(…Permissions)` | **BC's document** |
 | 8 | InherentEntitlements | `InherentEntitlements` | `CreatePermissionMaskString(…Entitlements)` | **BC's document** |
 | 9 | TestType | `TestType` | `GetOptionValue(9, (int)TestType)` | **BC's default** |
-| 10 | RequiredTestIsolation | `RequiredTestIsolation` | `GetOptionValue(10, (int)RequiredTestIsolation)` | **BC's document** |
+| 10 | RequiredTestIsolation | `RequiredTestIsolation` | `GetOptionValue(10, (int)RequiredTestIsolation)` | **BC's default** (see below) |
 | 11 | AL Namespace | `AL Namespace` | `GetNormalizedNamespace(11, …ALNamespace)` | **BC's document** |
 
 `GetNormalizedNamespace` is `NavText.Create(fieldValue)` — a passthrough despite the name.
 
-<a id="the-attribute-name-trap"></a>
+<a id="requiredtestisolation"></a>
 
-## The attribute-name trap: `TestIsolation` versus `RequiredTestIsolation`
+## `RequiredTestIsolation`: BC answers `None` for every codeunit, so the runner defaults it
 
-The AL compiler emits `TestIsolation="Disabled"`. BC's own document parser,
-`Microsoft.Dynamics.Nav.Types.Metadata.MetaCodeunit(XmlNode)`, switches on attribute name and
-compares against the string **`RequiredTestIsolation`** — a name the compiler never writes. So
-BC's XML path leaves `MetaCodeunit.RequiredTestIsolation` at its field initializer, `0` /
-`None`, for every codeunit, including one that declares `TestIsolation = Codeunit`.
+This column is **stated in the document** and must not be read from it. That is the one
+counter-intuitive fact on this page, and it cost a full implementation to find out.
 
-That is a fact about BC's XML path, and it is **not** the path a service tier's row travels.
-`CodeUnitDataProvider` reads `NclMetadata.GetMetaCodeunitById(id).RequiredTestIsolation` — an
-`NCLMetaCodeunit` built from the published app's compiled attribute, not from this document.
-The runner therefore reads the name the **compiler** writes, so its answer tracks the
-declaration, which is what the tier reports.
+### What a service tier answers
 
-This is the same asymmetry `SubType` has, where the value reaching the column is what the
-compiler wrote rather than what the AL author declared —
-`RecordPatches.CodeunitMetadataVirtualTable.cs`'s `AlSubtypeTheCompilerDoesNotEmit` records
-that one.
+Corpus PR 296 asked eight cloud legs (27.0, 27.3, 27.5, 28.0, 28.1, 28.2, 28.3, 28.4) what
+this column reports for three shapes. Identical answer on all eight:
 
-If BC ever renames either attribute, corpus PR 296's `RequiredTestIsolation` tests go red on
-that version, and `ReadRequiredTestIsolationOrdinal` is what changes.
+| codeunit | declares | tier answers |
+|---|---|---|
+| `ALT Iso Runner Disabled` | `Subtype = TestRunner`, `TestIsolation = Disabled` | `None` |
+| `ALT Codeunit Meta Probe` | ordinary codeunit, no `Subtype` | `None` |
+| the test codeunit itself | `Subtype = Test` | `None` |
+
+The decisive one is the first: a codeunit that **explicitly declares** `TestIsolation =
+Disabled` still reports `None`. So the column does not track the declaration, and a
+document-read implementation — which by construction answers `Disabled` there — is wrong.
+
+The failing assertion, from the BC 28.1 leg:
+
+```
+FAIL Record_CodeunitMetadata_Get_TestRunnerCodeunits_ReportEachDeclaredTestIsolation
+     Expected:<1> (Integer). Actual:<None> (Integer).
+     A TestRunner declaring TestIsolation = Disabled must report RequiredTestIsolation::Disabled.
+```
+
+### Why, in Ncl.dll
+
+Not a mystery, and not the XML parser. `CodeUnitDataProvider.GetValuesWithinRangeForKeyField`
+fills slot 9 from the `NCLMetaCodeunit`, never from the document:
+
+```csharp
+buffer[9] = codeUnitDataProvider.GetOptionValue(10, (int)metaCodeunitById.RequiredTestIsolation);
+```
+
+And `NCLMetaCodeunit.RequiredTestIsolation` is a property nothing ever assigns:
+
+```csharp
+public TestCodeunitRequiredTestIsolation RequiredTestIsolation { get; private set; }
+```
+
+- The `<RequiredTestIsolation>k__BackingField` has **zero writes** anywhere in `Ncl.dll`
+  (`find_usages` returns an empty set on 28.1).
+- The private constructor sets `subscriberReflectionWrapper` and `base.ALNamespace`, nothing else.
+- `LoadOptionsFromAttributeOrInstance`, which *does* read `NavCodeunitOptionsAttribute`,
+  assigns only `tableId` and `subtype`.
+
+`private set` with no writer means the property is permanently at its default, `0`, which this
+column names `None`. Verified identical on `bc270` and `bc281`, so it is not a version quirk.
+
+**BC's default is therefore the faithful answer**, and `NavValue.GetDefaultNavValue` already
+gives it. This is not a known gap: there is nothing to implement, because the tier value is
+not derived from anything the runner could read better.
+
+### What was tried, and why it is recorded here
+
+The first implementation of #3606 converted this column from the document's `TestIsolation`
+attribute, on the reasoning that BC's own XML parser matches `RequiredTestIsolation` — a name
+the compiler never writes — so the document path must not be the tier's path, and the
+compiler's name must be the one that tracks what a tier reports.
+
+The first half is true and the conclusion does not follow. The tier's row does travel
+`NCLMetaCodeunit` rather than the XML parser, but that path does not carry the value either.
+Both routes leave the property at `None`; the tier's behaviour happens to match what the XML
+parser's name mismatch would produce, for a different reason.
+
+That is the whole lesson: reading BC's parser established which path is *not* used, and was
+taken as evidence for what the used path answers. Only the service tier settled it. The
+conversion, its runner-side tests and the two corpus assertions were removed rather than
+adjusted.
 
 <a id="what-the-compiler-emits"></a>
 
 ## What the compiler actually emits, per declaration shape
+
+This is a measurement of the **document**, which is a different thing from what the column
+answers — see [`#requiredtestisolation`](#requiredtestisolation), where a tier answers `None`
+whatever this table says. It is kept because it explains the figure #3606 was filed on, and
+because the next person to notice `TestIsolation` sitting in the document will otherwise
+re-derive it.
 
 Measured on BC 28.1.49838.53910 by compiling one codeunit of each shape and dumping the
 captured document with `AL_RUNNER_TRACE_OBJECT_METADATA=2`:
@@ -69,14 +130,15 @@ captured document with `AL_RUNNER_TRACE_OBJECT_METADATA=2`:
 | `Subtype = TestRunner`, property declared | the declared member |
 | `Subtype = Test` | **absent** |
 
-So `Disabled` is supplied for everything except a `Subtype = Test` codeunit, and it is the
-**Test subtype**, not an omitted property, that reaches the column's `None` member.
+So the compiler supplies `Disabled` for everything except a `Subtype = Test` codeunit.
 
 That identifies #3606's "stated for 1,658 of 1,690" figure: the 32 Base Application documents
-with no `TestIsolation` attribute are the test codeunits. It also falsifies the obvious
-reading of that figure — that the 32 are codeunits which "declined to state" a property others
-stated — which is the assumption the first draft of the corpus test was written against and
-which a service tier would have rejected.
+with no `TestIsolation` attribute are the test codeunits, not codeunits that "declined to
+state" a property others stated.
+
+**None of it reaches the column.** A tier answers `None` for all four rows above, including
+the third — which is exactly what makes the document a bad source for this column and is why
+`RequiredTestIsolation` is defaulted rather than converted.
 
 **Two AL constraints make most of this unreachable from AL**, which is why the runner-side
 mechanism tests in `AlRunner.Tests/CodeunitMetadataDocumentColumnTests.cs` exist alongside the
@@ -141,13 +203,24 @@ own corpus test, and is deliberately not part of #3606.
 
 ## What adjudicated this
 
-Corpus PR 296 (`StefanMaron/BusinessCentral.AL.Language.Tests`) adds four tests and seven
-fixtures to `record/TestCodeunitMetadataVirtualTable.al`:
+Corpus PR 296 (`StefanMaron/BusinessCentral.AL.Language.Tests`), on eight cloud legs.
 
-- `Record_CodeunitMetadata_Get_TestRunnerCodeunits_ReportEachDeclaredTestIsolation`
-- `Record_CodeunitMetadata_Get_TestSubtypeCodeunit_ReportsADifferentTestIsolationFromAPlainOne`
-- `Record_CodeunitMetadata_Get_InherentPermissionsAndEntitlements_ReadIndependently`
-- `Record_CodeunitMetadata_Get_ALNamespace_ReportsTheDeclaringFilesNamespace`
+**Green, and what the two converted columns rest on:**
 
-All four fail against the runner as it stood before #3606, with concrete wrong values: `None`
-where `Disabled` is declared, `''` where `X` is declared, `''` where a namespace is declared.
+- `Record_CodeunitMetadata_Get_InherentPermissionsAndEntitlements_ReadIndependently` — a
+  codeunit declaring `InherentPermissions = X` reports `'X'` while its entitlement column
+  stays empty, and the reverse for the sibling; a codeunit declaring neither reports both
+  empty.
+- `Record_CodeunitMetadata_Get_ALNamespace_ReportsTheDeclaringFilesNamespace` — a namespaced
+  codeunit reports its full dotted namespace, an un-namespaced one the empty string.
+
+Both fail against the runner as it stood before #3606, with concrete wrong values: `''` where
+`X` is declared, `''` where a namespace is declared.
+
+**Red on all eight, and removed:** two `RequiredTestIsolation` tests, which asserted the
+column tracks the declared property. It does not — see
+[`#requiredtestisolation`](#requiredtestisolation). They were dropped from the corpus PR
+rather than inverted to assert `None`: pinning an observation without a mechanism is what
+`.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md` forbids, and the mechanism that
+*was* established (a property `Ncl.dll` never assigns) is a fact about the runtime engine
+rather than about AL, so it has no AL assertion that would fail if it were different.


### PR DESCRIPTION
Closes #3606

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/296

`CodeUnit Metadata` (2000000137) answered 5 of its 11 columns and handed the other 6
`NavValue.GetDefaultNavValue`. Three of those six are stated in the metadata document BC's own
emitter produces for every object it compiles, and are now read from it.

| column | read from | example |
|---|---|---|
| `AL Namespace` | `ALNamespace` | `ALLanguage.Coverage.MetadataProbes` |
| `InherentPermissions` | `InherentPermissions` | `16` → `X` |
| `InherentEntitlements` | `InherentEntitlements` | `16` → `X` |

## A fourth column was removed after a service tier refuted it

**This PR previously converted `RequiredTestIsolation` too, and that was wrong.** It was
CI-green here and red on all eight cloud legs of corpus PR #296. The failure was real, not
flaky — identical on every leg:

```
FAIL Record_CodeunitMetadata_Get_TestRunnerCodeunits_ReportEachDeclaredTestIsolation
     Expected:<1> (Integer). Actual:<None> (Integer).
     A TestRunner declaring TestIsolation = Disabled must report RequiredTestIsolation::Disabled.
```

A codeunit that **explicitly declares** `TestIsolation = Disabled` still reports `None` on a
real tier. So the column is not a readback of the declared property, which is exactly what the
conversion implemented. It was green here only because the runner and its runner-local tests
had been changed to match the same wrong belief — the failure mode `.claude/rules/tdd.md`
calls a test that passes against a wrong mental model.

The column is back on `NavValue.GetDefaultNavValue`, and the runner-side tests that encoded
the refuted belief are deleted rather than adjusted.

### The mechanism is established, not assumed

`CodeUnitDataProvider.GetValuesWithinRangeForKeyField` (Ncl.dll) fills the column from the
`NCLMetaCodeunit`, never from the document:

```csharp
buffer[9] = codeUnitDataProvider.GetOptionValue(10, (int)metaCodeunitById.RequiredTestIsolation);
```

and that property is one nothing ever assigns:

```csharp
public TestCodeunitRequiredTestIsolation RequiredTestIsolation { get; private set; }
```

- `<RequiredTestIsolation>k__BackingField` has **zero writes** anywhere in `Ncl.dll`
  (`find_usages` returns an empty set).
- The private constructor sets `subscriberReflectionWrapper` and `base.ALNamespace`, nothing else.
- `LoadOptionsFromAttributeOrInstance`, which *does* read `NavCodeunitOptionsAttribute`, assigns
  only `tableId` and `subtype`.

`private set` with no writer means the property sits permanently at its default `0`, which this
column names `None`. Checked on `bc270` and `bc281` — same on both, so not a version quirk.
**BC's default is the faithful answer**, so this is not a known gap: there is nothing to
implement.

### What the earlier reasoning got wrong, since it looked sound

The conversion rested on a real observation: BC's XML parser `MetaCodeunit(XmlNode)` matches
`RequiredTestIsolation`, a name the compiler never writes, so the document path cannot be the
tier's path — therefore, it concluded, read the name the *compiler* writes and the runner will
track what a tier reports.

The premise is true and the conclusion does not follow. The tier's row does travel
`NCLMetaCodeunit` rather than the XML parser, but that path does not carry the value either.
Both leave the property at `None`. Reading BC's parser established which path is *unused* and
was taken as evidence about what the used path *answers*. Only the service tier settled it.

## The corpus side

Corpus PR #296 now carries the two assertions a tier confirmed and no longer carries the two it
refuted, **and it is green on all eight cloud legs** (run `34311454488`).

The two failing assertions were **removed, not inverted to assert `None`**. The mechanism above
is a fact about the runtime engine, not about AL: no AL assertion would fail if it were
different, so pinning `None` in the corpus would record an observation with no mechanism behind
it — what `.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md` forbids. The fixture
`ALTIsolationRunnerProbes.al` went with them; nothing else referenced 60036/60048/60049/60137.

Execution verified rather than inferred from the tick (`tools/corpus-pass-count.py`):
**8 legs ran the codeunit, 18 distinct PASS each, 0 failures**; the 8 OnPrem legs run a
different 29-test suite and never carried it. Both kept tests confirmed by name on 28.1.

## RED → GREEN

Run against my corpus branch with `--package-cache "$HOME/.al-runner/platform-apps"`.

**RED** — the runner at the branch point (`96e1cbc4`), concrete wrong values, not merely absent:

```
FAIL Record_CodeunitMetadata_Get_InherentPermissionsAndEntitlements_ReadIndependently
     Expected:<X> (Text). Actual:<> (Text).
FAIL Record_CodeunitMetadata_Get_ALNamespace_ReportsTheDeclaringFilesNamespace
     Expected:<ALLanguage.Coverage.MetadataProbes> (Text). Actual:<> (Text).
```

16 pass / 2 fail.

**GREEN** — same bundle, this branch: **18 pass / 0 fail**.

## What I ran

**Full pinned corpus (`c9d5f656`), against this branch.** The counts are the verdict, not the
exit code, and they match `tests/expectations/count-baseline/` exactly:

| suite | baseline | measured |
|---|---|---|
| `al-language` | 3112 | **3112 pass / 0 fail** |
| `al-language-internals-fixture` | 0 | **0** |
| `al-language-onprem` | 29 | **29 pass / 0 fail** |

Classification breakdown unchanged: `pass-oos 4`, `pass-known-gap 6`, `pass-divergence 1`.

- **`runner-extras`**: **406 pass / 0 fail**, `--count-baseline` accepted (exit 0).
- **`AlRunner.Tests`, filtered** (`CodeunitMetadata`, `MetadataOptionColumnOrdinal`,
  `VirtualTableRefusalClaim`): **115 passed, 0 failed**.
- **`tools/test_doc_pointers.py`**: all checks pass.

## No pin bump

Not legal right now, and not attempted. The oldest held-out corpus commit is `26b0434`
(corpus #293), whose runner fix is #3580 — open, no PR — and corpus history is linear, so
everything is blocked behind it. `tests/expectations/count-baseline/history.md` records the
same. The bump for corpus #296 belongs in whichever PR unblocks that queue.

## Where the prose went

`docs/codeunit-metadata-from-bc.md` previously asserted the refuted hypothesis as established
fact, under a section titled "the attribute-name trap". That section is rewritten to state what
was measured — the eight-leg result, the `Ncl.dll` mechanism, and the fact that the earlier
reasoning was sound about which path is unused while establishing nothing about the used one.
The document-emission measurement is kept, because it still explains #3606's "1,658 of 1,690"
figure, but now says plainly that none of it reaches the column.

## Fixing the shape, not just the reported line

1. **Same wrong pattern elsewhere?** The two permission-mask columns exist identically on
   `Table Metadata` and `Page Metadata` and still default them. Not folded in: different files,
   different providers, and the mask there is not restricted to `X`, so each needs its own
   corpus adjudication. The bit walk here is written out in full rather than special-cased to
   16 for that reason.
2. **Sibling with the same assumption?** `RequiredTestIsolation` was the sibling, and it is the
   one this PR removes. Worth stating as a general shape: a value being **present in BC's
   document** does not imply the tier's column reads it. Two of the three kept columns were
   checked against `CodeUnitDataProvider`'s actual buffer assignments, not just against the
   document.
3. **Two paths writing the same state?** Both refusal paths are raised **outside**
   `InsertVirtualRow`, next to the existing subtype resolution, because a throw inside it
   escapes `GetDataAccessForTable` and costs the whole table rather than one row (#3536).

## Open issues in the same area I did NOT fold in

- **#3546** — `TableNo` reads 0 for five Base App codeunits with `#<appid>#`-qualified table
  names. Same file, and I looked: it is `status: blocked` / `blocked-by: metadata-emitter`, and
  `TableNo` is not in BC's document at all, so it comes from the symbol inventory and this
  conversion cannot touch it.
- **#3599 / PR #3610** — the metadata loader seam. Adjacent and in flight; this PR reaches
  `AlObjectMetadataRegistry` directly to avoid colliding with it.
- **#3607 / #3608 / #3609** — sibling conversions for Report Metadata, Query and PermissionSet.
  Different files, separate PRs by design.

## Deliberately left out

- **`RequiredTestIsolation`** — refuted above. Not a known gap; BC's default is correct.
- **`TestType`** — emitted 0 times in Base Application's 1,690 codeunit documents; BC *derives*
  it (`if (SubType == Test && TestType == 0) TestType = UnitTest;`). A separate BC claim needing
  its own corpus test.
- **`App ID`** — not an object property; BC fills it from the *publishing* app, per-run state a
  compiler cannot emit (#2326).

<sub>Implemented by the agent `stma-auto-2` (Claude), acting on the account holder's behalf.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
