### PR TITLE
docs(page-control-field): name the corpus PR that adjudicates the two unmeasured columns

### DIFF
--- a/AlRunner.Tests/PageControlFieldDocumentTests.cs
+++ b/AlRunner.Tests/PageControlFieldDocumentTests.cs
@@ -16,10 +16,15 @@
 //     `int.TryParse` a faithful reproduction of ControlDefinition.IsBoundToTableField;
 //   * an unbound control's source expression lives in <Expressions>, keyed by that same
 //     DataColumnName, and nowhere on the control element itself;
-//   * Enabled/Visible are omitted when defaulted while Editable is omitted when defaulted
-//     AND has no default, which is why the three are not filled in the same way.
+//   * Enabled, Editable and Visible are all omitted from the document when defaulted, so
+//     the document alone does not say what the virtual table's column then reports.
 //
 // docs/page-control-field-from-bc-document.md has the measurements behind all three.
+//
+// This file asserts what the emitted DOCUMENT contains and deliberately stops there. It
+// used to carry the further inference that an undeclared Editable makes the COLUMN answer
+// "" — refuted by corpus codeunit 60424 on eight cloud legs (run 34329910568), which
+// answered "True". #3653 is correcting the runner.
 
 using Xunit;
 
@@ -253,14 +258,18 @@ public sealed class PageControlFieldDocumentTests : IDisposable
         Assert.Equal("false", Named(controls, "PcfDocHidden").GetAttribute("Visible"));
         Assert.Equal("false", Named(controls, "PcfDocEditable").GetAttribute("Editable"));
 
-        // Negative, and the asymmetry the fix turns on: an UNDECLARED property is absent from
-        // the document, so what the column reports is whatever BC's deserializer supplies.
-        // ControlDefinition carries [DefaultValue("true")] on Enabled and Visible and NONE on
-        // Editable, so Enabled/Visible read "true" and Editable reads "". Substituting "true"
-        // for all three — which the AL derivation did — is therefore wrong for exactly one of
-        // them. See docs/page-control-field-from-bc-document.md#the-three-property-defaults.
-        // Corpus PR #310 (codeunit 60424) puts the Editable half in front of a real tier;
-        // until its cloud legs report, the "" answer is a reading, not a measurement.
+        // Negative: an UNDECLARED property is simply absent from the emitted document. That
+        // is all this test claims, and it is the part that is measured — what the virtual
+        // table COLUMN then reports is a separate question this test does not answer.
+        //
+        // Do not restore the inference that used to sit here. It read the absent attribute
+        // plus ControlDefinition's [DefaultValue] attributes ("true" on Enabled/Visible, none
+        // on Editable) as meaning the column answers "" for an undeclared Editable. Corpus
+        // codeunit 60424 asked a real tier and all eight cloud legs answered "True"
+        // (run 34329910568). A property read off a freshly constructed instance is not
+        // evidence about what the provider reports for a DESERIALIZED one. #3653 is
+        // correcting CollectBcPageControls; see
+        // docs/page-control-field-from-bc-document.md#the-three-property-defaults.
         var plain = Named(controls, "Entry No.");
         Assert.False(plain.HasAttribute("Enabled"));
         Assert.False(plain.HasAttribute("Editable"));

--- a/AlRunner.Tests/PageControlFieldDocumentTests.cs
+++ b/AlRunner.Tests/PageControlFieldDocumentTests.cs
@@ -258,8 +258,9 @@ public sealed class PageControlFieldDocumentTests : IDisposable
         // ControlDefinition carries [DefaultValue("true")] on Enabled and Visible and NONE on
         // Editable, so Enabled/Visible read "true" and Editable reads "". Substituting "true"
         // for all three — which the AL derivation did — is therefore wrong for exactly one of
-        // them. See docs/page-control-field-from-bc-document.md#the-three-property-defaults;
-        // #3625 tracks getting the Editable half in front of a real tier.
+        // them. See docs/page-control-field-from-bc-document.md#the-three-property-defaults.
+        // Corpus PR #310 (codeunit 60424) puts the Editable half in front of a real tier;
+        // until its cloud legs report, the "" answer is a reading, not a measurement.
         var plain = Named(controls, "Entry No.");
         Assert.False(plain.HasAttribute("Enabled"));
         Assert.False(plain.HasAttribute("Editable"));

--- a/docs/page-control-field-from-bc-document.md
+++ b/docs/page-control-field-from-bc-document.md
@@ -14,9 +14,9 @@ The corpus adjudication for this one is
 [corpus PR #300](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/300)
 (page 60427, codeunit 60426), extended by
 [corpus PR #310](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/310)
-(page 60425, codeunit 60424) for the two columns #300 left unmeasured — see
-[the three property defaults](#the-three-property-defaults) and
-[`OptionString` and Enum](#option-and-enum).
+(page 60425, codeunit 60424) for the two columns #300 left unmeasured. #310 settled the
+`Enum`-bound [`OptionString`](#option-and-enum) in the runner's favour and **refuted** the
+undeclared-[`Editable`](#the-three-property-defaults) reading, which #3653 is correcting.
 
 <a id="what-bc-does"></a>
 
@@ -168,7 +168,16 @@ is why it is written down here rather than left implicit at the call site.
 
 <a id="the-three-property-defaults"></a>
 
-## The three property defaults, and why `Editable` is not `"true"`
+## The three property defaults
+
+> **The `Editable` half of this section is REFUTED and is being rewritten by
+> [#3653](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3653).** Corpus
+> codeunit 60424 asked a real service tier what the column reports for a control declaring no
+> `Editable` property, and all eight cloud legs of run `34329910568` answered **`True`** —
+> `Assert.AreEqual failed. Expected:<> (Text). Actual:<True> (Text)`. The runner answers `''`,
+> so this is a live runner defect, not a documentation lag. Read nothing below about
+> `Editable` as current. `Enabled` and `Visible` are unaffected: both were asked in the same
+> codeunit and both answered `'true'` on all eight legs, as this section says.
 
 `Enabled`, `Editable` and `Visible` are **text** columns carrying the declared property
 expression, so a control with `Visible = NoFieldVisible` reports the variable's name. The
@@ -186,33 +195,26 @@ and reading each property off a fresh instance:
 | `Editable` | **no** | **`null`** |
 
 `Enabled` and `Visible` therefore default to `"true"`, which is what the AL derivation already
-substituted and what corpus codeunit 60921 pins for `Visible`. `Editable` does **not**: BC
-passes the null straight to `NavText.CreateTruncated`, which renders it as the empty string.
-The AL derivation substituted `"true"` there too, so this change makes `Editable` answer `""`
-for a control that does not declare it.
+substituted and what corpus codeunit 60921 pins for `Visible` — and codeunit 60424 has since
+confirmed both on eight cloud legs.
 
-The table above was re-measured for #3625 on **27.0, 27.5, 28.1 and 28.4**, and every cell is
-identical on all four — so the asymmetry is a stable property of the type across the whole
-matrix, not a quirk of one build. `Editable` is declared on `ControlDataboundDefinition`
-while `Enabled` and `Visible` are declared on `UIElementDefinition`, which is the structural
-reason the three do not share a default.
+~~`Editable` does **not**: BC passes the null straight to `NavText.CreateTruncated`, which
+renders it as the empty string. The AL derivation substituted `"true"` there too, so this
+change makes `Editable` answer `""` for a control that does not declare it.~~ **Refuted —
+the tier answers `True`; see the note at the top of this section. #3653 replaces this
+paragraph with the measurement.**
 
-**That last cell is still measured from BC's own type, not from a service tier.** No *merged*
-corpus test pins `Editable` — codeunit 60921 pins `Visible` only, and corpus PR #300's
-codeunit 60426 asserts `Editable` nowhere. So the claim rests on the reflection measurement
-above plus BC's decompiled `array[7] = NavText.CreateTruncated(len, control.Editable)`, and
-not on a real tier having answered it. It is the honest reading of both, and it is the kind
-of claim `.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md` says to name rather
-than to assert quietly.
+**What the tier refuted was the inference, not the reflection.** The table above re-measures
+identically on every build it was tried on, and `Editable` is genuinely declared on
+`ControlDataboundDefinition` while `Enabled` and `Visible` come from `UIElementDefinition` —
+that structural difference is real and unrefuted. What does not follow is the step from *a
+fresh reflected instance's field value* to *what the column reports*: something between
+deserialization and `GetControlsOnPage` supplies a default that a bare `Activator`-constructed
+instance never sees. #3653 owns finding it and correcting `CollectBcPageControls`.
 
-[Corpus PR #310](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/310)
-(codeunit 60424, page 60425), filed for #3625, is what settles it: it asserts all three
-columns on one control that declares none of them, so the asymmetry is pinned rather than
-assumed, plus the declared-`false` direction for `Editable` and `Enabled` so an empty answer
-cannot be read as the column never carrying anything. **Until those eight cloud legs report,
-this row is a reading.** If the tier answers `'true'`, the fix is
-`CollectBcPageControls` — the single place the three defaults are applied — and not the
-corpus assertion.
+The general lesson is worth more than the column: a property read off an object nobody
+deserialized into is not evidence about what a provider reading a deserialized object
+answers, however many builds agree on it.
 
 <a id="option-and-enum"></a>
 
@@ -243,26 +245,28 @@ reading an enum-typed record field, so the metadata side has to match or every
 (`RecordPatches.NclMetaTableBuilder.cs`). So `FieldNavType == NavType.Option` is true for an
 Enum-bound control here as well, and it answers the enum's members.
 
-**This is a reading of BC's document and BC's decompiled provider, not a tier measurement.**
-No *merged* corpus test pins `OptionString` for an Enum-bound page control — corpus codeunit
-60426's `OptionBoundControl_OptionStringIsTheFieldsMembers` uses `ALT Universal`'s
-`"Option Field"`, which is genuinely `Option`-typed, and `ALT Universal` also has an
-`Enum`-typed `"Status Field"` that no test binds a control to. An implementation keyed on
-"has option metadata" and one keyed on `NavType` therefore agree on everything the merged
-corpus measures, and this file takes the `NavType` route because it is what BC's code says.
+**This was a reading of BC's document and BC's decompiled provider. It is now a
+measurement.** Corpus codeunit 60424 (page 60425) binds a control to `"Status Field"`,
+declared `Enum "ALT Status"`, and asserts the members;
+`Record_PageControlField_EnumBoundControl_OptionStringIsTheEnumsMembers` passed on **all
+eight cloud legs** of run
+[`34329910568`](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/actions/runs/34329910568)
+— 27.0, 27.3, 27.5, 28.0, 28.1, 28.2, 28.3 and 28.4. An Enum-bound control reports the
+enum's members, and the runner already answers that.
 
-Note which way the two readings point here, because it is the opposite of the `Editable`
-case: the decompiled guard (`f.Type == NavType.Option`, with `NavType.Enum` a distinct
-member) reads as `''`, while the emitted document (`Datatype="Option"` on an `Enum` field
-too) reads as the enum's members. They disagree, so no amount of further reading settles it.
+The count is what makes it a measurement rather than a non-emptiness check: `ALT Status` has
+**five** values against `"Option Field"`'s four, so the assertion separates the right answer
+both from an empty one and from the wrong field's members. Its negative arm,
+`IntegerBoundControl_OptionStringIsEmpty`, passed on the same eight legs, so the column is
+not simply filled unconditionally.
 
-[Corpus PR #310](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/310)
-binds a control to `"Status Field"` on page 60425 and asserts the members. `ALT Status` has
-**five** values against `"Option Field"`'s four, so the asserted count separates the right
-answer both from an empty one and from the wrong field's members. If the tier answers `''`,
-the fix is the `FieldNavType` guard in `GetPageControlFieldRowsFromBcDocument` — and note
-that changing how the runner *types* an enum field is not available as a fix there, for the
-`ValidateExpectedType` reason above.
+Worth recording because it came out against the more obvious reading. The two available
+readings pointed opposite ways — the decompiled guard (`f.Type == NavType.Option`, with
+`NavType.Enum` a distinct member) reads as `''`, while the emitted document
+(`Datatype="Option"` on an `Enum` field too) reads as the enum's members — so nothing but a
+tier could settle it. The document won. This is also the direction the `ValidateExpectedType`
+constraint above required, which is why the two independent reasons for the `NavType.Option`
+route agreeing is a fact about the design and not a coincidence.
 
 <a id="scope"></a>
 

--- a/docs/page-control-field-from-bc-document.md
+++ b/docs/page-control-field-from-bc-document.md
@@ -12,7 +12,11 @@ The siblings are [`object-metadata-from-bc.md`](object-metadata-from-bc.md), whi
 [`report-metadata-from-bc.md`](report-metadata-from-bc.md), which did reports at #3607.
 The corpus adjudication for this one is
 [corpus PR #300](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/300)
-(page 60427, codeunit 60426).
+(page 60427, codeunit 60426), extended by
+[corpus PR #310](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/310)
+(page 60425, codeunit 60424) for the two columns #300 left unmeasured — see
+[the three property defaults](#the-three-property-defaults) and
+[`OptionString` and Enum](#option-and-enum).
 
 <a id="what-bc-does"></a>
 
@@ -187,14 +191,28 @@ passes the null straight to `NavText.CreateTruncated`, which renders it as the e
 The AL derivation substituted `"true"` there too, so this change makes `Editable` answer `""`
 for a control that does not declare it.
 
-**That last cell is measured from BC's own type, not from a service tier.** No corpus test
-pins `Editable` today — codeunit 60921 pins `Visible` only, and corpus PR #300's codeunit
-60426 asserts `Editable` nowhere. So the claim rests on the reflection measurement above plus
-BC's decompiled `array[7] = NavText.CreateTruncated(len, control.Editable)`, and not on a real
-tier having answered it. It is the honest reading of both, and it is the kind of claim
-`.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md` says to name rather than to
-assert quietly. A corpus test asserting `Editable` on an undeclared control is the follow-up
-that would settle it; #3625 tracks it.
+The table above was re-measured for #3625 on **27.0, 27.5, 28.1 and 28.4**, and every cell is
+identical on all four — so the asymmetry is a stable property of the type across the whole
+matrix, not a quirk of one build. `Editable` is declared on `ControlDataboundDefinition`
+while `Enabled` and `Visible` are declared on `UIElementDefinition`, which is the structural
+reason the three do not share a default.
+
+**That last cell is still measured from BC's own type, not from a service tier.** No *merged*
+corpus test pins `Editable` — codeunit 60921 pins `Visible` only, and corpus PR #300's
+codeunit 60426 asserts `Editable` nowhere. So the claim rests on the reflection measurement
+above plus BC's decompiled `array[7] = NavText.CreateTruncated(len, control.Editable)`, and
+not on a real tier having answered it. It is the honest reading of both, and it is the kind
+of claim `.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md` says to name rather
+than to assert quietly.
+
+[Corpus PR #310](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/310)
+(codeunit 60424, page 60425), filed for #3625, is what settles it: it asserts all three
+columns on one control that declares none of them, so the asymmetry is pinned rather than
+assumed, plus the declared-`false` direction for `Editable` and `Enabled` so an empty answer
+cannot be read as the column never carrying anything. **Until those eight cloud legs report,
+this row is a reading.** If the tier answers `'true'`, the fix is
+`CollectBcPageControls` — the single place the three defaults are applied — and not the
+corpus assertion.
 
 <a id="option-and-enum"></a>
 
@@ -226,14 +244,25 @@ reading an enum-typed record field, so the metadata side has to match or every
 Enum-bound control here as well, and it answers the enum's members.
 
 **This is a reading of BC's document and BC's decompiled provider, not a tier measurement.**
-No corpus test pins `OptionString` for an Enum-bound page control — corpus codeunit 60426's
-`OptionBoundControl_OptionStringIsTheFieldsMembers` uses `ALT Universal`'s `"Option Field"`,
-which is genuinely `Option`-typed, and `ALT Universal` also has an `Enum`-typed
-`"Status Field"` that no test binds a control to. An implementation keyed on "has option
-metadata" and one keyed on `NavType` therefore agree on everything the corpus currently
-measures, and this file takes the `NavType` route because it is what BC's code says.
-[#3625](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3625) tracks getting
-the Enum case in front of a real tier.
+No *merged* corpus test pins `OptionString` for an Enum-bound page control — corpus codeunit
+60426's `OptionBoundControl_OptionStringIsTheFieldsMembers` uses `ALT Universal`'s
+`"Option Field"`, which is genuinely `Option`-typed, and `ALT Universal` also has an
+`Enum`-typed `"Status Field"` that no test binds a control to. An implementation keyed on
+"has option metadata" and one keyed on `NavType` therefore agree on everything the merged
+corpus measures, and this file takes the `NavType` route because it is what BC's code says.
+
+Note which way the two readings point here, because it is the opposite of the `Editable`
+case: the decompiled guard (`f.Type == NavType.Option`, with `NavType.Enum` a distinct
+member) reads as `''`, while the emitted document (`Datatype="Option"` on an `Enum` field
+too) reads as the enum's members. They disagree, so no amount of further reading settles it.
+
+[Corpus PR #310](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/310)
+binds a control to `"Status Field"` on page 60425 and asserts the members. `ALT Status` has
+**five** values against `"Option Field"`'s four, so the asserted count separates the right
+answer both from an empty one and from the wrong field's members. If the tier answers `''`,
+the fix is the `FieldNavType` guard in `GetPageControlFieldRowsFromBcDocument` — and note
+that changing how the runner *types* an enum field is not available as a fix there, for the
+`ValidateExpectedType` reason above.
 
 <a id="scope"></a>
 


### PR DESCRIPTION
Opened by an agent (Claude, `stma-auto-2`) for #3625.

No linked issue: this records a corpus adjudication; #3625 stays open until the tier answers.

**#3625 stays open when this merges, on purpose** — its remaining half is now owned by
#3653. No closing keyword appears next to any issue number in this body or in the commit
messages, because GitHub's parser fires on one regardless of the prose around it.

## The tier answered, and it split the two questions

[Corpus PR #310](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/310)
(codeunit 60424, page 60425) ran as
[`34329910568`](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/actions/runs/34329910568).
Six of its seven tests passed on **all eight** cloud legs; one failed on all eight,
identically. Verified with `tools/corpus-pass-count.py` — 17 distinct PASS per cloud leg,
the eight OnPrem legs correctly `not-run`.

**`Editable` — REFUTED.** For a control declaring no `Editable` property:

```
Record_PageControlField_UndeclaredEditable_IsEmpty
Assert.AreEqual failed. Expected:<> (Text). Actual:<True> (Text)
```

Real BC answers `True`. The runner answers `''`. **#3604 shipped a defect on that column**,
and the test written to ask the question is what caught it. #3653 owns the fix in
`CollectBcPageControls`; this PR marks the wrong passages rather than rewriting the section
underneath the agent doing it.

What the tier refuted is the **inference, not the reflection**. `ControlDefinition` really
does declare `Editable` on `ControlDataboundDefinition` with no `DefaultValueAttribute`
while `Enabled` and `Visible` come from `UIElementDefinition` with one, identically on every
build tried. The step that does not follow is from *a freshly constructed instance's field
value* to *what the provider reports for a deserialized one* — something between
deserialization and `GetControlsOnPage` supplies a default an `Activator`-built instance
never sees. That distinction is kept in the doc, because it is the reusable part.

**`OptionString` — SETTLED, in the runner's favour, against the more obvious reading.** An
Enum-bound control does report the enum's members;
`EnumBoundControl_OptionStringIsTheEnumsMembers` and its negative arm both passed 8/8. The
two available readings pointed opposite ways — the decompiled `NavType` guard as `''`, the
emitted document as the members — so nothing but a tier could decide. Promoted from
"reading" to measurement, citing the run.

`Enabled` and `Visible` were asked in the same codeunit and answered `'true'` on all eight
legs, so the section's other two rows are now measured rather than assumed.

## What changed here

- `docs/page-control-field-from-bc-document.md` — the `Editable` half leads with the
  refutation and the run id; the two paragraphs asserting the refuted reading are deleted;
  the pre-existing #3604 paragraph that also asserted it is struck through and marked, since
  #3653 owns the rewrite. The `OptionString` half is promoted to a measurement.
- `AlRunner.Tests/PageControlFieldDocumentTests.cs` — comments only. Its assertions are
  about what the emitted **document** contains and remain true; only the comment reaching
  from there to the *column's* answer was wrong, and it would have gone stale in the
  opposite direction once #3653 lands.

**No runner behaviour changes in this PR.**

## The drift guard

`BcMatrixDocumentationDriftTests` was red on my own line 194 — a four-build version list
that is a historical measurement, not a matrix claim. It is **fixed by deletion, not by a
waiver**: those paragraphs were the refuted ones, so the list went with them, and no
`NotAMatrixClaim` entry is needed. That is the better outcome — a waiver would have been a
permanent exemption for a sentence that no longer exists. Verified locally: RED before
(naming `docs/page-control-field-from-bc-document.md:194`), `Passed! 5/5` after. The one
version list that remains is the full eight-version matrix, which the guard accepts natively.

`tools/test_doc_pointers.py` passes (66 markdown links, 13 anchored mentions).

## Sibling scan

Nothing folded. **#3504** (subform `Editable()`) is the nearest match and lands in
`MockTestPage.cs` / `RunnerPageInstance.cs` — a different file, held by open PRs
#3646/#3648, and `status: blocked`. Same word, different code path: that issue is the
`TestPage` object model, this one is the virtual table. **#3458** and **#3501** are the
`TestPage` surface too. No open PR touches
`RecordPatches.PageControlFieldFromBcDocument.cs` or this doc.

## Not done

- **The submodule pin is not bumped** — blocked by #3580, verified open. `tools/corpus-pin.py`
  reports pin, checkout and shared working directory all at `c9d5f656`; I used a private
  clone throughout and never `git checkout`ed inside `tests/al-language`.
- **The `Editable` runner fix** is #3653's, deliberately not started here.
- **Corpus #310 is left with one red assertion**, which is correct: the assertion is right
  and the runner is wrong. Inverting it to match the runner would destroy the finding.

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/310

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
