### PR TITLE
fix(metadata): apply tableextension modify(...) deltas from BC's document, and match the enum keyword case-insensitively

### DIFF
--- a/AlRunner.Tests/EnumTypeKeywordCaseTests.cs
+++ b/AlRunner.Tests/EnumTypeKeywordCaseTests.cs
@@ -1,0 +1,91 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #3574 — the enum-typed-field fix-up matches the field's raw AL source spelling, and AL
+/// keywords are case-insensitive, so <c>enum "X"</c> and <c>ENUM "X"</c> must resolve exactly
+/// as <c>Enum "X"</c> does.
+///
+/// <para>Why the failure was easy to miss, and why this test is worth its line: the field's
+/// runtime TYPE was never wrong. <c>MapNavType</c> uppercases before comparing, so a
+/// lowercase-declared enum field still became <c>NavType.Option</c> and ordinary reads of it
+/// worked. Only the ordinal-keyed option metadata went missing, which surfaces much later and
+/// somewhere else — measured on a probe bundle, as
+/// <c>GetEnumValueNameFromOrdinalValue</c> raising "An object with that ID does not exist",
+/// and on the corpus fixture as the whole bundle aborting with
+/// <c>NavMetadataNotFoundException</c> out of the Field virtual table.</para>
+///
+/// <para>The AL-observable claim — that all three spellings produce identical enum metadata —
+/// is adjudicated by a real service tier in corpus PR #304
+/// (<c>.claude/rules/bc-behavior-tests-go-upstream.md</c>). What is pinned here is the runner's
+/// own pattern, because a regex is where the defect was and where a regression would
+/// reappear.</para>
+/// </summary>
+public class EnumTypeKeywordCaseTests
+{
+    /// <summary>
+    /// The live pattern, read off the field rather than restated here. A copy of the regex
+    /// would keep passing after someone edited the real one, which is the one thing this test
+    /// must not do.
+    /// </summary>
+    private static Regex EnumTypeNameRegex()
+    {
+        var field = typeof(RecordPatches).GetField(
+            "_rxEnumTypeName", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(field);
+        return Assert.IsType<Regex>(field!.GetValue(null));
+    }
+
+    private static string? MatchedEnumName(string typeName)
+    {
+        var m = EnumTypeNameRegex().Match(typeName);
+        if (!m.Success) return null;
+        return m.Groups[1].Success ? m.Groups[1].Value : m.Groups[2].Value;
+    }
+
+    [Theory]
+    // The canonical spelling — the control. It passed before the fix, and a change that broke
+    // it while fixing the others would be a regression this row catches.
+    [InlineData("Enum \"ALT Status\"")]
+    [InlineData("enum \"ALT Status\"")]
+    [InlineData("ENUM \"ALT Status\"")]
+    // Mixed case is legal AL too; nothing about the keyword is position-sensitive.
+    [InlineData("EnUm \"ALT Status\"")]
+    public void EveryCapitalizationOfTheEnumKeyword_ResolvesTheSameQuotedEnumName(string typeName)
+        => Assert.Equal("ALT Status", MatchedEnumName(typeName));
+
+    [Theory]
+    [InlineData("Enum MyStatus")]
+    [InlineData("enum MyStatus")]
+    [InlineData("ENUM MyStatus")]
+    public void EveryCapitalizationOfTheEnumKeyword_ResolvesTheSameUnquotedEnumName(string typeName)
+        => Assert.Equal("MyStatus", MatchedEnumName(typeName));
+
+    [Theory]
+    // A quoted name may hold spaces and punctuation; the fix must not have narrowed that.
+    [InlineData("enum \"Name With Spaces\"", "Name With Spaces")]
+    [InlineData("ENUM \"Name-With-Dashes\"", "Name-With-Dashes")]
+    // Leading and trailing whitespace is what ParseFieldSyntax's raw `f.Type.ToString()` can
+    // carry, so the pattern anchors around it rather than assuming a trimmed value.
+    [InlineData("  enum \"Padded\"  ", "Padded")]
+    public void QuotedAndPaddedEnumNames_StillParse_AfterTheCaseRelaxation(string typeName, string expected)
+        => Assert.Equal(expected, MatchedEnumName(typeName));
+
+    [Theory]
+    // The negative direction. IgnoreCase relaxes the KEYWORD's case, and nothing else: a type
+    // whose name merely starts with those four letters is not an enum declaration, and neither
+    // is a bare `Enum` with no name. Without these rows the fix could have been "match
+    // anything containing enum" and every row above would still pass.
+    [InlineData("Enumerable")]
+    [InlineData("enumeration \"X\"")]
+    [InlineData("Enum")]
+    [InlineData("Option")]
+    [InlineData("Text[50]")]
+    [InlineData("Integer")]
+    public void ATypeThatIsNotAnEnumDeclaration_DoesNotMatch(string typeName)
+        => Assert.Null(MatchedEnumName(typeName));
+}

--- a/AlRunner.Tests/TableExtensionFieldDeltaTests.cs
+++ b/AlRunner.Tests/TableExtensionFieldDeltaTests.cs
@@ -1,0 +1,181 @@
+using AlRunner;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #3614 — the runner reads a tableextension's <c>modify(&lt;field&gt;)</c> property changes out
+/// of BC's own emitted delta document rather than re-deriving them from AL syntax.
+///
+/// <para>These pin the RUNNER-SIDE mechanism: that the delta document is parsed into the right
+/// field ids and captions, that a change naming a field the table does not have is reported
+/// rather than dropped, and that a malformed document is loud. The BC-behaviour claim itself —
+/// that <c>modify(...)</c> changes the caption AL reads back at all, with control arms for an
+/// unmodified field and for the field the same extension adds — is adjudicated by a real
+/// service tier in corpus PR #304, not here
+/// (<c>.claude/rules/bc-behavior-tests-go-upstream.md</c>).</para>
+///
+/// <para>The XML in these tests is not invented: it is what BC 28.1's emitter produced for a
+/// probe tableextension, captured through <c>AL_RUNNER_TRACE_OBJECT_METADATA=2</c>. An
+/// <c>ENU=</c>-prefixed <c>CaptionML</c> and a <c>TargetType="MetaField"</c> attribute are BC's
+/// shape, not this test's convention.</para>
+/// </summary>
+public class TableExtensionFieldDeltaTests
+{
+    private const int ExtensionId = 70901;
+
+    /// <summary>Exactly what BC 28.1 emitted for `modify(Description) { Caption = '...'; }`.</summary>
+    private const string RealDeltaXml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <MetadataRuntimeDeltas xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" MetadataVersion="130000" ID="70901" Name="Probe Ext" ALNamespace="" xmlns="urn:schemas-microsoft-com:dynamics:NAV:MetaObjects">
+          <FieldChange TargetID="2" TargetType="MetaField" CaptionML="ENU=Modified Description" />
+        </MetadataRuntimeDeltas>
+        """;
+
+    private static void Register(string xml) =>
+        AlObjectMetadataRegistry.Register(
+            RecordPatches.BcTableExtensionMetadataKind, ExtensionId, "Probe Ext", xml);
+
+    [Fact]
+    public void ReadBcFieldChanges_ReadsTheTargetFieldIdAndCaption_FromBcsOwnDocument()
+    {
+        Register(RealDeltaXml);
+
+        var changes = RecordPatches.ReadBcFieldChanges(ExtensionId);
+
+        var change = Assert.Single(changes);
+        Assert.Equal(2, change.TargetFieldId);
+        // Unwrapped from CaptionML's `ENU=` form: the derivation's ParsedField.Caption is the
+        // plain text, so a reader that passed the raw attribute through would put
+        // "ENU=Modified Description" on the field.
+        Assert.Equal("Modified Description", change.Caption);
+    }
+
+    [Fact]
+    public void ReadBcFieldChanges_AnswersEmpty_ForAnExtensionWithNoDocument()
+    {
+        // The ordinary case, and the one that must not throw: an extension that only ADDS
+        // fields emits no FieldChange, and BC folds its added fields into the base table's
+        // own document instead.
+        Assert.Empty(RecordPatches.ReadBcFieldChanges(int.MaxValue - 3614));
+    }
+
+    [Fact]
+    public void ReadBcFieldChanges_SkipsAnEntryThatIsNotAboutAField()
+    {
+        // MetadataRuntimeDeltas is the envelope BC uses for several extension kinds, so a
+        // non-MetaField entry is skipped deliberately rather than misread as a field change.
+        Register("""
+            <MetadataRuntimeDeltas xmlns="urn:schemas-microsoft-com:dynamics:NAV:MetaObjects">
+              <FieldChange TargetID="2" TargetType="MetaKey" CaptionML="ENU=Not A Field" />
+              <FieldChange TargetID="7" TargetType="MetaField" CaptionML="ENU=A Real One" />
+            </MetadataRuntimeDeltas>
+            """);
+
+        var change = Assert.Single(RecordPatches.ReadBcFieldChanges(ExtensionId));
+        Assert.Equal(7, change.TargetFieldId);
+        Assert.Equal("A Real One", change.Caption);
+    }
+
+    [Fact]
+    public void ReadBcFieldChanges_AnswersNothing_ForAChangeThatCarriesNoCaption()
+    {
+        // Measured: a design-time-only property (`Description`) makes BC emit a FieldChange
+        // with no property attributes at all. That is normal and is NOT a discard to report —
+        // there is no runtime property change in it.
+        Register("""
+            <MetadataRuntimeDeltas xmlns="urn:schemas-microsoft-com:dynamics:NAV:MetaObjects">
+              <FieldChange TargetID="2" TargetType="MetaField" />
+            </MetadataRuntimeDeltas>
+            """);
+
+        Assert.Empty(RecordPatches.ReadBcFieldChanges(ExtensionId));
+    }
+
+    [Fact]
+    public void ReadBcFieldChanges_ReportsAnUnreadableTargetId_RatherThanDroppingItSilently()
+    {
+        // The #3614 shape itself: a value that cannot be applied must SAY so. The diagnostic
+        // text is asserted, not merely its existence — a drop that logs nothing and a drop
+        // that logs at a verbosity nobody runs are the same defect.
+        Register("""
+            <MetadataRuntimeDeltas xmlns="urn:schemas-microsoft-com:dynamics:NAV:MetaObjects">
+              <FieldChange TargetID="not-a-number" TargetType="MetaField" CaptionML="ENU=Lost" />
+            </MetadataRuntimeDeltas>
+            """);
+
+        var stderr = new StringWriter();
+        var previous = Console.Error;
+        try
+        {
+            Console.SetError(stderr);
+            Assert.Empty(RecordPatches.ReadBcFieldChanges(ExtensionId));
+        }
+        finally { Console.SetError(previous); }
+
+        var written = stderr.ToString();
+        Assert.Contains("[TableExtDelta]", written);
+        Assert.Contains("no readable TargetID", written);
+        Assert.Contains("NOT applied", written);
+    }
+
+    [Fact]
+    public void ReadBcFieldChanges_ReportsAMalformedDocument_AndAnswersNothing()
+    {
+        // The document is the compiler's own output, so a malformed one is a runner-side shape
+        // gap worth seeing. It must not shrink quietly to "no changes" — that is exactly the
+        // silent discard this issue is about, one level up.
+        Register("<MetadataRuntimeDeltas><FieldChange TargetID=\"2\"");
+
+        var stderr = new StringWriter();
+        var previous = Console.Error;
+        try
+        {
+            Console.SetError(stderr);
+            Assert.Empty(RecordPatches.ReadBcFieldChanges(ExtensionId));
+        }
+        finally { Console.SetError(previous); }
+
+        var written = stderr.ToString();
+        Assert.Contains("[TableExtDelta]", written);
+        Assert.Contains("could not be parsed", written);
+        Assert.Contains("NOT applied", written);
+    }
+
+    [Fact]
+    public void ReadBcFieldChanges_ReadsEveryChangeAnExtensionDeclares()
+    {
+        // One modify(...) block per field produces one FieldChange each. A reader that stopped
+        // at the first would apply one field's change and drop the rest — a partial answer,
+        // which is worse than none because it looks like it worked.
+        Register("""
+            <MetadataRuntimeDeltas xmlns="urn:schemas-microsoft-com:dynamics:NAV:MetaObjects">
+              <FieldChange TargetID="2" TargetType="MetaField" CaptionML="ENU=First" />
+              <FieldChange TargetID="3" TargetType="MetaField" CaptionML="ENU=Second" />
+              <FieldChange TargetID="4" TargetType="MetaField" CaptionML="ENU=Third" />
+            </MetadataRuntimeDeltas>
+            """);
+
+        var changes = RecordPatches.ReadBcFieldChanges(ExtensionId);
+
+        Assert.Equal(3, changes.Count);
+        Assert.Equal(new[] { 2, 3, 4 }, changes.Select(c => c.TargetFieldId));
+        Assert.Equal(new[] { "First", "Second", "Third" }, changes.Select(c => c.Caption));
+    }
+
+    [Fact]
+    public void ReadBcFieldChanges_ReadsTheEnuCaption_FromAMultiLanguageAttribute()
+    {
+        // CaptionML is a `;`-separated list of `<lang>=<text>`. The runner is single-language
+        // and every other caption it handles is the ENU one; a reader that took the first
+        // entry would answer the wrong language here.
+        Register("""
+            <MetadataRuntimeDeltas xmlns="urn:schemas-microsoft-com:dynamics:NAV:MetaObjects">
+              <FieldChange TargetID="2" TargetType="MetaField" CaptionML="DEU=Deutsch;ENU=English;FRA=Francais" />
+            </MetadataRuntimeDeltas>
+            """);
+
+        Assert.Equal("English", Assert.Single(RecordPatches.ReadBcFieldChanges(ExtensionId)).Caption);
+    }
+}

--- a/AlRunner.Tests/TableExtensionFieldDeltaTests.cs
+++ b/AlRunner.Tests/TableExtensionFieldDeltaTests.cs
@@ -20,7 +20,17 @@ namespace AlRunner.Tests;
 /// probe tableextension, captured through <c>AL_RUNNER_TRACE_OBJECT_METADATA=2</c>. An
 /// <c>ENU=</c>-prefixed <c>CaptionML</c> and a <c>TargetType="MetaField"</c> attribute are BC's
 /// shape, not this test's convention.</para>
+///
+/// <para>Serialized for two independent reasons, both of which this one attribute covers.
+/// The two loudness tests swap <c>Console.SetError</c>, which is PROCESS-wide, so a
+/// concurrent class's <c>finally</c> could restore the real console mid-window and the
+/// diagnostic would read as swallowed — <see cref="ConsoleSwapIsolationGuardTests"/> enforces
+/// that. And every test here registers under one shared key (extension 70901) in the static
+/// <see cref="AlObjectMetadataRegistry"/>, which <see cref="ObjectMetadataRegistryTests"/>
+/// calls <c>Clear()</c> on in its own constructor and <c>Dispose</c>. This collection is the
+/// one those tests already use, so joining it fences both.</para>
 /// </summary>
+[Collection("object-metadata-registry")]
 public class TableExtensionFieldDeltaTests
 {
     private const int ExtensionId = 70901;
@@ -162,6 +172,59 @@ public class TableExtensionFieldDeltaTests
         Assert.Equal(3, changes.Count);
         Assert.Equal(new[] { 2, 3, 4 }, changes.Select(c => c.TargetFieldId));
         Assert.Equal(new[] { "First", "Second", "Third" }, changes.Select(c => c.Caption));
+    }
+
+    [Fact]
+    public void ReadBcFieldChanges_ReportsAPropertyItDoesNotApply_RatherThanIgnoringIt()
+    {
+        // Seven properties are legal in a table field's modify(...) and only Caption has an
+        // AL-readable surface on the derivation today. Staying quiet about the other six would
+        // rebuild #3614's own defect one level down — a change BC stated, dropped with nothing
+        // said. Both attributes below are real: BC emits OptionCaptionML for
+        // `OptionCaption = 'a,b'` on an Option field and BlankZero="1" for `BlankZero = true`
+        // on a Decimal field, measured on probe bundles.
+        Register("""
+            <MetadataRuntimeDeltas xmlns="urn:schemas-microsoft-com:dynamics:NAV:MetaObjects">
+              <FieldChange TargetID="4" TargetType="MetaField" OptionCaptionML="ENU=a,b" BlankZero="1" />
+            </MetadataRuntimeDeltas>
+            """);
+
+        var stderr = new StringWriter();
+        var previous = Console.Error;
+        try
+        {
+            Console.SetError(stderr);
+            // No Caption in this delta, so nothing is applied — but something WAS declared.
+            Assert.Empty(RecordPatches.ReadBcFieldChanges(ExtensionId));
+        }
+        finally { Console.SetError(previous); }
+
+        var written = stderr.ToString();
+        Assert.Contains("OptionCaptionML", written);
+        Assert.Contains("BlankZero", written);
+        // The field must be named: "some property was dropped somewhere" is not actionable.
+        Assert.Contains("field 4", written);
+        Assert.Contains("does not apply", written);
+    }
+
+    [Fact]
+    public void ReadBcFieldChanges_SaysNothingAboutTheAttributesItDoesApplyOrIgnoresByDesign()
+    {
+        // The negative direction, and the one that keeps the diagnostic worth reading. A
+        // report on CaptionML (applied) or on TargetID/TargetType (bookkeeping) would fire on
+        // every ordinary delta, and a warning that always fires is one nobody reads.
+        Register(RealDeltaXml);
+
+        var stderr = new StringWriter();
+        var previous = Console.Error;
+        try
+        {
+            Console.SetError(stderr);
+            Assert.Single(RecordPatches.ReadBcFieldChanges(ExtensionId));
+        }
+        finally { Console.SetError(previous); }
+
+        Assert.DoesNotContain("[TableExtDelta]", stderr.ToString());
     }
 
     [Fact]

--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -529,6 +529,15 @@ public static partial class BcRuntime
         AlRunner.Patches.RecordPatches.RebuildTablesFromBcMetadataAll();
         AlRunner.PerfTrace.Log($"SetTestAssembly.RebuildTablesFromBcMetadataAll {sw.ElapsedMilliseconds}ms");
 
+        // #3614 — the derivation-route sibling of the call above, and it runs for the same
+        // reason: a tableextension's modify(...) property changes live in the extension's own
+        // delta document, which Emit registers only after the AddSourceDir pass that built the
+        // table. Evicts the affected tables so the next lookup rebuilds them with the deltas
+        // applied; a bundle declaring no modify(...) evicts nothing.
+        sw.Restart();
+        AlRunner.Patches.RecordPatches.ApplyTableExtensionFieldDeltasAll();
+        AlRunner.PerfTrace.Log($"SetTestAssembly.ApplyTableExtensionFieldDeltasAll {sw.ElapsedMilliseconds}ms");
+
         // Field-level OnValidate/OnLookup wiring. NCLMetaField.EventTriggerDataValue
         // must point at the AL-emitted [FieldTriggerHandler] methods on the Record CLR
         // class. The NCLMetaTable was built during AddSourceDir (before AL emit), so

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -153,6 +153,14 @@ public static partial class RecordPatches
             var extFields = _parsedExtensionFields.TryGetValue(parsed.TableName.ToLowerInvariant(), out var ef)
                 ? ef : Enumerable.Empty<ParsedField>();
 
+            // #3614 — a tableextension's `modify(<field>)` block changes an EXISTING field's
+            // properties, and BC leaves that change in the extension's own delta document
+            // rather than folding it into this table's. Apply it here, ahead of the route
+            // choice, so the corrected field list is what every consumer below sees.
+            // Reads BC's own <FieldChange> rather than re-deriving the change from AL syntax;
+            // RecordPatches.TableExtensionFieldDeltas.cs has the reasoning and the measurement.
+            parsed = parsed with { Fields = ApplyTableExtensionFieldDeltas(parsed.TableName, parsed.Fields).ToList() };
+
             // #3552 — when BC's emitter handed the runner its own metadata document for this
             // table (#3548), let BC construct the NCLMetaTable from it rather than deriving one
             // below. AVAILABILITY decides the route, and a failure is never re-routed to the
@@ -2197,9 +2205,19 @@ public static partial class RecordPatches
     // (NavOption.Create, GetOptionFromIndex, IsValidOrdinal, ...) behave with
     // BC NCLEnumMetadata semantics — ordinal-keyed, not array-index-keyed.
     private static System.Reflection.FieldInfo? _fNCLMetaFieldFieldOptionMetadata;
+    // IgnoreCase because AL keywords are case-insensitive and this matches the field's RAW
+    // SOURCE SPELLING — ParseFieldSyntax stores `f.Type.ToString()` verbatim, so `enum "X"`
+    // and `ENUM "X"` reach here exactly as written (#3574). Matching only `Enum` made the
+    // failure silent AND narrow: MapNavType uppercases before comparing, so the field still
+    // got the right NavType.Option and every read of the field worked — only the ordinal-keyed
+    // option metadata went missing, surfacing much later as
+    // GetEnumValueNameFromOrdinalValue raising "An object with that ID does not exist".
+    // Every other regex in this repo that matches an AL source keyword already carries
+    // IgnoreCase; this was the only one that did not.
     private static System.Text.RegularExpressions.Regex _rxEnumTypeName = new(
         "^\\s*Enum\\s+(?:\"([^\"]+)\"|([A-Za-z_][\\w]*))\\s*$",
-        System.Text.RegularExpressions.RegexOptions.Compiled);
+        System.Text.RegularExpressions.RegexOptions.IgnoreCase
+        | System.Text.RegularExpressions.RegexOptions.Compiled);
 
     // Re-apply enum field-option metadata for every cached NCLMetaTable. Called
     // from BcRuntime.SetTestAssembly after Emit, by which time AlEnumMetadataRegistry

--- a/AlRunner/Patches/RecordPatches.TableExtensionFieldDeltas.cs
+++ b/AlRunner/Patches/RecordPatches.TableExtensionFieldDeltas.cs
@@ -109,6 +109,8 @@ public static partial class RecordPatches
 
                 if (caption != null)
                     changes.Add(new BcFieldChange(targetId, caption));
+
+                ReportUnappliedAttributes(extensionId, targetId, node);
             }
             return changes;
         }
@@ -119,6 +121,44 @@ public static partial class RecordPatches
                 + $"parsed ({ex.GetType().Name}: {ex.Message}); every modify(...) property change it "
                 + "declares is NOT applied");
             return Array.Empty<BcFieldChange>();
+        }
+    }
+
+    /// <summary>
+    /// Attributes on a <c>&lt;FieldChange&gt;</c> that carry no property change to apply:
+    /// the two that identify the entry, and the ones BC puts on every element.
+    /// </summary>
+    private static readonly HashSet<string> FieldChangeBookkeepingAttributes =
+        new(StringComparer.Ordinal) { "TargetID", "TargetType", "xmlns" };
+
+    /// <summary>
+    /// Report every property this reader did NOT apply, naming the property and the field.
+    ///
+    /// <para>Seven properties are legal in a table field's <c>modify(...)</c> and only
+    /// <c>Caption</c> has an AL-readable surface on the derivation today
+    /// (docs/object-metadata-from-bc.md#modify-accepts). Staying quiet about the other six
+    /// would rebuild the exact defect #3614 reports one level down: a property change BC
+    /// stated, dropped with nothing said. So the unhandled ones are named rather than
+    /// ignored, and the next one to acquire a surface shows up as a diagnostic instead of as
+    /// a wrong value.</para>
+    ///
+    /// <para>Attribute-driven rather than a list of known-unhandled names: a property BC adds
+    /// later is reported the day it appears, with no edit here.</para>
+    /// </summary>
+    private static void ReportUnappliedAttributes(int extensionId, int targetFieldId, XmlElement node)
+    {
+        foreach (var attribute in node.Attributes.OfType<XmlAttribute>())
+        {
+            var name = attribute.LocalName;
+            if (FieldChangeBookkeepingAttributes.Contains(name)) continue;
+            if (name.StartsWith("xmlns", StringComparison.Ordinal)) continue;
+            // The one this reader does apply.
+            if (string.Equals(name, "CaptionML", StringComparison.Ordinal)) continue;
+
+            Console.Error.WriteLine(
+                $"[TableExtDelta] tableextension {extensionId}: modify(...) on field {targetFieldId} "
+                + $"declares {name}='{attribute.Value}', which this runner does not apply — the field "
+                + "keeps its original value. See docs/object-metadata-from-bc.md#modify-accepts");
         }
     }
 

--- a/AlRunner/Patches/RecordPatches.TableExtensionFieldDeltas.cs
+++ b/AlRunner/Patches/RecordPatches.TableExtensionFieldDeltas.cs
@@ -1,0 +1,236 @@
+// RecordPatches.TableExtensionFieldDeltas — apply a tableextension's `modify(<field>)`
+// property changes, read from BC's OWN emitted delta document (issue #3614).
+//
+// WHY BC'S DOCUMENT AND NOT THE AL SOURCE
+//   The AL parse discards `modify(...)` at the syntax level: TryParseTableExtensionFile
+//   filters the extension's field list with OfType<FieldSyntax>(), and a modify block parses
+//   as FieldModificationSyntax. Re-deriving the property list from that syntax would mean
+//   re-implementing AL's rules for which properties a modify block may even set — and those
+//   rules are narrow and non-obvious (see the table in
+//   docs/object-metadata-from-bc.md#modify-deltas). BC's compiler has already applied them and
+//   emitted the answer, which AlObjectMetadataRegistry has been capturing since #3548:
+//
+//     <MetadataRuntimeDeltas ID="70901" Name="Probe Ext">
+//       <FieldChange TargetID="2" TargetType="MetaField" CaptionML="ENU=Modified Description" />
+//     </MetadataRuntimeDeltas>
+//
+//   So this reads the compiler's conclusion rather than recomputing it. Measured on BC 28.1;
+//   the probe and the full per-property acceptance table are in
+//   docs/object-metadata-from-bc.md#modify-deltas.
+//
+// WHY THE BASE TABLE'S OWN DOCUMENT IS NOT ENOUGH
+//   BC's compiler folds an extension's ADDED fields into the base table's document (a
+//   same-app add-only extension therefore needs nothing from here, which is what #3600's
+//   relaxed guard rests on) but leaves MODIFIED properties in the extension's own delta.
+//   Both halves were measured on the same probe: the base document carried the added
+//   `<Field Name="Extra" ID="50">` while its `Description` field still read
+//   CaptionML="ENU=Original Caption".
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+using Microsoft.Dynamics.Nav.Runtime;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    /// <summary>The <see cref="AlObjectMetadataRegistry"/> kind a tableextension's delta
+    /// document is stored under. BC's emitter reports the AL SymbolKind, so this is
+    /// "TableExtension" even though the document's root element is
+    /// <c>MetadataRuntimeDeltas</c> — see docs/object-metadata-capture.md#which-kinds-arrive,
+    /// which records that mismatch as the thing that put a non-existent kind into #3562.</summary>
+    internal const string BcTableExtensionMetadataKind = "TableExtension";
+
+    /// <summary>
+    /// One field-property change a <c>modify(...)</c> block declared, as BC's delta states it.
+    /// Only properties the derivation can actually carry onto an AL-observable surface are
+    /// modelled; <see cref="ApplyTableExtensionFieldDeltas"/> reports anything else loudly
+    /// rather than dropping it, because a silently discarded delta is the defect #3614 is.
+    /// </summary>
+    /// <param name="TargetFieldId">The base-table field id the change applies to.</param>
+    /// <param name="Caption">The new caption, already unwrapped from CaptionML's
+    /// <c>ENU=</c> form, or null when the delta changes no caption.</param>
+    internal readonly record struct BcFieldChange(int TargetFieldId, string? Caption);
+
+    /// <summary>
+    /// Every <c>&lt;FieldChange&gt;</c> BC emitted for tableextension <paramref name="extensionId"/>,
+    /// or an empty list when it emitted no delta document (the ordinary case: an extension that
+    /// only ADDS fields produces no FieldChange at all).
+    ///
+    /// <para>Parse failures are LOUD and return nothing rather than a partial list. A delta
+    /// this cannot read is a property change that will not be applied, which is exactly the
+    /// silent discard #3614 reports — so it says so on stderr instead of shrinking quietly.
+    /// The document is the compiler's own output, so a malformed one is a runner-side shape
+    /// gap worth seeing, not a user error to tolerate.</para>
+    /// </summary>
+    internal static IReadOnlyList<BcFieldChange> ReadBcFieldChanges(int extensionId)
+    {
+        if (!AlObjectMetadataRegistry.TryGet(BcTableExtensionMetadataKind, extensionId, out var xml)
+            || string.IsNullOrEmpty(xml))
+            return Array.Empty<BcFieldChange>();
+
+        try
+        {
+            var doc = new XmlDocument();
+            doc.LoadXml(xml);
+
+            var changes = new List<BcFieldChange>();
+            foreach (var node in doc.GetElementsByTagName("FieldChange").OfType<XmlElement>())
+            {
+                // TargetType discriminates what the change is about. A tableextension's delta
+                // can carry entries for things other than a field property (BC uses the same
+                // MetadataRuntimeDeltas envelope for several extension kinds), so a non-field
+                // entry is skipped ON PURPOSE and not counted as a failure.
+                var targetType = node.GetAttribute("TargetType");
+                if (!string.Equals(targetType, "MetaField", StringComparison.Ordinal)) continue;
+
+                // A FieldChange with no readable TargetID cannot be applied to anything. That
+                // is a real discard, so it is reported rather than skipped — the diagnostic
+                // sits ABOVE the `continue`, which is the shape #3609 found dropped four
+                // times over.
+                if (!int.TryParse(node.GetAttribute("TargetID"), out var targetId))
+                {
+                    Console.Error.WriteLine(
+                        $"[TableExtDelta] tableextension {extensionId}: a <FieldChange> carries no readable "
+                        + $"TargetID (got '{node.GetAttribute("TargetID")}'); its property changes are NOT applied");
+                    continue;
+                }
+
+                // CaptionML is BC's multi-language form, `ENU=<text>`. The derivation's
+                // ParsedField.Caption is the plain text, the same shape CaptionFrom produces
+                // from AL source, so unwrap to match. An absent attribute means this delta
+                // changes no caption — an empty FieldChange is normal and NOT a failure: a
+                // design-time-only property (Description) emits exactly that.
+                string? caption = null;
+                var captionMl = node.GetAttribute("CaptionML");
+                if (!string.IsNullOrEmpty(captionMl))
+                    caption = UnwrapEnuCaption(captionMl);
+
+                if (caption != null)
+                    changes.Add(new BcFieldChange(targetId, caption));
+            }
+            return changes;
+        }
+        catch (XmlException ex)
+        {
+            Console.Error.WriteLine(
+                $"[TableExtDelta] tableextension {extensionId}: its metadata delta document could not be "
+                + $"parsed ({ex.GetType().Name}: {ex.Message}); every modify(...) property change it "
+                + "declares is NOT applied");
+            return Array.Empty<BcFieldChange>();
+        }
+    }
+
+    /// <summary>
+    /// The text of a BC <c>CaptionML</c>/<c>ToolTipML</c> attribute for the ENU language, or
+    /// null when it states none. The value is a semicolon-separated list of
+    /// <c>&lt;lang&gt;=&lt;text&gt;</c> pairs; the runner is single-language and every other
+    /// caption it handles is the ENU one, so this reads ENU and ignores the rest.
+    /// </summary>
+    private static string? UnwrapEnuCaption(string captionMl)
+    {
+        foreach (var part in captionMl.Split(';'))
+        {
+            var eq = part.IndexOf('=');
+            if (eq <= 0) continue;
+            if (string.Equals(part.Substring(0, eq).Trim(), "ENU", StringComparison.OrdinalIgnoreCase))
+                return part.Substring(eq + 1);
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Return <paramref name="fields"/> with every <c>modify(...)</c> property change declared
+    /// by any tableextension on <paramref name="baseTableName"/> applied, reading the changes
+    /// from BC's own delta documents.
+    ///
+    /// <para>Returns the input unchanged when no extension declares one, which is the common
+    /// case — so the ordinary path allocates nothing.</para>
+    ///
+    /// <para><b>A change naming a field that is not there is reported, never dropped.</b> BC's
+    /// compiler will not emit a FieldChange for a field that does not exist, so if one arrives
+    /// for an id this table has no field for, the runner's own field list disagrees with the
+    /// compiler's — a shape gap worth a line on stderr rather than a silent no-op.</para>
+    /// </summary>
+    internal static IReadOnlyList<ParsedField> ApplyTableExtensionFieldDeltas(
+        string baseTableName, IReadOnlyList<ParsedField> fields)
+    {
+        if (string.IsNullOrEmpty(baseTableName) || fields.Count == 0) return fields;
+        if (!_extensionIdsByBaseTable.TryGetValue(baseTableName.ToLowerInvariant(), out var extIds)
+            || extIds.Count == 0)
+            return fields;
+
+        // Later extensions win on a contested field id, matching the order BC applies deltas
+        // in — the registry is keyed per extension, and _extensionIdsByBaseTable preserves
+        // merge order.
+        Dictionary<int, BcFieldChange>? byFieldId = null;
+        foreach (var extId in extIds)
+            foreach (var change in ReadBcFieldChanges(extId))
+                (byFieldId ??= new Dictionary<int, BcFieldChange>())[change.TargetFieldId] = change;
+
+        if (byFieldId == null || byFieldId.Count == 0) return fields;
+
+        var known = new HashSet<int>(fields.Select(f => f.FieldId));
+        foreach (var fieldId in byFieldId.Keys)
+            if (!known.Contains(fieldId))
+                Console.Error.WriteLine(
+                    $"[TableExtDelta] table '{baseTableName}': a modify(...) delta targets field {fieldId}, "
+                    + "which this table has no field for; its property changes are NOT applied");
+
+        var result = new List<ParsedField>(fields.Count);
+        foreach (var f in fields)
+            result.Add(byFieldId.TryGetValue(f.FieldId, out var change) && change.Caption != null
+                ? f with { Caption = change.Caption }
+                : f);
+        return result;
+    }
+
+    /// <summary>
+    /// Drop every cached NCLMetaTable whose <c>modify(...)</c> deltas were not available when it
+    /// was built, so the next lookup rebuilds it with them applied.
+    ///
+    /// <para><b>Why an eviction and not an in-place poke.</b> A field's caption is a constructor
+    /// argument to <c>MetaField</c>, and BC answers <c>FieldCaption</c> from the ORIGINAL
+    /// <c>MetaTable</c> the NCLMetaTable was built from (<c>NCLMetaField.CreateCaptionStrings</c>
+    /// → <c>GetMetaTableOriginal</c>). There is no setter to poke: applying a caption change
+    /// means building the MetaField again, which means building the table again.</para>
+    ///
+    /// <para><b>Why it has to run post-emit at all.</b> <c>BuildNCLMetaTable</c> first runs during
+    /// AddSourceDir and <c>Emit</c> — which registers the delta documents — runs after it, so the
+    /// cold build sees an empty registry. Measured on the probe fixture: table 70900 was built
+    /// three log lines BEFORE its extension's delta document was registered. This is the same
+    /// ordering <see cref="RebuildTablesFromBcMetadataAll"/> and
+    /// <c>FixupEnumFieldOptionMetadataAll</c> exist for, and it is called from the same
+    /// post-emit point in <c>BcRuntime.SetTestAssembly</c>.</para>
+    ///
+    /// <para>Eviction goes through <see cref="EvictCachedMetaTableForBaseTable"/> so this
+    /// inherits its two companion purges — the field-trigger wiring set (#2463) and the injected
+    /// event subscribers (#2510) — rather than reproducing a rebuild that silently loses
+    /// them.</para>
+    ///
+    /// <para>Only tables that actually have a delta are evicted. A bundle with no
+    /// <c>modify(...)</c> anywhere evicts nothing and rebuilds nothing.</para>
+    /// </summary>
+    public static void ApplyTableExtensionFieldDeltasAll()
+    {
+        // Snapshot first: EvictCachedMetaTableForBaseTable mutates _metaTableCache.
+        var toEvict = new List<string>();
+        foreach (var kvp in _metaTableCache)
+        {
+            if (kvp.Value is not NCLMetaTable) continue;
+            if (!_parsedTables.TryGetValue(kvp.Key, out var parsed)) continue;
+            if (toEvict.Contains(parsed.TableName)) continue;
+
+            // ReferenceEquals: ApplyTableExtensionFieldDeltas returns the SAME list when it
+            // changed nothing, so this asks "did any delta apply" without comparing captions
+            // field by field.
+            if (!ReferenceEquals(
+                    ApplyTableExtensionFieldDeltas(parsed.TableName, parsed.Fields), parsed.Fields))
+                toEvict.Add(parsed.TableName);
+        }
+
+        foreach (var tableName in toEvict)
+            EvictCachedMetaTableForBaseTable(tableName);
+    }
+}

--- a/docs/object-metadata-from-bc.md
+++ b/docs/object-metadata-from-bc.md
@@ -157,16 +157,32 @@ three log lines *before* its extension's delta was registered.
 This is much narrower than it looks, and it is the reason `Caption` is what the corpus test
 asserts. One probe bundle per property, BC 28.1, compiled through the runner:
 
-| accepted | rejected, and with what |
+| accepted | rejected (all `AL0246`, "cannot be customized") |
 |---|---|
-| `Caption`, `ToolTip`, `Description`, `TableRelation`, `CaptionClass` | `AL0246` — `NotBlank`, `Editable`, `DataClassification`, `ObsoleteState`, `ObsoleteReason`, `ExtendedDatatype`, `AccessByPermission`, `ValidateTableRelation`, `TestTableRelation`, `AutoFormatType`, `Numeric`, `CharAllowed`, `DateFormula`<br>`AL0294` — `MinValue`, `MaxValue`<br>`AL0843` — `OptionCaption` |
+| `Caption`, `ToolTip`, `Description`, `TableRelation`, `CaptionClass`, `OptionCaption`, `BlankZero` | `NotBlank`, `MinValue`, `MaxValue`, `Editable`, `DataClassification`, `ObsoleteState`, `ObsoleteReason`, `ExtendedDatatype`, `AccessByPermission`, `ValidateTableRelation`, `TestTableRelation`, `AutoFormatType`, `DecimalPlaces`, `Numeric`, `CharAllowed`, `DateFormula` |
 
-Two things this table settles. Every property #3614's own reproducer named — `NotBlank`,
-`MinValue`, `MaxValue` — is rejected by BC's compiler in that position, so that reproducer
-does not compile; the issue's *mechanism* was right and its example was not. And of the five
-accepted, `Description` emits an **empty** `<FieldChange>` (it is design-time only), and
-`ToolTip`/`CaptionClass`/`TableRelation` have no AL-readable surface on the derivation today —
-which leaves `Caption` as the one property that is both permitted here and observable from AL.
+**Put each property on a field whose TYPE accepts it, or the measurement is about the wrong
+thing.** A first version of this table declared every property on one `Text[50]` field and got
+two rows wrong: `MinValue`/`MaxValue` reported `AL0294` ("the type of property value 5 does not
+match the field's type") because a `Text` field cannot carry them at all, and `OptionCaption`
+reported `AL0843` for the same reason — neither compile ever reached the customizability check
+that `modify(...)` is the subject of. Re-measured against `Decimal` and `Option` fields, all
+three answer differently: the first two are `AL0246` like everything else in the rejected
+column, and `OptionCaption` is **accepted**. A type-mismatch diagnostic here is a statement
+about the probe, not about `modify(...)`.
+
+Two things the corrected table settles. Every property #3614's own reproducer named —
+`NotBlank`, `MinValue`, `MaxValue` — is rejected in that position, so that reproducer does not
+compile; the issue's *mechanism* was right and its example was not. And of the seven accepted,
+`Description` emits an **empty** `<FieldChange>` (it is design-time only), while `ToolTip`,
+`CaptionClass`, `TableRelation`, `OptionCaption` and `BlankZero` have no AL-readable surface on
+the derivation today — which leaves `Caption` as the one property that is both permitted here
+and observable from AL, and so the only one this conversion applies.
+
+The other six are **not** silently dropped: `ReadBcFieldChanges` reports any `<FieldChange>`
+attribute it does not apply, naming the property and the field, so the next one that acquires
+an AL-readable surface shows up as a diagnostic rather than as a wrong value. `OptionCaption`
+and `BlankZero` were themselves found this way — by re-measuring, not by reading the AL.
 
 <a id="scope"></a>
 

--- a/docs/object-metadata-from-bc.md
+++ b/docs/object-metadata-from-bc.md
@@ -118,6 +118,56 @@ Across the pinned corpus (`19560bd3`), 172 of the corpus app's own 178 tables ta
 route and the whole suite stays green. The six that did not, at that pin, are the scope
 boundary below — narrowed by #3600, which is what most of them now clear.
 
+<a id="modify-deltas"></a>
+
+## `modify(...)` field-property changes, and where BC puts them
+
+A `tableextension` has two halves, and BC's emitter treats them differently. Measured on
+BC 28.1 with a probe declaring both at once (`AL_RUNNER_TRACE_OBJECT_METADATA=2`):
+
+| the extension | where BC puts it |
+|---|---|
+| **adds** `field(50; Extra; Text[20])` | folded into the **base table's** own `<MetaTable>` document, as an ordinary `<Field>` |
+| **modifies** `modify(Description) { Caption = '...' }` | left in the **extension's own** delta document, as `<FieldChange>` |
+
+On that probe the base table's document carried `<Field Name="Extra" ID="50" …/>` while its
+`Description` field still read `CaptionML="ENU=Original Caption"`, and the extension's
+document carried the change:
+
+```xml
+<MetadataRuntimeDeltas ID="70901" Name="Probe Ext" …>
+  <FieldChange TargetID="2" TargetType="MetaField" CaptionML="ENU=Modified Description" />
+</MetadataRuntimeDeltas>
+```
+
+That asymmetry is why #3600's relaxed route guard is sound for an add-only extension and why
+`modify(...)` needed separate work (#3614): a consumer reading only the base table's document
+sees every added field and no modified property, with nothing failing.
+
+`RecordPatches.TableExtensionFieldDeltas.cs` reads the `<FieldChange>` entries and applies
+them. It runs **post-emit**, from `BcRuntime.SetTestAssembly`, for the same ordering reason
+`RebuildTablesFromBcMetadataAll` does: the cold `BuildNCLMetaTable` runs during `AddSourceDir`
+and `Emit` registers the documents afterwards. Measured on the probe, table 70900 was built
+three log lines *before* its extension's delta was registered.
+
+<a id="modify-accepts"></a>
+
+### Which properties AL actually permits in a table field's `modify(...)`
+
+This is much narrower than it looks, and it is the reason `Caption` is what the corpus test
+asserts. One probe bundle per property, BC 28.1, compiled through the runner:
+
+| accepted | rejected, and with what |
+|---|---|
+| `Caption`, `ToolTip`, `Description`, `TableRelation`, `CaptionClass` | `AL0246` — `NotBlank`, `Editable`, `DataClassification`, `ObsoleteState`, `ObsoleteReason`, `ExtendedDatatype`, `AccessByPermission`, `ValidateTableRelation`, `TestTableRelation`, `AutoFormatType`, `Numeric`, `CharAllowed`, `DateFormula`<br>`AL0294` — `MinValue`, `MaxValue`<br>`AL0843` — `OptionCaption` |
+
+Two things this table settles. Every property #3614's own reproducer named — `NotBlank`,
+`MinValue`, `MaxValue` — is rejected by BC's compiler in that position, so that reproducer
+does not compile; the issue's *mechanism* was right and its example was not. And of the five
+accepted, `Description` emits an **empty** `<FieldChange>` (it is design-time only), and
+`ToolTip`/`CaptionClass`/`TableRelation` have no AL-readable surface on the derivation today —
+which leaves `Caption` as the one property that is both permitted here and observable from AL.
+
 <a id="scope"></a>
 
 ## What still takes the derivation, and why
@@ -125,9 +175,10 @@ boundary below — narrowed by #3600, which is what most of them now clear.
 - **A base table a `tableextension` extends with a `modify(...)` block, or from a DIFFERENT
   app than the base table's own.** BC's document for a table is what **one** app's compiler
   emitted. A `modify(...)` block changes an existing field's properties only in the
-  extension's own delta document (`<FieldChange>`), never in the base table's — the derivation
-  applies neither today, so nothing regresses, but nothing is gained either (a separate,
-  still-open gap: #3614 [modify(...) property changes are silently dropped by BOTH routes]). A
+  extension's own delta document (`<FieldChange>`), never in the base table's. The derivation
+  now applies those deltas — #3614, see [`#modify-deltas`](#modify-deltas) above for the
+  measurement and for which properties AL permits there at all — so keeping such a table on
+  the derivation no longer loses the change. A
   cross-app extension's `<FieldAdd>` delta likewise never reaches a base document emitted by a
   DIFFERENT (and possibly earlier, possibly precompiled) compile — the service tier only
   merges it at publish time through `NavAppGroup`'s extension registry, which the runner does


### PR DESCRIPTION
Closes #3614
Closes #3574

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/304

Two defects that both land in `RecordPatches.NclMetaTableBuilder.cs` and the AL-source
parse around it, each with its own RED → GREEN. Filed by agent stma-auto-2.

## #3614 — `tableextension modify(...)` property changes were discarded

**The measurement that shaped the fix.** BC's emitter already answers this, and the runner
was already capturing the answer. Probing a tableextension that both adds a field and
modifies one (BC 28.1, `AL_RUNNER_TRACE_OBJECT_METADATA=2`) shows the two halves going to
different places:

- the **added** field is folded into the base table's own `<MetaTable>` document;
- the **modified** property stays in the extension's own delta, as
  `<FieldChange TargetID="2" TargetType="MetaField" CaptionML="ENU=Modified Description" />`,

while the base document's `Description` field still reads `CaptionML="ENU=Original Caption"`.

So the fix reads BC's `<FieldChange>` rather than re-deriving the change from
`FieldModificationSyntax`. That matters beyond taste: re-deriving would mean
re-implementing AL's rules for which properties a `modify` block may set, and those rules
are narrow and non-obvious (table below). The compiler has already applied them.

**Two things the issue got wrong, both corrected here.** Its reproducer declares `NotBlank`,
`MinValue` and `MaxValue` in a `modify(...)` block; BC's compiler **rejects all three** in
that position. One probe bundle per property, BC 28.1:

| accepted | rejected |
|---|---|
| `Caption`, `ToolTip`, `Description`, `TableRelation`, `CaptionClass` | `AL0246` — `NotBlank`, `Editable`, `DataClassification`, `ObsoleteState`, `ObsoleteReason`, `ExtendedDatatype`, `AccessByPermission`, `ValidateTableRelation`, `TestTableRelation`, `AutoFormatType`, `Numeric`, `CharAllowed`, `DateFormula` · `AL0294` — `MinValue`, `MaxValue` · `AL0843` — `OptionCaption` |

The issue's *mechanism* was right; its example does not compile. The full table is in
`docs/object-metadata-from-bc.md#modify-deltas`, where it can be re-run.

**Where it runs.** Post-emit, from `SetTestAssembly`, next to `RebuildTablesFromBcMetadataAll`
and for the same reason: the cold `BuildNCLMetaTable` runs during `AddSourceDir` and `Emit`
registers the documents afterwards. Measured — table 70900 was built **three log lines
before** its extension's delta was registered, so an in-place application at build time can
never see it. Eviction goes through the existing `EvictCachedMetaTableForBaseTable` so it
inherits the field-trigger (#2463) and injected-subscriber (#2510) purges rather than
reproducing a rebuild that silently loses them. A bundle declaring no `modify(...)` evicts
nothing.

**Loud, per `loud-failures.md`.** A `<FieldChange>` with an unreadable `TargetID`, a
malformed document, and a change naming a field the table does not have each get a named
stderr diagnostic *above* the `continue`, and the tests assert the diagnostic **text**, not
merely that something was written.

## #3574 — `enum` and `ENUM` got no enum option metadata

`_rxEnumTypeName` matched a capitalized `Enum` without `IgnoreCase`, against a value that is
the field's **raw source spelling** (`ParseFieldSyntax` stores `f.Type.ToString()` verbatim).

Why it stayed hidden: `MapNavType` uppercases before comparing, so a lowercase-declared enum
field still became `NavType.Option` and ordinary reads worked. Only the ordinal-keyed option
metadata went missing, surfacing far away — as
`GetEnumValueNameFromOrdinalValue` raising *"An object with that ID does not exist"*, and on
the corpus fixture as the **whole bundle aborting** with `NavMetadataNotFoundException` out
of the Field virtual table. That is more severe than the issue reported.

**Sibling scan (the shape, not the line).** Every regex in this repository that matches an AL
source keyword was checked: `ObjectDecl`, `SubtypeTest`, `_rxAnyTableId`, `ViewClauseRegex`,
`RxReportColumnHeader`, `_codeunitDecl`, `LayoutFilePropertyRx` all already carry `IgnoreCase`
or an inline `(?i)`. `_rxEnumTypeName` was **the only one that did not**. Nothing else to fix.

## RED → GREEN

Both measured against `origin/main` built in a separate worktree, not asserted.

| | RED (pre-fix) | GREEN |
|---|---|---|
| #3614, corpus `TableExtModify` | 2 fail / 4 pass — `Original Overridden Caption` where BC's delta says `Extension Overridden Caption`; **all four control arms pass**, so the failure is specific to `modify(...)` | 6/6 |
| #3574, corpus `EnumKeywordCase` | bundle **cannot execute** — `EXEC-FAIL … NavMetadataNotFoundException` on table 60497 | 5/5 |
| #3574, `EnumTypeKeywordCaseTests` | 8 of 16 rows fail | 16/16 |
| #3614, `TableExtensionFieldDeltaTests` | does not compile (type is the fix) | 8/8 |

The two corpus arms were run in separate trees so each RED is attributable to its own issue —
the enum fixture aborts the whole bundle, which would otherwise mask the `modify` result.

Cold and warm (`--cache`) both checked, since the registry is replayed from a sidecar on a
compile-cache HIT.

## Corpus regression: arms compared, not totals

Pinned corpus `c9d5f656`, same pin both arms (`tools/corpus-pin.py`: all three readings agree).

|  | before | after |
|---|---|---|
| pass / fail / error | 3112 / 0 / 0 | 3112 / 0 / 0 |
| `pass-oos` / `known-gap` / `divergence` | 4 / 6 / 1 | 4 / 6 / 1 |
| `--count-baseline` | satisfied | satisfied |

Totals alone would be weak evidence, so the PASS/FAIL lines were captured per test and
diffed: **3101 named results, `diff` empty** — same tests, same verdicts, both arms.

Also run: `TableMetadataFromBcDocumentTests`, `ObjectMetadataCaptureTests`,
`EnumCaptionCaptureTests` — 9 passed, 2 skipped, 0 failed. Those pin #3600's route guard,
the surface most at risk here.

## Corpus PR

Corpus PR #304 carries both BC-behaviour claims — `modify(...)` changing the caption AL reads
back (with control arms for an unmodified field and for the field the same extension adds),
and the three enum keyword capitalizations resolving identically. Object ids 60497-60501,
checked free against `master` **and every remote branch**.

**No pin bump here**, and that is not an omission: #3580 blocks corpus commit `26b0434` and
history is linear, so the pin cannot advance past it yet. The corpus tests are proven against
a local clone at the pin plus my branch.

## What I did NOT fold, and why

Scanned the open queue for this area. Three near neighbours, none of which lands in these
files:

- **#3605** (PageExtension deltas discarded) — the closest relative, and genuinely different
  work. It needs `RunnerXmlMetadataLoader.GetExtensionDeltasForAppObject` to return real
  deltas *for BC itself to consume*, and its own body says whether BC actually **applies**
  returned deltas is unsettled. Different file, different open question. Its own note warns
  not to carry a table intuition across, and this PR is evidence for that warning: for tables
  the added fields are already in the base document, for pages they are not.
- **#3577** (evict an enum's NCL cache entry on registration) and **#3579** (extensions of
  existing IDs missing from dependency sidecars) — both enum-adjacent, both land in
  `EnumMetadataPatches.cs` / `DependencyLoader.cs`. Neither is about the type keyword.

`<FieldChange>` has exactly one reader in the tree (this one), so there is no repeated call
site to fix alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
