### PR TITLE
fix(report-metadata): answer Sorting Fields and Request Filter Fields from BC's document

### DIFF
--- a/AlRunner.Tests/ReportMetadataDocumentColumnTests.cs
+++ b/AlRunner.Tests/ReportMetadataDocumentColumnTests.cs
@@ -13,6 +13,16 @@
 // came from. If a future BC version stopped emitting <WordMergeDataItem>, or started
 // writing the AL text into <DataItemTableView>, the corpus test would keep passing
 // against the AL-derived fallback and only this test would notice.
+//
+// #3620 adds the same claim for Sorting Fields and Request Filter Fields, and there the
+// premise is the whole fix. Both columns report comma-separated field NUMBERS, and Ncl
+// reaches those by resolving names through NCLMetaTable.FindFieldMatch. What the tests
+// below pin is that BC's emitter has ALREADY done that resolution: the document states
+// SORTING(Field5,Field2) and ReqFilterFields="Field2,Field5", and FindFieldMatch's first
+// branch strips a "Field" prefix and reads the rest as a number. If a future BC version
+// wrote field NAMES into either place, the runner would answer "" instead of a number and
+// the corpus test would report a plain wrong value with no indication of why — these tests
+// name the cause.
 
 using Xunit;
 
@@ -52,8 +62,15 @@ public sealed class ReportMetadataDocumentColumnTests : IDisposable
             {
                 field(1; "Entry No."; Integer) { DataClassification = CustomerContent; }
                 field(2; Description; Text[50]) { DataClassification = CustomerContent; }
+                field(5; "Alt Code"; Code[20]) { DataClassification = CustomerContent; }
             }
-            keys { key(PK; "Entry No.") { Clustered = true; } }
+            keys
+            {
+                key(PK; "Entry No.") { Clustered = true; }
+                // A non-primary key whose fields are neither field 1 nor in field order, so
+                // a SORTING clause resolved against it is distinguishable from both defaults.
+                key(Alt; "Alt Code", Description) { }
+            }
         }
 
         report 90311 "RptMetaDoc Fixture"
@@ -74,6 +91,26 @@ public sealed class ReportMetadataDocumentColumnTests : IDisposable
                         DataItemLink = "Entry No." = field("Entry No.");
                         column(ChildEntryNo; "Entry No.") { }
                     }
+                }
+
+                // #3620's shapes. Both properties name fields that are NOT field 1 and not
+                // the primary key, so "the first field" and "the primary key" are each a
+                // wrong answer rather than an accidentally-right one. The two orders also
+                // differ from each other — RequestFilterFields is written Description then
+                // "Alt Code" (2,5) while the key sorts "Alt Code" then Description (5,2) —
+                // so a value copied from the other column cannot pass either assertion.
+                dataitem(Filtered; "RptMetaDoc Sample")
+                {
+                    DataItemTableView = sorting("Alt Code", Description);
+                    RequestFilterFields = Description, "Alt Code";
+                    column(FilteredEntryNo; "Entry No.") { }
+                }
+
+                // Declares neither property: the shape whose correct answer is empty for
+                // both columns, which is what makes a non-empty answer above a real one.
+                dataitem(Plain; "RptMetaDoc Sample")
+                {
+                    column(PlainEntryNo; "Entry No.") { }
                 }
             }
         }
@@ -150,7 +187,7 @@ public sealed class ReportMetadataDocumentColumnTests : IDisposable
             _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
 
         var items = DataItems(EmitAndReadDocument());
-        Assert.Equal(2, items.Count);
+        Assert.Equal(4, items.Count);
 
         var rootItem = items.Single(i => Text(i, "DataItemVarName") == "Src");
         var childItem = items.Single(i => Text(i, "DataItemVarName") == "Child");
@@ -183,8 +220,8 @@ public sealed class ReportMetadataDocumentColumnTests : IDisposable
         var items = DataItems(EmitAndReadDocument());
         var ids = items.Select(i => int.Parse(Text(i, "ID"))).ToList();
 
-        Assert.Equal(2, ids.Count);
-        Assert.Equal(2, ids.Distinct().Count());
+        Assert.Equal(4, ids.Count);
+        Assert.Equal(4, ids.Distinct().Count());
 
         // The load-bearing property, and the reason the ordinal was not a harmless
         // stand-in: Ncl's ReportDataItemsDataProvider.GetReportDataItems keys, sorts and
@@ -192,5 +229,94 @@ public sealed class ReportMetadataDocumentColumnTests : IDisposable
         // one row and filters by it must select that row, which the ordinal could not do.
         Assert.DoesNotContain(1, ids);
         Assert.DoesNotContain(2, ids);
+    }
+
+    /// <summary>
+    /// Every <c>FilterControlDefinition</c> in the document's request page, keyed by the
+    /// <c>DataColumnName</c> that pairs it to a data item — the same pairing
+    /// <c>ReportDataItemsDataProvider.GetReportDataItems</c> performs. Selected by
+    /// <c>xsi:type</c> because every control in that tree is spelled &lt;Controls&gt;.
+    /// </summary>
+    private static Dictionary<string, System.Xml.XmlElement> FilterControls(System.Xml.XmlElement root)
+    {
+        var byColumn = new Dictionary<string, System.Xml.XmlElement>(StringComparer.Ordinal);
+        foreach (System.Xml.XmlNode n in root.GetElementsByTagName("Controls"))
+            if (n is System.Xml.XmlElement e
+                && e.GetAttribute("type", "http://www.w3.org/2001/XMLSchema-instance") == "FilterControlDefinition"
+                && e.GetAttribute("DataColumnName") is { Length: > 0 } column)
+                byColumn[column] = e;
+        return byColumn;
+    }
+
+    private static System.Xml.XmlElement DataItemNamed(System.Xml.XmlElement root, string varName)
+        => DataItems(root).Single(i => Text(i, "DataItemVarName") == varName);
+
+    /// <summary>
+    /// The premise behind <c>Request Filter Fields</c>: the property is not on the data item
+    /// at all, it is an attribute of the request page's filter control, and it is already
+    /// stated as field NUMBERS in the <c>Field&lt;N&gt;</c> token form.
+    ///
+    /// Both halves matter. Without the DataColumnName pairing there is no way to attribute a
+    /// filter control to a data item without building the request page — the cost this file's
+    /// sibling records as having blown the 60s watchdog. Without the token form the runner
+    /// would need an NCLMetaTable lookup per name, which is why #3607 deferred the column.
+    /// </summary>
+    [SkippableFact]
+    public void EmittedDocument_StatesReqFilterFieldsOnTheRequestPageControl_AsFieldNumbers()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var root = EmitAndReadDocument();
+        var controls = FilterControls(root);
+
+        // The data item does NOT state it — asserted rather than assumed, because if BC ever
+        // did put it here the runner's request-page lookup would be dead code answering "".
+        var filtered = DataItemNamed(root, "Filtered");
+        Assert.Equal(string.Empty, Text(filtered, "ReqFilterFields"));
+
+        // The pairing key, and the reason no page construction is needed.
+        var viewName = Text(filtered, "DataItemViewName");
+        Assert.NotEqual(string.Empty, viewName);
+        Assert.True(controls.TryGetValue(viewName, out var control),
+            $"expected a FilterControlDefinition with DataColumnName='{viewName}'; "
+            + $"the document has [{string.Join(", ", controls.Keys)}]");
+
+        // Already resolved, and in DECLARATION order: the fixture writes
+        // `RequestFilterFields = Description, "Alt Code"`, which is fields 2 then 5. Not the
+        // key order (5,2), so a value copied from the sorting clause fails here.
+        Assert.Equal("Field2,Field5", control!.GetAttribute("ReqFilterFields"));
+
+        // Negative: a data item declaring none produces a control with the attribute ABSENT,
+        // not present-and-empty. That is what makes "no answer" distinguishable, and it is
+        // the shape 1294 of Base Application's 1927 data items are in.
+        var plainViewName = Text(DataItemNamed(root, "Plain"), "DataItemViewName");
+        Assert.True(controls.TryGetValue(plainViewName, out var plainControl));
+        Assert.False(plainControl!.HasAttribute("ReqFilterFields"));
+    }
+
+    /// <summary>
+    /// The premise behind <c>Sorting Fields</c>: BC's compiled view states its SORTING clause
+    /// as field numbers too, in KEY order, so the column needs no TableViewParser run and no
+    /// NCLMetaTable.
+    /// </summary>
+    [SkippableFact]
+    public void EmittedDocument_StatesTheSortingClauseAsFieldNumbers_InKeyOrder()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var root = EmitAndReadDocument();
+
+        // The fixture sorts on key Alt = ("Alt Code", Description) = fields 5 then 2. Both
+        // assertions below would pass on an empty-or-default implementation only if BC
+        // answered the primary key (field 1), which neither number is.
+        var view = Text(DataItemNamed(root, "Filtered"), "DataItemTableView");
+        Assert.Equal("SORTING(Field5,Field2)", view);
+
+        // Negative: a data item that declares no view states none, rather than an implicit
+        // primary-key SORTING(Field1) — so an empty Sorting Fields answer is BC's answer,
+        // not the runner giving up.
+        Assert.Equal(string.Empty, Text(DataItemNamed(root, "Plain"), "DataItemTableView"));
     }
 }

--- a/AlRunner/Patches/RecordPatches.AlReportParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlReportParser.cs
@@ -101,8 +101,7 @@ public static partial class RecordPatches
             // A namespaced reference collapses to its last segment.
             RelatedTable: LastNameSegment(di.DataItemTable?.ToString()),
             Indentation: indentation,
-            DataItemTableView: TableViewText(PropertyTextFrom(PropValue(props, "DataItemTableView"))),
-            RequestFilterFields: PropertyTextFrom(PropValue(props, "RequestFilterFields"))));
+            DataItemTableView: TableViewText(PropertyTextFrom(PropValue(props, "DataItemTableView")))));
 
         foreach (var child in di.Elements.OfType<NavSyntax.ReportDataItemSyntax>())
             AddDataItem(child, indentation + 1, result);
@@ -152,6 +151,12 @@ internal record ParsedReport(int Id, string Name, bool IsExtension, bool Process
 /// One entry of a report's data-item tree, as the Report Data Items virtual table
 /// (2000000203) exposes it. <paramref name="Ordinal"/> is 1-based declaration order.
 /// </summary>
+/// <remarks>
+/// Carries no RequestFilterFields. The Report Data Items column of that name reports
+/// comma-separated field NUMBERS, which the AL text cannot state — BC's own emitted document
+/// does, already resolved, and RecordPatches.ReportRowFromBcDocument reads it from there
+/// (#3620). Parsing the AL names here only ever produced a value of the wrong kind.
+/// </remarks>
 internal record ParsedReportDataItem(
     int Ordinal, string Name, string RelatedTable, int Indentation,
-    string? DataItemTableView, string? RequestFilterFields);
+    string? DataItemTableView);

--- a/AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs
@@ -106,9 +106,15 @@ public static partial class RecordPatches
         string WordMergeDataItem, int FirstDataItemTableId,
         List<ReportDataItemRow> DataItems);
 
+    /// <summary>
+    /// <see cref="RequestFilterFields"/> and <see cref="SortingFields"/> carry BC's own answer
+    /// for those two columns: comma-separated field NUMBERS, not names. They are populated by
+    /// RecordPatches.ReportRowFromBcDocument from the report's emitted document, and are empty
+    /// for a report with no document (the AL parser cannot answer either one — see #3620).
+    /// </summary>
     private sealed record ReportDataItemRow(
         int Id, string Name, int RelatedTableId, int Indentation,
-        string DataItemTableView, string RequestFilterFields);
+        string DataItemTableView, string RequestFilterFields, string SortingFields = "");
 
     // Cached inventory both tables read. Rebuilt whenever the runner has learned about
     // more source-parsed reports or registered another dependency .app since the last
@@ -258,11 +264,14 @@ public static partial class RecordPatches
                 return _aovNavIntegerCreate!.Invoke(null, new object?[] { item.Indentation });
             case "dataitemtableview":
                 return Text(item.DataItemTableView);
+            // Both are comma-separated field NUMBERS on a real tier, and both are already in
+            // that form on the row — resolved from BC's own document, never from an AL name.
+            // A report with no document answers "" for both rather than a name, which is the
+            // type default and the same thing BC answers for a data item declaring neither.
             case "requestfilterfields":
                 return Text(item.RequestFilterFields);
-            // "Sorting Fields" is derived from the table view's sorting(...) clause on a
-            // real tier; the runner does not parse that expression, so it gets the type
-            // default rather than a guess. The full view text is on the row above it.
+            case "sortingfields":
+                return Text(item.SortingFields);
             default:
                 return _aovGetDefaultNavValue!.Invoke(null, new object?[] { field, false });
         }
@@ -310,8 +319,17 @@ public static partial class RecordPatches
                         ok = false;
                         break;
                     }
+                    // RequestFilterFields is deliberately EMPTY here, not the AL text. The
+                    // column's contract is comma-separated field NUMBERS
+                    // (ReportDataItemsDataProvider.GetRequestFilterFieldsIfAny), and the AL
+                    // parser has only the names the source wrote. ApplyBcReportDocument
+                    // replaces this whole list with BC's own numbers whenever the report has
+                    // an emitted document, which for a source-compiled report is always;
+                    // handing out a name in the meantime was a wrong answer, not a partial
+                    // one (#3620). Same for Sorting Fields, which the AL text cannot answer
+                    // at all.
                     items.Add(new ReportDataItemRow(di.Ordinal, di.Name, tableId, di.Indentation,
-                        di.DataItemTableView ?? string.Empty, di.RequestFilterFields ?? string.Empty));
+                        di.DataItemTableView ?? string.Empty, string.Empty));
                 }
                 if (!ok) continue;
 
@@ -342,8 +360,23 @@ public static partial class RecordPatches
                     }
                     // The symbol file's own compiler-assigned data-item id when it has one,
                     // else declaration order. Never a fabricated hash.
+                    //
+                    // RequestFilterFields is run through the same Field<N> -> number rule the
+                    // emitted document goes through, because SymbolReference.json states it
+                    // in that identical form: measured on BC 28.1's Base Application, all 633
+                    // of its reports' RequestFilterFields values are Field<N> lists. So this
+                    // path reaches BC's answer with no NCLMetaTable lookup either (#3620).
+                    //
+                    // Sorting Fields stays empty on this path, which is BC's own default for
+                    // a column it cannot compute. Unlike the document, a symbol file's
+                    // DataItemTableView is the AL SOURCE TEXT — sorting("Company Name"), field
+                    // NAMES — so answering it here would need a real per-table field lookup
+                    // for all 659 reports at virtual-table population time, which is the cost
+                    // this file's header records as having blown the 60s watchdog. Empty is
+                    // the honest answer; #3620's PR body records it as deliberately left.
                     items.Add(new ReportDataItemRow(di.Id != 0 ? di.Id : ordinal, di.Name, tableId, di.Indentation,
-                        di.DataItemTableView ?? string.Empty, di.RequestFilterFields ?? string.Empty));
+                        di.DataItemTableView ?? string.Empty,
+                        FieldNumbersFrom(di.RequestFilterFields ?? string.Empty)));
                 }
                 if (!ok) continue;
 

--- a/AlRunner/Patches/RecordPatches.ReportRowFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.ReportRowFromBcDocument.cs
@@ -41,12 +41,19 @@
 // SCOPE — WHAT THIS DOES NOT CLAIM
 //   Ncl's provider fills 29 Report Metadata columns off NCLMetaReport. This fills the ones
 //   the document states directly and leaves the rest on BC's own GetDefaultNavValue, exactly
-//   as before. Sorting Fields and Request Filter Fields both resolve through a table's
-//   NCLMetaField numbering (GetSortingFieldsIfAny / GetRequestFilterFieldsIfAny), and
-//   ReqFilterFields is stated on the request page's filter control rather than on the data
-//   item at all — a separate resolution step this change does not take on; #3620 tracks it.
-//   Nothing here answers a column with a guess: a report with no registered document keeps
-//   the AL-derived row it had before.
+//   as before. Nothing here answers a column with a guess: a report with no registered
+//   document keeps the AL-derived row it had before.
+//
+// SORTING FIELDS AND REQUEST FILTER FIELDS — NO NCLMetaTable LOOKUP IS NEEDED (#3620)
+//   Ncl resolves both through a table's field numbering — GetSortingFieldsIfAny runs
+//   TableViewParser over DataItemTableView, GetRequestFilterFieldsIfAny calls
+//   NCLMetaTable.FindFieldMatch per name — so #3607 deferred them as "a different mechanism".
+//   Measured against the emitted document, that resolution has ALREADY HAPPENED at compile
+//   time: BC writes both as the Field<N> token form, and FindFieldMatch's first branch strips
+//   a "Field" prefix and parses the rest as a field number. So reading the numbers out of the
+//   document is not an approximation of BC's resolution — it lands on the identical value by
+//   the identical rule, without a table lookup and without a request-page build.
+//   docs/report-metadata-from-bc.md#sorting-and-request-filter-fields has the measurement.
 //
 // PRECOMPILED-DLL RESPECT
 //   Reads an XML document BC's own emitter produced. No BC method body is rewritten, no BC
@@ -66,8 +73,16 @@ public static partial class RecordPatches
         bool ProcessingOnly, bool UseRequestPage, string WordMergeDataItem,
         List<BcReportDocumentDataItem> DataItems);
 
+    /// <summary>
+    /// <see cref="SortingFields"/> and <see cref="RequestFilterFields"/> are already the
+    /// comma-separated FIELD NUMBERS Ncl's provider hands out, derived from the document by
+    /// <see cref="FieldNumbersFrom"/>. <see cref="ViewName"/> is the document's own
+    /// <c>DataItemViewName</c> — the key Ncl matches a data item to its request-page filter
+    /// control on, and the reason a filter control is reachable without building the page.
+    /// </summary>
     private sealed record BcReportDocumentDataItem(
-        int Id, string VarName, int TableId, int Indent, string TableView);
+        int Id, string VarName, int TableId, int Indent, string TableView,
+        string ViewName, string SortingFields, string RequestFilterFields);
 
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<int, BcReportDocument?>
         _bcReportDocuments = new();
@@ -118,10 +133,12 @@ public static partial class RecordPatches
 
     private static BcReportDocument ParseBcReportDocument(XmlElement root)
     {
+        var reqFilterFieldsByViewName = CollectBcRequestPageFilterFields(root);
+
         var items = new List<BcReportDocumentDataItem>();
         foreach (XmlNode child in root.ChildNodes)
             if (child is XmlElement e && e.Name == "DataItem")
-                CollectBcDataItem(e, items);
+                CollectBcDataItem(e, reqFilterFieldsByViewName, items);
 
         return new BcReportDocument(
             // AL's own defaults where the document is silent, which is what BC's emitter does
@@ -138,18 +155,131 @@ public static partial class RecordPatches
     /// anything that still pairs them up. DataItemIndent is read from the document rather than
     /// counted, because the document states it and a counted depth would be a second opinion.
     /// </summary>
-    private static void CollectBcDataItem(XmlElement item, List<BcReportDocumentDataItem> into)
+    private static void CollectBcDataItem(
+        XmlElement item, Dictionary<string, string> reqFilterFieldsByViewName,
+        List<BcReportDocumentDataItem> into)
     {
+        var viewName = ReadBcText(item, "DataItemViewName");
+        var tableView = ReadBcText(item, "DataItemTableView");
+
         into.Add(new BcReportDocumentDataItem(
             Id: ReadBcInt(item, "ID"),
             VarName: ReadBcText(item, "DataItemVarName"),
             TableId: ReadBcInt(item, "DataItemTable"),
             Indent: ReadBcInt(item, "DataItemIndent"),
-            TableView: ReadBcText(item, "DataItemTableView")));
+            TableView: tableView,
+            ViewName: viewName,
+            SortingFields: FieldNumbersFrom(SortingClauseOf(tableView)),
+            RequestFilterFields: FieldNumbersFrom(
+                viewName.Length > 0 && reqFilterFieldsByViewName.TryGetValue(viewName, out var rff)
+                    ? rff : string.Empty)));
 
         foreach (XmlNode child in item.ChildNodes)
             if (child is XmlElement e && e.Name == "DataItem")
-                CollectBcDataItem(e, into);
+                CollectBcDataItem(e, reqFilterFieldsByViewName, into);
+    }
+
+    /// <summary>
+    /// Every request-page filter control's <c>ReqFilterFields</c>, keyed by the
+    /// <c>DataColumnName</c> that matches a data item's <c>DataItemViewName</c> — the exact
+    /// pairing <c>ReportDataItemsDataProvider.GetReportDataItems</c> performs with
+    /// <c>filterControls.SingleOrDefault(x =&gt; x.DataColumnName == dataColumnName)</c>.
+    ///
+    /// <para>Walks the whole subtree rather than the documented nesting
+    /// (<c>RequestPage/PageDefinition/Content/Containers/Controls/Controls</c>): Ncl reaches
+    /// these through <c>RequestPageDefinition.FindAll</c>, which is also depth-agnostic, and a
+    /// control group nested one level deeper for an extra data item would otherwise be
+    /// silently dropped. The element is identified by its <c>xsi:type</c> attribute, because
+    /// every control in that tree is spelled <c>&lt;Controls&gt;</c>.</para>
+    ///
+    /// <para>A control with no <c>ReqFilterFields</c> attribute — the shape a data item that
+    /// declares none produces — is skipped rather than stored empty, so the two are
+    /// indistinguishable downstream, which is what BC does with a null: an absent entry and an
+    /// empty string both yield <c>string.Empty</c> from <c>GetRequestFilterFieldsIfAny</c>.</para>
+    ///
+    /// <para>A duplicate <c>DataColumnName</c> is dropped, not overwritten. Ncl's own
+    /// <c>SingleOrDefault</c> THROWS on that shape, so a document containing one is malformed;
+    /// answering nothing for the ambiguous data item is the closer of the two available
+    /// approximations to "no answer", and it cannot silently pick the wrong control.</para>
+    /// </summary>
+    private static Dictionary<string, string> CollectBcRequestPageFilterFields(XmlElement root)
+    {
+        var byViewName = new Dictionary<string, string>(StringComparer.Ordinal);
+        var ambiguous = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (XmlNode node in root.GetElementsByTagName("Controls"))
+        {
+            if (node is not XmlElement control) continue;
+            var type = control.GetAttribute("type", "http://www.w3.org/2001/XMLSchema-instance");
+            if (type != "FilterControlDefinition") continue;
+
+            var dataColumnName = control.GetAttribute("DataColumnName");
+            if (dataColumnName.Length == 0) continue;
+            if (!control.HasAttribute("ReqFilterFields")) continue;
+
+            if (!byViewName.TryAdd(dataColumnName, control.GetAttribute("ReqFilterFields")))
+                ambiguous.Add(dataColumnName);
+        }
+
+        foreach (var name in ambiguous) byViewName.Remove(name);
+        return byViewName;
+    }
+
+    /// <summary>
+    /// The contents of the compiled view's <c>SORTING(...)</c> clause, or empty when it states
+    /// none. The view is BC's own normal form — <c>SORTING(Field5,Field2) ORDER(1)
+    /// WHERE(Field5=1(&gt;A))</c> — so the clause is delimited by the first <c>)</c>: a field
+    /// token cannot contain one, and the parenthesised filter expressions that can all sit
+    /// inside WHERE, after this clause.
+    /// </summary>
+    private static string SortingClauseOf(string tableView)
+    {
+        const string marker = "SORTING(";
+        var start = tableView.IndexOf(marker, StringComparison.Ordinal);
+        if (start < 0) return string.Empty;
+        start += marker.Length;
+        var end = tableView.IndexOf(')', start);
+        return end < 0 ? string.Empty : tableView.Substring(start, end - start);
+    }
+
+    /// <summary>
+    /// A comma-separated list of the document's <c>Field&lt;N&gt;</c> tokens, rendered as the
+    /// comma-separated field NUMBERS both columns carry.
+    ///
+    /// <para>This is BC's own resolution rule, not an approximation of it.
+    /// <c>NCLMetaTable.FindFieldMatch</c> — which is what both
+    /// <c>GetRequestFilterFieldsIfAny</c> and, through <c>TableViewResolver.AddSortingField</c>,
+    /// <c>GetSortingFieldsIfAny</c> call — begins by stripping a leading <c>Field</c> (or
+    /// <c>#</c>) and returning <c>GetFieldByNo</c> of the remainder when it parses as an
+    /// integer. Every token BC's emitter writes into these two places is in that form, so the
+    /// name-lookup and prefix-fallback branches below it are never reached from here and no
+    /// <c>NCLMetaTable</c> is required. Verified on BC 28.1; the fixture measurement is in
+    /// docs/report-metadata-from-bc.md#sorting-and-request-filter-fields.</para>
+    ///
+    /// <para>A token in any other shape is DROPPED, which is what BC does with one it cannot
+    /// resolve: <c>GetRequestFilterFieldsIfAny</c> skips a null <c>FindFieldMatch</c> result
+    /// (it passes <c>trapError: true</c>) and <c>AddSortingField</c> traces and skips. Dropping
+    /// keeps the answer a list of field numbers in every case — never a name leaking into a
+    /// column whose contract is numbers, which is exactly the wrong answer this replaces.</para>
+    /// </summary>
+    private static string FieldNumbersFrom(string tokens)
+    {
+        if (string.IsNullOrEmpty(tokens)) return string.Empty;
+
+        var sb = new System.Text.StringBuilder();
+        foreach (var raw in tokens.Split(',', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var token = raw.Trim();
+            if (token.StartsWith("Field", StringComparison.OrdinalIgnoreCase))
+                token = token.Substring(5);
+            else if (token.StartsWith('#'))
+                token = token.Substring(1);
+            if (!int.TryParse(token, out var fieldNo)) continue;
+
+            if (sb.Length > 0) sb.Append(',');
+            sb.Append(fieldNo);
+        }
+        return sb.ToString();
     }
 
     private static string ReadBcText(XmlElement parent, string name)
@@ -203,13 +333,12 @@ public static partial class RecordPatches
             // to claim one, so the whole row falls back rather than answering 0 — the same
             // refusal EnumerateKnownReports makes for a table it cannot resolve by name.
             if (di.TableId <= 0) return row;
+            // Both field-number columns come from the document (#3620). Neither falls back to
+            // the AL-derived text: the columns' contract is field NUMBERS, so the AL names the
+            // row used to carry were never a partial answer — they were a different answer.
             items.Add(new ReportDataItemRow(
                 di.Id, di.VarName, di.TableId, di.Indent, di.TableView,
-                // ReqFilterFields is stated on the request page's filter control, not on the
-                // data item, and BC resolves it to field NUMBERS. Keeping the AL-derived text
-                // is the honest half-answer until #3620 does that resolution; replacing it
-                // with "" would lose information the row already carried.
-                RequestFilterFieldsFor(row, di)));
+                di.RequestFilterFields, di.SortingFields));
         }
 
         return row with
@@ -220,18 +349,5 @@ public static partial class RecordPatches
             FirstDataItemTableId = FirstRootTableId(items),
             DataItems = items,
         };
-    }
-
-    /// <summary>
-    /// The AL-derived Request Filter Fields text for the data item BC calls
-    /// <paramref name="di"/>, matched by variable name — the one key both sources agree on,
-    /// since BC's id and the parser's ordinal are different numbers.
-    /// </summary>
-    private static string RequestFilterFieldsFor(ReportRow row, BcReportDocumentDataItem di)
-    {
-        foreach (var existing in row.DataItems)
-            if (string.Equals(existing.Name, di.VarName, StringComparison.OrdinalIgnoreCase))
-                return existing.RequestFilterFields;
-        return string.Empty;
     }
 }

--- a/docs/report-metadata-from-bc.md
+++ b/docs/report-metadata-from-bc.md
@@ -91,11 +91,8 @@ document states directly and leaves the rest on BC's own `GetDefaultNavValue`, e
 A report with no registered document — one from a precompiled dependency — keeps the row it had.
 Nothing here answers a column with a guess.
 
-Three things were deliberately left alone, each for a reason worth not rediscovering:
+Two things were deliberately left alone, each for a reason worth not rediscovering:
 
-- **`Sorting Fields` and `Request Filter Fields`** resolve through a table's `NCLMetaField`
-  numbering, and `ReqFilterFields` is stated on the request page's *filter control* rather than
-  on the data item at all. That is a different mechanism; **#3620** tracks it.
 - **`ProcessingOnly = true` at `NavReportSync.cs:148`** is not this table's answer. RED-baselined:
   the virtual table already answered `false` correctly from the AL parser. That hardcode is on the
   legacy stub-`MetaReport` execution path and carries its own note recording that flipping it was
@@ -103,6 +100,106 @@ Three things were deliberately left alone, each for a reason worth not rediscove
 - **`Report Layout List` (2000000234)** needed no conversion — it already reads the compiler's
   captured `rendering` block.
 
-`AlReportParser.cs` loses nothing either: it remains the fallback, and the only source of
-`Caption` and `RequestFilterFields`. #3607 expected a line-count drop there; deleting any of it
-would have been a regression.
+`AlReportParser.cs` loses nothing at #3607: it remains the fallback, and at that point was still
+the only source of `Caption` and `RequestFilterFields`. #3607 expected a line-count drop there;
+deleting any of it would have been a regression. #3620 then took `RequestFilterFields` off it —
+see the next section for why that one field was not a fallback but a wrong answer.
+
+<a id="sorting-and-request-filter-fields"></a>
+
+## `Sorting Fields` and `Request Filter Fields` — already resolved in the document
+
+#3607 deferred these two columns to **#3620** on the grounds that they are a different
+mechanism: Ncl resolves both through a table's field numbering rather than reading them off
+the row. That reading of `ReportDataItemsDataProvider` is correct —
+
+```csharp
+string dataColumnName = item.Key.DataItemViewName;
+MetaFilterControlDefinition metaFilterControlDefinition =
+    filterControls.SingleOrDefault(x => x.DataColumnName == dataColumnName);
+NCLMetaTable metaTableById = base.NclMetadata.GetMetaTableById(key.DataItemTable, requireCompiled: false);
+string sortingFieldsIfAny      = GetSortingFieldsIfAny(session, metaTableById, key.DataItemTableView);
+string requestFilterFieldsIfAny = GetRequestFilterFieldsIfAny(metaTableById, metaFilterControlDefinition?.ReqFilterFields);
+```
+
+— and the conclusion drawn from it was wrong. **The resolution has already happened at compile
+time**, and the runner can reach the identical numbers by reading the document.
+
+### The measurement
+
+Same fixture as above, extended with a data item that declares both properties against a
+**non-primary** key and fields that are neither field 1 nor in field order, so neither "the
+first field" nor "the primary key" is an accidentally-right answer:
+
+```al
+dataitem(Filtered; "RptMetaDoc Sample")          // fields 1 "Entry No.", 2 Description, 5 "Alt Code"
+{                                                 // keys: PK ("Entry No."), Alt ("Alt Code", Description)
+    DataItemTableView = sorting("Alt Code", Description);
+    RequestFilterFields = Description, "Alt Code";
+}
+```
+
+BC 28.1 emits, for that data item:
+
+```xml
+<DataItem>
+  <DataItemTableView>SORTING(Field5,Field2)</DataItemTableView>
+  <DataItemViewName>Report90311DataItem2TableView</DataItemViewName>
+</DataItem>
+...
+<RequestPage><PageDefinition><Content><Containers>
+  <Controls xsi:type="ControlGroupDefinition">
+    <Controls xsi:type="FilterControlDefinition"
+              DataColumnName="Report90311DataItem2TableView"
+              FilterTableID="90310" Sorting="1" ReqFilterFields="Field2,Field5" />
+```
+
+Both are field numbers in the `Field<N>` token form, and the two orders differ from each other:
+`ReqFilterFields` keeps AL declaration order (2 then 5), `SORTING` keeps key order (5 then 2).
+A value copied from either column into the other is therefore detectably wrong.
+
+### Why reading them is BC's own rule, not an approximation of it
+
+`NCLMetaTable.FindFieldMatch` — which `GetRequestFilterFieldsIfAny` calls directly and
+`GetSortingFieldsIfAny` reaches through `TableViewResolver.AddSortingField` → `ResolveField` —
+opens with:
+
+```csharp
+string s = fieldIdentifier.StartsWith("Field", StringComparison.OrdinalIgnoreCase)
+    ? fieldIdentifier.Substring(5)
+    : (fieldIdentifier.StartsWith("#") ? fieldIdentifier.Substring(1) : fieldIdentifier);
+if (int.TryParse(s, out var result))
+    return GetFieldByNo(result, trapError);
+```
+
+Every token BC's emitter writes into either place is in that form, so the name-lookup and
+prefix-fallback branches below it are never reached from this caller. `RecordPatches`'
+`FieldNumbersFrom` applies exactly that rule and nothing else: strip `Field` or `#`, parse,
+drop what does not parse — which is also what BC does with an unresolvable one, since
+`GetRequestFilterFieldsIfAny` skips a null `FindFieldMatch` result and `AddSortingField` traces
+and skips.
+
+So there is no `NCLMetaTable` lookup on this path and — the point that mattered — **no request
+page is built**. The filter control is reached by walking the document's own XML and pairing on
+`DataColumnName`, which is the same key Ncl pairs on.
+
+### The dependency path answers `Request Filter Fields` too
+
+A precompiled dependency report has no emitted document, so it keeps its
+`SymbolReference.json`-derived row. That row can answer this column as well: measured on BC
+28.1's Base Application, **all 633 `RequestFilterFields` values across its 659 reports are
+`Field<N>` lists** (the other 1294 data items state the property not at all). The same
+`FieldNumbersFrom` therefore lands on BC's answer for every one of them.
+
+`Sorting Fields` does **not** follow, and stays empty on that path. A symbol file's
+`DataItemTableView` is the AL *source text* — `sorting("Company Name")`, field names — not the
+compiled form, so answering it would need a real per-table field lookup for all 659 reports at
+virtual-table population time. That is the cost recorded above as having blown the 60s
+watchdog, and BC's type default is the honest answer until something cheaper exists.
+
+### What the AL parser lost
+
+`ParsedReportDataItem.RequestFilterFields` is gone. The column reports numbers and the AL text
+states names, so what the parser produced was not a partial answer that a better one improved
+on — it was a value of the wrong kind, and a caller reading `Description` out of a column whose
+contract is `2` had no way to tell. Nothing else read the field.


### PR DESCRIPTION
Closes #3620

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/302

`Report Data Items` (2000000203) reports two columns as comma-separated field **numbers**. The
runner answered one with the AL source text and the other not at all:

| column | runner, before | BC |
|---|---|---|
| `Request Filter Fields` | `Description, "Alt Code"` | `2,5` |
| `Sorting Fields` | `` (the type default) | `5,2` |

## The premise #3607 deferred on, and why it was wrong

#3607 left both out, and its reasoning was sound as far as it went: Ncl resolves them through a
table's `NCLMetaField` numbering — `GetSortingFieldsIfAny` runs `TableViewParser` over the view,
`GetRequestFilterFieldsIfAny` calls `FindFieldMatch` per name — and `ReqFilterFields` is stated
on the request page's *filter control*, not on the data item. That reading of
`ReportDataItemsDataProvider.GetReportDataItems` is correct.

The conclusion drawn from it is not. **The resolution has already happened at compile time.**
Measured on BC 28.1, the emitted document states:

```xml
<DataItem>
  <DataItemTableView>SORTING(Field5,Field2)</DataItemTableView>
  <DataItemViewName>Report90311DataItem2TableView</DataItemViewName>
</DataItem>
<RequestPage>...
  <Controls xsi:type="FilterControlDefinition"
            DataColumnName="Report90311DataItem2TableView"
            ReqFilterFields="Field2,Field5" />
```

and `NCLMetaTable.FindFieldMatch` — which both helpers reach — opens with:

```csharp
string s = fieldIdentifier.StartsWith("Field", StringComparison.OrdinalIgnoreCase)
    ? fieldIdentifier.Substring(5) : (...);
if (int.TryParse(s, out var result)) return GetFieldByNo(result, trapError);
```

So reading the numbers out of the document is not an approximation of BC's resolution — it lands
on the identical value by the identical rule. `FieldNumbersFrom` applies exactly that rule and
nothing else, including the drop-what-does-not-resolve behaviour (`GetRequestFilterFieldsIfAny`
skips a null `FindFieldMatch`; `AddSortingField` traces and skips).

**No `NCLMetaTable` lookup, and — the point that mattered — no request page is built.** The
filter control is reached by walking the document's own XML and pairing on `DataColumnName ==
DataItemViewName`, the same key Ncl pairs on. That avoids the trap this file's header records:
`GetRealMetaReport` forces `RequestFormMetadata`, and populating a virtual table asks about every
report, which blew the 60s watchdog at #3607.

## Fixing the shape, not the reported line

**1. Does the same wrong pattern appear at another call site?** Yes — the dependency path in
`EnumerateKnownReports` passed a symbol file's `RequestFilterFields` straight through, same wrong
kind of value. It is fixed by the same rule, because `SymbolReference.json` states it in the same
form: measured on BC 28.1's Base Application, **all 633 `RequestFilterFields` values across its
659 reports are `Field<N>` lists** (the other 1294 data items state the property not at all). So
that path now reaches BC's answer for every Base Application report, with no lookup either.

**2. Does a sibling function make the same assumption?** `ParsedReportDataItem.RequestFilterFields`
did, and is now **removed**. The column reports numbers and the AL text states names, so what the
parser produced was a value of the wrong kind, not a fallback a better source improved on — a
caller reading `Description` out of a column whose contract is `2` had no way to tell. Nothing
else read it. This is the one place #3607's "`AlReportParser.cs` retires nothing" note changes,
and `docs/report-metadata-from-bc.md` now says so.

**3. Do two code paths writing the same state maintain the same invariant?** They do now: all
three construction sites produce field numbers or empty, never a name. The AL-parser site
deliberately writes empty rather than the text, because `ApplyBcReportDocument` replaces the whole
list for any report with a document — which for a source-compiled report is always.

## Deliberately left, and why

`Sorting Fields` stays empty on the **dependency** path. Unlike the emitted document, a symbol
file's `DataItemTableView` is the AL *source text* — `sorting("Company Name")`, field names — so
answering it would need a real per-table field lookup for all 659 reports at virtual-table
population time, which is exactly the cost that blew the watchdog. BC's type default is the
honest answer; nothing here answers it with a guess.

## Open-issue queue scan

Searched the open queue for `Report Metadata`, `Report Data Items`, `ReportRowFromBcDocument`,
`AlReportParser` and `2000000203`. Nothing else lands in these three files, so nothing was folded
in. The nearest neighbours are other virtual-table conversions under `area: metadata-conversion`
(#3604 Page Control Field, #3606 CodeUnit Metadata), each in its own file and each claimed by a
sibling agent.

## RED → GREEN

**Corpus, both arms, same tree, `--package-cache "$HOME/.al-runner/platform-apps"`:**

| | tests | pass | fail |
|---|---|---|---|
| before (`origin/main`'s runner) | 3167 | 3152 | **15** |
| after | 3167 | 3155 | **12** |

The delta is exactly my three RED tests. The 12 remaining failures are identical in both arms —
they are corpus `master` running ahead of this repository's pin, not this change.

Three of the four new corpus tests fail before:

```
TestReportDataItems_RequestFilterFields_...  Expected:<2,5>  Actual:<Description, "Alt Code">
TestReportDataItems_SortingFields_...        Expected:<5,2>  Actual:<>
TestReportDataItems_..._AreIndependentColumns Expected:<1>   Actual:<>
```

The fourth — both columns empty for a data item declaring neither — correctly passes in both
arms. It is the negative that gives the other three their meaning, and saying so is more useful
than pretending it was RED.

**Runner mechanism tests:** `ReportMetadataDocumentColumnTests` 5/5 pass (3 existing + 2 new).
The two new ones pin the premise a corpus test cannot see — that BC's emitter states both values
already resolved, and that the filter control is reachable by `DataColumnName` without building
the page. If a future BC version wrote field names into either place, the corpus test would report
a plain wrong value with no indication of why; these name the cause.

**Not run:** the full `AlRunner.Tests` suite. The change is confined to three files behind the two
report virtual tables, and the corpus run above exercises them end to end.

## Where the prose went

The derivation — the fixture, the emitted XML, the `FindFieldMatch` branch, the 633/659
measurement — is in `docs/report-metadata-from-bc.md#sorting-and-request-filter-fields`, cited
from both changed patch files. The code keeps the claim and the citation.

---

Authored by an agent (Claude, `stma-auto-2`) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
