### PR TITLE
docs(manual): user-facing documentation in a directory of its own

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,12 +252,17 @@ Out of scope by design: SMTP, HTTP egress to external services, file I/O against
 
 ## Exit Codes
 
+Read these out of `al-runner --help`, which generates them from the code; this
+table is a copy and the CLI is the authority.
+
 | Code | Meaning |
 |------|---------|
 | `0` | All tests passed |
-| `1` | Test assertion failures, runner errors, or argument error |
-| `2` | Runner limitations only |
-| `3` | AL compilation error |
+| `1` | At least one test FAILED or ERRORED |
+| `2` | A bundle could not execute — a process-level error, and also a bad invocation (unknown flag, or a bundle path that does not exist) |
+| `3` | A bundle could not compile |
+| `4` | `--count-baseline`: a suite's test or app-group count did not exactly match its declared baseline |
+| `5` | `--expectations-require-match`: an expectations entry matched no test in this run |
 
 ## Tooling for AI-assisted development (optional)
 

--- a/docs/manual/_index.md
+++ b/docs/manual/_index.md
@@ -1,0 +1,35 @@
+---
+title: "AL Runner"
+weight: 1
+---
+
+Run Business Central AL unit tests in milliseconds. No service tier, no Docker,
+no SQL Server, no license.
+
+AL Runner loads Business Central's own compiler and runtime assemblies in
+process and executes your AL test codeunits directly against them. Your tests
+run against real Base Application and System Application code, not against a
+mock — the runner replaces the host Business Central usually needs, not the
+business logic you are testing.
+
+## Where to start
+
+- **[Getting started](getting-started.md)** — install it and run a test.
+- **[Writing tests](writing-tests.md)** — what a bundle is and how tests are structured.
+- **[What works](what-works.md)** — the supported surface, and what is deliberately out of scope.
+- **[Command line reference](cli-reference.md)** — the flags you will actually use.
+- **[Troubleshooting](troubleshooting.md)** — what the common failures mean.
+
+## What it is for
+
+Fast feedback. A Business Central test suite that normally needs a container and
+several minutes runs here in seconds, on Windows, Linux or macOS, with nothing
+installed but the .NET SDK. That makes AL tests something you can run on every
+save and in ordinary CI, rather than something you run occasionally because it
+is expensive.
+
+It is not a replacement for testing against a real environment. Anything that
+needs the service tier itself — sending mail, calling a web service, rendering a
+report, publishing an endpoint — is out of scope by design and refuses loudly
+rather than quietly returning a default. [What works](what-works.md) draws the
+line.

--- a/docs/manual/cli-reference.md
+++ b/docs/manual/cli-reference.md
@@ -1,0 +1,74 @@
+---
+title: "Command line reference"
+weight: 4
+---
+
+This page covers the flags you are likely to reach for. `al-runner --help` is
+the complete, authoritative list and is generated from the code, so prefer it
+whenever the two disagree.
+
+```
+al-runner [OPTIONS] <bundle-dir>...
+```
+
+## Choosing what runs
+
+| Flag | Effect |
+|---|---|
+| `--test PATTERN`, `--filter PATTERN` | Run only tests whose qualified name (`CodeunitNNNN.Method`) contains PATTERN, case-insensitively. |
+| `--isolation MODE` | `codeunit` (default), `test`, or `disabled`. See [Writing tests](writing-tests.md). |
+| `--test-timeout SECONDS` | Per-test timeout. Default 60. |
+
+## Resolving dependencies
+
+| Flag | Effect |
+|---|---|
+| `--package-cache PATH` | An extra `.app` package cache directory. Repeatable. |
+| `--test-data`, `--test-data=PATH` | Hydrate the database from a Business Central backup. Needs the `bcbak` reader. |
+| `--test-data-company NAME` | Which company inside the backup to use. Defaults to the first one. |
+
+## Speed
+
+| Flag | Effect |
+|---|---|
+| `--cache PATH` | Cache compiled AL output between runs. |
+| `--watch` | Stay resident and re-run on every `.al` change. |
+| `--jobs N`, `-j N` | Run the given bundles across N worker processes. Also bounds memory: peak usage tracks how many bundles a process loads, not how many tests it runs. |
+| `--server` | Long-running JSON-RPC daemon over stdin and stdout, for editor integrations. |
+
+## Output
+
+| Flag | Effect |
+|---|---|
+| `--output-junit PATH` | Write a JUnit XML report, grouped by codeunit. |
+| `--output-json` | Per-test JSON on stdout instead of the normal text output. |
+| `--coverage` | Statement-level coverage using Business Central's own instrumentation. Writes Cobertura XML. |
+| `--failures-only`, `--quiet` | Print only failures. |
+| `--verbose` | Show internal diagnostic logs. |
+| `--no-strict-exit` | Always exit 0, so a caller can parse the output without the step failing. |
+
+## Debugging
+
+| Flag | Effect |
+|---|---|
+| `--dap [PORT]` | Debug Adapter Protocol server, default port 4711: set AL breakpoints, pause, inspect locals. Needs exactly one bundle. |
+| `--dump-csharp DIR` | Write the intermediate C# that Business Central's compiler emitted, one file per AL object. |
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Every test passed. |
+| `1` | At least one test failed or errored. |
+| `2` | A bundle could not execute — a process-level error, or a bad invocation such as an unknown flag or a path that does not exist. |
+| `3` | A bundle could not compile. |
+| `4` | A suite's test or app-group count did not match its declared baseline (`--count-baseline`). |
+| `5` | An expectations entry matched no test in this run (`--expectations-require-match`). |
+
+## Environment variables
+
+`AL_RUNNER_VERBOSE=1` and `AL_RUNNER_SHOW_PASS=1` mirror the flags of the same
+name. `AL_RUNNER_BCBAK` points at the backup reader used by `--test-data`.
+`AL_RUNNER_ARTIFACTS_ROOT` moves the Business Central artifact cache off your
+home directory, which is useful when it has to live on another volume or on a CI
+runner's mounted path.

--- a/docs/manual/getting-started.md
+++ b/docs/manual/getting-started.md
@@ -1,0 +1,80 @@
+---
+title: "Getting started"
+weight: 2
+---
+
+## Prerequisites
+
+The .NET SDK, version 9 or 10 — [download it here](https://aka.ms/dotnet/download).
+That is the whole list on Windows and macOS.
+
+On Linux there is one extra detail, and it usually needs nothing from you. A few
+Business Central assemblies call Win32 functions directly — the locale APIs, for
+example, which anything evaluating a `TextConstant` reaches. The runner
+redirects those to a small shim, and a prebuilt shim ships for `linux-x64` and
+`linux-arm64`. If you are on a different architecture the runner compiles the
+shim on first use, which needs a C compiler (`cc`, `gcc` or `clang`) on your
+`PATH`. If one is missing the run fails and says so by name.
+
+## Install
+
+```bash
+dotnet tool install --global MSDyn365BC.AL.Runner
+```
+
+On the first run the runner downloads the AL compiler and the Business Central
+assemblies it needs — around 11 MB, fetched with HTTP range requests — and
+caches them. Later runs use the cache.
+
+## Run your first test
+
+The runner takes one or more **bundle directories**. A bundle is a folder with
+an `app.json` at its root: the same shape as any Business Central extension. If
+you point at a folder below one, the runner climbs the path to find the
+`app.json` itself.
+
+```bash
+al-runner ./my-test-app
+```
+
+That is the whole invocation. Dependencies declared in `app.json` are resolved
+against the runner's artifact cache, the dotnet tool store, and any extra
+package caches you name:
+
+```bash
+al-runner --package-cache ~/.al-runner/platform-apps ./my-test-app
+```
+
+A run prints one line per test and a summary. It exits 0 when everything
+passed — see [the exit codes](cli-reference.md) for what the other values mean.
+
+## Make repeat runs fast
+
+Two caches matter, and both are worth turning on for day-to-day work.
+
+```bash
+al-runner --cache ~/.cache/al-runner/al-out ./my-test-app
+```
+
+`--cache` keeps the compiled output of your AL, keyed on the source, the
+dependency set and the runner build, so an unchanged bundle skips compilation
+entirely.
+
+The second cache needs no flag. The runner stores the result of your
+dependencies' install triggers and `Company-Initialize` and reloads it instead
+of re-running those AL bodies in each new process. On a warm single-fixture run
+that is the difference between 6.3 seconds and 0.8.
+
+For a tight edit-and-test loop, stay resident instead:
+
+```bash
+al-runner --watch ./my-test-app
+```
+
+Watch mode keeps dependencies warm and re-runs on every `.al` change, in
+process, in about a second. It waits for changes to settle before starting, so a
+branch switch or a formatter run does not fire a cycle halfway through.
+
+## Next
+
+[Writing tests](writing-tests.md) covers how a test bundle is put together.

--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -1,0 +1,80 @@
+---
+title: "Troubleshooting"
+weight: 6
+---
+
+## A test fails on a table with no rows
+
+Business Central tests usually expect setup records — number series, posting
+groups, company information — that an empty database does not have.
+
+The runner detects this: when a failure names a table and that table is
+measurably empty, it prints a one-line `[test-data]` note underneath naming the
+table and pointing at `--test-data`. Business Central's own message, exception
+type and AL call stack are left untouched; the explanation sits beside the
+failure rather than replacing it.
+
+The fix is usually [`--test-data`](writing-tests.md). If it is already on, the
+note says instead why the table is *still* empty — refused, absent from this
+backup, or empty inside it.
+
+## "The TestPage is not open."
+
+That is Business Central's own message, and it names the symptom rather than the
+cause. It means the page's row-load trigger raised an AL error, so the page was
+torn down; the raised error's text never reaches AL, on a real service tier
+either.
+
+The runner prints the underlying error on a `[testpage]` note under the failure.
+What AL sees is unchanged — `asserterror` and `GetLastErrorText` still read only
+Business Central's message — so the note is the only place the real cause
+appears.
+
+## `RunnerOutOfScopeException`
+
+The test reached a surface the runner does not support. The message names the
+API and the reason. If the reason cites [`docs/scope.md`](../scope.md), it is
+out of scope by design and the test needs a real environment. If the reason is
+`not-yet-implemented`, it is a gap that is intended to be filled, and there
+should be an open issue for it.
+
+Either way the refusal is deliberate. The runner never returns a default in
+place of a surface it cannot honour, because a test that passes that way is
+worse than one that fails.
+
+## The run exits 2 with no test failures
+
+Exit 2 means a bundle could not execute at all, as opposed to running and
+failing. The most common causes are a bundle path that does not exist and an
+unknown flag — both are argument errors, and both print the reason.
+
+See [the exit codes](cli-reference.md) for the rest.
+
+## Compilation fails (exit 3)
+
+The AL did not compile. The compiler diagnostics are Business Central's own and
+appear in the output. One thing worth knowing: emit is atomic per module, so a
+single object that cannot be emitted takes its whole module with it rather than
+being skipped silently.
+
+## A first run on Linux fails asking for a C compiler
+
+The runner needs a small shim for a handful of Win32 calls that Business
+Central's assemblies make. Prebuilt shims ship for `linux-x64` and
+`linux-arm64`; on any other architecture it compiles one on first use and needs
+`cc`, `gcc` or `clang` on your `PATH`. Install one, or build the shim yourself
+and point `AL_RUNNER_WIN32_STUBS_SO` at it.
+
+## The first run is slow on Windows
+
+Windows Defender locking a freshly written DLL to scan it is a known source of
+first-run delay. The runner retries around it, but excluding its cache and
+output directories from real-time scanning avoids the wait.
+
+## Something else
+
+If AL code fails to run and none of the above explains it, treat it as a runner
+gap rather than a problem with your AL, and
+[open an issue](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/new).
+A minimal reproducer — the smallest AL that shows the behaviour, plus the exact
+failing assertion or compiler diagnostic — is what makes a gap fixable.

--- a/docs/manual/what-works.md
+++ b/docs/manual/what-works.md
@@ -1,0 +1,61 @@
+---
+title: "What works"
+weight: 5
+---
+
+The goal is broad AL-language compatibility: any AL code that can run without
+the Business Central service tier should compile and execute here. This page is
+the short version. [`docs/scope.md`](../scope.md) is the authoritative per-API
+list, and [`docs/limitations.md`](../limitations.md) records every known limit
+with the measurement behind it.
+
+## Supported
+
+Records — create, read, update, delete, filters, keys, `CalcFields`, `CalcSums`,
+and every trigger. Codeunits, including interface dispatch, event subscribers and
+the Business Central lifecycle events. The Microsoft test toolkit, `LibraryAssert`
+and `Any` among them. Test handlers: confirm, message, modal page, request page,
+report and notification. `TestPage`. `RecordRef` and `FieldRef`. BLOBs and
+streams, JSON and XML, regular expressions, in-process cryptography and
+`IsolatedStorage`.
+
+Because these are Business Central's own assemblies, your test exercises the real
+Base Application and System Application code paths. That is the point of the
+design: a test that passes here passed against Microsoft's logic, not against an
+approximation of it.
+
+## Out of scope, by design
+
+Anything that needs a process or service outside the runner:
+
+- sending mail over SMTP
+- HTTP calls to external services, and OAuth flows
+- file input and output against external filesystems or blob storage
+- publishing OData or SOAP endpoints
+- physical printers
+- background job scheduling against a real scheduler
+- page and report **rendering** — handler callbacks fire, layout is not evaluated
+
+These do not quietly return a default. Touching one raises
+`RunnerOutOfScopeException`, naming the API and the reason, so a test can never
+pass by silently skipping the part that mattered. AL code that asks permission
+first gets an honest answer: `TaskScheduler.CanCreateTask` returns false here,
+which is true.
+
+## Not yet implemented
+
+Some things are in scope and simply are not built yet. Those also refuse loudly
+rather than returning a default, with the reason `not-yet-implemented`, and each
+one has an open issue. [`docs/limitations.md`](../limitations.md) lists them with
+what is known about each.
+
+If you hit a failure that is not explained by any of the above, that is a gap
+worth reporting — see [Troubleshooting](troubleshooting.md).
+
+## When to use a real environment instead
+
+Use the full Business Central pipeline when what you are testing *is* the part
+that is out of scope: an integration against a live web service, a report's
+rendered layout, a permissions question that depends on real authentication, or
+anything about the service tier's own behaviour under load. The runner is for
+the logic underneath.

--- a/docs/manual/writing-tests.md
+++ b/docs/manual/writing-tests.md
@@ -1,0 +1,113 @@
+---
+title: "Writing tests"
+weight: 3
+---
+
+Tests for AL Runner are ordinary Business Central test codeunits. There is no
+runner-specific test framework, no attribute you have to add, and nothing to
+change if you later run the same tests against a real environment. That is
+deliberate: a test that only works here would not be evidence about Business
+Central.
+
+## A bundle
+
+A bundle is a folder with an `app.json` at its root — the same shape as any
+extension. The runner reads that manifest for the app's identity and its
+dependencies, resolves those dependencies from its caches, and compiles the AL
+underneath.
+
+```
+my-test-app/
+  app.json
+  src/
+    MyFeatureTests.Codeunit.al
+```
+
+You can pass several bundles in one invocation. They run in sequence and report
+one combined summary. Two arguments naming the same directory are collapsed onto
+one run — `x`, `./x`, `x/` and a symlink to `x` are the same bundle — and the run
+says which argument it dropped.
+
+## A test codeunit
+
+```al
+codeunit 50100 "My Feature Tests"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure DiscountAppliesToTheLineAmount()
+    var
+        Line: Record "Sales Line";
+    begin
+        // your arrangement here
+        Assert.AreEqual(90, Line."Line Amount", 'A 10% discount should leave 90.');
+    end;
+
+    var
+        Assert: Codeunit "Library Assert";
+}
+```
+
+`Subtype = Test` marks the codeunit; `[Test]` marks each test procedure. The
+Microsoft test libraries are available — `Library Assert` (codeunit 130), `Any`
+(130500) and the rest of the test toolkit — because they are real Business
+Central code running here, not reimplementations.
+
+Handler attributes work as they do on a service tier:
+`[ConfirmHandler]`, `[MessageHandler]`, `[ModalPageHandler]`,
+`[RequestPageHandler]`, `[ReportHandler]` and `[SendNotificationHandler]` all
+fire. Report and page *rendering* does not happen — the handler callback is in
+scope, the layout is not.
+
+## Test isolation
+
+Between tests, the runner resets state the way Business Central's own
+`TestIsolation` does:
+
+```bash
+al-runner --isolation codeunit ./my-test-app   # default
+al-runner --isolation test     ./my-test-app
+al-runner --isolation disabled ./my-test-app
+```
+
+`codeunit` shares state inside a codeunit and resets between codeunits, matching
+AL's `TestIsolation = Codeunit`. `test` gives every `[Test]` a fresh state
+(`TestIsolation = Function`). `disabled` never resets. The default is `codeunit`,
+which is what Business Central does by default too.
+
+## Running a subset
+
+```bash
+al-runner --test DiscountApplies ./my-test-app
+```
+
+`--test` (or `--filter`) matches against the qualified name,
+`CodeunitNNNN.Method`, case-insensitively.
+
+## Setup data
+
+Many Business Central tests expect setup records — number series, posting
+groups, company information — that a real environment has and an empty database
+does not. By default the runner starts empty, so those tests fail on missing
+rows.
+
+`--test-data` hydrates the in-memory database from a Business Central backup,
+reading each table the first time the run touches it rather than loading
+everything up front:
+
+```bash
+al-runner --test-data ./my-test-app
+```
+
+It needs the `bcbak` backup reader on your `PATH`. When a test fails on a table
+with no rows, the runner prints a one-line note naming that table and pointing
+here — so you find out that the cause was missing data rather than guessing at
+the assertion.
+
+## Where the canonical examples are
+
+The [AL language test corpus](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests)
+is thousands of tests written in exactly this shape, each one validated against a
+real Business Central service tier on every push. It is the best available
+reference for how a test should look.


### PR DESCRIPTION
Opened by an agent (Claude, coordinator session) at the repository owner's request.

Adds `docs/manual/` — six pages written for someone who wants to **use** the runner. Nothing under `docs/` moves, and no existing pointer changes.

| page | |
|---|---|
| `_index.md` | what the runner is, where to start |
| `getting-started.md` | prerequisites, install, first run, the two caches worth turning on |
| `writing-tests.md` | bundles, test codeunits, isolation, `--test-data` |
| `cli-reference.md` | the flags you actually reach for, and the exit codes |
| `what-works.md` | supported surface, out-of-scope by design, not-yet-implemented |
| `troubleshooting.md` | what the common failures mean |

## Why a new directory rather than reworking `docs/`

`docs/` is a maintainer surface **by design**: `.claude/rules/loud-failures.md` pushes derivation prose out of code comments and into it, which is why its files open with lines like "Derivation behind `AlRunner/Patches/BlobStoreIsolationPatches.cs`". That is correct and should stay.

Restructuring it would also have been far more expensive than it looks. Measured on this tree:

- `docs/limitations.md` is referenced **198 times**, **67 of them anchored** (`#bc-shape-gaps`, `#runtime-shape-gaps`, …)
- from `AlRunner/` (57), `AlRunner.Tests/` (44), `tests/expectations/` (19), `.claude/`, `README.md`, `CONTRIBUTING.md`
- and `tools/test_doc_pointers.py` gates on every one of them resolving

Splitting that file is a repository-wide rename behind a required check, not a documentation edit.

## A defect this surfaced, fixed here

The manual was written from `al-runner --help`, not from `README.md`, and the two disagree. **README's exit-code table was wrong**: it said `2` was "Runner limitations only" and stopped at `3`. The CLI says `2` is "a bundle could not execute" — a process-level error, and also a bad invocation — and `4` and `5` exist (`--count-baseline` mismatch, `--expectations-require-match`).

Nothing pinned that table and README was the only file carrying the wrong text, so it drifted silently. Anyone reading it to branch a CI step on the exit code was told the wrong thing for both of the values they were most likely to use.

Corrected in this PR rather than a second one. The header now states that `--help` is the authority and the table is a copy, which is the honest description of a hand-maintained duplicate. **A drift test pinning the table against the CLI is the real fix**, and is worth filing separately — it would change this PR from docs-only into one that runs the BC matrix.

## Verification

`tools/test_doc_pointers.py` passes with the new pages in place — 306 code pointers, 58 markdown links, 13 anchored mentions, 16 expectation `Doc` values, all resolving. The manual links into `docs/scope.md` and `docs/limitations.md` rather than restating them, so the deep reference stays the single copy under test.

## Publishing

`aldevtools/aldev.tools` mounts `docs/manual` as a Hugo module and publishes it at aldev.tools. Hugo modules resolve to the newest git tag, so the site shows the manual as of the released version rather than `main` — releasing is what publishes documentation.

Corpus-NA: documentation only; no AL-observable behaviour changes and no runner code is touched.

Closes #3635

https://claude.ai/code/session_01F7HLDeNwiGQoLT5wFanqmH
