### PR TITLE
fix(tests): delete the dead NotAMatrixClaim entry left by #3639's squash

### DIFF
--- a/AlRunner.Tests/BcMatrixDocumentationDriftTests.cs
+++ b/AlRunner.Tests/BcMatrixDocumentationDriftTests.cs
@@ -102,10 +102,6 @@ public sealed class BcMatrixDocumentationDriftTests
         ("docs/virtual-tables-allobj.md", "27.0 27.3 27.5 28.2 28.3",
             "the corpus legs that had reported when the upstream Install-subtype assertion was "
             + "adjudicated — a historical observation of which legs answered, not the matrix"),
-        ("docs/codeunit-metadata-from-bc.md", "27.0 28.1 28.4",
-            "the three BC versions whose Ncl.dll was provisioned on the machine that hand-scanned "
-            + "every method body for the backing-field write in #3629 — a historical measurement, "
-            + "not the matrix"),
     };
 
     // ---- version lists written out in prose --------------------------------------------


### PR DESCRIPTION
**`main` is red** on `BcMatrixDocumentationDriftTests.StaleVersionListAllowlist_HasNoDeadEntries`, and this deletes the one dead entry causing it.

No linked issue: repairs a red `main` left by an incomplete squash of #3639; there is no defect to track beyond the leftover entry.

## What happened

#3639 was meant to do two things:

1. reword `docs/codeunit-metadata-from-bc.md` so it states the version-invariant fact and contains no version list;
2. delete the `NotAMatrixClaim` waiver that had covered that list.

**Only the first reached `main`.** The squashed commit `aa34c8a3` carries a single file — `docs/codeunit-metadata-from-bc.md`, one line changed. The waiver survived, and now matches nothing.

That is precisely the state its own guard exists to catch, in the guard's own words:

> an allowlist nobody prunes is how the next stale claim gets in wearing a waiver

## Why deleting is correct rather than restoring the list

The sentence on `main` already reads:

> A Mono.Cecil scan over every method body found the write immediately, **on every BC version this repository tests — the method is byte-identical across them.**

There is no version list left to waive. `NCLMetaCodeunit.LoadMetadata` decompiles byte-identically on 27.0 and 28.1 (same source hash), and an independent Mono.Cecil pass over all ten cached `Ncl.dll` artifacts gives the identical answer on every one — which is why the reword was the better fix than the waiver in the first place.

## Verified

```
Passed! - Failed: 0, Passed: 5, Skipped: 1, Total: 6
```

Ran against `origin/main` before the change too, reproducing the failure at `BcMatrixDocumentationDriftTests.cs:172`.

## My error

I pushed the reword and the deletion together, then merged without re-reading `main` to confirm **both** had landed. A merge is not evidence that everything in the branch arrived — the squash is a separate step that can carry less than the branch did.

---

Authored by an agent (Claude, `stma-auto-2`) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
