### PR TITLE
test(metadata): serialize every in-process AlObjectMetadataRegistry user, and correct a false comment

### DIFF
--- a/AlRunner.Tests/MetadataLoaderKindCoverageTests.cs
+++ b/AlRunner.Tests/MetadataLoaderKindCoverageTests.cs
@@ -22,6 +22,7 @@ using Xunit;
 
 namespace AlRunner.Tests;
 
+[Collection(ObjectMetadataRegistrySerialCollection.Name)]
 public sealed class MetadataLoaderKindCoverageTests : IDisposable
 {
     public MetadataLoaderKindCoverageTests() => AlObjectMetadataRegistry.Clear();
@@ -61,9 +62,14 @@ public sealed class MetadataLoaderKindCoverageTests : IDisposable
         var result = Loader.GetMetaObjectXmlMetadata(new ApplicationObjectId(objectType, id), appGroup: null!);
 
         Assert.NotNull(result.Document.DocumentElement);
-        // A concrete value out of the registered document, not merely "did not throw": the
-        // marker text is unique per (kind, id) so a wrong-kind or wrong-id lookup would fail
-        // this assertion even though it returned SOME document.
+        // A concrete value out of the registered document, not merely "did not throw". What
+        // this pins is that the ObjectType was routed to the RIGHT registry kind: the marker
+        // text is unique per (kind, id), so a mapping that sent CodeUnit at "Query" would
+        // read back the wrong payload here. It is NOT a defence against a wrong-kind lookup
+        // returning some other document -- that state is unreachable, because the per-test
+        // Clear() plus this method's single Register() leave the registry holding exactly one
+        // entry, and any miss falls through to GetMetaObjectXmlMetadata's final throw.
+        // UnregisteredId_StillThrowsRunnerOutOfScopeException is what covers the miss.
         Assert.Equal($"{registryKind}-{id}-payload", result.Document.DocumentElement!.SelectSingleNode("Marker")!.InnerText);
     }
 

--- a/AlRunner.Tests/ObjectMetadataRegistryIsolationGuardTests.cs
+++ b/AlRunner.Tests/ObjectMetadataRegistryIsolationGuardTests.cs
@@ -1,0 +1,486 @@
+// ObjectMetadataRegistryIsolationGuardTests — meta-guard for #3613.
+//
+// AlObjectMetadataRegistry is a process-wide static. Its ConcurrentDictionary makes each
+// individual operation thread-safe, which is exactly what makes the hazard quiet: nothing
+// ever throws. What breaks is a test that WRITES the registry and READS it back across a
+// window, because xunit runs test collections in parallel (xunit.runner.json:
+// parallelizeTestCollections=true, maxParallelThreads=4) and a class with no [Collection]
+// gets its own parallelizable one.
+//
+// Both directions were measured on this branch, at 8bf9f508, by interleaving the two real
+// classes' operations directly:
+//   A. a concurrent Clear() between MetadataLoaderKindCoverageTests' Register and its lookup
+//      turns a passing lookup into RunnerOutOfScopeException;
+//   B. a concurrent Clear() makes QueryMetadataDocumentPredicateTests' Assert.True on
+//      HasBcQueryMetadataDocument fail.
+// Either presents as an unreproducible one-leg CI failure.
+//
+// #3613 filed this as latent, on the reading that MetadataLoaderKindCoverageTests was the
+// only unserialized in-process user and so had nobody to race with. That was not so: the
+// then-QueryMetadataFromBcDocumentTests carried an in-process [Fact] on the same registry,
+// also unserialized, since #3608. Two parallel writers of one static is a live race, and the
+// pair could only ever have passed by scheduling luck. Hence a guard rather than two
+// attributes: the attributes fix today's pair, this fixes the class of mistake.
+//
+// ── How the detection works, and what it does NOT catch ──────────────────────────────────
+//
+// Unlike the parse statics (see ParserStaticsIsolationGuardTests), this registry is PUBLIC,
+// so a violation is an ordinary compiled call and not reflection-by-name. The detector still
+// scans SOURCE rather than IL, for one reason that decides it: a class that touches the
+// registry only from a SUBPROCESS it spawns is not a violation at all — the registry it
+// populates lives in the child process — and IL cannot tell those apart, because both spell
+// the same call. Source can: the subprocess-driving classes name the registry in prose only.
+//
+// Caught:
+//   * a real call to AlObjectMetadataRegistry.{Clear,Register,LoadSidecar,LoadFromJsonArray}(
+//     — the mutating surface, which is what creates a window for another class.
+// NOT caught:
+//   * a read-only user (TryGet/Count/Snapshot). Deliberate: a reader alone cannot corrupt
+//     another class's state, and it is a violation only if something else writes — which the
+//     write side of this guard already forces into the serial collection.
+//   * a helper in another file mutating on the class's behalf; the scan is per source file.
+//   * a mutation through a computed/reflected member name.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class ObjectMetadataRegistryIsolationGuardTests
+{
+    // ── the detector, as pure functions over (class name, [Collection] name, source text) ──
+
+    // A real CALL to a mutating member. The trailing `(` is what keeps prose out: several
+    // classes discuss AlObjectMetadataRegistry.Clear in a comment without ever calling it,
+    // and RadObjectMetadataSnapshotReloadTests names it in a doc header as well as calling it.
+    private static readonly Regex MutationRegex = new(
+        @"\bAlObjectMetadataRegistry\s*\.\s*(?:Clear|Register|LoadSidecar|LoadFromJsonArray)\s*\(",
+        RegexOptions.Compiled);
+
+    internal static bool MutatesTheRegistry(string sourceText) => MutationRegex.IsMatch(sourceText);
+
+    /// <summary>
+    /// The collections a registry-mutating class may live in. What makes a collection safe is
+    /// <c>DisableParallelization = true</c> on its <c>[CollectionDefinition]</c>, not its name:
+    /// xUnit runs every non-parallelizable collection serially and one at a time, so a class in
+    /// any of them has the static registry to itself.
+    ///
+    /// <para><see cref="BcEngineCollection"/> earns its place for the same reason it does in
+    /// <see cref="ParserStaticsIsolationGuardTests"/>: a class may carry only ONE
+    /// <c>[Collection]</c>, and a test driving the in-process BC engine needs
+    /// <see cref="BcEngineFixture"/>, which only that collection supplies.
+    /// RadObjectMetadataSnapshotReloadTests is the case — it clears the registry on every
+    /// reload cycle AND needs the engine.</para>
+    ///
+    /// <para>Pinned by <see cref="EverySerialCollection_ReallyDisablesParallelization"/>, so
+    /// this list cannot quietly start naming a collection that runs in parallel.</para>
+    /// </summary>
+    internal static readonly string[] SerialCollectionNames =
+    {
+        ObjectMetadataRegistrySerialCollection.Name,
+        BcEngineCollection.Name,
+    };
+
+    internal static string? FindViolation(string className, string? collectionName, string sourceText)
+    {
+        if (!MutatesTheRegistry(sourceText)) return null;
+        if (collectionName is not null && Array.IndexOf(SerialCollectionNames, collectionName) >= 0)
+            return null;
+
+        return $"{className} mutates the process-wide AlObjectMetadataRegistry in-process " +
+               "(Clear/Register/LoadSidecar/LoadFromJsonArray) but is " +
+               (collectionName is null
+                   ? "in no xunit collection"
+                   : $"in collection \"{collectionName}\"") +
+               ". Add [Collection(ObjectMetadataRegistrySerialCollection.Name)] to it — or " +
+               "[Collection(BcEngineCollection.Name)] if it also needs the in-process BC " +
+               "engine fixture. The registry is a static that xunit's parallel collections " +
+               "share, so a concurrent Clear() can land between your Register and your read " +
+               "(#3613): the lookup then throws RunnerOutOfScopeException, or another class's " +
+               "assertion flips, as a one-leg CI failure nobody can reproduce. If this class " +
+               "only touches the registry from a SUBPROCESS it spawns, it is not a violation " +
+               "— say so without spelling a call, since the child process has its own registry.";
+    }
+
+    /// <summary>
+    /// The allowance above rests entirely on <c>DisableParallelization = true</c>. Read the flag
+    /// off each collection's own <c>[CollectionDefinition]</c> rather than trusting the comment,
+    /// so flipping it fails here instead of silently reopening the race for every class that
+    /// joined on this guard's say-so.
+    /// </summary>
+    [Fact]
+    public void EverySerialCollection_ReallyDisablesParallelization()
+    {
+        // Read the attribute as DATA: xunit's CollectionDefinitionAttribute takes the name as a
+        // constructor argument and exposes no Name property, so GetCustomAttribute<T>() can tell
+        // us DisableParallelization but not which collection it belongs to.
+        var definitions = new Dictionary<string, (string TypeName, bool DisableParallelization)>(StringComparer.Ordinal);
+        foreach (var type in typeof(ObjectMetadataRegistryIsolationGuardTests).Assembly.GetTypes())
+        {
+            foreach (var data in CustomAttributeData.GetCustomAttributes(type))
+            {
+                if (data.AttributeType != typeof(CollectionDefinitionAttribute)) continue;
+                if (data.ConstructorArguments.Count != 1) continue;
+                if (data.ConstructorArguments[0].Value is not string name) continue;
+                var disabled = data.NamedArguments
+                    .Any(a => a.MemberName == nameof(CollectionDefinitionAttribute.DisableParallelization)
+                              && a.TypedValue.Value is true);
+                definitions[name] = (type.Name, disabled);
+            }
+        }
+
+        foreach (var name in SerialCollectionNames)
+        {
+            Assert.True(definitions.TryGetValue(name, out var definition),
+                $"SerialCollectionNames lists \"{name}\", but no [CollectionDefinition] in this " +
+                "assembly declares it. The guard cannot vouch for a collection it cannot find.");
+            Assert.True(definition.DisableParallelization,
+                $"collection \"{name}\" ({definition.TypeName}) is accepted by this guard, but its " +
+                "[CollectionDefinition] no longer sets DisableParallelization = true. Either " +
+                "restore that, or drop it from SerialCollectionNames — a parallel collection " +
+                "gives a class no exclusive access to the static registry, which is the whole " +
+                "property this guard requires (#3613).");
+        }
+    }
+
+    // ── RED: the detector catches a real violation ─────────────────────────────────────────
+
+    // Positive control, spelled as MetadataLoaderKindCoverageTests actually was at 738ec1cf.
+    // Without this, every assertion below would still pass if FindViolation were hard-wired to
+    // return null — i.e. the whole guard would be noise.
+    private const string ViolatingClassSource = """
+        public sealed class HypotheticalNewRegistryTests : IDisposable
+        {
+            public HypotheticalNewRegistryTests() => AlObjectMetadataRegistry.Clear();
+            public void Dispose() => AlObjectMetadataRegistry.Clear();
+
+            [Fact]
+            public void ReadsBackWhatItRegistered()
+            {
+                AlObjectMetadataRegistry.Register("Codeunit", 88010, "Thing", "<Codeunit/>");
+                Assert.True(AlObjectMetadataRegistry.TryGet("Codeunit", 88010, out _));
+            }
+        }
+        """;
+
+    [Fact]
+    public void Detector_ClassMutatingTheRegistryInNoCollection_IsReported()
+    {
+        var violation = FindViolation("HypotheticalNewRegistryTests", null, ViolatingClassSource);
+
+        Assert.NotNull(violation);
+        Assert.Contains("HypotheticalNewRegistryTests", violation);
+        Assert.Contains("in no xunit collection", violation);
+        Assert.Contains("[Collection(ObjectMetadataRegistrySerialCollection.Name)]", violation);
+    }
+
+    [Fact]
+    public void Detector_ClassMutatingTheRegistryInAParallelCollection_IsReported()
+    {
+        Assert.DoesNotContain("some-other-collection", SerialCollectionNames);
+
+        var violation = FindViolation(
+            "HypotheticalNewRegistryTests", "some-other-collection", ViolatingClassSource);
+
+        Assert.NotNull(violation);
+        Assert.Contains("some-other-collection", violation);
+    }
+
+    [Theory]
+    [InlineData(ObjectMetadataRegistrySerialCollectionNameLiteral)]
+    [InlineData(BcEngineCollectionNameLiteral)]
+    public void Detector_ClassMutatingTheRegistryInASerialCollection_IsNotReported(string collection)
+        => Assert.Null(FindViolation("HypotheticalNewRegistryTests", collection, ViolatingClassSource));
+
+    // [InlineData] needs compile-time constants; these two pin that the literals the theory
+    // uses are the very names the collections declare, so a rename cannot leave the theory
+    // silently asserting about collections that no longer exist.
+    private const string ObjectMetadataRegistrySerialCollectionNameLiteral = "object-metadata-registry";
+    private const string BcEngineCollectionNameLiteral = "bc-engine-serial";
+
+    [Fact]
+    public void TheInlineDataLiterals_AreTheRealCollectionNames()
+    {
+        Assert.Equal(ObjectMetadataRegistrySerialCollection.Name, ObjectMetadataRegistrySerialCollectionNameLiteral);
+        Assert.Equal(BcEngineCollection.Name, BcEngineCollectionNameLiteral);
+    }
+
+    [Theory]
+    [InlineData("Clear")]
+    [InlineData("Register")]
+    [InlineData("LoadSidecar")]
+    [InlineData("LoadFromJsonArray")]
+    public void Detector_RecognisesEveryMutatingMember(string member)
+    {
+        Assert.True(MutatesTheRegistry($"AlObjectMetadataRegistry.{member}(x);"),
+            $"the detector must recognise a call to AlObjectMetadataRegistry.{member}");
+
+        // …and the bare name in prose must still not trip it.
+        Assert.False(MutatesTheRegistry($"// AlObjectMetadataRegistry.{member} wipes the registry"));
+    }
+
+    // The mutating surface is read off the production type, so a member added to
+    // AlObjectMetadataRegistry that writes _byKey and is not in the regex fails HERE rather
+    // than silently widening the hole the guard is supposed to close.
+    [Fact]
+    public void TheDetectorCoversEveryPublicMutatingMemberOfTheRegistry()
+    {
+        var mutators = typeof(AlObjectMetadataRegistry)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .Select(m => m.Name)
+            .Distinct(StringComparer.Ordinal)
+            // Read-only members cannot corrupt another class's state; see the header.
+            .Where(n => n is not ("TryGet" or "TryGetByName" or "TryGetByKey" or "KeyFor"
+                                 or "Snapshot" or "SaveSidecar" or "get_Count" or "get_Keys"))
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.NotEmpty(mutators);
+        foreach (var name in mutators)
+        {
+            Assert.True(MutatesTheRegistry($"AlObjectMetadataRegistry.{name}(x);"),
+                $"AlObjectMetadataRegistry.{name} writes the static registry but the guard's " +
+                "detector does not recognise a call to it — add it to MutationRegex, or, if it " +
+                "is read-only, to the exclusion list in this test with the reason.");
+        }
+    }
+
+    // Negative direction: an over-eager detector that flagged every test class would be useless
+    // and would "pass" the assembly-wide assertion for the wrong reason. Modelled on
+    // ObjectMetadataCaptureTests, which drives the runner as a SUBPROCESS: the registry it
+    // populates lives in the child process, so it is genuinely not a violation.
+    [Fact]
+    public void Detector_SubprocessDrivingClassThatOnlyNamesTheRegistryInProse_IsNotReported()
+    {
+        const string innocentSource = """
+            /// The compiler's own AlObjectMetadataRegistry keeps every kind; this spawns the
+            /// runner and reads the trace, so the registry it fills is the CHILD's.
+            public class ObjectMetadataCaptureLikeTests
+            {
+                [SkippableFact]
+                public void EveryKindIsCaptured()
+                {
+                    var output = RunRunner(bundle);
+                    Assert.Contains("[object-metadata] registered Codeunit 70660", output);
+                }
+            }
+            """;
+
+        Assert.Null(FindViolation("ObjectMetadataCaptureLikeTests", null, innocentSource));
+        Assert.False(MutatesTheRegistry(innocentSource));
+    }
+
+    [Fact]
+    public void Detector_OrdinaryTestClass_IsNotReported()
+    {
+        const string ordinarySource = """
+            public class ErrorClassifierLikeTests
+            {
+                [Fact]
+                public void ClassifiesACompileError()
+                {
+                    Assert.Equal(ErrorKind.Compile, Classify("AL0118: unknown type"));
+                }
+            }
+            """;
+
+        Assert.Null(FindViolation("ErrorClassifierLikeTests", null, ordinarySource));
+    }
+
+    // This file necessarily CONTAINS the call pattern — the fixtures above spell out exactly
+    // what the detector must recognise — but never mutates the registry at runtime, so
+    // serialising it would be pointless. TheDetectorFiresOnThisOwnFile_WhichIsWhyItIsExcluded
+    // pins that the exclusion stays justified rather than becoming a silent hole.
+    private static readonly string[] SelfExcludedClasses =
+    {
+        nameof(ObjectMetadataRegistryIsolationGuardTests),
+    };
+
+    // ── GREEN: the real assembly is clean, and the detector really fires on real source ────
+
+    [Fact]
+    public void EveryTestClassMutatingTheRegistry_IsInASerialCollection()
+    {
+        var sources = TestSourceByTypeName();
+        var violations = new List<string>();
+
+        foreach (var type in TestClasses())
+        {
+            if (SelfExcludedClasses.Contains(type.Name)) continue;
+            if (!sources.TryGetValue(type.Name, out var source))
+            {
+                throw new Xunit.Sdk.XunitException(
+                    $"no source file under {TestSourceDirectory()} declares test class " +
+                    $"{type.Name}. This guard scans source, and a guard that silently skips " +
+                    "classes is worse than no guard.");
+            }
+
+            var violation = FindViolation(type.Name, CollectionNameOf(type), source.Text);
+            if (violation is not null) violations.Add($"{source.Path}: {violation}");
+        }
+
+        Assert.True(violations.Count == 0, string.Join("\n\n", violations));
+    }
+
+    // Proves the assertion above is not passing because the detector never fires. These three
+    // classes DO mutate the registry in-process today; if the detector stopped recognising the
+    // pattern, this fails instead of the guard quietly going green forever.
+    [Theory]
+    [InlineData(nameof(MetadataLoaderKindCoverageTests))]
+    [InlineData(nameof(ObjectMetadataRegistryTests))]
+    [InlineData(nameof(QueryMetadataDocumentPredicateTests))]
+    public void TheKnownInProcessRegistryClasses_AreDetected_AndAreAttributed(string className)
+    {
+        var sources = TestSourceByTypeName();
+        Assert.True(sources.ContainsKey(className), $"source for {className} was not found");
+
+        Assert.True(MutatesTheRegistry(sources[className].Text),
+            $"{className} mutates the registry in-process, so the detector must flag it — if it " +
+            "does not, the assembly-wide guard is vacuous");
+
+        var type = TestClasses().Single(t => t.Name == className);
+        Assert.Equal(ObjectMetadataRegistrySerialCollection.Name, CollectionNameOf(type));
+    }
+
+    // RadObjectMetadataSnapshotReloadTests is the BcEngineCollection case: it clears the
+    // registry AND needs the engine fixture, so it must be detected and allowed there.
+    [Fact]
+    public void TheEngineDrivenRegistryClass_IsDetected_AndSitsInTheEngineCollection()
+    {
+        var sources = TestSourceByTypeName();
+        var name = nameof(RadObjectMetadataSnapshotReloadTests);
+
+        Assert.True(MutatesTheRegistry(sources[name].Text));
+        Assert.Equal(BcEngineCollection.Name,
+            CollectionNameOf(TestClasses().Single(t => t.Name == name)));
+    }
+
+    // The other half of "not vacuous": the detector must also say NO a lot. If it flagged every
+    // test class, the assembly-wide assertion would only be measuring how diligent we were about
+    // sprinkling the attribute everywhere.
+    [Fact]
+    public void MostTestClasses_AreNotDetectedAsMutatingTheRegistry()
+    {
+        var sources = TestSourceByTypeName();
+        var testClasses = TestClasses().Select(t => t.Name).ToArray();
+        Assert.True(testClasses.Length >= 20,
+            $"expected the test assembly to hold at least 20 test classes, found {testClasses.Length}");
+
+        var untouched = testClasses
+            .Where(n => sources.TryGetValue(n, out var s) && !MutatesTheRegistry(s.Text))
+            .ToArray();
+
+        Assert.True(untouched.Length >= 20,
+            $"only {untouched.Length} of {testClasses.Length} test classes are detected as NOT " +
+            "mutating the registry — the detector is over-eager and the guard proves nothing");
+    }
+
+    [Fact]
+    public void TheDetectorFiresOnThisOwnFile_WhichIsWhyItIsExcluded()
+    {
+        var sources = TestSourceByTypeName();
+        Assert.True(MutatesTheRegistry(sources[nameof(ObjectMetadataRegistryIsolationGuardTests)].Text));
+        Assert.Equal(new[] { nameof(ObjectMetadataRegistryIsolationGuardTests) }, SelfExcludedClasses);
+    }
+
+    // ── source + reflection plumbing (fails loudly rather than finding nothing to check) ───
+
+    private sealed record TestSource(string Path, string Text);
+
+    private static string ThisFilePath([CallerFilePath] string path = "") => path;
+
+    private static string TestSourceDirectory()
+    {
+        // First choice: the compile-time path of this very file. In practice never taken —
+        // Directory.Build.props sets PathMap on every dev/CI build, which rewrites the value
+        // baked into [CallerFilePath], so the File.Exists probe below fails and the walk-up
+        // runs. Kept because the probe makes the choice safe either way, and the release-pack
+        // build (no PathMap) does produce a real absolute path here.
+        var compileTimeDir = Path.GetDirectoryName(ThisFilePath());
+        if (compileTimeDir is not null &&
+            File.Exists(Path.Combine(compileTimeDir, "AlRunner.Tests.csproj")))
+        {
+            return compileTimeDir;
+        }
+
+        for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir is not null; dir = dir.Parent)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "AlRunner.Tests.csproj"))) return dir.FullName;
+            var nested = Path.Combine(dir.FullName, "AlRunner.Tests", "AlRunner.Tests.csproj");
+            if (File.Exists(nested)) return Path.GetDirectoryName(nested)!;
+        }
+
+        throw new Xunit.Sdk.XunitException(
+            "the AlRunner.Tests source directory could not be located (compile-time path was " +
+            $"'{ThisFilePath()}', assembly base was '{AppContext.BaseDirectory}'). This guard " +
+            "scans source, so with no source it would check nothing and read as passing — " +
+            "failing instead.");
+    }
+
+    // Matches a type declaration at the start of a line, optionally preceded by attributes and
+    // modifiers. Anchoring at line start keeps prose in a `//` comment from registering.
+    private static readonly Regex TypeDeclRegex = new(
+        @"^[ \t]*(?:\[[^\]]*\][ \t]*)*(?:public|internal|private|protected|file)?[ \t]*" +
+        @"(?:(?:sealed|abstract|static|partial|unsafe|readonly|ref)[ \t]+)*" +
+        @"(?:class|record|struct)[ \t]+(?<name>[A-Za-z_]\w*)",
+        RegexOptions.Compiled | RegexOptions.Multiline);
+
+    private static Dictionary<string, TestSource> TestSourceByTypeName()
+    {
+        var root = TestSourceDirectory();
+        var files = Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories)
+            .Where(p => !p.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}")
+                     && !p.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"))
+            .ToArray();
+
+        if (files.Length == 0)
+        {
+            throw new Xunit.Sdk.XunitException(
+                $"no .cs files found under '{root}' — this guard would check nothing and still " +
+                "go green. Failing loudly instead.");
+        }
+
+        var map = new Dictionary<string, TestSource>(StringComparer.Ordinal);
+        foreach (var path in files)
+        {
+            var text = File.ReadAllText(path);
+            foreach (Match m in TypeDeclRegex.Matches(text))
+            {
+                map[m.Groups["name"].Value] = new TestSource(path, text);
+            }
+        }
+        return map;
+    }
+
+    private static IEnumerable<Type> TestClasses() =>
+        typeof(ObjectMetadataRegistryIsolationGuardTests).Assembly
+            .GetTypes()
+            .Where(t => t is { IsClass: true, IsAbstract: false })
+            .Where(t => t.GetMethods(BindingFlags.Public | BindingFlags.Instance |
+                                     BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .Any(m => m.GetCustomAttributes(typeof(FactAttribute), inherit: true).Length > 0))
+            .OrderBy(t => t.Name, StringComparer.Ordinal);
+
+    // xunit 2.x's CollectionAttribute exposes its name only through the constructor argument.
+    private static string? CollectionNameOf(Type type)
+    {
+        for (var t = type; t is not null && t != typeof(object); t = t.BaseType)
+        {
+            foreach (var attr in CustomAttributeData.GetCustomAttributes(t))
+            {
+                if (attr.AttributeType.FullName != "Xunit.CollectionAttribute") continue;
+                if (attr.ConstructorArguments.Count > 0 &&
+                    attr.ConstructorArguments[0].Value is string name)
+                {
+                    return name;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/AlRunner.Tests/ObjectMetadataRegistryTests.cs
+++ b/AlRunner.Tests/ObjectMetadataRegistryTests.cs
@@ -13,7 +13,7 @@ namespace AlRunner.Tests;
 /// Serialized against the other tests that touch this static registry — see
 /// <see cref="ObjectMetadataRegistrySerialCollection"/>.
 /// </summary>
-[Collection("object-metadata-registry")]
+[Collection(ObjectMetadataRegistrySerialCollection.Name)]
 public class ObjectMetadataRegistryTests : IDisposable
 {
     public ObjectMetadataRegistryTests() => AlObjectMetadataRegistry.Clear();
@@ -128,5 +128,16 @@ public class ObjectMetadataRegistryTests : IDisposable
     }
 }
 
-[CollectionDefinition("object-metadata-registry", DisableParallelization = true)]
-public class ObjectMetadataRegistrySerialCollection { }
+/// <summary>
+/// Serial collection for every test class that mutates the process-wide
+/// <see cref="AlObjectMetadataRegistry"/> IN-PROCESS. The registry is a static
+/// <c>ConcurrentDictionary</c>: thread-safe per operation, but a <c>Clear()</c> landing
+/// between another class's <c>Register</c> and its lookup flips that lookup's outcome in
+/// both directions (#3613). <c>DisableParallelization</c> is what makes membership mean
+/// anything; <see cref="ObjectMetadataRegistryIsolationGuardTests"/> enforces both halves.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class ObjectMetadataRegistrySerialCollection
+{
+    public const string Name = "object-metadata-registry";
+}

--- a/AlRunner.Tests/QueryMetadataDocumentPredicateTests.cs
+++ b/AlRunner.Tests/QueryMetadataDocumentPredicateTests.cs
@@ -1,0 +1,40 @@
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// The one IN-PROCESS half of <see cref="QueryMetadataFromBcDocumentTests"/>, split out so it
+/// can join <see cref="ObjectMetadataRegistrySerialCollection"/> without dragging that class's
+/// subprocess-spawning <c>[SkippableFact]</c> into a serial collection with it (#3613). The
+/// registry is process-global, and this test both writes it and reads it back across a window.
+/// </summary>
+[Collection(ObjectMetadataRegistrySerialCollection.Name)]
+public class QueryMetadataDocumentPredicateTests : IDisposable
+{
+    private const int DivergentQueryId = 70720;
+    private const int PlainQueryId = 70721;
+
+    public QueryMetadataDocumentPredicateTests() => AlObjectMetadataRegistry.Clear();
+    public void Dispose() => AlObjectMetadataRegistry.Clear();
+
+    /// <summary>
+    /// The route is chosen on AVAILABILITY, so a query with no document keeps the derivation
+    /// rather than failing. Nothing in the fixture can produce that state — every query there
+    /// is compiled — so the claim is made against the predicate itself, which is what both
+    /// call sites consult.
+    /// </summary>
+    [Fact]
+    public void QueryWithNoRegisteredDocument_KeepsTheDerivation()
+    {
+        Assert.False(AlRunner.Patches.RecordPatches.HasBcQueryMetadataDocument(DivergentQueryId));
+
+        AlObjectMetadataRegistry.Register(
+            AlRunner.Patches.RecordPatches.BcQueryMetadataKind, DivergentQueryId,
+            "QMD Divergent", "<Query><ID>70720</ID></Query>");
+        Assert.True(AlRunner.Patches.RecordPatches.HasBcQueryMetadataDocument(DivergentQueryId));
+
+        // Keyed by (kind, id), not by id alone: a TABLE numbered 70720 is a different
+        // object and must not satisfy the query's predicate.
+        Assert.False(AlRunner.Patches.RecordPatches.HasBcQueryMetadataDocument(PlainQueryId));
+    }
+}

--- a/AlRunner.Tests/QueryMetadataFromBcDocumentTests.cs
+++ b/AlRunner.Tests/QueryMetadataFromBcDocumentTests.cs
@@ -190,32 +190,8 @@ public class QueryMetadataFromBcDocumentTests
         AssertBothQueriesCameFromBcDocument(warm, "warm run (AL-output cache HIT)");
     }
 
-    /// <summary>
-    /// The route is chosen on AVAILABILITY, so a query with no document keeps the derivation
-    /// rather than failing. Nothing in this fixture can produce that state — every query here
-    /// is compiled — so the claim is made against the predicate itself, which is what both
-    /// call sites consult.
-    /// </summary>
-    [Fact]
-    public void QueryWithNoRegisteredDocument_KeepsTheDerivation()
-    {
-        AlObjectMetadataRegistry.Clear();
-        try
-        {
-            Assert.False(AlRunner.Patches.RecordPatches.HasBcQueryMetadataDocument(DivergentQueryId));
-
-            AlObjectMetadataRegistry.Register(
-                AlRunner.Patches.RecordPatches.BcQueryMetadataKind, DivergentQueryId,
-                "QMD Divergent", "<Query><ID>70720</ID></Query>");
-            Assert.True(AlRunner.Patches.RecordPatches.HasBcQueryMetadataDocument(DivergentQueryId));
-
-            // Keyed by (kind, id), not by id alone: a TABLE numbered 70720 is a different
-            // object and must not satisfy the query's predicate.
-            Assert.False(AlRunner.Patches.RecordPatches.HasBcQueryMetadataDocument(PlainQueryId));
-        }
-        finally
-        {
-            AlObjectMetadataRegistry.Clear();
-        }
-    }
+    // The predicate half of #3608 lives in QueryMetadataDocumentPredicateTests.cs: it drives
+    // AlObjectMetadataRegistry IN-PROCESS, so it has to sit in a serial collection, and this
+    // class must not — its [SkippableFact] spawns the runner and would then serialize with
+    // every other registry test for no benefit (#3613).
 }

--- a/AlRunner/Patches/RunnerXmlMetadataLoader.cs
+++ b/AlRunner/Patches/RunnerXmlMetadataLoader.cs
@@ -55,15 +55,11 @@ namespace AlRunner.Patches;
 /// </summary>
 public sealed class RunnerXmlMetadataLoader : INCLObjectXmlMetadataLoader
 {
-    // BC's runtime ObjectType (Microsoft.Dynamics.Nav.Types.ObjectType) and the AL compiler's
-    // SymbolKind (Microsoft.Dynamics.Nav.CodeAnalysis.SymbolKind — the string
-    // AlObjectMetadataRegistry is keyed by, via BcCompiler.CaptureOutputter.AddApplicationObject's
-    // `symbol.Kind.ToString()`) are two different enums. Measured by decompiling both
-    // (Microsoft.Dynamics.Nav.Types.dll / Microsoft.Dynamics.Nav.CodeAnalysis.dll, BC 28.1):
-    // every kind AlObjectMetadataRegistry captures (docs/object-metadata-capture.md) names
-    // identically in ObjectType, with exactly one spelling divergence — ObjectType.CodeUnit vs
-    // SymbolKind.Codeunit. Report/Page/Table/XmlPort are excluded here because the branches
-    // above already serve them from their own registries.
+    // BC's runtime ObjectType and the AL compiler's SymbolKind (the string the registry is
+    // keyed by) are two different enums; they name every captured kind identically except
+    // ObjectType.CodeUnit vs SymbolKind.Codeunit. Report/Page/Table/XmlPort are absent
+    // because the branches above already serve them from their own registries.
+    // see docs/object-metadata-capture.md#objecttype-vs-symbolkind
     private static readonly System.Collections.Generic.IReadOnlyDictionary<ObjectType, string>
         RegistryKindByObjectType = new System.Collections.Generic.Dictionary<ObjectType, string>
         {

--- a/docs/object-metadata-capture.md
+++ b/docs/object-metadata-capture.md
@@ -66,6 +66,34 @@ query all numbered 70660. A registry keyed on the id alone answers seven objects
 document. The registry still accepts an id-less registration and keys it by name, so a
 kind BC starts delivering later is stored rather than dropped.
 
+<a id="objecttype-vs-symbolkind"></a>
+
+## `ObjectType` vs `SymbolKind`: two enums, one spelling divergence
+
+The registry is keyed by the **AL compiler's** `SymbolKind` name (BcCompiler's
+`CaptureOutputter.AddApplicationObject` stores `symbol.Kind.ToString()`). BC's **runtime**
+asks for metadata by `Microsoft.Dynamics.Nav.Types.ObjectType`, through
+`MetaObjectCache` / `NCLObjectMetadataLoaderExtensions.GetMeta*` ->
+`RetrieveRuntimeObject` -> `loader.GetMetaObjectXmlMetadata(new ApplicationObjectId(...))`.
+So anything serving the runtime out of this registry has to bridge the two.
+
+Measured by decompiling both enums (`Microsoft.Dynamics.Nav.Types.dll` and
+`Microsoft.Dynamics.Nav.CodeAnalysis.dll`, BC 28.1): **every kind this capture produces
+names identically in `ObjectType`, with exactly one divergence** —
+
+| `ObjectType` | `SymbolKind` |
+|---|---|
+| `CodeUnit` | `Codeunit` |
+
+The mapping table lives in `RegistryKindByObjectType` (`AlRunner/Patches/RunnerXmlMetadataLoader.cs`).
+It deliberately omits `Report`, `Page`, `Table` and `XmlPort`: those four are served by
+earlier branches in `GetMetaObjectXmlMetadata`, out of their own per-kind registries
+(`AlReportMetadataRegistry`, `AlPageMetadataRegistry`, `AlXmlPortMetadataRegistry`) or, for
+`Table`, out of this registry under `RecordPatches.BcTableMetadataKind`.
+
+`AlRunner.Tests/MetadataLoaderKindCoverageTests.cs` pins the divergence, so a rename of
+either enum fails there rather than silently losing a kind to the fallback's final `throw`.
+
 <a id="surviving-a-warm-run"></a>
 
 ## Surviving a warm run


### PR DESCRIPTION
Closes #3612
Closes #3613

Corpus-NA: the only production file in this diff is AlRunner/Patches/RunnerXmlMetadataLoader.cs and the change to it is comment-only — `git diff origin/main...HEAD -- AlRunner/Patches/RunnerXmlMetadataLoader.cs` filtered to non-comment lines is empty, so no AL-observable behaviour exists for a service tier to adjudicate. Verified by measurement rather than by inspection: the pinned corpus (c9d5f656) was run in both arms and every one of 3112 tests holds the same verdict by name.

Filed and implemented by an agent (Claude, `stma-auto-2`).

Two issues, both naming `AlRunner.Tests/MetadataLoaderKindCoverageTests.cs`. The same-file premise held, so they are folded per `.claude/rules/batch-sibling-issues-by-file.md`, each with its own RED → GREEN.

Both are about a **test proving less than it claims**, so the RED here is a demonstration that the claimed guarantee is absent — not a runtime failure.

## #3613 — the registry race is LIVE, not latent

The issue reported one unserialized in-process mutator of the process-wide static `AlObjectMetadataRegistry`, and concluded it was a latent hazard because "there is currently no second parallel user for the new class to race with".

**There was.** Enumerating every in-process mutator by scanning for a real call (not prose) found two, not one:

| class | mutates in-process | collection at `8bf9f508` |
|---|---|---|
| `MetadataLoaderKindCoverageTests` | yes | **`<NONE>`** |
| `QueryMetadataFromBcDocumentTests` | yes | **`<NONE>`** |
| `ObjectMetadataRegistryTests` | yes | `object-metadata-registry` (serial) |
| `RadObjectMetadataSnapshotReloadTests` | yes | `bc-engine-serial` (serial) |
| `ObjectMetadataCaptureTests`, `TableMetadataFromBcDocumentTests` | no — subprocess, so the registry is the child's | n/a, correctly |

`QueryMetadataFromBcDocumentTests` has carried an in-process `[Fact]` on this registry since #3608. Two unserialized writers of one static in a suite with `parallelizeTestCollections: true` is a live race; the pair could only have been passing by scheduling luck.

**Both directions reproduce**, measured at `8bf9f508` by interleaving the two real classes' operations directly:

- **A** — a concurrent `Clear()` between `MetadataLoaderKindCoverageTests`' `Register` and its lookup turns a passing lookup into `RunnerOutOfScopeException`.
- **B** — a concurrent `Clear()` makes `HasBcQueryMetadataDocument`'s `Assert.True` fail.

Either presents as an unreproducible one-leg CI failure.

### The map: which clear is load-bearing, which is harmful

The issue asked for this, and it is the more useful half of the answer. **Every one of these `Clear()` calls is load-bearing for its own class and harmful to the others** — that is the whole shape of the defect. `MetadataLoaderKindCoverageTests` needs a clear registry so a wrong-kind lookup is a miss (that is what makes #3612's assertion mean anything); `QueryMetadataDocumentPredicateTests` needs one so its first `Assert.False` is not satisfied by a leftover; `ObjectMetadataRegistryTests` asserts on `Count` directly. None of them can drop its clear. So the fix is not to remove a clear anywhere — it is to stop two of them from running concurrently.

### Fix

The one-line attribute fixes today's pair; a guard fixes the class of mistake, which is what the issue suggested and what would have caught #3610 at review.

- `MetadataLoaderKindCoverageTests` joins `ObjectMetadataRegistrySerialCollection`.
- The in-process `[Fact]` of `QueryMetadataFromBcDocumentTests` is split into `QueryMetadataDocumentPredicateTests`, **in its own file**, and joins the same collection. Splitting rather than attributing the whole class keeps that class's subprocess-spawning `[SkippableFact]` out of a serial collection, where it would have serialized against every other registry test for no benefit. Its own file because the guard's scan is per source file — with both classes in one file the guard correctly flagged the *outer* class too, which is how I found that the split alone was not sufficient.
- `ObjectMetadataRegistrySerialCollection` gains a `Name` const, so membership is symbolic rather than a bare string literal in three places.
- New `ObjectMetadataRegistryIsolationGuardTests`, modelled on the existing `ParserStaticsIsolationGuardTests`.

**RED → GREEN.** With the two attributes removed (the `8bf9f508` state), the guard fails 3 of 20:

```
EveryTestClassMutatingTheRegistry_IsInASerialCollection                          [FAIL]
TheKnownInProcessRegistryClasses_AreDetected_AndAreAttributed("MetadataLoader…") [FAIL]
TheKnownInProcessRegistryClasses_AreDetected_AndAreAttributed("QueryMetadata…")  [FAIL]
Failed: 3, Passed: 17, Total: 20
```

naming all three violating classes with the fix in the message. With the attributes in place: **20/20 passed**.

### Why the guard is not vacuous

`tdd.md`'s "would this still pass with a no-op implementation" is the risk for a meta-test, so it is answered explicitly:

- a **positive control** (`ViolatingClassSource`, spelled as `MetadataLoaderKindCoverageTests` actually was at `738ec1cf`) that must be reported in no collection and in a parallel collection;
- `MostTestClasses_AreNotDetectedAsMutatingTheRegistry` — the detector must say NO at least 20 times, so an over-eager detector cannot pass the assembly-wide assertion for the wrong reason;
- `TheDetectorCoversEveryPublicMutatingMemberOfTheRegistry` reads the mutating surface **off the production type by reflection**, so a member added to `AlObjectMetadataRegistry` that writes `_byKey` fails here rather than silently widening the hole;
- `EverySerialCollection_ReallyDisablesParallelization` reads `DisableParallelization` off each `[CollectionDefinition]` as attribute data, so flipping it fails here rather than silently reopening the race for every class that joined on the guard's say-so;
- the self-exclusion is pinned by a test asserting this file really does trip its own detector, so it stays justified rather than becoming a silent hole.

**Deliberate limits**, stated in the file header: read-only users (`TryGet`/`Count`/`Snapshot`) are not flagged — a reader alone cannot corrupt another class's state, and it is only a violation if something else writes, which the write side already forces into the serial collection. Detection is over **source**, not IL, for one reason that decides it: a class touching the registry only from a subprocess it spawns is not a violation at all, and IL cannot distinguish that from an in-process call because both spell the same thing.

## #3612 — the comment asserts a failure mode the test cannot have

The comment claimed a wrong-kind or wrong-id lookup "would fail this assertion **even though it returned SOME document**".

**Measured, not read.** Forcing each named condition against the real loader:

| forced condition | claimed | actual |
|---|---|---|
| wrong kind (registered `Query`, asked `CodeUnit` at the same id) | returns some document | `RunnerOutOfScopeException` |
| wrong id (registered 88010, asked 88099) | returns some document | `RunnerOutOfScopeException` |
| **every** kind registered at one id — the state closest to "registry never cleared" | — | each `ObjectType` still answers its own kind's payload |

The third row is the one that settles it. `GetMetaObjectXmlMetadata` dispatches an `ObjectType` to exactly one registry kind, so a wrong-kind lookup is a *miss* that falls through to the final `throw` — there is no reachable state in which it returns a different kind's document. The claimed failure mode does not exist, which is precisely the risk the issue named: a reader who believed it might relax the per-test clear that makes the real guarantee hold.

Replaced with what the assertion does pin — that the `ObjectType` was routed to the **right** kind, the marker being unique per `(kind, id)` — plus a pointer to `UnregisteredId_StillThrowsRunnerOutOfScopeException`, which is what actually covers the miss. No new test: the correction is that the existing assertion means something narrower than the comment said, and both facts are already covered by tests in the file.

### The duplicated provenance

`RegistryKindByObjectType`'s header repeated the decompilation derivation already in #3610's body and `docs/object-metadata-capture.md`. Per `.claude/rules/loud-failures.md` § "The justification is a claim plus a citation", the claim and the pointer stay at the call site (5 lines, down from 9) and the derivation moves to a new `docs/object-metadata-capture.md#objecttype-vs-symbolkind` section — the two-enum divergence table, why `Report`/`Page`/`Table`/`XmlPort` are excluded, and which test pins it. `python3 tools/test_doc_pointers.py` passes, so the new pointer resolves.

## Where the prose went

Both long headers answer the "would this change what the next person TYPES" question. The guard's header stays in code: it is the file a next editor edits when adding a registry test, and the limits section is what stops them believing the guard covers more than it does. The `ObjectType`/`SymbolKind` derivation moved to `docs/`, with a one-line pointer left behind.

## Measurement

**Corpus, both arms, same pin `c9d5f656`, BC `28.1.49838.53910`** — arms compared, never absolutes:

| | tests | pass | fail | error | count-baseline | exit |
|---|---|---|---|---|---|---|
| before (`8bf9f508`) | 3112 | 3112 | 0 | 0 | ok (`al-language` = 3112) | 0 |
| after (this branch) | 3112 | 3112 | 0 | 0 | ok | 0 |

Not just the aggregate: the per-test PASS/FAIL lines were sorted and diffed by name — **every one of 3112 tests holds the same verdict in both arms**, zero differences. That is the structurally expected result for a comment-only production diff, and it is the measurement that confirms it rather than an assumption.

**Unit tests**, same filter (`Metadata|IsolationGuard|Collection`) on both arms:

| | passed | failed | skipped |
|---|---|---|---|
| before (`8bf9f508`) | 391 | 0 | 21 |
| after | 411 | 0 | 21 |

+20 = exactly the new guard's tests; identical skip count, so nothing was skipped into passing. Also run: `ReflectionDrivenHelperLiveness` (1/1 — no reflection-pinned signature changed), `ParserStaticsIsolationGuardTests` and `ConsoleSwapIsolationGuardTests` green alongside the changed collection definition.

## What I did NOT fold, and why

Per point 5 of the batching rule — the queue scan, including the cases that did not fold:

| issue | why not |
|---|---|
| **#3282** — RAD snapshot reads the process-wide page/xmlport registry, so a colliding id borrows another module's metadata | Same *theme* (process-wide registry), different file and different kind of defect: it lands in `BcCompiler.CaptureRadMetadataSnapshotFull`, is a production behaviour bug about `AlPageMetadataRegistry`/`AlXmlPortMetadataRegistry`, and needs a service-tier-adjudicable claim. Same-subsystem, not same-file — the case the rule explicitly excludes. |
| **#2676** — `DepSymbolCompilerCache` mutates a static `Dictionary` with no lock | The closest sibling in *shape* (unsynchronized process-wide state), but the fix lands in `AlRunner/Infrastructure/DepSymbolCompilerCache.cs` and is production locking, not test isolation. Different file, different reasoning to review. |
| **#3191**, **#3460** — comments claiming proofs they do not perform | Same defect *class* as #3612 and worth doing, but in `PermissionSet*` and swallowed-refusal call sites. #3191's file is owned by open PR #3623. |

Nothing else in the open queue lands in these files.

**Related but distinct, not filed as new:** the same static-registry-sharing shape exists for `AlReportMetadataRegistry`, `AlPageMetadataRegistry` and `AlXmlPortMetadataRegistry`, as #3613 noted. Three test classes DO mutate them in-process — `ReportMetadataDocumentColumnTests.cs:42,47`, `PageRealMetadataEpochRevalidationTests.cs:133` and `XmlPortRealMetadataBundleBoundaryTests.cs:87,118,150` — but **all three already sit in serial collections that disable parallelization**, so there is no live race to guard against and extending the guard would add a check with nothing to catch. (An earlier revision of this line said no class mutates them at all. That was wrong; the conclusion survives for this better reason. Corrected after review.) #3282 already tracks the production half for two of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
