### PR TITLE
docs(codeunit-metadata): correct the RequiredTestIsolation mechanism, which was wrong

### DIFF
--- a/docs/codeunit-metadata-from-bc.md
+++ b/docs/codeunit-metadata-from-bc.md
@@ -84,7 +84,6 @@ protected override void LoadMetadata()
     base.LoadMetadata();
     MetaCodeunit metaCodeunit = base.ObjectLoader.XmlMetadataLoader.GetMetaCodeunit(...);
     ...
-    TestType = metaCodeunit.TestType;
     RequiredTestIsolation = metaCodeunit.RequiredTestIsolation;
 }
 ```
@@ -99,8 +98,10 @@ case 21:                                  // name.Length
 ```
 
 **The AL compiler emits the attribute as `TestIsolation`** — 13 characters — so the length-21
-branch never fires and the field keeps its constructor default `0` = `None`. That matches the
-corpus failure exactly: `Expected:<1>` (Disabled) `Actual:<None>`.
+branch never fires and the field keeps its constructor default `0` = `None`. Measured across the
+cached emitted documents: **2,167 occurrences of `TestIsolation="…"` and 0 of
+`RequiredTestIsolation`.** That matches the corpus failure exactly: `Expected:<1>` (Disabled)
+`Actual:<None>`.
 
 **BC's default is therefore the faithful answer**, and `NavValue.GetDefaultNavValue` already
 gives it. This is not a known gap: there is nothing to implement.
@@ -130,3 +131,118 @@ Two lessons, cheap to state and expensive to relearn:
 - **Establishing which path is *unused* says nothing about what the used path answers.** The
   earlier reasoning correctly found the parser's name mismatch, then discarded it on the strength
   of the false zero. It was the answer all along.
+
+<a id="what-the-compiler-emits"></a>
+
+## What the compiler actually emits, per declaration shape
+
+This is a measurement of the **document**, which is a different thing from what the column
+answers — see [`#requiredtestisolation`](#requiredtestisolation), where a tier answers `None`
+whatever this table says. It is kept because it explains the figure #3606 was filed on, and
+because the next person to notice `TestIsolation` sitting in the document will otherwise
+re-derive it.
+
+Measured on BC 28.1.49838.53910 by compiling one codeunit of each shape and dumping the
+captured document with `AL_RUNNER_TRACE_OBJECT_METADATA=2`:
+
+| declaration | `TestIsolation` attribute |
+|---|---|
+| `Subtype = Normal`, property absent | `"Disabled"` |
+| `Subtype = TestRunner`, property absent | `"Disabled"` |
+| `Subtype = TestRunner`, property declared | the declared member |
+| `Subtype = Test` | **absent** |
+
+So the compiler supplies `Disabled` for everything except a `Subtype = Test` codeunit.
+
+That identifies #3606's "stated for 1,658 of 1,690" figure: the 32 Base Application documents
+with no `TestIsolation` attribute are the test codeunits, not codeunits that "declined to
+state" a property others stated.
+
+**None of it reaches the column.** A tier answers `None` for all four rows above, including
+the third — which is exactly what makes the document a bad source for this column and is why
+`RequiredTestIsolation` is defaulted rather than converted.
+
+**Two AL constraints make most of this unreachable from AL**, which is why the runner-side
+mechanism tests in `AlRunner.Tests/CodeunitMetadataDocumentColumnTests.cs` exist alongside the
+corpus tests:
+
+- `AL0223` — `TestIsolation` is accepted only when `Subtype = TestRunner`.
+- `AL0195` — on a codeunit, `InherentPermissions` and `InherentEntitlements` accept only `X`.
+
+<a id="permission-mask-spelling"></a>
+
+## How a permission mask is spelled
+
+`MetadataDataProvider.CreatePermissionMaskString` (Ncl.dll) returns `NavText.Empty` for
+`PermissionMask.None`; otherwise it walks bits 0..4 and emits `permissions[n]` for a direct
+bit, or `permissions[n] + 32` — the lowercase letter — for the matching indirect bit at `n+5`.
+It sizes its stack buffer with `PopCount((num >> 5) | (num & 0x1F))`, so one permission never
+contributes two characters.
+
+`permissions` is a static `char[5]` initialized from a blob. Decoded from BC 28.1's
+`<PrivateImplementationDetails>`:
+
+```
+52 00 49 00 4D 00 44 00 58 00   ->  'R' 'I' 'M' 'D' 'X'
+```
+
+`PermissionMask` itself (Types.dll) numbers `Read=1, Insert=2, Modify=4, Delete=8,
+Execute=16`, then `IndirectRead=32` … `IndirectExecute=512`, plus flags above that
+(`HasExpDate=4096`, `IgnoreWildcard=32768`) which no permission column spells.
+
+The attribute BC emits is the mask's **numeric** value — `InherentPermissions="16"` for
+`InherentPermissions = X` — and BC's own parser reads it with
+`Enum.Parse(typeof(PermissionMask), value)`, which accepts a numeric string or a member name.
+The runner accepts both for the same reason, and refuses anything it cannot read rather than
+answering the empty string, which would be indistinguishable from a codeunit declaring no
+permission.
+
+<a id="the-two-columns-left-at-bcs-default"></a>
+
+## The two columns left at BC's default
+
+Neither is waiting on this conversion; neither is in the document to convert.
+
+**`App ID`** is not an object property. BC fills it with
+`MetadataDataProvider.GetAppId(metaCodeunit)` — the id of the app the object was *published*
+from, which is per-run state a compiler cannot emit. Answering it needs per-object app
+attribution, the same data #2326 tracks for `AllObj`'s "Object Subtype".
+
+**`TestType`** is emitted **0 times** in Base Application's 1,690 codeunit documents, and BC
+does not read it from the document either. `MetaCodeunit`'s ctor **derives** it, in a tail
+block after the attribute loop:
+
+```
+if (SubType == CodeunitSubType.Test && TestType == 0)
+    TestType = TestCodeunitTestType.UnitTest;      // i.e. 1
+```
+
+So a service tier reports `UnitTest` for a test codeunit that declares nothing, which is a
+derivation rather than a stated value. Reproducing it is a separate claim about BC needing its
+own corpus test, and is deliberately not part of #3606.
+
+<a id="what-adjudicated-this"></a>
+
+## What adjudicated this
+
+Corpus PR 296 (`StefanMaron/BusinessCentral.AL.Language.Tests`), on eight cloud legs.
+
+**Green, and what the two converted columns rest on:**
+
+- `Record_CodeunitMetadata_Get_InherentPermissionsAndEntitlements_ReadIndependently` — a
+  codeunit declaring `InherentPermissions = X` reports `'X'` while its entitlement column
+  stays empty, and the reverse for the sibling; a codeunit declaring neither reports both
+  empty.
+- `Record_CodeunitMetadata_Get_ALNamespace_ReportsTheDeclaringFilesNamespace` — a namespaced
+  codeunit reports its full dotted namespace, an un-namespaced one the empty string.
+
+Both fail against the runner as it stood before #3606, with concrete wrong values: `''` where
+`X` is declared, `''` where a namespace is declared.
+
+**Red on all eight, and removed:** two `RequiredTestIsolation` tests, which asserted the
+column tracks the declared property. It does not — see
+[`#requiredtestisolation`](#requiredtestisolation). They were dropped from the corpus PR
+rather than inverted to assert `None`: pinning an observation without a mechanism is what
+`.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md` forbids, and the mechanism that
+*was* established (a property `Ncl.dll` never assigns) is a fact about the runtime engine
+rather than about AL, so it has no AL assertion that would fail if it were different.

--- a/docs/codeunit-metadata-from-bc.md
+++ b/docs/codeunit-metadata-from-bc.md
@@ -67,160 +67,66 @@ FAIL Record_CodeunitMetadata_Get_TestRunnerCodeunits_ReportEachDeclaredTestIsola
 
 ### Why, in Ncl.dll
 
-Not a mystery, and not the XML parser. `CodeUnitDataProvider.GetValuesWithinRangeForKeyField`
-fills slot 9 from the `NCLMetaCodeunit`, never from the document:
+It **is** the XML parser, and the name mismatch is the whole mechanism.
+
+`CodeUnitDataProvider.GetValuesWithinRangeForKeyField` fills slot 9 from the `NCLMetaCodeunit`:
 
 ```csharp
 buffer[9] = codeUnitDataProvider.GetOptionValue(10, (int)metaCodeunitById.RequiredTestIsolation);
 ```
 
-And `NCLMetaCodeunit.RequiredTestIsolation` is a property nothing ever assigns:
+`NCLMetaCodeunit.RequiredTestIsolation` **is** assigned — by `NCLMetaCodeunit.LoadMetadata()`,
+which copies it straight off the parsed document object:
 
 ```csharp
-public TestCodeunitRequiredTestIsolation RequiredTestIsolation { get; private set; }
+protected override void LoadMetadata()
+{
+    base.LoadMetadata();
+    MetaCodeunit metaCodeunit = base.ObjectLoader.XmlMetadataLoader.GetMetaCodeunit(...);
+    ...
+    TestType = metaCodeunit.TestType;
+    RequiredTestIsolation = metaCodeunit.RequiredTestIsolation;
+}
 ```
 
-- The `<RequiredTestIsolation>k__BackingField` has **zero writes** anywhere in `Ncl.dll`
-  (`find_usages` returns an empty set on 28.1).
-- The private constructor sets `subscriberReflectionWrapper` and `base.ALNamespace`, nothing else.
-- `LoadOptionsFromAttributeOrInstance`, which *does* read `NavCodeunitOptionsAttribute`,
-  assigns only `tableId` and `subtype`.
+So the value comes from `Types.dll`'s `MetaCodeunit(XmlNode)`, which defaults the field and then
+matches attributes by name and length:
 
-`private set` with no writer means the property is permanently at its default, `0`, which this
-column names `None`. Verified identical on `bc270` and `bc281`, so it is not a version quirk.
+```csharp
+case 21:                                  // name.Length
+    if (name == "RequiredTestIsolation")
+        RequiredTestIsolation = (TestCodeunitRequiredTestIsolation)Enum.Parse(...);
+```
+
+**The AL compiler emits the attribute as `TestIsolation`** — 13 characters — so the length-21
+branch never fires and the field keeps its constructor default `0` = `None`. That matches the
+corpus failure exactly: `Expected:<1>` (Disabled) `Actual:<None>`.
 
 **BC's default is therefore the faithful answer**, and `NavValue.GetDefaultNavValue` already
-gives it. This is not a known gap: there is nothing to implement, because the tier value is
-not derived from anything the runner could read better.
+gives it. This is not a known gap: there is nothing to implement.
+
+**What to re-check if this ever changes**: whether BC's parser label and the compiler's emitted
+attribute name still disagree. That is the governing fact — not whether anything assigns the
+property, which is a stably-false-looking irrelevance.
 
 ### What was tried, and why it is recorded here
 
 The first implementation of #3606 converted this column from the document's `TestIsolation`
-attribute, on the reasoning that BC's own XML parser matches `RequiredTestIsolation` — a name
-the compiler never writes — so the document path must not be the tier's path, and the
-compiler's name must be the one that tracks what a tier reports.
+attribute, and a service tier refuted it on all eight cloud legs. The conversion, its
+runner-side tests and the two corpus assertions were removed rather than adjusted.
 
-The first half is true and the conclusion does not follow. The tier's row does travel
-`NCLMetaCodeunit` rather than the XML parser, but that path does not carry the value either.
-Both routes leave the property at `None`; the tier's behaviour happens to match what the XML
-parser's name mismatch would produce, for a different reason.
+An earlier revision of this page then blamed the wrong mechanism. It claimed the property was
+"never assigned" and that its backing field had "zero writes anywhere in `Ncl.dll`", citing an
+empty `find_usages`. **Both statements are false.** `find_usages` on a
+`<Property>k__BackingField` does not see writes routed through the compiler-generated setter, so
+the empty result was a tool artifact rather than a finding — a false negative of the same family
+`CLAUDE.md` documents for `grep -E` and `rg`. A Mono.Cecil scan over every method body found the
+write immediately, present on 27.0, 28.1 and 28.4.
 
-That is the whole lesson: reading BC's parser established which path is *not* used, and was
-taken as evidence for what the used path answers. Only the service tier settled it. The
-conversion, its runner-side tests and the two corpus assertions were removed rather than
-adjusted.
+Two lessons, cheap to state and expensive to relearn:
 
-<a id="what-the-compiler-emits"></a>
-
-## What the compiler actually emits, per declaration shape
-
-This is a measurement of the **document**, which is a different thing from what the column
-answers — see [`#requiredtestisolation`](#requiredtestisolation), where a tier answers `None`
-whatever this table says. It is kept because it explains the figure #3606 was filed on, and
-because the next person to notice `TestIsolation` sitting in the document will otherwise
-re-derive it.
-
-Measured on BC 28.1.49838.53910 by compiling one codeunit of each shape and dumping the
-captured document with `AL_RUNNER_TRACE_OBJECT_METADATA=2`:
-
-| declaration | `TestIsolation` attribute |
-|---|---|
-| `Subtype = Normal`, property absent | `"Disabled"` |
-| `Subtype = TestRunner`, property absent | `"Disabled"` |
-| `Subtype = TestRunner`, property declared | the declared member |
-| `Subtype = Test` | **absent** |
-
-So the compiler supplies `Disabled` for everything except a `Subtype = Test` codeunit.
-
-That identifies #3606's "stated for 1,658 of 1,690" figure: the 32 Base Application documents
-with no `TestIsolation` attribute are the test codeunits, not codeunits that "declined to
-state" a property others stated.
-
-**None of it reaches the column.** A tier answers `None` for all four rows above, including
-the third — which is exactly what makes the document a bad source for this column and is why
-`RequiredTestIsolation` is defaulted rather than converted.
-
-**Two AL constraints make most of this unreachable from AL**, which is why the runner-side
-mechanism tests in `AlRunner.Tests/CodeunitMetadataDocumentColumnTests.cs` exist alongside the
-corpus tests:
-
-- `AL0223` — `TestIsolation` is accepted only when `Subtype = TestRunner`.
-- `AL0195` — on a codeunit, `InherentPermissions` and `InherentEntitlements` accept only `X`.
-
-<a id="permission-mask-spelling"></a>
-
-## How a permission mask is spelled
-
-`MetadataDataProvider.CreatePermissionMaskString` (Ncl.dll) returns `NavText.Empty` for
-`PermissionMask.None`; otherwise it walks bits 0..4 and emits `permissions[n]` for a direct
-bit, or `permissions[n] + 32` — the lowercase letter — for the matching indirect bit at `n+5`.
-It sizes its stack buffer with `PopCount((num >> 5) | (num & 0x1F))`, so one permission never
-contributes two characters.
-
-`permissions` is a static `char[5]` initialized from a blob. Decoded from BC 28.1's
-`<PrivateImplementationDetails>`:
-
-```
-52 00 49 00 4D 00 44 00 58 00   ->  'R' 'I' 'M' 'D' 'X'
-```
-
-`PermissionMask` itself (Types.dll) numbers `Read=1, Insert=2, Modify=4, Delete=8,
-Execute=16`, then `IndirectRead=32` … `IndirectExecute=512`, plus flags above that
-(`HasExpDate=4096`, `IgnoreWildcard=32768`) which no permission column spells.
-
-The attribute BC emits is the mask's **numeric** value — `InherentPermissions="16"` for
-`InherentPermissions = X` — and BC's own parser reads it with
-`Enum.Parse(typeof(PermissionMask), value)`, which accepts a numeric string or a member name.
-The runner accepts both for the same reason, and refuses anything it cannot read rather than
-answering the empty string, which would be indistinguishable from a codeunit declaring no
-permission.
-
-<a id="the-two-columns-left-at-bcs-default"></a>
-
-## The two columns left at BC's default
-
-Neither is waiting on this conversion; neither is in the document to convert.
-
-**`App ID`** is not an object property. BC fills it with
-`MetadataDataProvider.GetAppId(metaCodeunit)` — the id of the app the object was *published*
-from, which is per-run state a compiler cannot emit. Answering it needs per-object app
-attribution, the same data #2326 tracks for `AllObj`'s "Object Subtype".
-
-**`TestType`** is emitted **0 times** in Base Application's 1,690 codeunit documents, and BC
-does not read it from the document either. `MetaCodeunit`'s ctor **derives** it, in a tail
-block after the attribute loop:
-
-```
-if (SubType == CodeunitSubType.Test && TestType == 0)
-    TestType = TestCodeunitTestType.UnitTest;      // i.e. 1
-```
-
-So a service tier reports `UnitTest` for a test codeunit that declares nothing, which is a
-derivation rather than a stated value. Reproducing it is a separate claim about BC needing its
-own corpus test, and is deliberately not part of #3606.
-
-<a id="what-adjudicated-this"></a>
-
-## What adjudicated this
-
-Corpus PR 296 (`StefanMaron/BusinessCentral.AL.Language.Tests`), on eight cloud legs.
-
-**Green, and what the two converted columns rest on:**
-
-- `Record_CodeunitMetadata_Get_InherentPermissionsAndEntitlements_ReadIndependently` — a
-  codeunit declaring `InherentPermissions = X` reports `'X'` while its entitlement column
-  stays empty, and the reverse for the sibling; a codeunit declaring neither reports both
-  empty.
-- `Record_CodeunitMetadata_Get_ALNamespace_ReportsTheDeclaringFilesNamespace` — a namespaced
-  codeunit reports its full dotted namespace, an un-namespaced one the empty string.
-
-Both fail against the runner as it stood before #3606, with concrete wrong values: `''` where
-`X` is declared, `''` where a namespace is declared.
-
-**Red on all eight, and removed:** two `RequiredTestIsolation` tests, which asserted the
-column tracks the declared property. It does not — see
-[`#requiredtestisolation`](#requiredtestisolation). They were dropped from the corpus PR
-rather than inverted to assert `None`: pinning an observation without a mechanism is what
-`.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md` forbids, and the mechanism that
-*was* established (a property `Ncl.dll` never assigns) is a fact about the runtime engine
-rather than about AL, so it has no AL assertion that would fail if it were different.
+- **An empty result from one tool is not evidence.** Confirm it with a differently-shaped query
+  before building an argument on it — the rule this repository already applies to search.
+- **Establishing which path is *unused* says nothing about what the used path answers.** The
+  earlier reasoning correctly found the parser's name mismatch, then discarded it on the strength
+  of the false zero. It was the answer all along.


### PR DESCRIPTION
`docs/codeunit-metadata-from-bc.md` explains why BC answers `RequiredTestIsolation::None`. Its explanation is wrong, and the explanation it explicitly dismisses is the correct one.

**The shipped behaviour is unchanged and still correct** — BC's default is the faithful answer, exactly as PR #3618 concluded and as eight cloud legs measured. Only the stated mechanism was wrong. This PR touches one documentation file and no code.

No linked issue: corrects a false mechanism explanation introduced by merged PR #3618; no behaviour change and no defect to track, so there is nothing to close.

Corpus-NA: documentation-only correction to a mechanism explanation; no AL-observable behaviour changes, so no corpus test can express it.

## What the page claimed

> `NCLMetaCodeunit.RequiredTestIsolation` is a property nothing ever assigns
> The `<RequiredTestIsolation>k__BackingField` has **zero writes** anywhere in `Ncl.dll` (`find_usages` returns an empty set on 28.1)

and, of the XML-parser name mismatch:

> The first half is true and the conclusion does not follow.

## Both claims are false

`NCLMetaCodeunit.LoadMetadata()` assigns the property directly:

```csharp
protected override void LoadMetadata()
{
    base.LoadMetadata();
    MetaCodeunit metaCodeunit = base.ObjectLoader.XmlMetadataLoader.GetMetaCodeunit(...);
    ...
    RequiredTestIsolation = metaCodeunit.RequiredTestIsolation;
}
```

**The empty `find_usages` was a tool artifact, not a finding.** A query against a `<Property>k__BackingField` does not see writes routed through the compiler-generated setter. A Mono.Cecil scan over every method body finds the write immediately, present on 27.0, 28.1 and 28.4 — including the version the page cited. This is the same false-negative family `CLAUDE.md` documents for `grep -E` and `rg`.

## The real mechanism is the name mismatch after all

`Types.dll`'s `MetaCodeunit(XmlNode)` defaults the field, then matches attributes by name **and length**:

```csharp
case 21:                                  // name.Length
    if (name == "RequiredTestIsolation")
        RequiredTestIsolation = (TestCodeunitRequiredTestIsolation)Enum.Parse(...);
```

The AL compiler emits the attribute as **`TestIsolation`** — 13 characters — so the length-21 branch never fires and the field keeps its constructor default `0` = `None`. That matches the corpus failure exactly: `Expected:<1>` (Disabled) `Actual:<None>`.

Verified independently with the decompiler against `bc281` and cross-checked on `bc270`. The reviewer then closed the chain empirically: **2,167 occurrences of `TestIsolation="…"` against 0 of `RequiredTestIsolation`** across the cached emitted documents.

## Why it matters even though no behaviour changes

Durability. A future reader checking "does anything assign this property" checks a stably-false-looking irrelevance, and would conclude the page is still accurate. The governing fact is whether BC's parser label and the compiler's emitted attribute name still disagree — so the page now says that explicitly, under **What to re-check if this ever changes**.

The page also now records the two lessons rather than the wrong conclusion:

- **An empty result from one tool is not evidence.** Confirm it with a differently-shaped query before building an argument on it.
- **Establishing which path is *unused* says nothing about what the used path answers.** The earlier reasoning found the parser's name mismatch, then discarded it on the strength of the false zero.

Found by the reviewer on PR #3618 after it merged.

---

Authored by an agent (Claude, `stma-auto-2`) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
