### PR TITLE
fix(testpage): discard a refused write's Rec mutations, as BC does

### DIFF
--- a/AlRunner.Tests/BcMatrixDocumentationDriftTests.cs
+++ b/AlRunner.Tests/BcMatrixDocumentationDriftTests.cs
@@ -102,6 +102,18 @@ public sealed class BcMatrixDocumentationDriftTests
         ("docs/virtual-tables-allobj.md", "27.0 27.3 27.5 28.2 28.3",
             "the corpus legs that had reported when the upstream Install-subtype assertion was "
             + "adjudicated — a historical observation of which legs answered, not the matrix"),
+        // The two halves of one measured version split (#3640). Corpus run 34328827788
+        // answered differently on the two families for closing a page after a refused write
+        // that a successful write had followed; the arms were then split so each half is
+        // green on all eight, confirmed by run 34331496862. Both rows record which legs gave
+        // which answer on a particular run — a historical measurement, and the whole finding.
+        // Rewriting either into a matrix set would delete the observation the table exists for.
+        ("docs/testpage-write-buffer.md", "28.0 28.1 28.2 28.3 28.4",
+            "the legs that closed the page cleanly after a refused-then-successful write, "
+            + "corpus run 34328827788 — a measured half of a version split, not the matrix"),
+        ("docs/testpage-write-buffer.md", "27.0 27.3 27.5",
+            "the legs that raised \"The record that you tried to open is not available.\" on "
+            + "the same write sequence, corpus run 34328827788 — the other measured half"),
     };
 
     // ---- version lists written out in prose --------------------------------------------

--- a/AlRunner.Tests/TestPageWriteBufferTests.cs
+++ b/AlRunner.Tests/TestPageWriteBufferTests.cs
@@ -1,0 +1,219 @@
+// TestPageWriteBufferTests — the C# unwind policy behind the TestPage write buffer (#3640).
+//
+// What this pins is the RUNNER's own mechanism, not what BC does. The BC claim — that a
+// page-driven write which raises leaves none of its triggers' Rec mutations visible — is
+// stated upstream by StefanMaron/BusinessCentral.AL.Language.Tests#309, which is where a
+// real service tier adjudicates it. Duplicating that claim here would only prove the runner
+// agrees with itself.
+//
+// What IS provable without a loaded BC runtime is the policy: a refused write is unwound to
+// the values the buffer held before it, a successful one is left alone, the original
+// exception reaches the caller unchanged, and one field that refuses restoration does not
+// abandon the rest of the row half-restored. FakeBuffer stands in for the NavRecord-backed
+// buffer; the production implementation differs only in where the field numbers and values
+// come from.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AlRunner.Patches;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestPageWriteBufferTests
+{
+    private sealed class FakeBuffer : TestPageWriteBuffer.IRestorableBuffer
+    {
+        private readonly Dictionary<int, object?> _values;
+
+        // Field numbers this buffer refuses to have written back, so the per-field
+        // fault-tolerance arm has something concrete to fail on.
+        private readonly HashSet<int> _unwritable;
+
+        // Set when RestorableFieldNos is enumerated with this true, so the snapshot-failure
+        // arm can make the READ side raise rather than the write side.
+        internal bool FailOnRead { get; set; }
+
+        internal int WriteCount { get; private set; }
+
+        internal FakeBuffer(Dictionary<int, object?> values, params int[] unwritable)
+        {
+            _values = values;
+            _unwritable = new HashSet<int>(unwritable);
+        }
+
+        public IEnumerable<int> RestorableFieldNos => _values.Keys.ToArray();
+
+        public object? Read(int fieldNo)
+        {
+            if (FailOnRead) throw new InvalidOperationException("record is stale or not open");
+            return _values[fieldNo];
+        }
+
+        public void Write(int fieldNo, object? value)
+        {
+            WriteCount++;
+            if (_unwritable.Contains(fieldNo))
+                throw new InvalidOperationException($"field {fieldNo} refuses a write");
+            _values[fieldNo] = value;
+        }
+
+        internal object? Peek(int fieldNo) => _values[fieldNo];
+    }
+
+    private sealed class RefusalException : Exception
+    {
+        internal RefusalException(string message) : base(message) { }
+    }
+
+    [Fact]
+    public void ARefusedWrite_UnwindsEveryFieldItMutated()
+    {
+        var buffer = new FakeBuffer(new Dictionary<int, object?> { [1] = 3, [2] = "", [5] = "" });
+
+        Assert.Throws<RefusalException>(() =>
+            TestPageWriteBuffer.RunRestoringOnRefusal(buffer, () =>
+            {
+                // What a before-validate trigger would do, then the refusal it raises.
+                buffer.Write(5, "before;");
+                buffer.Write(2, "stop");
+                throw new RefusalException("MCV stopped in OnBeforeValidate");
+            }));
+
+        Assert.Equal(3, buffer.Peek(1));
+        Assert.Equal("", buffer.Peek(2));
+        Assert.Equal("", buffer.Peek(5));
+    }
+
+    [Fact]
+    public void ARefusedWrite_RethrowsTheOriginalExceptionUnchanged()
+    {
+        var buffer = new FakeBuffer(new Dictionary<int, object?> { [5] = "" });
+
+        var thrown = Assert.Throws<RefusalException>(() =>
+            TestPageWriteBuffer.RunRestoringOnRefusal(buffer, () =>
+            {
+                buffer.Write(5, "before;");
+                throw new RefusalException("MCV stopped in OnBeforeValidate");
+            }));
+
+        // The type AND the message, because BC's NavTestField.CheckError records the message
+        // and AL's asserterror matches on it — swallowing or wrapping the refusal here would
+        // turn a refused write into a silent one.
+        Assert.Equal("MCV stopped in OnBeforeValidate", thrown.Message);
+    }
+
+    [Fact]
+    public void ASuccessfulWrite_IsLeftExactlyAsItWasWritten()
+    {
+        var buffer = new FakeBuffer(new Dictionary<int, object?> { [2] = "", [5] = "" });
+
+        TestPageWriteBuffer.RunRestoringOnRefusal(buffer, () =>
+        {
+            buffer.Write(2, "value");
+            buffer.Write(5, "before;page;after;");
+        });
+
+        Assert.Equal("value", buffer.Peek(2));
+        Assert.Equal("before;page;after;", buffer.Peek(5));
+    }
+
+    [Fact]
+    public void ASuccessfulWrite_WritesNothingOfItsOwn()
+    {
+        var buffer = new FakeBuffer(new Dictionary<int, object?> { [2] = "", [5] = "" });
+
+        TestPageWriteBuffer.RunRestoringOnRefusal(buffer, () => buffer.Write(2, "value"));
+
+        // Exactly the one write the body made. A restore on the success path would be
+        // invisible in the VALUES (they would be re-written to what they already are) and is
+        // only observable as extra writes — which on a real NavRecord means extra
+        // SetFieldValue calls through BC's own validate-free store path.
+        Assert.Equal(1, buffer.WriteCount);
+    }
+
+    [Fact]
+    public void OneFieldRefusingRestoration_DoesNotAbandonTheRest()
+    {
+        // Field 2 refuses a write back; 1 and 5 must still be restored.
+        var buffer = new FakeBuffer(new Dictionary<int, object?> { [1] = 3, [2] = "", [5] = "" }, unwritable: 2);
+
+        Assert.Throws<RefusalException>(() =>
+            TestPageWriteBuffer.RunRestoringOnRefusal(buffer, () =>
+            {
+                buffer.Write(1, 99);
+                buffer.Write(5, "before;");
+                throw new RefusalException("refused");
+            }));
+
+        Assert.Equal(3, buffer.Peek(1));
+        Assert.Equal("", buffer.Peek(5));
+    }
+
+    [Fact]
+    public void ABufferThatCannotBeRead_LeavesTheWriteUnwrapped()
+    {
+        var buffer = new FakeBuffer(new Dictionary<int, object?> { [5] = "" }) { FailOnRead = true };
+
+        // The snapshot fails, so nothing can be restored — but the write must still run and
+        // its refusal must still reach the caller. Refusing the write outright would be a
+        // worse error than not unwinding it: BC allows the write.
+        Assert.Throws<RefusalException>(() =>
+            TestPageWriteBuffer.RunRestoringOnRefusal(buffer, () =>
+            {
+                buffer.FailOnRead = false;
+                buffer.Write(5, "before;");
+                throw new RefusalException("refused");
+            }));
+
+        Assert.Equal("before;", buffer.Peek(5));
+    }
+
+    [Fact]
+    public void ANullBuffer_RunsTheWriteRatherThanRefusingIt()
+    {
+        // The record-less binding: a page over no source table has no Rec to unwind.
+        var ran = false;
+        TestPageWriteBuffer.RunRestoringOnRefusal((TestPageWriteBuffer.IRestorableBuffer?)null,
+            () => ran = true);
+        Assert.True(ran);
+    }
+
+    // The two callers, pinned in IL — a wiring claim, so that removing the unwind from either
+    // write path fails here rather than only in the corpus.
+    //
+    // The Rec-bound path is the one with a constraint on HOW it calls: it snapshots inline and
+    // restores in its own catch, because TestPageNewRowLinePromotionTests reads
+    // LiveNavTestField.Write's IL for the #2923 ordering and a lambda would hide all three of
+    // its markers inside a closure. This arm holds that spelling in place; without it a later
+    // editor tidying Write into RunRestoringOnRefusal turns the ordering test green-for-the-
+    // wrong-reason and nothing objects.
+    [Theory]
+    [InlineData("AlRunner.LiveNavTestField", "Write", "Snapshot")]
+    [InlineData("AlRunner.PageVariableTestField", "set_Value", "RunRestoringOnRefusal")]
+    public void BothWritePathsUnwindTheirBuffer(string typeName, string methodName, string expectedCall)
+    {
+        var module = AssemblyDefinition
+            .ReadAssembly(typeof(TestPageWriteBuffer).Assembly.Location).MainModule;
+        var type = module.GetType(typeName);
+        Assert.NotNull(type);
+
+        // The call can sit in the method itself or in a closure the compiler lifted out of it,
+        // which is exactly the difference the two spellings are about — so both are searched
+        // and the ASSERTION is on which entry point is reached, not on where it is reached from.
+        var bodies = type!.Methods.Where(m => m.HasBody && m.Name == methodName)
+            .Concat(type.NestedTypes.SelectMany(n => n.Methods).Where(m => m.HasBody));
+
+        var calls = bodies
+            .SelectMany(m => m.Body.Instructions)
+            .Where(i => i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt)
+            .Select(i => i.Operand as MethodReference)
+            .Where(mr => mr != null && mr.DeclaringType.Name == nameof(TestPageWriteBuffer))
+            .Select(mr => mr!.Name)
+            .ToList();
+
+        Assert.Contains(expectedCall, calls);
+    }
+}

--- a/AlRunner.Tests/TestPageWriteBufferTests.cs
+++ b/AlRunner.Tests/TestPageWriteBufferTests.cs
@@ -181,32 +181,79 @@ public sealed class TestPageWriteBufferTests
         Assert.True(ran);
     }
 
-    // The two callers, pinned in IL — a wiring claim, so that removing the unwind from either
-    // write path fails here rather than only in the corpus.
+    // Every call this type makes into TestPageWriteBuffer, from the named method's OWN body
+    // only — not from a lambda the compiler lifted into a nested type, and not from a local
+    // function, which lands beside the method as `<Name>g__Local|0_0` rather than under it.
     //
-    // The Rec-bound path is the one with a constraint on HOW it calls: it snapshots inline and
-    // restores in its own catch, because TestPageNewRowLinePromotionTests reads
-    // LiveNavTestField.Write's IL for the #2923 ordering and a lambda would hide all three of
-    // its markers inside a closure. This arm holds that spelling in place; without it a later
-    // editor tidying Write into RunRestoringOnRefusal turns the ordering test green-for-the-
-    // wrong-reason and nothing objects.
-    [Theory]
-    [InlineData("AlRunner.LiveNavTestField", "Write", "Snapshot")]
-    [InlineData("AlRunner.PageVariableTestField", "set_Value", "RunRestoringOnRefusal")]
-    public void BothWritePathsUnwindTheirBuffer(string typeName, string methodName, string expectedCall)
+    // Measured rather than assumed (net8.0, `dotnet build`): a lambda body compiles to
+    // `<>c.<WithLambda>b__1_0` inside a NESTED type, a local function to a method named
+    // `<WithLocal>g__Local|0_0` on the DECLARING type. Neither is `Write`, so restricting to
+    // the exact method name excludes both — which is the point here, not an oversight.
+    private static List<string> DirectCallsIntoWriteBuffer(string typeName, string methodName)
     {
         var module = AssemblyDefinition
             .ReadAssembly(typeof(TestPageWriteBuffer).Assembly.Location).MainModule;
         var type = module.GetType(typeName);
         Assert.NotNull(type);
 
-        // The call can sit in the method itself or in a closure the compiler lifted out of it,
-        // which is exactly the difference the two spellings are about — so both are searched
-        // and the ASSERTION is on which entry point is reached, not on where it is reached from.
-        var bodies = type!.Methods.Where(m => m.HasBody && m.Name == methodName)
-            .Concat(type.NestedTypes.SelectMany(n => n.Methods).Where(m => m.HasBody));
+        var method = type!.Methods.SingleOrDefault(m => m.HasBody && m.Name == methodName);
+        Assert.True(method != null, $"{typeName}.{methodName} not found, or not unique — this "
+            + "test reads one specific method body and cannot answer if the name is ambiguous.");
 
-        var calls = bodies
+        return method!.Body.Instructions
+            .Where(i => i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt)
+            .Select(i => i.Operand as MethodReference)
+            .Where(mr => mr != null && mr.DeclaringType.Name == nameof(TestPageWriteBuffer))
+            .Select(mr => mr!.Name)
+            .ToList();
+    }
+
+    // The Rec-bound path, and the one arm with a constraint on HOW it calls.
+    //
+    // LiveNavTestField.Write must reach TestPageWriteBuffer.Snapshot from its own body, so the
+    // restore is an inline try/catch rather than a wrapped lambda.
+    // TestPageNewRowLinePromotionTests reads THAT method's IL to pin the #2923 ordering
+    // (_onBeforeEdit before ALValidateAsync, _onEdited after), and wrapping the body in a
+    // lambda moves all three markers into a nested closure type where that test cannot see
+    // them — it then finds none of its three markers and fails for the wrong reason, which is
+    // what happened while #3640 was being implemented.
+    //
+    // A local function has the same effect for the same reason and is NOT caught by looking in
+    // nested types, which is why this reads one exact method body and nothing else.
+    [Fact]
+    public void TheRecBoundWritePathSnapshotsInline()
+    {
+        var calls = DirectCallsIntoWriteBuffer("AlRunner.LiveNavTestField", "Write");
+
+        Assert.Contains("Snapshot", calls);
+
+        // And specifically NOT the wrapping spelling: reaching for RunRestoringOnRefusal here
+        // is exactly the tidy-up that would hide the ordering markers.
+        Assert.DoesNotContain("RunRestoringOnRefusal", calls);
+    }
+
+    // The page-variable path has no such constraint — nothing reads its IL for ordering — so it
+    // uses the wrapping spelling, which cannot get the try/catch wrong. Pinned so that removing
+    // the unwind from this path fails here rather than only in the corpus.
+    //
+    // Searched WIDELY on purpose, unlike the arm above: this setter hands a lambda to
+    // RunRecordingRefusal, so its own body makes no direct call at all and the call to
+    // RunRestoringOnRefusal sits in the compiler-generated closure type. Measured — restricting
+    // this arm to the setter's own body finds an empty collection. The asymmetry between the
+    // two arms IS the claim: one path must call inline, the other may call through a closure.
+    [Fact]
+    public void ThePageVariableWritePathWrapsItsWrite()
+    {
+        var module = AssemblyDefinition
+            .ReadAssembly(typeof(TestPageWriteBuffer).Assembly.Location).MainModule;
+        var type = module.GetType("AlRunner.PageVariableTestField");
+        Assert.NotNull(type);
+
+        var calls = type!.Methods.Where(m => m.HasBody && m.Name == "set_Value")
+            .Concat(type.NestedTypes.SelectMany(n => n.Methods).Where(m => m.HasBody))
+            // A local function lands beside the method rather than under it, so the
+            // compiler-generated `<set_Value>g__...` spelling is picked up here too.
+            .Concat(type.Methods.Where(m => m.HasBody && m.Name.StartsWith("<set_Value>g__")))
             .SelectMany(m => m.Body.Instructions)
             .Where(i => i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt)
             .Select(i => i.Operand as MethodReference)
@@ -214,6 +261,6 @@ public sealed class TestPageWriteBufferTests
             .Select(mr => mr!.Name)
             .ToList();
 
-        Assert.Contains(expectedCall, calls);
+        Assert.Contains("RunRestoringOnRefusal", calls);
     }
 }

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -3772,6 +3772,21 @@ internal sealed class LiveNavTestField : ITestField
         // refusal of the value itself would be.
         _onBeforeEdit?.Invoke();
 
+        // #3640: everything from here on can mutate Rec — the field's own OnValidate, the
+        // control's, and any pageextension modify() trigger around them — and real BC discards
+        // those mutations when the write raises. Snapshot AFTER _onBeforeEdit, because the
+        // new-row promotion above writes the row's KEY, which is page state settled before the
+        // value is validated rather than a trigger's mutation of it; the tier measured the
+        // trigger half and says nothing about unwinding the promotion.
+        //
+        // Taken and put back INLINE rather than by wrapping the rest of this method in a
+        // lambda: TestPageNewRowLinePromotionTests reads this method's IL to pin that
+        // _onBeforeEdit precedes ALValidateAsync and _onEdited follows it (#2923), and moving
+        // any of those three into a compiler-generated closure hides the ordering from the
+        // one test that guards it. See TestPageWriteBuffer.
+        var restore = TestPageWriteBuffer.Snapshot(_record);
+        try
+        {
         // Issue #1870 — the Rec-bound half of #1837 that #1869 (the page-variable half)
         // left open. FieldType (sourced from the source table field's own declared type,
         // see TryGetMetaFieldType) answers Boolean for a `field(Flag; Rec.Flag)` control
@@ -3855,6 +3870,12 @@ internal sealed class LiveNavTestField : ITestField
         }
 
         _onEdited?.Invoke();
+        }
+        catch
+        {
+            restore?.Invoke();
+            throw;
+        }
     }
 
     // The stored NavValue, not the unwrapped ClientObject — the option metadata rides on the
@@ -4078,11 +4099,21 @@ internal sealed class PageVariableTestField : ITestField
         // Codeunit134614 asserts the bare text with exact equality for exactly this binding
         // shape (verified mechanically to be page-variable-bound, not Rec-bound). This is the
         // half no service-tier run has confirmed yet — corpus PR #184 asks it.
-        set => _validationErrors.RunRecordingRefusal(() =>
-        {
-            RunnerPageInstance.SetValue(_expression, ToBoundValue(value));
-            _page.RaiseOnValidate(_controlId);
-        }, appendRefreshSuffix: false);
+        //
+        // #3640: the Rec-bound sibling's restore-on-refusal applies here too. A page-variable
+        // control's OnValidate is ordinary AL and can write Rec exactly as a Rec-bound one's
+        // can, and a page-driven write is a page-driven write whichever way the CONTROL that
+        // started it happens to be bound — so leaving this half out would make the same AL
+        // observable depend on a binding detail the tier's claim does not mention. Only Rec is
+        // restored: what a failed write leaves in a page GLOBAL is a separate claim no service
+        // tier has measured, and inventing an answer for it is what
+        // ask-the-corpus-before-claiming-bc-behavior.md forbids.
+        set => _validationErrors.RunRecordingRefusal(
+            () => TestPageWriteBuffer.RunRestoringOnRefusal(_page.Record, () =>
+            {
+                RunnerPageInstance.SetValue(_expression, ToBoundValue(value));
+                _page.RaiseOnValidate(_controlId);
+            }), appendRefreshSuffix: false);
     }
 
     public object? ObjectValue => LiveNavTestPage.Unwrap(RunnerPageInstance.GetValue(_expression));

--- a/AlRunner/Patches/TestPageWriteBuffer.cs
+++ b/AlRunner/Patches/TestPageWriteBuffer.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+using Microsoft.Dynamics.Nav.Types.Metadata;
+
+namespace AlRunner.Patches;
+
+/// <summary>
+/// The record buffer behind a TestPage control write, snapshotted before the write and put
+/// back when the write is refused (#3640).
+///
+/// <para>Observably equivalent: real BC discards the in-memory Rec mutations a page-driven
+/// write's triggers made once that write raises, so the still-open page reads the values it
+/// held before the write. Measured on a real service tier, not inferred — corpus PR #305's
+/// original failed-write arm was answered <c>''</c> on all eight cloud legs (run
+/// <c>34319509704</c>) where the runner answered <c>'before;'</c>, unanimously and
+/// deterministically. The claim is stated upstream by corpus PR #309; see
+/// docs/testpage-write-buffer.md for what the tier measured and what it did not.</para>
+///
+/// <para>Trap for a later editor: the restore is by <em>value</em>, field by field, because
+/// <c>NavRecord.CopyRecord</c> is <c>internal</c>. A NavValue is immutable — BC's
+/// <c>SetFieldValue</c> stores the instance and <c>GetFieldValue</c> hands the same one back —
+/// so holding the reference is a faithful snapshot. If a future BC build makes NavValue
+/// mutable in place, this silently becomes a no-op and every arm still passes.</para>
+/// </summary>
+internal static class TestPageWriteBuffer
+{
+    /// <summary>
+    /// The buffer a write is unwound against, named so the unwind policy can be exercised
+    /// without a loaded BC runtime. <see cref="NavRecordBuffer"/> is the only production
+    /// implementation; <c>AlRunner.Tests.TestPageWriteBufferTests</c> drives the same policy
+    /// over a dictionary.
+    /// </summary>
+    internal interface IRestorableBuffer
+    {
+        /// <summary>The field numbers this buffer restores — see NavRecordBuffer for which
+        /// fields are excluded and why.</summary>
+        IEnumerable<int> RestorableFieldNos { get; }
+        object? Read(int fieldNo);
+        void Write(int fieldNo, object? value);
+    }
+
+    /// <summary>
+    /// Take a snapshot and hand back the action that puts it back, or null when there is
+    /// nothing restorable (a record-less binding, or a buffer that cannot be read at all).
+    ///
+    /// <para>The two-part spelling exists for one caller: <c>LiveNavTestField.Write</c>, whose
+    /// IL is read by <c>TestPageNewRowLinePromotionTests</c> to pin that <c>_onBeforeEdit</c>
+    /// precedes <c>ALValidateAsync</c> and <c>_onEdited</c> follows it (#2923). Wrapping that
+    /// method's body in a lambda moves all three into a compiler-generated closure, and the
+    /// ordering test then finds none of its three markers and fails for the wrong reason. So
+    /// that caller snapshots inline and restores in its own <c>catch</c>; every other caller
+    /// should use <see cref="RunRestoringOnRefusal(NavRecord?, Action)"/>, which cannot get
+    /// the try/catch wrong.</para>
+    /// </summary>
+    internal static Action? Snapshot(NavRecord? record)
+    {
+        if (record == null) return null;
+
+        var buffer = new NavRecordBuffer(record);
+        var snapshot = TrySnapshot(buffer);
+        return snapshot == null ? null : () => Restore(buffer, snapshot);
+    }
+
+    /// <summary>
+    /// Run <paramref name="write"/>, and if it raises, put the record's field values back as
+    /// they were before returning the exception to the caller.
+    ///
+    /// <para>A null record is the record-less binding (a page over no source table), which has
+    /// no buffer to restore; the write runs unwrapped rather than being refused.</para>
+    /// </summary>
+    internal static void RunRestoringOnRefusal(NavRecord? record, Action write)
+        => RunRestoringOnRefusal(record == null ? null : new NavRecordBuffer(record), write);
+
+    internal static void RunRestoringOnRefusal(IRestorableBuffer? buffer, Action write)
+    {
+        if (buffer == null) { write(); return; }
+
+        var snapshot = TrySnapshot(buffer);
+        if (snapshot == null) { write(); return; }
+
+        try
+        {
+            write();
+        }
+        catch
+        {
+            Restore(buffer, snapshot);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// The current value of every restorable field, or null if the buffer cannot be read at
+    /// all (a closed or stale record — BC's GetFieldValue raises rather than answering).
+    /// Failing to snapshot leaves the write unwrapped: keeping today's behaviour is a smaller
+    /// error than refusing a write BC allows.
+    /// </summary>
+    private static Dictionary<int, object?>? TrySnapshot(IRestorableBuffer buffer)
+    {
+        try
+        {
+            var snapshot = new Dictionary<int, object?>();
+            foreach (var fieldNo in buffer.RestorableFieldNos)
+                snapshot[fieldNo] = buffer.Read(fieldNo);
+            return snapshot;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void Restore(IRestorableBuffer buffer, Dictionary<int, object?> snapshot)
+    {
+        foreach (var pair in snapshot)
+        {
+            // Per field, so one unrestorable field cannot abandon the rest of the row
+            // half-restored — a partially-restored buffer is the exact state this rule exists
+            // to remove, and it would be harder to diagnose than the un-restored one.
+            try { buffer.Write(pair.Key, pair.Value); }
+            catch { /* leave that one field as the failed write left it */ }
+        }
+    }
+
+    private sealed class NavRecordBuffer : IRestorableBuffer
+    {
+        private readonly NavRecord _record;
+        internal NavRecordBuffer(NavRecord record) => _record = record;
+
+        public IEnumerable<int> RestorableFieldNos
+        {
+            get
+            {
+                foreach (var field in _record.MetaTable.Fields)
+                    if (IsRestorable(field)) yield return field.FieldNo;
+            }
+        }
+
+        public object? Read(int fieldNo) => _record.GetFieldValue(fieldNo);
+
+        public void Write(int fieldNo, object? value)
+        {
+            if (value is NavValue navValue) _record.SetFieldValue(fieldNo, navValue);
+        }
+
+        /// <summary>
+        /// Only a Normal field is snapshotted and restored.
+        ///
+        /// <para>A FlowField is computed from other rows and holds no stored value of its own —
+        /// writing one back would push a cached calculation into the buffer as though it had
+        /// been stored. A FlowFilter is a filter, not a value. An inactive or obsoleted field
+        /// answers BC's default rather than a stored value
+        /// (<c>NavRecord.GetFieldValue</c> returns <c>GetDefaultNavValue</c> for it), so
+        /// restoring it would write that default over whatever the buffer holds. Field index 0
+        /// is the row timestamp, which <c>SetFieldValue</c> routes to
+        /// <c>SetRecordTimestamp</c> rather than to the field store.</para>
+        /// </summary>
+        private static bool IsRestorable(NCLMetaField field)
+            => field.FieldClass == FieldClass.Normal && field.FieldActive && field.FieldIndex != 0;
+    }
+}

--- a/docs/testpage-write-buffer.md
+++ b/docs/testpage-write-buffer.md
@@ -1,0 +1,109 @@
+# The TestPage write buffer: what a refused write leaves behind
+
+Issue [#3640](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3640).
+Implementation: `AlRunner/Patches/TestPageWriteBuffer.cs`, called from both write paths in
+`AlRunner/Patches/MockTestPage.cs`.
+
+## The claim, and what measured it
+
+Real BC **discards** the in-memory `Rec` mutations a page-driven write's triggers made, once
+that write raises. A still-open page reads the values it held before the write, not the
+partially-applied ones.
+
+This is a service-tier measurement, not a derivation. Corpus PR
+[#305](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/305) originally
+carried an arm asserting the **opposite** — the runner's behaviour. All eight cloud legs
+failed it, unanimously and deterministically (run `34319509704`, 7 PASS / 1 FAIL on each of
+27.0, 27.3, 27.5, 28.0, 28.1, 28.2, 28.3, 28.4):
+
+```
+FAIL AnErrorInOnBeforeValidatePreventsTheBaseTriggerAndOnAfterValidate
+     Assert.AreEqual failed. Expected:<before;> (Text). Actual:<> (Text).
+```
+
+| | `Card.Trace.Value()` after `asserterror Card.Name.SetValue('stop')` |
+|---|---|
+| real BC, 8/8 cloud legs | `''` — the mutation is gone |
+| AL Runner, before #3640 | `'before;'` — the mutation survives |
+
+The arm was removed from #305 rather than weakened, and the fixture's
+`if Rec.Name = 'stop' then Error(...)` hook was left in deliberately so that stating the claim
+would mean adding an arm rather than re-shaping the fixture. Corpus PR
+[#309](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/309) is that arm.
+
+## What the tier measured, and what it did not
+
+Stated separately because the gap is where a future editor is most likely to over-reach.
+
+**Measured:**
+
+- A `Rec`-bound control whose pageextension `modify()` `OnBeforeValidate` mutates `Rec` and
+  then raises. The mutation is not visible afterwards.
+- The success path of the same control, on the same eight legs, reads
+  `'before;page;after;'` — so trigger dispatch and ordering are right, and the divergence is
+  isolated to what survives a *failed* write.
+
+**Not measured, and therefore not asserted anywhere:**
+
+- What a failed write leaves in a **page global** (a `PageVariableTestField` binding). The
+  runner unwinds `Rec` on that path too, on the ground that a page-driven write is a
+  page-driven write whichever way the control that started it is bound — but the page
+  variable itself is left alone, because inventing an answer for it is exactly what
+  `ask-the-corpus-before-claiming-bc-behavior.md` forbids.
+- Whether a failed write also unwinds the **new-row promotion** — the key stamping that
+  `_onBeforeEdit` performs before the value is validated (#2923). The runner snapshots
+  *after* that step, so the promotion survives a refusal. That is a deliberate choice about
+  an unmeasured question, not a claim.
+- Whether the discard is a restore or a re-read from the database. Observationally the corpus
+  cannot distinguish them for a row that was never written; the runner restores, and corpus
+  arm `AWriteAfterARefusedOneTracesFromTheRestoredBuffer` pins that whichever mechanism BC
+  uses leaves the page usable with a clean buffer.
+
+## How the runner does it
+
+`NavRecord.CopyRecord` is `internal`, so the snapshot is by value, field by field, through
+BC's own public `GetFieldValue` / `SetFieldValue` pair. That pair is symmetric over
+`recordImplementation` (minus media-info decoration on the read), and a `NavValue` is
+immutable — `SetFieldValue` stores the instance and `GetFieldValue` hands the same one back —
+so holding the reference is a faithful snapshot.
+
+Only **Normal, active, non-timestamp** fields are snapshotted:
+
+| excluded | why |
+|---|---|
+| FlowField | computed from other rows; writing one back stores a cached calculation as though it had been stored |
+| FlowFilter | a filter, not a value |
+| inactive / obsoleted | `GetFieldValue` answers `GetDefaultNavValue` for these, so restoring writes that default over the buffer |
+| `FieldIndex == 0` | the row timestamp; `SetFieldValue` routes it to `SetRecordTimestamp`, not to the field store |
+
+Two failure modes are handled by keeping today's behaviour rather than refusing:
+
+- **The buffer cannot be read at all** (a stale or closed record — BC's `GetFieldValue`
+  raises). The write runs unwrapped. Not unwinding is a smaller error than refusing a write
+  BC allows.
+- **One field refuses restoration.** Restoration is per field, so the rest of the row still
+  goes back. A partially-restored buffer is the state this rule exists to remove, and it
+  would be harder to diagnose than the un-restored one.
+
+## Why `LiveNavTestField.Write` snapshots inline
+
+`TestPageWriteBuffer` offers two spellings, and the two-part one exists for a single caller.
+
+`AlRunner.Tests/TestPageNewRowLinePromotionTests` reads `LiveNavTestField.Write`'s **IL** to
+pin the #2923 ordering: `_onBeforeEdit` before `ALValidateAsync`, `_onEdited` after it.
+Wrapping that method's body in a lambda moves all three markers into a compiler-generated
+closure, and the ordering test then finds none of them and fails for the wrong reason — which
+is what happened while implementing #3640, before the shape was changed back.
+
+So that one caller uses `TestPageWriteBuffer.Snapshot(record)` plus its own `catch`; every
+other caller uses `RunRestoringOnRefusal`, which cannot get the try/catch wrong.
+`TestPageWriteBufferTests.BothWritePathsUnwindTheirBuffer` pins both spellings in IL, so a
+later tidy-up that collapses them fails there rather than silently making the ordering test
+vacuous.
+
+## Sister documents
+
+- `.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md` — why the tier's eight legs
+  outrank reading the AL
+- `.claude/rules/bc-behavior-tests-go-upstream.md` — why the proving arms live in the corpus
+  and only the mechanism is pinned here

--- a/docs/testpage-write-buffer.md
+++ b/docs/testpage-write-buffer.md
@@ -57,7 +57,60 @@ Stated separately because the gap is where a future editor is most likely to ove
 - Whether the discard is a restore or a re-read from the database. Observationally the corpus
   cannot distinguish them for a row that was never written; the runner restores, and corpus
   arm `AWriteAfterARefusedOneTracesFromTheRestoredBuffer` pins that whichever mechanism BC
-  uses leaves the page usable with a clean buffer.
+  uses leaves the buffer **clean for a subsequent write** — it does *not* claim the page stays
+  usable in every respect. See the next section: on 27.x it does not.
+
+## Closing the page afterwards is version-split, and the corpus says so
+
+The claim above — that the buffer is restored — is green on all eight cloud legs. **Closing
+the page after a refused write is not uniform**, and an earlier revision of the corpus arm
+overstated it by folding the two together.
+
+Measured, corpus run
+[`34328827788`](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/actions/runs/34328827788):
+
+| legs | a refused write, then a **successful** one, then `Close()` |
+|---|---|
+| 28.0, 28.1, 28.2, 28.3, 28.4 | closes cleanly |
+| 27.0, 27.3, 27.5 | raises `The record that you tried to open is not available. The page will close or show the next record.` |
+
+Three of eight, unanimous within the 27.x family and deterministic.
+
+**What the failure was not.** The `Assert.AreEqual` on the trace passed on all eight. Two
+independent signals say so: the stack frame is `Test Runner - Mgt.RunTests` with **no `Assert`
+codeunit frame** (a real mismatch shows one, and shows the expected/actual pair), and the
+message is a UI message rather than a value comparison. The leg summary reads
+`3211 total, 3210 passed, 1 failed`, so the suite reached the test phase and the other arms
+executed.
+
+**What discriminates it.** All three of the failed-write arms do `asserterror` then `Close()`,
+and two of them pass on those same three legs. The only structural difference in the failing
+one was the extra **successful write following the refused one**. So the split is not "a
+refused write leaves the page unusable on 27.x" — that is refuted by the two passing arms on
+the same legs — but the narrower "a refused write *followed by a successful one* leaves 27.x
+unable to close the page".
+
+**How the corpus states it now.** Two arms rather than one:
+
+- `AWriteAfterARefusedOneTracesFromTheRestoredBuffer` asserts the trace and **does not close
+  the page** — green on all eight.
+- `APageIsStillClosableAfterARefusedWrite` closes the page after a refusal with no second
+  write — green on all eight.
+
+The version split itself is recorded in a comment at the arm, with the run id, and is
+deliberately **not** asserted with a version branch: a test that branches on the platform
+version to pick an expected value records a split rather than testing anything. Neither
+version's answer is asserted as the correct one.
+
+**Not settled: whether the 27.x behaviour is BC or the Linux image.** The corpus tier is
+`MsDyn365Bc.On.Linux`, which patches BC, and the message is a client/server resource string
+that is not in `Microsoft.Dynamics.Nav.Ncl.dll` — so it cannot be read with the decompiler
+from the runner side. The route to settle it is the `run-nightly-windows` label on the corpus
+PR, per `.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md`. Until that runs, the
+table above is what the tier answered and nothing here claims more than that.
+
+**Nothing in the runner changed for this.** The runner's restore is green on both families;
+this section documents a corpus-side scoping decision, not a runner behaviour.
 
 ## How the runner does it
 
@@ -97,9 +150,24 @@ is what happened while implementing #3640, before the shape was changed back.
 
 So that one caller uses `TestPageWriteBuffer.Snapshot(record)` plus its own `catch`; every
 other caller uses `RunRestoringOnRefusal`, which cannot get the try/catch wrong.
-`TestPageWriteBufferTests.BothWritePathsUnwindTheirBuffer` pins both spellings in IL, so a
-later tidy-up that collapses them fails there rather than silently making the ordering test
-vacuous.
+
+Two tests pin the two spellings, and they are deliberately **asymmetric**:
+
+- `TheRecBoundWritePathSnapshotsInline` reads `LiveNavTestField.Write`'s own body **only** and
+  requires a direct `Snapshot` call, plus the absence of `RunRestoringOnRefusal`.
+- `ThePageVariableWritePathWrapsItsWrite` searches the setter, its nested closure types and
+  any lifted local function, because that setter legitimately hands a lambda to
+  `RunRecordingRefusal` and so makes no direct call at all.
+
+The asymmetry is the claim: one path must call inline, the other may call through a closure.
+
+**Why the narrow arm is narrow.** A first version searched nested types for both, and a
+reviewer found the hole: a **local function** does not compile into a nested type. Measured on
+net8.0 — a lambda body becomes `<>c.<M>b__1_0` inside a nested type, a local function becomes
+`<M>g__Local|0_0` as a method on the *declaring* type. So re-wrapping `Write`'s body in a
+local function would have kept the old test green while hiding the ordering markers, leaving
+the hazard caught only by the ordering test failing for a reason that does not name it.
+Verified by applying exactly that rewrite: the old shape passed, the current one fails.
 
 ## Sister documents
 


### PR DESCRIPTION
Closes #3640

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/309

Written by agent `stma-auto-2`.

## The defect

A page-driven `SetValue` that raises left the `Rec` mutations its triggers had already made visible on the still-open page. Real BC discards them.

```al
Card.OpenNew();
Card.Id.SetValue(3);
asserterror Card.Name.SetValue('stop');
Card.Trace.Value()   // real BC: ''      runner, before this: 'before;'
```

## The measurement I honoured, and did not re-derive

Corpus PR #305 originally carried an arm asserting the runner's behaviour. **All eight cloud legs failed it**, unanimously and deterministically (run `34319509704`, 7 PASS / 1 FAIL on each of 27.0, 27.3, 27.5, 28.0, 28.1, 28.2, 28.3, 28.4) — `Expected:<before;>, Actual:<>`. The arm was removed rather than weakened, and the fixture's `if Rec.Name = 'stop' then Error(...)` hook was deliberately left in place so stating the claim would mean adding an arm.

## Where the proving test is

**Upstream, in corpus PR #309** — this is a plain BC claim, so a service tier adjudicates it. **Four** arms, because no single wrong implementation may satisfy the set:

| arm | what it rules out |
|---|---|
| `AnErrorInOnBeforeValidateDiscardsThatTriggersOwnRecMutation` | the mutation surviving |
| `TheRaisingTriggerDidRunEvenThoughItsMutationIsDiscarded` | a platform that dispatched **no** trigger at all, which also produces an empty trace |
| `AWriteAfterARefusedOneTracesFromTheRestoredBuffer` | a discard implemented by tearing the buffer down rather than restoring it |
| `APageIsStillClosableAfterARefusedWrite` | the discard leaving the page unusable |

## The tier refused part of the first revision, and that is in the arms now

The first revision had **three** arms and came back red on 3 of 8 cloud legs (run [`34328827788`](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/actions/runs/34328827788)) — 27.0 / 27.3 / 27.5 fail, all four 28.x pass. Deterministic, unanimous within the 27.x family.

**The trace claim was never what failed.** `AWriteAfterARefusedOneTracesFromTheRestoredBuffer` ended in `Card.Close()`, and the `Close()` is what raised:

```
FAIL  AWriteAfterARefusedOneTracesFromTheRestoredBuffer — Unhandled UI: Message
      The record that you tried to open is not available. The page will close or show the next record.
```

Two independent signals confirm the `Assert.AreEqual` had already passed: the stack frame is `Test Runner - Mgt.RunTests` with **no `Assert` codeunit frame** (a real mismatch shows one, plus the expected/actual pair — as my local RED run did), and the leg summary reads `3211 total, 3210 passed, 1 failed`.

**A refinement on the diagnosis.** It is not "the record is unavailable after a refused write" — all three failed-write arms do `asserterror` then `Close()`, and **two of them pass on those same three legs**. The only structural difference in the failing one was the extra **successful write following the refused one**. So the narrow claim is: on 27.x, a refused write *followed by a successful one* leaves the page unable to close.

**Split, not weakened.** The trace arm no longer closes the page (green 8/8); a new `APageIsStillClosableAfterARefusedWrite` closes after a refusal with no second write (green 8/8). The version split is recorded in a comment at the arm with the run id, and is deliberately **not** asserted with a version branch — a test that branches on the platform version records a split rather than testing anything. Neither version's answer is asserted as correct.

**Unsettled: BC or the Linux image.** The message is a client/server resource string, not in `Ncl.dll`, so the decompiler cannot answer it from here. The route is the `run-nightly-windows` label on #309. `docs/testpage-write-buffer.md` says so rather than guessing.

**Nothing in the runner changed for any of this** — the restore is green on both families. The split is a corpus-side scoping decision.

**#309 has merged** — `0b19a3bd`, 2026-09-09T09:05:32Z. Verified by execution, not by the tick: `tools/corpus-pass-count.py` on its final run (`34331496862`) reports **8 cloud legs ran the codeunit, 0 failures** for both `AWriteAfterARefusedOneTracesFromTheRestoredBuffer` and `APageIsStillClosableAfterARefusedWrite`. The 27.x legs that refused the pre-split arm now pass it.

**No pin bump here.** The pin is still `c9d5f656`; catching it up pulls in unrelated corpus commits and belongs in its own catch-up PR (`al-language-submodule.md`). The `Tests updated` gate is met by the runner-side mechanism tests.

See the note under the arms table for the pin: #309 has merged, but this PR carries no bump.

## RED → GREEN

Against the corpus branch, with the restore disabled and then enabled:

| | restore off | restore on |
|---|---|---|
| `AnErrorInOnBeforeValidateDiscards...` | **FAIL** `Expected:<> Actual:<before;>` | PASS |
| `AWriteAfterARefusedOneTraces...` | **FAIL** `Expected:<before;page;after;> Actual:<before;before;page;after;>` | PASS |
| `TheRaisingTriggerDidRun...` | PASS | PASS |
| the seven pre-existing #305 arms | PASS | PASS |

The third arm passing in both directions is the point of it: it discriminates against a *different* wrong implementation, not against this one.

`AlRunner.Tests/TestPageWriteBufferTests` went 2 FAIL / 5 PASS with the policy disabled, 9/9 with it enabled.

## Fixing the shape, not the reported line

1. **Another call site with the same wrong pattern?** Yes — `PageVariableTestField`. Its `OnValidate` is ordinary AL and can write `Rec` exactly as a `Rec`-bound control's can, and a page-driven write is a page-driven write whichever way the *control* is bound. Both paths now unwind; `BothWritePathsUnwindTheirBuffer` pins both in IL.
2. **A sibling making the same assumption?** `LiveNavTestField.Lookup` writes through `Value`, so it inherits the fix. `AssistEdit()` and `Invoke()` are literal no-ops today (#2362, #2943) and have no write to unwind.
3. **Two paths writing the same state with different invariants?** That was exactly the defect: `Write` and the page-variable setter both wrote `Rec` and neither unwound. They now share one entry point.

## Deliberately not done

- **The page variable itself is not unwound**, only `Rec`. What a failed write leaves in a page global is a separate claim **no service tier has measured**, and inventing one is what `ask-the-corpus-before-claiming-bc-behavior.md` forbids.
- **The new-row promotion is not unwound.** The snapshot is taken *after* `_onBeforeEdit`, so the key stamping of #2923 survives a refusal. Also unmeasured; stated in `docs/testpage-write-buffer.md` as a choice, not a claim.

## Same-file sibling scan

I scanned the open queue for anything landing in `AlRunner/Patches/MockTestPage.cs`. **Nothing folded.** The map, and why:

| issue | why not folded |
|---|---|
| #3642 (`modify()` triggers with no dispatch surface) | lands in `RunnerPageInstance.cs` / the AL page parser — trigger *discovery*, not the write buffer |
| #3504 (subform `Editable()`) | control-metadata resolution; different reasoning to review |
| #3501 (DateFormula `SetValue` casts) | `TestPageTemporalValue`, a value-conversion arm reached before the buffer exists |
| #3458 (refusal names the field caption) | `TestFieldValidationErrors` message shape |
| #3339, #3258, #3228, #3223, #3190, #3029, #2943, #2362 | all TestPage, none in the write path — folding any would stop this being one change a reviewer can hold |
| #3586 (`TransactionModel::None` Modify never checked) | closest neighbour, and genuinely adjacent to the `EnterRunTransaction` bracket in this same method — but it is about the *commit* path, needs its own tier measurement, and pulling it in would double the reasoning |

## What I ran

- Full corpus at pin `c9d5f656`: **3112/3112 pass, 0 fail** (re-run after the rebase onto `a9b7309d`; the pin has not moved since).
- `tests/runner-extras`: **399/399 pass, 0 fail**.
- `dotnet test AlRunner.Tests --filter FullyQualifiedName~TestPage`: **410 pass, 1 fail**, that one being `TestPageEvaluatorFaultTests.TryResolve_AnUnreadableSpelling_IsRefusedByBcRatherThanFaulting` — the known ordering dependency of **#3486**. I confirmed it rather than assumed it: it fails identically in a fresh worktree at `origin/main`, a commit predating this branch.

Both wide runs are warranted here rather than routine — this changes the write path every TestPage field write shares.

## A real interaction, worth a reviewer's attention

My first shape wrapped `LiveNavTestField.Write`'s body in a lambda. That broke `TestPageNewRowLinePromotionTests`, which reads that method's **IL** to pin the #2923 ordering — the ordering was intact, but all three of its markers had moved into a compiler-generated closure, so the test could no longer see them. The write path now snapshots inline and restores in its own `catch`.

**A reviewer then found the guard I added for that was too weak, and was right.** `BothWritePathsUnwindTheirBuffer` searched `NestedTypes`, so it would still have passed if someone re-wrapped the body in a **local function** — the hazard would then have been caught only by the ordering test, failing for a reason that does not name it.

Measured on net8.0 rather than assumed: a lambda body compiles to `<>c.<M>b__1_0` inside a **nested type**; a local function to `<M>g__Local|0_0`, a method on the **declaring** type. So `NestedTypes` genuinely misses it.

Now two **asymmetric** arms, and the asymmetry is the claim:

- `TheRecBoundWritePathSnapshotsInline` reads `Write`'s own body **only**, requires a direct `Snapshot`, and asserts the absence of `RunRestoringOnRefusal`.
- `ThePageVariableWritePathWrapsItsWrite` searches widely, because that setter legitimately hands a lambda to `RunRecordingRefusal` and makes no direct call at all — I confirmed that by writing the narrow version first and watching it find an empty collection.

Verified end to end by applying the local-function rewrite: the old shape passed, the new one fails.

## The docs-drift guard, and why two waivers rather than a reword

The version table above trips `BcMatrixDocumentationDriftTests.VersionListsInDocs_NameOnlyASetDerivedFromTheVersionFiles`: neither `28.0 28.1 28.2 28.3 28.4` nor `27.0 27.3 27.5` is one of the three sets it derives from the version files.

Two `NotAMatrixClaim` entries, not a reword — **the split is the finding**, and rewriting either half into a matrix set would delete the observation the table exists for. Each cites run `34328827788`, the run that measured it.

Both verified **individually load-bearing** by removing each alone: either removal fails the guard, so neither is dead and neither masks the other. The doc's third version run (line 17, the full eight) is genuinely the full matrix, correctly needs no waiver, and will track the matrix if it grows.

Guard green locally: `BcMatrixDocumentationDriftTests` 6/6, including `StaleVersionListAllowlist_HasNoDeadEntries`.

## Where the prose went

The tier measurement, what it did *not* measure, the excluded-field table and the IL-shape constraint are in **`docs/testpage-write-buffer.md`**, with one-line `see docs/...` pointers at the two call sites and on `TestPageWriteBuffer`. The equivalence claim and its citation stay in the code, per `loud-failures.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
