### PR TITLE
fix(testpage): dispatch OnAssistEdit, on a base control and in a modify() block

### DIFF
--- a/AlRunner.Tests/TestPageAssistEditDispatchTests.cs
+++ b/AlRunner.Tests/TestPageAssistEditDispatchTests.cs
@@ -1,0 +1,338 @@
+// TestPageAssistEditDispatchTests — issues #2362 and #3642.
+//
+// A TestPage field's AssistEdit() never reached the control's OnAssistEdit trigger: both live
+// ITestField implementations in MockTestPage carried `public void AssistEdit() { }`. #2362 is
+// the base-page form of that (Microsoft's Tests-SINGLESERVER bucket: 8 tests on page 9807
+// "User Card" whose declared UI handlers went unexecuted, so the test failed at teardown
+// naming the handlers rather than the trigger). #3642 is the pageextension form — a control a
+// `modify()` block contributes an OnAssistEdit to.
+//
+// This is a RUNNER-MECHANISM test, not a claim about what real BC does. The behavioural claim
+// is upstream in StefanMaron/BusinessCentral.AL.Language.Tests PR #308, which adds four arms
+// to codeunit 60514 covering both routes, targeting, and once-per-call. This file exists so a
+// regression in OUR OWN dispatch fails loudly here without the al-language pin being bumped
+// (the corpus PR has not merged yet, so the pin cannot move).
+//
+// WHY AN OBSERVABLE SIDE EFFECT AND NOT "did not throw". BC's own NavTestField.ALAssistEdit is
+// `CheckError(() => testField.AssistEdit())` and ITestField.AssistEdit returns void, so the
+// pre-fix no-op and a correct dispatch are the SAME observable unless the trigger leaves
+// something behind. Every assertion below is therefore on a marker row the trigger writes.
+// That is also why the absent-trigger arm asserts silence rather than an error: BC raises
+// nothing for a control with no OnAssistEdit, so a refusal would invent an error real BC does
+// not raise — see RunnerPageInstance.RaiseOnAssistEdit.
+//
+// RED/GREEN proof, measured on this branch with a probe bundle before the fix: both dispatch
+// arms failed with an EMPTY trace (the trigger never ran, silently) and pass after it.
+
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Spawns the runner as a subprocess, same convention as TestPageDrillDownDispatchTests, whose
+// shape this follows deliberately: assist-edit is that test's sibling surface and the two
+// should not diverge in how they are driven.
+public sealed class TestPageAssistEditDispatchTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private readonly string _root;
+
+    public TestPageAssistEditDispatchTests()
+    {
+        _root = TestScratch.Dir("al-runner-assistedit-dispatch");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private static string[] ExtraPackageCacheArgs()
+    {
+        var platformApps = TestArtifacts.PlatformAppsDir();
+        return Directory.Exists(platformApps)
+            ? new[] { "--package-cache", platformApps }
+            : Array.Empty<string>();
+    }
+
+    /// <summary>
+    /// Three controls, so the two dispatch routes and the absent-trigger case are told apart
+    /// in one run: BaseAssist carries the base page's OWN OnAssistEdit, ExtAssist carries none
+    /// on the page and gets one from a pageextension's <c>modify()</c> block, and NoTrigger
+    /// carries none anywhere.
+    ///
+    /// Each trigger appends its own tag to the row's Trace field rather than setting a flag,
+    /// so an implementation that fires the wrong control's trigger — or fires every trigger it
+    /// can find — produces a different string instead of the same "something happened".
+    /// </summary>
+    private void WriteBundle()
+    {
+        Directory.CreateDirectory(_root);
+        File.WriteAllText(Path.Combine(_root, "app.json"), """
+        {
+          "id": "c9e5a3b2-7f14-4d62-8b03-5a9e1c7d4f80",
+          "name": "Runner Mechanism - TestPage AssistEdit Dispatch",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62710, "to": 62719 } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "AEMechRow.Table.al"), """
+        table 62710 "AE Mech Row"
+        {
+            DataClassification = CustomerContent;
+
+            fields
+            {
+                field(1; "No."; Code[20]) { }
+                field(2; Val; Text[50]) { }
+                field(3; Extra; Text[50]) { }
+                field(4; Trace; Text[250]) { }
+            }
+
+            keys
+            {
+                key(PK; "No.") { Clustered = true; }
+            }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "AEMechCard.Page.al"), """
+        page 62711 "AE Mech Card"
+        {
+            PageType = Card;
+            SourceTable = "AE Mech Row";
+            ApplicationArea = All;
+            UsageCategory = Administration;
+
+            layout
+            {
+                area(Content)
+                {
+                    field("No."; Rec."No.")
+                    {
+                        ApplicationArea = All;
+                    }
+
+                    field(BaseAssist; Rec.Val)
+                    {
+                        ApplicationArea = All;
+
+                        trigger OnAssistEdit()
+                        begin
+                            Rec.Trace := Rec.Trace + 'base;';
+                        end;
+                    }
+
+                    // No OnAssistEdit here: the pageextension below is the only possible
+                    // source of an 'ext;' tag, which is what makes the extension arm about
+                    // the extension route rather than a second reading of the base one.
+                    field(ExtAssist; Rec.Extra)
+                    {
+                        ApplicationArea = All;
+                    }
+
+                    // No OnAssistEdit anywhere, on the page or in any extension.
+                    field(NoTrigger; Rec."No.")
+                    {
+                        ApplicationArea = All;
+                    }
+
+                    field(Trace; Rec.Trace)
+                    {
+                        ApplicationArea = All;
+                        Editable = false;
+                    }
+                }
+            }
+        }
+
+        pageextension 62713 "AE Mech Card Ext" extends "AE Mech Card"
+        {
+            layout
+            {
+                modify(ExtAssist)
+                {
+                    trigger OnAssistEdit()
+                    begin
+                        Rec.Trace := Rec.Trace + 'ext;';
+                    end;
+                }
+            }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "AEMechTests.Codeunit.al"), """
+        codeunit 62712 "AE Mech Tests"
+        {
+            Subtype = Test;
+
+            // The base-page route (#2362), asserted on a concrete tag rather than on the
+            // trigger merely not throwing.
+            [Test]
+            procedure AssistEditRunsTheBaseControlsOwnTrigger()
+            var
+                Row: Record "AE Mech Row";
+                Card: TestPage "AE Mech Card";
+                Trace: Text;
+            begin
+                Row.DeleteAll();
+
+                Card.OpenNew();
+                Card."No.".SetValue('ROW1');
+                Card.BaseAssist.AssistEdit();
+                Trace := Card.Trace.Value();
+                Card.Close();
+
+                if Trace <> 'base;' then
+                    Error('AssistEdit() must run the control''s own OnAssistEdit; trace was ''%1''', Trace);
+            end;
+
+            // The pageextension modify() route (#3642). ExtAssist declares no OnAssistEdit on
+            // the base page, so only the extension's block can produce this tag.
+            [Test]
+            procedure AssistEditRunsAModifyBlocksTrigger()
+            var
+                Row: Record "AE Mech Row";
+                Card: TestPage "AE Mech Card";
+                Trace: Text;
+            begin
+                Row.DeleteAll();
+
+                Card.OpenNew();
+                Card."No.".SetValue('ROW2');
+                Card.ExtAssist.AssistEdit();
+                Trace := Card.Trace.Value();
+                Card.Close();
+
+                if Trace <> 'ext;' then
+                    Error('AssistEdit() must run a modify() block''s OnAssistEdit; trace was ''%1''', Trace);
+            end;
+
+            // Targeting: an implementation that raises every OnAssistEdit it can find on the
+            // page passes both arms above and fails this one.
+            [Test]
+            procedure AssistEditIsRaisedOnlyForTheControlItWasCalledOn()
+            var
+                Row: Record "AE Mech Row";
+                Card: TestPage "AE Mech Card";
+                AfterBase: Text;
+                AfterExt: Text;
+            begin
+                Row.DeleteAll();
+
+                Card.OpenNew();
+                Card."No.".SetValue('ROW3');
+                Card.BaseAssist.AssistEdit();
+                AfterBase := Card.Trace.Value();
+                Card.ExtAssist.AssistEdit();
+                AfterExt := Card.Trace.Value();
+                Card.Close();
+
+                if AfterBase <> 'base;' then
+                    Error('assist-editing BaseAssist must raise only its own trigger; got ''%1''', AfterBase);
+                if AfterExt <> 'base;ext;' then
+                    Error('each AssistEdit() must raise exactly its own control''s trigger, in call order; got ''%1''', AfterExt);
+            end;
+
+            // Once per call, not once per page: an implementation that latches after the first
+            // dispatch, or raises at page open, fails here and passes the arms above.
+            [Test]
+            procedure AssistEditRunsOncePerCall()
+            var
+                Row: Record "AE Mech Row";
+                Card: TestPage "AE Mech Card";
+                Trace: Text;
+            begin
+                Row.DeleteAll();
+
+                Card.OpenNew();
+                Card."No.".SetValue('ROW4');
+                Card.BaseAssist.AssistEdit();
+                Card.BaseAssist.AssistEdit();
+                Trace := Card.Trace.Value();
+                Card.Close();
+
+                if Trace <> 'base;base;' then
+                    Error('each AssistEdit() call must run the trigger again; trace was ''%1''', Trace);
+            end;
+
+            // The negative that keeps the fix honest in the OTHER direction. BC's ALAssistEdit
+            // raises nothing for a control with no OnAssistEdit, so this must stay silent --
+            // a refusal here would be inventing an error real BC does not raise, and would be
+            // just as wrong as the no-op this fix removed.
+            [Test]
+            procedure AssistEditOnAControlWithNoTriggerIsSilent()
+            var
+                Row: Record "AE Mech Row";
+                Card: TestPage "AE Mech Card";
+                Trace: Text;
+            begin
+                Row.DeleteAll();
+
+                Card.OpenNew();
+                Card."No.".SetValue('ROW5');
+                Card.NoTrigger.AssistEdit();
+                Trace := Card.Trace.Value();
+                Card.Close();
+
+                if Trace <> '' then
+                    Error('a control with no OnAssistEdit must leave no trace; got ''%1''', Trace);
+            end;
+        }
+        """);
+    }
+
+    private (string output, int exit) RunBundled()
+    {
+        var args = new StringBuilder(
+            TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg + $" \"{_root}\"");
+        foreach (var a in ExtraPackageCacheArgs()) args.Append($" \"{a}\"");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(600_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>
+    /// All five arms in one runner invocation: both dispatch routes produce their own concrete
+    /// tag, neither leaks into the other, a second call runs the trigger again, and a control
+    /// with no trigger stays silent rather than being refused.
+    /// </summary>
+    [SkippableFact]
+    public void AssistEdit_DispatchesBothRoutesAndStaysSilentWhenAbsent()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        WriteBundle();
+        var (output, exit) = RunBundled();
+
+        Assert.True(exit == 0, $"Expected the bundle to pass; exit={exit}\n{output}");
+        Assert.Contains("PASS  Codeunit62712.AssistEditRunsTheBaseControlsOwnTrigger", output);
+        Assert.Contains("PASS  Codeunit62712.AssistEditRunsAModifyBlocksTrigger", output);
+        Assert.Contains("PASS  Codeunit62712.AssistEditIsRaisedOnlyForTheControlItWasCalledOn", output);
+        Assert.Contains("PASS  Codeunit62712.AssistEditRunsOncePerCall", output);
+        Assert.Contains("PASS  Codeunit62712.AssistEditOnAControlWithNoTriggerIsSilent", output);
+        Assert.DoesNotContain("FAIL", output);
+    }
+}

--- a/AlRunner.Tests/TestPageRefusalClaimTests.cs
+++ b/AlRunner.Tests/TestPageRefusalClaimTests.cs
@@ -400,7 +400,11 @@ public sealed class TestPageRefusalClaimTests
         var mock = CodeOf("MockTestPage.cs");
         var page = CodeOf("RunnerPageInstance.cs");
 
-        Assert.Equal(10, Regex.Matches(mock, @"throw TestPageShapeGap\.").Count);
+        // 11 since #2362/#3642 gave LiveNavTestField.AssistEdit a real dispatch: like its
+        // Lookup and Drilldown siblings it refuses when there is no AL page object to reach a
+        // trigger through. Note what this 11th site is NOT — a control that simply declares no
+        // OnAssistEdit stays silent, because BC's own ALAssistEdit raises nothing there either.
+        Assert.Equal(11, Regex.Matches(mock, @"throw TestPageShapeGap\.").Count);
         // 6: the SubPageLink FilterType site, the two evaluator-fault arms #3444 added - a
         // fault inside BC's own NavValueEvaluator, and a signature mismatch against it -
         // #3462's bind refusal, which claimed testpage-temporal-evaluator under

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -3933,7 +3933,24 @@ internal sealed class LiveNavTestField : ITestField
     }
 
     public void Lookup(NavDataSet dataSet) => Lookup();
-    public void AssistEdit() { }
+
+    /// <summary>
+    /// Run the control's OnAssistEdit trigger — see RunnerPageInstance.RaiseOnAssistEdit,
+    /// including why a control with no such trigger stays silent here rather than refusing.
+    /// Was a literal no-op (#2362, #3642), so a page's declared OnAssistEdit never ran and
+    /// nothing said so: the UI handlers the test bound for what that trigger raises went
+    /// unexecuted and the test failed at teardown, pointing at the handlers rather than here.
+    /// </summary>
+    public void AssistEdit()
+    {
+        if (_page == null)
+            throw TestPageShapeGap.AssistEdit(
+                $"TestPage assist-edit on field {_fieldNo}",
+                "no AL page object was built for this page, so its OnAssistEdit trigger cannot "
+                + "be reached");
+
+        _page.RaiseOnAssistEdit(_controlId);
+    }
 
     /// <summary>
     /// Run the control's OnDrillDown trigger — see RunnerPageInstance.RaiseOnDrillDown for the
@@ -4193,7 +4210,8 @@ internal sealed class PageVariableTestField : ITestField
         if (picked != null) Value = picked.ToString();
     }
     public void Lookup(NavDataSet dataSet) => Lookup();
-    public void AssistEdit() { }
+    /// <summary>Run the control's OnAssistEdit trigger — see LiveNavTestField.AssistEdit.</summary>
+    public void AssistEdit() => _page.RaiseOnAssistEdit(_controlId);
     /// <summary>Run the control's OnDrillDown trigger — see LiveNavTestField.Drilldown.</summary>
     public void Drilldown() => _page.RaiseOnDrillDown(_controlId);
     public void Invoke() { }

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -1635,6 +1635,37 @@ internal sealed partial class RunnerPageInstance
     }
 
     /// <summary>
+    /// Run the control's OnAssistEdit trigger — the AL a user's AssistEdit (the "…" button)
+    /// would run. Issues #2362 and #3642.
+    ///
+    /// <para>Reached from BC's own <c>NavTestField.ALAssistEdit</c>, whose whole body is
+    /// <c>CheckError(() =&gt; testField.AssistEdit())</c> — so <c>ITestField.AssistEdit</c>,
+    /// which this runner implements, IS the dispatch surface, and implementing it as
+    /// <c>{ }</c> is what made every declared OnAssistEdit inert.</para>
+    ///
+    /// <para>A control with NO OnAssistEdit does nothing here, and that absence is the whole
+    /// reason this cannot follow RaiseOnDrillDown's shape. Drilldown has a loud documented
+    /// answer to raise ("The NavDrilldownAction method is not supported."); assist-edit has
+    /// none — BC's ALAssistEdit returns void and raises nothing — so a refusal here would
+    /// invent an error real BC does not raise, which is a worse wrong answer than the silence
+    /// it replaces. The silence is faithful; what was unfaithful was staying silent when the
+    /// control DOES declare a trigger.</para>
+    ///
+    /// <para>Resolution is the ordinary <see cref="FindTrigger"/>, which is what makes this
+    /// serve both forms the issues name. Measured on BC 28.1: a base-page control emits
+    /// <c>Name_a45_OnAssistEdit(0)</c> on <c>Page{id}</c>, and a control a pageextension's
+    /// <c>modify()</c> block contributes emits <c>Extra_a45_OnAssistEdit(0)</c> on
+    /// <c>PageExtension{id}</c> — the SAME suffix and arity, differing only in which object
+    /// carries it and in which id space its name hashes. FindTrigger's three arms already
+    /// cover all three of those spaces after #3573, so no new resolution is needed.</para>
+    /// </summary>
+    internal void RaiseOnAssistEdit(int controlId)
+    {
+        var trigger = FindTrigger(controlId, "_OnAssistEdit", "OnAssistEdit");
+        if (trigger != null) Invoke(trigger.Value);
+    }
+
+    /// <summary>
     /// Run the page's own OnAfterGetRecord trigger.
     ///
     /// BC fires it every time the page loads a row, and it is where a page computes the

--- a/AlRunner/Patches/TestPageShapeGaps.cs
+++ b/AlRunner/Patches/TestPageShapeGaps.cs
@@ -235,6 +235,14 @@ internal static class TestPageShapeGap
         => Build(api, "testpage-drilldown", detail);
 
     /// <summary>
+    /// An OnAssistEdit trigger the runner could not reach. Raised only when there is no AL page
+    /// object to ask at all — a control that HAS no OnAssistEdit is silent rather than refused,
+    /// because BC's own ALAssistEdit raises nothing there either (RunnerPageInstance.RaiseOnAssistEdit).
+    /// </summary>
+    internal static RunnerOutOfScopeException AssistEdit(string api, string detail)
+        => Build(api, "testpage-assist-edit", detail);
+
+    /// <summary>
     /// Two emitted methods on one object resolving to a single member id. The surface is passed
     /// in because the caller serves OnValidate, OnAction, OnLookup and OnDrillDown from one
     /// method and the anchor names which one was being resolved.


### PR DESCRIPTION
Closes #3642
Closes #2362

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/308

## The defect

`TestPage.<Field>.AssistEdit()` reached no trigger at all. Both live `ITestField`
implementations in `MockTestPage.cs` carried `public void AssistEdit() { }`, so a control's
declared `OnAssistEdit` never ran and nothing reported that it had not — sitting directly
between `Lookup()` and `Drilldown()`, which both dispatch.

It is the silent wrong answer `loud-failures.md` names, and it bites twice over. In
Microsoft's `Tests-SINGLESERVER` bucket (#2362) the trigger's UI handlers went unexecuted, so
8 tests on page 9807 failed at **teardown**, naming the handlers rather than the trigger — a
failure that points at the wrong place.

## What I verified rather than assumed

The issue asserted that two of the six `ControlExtension*` triggers have no dispatch surface.
That is a claim about liveness, so I measured it.

**`OnAssistEdit` — the surface exists and we were the ones no-opping it.** BC's own
`NavTestField.ALAssistEdit` is, in full:

```csharp
public void ALAssistEdit() { CheckError(delegate { testField.AssistEdit(); }); }
```

So `ITestField.AssistEdit` — which this runner implements — **is** BC's dispatch surface. No
Cecil rewrite intercepts it (`AlRunner/Infrastructure/`, `AlRunner/Rewriters/`: no match), and
the pre-fix RED run confirmed dynamically that BC reaches our method and our method does
nothing.

**Resolution needed nothing new.** I probed the emitted method names on BC 28.1 rather than
inferring them, and both forms are the same shape:

```
[probe] AssistEdit page=65601 controlId=1098485690
[probe]  base type=Page65601
[probe]   base m: Name_a45_OnAssistEdit(0)
[probe]  ext 65602 inst=PageExtension65602
[probe]   ext m: Extra_a45_OnAssistEdit(0)
```

Same suffix, same arity; they differ only in which object carries the method and in which id
space its name hashes. `FindTrigger`'s three arms already span all three id spaces after
#3573, so `RaiseOnAssistEdit` is a single `FindTrigger` call and the `modify()` form comes
along for free.

## Why this is NOT shaped like `RaiseOnDrillDown`

Deliberate, and the most important judgement in the diff. Drilldown has a loud documented
answer when no trigger is declared — `The NavDrilldownAction method is not supported.` —
so it refuses. Assist-edit has none: `ALAssistEdit` returns `void` and raises nothing.

**A refusal for an absent `OnAssistEdit` would invent an error real BC does not raise**, which
is a worse wrong answer than the silence it replaces. So a control with no trigger stays
silent, and only "no AL page object at all" refuses — the same precondition `Lookup` and
`Drilldown` already refuse on. The fifth test arm pins that direction, so a later change
cannot "improve" this into a refusal unnoticed.

## `OnAfterAfterLookup`: the issue's second gap is not a runner gap

The issue asked for a dispatch surface for this too. Measured on BC 28.1, it should not get
one:

- BC raises it from `NavForm.RaiseOnAfterLookupAsync`, reached over the client-server protocol
  (`TestServiceConnection.IService.AfterLookupField`) when a user picks a row in a lookup
  **page**.
- `Microsoft.Dynamics.Nav.Types.ITestField` — the interface a TestPage drives a control
  through — declares `Lookup`, `Lookup`, `AssistEdit`, `Drilldown`, `Invoke` and no
  after-lookup member at all (read from `Microsoft.Dynamics.Nav.Types.dll` metadata).

So **a TestPage cannot raise it on real BC either.** Adding a runner surface for it would
invent an API BC does not have. Corpus PR #308 records this in the fixture, so the next reader
does not take its absence for an oversight. Reaching it would need a lookup page plus a
handler selecting a row — a different suite, and a different issue if anyone wants it.

That leaves #3642 fully addressed: one of its two triggers is fixed, and the other is
established as out of reach by construction rather than left unmentioned.

## Fixing the shape, not the reported line

**Does the same wrong pattern appear at another call site?** Yes — `AssistEdit()` was a no-op
on **both** live implementations (`LiveNavTestField` and the page-global `PageVariableTestField`),
and both are fixed. The third, `MockITestField`, stays a no-op deliberately: its `Lookup` and
`Drilldown` are no-ops too, it is the degraded path with no live page, and its own comment
already explains why.

**Does a sibling function make the same assumption?** This *is* the sibling gap —
`Lookup`/`Drilldown` were fixed earlier (#1774, #2549) and assist-edit was left behind. After
this, all three live surfaces dispatch the same way.

**Do two code paths write the same state with different invariants?** No. There is one
resolution path (`FindTrigger` → `FindTriggerOnTarget`); `RaiseOnAssistEdit` joins
`RaiseOnLookup` and `RaiseOnDrillDown` on it.

## What I folded, and what I did not

**Folded: #2362**, the base-page form of this exact defect — same file, same one-line
dispatch, its own proving arm. Found by scanning the open-issue queue per
`batch-sibling-issues-by-file.md`.

**Not folded**, all sharing the TestPage area but not this code:

- **#3518** (TableRelation-only lookup refused) — `RaiseSourceFieldOnLookup`'s fallback chain, a
  different refusal with a different remedy.
- **#3458** (AssertEquals names the caption, not the control) — message construction, not dispatch.
- **#3339** (`GetAction()` accepts any id where BC raises) — the action surface.
- **#3228** (a pageextension's own-variable control is refused) — metadata capture in the
  parser, not trigger dispatch.
- **#3605 / #3614** — the `modify()` siblings #3638 already declined, for the reasons it gave.

## Evidence

**RED first.** A probe bundle carrying both forms failed with an **empty trace** on both arms
— the trigger never ran, silently — which is the defect exactly as filed. GREEN after: both
pass.

**The proving test cannot pass a no-op.** Reverting `AssistEdit()` to `{ }` underneath the
finished test fails four of its five arms:

```
NavNCLDialogException: AssistEdit() must run the control's own OnAssistEdit; trace was ''
NavNCLDialogException: AssistEdit() must run a modify() block's OnAssistEdit; trace was ''
NavNCLDialogException: each AssistEdit() call must run the trigger again; trace was ''
```

The fifth (silence when no trigger) correctly still passes — it guards the opposite direction.

**Where the BC claim lives.** Upstream in corpus PR #308: four arms on codeunit 60514 covering
both routes, targeting, and once-per-call. The pin is not bumped here because that PR has not
merged; this carries a runner-mechanism test instead, per `bc-behavior-tests-go-upstream.md`.

**Local runs.** `dotnet test --filter FullyQualifiedName~TestPage`: **401 passed, 1 failed**.
The one failure is `TestPageEvaluatorFaultTests.TryResolve_AnUnreadableSpelling_IsRefusedByBcRatherThanFaulting`,
which is **#3486** (a documented cross-class ordering dependency). I did not assume that —
I reverted my three source files to `origin/main` and it failed identically, so it is
pre-existing and not mine.

`TestPageRefusalClaimTests`' drift-guard count moves 10 → 11 for the new no-page-object
refusal, with the reason recorded in place so the guard keeps its meaning instead of just
being bumped.

## Where the prose went

The id-space/emitted-name rule a later editor would get wrong stays at `RaiseOnAssistEdit`,
with the measured method names. The reasoning about `OnAfterAfterLookup`'s reachability is in
this PR body and in the corpus fixture, not in the code.

---

Implemented by agent `stma-auto-2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
