### PR TITLE
fix(page-control-field): answer the control tree from BC's document, not parsed AL

### DIFF
--- a/AlRunner.Tests/PageControlFieldDocumentTests.cs
+++ b/AlRunner.Tests/PageControlFieldDocumentTests.cs
@@ -1,0 +1,273 @@
+// PageControlFieldDocumentTests — issue #3604.
+//
+// RUNNER-MECHANISM tests, not claims about what real BC does. The behavioural claim
+// ("Page Control Field 2000000192 reports these values") is adjudicated upstream against a
+// live BC service tier by corpus PR #300 (codeunit 60426 "Test Page Control Field Tree"),
+// per .claude/rules/bc-behavior-tests-go-upstream.md.
+//
+// What these pin instead is the premise the fix rests on, which is the half a corpus test
+// cannot see: the corpus asserts what the virtual table ANSWERS, never WHERE the answer came
+// from. Three properties of BC's emitted page document are load-bearing here, and if a future
+// BC version changed any of them the corpus test would keep passing against the AL-derived
+// fallback while the conversion had silently stopped applying:
+//
+//   * the document states the binding decision as DataColumnName — a field NUMBER for a
+//     table-bound control, a synthetic name for an unbound one — which is what makes
+//     `int.TryParse` a faithful reproduction of ControlDefinition.IsBoundToTableField;
+//   * an unbound control's source expression lives in <Expressions>, keyed by that same
+//     DataColumnName, and nowhere on the control element itself;
+//   * Enabled/Visible are omitted when defaulted while Editable is omitted when defaulted
+//     AND has no default, which is why the three are not filled in the same way.
+//
+// docs/page-control-field-from-bc-document.md has the measurements behind all three.
+
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class PageControlFieldDocumentTests : IDisposable
+{
+    private readonly string _root;
+    private readonly BcEngineFixture _engine;
+
+    public PageControlFieldDocumentTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = TestScratch.Dir("al-runner-page-control-field-document-tests");
+        Directory.CreateDirectory(_root);
+        AlObjectMetadataRegistry.Clear();
+    }
+
+    public void Dispose()
+    {
+        AlObjectMetadataRegistry.Clear();
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    /// <summary>
+    /// Mirrors corpus fixture page 60427's shapes: a Rec-bound control, a control bound to a
+    /// page VARIABLE, an Option-bound control, and two controls three group levels deep — one
+    /// declaring Visible = false and one declaring Editable = false. Every assertion below
+    /// fails against what the AL derivation produced before #3604.
+    /// </summary>
+    private const string FixtureAl = """
+        table 90320 "PcfDoc Sample"
+        {
+            DataClassification = CustomerContent;
+            fields
+            {
+                field(1; "Entry No."; Integer) { DataClassification = CustomerContent; }
+                field(14; "Option Field"; Option) { OptionMembers = " ",Draft,Active,Closed; DataClassification = CustomerContent; }
+                field(17; "Description Field"; Text[250]) { DataClassification = CustomerContent; }
+                field(18; "Name Field"; Text[50]) { DataClassification = CustomerContent; }
+            }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+
+        page 90321 "PcfDoc Fixture"
+        {
+            PageType = Card;
+            SourceTable = "PcfDoc Sample";
+
+            layout
+            {
+                area(Content)
+                {
+                    group(Level1)
+                    {
+                        field("Entry No."; Rec."Entry No.") { ApplicationArea = All; }
+                        field(PcfDocLocalVar; LocalVar) { ApplicationArea = All; }
+                        group(Level2)
+                        {
+                            field(PcfDocOption; Rec."Option Field") { ApplicationArea = All; }
+                            group(Level3)
+                            {
+                                field(PcfDocHidden; Rec."Name Field") { ApplicationArea = All; Visible = false; }
+                                field(PcfDocEditable; Rec."Description Field") { ApplicationArea = All; Editable = false; }
+                            }
+                        }
+                    }
+                }
+            }
+
+            var
+                LocalVar: Integer;
+        }
+        """;
+
+    private System.Xml.XmlElement EmitAndReadDocument()
+    {
+        File.WriteAllText(Path.Combine(_root, "PcfDoc.al"), FixtureAl);
+
+        var output = new BcCompiler().Emit(new[] { _root }, "PcfDocModule");
+        Assert.True(output.Sources.Count > 0,
+            $"Expected the page to emit; diagnostics: {string.Join(" | ", output.Diagnostics.Take(10))}");
+
+        // "Page" is the AL compiler's own SymbolKind name, and it is the key the conversion
+        // reads. A kind spelled anything else here means HasBcPageMetadataDocument answers
+        // false for every page and the whole conversion silently reverts to the AL parser.
+        Assert.True(AlObjectMetadataRegistry.TryGet("Page", 90321, out var xml),
+            "Expected page 90321's metadata document to be captured at emit time under kind "
+            + "\"Page\" — without it the virtual table falls back to AL source text.");
+        Assert.False(string.IsNullOrEmpty(xml), "the captured document is empty");
+
+        var doc = new System.Xml.XmlDocument();
+        doc.LoadXml(xml);
+        Assert.NotNull(doc.DocumentElement);
+        return doc.DocumentElement!;
+    }
+
+    private const string Xsi = "http://www.w3.org/2001/XMLSchema-instance";
+
+    /// <summary>Every element BC's <c>ed is ControlDefinition</c> predicate selects, in the
+    /// document order its <c>FindAll</c> walk visits them.</summary>
+    private static List<System.Xml.XmlElement> FieldControls(System.Xml.XmlElement parent)
+    {
+        var found = new List<System.Xml.XmlElement>();
+        foreach (System.Xml.XmlNode n in parent.ChildNodes)
+        {
+            if (n is not System.Xml.XmlElement e) continue;
+            var type = e.GetAttribute("type", Xsi);
+            if (e.Name == "Controls" && (type == "ControlDefinition" || type == "MetaControlDefinition"))
+                found.Add(e);
+            found.AddRange(FieldControls(e));
+        }
+        return found;
+    }
+
+    private static System.Xml.XmlElement Named(List<System.Xml.XmlElement> controls, string name)
+        => controls.Single(c => c.GetAttribute("Name") == name);
+
+    [SkippableFact]
+    public void EmittedDocument_ListsEveryFieldControl_BoundOrNot_AtEveryDepth()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var controls = FieldControls(EmitAndReadDocument());
+
+        // Positive: all five, including the variable-bound one the AL derivation dropped
+        // entirely and the two nested three group levels deep.
+        Assert.Equal(
+            new[] { "Entry No.", "PcfDocLocalVar", "PcfDocOption", "PcfDocHidden", "PcfDocEditable" },
+            controls.Select(c => c.GetAttribute("Name")).ToArray());
+
+        // Negative: the predicate is not "anything under <Content>". The three groups are
+        // ControlGroupDefinition and the auto-added fact box part is an
+        // InfopartSystemDefinition; none of them is a row, so a walk that matched on element
+        // name alone — or on an xsi:type PREFIX — would be caught here.
+        Assert.DoesNotContain("Level1", controls.Select(c => c.GetAttribute("Name")));
+        Assert.DoesNotContain("Level3", controls.Select(c => c.GetAttribute("Name")));
+        Assert.DoesNotContain("DefaultSummaryPart", controls.Select(c => c.GetAttribute("Name")));
+    }
+
+    [SkippableFact]
+    public void EmittedDocument_StatesTheBindingAsDataColumnName_ANumberOnlyWhenTableBound()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var controls = FieldControls(EmitAndReadDocument());
+
+        // Positive: a table-bound control's DataColumnName IS the field number, which is why
+        // ControlDefinition.IsBoundToTableField is int.TryParse and nothing more. Asserting
+        // the exact ids proves the document resolves the binding, rather than merely that it
+        // parses as an integer.
+        Assert.Equal("1", Named(controls, "Entry No.").GetAttribute("DataColumnName"));
+        Assert.Equal("14", Named(controls, "PcfDocOption").GetAttribute("DataColumnName"));
+        Assert.Equal("17", Named(controls, "PcfDocEditable").GetAttribute("DataColumnName"));
+        Assert.Equal("18", Named(controls, "PcfDocHidden").GetAttribute("DataColumnName"));
+
+        // Negative: the variable-bound control's is NOT parseable as a field number, so the
+        // same test routes it to the unbound branch. If BC ever emitted a number here the
+        // control would be silently mis-bound to a real field.
+        var unbound = Named(controls, "PcfDocLocalVar").GetAttribute("DataColumnName");
+        Assert.False(int.TryParse(unbound, out _),
+            $"expected a non-numeric DataColumnName for a variable-bound control, got '{unbound}'");
+
+        // And the control element itself carries NO SourceExpression — the whole reason the
+        // <Expressions> lookup in the next test has to exist.
+        Assert.False(Named(controls, "PcfDocLocalVar").HasAttribute("SourceExpression"));
+    }
+
+    [SkippableFact]
+    public void EmittedDocument_StatesAnUnboundControlsSourceExpressionInExpressions()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var root = EmitAndReadDocument();
+        var unboundKey = Named(FieldControls(root), "PcfDocLocalVar").GetAttribute("DataColumnName");
+
+        var expressions = root.ChildNodes.Cast<System.Xml.XmlNode>()
+            .OfType<System.Xml.XmlElement>().SingleOrDefault(e => e.Name == "Expressions");
+        Assert.NotNull(expressions);
+
+        var entries = expressions!.ChildNodes.Cast<System.Xml.XmlNode>()
+            .OfType<System.Xml.XmlElement>().Where(e => e.Name == "Expression").ToList();
+
+        // Positive: keyed by the control's own DataColumnName — BC's lookup is
+        // page.Expressions.FirstOrDefault(x => x.Name == control.DataColumnName) — and it
+        // states the AL VARIABLE's name.
+        var entry = entries.Single(e => e.GetAttribute("Name") == unboundKey);
+        Assert.Equal("LocalVar", entry.GetAttribute("SourceExpression"));
+
+        // Negative: only the unbound control gets an entry. A table-bound control resolves
+        // through the metatable instead, so an <Expressions> section that also described
+        // those would mean the two branches could disagree.
+        Assert.Single(entries);
+    }
+
+    [SkippableFact]
+    public void EmittedDocument_OmitsDefaultedProperties_AndEditableHasNoDefaultToOmitTo()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var controls = FieldControls(EmitAndReadDocument());
+
+        // Positive: a DECLARED property is stated verbatim, in both directions.
+        Assert.Equal("false", Named(controls, "PcfDocHidden").GetAttribute("Visible"));
+        Assert.Equal("false", Named(controls, "PcfDocEditable").GetAttribute("Editable"));
+
+        // Negative, and the asymmetry the fix turns on: an UNDECLARED property is absent from
+        // the document, so what the column reports is whatever BC's deserializer supplies.
+        // ControlDefinition carries [DefaultValue("true")] on Enabled and Visible and NONE on
+        // Editable, so Enabled/Visible read "true" and Editable reads "". Substituting "true"
+        // for all three — which the AL derivation did — is therefore wrong for exactly one of
+        // them. See docs/page-control-field-from-bc-document.md#the-three-property-defaults;
+        // #3625 tracks getting the Editable half in front of a real tier.
+        var plain = Named(controls, "Entry No.");
+        Assert.False(plain.HasAttribute("Enabled"));
+        Assert.False(plain.HasAttribute("Editable"));
+
+        // Visible IS stated on this control even though it is defaulted, which is why the
+        // reader must not infer "absent means declared-default" from Visible's presence.
+        Assert.Equal("true", plain.GetAttribute("Visible"));
+    }
+
+    [SkippableFact]
+    public void EmittedDocument_StatesThePagesSourceTableOnce_NotPerControl()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var root = EmitAndReadDocument();
+
+        // BC assigns array[4] = tableNo OUTSIDE the bound/unbound branch, from
+        // page.PageProperties.SourceObject.SourceTable — so TableNo is a property of the
+        // PAGE, reported on every row including one whose control has no source field.
+        var properties = root.ChildNodes.Cast<System.Xml.XmlNode>()
+            .OfType<System.Xml.XmlElement>().Single(e => e.Name == "Properties");
+        var sourceObject = properties.ChildNodes.Cast<System.Xml.XmlNode>()
+            .OfType<System.Xml.XmlElement>().Single(e => e.Name == "SourceObject");
+        Assert.Equal("90320", sourceObject.GetAttribute("SourceTable"));
+
+        // Negative: no control element states a table of its own, so a per-control reading
+        // would have nothing to read and the page-level one is the only source.
+        foreach (var c in FieldControls(root))
+            Assert.False(c.HasAttribute("SourceTable"),
+                $"control '{c.GetAttribute("Name")}' unexpectedly states its own SourceTable");
+    }
+}

--- a/AlRunner/Patches/RecordPatches.AlPageParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlPageParser.cs
@@ -635,11 +635,20 @@ public static partial class RecordPatches
     /// for the "Page Control Field" (2000000192) virtual table. Same base+extension merge
     /// rule as <see cref="GetPageControlFieldMap"/> (only extensions of THIS page), same
     /// Rec.-bound-only scope as <see cref="ParsePageControls"/> — see that method's remarks.
-    /// <para>Sequence is assigned here, at merge time, 1-based in enumeration order (base
-    /// page controls first, then each matching extension's, in registration order) — never
+    /// <para>Sequence is assigned here, at merge time, in enumeration order (base page
+    /// controls first, then each matching extension's, in registration order) — never
     /// trusted from the per-object parse pass, since a base page and an extension each start
-    /// their own local layout walk at 1 and merging them naively would produce duplicate
-    /// Sequence values.</para>
+    /// their own local layout walk and merging them naively would produce duplicate Sequence
+    /// values.</para>
+    /// <para><b>0-based</b>, because BC's is (#3604). <c>GetControlsOnPage</c> numbers the
+    /// walk with <c>Select((cd, i) =&gt; (sequence: i, control: cd))</c> — a 0-based
+    /// enumeration index, captured BEFORE the <c>OrderBy</c> that sorts the rows by control
+    /// id — and writes it straight to the column. This counter was 1-based, so every row of
+    /// every page was off by one. No corpus test pins Sequence, so nothing was ever going to
+    /// catch it either way; it is corrected here because the BC-document path beside it
+    /// (RecordPatches.PageControlFieldFromBcDocument.cs) reproduces BC's numbering exactly,
+    /// and leaving the fallback disagreeing with it would make the column mean two different
+    /// things depending on which route answered.</para>
     /// </summary>
     internal static List<PageControlRow> GetSourceParsedPageControlRows(int pageId)
     {
@@ -650,7 +659,7 @@ public static partial class RecordPatches
         void AddAll(IReadOnlyList<PageControlRow> controls)
         {
             foreach (var c in controls)
-                result.Add(c with { Sequence = ++seq });
+                result.Add(c with { Sequence = seq++ });
         }
 
         AddAll(page.Controls);

--- a/AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs
@@ -1,0 +1,306 @@
+// RecordPatches.PageControlFieldFromBcDocument — answer Page Control Field (2000000192)
+// from BC's own emitted page document instead of re-deriving the control tree from AL
+// source text (issue #3604, part of the conversion chain #3562 tracks). Follows
+// RecordPatches.ReportRowFromBcDocument.cs (#3607) and
+// RecordPatches.NclMetaTableFromBcDocument.cs (#3584).
+//
+// WHERE THE DOCUMENT COMES FROM
+//   AlObjectMetadataRegistry holds the runtime metadata document BC's own Compilation.Emit
+//   produced for every object the runner compiled, keyed (kind, id) — "Page" here. The page
+//   EXECUTION path already loads it (RecordPatches.RealPageMetadata.cs); this virtual table
+//   read none of it.
+//
+// WHAT BC DOES, AND WHY THE AL DERIVATION DISAGREES WITH IT
+//   PageControlFieldDataProvider.GetControlsOnPage (Ncl 28.1) walks the merged master page
+//   with `FindAll(ed => ed is ControlDefinition)`, numbering the walk as Sequence, then
+//   sorting by control ID. Four consequences, each of which the AL derivation got wrong and
+//   each of which corpus codeunit 60426 pins on a concrete value:
+//
+//     SourceExpression   BC states the source FIELD's Name for a bound control, and the
+//                        DataFieldDefinition's SourceExpression for an unbound one. The AL
+//                        derivation stated the binding TEXT: `Rec."Entry No."`, not
+//                        `Entry No.`.
+//     unbound controls   BC lists every field control. The AL derivation dropped any control
+//                        not bound as exactly `Rec.Something`, so a control bound to a page
+//                        variable had NO ROW AT ALL.
+//     OptionString       BC states the source field's option string for an Option-bound
+//                        control. The AL derivation always fell through to
+//                        GetDefaultNavValue, i.e. ''.
+//     TableNo            BC states the page's source table on EVERY row, including one with
+//                        no source field.
+//
+//   docs/page-control-field-from-bc-document.md has the emitted document, the reflection
+//   measurements behind the three attribute defaults, and what is deliberately left alone.
+//
+// WHY THE XML AND NOT THE MERGED MetaPageDefinition EnsureRealPageMetadata BUILDS
+//   Written down rather than rediscovered, because it is the same trap #3607 hit one table
+//   over. EnsureRealPageMetadata forces a real NCLMetaForm metadata load per page as a
+//   deliberate side effect. Populating a virtual table asks about EVERY known page, so that
+//   turns one Page Control Field read into a metadata load per page and blows the 60s
+//   per-test watchdog. Every value below is stated directly by the document.
+//
+// SCOPE — EMIT-CAPTURED PAGES ONLY
+//   A page from a precompiled dependency .app keeps its SymbolReference.json-derived rows.
+//   DependencyPageMetadataXml.EmitPageXml deliberately reconstructs NO <Controls> element
+//   for such a page (its own header says so), so routing dependency pages through this file
+//   would answer zero rows for every one of them — a regression, not a conversion. The gate
+//   is HasBcPageMetadataDocument, mirroring HasBcTableMetadataDocument (#3552).
+//
+// PRECOMPILED-DLL RESPECT
+//   Reads an XML document BC's own emitter produced, and resolves the source field through
+//   the same NCLMetaTable the runner already builds. No BC method body is rewritten and no
+//   AL business logic is touched.
+using System.Xml;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    /// <summary>The AL compiler's own <c>SymbolKind</c> name for a page, as
+    /// <see cref="AlObjectMetadataRegistry"/> keys it. Measured from the emitter's own trace
+    /// (<c>AL_RUNNER_TRACE_OBJECT_METADATA=2</c> prints <c>Page|id:70002</c>), not assumed
+    /// from the AL keyword.</summary>
+    internal const string BcPageMetadataKind = "Page";
+
+    /// <summary>
+    /// One field control as BC's document states it, before the source field is resolved.
+    /// <paramref name="DataColumnName"/> is the whole binding decision: BC's
+    /// <c>ControlDefinition.IsBoundToTableField(out fieldNo)</c> is
+    /// <c>int.TryParse(DataColumnName, out fieldNo)</c> and nothing else.
+    /// </summary>
+    private sealed record BcPageControl(
+        int ControlId, string ControlName, string DataColumnName,
+        string Enabled, string Editable, string Visible, int Sequence);
+
+    /// <summary>The subset of BC's page document this table reads.
+    /// <paramref name="Expressions"/> is <c>page.Expressions</c> — the
+    /// <c>DataFieldDefinition</c> list BC looks an unbound control's source expression up in,
+    /// keyed by the control's <c>DataColumnName</c>.</summary>
+    private sealed record BcPageDocument(
+        int SourceTableId,
+        List<BcPageControl> Controls,
+        Dictionary<string, (string SourceExpression, string OptionString, bool IsOption)> Expressions);
+
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<int, BcPageDocument?>
+        _bcPageControlDocuments = new();
+
+    /// <summary>
+    /// Drop the parsed documents on a <c>--watch</c>/<c>--server</c> reload. Page ids repeat
+    /// across reloads, so an entry parsed from the PREVIOUS bundle's document is a wrong
+    /// answer rather than a miss — the same statement <see cref="ClearBcReportDocuments"/>
+    /// makes for reports (#3607).
+    /// </summary>
+    internal static void ClearBcPageControlDocuments() => _bcPageControlDocuments.Clear();
+
+    /// <summary>
+    /// True when BC's emitter handed the runner a metadata document for this page id. A page
+    /// with none — a precompiled dependency's, or one served from a cache written before the
+    /// registry existed — answers false and keeps the AL/symbol derivation.
+    /// </summary>
+    internal static bool HasBcPageMetadataDocument(int pageId)
+        => AlObjectMetadataRegistry.TryGet(BcPageMetadataKind, pageId, out var xml)
+           && !string.IsNullOrEmpty(xml);
+
+    private static BcPageDocument? TryGetBcPageControlDocument(int pageId)
+        => _bcPageControlDocuments.GetOrAdd(pageId, static id =>
+        {
+            if (!AlObjectMetadataRegistry.TryGet(BcPageMetadataKind, id, out var xml) || string.IsNullOrEmpty(xml))
+                return null;
+            try
+            {
+                var doc = new XmlDocument();
+                doc.LoadXml(xml);
+                return doc.DocumentElement == null ? null : ParseBcPageDocument(doc.DocumentElement);
+            }
+            catch (XmlException ex)
+            {
+                // A malformed document is a capture bug, not a reason to serve nothing: fall
+                // back to the AL-derived rows and name the page once so it is diagnosable.
+                Console.Error.WriteLine(
+                    $"[page-control-field] page {id}: BC's metadata document did not parse "
+                    + $"({ex.Message}) — falling back to the AL-derived rows");
+                return null;
+            }
+        });
+
+    private static BcPageDocument ParseBcPageDocument(XmlElement root)
+    {
+        var controls = new List<BcPageControl>();
+        var expressions = new Dictionary<string, (string, string, bool)>(StringComparer.Ordinal);
+        int sourceTableId = 0;
+
+        foreach (XmlNode node in root.ChildNodes)
+        {
+            if (node is not XmlElement e) continue;
+            switch (e.Name)
+            {
+                case "Properties":
+                    foreach (XmlNode p in e.ChildNodes)
+                        if (p is XmlElement so && so.Name == "SourceObject")
+                            sourceTableId = ReadBcAttrInt(so, "SourceTable");
+                    break;
+                case "Content":
+                    // Sequence is the index of the FindAll walk, assigned before BC sorts the
+                    // rows by control id — so it is the document's own document order, and a
+                    // counter threaded through the walk is the only way to reproduce it.
+                    var sequence = 0;
+                    CollectBcPageControls(e, controls, ref sequence);
+                    break;
+                case "Expressions":
+                    foreach (XmlNode x in e.ChildNodes)
+                    {
+                        if (x is not XmlElement expr || expr.Name != "Expression") continue;
+                        var name = expr.GetAttribute("Name");
+                        if (string.IsNullOrEmpty(name)) continue;
+                        expressions[name] = (
+                            expr.GetAttribute("SourceExpression"),
+                            expr.GetAttribute("OptionString"),
+                            expr.GetAttribute("Datatype") == "Option");
+                    }
+                    break;
+            }
+        }
+
+        return new BcPageDocument(sourceTableId, controls, expressions);
+    }
+
+    /// <summary>
+    /// Depth-first over the whole layout, collecting exactly the elements BC's
+    /// <c>ed is ControlDefinition</c> predicate selects.
+    ///
+    /// <para>The predicate is a type test on the document's own <c>xsi:type</c>, and it is
+    /// exact rather than a prefix match: <c>ControlDefinition</c> and
+    /// <c>MetaControlDefinition</c> each have NO subtypes in
+    /// <c>Microsoft.Dynamics.Nav.Types</c> 28.x (measured by reflection —
+    /// docs/page-control-field-from-bc-document.md#control-definition-has-no-subtypes), so
+    /// naming the two type strings selects precisely the field controls. A group
+    /// (<c>ControlGroupDefinition</c>), a repeater, a part
+    /// (<c>InfopartSystemDefinition</c>) and every action are all excluded by the same
+    /// test, which is why nothing here filters on "is this bound to a table field".</para>
+    /// </summary>
+    private static void CollectBcPageControls(XmlElement parent, List<BcPageControl> into, ref int sequence)
+    {
+        foreach (XmlNode node in parent.ChildNodes)
+        {
+            if (node is not XmlElement e) continue;
+            // Containers and Controls are both walked; anything else on the page (actions,
+            // action containers) can hold no ControlDefinition and is skipped whole.
+            if (e.Name != "Containers" && e.Name != "Controls") continue;
+
+            var type = e.GetAttribute("type", "http://www.w3.org/2001/XMLSchema-instance");
+            if (e.Name == "Controls" && (type == "ControlDefinition" || type == "MetaControlDefinition"))
+            {
+                into.Add(new BcPageControl(
+                    ControlId: ReadBcAttrInt(e, "ID"),
+                    ControlName: e.GetAttribute("Name"),
+                    DataColumnName: e.GetAttribute("DataColumnName"),
+                    // Enabled and Visible carry [DefaultValue("true")] on
+                    // ControlDefinition, so BC's deserializer supplies "true" when the
+                    // attribute is absent. Editable carries NO DefaultValue and defaults to
+                    // null, which BC renders as the empty string through
+                    // NavText.CreateTruncated — so absent means "" here, not "true". Measured
+                    // by reflection over Microsoft.Dynamics.Nav.Types 28.1; see
+                    // docs/page-control-field-from-bc-document.md#the-three-property-defaults.
+                    Enabled: ReadBcAttrOrDefault(e, "Enabled", "true"),
+                    Editable: e.GetAttribute("Editable"),
+                    Visible: ReadBcAttrOrDefault(e, "Visible", "true"),
+                    Sequence: sequence++));
+            }
+
+            CollectBcPageControls(e, into, ref sequence);
+        }
+    }
+
+    private static int ReadBcAttrInt(XmlElement e, string name)
+        => int.TryParse(e.GetAttribute(name), out var v) ? v : 0;
+
+    private static string ReadBcAttrOrDefault(XmlElement e, string name, string fallback)
+        => e.HasAttribute(name) ? e.GetAttribute(name) : fallback;
+
+    /// <summary>
+    /// The Page Control Field rows for <paramref name="pageId"/>, built from BC's document.
+    /// Never called unless <see cref="HasBcPageMetadataDocument"/> is true; returns null when
+    /// the document nonetheless did not parse, so the caller keeps the AL derivation.
+    ///
+    /// <para>Mirrors <c>GetControlsOnPage</c> value for value: <c>TableNo</c> is the page's
+    /// source table on every row (BC assigns <c>array[4]</c> from <c>tableNo</c> outside the
+    /// bound/unbound branch); <c>FieldNo</c> is the <c>out</c> of the <c>int.TryParse</c>, so
+    /// 0 for an unbound control; and SourceExpression/OptionString take the bound branch's
+    /// field-derived values or the unbound branch's expression-derived ones.</para>
+    /// </summary>
+    private static List<PageControlFieldRow>? GetPageControlFieldRowsFromBcDocument(int pageId)
+    {
+        var doc = TryGetBcPageControlDocument(pageId);
+        if (doc == null) return null;
+
+        var rows = new List<PageControlFieldRow>(doc.Controls.Count);
+        foreach (var c in doc.Controls)
+        {
+            var isBound = int.TryParse(c.DataColumnName, out var fieldNo);
+            var sourceExpression = string.Empty;
+            var optionString = string.Empty;
+
+            if (isBound)
+            {
+                // BC: `if (tableNo > 0) { metaTable ??= GetTableMetadata(tableNo);
+                //      var f = metaTable.GetFieldsById(fieldNo); if (f != null) { … } }`.
+                // A field the metatable does not carry leaves both values empty rather than
+                // being guessed at, exactly as BC's null check does.
+                if (doc.SourceTableId > 0)
+                {
+                    var field = FindMetaFieldById(doc.SourceTableId, fieldNo);
+                    if (field != null)
+                    {
+                        sourceExpression = field.FieldName ?? string.Empty;
+                        // BC gates this on `f.Type == NavType.Option`, so the guard is the
+                        // field's NavType and not "does the field carry option metadata".
+                        // The two happen to agree here, and the reason is worth stating
+                        // because it looks like a bug: an AL `Enum "X"` field is
+                        // NavType.Option as well. BC's own emitted table document writes
+                        // Datatype="Option" for an Enum field and distinguishes it only by
+                        // an EnumTypeId attribute (measured — see
+                        // docs/page-control-field-from-bc-document.md#option-and-enum), and
+                        // the runner stores it the same way for a load-bearing reason of its
+                        // own: BC's generated AL calls ValidateExpectedType(fieldNo,
+                        // NavType.Option) when reading an enum-typed record field
+                        // (RecordPatches.NclMetaTableBuilder.cs). So an Enum-bound control
+                        // takes this branch too, which is what a real tier is expected to do
+                        // and is NOT pinned by any corpus test today — #3625 tracks it.
+                        optionString = field.FieldNavType == Microsoft.Dynamics.Nav.Types.NavType.Option
+                            ? field.FieldOptionMetadata?.OptionString ?? string.Empty
+                            : string.Empty;
+                    }
+                }
+            }
+            else if (doc.Expressions.TryGetValue(c.DataColumnName, out var expr))
+            {
+                sourceExpression = expr.SourceExpression ?? string.Empty;
+                if (expr.IsOption) optionString = expr.OptionString ?? string.Empty;
+            }
+
+            rows.Add(new PageControlFieldRow(
+                pageId, c.ControlId, c.ControlName,
+                doc.SourceTableId, isBound ? fieldNo : 0,
+                c.Enabled, c.Editable, c.Visible,
+                sourceExpression, optionString, c.Sequence));
+        }
+
+        return rows;
+    }
+
+    /// <summary>
+    /// The source field BC would resolve through
+    /// <c>MetadataProvider.GetTableMetadata(tableNo).GetFieldsById(fieldNo)</c>. Goes through
+    /// the runner's own NCLMetaTable rather than the parsed AL table, because that is the
+    /// object that carries tableextension-added fields and the resolved option metadata for an
+    /// Enum-typed field; the parsed table carries neither.
+    /// </summary>
+    private static Microsoft.Dynamics.Nav.Runtime.NCLMetaField? FindMetaFieldById(int tableId, int fieldNo)
+    {
+        var meta = GetOrBuildNCLMetaTable(tableId);
+        if (meta == null) return null;
+        foreach (var f in GetAllFields(meta) ?? Enumerable.Empty<Microsoft.Dynamics.Nav.Runtime.NCLMetaField>())
+            if (f.FieldNo == fieldNo) return f;
+        return null;
+    }
+}

--- a/AlRunner/Patches/RecordPatches.PageControlFieldVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.PageControlFieldVirtualTable.cs
@@ -75,7 +75,8 @@ public static partial class RecordPatches
     /// <summary>One field control as Page Control Field exposes it.</summary>
     private sealed record PageControlFieldRow(
         int PageNo, int ControlId, string ControlName, int TableNo, int FieldNo,
-        string Enabled, string Editable, string Visible, string SourceExpression, int Sequence);
+        string Enabled, string Editable, string Visible, string SourceExpression,
+        string OptionString, int Sequence);
 
     private static List<PageControlFieldRow>? _pageControlFieldRows;
     // The .app term is RecordPatches' registration EPOCH, never _bcAppPaths.Count (#2888):
@@ -122,10 +123,8 @@ public static partial class RecordPatches
             "editable" => Text(row.Editable),
             "visible" => Text(row.Visible),
             "sourceexpression" => Text(row.SourceExpression),
+            "optionstring" => Text(row.OptionString),
             "sequence" => Int(row.Sequence),
-            // "OptionString" is derived from the source field's OptionMembers on a real
-            // tier; the runner does not resolve that here, so it gets the type default
-            // rather than a guess.
             _ => _aovGetDefaultNavValue!.Invoke(null, new object?[] { field, false }),
         };
     }
@@ -142,11 +141,23 @@ public static partial class RecordPatches
             var rows = new List<PageControlFieldRow>();
             var sourceParsedPageIds = new HashSet<int>();
 
-            // 1. Pages the runner source-compiled (base page controls merged with matching
-            //    pageextensions' — see GetSourceParsedPageControlRows).
+            // 1. Pages the runner source-compiled. BC's own emitted document wins whenever
+            //    the emitter captured one (#3604) — it is what BC's provider reads, and it
+            //    differs from the AL text on four columns; see
+            //    RecordPatches.PageControlFieldFromBcDocument.cs. The AL derivation below
+            //    remains reachable and is NOT dead: a page compiled before the object-metadata
+            //    registry existed, or served from a cache written without it, has no document.
             foreach (var page in _parsedPages.Values)
             {
                 sourceParsedPageIds.Add(page.Id);
+
+                if (HasBcPageMetadataDocument(page.Id)
+                    && GetPageControlFieldRowsFromBcDocument(page.Id) is { } fromDocument)
+                {
+                    rows.AddRange(fromDocument);
+                    continue;
+                }
+
                 var tableId = GetSourceTableIdForPage(page.Id);
                 var table = tableId != 0 && _parsedTables.TryGetValue(tableId, out var t) ? t : null;
 
@@ -157,7 +168,7 @@ public static partial class RecordPatches
                         page.Id, c.ControlId, c.ControlName,
                         pField != null ? tableId : 0, pField?.FieldId ?? 0,
                         c.EnabledExpr ?? "true", c.EditableExpr ?? "true", c.VisibleExpr ?? "true",
-                        c.SourceExpressionText, c.Sequence));
+                        c.SourceExpressionText, string.Empty, c.Sequence));
                 }
             }
 
@@ -177,7 +188,11 @@ public static partial class RecordPatches
                     rows.Add(new PageControlFieldRow(
                         symbol.Id, c.Id, c.Name, tableNo, fieldNo,
                         c.EnabledExpr ?? "true", c.EditableExpr ?? "true", c.VisibleExpr ?? "true",
-                        c.SourceExpression, c.Sequence));
+                        // A dependency page's SymbolReference.json does not state the source
+                        // field's option members, and DependencyPageMetadataXml.EmitPageXml
+                        // reconstructs no <Controls> element to read them from, so this stays
+                        // the empty string it answered before rather than becoming a guess.
+                        c.SourceExpression, string.Empty, c.Sequence));
                 }
             }
 

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -290,6 +290,11 @@ public static partial class RecordPatches
         // for it. Report ids repeat across reloads, so a stale entry is a wrong answer rather
         // than a miss.
         ClearBcReportDocuments();
+        // #3604, the same statement one object kind over: the memo holds the control tree
+        // parsed out of the PREVIOUS bundle's page documents, and a --watch cycle that adds
+        // or hides a control would otherwise keep answering the old tree. Page ids repeat
+        // across reloads, so a stale entry is a wrong answer rather than a miss.
+        ClearBcPageControlDocuments();
         // #3121: every table is rebuilt from scratch below, so carrying the previous bundle's
         // pending CalcFormula rebuilds forward only buys a wasted repopulate pass on the next
         // .app registration.

--- a/docs/page-control-field-from-bc-document.md
+++ b/docs/page-control-field-from-bc-document.md
@@ -1,0 +1,279 @@
+# Answering Page Control Field from BC's own document
+
+`Page Control Field` (2000000192) used to be derived entirely from AL source text by
+`RecordPatches.AlPageParser`, while BC's own emitted page document — the one BC's real
+provider reads — sat in `AlObjectMetadataRegistry` feeding the page *execution* path.
+The two disagreed on four columns, and a caller could observe every one of them.
+`RecordPatches.PageControlFieldFromBcDocument` reads the document; this page is the
+derivation its header points at.
+
+The siblings are [`object-metadata-from-bc.md`](object-metadata-from-bc.md), which
+`RecordPatches.NclMetaTableFromBcDocument` did first for tables at #3584, and
+[`report-metadata-from-bc.md`](report-metadata-from-bc.md), which did reports at #3607.
+The corpus adjudication for this one is
+[corpus PR #300](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/300)
+(page 60427, codeunit 60426).
+
+<a id="what-bc-does"></a>
+
+## What BC does
+
+`Microsoft.Dynamics.Nav.Runtime.PageControlFieldDataProvider.GetControlsOnPage`, decompiled
+from `Microsoft.Dynamics.Nav.Ncl.dll` 28.1, is the whole specification. The relevant part:
+
+```csharp
+page     = MetadataProvider.GetMasterPageForDesigner(pageNo, out metaTable);
+tableNo  = page.PageProperties.SourceObject.SourceTable;
+
+var enumerable = page.FindAll(ed => ed is ControlDefinition)
+                     .Cast<ControlDefinition>()
+                     .Select((cd, i) => (sequence: i, control: cd));
+var val = enumerable.OrderBy(c => c.control.ID);        // Ascending; OrderByDescending otherwise
+
+foreach (var pageControl in val) {
+    string value = string.Empty, value2 = string.Empty;
+    if (pageControl.control.IsBoundToTableField(out var fieldNo)) {
+        if (tableNo > 0) {
+            metaTable ??= MetadataProvider.GetTableMetadata(tableNo);
+            var f = metaTable.GetFieldsById(fieldNo);
+            if (f != null) {
+                value  = (f.Type == NavType.Option) ? f.OptionString : string.Empty;
+                value2 = f.Name;
+            }
+        }
+    } else {
+        var dfd = page.Expressions.FirstOrDefault(x => x.Name == pageControl.control.DataColumnName);
+        if (dfd != null) {
+            value2 = dfd.SourceExpression;
+            if (dfd.Datatype == DataType.Option) value = dfd.OptionString;
+        }
+    }
+    array[4]  = NavInteger.Create(tableNo);              // TableNo — outside both branches
+    array[5]  = NavInteger.Create(fieldNo);              // FieldNo — the TryParse out
+    array[6]  = ... pageControl.control.Enabled;
+    array[7]  = ... pageControl.control.Editable;
+    array[8]  = ... pageControl.control.Visible;
+    array[9]  = ... value2;                              // SourceExpression
+    array[10] = ... value;                               // OptionString
+    array[11] = NavInteger.Create(pageControl.sequence);
+}
+```
+
+Two things in there are easy to read past and both are load-bearing:
+
+* **`array[4]` sits outside the bound/unbound branch**, so `TableNo` is the *page's* source
+  table on every row — including a row whose control has no source field at all.
+* **`sequence` is numbered on the `FindAll` walk, before the `OrderBy`**, so it is the
+  document's own document order, not the sorted position.
+
+<a id="the-four-wrong-answers"></a>
+
+## The four wrong answers this removes
+
+Measured on the probe bundle in the next section, against BC 28.1, and pinned by corpus
+codeunit 60426 against a real service tier:
+
+| column | AL derivation answered | BC answers |
+|---|---|---|
+| `SourceExpression` (bound) | `Rec."Entry No."` — the binding *text* | `Entry No.` — the source field's **name** |
+| a variable-bound control | **no row at all** | a row whose `SourceExpression` is `LocalTreeVar` |
+| `OptionString` (Option-bound) | `''` — fell through to `GetDefaultNavValue` | `" ",Draft,Active,Closed` |
+| `SourceExpression` (Text-bound) | `Rec."Description Field"` | `Description Field` |
+
+The missing-row defect had a named cause: the AL derivation kept only a control whose source
+expression was exactly `Rec.Something`, and omitted everything else rather than guessing at
+it. That was a defensible rule for a text-parsing derivation and it is simply not what the
+table is. BC applies **no** binding filter — `ed is ControlDefinition` is the only predicate.
+
+**Nesting was not one of the defects.** The issue's "done when" asked for depth coverage; the
+AL parser already walked the layout to arbitrary depth, and the depth-3 test
+(`ControlNestedThreeGroupsDeep_IsARow`) passed before this change as well as after. It is
+carried as a regression guard, not as a RED.
+
+<a id="the-emitted-document"></a>
+
+## The emitted document
+
+A probe bundle declaring the same shapes as corpus fixture 60427 emits this (elided to the
+attributes that matter; `AL_RUNNER_TRACE_OBJECT_METADATA=2` prints it in full):
+
+```xml
+<PageDefinition ID="70002" Name="PCF Probe Page">
+  <Properties PageType="Card" Editable="1">
+    <SourceObject SourceTable="70001"/>
+  </Properties>
+  <Content>
+    <Containers xsi:type="ControlContainerDefinition" ContainerType="ContentArea">
+      <Controls xsi:type="ControlGroupDefinition" ID="1780766225" Name="Level1" Editable="true" Enabled="true" Visible="true">
+        <Controls xsi:type="ControlDefinition" ID="369657861"  Name="Entry No."        DataColumnName="1"                Visible="true"/>
+        <Controls xsi:type="ControlDefinition" ID="419265194"  Name="TreeLocalVar"     DataColumnName="Control419265194" Visible="true"/>
+        <Controls xsi:type="ControlGroupDefinition" ID="601111220" Name="Level2" ...>
+          <Controls xsi:type="ControlDefinition" ID="1110612037" Name="TreeOption"     DataColumnName="14"               Visible="true"/>
+          <Controls xsi:type="ControlGroupDefinition" ID="1238807837" Name="Level3" ...>
+            <Controls xsi:type="ControlDefinition" ID="1061314080" Name="TreeDeepHidden"   DataColumnName="18" Visible="false"/>
+            <Controls xsi:type="ControlDefinition" ID="1327436012" Name="TreeDeepEditable" DataColumnName="17" Editable="false" Visible="true"/>
+          </Controls>
+        </Controls>
+      </Controls>
+    </Containers>
+    <Containers xsi:type="ControlContainerDefinition" ContainerType="FactBoxArea">
+      <Controls xsi:type="InfopartSystemDefinition" ID="2016712184" Name="DefaultSummaryPart" .../>
+    </Containers>
+  </Content>
+  <Expressions>
+    <Expression Name="Control419265194" Datatype="Integer" ExpressionType="SourceExpression"
+                SourceExpression="LocalTreeVar" ExpressionIsAssignable="1"/>
+  </Expressions>
+</PageDefinition>
+```
+
+Three things to read off it:
+
+* `DataColumnName` is `"1"`, `"14"`, `"17"`, `"18"` for the Rec-bound controls and
+  `"Control419265194"` for the variable-bound one. `ControlDefinition.IsBoundToTableField` is
+  13 bytes of IL — `int.TryParse(DataColumnName, out fieldNo)` — so the document states the
+  binding decision directly and nothing has to parse an AL expression to recover it.
+* The variable-bound control carries **no** `SourceExpression` attribute. The name lives in
+  the `<Expressions>` section, keyed by the control's `DataColumnName` — which is exactly
+  `page.Expressions.FirstOrDefault(x => x.Name == control.DataColumnName)` in BC's code.
+* The fact box part is an `InfopartSystemDefinition` and the groups are
+  `ControlGroupDefinition`. Neither is a `ControlDefinition`, so neither becomes a row.
+
+<a id="control-definition-has-no-subtypes"></a>
+
+## `ControlDefinition` has no subtypes
+
+BC's predicate is `ed is ControlDefinition`, a type test that would also select any subclass.
+The runner matches on the document's `xsi:type` *string*, so it has to know whether that
+predicate can select a type spelled anything other than `ControlDefinition` or
+`MetaControlDefinition`. Measured by reflection over
+`Microsoft.Dynamics.Nav.Types.dll` 28.1 — enumerate every type whose `BaseType` is the one in
+question:
+
+| type | base | direct subtypes |
+|---|---|---|
+| `ControlDefinition` | `ControlDataboundDefinition` | **none** |
+| `MetaControlDefinition` | `MetaControlDataboundDefinition` | **none** |
+| `DataFieldDefinition` | `ElementDefinition` | **none** |
+| `ControlGroupDefinition` | `ControlGroupBaseDefinition` | **none** |
+
+So naming the two type strings selects precisely the set BC's `is` test selects. This is the
+one place where an exact string match is equivalent to a type test rather than an
+approximation of one, and it stops being true the moment a BC release adds a subclass — which
+is why it is written down here rather than left implicit at the call site.
+
+<a id="the-three-property-defaults"></a>
+
+## The three property defaults, and why `Editable` is not `"true"`
+
+`Enabled`, `Editable` and `Visible` are **text** columns carrying the declared property
+expression, so a control with `Visible = NoFieldVisible` reports the variable's name. The
+question this section answers is narrower: what does BC report when the property is *absent*
+from the document, which is the common case?
+
+The document omits an attribute when the property is at its default, so the answer is whatever
+BC's deserializer supplies. Measured by instantiating `ControlDefinition` through reflection
+and reading each property off a fresh instance:
+
+| property | `DefaultValueAttribute` | value on a fresh instance |
+|---|---|---|
+| `Enabled` | yes | `"true"` |
+| `Visible` | yes | `"true"` |
+| `Editable` | **no** | **`null`** |
+
+`Enabled` and `Visible` therefore default to `"true"`, which is what the AL derivation already
+substituted and what corpus codeunit 60921 pins for `Visible`. `Editable` does **not**: BC
+passes the null straight to `NavText.CreateTruncated`, which renders it as the empty string.
+The AL derivation substituted `"true"` there too, so this change makes `Editable` answer `""`
+for a control that does not declare it.
+
+**That last cell is measured from BC's own type, not from a service tier.** No corpus test
+pins `Editable` today — codeunit 60921 pins `Visible` only, and corpus PR #300's codeunit
+60426 asserts `Editable` nowhere. So the claim rests on the reflection measurement above plus
+BC's decompiled `array[7] = NavText.CreateTruncated(len, control.Editable)`, and not on a real
+tier having answered it. It is the honest reading of both, and it is the kind of claim
+`.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md` says to name rather than to
+assert quietly. A corpus test asserting `Editable` on an undeclared control is the follow-up
+that would settle it; #3625 tracks it.
+
+<a id="option-and-enum"></a>
+
+## `OptionString`, and why an Enum field takes the same branch
+
+BC gates `OptionString` on `f.Type == NavType.Option`, so the guard is the field's `NavType`
+and explicitly not "does the field carry option metadata". Those two look interchangeable and
+are not, which is worth stating because the obvious reading of the guard is that an AL
+`Enum "X"` field — a different AL type, and a distinct `NavType.Enum` member exists — should
+answer `''`.
+
+It does not, and the document says so. BC's own emitted **table** document, for a table
+declaring both an `Option` field and an `Enum` field:
+
+```xml
+<Field Name="Option Field" ID="14" Datatype="Option" OptionString=" ,Draft,Active,Closed" ... />
+<Field Name="Status Field" ID="19" Datatype="Option" EnumTypeName="PCF Probe Status" EnumTypeId="70004" ... />
+```
+
+Both are `Datatype="Option"`. The Enum field is distinguished only by carrying an
+`EnumTypeId`/`EnumTypeName` pair, and by having no inline `OptionString` of its own — BC
+resolves that from the enum object instead.
+
+The runner stores it the same way, for a reason of its own that is load-bearing and
+independent: BC's generated AL calls `ValidateExpectedType(fieldNo, NavType.Option)` when
+reading an enum-typed record field, so the metadata side has to match or every
+`TestField`/`Read*EnumField` path throws `NavObjectDefinitionChangedException`
+(`RecordPatches.NclMetaTableBuilder.cs`). So `FieldNavType == NavType.Option` is true for an
+Enum-bound control here as well, and it answers the enum's members.
+
+**This is a reading of BC's document and BC's decompiled provider, not a tier measurement.**
+No corpus test pins `OptionString` for an Enum-bound page control — corpus codeunit 60426's
+`OptionBoundControl_OptionStringIsTheFieldsMembers` uses `ALT Universal`'s `"Option Field"`,
+which is genuinely `Option`-typed, and `ALT Universal` also has an `Enum`-typed
+`"Status Field"` that no test binds a control to. An implementation keyed on "has option
+metadata" and one keyed on `NavType` therefore agree on everything the corpus currently
+measures, and this file takes the `NavType` route because it is what BC's code says.
+[#3625](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3625) tracks getting
+the Enum case in front of a real tier.
+
+<a id="scope"></a>
+
+## Scope — emit-captured pages only
+
+The gate is `HasBcPageMetadataDocument(pageId)`, mirroring `HasBcTableMetadataDocument`
+(#3552). A page from a precompiled dependency `.app` keeps its `SymbolReference.json`-derived
+rows, and that is deliberate rather than incidental: `DependencyPageMetadataXml.EmitPageXml`
+reconstructs **no `<Controls>` element** for such a page — its own header says so — so routing
+dependency pages through this file would answer **zero rows for every one of them**. That is a
+regression wearing the shape of a conversion, and it is the single decision on this change
+that a reviewer should check first.
+
+Two consequences follow, and both are the reason the AL derivation is **not** dead code:
+
+* a dependency page still needs `ResolveDependencyControlField` and the symbol-derived path;
+* a source-compiled page whose document was never captured — compiled before the registry
+  existed, or served from a cache written without it — still needs the AL-parsed path.
+
+`OptionString` for a dependency page stays the empty string. `SymbolReference.json` does not
+state the source field's option members and there is no `<Controls>` element to read them
+from, so answering anything else would be a guess rather than a narrower answer.
+
+<a id="not-done"></a>
+
+## Deliberately not done here
+
+* **Pageextension deltas (#3605).** A `pageextension`'s added controls do not appear in the
+  base page's `<PageDefinition>` at all; BC emits them in a separate `MetadataRuntimeDeltas`
+  document with `<ControlAdd>`/`<ControlChange>` elements. That is a second document source
+  reached through a different registry entry, not a different branch of this file's parse, so
+  it stays its own change.
+* **`Sequence` on the dependency-symbol path.** BC's `Sequence` is a **0-based** enumeration
+  index, captured before the `OrderBy` that sorts rows by control id
+  (`Select((cd, i) => (sequence: i, control: cd))`). Both paths this change touches now
+  produce that: the document path by construction, and the AL fallback by correcting
+  `GetSourceParsedPageControlRows` from `++seq` to `seq++`. The **precompiled-dependency**
+  path in `BcAppSymbolCache.CollectPageControlSymbols` is still 1-based and is deliberately
+  left alone here — that file is being changed by another open pull request, and the fix is a
+  one-character edit that belongs with whoever owns it rather than in a merge conflict. No
+  corpus test pins `Sequence` on any path, so nothing catches any of this either way; the
+  document and AL paths were corrected because leaving them disagreeing with each other would
+  make one column mean two different things depending on which route answered.


### PR DESCRIPTION
Closes #3604

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/300

`Page Control Field` (2000000192) was built entirely from parsed AL source text, while BC's
own emitted page document — the one BC's real provider reads — sat in
`AlObjectMetadataRegistry` feeding the page *execution* path. This routes the table through
that document.

Authored by an agent (Claude, `stma-auto-2`) on the account holder's behalf.

## RED → GREEN

Corpus codeunit 60426, measured against pinned corpus `c9d5f656` with only PR #300's two
files overlaid, BC 28.1. Four of the five fail on **concrete wrong values** before, all five
pass after:

| test | before | after / BC |
|---|---|---|
| `TableBoundControl_SourceExpressionIsTheFieldName` | `Rec."Entry No."` | `Entry No.` |
| `VariableBoundControl_IsARowNamingTheVariable` | **no row at all** | row, `SourceExpression` = `LocalTreeVar` |
| `OptionBoundControl_OptionStringIsTheFieldsMembers` | `''` | `" ",Draft,Active,Closed` |
| `TextBoundControl_OptionStringIsEmpty` | `Rec."Description Field"` | `Description Field` |
| `ControlNestedThreeGroupsDeep_IsARow` | passes already | — |

Codeunit 60921's three pre-existing tests pass throughout.

Reading the rows straight off the fixture page confirms all four together, plus the
`TableNo`-on-every-row and 0-based-`Sequence` properties no test pins:

```
[Entry No.        |seq=0|tbl=70001|fld=1 |src=Entry No.        |opt=                  |edi=     ]
[TreeLocalVar     |seq=1|tbl=70001|fld=0 |src=LocalTreeVar     |opt=                  |edi=     ]
[TreeOption       |seq=2|tbl=70001|fld=14|src=Option Field     |opt= ,Draft,Active,Closed|edi=  ]
[TreeDeepHidden   |seq=3|tbl=70001|fld=18|src=Name Field       |opt=                  |edi=     ]
[TreeDeepEditable |seq=4|tbl=70001|fld=17|src=Description Field|opt=                  |edi=false]
```

## What BC does

`PageControlFieldDataProvider.GetControlsOnPage` (Ncl 28.1) walks the merged master page with
`FindAll(ed => ed is ControlDefinition)`, numbering the walk as `Sequence`, then sorting by
control id. Two lines are easy to read past and both are load-bearing: `array[4] = tableNo`
sits **outside** the bound/unbound branch, and `sequence` is numbered **before** the
`OrderBy`. Full decompile, the emitted document, and the reflection measurements are in
`docs/page-control-field-from-bc-document.md`.

The missing-row defect had a named cause: the AL derivation kept only a control bound as
exactly `Rec.Something`. BC applies **no** binding filter — `ed is ControlDefinition` is the
only predicate, and `ControlDefinition`/`MetaControlDefinition` each have **no subtypes** in
`Microsoft.Dynamics.Nav.Types` 28.x (measured), so that predicate selects precisely the field
controls and never a group, repeater or part.

## A fifth divergence, which no test pins in either direction

`Sequence` was **1-based**; BC's is a 0-based enumeration index. Every row of every page was
off by one, and nothing was ever going to catch it. Corrected on both paths this PR touches —
the document path by construction, the AL fallback by `++seq` → `seq++`.

**Left alone deliberately:** the precompiled-dependency path in
`BcAppSymbolCache.CollectPageControlSymbols` is still 1-based. That file is being changed by
another open PR (#3623), and a one-character edit there belongs with whoever owns it rather
than in a merge conflict. Named in `docs/…#not-done` so it is not lost.

## The scoping decision to check first

Gated on `HasBcPageMetadataDocument`, mirroring `HasBcTableMetadataDocument` (#3552).
`DependencyPageMetadataXml.EmitPageXml` reconstructs **no `<Controls>` element** for a
precompiled-dependency page — its own header says so — so routing those pages through BC's
document would answer **zero rows for every one of them**. That is a regression wearing the
shape of a conversion, and it is the single decision here most worth a second reader.

Reads the captured XML directly rather than through `EnsureRealPageMetadata`. Same document,
but a real metadata load per page is a deliberate side effect there, and populating a virtual
table asks about *every* known page — the trap that put the report side past the 60s
watchdog (#3607).

## "Done when" clause 3: what is dead, and what is not

Nothing was removed, and the reason is specific rather than cautious:

- **`ResolveDependencyControlField` + the symbol path** still serve every precompiled-
  dependency page, per the gate above.
- **The AL-parsed path** still serves a source-compiled page whose document was never
  captured — compiled before the registry existed, or served from a cache written without it.
- **`ParsePageControls` could not be removed regardless.** It returns
  `(fieldMap, controls)`, and `fieldMap` is what `GetPageControlFieldMap` hands to
  `LiveNavTestPage` at three call sites (`CodeunitPatches.cs` ×2, `RunnerTestClientSession.cs`).
  Deleting it breaks TestPage.

So the conversion removes the derivation's *role as the answer*, not its code — the same
conclusion #3621 and #3623 reached about their parsers.

## Two answers that rest on BC's code rather than on a tier

Recorded as such rather than asserted quietly, per
`ask-the-corpus-before-claiming-bc-behavior.md`. **#3625** tracks getting both measured.

1. **`Editable` when undeclared.** `ControlDefinition` carries `[DefaultValue("true")]` on
   `Enabled` and `Visible` and **none** on `Editable` (measured on a fresh instance: `"true"`,
   `"true"`, `null`), and BC passes it to `NavText.CreateTruncated`, which renders null as
   `""`. So `Editable` answers `''` where the other two answer `'true'`. The AL derivation
   substituted `'true'` for all three. **No corpus test pins `Editable`** — 60921 pins
   `Visible` only, and 60426 does not assert it.

2. **`OptionString` for an `Enum`-typed field.** BC gates on `f.Type == NavType.Option`, and
   `NavType.Enum` is a distinct member — so the obvious reading is that an Enum field answers
   `''`. The measurement says otherwise: BC's emitted **table** document writes
   `Datatype="Option"` for an Enum field too, distinguishing it only by `EnumTypeId`. The
   runner stores it the same way for an independent, load-bearing reason (BC's generated AL
   calls `ValidateExpectedType(fieldNo, NavType.Option)`), so an Enum-bound control takes the
   Option branch. Corpus 60426's Option case uses a genuinely `Option`-typed field, and
   `ALT Universal`'s `Enum`-typed `"Status Field"` has no control bound to it — so an
   implementation keyed on "has option metadata" and one keyed on `NavType` agree on
   everything the corpus measures today. This one takes the `NavType` route because that is
   what BC's code says.

## Verification

**Corpus, both arms, per-app counts against `tests/expectations/count-baseline/`:**

| suite | before | after | baseline |
|---|---|---|---|
| al-language | 3112/3112 | 3112/3112 | 3112 |
| runner-extras | 406/406 | 406/406 | 406 |

Both classification JSONs are **byte-identical apart from their timestamps**.

**Runner-side mechanism tests** — `AlRunner.Tests/PageControlFieldDocumentTests.cs`, 5 tests,
all passing (and actually *running*: they skip without `engine.runsettings`, so they were
confirmed under `tools/engine-test-bootstrap.sh`). They pin the premise a corpus test cannot
see — the corpus asserts what the table *answers*, never *where the answer came from*: that
the document states the binding as `DataColumnName`, that an unbound control's expression
lives in `<Expressions>` keyed by it, and that `Enabled`/`Visible` are omitted-with-a-default
while `Editable` is omitted-with-none. Mutation-checked: replacing the `xsi:type` test with an
element-name-only walk fails them (it picks up `Level1`/`Level2`).

**Targeted C# suite**, `PageControlField|PageMetadata|AlPageParser|TestPageEvaluatorFault`
under `engine.runsettings`: **73/73 pass**.

Two failures seen while iterating were chased to ground and are **not** from this change —
both are `Ncl.dll` bootstrap state, and each fails in exactly one of the two states:
`TestPageTemporalValueTests` fails only against the *Cecil-rewritten* Ncl, and
`TestPageEvaluatorFaultTests` fails only against the *pristine* one (confirmed failing
identically on clean `origin/main`). Both pass in the state CI uses.

## No pin bump

Corpus PR #300 has merged, but the pin cannot advance: corpus history is linear and the
oldest held-out commit is `26b0434` (corpus #293), whose runner fix **#3580 is open with no
PR** (re-verified). A missing bump is therefore not a defect in this PR.

## Not folded — #3605 (pageextension deltas)

Re-checked against where this fix actually landed, and the earlier judgement holds. A
`pageextension`'s added controls do not appear in the base page's `<PageDefinition>` at all;
BC emits them in a separate `MetadataRuntimeDeltas` document with `<ControlAdd>`/
`<ControlChange>` elements. That is a **second document source reached through a different
registry entry**, not another branch of this file's parse — it would need its own capture
path before any of this code could read it. Different mechanism, so it stays its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
