### PR TITLE
fix(page-control-field): merge a pageextension's added controls from BC's own delta document

### DIFF
--- a/AlRunner.Tests/BcAppSymbolCachePageMetadataTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCachePageMetadataTests.cs
@@ -136,7 +136,14 @@ public class BcAppSymbolCachePageMetadataTests
             Assert.NotNull(card.Controls);
             Assert.Equal(3, card.Controls!.Count);
 
-            // Sequence follows document order, 1-based, depth-first through the group.
+            // Sequence follows document order, 0-BASED, depth-first through the group.
+            // 0-based because that is what BC's own provider answers: GetControlsOnPage
+            // numbers its FindAll walk with `Select((cd, i) => …)`, an index captured before
+            // the OrderBy that sorts rows by control id. #3628 corrected the two
+            // source-compiled paths and deliberately left this one 1-based because the file
+            // was being changed by another PR; #3631 is that residue. These assertions said
+            // 1/2/3 and passed the whole time, which is why nothing noticed — a column
+            // answering a plausible wrong value that no test contradicts.
             var no = card.Controls[0];
             Assert.Equal(640644145, no.Id);
             Assert.Equal("No.", no.Name);
@@ -144,7 +151,7 @@ public class BcAppSymbolCachePageMetadataTests
             // A Visible driven by a variable name is stored VERBATIM — not coerced to a
             // boolean, not dropped. Real BC's own column is Text for exactly this reason.
             Assert.Equal("NoFieldVisible", no.VisibleExpr);
-            Assert.Equal(1, no.Sequence);
+            Assert.Equal(0, no.Sequence);
 
             var name = card.Controls[1];
             Assert.Equal("Name", name.Name);
@@ -153,12 +160,19 @@ public class BcAppSymbolCachePageMetadataTests
             // the parser must not invent a value; the provider (not this parser) supplies
             // the "true" default. See RecordPatches.PageControlFieldVirtualTable.cs.
             Assert.Null(name.VisibleExpr);
-            Assert.Equal(2, name.Sequence);
+            Assert.Equal(1, name.Sequence);
 
             var name2 = card.Controls[2];
             Assert.Equal("Name 2", name2.Name);
             Assert.Equal("false", name2.VisibleExpr);
-            Assert.Equal(3, name2.Sequence);
+            Assert.Equal(2, name2.Sequence);
+
+            // The point of #3631 is CONSISTENCY, not the absolute value: Page Control Field's
+            // Sequence must mean the same thing whether the page was source-compiled or came
+            // from a precompiled dependency, because AL cannot see which one it has. So pin
+            // the property that matters — the first control is index 0 on this path too.
+            Assert.Equal(0, card.Controls.Min(c => c.Sequence));
+            Assert.Equal(new[] { 0, 1, 2 }, card.Controls.Select(c => c.Sequence).ToArray());
         }
         finally
         {

--- a/AlRunner.Tests/PageControlFieldDocumentTests.cs
+++ b/AlRunner.Tests/PageControlFieldDocumentTests.cs
@@ -42,7 +42,29 @@ public sealed class PageControlFieldDocumentTests : IDisposable
     public void Dispose()
     {
         AlObjectMetadataRegistry.Clear();
+        // The AL parser's dictionaries and the delta memo are static, so a fixture left
+        // behind here would answer for the NEXT class's page of the same id. Both are
+        // dropped for the same reason the runtime drops them on a --watch reload.
+        RemoveParsedPage(90331);
+        RemoveParsedPageExtension(90333);
+        ClearBcPageExtensionControls();
         try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private static void ClearBcPageExtensionControls()
+        => typeof(AlRunner.Patches.RecordPatches)
+            .GetMethod("ClearBcPageExtensionControls",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+            ?.Invoke(null, null);
+
+    private static void RemoveParsedPage(int id) => RemoveFromDict("_parsedPages", id);
+    private static void RemoveParsedPageExtension(int id) => RemoveFromDict("_parsedPageExtensions", id);
+
+    private static void RemoveFromDict(string field, int id)
+    {
+        var f = typeof(AlRunner.Patches.RecordPatches).GetField(field,
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        if (f?.GetValue(null) is System.Collections.IDictionary d && d.Contains(id)) d.Remove(id);
     }
 
     /// <summary>
@@ -270,4 +292,244 @@ public sealed class PageControlFieldDocumentTests : IDisposable
             Assert.False(c.HasAttribute("SourceTable"),
                 $"control '{c.GetAttribute("Name")}' unexpectedly states its own SourceTable");
     }
+
+    // ---------------------------------------------------------------------------------
+    // #3605 — a pageextension's added controls live ONLY in the extension's own
+    // MetadataRuntimeDeltas document, never in the base page's <PageDefinition>.
+    //
+    // This is the exact inverse of tables (#3600), where a same-app tableextension's added
+    // fields ARE folded into the base <MetaTable>. Carrying a table intuition across is
+    // what makes the page case look already-solved when it is not.
+    // ---------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A base page plus a pageextension that adds one control, over a table extended by a
+    /// tableextension — the smallest shape in which "the control the base document does not
+    /// mention" is a real, resolvable field rather than a dangling name.
+    /// </summary>
+    private const string ExtensionFixtureAl = """
+        table 90330 "PcfExt Sample"
+        {
+            DataClassification = CustomerContent;
+            fields
+            {
+                field(1; "Entry No."; Integer) { DataClassification = CustomerContent; }
+            }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+
+        tableextension 90332 "PcfExt Sample Ext" extends "PcfExt Sample"
+        {
+            fields
+            {
+                field(50; "Extra Note"; Text[30]) { DataClassification = CustomerContent; }
+            }
+        }
+
+        page 90331 "PcfExt Fixture"
+        {
+            PageType = List;
+            SourceTable = "PcfExt Sample";
+
+            layout
+            {
+                area(Content)
+                {
+                    repeater(Rows)
+                    {
+                        field("Entry No."; Rec."Entry No.") { ApplicationArea = All; }
+                    }
+                }
+            }
+        }
+
+        pageextension 90333 "PcfExt Fixture Ext" extends "PcfExt Fixture"
+        {
+            layout
+            {
+                addlast(Content)
+                {
+                    field("Extra Note"; Rec."Extra Note") { ApplicationArea = All; }
+                }
+            }
+        }
+        """;
+
+    private void EmitExtensionFixture()
+    {
+        File.WriteAllText(Path.Combine(_root, "PcfExt.al"), ExtensionFixtureAl);
+        var output = new BcCompiler().Emit(new[] { _root }, "PcfExtModule");
+        Assert.True(output.Sources.Count > 0,
+            $"Expected the fixture to emit; diagnostics: {string.Join(" | ", output.Diagnostics.Take(10))}");
+
+        // A bare Emit captures the metadata documents but does NOT run the AL source parser,
+        // which a real run does on the same sources. GetPageExtensionIdsForPage resolves a
+        // page id to its NAME through that parser's dictionaries, so without this the lookup
+        // finds no extensions and the conversion silently contributes nothing — the same
+        // shape as the bug under test, which would make the assertion untrustworthy in both
+        // directions. Driving the real parser here keeps the test on the production path.
+        ParseAlSource("TryParsePageFile", ExtensionFixtureAl);
+    }
+
+    private static void ParseAlSource(string method, string source)
+        => typeof(AlRunner.Patches.RecordPatches)
+            .GetMethod(method,
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+            ?.Invoke(null, new object[] { source });
+
+    [SkippableFact]
+    public void BasePageDocument_DoesNotMentionAPageExtensionsAddedControl()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        EmitExtensionFixture();
+
+        Assert.True(AlObjectMetadataRegistry.TryGet("Page", 90331, out var pageXml),
+            "expected the base page's document to be captured under kind \"Page\"");
+
+        var doc = new System.Xml.XmlDocument();
+        doc.LoadXml(pageXml);
+        var controls = FieldControls(doc.DocumentElement!);
+
+        // Positive: the base page's own control is there, so the document did parse and the
+        // walk does find controls — without this the negative below would pass vacuously.
+        Assert.Equal(new[] { "Entry No." }, controls.Select(c => c.GetAttribute("Name")).ToArray());
+
+        // Negative, and the whole premise of #3605: the extension's control is absent from
+        // the base document ENTIRELY — not merely from the walk. A substring check over the
+        // raw XML cannot be fooled by a walk that skips an element shape it does not know.
+        Assert.DoesNotContain("Extra Note", pageXml, StringComparison.Ordinal);
+    }
+
+    [SkippableFact]
+    public void PageExtensionDocument_CarriesTheAddedControlUnderControlAdd()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        EmitExtensionFixture();
+
+        // The kind string is load-bearing: the conversion looks the delta up under
+        // "PageExtension", and any other spelling silently contributes zero extra controls.
+        Assert.True(AlObjectMetadataRegistry.TryGet("PageExtension", 90333, out var extXml),
+            "expected pageextension 90333's delta document to be captured under kind "
+            + "\"PageExtension\" — without it the added control cannot be answered at all");
+
+        var doc = new System.Xml.XmlDocument();
+        doc.LoadXml(extXml);
+        var root = doc.DocumentElement!;
+
+        // The root element is MetadataRuntimeDeltas, NOT PageDefinition — this is a different
+        // document shape from the base page's, which is why it needs its own read.
+        Assert.Equal("MetadataRuntimeDeltas", root.Name);
+
+        var adds = root.ChildNodes.Cast<System.Xml.XmlNode>()
+            .OfType<System.Xml.XmlElement>().Where(e => e.Name == "ControlAdd").ToList();
+        Assert.Single(adds);
+
+        // Positive: the added control sits under <ControlAdd> in exactly the <Controls
+        // xsi:type="ControlDefinition"> shape the base document uses, which is why the same
+        // collector reads both rather than needing a second parser.
+        var added = FieldControls(adds[0]);
+        Assert.Equal(new[] { "Extra Note" }, added.Select(c => c.GetAttribute("Name")).ToArray());
+
+        // ...and it states the binding as a field NUMBER, so the bound branch resolves it
+        // against the metatable the same way a base-page control resolves.
+        Assert.Equal("50", added[0].GetAttribute("DataColumnName"));
+    }
+
+    [SkippableFact]
+    public void PageControlFieldRows_IncludeAPageExtensionsAddedControl_WithItsResolvedField()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        EmitExtensionFixture();
+
+        var rows = PageControlFieldRowsFor(90331);
+
+        // Positive: BOTH controls, the base page's and the extension's. Before #3605 this
+        // answered only "Entry No." — the document path replaced an AL derivation that did
+        // merge extensions, so the added control was dropped silently.
+        Assert.Equal(new[] { "Entry No.", "Extra Note" },
+            rows.Select(r => r.ControlName).ToArray());
+
+        // The extension row carries BC's own resolved values, not defaults: field 50 comes
+        // from the TABLEEXTENSION (so the delta's DataColumnName was really resolved against
+        // the extended table, not echoed back), and TableNo is the page's source table, which
+        // BC assigns on every row.
+        //
+        // SourceExpression is deliberately NOT asserted here. Resolving it needs a built
+        // NCLMetaTable, which a bare BcCompiler.Emit does not construct — in this harness it
+        // is empty for the base page's row too, so an assertion either way would measure the
+        // harness rather than the conversion. It IS pinned end-to-end: a live runner probe on
+        // this exact shape answers `Extra Note` (BC's field-NAME form, not the binding text
+        // `Rec."Extra Note"`), and corpus codeunit 60426 pins the column against a real tier.
+        var extra = rows.Single(r => r.ControlName == "Extra Note");
+        Assert.Equal(50, extra.FieldNo);
+        Assert.Equal(90330, extra.TableNo);
+
+        // Sequence continues the base page's numbering rather than restarting at 0 — BC
+        // numbers its FindAll walk over the MERGED page, so two rows may not share an index.
+        Assert.Equal(0, rows.Single(r => r.ControlName == "Entry No.").Sequence);
+        Assert.Equal(1, extra.Sequence);
+
+        // Negative: the control id is hashed in the EXTENSION's id space, not the base
+        // page's. Asserting inequality as well as equality is what catches a future change
+        // that "fixes" the id by hashing against the page — which would make every TestPage
+        // lookup of an extension control miss.
+        Assert.Equal(MemberIdOf(90333, "Extra Note"), extra.ControlId);
+        Assert.NotEqual(MemberIdOf(90331, "Extra Note"), extra.ControlId);
+    }
+
+    /// <summary>BC's IdSpace.GetMemberId, reached on the runner's own implementation by
+    /// reflection so this cannot drift from the hash the runtime resolves controls with.</summary>
+    private static int MemberIdOf(int ancestorObjectId, string name)
+    {
+        var t = typeof(AlRunner.Patches.RecordPatches).Assembly
+            .GetType("AlRunner.Patches.RunnerPageInstance")
+            ?? throw new InvalidOperationException("AlRunner.Patches.RunnerPageInstance not found.");
+        var m = t.GetMethod("MemberId",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+            ?? throw new InvalidOperationException("RunnerPageInstance.MemberId not found.");
+        return (int)m.Invoke(null, new object[] { ancestorObjectId, name })!;
+    }
+
+    /// <summary>
+    /// The rows the virtual table would report for one page, taken from the document path
+    /// itself (<c>GetPageControlFieldRowsFromBcDocument</c>) rather than from the populated
+    /// table, so the assertion is about the conversion under test and not about whether a
+    /// virtual-table populate ran in this process.
+    /// </summary>
+    private static List<PageControlFieldRowView> PageControlFieldRowsFor(int pageId)
+    {
+        var rp = typeof(AlRunner.Patches.RecordPatches);
+        var m = rp.GetMethod("GetPageControlFieldRowsFromBcDocument",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+            ?? throw new InvalidOperationException(
+                "RecordPatches.GetPageControlFieldRowsFromBcDocument not found — the "
+                + "#3604/#3605 conversion this class pins has been renamed or removed.");
+
+        var raw = m.Invoke(null, new object[] { pageId });
+        Assert.True(raw != null,
+            $"page {pageId}: the document path returned null, meaning BC's document was not "
+            + "captured or did not parse — the conversion is not being exercised at all.");
+
+        var view = new List<PageControlFieldRowView>();
+        foreach (var row in (System.Collections.IEnumerable)raw!)
+        {
+            var t = row.GetType();
+            string S(string n) => (string)t.GetProperty(n)!.GetValue(row)!;
+            int I(string n) => (int)t.GetProperty(n)!.GetValue(row)!;
+            view.Add(new PageControlFieldRowView(
+                I("ControlId"), S("ControlName"), I("TableNo"), I("FieldNo"),
+                S("SourceExpression"), I("Sequence")));
+        }
+        return view;
+    }
+
+    private sealed record PageControlFieldRowView(
+        int ControlId, string ControlName, int TableNo, int FieldNo,
+        string SourceExpression, int Sequence);
 }

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -1479,11 +1479,18 @@ internal static partial class BcAppSymbolCache
             int id = control.TryGetProperty("Id", out var idProp) && idProp.TryGetInt32(out var idv) ? idv : 0;
             if (!string.IsNullOrEmpty(name) && id != 0)
             {
-                sequence++;
                 props.TryGetValue("Visible", out var visible);
                 props.TryGetValue("Editable", out var editable);
                 props.TryGetValue("Enabled", out var enabled);
-                into.Add(new PageControlSymbol(id, name!, srcExpr, visible, editable, enabled, sequence));
+                // 0-based, POST-increment (#3631). BC numbers its FindAll walk with
+                // `Select((cd, i) => …)`, an index captured before the OrderBy that sorts by
+                // control id, so the first control is 0. This path was left 1-based when
+                // #3628 corrected the other two only because this file was being changed by
+                // another PR at the time; the inconsistency is worse than either value,
+                // because Page Control Field's Sequence then meant different things for a
+                // source-compiled and a precompiled-dependency page and AL cannot see which
+                // it has.
+                into.Add(new PageControlSymbol(id, name!, srcExpr, visible, editable, enabled, sequence++));
             }
         }
 

--- a/AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs
@@ -211,6 +211,69 @@ public static partial class RecordPatches
         }
     }
 
+    /// <summary>The AL compiler's own <c>SymbolKind</c> name for a pageextension, as
+    /// <see cref="AlObjectMetadataRegistry"/> keys it — measured from the emitter's own trace
+    /// (<c>AL_RUNNER_TRACE_OBJECT_METADATA=2</c> prints <c>PageExtension|id:70663</c>).</summary>
+    internal const string BcPageExtensionMetadataKind = "PageExtension";
+
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<int, List<BcPageControl>>
+        _bcPageExtensionControls = new();
+
+    /// <summary>
+    /// Drop the parsed pageextension deltas on a <c>--watch</c>/<c>--server</c> reload, for the
+    /// same reason <see cref="ClearBcPageControlDocuments"/> does: extension ids repeat across
+    /// reloads, so an entry from the previous bundle is a wrong answer rather than a miss.
+    /// </summary>
+    internal static void ClearBcPageExtensionControls() => _bcPageExtensionControls.Clear();
+
+    /// <summary>
+    /// The field controls every pageextension over <paramref name="pageId"/> ADDS, read from
+    /// each extension's own <c>MetadataRuntimeDeltas</c> document.
+    ///
+    /// <para>An extension whose document the emitter never captured contributes nothing here;
+    /// it is not silently dropped, because the caller only reaches this path for a page whose
+    /// own document exists, and a missing extension document leaves the base page's rows
+    /// intact rather than replacing them with a guess.</para>
+    /// </summary>
+    private static List<BcPageControl> GetBcPageExtensionControls(int pageId)
+    {
+        var result = new List<BcPageControl>();
+        foreach (var extId in GetPageExtensionIdsForPage(pageId))
+        {
+            var controls = _bcPageExtensionControls.GetOrAdd(extId, static id =>
+            {
+                var into = new List<BcPageControl>();
+                if (!AlObjectMetadataRegistry.TryGet(BcPageExtensionMetadataKind, id, out var xml)
+                    || string.IsNullOrEmpty(xml))
+                    return into;
+                try
+                {
+                    var d = new XmlDocument();
+                    d.LoadXml(xml);
+                    if (d.DocumentElement == null) return into;
+                    // <MetadataRuntimeDeltas><ControlAdd><Controls xsi:type="ControlDefinition" …/>
+                    // The <Controls> element carries exactly the attributes the base document's
+                    // controls do, so the same collector reads both. Only ControlAdd is read:
+                    // ControlChange/ControlMove modify an EXISTING row rather than adding one,
+                    // and applying them is a separate claim this change does not make (#3605).
+                    var sequence = 0;
+                    foreach (XmlNode n in d.DocumentElement.ChildNodes)
+                        if (n is XmlElement add && add.Name == "ControlAdd")
+                            CollectBcPageControls(add, into, ref sequence);
+                }
+                catch (XmlException ex)
+                {
+                    Console.Error.WriteLine(
+                        $"[page-control-field] pageextension {id}: BC's delta document did not "
+                        + $"parse ({ex.Message}) — its added controls are omitted");
+                }
+                return into;
+            });
+            result.AddRange(controls);
+        }
+        return result;
+    }
+
     private static int ReadBcAttrInt(XmlElement e, string name)
         => int.TryParse(e.GetAttribute(name), out var v) ? v : 0;
 
@@ -233,8 +296,26 @@ public static partial class RecordPatches
         var doc = TryGetBcPageControlDocument(pageId);
         if (doc == null) return null;
 
-        var rows = new List<PageControlFieldRow>(doc.Controls.Count);
-        foreach (var c in doc.Controls)
+        // A pageextension's added controls are NOT in the base page's document — measured on
+        // the ObjectMetadataCapture fixture: `Extra Note` appears zero times in
+        // PageDefinition 70660 and only in PageExtension 70663's own MetadataRuntimeDeltas
+        // document. Tables are the opposite (#3600), so a table intuition does not carry.
+        // See docs/page-control-field-from-bc-document.md#pageextension-deltas.
+        var controls = doc.Controls;
+        var extensionControls = GetBcPageExtensionControls(pageId);
+        if (extensionControls.Count > 0)
+        {
+            // BC numbers Sequence by its own FindAll walk over the MERGED page, so an added
+            // control continues the base page's numbering rather than restarting.
+            var merged = new List<BcPageControl>(controls);
+            var sequence = controls.Count;
+            foreach (var c in extensionControls)
+                merged.Add(c with { Sequence = sequence++ });
+            controls = merged;
+        }
+
+        var rows = new List<PageControlFieldRow>(controls.Count);
+        foreach (var c in controls)
         {
             var isBound = int.TryParse(c.DataColumnName, out var fieldNo);
             var sourceExpression = string.Empty;

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -295,6 +295,9 @@ public static partial class RecordPatches
         // or hides a control would otherwise keep answering the old tree. Page ids repeat
         // across reloads, so a stale entry is a wrong answer rather than a miss.
         ClearBcPageControlDocuments();
+        // #3605: and the pageextension deltas that merge into those documents, which are keyed
+        // by the EXTENSION's id — a separate id space, so a separate memo to drop.
+        ClearBcPageExtensionControls();
         // #3121: every table is rebuilt from scratch below, so carrying the previous bundle's
         // pending CalcFormula rebuilds forward only buys a wasted repopulate pass on the next
         // .app registration.

--- a/docs/page-control-field-from-bc-document.md
+++ b/docs/page-control-field-from-bc-document.md
@@ -257,23 +257,102 @@ Two consequences follow, and both are the reason the AL derivation is **not** de
 state the source field's option members and there is no `<Controls>` element to read them
 from, so answering anything else would be a guess rather than a narrower answer.
 
+<a id="pageextension-deltas"></a>
+
+## Pageextension deltas — a second document, not a second branch
+
+A `pageextension`'s added controls are **not** in the base page's `<PageDefinition>`. BC emits
+them in the extension's own document, rooted `<MetadataRuntimeDeltas>`, and the runner keeps it
+in `AlObjectMetadataRegistry` under kind `PageExtension` (#3548). Measured on
+`AlRunner.Tests/Fixtures/ObjectMetadataCapture` with `AL_RUNNER_TRACE_OBJECT_METADATA=2`, where
+`pageextension 70663` adds `Extra Note` to `page 70660`: the string `Extra Note` appears
+**zero** times in the page's document and only in the extension's.
+
+**Tables are the exact inverse** (#3600): a same-app `tableextension`'s added fields *are*
+folded into the base `<MetaTable>`. A table intuition carried across produces the wrong
+conclusion here, which is why this is written down rather than left to be re-derived.
+
+The delta's payload is the same element shape the base document uses, so the same collector
+reads both:
+
+```xml
+<MetadataRuntimeDeltas ID="70663" Name="OMR Thing List Ext">
+  <ControlAdd ParentContainer="ContentArea" SemanticKind="Content" Operation="ContentLast">
+    <Controls xsi:type="ControlDefinition" ID="114635149" Name="Extra Note"
+              DataColumnName="50" ExtensionId="70662" ApplicationArea="#All" Visible="true" />
+  </ControlAdd>
+</MetadataRuntimeDeltas>
+```
+
+`DataColumnName="50"` is the `tableextension`'s field number, so the bound branch resolves it
+against the extended table exactly as a base-page control resolves. The control `ID` is hashed
+in the **extension's** id space, not the base page's — `RunnerPageInstance.MemberId(70663,
+"Extra Note")`, matching what BC asks `LiveNavTestPage.GetField` for.
+
+Only `<ControlAdd>` is read. `<ControlChange>` and `<ControlMove>` modify an *existing* row
+rather than adding one; applying them is a separate claim, tracked by #3614 for the table twin.
+
+### This was a regression, and the shape of it is worth keeping
+
+Before #3628 the AL derivation merged extensions — `GetSourceParsedPageControlRows` folds
+`_parsedPageExtensions` into the base page's rows. The document path short-circuits before
+reaching it, so converting the table silently dropped every extension-added control. Measured
+on a live probe (page 70700, `pageextension` 70702 adding `Extra Note`):
+
+| runner | Page Control Field rows for page 70700 |
+|---|---|
+| `e2d96307~1` (before #3628) | `Entry No.`, `Extra Note` |
+| `84068be8` (after #3628) | `Entry No.` |
+| with #3605 | `Entry No.`, `Extra Note` |
+
+**`TestPage` binding was never affected**, and that is measured rather than assumed: the same
+probe reads `tp."Extra Note"` as `HELLO` on all three, because `GetPageControlFieldMap` merges
+extensions on its own path. The damage was confined to the virtual table.
+
+### `GetExtensionDeltasForAppObject` is not the route, and returning deltas there changes nothing
+
+#3605 proposed making `RunnerXmlMetadataLoader.GetExtensionDeltasForAppObject` return the real
+deltas instead of `null`. Decompiled on BC 28.1, that would have had no effect, because BC
+reaches a page's extensions by a different path and three independent gates on it are shut:
+
+```
+NCLMetaForm.CreatePageDefinitionWithExtensions
+  -> GetExtensionObjects<NCLPageExtension>(MetadataAppGroup)     <- gate 1 and 2
+  -> ApplyPageExtensions -> ApplyExtensionObjects
+       -> NCLApplicationObjectExtension.ApplyRuntimeDeltas       <- reads .Deltas
+```
+
+`GetExtensionDeltasForAppObject` is called from exactly one place —
+`NCLApplicationObjectExtension.LoadMetadata`, which sets `base.Deltas` on an
+`NCLPageExtension` object that BC only ever obtains through `GetExtensionObjects`. So the
+loader method cannot be reached until that enumeration returns something:
+
+| gate | BC's condition | runner |
+|---|---|---|
+| 1 | `group != NavAppGroup.BaseGroup` | `SessionPatches.NavSession_NavAppGroup` returns `BaseGroup` |
+| 2 | `ObjectLoader.MetadataCache != null` | `RunnerMetaApplicationObjectLoader.MetadataCache` **throws** |
+| 3 | `NCLMetadata.GetExtensionApplicationObjects` walks `navAppGroup.OrderedAppMetadata` | empty — the runner's app group carries no object metadata summaries (measured for #2893) |
+
+Populating all three means constructing a real `NavAppGroup` with per-app runtime metadata and
+an extension registry — the same obstacle `RecordPatches.PermissionMetadataPopulator.cs`
+documents for permission sets, where replacing `BaseGroup` would disturb roughly 60 BC call
+sites that compare group identity. Reading the delta document directly is both reachable and
+strictly less invasive, so that is what this file does. `GetExtensionDeltasForAppObject`
+therefore still answers `null`, which is BC's own "no deltas" value.
+
 <a id="not-done"></a>
 
 ## Deliberately not done here
 
-* **Pageextension deltas (#3605).** A `pageextension`'s added controls do not appear in the
-  base page's `<PageDefinition>` at all; BC emits them in a separate `MetadataRuntimeDeltas`
-  document with `<ControlAdd>`/`<ControlChange>` elements. That is a second document source
-  reached through a different registry entry, not a different branch of this file's parse, so
-  it stays its own change.
-* **`Sequence` on the dependency-symbol path.** BC's `Sequence` is a **0-based** enumeration
-  index, captured before the `OrderBy` that sorts rows by control id
-  (`Select((cd, i) => (sequence: i, control: cd))`). Both paths this change touches now
-  produce that: the document path by construction, and the AL fallback by correcting
-  `GetSourceParsedPageControlRows` from `++seq` to `seq++`. The **precompiled-dependency**
-  path in `BcAppSymbolCache.CollectPageControlSymbols` is still 1-based and is deliberately
-  left alone here — that file is being changed by another open pull request, and the fix is a
-  one-character edit that belongs with whoever owns it rather than in a merge conflict. No
-  corpus test pins `Sequence` on any path, so nothing catches any of this either way; the
-  document and AL paths were corrected because leaving them disagreeing with each other would
-  make one column mean two different things depending on which route answered.
+* **`<ControlChange>` / `<ControlMove>`.** Only `<ControlAdd>` is applied; see above.
+* **`Sequence` is now 0-based on all three paths.** BC's `Sequence` is a 0-based enumeration
+  index captured before the `OrderBy` that sorts rows by control id
+  (`Select((cd, i) => (sequence: i, control: cd))`). The document path produces that by
+  construction and the AL fallback by `seq++`; the precompiled-dependency path in
+  `BcAppSymbolCache.CollectPageControlSymbols` was left 1-based by #3628 only because that file
+  was being changed by another open pull request, and #3631 closed that residue once it merged.
+  The inconsistency mattered more than either value: AL cannot see whether a page was
+  source-compiled or came from a dependency, so one column meant two different things.
+  `BcAppSymbolCachePageMetadataTests` pins it on the dependency path, which no corpus test can
+  reach — corpus tests are compiled from AL source by the runner, so they always take the
+  source-compiled route.


### PR DESCRIPTION
Closes #3605
Closes #3631

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/306

## What this is, and what it turned out not to be

#3605 was filed as "`GetExtensionDeltasForAppObject` returns `null!`, so make it return the real deltas." The premise it rests on is **true and now measured**; the proposed fix is **not the route**, and this PR takes the reachable one instead. Two agents previously declined to fold this issue on the grounds that the deltas need a different capture path — that judgement was right about the shape and wrong about the cost: the capture already exists.

**It is also a regression, not the pre-existing gap the issue describes.** Measured on a live probe (page 70700, `pageextension` 70702 adding `Extra Note`):

| runner | Page Control Field rows for page 70700 |
|---|---|
| `e2d96307~1` (before #3628) | `Entry No.`, `Extra Note` |
| `84068be8` (after #3628) | `Entry No.` |
| this PR | `Entry No.`, `Extra Note` |

The AL derivation #3628 replaced *did* merge extensions — `GetSourceParsedPageControlRows` folds `_parsedPageExtensions` into the base page's rows. The document path short-circuits before reaching it, so converting the table silently dropped every extension-added control on every extended page.

**`TestPage` binding was never affected**, and that is measured rather than assumed: the same probe reads `tp."Extra Note"` as `HELLO` on all three builds, because `GetPageControlFieldMap` merges extensions on its own path. The damage was confined to the virtual table.

## The compiler had already done the work

`AlObjectMetadataRegistry` has held the pageextension's own `MetadataRuntimeDeltas` document under kind `PageExtension` since #3548. No new capture path was needed. Measured on `AlRunner.Tests/Fixtures/ObjectMetadataCapture` with `AL_RUNNER_TRACE_OBJECT_METADATA=2` — `Extra Note` appears **zero** times in `PageDefinition` 70660 and only in `PageExtension` 70663:

```xml
<ControlAdd ParentContainer="ContentArea" Operation="ContentLast">
  <Controls xsi:type="ControlDefinition" ID="114635149" Name="Extra Note"
            DataColumnName="50" ExtensionId="70662" Visible="true" />
</ControlAdd>
```

Same element shape as the base document, so the existing collector reads both — no second parser. `DataColumnName="50"` is the *tableextension*'s field number, so the bound branch resolves it against the extended table. **Tables are the exact inverse** (#3600): a same-app `tableextension`'s added fields *are* folded into the base `<MetaTable>`, so a table intuition carried across gives the wrong answer here.

Only `<ControlAdd>` is applied. `<ControlChange>`/`<ControlMove>` modify an existing row rather than adding one; that is a separate claim, and #3614 tracks the table twin.

## Why `GetExtensionDeltasForAppObject` is not the route

Decompiled on BC 28.1. BC reaches a page's extensions through a different path, and returning real deltas from the loader would have changed nothing observable:

```
NCLMetaForm.CreatePageDefinitionWithExtensions
  -> GetExtensionObjects<NCLPageExtension>(MetadataAppGroup)     <- gates 1 and 2
  -> ApplyPageExtensions -> ApplyExtensionObjects
       -> NCLApplicationObjectExtension.ApplyRuntimeDeltas       <- reads .Deltas
```

`GetExtensionDeltasForAppObject` has exactly one caller — `NCLApplicationObjectExtension.LoadMetadata` — which sets `.Deltas` on an object BC only ever obtains through `GetExtensionObjects`. Three independent gates on that enumeration are shut:

| gate | BC's condition | runner |
|---|---|---|
| 1 | `group != NavAppGroup.BaseGroup` | `SessionPatches.NavSession_NavAppGroup` returns `BaseGroup` |
| 2 | `ObjectLoader.MetadataCache != null` | `RunnerMetaApplicationObjectLoader.MetadataCache` **throws** |
| 3 | `GetExtensionApplicationObjects` walks `navAppGroup.OrderedAppMetadata` | empty — measured for #2893 |

Opening all three means constructing a real `NavAppGroup` with an extension registry — the obstacle `RecordPatches.PermissionMetadataPopulator.cs` already documents, where replacing `BaseGroup` disturbs ~60 BC call sites that compare group identity. So the loader still answers `null`, which is BC's own "no deltas" value, and this is stated in `docs/` rather than left to be rediscovered.

## Also closes #3631 (same column, same virtual table)

`Sequence` was 0-based for a source-compiled page and 1-based for a precompiled dependency, so one column meant two things and AL cannot see which route answered. #3628 left `BcAppSymbolCache.CollectPageControlSymbols` alone only because PR #3623 was changing that file; #3623 has merged, so the file is free. Pre-increment → post-increment.

What made it invisible is the sharper half: `BcAppSymbolCachePageMetadataTests` already asserted `1/2/3` and passed the whole time — the wrong value was **encoded as correct**. Those now read `0/1/2`, plus an assertion on the property actually at stake (the first control is index 0) rather than three absolutes that could drift together again.

## RED → GREEN

Every arm verified armed, not merely green.

- **AL, end-to-end** — the probe table above. `OBSERVED_CONTROLS` gains `Extra Note` with `tbl=70700 fld=50 src=Extra Note seq=1`: BC's resolved values, not defaults.
- **C#** (`PageControlFieldDocumentTests`, 3 new) — with the merge disabled, `PageControlFieldRows_...` fails `Expected: ["Entry No.", "Extra Note"] / Actual: ["Entry No."]`. The two document tests pass either way by design: they pin the *premise* (the base document does not carry the control), which is independent of the fix.
- **#3631** (`BcAppSymbolCachePageMetadataTests`) — reverting to pre-increment fails with `Expected: 0 / Actual: 1`.
- **Corpus** (PR #306, codeunit 60524) — on pinned `c9d5f656`: both positive tests **FAIL** on `84068be8` and **PASS** with this fix; 3112 → 3115.

## Suites run

| suite | before (`84068be8`) | after |
|---|---|---|
| al-language (pin `c9d5f656`) | 3112/3112 | 3112/3112 |
| al-language, warm second run | — | 3112/3112 |
| runner-extras | 406/406 (#3628 baseline) | 406/406, 0 compile-fail |
| targeted C# (29 tests over the changed surfaces) | — | 29/29 |

Equal totals are weak evidence, so the al-language arms were diffed **per test**: 3101 named PASS/FAIL results, **zero differences**. (3101 vs 3112 is the 11 oos/known-gap/divergence results, which print differently, and is identical in both arms.) Warm run included because this change adds a memo.

## No pin bump

#3580 is open and blocks corpus `26b0434`; history is linear, so no bump is legal here. Corpus PR #306 must merge first, then the bump is a separate catch-up.

## Not folded, and why

- **#3625** — `Editable`'s absent-property default and Enum-bound `OptionString`. Same file, but it needs a *service-tier measurement*, not a code change; nothing here would settle it.
- **#3228** — a pageextension control bound to the extension's **own variable**. Adjacent, but it is a `TestPage` binding claim through `GetPageControlFieldMap`, which this PR measured as unaffected. Different path, different fix.
- **#3614** — `tableextension modify(...)` discarded. The table twin of the `<ControlChange>` case deliberately left out above.

## Scope check

Applied the three questions to the shape rather than the line. The **report** analogue was checked and has no equivalent hole: `_parsedReportExtensions` feeds only AllObj inventory, and no per-row merge existed on either path, so there is nothing to regress. The AllObj rows for pageextensions were verified unaffected.

Two runner-side observations worth stating, neither acted on here: `tools/agent_scratchpad.py` refuses with `no scratchpad directory known` unless `--scratchpad` is passed explicitly, and the `runner-extras` glob `tests/runner-extras/*` picks up `README.md` and aborts the run — directories have to be filtered.

Implemented by an agent (Claude, `stma-auto-2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
