### PR TITLE
fix(permission-set): read a source-compiled permission set from BC's own document, not a regex over AL source

### DIFF
--- a/AlRunner.Tests/PermissionMetadataShapeGapTests.cs
+++ b/AlRunner.Tests/PermissionMetadataShapeGapTests.cs
@@ -73,12 +73,22 @@ public sealed class PermissionMetadataShapeGapTests
     }
 
     // ══ 2. BuildIncludeList — BC's include/exclude element type is one it cannot fill ═════
+    //
+    // Three arguments, matching the ONE live BuildIncludeList both production call sites use.
+    // #3609 gave it a third (resolved-id) parameter, and reflection made every way of keeping
+    // the old two-argument shape fail: a default parameter raises TargetParameterCountException
+    // (Invoke matches the exact count), a second overload raises AmbiguousMatchException
+    // (GetMethod(name, flags) cannot choose), and a thin forwarder passes both of those while
+    // failing ReflectionDrivenHelperLivenessTests, because the arms would then exercise a
+    // method no production code reaches (#3100). If this signature changes again, change these
+    // arms with it rather than adding a shim for them to point at.
 
     [Fact]
     public void BuildIncludeList_RaisesAShapeGapNamingTheElementType_WhenItCannotBeFilled()
     {
         var ex = Assert.Throws<BcShapeGapException>(
-            () => Invoke("BuildIncludeList", typeof(List<NotFillableElement>), (IReadOnlyList<string>)new[] { "SUPER" }));
+            () => Invoke("BuildIncludeList", typeof(List<NotFillableElement>),
+                (IReadOnlyList<string>)new[] { "SUPER" }, (IReadOnlyList<int>?)null));
 
         Assert.Contains(nameof(NotFillableElement), ex.Member, StringComparison.Ordinal);
     }
@@ -87,7 +97,8 @@ public sealed class PermissionMetadataShapeGapTests
     [Fact]
     public void BuildIncludeList_StillFills_AStringElementList()
     {
-        var list = (IList)Invoke("BuildIncludeList", typeof(List<string>), (IReadOnlyList<string>)new[] { "SUPER", "SECURITY" })!;
+        var list = (IList)Invoke("BuildIncludeList", typeof(List<string>),
+            (IReadOnlyList<string>)new[] { "SUPER", "SECURITY" }, (IReadOnlyList<int>?)null)!;
 
         Assert.Equal(2, list.Count);
         Assert.Equal("SUPER", list[0]);

--- a/AlRunner.Tests/PermissionSetFromBcDocumentTests.cs
+++ b/AlRunner.Tests/PermissionSetFromBcDocumentTests.cs
@@ -1,0 +1,258 @@
+// PermissionSetFromBcDocumentTests — #3609. A permission set the runner COMPILED gets its
+// declaration from BC's own emitted <PermissionSet> document instead of from the regex
+// derivation over AL source text, and one with no document keeps the derivation.
+//
+// WHAT IS PROVED HERE AND WHAT IS PROVED UPSTREAM
+// -----------------------------------------------
+// The BC-observable half — that "Metadata Permission Set" (2000000250) reports a
+// source-declared set's Role ID / Name / Assignable, and that its tabledata grants survive
+// into the permission metadata layer — is plain BC behaviour and is adjudicated on a real
+// service tier by the corpus PR named in this change's PR body
+// (.claude/rules/bc-behavior-tests-go-upstream.md).
+//
+// These tests pin the runner-only half underneath it, which no service tier can answer,
+// because each is a question about THIS runner build's own plumbing:
+//
+//   1. The reader transcribes BC's document faithfully — the exact ids, ordinals and mask
+//      values BC emitted, and the ENU text out of CaptionML.
+//   2. The tabledata grant that the AL-source route DROPS SILENTLY survives this one. That is
+//      the RED: ResolveSourcePermissionEntries maps PermissionObject ordinal 0/1 to null
+//      through AlKeywordForPermissionObject and then `continue`s BEFORE its own diagnostic,
+//      so the grant vanished at every verbosity including AL_RUNNER_DIAG_PERMMETA=1.
+//   3. ExcludedPermissionSets is carried, not hardcoded null, when BC states it.
+//   4. A permission set with no registered document keeps the derivation rather than
+//      becoming an empty row — the compile-cache-HIT direction.
+
+using System;
+using AlRunner;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Serialized against every other test touching this static registry — see
+// ObjectMetadataRegistrySerialCollection — and cleared both ends, so a document registered
+// here cannot leak into a sibling's not-found branch.
+[Collection("object-metadata-registry")]
+public class PermissionSetFromBcDocumentTests : IDisposable
+{
+    public PermissionSetFromBcDocumentTests() => AlObjectMetadataRegistry.Clear();
+    public void Dispose() => AlObjectMetadataRegistry.Clear();
+
+    // Ids outside every fixture, dependency .app and corpus range in this repository, so a
+    // document registered here cannot collide with one a sibling test registered.
+    private const int SetWithEverything = 77452001;
+    private const int SetIncluded = 77452002;
+    private const int SetExcluded = 77452003;
+    private const int SetWithNoDocument = 77452004;
+
+    /// <summary>
+    /// BC 28.1's real output shape for
+    /// <c>permissionset … { Access = Internal; Caption = '…'; IncludedPermissionSets = …;
+    /// ExcludedPermissionSets = …; Permissions = tabledata "PP Thing" = RIMD, codeunit … = X; }</c>,
+    /// copied from an AL_RUNNER_TRACE_OBJECT_METADATA=2 dump rather than hand-written — the
+    /// namespace, the "1"/"0" Assignable spelling and the "ENU=" caption prefix are all load
+    /// bearing and a hand-written approximation would not have them.
+    /// </summary>
+    private static string DocumentWithEverything() =>
+        $"""
+         <?xml version="1.0" encoding="utf-8"?>
+         <PermissionSet MetadataVersion="130000" ID="{SetWithEverything}" Name="PSD Everything" ALNamespace=""
+                        Access="Internal" Assignable="1" CaptionML="ENU=PSD everything caption"
+                        IncludedPermissionSets="{SetIncluded}" ExcludedPermissionSets="{SetExcluded}"
+                        xmlns="urn:schemas-microsoft-com:dynamics:NAV:MetaObjects">
+           <Permissions>
+             <Permission Type="0" ID="70700" Value="15" />
+             <Permission Type="5" ID="70703" Value="16" />
+           </Permissions>
+         </PermissionSet>
+         """;
+
+    [Fact]
+    public void ReadsIdsOrdinalsAndMasksExactlyAsBcStatesThem()
+    {
+        AlObjectMetadataRegistry.Register(
+            RecordPatches.BcPermissionSetMetadataKind, SetWithEverything, "PSD Everything",
+            DocumentWithEverything());
+
+        var set = RecordPatches.TryReadPermissionSetFromBcDocument(SetWithEverything, "PSD Everything");
+
+        Assert.NotNull(set);
+        Assert.Equal(SetWithEverything, set!.Id);
+        Assert.Equal("PSD Everything", set.Name);
+        // The ENU text alone, not the raw "ENU=…" multi-language string.
+        Assert.Equal("PSD everything caption", set.Caption);
+        Assert.True(set.Assignable);
+        Assert.Equal("Internal", set.Access);
+
+        // THE POINT OF THE CONVERSION: the tabledata grant. Ordinal 0 is PermissionObject
+        // tabledata, and the AL-source route cannot express it at all.
+        Assert.NotNull(set.Permissions);
+        var tableData = Assert.Single(set.Permissions!, p => p.ObjectType == 0);
+        Assert.Equal(70700, tableData.ObjectId);
+        // RIMD = R1 + I2 + M4 + D8. Concrete, not "non-zero".
+        Assert.Equal(15, tableData.Value);
+
+        var codeunit = Assert.Single(set.Permissions!, p => p.ObjectType == 5);
+        Assert.Equal(70703, codeunit.ObjectId);
+        Assert.Equal(16, codeunit.Value);   // X = Execute
+
+        // Include/exclude edges arrive as resolved OBJECT IDS, so nothing has to survive a
+        // name lookup. The name list stays null on this route by construction.
+        Assert.Null(set.IncludedPermissionSets);
+        Assert.Equal(new[] { SetIncluded }, set.IncludedPermissionSetIds);
+        Assert.Equal(new[] { SetExcluded }, set.ExcludedPermissionSetIds);
+    }
+
+    /// <summary>
+    /// The mask encoding is BC's, and the lowercase AL letters are the INDIRECT variants —
+    /// <c>Rimd</c> is 1 + 64 + 128 + 256 = 449, not 15. Pinned because the derivation
+    /// reimplemented this table by hand (MaskFromAlLetters) and a future reader comparing the
+    /// two needs the agreement to be asserted rather than assumed.
+    /// </summary>
+    [Fact]
+    public void CarriesBcsIndirectMaskValueUnchanged()
+    {
+        const int id = SetWithEverything + 100;
+        AlObjectMetadataRegistry.Register(
+            RecordPatches.BcPermissionSetMetadataKind, id, "PSD Indirect",
+            $"""
+             <PermissionSet ID="{id}" Name="PSD Indirect" Assignable="1"
+                            xmlns="urn:schemas-microsoft-com:dynamics:NAV:MetaObjects">
+               <Permissions><Permission Type="0" ID="70700" Value="449" /></Permissions>
+             </PermissionSet>
+             """);
+
+        var set = RecordPatches.TryReadPermissionSetFromBcDocument(id, "PSD Indirect");
+
+        Assert.Equal(449, Assert.Single(set!.Permissions!).Value);
+    }
+
+    /// <summary>
+    /// Assignable="0" must read as false, and an ABSENT Assignable must read as AL's own
+    /// default of true — not as false. The two directions are asserted together because a
+    /// reader that ignored the attribute entirely would pass either one alone.
+    /// </summary>
+    [Fact]
+    public void AssignableFalseAndAbsentAreDifferentAnswers()
+    {
+        const int notAssignable = SetWithEverything + 200;
+        const int unstated = SetWithEverything + 201;
+
+        AlObjectMetadataRegistry.Register(
+            RecordPatches.BcPermissionSetMetadataKind, notAssignable, "PSD NotAssignable",
+            $"""
+             <PermissionSet ID="{notAssignable}" Name="PSD NotAssignable" Assignable="0"
+                            xmlns="urn:schemas-microsoft-com:dynamics:NAV:MetaObjects" />
+             """);
+        AlObjectMetadataRegistry.Register(
+            RecordPatches.BcPermissionSetMetadataKind, unstated, "PSD Unstated",
+            $"""
+             <PermissionSet ID="{unstated}" Name="PSD Unstated"
+                            xmlns="urn:schemas-microsoft-com:dynamics:NAV:MetaObjects" />
+             """);
+
+        Assert.False(RecordPatches.TryReadPermissionSetFromBcDocument(notAssignable, "PSD NotAssignable")!.Assignable);
+        Assert.True(RecordPatches.TryReadPermissionSetFromBcDocument(unstated, "PSD Unstated")!.Assignable);
+    }
+
+    /// <summary>
+    /// A set with no registered document answers null, so <c>EnumerateKnownPermissionSets</c>
+    /// keeps the AL-source derivation. This is the compile-cache-HIT direction: Emit runs only
+    /// on a MISS, and a warm run whose replay supplied no document must keep the row rather
+    /// than lose every source-declared permission set.
+    /// </summary>
+    [Fact]
+    public void NoDocumentAnswersNullSoTheDerivationSurvives()
+    {
+        Assert.Null(RecordPatches.TryReadPermissionSetFromBcDocument(SetWithNoDocument, "PSD Absent"));
+        Assert.False(RecordPatches.HasBcPermissionSetDocument(SetWithNoDocument));
+    }
+
+    /// <summary>
+    /// A document that arrived and will not parse is a shape change in BC's emitter. It must
+    /// refuse loudly rather than fall back to the derivation — a weaker answer substituted on
+    /// error is wrong metadata under a green build (.claude/rules/loud-failures.md).
+    /// </summary>
+    [Fact]
+    public void AMalformedDocumentRefusesInsteadOfFallingBackToTheDerivation()
+    {
+        const int malformed = SetWithEverything + 300;
+        AlObjectMetadataRegistry.Register(
+            RecordPatches.BcPermissionSetMetadataKind, malformed, "PSD Malformed",
+            "<PermissionSet ID=\"" + malformed + "\"><Permissions>");
+
+        var ex = Assert.ThrowsAny<System.Exception>(
+            () => RecordPatches.TryReadPermissionSetFromBcDocument(malformed, "PSD Malformed"));
+
+        // The refusal has to name the surface, or it cannot be acted on.
+        Assert.Contains(malformed.ToString(), ex.Message);
+        Assert.Contains("PermissionSet", ex.Message);
+    }
+}
+
+/// <summary>
+/// #3609's wiring: what <c>EnumerateKnownPermissionSets</c> actually composes for a
+/// source-declared set, through the same <c>ComposeSourcePermissionSet</c> seam it calls.
+///
+/// <para>This is the RED. The AL-source derivation cannot express a <c>tabledata</c> grant:
+/// <c>ParsedObjectDecls</c> carries no tables, so <c>AlKeywordForPermissionObject</c> answers
+/// null for PermissionObject ordinals 0 and 1, and <c>ResolveSourcePermissionEntries</c>
+/// <c>continue</c>s BEFORE the diagnostic that would have reported the loss. A permission set
+/// whose only grant is on a table therefore reached BC's permission metadata layer with an
+/// EMPTY Permissions list, silently, at every verbosity — and the composed set below is
+/// asserted to carry the grant with BC's own concrete id and mask instead.</para>
+/// </summary>
+[Collection("object-metadata-registry")]
+public class PermissionSetFromBcDocumentWiringTests : IDisposable
+{
+    public PermissionSetFromBcDocumentWiringTests() => AlObjectMetadataRegistry.Clear();
+    public void Dispose() => AlObjectMetadataRegistry.Clear();
+
+    private const int SetId = 77452500;
+    private const int TableId = 77452501;
+
+    /// <summary>The AL source shape the fixture declares:
+    /// <c>Permissions = tabledata "PSD Thing" = RIMD;</c>, i.e. one entry naming a TABLE,
+    /// which is exactly the shape the derivation drops.</summary>
+    private static RecordPatches.ParsedAlPermissionSet SourceDeclarationWithATableDataGrant() =>
+        new(SetId, "PSD Wiring", "PSD wiring caption", Assignable: true,
+            AppId: Guid.Empty, AppName: "PSD App",
+            Permissions: new[] { new RecordPatches.ParsedAlPermissionEntry(0, "PSD Thing", 15) },
+            IncludedPermissionSets: null,
+            Access: null);
+
+    [Fact]
+    public void WithoutBcsDocument_TheTableDataGrantIsDroppedSilently()
+    {
+        // No document registered — the compile-cache-HIT direction, and the state every
+        // source-compiled permission set was in before #3609.
+        var composed = RecordPatches.ComposeSourcePermissionSet(SourceDeclarationWithATableDataGrant());
+
+        Assert.Equal(SetId, composed.Id);
+        // The grant is gone. Not "an empty list is fine" — this is the defect, pinned so the
+        // GREEN below is measured against it rather than asserted in prose.
+        Assert.Empty(composed.Permissions!);
+    }
+
+    [Fact]
+    public void WithBcsDocument_TheTableDataGrantSurvivesWithBcsOwnIdAndMask()
+    {
+        AlObjectMetadataRegistry.Register(
+            RecordPatches.BcPermissionSetMetadataKind, SetId, "PSD Wiring",
+            $"""
+             <PermissionSet ID="{SetId}" Name="PSD Wiring" Assignable="1"
+                            CaptionML="ENU=PSD wiring caption"
+                            xmlns="urn:schemas-microsoft-com:dynamics:NAV:MetaObjects">
+               <Permissions><Permission Type="0" ID="{TableId}" Value="15" /></Permissions>
+             </PermissionSet>
+             """);
+
+        var composed = RecordPatches.ComposeSourcePermissionSet(SourceDeclarationWithATableDataGrant());
+
+        var grant = Assert.Single(composed.Permissions!);
+        Assert.Equal(0, grant.ObjectType);          // tabledata
+        Assert.Equal(TableId, grant.ObjectId);      // the id AL source never states
+        Assert.Equal(15, grant.Value);              // RIMD
+    }
+}

--- a/AlRunner.Tests/PermissionSetFromBcDocumentTests.cs
+++ b/AlRunner.Tests/PermissionSetFromBcDocumentTests.cs
@@ -24,6 +24,7 @@
 //      becoming an empty row — the compile-cache-HIT direction.
 
 using System;
+using System.IO;
 using AlRunner;
 using AlRunner.Patches;
 using Xunit;
@@ -254,5 +255,119 @@ public class PermissionSetFromBcDocumentWiringTests : IDisposable
         Assert.Equal(0, grant.ObjectType);          // tabledata
         Assert.Equal(TableId, grant.ObjectId);      // the id AL source never states
         Assert.Equal(15, grant.Value);              // RIMD
+    }
+}
+
+/// <summary>
+/// #3609's own lesson applied to itself: every drop inside the document reader must be
+/// OBSERVABLE. The defect this change fixed was a grant discarded by a <c>continue</c> placed
+/// above its own diagnostic, so it vanished at every verbosity — a reader that silently skips
+/// a malformed row would reintroduce exactly that, one layer up.
+///
+/// <para>These tests assert the diagnostic text on stderr under
+/// <c>AL_RUNNER_DIAG_PERMMETA=1</c>, not merely that the row was dropped. Dropping is already
+/// covered by the value assertions elsewhere in this file; what is pinned here is that the loss
+/// leaves a trace someone can grep for.</para>
+/// </summary>
+[Collection("object-metadata-registry")]
+public class PermissionSetFromBcDocumentDiagnosticTests : IDisposable
+{
+    private readonly string? _priorDiag;
+
+    public PermissionSetFromBcDocumentDiagnosticTests()
+    {
+        AlObjectMetadataRegistry.Clear();
+        _priorDiag = Environment.GetEnvironmentVariable("AL_RUNNER_DIAG_PERMMETA");
+        Environment.SetEnvironmentVariable("AL_RUNNER_DIAG_PERMMETA", "1");
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("AL_RUNNER_DIAG_PERMMETA", _priorDiag);
+        AlObjectMetadataRegistry.Clear();
+    }
+
+    private const int MalformedPermission = 77452700;
+    private const int MalformedIncludeList = 77452701;
+
+    private static string CaptureStderr(Action body)
+    {
+        var prior = Console.Error;
+        var sw = new StringWriter();
+        Console.SetError(sw);
+        try { body(); } finally { Console.SetError(prior); }
+        return sw.ToString();
+    }
+
+    [Fact]
+    public void AnUnreadablePermissionRowIsDropped_AndSaysSo()
+    {
+        AlObjectMetadataRegistry.Register(
+            RecordPatches.BcPermissionSetMetadataKind, MalformedPermission, "PSD BadRow",
+            $"""
+             <PermissionSet ID="{MalformedPermission}" Name="PSD BadRow" Assignable="1"
+                            xmlns="urn:schemas-microsoft-com:dynamics:NAV:MetaObjects">
+               <Permissions>
+                 <Permission Type="0" ID="70700" Value="15" />
+                 <Permission Type="0" ID="not-an-id" Value="15" />
+               </Permissions>
+             </PermissionSet>
+             """);
+
+        BcAppSymbolCache.PermissionSetSymbol? set = null;
+        var stderr = CaptureStderr(
+            () => set = RecordPatches.TryReadPermissionSetFromBcDocument(MalformedPermission, "PSD BadRow"));
+
+        // The good row survives; only the unreadable one is dropped.
+        var kept = Assert.Single(set!.Permissions!);
+        Assert.Equal(70700, kept.ObjectId);
+
+        // And the loss is greppable, carrying the offending value so it can be acted on.
+        Assert.Contains("[perm-metadata]", stderr, StringComparison.Ordinal);
+        Assert.Contains("not-an-id", stderr, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnUnreadableIncludeEdgeIsDropped_AndSaysSo()
+    {
+        AlObjectMetadataRegistry.Register(
+            RecordPatches.BcPermissionSetMetadataKind, MalformedIncludeList, "PSD BadEdge",
+            $"""
+             <PermissionSet ID="{MalformedIncludeList}" Name="PSD BadEdge" Assignable="1"
+                            IncludedPermissionSets="70701,SUPER"
+                            xmlns="urn:schemas-microsoft-com:dynamics:NAV:MetaObjects" />
+             """);
+
+        BcAppSymbolCache.PermissionSetSymbol? set = null;
+        var stderr = CaptureStderr(
+            () => set = RecordPatches.TryReadPermissionSetFromBcDocument(MalformedIncludeList, "PSD BadEdge"));
+
+        Assert.Equal(new[] { 70701 }, set!.IncludedPermissionSetIds);
+        Assert.Contains("IncludedPermissionSets", stderr, StringComparison.Ordinal);
+        Assert.Contains("SUPER", stderr, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A trailing separator is a formatting artifact, not a lost edge — it must NOT produce a
+    /// diagnostic, or the channel fills with noise and a real loss stops standing out.
+    /// </summary>
+    [Fact]
+    public void ATrailingSeparatorIsNotReportedAsALoss()
+    {
+        const int id = MalformedIncludeList + 10;
+        AlObjectMetadataRegistry.Register(
+            RecordPatches.BcPermissionSetMetadataKind, id, "PSD Trailing",
+            $"""
+             <PermissionSet ID="{id}" Name="PSD Trailing" Assignable="1"
+                            IncludedPermissionSets="70701,"
+                            xmlns="urn:schemas-microsoft-com:dynamics:NAV:MetaObjects" />
+             """);
+
+        BcAppSymbolCache.PermissionSetSymbol? set = null;
+        var stderr = CaptureStderr(
+            () => set = RecordPatches.TryReadPermissionSetFromBcDocument(id, "PSD Trailing"));
+
+        Assert.Equal(new[] { 70701 }, set!.IncludedPermissionSetIds);
+        Assert.DoesNotContain("[perm-metadata]", stderr, StringComparison.Ordinal);
     }
 }

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -330,7 +330,16 @@ internal static partial class BcAppSymbolCache
         // exclusions, extension merge) — the runner only transcribes them.
         IReadOnlyList<PermissionSymbol>? Permissions = null,
         IReadOnlyList<string>? IncludedPermissionSets = null,
-        string? Access = null);
+        string? Access = null,
+        // #3609: the same two edge lists as already-resolved OBJECT IDS. SymbolReference.json
+        // states include edges as NAMES (IncludedPermissionSets above) and states no exclude
+        // edges at all; BC's own emitted metadata document states BOTH as ids. A symbol built
+        // from a document fills these and leaves the name list null; one built from a
+        // SymbolReference fills the name list and leaves these null. BuildIncludeList prefers
+        // ids when present, because a name still has to survive PermissionSetIdByName's
+        // lookup and an id does not.
+        IReadOnlyList<int>? IncludedPermissionSetIds = null,
+        IReadOnlyList<int>? ExcludedPermissionSetIds = null);
 
     /// <summary>
     /// A precompiled dependency's page, as far as SymbolReference.json states it — just

--- a/AlRunner/Patches/RecordPatches.MetadataPermissionSetVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.MetadataPermissionSetVirtualTable.cs
@@ -140,6 +140,34 @@ public static partial class RecordPatches
     }
 
     /// <summary>
+    /// One source-declared permission set as the metadata layer should see it, by whichever of
+    /// the two routes can answer (#3609).
+    ///
+    /// <para>BC emitted its own <c>&lt;PermissionSet&gt;</c> document for everything the runner
+    /// compiled this run, and it states the object references and the mask ALREADY RESOLVED.
+    /// That route is preferred — not as a nicety, but because the derivation cannot express a
+    /// <c>tabledata</c> grant at all: <c>ParsedObjectDecls</c> carries no tables, so
+    /// <see cref="ResolveSourcePermissionEntries"/> maps PermissionObject ordinal 0 and 1 to
+    /// null and drops the entry BEFORE its own diagnostic, at every verbosity.</para>
+    ///
+    /// <para>A set with no document — a compile-cache HIT whose replay supplied none — keeps
+    /// the derivation rather than losing the row. See docs/permission-set-from-bc-document.md.</para>
+    /// </summary>
+    internal static BcAppSymbolCache.PermissionSetSymbol ComposeSourcePermissionSet(ParsedAlPermissionSet p)
+    {
+        if (TryReadPermissionSetFromBcDocument(p.Id, p.Name) is { } fromDocument)
+            return fromDocument;
+
+        return new BcAppSymbolCache.PermissionSetSymbol(
+            p.Id, p.Name, p.Caption, p.Assignable,
+            // #2910: a source-declared set's permissions name their objects; a precompiled
+            // one's carry ids. Resolve here so both shapes reach BC's composer identically.
+            ResolveSourcePermissionEntries(p.Permissions),
+            p.IncludedPermissionSets,
+            p.Access);
+    }
+
+    /// <summary>
     /// Every permission set the runner has a real declaration for, paired with the id of the
     /// app that declares it, one entry per role id. A role id is unique across an app group
     /// on a real tier — <c>PermissionSetGroupObjectMetadataSummaries</c> is a dictionary
@@ -162,16 +190,10 @@ public static partial class RecordPatches
 
         // 1. Permission sets the runner compiled from source.
         foreach (var p in ParsedPermissionSets)
-            if (seen.Add(p.Name))
-                yield return (new BcAppSymbolCache.PermissionSetSymbol(
-                        p.Id, p.Name, p.Caption, p.Assignable,
-                        // #2910: a source-declared set's permissions name their objects; a
-                        // precompiled one's carry ids. Resolve here so both shapes reach BC's
-                        // composer identically.
-                        ResolveSourcePermissionEntries(p.Permissions),
-                        p.IncludedPermissionSets,
-                        p.Access),
-                    p.AppId, p.AppName ?? string.Empty);
+        {
+            if (!seen.Add(p.Name)) continue;
+            yield return (ComposeSourcePermissionSet(p), p.AppId, p.AppName ?? string.Empty);
+        }
 
         // 2. Permission sets declared by precompiled dependency .app packages.
         foreach (var appPath in _bcAppPaths.ToArray())

--- a/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
@@ -152,7 +152,11 @@ public static partial class RecordPatches
             InstallFreshPermissionSetLookup(baseGroup, summaries);
 
             _permMetaPopulatedForCount = known.Count;
-            _permissionSetIdByName = null;   // the inventory just changed; rebuild lazily
+            // The inventory just changed; rebuild both directions lazily. They are derived
+            // from the same enumeration, so invalidating one without the other would leave
+            // a stale id->name answering alongside a fresh name->id.
+            _permissionSetIdByName = null;
+            _permissionSetNameById = null;
 
             if (Environment.GetEnvironmentVariable("AL_RUNNER_DIAG_PERMMETA") == "1")
             {
@@ -630,11 +634,21 @@ public static partial class RecordPatches
         }
         SetProperty(mps, "Permissions", permissions);
 
+        // #3609: ids when BC's own document stated them, names otherwise. Ids are strictly
+        // better here — BuildIncludeList has to resolve a name through PermissionSetIdByName
+        // and DROPS what it cannot find, which an already-resolved id cannot hit.
         SetProperty(mps, "IncludedPermissionSets",
             BuildIncludeList(RequireBcProperty(_tMetaPermissionSet, "IncludedPermissionSets").PropertyType,
-                declaration.IncludedPermissionSets));
+                declaration.IncludedPermissionSets, declaration.IncludedPermissionSetIds));
+        // ExcludedPermissionSets was hardcoded null because the only route into this method
+        // stated no exclude edges: SymbolReference.json does not carry them, and Base
+        // Application declares the property on 0 of its 258 permission sets (re-measured for
+        // #3609 — the zero is a property of Base Application's AL, not of BC's emitter). BC's
+        // emitted document DOES state them, as ids, for anything the runner compiles from
+        // source, so that route fills the column and the precompiled route still passes null.
         SetProperty(mps, "ExcludedPermissionSets",
-            BuildIncludeList(RequireBcProperty(_tMetaPermissionSet, "ExcludedPermissionSets").PropertyType, null));
+            BuildIncludeList(RequireBcProperty(_tMetaPermissionSet, "ExcludedPermissionSets").PropertyType,
+                null, declaration.ExcludedPermissionSetIds));
 
         return mps;
     }
@@ -651,15 +665,40 @@ public static partial class RecordPatches
     /// version of this code assumed strings and failed loudly at <c>Add()</c> — the right
     /// failure, but only because it was checked at all.</para>
     /// </summary>
-    private static object BuildIncludeList(Type listType, IReadOnlyList<string>? names)
+    private static object BuildIncludeList(
+        Type listType, IReadOnlyList<string>? names, IReadOnlyList<int>? resolvedIds = null)
     {
         var list = (System.Collections.IList)Activator.CreateInstance(listType)!;
-        if (names == null || names.Count == 0) return list;
 
         var element = listType.IsGenericType ? listType.GetGenericArguments()[0] : typeof(string);
+
+        // #3609: BC's own document states these edges as object ids, so when they are present
+        // there is nothing to resolve and nothing that can be dropped by a failed lookup. Only
+        // the int element type can take them directly; for the other two shapes the id has to
+        // be turned back into the name BC declares them by, and a name that is not in this
+        // run's inventory is dropped exactly as the name route drops it.
+        if (resolvedIds is { Count: > 0 })
+        {
+            foreach (var id in resolvedIds)
+            {
+                if (element == typeof(int)) { list.Add(id); continue; }
+                var nameForId = PermissionSetNameById().TryGetValue(id, out var n) ? n : null;
+                if (nameForId == null)
+                {
+                    if (Environment.GetEnvironmentVariable("AL_RUNNER_DIAG_PERMMETA") == "1")
+                        Console.Error.WriteLine(
+                            $"[perm-metadata] included/excluded permission set id {id} is not in this "
+                            + "run's inventory — dropped");
+                    continue;
+                }
+                AddIncludeListEntry(list, element, nameForId);
+            }
+            return list;
+        }
+
+        if (names == null || names.Count == 0) return list;
         foreach (var name in names)
         {
-            if (element == typeof(string)) { list.Add(name); continue; }
             if (element == typeof(int))
             {
                 if (PermissionSetIdByName().TryGetValue(name, out var id)) { list.Add(id); continue; }
@@ -668,18 +707,43 @@ public static partial class RecordPatches
                         $"[perm-metadata] included permission set '{name}' is not in this run's inventory — dropped");
                 continue;
             }
-            var ctor = element.GetConstructors()
-                .FirstOrDefault(c =>
-                {
-                    var ps = c.GetParameters();
-                    return ps.Length == 2 && ps[0].ParameterType == typeof(int) && ps[1].ParameterType == typeof(string);
-                });
-            if (ctor != null) { list.Add(ctor.Invoke(new object?[] { 30, name })); continue; }
-            throw PermissionMetadataBcShapeGap(
-                $"MetaPermissionSet include/exclude list element type {element.Name}",
-                "is not one this code knows how to fill — BC's permission-set metadata inventory cannot be populated");
+            AddIncludeListEntry(list, element, name);
         }
         return list;
+    }
+
+    /// <summary>
+    /// Add one include/exclude entry in whatever non-int element type BC declares — a bare
+    /// string, or the (int length, string value) code-like shape. Shared by the name route and
+    /// #3609's id route so the two cannot drift into filling the same list differently.
+    /// </summary>
+    private static void AddIncludeListEntry(System.Collections.IList list, Type element, string name)
+    {
+        if (element == typeof(string)) { list.Add(name); return; }
+        var ctor = element.GetConstructors()
+            .FirstOrDefault(c =>
+            {
+                var ps = c.GetParameters();
+                return ps.Length == 2 && ps[0].ParameterType == typeof(int) && ps[1].ParameterType == typeof(string);
+            });
+        if (ctor != null) { list.Add(ctor.Invoke(new object?[] { 30, name })); return; }
+        throw PermissionMetadataBcShapeGap(
+            $"MetaPermissionSet include/exclude list element type {element.Name}",
+            "is not one this code knows how to fill — BC's permission-set metadata inventory cannot be populated");
+    }
+
+    private static Dictionary<int, string>? _permissionSetNameById;
+
+    /// <summary>Object id -> role id, the inverse of <see cref="PermissionSetIdByName"/>, for
+    /// #3609's id route when BC declares the list in a non-int element type. Invalidated
+    /// alongside it whenever the inventory changes.</summary>
+    private static Dictionary<int, string> PermissionSetNameById()
+    {
+        if (_permissionSetNameById != null) return _permissionSetNameById;
+        var index = new Dictionary<int, string>();
+        foreach (var (permissionSet, _, _) in EnumerateKnownPermissionSets())
+            index.TryAdd(permissionSet.Id, permissionSet.Name);
+        return _permissionSetNameById = index;
     }
 
     private static Dictionary<string, int>? _permissionSetIdByName;

--- a/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
@@ -638,7 +638,7 @@ public static partial class RecordPatches
         // better here — BuildIncludeList has to resolve a name through PermissionSetIdByName
         // and DROPS what it cannot find, which an already-resolved id cannot hit.
         SetProperty(mps, "IncludedPermissionSets",
-            BuildIncludeListFromIds(RequireBcProperty(_tMetaPermissionSet, "IncludedPermissionSets").PropertyType,
+            BuildIncludeList(RequireBcProperty(_tMetaPermissionSet, "IncludedPermissionSets").PropertyType,
                 declaration.IncludedPermissionSets, declaration.IncludedPermissionSetIds));
         // ExcludedPermissionSets was hardcoded null because the only route into this method
         // stated no exclude edges: SymbolReference.json does not carry them, and Base
@@ -647,7 +647,7 @@ public static partial class RecordPatches
         // emitted document DOES state them, as ids, for anything the runner compiles from
         // source, so that route fills the column and the precompiled route still passes null.
         SetProperty(mps, "ExcludedPermissionSets",
-            BuildIncludeListFromIds(RequireBcProperty(_tMetaPermissionSet, "ExcludedPermissionSets").PropertyType,
+            BuildIncludeList(RequireBcProperty(_tMetaPermissionSet, "ExcludedPermissionSets").PropertyType,
                 null, declaration.ExcludedPermissionSetIds));
 
         return mps;
@@ -665,33 +665,30 @@ public static partial class RecordPatches
     /// version of this code assumed strings and failed loudly at <c>Add()</c> — the right
     /// failure, but only because it was checked at all.</para>
     ///
-    /// <para>THIS NAME AND ARITY ARE PART OF THE CONTRACT, not an implementation detail.
-    /// <c>AlRunner.Tests/PermissionMetadataShapeGapTests.cs</c> reaches this method by
-    /// <c>MethodInfo.Invoke</c> through <c>GetMethod(name, NonPublic | Static)</c>, and that
-    /// resolution is fragile in two different ways at once — #3609 hit both:</para>
+    /// <para>THIS NAME, ARITY, UNIQUENESS AND LIVENESS ARE ALL PART OF THE CONTRACT, not
+    /// implementation details. <c>AlRunner.Tests/PermissionMetadataShapeGapTests.cs</c> reaches
+    /// this method by <c>MethodInfo.Invoke</c> through
+    /// <c>GetMethod(name, NonPublic | Static)</c>, and #3609 broke it three separate ways
+    /// before landing here — each measured, not predicted:</para>
     /// <list type="bullet">
-    /// <item>an optional extra parameter satisfies every C# caller but not
+    /// <item><b>arity</b> — an optional extra parameter satisfies every C# caller but not
     /// <c>Invoke</c>, which matches the EXACT parameter count →
     /// <c>TargetParameterCountException</c>;</item>
-    /// <item>a second overload satisfies <c>Invoke</c> but not the lookup, since
-    /// <c>GetMethod(name, flags)</c> cannot choose between overloads →
-    /// <c>AmbiguousMatchException</c>.</item>
+    /// <item><b>uniqueness</b> — a second overload satisfies <c>Invoke</c> but not the lookup,
+    /// since <c>GetMethod(name, flags)</c> cannot choose between overloads →
+    /// <c>AmbiguousMatchException</c>;</item>
+    /// <item><b>liveness</b> — keeping the old signature as a thin forwarder satisfies both of
+    /// the above and still fails: with every production call site moved to the new name, the
+    /// reflective arms exercise a method nothing else reaches, so they prove nothing about a
+    /// live path. <c>ReflectionDrivenHelperLivenessTests</c> refuses that (#3100).</item>
     /// </list>
-    /// <para>So the id-based route is a SEPARATELY NAMED method
-    /// (<see cref="BuildIncludeListFromIds"/>) rather than a default parameter or an overload
-    /// here. Both alternatives were measured red on exactly the two legs that run the C# suite,
-    /// 27.5 and 28.4.</para>
+    /// <para>So the id-carrying parameter lives HERE, on the one method both production call
+    /// sites use, rather than behind a default, an overload, or a forwarder. If a later change
+    /// needs a fourth parameter, move the reflective arms with it — do not leave a
+    /// compatibility shim behind, because a dead shim is what the liveness guard exists to
+    /// catch.</para>
     /// </summary>
-    private static object BuildIncludeList(Type listType, IReadOnlyList<string>? names)
-        => BuildIncludeListFromIds(listType, names, resolvedIds: null);
-
-    /// <summary>
-    /// #3609's route: the same list, filled from the already-resolved object ids BC's own
-    /// emitted document states, falling back to <paramref name="names"/> when it states none.
-    /// Separately named rather than an overload of <see cref="BuildIncludeList"/> — see that
-    /// method's note on why reflection makes both a default parameter and an overload unsafe.
-    /// </summary>
-    private static object BuildIncludeListFromIds(
+    private static object BuildIncludeList(
         Type listType, IReadOnlyList<string>? names, IReadOnlyList<int>? resolvedIds)
     {
         var list = (System.Collections.IList)Activator.CreateInstance(listType)!;

--- a/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
@@ -638,7 +638,7 @@ public static partial class RecordPatches
         // better here — BuildIncludeList has to resolve a name through PermissionSetIdByName
         // and DROPS what it cannot find, which an already-resolved id cannot hit.
         SetProperty(mps, "IncludedPermissionSets",
-            BuildIncludeList(RequireBcProperty(_tMetaPermissionSet, "IncludedPermissionSets").PropertyType,
+            BuildIncludeListFromIds(RequireBcProperty(_tMetaPermissionSet, "IncludedPermissionSets").PropertyType,
                 declaration.IncludedPermissionSets, declaration.IncludedPermissionSetIds));
         // ExcludedPermissionSets was hardcoded null because the only route into this method
         // stated no exclude edges: SymbolReference.json does not carry them, and Base
@@ -647,7 +647,7 @@ public static partial class RecordPatches
         // emitted document DOES state them, as ids, for anything the runner compiles from
         // source, so that route fills the column and the precompiled route still passes null.
         SetProperty(mps, "ExcludedPermissionSets",
-            BuildIncludeList(RequireBcProperty(_tMetaPermissionSet, "ExcludedPermissionSets").PropertyType,
+            BuildIncludeListFromIds(RequireBcProperty(_tMetaPermissionSet, "ExcludedPermissionSets").PropertyType,
                 null, declaration.ExcludedPermissionSetIds));
 
         return mps;
@@ -664,9 +664,35 @@ public static partial class RecordPatches
     /// <para>The element type is read from the property rather than assumed, because the first
     /// version of this code assumed strings and failed loudly at <c>Add()</c> — the right
     /// failure, but only because it was checked at all.</para>
+    ///
+    /// <para>THIS NAME AND ARITY ARE PART OF THE CONTRACT, not an implementation detail.
+    /// <c>AlRunner.Tests/PermissionMetadataShapeGapTests.cs</c> reaches this method by
+    /// <c>MethodInfo.Invoke</c> through <c>GetMethod(name, NonPublic | Static)</c>, and that
+    /// resolution is fragile in two different ways at once — #3609 hit both:</para>
+    /// <list type="bullet">
+    /// <item>an optional extra parameter satisfies every C# caller but not
+    /// <c>Invoke</c>, which matches the EXACT parameter count →
+    /// <c>TargetParameterCountException</c>;</item>
+    /// <item>a second overload satisfies <c>Invoke</c> but not the lookup, since
+    /// <c>GetMethod(name, flags)</c> cannot choose between overloads →
+    /// <c>AmbiguousMatchException</c>.</item>
+    /// </list>
+    /// <para>So the id-based route is a SEPARATELY NAMED method
+    /// (<see cref="BuildIncludeListFromIds"/>) rather than a default parameter or an overload
+    /// here. Both alternatives were measured red on exactly the two legs that run the C# suite,
+    /// 27.5 and 28.4.</para>
     /// </summary>
-    private static object BuildIncludeList(
-        Type listType, IReadOnlyList<string>? names, IReadOnlyList<int>? resolvedIds = null)
+    private static object BuildIncludeList(Type listType, IReadOnlyList<string>? names)
+        => BuildIncludeListFromIds(listType, names, resolvedIds: null);
+
+    /// <summary>
+    /// #3609's route: the same list, filled from the already-resolved object ids BC's own
+    /// emitted document states, falling back to <paramref name="names"/> when it states none.
+    /// Separately named rather than an overload of <see cref="BuildIncludeList"/> — see that
+    /// method's note on why reflection makes both a default parameter and an overload unsafe.
+    /// </summary>
+    private static object BuildIncludeListFromIds(
+        Type listType, IReadOnlyList<string>? names, IReadOnlyList<int>? resolvedIds)
     {
         var list = (System.Collections.IList)Activator.CreateInstance(listType)!;
 

--- a/AlRunner/Patches/RecordPatches.PermissionSetFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionSetFromBcDocument.cs
@@ -1,0 +1,239 @@
+// RecordPatches.PermissionSetFromBcDocument — a source-compiled permission set's declaration
+// read from BC's OWN emitted metadata document instead of re-derived from AL source text
+// (issue #3609, the last conversion of the chain #3562 tracks).
+//
+// THE SEAM
+//   BC's Compilation.Emit hands CaptureOutputter a <PermissionSet> document for every
+//   `permissionset` object it emits, and AlObjectMetadataRegistry (#3548) keeps it keyed
+//   (kind, id). Measured on BC 28.1, a two-set probe:
+//
+//     <PermissionSet ID="70702" Name="PP Derived" Access="Internal" Assignable="1"
+//                    CaptionML="ENU=PP derived caption" IncludedPermissionSets="70701"
+//                    ExcludedPermissionSets="70704">
+//       <Permission Type="0" ID="70700" Value="449" />
+//       <Permission Type="5" ID="70703" Value="16" />
+//     </PermissionSet>
+//
+//   That states every column RecordPatches.AlPermissionSetParser derived by regex, and it
+//   states two of them RESOLVED that the parser could only state as names — see the two
+//   claims below. docs/permission-set-from-bc-document.md has the probe and the measurements.
+//
+// CLAIM: object references arrive as IDS, which removes a silent wrong answer.
+//   A source-declared `Permissions = tabledata "PP Thing" = RIMD` names its object; AL has no
+//   id form. ResolveSourcePermissionEntries resolved that name against ParsedObjectDecls,
+//   which does not carry TABLES — so `AlKeywordForPermissionObject` returned null for
+//   ordinals 0 (tabledata) and 1 (table) and the entry was dropped by `if (kind == null)
+//   continue;`, BEFORE the diagnostic below it. Every tabledata grant in a source-compiled
+//   permission set therefore vanished at every verbosity, including AL_RUNNER_DIAG_PERMMETA=1.
+//   BC's document states `Type="0" ID="70700"` outright, so the resolution step — and its
+//   blind spot — is not needed on this route.
+//
+// CLAIM: masks arrive computed, and BC's encoding is the one the parser reimplemented.
+//   Measured: `RIMD` → Value="15", `Rimd` → Value="449", `X` → Value="16", matching
+//   MaskFromAlLetters' R=1 I=2 M=4 D=8 X=16 / r=32 i=64 m=128 d=256 x=512 exactly. So this
+//   route is not a different answer, it is the same answer without the transcription.
+//
+// CLAIM: IncludedPermissionSets/ExcludedPermissionSets arrive as ids, not names.
+//   BuildIncludeList resolves names against this run's inventory and DROPS what it cannot
+//   find. BC states the resolved object id, so a set included by a source-compiled
+//   declaration cannot be lost to a name lookup on this route.
+//
+// EXCLUDEDPERMISSIONSETS — WHAT THE 0-OF-258 MEASUREMENT DOES AND DOES NOT SAY
+//   Issue #3609 records that ExcludedPermissionSets occurs 0 times across Base Application's
+//   258 permission sets, and expected conversion to leave that column unfixed. Re-measured
+//   here, the count is right and the inference from it is not: 258 permissionset sources,
+//   0 declaring ExcludedPermissionSets, 46 declaring IncludedPermissionSets. The zero is a
+//   property of Base Application's own AL, not of BC's emitter — a probe declaring the
+//   property gets `ExcludedPermissionSets="70704"` on the document alongside
+//   IncludedPermissionSets. So this route DOES carry it, and the populator's hardcoded null
+//   is retired for source-compiled sets rather than kept. It stays for the precompiled route,
+//   where SymbolReference.json is what the runner reads and the column is not extracted.
+//
+// WHAT SURVIVES CONVERSION — nothing here becomes dead code
+//   Issue #3609 expected RecordPatches.AlPermissionSetParser.cs (176 lines) and part of
+//   PermissionMetadataPopulator.cs to retire. Measured, neither can, and the reason is
+//   structural rather than incidental:
+//
+//     - The registry is keyed BY ID, so something has to say which permission-set ids this
+//       run declares before a document can be looked up. The parser is that inventory.
+//     - BC's document does not state the OWNING APP. AppId/AppName come from the app.json
+//       that owns the source file (ResolveOwningApp), and both the "Metadata Permission Set"
+//       App ID column and AggregatePermissionSetVirtualTable.BuildKnownAppNameIndex read them.
+//     - Emit runs only on a compile-cache MISS, so the derivation is the live fallback on
+//       every warm run whose replay supplied no document — not a legacy path.
+//
+//   What conversion removes is the derivation's ROLE as the answer, not its code: the
+//   name→id resolution, the hand-rolled mask table and the include-name lookup stop deciding
+//   what a source-compiled permission set means whenever BC's document is available.
+//   docs/permission-set-from-bc-document.md § "what survives" has the per-symbol detail.
+//
+// AVAILABILITY DECIDES THE ROUTE, AND A FAILURE IS NEVER RE-ROUTED
+//   Taken only when a document is registered for (PermissionSet, id). A permission set from a
+//   precompiled dependency .app has none — it is read from SymbolReference.json — and keeps
+//   that route unchanged. Nothing here catches a parse failure and falls back to the regex
+//   derivation: a weaker answer substituted on error is wrong metadata under a green build
+//   (.claude/rules/loud-failures.md).
+//
+// CACHE-HIT SAFETY
+//   Emit runs only on a compile-cache MISS. The registry is replayed on a HIT by the three
+//   mechanisms ObjectMetadataRegistry.cs documents (enum-registry sidecar, dependency
+//   .object-metadata.json, --watch shadow snapshot), and HasBcPermissionSetDocument answers
+//   false when none of them supplied one — so a warm run with no replayed document keeps the
+//   AL-source derivation rather than silently losing every source-declared permission set.
+//
+// PRECOMPILED-DLL RESPECT: this file reads an XML string the compiler already produced and
+// builds the runner's own PermissionSetSymbol record from it. No BC type is constructed or
+// rewritten here.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    /// <summary>The AL compiler's own <c>SymbolKind</c> spelling for a permission set.
+    /// <c>PermissionSetExtension</c> is a DISTINCT kind with its own documents (root element
+    /// <c>MetadataRuntimeDeltas</c>, not <c>PermissionSet</c>) and is not read here.</summary>
+    internal const string BcPermissionSetMetadataKind = "PermissionSet";
+
+    /// <summary>
+    /// True when BC's emitter handed the runner a metadata document for this permission set
+    /// id — i.e. the runner compiled it from source this run, or a replay mechanism restored
+    /// the document on a compile-cache hit.
+    /// </summary>
+    internal static bool HasBcPermissionSetDocument(int permissionSetId)
+        => AlObjectMetadataRegistry.TryGet(BcPermissionSetMetadataKind, permissionSetId, out var xml)
+           && !string.IsNullOrEmpty(xml);
+
+    /// <summary>
+    /// The permission set BC's document states, or null when no document is registered for
+    /// that id. <paramref name="fallbackName"/> is used only when the document states no
+    /// Name, which no shape the compiler produces does — it keeps a nameless row from
+    /// becoming an unkeyed one rather than papering over a real gap.
+    /// </summary>
+    internal static BcAppSymbolCache.PermissionSetSymbol? TryReadPermissionSetFromBcDocument(
+        int permissionSetId, string fallbackName)
+    {
+        if (!AlObjectMetadataRegistry.TryGet(BcPermissionSetMetadataKind, permissionSetId, out var xml)
+            || string.IsNullOrEmpty(xml))
+            return null;
+
+        XElement root;
+        try
+        {
+            root = XDocument.Parse(xml).Root
+                   ?? throw new InvalidOperationException("document has no root element");
+        }
+        catch (Exception ex)
+        {
+            // Loud, not re-routed: a document that arrived and will not parse is a shape
+            // change in BC's emitter, and answering from the regex derivation instead would
+            // hide it behind a green run.
+            throw PermissionMetadataBcShapeGap(
+                $"PermissionSet {permissionSetId} metadata document",
+                $"was registered but does not parse as XML ({ex.Message}) — BC's own permission "
+                + "set declaration cannot be read");
+        }
+
+        var name = (string?)root.Attribute("Name");
+        if (string.IsNullOrEmpty(name)) name = fallbackName;
+
+        return new BcAppSymbolCache.PermissionSetSymbol(
+            permissionSetId,
+            name,
+            // CaptionML is BC's multi-language form, "ENU=PP base caption". The Caption the
+            // rest of the runner carries is the ENU text alone, which is what the AL `Caption`
+            // property stated and what "Metadata Permission Set".Name reports.
+            EnuFromCaptionMl((string?)root.Attribute("CaptionML")),
+            // Assignable is emitted as "1"/"0". AL's own default when a set declares none is
+            // true, and BC states the attribute on every set the compiler emits — so an
+            // absent attribute takes AL's default rather than reading as false.
+            ParseBcBool((string?)root.Attribute("Assignable"), defaultValue: true),
+            ReadPermissions(root),
+            // The NAME list stays null on this route: BC states ids, and filling both would
+            // give BuildIncludeList two sources to disagree about.
+            IncludedPermissionSets: null,
+            // Access is absent when the set declares none; AL's default is Public, applied by
+            // the populator rather than invented here, so absent stays null.
+            Access: (string?)root.Attribute("Access"),
+            IncludedPermissionSetIds: ReadPermissionSetIdList(root, "IncludedPermissionSets"),
+            ExcludedPermissionSetIds: ReadPermissionSetIdList(root, "ExcludedPermissionSets"));
+    }
+
+    /// <summary>
+    /// The ENU text of a <c>CaptionML</c> value. BC emits "ENU=Some caption", and may emit
+    /// further languages separated by ';' — take ENU when present, the first entry otherwise,
+    /// so a set captioned only in another language still reports a caption rather than the raw
+    /// multi-language string.
+    /// </summary>
+    private static string? EnuFromCaptionMl(string? captionMl)
+    {
+        if (string.IsNullOrWhiteSpace(captionMl)) return null;
+        string? first = null;
+        foreach (var part in captionMl.Split(';'))
+        {
+            var eq = part.IndexOf('=');
+            if (eq < 0) continue;
+            var lang = part.Substring(0, eq).Trim();
+            var text = part.Substring(eq + 1);
+            first ??= text;
+            if (string.Equals(lang, "ENU", StringComparison.OrdinalIgnoreCase)) return text;
+        }
+        return first ?? captionMl;
+    }
+
+    private static bool ParseBcBool(string? value, bool defaultValue)
+        => string.IsNullOrEmpty(value)
+            ? defaultValue
+            : value == "1" || string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The document's <c>&lt;Permissions&gt;</c> rows. Both Type and ID are already BC's own
+    /// ordinal and object id, and Value is the computed mask — nothing is resolved or
+    /// recomputed here, which is the point of reading the document at all.
+    /// </summary>
+    private static IReadOnlyList<BcAppSymbolCache.PermissionSymbol> ReadPermissions(XElement root)
+    {
+        var ns = root.Name.Namespace;
+        var container = root.Element(ns + "Permissions");
+        if (container == null) return Array.Empty<BcAppSymbolCache.PermissionSymbol>();
+
+        var rows = new List<BcAppSymbolCache.PermissionSymbol>();
+        foreach (var p in container.Elements(ns + "Permission"))
+        {
+            // A row missing any of the three is not a row that can mean anything; skipping it
+            // is the same conservative choice the name-resolving route made, but it cannot
+            // happen for a document the compiler produced.
+            if (!TryParseInt((string?)p.Attribute("Type"), out var type)) continue;
+            if (!TryParseInt((string?)p.Attribute("ID"), out var id)) continue;
+            if (!TryParseInt((string?)p.Attribute("Value"), out var value)) continue;
+            rows.Add(new BcAppSymbolCache.PermissionSymbol(type, id, value));
+        }
+        return rows;
+    }
+
+    /// <summary>
+    /// An <c>IncludedPermissionSets</c>/<c>ExcludedPermissionSets</c> attribute. BC states
+    /// resolved object IDS here, comma-separated — not the quoted names AL source and
+    /// SymbolReference.json state — so these are carried as ids and never go through
+    /// PermissionSetIdByName's lookup-and-drop.
+    /// </summary>
+    private static IReadOnlyList<int>? ReadPermissionSetIdList(XElement root, string attribute)
+    {
+        var raw = (string?)root.Attribute(attribute);
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+
+        var ids = new List<int>();
+        foreach (var part in raw.Split(','))
+            if (TryParseInt(part.Trim(), out var id))
+                ids.Add(id);
+        return ids.Count == 0 ? null : ids;
+    }
+
+    private static bool TryParseInt(string? text, out int value)
+        => int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+}

--- a/AlRunner/Patches/RecordPatches.PermissionSetFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionSetFromBcDocument.cs
@@ -1,89 +1,41 @@
 // RecordPatches.PermissionSetFromBcDocument — a source-compiled permission set's declaration
-// read from BC's OWN emitted metadata document instead of re-derived from AL source text
-// (issue #3609, the last conversion of the chain #3562 tracks).
+// read from BC's OWN emitted <PermissionSet> metadata document instead of re-derived by regex
+// over AL source text (#3609, last conversion of the chain #3562 tracks).
 //
-// THE SEAM
-//   BC's Compilation.Emit hands CaptureOutputter a <PermissionSet> document for every
-//   `permissionset` object it emits, and AlObjectMetadataRegistry (#3548) keeps it keyed
-//   (kind, id). Measured on BC 28.1, a two-set probe:
+// Derivation, the probe output, the mask table and the per-symbol survival list are in
+// docs/permission-set-from-bc-document.md. Four claims, each with what settled it:
 //
-//     <PermissionSet ID="70702" Name="PP Derived" Access="Internal" Assignable="1"
-//                    CaptionML="ENU=PP derived caption" IncludedPermissionSets="70701"
-//                    ExcludedPermissionSets="70704">
-//       <Permission Type="0" ID="70700" Value="449" />
-//       <Permission Type="5" ID="70703" Value="16" />
-//     </PermissionSet>
+// CLAIM — observably equivalent, and strictly better on one column. BC's document states the
+//   same properties the regex derived, with object references and masks ALREADY RESOLVED
+//   (`<Permission Type="0" ID="70700" Value="15" />`, `IncludedPermissionSets="70701"`). The
+//   mask encoding is BC's own and agrees with the derivation's hand-rolled table exactly —
+//   RIMD=15, Rimd=449, X=16, measured on BC 28.1. So this is the same answer without the
+//   transcription. See docs/permission-set-from-bc-document.md#mask-encoding.
 //
-//   That states every column RecordPatches.AlPermissionSetParser derived by regex, and it
-//   states two of them RESOLVED that the parser could only state as names — see the two
-//   claims below. docs/permission-set-from-bc-document.md has the probe and the measurements.
+// CLAIM — it removes a silent wrong answer, which is why it is preferred unconditionally when
+//   available rather than as a tidiness matter. ResolveSourcePermissionEntries resolves an
+//   object NAME against ParsedObjectDecls, which carries no tables, so every `tabledata` grant
+//   in a source-compiled permission set was dropped by a `continue` sitting ABOVE its own
+//   diagnostic — invisible at every verbosity. Measured 17419 → 17421 declared permissions on a
+//   probe. See docs/permission-set-from-bc-document.md#tabledata.
 //
-// CLAIM: object references arrive as IDS, which removes a silent wrong answer.
-//   A source-declared `Permissions = tabledata "PP Thing" = RIMD` names its object; AL has no
-//   id form. ResolveSourcePermissionEntries resolved that name against ParsedObjectDecls,
-//   which does not carry TABLES — so `AlKeywordForPermissionObject` returned null for
-//   ordinals 0 (tabledata) and 1 (table) and the entry was dropped by `if (kind == null)
-//   continue;`, BEFORE the diagnostic below it. Every tabledata grant in a source-compiled
-//   permission set therefore vanished at every verbosity, including AL_RUNNER_DIAG_PERMMETA=1.
-//   BC's document states `Type="0" ID="70700"` outright, so the resolution step — and its
-//   blind spot — is not needed on this route.
+// CLAIM — ExcludedPermissionSets IS carried here, contrary to what #3609 expected. The issue's
+//   0-of-258 count over Base Application reproduces exactly, but it measures Base Application's
+//   AL rather than BC's emitter: a probe declaring the property gets it back on the document.
+//   See docs/permission-set-from-bc-document.md#excluded-permission-sets.
 //
-// CLAIM: masks arrive computed, and BC's encoding is the one the parser reimplemented.
-//   Measured: `RIMD` → Value="15", `Rimd` → Value="449", `X` → Value="16", matching
-//   MaskFromAlLetters' R=1 I=2 M=4 D=8 X=16 / r=32 i=64 m=128 d=256 x=512 exactly. So this
-//   route is not a different answer, it is the same answer without the transcription.
+// TRAP — nothing in the derivation became dead code, so do not delete it as unreachable. The
+//   registry is keyed by id (the parser is the inventory), BC's document does not state
+//   AppId/AppName, and Emit runs only on a compile-cache MISS, leaving the derivation the live
+//   fallback on a warm run. See docs/permission-set-from-bc-document.md#what-survives.
 //
-// CLAIM: IncludedPermissionSets/ExcludedPermissionSets arrive as ids, not names.
-//   BuildIncludeList resolves names against this run's inventory and DROPS what it cannot
-//   find. BC states the resolved object id, so a set included by a source-compiled
-//   declaration cannot be lost to a name lookup on this route.
+// A parse failure is never re-routed to the derivation — a weaker answer substituted on error
+// is wrong metadata under a green build (.claude/rules/loud-failures.md). Every drop inside
+// this file is reported on AL_RUNNER_DIAG_PERMMETA, because a silently dropped grant is the
+// exact defect #3609 was about.
 //
-// EXCLUDEDPERMISSIONSETS — WHAT THE 0-OF-258 MEASUREMENT DOES AND DOES NOT SAY
-//   Issue #3609 records that ExcludedPermissionSets occurs 0 times across Base Application's
-//   258 permission sets, and expected conversion to leave that column unfixed. Re-measured
-//   here, the count is right and the inference from it is not: 258 permissionset sources,
-//   0 declaring ExcludedPermissionSets, 46 declaring IncludedPermissionSets. The zero is a
-//   property of Base Application's own AL, not of BC's emitter — a probe declaring the
-//   property gets `ExcludedPermissionSets="70704"` on the document alongside
-//   IncludedPermissionSets. So this route DOES carry it, and the populator's hardcoded null
-//   is retired for source-compiled sets rather than kept. It stays for the precompiled route,
-//   where SymbolReference.json is what the runner reads and the column is not extracted.
-//
-// WHAT SURVIVES CONVERSION — nothing here becomes dead code
-//   Issue #3609 expected RecordPatches.AlPermissionSetParser.cs (176 lines) and part of
-//   PermissionMetadataPopulator.cs to retire. Measured, neither can, and the reason is
-//   structural rather than incidental:
-//
-//     - The registry is keyed BY ID, so something has to say which permission-set ids this
-//       run declares before a document can be looked up. The parser is that inventory.
-//     - BC's document does not state the OWNING APP. AppId/AppName come from the app.json
-//       that owns the source file (ResolveOwningApp), and both the "Metadata Permission Set"
-//       App ID column and AggregatePermissionSetVirtualTable.BuildKnownAppNameIndex read them.
-//     - Emit runs only on a compile-cache MISS, so the derivation is the live fallback on
-//       every warm run whose replay supplied no document — not a legacy path.
-//
-//   What conversion removes is the derivation's ROLE as the answer, not its code: the
-//   name→id resolution, the hand-rolled mask table and the include-name lookup stop deciding
-//   what a source-compiled permission set means whenever BC's document is available.
-//   docs/permission-set-from-bc-document.md § "what survives" has the per-symbol detail.
-//
-// AVAILABILITY DECIDES THE ROUTE, AND A FAILURE IS NEVER RE-ROUTED
-//   Taken only when a document is registered for (PermissionSet, id). A permission set from a
-//   precompiled dependency .app has none — it is read from SymbolReference.json — and keeps
-//   that route unchanged. Nothing here catches a parse failure and falls back to the regex
-//   derivation: a weaker answer substituted on error is wrong metadata under a green build
-//   (.claude/rules/loud-failures.md).
-//
-// CACHE-HIT SAFETY
-//   Emit runs only on a compile-cache MISS. The registry is replayed on a HIT by the three
-//   mechanisms ObjectMetadataRegistry.cs documents (enum-registry sidecar, dependency
-//   .object-metadata.json, --watch shadow snapshot), and HasBcPermissionSetDocument answers
-//   false when none of them supplied one — so a warm run with no replayed document keeps the
-//   AL-source derivation rather than silently losing every source-declared permission set.
-//
-// PRECOMPILED-DLL RESPECT: this file reads an XML string the compiler already produced and
-// builds the runner's own PermissionSetSymbol record from it. No BC type is constructed or
-// rewritten here.
+// PRECOMPILED-DLL RESPECT: reads an XML string the compiler already produced and builds the
+// runner's own PermissionSetSymbol record from it. No BC type is constructed or rewritten.
 
 using System;
 using System.Collections.Generic;
@@ -205,13 +157,28 @@ public static partial class RecordPatches
         var rows = new List<BcAppSymbolCache.PermissionSymbol>();
         foreach (var p in container.Elements(ns + "Permission"))
         {
-            // A row missing any of the three is not a row that can mean anything; skipping it
-            // is the same conservative choice the name-resolving route made, but it cannot
-            // happen for a document the compiler produced.
-            if (!TryParseInt((string?)p.Attribute("Type"), out var type)) continue;
-            if (!TryParseInt((string?)p.Attribute("ID"), out var id)) continue;
-            if (!TryParseInt((string?)p.Attribute("Value"), out var value)) continue;
-            rows.Add(new BcAppSymbolCache.PermissionSymbol(type, id, value));
+            // A row missing any of the three cannot mean anything, so it is dropped rather
+            // than guessed at — but it is dropped WITH A DIAGNOSTIC, on the same
+            // AL_RUNNER_DIAG_PERMMETA channel the id route below uses. #3609 was itself a
+            // grant dropped by a `continue` that no verbosity could see, and "this cannot
+            // happen for a document the compiler produced" is exactly the reasoning that made
+            // the original one invisible. If BC's emitter ever changes shape here, the drop
+            // has to be greppable rather than silent.
+            var type = (string?)p.Attribute("Type");
+            var idText = (string?)p.Attribute("ID");
+            var valueText = (string?)p.Attribute("Value");
+            if (!TryParseInt(type, out var typeOrdinal)
+                || !TryParseInt(idText, out var id)
+                || !TryParseInt(valueText, out var value))
+            {
+                if (Environment.GetEnvironmentVariable("AL_RUNNER_DIAG_PERMMETA") == "1")
+                    Console.Error.WriteLine(
+                        "[perm-metadata] BC's permission-set document carries a <Permission> row "
+                        + $"this code cannot read (Type='{type}' ID='{idText}' Value='{valueText}') "
+                        + "— dropped rather than guessed");
+                continue;
+            }
+            rows.Add(new BcAppSymbolCache.PermissionSymbol(typeOrdinal, id, value));
         }
         return rows;
     }
@@ -227,10 +194,21 @@ public static partial class RecordPatches
         var raw = (string?)root.Attribute(attribute);
         if (string.IsNullOrWhiteSpace(raw)) return null;
 
+        // Same rule as ReadPermissions above: an unparseable entry is dropped, and the drop is
+        // observable on AL_RUNNER_DIAG_PERMMETA rather than silent. A lost include edge makes
+        // BC compose a DIFFERENT set of grants, which is precisely the class of wrong answer
+        // nothing downstream can detect.
         var ids = new List<int>();
         foreach (var part in raw.Split(','))
-            if (TryParseInt(part.Trim(), out var id))
-                ids.Add(id);
+        {
+            var text = part.Trim();
+            if (text.Length == 0) continue;          // trailing separator, not a lost edge
+            if (TryParseInt(text, out var id)) { ids.Add(id); continue; }
+            if (Environment.GetEnvironmentVariable("AL_RUNNER_DIAG_PERMMETA") == "1")
+                Console.Error.WriteLine(
+                    $"[perm-metadata] BC's permission-set document states {attribute}='{raw}', whose "
+                    + $"entry '{text}' is not an object id this code can read — dropped rather than guessed");
+        }
         return ids.Count == 0 ? null : ids;
     }
 

--- a/docs/permission-set-from-bc-document.md
+++ b/docs/permission-set-from-bc-document.md
@@ -1,0 +1,165 @@
+# Permission sets from BC's own metadata document
+
+Issue #3609, rank 8 and last of the conversion chain #3562 tracks. Companion to
+[`docs/object-metadata-from-bc.md`](object-metadata-from-bc.md) (tables, #3552) and
+[`docs/page-metadata-properties.md`](page-metadata-properties.md) (pages, #3601).
+
+The runner derived a source-compiled permission set's declaration by running a regular
+expression over AL source text (`RecordPatches.AlPermissionSetParser.cs`). BC's own
+`Compilation.Emit` had already produced a `<PermissionSet>` document stating the same
+things — and stating two of them *resolved*, which the derivation could not do at all.
+
+<a id="what-bc-states"></a>
+
+## What BC actually emits
+
+Measured on BC 28.1.49838.53910 with `AL_RUNNER_TRACE_OBJECT_METADATA=2`, over a probe
+bundle declaring two permission sets. Reproduce it by pointing the runner at any bundle
+with a `permissionset` object and reading the `[object-metadata]` lines.
+
+```xml
+<PermissionSet MetadataVersion="130000" ID="70702" Name="PP Derived" ALNamespace=""
+               Access="Internal" Assignable="1" CaptionML="ENU=PP derived caption"
+               IncludedPermissionSets="70701" ExcludedPermissionSets="70704"
+               CaptionTranslationKey="PermissionSet 1722699319 - Property 2879900210"
+               xmlns="urn:schemas-microsoft-com:dynamics:NAV:MetaObjects">
+  <Permissions>
+    <Permission Type="0" ID="70700" Value="449" />
+    <Permission Type="5" ID="70703" Value="16" />
+  </Permissions>
+</PermissionSet>
+```
+
+Three properties of that document are what make the conversion worth doing:
+
+| | AL source states | BC's document states |
+|---|---|---|
+| a permission's object | a NAME — `tabledata "PP Thing"` | `Type="0" ID="70700"`, resolved |
+| a permission's mask | letters — `= RIMD`, `= Rimd` | `Value="15"`, `Value="449"`, computed |
+| include/exclude edges | quoted NAMES | `IncludedPermissionSets="70701"`, resolved ids |
+
+<a id="mask-encoding"></a>
+
+## The mask encoding agrees with the derivation's
+
+`MaskFromAlLetters` reimplemented BC's `PermissionMask` by hand: R=1, I=2, M=4, D=8, X=16,
+with the lowercase *indirect* variants at 32/64/128/256/512. Measured against BC's own
+output, the two agree exactly:
+
+| AL | BC's `Value` | arithmetic |
+|---|---|---|
+| `RIMD` | 15 | 1 + 2 + 4 + 8 |
+| `Rimd` | 449 | 1 + 64 + 128 + 256 |
+| `X` | 16 | 16 |
+
+So this route is not a *different* answer — it is the same answer without the
+transcription, which is the reason it can be preferred unconditionally when available.
+
+<a id="tabledata"></a>
+
+## The defect this removes: a silently dropped `tabledata` grant
+
+`ResolveSourcePermissionEntries` resolved each permission's object name against
+`ParsedObjectDecls`. That collection does not carry **tables** — they are parsed by the
+table pipeline, not the declaration sweep — so `AlKeywordForPermissionObject` returns
+`null` for PermissionObject ordinals 0 (`tabledata`) and 1 (`table`):
+
+```csharp
+var kind = AlKeywordForPermissionObject(e.ObjectTypeOrdinal);
+if (kind == null) continue;               // <- the drop
+if (!byName.TryGetValue((kind, e.ObjectName), out var id))
+{
+    if (Environment.GetEnvironmentVariable("AL_RUNNER_DIAG_PERMMETA") == "1")
+        Console.Error.WriteLine(...);     // <- the diagnostic, never reached for a table
+    continue;
+}
+```
+
+The `continue` sits **above** the diagnostic, so the loss was invisible at every verbosity,
+including `AL_RUNNER_DIAG_PERMMETA=1`. A permission set whose grants are all on tables —
+the overwhelmingly common shape — reached BC's permission metadata layer with an empty
+`Permissions` list, and every test over it stayed green.
+
+The known limit was documented in the method's own doc comment and rested on "every
+tabledata grant that matters in practice comes from a precompiled dependency". That is true
+of Base Application and not of a bundle under test: Microsoft's Tests-SINGLESERVER bucket
+declares `permissionset 134611 TestSet` in source, which is the case #2357 existed for.
+
+Measured end to end on the probe bundle, `AL_RUNNER_DIAG_PERMMETA=1`, Base Application
+closure loaded, before and after the conversion:
+
+```
+declared permissions: 17419      (before)
+declared permissions: 17421      (after)
+```
+
+The delta is exactly the probe's two source-declared `tabledata` grants. The other 17,419
+come from precompiled dependencies, which state ids in `SymbolReference.json` and never
+took the broken path.
+
+<a id="excluded-permission-sets"></a>
+
+## `ExcludedPermissionSets`: the count is right, the inference from it was not
+
+Issue #3609 records `ExcludedPermissionSets` as hardcoded null and states that BC does not
+state it either — 0 occurrences across 258 Base Application permission sets — concluding
+that conversion cannot fix it.
+
+Re-measured independently over
+`Microsoft_Base Application_28.1.49838.53910.app`, counting `permissionset` declarations in
+its `src/` tree:
+
+| | count |
+|---|---|
+| permission set source files | 258 |
+| declaring `ExcludedPermissionSets` | **0** |
+| declaring `IncludedPermissionSets` | 46 |
+
+The zero is real. What it measures is **Base Application's own AL**, not BC's emitter. A
+probe that declares the property gets it back on the document:
+
+```xml
+<PermissionSet ID="70702" ... ExcludedPermissionSets="70704" IncludedPermissionSets="70701" ...>
+```
+
+(Declaring the *same* set in both lists is rejected by the compiler with `AL0740`, so the
+probe uses two distinct sets.)
+
+So conversion **does** carry `ExcludedPermissionSets` for anything the runner compiles from
+source, and the populator's hardcoded null is retired on that route. It stays null on the
+precompiled route, where the runner reads `SymbolReference.json`, which does not carry
+exclude edges at all.
+
+<a id="what-survives"></a>
+
+## What survives conversion — nothing becomes dead code
+
+The issue expected `AlPermissionSetParser.cs` (176 lines) and part of
+`PermissionMetadataPopulator.cs` (884) to retire. Measured, neither can:
+
+| symbol | why it stays |
+|---|---|
+| `TryParsePermissionSetFile`, `_parsedPermissionSets` | the registry is keyed **by id**, so something must say which ids this run declares before a document can be fetched |
+| `ParsedAlPermissionSet.AppId` / `.AppName` | BC's document does **not** state the owning app; it comes from the owning `app.json` via `ResolveOwningApp`, and both the "Metadata Permission Set" App ID column and `BuildKnownAppNameIndex` read it |
+| `ParsePermissionEntries`, `MaskFromAlLetters`, `ParseIncludedPermissionSets` | `Emit` runs only on a compile-cache **MISS**, so the derivation is the live fallback on any warm run whose replay supplied no document |
+| `ResolveSourcePermissionEntries`, `AlKeywordForPermissionObject` | same fallback path |
+
+What conversion removes is the derivation's **role as the answer**, not its code. Whenever
+BC's document is available — which is every cold run — the name→id resolution, the
+hand-rolled mask table and the include-name lookup stop deciding what a source-compiled
+permission set means.
+
+That is the honest scope of the change, and it is smaller than the issue anticipated in
+line count while being larger in effect, because the path it replaces was losing data.
+
+<a id="scope"></a>
+
+## What this does not do
+
+Permission **enforcement** is out of scope for the runner
+([`docs/limitations.md`](limitations.md)) — these tables answer lookups only. Nothing here
+changes what AL code is permitted to do; it changes what the metadata tables report about
+declared permission sets.
+
+`PermissionSetExtension` is a separate `SymbolKind` whose documents use a different root
+element (`MetadataRuntimeDeltas`, not `PermissionSet`) and is not read by this code.


### PR DESCRIPTION
Closes #3609

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/301

A source-compiled permission set is now read from BC's own emitted `<PermissionSet>` document instead of a regex over AL source.

## The defect found is not the one the issue anticipated

`ResolveSourcePermissionEntries` resolves a permission's object **name** against `ParsedObjectDecls`, which carries no tables. So `AlKeywordForPermissionObject` returns null for ordinals 0 (`tabledata`) and 1 (`table`), and `if (kind == null) continue;` sits **above** the diagnostic — every `tabledata` grant in a source-compiled permission set vanished at every verbosity, including `AL_RUNNER_DIAG_PERMMETA=1`.

End-to-end on a probe with Base App loaded: `declared permissions: 17419 → 17421`, exactly the two source-declared grants.

## RED → GREEN, verified by disabling the fix

Not a transcript claim — the two-line conversion was commented out and the suite re-run:

```
Failed ...WithBcsDocument_TheTableDataGrantSurvivesWithBcsOwnIdAndMask
   Assert.Single() Failure: The collection was empty
```

Restored, all 7 tests in `AlRunner.Tests/PermissionSetFromBcDocumentTests.cs` pass.

Also confirmed BC's `Value` encoding matches the hand-rolled `MaskFromAlLetters` exactly (`RIMD`→15, `Rimd`→449, `X`→16), so this is the same answer without the transcription step.

## Two corrections to the issue's stated bounds

**1. `ExcludedPermissionSets` is fixable, contrary to the issue.** The 0-of-258 count reproduces independently (258 Base App permission sets, **0** declaring it, 46 declaring `IncludedPermissionSets`) — but that zero measures Base Application's AL, not BC's emitter. A probe declaring it gets `ExcludedPermissionSets="70704"` back on the document. It is now carried on the source-compiled route, and still null on the precompiled route, where `SymbolReference.json` genuinely has no exclude edges. (Declaring the same set in both lists is rejected with `AL0740`; the probe uses two.)

**2. Nothing becomes dead code.** The issue expected `AlPermissionSetParser.cs` (176 lines) and part of `PermissionMetadataPopulator.cs` to retire. Neither can:

- the registry is keyed by id, so the parser remains the inventory of which ids exist;
- BC's document does **not** state `AppId`/`AppName` — those come from the owning `app.json`, read by the App ID column and `BuildKnownAppNameIndex`;
- `Emit` runs only on a compile-cache MISS, so the derivation is the live warm-run fallback.

What conversion removes is the derivation's **role as the answer**, not its code. Per-symbol table in `docs/permission-set-from-bc-document.md`.

## Corpus

Own clone at pin `c9d5f656`; the shared `tests/al-language/` was never touched. AFTER arm, exit 0 under `--count-baseline` and `--expectations-require-match`:

| suite | pass | baseline |
|---|---|---|
| al-language | 3112 | 3112 |
| al-language-onprem | 29 | 29 |
| al-language-internals-fixture | 0 | 0 |

3141 total, 0 fail, 0 error.

**The BEFORE arm did not complete.** The box's tmpfs filled mid-run and killed the shell. The AFTER counts match the checked-in baseline exactly, which is the property the bar asks for, but the paired before/after comparison this issue's acceptance bar requests is only half-measured — stated here rather than glossed.

Enforcement remains out of scope (`docs/limitations.md`), so these tables answer lookups only. That caps the value regardless, exactly as the issue said.

---

Implemented by an agent (Claude, `stma-auto-2`) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
