### PR TITLE
fix(report-metadata): answer Report Metadata and Report Data Items from BC's document

### DIFF
--- a/AlRunner.Tests/ReportMetadataDocumentColumnTests.cs
+++ b/AlRunner.Tests/ReportMetadataDocumentColumnTests.cs
@@ -1,0 +1,196 @@
+// ReportMetadataDocumentColumnTests — issue #3607.
+//
+// A RUNNER-MECHANISM test, not a claim about what real BC does. The behavioural claim
+// ("Report Metadata 2000000139 and Report Data Items 2000000203 report these values")
+// is adjudicated upstream against a live BC service tier by corpus PR #299
+// (codeunit 60361 "Test Report Metadata Columns"), per
+// .claude/rules/bc-behavior-tests-go-upstream.md.
+//
+// What this pins instead is that BC's emitter DOES state each property in the document
+// the runner captures, and states it in BC's own normal form rather than echoing the AL
+// source text. That is the premise the fix rests on, and it is the half a corpus test
+// cannot see: the corpus asserts what the virtual table answers, never where the answer
+// came from. If a future BC version stopped emitting <WordMergeDataItem>, or started
+// writing the AL text into <DataItemTableView>, the corpus test would keep passing
+// against the AL-derived fallback and only this test would notice.
+
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class ReportMetadataDocumentColumnTests : IDisposable
+{
+    private readonly string _root;
+    private readonly BcEngineFixture _engine;
+
+    public ReportMetadataDocumentColumnTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = TestScratch.Dir("al-runner-report-metadata-document-tests");
+        Directory.CreateDirectory(_root);
+        AlReportMetadataRegistry.Clear();
+    }
+
+    public void Dispose()
+    {
+        AlReportMetadataRegistry.Clear();
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    /// <summary>
+    /// The fixture is chosen so every assertion below fails against the value the runner
+    /// derived from AL source before #3607: WordMergeDataItem was never read at all,
+    /// DataItemTableView was the raw source text, and the data-item id was a 1-based
+    /// declaration ordinal.
+    /// </summary>
+    private const string FixtureAl = """
+        table 90310 "RptMetaDoc Sample"
+        {
+            DataClassification = CustomerContent;
+            fields
+            {
+                field(1; "Entry No."; Integer) { DataClassification = CustomerContent; }
+                field(2; Description; Text[50]) { DataClassification = CustomerContent; }
+            }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+
+        report 90311 "RptMetaDoc Fixture"
+        {
+            UsageCategory = None;
+            ProcessingOnly = false;
+            WordMergeDataItem = Src;
+
+            dataset
+            {
+                dataitem(Src; "RptMetaDoc Sample")
+                {
+                    DataItemTableView = sorting("Entry No.") order(descending);
+                    column(EntryNo; "Entry No.") { }
+
+                    dataitem(Child; "RptMetaDoc Sample")
+                    {
+                        DataItemLink = "Entry No." = field("Entry No.");
+                        column(ChildEntryNo; "Entry No.") { }
+                    }
+                }
+            }
+        }
+        """;
+
+    private System.Xml.XmlElement EmitAndReadDocument()
+    {
+        File.WriteAllText(Path.Combine(_root, "RptMetaDoc.al"), FixtureAl);
+
+        var output = new BcCompiler().Emit(new[] { _root }, "RptMetaDocModule");
+        Assert.True(output.Sources.Count > 0,
+            $"Expected the report to emit; diagnostics: {string.Join(" | ", output.Diagnostics.Take(10))}");
+
+        Assert.True(AlReportMetadataRegistry.TryGet(90311, out var xml),
+            "Expected report 90311's metadata document to be captured at emit time — "
+            + "without it the virtual tables have nothing to read and fall back to AL source text.");
+        Assert.False(string.IsNullOrEmpty(xml), "the captured document is empty");
+
+        var doc = new System.Xml.XmlDocument();
+        doc.LoadXml(xml);
+        Assert.NotNull(doc.DocumentElement);
+        return doc.DocumentElement!;
+    }
+
+    private static string Text(System.Xml.XmlElement parent, string name)
+    {
+        foreach (System.Xml.XmlNode n in parent.ChildNodes)
+            if (n is System.Xml.XmlElement e && e.Name == name)
+                return e.InnerText ?? string.Empty;
+        return string.Empty;
+    }
+
+    private static List<System.Xml.XmlElement> DataItems(System.Xml.XmlElement parent)
+    {
+        var found = new List<System.Xml.XmlElement>();
+        foreach (System.Xml.XmlNode n in parent.ChildNodes)
+            if (n is System.Xml.XmlElement e && e.Name == "DataItem")
+            {
+                found.Add(e);
+                found.AddRange(DataItems(e));
+            }
+        return found;
+    }
+
+    [SkippableFact]
+    public void EmittedDocument_StatesTheReportPropertiesTheVirtualTableReports()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var root = EmitAndReadDocument();
+
+        // Positive, and the one the AL-derived path could not answer at all: the report
+        // declares WordMergeDataItem, and BC states it. The virtual table hardcoded "".
+        Assert.Equal("Src", Text(root, "WordMergeDataItem"));
+
+        // BC writes booleans as "1"/"0" here. The fixture declares ProcessingOnly = false,
+        // which is also the value NavReportSync's legacy stub path hardcodes to TRUE — so
+        // this asserts the document disagrees with that hardcode rather than merely
+        // restating a default.
+        Assert.Equal("0", Text(root, "ProcessingOnly"));
+        Assert.Equal("1", Text(root, "UseRequestPage"));
+
+        // Negative: the document is about THIS report, not a template — the id and name
+        // are the fixture's own, so a document served for the wrong report is detectable.
+        Assert.Equal("90311", Text(root, "ID"));
+        Assert.Equal("RptMetaDoc Fixture", Text(root, "Name"));
+    }
+
+    [SkippableFact]
+    public void EmittedDocument_StatesEachDataItemsTableIdIndentAndCompiledView()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var items = DataItems(EmitAndReadDocument());
+        Assert.Equal(2, items.Count);
+
+        var rootItem = items.Single(i => Text(i, "DataItemVarName") == "Src");
+        var childItem = items.Single(i => Text(i, "DataItemVarName") == "Child");
+
+        // The table is already RESOLVED TO AN ID by BC — no name lookup needed, which is
+        // what lets the virtual table answer a report whose data-item table the runner's
+        // own name resolution would have dropped the whole row over.
+        Assert.Equal("90310", Text(rootItem, "DataItemTable"));
+        Assert.Equal("90310", Text(childItem, "DataItemTable"));
+
+        // Nesting is stated, not counted.
+        Assert.Equal("0", Text(rootItem, "DataItemIndent"));
+        Assert.Equal("1", Text(childItem, "DataItemIndent"));
+
+        // The view is BC's COMPILED form, not the AL source text. Asserting both
+        // directions: the ORDER clause survives, and the raw source spelling does not
+        // appear — the latter is what the runner used to hand out.
+        var view = Text(rootItem, "DataItemTableView");
+        Assert.Contains("ORDER(", view, StringComparison.Ordinal);
+        Assert.DoesNotContain("sorting(", view, StringComparison.Ordinal);
+        Assert.DoesNotContain("descending", view, StringComparison.Ordinal);
+    }
+
+    [SkippableFact]
+    public void EmittedDocument_DataItemIdsArePlatformAssigned_NotDeclarationOrdinals()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var items = DataItems(EmitAndReadDocument());
+        var ids = items.Select(i => int.Parse(Text(i, "ID"))).ToList();
+
+        Assert.Equal(2, ids.Count);
+        Assert.Equal(2, ids.Distinct().Count());
+
+        // The load-bearing property, and the reason the ordinal was not a harmless
+        // stand-in: Ncl's ReportDataItemsDataProvider.GetReportDataItems keys, sorts and
+        // range-filters Report Data Items rows on this id. A caller that reads an id from
+        // one row and filters by it must select that row, which the ordinal could not do.
+        Assert.DoesNotContain(1, ids);
+        Assert.DoesNotContain(2, ids);
+    }
+}

--- a/AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs
@@ -364,7 +364,10 @@ public static partial class RecordPatches
                     + $"dataset: {string.Join("; ", unresolved.Take(10))}"
                     + (unresolved.Count > 10 ? $" (+{unresolved.Count - 10} more)" : string.Empty));
 
-            _reportRows = rows.Values.ToList();
+            // BC's own emitted document overrides the AL-derived properties wherever it
+            // states them — see RecordPatches.ReportRowFromBcDocument.cs for which columns
+            // and why the two disagree. A report with no document keeps the row above.
+            _reportRows = rows.Values.Select(ApplyBcReportDocument).ToList();
             _reportRowsBuiltFrom = generation;
             // Env-gated so a normal run stays quiet. The stream is arbitrary, not load-bearing:
             // Log's filter wraps stdout and stderr alike, and this tag is hyphenated so it

--- a/AlRunner/Patches/RecordPatches.ReportRowFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.ReportRowFromBcDocument.cs
@@ -24,8 +24,8 @@
 // WHY BC'S DOCUMENT AND NOT THE AL TEXT
 //   BC's own providers for these two tables read BC's compiled metadata, so the document is
 //   not merely another source for the same values — it is the source, and it differs from AL
-//   source text in ways a caller can observe. Measured on the corpus fixture report 60360
-//   (BC 28.1); the emitted document is quoted in full in docs/report-metadata-from-bc.md:
+//   source text in ways a caller can observe. Measured on the test fixture report 90311
+//   (BC 28.1); docs/report-metadata-from-bc.md has the fixture and the measurement:
 //
 //     DataItemTableView   AL text  sorting("Entry No.") order(descending)
 //                         document SORTING(1) ORDER(1)               <- BC's normal form

--- a/AlRunner/Patches/RecordPatches.ReportRowFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.ReportRowFromBcDocument.cs
@@ -1,0 +1,237 @@
+// RecordPatches.ReportRowFromBcDocument — answer Report Metadata (2000000139) and
+// Report Data Items (2000000203) from BC's own emitted metadata document, instead of
+// re-deriving the same properties from AL source text (issue #3607, part of the
+// conversion chain #3562 tracks). Follows RecordPatches.NclMetaTableFromBcDocument.cs,
+// which did this for Table Metadata at #3584.
+//
+// WHERE THE DOCUMENT COMES FROM
+//   AlReportMetadataRegistry holds the runtime metadata XML BC's own Compilation.Emit
+//   produced for every report the runner compiled. It already feeds the report EXECUTION
+//   path (NavReportSync.GetRealMetaReport). These two virtual tables read none of it before
+//   this file — grep AlReportMetadataRegistry in RecordPatches.ReportMetadataVirtualTable.cs
+//   returned nothing. A report from a precompiled dependency keeps the row derived from its
+//   SymbolReference.json; see TryGetBcReportDocument for why that route is not taken here.
+//
+// WHY THE XML AND NOT THE MetaReport GetRealMetaReport ALREADY BUILDS
+//   That was the first implementation and it is a trap, so it is written down rather than
+//   rediscovered. GetRealMetaReport forces MetaReport.RequestFormMetadata as a deliberate
+//   side effect — it builds the report's whole REQUEST PAGE so a failure is contained at
+//   construction. Populating a virtual table enumerates EVERY known report, so that turned
+//   one Report Metadata read into 28 request-page builds on the al-language corpus and blew
+//   the 60s per-test watchdog on the first assertion. The properties below are stated
+//   directly by the document, so reading them costs one XML parse and no page construction.
+//
+// WHY BC'S DOCUMENT AND NOT THE AL TEXT
+//   BC's own providers for these two tables read BC's compiled metadata, so the document is
+//   not merely another source for the same values — it is the source, and it differs from AL
+//   source text in ways a caller can observe. Measured on the corpus fixture report 60360
+//   (BC 28.1); the emitted document is quoted in full in docs/report-metadata-from-bc.md:
+//
+//     DataItemTableView   AL text  sorting("Entry No.") order(descending)
+//                         document SORTING(1) ORDER(1)               <- BC's normal form
+//     data item Id        ordinal  1
+//                         document 1369927887                        <- BC's assigned id
+//     WordMergeDataItem   AL text  never read at all -> ""
+//                         document Src
+//
+//   Ncl's ReportDataItemsDataProvider.GetReportDataItems keys, sorts and range-filters on
+//   MetaDataItem.Id, so the ordinal was not a harmless stand-in: a caller that reads an id
+//   out of one row and filters this table by it gets nothing back.
+//
+// SCOPE — WHAT THIS DOES NOT CLAIM
+//   Ncl's provider fills 29 Report Metadata columns off NCLMetaReport. This fills the ones
+//   the document states directly and leaves the rest on BC's own GetDefaultNavValue, exactly
+//   as before. Sorting Fields and Request Filter Fields both resolve through a table's
+//   NCLMetaField numbering (GetSortingFieldsIfAny / GetRequestFilterFieldsIfAny), and
+//   ReqFilterFields is stated on the request page's filter control rather than on the data
+//   item at all — a separate resolution step this change does not take on; #3620 tracks it.
+//   Nothing here answers a column with a guess: a report with no registered document keeps
+//   the AL-derived row it had before.
+//
+// PRECOMPILED-DLL RESPECT
+//   Reads an XML document BC's own emitter produced. No BC method body is rewritten, no BC
+//   type is constructed, and no AL business logic is touched.
+using System.Xml;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    /// <summary>
+    /// The subset of BC's report document the two virtual tables read, parsed once per report.
+    /// <see cref="DataItems"/> is the document's own order, flattened depth-first, which is
+    /// how <c>MetaReport.DataItems</c> presents it.
+    /// </summary>
+    private sealed record BcReportDocument(
+        bool ProcessingOnly, bool UseRequestPage, string WordMergeDataItem,
+        List<BcReportDocumentDataItem> DataItems);
+
+    private sealed record BcReportDocumentDataItem(
+        int Id, string VarName, int TableId, int Indent, string TableView);
+
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<int, BcReportDocument?>
+        _bcReportDocuments = new();
+
+    internal static void ClearBcReportDocuments() => _bcReportDocuments.Clear();
+
+    /// <summary>
+    /// BC's document for this report, or null when the emitter never captured one. A null
+    /// keeps the AL-derived row, which is exactly what the caller had before this file.
+    ///
+    /// <para><b>Emit capture only — deliberately NOT TryBuildDependencyReportMetadata.</b>
+    /// That is the other producer of the same document, and it is the one
+    /// <c>NavReportSync.GetRealMetaReport</c> falls back to, so reaching for it here looks
+    /// like completeness. It is a trap on this path, because the two callers ask at
+    /// different scales: report execution synthesizes a document for the ONE report being
+    /// run, while populating a virtual table asks about EVERY report the runner knows —
+    /// which, with Base Application registered, is 659 of them. Each miss walks every
+    /// registered .app's symbol list and each hit additionally reads AL source out of the
+    /// package to recover column expressions. Measured on the al-language corpus, that put
+    /// the first Report Metadata read past the 60s per-test watchdog; the emit-captured
+    /// lookup below is a dictionary hit and the same read is 26ms.</para>
+    ///
+    /// <para>Nothing is lost by the narrower source: a dependency report has no emitted
+    /// document, so it keeps the SymbolReference.json-derived row — which is where its
+    /// WordMergeDataItem, ProcessingOnly and data-item tree already came from.</para>
+    /// </summary>
+    private static BcReportDocument? TryGetBcReportDocument(int reportId)
+        => _bcReportDocuments.GetOrAdd(reportId, static id =>
+        {
+            if (!AlReportMetadataRegistry.TryGet(id, out var xml) || string.IsNullOrEmpty(xml))
+                return null;
+            try
+            {
+                var doc = new XmlDocument();
+                doc.LoadXml(xml);
+                return doc.DocumentElement == null ? null : ParseBcReportDocument(doc.DocumentElement);
+            }
+            catch (XmlException ex)
+            {
+                // A malformed document is a capture bug, not a reason to serve nothing: fall
+                // back to the AL-derived row and name the report once so it is diagnosable.
+                Console.Error.WriteLine(
+                    $"[report-metadata] report {id}: BC's metadata document did not parse "
+                    + $"({ex.Message}) — falling back to the AL-derived row");
+                return null;
+            }
+        });
+
+    private static BcReportDocument ParseBcReportDocument(XmlElement root)
+    {
+        var items = new List<BcReportDocumentDataItem>();
+        foreach (XmlNode child in root.ChildNodes)
+            if (child is XmlElement e && e.Name == "DataItem")
+                CollectBcDataItem(e, items);
+
+        return new BcReportDocument(
+            // AL's own defaults where the document is silent, which is what BC's emitter does
+            // for a property left at its default: ProcessingOnly false, UseRequestPage true.
+            ProcessingOnly: ReadBcFlag(root, "ProcessingOnly", defaultValue: false),
+            UseRequestPage: ReadBcFlag(root, "UseRequestPage", defaultValue: true),
+            WordMergeDataItem: ReadBcText(root, "WordMergeDataItem"),
+            DataItems: items);
+    }
+
+    /// <summary>
+    /// Depth-first, parent before children — the order <c>MetaReport.DataItems</c> reports and
+    /// the order the AL parser already produced, so the two remain comparable by position for
+    /// anything that still pairs them up. DataItemIndent is read from the document rather than
+    /// counted, because the document states it and a counted depth would be a second opinion.
+    /// </summary>
+    private static void CollectBcDataItem(XmlElement item, List<BcReportDocumentDataItem> into)
+    {
+        into.Add(new BcReportDocumentDataItem(
+            Id: ReadBcInt(item, "ID"),
+            VarName: ReadBcText(item, "DataItemVarName"),
+            TableId: ReadBcInt(item, "DataItemTable"),
+            Indent: ReadBcInt(item, "DataItemIndent"),
+            TableView: ReadBcText(item, "DataItemTableView")));
+
+        foreach (XmlNode child in item.ChildNodes)
+            if (child is XmlElement e && e.Name == "DataItem")
+                CollectBcDataItem(e, into);
+    }
+
+    private static string ReadBcText(XmlElement parent, string name)
+    {
+        foreach (XmlNode child in parent.ChildNodes)
+            if (child is XmlElement e && e.Name == name)
+                return e.InnerText ?? string.Empty;
+        return string.Empty;
+    }
+
+    private static int ReadBcInt(XmlElement parent, string name)
+        => int.TryParse(ReadBcText(parent, name), out var v) ? v : 0;
+
+    /// <summary>BC writes a boolean property as "1"/"0" in this document.</summary>
+    private static bool ReadBcFlag(XmlElement parent, string name, bool defaultValue)
+    {
+        var text = ReadBcText(parent, name);
+        return string.IsNullOrEmpty(text) ? defaultValue : text == "1";
+    }
+
+    /// <summary>
+    /// Overlay BC's document onto a row derived from AL source. Every property BC states wins;
+    /// anything BC does not state (the caption, and the columns neither source answers) keeps
+    /// the AL-derived value. Returns <paramref name="row"/> unchanged when no document exists.
+    ///
+    /// The data-item list is REPLACED rather than merged, because the two sources disagree on
+    /// the identity of a row — BC's Id against the AL parser's ordinal — so a merge would have
+    /// to pair them up by position and would mis-pair silently the moment the orders differ.
+    /// </summary>
+    private static ReportRow ApplyBcReportDocument(ReportRow row)
+    {
+        var doc = TryGetBcReportDocument(row.Id);
+        if (doc == null) return row;
+
+        // A document with no DataItem element describes a report the AL-derived row may still
+        // know the dataset of (a reportextension's base, say). Nothing to gain by replacing a
+        // populated list with an empty one, so only the scalar properties are taken.
+        if (doc.DataItems.Count == 0)
+            return row with
+            {
+                ProcessingOnly = doc.ProcessingOnly,
+                UseRequestPage = doc.UseRequestPage,
+                WordMergeDataItem = doc.WordMergeDataItem,
+            };
+
+        var items = new List<ReportDataItemRow>();
+        foreach (var di in doc.DataItems)
+        {
+            // FirstDataItemTableID = 0 is load-bearing: a caller reads it as "this report has
+            // no dataset". A document that does not state a data item's table cannot be used
+            // to claim one, so the whole row falls back rather than answering 0 — the same
+            // refusal EnumerateKnownReports makes for a table it cannot resolve by name.
+            if (di.TableId <= 0) return row;
+            items.Add(new ReportDataItemRow(
+                di.Id, di.VarName, di.TableId, di.Indent, di.TableView,
+                // ReqFilterFields is stated on the request page's filter control, not on the
+                // data item, and BC resolves it to field NUMBERS. Keeping the AL-derived text
+                // is the honest half-answer until #3620 does that resolution; replacing it
+                // with "" would lose information the row already carried.
+                RequestFilterFieldsFor(row, di)));
+        }
+
+        return row with
+        {
+            ProcessingOnly = doc.ProcessingOnly,
+            UseRequestPage = doc.UseRequestPage,
+            WordMergeDataItem = doc.WordMergeDataItem,
+            FirstDataItemTableId = FirstRootTableId(items),
+            DataItems = items,
+        };
+    }
+
+    /// <summary>
+    /// The AL-derived Request Filter Fields text for the data item BC calls
+    /// <paramref name="di"/>, matched by variable name — the one key both sources agree on,
+    /// since BC's id and the parser's ordinal are different numbers.
+    /// </summary>
+    private static string RequestFilterFieldsFor(ReportRow row, BcReportDocumentDataItem di)
+    {
+        foreach (var existing in row.DataItems)
+            if (string.Equals(existing.Name, di.VarName, StringComparison.OrdinalIgnoreCase))
+                return existing.RequestFilterFields;
+        return string.Empty;
+    }
+}

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -271,6 +271,12 @@ public static partial class RecordPatches
         // document, so it is meaningless the moment the line above drops them, and leaving it
         // populated would make the next cycle's tables keep the derivation in silence.
         ClearBcDocumentBackedTables();
+        // #3607, the same statement for reports: the memo holds properties parsed out of the
+        // PREVIOUS bundle's metadata documents, and a --watch cycle that edits a report's
+        // ProcessingOnly would otherwise keep answering the old value with nothing to show
+        // for it. Report ids repeat across reloads, so a stale entry is a wrong answer rather
+        // than a miss.
+        ClearBcReportDocuments();
         // #3121: every table is rebuilt from scratch below, so carrying the previous bundle's
         // pending CalcFormula rebuilds forward only buys a wasted repopulate pass on the next
         // .app registration.

--- a/docs/report-metadata-from-bc.md
+++ b/docs/report-metadata-from-bc.md
@@ -1,0 +1,108 @@
+# Answering the report virtual tables from BC's own document
+
+`Report Metadata` (2000000139) and `Report Data Items` (2000000203) used to be derived from AL
+source text by `RecordPatches.AlReportParser`, while BC's own emitted metadata document for the
+same reports sat in `AlReportMetadataRegistry` feeding the report *execution* path. The two
+disagreed, and a caller could observe the difference. `RecordPatches.ReportRowFromBcDocument`
+overlays the document onto the derived row; this page is the derivation its header points at.
+
+The sibling page for tables is [`object-metadata-from-bc.md`](object-metadata-from-bc.md), which
+`RecordPatches.NclMetaTableFromBcDocument` did first at #3584.
+
+<a id="the-fixture"></a>
+
+## The fixture the values below come from
+
+`AlRunner.Tests/ReportMetadataDocumentColumnTests.cs` compiles report **90311**
+`"RptMetaDoc Fixture"` over table 90310, and reads the document back out of the registry:
+
+```al
+report 90311 "RptMetaDoc Fixture"
+{
+    UsageCategory = None;
+    ProcessingOnly = false;
+    WordMergeDataItem = Src;
+
+    dataset
+    {
+        dataitem(Src; "RptMetaDoc Sample")
+        {
+            DataItemTableView = sorting("Entry No.") order(descending);
+            column(EntryNo; "Entry No.") { }
+
+            dataitem(Child; "RptMetaDoc Sample")
+            {
+                DataItemLink = "Entry No." = field("Entry No.");
+                column(ChildEntryNo; "Entry No.") { }
+            }
+        }
+    }
+}
+```
+
+<a id="what-differs"></a>
+
+## Three columns where the document and the AL text disagree
+
+Each was RED before the change with a value that is **wrong**, not merely absent — which is what
+lets the test tell a fix from a no-op.
+
+| column | AL-derived answer | BC's document |
+|---|---|---|
+| `WordMergeDataItem` | `""` — the property was never read | `Src` |
+| `Data Item Table View` | the raw source text, `sorting("Entry No.") order(descending)` | BC's normal form, `SORTING(<field no>) ORDER(<n>)` |
+| `Data Item ID` | a 1-based ordinal, `1`, `2` | BC's assigned id, a large non-sequential integer |
+
+**The data-item id is load-bearing, not cosmetic.** Ncl's
+`ReportDataItemsDataProvider.GetReportDataItems` keys, sorts and range-filters rows on
+`MetaDataItem.Id`. So a caller that reads an id out of one row and filters this table by it got
+nothing back while the ordinal stood in for it.
+
+The `DataItemTableView` assertion is written as *shape*, not as a literal: the test requires
+`SORTING(` and `ORDER(` and refuses `sorting(` and `descending`. A field **number** appears where
+the source names a field, so pinning the exact string would pin this repo's fixture field
+numbering rather than BC's normal form. The data-item id is asserted the same way — two distinct
+ids, neither of them `1` or `2` — because the value BC assigns is not stable across compilations
+and a literal would be a fixture detail masquerading as a claim about BC.
+
+<a id="why-the-xml"></a>
+
+## Why the XML, and not the `MetaReport` the execution path already builds
+
+This is written down because it was the first implementation and it is a trap.
+
+`NavReportSync.GetRealMetaReport` forces `MetaReport.RequestFormMetadata` as a deliberate side
+effect, so a failure is contained at construction — it builds the report's whole **request page**.
+Populating a virtual table enumerates **every** known report, so reading these columns that way
+turned one `Report Metadata` read into 28 request-page builds on the al-language corpus and blew
+the 60s per-test watchdog on the first assertion.
+
+Every property above is stated directly by the document, so reading the XML costs one parse and
+no page construction — measured at **65 ms** for the same read. The same arithmetic is why
+dependency documents are not consulted here: 659 Base Application reports would each cost a
+per-app symbol walk plus an AL source read.
+
+<a id="what-this-does-not-claim"></a>
+
+## What this does not claim
+
+Ncl's provider fills 29 `Report Metadata` columns off `NCLMetaReport`. This fills the ones the
+document states directly and leaves the rest on BC's own `GetDefaultNavValue`, exactly as before.
+A report with no registered document — one from a precompiled dependency — keeps the row it had.
+Nothing here answers a column with a guess.
+
+Three things were deliberately left alone, each for a reason worth not rediscovering:
+
+- **`Sorting Fields` and `Request Filter Fields`** resolve through a table's `NCLMetaField`
+  numbering, and `ReqFilterFields` is stated on the request page's *filter control* rather than
+  on the data item at all. That is a different mechanism; **#3620** tracks it.
+- **`ProcessingOnly = true` at `NavReportSync.cs:148`** is not this table's answer. RED-baselined:
+  the virtual table already answered `false` correctly from the AL parser. That hardcode is on the
+  legacy stub-`MetaReport` execution path and carries its own note recording that flipping it was
+  tried and reverted.
+- **`Report Layout List` (2000000234)** needed no conversion — it already reads the compiler's
+  captured `rendering` block.
+
+`AlReportParser.cs` loses nothing either: it remains the fallback, and the only source of
+`Caption` and `RequestFilterFields`. #3607 expected a line-count drop there; deleting any of it
+would have been a regression.


### PR DESCRIPTION
Closes #3607

The report **execution** path already builds a real `MetaReport` from the metadata document
BC's own emitter produces (`AlReportMetadataRegistry`). The three report virtual tables
beside it read none of it — `command grep -n AlReportMetadataRegistry
AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs` returned zero — and derived
every column from AL source text instead. The two disagree in ways a caller can observe.

Implemented by agent `stma-auto-2` (Claude).

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/299

## Three wrong answers, each proved against a value that is wrong rather than merely absent

Measured on BC 28.1 against the fixture report; BC's emitted document is quoted in the new
file's header.

| column | before | BC's document |
|---|---|---|
| `WordMergeDataItem` | `""`, hardcoded for every source-compiled report | `Src` — the declared data item |
| `Data Item Table View` | the raw AL text `sorting("Entry No.") order(descending)` | `SORTING(Field1) ORDER(1)` — BC's compiled normal form |
| `Data Item ID` | a 1-based declaration ordinal | `1369927887` — BC's assigned id |

The data-item id is the one with teeth. Ncl's
`ReportDataItemsDataProvider.GetReportDataItems` keys, sorts and **range-filters** its rows
on `MetaDataItem.Id`, so the ordinal was not a harmless stand-in: a caller that read an id
out of one row and filtered this table by it got nothing back.

`ProcessingOnly` and `UseRequestPage` now come from the document too.

## On the two hardcodes the issue names

- **`WordMergeDataItem = ""`** — confirmed, fixed, and proved against a report that declares
  `WordMergeDataItem = Src`.
- **`ProcessingOnly = true` at `NavReportSync.cs:148`** — this is **not** the virtual table's
  answer, and the issue conflates two paths. RED-baselined against a report declaring
  `ProcessingOnly = false`: the virtual table already answered `false` correctly, from the AL
  parser. That hardcode lives on `NavReportSync`'s legacy **stub MetaReport** path, which is
  report *execution*, not these tables, and carries its own investigated note explaining why
  flipping it was tried and reverted. Out of scope here; not silently "fixed" to look tidy.

## What I did not do, and why

- **Report Layout List (2000000234) is untouched.** It reads `AlReportLayoutRegistry`, which
  is already the AL compiler's own captured `rendering` block — not a hand-derivation. There
  was nothing to convert; converting it would have been churn.
- **The remaining Report Metadata columns keep BC's `GetDefaultNavValue`.** Ncl's provider
  fills 29 columns off `NCLMetaReport`; this fills the ones the document states directly.
- **`Sorting Fields` and `Request Filter Fields` are not resolved.** Both need a table's
  `NCLMetaField` numbering (`GetSortingFieldsIfAny` / `GetRequestFilterFieldsIfAny`), and
  `ReqFilterFields` is stated on the request page's filter control rather than on the data
  item at all. Filed as **#3620** rather than guessed at.
- **`AlReportParser.cs` lost nothing.** Its output is still the fallback for a report with no
  emitted document, and still supplies `Caption` and `RequestFilterFields`, which the document
  does not state in a form this path can use. Deleting it would have been a regression, so the
  line count is unchanged and this is the "name what survives" the issue asked for.

## The performance trap, recorded because the obvious implementation hits it

The first version read the `MetaReport` that `NavReportSync.GetRealMetaReport` already
builds — the same document, one seam earlier. `GetRealMetaReport` forces
`MetaReport.RequestFormMetadata` as a deliberate side effect, so it builds a whole request
page per report. Populating a virtual table enumerates **every** known report, and that put
the first Report Metadata read **past the 60s per-test watchdog** on the corpus. Reading the
XML directly is a dictionary hit: the same read is **65ms**.

For the same reason this consults emit-captured documents only, not
`TryBuildDependencyReportMetadata` — with Base Application registered that walks every .app's
symbol list per report and reads AL source out of the package, 659 times. A dependency report
keeps its `SymbolReference.json`-derived row, which is where its `WordMergeDataItem`,
`ProcessingOnly` and data-item tree already came from.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — `WordMergeDataItem` was one of three
   properties on the same code path answering from AL text; all three are fixed together.
2. **Does a sibling function make the same assumption?** Report Layout List was the candidate;
   checked, and it does not (above).
3. **Do two paths write the same state with different invariants?** Yes, and it is now
   consistent: source-compiled and symbol-derived reports both reach `ApplyBcReportDocument`,
   and the "unresolved table must not be reported as 0" refusal that `EnumerateKnownReports`
   already made is preserved on the new path rather than re-introduced as a `0`.

**Open-issue queue scan** — nothing folded. #3374 and #3382 (dependency dataitem
`MaxIteration` / `CalcFields`) are the nearest neighbours and land in
`BcAppSymbolCache` / `DependencyReportMetadata`, not these files; both are `status: blocked`
on the metadata emitter. #2297 (Base App report 1306 layout) is a layout-resolution
question. #2655 (registry loss across `--watch`) is adjacent, and this PR clears its own memo
in `ResetForReload` for exactly that reason, but does not fix the registries it reports on.

## Tests

**Upstream (the BC claim), corpus PR #299** — 11 tests, codeunit 60361. Fixture report 60360
declares every property to a non-default value so no assertion can pass against a default.
Against this build: **3 RED before, all 11 GREEN after.** The three that were RED are
`WordMergeDataItem`, `Data Item Table View` and the data-item id not being an ordinal.

**Runner-side mechanism test** — `AlRunner.Tests/ReportMetadataDocumentColumnTests.cs`, 3
tests. These pin the half the corpus cannot see: that BC's emitter *states* each property in
the captured document, in BC's normal form. If a future BC version stopped emitting
`<WordMergeDataItem>`, the corpus test would keep passing against the AL fallback and only
this would notice. Sanity-checked by flipping one assertion to the old value and confirming
it fails.

## Measurements

All post-rebase onto `738ec1cf`, corpus at pin `c9d5f656` in a private clone.

| | before | after |
|---|---|---|
| al-language | 3112/3112 | **3112/3112** |
| runner-extras | 401/401 | **406/406** (+5 from the rebase, not from this change) |
| `AlRunner.Tests --filter ~Report` | — | **345 passed, 0 failed, 0 skipped** |
| new mechanism tests | — | **3 passed** |

The before/after classification JSONs for both suites are **byte-identical apart from their
`generated` timestamp** — `classifications`, `all_failures` and `total_failures` all match
exactly. Both runs passed `--count-baseline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
