### PR TITLE
fix(testpage): dispatch a pageextension modify(control) block's triggers

### DIFF
--- a/AlRunner.Tests/PageExtensionParserTests.cs
+++ b/AlRunner.Tests/PageExtensionParserTests.cs
@@ -313,6 +313,98 @@ public class PageExtensionParserTests
         finally { Cleanup(); }
     }
 
+    // #3573 — RUNNER-MECHANISM guard, not a claim about BC.
+    //
+    // What real BC does with a `modify(Control)` block's triggers is stated upstream, where a
+    // service tier adjudicates it: corpus codeunit 60514 "MCV Validate Trigger Tests"
+    // (StefanMaron/BusinessCentral.AL.Language.Tests#305). This test pins the one piece of the
+    // fix that lives on OUR side of that line — that the parser captures which BASE-PAGE
+    // controls a pageextension modifies, keyed by the extension's id, so trigger dispatch has
+    // something to resolve against.
+    //
+    // The id space is the whole point and is why this needed a capture at all. A control an
+    // extension ADDS hashes from the extension's own object id, which ParseMemberNames already
+    // indexes. A control an extension MODIFIES keeps the BASE page's identity — measured on the
+    // #3573 reproducer, the control being validated is MemberId(basePage, "Name") while the
+    // trigger method sits on the extension's type — so no entry in MemberIdToName can reach it
+    // and the name has to travel separately. Asserting on the NAME rather than on a derived id
+    // keeps this test about the capture; MemberIdMatchesTheIdBcActuallyEmitted above is what
+    // pins the hash itself.
+    [Fact]
+    public void ModifiedControlNames_CapturesTheBasePageControlsAPageextensionModifies()
+    {
+        try
+        {
+            Parse("TryParsePageFile", $$"""
+                page {{PageId}} "PX Card"
+                {
+                    SourceTable = "PX Base Table";
+                    layout
+                    {
+                        area(Content)
+                        {
+                            field(Alpha; Rec.Alpha) { }
+                            field(Beta; Rec.Beta) { }
+                        }
+                    }
+                }
+
+                pageextension {{PageExtId}} "PX Card Ext" extends "PX Card"
+                {
+                    layout
+                    {
+                        modify(Alpha)
+                        {
+                            trigger OnBeforeValidate() begin end;
+                            trigger OnAfterValidate() begin end;
+                        }
+
+                        addlast(Content)
+                        {
+                            field(Gamma; Rec.Gamma) { }
+                        }
+                    }
+                }
+                """);
+
+            var modified = ModifiedNames(PageExtId);
+
+            // Positive: the modified control is captured, under the name the AL source spells.
+            Assert.Contains("Alpha", modified);
+
+            // Negative, and the reason this test is not satisfied by "returns everything":
+            // Beta is a base-page control the extension does NOT modify, and Gamma is one the
+            // extension ADDS. Neither belongs here — Gamma in particular already resolves
+            // through the extension's own id space, and pulling it into this set would make
+            // dispatch look for it in the base page's space, where it does not exist.
+            Assert.DoesNotContain("Beta", modified);
+            Assert.DoesNotContain("Gamma", modified);
+            Assert.Single(modified);
+
+            // AL identifiers are case-insensitive: `modify(alpha)` targets `field(Alpha; ...)`,
+            // so a set that only matched the source's exact casing would miss real code.
+            Assert.Contains("ALPHA", modified);
+
+            // A page is not an extension and modifies nothing, so it must answer empty rather
+            // than inherit its extension's set.
+            Assert.Empty(ModifiedNames(PageId));
+
+            // An object this run never parsed answers empty too, rather than throwing — that is
+            // what a precompiled-dependency pageextension hits, and it is a declared gap
+            // (the dependency's SymbolReference.json does not state modified controls) rather
+            // than an error.
+            Assert.Empty(ModifiedNames(PageExtId + 500));
+        }
+        finally { Cleanup(); }
+    }
+
+    private static IReadOnlySet<string> ModifiedNames(int extensionId)
+    {
+        var m = RP.GetMethod("GetModifiedControlNames", BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("RecordPatches.GetModifiedControlNames not found.");
+        return (IReadOnlySet<string>)m.Invoke(null, new object[] { extensionId })!;
+    }
+
     // ─── helpers ─────────────────────────────────────────────────────────────────────────
 
     private static System.Collections.IEnumerable ExtensionFields(string baseTableName)

--- a/AlRunner/Patches/RecordPatches.AlPageParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlPageParser.cs
@@ -98,7 +98,8 @@ public static partial class RecordPatches
                 BaseName: Unquote(pe.BaseObject?.ToString()?.Trim() ?? ""),
                 Controls: extControls,
                 MemberIdToName: ParseMemberNames(id, pe),
-                MemberIdToActionRefTarget: ParseActionRefTargets(id, pe));
+                MemberIdToActionRefTarget: ParseActionRefTargets(id, pe),
+                ModifiedControlNames: ParseModifiedControlNames(pe));
         }
     }
 
@@ -158,6 +159,47 @@ public static partial class RecordPatches
     internal static bool PageDeclaresSystemAction(int pageId, string systemActionName)
         => _parsedPages.TryGetValue(pageId, out var page)
            && page.DeclaredSystemActions.Contains(systemActionName);
+
+    /// <summary>
+    /// The NAMES of the base-page controls a pageextension's <c>modify(...)</c> blocks target.
+    ///
+    /// <para>Issue #3573. A <c>modify(Control)</c> block keeps the EXISTING control's identity:
+    /// the control still belongs to the base page and BC still drives it by the base page's own
+    /// member id, but any <c>OnBeforeValidate</c>/<c>OnAfterValidate</c> the block declares is
+    /// compiled onto the EXTENSION's type. So the emitted method's name mangles the base page's
+    /// control name while living on an object whose id space would hash it differently — which
+    /// is precisely why <see cref="RecordPatches"/>.ParseMemberNames (keyed in the DECLARING
+    /// object's id space) cannot reach it, and why dispatch has to re-derive the id in the BASE
+    /// page's space instead. See RunnerPageInstance.FindModifiedControlTriggers.</para>
+    ///
+    /// <para>An <c>addfirst</c>/<c>addlast</c> control is a different case entirely and is NOT
+    /// collected here: that control is declared BY the extension, so it lives in the
+    /// extension's own id space and ParseMemberNames already indexes it.</para>
+    /// </summary>
+    private static HashSet<string> ParseModifiedControlNames(SyntaxNode obj)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var modify in obj.DescendantNodes().OfType<NavSyntax.ControlModifyChangeSyntax>())
+        {
+            var name = IdentText(modify.Name);
+            if (name.Length > 0) names.Add(name);
+        }
+        return names;
+    }
+
+    /// <summary>
+    /// The base-page control names <paramref name="extensionId"/>'s <c>modify(...)</c> blocks
+    /// target, or an empty set for an extension this run never AL-source-parsed. See
+    /// <see cref="ParseModifiedControlNames"/> (#3573).
+    /// <para>Empty for a PRECOMPILED pageextension: a dependency's SymbolReference.json states
+    /// the extension's own controls, not which inherited controls it modifies, so a precompiled
+    /// extension's modified-control triggers stay unreachable. That is a narrower, DECLARED gap
+    /// than the silent skip it replaces — tracked separately rather than guessed at.</para>
+    /// </summary>
+    internal static IReadOnlySet<string> GetModifiedControlNames(int extensionId)
+        => _parsedPageExtensions.TryGetValue(extensionId, out var ext)
+            ? ext.ModifiedControlNames
+            : (IReadOnlySet<string>)new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
     private static Dictionary<int, string> ParseMemberNames(int declaringObjectId, SyntaxNode obj)
     {
@@ -791,7 +833,11 @@ internal record ParsedPage(
     IReadOnlyDictionary<int, string>? MemberIdToActionRefTarget = null,
     /// <summary>The names declared inside <c>area(SystemActions)</c> — see
     /// <see cref="RecordPatches"/>.ParseDeclaredSystemActions (#3283).</summary>
-    IReadOnlySet<string>? DeclaredSystemActions = null)
+    IReadOnlySet<string>? DeclaredSystemActions = null,
+    /// <summary>For a pageextension: the BASE-page control names its <c>modify(...)</c> blocks
+    /// target — see <see cref="RecordPatches"/>.ParseModifiedControlNames (#3573). Always empty
+    /// for a page.</summary>
+    IReadOnlySet<string>? ModifiedControlNames = null)
 {
     // Positional records can't give a collection parameter a literal default that isn't a
     // constant, so a null Controls (constructed via the shorter historical call sites/tests,
@@ -805,4 +851,7 @@ internal record ParsedPage(
     // the literal "OK"/"Cancel" spellings while the source may say `systemaction(ok)`.
     public IReadOnlySet<string> DeclaredSystemActions { get; init; }
         = DeclaredSystemActions ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    // OrdinalIgnoreCase for the same reason: `modify(name)` targets `field(Name; ...)`.
+    public IReadOnlySet<string> ModifiedControlNames { get; init; }
+        = ModifiedControlNames ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 }

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -1255,9 +1255,70 @@ internal sealed partial class RunnerPageInstance
     /// </summary>
     internal void RaiseOnValidate(int controlId)
     {
+        // #3573: a pageextension `modify(Control)` block may wrap the base control's own
+        // OnValidate with OnBeforeValidate / OnAfterValidate. BC runs all three in one
+        // sequence — before, base, after — so an Error() in a before-trigger must prevent
+        // both later stages, which falling out of this method on the exception achieves.
+        foreach (var before in FindModifiedControlTriggers(controlId, "_OnBeforeValidate"))
+            Invoke(before);
+
         var trigger = FindTrigger(controlId, "_OnValidate", "OnValidate");
         // A control with no OnValidate simply has no such method, which is not an error.
         if (trigger != null) Invoke(trigger.Value);
+
+        foreach (var after in FindModifiedControlTriggers(controlId, "_OnAfterValidate"))
+            Invoke(after);
+    }
+
+    /// <summary>
+    /// Every pageextension trigger a <c>modify(<paramref name="controlId"/>)</c> block declares
+    /// carrying <paramref name="suffix"/>, in ascending pageextension-id order.
+    ///
+    /// <para>Issue #3573. This is a DIFFERENT resolution from <see cref="FindTrigger"/>, and the
+    /// difference is the id space. A control a pageextension ADDS belongs to the extension, so
+    /// its member id hashes from the extension's own object id and FindTrigger's extension arm
+    /// finds it. A control a pageextension MODIFIES still belongs to the BASE PAGE — AL's
+    /// <c>modify(Name)</c> keeps the existing control's identity — so BC drives it by the base
+    /// page's member id while the trigger body compiles onto the extension's type. Measured on
+    /// the reproducer in #3573: the control being validated is id 709536759 =
+    /// <c>MemberId(64520, "Name")</c> (the base page), while FindTrigger's extension arm asks
+    /// for <c>MemberId(64521, "Name")</c> = 1257079618 and can never match. Hence the base
+    /// page's id space here, against the extension's own methods.</para>
+    ///
+    /// <para>Scoped to control names the extension's AL source actually declares a
+    /// <c>modify(...)</c> for (RecordPatches.GetModifiedControlNames), so this cannot reach a
+    /// method belonging to an extension-added control that merely shares a name with a base
+    /// control — those keep FindTrigger's ordinary path, which is the acceptance criterion
+    /// "extension-added controls keep their ordinary trigger path".</para>
+    ///
+    /// <para>Order is the extensions' own id order, which GetPageExtensionIdsForPage sorts. That
+    /// is deterministic but is NOT a claim about the order real BC uses when two extensions
+    /// modify one control — nothing here has measured that, and no corpus test asserts it. The
+    /// upstream test that accompanies this fix pins the single-extension sequence only.</para>
+    /// </summary>
+    private List<TriggerMatch> FindModifiedControlTriggers(int controlId, string suffix, int arity = 0)
+    {
+        var matches = new List<TriggerMatch>();
+        foreach (var extensionId in RecordPatches.GetPageExtensionIdsForPage(_pageId))
+        {
+            var modified = RecordPatches.GetModifiedControlNames(extensionId);
+            if (modified.Count == 0) continue;
+
+            var extInstance = GetOrCreateExtensionInstance(extensionId);
+            if (extInstance == null) continue;
+
+            foreach (var controlName in modified)
+            {
+                // The BASE page's id space — see the remarks. A modify() block whose target is
+                // not the control being validated simply does not match.
+                if (MemberId(_pageId, controlName) != controlId) continue;
+
+                var match = FindTriggerOnTarget(extInstance, _pageId, controlId, suffix,
+                    suffix.TrimStart('_'), arity, declaredName: controlName);
+                if (match != null) matches.Add(match.Value);
+            }
+        }
+        return matches;
     }
 
     /// <summary>
@@ -2208,7 +2269,19 @@ internal sealed partial class RunnerPageInstance
                 RecordPatches.TryGetPageMemberName(extensionId, memberId, isExtension: true));
             if (extMatch != null) return extMatch;
         }
-        return null;
+
+        // #3573: last, the id space the two arms above cannot reach — a control an extension
+        // MODIFIES rather than declares. See FindModifiedControlTriggers for why that needs the
+        // BASE page's id space against the EXTENSION's methods. Last, not first, so an
+        // extension-added control keeps the ordinary path above unchanged.
+        //
+        // A `modify()` block accepts OnLookup, OnDrillDown and OnAssistEdit alongside the
+        // before/after validate pair (measured on BC 28.1: the compiler rejects OnValidate and
+        // OnControlAddIn there with AL0162, and accepts these), so this belongs in FindTrigger
+        // rather than only on the validate path — RaiseOnLookup and RaiseOnDrillDown resolve
+        // through here and were refusing a control that plainly declares the trigger.
+        var modified = FindModifiedControlTriggers(memberId, suffix, arity);
+        return modified.Count > 0 ? modified[0] : null;
     }
 
     /// <summary>

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -2275,11 +2275,11 @@ internal sealed partial class RunnerPageInstance
         // BASE page's id space against the EXTENSION's methods. Last, not first, so an
         // extension-added control keeps the ordinary path above unchanged.
         //
-        // A `modify()` block accepts OnLookup, OnDrillDown and OnAssistEdit alongside the
-        // before/after validate pair (measured on BC 28.1: the compiler rejects OnValidate and
-        // OnControlAddIn there with AL0162, and accepts these), so this belongs in FindTrigger
-        // rather than only on the validate path — RaiseOnLookup and RaiseOnDrillDown resolve
-        // through here and were refusing a control that plainly declares the trigger.
+        // Here rather than only on the validate path, because a `modify()` block carries more
+        // than the before/after validate pair: the compiler's own TriggerTypeKind enum names
+        // six ControlExtension* triggers. RaiseOnLookup and RaiseOnDrillDown resolve through
+        // this method and were refusing a control that plainly declares the trigger. Two of
+        // the six have no dispatch surface anywhere in the runner — #3642.
         var modified = FindModifiedControlTriggers(memberId, suffix, arity);
         return modified.Count > 0 ? modified[0] : null;
     }


### PR DESCRIPTION
Closes #3573

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/305

## The defect

A pageextension `modify(Control)` block's `OnBeforeValidate` / `OnAfterValidate` never ran.
A TestPage `SetValue` on the modified control fired the base control's own `OnValidate` and
nothing else — the AL ran, nothing errored, and the extension's validation simply did not
happen. A silent wrong answer, not a refusal.

## Diagnosis, measured

The issue named `RunnerPageInstance.RaiseOnValidate` as dispatching one trigger, which is
true, but the mechanism underneath is an **id-space mismatch**, and that is what the fix
turns on. Instrumented run of the issue's own reproducer:

```
[probe] RaiseOnValidate page=64520 controlId=709536759
[probe]  base type=Page64520
[probe]   base m: Name_a45_OnValidate(0)
[probe]  ext 64521 inst=PageExtension64521
[probe]   ext m: Name_a45_OnBeforeValidate(0)   memberIdOfName=1257079618
[probe]   ext m: Name_a45_OnAfterValidate(0)    memberIdOfName=1257079618
```

The extension instance is constructed and the methods **are** emitted. `FindTrigger`'s
extension arm hashes the member name in the **extension's** id space —
`MemberId(64521, "Name")` = `1257079618` — while the control being validated is
`MemberId(64520, "Name")` = `709536759`, the **base page's**. The two can never meet.

That asymmetry is the AL semantics, not an accident: a control an extension **adds** belongs
to the extension, so the existing arm is right for it. A control an extension **modifies**
keeps the base page's identity — `modify(Name)` names an existing control — while its new
trigger bodies compile onto the extension's type.

## The fix

1. **`RecordPatches.AlPageParser.cs`** — capture which base-page control names each
   pageextension's `modify(...)` blocks target (`ControlModifyChangeSyntax.Name`). This is
   the piece that could not be derived: no entry in `MemberIdToName` can reach a control the
   extension does not declare, so the name has to travel separately.
2. **`RunnerPageInstance.cs`** — `FindModifiedControlTriggers` resolves those against the
   **base page's** id space on the **extension's** methods, and `RaiseOnValidate` runs
   before → base → after. It is tried **last** in `FindTrigger`, so extension-added controls
   keep their existing path unchanged.

An `Error()` in a before-trigger propagates out of `RaiseOnValidate`, which is what stops
both later stages — no separate guard, and no path that swallows it.

## Fixing the shape, not the reported line

Answering the three questions, with measurements rather than assertions.

**Does a sibling surface make the same assumption? Yes — two, and I folded them in.**
A `modify()` block accepts more than the validate pair. My original probe sweep found
`OnBeforeValidate`, `OnAfterValidate`, `OnLookup`, `OnDrillDown` and `OnAssistEdit` accepted,
with `OnValidate` and `OnControlAddIn` rejected via `AL0162`.

**That list was non-exhaustive and I have corrected it.** The compiler's own
`TriggerTypeKind` enum names **six** `ControlExtension*` triggers; the sweep found five. It
missed `OnAfterAfterLookup` — the doubled `After` is the real spelling, and the near-miss
`OnAfterLookup` is rejected with `AL0162`, so a sweep guessing names lands on the rejection
and concludes the trigger does not exist. The enum, not a sweep, is the authority. The table
is out of the code (a table that looks complete and is not is worse than none) and the two
triggers with **no dispatch surface anywhere in the runner** — `OnAssistEdit` and
`OnAfterAfterLookup` — are filed as **#3642**. `RaiseOnLookup` and `RaiseOnDrillDown` both resolve through `FindTrigger`, so they
had the identical blind spot. Measured before the fix, on a control whose only trigger came
from a `modify()` block:

- `DrillDown()` → `The NavDrilldownAction method is not supported.`
- `Lookup()` → `out-of-scope: ... neither the control nor its source table field declares an
  OnLookup trigger` — a **loud refusal naming a trigger the control plainly declares**.

Both now dispatch. This is why the resolution went into `FindTrigger` rather than staying on
the validate path: fixing only what was reported would have left two call sites broken, one
of them refusing by name for a reason that was not true.

That `OnValidate` is rejected inside a `modify()` block is also why the before/after path
cannot double-dispatch through the new `FindTrigger` arm — there is no `_OnValidate` method
on the extension for it to find.

**Do two code paths write the same state with different invariants?** No. There is one
resolution path (`FindTriggerOnTarget`) and all three arms of `FindTrigger` now feed it.

**What I did not fold, and why.** #3605 (a pageextension's *added* controls live only in a
`MetadataRuntimeDeltas` delta) and #3614 (tableextension `modify(...)` property changes) both
say "modify" and neither is this. #3605 is about controls in the extension's **own** id space,
which the arm I did not touch already handles; #3614 is the table parser, a different file
and a different capture. Folding either would have meant a diff a reviewer could not hold.

## Where the prose went

The id-space rule is the thing a later editor would get wrong, so the claim and the measured
ids stay at `FindModifiedControlTriggers`. The trigger-acceptance measurement is in this PR
body, not in the code.

## Evidence

**The upstream suite ran on real BC, and one arm came back red. That is stated here first
because an earlier version of this body presented the corpus evidence as green.**

Corpus PR #305, run `34319509704`: eight cloud legs, **unanimous and deterministic — 7 PASS,
1 FAIL on every one of 27.0, 27.3, 27.5, 28.0, 28.1, 28.2, 28.3 and 28.4.** The tests did
execute (`corpus-pass-count.py` confirms the codeunit ran on all eight; the eight OnPrem
zeros are the expected different-suite answer, not a miss).

The failing arm asserted what a `modify()` before-trigger leaves behind when it raises:

```
FAIL AnErrorInOnBeforeValidatePreventsTheBaseTriggerAndOnAfterValidate
     Assert.AreEqual failed. Expected:<before;> (Text). Actual:<> (Text).
```

**Real BC discards the in-memory `Rec` mutation when the enclosing `SetValue` raises; this
runner keeps it.** The tier is right and the runner is wrong.

**What that does and does not impugn.** The divergence is isolated, not inferred: the same
suite's success path reads `'before;page;after;'` correctly on all eight legs. So `modify()`
dispatch and ordering — everything this PR changes — is *validated by a real service tier on
seven arms*. What the eighth found is a **different defect, on the shared page-write buffer**.

**I took the split.** The arm is **removed from #305 rather than weakened** — adjusting an
assertion until the runner passes it is the one thing
`ask-the-corpus-before-claiming-bc-behavior.md` forbids, and it would have converted a real
finding into a false green. The buffer defect is filed as **#3640**, with the measurement.
The fixture's `Error()` hook stays upstream, deliberately undriven and commented as such, so
stating that claim later means adding an arm rather than re-shaping the fixture.

So the corpus evidence for *this* PR is seven arms green on eight legs each:

| | before (`e2d96307`) | after |
|---|---|---|
| arms failing, locally | **7 of 8** | **0 of 7** |

The one arm green in both locally was `AModifyBlockOnAnotherControlIsNotRaisedForThisOne` — a
negative a no-op satisfies, which is why the suite is not made of negatives. Sample RED
values, all concrete:

```
Expected:<before;page;after;>                    Actual:<page;>
Expected:<otherbefore;otherpage;otherafter;>     Actual:<otherpage;>
Expected:<before;page;after;before;page;after;>  Actual:<page;page;>
```

**Pinned corpus (`c9d5f656`), regression check, both arms** — `--strict` with the count
baseline, exit 0 both times:

| | tests | pass | fail |
|---|---|---|---|
| before (`e2d96307`) | 3112 | 3112 | 0 |
| after | 3112 | 3112 | 0 |

Totals matching is weak evidence, so I diffed the **3112 named per-test results** between the
two arms: **empty**. Nothing traded places, including after the change to `FindTrigger`, whose
blast radius is every page trigger surface.

**Cache-sensitivity** — cold and warm (`AL emit: 0.0s`, a genuine hit) runs of the new suite
both 3120 pass / 0 fail. The fix reads AL-parsed metadata, which survives the compile cache.

**Targeted C# tests** — `PageExtension|TestPage|ReflectionDrivenHelperLiveness|AlPageParser`:
401 passed / 1 failed, and the same 1 fails identically on unmodified `e2d96307`. It is
`TestPageEvaluatorFaultTests.TryResolve_AnUnreadableSpelling_IsRefusedByBcRatherThanFaulting`,
the known ordering dependency in open issue #3486 — pre-existing, not mine.

## The `Tests updated` gate

The behavioural proof is upstream and the pin cannot move yet (corpus PR #305 is open, and
#3580 blocks the pin independently). So this carries a **runner-mechanism** test instead —
`PageExtensionParserTests.ModifiedControlNames_CapturesTheBasePageControlsAPageextensionModifies`
— pinning the runner's own capture, not restating the BC claim. It asserts the modified
control is captured, that a base control the extension does **not** modify and one it
**adds** are both excluded, case-insensitive lookup, and that a page and an unparsed object
each answer empty.

I verified it is **armed rather than merely quiet**: neutering only the capture (leaving the
accessor, so it still compiles) makes it fail. Both files were copied outside the repository
before that experiment and restored from those copies.

## Known gap, declared rather than guessed

A **precompiled** pageextension's `modify()` triggers stay unreachable: a dependency's
`SymbolReference.json` states the extension's own controls, not which inherited ones it
modifies. That is narrower than the silent skip it replaces, and it is stated at
`GetModifiedControlNames` rather than papered over.

Also deliberately unasserted: the order when **two** extensions modify one control. AL gives
no way to state which wins, so it is a property of platform load order. Dispatch is
deterministic (ascending extension id) but the PR does not claim that is BC's order, and the
corpus suite does not test it.

## Follow-ups filed

- **#3640** — a failed TestPage `SetValue` leaves the trigger's `Rec` mutation visible, where
  BC discards it. The defect the eighth corpus arm found. Measured on eight legs.
- **#3642** — two of the six `ControlExtension*` triggers (`OnAssistEdit`,
  `OnAfterAfterLookup`) have no dispatch surface at all. `OnAssistEdit` is inert on base
  pages too, and silently so.

---

Authored by agent `stma-auto-2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
