### PR TITLE
fix(report-metadata): resolve Sorting Fields for a precompiled-dependency report, paid once per run

### DIFF
--- a/AlRunner.Tests/DependencyReportSortingFieldsTests.cs
+++ b/AlRunner.Tests/DependencyReportSortingFieldsTests.cs
@@ -1,0 +1,344 @@
+// DependencyReportSortingFieldsTests — runner-mechanism guard for #3627.
+//
+// The gap
+// -------
+// "Report Data Items" (2000000203) answers Sorting Fields as a comma-separated list of
+// field NUMBERS. #3620 reached those numbers by reading BC's own emitted document, whose
+// DataItemTableView is already in BC's normal form — SORTING(Field5,Field2). A report from
+// a PRECOMPILED dependency has no such document: its SymbolReference.json states
+// DataItemTableView as AL SOURCE TEXT — sorting("Alt Code", Description), field NAMES —
+// and RecordPatches.FieldNumbersFrom drops every token that is not Field<N>. So the column
+// answered EMPTY for every Base Application report.
+//
+// Measured on Base Application 28.1.49838.53910's SymbolReference.json: 659 reports,
+// 1927 data items, 1795 stating a DataItemTableView and 1759 of those stating a SORTING
+// clause — 3201 sorting tokens, 988 bare identifiers and 2213 double-quoted names, and
+// ZERO in Field<N> form. Every one of them answered empty.
+//
+// Why this test is here and not in the corpus
+// -------------------------------------------
+// A corpus test is compiled from AL source BY THE RUNNER, so it takes the source-compiled
+// path where the column already answers correctly (pinned upstream by corpus PR #302).
+// The dependency path is only reachable with a precompiled .app in hand, which is the
+// structural precompiled-only case .claude/rules/bc-behavior-tests-go-upstream.md
+// describes. The BC-behaviour claim underneath ("2000000203 reports field numbers") is
+// already adjudicated upstream; what is pinned here is the runner mechanism that reaches
+// the same numbers from a symbol file's AL text.
+//
+// What would make this test vacuous
+// ---------------------------------
+// Asserting merely "not empty" would pass against any stub. Every assertion below names
+// the exact field numbers, chosen so they are neither the declaration order nor the
+// primary key: the fixture's fields are 1/2/5 and the sorting clauses name them in orders
+// that no default could produce.
+using System.Collections;
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Reflection;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Drives EnumerateKnownReports and the process-global _parsedTables / registered .app list,
+// so it takes the RecordPatches parser-statics lock for the same reason
+// DependencyReportProcessingOnlyTests does.
+[Collection(RecordPatchesSerialCollection.Name)]
+public class DependencyReportSortingFieldsTests
+{
+    private static readonly Type RecordPatchesType = typeof(RecordPatches);
+
+    // Far outside every other test's range: the registered .app list is process-global.
+    private const int QuotedNamesReportId = 88451101;
+    private const int BareNameReportId = 88451102;
+    private const int NoSortingReportId = 88451103;
+    private const int UnknownFieldReportId = 88451104;
+    private const int NormalFormReportId = 88451105;
+    private const int DepTableId = 88451190;
+
+    // The fixture table's fields are 1 / 2 / 5, deliberately non-contiguous, so a resolved
+    // answer cannot coincide with a declaration ordinal. The reports below then name them
+    // in orders that are neither field order nor primary-key order.
+    private const string SymbolReference = """
+        {
+          "RuntimeVersion": "15.1",
+          "Namespaces": [
+            {
+              "Name": "DRSF",
+              "Reports": [
+                {
+                  "Id": 88451101,
+                  "Name": "DRSF Quoted Names",
+                  "Properties": [],
+                  "DataItems": [
+                    {
+                      "Id": 11,
+                      "Name": "Src",
+                      "RelatedTable": "DRSF Sample",
+                      "Indentation": 0,
+                      "Properties": [
+                        { "Name": "DataItemTableView", "Value": "sorting(\"Alt Code\", Description)" }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Id": 88451102,
+                  "Name": "DRSF Bare Name",
+                  "Properties": [],
+                  "DataItems": [
+                    {
+                      "Id": 12,
+                      "Name": "Src",
+                      "RelatedTable": "DRSF Sample",
+                      "Indentation": 0,
+                      "Properties": [
+                        { "Name": "DataItemTableView", "Value": "sorting(Description) where(\"Alt Code\" = const('X'))" }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Id": 88451103,
+                  "Name": "DRSF No Sorting",
+                  "Properties": [],
+                  "DataItems": [
+                    {
+                      "Id": 13,
+                      "Name": "Src",
+                      "RelatedTable": "DRSF Sample",
+                      "Indentation": 0,
+                      "Properties": [
+                        { "Name": "DataItemTableView", "Value": "where(\"Alt Code\" = const('X'))" }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Id": 88451104,
+                  "Name": "DRSF Unknown Field",
+                  "Properties": [],
+                  "DataItems": [
+                    {
+                      "Id": 14,
+                      "Name": "Src",
+                      "RelatedTable": "DRSF Sample",
+                      "Indentation": 0,
+                      "Properties": [
+                        { "Name": "DataItemTableView", "Value": "sorting(\"Alt Code\", \"No Such Field\", Description)" }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Id": 88451105,
+                  "Name": "DRSF Normal Form",
+                  "Properties": [],
+                  "DataItems": [
+                    {
+                      "Id": 15,
+                      "Name": "Src",
+                      "RelatedTable": "DRSF Sample",
+                      "Indentation": 0,
+                      "Properties": [
+                        { "Name": "DataItemTableView", "Value": "SORTING(Field5,Field2) ORDER(1)" }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "Tables": [
+            {
+              "Id": 88451190,
+              "Name": "DRSF Sample",
+              "Properties": [],
+              "Fields": [
+                { "TypeDefinition": { "Name": "Integer" }, "Properties": [], "Id": 1, "Name": "Entry No." },
+                { "TypeDefinition": { "Name": "Text[50]" }, "Properties": [], "Id": 2, "Name": "Description" },
+                { "TypeDefinition": { "Name": "Code[20]" }, "Properties": [], "Id": 5, "Name": "Alt Code" }
+              ]
+            }
+          ],
+          "TableExtensions": []
+        }
+        """;
+
+    private static string WriteApp(string dir)
+    {
+        var appPath = Path.Combine(dir, Guid.NewGuid().ToString("N") + ".app");
+        using var zip = new FileStream(appPath, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(SymbolReference);
+        return appPath;
+    }
+
+    [Fact]
+    public void DependencyReportSortingClause_ResolvesQuotedFieldNamesToNumbers()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-report-sorting-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir));
+
+            // "Alt Code" is field 5 and Description is field 2, and the clause names them in
+            // that order — so the expected answer is neither field order (2,5) nor the
+            // ordinal positions of the tokens (1,2). A stub returning "" fails; one echoing
+            // declaration order fails; one sorting the numbers fails.
+            Assert.Equal("5,2", SortingFieldsOf(QuotedNamesReportId, dataItemId: 11));
+
+            // Negative direction on the same code path: a bare (unquoted) AL identifier is
+            // the other half of what a symbol file writes — 988 of Base Application's 3201
+            // sorting tokens are bare — and the WHERE clause that follows must not leak into
+            // the answer.
+            Assert.Equal("2", SortingFieldsOf(BareNameReportId, dataItemId: 12));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void DependencyReportWithNoSortingClause_AnswersEmpty()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-report-sorting-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir));
+
+            // Control: the .app really is registered and its reports really are in the
+            // inventory, so the empty assertion below is an observation, not a vacuous
+            // "nothing was loaded".
+            Assert.Equal("5,2", SortingFieldsOf(QuotedNamesReportId, dataItemId: 11));
+
+            // A data item whose view states only a WHERE clause declares no sorting, and
+            // GetSortingFieldsIfAny answers string.Empty for that on a real tier. The fix
+            // must not invent a primary key here.
+            Assert.Equal(string.Empty, SortingFieldsOf(NoSortingReportId, dataItemId: 13));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SortingToken_ThatNamesNoField_IsDroppedAndTheRestSurvive()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-report-sorting-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir));
+
+            // BC's AddSortingField traces and SKIPS a name FindFieldMatch cannot resolve, so
+            // the surrounding tokens still answer. An implementation that abandoned the whole
+            // clause on one bad token would answer ""; one that emitted a placeholder would
+            // answer "5,0,2" or leak the name.
+            Assert.Equal("5,2", SortingFieldsOf(UnknownFieldReportId, dataItemId: 14));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SortingClauseAlreadyInBcNormalForm_KeepsAnsweringFieldNumbers()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-report-sorting-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir));
+
+            // Regression guard on the path #3620 already fixed: a view already stating
+            // SORTING(Field5,Field2) must keep resolving through the Field<N> rule and must
+            // not be pushed through a name lookup that would find no field called "Field5".
+            Assert.Equal("5,2", SortingFieldsOf(NormalFormReportId, dataItemId: 15));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The cost guard #3627 exists for. Populating a virtual table enumerates EVERY report,
+    /// so a per-object field-number resolution is paid once per data item per POPULATION,
+    /// and on Base Application that is 1927 of them. This asserts the inventory is built
+    /// once and then handed back, so a later read cannot re-pay it — the property a filtered
+    /// pass/fail run cannot see, and the one whose loss blew the 60s per-test watchdog on
+    /// the first attempt at #3607.
+    /// </summary>
+    [Fact]
+    public void ReportInventory_IsBuiltOnce_AndRepeatedReadsAreCached()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-report-sorting-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir));
+
+            // First read builds the inventory (and pays whatever resolution costs).
+            var first = EnumerateKnownReports();
+            var cold = Stopwatch.StartNew();
+            var second = EnumerateKnownReports();
+            cold.Stop();
+
+            // Same LIST INSTANCE, not merely an equal one: that is what proves the second
+            // read did no work at all rather than re-deriving an identical answer quickly.
+            // An implementation that resolved lazily per read would return a fresh list here
+            // even if its answers matched.
+            Assert.Same(first, second);
+
+            // And the values survive the caching, so "cached" cannot be satisfied by caching
+            // an empty answer.
+            Assert.Equal("5,2", SortingFieldsOf(QuotedNamesReportId, dataItemId: 11));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static IEnumerable EnumerateKnownReports()
+    {
+        var m = RecordPatchesType.GetMethod("EnumerateKnownReports", BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("RecordPatches.EnumerateKnownReports not found by reflection.");
+        return (IEnumerable)m.Invoke(null, null)!;
+    }
+
+    /// <summary>
+    /// The <c>SortingFields</c> the inventory carries for one data item of one report — the
+    /// exact string BuildReportDataItemValue hands to the "Sorting Fields" column.
+    /// </summary>
+    private static string SortingFieldsOf(int reportId, int dataItemId)
+    {
+        foreach (var row in EnumerateKnownReports())
+        {
+            var t = row.GetType();
+            if ((int)t.GetProperty("Id")!.GetValue(row)! != reportId) continue;
+            var items = (IEnumerable)t.GetProperty("DataItems")!.GetValue(row)!;
+            foreach (var item in items)
+            {
+                var it = item.GetType();
+                if ((int)it.GetProperty("Id")!.GetValue(item)! != dataItemId) continue;
+                return (string)it.GetProperty("SortingFields")!.GetValue(item)!;
+            }
+            throw new InvalidOperationException(
+                $"report {reportId} is in the inventory but has no data item {dataItemId}");
+        }
+        throw new InvalidOperationException(
+            $"report {reportId} is not in the report inventory — the fixture .app did not register");
+    }
+}

--- a/AlRunner.Tests/DependencyReportSortingFieldsTests.cs
+++ b/AlRunner.Tests/DependencyReportSortingFieldsTests.cs
@@ -55,6 +55,7 @@ public class DependencyReportSortingFieldsTests
     private const int NoSortingReportId = 88451103;
     private const int UnknownFieldReportId = 88451104;
     private const int NormalFormReportId = 88451105;
+    private const int ExtensionFieldReportId = 88451106;
     private const int DepTableId = 88451190;
 
     // The fixture table's fields are 1 / 2 / 5, deliberately non-contiguous, so a resolved
@@ -132,6 +133,22 @@ public class DependencyReportSortingFieldsTests
                   ]
                 },
                 {
+                  "Id": 88451106,
+                  "Name": "DRSF Extension Field",
+                  "Properties": [],
+                  "DataItems": [
+                    {
+                      "Id": 16,
+                      "Name": "Src",
+                      "RelatedTable": "DRSF Sample",
+                      "Indentation": 0,
+                      "Properties": [
+                        { "Name": "DataItemTableView", "Value": "sorting(\"Alt Code\", \"DRSF Ext Field\")" }
+                      ]
+                    }
+                  ]
+                },
+                {
                   "Id": 88451105,
                   "Name": "DRSF Normal Form",
                   "Properties": [],
@@ -162,7 +179,16 @@ public class DependencyReportSortingFieldsTests
               ]
             }
           ],
-          "TableExtensions": []
+          "TableExtensions": [
+            {
+              "Id": 88451191,
+              "Name": "DRSF Sample Ext",
+              "TargetObject": "DRSF Sample",
+              "Fields": [
+                { "TypeDefinition": { "Name": "Code[10]" }, "Properties": [], "Id": 40, "Name": "DRSF Ext Field" }
+              ]
+            }
+          ]
         }
         """;
 
@@ -263,6 +289,40 @@ public class DependencyReportSortingFieldsTests
             // SORTING(Field5,Field2) must keep resolving through the Field<N> rule and must
             // not be pushed through a name lookup that would find no field called "Field5".
             Assert.Equal("5,2", SortingFieldsOf(NormalFormReportId, dataItemId: 15));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// A sorting token may name a field a TABLEEXTENSION added, and <c>ParsedTable.Fields</c>
+    /// does not carry one. Found by asking whether a sibling doing the same job has a guard
+    /// this one lacks: <c>TryResolveDependencyFieldId</c>, the page-control field map and the
+    /// AL page parser each resolve a dependency field name through
+    /// <c>GetAllFieldsIncludingExtensions</c>, each with its own comment saying "not
+    /// table.Fields alone" (#2490).
+    ///
+    /// <para>Base Application 28.1 has no such sorting token today — 0 of its 3201 resolve
+    /// only through an extension — so this could not have been caught by the corpus, by the
+    /// AL-level tests in this PR, or by any Base Application measurement. It would have
+    /// shipped and answered a SHORTER sort key than BC applies for the first ISV app whose
+    /// report sorts by an extension field.</para>
+    /// </summary>
+    [Fact]
+    public void SortingToken_NamingATableExtensionField_Resolves()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-report-sorting-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir));
+
+            // "Alt Code" is a base field (5) and "DRSF Ext Field" is contributed by
+            // tableextension 88451191 as field 40. Against table.Fields alone the second
+            // token is dropped and the answer is "5" — a shorter key, silently.
+            Assert.Equal("5,40", SortingFieldsOf(ExtensionFieldReportId, dataItemId: 16));
         }
         finally
         {

--- a/AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs
@@ -258,10 +258,20 @@ public static partial class RecordPatches
     /// </summary>
     private static Dictionary<string, int> BuildSortFieldIndex(ParsedTable table)
     {
+        // GetAllFieldsIncludingExtensions, not table.Fields alone — the same rule
+        // TryResolveDependencyFieldId (#2490), the page-control map and the AL page parser
+        // each state at their own call site. A report may sort by a field a TABLEEXTENSION
+        // added, and table.Fields does not carry one, so the token would be dropped and the
+        // data item would answer a SHORTER key than BC applies. Base Application 28.1 has no
+        // such token today (measured: 0 of its 3201 sorting tokens resolve only through an
+        // extension), which is exactly why this would have shipped unnoticed and broken on
+        // the first ISV app that did it.
+        // Materialised once: the source is a lazy Concat, and it is walked twice below.
+        var all = GetAllFieldsIncludingExtensions(table).ToList();
         var byName = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-        foreach (var f in table.Fields)
+        foreach (var f in all)
             byName.TryAdd(f.FieldName, f.FieldId);
-        foreach (var f in table.Fields)
+        foreach (var f in all)
             if (!string.IsNullOrEmpty(f.Caption))
                 byName.TryAdd(f.Caption!, f.FieldId);
         return byName;

--- a/AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs
@@ -246,6 +246,43 @@ public static partial class RecordPatches
         }
     }
 
+    /// <summary>
+    /// One table's AL field NAME and CAPTION index, for resolving a report data item's SORTING
+    /// tokens the way <c>NCLMetaTable.FindFieldMatch</c> does. Built from the
+    /// <see cref="ParsedTable"/> already in <c>_parsedTables</c> — a plain walk of a list
+    /// already in memory, with no symbol read and no <c>NCLMetaTable</c> construction.
+    ///
+    /// <para>Names win over captions on a collision, because <c>FindFieldMatch</c> tries
+    /// <c>TryGetFieldByName</c> before <c>TryGetFieldByCaption</c>; a caption is only added
+    /// when it does not shadow a real field name.</para>
+    /// </summary>
+    private static Dictionary<string, int> BuildSortFieldIndex(ParsedTable table)
+    {
+        var byName = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var f in table.Fields)
+            byName.TryAdd(f.FieldName, f.FieldId);
+        foreach (var f in table.Fields)
+            if (!string.IsNullOrEmpty(f.Caption))
+                byName.TryAdd(f.Caption!, f.FieldId);
+        return byName;
+    }
+
+    /// <summary>
+    /// <c>FindFieldMatch</c>'s name half, in its order: exact name (or caption, folded into the
+    /// same index above), then — because a sorting token reaches it through
+    /// <c>TableFilterResolver.ResolveField</c>, which passes <c>prefixFallback: true</c> — the
+    /// first field whose name starts with the token. Returns 0 for a token BC would answer
+    /// null for, which <c>AddSortingField</c> traces and skips.
+    /// </summary>
+    private static int ResolveSortFieldNo(Dictionary<string, int> index, string identifier)
+    {
+        if (index.TryGetValue(identifier, out var exact)) return exact;
+        foreach (var (name, no) in index)
+            if (name.StartsWith(identifier, StringComparison.OrdinalIgnoreCase))
+                return no;
+        return 0;
+    }
+
     private static object? BuildReportDataItemValue(NCLMetaField field, ReportRow report, ReportDataItemRow item)
     {
         object? Text(string s) => _aovNavTextCreateTruncated!.Invoke(null, new object?[] { field.FieldDefinedLength, s ?? string.Empty });
@@ -303,6 +340,32 @@ public static partial class RecordPatches
                 var id = ResolveTableIdByName(name);
                 tableIdCache[name] = id;
                 return id;
+            }
+
+            // #3627. A dependency report's SORTING clause names fields by AL NAME, so answering
+            // Sorting Fields for it needs a name -> number lookup. The cost is the whole reason
+            // the column was left empty, so note where it is and is not paid.
+            //
+            // Paid ONCE PER BUILD, and this method builds once per (registration epoch, parsed
+            // report count) — every population after the first is the cached list handed back.
+            // Within one build the map is memoized per TABLE, so Base Application's 1927 data
+            // items cost one map per distinct data-item table, not one per data item; the map
+            // itself is built off the ParsedTable that ResolveTable has already faulted into
+            // _parsedTables one line above, so it costs no symbol read of its own and never
+            // constructs an NCLMetaTable. That is the difference from the first attempt at
+            // #3607, which reached for the request-page-building metadata synthesizer per
+            // object and blew the 60s per-test watchdog.
+            var sortFieldMaps = new Dictionary<int, Dictionary<string, int>?>();
+
+            Func<string, int>? SortFieldResolverFor(int tableId)
+            {
+                if (tableId <= 0) return null;
+                if (!sortFieldMaps.TryGetValue(tableId, out var map))
+                {
+                    map = _parsedTables.TryGetValue(tableId, out var pt) ? BuildSortFieldIndex(pt) : null;
+                    sortFieldMaps[tableId] = map;
+                }
+                return map == null ? null : identifier => ResolveSortFieldNo(map, identifier);
             }
 
             // 1. Reports the runner source-compiled.
@@ -367,16 +430,17 @@ public static partial class RecordPatches
                     // of its reports' RequestFilterFields values are Field<N> lists. So this
                     // path reaches BC's answer with no NCLMetaTable lookup either (#3620).
                     //
-                    // Sorting Fields stays empty on this path, which is BC's own default for
-                    // a column it cannot compute. Unlike the document, a symbol file's
-                    // DataItemTableView is the AL SOURCE TEXT — sorting("Company Name"), field
-                    // NAMES — so answering it here would need a real per-table field lookup
-                    // for all 659 reports at virtual-table population time, which is the cost
-                    // this file's header records as having blown the 60s watchdog. Empty is
-                    // the honest answer; #3620's PR body records it as deliberately left.
+                    // Sorting Fields needs the name -> number lookup SortFieldResolverFor
+                    // memoizes, because a symbol file's DataItemTableView is the AL SOURCE
+                    // TEXT — sorting("Company Name"), field NAMES — where the document is
+                    // already SORTING(Field5). #3627; see SortFieldResolverFor above for
+                    // where that lookup's cost is paid and why it is not the per-object cost
+                    // this file's header records as having blown the 60s watchdog.
                     items.Add(new ReportDataItemRow(di.Id != 0 ? di.Id : ordinal, di.Name, tableId, di.Indentation,
                         di.DataItemTableView ?? string.Empty,
-                        FieldNumbersFrom(di.RequestFilterFields ?? string.Empty)));
+                        FieldNumbersFrom(di.RequestFilterFields ?? string.Empty),
+                        SortingFieldNumbersFromAlView(
+                            di.DataItemTableView ?? string.Empty, SortFieldResolverFor(tableId))));
                 }
                 if (!ok) continue;
 

--- a/AlRunner/Patches/RecordPatches.ReportRowFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.ReportRowFromBcDocument.cs
@@ -282,6 +282,185 @@ public static partial class RecordPatches
         return sb.ToString();
     }
 
+    /// <summary>
+    /// The comma-separated field NUMBERS for a data item whose <c>DataItemTableView</c> is AL
+    /// SOURCE TEXT rather than BC's compiled normal form — the shape a precompiled
+    /// dependency's SymbolReference.json states (#3627). <paramref name="fieldNoByIdentifier"/>
+    /// resolves an AL field name; a null one means the data item's table could not be
+    /// resolved, and then only the <c>Field&lt;N&gt;</c> tokens survive, exactly as before.
+    ///
+    /// <para><b>Why this exists at all.</b> <see cref="FieldNumbersFrom"/> alone is right for
+    /// BC's document, where the emitter has already resolved every token to
+    /// <c>Field&lt;N&gt;</c>. A symbol file has NOT: measured on Base Application
+    /// 28.1.49838.53910, its 659 reports carry 1927 data items, 1759 of which state a
+    /// <c>SORTING</c> clause, and all 3201 of those tokens are AL identifiers — 988 bare and
+    /// 2213 double-quoted, none in <c>Field&lt;N&gt;</c> form. So the column answered empty for
+    /// every one of them.</para>
+    ///
+    /// <para><b>The resolution order is BC's, not an approximation.</b> A sorting token reaches
+    /// <c>TableViewResolver.AddSortingField</c>, which calls
+    /// <c>TableFilterResolver.ResolveField(field, trapError: true)</c> —
+    /// <c>NCLMetaTable.FindFieldMatch(field, prefixFallback: true, trapError: true)</c>. That
+    /// method, decompiled from BC 28.1: strip a leading <c>Field</c> or <c>#</c> and use
+    /// <c>GetFieldByNo</c> when the remainder parses as an integer; else exact name, then exact
+    /// caption; else, because <c>prefixFallback</c> is true here, a name prefix then a caption
+    /// prefix; else null, which <c>AddSortingField</c> traces and SKIPS. The steps below are
+    /// that list in that order, so a token resolves to the same field BC would pick or is
+    /// dropped the same way. See docs/report-metadata-from-bc.md#sorting-fields-on-the-dependency-path.</para>
+    ///
+    /// <para><b>Cost.</b> Paid once per run, not per read: the only caller is
+    /// <c>EnumerateKnownReports</c>, whose result is cached per (registration epoch, parsed
+    /// report count), and the map it passes is memoized per table for the whole build. See
+    /// that method for why paying it per population would reproduce the #3607 watchdog
+    /// timeout.</para>
+    /// </summary>
+    private static string SortingFieldNumbersFromAlView(
+        string tableView, Func<string, int>? fieldNoByIdentifier)
+    {
+        var clause = AlSortingClauseOf(tableView);
+        if (clause.Length == 0) return string.Empty;
+
+        var sb = new System.Text.StringBuilder();
+        foreach (var raw in SplitSortingTokens(clause))
+        {
+            var token = UnquoteAlIdentifier(raw.Trim());
+            if (token.Length == 0) continue;
+
+            // Step 1 — FindFieldMatch's own first branch, before any name is consulted. A view
+            // already in BC's normal form (SORTING(Field5,Field2)) therefore still resolves
+            // here without a lookup, which is the path #3620 fixed and must not regress.
+            var stripped = token;
+            if (stripped.StartsWith("Field", StringComparison.OrdinalIgnoreCase))
+                stripped = stripped.Substring(5);
+            else if (stripped.StartsWith('#'))
+                stripped = stripped.Substring(1);
+
+            int fieldNo;
+            if (int.TryParse(stripped, out var byNumber)) fieldNo = byNumber;
+            else if (fieldNoByIdentifier == null) continue;   // no table: nothing to look up
+            else fieldNo = fieldNoByIdentifier(token);
+
+            // A token BC's FindFieldMatch would answer null for is DROPPED, not emitted as a
+            // placeholder and not allowed to abandon the rest of the clause — AddSortingField
+            // traces and moves on to the next field.
+            if (fieldNo <= 0) continue;
+
+            if (sb.Length > 0) sb.Append(',');
+            sb.Append(fieldNo);
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// The <c>sorting(...)</c> body of a view written as AL SOURCE TEXT, which differs from
+    /// <see cref="SortingClauseOf"/> in the two ways that matter, both measured on Base
+    /// Application 28.1's SymbolReference.json:
+    ///
+    /// <para>1. <b>The keyword is lowercase.</b> AL writes <c>sorting(</c>; BC's compiled
+    /// normal form writes <c>SORTING(</c>. <see cref="SortingClauseOf"/> matches
+    /// <c>StringComparison.Ordinal</c>, correctly, because the document it reads is always in
+    /// BC's form — pointing it at AL text answers empty for every one of the 1759 data items
+    /// that state a clause, which is exactly the #3627 symptom.</para>
+    ///
+    /// <para>2. <b>The body can contain a <c>)</c>.</b> The document's form cannot, so
+    /// <see cref="SortingClauseOf"/> ends the clause at the first one. AL text can:
+    /// <c>sorting("Amount (LCY)")</c> is a legal field name, and a quoted identifier is where
+    /// a parenthesis hides. So the close is matched by depth, ignoring anything inside AL
+    /// quotes.</para>
+    ///
+    /// <para>Kept separate rather than widening <see cref="SortingClauseOf"/>: that method is
+    /// on the document path, where a case-insensitive match would also accept a WHERE-clause
+    /// filter value that happens to spell "sorting(", and where the first-<c>)</c> rule is a
+    /// stated property of the input rather than a shortcut.</para>
+    /// </summary>
+    private static string AlSortingClauseOf(string tableView)
+    {
+        const string marker = "sorting";
+        int start = -1;
+        for (int i = 0; i + marker.Length <= tableView.Length; i++)
+        {
+            // Skip over a quoted identifier so a field named "Sorting Code" cannot be read as
+            // the keyword.
+            if (tableView[i] == '"')
+            {
+                i = SkipAlQuoted(tableView, i) - 1;
+                continue;
+            }
+            if (string.Compare(tableView, i, marker, 0, marker.Length, StringComparison.OrdinalIgnoreCase) != 0)
+                continue;
+            // A keyword, not the tail of a longer identifier.
+            if (i > 0 && (char.IsLetterOrDigit(tableView[i - 1]) || tableView[i - 1] == '_')) continue;
+            int j = i + marker.Length;
+            while (j < tableView.Length && char.IsWhiteSpace(tableView[j])) j++;
+            if (j < tableView.Length && tableView[j] == '(') { start = j + 1; break; }
+        }
+        if (start < 0) return string.Empty;
+
+        int depth = 1;
+        for (int i = start; i < tableView.Length; i++)
+        {
+            var c = tableView[i];
+            if (c == '"') { i = SkipAlQuoted(tableView, i) - 1; continue; }
+            if (c == '(') depth++;
+            else if (c == ')' && --depth == 0) return tableView.Substring(start, i - start);
+        }
+        // Unbalanced: the AL compiler would not have produced this, so there is no clause to
+        // read rather than a truncated guess.
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// A <c>SORTING(...)</c> body split on the commas that separate fields, ignoring commas
+    /// inside an AL quoted identifier. <c>sorting("Posting Date", "Document No.")</c> is the
+    /// ordinary case, but a field may legitimately be named <c>"Amount, LCY"</c>, and splitting
+    /// that on a bare <c>,</c> yields two tokens that resolve to nothing — dropping a field
+    /// BC would have sorted by.
+    /// </summary>
+    private static List<string> SplitSortingTokens(string clause)
+    {
+        var result = new List<string>();
+        var current = new System.Text.StringBuilder();
+        bool inQuotes = false;
+        for (int i = 0; i < clause.Length; i++)
+        {
+            var c = clause[i];
+            if (c == '"')
+            {
+                // AL doubles a literal quote inside an identifier; both halves stay in the
+                // token so UnquoteAlIdentifier can collapse them.
+                if (inQuotes && i + 1 < clause.Length && clause[i + 1] == '"')
+                {
+                    current.Append('"').Append('"');
+                    i++;
+                    continue;
+                }
+                inQuotes = !inQuotes;
+                current.Append(c);
+                continue;
+            }
+            if (c == ',' && !inQuotes)
+            {
+                result.Add(current.ToString());
+                current.Clear();
+                continue;
+            }
+            current.Append(c);
+        }
+        if (current.Length > 0) result.Add(current.ToString());
+        return result;
+    }
+
+    /// <summary>
+    /// An AL quoted identifier reduced to the name BC matches on: the surrounding quotes
+    /// removed and a doubled <c>""</c> collapsed to one. A bare identifier is returned
+    /// unchanged — 988 of Base Application's 3201 sorting tokens are bare.
+    /// </summary>
+    private static string UnquoteAlIdentifier(string token)
+    {
+        if (token.Length < 2 || token[0] != '"' || token[^1] != '"') return token;
+        return token.Substring(1, token.Length - 2).Replace("\"\"", "\"");
+    }
+
     private static string ReadBcText(XmlElement parent, string name)
     {
         foreach (XmlNode child in parent.ChildNodes)

--- a/docs/report-metadata-from-bc.md
+++ b/docs/report-metadata-from-bc.md
@@ -191,11 +191,78 @@ A precompiled dependency report has no emitted document, so it keeps its
 `Field<N>` lists** (the other 1294 data items state the property not at all). The same
 `FieldNumbersFrom` therefore lands on BC's answer for every one of them.
 
-`Sorting Fields` does **not** follow, and stays empty on that path. A symbol file's
-`DataItemTableView` is the AL *source text* — `sorting("Company Name")`, field names — not the
-compiled form, so answering it would need a real per-table field lookup for all 659 reports at
-virtual-table population time. That is the cost recorded above as having blown the 60s
-watchdog, and BC's type default is the honest answer until something cheaper exists.
+`Sorting Fields` does **not** follow from the same rule, and needed its own mechanism —
+[below](#sorting-fields-on-the-dependency-path).
+
+<a id="sorting-fields-on-the-dependency-path"></a>
+
+### `Sorting Fields` on the dependency path (#3627)
+
+A symbol file's `DataItemTableView` is the AL *source text*, not the compiled form. Measured on
+BC 28.1's Base Application `SymbolReference.json`: its **659 reports carry 1927 data items, 1795
+of which state a `DataItemTableView` and 1759 of those a `SORTING` clause — 3201 sorting tokens
+in total, 988 bare identifiers and 2213 double-quoted names, and none in `Field<N>` form.** So
+`FieldNumbersFrom`, which drops every token that is not `Field<N>`, answered empty for all 1759.
+
+Two things had to be different from the document path:
+
+| | document (`SortingClauseOf`) | AL text (`AlSortingClauseOf`) |
+|---|---|---|
+| keyword | `SORTING(`, matched `Ordinal` | `sorting(`, matched case-insensitively |
+| clause end | the first `)` — a field token cannot contain one | matched by depth, ignoring AL quotes: `sorting("Amount (LCY)")` is a legal name |
+
+Pointing the document's parser at AL text answers empty for every one of the 1759, which is the
+symptom the issue records. The two are kept as separate methods rather than one widened one: on
+the document path a case-insensitive match would also accept a `WHERE` filter value that happens
+to spell `sorting(`, and the first-`)` rule there is a stated property of the input.
+
+#### The resolution order is BC's
+
+A sorting token reaches `TableViewResolver.AddSortingField`, which calls
+`TableFilterResolver.ResolveField(field, trapError: true)` —
+`NCLMetaTable.FindFieldMatch(field, prefixFallback: true, trapError: true)`. Decompiled from BC
+28.1, that method is, in order:
+
+1. strip a leading `Field` or `#`; if the remainder parses as an integer, `GetFieldByNo`;
+2. else `TryGetFieldByName`, then `TryGetFieldByCaption`;
+3. else — `prefixFallback` is `true` on this path — the first field whose *name*, then whose
+   *caption*, starts with the token;
+4. else `null`, which `AddSortingField` traces and **skips**, keeping the rest of the clause.
+
+`BuildSortFieldIndex` / `ResolveSortFieldNo` are that list. Step 1 is why a view already in BC's
+normal form still resolves here without a lookup, so the #3620 path does not regress; step 4 is
+why one unresolvable token does not discard the fields around it.
+
+`BuildSortFieldIndex` reads `GetAllFieldsIncludingExtensions`, not `ParsedTable.Fields` — the
+same rule `TryResolveDependencyFieldId`, the page-control field map and the AL page parser each
+state at their own call site (#2490). Base Application 28.1 has **0 of its 3201 sorting tokens**
+resolving only through a tableextension, so this is unmeasurable there and would have shipped
+answering a silently *shorter* sort key for the first ISV app whose report sorts by an extension
+field. `AlRunner.Tests/DependencyReportSortingFieldsTests.SortingToken_NamingATableExtensionField_Resolves`
+pins it.
+
+#### Where the cost is paid
+
+The cost is the whole reason the column was left empty, so: the lookup is paid **once per run**,
+not per population. `EnumerateKnownReports` caches its result per (registration epoch, parsed
+report count), so every population after the first hands back the same list; within one build the
+name index is memoized per *table*, so 1927 data items cost one index per distinct data-item
+table; and each index is built off the `ParsedTable` that `ResolveTableIdByName` has already
+faulted into `_parsedTables` one line above, so it costs no symbol read and constructs no
+`NCLMetaTable`.
+
+Measured end to end on the real Base Application — `tests/runner-extras/standalone-suites`
+filtered to codeunit 61952, which loads all 660 dependency reports, five warm reps per arm on one
+box, BC 28.1.49838.53910:
+
+| | test-run phase | codeunit 61952 |
+|---|---|---|
+| before | 2.6 / 2.7 / 2.7 / 2.5 / 2.8 s — mean **2.66 s** | 6 of 9 passing |
+| after | 2.7 / 2.5 / 2.7 / 2.8 / 2.6 s — mean **2.66 s** | 9 of 9 passing |
+
+No measurable cost. The contrast is with the first attempt at #3607, which reached for the
+request-page-building metadata synthesizer *per object* and blew the 60s per-test watchdog; that
+is a per-population cost, and this is not one.
 
 ### What the AL parser lost
 

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -2125,3 +2125,21 @@ at `23a9e869` and carried `expect-oos` entries in
 `tests/expectations/oos-date-virtual-table.json`, which this PR deletes.
 
 Written by the fbk-3 agent.
+
+## runner-extras `standalone-suites` 113 -> 116 (#3627)
+
+Three new AL tests in codeunit 61952 "RMVT Tests", reading `Sorting Fields` off
+`Report Data Items` (2000000203) for a report that lives in a PRECOMPILED dependency — the path
+the existing tests in that codeunit never took, because every report they read was source-compiled
+by the runner moments earlier.
+
+`standalone-suites` declares `"application": "27.0.0.0"`, so Base Application is loaded and its
+660 reports are in the inventory. The three arms read two of them: report 1306 root data item
+answers `3` (Sales Invoice Header `"No."`, resolved from the symbol file's `sorting("No.")` — not
+field 1, so no primary-key default produces it) and its VATAmountLine answers `5,9,10,13,16`; and
+report 705, where one data item states only a `where(...)` and must answer empty while its sibling
+answers `1,3,2`. Before this PR all three read empty.
+
+Measured 116P/0F/0E on the whole bundle, not computed from the diff.
+
+Written by an agent (Claude, `stma-auto-2`).

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -56,7 +56,7 @@
         "server-reload-main": { "tests": 1 },
         "session-user-row": { "tests": 4 },
         "source-tableext-relation": { "tests": 5 },
-        "standalone-suites": { "tests": 113 },
+        "standalone-suites": { "tests": 116 },
         "static-runmodal-record": { "tests": 5 },
         "table-connection-live-oos": { "tests": 2 },
         "tableext-eviction-field-trigger-timing": { "tests": 2 },

--- a/tests/runner-extras/standalone-suites/report-metadata-virtual-table/RmvtTests.Codeunit.al
+++ b/tests/runner-extras/standalone-suites/report-metadata-virtual-table/RmvtTests.Codeunit.al
@@ -142,4 +142,100 @@ codeunit 61952 "RMVT Tests"
             Error('Report Data Items returned %1 row(s) for report 61951, which declares no dataset at all.',
                 ReportDataItems.Count());
     end;
+
+    // ── The dependency path (#3627) ────────────────────────────────────────
+    //
+    // Everything above reads a report the runner SOURCE-COMPILED moments ago,
+    // whose Sorting Fields come from BC's own emitted document (#3620). The
+    // tests below read Base Application report 1306, which lives in a
+    // PRECOMPILED dependency: it has no emitted document at all, so its row is
+    // built from that .app's SymbolReference.json, where DataItemTableView is
+    // AL SOURCE TEXT — sorting("Document No.", "Line No."), field NAMES.
+    //
+    // Before #3627 the runner dropped every token that was not Field<N> and
+    // answered EMPTY here, for all 1759 of Base Application's data items that
+    // state a SORTING clause. The expected values below are field NUMBERS
+    // resolved through those names, and each is chosen so no default can
+    // produce it: Sales Invoice Header."No." is field 3, not field 1, so a
+    // provider echoing the primary key or the first field fails immediately.
+
+    [Test]
+    procedure ReportDataItems_SortingFieldsOfAPrecompiledDependencyReport()
+    var
+        ReportDataItems: Record "Report Data Items";
+    begin
+        // Root data item of Base App 1306 "Standard Sales - Invoice":
+        // dataitem Header over Sales Invoice Header, sorting("No.").
+        // "No." is field 3 of table 112 — NOT field 1 — so "3" cannot come
+        // from a field ordinal, a declaration order, or a primary-key default.
+        ReportDataItems.SetRange("Report ID", 1306);
+        ReportDataItems.SetRange("Indentation Level", 0);
+        if not ReportDataItems.FindFirst() then
+            Error('Report Data Items had no Indentation Level 0 row for Base Application report 1306.');
+
+        if ReportDataItems."Sorting Fields" <> '3' then
+            Error('Report 1306 root data item Sorting Fields was "%1", expected "3" — Sales Invoice Header."No." resolved from the dependency symbol file''s sorting("No.").',
+                ReportDataItems."Sorting Fields");
+    end;
+
+    [Test]
+    procedure ReportDataItems_MultiFieldSortingOfADependencyReportKeepsClauseOrder()
+    var
+        ReportDataItems: Record "Report Data Items";
+    begin
+        // dataitem VATAmountLine over VAT Amount Line, sorting("VAT Identifier",
+        // "VAT Calculation Type", "Tax Group Code", "Use Tax", Positive) —
+        // fields 5, 9, 10, 13 and 16. Five tokens, non-contiguous, and the last
+        // one is BARE (unquoted), which is the other spelling a symbol file
+        // uses. The order is the CLAUSE's, not ascending by chance: any
+        // implementation that sorted, deduplicated, or dropped the bare token
+        // answers something else.
+        ReportDataItems.SetRange("Report ID", 1306);
+        ReportDataItems.SetRange(Name, 'VATAmountLine');
+        if not ReportDataItems.FindFirst() then
+            Error('Report Data Items had no VATAmountLine row for Base Application report 1306.');
+
+        if ReportDataItems."Sorting Fields" <> '5,9,10,13,16' then
+            Error('Report 1306 VATAmountLine Sorting Fields was "%1", expected "5,9,10,13,16".',
+                ReportDataItems."Sorting Fields");
+    end;
+
+    // Negative: a dependency data item whose view states a WHERE clause but NO
+    // sorting(...) must answer EMPTY, not a fabricated primary key. This is
+    // BC's own answer — GetSortingFieldsIfAny returns string.Empty — and it is
+    // what stops the two tests above from being satisfied by an implementation
+    // that always says something. Base Application report 705 "Inventory
+    // Availability" carries one data item of each kind, so both directions are
+    // measured on the same report through the same code path.
+    [Test]
+    procedure ReportDataItems_DependencyDataItemWithNoSortingClauseAnswersEmpty()
+    var
+        ReportDataItems: Record "Report Data Items";
+    begin
+        // dataitem Item, view where(Type = const(Inventory)) — a filter and no
+        // sorting at all. Item's primary key is field 1, so an implementation
+        // defaulting to the primary key would answer "1" here.
+        ReportDataItems.SetRange("Report ID", 705);
+        ReportDataItems.SetRange(Name, 'Item');
+        if not ReportDataItems.FindFirst() then
+            Error('Report Data Items had no Item row for Base Application report 705.');
+
+        if ReportDataItems."Sorting Fields" <> '' then
+            Error('Report 705 data item Item states only where(Type = const(Inventory)) and no sorting(...), so Sorting Fields must be empty; it was "%1".',
+                ReportDataItems."Sorting Fields");
+
+        // Control, same report and same code path: the sibling data item DOES
+        // state a clause and must answer its field numbers — so the empty
+        // answer above is a real distinction, not a report the runner failed to
+        // read at all. Stockkeeping Unit sorts ("Location Code", "Variant Code",
+        // "Item No.") = 1,3,2 — an order that is neither ascending nor field
+        // order, so it cannot be produced by sorting or by echoing a key.
+        ReportDataItems.SetRange(Name, 'Stockkeeping Unit');
+        if not ReportDataItems.FindFirst() then
+            Error('Report Data Items had no Stockkeeping Unit row for Base Application report 705.');
+
+        if ReportDataItems."Sorting Fields" <> '1,3,2' then
+            Error('Report 705 data item Stockkeeping Unit Sorting Fields was "%1", expected "1,3,2".',
+                ReportDataItems."Sorting Fields");
+    end;
 }


### PR DESCRIPTION
Closes #3627

Corpus-NA: structurally precompiled-only — a corpus test is compiled from AL source BY THE RUNNER, so it takes the source-compiled path where this column already answers correctly (pinned upstream by corpus PR #302, merged, 4 tests green on 8 cloud legs); the broken path is only reachable with a precompiled dependency .app in hand

`Report Data Items` (2000000203) answered **`Sorting Fields` as empty for every report from a
precompiled dependency**, while answering correctly for a source-compiled one. #3620 reached the
column's field numbers by reading BC's emitted document, whose `DataItemTableView` is already
`SORTING(Field5,Field2)`. A dependency report has no document: its `SymbolReference.json` states
that property as **AL source text** — `sorting("Company Name")`, field *names* — and
`FieldNumbersFrom` drops every token that is not `Field<N>`.

## What the symbol file actually contains

Measured on `Microsoft_Base Application_28.1.49838.53910.app`'s own `SymbolReference.json`:

| | |
|---|---|
| reports | 659 |
| data items | 1927 |
| stating a `DataItemTableView` | 1795 |
| **stating a `SORTING` clause** | **1759** |
| sorting tokens across those | 3201 — **988 bare identifiers, 2213 double-quoted, 0 in `Field<N>` form** |

So the column answered empty 1759 times out of 1759.

## The fix, and where its cost is paid

The issue is explicit that **the cost is the whole problem** — a naive per-object resolution is
paid 659 times at population time and blew the 60s watchdog on the first attempt at #3607. So:

- The only caller is `EnumerateKnownReports`, which **already caches per (registration epoch,
  parsed report count)** — every population after the first hands back the same list. A new test
  asserts `Assert.Same(first, second)`, so a future lazy-per-read implementation fails rather than
  quietly reintroducing the per-population cost.
- Within one build the name index is memoized **per table**, so 1927 data items cost one index per
  distinct data-item table, not one per data item.
- Each index is built off the `ParsedTable` that `ResolveTableIdByName` has *already* faulted into
  `_parsedTables` one line above — no symbol read of its own, and **no `NCLMetaTable` construction**,
  which is what the #3607 attempt reached for.

### Measured, on the real Base Application

`tests/runner-extras/standalone-suites` filtered to codeunit 61952 — which loads all **660**
dependency reports (`[report-metadata] 666 report(s) known … 660 of them from dependency symbols`).
Five warm reps per arm, same box, BC 28.1.49838.53910. The two arms differ only in the two
`AlRunner/Patches/` files:

| | test-run phase, 5 warm reps | mean | codeunit 61952 |
|---|---|---|---|
| before | 2.6 / 2.7 / 2.7 / 2.5 / 2.8 s | **2.66 s** | 6 of 9 passing |
| after | 2.7 / 2.5 / 2.7 / 2.8 / 2.6 s | **2.66 s** | **9 of 9 passing** |

**No measurable cost**, with three more tests passing. Cold reps were 15.7-16.2 s before and
17.4 s after, dominated by AL emit and compile.

This is a whole-bundle run against 660 real reports, not a filtered unit test, so it is the shape
that would show a per-population regression: the same suite is what the numbers above come from.

## The resolution order is BC's, decompiled — not an approximation

A sorting token reaches `TableViewResolver.AddSortingField` → `TableFilterResolver.ResolveField(field, trapError: true)`
→ `NCLMetaTable.FindFieldMatch(field, prefixFallback: true, trapError: true)`. From BC 28.1's
`Ncl.dll`, in order: strip a leading `Field`/`#` and use `GetFieldByNo` if the remainder parses as
an integer; else exact name, then exact caption; else — `prefixFallback` is `true` here — a name
prefix then a caption prefix; else `null`, which `AddSortingField` **traces and skips**, keeping
the rest of the clause. The implementation is that list in that order.

Two consequences that are tested rather than assumed: a view already in BC's normal form still
resolves through step 1 without any lookup, so **#3620's path does not regress**; and one
unresolvable token does not discard the fields around it.

## Fixing the shape, not the reported line

**Q1 — the same wrong pattern at another call site?** `SortingClauseOf` has exactly one caller
(the document path, where it is correct). `AlSortingClauseOf` is new and separate rather than a
widened `SortingClauseOf`, because on the document path a case-insensitive match would also accept
a `WHERE` filter value spelling `sorting(`, and the first-`)` rule there is a stated property of
the input. AL text needs both: the keyword is lowercase, and the clause can contain a `)` —
`sorting("Amount (LCY)")` is a legal field name — so the close is matched by depth, ignoring quotes.

**Q2 — a sibling making the same assumption?** `DependencyPageMetadataXml.EmitSourceTableViewXml`
does the same job for a page's `SourceTableView`. It already resolves structurally through
`TryResolveDependencyFieldId`; not a sibling defect.

**Q3 — two paths writing the same state, one with a guard the other lacks? YES, and this is the
find.** `TryResolveDependencyFieldId`, the page-control field map and the AL page parser each
resolve a dependency field name through **`GetAllFieldsIncludingExtensions`, not `ParsedTable.Fields`**,
each with its own comment saying so (#2490): a field name may be one a **tableextension** added.
My first implementation used `table.Fields` and was the odd one out.

Base Application 28.1 has **0 of its 3201 sorting tokens** resolving only through an extension, so
this is unmeasurable there — it would have shipped green and answered a silently **shorter** sort
key for the first ISV app whose report sorts by an extension field.
`SortingToken_NamingATableExtensionField_Resolves` pins it, and is genuinely RED against
`table.Fields`: `Expected: "5,40" / Actual: "5"`.

## Not made to throw — deliberately

Empty is BC's own answer here (`GetSortingFieldsIfAny` returns `string.Empty` on two of its own
paths). The two OOS factories in `RecordPatches.ReportMetadataVirtualTable.cs` are for the
*infrastructure* refusal at `:147`/`:172` ("data access has no in-memory provider"); throwing
per-column would make every Base Application report unreadable through 2000000203. Per the issue,
this is explicitly not a `loud-failures.md` case, and the negative tests below assert the empty
answer where BC gives one.

`RequestFilterFields` was already correct on both paths (633 of 659 state it, all `Field<N>`) and
is untouched.

## RED → GREEN

**C# mechanism tests** — `AlRunner.Tests/DependencyReportSortingFieldsTests.cs`, 6 tests, driving a
fixture `.app` whose table has fields **1 / 2 / 5** (non-contiguous, so no answer can coincide with
a declaration ordinal). RED before the fix: `Expected: "5,2" / Actual: ""`.

| test | asserts |
|---|---|
| `...ResolvesQuotedFieldNamesToNumbers` | `"5,2"` — clause order, not field order, not ordinals; plus a bare identifier answering `"2"` with the following `where(...)` not leaking in |
| `...WithNoSortingClause_AnswersEmpty` | empty for a view stating only `where(...)`, with a passing control so it is not vacuous |
| `SortingToken_ThatNamesNoField_IsDroppedAndTheRestSurvive` | `"5,2"` across an unresolvable middle token — BC's skip, not an abandoned clause or a `0` placeholder |
| `SortingClauseAlreadyInBcNormalForm_...` | `"5,2"` — the #3620 path does not regress |
| `SortingToken_NamingATableExtensionField_Resolves` | `"5,40"` — the Q3 find |
| `ReportInventory_IsBuiltOnce_AndRepeatedReadsAreCached` | `Assert.Same` on two reads — the cost guard |

**AL tests against the real Base Application** — 3 added to codeunit 61952 (`RmvtTests.Codeunit.al`),
which reach the dependency path because `standalone-suites` declares `"application": "27.0.0.0"`:

- report **1306** root data item → `3` (Sales Invoice Header `"No."` — field 3, *not* 1, so a
  primary-key or first-field default fails here);
- report **1306** `VATAmountLine` → `5,9,10,13,16` — five non-contiguous fields in clause order,
  the last token bare, so sorting/dedup/dropping-the-bare-token all answer something else;
- report **705**: the `Item` data item states only `where(Type = const(Inventory))` and must answer
  **empty** (Item's PK is field 1, so a PK default answers `1`), while its sibling
  `Stockkeeping Unit` answers `1,3,2` — an order that is neither ascending nor field order.

All three read empty before this PR.

## What was run

- `AlRunner.Tests --filter FullyQualifiedName~DependencyReportSortingFieldsTests` — **6/6**, and
  RED confirmed twice by reverting (once for the whole fix, once for the extension guard alone).
- `AlRunner.Tests --filter FullyQualifiedName~Report` — **324 passed, 0 failed**, 29 skipped.
- `tests/runner-extras/standalone-suites`, whole bundle — **116/116**, 0 failed, 0 errors.
- `tools/test_doc_pointers.py` — all checks pass, including the new
  `docs/report-metadata-from-bc.md#sorting-fields-on-the-dependency-path` anchor the code points at.

## Where the prose went

The derivation — the leg-by-leg symbol measurement, the decompiled `FindFieldMatch` walk, the
before/after timing table — is in `docs/report-metadata-from-bc.md` under a new anchored section,
with a one-line pointer at the call site. The claim and its citation stay in the code.

## Queue scan — what did NOT fold

Scanned the open queue for `area: metadata-conversion` and for report/data-item/2000000203. Nothing
folds, and the near misses are worth naming:

- **#3382** (dependency dataitem `CalcFields` dropped) and **#3374** (dependency dataitem
  `MaxIteration` dropped) are the closest in shape — same "a dependency report's data-item property
  is lost" family. Both are `status: blocked` / `blocked-by: metadata-emitter`, and both land in
  `BcAppSymbolCache.cs` and `DependencyReportMetadata.cs`, not in either file this PR touches. Not
  same-file, so not folded. (#3374's body is also stale on one point: `MaxIteration` *is* parsed
  now — `ReportDataItemSymbol` carries it and `CollectReportDataItems` reads it.)
- **#3562** is the tracking issue this conversion chain hangs off; it stays open.
- **#2297** (report 1306 resolves no valid layout) touches the same report id and nothing else in
  common — layout resolution, a different subsystem.

## Files held by others

`AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs` (PRs #3632/#3645) is **not touched** — no
part of this fix needed it. Checked every open PR's file list against all four files here: no
overlap.

## Deliberately left

`ParsedTable.Fields` carries no `Caption` for most dependency tables, so `FindFieldMatch`'s
caption-match and caption-prefix steps are implemented but will usually find nothing. That is
strictly better than before (they were absent) and is the same limitation the sibling resolvers
have; no Base Application sorting token needs them.

---

Written by an agent (Claude, `stma-auto-2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
