### PR TITLE
feat(company-init): a targeted opt-out for a knowingly-partial company, per-request server drain, collapsed duplicates

### DIFF
--- a/AlRunner.Tests/CipAcceptanceHarness.cs
+++ b/AlRunner.Tests/CipAcceptanceHarness.cs
@@ -1,0 +1,92 @@
+// CipAcceptanceHarness — the runner spawn accept-partial-company-init's process-level arms share
+// (#3561). Extracted from PartialCompanyInitAcceptanceTests when the escalation arms needed the
+// same spawn: two copies of it would let the two classes drift into driving different runners.
+using System.Diagnostics;
+using System.Text;
+
+namespace AlRunner.Tests;
+
+internal static class CipAcceptanceHarness
+{
+    internal static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    internal static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    internal static readonly string FixturePath = Path.Combine(
+        RepoRoot, "AlRunner.Tests", "Fixtures", "CompanyInitPartial");
+    /// <summary>The same bundle with one deliberately failing test, so the run earns exit 1.</summary>
+    internal static readonly string FailingFixturePath = Path.Combine(
+        RepoRoot, "AlRunner.Tests", "Fixtures", "CompanyInitPartialFailing");
+
+    /// <summary>The value the seam turns into the exception message, so every assertion is
+    /// against text that could only have come through the real catch path.</summary>
+    internal const string InjectedReason = "CIP-INJECTED-ABORT: InitSourceCodeSetup did not finish";
+
+    internal const string AcceptedBecause =
+        "this project ships without the Manufacturing dependency codeunit 2 needs; tracked in-house";
+
+    internal sealed record Run(string Output, int Exit);
+
+    internal static Run RunRunner(string cacheDir, string? expectationsDir,
+        bool injectAbort = true, bool injectCompleted = false, bool outputJson = false,
+        string[]? bundles = null)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" --cache \"{cacheDir}\"");
+        if (expectationsDir != null) args.Append($" --expectations \"{expectationsDir}\"");
+        if (outputJson) args.Append(" --output-json");
+        foreach (var b in bundles ?? new[] { FixturePath }) args.Append($" \"{b}\"");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = args.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        if (injectAbort) psi.Environment["AL_RUNNER_TEST_FAIL_COMPANY_INIT"] = InjectedReason;
+        else psi.Environment.Remove("AL_RUNNER_TEST_FAIL_COMPANY_INIT");
+        if (injectCompleted) psi.Environment["AL_RUNNER_TEST_COMPANY_INIT_COMPLETED"] = "1";
+
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(240_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return new Run(sb.ToString(), p.ExitCode);
+    }
+
+    internal static string NewCacheDir()
+    {
+        var dir = TestScratch.Dir("al-runner-cipa-cache");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    /// <summary>Write a one-entry manifest directory and return its path.</summary>
+    internal static string ManifestDir(string name, string entryJson)
+    {
+        var dir = TestScratch.Dir("al-runner-cipa-manifest-" + name);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "accept-company-init.json"), "[\n" + entryJson + "\n]\n");
+        return dir;
+    }
+
+    internal static string AcceptEntry(int codeunitId = 2, string codeunitName = "Company-Initialize",
+        string reason = AcceptedBecause, string method = "*")
+        => $$"""
+          {
+            "codeunitId": {{codeunitId}},
+            "CodeunitName": "{{codeunitName}}",
+            "Method": "{{method}}",
+            "Mode": "accept-partial-company-init",
+            "Reason": "{{reason}}"
+          }
+        """;
+}

--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -182,6 +182,30 @@ public sealed class CollectionCostOrderer : ITestCollectionOrderer
             // the true figure is a little higher; re-measure with scripts/trx-occupancy.py
             // rather than trusting this line if the class changes shape again.
             ["PartialCompanyInitializationTests"] = 113,
+            // #3561: 8 arms, every one of them a runner spawn and two of them two (a plain run
+            // then --output-json, which redirects everything else to stderr). Absent from this
+            // table on its first review pass, where check-collection-weights.py --fail-threshold
+            // 75 named it at 189.8s and took the leg red. Recorded at 189: measured 184.9s here
+            // on a 4-way local run of the five company-init classes together (a Windows dev box,
+            // NOT a CI leg — the sibling PartialCompanyInitializationTests summed 365.5s in that
+            // same run against the 113.5s its own line records from a leg), so 189 is the higher
+            // of the two local observations and the table's "carry the observed maximum" rule.
+            // Far above UnmeasuredWeightSeconds either way, which is what makes the entry change
+            // dispatch order rather than decorate the file.
+            ["PartialCompanyInitAcceptanceTests"] = 189,
+            // #3561: the two escalation arms live in their own collection precisely so the entry
+            // above does not grow further — a collection is strictly serial, so a longer one is a
+            // longer tail. 58.2s local; the reviewer's 58.3s figure for the sibling drain class
+            // below is the same order, and both sit between UnmeasuredWeightSeconds and the 60s
+            // report band, which is exactly the range this table exists to keep out of the
+            // fallback.
+            ["PartialCompanyInitAcceptanceEscalationTests"] = 58,
+            // #3561: 3 arms, each driving its own CliServer subprocess (the abort is a
+            // startup-time env var, so this class cannot share SharedCliServer). 52.6s on the
+            // local run above and 58.3s on the review pass's — under both bands, so the gate has
+            // not named it, and listed here for the dispatch-order half rather than the
+            // freshness half. Carries the observed MAXIMUM for the reason the entries below give.
+            ["ServerCompanyInitDrainTests"] = 58,
             // #2348: EmptySetupTable_Get/EmptySetupTable_TestField now call DeleteAll() on
             // "Source Code Setup" before asserting it's empty (fixing IncludeSender's
             // sender-position dispatch also fixed a latent install-time bug that used to

--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -182,30 +182,30 @@ public sealed class CollectionCostOrderer : ITestCollectionOrderer
             // the true figure is a little higher; re-measure with scripts/trx-occupancy.py
             // rather than trusting this line if the class changes shape again.
             ["PartialCompanyInitializationTests"] = 113,
-            // #3561: 8 arms, every one of them a runner spawn and two of them two (a plain run
-            // then --output-json, which redirects everything else to stderr). Absent from this
-            // table on its first review pass, where check-collection-weights.py --fail-threshold
-            // 75 named it at 189.8s and took the leg red. Recorded at 189: measured 184.9s here
-            // on a 4-way local run of the five company-init classes together (a Windows dev box,
-            // NOT a CI leg — the sibling PartialCompanyInitializationTests summed 365.5s in that
-            // same run against the 113.5s its own line records from a leg), so 189 is the higher
-            // of the two local observations and the table's "carry the observed maximum" rule.
-            // Far above UnmeasuredWeightSeconds either way, which is what makes the entry change
-            // dispatch order rather than decorate the file.
-            ["PartialCompanyInitAcceptanceTests"] = 189,
-            // #3561: the two escalation arms live in their own collection precisely so the entry
-            // above does not grow further — a collection is strictly serial, so a longer one is a
-            // longer tail. 58.2s local; the reviewer's 58.3s figure for the sibling drain class
-            // below is the same order, and both sit between UnmeasuredWeightSeconds and the 60s
-            // report band, which is exactly the range this table exists to keep out of the
-            // fallback.
+            // #3561: 8 arms (one of them a 3-case theory), every one a runner spawn and one of
+            // them two — a plain run then --output-json, which redirects everything else to
+            // stderr. 9 spawns per run of the class. Absent from this table on its first review
+            // pass; recorded at 71 from the BC 28.4 leg of run 34322324604 (71.3s summed), which
+            // is the clock this table is written in. A local 4-way Windows run of the five
+            // company-init classes measured 184.9s for the same 8 arms, and the review pass
+            // measured 189.8s — a dev box runs a runner spawn ~2.6x the leg's cost, and the
+            // sibling PartialCompanyInitializationTests shows the same gap (365.5s local against
+            // the 113.5s its own line records from a leg). Recording the local figure would rank
+            // this class alongside genuinely 190s ones and displace them.
+            ["PartialCompanyInitAcceptanceTests"] = 71,
+            // #3561: the two escalation arms are their own collection precisely so the entry
+            // above does not grow — a collection is strictly serial, so a longer one is a longer
+            // tail. 58.2s local, no leg figure yet (the class is new); by the ~2.6x local/leg
+            // ratio measured directly above, the leg figure is likely nearer 25, so this entry
+            // is an over-estimate carried until a leg measures it rather than a scaled guess.
             ["PartialCompanyInitAcceptanceEscalationTests"] = 58,
-            // #3561: 3 arms, each driving its own CliServer subprocess (the abort is a
-            // startup-time env var, so this class cannot share SharedCliServer). 52.6s on the
-            // local run above and 58.3s on the review pass's — under both bands, so the gate has
-            // not named it, and listed here for the dispatch-order half rather than the
-            // freshness half. Carries the observed MAXIMUM for the reason the entries below give.
-            ["ServerCompanyInitDrainTests"] = 58,
+            // #3561: 2 arms, each driving its own CliServer subprocess (the abort is a
+            // startup-time env var, so this class cannot share SharedCliServer), and each now
+            // forcing a dependency-company-baseline MISS so codeunit 2 is genuinely attempted —
+            // see that file's header. 80.6s local after that change, against 52.6s local and
+            // 58.3s before it; the forced MISS is most of the difference and it is permanent, so
+            // the post-change figure is the one recorded.
+            ["ServerCompanyInitDrainTests"] = 80,
             // #2348: EmptySetupTable_Get/EmptySetupTable_TestField now call DeleteAll() on
             // "Source Code Setup" before asserting it's empty (fixing IncludeSender's
             // sender-position dispatch also fixed a latent install-time bug that used to

--- a/AlRunner.Tests/ExpectationManifestSchemaTests.cs
+++ b/AlRunner.Tests/ExpectationManifestSchemaTests.cs
@@ -34,6 +34,9 @@ public class ExpectationManifestSchemaTests : IDisposable
 
     private const string Head = @"[{""codeunitId"":60877,""CodeunitName"":""Cu"",""Method"":""M"",""Mode"":""expect-divergence""";
 
+    private const string AcceptHead = @"[{""codeunitId"":2,""CodeunitName"":""Company-Initialize"","
+        + @"""Method"":""*"",""Mode"":""accept-partial-company-init""";
+
     [Fact]
     public void ExpectDivergence_WithReasonAndDoc_Loads()
     {
@@ -69,6 +72,37 @@ public class ExpectationManifestSchemaTests : IDisposable
         Assert.Contains("must not carry 'Issue'",
             LoadError(Head + @",""Reason"":""r"",""Doc"":""docs/scope.md#jobs"","
                 + @"""Issue"":""https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/1733""}]"));
+    }
+
+    /// <summary>
+    /// #3561: an accept-partial-company-init entry is a standing decision about this project's
+    /// company, not tracked work, so an <c>Issue</c> link is refused at load time — the same
+    /// refusal expect-divergence has directly above, for the same reason. The end-to-end arms in
+    /// PartialCompanyInitAcceptanceTests cover the placeholder-Reason and non-"*" Method
+    /// refusals; this one is in-process because the loader is where all three are decided and a
+    /// third runner spawn would buy nothing.
+    /// </summary>
+    [Fact]
+    public void AcceptPartialCompanyInit_WithAnIssueLink_IsRejected()
+    {
+        Assert.Contains("must not carry 'Issue'", LoadError(AcceptHead
+            + @",""Reason"":""ships without the dependency codeunit 2 needs"","
+            + @"""Issue"":""https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3561""}]"));
+    }
+
+    /// <summary>The positive control for the arm above: the same entry without the link loads,
+    /// stays out of the test-lookup table (it names no test) and is offered as an acceptance.</summary>
+    [Fact]
+    public void AcceptPartialCompanyInit_WithoutAnIssue_LoadsAsARunLevelAcceptance()
+    {
+        var m = Load(AcceptHead + @",""Reason"":""ships without the dependency codeunit 2 needs""}]");
+        Assert.Null(m.Lookup("Company-Initialize", "*"));
+        var e = Assert.Single(m.CompanyInitAcceptances);
+        Assert.Equal(ExpectationMode.AcceptPartialCompanyInit, e.Mode);
+        Assert.Equal(2, e.CodeunitId);
+        Assert.Equal("ships without the dependency codeunit 2 needs", e.Reason);
+        Assert.NotNull(m.FindCompanyInitAcceptance(2, "Company-Initialize"));
+        Assert.Null(m.FindCompanyInitAcceptance(2, "Some Other Initialize"));
     }
 
     [Fact]

--- a/AlRunner.Tests/PartialCompanyInitAcceptanceEscalationTests.cs
+++ b/AlRunner.Tests/PartialCompanyInitAcceptanceEscalationTests.cs
@@ -1,0 +1,100 @@
+// PartialCompanyInitAcceptanceEscalationTests — issue #3561, the "and nothing else" half.
+//
+// accept-partial-company-init suppresses ONE transition: company-init's 0 → 2. That is the whole
+// claim that makes it a targeted alternative to --no-strict-exit, which forces 0 for a failing
+// test, a compile failure and a lost output file as well. An implementation that suppressed more
+// than the one transition — forcing 0, or clearing the accumulator before the exit code is
+// computed — passes every arm in PartialCompanyInitAcceptanceTests, because nothing there earns
+// an exit code of its own. These two arms are what it fails.
+//
+// A separate class rather than two more arms next door for a measured reason: the acceptance
+// class already sums ~190 s of runner spawns, and CollectionCostOrderer schedules by COLLECTION,
+// so a longer one is a longer single-threaded tail (#1887). Both are in that table.
+using Xunit;
+using static AlRunner.Tests.CipAcceptanceHarness;
+
+namespace AlRunner.Tests;
+
+public sealed class PartialCompanyInitAcceptanceEscalationTests
+{
+    /// <summary>
+    /// Exit 1 is a statement about the AL, and the acceptance says nothing about the AL. The
+    /// failing test still earns it, the accepted abort is still on every reporting surface, and
+    /// the escalation line — which only ever explains a MOVED exit code — is absent because
+    /// nothing moved.
+    /// </summary>
+    [SkippableFact]
+    public void AnAcceptedAbort_WithAFailingTest_StillExitsOne()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var run = RunRunner(NewCacheDir(), ManifestDir("accept-failing", AcceptEntry()),
+            bundles: new[] { FailingFixturePath });
+
+        Assert.True(run.Exit == 1,
+            $"a failing test earns exit 1; accepting the abort must not lower it to 0. "
+            + $"exit={run.Exit}\n{run.Output}");
+        Assert.Contains("fail:        1", run.Output);
+        // Accepted, therefore recorded — the acceptance is not a silencer.
+        Assert.Contains("Company initialization: INCOMPLETE", run.Output);
+        Assert.Contains($"[accepted: {AcceptedBecause}]", run.Output);
+        Assert.DoesNotContain("[warn] company-init:", run.Output);
+    }
+
+    /// <summary>
+    /// Exit 3 is the compile ladder, one rung the acceptance has no opinion about either. Two
+    /// bundles, the good one FIRST so its abort is genuinely recorded in this run before the
+    /// broken one fails to compile: the `[accepted:` marker is what proves that, and without it
+    /// a runner that gave up at the compile failure would satisfy the exit-code assertion while
+    /// never reaching the code under test.
+    /// </summary>
+    [SkippableFact]
+    public void AnAcceptedAbort_WithACompileFailure_StillExitsThree()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var run = RunRunner(NewCacheDir(), ManifestDir("accept-broken", AcceptEntry()),
+            bundles: new[] { FixturePath, WriteUncompilableBundle() });
+
+        Assert.True(run.Exit == 3,
+            $"a compile failure earns exit 3; accepting the abort must not lower it to 0, nor "
+            + $"let the abort raise it to 2. exit={run.Exit}\n{run.Output}");
+        Assert.Contains("Company initialization: INCOMPLETE", run.Output);
+        Assert.Contains($"[accepted: {AcceptedBecause}]", run.Output);
+        Assert.DoesNotContain("[warn] company-init:", run.Output);
+    }
+
+    /// <summary>A bundle that reaches the compiler and does not survive it: the procedure body
+    /// references an identifier nothing declares, which is a diagnostic rather than a parse
+    /// error, so the object is genuinely compiled and genuinely rejected.</summary>
+    private static string WriteUncompilableBundle()
+    {
+        var dir = TestScratch.Dir("al-runner-cipa-broken");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "a1b2c3d4-e5f6-4708-9a1b-2c3d4e5f6013",
+          "name": "Runner Tests Fixture - Company Init Partial Uncompilable",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 70740, "to": 70759 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "CipBroken.Codeunit.al"), """
+        codeunit 70740 "CIP Broken Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure ThisDoesNotCompile()
+            begin
+                NoSuchVariable := 1;
+            end;
+        }
+        """);
+        return dir;
+    }
+}

--- a/AlRunner.Tests/PartialCompanyInitAcceptanceTests.cs
+++ b/AlRunner.Tests/PartialCompanyInitAcceptanceTests.cs
@@ -1,0 +1,257 @@
+// PartialCompanyInitAcceptanceTests — issue #3561.
+//
+// What is being pinned
+// --------------------
+// #3538 made a run whose company initialization did not complete exit 2 instead of 0. The only
+// escape from that was `--no-strict-exit`, which forces 0 for a failing test, a compile failure
+// and a lost output file too — a suite that knowingly accepts one abort had to give up its exit
+// code entirely. The targeted opt-out is an expectations-manifest entry:
+//
+//   { "codeunitId": 2, "CodeunitName": "Company-Initialize", "Method": "*",
+//     "Mode": "accept-partial-company-init", "Reason": "<why this project accepts it>" }
+//
+// A matching abort is still printed in the summary (marked `[accepted: <reason>]`), still in
+// --out, --output-json and the JUnit comment — ONLY the exit 0 → 2 escalation is suppressed, and
+// only for the codeunit the entry names. Exit codes 1/3/4/5 are untouched.
+//
+// The drift half mirrors expect-oos's "the test passed, remove the entry": an entry whose
+// codeunit RAN TO COMPLETION in this run is an exit-code suppression with nothing behind it, and
+// the run says so and does not exit 0.
+//
+// Why two injected seams
+// ----------------------
+// Whether codeunit 2 aborts is a property of a particular Base Application build (#3054 measured
+// five of eight legs; today, none), so the abort arms drive AL_RUNNER_TEST_FAIL_COMPANY_INIT,
+// exactly as PartialCompanyInitializationTests does. The drift arm needs the opposite fact —
+// codeunit 2 found and COMPLETED — which for real requires the Base Application floor, forbidden
+// in a C# fixture (.claude/rules/no-base-app-in-csharp-tests.md) and, at ~70s per invocation,
+// unable to guarantee the completion anyway. AL_RUNNER_TEST_COMPANY_INIT_COMPLETED=1 records the
+// completion at exactly the line the real one does, so the drift check under test is the real one.
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PartialCompanyInitAcceptanceTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string FixturePath = Path.Combine(
+        RepoRoot, "AlRunner.Tests", "Fixtures", "CompanyInitPartial");
+
+    private const string InjectedReason = "CIP-INJECTED-ABORT: InitSourceCodeSetup did not finish";
+    private const string AcceptedBecause =
+        "this project ships without the Manufacturing dependency codeunit 2 needs; tracked in-house";
+
+    private sealed record Run(string Output, int Exit);
+
+    private static Run RunRunner(string cacheDir, string? expectationsDir,
+        bool injectAbort = true, bool injectCompleted = false, bool outputJson = false)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" --cache \"{cacheDir}\"");
+        if (expectationsDir != null) args.Append($" --expectations \"{expectationsDir}\"");
+        if (outputJson) args.Append(" --output-json");
+        args.Append($" \"{FixturePath}\"");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = args.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        if (injectAbort) psi.Environment["AL_RUNNER_TEST_FAIL_COMPANY_INIT"] = InjectedReason;
+        else psi.Environment.Remove("AL_RUNNER_TEST_FAIL_COMPANY_INIT");
+        if (injectCompleted) psi.Environment["AL_RUNNER_TEST_COMPANY_INIT_COMPLETED"] = "1";
+
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(240_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return new Run(sb.ToString(), p.ExitCode);
+    }
+
+    private static string NewCacheDir()
+    {
+        var dir = TestScratch.Dir("al-runner-cipa-cache");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    /// <summary>Write a one-entry manifest directory and return its path.</summary>
+    private static string ManifestDir(string name, string entryJson)
+    {
+        var dir = TestScratch.Dir("al-runner-cipa-manifest-" + name);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "accept-company-init.json"), "[\n" + entryJson + "\n]\n");
+        return dir;
+    }
+
+    private static string AcceptEntry(int codeunitId = 2, string codeunitName = "Company-Initialize",
+        string reason = AcceptedBecause, string method = "*")
+        => $$"""
+          {
+            "codeunitId": {{codeunitId}},
+            "CodeunitName": "{{codeunitName}}",
+            "Method": "{{method}}",
+            "Mode": "accept-partial-company-init",
+            "Reason": "{{reason}}"
+          }
+        """;
+
+    /// <summary>
+    /// The positive case. An accepted abort keeps every reporting surface it already had — the
+    /// summary block, the reason text, the JSON document — and adds the entry's reason to them,
+    /// while the process exits 0 because nothing about the AL failed. The escalation line is
+    /// absent, because there is no moved exit code for it to explain.
+    /// </summary>
+    [SkippableFact]
+    public void AnAcceptedAbort_IsStillReportedEverywhere_ButDoesNotEscalateTheExitCode()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var manifest = ManifestDir("accept", AcceptEntry());
+        var run = RunRunner(NewCacheDir(), manifest);
+
+        Assert.True(run.Exit == 0,
+            $"an accepted company-init abort must not move the exit code. exit={run.Exit}\n{run.Output}");
+        // Recorded, not silenced: the whole point of the entry over --no-strict-exit.
+        Assert.Contains("Company initialization: INCOMPLETE", run.Output);
+        Assert.Contains(InjectedReason, run.Output);
+        Assert.Contains($"[accepted: {AcceptedBecause}]", run.Output);
+        Assert.Contains("accept-partial-company-init", run.Output);
+        // ...and the tests are still real results.
+        Assert.Contains("pass:        1", run.Output);
+        // The escalation line only ever explains a MOVED exit code.
+        Assert.DoesNotContain("[warn] company-init: 1 company initialization abort(s)", run.Output);
+
+        // --output-json carries the acceptance as a field, so a consumer reading only the
+        // document can tell an accepted condition from one nobody has looked at.
+        var json = RunRunner(NewCacheDir(), manifest, outputJson: true);
+        Assert.Equal(0, json.Exit);
+        var doc = JsonDocument.Parse(json.Output[json.Output.IndexOf('{')..]).RootElement;
+        Assert.Equal(0, doc.GetProperty("exitCode").GetInt32());
+        var failures = doc.GetProperty("companyInitFailures").EnumerateArray().ToList();
+        Assert.Single(failures);
+        Assert.Equal(AcceptedBecause, failures[0].GetProperty("accepted").GetString());
+        Assert.Equal(1, failures[0].GetProperty("count").GetInt32());
+        Assert.Equal(InjectedReason, failures[0].GetProperty("message").GetString());
+    }
+
+    /// <summary>
+    /// The negative control, and what makes the acceptance targeted rather than a blanket
+    /// switch: an entry naming a DIFFERENT initialization codeunit accepts nothing here. Same
+    /// manifest machinery, same run, exit 2 — so a project cannot suppress an abort it has not
+    /// actually declared, which is the failure mode `--no-strict-exit` has by design.
+    /// </summary>
+    [SkippableFact]
+    public void AnEntryNamingAnotherCodeunit_DoesNotAcceptThisAbort()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var manifest = ManifestDir("other",
+            AcceptEntry(codeunitId: 9999, codeunitName: "Some Other Initialize"));
+        var run = RunRunner(NewCacheDir(), manifest);
+
+        Assert.True(run.Exit == 2,
+            $"an abort no entry names must still exit 2. exit={run.Exit}\n{run.Output}");
+        Assert.Contains("[warn] company-init:", run.Output);
+        Assert.DoesNotContain("[accepted:", run.Output);
+    }
+
+    /// <summary>
+    /// The drift half. The entry says "this codeunit aborts here"; once it completes, the entry
+    /// is a suppression nobody is watching, and the run refuses to be clean until it is removed
+    /// — the same loudness expect-oos has for a test that started passing.
+    /// </summary>
+    [SkippableFact]
+    public void AnEntryWhoseCodeunitCompleted_IsDrift_AndTheRunSaysSo()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var manifest = ManifestDir("stale", AcceptEntry());
+        var run = RunRunner(NewCacheDir(), manifest, injectAbort: false, injectCompleted: true);
+
+        Assert.True(run.Exit == 2,
+            $"a stale acceptance entry must not leave the run reporting clean. exit={run.Exit}\n{run.Output}");
+        Assert.Contains("declares accept-partial-company-init for codeunit 2", run.Output);
+        Assert.Contains("ran to completion in this run", run.Output);
+        Assert.Contains("Remove the entry", run.Output);
+        Assert.Contains("accept-company-init.json", run.Output);
+        // The company DID initialize, so none of the abort reporting appears.
+        Assert.DoesNotContain("Company initialization: INCOMPLETE", run.Output);
+    }
+
+    /// <summary>
+    /// The same entry in a run that never attempted the codeunit is INERT, not drift. The
+    /// manifest directory is auto-probed and shared by every invocation in a project — the
+    /// reason `--expectations-require-match` is opt-in — so a bundle carrying no Base App must
+    /// not fail because another bundle's declaration is in the same directory.
+    /// </summary>
+    [SkippableFact]
+    public void AnEntryWhoseCodeunitWasNeverAttempted_IsInert()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var manifest = ManifestDir("inert", AcceptEntry());
+        var run = RunRunner(NewCacheDir(), manifest, injectAbort: false);
+
+        Assert.True(run.Exit == 0,
+            $"an entry for a codeunit this run never ran must not fail it. exit={run.Exit}\n{run.Output}");
+        Assert.DoesNotContain("Remove the entry", run.Output);
+        Assert.DoesNotContain("Company initialization: INCOMPLETE", run.Output);
+    }
+
+    /// <summary>
+    /// The reason is what a reviewer reads, so a marker with nothing behind it is refused at
+    /// load time — before a single test runs, like every other schema violation. Same fixed
+    /// token list as .github/scripts/check_corpus_linkage.sh's Corpus-NA reason.
+    /// </summary>
+    [SkippableTheory]
+    [InlineData("n/a")]
+    [InlineData("TBD")]
+    [InlineData("-")]
+    public void APlaceholderReason_IsRefusedAtLoadTime(string placeholder)
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var manifest = ManifestDir("placeholder-" + placeholder.Replace("/", ""),
+            AcceptEntry(reason: placeholder));
+        var run = RunRunner(NewCacheDir(), manifest);
+
+        Assert.Equal(2, run.Exit);
+        Assert.Contains("is a placeholder", run.Output);
+        Assert.Contains("expectations manifest", run.Output);
+        // Refused BEFORE the run, so no test result exists to read.
+        Assert.DoesNotContain("pass:        1", run.Output);
+    }
+
+    /// <summary>
+    /// The entry names an initialization codeunit, not a test, so a Method other than "*" is a
+    /// misunderstanding worth refusing rather than silently ignoring — nothing would ever look
+    /// such an entry up, and it would read as an accepted abort that never accepts anything.
+    /// </summary>
+    [SkippableFact]
+    public void AMethodOtherThanWildcard_IsRefusedAtLoadTime()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var manifest = ManifestDir("method", AcceptEntry(method: "SomeTestMethod"));
+        var run = RunRunner(NewCacheDir(), manifest);
+
+        Assert.Equal(2, run.Exit);
+        Assert.Contains("'Method' must be", run.Output);
+    }
+}

--- a/AlRunner.Tests/PartialCompanyInitAcceptanceTests.cs
+++ b/AlRunner.Tests/PartialCompanyInitAcceptanceTests.cs
@@ -27,90 +27,16 @@
 // in a C# fixture (.claude/rules/no-base-app-in-csharp-tests.md) and, at ~70s per invocation,
 // unable to guarantee the completion anyway. AL_RUNNER_TEST_COMPANY_INIT_COMPLETED=1 records the
 // completion at exactly the line the real one does, so the drift check under test is the real one.
-using System.Diagnostics;
-using System.Text;
 using System.Text.Json;
 using Xunit;
+using static AlRunner.Tests.CipAcceptanceHarness;
 
 namespace AlRunner.Tests;
 
+// The runner spawn, the manifest writer and the two injected env vars live in
+// CipAcceptanceHarness, shared with PartialCompanyInitAcceptanceEscalationTests.
 public sealed class PartialCompanyInitAcceptanceTests
 {
-    private static readonly string RepoRoot = Path.GetFullPath(
-        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
-    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
-    private static readonly string FixturePath = Path.Combine(
-        RepoRoot, "AlRunner.Tests", "Fixtures", "CompanyInitPartial");
-
-    private const string InjectedReason = "CIP-INJECTED-ABORT: InitSourceCodeSetup did not finish";
-    private const string AcceptedBecause =
-        "this project ships without the Manufacturing dependency codeunit 2 needs; tracked in-house";
-
-    private sealed record Run(string Output, int Exit);
-
-    private static Run RunRunner(string cacheDir, string? expectationsDir,
-        bool injectAbort = true, bool injectCompleted = false, bool outputJson = false)
-    {
-        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
-        args.Append(TestBuildConfig.BcVersionArg);
-        args.Append($" --cache \"{cacheDir}\"");
-        if (expectationsDir != null) args.Append($" --expectations \"{expectationsDir}\"");
-        if (outputJson) args.Append(" --output-json");
-        args.Append($" \"{FixturePath}\"");
-
-        var psi = new ProcessStartInfo
-        {
-            FileName = "dotnet",
-            Arguments = args.ToString(),
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-            WorkingDirectory = RepoRoot,
-        };
-        if (injectAbort) psi.Environment["AL_RUNNER_TEST_FAIL_COMPANY_INIT"] = InjectedReason;
-        else psi.Environment.Remove("AL_RUNNER_TEST_FAIL_COMPANY_INIT");
-        if (injectCompleted) psi.Environment["AL_RUNNER_TEST_COMPANY_INIT_COMPLETED"] = "1";
-
-        var sb = new StringBuilder();
-        using var p = Process.Start(psi)!;
-        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
-        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
-        p.BeginOutputReadLine();
-        p.BeginErrorReadLine();
-        if (!p.WaitForExit(240_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
-        p.WaitForExit();
-        lock (sb) return new Run(sb.ToString(), p.ExitCode);
-    }
-
-    private static string NewCacheDir()
-    {
-        var dir = TestScratch.Dir("al-runner-cipa-cache");
-        Directory.CreateDirectory(dir);
-        return dir;
-    }
-
-    /// <summary>Write a one-entry manifest directory and return its path.</summary>
-    private static string ManifestDir(string name, string entryJson)
-    {
-        var dir = TestScratch.Dir("al-runner-cipa-manifest-" + name);
-        Directory.CreateDirectory(dir);
-        File.WriteAllText(Path.Combine(dir, "accept-company-init.json"), "[\n" + entryJson + "\n]\n");
-        return dir;
-    }
-
-    private static string AcceptEntry(int codeunitId = 2, string codeunitName = "Company-Initialize",
-        string reason = AcceptedBecause, string method = "*")
-        => $$"""
-          {
-            "codeunitId": {{codeunitId}},
-            "CodeunitName": "{{codeunitName}}",
-            "Method": "{{method}}",
-            "Mode": "accept-partial-company-init",
-            "Reason": "{{reason}}"
-          }
-        """;
-
     /// <summary>
     /// The positive case. An accepted abort keeps every reporting surface it already had — the
     /// summary block, the reason text, the JSON document — and adds the entry's reason to them,

--- a/AlRunner.Tests/PartialCompanyInitCollapseTests.cs
+++ b/AlRunner.Tests/PartialCompanyInitCollapseTests.cs
@@ -1,0 +1,120 @@
+// PartialCompanyInitCollapseTests — issue #3561, the two arms that have no end-to-end route.
+//
+// Everything else about accept-partial-company-init is driven through a real runner process
+// (PartialCompanyInitAcceptanceTests, PartialCompanyInitAcceptanceEscalationTests). These two
+// cannot be: CompanyInitializer only ever records Base App's codeunit 2, and acceptance is keyed
+// on the codeunit, so a single run cannot produce two aborts that differ in the way each arm
+// needs — one accepted and one not, or two messages under one codeunit. Driving the two helpers
+// the run itself calls (Reporter.FinalizeCompanyInitFailures at both drain sites,
+// Reporter.UnacceptedCompanyInitFailures at the escalation) is the closest reachable statement,
+// and it is the mechanism rather than a re-statement of the exit-code wiring the process-level
+// arms already pin.
+using AlRunner;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PartialCompanyInitCollapseTests : IDisposable
+{
+    private readonly string _dir = TestScratch.FlatDir("al-runner-cip-collapse-unit-");
+
+    public PartialCompanyInitCollapseTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    private ExpectationManifest AcceptingCodeunit2()
+    {
+        File.WriteAllText(Path.Combine(_dir, "accept-company-init.json"),
+            """
+            [{ "codeunitId": 2, "CodeunitName": "Company-Initialize", "Method": "*",
+               "Mode": "accept-partial-company-init",
+               "Reason": "ships without the dependency codeunit 2 needs" }]
+            """);
+        return ExpectationManifest.LoadFromDirectory(_dir);
+    }
+
+    private static CompanyInitFailure Abort(int id, string name, string message)
+        => new(id, name, "InvalidOperationException", message);
+
+    private static BucketResult Bucket(params CompanyInitFailure[] failures)
+        => new("/b", BucketStage.Ran, Array.Empty<string>(), null, Array.Empty<TestResult>(),
+            TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, CompanyInitFailures: failures);
+
+    /// <summary>
+    /// The key is the whole of what the accumulator records, so two aborts of the SAME codeunit
+    /// that failed at different points stay two records. Collapsing on the codeunit alone would
+    /// report one of the two causes and silently drop the other — the opposite defect to the
+    /// duplication #3561 removed, and the more expensive one, since the dropped line is the one
+    /// nobody knows to look for.
+    /// </summary>
+    [Fact]
+    public void TwoAbortsOfOneCodeunit_WithDifferentMessages_DoNotCollapse()
+    {
+        var finalized = Reporter.FinalizeCompanyInitFailures(
+            new[]
+            {
+                Abort(2, "Company-Initialize", "InitSourceCodeSetup did not finish"),
+                Abort(2, "Company-Initialize", "InitSourceCodeSetup did not finish"),
+                Abort(2, "Company-Initialize", "InsertMarketingSetup did not finish"),
+            },
+            manifest: null);
+
+        Assert.Equal(2, finalized.Count);
+        var first = Assert.Single(finalized, f => f.Message.StartsWith("InitSourceCodeSetup"));
+        var second = Assert.Single(finalized, f => f.Message.StartsWith("InsertMarketingSetup"));
+        // Only the two IDENTICAL records folded, and the fold carries the count.
+        Assert.Equal(2, first.Count);
+        Assert.Equal(1, second.Count);
+        Assert.Contains("×2 app group(s)", Reporter.DescribeCompanyInitFailure(first));
+        Assert.DoesNotContain("app group(s)", Reporter.DescribeCompanyInitFailure(second));
+    }
+
+    /// <summary>
+    /// The acceptance is per codeunit, so a run carrying an accepted abort AND one of a codeunit
+    /// no entry names is still not clean: the escalation reads
+    /// <see cref="Reporter.UnacceptedCompanyInitFailures"/>, which keeps exactly the second one.
+    /// A "any acceptance accepts the run" implementation — the shortcut this mode is a targeted
+    /// alternative to — passes every other arm in this suite and fails here.
+    /// </summary>
+    [Fact]
+    public void AnAcceptedAbortAlongsideAnUnacceptedOne_LeavesTheRunUnclean()
+    {
+        var manifest = AcceptingCodeunit2();
+        var finalized = Reporter.FinalizeCompanyInitFailures(
+            new[]
+            {
+                Abort(2, "Company-Initialize", "InitSourceCodeSetup did not finish"),
+                Abort(9999, "Some Other Initialize", "the other one did not finish either"),
+            },
+            manifest);
+
+        // Both are still REPORTED — acceptance suppresses the escalation, never the record.
+        Assert.Equal(2, finalized.Count);
+        Assert.Equal("ships without the dependency codeunit 2 needs",
+            Assert.Single(finalized, f => f.CodeunitId == 2).AcceptedReason);
+        Assert.Null(Assert.Single(finalized, f => f.CodeunitId == 9999).AcceptedReason);
+
+        var unaccepted = Reporter.UnacceptedCompanyInitFailures(new[] { Bucket(finalized.ToArray()) });
+        Assert.Equal(9999, Assert.Single(unaccepted).CodeunitId);
+    }
+
+    /// <summary>
+    /// The control for the arm above: with only the accepted abort, nothing is left for the
+    /// escalation to read, which is the whole of what the mode buys.
+    /// </summary>
+    [Fact]
+    public void AnAcceptedAbortAlone_LeavesNothingForTheEscalation()
+    {
+        var finalized = Reporter.FinalizeCompanyInitFailures(
+            new[] { Abort(2, "Company-Initialize", "InitSourceCodeSetup did not finish") },
+            AcceptingCodeunit2());
+
+        Assert.Single(finalized);
+        Assert.Empty(Reporter.UnacceptedCompanyInitFailures(new[] { Bucket(finalized.ToArray()) }));
+    }
+}

--- a/AlRunner.Tests/PartialCompanyInitializationTests.cs
+++ b/AlRunner.Tests/PartialCompanyInitializationTests.cs
@@ -353,8 +353,52 @@ public sealed class PartialCompanyInitializationTests
             // The HIT is what makes this test about the carry rather than about two aborts.
             Assert.Contains("InstallBaseline.DepCompanyCache HIT", run.Output);
             // One abort per app group: each ran its tests against the partial company, and the
-            // one that reused the snapshot has no other way to say so.
+            // one that reused the snapshot has no other way to say so. The header still counts
+            // app groups...
             Assert.Contains("Company initialization: INCOMPLETE (2 abort(s))", run.Output);
+            // ...and #3561 collapses the two IDENTICAL lines below it into one carrying the
+            // count, instead of printing the same codeunit, exception and message twice.
+            Assert.Contains("×2 app group(s)", run.Output);
+            // Exactly one line in the summary block, not two identical ones. The `[warn]`
+            // lines printed at abort time are excluded by the leading tag: those are per
+            // occurrence by design and are not what collapses.
+            var summaryLines = run.Output.Split("\n")
+                .Select(l => l.Trim())
+                .Where(l => l.StartsWith("codeunit 2 \"Company-Initialize\" did not complete",
+                    StringComparison.Ordinal))
+                .ToList();
+            Assert.Single(summaryLines);
+        }
+        finally { try { Directory.Delete(root, true); } catch { } }
+    }
+
+    /// <summary>
+    /// The same two app groups in --output-json (#3561): ONE entry carrying `count: 2`, not two
+    /// identical objects a consumer has to deduplicate itself. The count is the claim — each app
+    /// group really did run its tests against the partial company — and losing it would be the
+    /// opposite defect to the duplication.
+    /// </summary>
+    [SkippableFact]
+    public void PartialCompanyInit_AcrossAppGroups_CollapsesToOneEntryWithACount()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = TestScratch.Dir("al-runner-cip-collapse");
+        try
+        {
+            var (appA, appB, _) = InstallSeedClosure.WriteSharedClosure(root, "cipcol", 61930);
+            var run = RunRunner(NewCacheDir(), injectAbort: true,
+                bundles: new[] { appA, appB }, outputJson: true, perfMarkers: true);
+
+            Assert.Equal(2, run.Exit);
+            var doc = JsonDocument.Parse(run.Output[run.Output.IndexOf('{')..]).RootElement;
+            var failures = doc.GetProperty("companyInitFailures").EnumerateArray().ToList();
+            Assert.Single(failures);
+            Assert.Equal(2, failures[0].GetProperty("count").GetInt32());
+            Assert.Equal(InjectedReason, failures[0].GetProperty("message").GetString());
+            // Nothing accepted it, so the field is absent rather than carrying a null a consumer
+            // would have to interpret.
+            Assert.False(failures[0].TryGetProperty("accepted", out _));
         }
         finally { try { Directory.Delete(root, true); } catch { } }
     }

--- a/AlRunner.Tests/ServerCompanyInitDrainTests.cs
+++ b/AlRunner.Tests/ServerCompanyInitDrainTests.cs
@@ -1,0 +1,123 @@
+// ServerCompanyInitDrainTests — issue #3561, the server-mode half.
+//
+// CompanyInitializer's accumulator is run-wide and is drained where Program.cs builds a bucket's
+// BucketResult — a path `--server` never takes. So under --server the static list grew for the
+// life of the process and NOTHING ever reported it: a client had no surface at all saying its
+// tests had run against a company real BC cannot produce, and the second request inherited the
+// first's entries. Both halves are asserted here, and the second is what a growing static looks
+// like from outside: request 2 carrying request 1's abort as well as its own.
+//
+// The abort is injected with AL_RUNNER_TEST_FAIL_COMPANY_INIT for the same reason
+// PartialCompanyInitializationTests injects it — see that file's header. This class starts its
+// OWN server rather than sharing SharedCliServer, because the seam is a startup-time environment
+// variable and every other class sharing that fixture must not get it.
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ServerCompanyInitDrainTests
+{
+    private const string InjectedReason = "CIP-INJECTED-ABORT: InitSourceCodeSetup did not finish";
+
+    private static string MakeBundle(int variant)
+    {
+        var dir = TestScratch.Dir("al-runner-server-cip");
+        Directory.CreateDirectory(dir);
+        var baseId = 61860 + variant * 10;
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "a1b2c3d4-e5f6-4708-a9ba-cbdcedfe1f1{{variant:x1}}",
+          "name": "Runner Tests Fixture - Server Company Init {{variant}}",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 9}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "ServerCipTest.Codeunit.al"), $$"""
+        codeunit {{baseId}} "Server CIP Probe {{variant}}"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure ArithmeticStillRuns()
+            var
+                Sum: Integer;
+            begin
+                Sum := 2 + 40;
+                if Sum <> 42 then
+                    Error('expected 42, got %1', Sum);
+            end;
+        }
+        """);
+        return dir;
+    }
+
+    private static string RunTestsReq(string bundleDir)
+        => JsonSerializer.Serialize(new
+        {
+            command = "runTests",
+            sourcePaths = new[] { bundleDir },
+            packagePaths = Array.Empty<string>(),
+        });
+
+    /// <summary>
+    /// Two requests against a server whose company initialization aborts. Each summary carries
+    /// the condition — the field a client can read at all, which server mode had none of — and
+    /// each carries exactly ONE entry. Request 2 carrying two is the shape of the defect: the
+    /// accumulator never drained, so the second response reports the first request's abort as
+    /// well. The exit code mirrors the CLI's: nothing about the AL failed, and the database the
+    /// AL ran against was not the one asked for.
+    /// </summary>
+    [SkippableFact]
+    public async Task EachRequestReportsItsOwnCompanyInitAbort_AndTheAccumulatorDoesNotGrow()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        await using var server = await CliServer.StartAsync(extraEnv: new Dictionary<string, string>
+        {
+            ["AL_RUNNER_TEST_FAIL_COMPANY_INIT"] = InjectedReason,
+        });
+
+        var first = await server.SendRequestStreamingAsync(RunTestsReq(MakeBundle(0)));
+        var firstSummary = JsonSerializer.Deserialize<JsonElement>(first[^1]);
+        Assert.Equal("summary", firstSummary.GetProperty("type").GetString());
+        Assert.Equal(1, firstSummary.GetProperty("passed").GetInt32());
+        var firstFailures = firstSummary.GetProperty("companyInitFailures").EnumerateArray().ToList();
+        Assert.Single(firstFailures);
+        Assert.Equal(2, firstFailures[0].GetProperty("codeunitId").GetInt32());
+        Assert.Equal("Company-Initialize", firstFailures[0].GetProperty("codeunit").GetString());
+        Assert.Equal(InjectedReason, firstFailures[0].GetProperty("message").GetString());
+        Assert.Equal(2, firstSummary.GetProperty("exitCode").GetInt32());
+
+        var second = await server.SendRequestStreamingAsync(RunTestsReq(MakeBundle(1)));
+        var secondSummary = JsonSerializer.Deserialize<JsonElement>(second[^1]);
+        var secondFailures = secondSummary.GetProperty("companyInitFailures").EnumerateArray().ToList();
+        Assert.True(secondFailures.Count == 1,
+            $"the second request must report its own abort only; {secondFailures.Count} entries means "
+            + $"the accumulator was never drained.\n{second[^1]}");
+        Assert.Equal(1, secondFailures[0].GetProperty("count").GetInt32());
+        Assert.Equal(2, secondSummary.GetProperty("exitCode").GetInt32());
+    }
+
+    /// <summary>
+    /// The negative control: with nothing injected, the same server, the same request shape and
+    /// the same bundle produce a summary with no such field at all — so the field means "this
+    /// happened", never "the server always says this".
+    /// </summary>
+    [SkippableFact]
+    public async Task ACleanServerRun_CarriesNoCompanyInitField()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        await using var server = await CliServer.StartAsync();
+        var lines = await server.SendRequestStreamingAsync(RunTestsReq(MakeBundle(2)));
+        var summary = JsonSerializer.Deserialize<JsonElement>(lines[^1]);
+
+        Assert.Equal(0, summary.GetProperty("exitCode").GetInt32());
+        Assert.False(summary.TryGetProperty("companyInitFailures", out _));
+    }
+}

--- a/AlRunner.Tests/ServerCompanyInitDrainTests.cs
+++ b/AlRunner.Tests/ServerCompanyInitDrainTests.cs
@@ -11,6 +11,17 @@
 // PartialCompanyInitializationTests injects it — see that file's header. This class starts its
 // OWN server rather than sharing SharedCliServer, because the seam is a startup-time environment
 // variable and every other class sharing that fixture must not get it.
+//
+// Every server here is started with a PRIVATE --cache and with the dependency-company baseline
+// cache switched off. Measured, not precautionary: on the BC 27.5 and 28.4 legs of run
+// 34322324604 this class failed with the summary carrying no companyInitFailures field at all,
+// while the CLI-side class passed on the same legs — and the one difference between them was
+// that the CLI arms each pass a fresh --cache and this one used the leg's shared cache root. A
+// baseline restored for an empty dependency closure (which every no-dependency fixture in the
+// suite shares) skips EnsureCompanyInitialized, so codeunit 2 is never attempted and there is no
+// abort to report. Forcing the MISS makes "the codeunit was attempted" a property of the test
+// rather than of what else ran on the leg first; the drain the class is actually about is
+// unaffected either way.
 using System.Text.Json;
 using Xunit;
 
@@ -56,6 +67,15 @@ public sealed class ServerCompanyInitDrainTests
         return dir;
     }
 
+    /// <summary>A cache root nothing else on this leg has written to — see the file header for
+    /// what a shared one did to the first request's summary.</summary>
+    private static string[] PrivateCacheArgs()
+    {
+        var dir = TestScratch.Dir("al-runner-server-cip-cache");
+        Directory.CreateDirectory(dir);
+        return new[] { "--cache", dir };
+    }
+
     private static string RunTestsReq(string bundleDir)
         => JsonSerializer.Serialize(new
         {
@@ -77,10 +97,13 @@ public sealed class ServerCompanyInitDrainTests
     {
         TestArtifacts.SkipIfMissing();
 
-        await using var server = await CliServer.StartAsync(extraEnv: new Dictionary<string, string>
-        {
-            ["AL_RUNNER_TEST_FAIL_COMPANY_INIT"] = InjectedReason,
-        });
+        await using var server = await CliServer.StartAsync(
+            extraArgs: PrivateCacheArgs(),
+            extraEnv: new Dictionary<string, string>
+            {
+                ["AL_RUNNER_TEST_FAIL_COMPANY_INIT"] = InjectedReason,
+                ["AL_RUNNER_NO_DEP_COMPANY_CACHE"] = "1",
+            });
 
         var first = await server.SendRequestStreamingAsync(RunTestsReq(MakeBundle(0)));
         var firstSummary = JsonSerializer.Deserialize<JsonElement>(first[^1]);
@@ -113,7 +136,9 @@ public sealed class ServerCompanyInitDrainTests
     {
         TestArtifacts.SkipIfMissing();
 
-        await using var server = await CliServer.StartAsync();
+        await using var server = await CliServer.StartAsync(
+            extraArgs: PrivateCacheArgs(),
+            extraEnv: new Dictionary<string, string> { ["AL_RUNNER_NO_DEP_COMPANY_CACHE"] = "1" });
         var lines = await server.SendRequestStreamingAsync(RunTestsReq(MakeBundle(2)));
         var summary = JsonSerializer.Deserialize<JsonElement>(lines[^1]);
 

--- a/AlRunner/CompanyInitializer.cs
+++ b/AlRunner/CompanyInitializer.cs
@@ -29,6 +29,7 @@
 //   presents a half-initialized company, so a run carrying one is in a state no service tier
 //   can produce, and every reporting surface says so — including the exit code. The decision,
 //   the BC citation and the exit-code rule are in docs/partial-company-initialization.md.
+using System.Linq;
 using System.Reflection;
 
 namespace AlRunner;
@@ -48,6 +49,15 @@ internal static class CompanyInitializer
     // came through the formatting below rather than a fixed string.
     private const string InjectFailureEnvVar = "AL_RUNNER_TEST_FAIL_COMPANY_INIT";
 
+    // Test-only seam, #3561, and the same justification as the one above: the drift half of
+    // accept-partial-company-init fires when the named codeunit RAN TO COMPLETION, and the only
+    // way to complete codeunit 2 for real is to load the Base Application floor — which costs
+    // ~70s per invocation and is forbidden in C# test fixtures
+    // (.claude/rules/no-base-app-in-csharp-tests.md). Set to 1, this stands in for "codeunit 2
+    // was found and returned normally": the completion is recorded exactly where the real one
+    // is, so the drift check under test is the real one. No shipped code path sets it.
+    private const string InjectCompletedEnvVar = "AL_RUNNER_TEST_COMPANY_INIT_COMPLETED";
+
     private static bool _ranForThisBundle;
 
     // Run-wide, NOT per app group: ResetForNewBundle runs once per app group and a bucket has
@@ -57,6 +67,18 @@ internal static class CompanyInitializer
     private static readonly object _failuresLock = new();
 
     internal static void ResetForNewBundle() => _ranForThisBundle = false;
+
+    // #3561: the initialization codeunits that ran to COMPLETION in this process, which is what
+    // makes an accept-partial-company-init entry drift rather than merely unused. Never drained:
+    // an entry is judged against the whole run, and under --server against the whole session,
+    // where "this codeunit initialized cleanly" stays true for every later request.
+    private static readonly HashSet<(int Id, string Name)> _completed = new();
+
+    /// <summary>Initialization codeunits that ran to completion in this process (#3561).</summary>
+    internal static IReadOnlyCollection<(int Id, string Name)> CompletedInitializations
+    {
+        get { lock (_failuresLock) return _completed.ToArray(); }
+    }
 
     /// <summary>Everything this run has recorded so far, removed from the accumulator.</summary>
     internal static IReadOnlyList<CompanyInitFailure> DrainFailures()
@@ -73,7 +95,7 @@ internal static class CompanyInitializer
     /// <summary>Discard what has been recorded. For tests that reuse one process.</summary>
     internal static void ResetFailuresForTests()
     {
-        lock (_failuresLock) _failures.Clear();
+        lock (_failuresLock) { _failures.Clear(); _completed.Clear(); }
         LastRecordedFailure = null;
     }
 
@@ -103,6 +125,15 @@ internal static class CompanyInitializer
         LastRecordedFailure = null;
 
         var injected = Environment.GetEnvironmentVariable(InjectFailureEnvVar);
+        // #3561: stands in for a codeunit 2 that completed — see InjectCompletedEnvVar. Ignored
+        // when an abort is injected too, because a run cannot both abort and complete and the
+        // abort is the more specific instruction.
+        if (string.IsNullOrEmpty(injected)
+            && Environment.GetEnvironmentVariable(InjectCompletedEnvVar) == "1")
+        {
+            NoteCompleted();
+            return;
+        }
         // The exists-check is gated by the seam deliberately: the seam stands in for "codeunit
         // 2 was found and threw", and whether Base App is loaded at all is upstream of
         // everything this path reports. Gating it the other way would force every test of the
@@ -119,6 +150,7 @@ internal static class CompanyInitializer
                 throw new InvalidOperationException(injected);
             BcRuntime.NavCodeunit_RunCodeunit(
                 Microsoft.Dynamics.Nav.Types.DataError.ThrowError, CompanyInitializeCodeunitId, null);
+            NoteCompleted();
             PerfTrace.Log("CompanyInitializer: ran codeunit 2 Company-Initialize");
         }
         catch (Exception ex)
@@ -130,6 +162,11 @@ internal static class CompanyInitializer
             LastRecordedFailure = failure;
             Report(failure);
         }
+    }
+
+    private static void NoteCompleted()
+    {
+        lock (_failuresLock) _completed.Add((CompanyInitializeCodeunitId, CompanyInitializeCodeunitName));
     }
 
     private static void Report(CompanyInitFailure failure)

--- a/AlRunner/CompanyInitializer.cs
+++ b/AlRunner/CompanyInitializer.cs
@@ -56,6 +56,13 @@ internal static class CompanyInitializer
     // (.claude/rules/no-base-app-in-csharp-tests.md). Set to 1, this stands in for "codeunit 2
     // was found and returned normally": the completion is recorded exactly where the real one
     // is, so the drift check under test is the real one. No shipped code path sets it.
+    //
+    // Note the DIRECTION, which is the opposite of its two siblings and the reason to be careful
+    // with it: this one HIDES. It takes an early return that skips the real codeunit 2 call
+    // entirely, so set outside a test it leaves the company uninitialized AND suppresses the
+    // 0 → 2 escalation that would have said so. Gating is the family's — a bare env-var read,
+    // exactly as AL_RUNNER_TEST_FAIL_COMPANY_INIT and AL_RUNNER_TEST_BARRIER_DIR are, with no
+    // build guard anywhere in the family; setting it is as deliberate as passing --no-strict-exit.
     private const string InjectCompletedEnvVar = "AL_RUNNER_TEST_COMPANY_INIT_COMPLETED";
 
     private static bool _ranForThisBundle;

--- a/AlRunner/Infrastructure/ExpectationManifest.cs
+++ b/AlRunner/Infrastructure/ExpectationManifest.cs
@@ -40,6 +40,15 @@ public enum ExpectationMode
     ExpectDivergence,
     /// <summary>Test must not be invoked.</summary>
     Skip,
+    /// <summary>
+    /// NOT a test expectation (#3561). Declares that this project knowingly accepts a company
+    /// initialization that did not complete for the named codeunit, so the run records the
+    /// condition everywhere it already did but does not escalate exit 0 to 2. The alternative
+    /// was --no-strict-exit, which forces 0 for a failing test, a compile failure and a lost
+    /// output file too. <c>Reason</c> is mandatory free text; <c>Method</c> must be "*" because
+    /// there is no test to name. See docs/partial-company-initialization.md.
+    /// </summary>
+    AcceptPartialCompanyInit,
 }
 
 /// <summary>
@@ -106,8 +115,33 @@ public sealed class ExpectationManifest
     private ExpectationManifest(IReadOnlyList<ExpectationEntry> entries)
     {
         Entries = entries;
-        _byName = entries.ToDictionary(e => (e.CodeunitName, e.Method), e => e);
+        // #3561: an accept-partial-company-init entry names an INSTALL codeunit, not a test, so
+        // it must never enter the test-lookup table (nothing would ever look it up) nor the
+        // match audit below, where --expectations-require-match would report it as matching no
+        // test and fail the run with exit 5 for an entry that is entirely correct.
+        _byName = entries
+            .Where(e => e.Mode != ExpectationMode.AcceptPartialCompanyInit)
+            .ToDictionary(e => (e.CodeunitName, e.Method), e => e);
+        CompanyInitAcceptances = entries
+            .Where(e => e.Mode == ExpectationMode.AcceptPartialCompanyInit)
+            .ToList();
     }
+
+    /// <summary>
+    /// The accept-partial-company-init entries (#3561), which are run-level declarations rather
+    /// than test expectations. Empty in every manifest that does not use the mode.
+    /// </summary>
+    public IReadOnlyList<ExpectationEntry> CompanyInitAcceptances { get; } = Array.Empty<ExpectationEntry>();
+
+    /// <summary>
+    /// The entry accepting an abort of this initialization codeunit, or null (#3561). Matched on
+    /// the codeunit id AND the name the accumulator recorded, so an entry naming a different
+    /// codeunit cannot silently accept this one.
+    /// </summary>
+    public ExpectationEntry? FindCompanyInitAcceptance(int codeunitId, string codeunitName)
+        => CompanyInitAcceptances.FirstOrDefault(
+            e => e.CodeunitId == codeunitId
+                && string.Equals(e.CodeunitName, codeunitName, StringComparison.Ordinal));
 
     /// <summary>
     /// Record a test codeunit this run loaded. Called from the executor at discovery
@@ -189,6 +223,9 @@ public sealed class ExpectationManifest
         var unmatched = new List<UnmatchedExpectation>();
         foreach (var entry in Entries)
         {
+            // #3561: not a test expectation - see the constructor. Its own drift check is the
+            // end-of-run one in Program.cs ("the codeunit completed, remove the entry").
+            if (entry.Mode == ExpectationMode.AcceptPartialCompanyInit) continue;
             // Mirrors LookupExpectation: entries may be written against the AL object
             // name OR the CLR type name, and "*" matches every test method.
             var named = discovered
@@ -359,9 +396,10 @@ public sealed class ExpectationManifest
             "expect-fail-known-gap" => ExpectationMode.ExpectFailKnownGap,
             "expect-divergence" => ExpectationMode.ExpectDivergence,
             "skip" => ExpectationMode.Skip,
+            "accept-partial-company-init" => ExpectationMode.AcceptPartialCompanyInit,
             _ => throw new InvalidOperationException(
                 $"{relName}[{idx}] ({codeunitName}.{method}): unknown Mode '{modeRaw}' — must be expect-oos, "
-                + "expect-fail-known-gap, expect-divergence, or skip"),
+                + "expect-fail-known-gap, expect-divergence, skip, or accept-partial-company-init"),
         };
 
         if (mode == ExpectationMode.ExpectOos && string.IsNullOrWhiteSpace(reason))
@@ -388,9 +426,46 @@ public sealed class ExpectationManifest
                     + "an intended divergence has no open work to link. Use expect-fail-known-gap if it is a gap.");
         }
 
+        if (mode == ExpectationMode.AcceptPartialCompanyInit)
+        {
+            // #3561. The entry buys a suppressed exit-code escalation, so what it must carry is
+            // WHY that is acceptable here — free text a reviewer reads, refused when it is a
+            // placeholder with nothing behind it. Same fixed token list as the Corpus-NA reason
+            // in .github/scripts/check_corpus_linkage.sh: mechanical, not a quality bar.
+            if (string.IsNullOrWhiteSpace(reason))
+                throw new InvalidOperationException(
+                    $"{relName}[{idx}] ({codeunitName}): Mode=accept-partial-company-init requires a "
+                    + "non-empty 'Reason' saying why a partially initialized company is accepted here");
+            if (IsPlaceholderReason(reason!))
+                throw new InvalidOperationException(
+                    $"{relName}[{idx}] ({codeunitName}): Mode=accept-partial-company-init 'Reason' is a "
+                    + $"placeholder ('{reason}'). Say why this project accepts a company real BC cannot "
+                    + "produce — the reason is what a reviewer reads, and it is printed in the summary.");
+            if (method != "*")
+                throw new InvalidOperationException(
+                    $"{relName}[{idx}] ({codeunitName}): Mode=accept-partial-company-init names an "
+                    + $"initialization codeunit, not a test, so 'Method' must be \"*\" (got '{method}')");
+            if (!string.IsNullOrWhiteSpace(issue))
+                throw new InvalidOperationException(
+                    $"{relName}[{idx}] ({codeunitName}): Mode=accept-partial-company-init must not carry "
+                    + "'Issue' — an accepted condition is a standing decision, not tracked work. Fix the "
+                    + "abort, or leave the entry's Reason pointing at your own tracking issue.");
+        }
+
         return new ExpectationEntry(
             codeunitId, codeunitName, method, mode, reason, issue, docAnchor, note, relName);
     }
+
+    /// <summary>
+    /// A reason with nothing behind it (#3561). The list is the one
+    /// <c>.github/scripts/check_corpus_linkage.sh</c> refuses for a <c>Corpus-NA:</c> reason,
+    /// mirrored deliberately so the two refusals cannot drift into different answers.
+    /// </summary>
+    internal static bool IsPlaceholderReason(string reason) => reason.Trim().ToLowerInvariant() switch
+    {
+        "" or "n/a" or "na" or "none" or "no" or "-" or "--" or "." or "?" or "tbd" or "todo" or "x" => true,
+        _ => false,
+    };
 }
 
 /// <summary>

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -6680,14 +6680,7 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                     "affectedOnly selection is applied to runTests; execute always runs the lowest-object-id OnRun codeunit");
             }
 
-            // #3561: drained ONCE PER REQUEST, here. CompanyInitializer's accumulator is
-            // run-wide and the CLI drains it where it builds a bucket's BucketResult, a path
-            // --server never takes: the static therefore grew for the life of the server
-            // process and no response ever carried the condition, so a client had no surface
-            // saying its tests had run against a company real BC cannot produce. Same
-            // Finalize call as the CLI, so collapse and manifest acceptance behave identically
-            // on both transports; the escalation mirrors the CLI's, because a client reading
-            // only exitCode is exactly the consumer #3538 was filed for.
+            // #3561: drained once per request, as in the runTests handler above.
             var companyInitFailures = Reporter.FinalizeCompanyInitFailures(
                 CompanyInitializer.DrainFailures(), expectations);
             if (exitCode == 0 && companyInitFailures.Any(f => f.AcceptedReason == null))

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3903,7 +3903,10 @@ foreach (var bundle in bundles)
     results.Add(new BucketResult(bundleAbs, bundleStage,
         bundleErrors, null, bundleTests,
         bundleEmit, bundleComp, bundleRun, ranGroupCount, bundleProvisionGaps,
-        CompanyInitializer.DrainFailures()));
+        // #3561: collapsed (identical aborts across app groups sharing one cached baseline) and
+        // marked with any accept-partial-company-init reason the manifest declares, in the one
+        // helper --server's per-request drain calls too.
+        Reporter.FinalizeCompanyInitFailures(CompanyInitializer.DrainFailures(), expectations)));
     // Appended here, not buffered to process exit: a run that dies mid-way still
     // yields a row for every bundle it did finish. The row's wall clock covers this
     // whole loop turn, so wall − (emit+compile+run) is the per-bundle overhead
@@ -4501,16 +4504,44 @@ if (!serverMode && !watchMode && !dapMode
 // a zero as "the company was initialized". Never RAISED above what the tests earned, so a
 // failing run still reports its own, more specific code, and --no-strict-exit still forces 0
 // for a consumer that wants the old behaviour.
-var companyInitFailures = Reporter.CompanyInitFailures(allResults);
+// #3561: an abort the expectations manifest accepts is still printed, still in --out, still in
+// --output-json and still in the JUnit comment — only the escalation is suppressed, and only for
+// the codeunit the entry names. The alternative a project had was --no-strict-exit, which also
+// forces 0 for a failing test, a compile failure and a lost output file.
+var companyInitFailures = Reporter.UnacceptedCompanyInitFailures(allResults);
 if (companyInitFailures.Count > 0 && computedExitCode == 0)
 {
     Console.Error.WriteLine(
-        $"[warn] company-init: {companyInitFailures.Count} company initialization abort(s) — "
+        $"[warn] company-init: {companyInitFailures.Sum(f => f.Count)} company initialization abort(s) — "
         + "every test in this run used a PARTIALLY initialized company, so AL reading a setup "
         + "row the codeunit never reached will fail for that reason and not its own; "
         + "exiting 2 because the run is not clean. See the summary above, and "
         + "docs/partial-company-initialization.md.");
     computedExitCode = 2;
+}
+
+// #3561: the drift half, mirroring expect-oos's "test passed, remove the entry". An acceptance
+// entry is a standing statement that THIS codeunit aborts here; once it stops aborting, the
+// entry is a suppression nobody is watching. It fires only when the named codeunit actually RAN
+// TO COMPLETION in this run, for the reason --expectations-require-match is opt-in: the manifest
+// directory is auto-probed and shared by every invocation in a project, so an entry naming a
+// codeunit this run never attempted (no Base App in the bundle, or a dependency-company baseline
+// restored from disk without re-running it) is inert rather than wrong.
+if (expectations != null && expectations.CompanyInitAcceptances.Count > 0)
+{
+    var reported = Reporter.CompanyInitFailures(allResults);
+    var completed = CompanyInitializer.CompletedInitializations;
+    var stale = expectations.CompanyInitAcceptances
+        .Where(e => completed.Any(c => c.Id == e.CodeunitId && c.Name == e.CodeunitName))
+        .Where(e => !reported.Any(f => f.CodeunitId == e.CodeunitId && f.CodeunitName == e.CodeunitName))
+        .ToList();
+    foreach (var e in stale)
+        Console.Error.WriteLine(
+            $"[warn] company-init: {e.SourceFile} declares accept-partial-company-init for codeunit "
+            + $"{e.CodeunitId} \"{e.CodeunitName}\" (reason: {e.Reason}), but that codeunit ran to "
+            + "completion in this run — the company initialized cleanly. Remove the entry: it is now "
+            + "an exit-code suppression with nothing behind it. See docs/partial-company-initialization.md.");
+    if (stale.Count > 0 && computedExitCode == 0) computedExitCode = 2;
 }
 
 // #2403: an output file the caller asked for and did not get. Ranked exactly like
@@ -6490,6 +6521,19 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                     forcedReasons.Count > 0 ? string.Join(" | ", forcedReasons) : null);
             }
 
+            // #3561: drained ONCE PER REQUEST, here. CompanyInitializer's accumulator is
+            // run-wide and the CLI drains it where it builds a bucket's BucketResult, a path
+            // --server never takes: the static therefore grew for the life of the server
+            // process and no response ever carried the condition, so a client had no surface
+            // saying its tests had run against a company real BC cannot produce. Same
+            // Finalize call as the CLI, so collapse and manifest acceptance behave identically
+            // on both transports; the escalation mirrors the CLI's, because a client reading
+            // only exitCode is exactly the consumer #3538 was filed for.
+            var companyInitFailures = Reporter.FinalizeCompanyInitFailures(
+                CompanyInitializer.DrainFailures(), expectations);
+            if (exitCode == 0 && companyInitFailures.Any(f => f.AcceptedReason == null))
+                exitCode = 2;
+
             lock (outputLock)
             {
                 output.WriteLine(AlRunner.ServerProtocol.Summary(
@@ -6498,7 +6542,8 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                     cancelled: cancelled, wallSeconds: reqSw.Elapsed.TotalSeconds,
                     selection: requestSelection,
                     statementTable: statementTable,
-                    perTestStatementTable: requestPerTestCoverage ? perTestStatementTable : null));
+                    perTestStatementTable: requestPerTestCoverage ? perTestStatementTable : null,
+                    companyInitFailures: companyInitFailures));
                 output.Flush();
             }
         }
@@ -6635,6 +6680,19 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                     "affectedOnly selection is applied to runTests; execute always runs the lowest-object-id OnRun codeunit");
             }
 
+            // #3561: drained ONCE PER REQUEST, here. CompanyInitializer's accumulator is
+            // run-wide and the CLI drains it where it builds a bucket's BucketResult, a path
+            // --server never takes: the static therefore grew for the life of the server
+            // process and no response ever carried the condition, so a client had no surface
+            // saying its tests had run against a company real BC cannot produce. Same
+            // Finalize call as the CLI, so collapse and manifest acceptance behave identically
+            // on both transports; the escalation mirrors the CLI's, because a client reading
+            // only exitCode is exactly the consumer #3538 was filed for.
+            var companyInitFailures = Reporter.FinalizeCompanyInitFailures(
+                CompanyInitializer.DrainFailures(), expectations);
+            if (exitCode == 0 && companyInitFailures.Any(f => f.AcceptedReason == null))
+                exitCode = 2;
+
             return AlRunner.ServerProtocol.Execute(allTests, exitCode,
                 AlRunner.Infrastructure.AlMessageCapture.Snapshot(),
                 AlRunner.Infrastructure.AlIterationTracker.Enabled
@@ -6642,7 +6700,8 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                 allCompileErrors.Count > 0 ? allCompileErrors : null,
                 selection: selection,
                 statementTable: statementTable,
-                perTestStatementTable: perTestStatementTable);
+                perTestStatementTable: perTestStatementTable,
+                companyInitFailures: companyInitFailures);
         }
         finally
         {

--- a/AlRunner/ProgramSupport/CliText.cs
+++ b/AlRunner/ProgramSupport/CliText.cs
@@ -688,6 +688,11 @@ internal static partial class ProgramSupport
         w.WriteLine("                          invoked. Manifest drift is loud: an entry whose test now");
         w.WriteLine("                          passes, or an out-of-scope throw with no entry, fails");
         w.WriteLine("                          the run with a diagnostic naming the entry to fix.");
+        w.WriteLine("                          accept-partial-company-init is the one run-level mode: it");
+        w.WriteLine("                          names an initialization codeunit whose abort this project");
+        w.WriteLine("                          accepts, with a mandatory Reason, and suppresses ONLY the");
+        w.WriteLine("                          company-init exit 0->2 escalation (never 1/3/4/5, unlike");
+        w.WriteLine("                          --no-strict-exit). The abort is still reported everywhere.");
         w.WriteLine("  --expectations-require-match");
         w.WriteLine("                          Assert that this RUN discovers a test for EVERY entry in");
         w.WriteLine("                          the active manifest, and fail (exit 5) on any that");

--- a/AlRunner/Reporter.cs
+++ b/AlRunner/Reporter.cs
@@ -16,7 +16,22 @@ public enum BucketStage { CompileFailed, ExecuteFailed, Ran }
 /// docs/partial-company-initialization.md.
 /// </summary>
 public sealed record CompanyInitFailure(int CodeunitId, string CodeunitName,
-                                        string ExceptionType, string Message);
+                                        string ExceptionType, string Message,
+                                        // #3561: how many app groups reported THIS abort. The
+                                        // dependency-company-baseline carry re-reports on every
+                                        // cache HIT — deliberately, each group did run against the
+                                        // partial company — so N groups sharing one closure used to
+                                        // print N identical lines. Collapsed at drain time by
+                                        // Reporter.FinalizeCompanyInitFailures; 1 for an
+                                        // uncollapsed abort, so an existing caller sees no change.
+                                        int Count = 1,
+                                        // #3561: non-null when the run's expectations manifest
+                                        // declares this abort accepted (Mode =
+                                        // accept-partial-company-init). The condition is still
+                                        // printed and still recorded — only the exit-code
+                                        // escalation is suppressed. Carries the entry's free-text
+                                        // Reason, which is what the summary prints.
+                                        string? AcceptedReason = null);
 
 public sealed record BucketResult(string BucketPath, BucketStage Stage,
                                    IReadOnlyList<string> CompileErrors,
@@ -108,14 +123,93 @@ public static class Reporter
     /// condition differently — the reason IsSuspect exists one concept over.
     /// </summary>
     public static IReadOnlyList<CompanyInitFailure> CompanyInitFailures(IReadOnlyList<BucketResult> buckets)
-        => buckets
-            .SelectMany(b => b.CompanyInitFailures ?? Array.Empty<CompanyInitFailure>())
-            .ToList();
+        // #3561: collapsed ACROSS buckets as well as within one. The dependency-company baseline
+        // is cached per dependency set, not per bundle, so the app groups re-reporting one abort
+        // on a cache HIT are routinely in different buckets — collapsing only at the drain site
+        // would still print one abort as N identical lines. --out is deliberately NOT collapsed
+        // this way: it is a per-bucket triage worklist and each bucket's record belongs to it.
+        => Collapse(buckets.SelectMany(b => b.CompanyInitFailures ?? Array.Empty<CompanyInitFailure>()));
 
-    /// <summary>One abort, rendered the same way wherever it is printed.</summary>
+    /// <summary>
+    /// Fold aborts that say the same thing into one record carrying the total app-group count.
+    /// "The same thing" is the whole of what the accumulator records: codeunit id, codeunit
+    /// name, exception type and message. The app id is not part of the key because the
+    /// accumulator holds none and the codeunit it records is always Base App's codeunit 2, so an
+    /// app dimension would be constant today and invented rather than measured (#3561).
+    /// </summary>
+    private static IReadOnlyList<CompanyInitFailure> Collapse(IEnumerable<CompanyInitFailure> failures)
+    {
+        var collapsed = new List<CompanyInitFailure>();
+        var index = new Dictionary<(int, string, string, string), int>();
+        foreach (var f in failures)
+        {
+            var key = (f.CodeunitId, f.CodeunitName, f.ExceptionType, f.Message);
+            if (index.TryGetValue(key, out var at))
+            {
+                collapsed[at] = collapsed[at] with
+                {
+                    Count = collapsed[at].Count + f.Count,
+                    // An acceptance is a property of the codeunit, so every member of a
+                    // collapsed group carries the same answer; keeping the first non-null is
+                    // just defensive about a group whose members were marked in different
+                    // processes (a resumed run merges carried buckets).
+                    AcceptedReason = collapsed[at].AcceptedReason ?? f.AcceptedReason,
+                };
+                continue;
+            }
+            index[key] = collapsed.Count;
+            collapsed.Add(f);
+        }
+        return collapsed;
+    }
+
+    /// <summary>
+    /// One abort, rendered the same way wherever it is printed. The two suffixes are #3561: how
+    /// many app groups reported this same abort (omitted at 1), and the manifest reason that
+    /// accepted it (omitted when nothing did). Both are part of the one rendering so the
+    /// summary, the JUnit comment and a reader of either cannot see different facts.
+    /// </summary>
     public static string DescribeCompanyInitFailure(CompanyInitFailure f)
         => $"codeunit {f.CodeunitId} \"{f.CodeunitName}\" did not complete: "
-            + $"{f.ExceptionType}: {f.Message}";
+            + $"{f.ExceptionType}: {f.Message}"
+            + (f.Count > 1 ? $" ×{f.Count} app group(s)" : "")
+            + (f.AcceptedReason != null ? $" [accepted: {f.AcceptedReason}]" : "");
+
+    /// <summary>
+    /// Turn what the accumulator drained into what the run reports (#3561). Called from BOTH
+    /// drain sites — the CLI bucket loop and the server per-request handler — so the two cannot
+    /// describe the same condition differently.
+    ///
+    /// <para>Two things happen here. Identical aborts are COLLAPSED into one record carrying a
+    /// count: N app groups sharing one dependency-company baseline each re-report the abort on
+    /// their cache HIT (deliberately — each really did run against the partial company), which
+    /// used to print N identical lines and emit N identical JSON entries. "Identical" is the
+    /// whole of what the accumulator records: codeunit id, codeunit name, exception type and
+    /// message. The app id is not part of the key because the accumulator holds no app id and
+    /// the codeunit it records is always Base App's codeunit 2, so an app dimension would be
+    /// constant today and invented rather than measured.</para>
+    ///
+    /// <para>And an abort the manifest ACCEPTS is marked with the entry's reason. That marking
+    /// is the only thing that suppresses the exit 0 → 2 escalation in Program.cs; every
+    /// reporting surface still carries the condition.</para>
+    /// </summary>
+    public static IReadOnlyList<CompanyInitFailure> FinalizeCompanyInitFailures(
+        IReadOnlyList<CompanyInitFailure> drained, Infrastructure.ExpectationManifest? manifest)
+    {
+        if (drained.Count == 0) return Array.Empty<CompanyInitFailure>();
+        return Collapse(drained.Select(f => f with
+        {
+            AcceptedReason = manifest?.FindCompanyInitAcceptance(f.CodeunitId, f.CodeunitName)?.Reason,
+        }));
+    }
+
+    /// <summary>
+    /// The aborts that make the run unclean (#3561): everything the manifest did not accept.
+    /// The escalation reads this; every reporting surface reads the whole list.
+    /// </summary>
+    public static IReadOnlyList<CompanyInitFailure> UnacceptedCompanyInitFailures(
+        IReadOnlyList<BucketResult> buckets)
+        => CompanyInitFailures(buckets).Where(f => f.AcceptedReason == null).ToList();
 
     /// <summary>Whether anything in this bucket is marked — i.e. whether the notes that
     /// introduce the marker have anything below them to introduce.</summary>
@@ -372,10 +466,16 @@ public static class Reporter
         if (companyInitFailures.Count > 0)
         {
             w.WriteLine("-----------------------------------------------------------------");
-            w.WriteLine($"Company initialization: INCOMPLETE ({companyInitFailures.Count} abort(s)) — "
+            // #3561: the count is app groups, not lines — identical aborts are collapsed into one
+            // line carrying its own ×N, so the header keeps saying how many app groups ran against
+            // a partial company while the body stops repeating itself.
+            w.WriteLine($"Company initialization: INCOMPLETE ({companyInitFailures.Sum(f => f.Count)} abort(s)) — "
                 + "the tests above ran against a PARTIALLY initialized company.");
             foreach (var f in companyInitFailures)
                 w.WriteLine($"  {DescribeCompanyInitFailure(f)}");
+            if (companyInitFailures.All(f => f.AcceptedReason != null))
+                w.WriteLine("  → accepted by tests/expectations (accept-partial-company-init), so the run "
+                    + "still exits on what the tests earned. See docs/partial-company-initialization.md.");
             w.WriteLine("  → setup rows the codeunit had not reached are missing, so a failure "
                 + "reading one is caused by this, not by the AL under test.");
         }
@@ -681,6 +781,12 @@ public static class Reporter
                     codeunit = f.CodeunitName,
                     exceptionType = f.ExceptionType,
                     message = f.Message,
+                    // #3561: how many app groups reported this same abort, and the manifest
+                    // reason accepting it. `count` is always present so a consumer never has to
+                    // decide whether a missing field means one or none; `accepted` is
+                    // null-omitted, so a document from a run with no acceptance is unchanged.
+                    count = f.Count,
+                    accepted = f.AcceptedReason,
                 }).ToList()
                 : null,
             // #1936: same "real wall clock, not just the measured phases" gap as the
@@ -745,6 +851,9 @@ public static class Reporter
                         codeunit = f.CodeunitName,
                         exceptionType = f.ExceptionType,
                         message = f.Message,
+                        // #3561 — see the JSON document's own fields.
+                        count = f.Count,
+                        accepted = f.AcceptedReason,
                         classification = "company-init/partial",
                     });
                 }

--- a/AlRunner/Reporter.cs
+++ b/AlRunner/Reporter.cs
@@ -126,16 +126,16 @@ public static class Reporter
         // #3561: collapsed ACROSS buckets as well as within one. The dependency-company baseline
         // is cached per dependency set, not per bundle, so the app groups re-reporting one abort
         // on a cache HIT are routinely in different buckets — collapsing only at the drain site
-        // would still print one abort as N identical lines. --out is deliberately NOT collapsed
-        // this way: it is a per-bucket triage worklist and each bucket's record belongs to it.
+        // would still print one abort as N identical lines. --out gets only the WITHIN-bucket
+        // collapse each BucketResult already carries, and no cross-bucket one: it is a per-bucket
+        // triage worklist and each bucket's record belongs to that bucket.
         => Collapse(buckets.SelectMany(b => b.CompanyInitFailures ?? Array.Empty<CompanyInitFailure>()));
 
     /// <summary>
     /// Fold aborts that say the same thing into one record carrying the total app-group count.
     /// "The same thing" is the whole of what the accumulator records: codeunit id, codeunit
-    /// name, exception type and message. The app id is not part of the key because the
-    /// accumulator holds none and the codeunit it records is always Base App's codeunit 2, so an
-    /// app dimension would be constant today and invented rather than measured (#3561).
+    /// name, exception type and message — see FinalizeCompanyInitFailures for why the key holds
+    /// no app id (#3561).
     /// </summary>
     private static IReadOnlyList<CompanyInitFailure> Collapse(IEnumerable<CompanyInitFailure> failures)
     {

--- a/AlRunner/ServerProtocol.cs
+++ b/AlRunner/ServerProtocol.cs
@@ -323,7 +323,8 @@ public static class ServerProtocol
         double? wallSeconds = null,
         ServerSelection? selection = null,
         IReadOnlyList<Infrastructure.AlCoverageTracker.AlStatementRecord>? statementTable = null,
-        IReadOnlyDictionary<string, List<Infrastructure.AlCoverageTracker.AlStatementRecord>>? perTestStatementTable = null)
+        IReadOnlyDictionary<string, List<Infrastructure.AlCoverageTracker.AlStatementRecord>>? perTestStatementTable = null,
+        IReadOnlyList<CompanyInitFailure>? companyInitFailures = null)
     {
         var payload = new
         {
@@ -350,6 +351,7 @@ public static class ServerProtocol
                 : null,
             coverage = ToStatementTableWire(statementTable),
             perTestCoverage = ToPerTestCoverageWire(perTestStatementTable),
+            companyInitFailures = ToCompanyInitWire(companyInitFailures),
             wallSeconds,
             protocolVersion = 2,
         };
@@ -370,7 +372,8 @@ public static class ServerProtocol
         IReadOnlyList<CompilationErrorGroup>? compilationErrors = null,
         ServerSelection? selection = null,
         IReadOnlyList<Infrastructure.AlCoverageTracker.AlStatementRecord>? statementTable = null,
-        IReadOnlyDictionary<string, List<Infrastructure.AlCoverageTracker.AlStatementRecord>>? perTestStatementTable = null)
+        IReadOnlyDictionary<string, List<Infrastructure.AlCoverageTracker.AlStatementRecord>>? perTestStatementTable = null,
+        IReadOnlyList<CompanyInitFailure>? companyInitFailures = null)
     {
         var payload = new
         {
@@ -391,9 +394,27 @@ public static class ServerProtocol
                 : null,
             coverage = ToStatementTableWire(statementTable),
             perTestCoverage = ToPerTestCoverageWire(perTestStatementTable),
+            companyInitFailures = ToCompanyInitWire(companyInitFailures),
         };
         return JsonSerializer.Serialize(payload, Opts);
     }
+
+    // #3561: the company-initialization condition on a server response, in the same field shape
+    // the CLI's --output-json document already uses (codeunitId / codeunit / exceptionType /
+    // message / count / accepted). Null-omitted, and an EMPTY list omits too — unlike coverage
+    // there is no "asked and found nothing" state to distinguish: no aborts is no condition.
+    private static IEnumerable<object>? ToCompanyInitWire(IReadOnlyList<CompanyInitFailure>? failures)
+        => failures is { Count: > 0 }
+            ? failures.Select(f => (object)new
+            {
+                codeunitId = f.CodeunitId,
+                codeunit = f.CodeunitName,
+                exceptionType = f.ExceptionType,
+                message = f.Message,
+                count = f.Count,
+                accepted = f.AcceptedReason,
+            })
+            : null;
 
     // Groups a flat statement list into the wire's per-file shape (issue #2042):
     // {file, statements:[{id, scope, line, column, endLine, endColumn, hits}]}.

--- a/AlRunner/ServerProtocol.cs
+++ b/AlRunner/ServerProtocol.cs
@@ -17,7 +17,7 @@ namespace AlRunner;
 ///             {"type":"summary", exitCode, passed, failed, errors,
 ///             total, cached, cancelled|omitted, changedFiles|omitted,
 ///             compilationErrors|omitted, coverage|omitted, perTestCoverage|omitted,
-///             selection|omitted,
+///             selection|omitted, companyInitFailures|omitted,
 ///             wallSeconds|omitted, protocolVersion:2} line.
 ///             `cancelled` (true) is present only when a concurrent `cancel`
 ///             command actually stopped the run before every test ran; omitted
@@ -34,7 +34,7 @@ namespace AlRunner;
 ///             shape (#1613/#1614), reused verbatim rather than inventing a new one.
 ///   execute : {exitCode, tests:[{name,status,durationMs,message,stackTrace,
 ///              capturedValues|omitted, iterations|omitted}], messages|omitted, compilationErrors|null,
-///              coverage|omitted, selection|omitted} —
+///              coverage|omitted, selection|omitted, companyInitFailures|omitted} —
 ///              single response, not streamed (matches v1: only runTests streams).
 ///              `capturedValues` (#1640) is present per test only when the request
 ///              set `captureValues:true`; each entry is {scopeName, variableName,
@@ -107,6 +107,16 @@ namespace AlRunner;
 ///   error   : {error}
 ///   shutdown: {status}
 /// </summary>
+/// <remarks>
+/// `companyInitFailures` (#3561) is on BOTH `runTests`' summary and `execute`'s response, and
+/// unlike `coverage` it has no request-side opt-in: it is present exactly when a company
+/// initialization codeunit did not run to completion during that request, and absent otherwise
+/// — never an empty array. Each entry is {codeunitId, codeunit, exceptionType, message, count,
+/// accepted|omitted}; `count` is how many app groups reported that same abort, and `accepted`
+/// carries the expectations-manifest reason when the project declares the condition accepted
+/// (docs/partial-company-initialization.md). The accumulator is drained ONCE PER REQUEST, so a
+/// response reports its own request's aborts and never a previous one's.
+/// </remarks>
 public sealed class ServerRequest
 {
     [JsonPropertyName("command")] public string? Command { get; set; }

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -98,6 +98,7 @@ tests/expectations/
   known-gaps-<area>.json  ← in-scope but not yet implemented (transient, links to GH issues)
   divergence-<area>.json  ← runner intentionally answers differently from BC (permanent)
   disabled-<area>.json    ← won't compile or won't run; pure skip
+  accept-<area>.json      ← run-level conditions this project accepts (#3561)
 ```
 
 One file per area. Sharding matches Microsoft's
@@ -118,6 +119,7 @@ rather than replace it.
     // Required runner extension
     "Mode": "expect-oos",                          // expect-oos | expect-fail-known-gap
                                                    //   | expect-divergence | skip
+                                                   //   | accept-partial-company-init
 
     // Conditional
     "Reason": "report-rendering",                  // required when Mode = expect-oos
@@ -155,6 +157,42 @@ when only some tests in a codeunit are affected.
 | `expect-fail-known-gap` | fail (any exception or assertion mismatch) | `pass-known-gap` | Surface is in scope but not yet implemented; `Issue` tracks the work |
 | `expect-divergence` | fail, without raising an out-of-scope signal | `pass-divergence` | Runner *intentionally* answers differently from real BC, permanently; `Doc` cites the decision |
 | `skip` | n/a — runner does not invoke the test | `skipped` | Test cannot compile against the current AL output, or otherwise must not run |
+| `accept-partial-company-init` | n/a — not a test expectation | n/a | This project knowingly runs against a company whose initialization codeunit aborts; see below |
+
+### `accept-partial-company-init`: a run-level condition, not a test (#3561)
+
+Every other mode classifies a TEST. This one classifies the RUN: it declares that this project
+knowingly accepts a company initialization that did not complete, so the abort stops escalating
+the exit code from 0 to 2 (`docs/partial-company-initialization.md`).
+
+```jsonc
+[
+  {
+    "codeunitId":   2,
+    "CodeunitName": "Company-Initialize",
+    "Method":       "*",                     // must be "*" — the entry names a codeunit, not a test
+    "Mode":         "accept-partial-company-init",
+    "Reason":       "this project ships without the dependency codeunit 2 needs; tracked in <issue>"
+  }
+]
+```
+
+- **`Reason` is mandatory free text**, and a bare placeholder (`n/a`, `none`, `TBD`, `-`, …) is
+  refused at load time — the same fixed token list `.github/scripts/check_corpus_linkage.sh`
+  refuses for a `Corpus-NA:` reason. It is printed in the summary next to the abort, so it is
+  what a reader of the run sees.
+- **`Issue` is forbidden** and `Method` must be `"*"`; both are refused before a test runs.
+- **Nothing is silenced.** The abort still appears in the printed summary (marked
+  `[accepted: <reason>]`), in `--out`, in `--output-json` (`companyInitFailures[].accepted`) and
+  in the JUnit comment. Only the escalation is suppressed, and only for the codeunit the entry
+  names — exit codes 1, 3, 4 and 5 are untouched, and an abort of a codeunit no entry names
+  still exits 2.
+- **Drift is loud**, mirroring `expect-oos`: if the named codeunit RAN TO COMPLETION in this
+  run, the entry is an exit-code suppression with nothing behind it, and the run says
+  "remove the entry" and does not exit 0. An entry whose codeunit this run never attempted is
+  inert rather than wrong — the manifest directory is auto-probed and shared by every
+  invocation in a project, which is the same reason `--expectations-require-match` is opt-in.
+  These entries are excluded from that audit for the same reason: they name no test.
 
 ### Which throw shapes `expect-oos` recognises
 

--- a/docs/partial-company-initialization.md
+++ b/docs/partial-company-initialization.md
@@ -46,7 +46,53 @@ refuse to run, and it does not discard results.
 | `--output-json` | `companyInitFailures`: `codeunitId`, `codeunit`, `exceptionType`, `message`. Additive and null-omitted — a clean run's document is unchanged |
 | `--out` | a record with `"kind": "company-init"` and `"classification": "company-init/partial"`, ranked ahead of the test failures it may explain |
 | `--output-junit` | an XML comment per affected bucket, the same convention #2919 chose for a lost suite: a synthetic `testsuite` would have to invent counts, and this reports a condition without moving the numbers a dashboard plots |
-| exit code | **2**, and only when the run would otherwise have exited 0 |
+| exit code | **2**, and only when the run would otherwise have exited 0 — unless the manifest accepts the abort (below) |
+
+### The targeted opt-out, and what the blanket one costs (#3561)
+
+`--no-strict-exit` is not an opt-out from *this*: it forces exit **0 for everything** — a failing
+test, a compile failure (3), a lost `--out` file, a carried resume attempt that did not arrive.
+A suite that accepts one known abort had to give up its exit code entirely to stop tripping over
+it, which is a strictly worse trade than the one it wanted.
+
+The targeted opt-out is an expectations-manifest entry naming the initialization codeunit
+(`docs/expectations.md` § `accept-partial-company-init`), with a mandatory free-text `Reason`:
+
+```jsonc
+{ "codeunitId": 2, "CodeunitName": "Company-Initialize", "Method": "*",
+  "Mode": "accept-partial-company-init", "Reason": "<why this project accepts it>" }
+```
+
+It suppresses the 0 → 2 escalation and **nothing else**. The abort is still in the summary
+(`[accepted: <reason>]`), `--out`, `--output-json` (`accepted`) and the JUnit comment; 1/3/4/5
+are untouched; an abort of a codeunit no entry names still exits 2. An entry whose codeunit ran
+to completion is drift and fails the run with "remove the entry".
+
+**The residual, deliberately.** Drift fires only when the codeunit actually ran to completion in
+this run. A run that never attempted it — no Base App in the bundle, or a clean dependency-company
+baseline restored from disk without re-running codeunit 2 — leaves the entry inert, so a stale
+entry is caught on the first run that initializes cleanly for real rather than on every run. The
+alternative, failing whenever an entry did not match, is exactly what `--expectations-require-match`
+is opt-in to avoid: the manifest directory is auto-probed and shared by every invocation.
+
+### One abort, one line
+
+N app groups sharing one cached dependency-company baseline each re-report the abort on their
+cache HIT — deliberately: each really did run its tests against the partial company. Identical
+records (same codeunit id, codeunit name, exception type and message) are collapsed into one
+summary line carrying `×N app group(s)` and one `--output-json` entry carrying `count: N`; the
+header keeps counting app groups. `--out` is not collapsed, because it is a per-bucket triage
+worklist and each bucket's record belongs to that bucket. The app id is not part of "identical":
+the accumulator records none, and the codeunit it records is always Base App's codeunit 2.
+
+### Server mode
+
+`--server` never builds a `BucketResult`, so before #3561 it never drained the accumulator: the
+static list grew for the life of the process and no response carried the condition at all. It is
+now drained once per request, in both the `runTests` and `execute` handlers, and the responses
+carry `companyInitFailures` (same field shape as `--output-json`, null-omitted). The response's
+`exitCode` escalates exactly as the CLI's does, because a client reading only `exitCode` is the
+consumer this was filed for.
 
 ### Why exit 2, and why it is safe
 

--- a/docs/partial-company-initialization.md
+++ b/docs/partial-company-initialization.md
@@ -81,8 +81,8 @@ N app groups sharing one cached dependency-company baseline each re-report the a
 cache HIT — deliberately: each really did run its tests against the partial company. Identical
 records (same codeunit id, codeunit name, exception type and message) are collapsed into one
 summary line carrying `×N app group(s)` and one `--output-json` entry carrying `count: N`; the
-header keeps counting app groups. `--out` is not collapsed, because it is a per-bucket triage
-worklist and each bucket's record belongs to that bucket. The app id is not part of "identical":
+header keeps counting app groups. `--out` carries the within-bucket collapse and no cross-bucket
+one, because it is a per-bucket triage worklist and each bucket's record belongs to that bucket. The app id is not part of "identical":
 the accumulator records none, and the codeunit it records is always Base App's codeunit 2.
 
 ### Server mode

--- a/docs/server-mode.md
+++ b/docs/server-mode.md
@@ -546,8 +546,40 @@ seen. So adding/removing/retyping a *field* (or other table-shape change) is not
 reliably picked up by a warm reload — restart the server after a schema change.
 Trigger/logic edits within an unchanged field layout are fine.
 
+## `companyInitFailures` — the company the tests ran against (#3561)
+
+Present on a `runTests` summary and on an `execute` response exactly when a company
+initialization codeunit did not run to completion during **that request**; absent otherwise,
+never an empty array, and there is no request field that opts into it. Each entry is
+`{codeunitId, codeunit, exceptionType, message, count, accepted|omitted}`:
+
+```json
+{"type":"summary","exitCode":2,"passed":1,"failed":0,"errors":0,"total":1,
+ "companyInitFailures":[{"codeunitId":2,"codeunit":"Company-Initialize",
+   "exceptionType":"InvalidOperationException","message":"…","count":1}],
+ "protocolVersion":2}
+```
+
+Real BC cannot present a half-initialized company, so this says the DATABASE the AL ran against
+was not the one asked for — not that anything about the AL failed. `count` is how many app
+groups reported the same abort (identical records are collapsed into one entry). `accepted`
+carries the expectations-manifest reason when the project declares the condition accepted, and
+then the escalation below does not happen; see
+[partial-company-initialization.md](partial-company-initialization.md).
+
+Two consequences of the manifest being resolved at **server startup**, not per request: the
+acceptance only applies when the server was started with `--expectations <dir>` (or from a
+working directory carrying `tests/expectations`), and the stale-entry drift check is CLI-only —
+"this codeunit completed" is a per-process fact, and a long-lived server has no end of run to
+judge it at.
+
+The accumulator is drained once per request, so a response reports its own request's aborts and
+never a previous one's.
+
 ## Exit codes
 
 Same ladder as normal mode: `0` all pass · `1` test failures · `2` execution
 error · `3` compilation error. In server mode the code rides on each `runTests`
-response's `exitCode`; the process itself exits `0` on `shutdown`/EOF.
+response's `exitCode`; the process itself exits `0` on `shutdown`/EOF. A request whose company
+initialization did not complete reports `2` on that response — the same escalation the CLI
+makes, and for the same reason: a client reading only `exitCode` must not read the run as clean.

--- a/protocol-v2.schema.json
+++ b/protocol-v2.schema.json
@@ -134,8 +134,32 @@
           "items": { "$ref": "#/definitions/FileStatements" },
           "description": "Present only when the request set `coverage:true` (#2042). One entry per AL source file with per-statement hit counts and positions — see StatementRecord/FileStatements. Supersedes the older, never-implemented FileCoverage{lines[], totalStatements, hitStatements} shape (this repo shipped no working `coverage` producer for it, so there is no compatibility break): per-statement detail with positions strictly subsumes a line-hit rollup, which a caller can still derive client-side by grouping `statements` on `line`."
         },
+        "companyInitFailures": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/CompanyInitFailure" },
+          "description": "Present only when a company initialization codeunit did not run to completion during this request (#3538/#3561). Absent means the company initialized cleanly \u2014 never an empty array. Every test in the response ran against a company real BC cannot produce, so `exitCode` is 2 unless the run earned something more specific, or unless the expectations manifest accepts the abort (see `accepted`)."
+        },
         "wallSeconds": { "type": "number", "minimum": 0 },
         "protocolVersion": { "const": 2 }
+      }
+    },
+    "CompanyInitFailure": {
+      "type": "object",
+      "required": ["codeunitId", "codeunit", "exceptionType", "message", "count"],
+      "properties": {
+        "codeunitId": { "type": "integer" },
+        "codeunit": { "type": "string" },
+        "exceptionType": { "type": "string" },
+        "message": { "type": "string" },
+        "count": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "How many app groups reported this same abort. Identical records are collapsed into one entry (#3561); each counted app group really did run its tests against the partial company."
+        },
+        "accepted": {
+          "type": "string",
+          "description": "Present only when the run's expectations manifest declares this abort accepted (Mode: accept-partial-company-init); carries that entry's Reason. The condition is still reported \u2014 only the exit 0 \u2192 2 escalation is suppressed."
+        }
       }
     },
     "Ack": {

--- a/tests/expectations/README.md
+++ b/tests/expectations/README.md
@@ -19,6 +19,12 @@ naming convention:
   differently from real BC. `Mode: expect-divergence`; carries `Reason` + `Doc`
   and no `Issue`, because there is no open work to link.
 - `disabled-<area>.json` — won't compile or won't run; pure skip.
+- `accept-<area>.json` — a RUN-level condition this project knowingly accepts, not
+  a test expectation. Today one mode: `accept-partial-company-init`, which names an
+  initialization codeunit whose abort is accepted here and carries a mandatory
+  free-text `Reason` and no `Issue`. It suppresses only the company-init exit 0 → 2
+  escalation; the abort is still reported on every surface. See
+  [`docs/partial-company-initialization.md`](../../docs/partial-company-initialization.md).
 
 Sharding by area keeps PR diffs small. A single PR adding or removing one
 expectation should touch one file with one entry.


### PR DESCRIPTION
Closes #3561

Corpus-NA: runner exit-code and manifest behaviour; not observable on a service tier

## The design: an expectations entry, not a flag

#3538 made a run whose company initialization did not complete exit 2 instead of 0. The only
escape was `--no-strict-exit`, which forces exit 0 for **everything** — a failing test, a compile
failure (3), a lost `--out` file, a carried resume attempt that did not arrive. A suite that
knowingly accepts one abort had to give up its exit code entirely to stop tripping over it.

The targeted opt-out is an **expectations-manifest entry**, not a new CLI flag:

```jsonc
{ "codeunitId": 2, "CodeunitName": "Company-Initialize", "Method": "*",
  "Mode": "accept-partial-company-init", "Reason": "<why this project accepts it>" }
```

Why an entry rather than a flag. The condition is a standing property of a *project*, not of an
invocation: a flag has to be repeated on every call site (CI step, local run, server startup) and
carries no reason with it, so a reader of a red-turned-green pipeline has nothing to read. The
manifest already exists to declare "the runner and real BC differ here, on purpose, and here is
why", it is already auto-probed per project, and it is already loud when a declaration stops
matching reality. This is the same contract one level up: a run-level condition instead of a test
outcome.

What it does and does not do:

- **Nothing is silenced.** The abort is still in the printed summary (now marked
  `[accepted: <reason>]`), in `--out`, in `--output-json` (`companyInitFailures[].accepted`) and
  in the JUnit comment. Only the exit **0 → 2** escalation is suppressed, and only for the
  codeunit the entry names.
- **Exit codes 1/3/4/5 are untouched**, and an abort of a codeunit no entry names still exits 2.
- **`Reason` is mandatory free text**, and a bare placeholder (`n/a`, `none`, `TBD`, `-`, …) is
  refused at load time — the same fixed token list `.github/scripts/check_corpus_linkage.sh`
  refuses for a `Corpus-NA:` reason. `Issue` is forbidden and `Method` must be `"*"`.
- **Drift is loud**, mirroring `expect-oos`'s "the test passed, remove the entry": an entry whose
  codeunit **ran to completion** in this run is an exit-code suppression with nothing behind it,
  so the run says so and does not exit 0.
- **The residual, deliberately.** Drift fires only on an actual completion. A run that never
  attempted the codeunit — no Base App in the bundle, or a clean baseline restored from disk
  without re-running codeunit 2 — leaves the entry inert. Failing on "did not match" is exactly
  what `--expectations-require-match` is opt-in to avoid: the manifest directory is auto-probed
  and shared by every invocation in a project. These entries are excluded from that audit, and
  from the test-lookup table, for the same reason: they name a codeunit, not a test.
- `docs/partial-company-initialization.md` now says what `--no-strict-exit` silences and points
  at the entry; `docs/expectations.md` carries the schema, and `--guide`'s `--expectations`
  section names the mode.

## The two smaller items from the issue

**Server mode never drained the accumulator.** `--server` never builds a `BucketResult`, so the
static list grew for the life of the process and no response carried the condition at all. It is
now drained **once per request** in both the `runTests` and `execute` handlers, through the same
`Reporter.FinalizeCompanyInitFailures` the CLI drain calls, and both responses carry
`companyInitFailures` (same field shape as `--output-json`, null-omitted). **Decision worth
flagging:** the response's `exitCode` escalates 0 → 2 exactly as the CLI's does, because a client
reading only `exitCode` is the consumer #3538 was filed for.

Two scoping facts a reader of the server section should have, both properties of where the
manifest already loads rather than defects: `expectations` is resolved once at **server startup**,
so acceptance applies only when the server was started with `--expectations <dir>` (or from a
working directory carrying `tests/expectations`); and the stale-entry drift check is CLI-only,
because "this codeunit completed" is a per-process fact and a long-lived server has no end of run
to judge it at. Both are now in `docs/server-mode.md`, along with the field itself, which also
went into `protocol-v2.schema.json` and `ServerProtocol.cs`'s protocol header — a VS Code client
reads the schema, not the C#.

**N app groups sharing one cached baseline reported the abort N times.** Identical records
collapse into one summary line carrying `×N app group(s)` and one JSON entry carrying `count: N`;
the header keeps counting app groups, so no information is lost. "Identical" is the whole of what
the accumulator records: codeunit id, codeunit name, exception type, message. The issue's phrasing
included the app id — the accumulator holds none, and the codeunit it records is always Base App's
codeunit 2, so an app dimension would be constant today and invented rather than measured; that is
stated here rather than fabricated as a field. Collapse happens at the run-level aggregation as
well as at the drain site, because the dependency-company baseline is cached per dependency set,
not per bundle, so the re-reporting app groups are routinely in different buckets. `--out` carries the within-bucket collapse each `BucketResult` already
holds, and no cross-bucket one: it is a per-bucket triage worklist and each bucket's record
belongs to that bucket.

## RED → GREEN

New/extended tests, run against `origin/main` (`43fb93d7`) with only the test files copied in:

```
Failed!  - Failed: 11, Passed: 1, Skipped: 0, Total: 12
  PartialCompanyInitAcceptanceTests            8 FAIL   (all of the opt-out, drift, placeholder,
                                                         Method-shape and targeting arms)
  ServerCompanyInitDrainTests
    EachRequestReportsItsOwnCompanyInitAbort…    FAIL   (no field on the response at all)
    ACleanServerRun_CarriesNoCompanyInitField    PASS   (the negative control — passes both sides)
  PartialCompanyInit_OnAnInMemoryCacheHit…       FAIL   (two identical summary lines)
  PartialCompanyInit_AcrossAppGroups…            FAIL   "Assert.Single() Failure: The collection
                                                         contained 2 items"
```

With the change, on this branch:

```
PartialCompanyInitAcceptanceTests                       8/8   pass (3 m 14 s)
ServerCompanyInitDrainTests + PartialCompanyInitializationTests
                                                        9/9   pass (4 m 44 s)
CliDocumentation|ExpectationManifestWiring|ExpectationClassifier|
LoudDiagnosisReachesTheUser|ServerProtocol            117/117  pass (4 m 24 s)
tools/test_doc_pointers.py                              all checks passed
```

Two seams drive this, both `AL_RUNNER_TEST_*` env vars no shipped path sets, both justified in
place. `AL_RUNNER_TEST_FAIL_COMPANY_INIT` is #3538's existing one. The drift arm needs the
opposite fact — codeunit 2 **found and completed** — which for real requires the Base Application
floor, forbidden in a C# fixture (`no-base-app-in-csharp-tests.md`) and, at ~70 s per invocation,
unable to guarantee the completion anyway; `AL_RUNNER_TEST_COMPANY_INIT_COMPLETED=1` records the
completion at exactly the line the real one does, so the drift check under test is the real one.
No new fixture app declares `"application"`; the abort arms reuse #3554's `CompanyInitPartial`.

## Shape check, and the queue

- Same wrong pattern elsewhere: the accumulator has exactly **two** consumers, and the missing one
  was the finding — both now go through one `FinalizeCompanyInitFailures`, so a third transport
  cannot get a third behaviour.
- Sibling assumption: `Reporter.CompanyInitFailures` was the only run-level aggregation; `--out`
  reads per bucket by design and is left that way, stated above.
- Two paths writing the same state: the CLI drain and the server drain now maintain the same
  invariant (collapse + acceptance marking + escalation) rather than one having it.
- **Not folded:** #3114 (`tests/expectations` file prefix and entry `Mode` must agree, nothing
  checks it). Same subsystem and it now has one more prefix to cover — this PR documents
  `accept-<area>.json` — but its fix is a new schema test over the shipped manifest, not the
  loader this PR edits, and it needs a different shape of reasoning to review. Left for whoever
  claims it, with the new mode already in `docs/expectations.md`'s table. Nothing else in the
  open queue lands in these files (#3589 is `tools/pr-body.py`).
- `CollectionCostOrderer`'s `PartialCompanyInitializationTests` weight (113 s) is now stale by
  construction: that class gains one runner spawn, and the new `PartialCompanyInitAcceptanceTests`
  (~194 s here, 8 spawns) and `ServerCompanyInitDrainTests` (2 server processes) have no entry.
  Not guessed at — re-measure with `scripts/trx-occupancy.py` on a green matrix leg, per that
  file's own header.

Authored by the `fbk-3` implementation agent, an automated agent acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kko97BZZL71nF2nK5aftu4
