### PR TITLE
fix(metadata): refuse an unparseable DataClassification instead of defaulting to CustomerContent

### DIFF
--- a/AlRunner.Tests/DataClassificationParseRefusalTests.cs
+++ b/AlRunner.Tests/DataClassificationParseRefusalTests.cs
@@ -1,0 +1,225 @@
+// DataClassificationParseRefusalTests — issue #3602.
+//
+// BuildMetaField used to hand a DataClassification to MetaField's constructor only when
+// Enum.TryParse succeeded, and did nothing at all when it failed. Doing nothing leaves the
+// argument at its constructor default, which for ALDataClassification is CustomerContent — so a
+// value the runner could not understand became a real, plausible classification with nothing in
+// the built metadata to say it was invented. That is the silent fallback
+// .claude/rules/loud-failures.md forbids: the failure mode is a green run carrying a wrong
+// value, not a red one.
+//
+// LATENT, NOT LIVE. Every DataClassificationName reaching this code today comes from BC's own
+// symbol file, so the parse does not fail in any measured population — AllDataClassifications
+// below is enumerated off the shipped ALDataClassification enum and every member of it parses.
+// The trap is the NEXT BC version adding a member the runner has not seen, or a caller reaching
+// here with a value from somewhere other than a symbol file.
+//
+// WHY THIS IS NOT A BC-BEHAVIOUR TEST, AND NOT A CORPUS TEST
+// ---------------------------------------------------------
+// The claim is not "BC classifies field X as Y" — that would belong upstream. The claim is that
+// the RUNNER'S OWN metadata builder refuses a value it cannot map instead of substituting one.
+// A corpus test structurally cannot express it: an unparseable DataClassification cannot come
+// out of a symbol file, because the AL compiler rejects the source before a symbol file exists,
+// so no AL a service tier will accept can reach the refused branch.
+//
+// WHY THE BUILDER IS CALLED BY REFLECTION
+// ---------------------------------------
+// BuildMetaField is private and its public entry point is the full NCLMetaTable build, which
+// needs the whole engine standing up. The reflection statics it reads (_tMetaField,
+// _tALDataClassification, _tNavType, _tFieldClass) are otherwise assigned only by
+// RecordPatches.Register(); they are set here from the SAME Microsoft.Dynamics.Nav.Types types
+// Register() resolves, which this test project already references directly — idempotent with
+// Register() rather than a substitute for it. Same technique, and the same
+// save-and-restore discipline, as ObjectRefConstCallSiteWiringTests.
+using System.Reflection;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// MUST be serial: writes the process-global metadata reflection statics.
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class DataClassificationParseRefusalTests : IDisposable
+{
+    private const int FieldId = 7;
+    private const string FieldName = "DC Probe Field";
+
+    private readonly Dictionary<string, object?> _savedStatics = new();
+
+    public DataClassificationParseRefusalTests() => EnsureMetadataReflection();
+
+    public void Dispose()
+    {
+        foreach (var (name, value) in _savedStatics)
+            try { Static(name).SetValue(null, value); } catch { }
+    }
+
+    private static Type AlDataClassificationType =>
+        typeof(Microsoft.Dynamics.Nav.Types.Metadata.MetaTable).Assembly
+            .GetType("Microsoft.Dynamics.Nav.Types.Metadata.ALDataClassification")
+        ?? throw new InvalidOperationException(
+            "ALDataClassification not found in Microsoft.Dynamics.Nav.Types — this test tracks that type.");
+
+    /// <summary>
+    /// Every member of the SHIPPED enum, read off the assembly rather than hardcoded, so this
+    /// stays the real live-path control when a BC version adds a member. The name is exactly
+    /// what a symbol file's DataClassification property carries.
+    /// </summary>
+    public static TheoryData<string> AllDataClassifications()
+    {
+        var data = new TheoryData<string>();
+        foreach (var n in Enum.GetNames(AlDataClassificationType)) data.Add(n);
+        return data;
+    }
+
+    // ---- the refusal -------------------------------------------------------------------
+
+    [Fact]
+    public void UnparseableDataClassification_IsRefused_NamingTheValueAndTheField()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => BuildField("NotARealClassification"));
+
+        // The message content is the deliverable, not the throw: a refusal that does not name
+        // the offending value leaves the reader exactly where the silent fallback did.
+        Assert.Contains("NotARealClassification", ex.Message);
+        Assert.Contains(FieldName, ex.Message);
+        Assert.Contains(FieldId.ToString(), ex.Message);
+        Assert.Contains("DataClassification", ex.Message);
+        // ...and it must say what the silent alternative WAS, or the next reader re-derives it.
+        Assert.Contains("CustomerContent", ex.Message);
+        Assert.Contains("#3602", ex.Message);
+    }
+
+    [Fact]
+    public void RefusalNamesTheOfferedValue_NotAFixedString()
+    {
+        // A refusal that hardcoded one example value would pass the test above. Two different
+        // bad values must produce two different messages, each naming its own.
+        var a = Assert.Throws<InvalidOperationException>(() => BuildField("Zzz_First_Bad"));
+        var b = Assert.Throws<InvalidOperationException>(() => BuildField("Zzz_Second_Bad"));
+
+        Assert.Contains("Zzz_First_Bad", a.Message);
+        Assert.DoesNotContain("Zzz_Second_Bad", a.Message);
+        Assert.Contains("Zzz_Second_Bad", b.Message);
+        Assert.DoesNotContain("Zzz_First_Bad", b.Message);
+    }
+
+    // ---- the live path, which must be untouched ----------------------------------------
+
+    [Theory]
+    [MemberData(nameof(AllDataClassifications))]
+    public void EveryShippedMemberStillParses_AndReachesTheMetaFieldAsItself(string member)
+    {
+        var built = BuildField(member);
+
+        var actual = ReadDataClassification(built);
+        Assert.NotNull(actual);
+        Assert.Equal(member, actual!.ToString());
+    }
+
+    [Theory]
+    [MemberData(nameof(AllDataClassifications))]
+    public void ShippedMembersParseCaseInsensitively(string member)
+    {
+        // AL keywords are case-insensitive and the parse has always been ignoreCase; the
+        // refusal must not narrow that. Lower-cased so a member that is already all-upper
+        // still exercises a spelling different from the declared one.
+        var built = BuildField(member.ToLowerInvariant());
+
+        Assert.Equal(member, ReadDataClassification(built)?.ToString());
+    }
+
+    [Fact]
+    public void CustomerContent_IsCarriedBecauseItWasDeclared_NotBecauseNothingWasPassed()
+    {
+        // The one value the old fallback was indistinguishable from. It must still arrive, and
+        // it must arrive because the field declared it.
+        Assert.Equal("CustomerContent", ReadDataClassification(BuildField("CustomerContent"))?.ToString());
+    }
+
+    [Fact]
+    public void NoDeclaredDataClassification_IsNotRefused()
+    {
+        // Absent is not unparseable. A field that declares nothing leaves the ctor default
+        // standing, exactly as before — refusing here would break every field in every table
+        // that says nothing, which is most of them.
+        var built = BuildField(null);
+        Assert.NotNull(built);
+
+        var blank = BuildField("   ");
+        Assert.NotNull(blank);
+    }
+
+    // ---- plumbing ----------------------------------------------------------------------
+
+    private static object BuildField(string? dataClassification)
+    {
+        var f = new ParsedField(
+            FieldId: FieldId,
+            FieldName: FieldName,
+            TypeName: "Code[20]",
+            Length: 20,
+            DataClassificationName: dataClassification);
+
+        return Invoke("BuildMetaField", f, 0, false, null)
+               ?? throw new InvalidOperationException("BuildMetaField answered null.");
+    }
+
+    /// <summary>
+    /// The DataClassification the constructed MetaField actually carries. Read off the built
+    /// object rather than inferred from the argument array, so the assertion is about what BC
+    /// would see.
+    /// </summary>
+    private static object? ReadDataClassification(object metaField)
+    {
+        var t = metaField.GetType();
+        var p = t.GetProperty("DataClassification", BindingFlags.Public | BindingFlags.Instance);
+        if (p != null) return p.GetValue(metaField);
+
+        var fld = t.GetField("dataClassification",
+                      BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public)
+                  ?? throw new InvalidOperationException(
+                      $"{t.FullName} exposes neither a DataClassification property nor a "
+                      + "dataClassification field — this test tracks that shape.");
+        return fld.GetValue(metaField);
+    }
+
+    private void EnsureMetadataReflection()
+    {
+        var types = typeof(Microsoft.Dynamics.Nav.Types.Metadata.MetaTable).Assembly;
+        foreach (var (field, typeName) in new[]
+                 {
+                     ("_tMetaField",             "Microsoft.Dynamics.Nav.Types.Metadata.MetaField"),
+                     ("_tALDataClassification",  "Microsoft.Dynamics.Nav.Types.Metadata.ALDataClassification"),
+                     ("_tNavType",               "Microsoft.Dynamics.Nav.Types.NavType"),
+                     ("_tFieldClass",            "Microsoft.Dynamics.Nav.Types.Metadata.FieldClass"),
+                     ("_tObsoleteState",         "Microsoft.Dynamics.Nav.Types.Metadata.ObsoleteState"),
+                 })
+        {
+            var t = types.GetType(typeName)
+                    ?? throw new InvalidOperationException($"{typeName} not found in {types.GetName().Name}.");
+            var fi = Static(field);
+            _savedStatics[field] = fi.GetValue(null);
+            fi.SetValue(null, t);
+        }
+    }
+
+    private static FieldInfo Static(string name) =>
+        typeof(RecordPatches).GetField(name, BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException($"RecordPatches.{name} not found — this test tracks that field.");
+
+    private static object? Invoke(string method, params object?[] args)
+    {
+        var m = typeof(RecordPatches).GetMethod(method, BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new InvalidOperationException($"RecordPatches.{method} not found — this test drives it.");
+        try { return m.Invoke(null, args); }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            // Rethrow the real exception with its stack, so Assert.Throws sees the type and the
+            // message the production code produced rather than a reflection wrapper.
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
+            throw; // unreachable
+        }
+    }
+}

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -541,10 +541,31 @@ public static partial class RecordPatches
             if (p.Name == "editable" && f.Editable == false) { args[i] = (bool?)false; continue; }
             // #3545 — DataClassification. ParsedField already carries the EFFECTIVE value
             // (ApplyOwnerDataClassification), so nothing is resolved here.
+            //
+            // #3602 — a value that fails the parse is REFUSED, not skipped. Skipping left the
+            // argument at MetaField's own default, CustomerContent, so an unmappable value
+            // became a real classification a reader cannot tell from a declared one — the
+            // silent fallback loud-failures.md forbids. Absent is still absent: a field that
+            // declares nothing falls through and BC's default stands, which is what most
+            // fields do.
+            //
+            // Latent today: every value here comes from BC's own symbol file, so the parse
+            // does not fail in any measured population (the metadata-equivalence harness is
+            // unchanged by this refusal). The trap it closes is a BC version adding an
+            // ALDataClassification member, or a caller arriving with a value from anywhere
+            // other than a symbol file.
             if (p.Name == "dataClassification" && _tALDataClassification != null
-                && !string.IsNullOrWhiteSpace(f.DataClassificationName)
-                && Enum.TryParse(_tALDataClassification, f.DataClassificationName, ignoreCase: true, out var dcVal))
+                && !string.IsNullOrWhiteSpace(f.DataClassificationName))
             {
+                if (!Enum.TryParse(_tALDataClassification, f.DataClassificationName, ignoreCase: true, out var dcVal))
+                    throw new InvalidOperationException(
+                        $"[RecordPatches] #3602: field '{f.FieldName}' (id {f.FieldId}) in "
+                        + $"'{parentTable?.TableName ?? "<no parent table>"}' declares "
+                        + $"DataClassification '{f.DataClassificationName}', which is not a member of "
+                        + $"{_tALDataClassification.Name} ({string.Join(", ", Enum.GetNames(_tALDataClassification))}). "
+                        + "Refusing rather than leaving the ctor default (CustomerContent) standing, "
+                        + "which would report an invented classification as a real one. If a caller "
+                        + "genuinely needs tolerance here, it passes an explicit default and says why.");
                 args[i] = dcVal;
                 continue;
             }


### PR DESCRIPTION
Closes #3602

Written by an agent (`stma-auto-2`).

`BuildMetaField` handed a `DataClassification` to `MetaField`'s constructor only when
`Enum.TryParse` succeeded, and did **nothing** when it failed. Doing nothing leaves the
argument at its constructor default — `CustomerContent` — so a value the runner could not
understand became a real, plausible classification, with nothing in the built metadata to
say it was invented. That is the silent fallback `.claude/rules/loud-failures.md` forbids:
the failure mode is a green run carrying a wrong value.

The fix refuses instead, naming the offending value, the field, its id, the owning table and
the full set of members it could have been. Absent stays absent — a field that declares no
`DataClassification` still falls through and BC's own default stands, which is what most
fields do.

Corpus-NA: an unparseable DataClassification cannot come out of a symbol file — the AL compiler rejects the source before a symbol file exists — so no AL a service tier will accept can reach the refused branch; the claim is about the runner's own builder refusing rather than substituting, not about what BC classifies anything as.

## The issue body names the wrong file

#3602 says `BuildMetaField` is in `AlRunner/Patches/BcAppSymbolCache.cs`. It is not — it is
in `AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs:544`, and `BcAppSymbolCache.cs`
has no `Enum.TryParse` on `DataClassificationName` at all (it only carries the string
through to `ParsedField`). Flagging it because the misattribution had a real consequence:
it is what made this look like it collided with PRs #3630 and #3643, and it does not.

## Latent, not live — and condition 3 is measured, not asserted

Every `DataClassificationName` reaching this code today comes from BC's own symbol file, so
the parse does not fail in any measured population. The trap is the next BC version adding
an `ALDataClassification` member, or a caller arriving with a value from somewhere other
than a symbol file.

The issue's condition 3 asks that the metadata-equivalence harness be unchanged, proving no
measured field relied on the fallback. I ran it rather than claiming it:

- generated ground truth for BC `28.1.49838.54308` — Business Foundation + System
  Application, **1,218 documents, 138 MetaTables** (`tools/gen-metadata-ground-truth.sh`);
- brought the in-process engine up (`tools/engine-test-bootstrap.sh`), because without it
  every `bc-engine-serial` test *skips* and a green run would have measured nothing;
- `MetadataEquivalenceHarnessTests`: **7 passed, 0 skipped**. `allowlist.json` is untouched
  and `No_allowlist_entry_has_gone_stale` passes, so the refusal fired for zero fields
  across both apps.

The harness does compare this member — the dumped report carries 41 `DataClassification`
lines. All 41 are `MetaTable.DataClassification` (the table-level entry already allowlisted
at `allowlist.json:335`), a **different code path** from the field-level parse this changes,
and pre-existing. So the harness both exercises the area and is unmoved by the fix, which is
the evidence the issue asked for.

## RED → GREEN

New `AlRunner.Tests/DataClassificationParseRefusalTests.cs`, 18 tests. RED first: the two
refusal tests failed with `Assert.Throws() Failure: No exception was thrown` — the silent
fallback itself — while the 16 live-path tests already passed, which is the negative control
working before the fix. GREEN: 18/18.

Message content is asserted, not merely that something threw:

- `UnparseableDataClassification_IsRefused_NamingTheValueAndTheField` — the message must
  contain the offending value, the field name, the field id, `DataClassification`,
  `CustomerContent` (what the silent alternative *was*), and `#3602`.
- `RefusalNamesTheOfferedValue_NotAFixedString` — two different bad values must produce two
  different messages, each naming its own and **not** the other. A refusal that hardcoded
  one example value would pass the first test and fails this one.

Live-path controls, so the fix cannot pass by breaking the thing it protects:

- `EveryShippedMemberStillParses_AndReachesTheMetaFieldAsItself` and
  `ShippedMembersParseCaseInsensitively` are `[Theory]`s over
  `Enum.GetNames(ALDataClassification)` — read off the shipped assembly rather than
  hardcoded, so they stay the real control when a BC version adds a member. The value is
  read back **off the constructed MetaField**, not inferred from the argument array.
- `CustomerContent_IsCarriedBecauseItWasDeclared_NotBecauseNothingWasPassed` — the one value
  the old fallback was indistinguishable from.
- `NoDeclaredDataClassification_IsNotRefused` — null and whitespace are absent, not
  unparseable; refusing there would break most fields in most tables.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site?** Two other `Enum.TryParse` sites in this file.
   `obsoleteState` (line ~587) uses `Enum.Parse` and already throws — correct by
   construction. `tableType` (line ~377) *does* fall back deliberately, and I left it: its
   comment states the fallback as intended behaviour ("an unrecognised spelling falls back to
   the two-valued view"), it falls back to a *computed* `Temporary`/`Normal` rather than to a
   constructor default nobody chose, and changing it is a behaviour change #3602 does not
   ask for. Flagging it rather than silently widening scope.
2. **Sibling function making the same assumption?** `ApplyOwnerDataClassification`
   (line ~1063) only copies the owner's string onto fields that declare nothing; it never
   parses, so the refusal is correctly placed at the single point where the string becomes an
   enum.
3. **Two paths writing the same state?** The tableextension path
   (`BcAppSymbolCache.TableExtensions.cs`) also produces `DataClassificationName`, but it
   flows into the *same* `BuildMetaField`, so it is now covered by the same refusal rather
   than needing a second one.

## Open-issue queue: what I did NOT fold, and why

Scanned for same-file siblings. **Nothing folded** — none of these lands in
`RecordPatches.NclMetaTableBuilder.cs` at the lines this touches:

- **#3603** — "40 of 3,888 fields unaccounted for" in the DataClassification rule. Adjacent
  subject, but it is an *accounting/derivation* question about `ApplyOwnerDataClassification`
  coverage, not this parse; it was explicitly reserved to another agent, and PR #3632 holds
  the file.
- **#3367** — CalcFormula `where()`/sign refusals dropped silently. Genuinely the same
  *shape* as this bug and worth fixing, but it lands in the CalcFormula parser
  (`RecordPatches.AlSourceParser.cs` / `BuildMetaCalcFormula`), not here, and needs
  materially different reasoning to review.
- **#3594** (`MetaField.EnumTypeId`) — same method, but it needs a resolvable metadata object
  for a precompiled app's enum; that is a registration problem, not a parse refusal, and it
  is allowlisted for a stated reason.
- **#3549**, **#3274**, **#2417** — different files/subsystems entirely.

## File ownership

Rebased on current `origin/main`. **No collision** with PR #3630 (`agent/stma-auto-2/issue-3571`),
which is armed for auto-merge: it does not touch
`RecordPatches.NclMetaTableBuilder.cs` at all — its diff is `BcAppSymbolCache.cs`,
`RecordPatches.NclMetaQueryBuilder.cs`, `RecordPatches.QueryProjection.cs` and fixtures. PR
#3632 does touch this file, at lines ~153 and ~2205; this change is at line ~544, so the two
do not overlap. I did not push to either branch and did not disarm anything.

## What I could not prove

- The 27.x legs. The equivalence harness ran on **28.1.49838.54308** only — the 28.4 build on
  this box has the Microsoft app packages but not the service-tier DLLs the generator compiles
  against, and 28.1.49838.53910 / 27.5 have the DLLs but no app packages, so no other build on
  this machine can produce a bundle. CI covers 27.0 / 27.5 / 28.4.
- That the refusal is reachable in production from a *symbol-file* input. By the argument
  above it should not be, which is the point of the change; it is proven reachable through the
  builder by direct invocation.

## Tests run

- `DataClassificationParseRefusalTests` — RED 2 failed / 16 passed, GREEN **18/18**.
- `MetadataEquivalenceHarnessTests` — **7 passed, 0 skipped**, engine up, real ground truth.
- Targeted regression over the metadata-builder surface (`DataClassification`,
  `ObsoleteStateFieldParsing`, `ObjectRefConstCallSiteWiring`, `TableCaptionResolution`,
  `NamespaceQualifiedRelationTarget`, `TableRelationUnresolvedRefusal`,
  `TableExtensionFieldDelta`) — **37 passed**, 3 skipped (engine-gated, unrelated).

Per `.claude/rules/local-test-scope.md` I did not run the full `AlRunner.Tests` sweep; CI does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
