### PR TITLE
docs(metadata): identify the 40 unaccounted fields as extension-added, and state the rule for them

### DIFF
--- a/AlRunner.Tests/MetadataEquivalencePopulationTests.cs
+++ b/AlRunner.Tests/MetadataEquivalencePopulationTests.cs
@@ -1,0 +1,155 @@
+// MetadataEquivalencePopulationTests — the gate for issue #3603.
+//
+// #3598 measured the DataClassification/Editable/EnumTypeId rules and reported "3,848 field
+// observations" under the phrase "every field of both apps". Those are two different claims
+// and only the first was true: the two apps declare more fields than the join reaches, and
+// nobody had established what the difference was. An unexplained gap under the word "every"
+// is the kind of overstatement that later reads as a counterexample rather than as an
+// unmeasured case.
+//
+// The gap is now identified (docs/metadata-equivalence.md#the-125-extension-added-fields) and
+// this file pins the two facts the prose rests on, so the prose cannot drift from the bundle:
+//
+//   1. BC emits MORE fields across the MetaTable set than the tables themselves declare,
+//      because a tableextension's fields are merged into the extended table's document. That
+//      is what makes 978 (symbol-side, table-declared) and 988 (emitted-side) both correct,
+//      which is the reconciliation the issue's condition 3 asks for.
+//   2. An ObsoleteState=Moved field is absent from the emitted table entirely. That is WHY
+//      only 10 of the 125 extension-added fields per build are observable at all -- BC emits
+//      nothing for the other 115, so there is no ground truth for them to agree or disagree
+//      with. Table 242 is the extreme case: 107 fields named by its extension, 1 emitted.
+//
+// Both are read straight out of the generated bundle, so this test needs no BC engine and
+// does not sit in the bc-engine-serial collection -- it cannot be silenced by the engine
+// bootstrap skip that hides the rest of the harness.
+
+using System.Xml;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class MetadataEquivalencePopulationTests
+{
+    private const string Ns = "urn:schemas-microsoft-com:dynamics:NAV:MetaObjects";
+
+    private static IReadOnlyList<GroundTruthBundle> Bundles()
+        => MetadataEquivalenceHarness.LoadBundles(MetadataEquivalencePaths.GroundTruthDirForThisBuild());
+
+    private static XmlElement Root(GroundTruthBundle b, GroundTruthObject o)
+    {
+        var doc = new XmlDocument();
+        doc.Load(Path.Combine(b.Directory, o.File));
+        return doc.DocumentElement!;
+    }
+
+    private static IEnumerable<XmlElement> Fields(XmlElement table)
+        => table.GetElementsByTagName("Field", Ns).Cast<XmlElement>();
+
+    /// <summary>
+    /// The emitted-side field population is what the harness compares, and it is NOT the
+    /// count of fields the tables declare — a tableextension's surviving fields are merged in.
+    ///
+    /// <para>Pinned by naming the two tables that carry merged fields on the builds measured
+    /// for #3603, rather than by asserting a total: a total moves on every Microsoft release
+    /// and would make this test a version tripwire instead of a statement about the shape.</para>
+    /// </summary>
+    [SkippableFact]
+    public void A_tableextension_field_is_merged_into_the_extended_tables_emitted_document()
+    {
+        var bundles = Bundles();
+        Skip.If(bundles.Count == 0, "no metadata ground-truth bundle for this BC build.");
+
+        // User Details 774: System Application's own extension adds 774-779. They are the six
+        // that established the owner is the tableextension and not the extended table --
+        // the table declares SystemMetadata, BC answers CustomerContent on all six.
+        var userDetails = bundles
+            .SelectMany(b => b.Objects.Where(o => o.Kind == "MetaTable" && o.Id == 774).Select(o => Root(b, o)))
+            .FirstOrDefault();
+
+        if (userDetails is not null)
+        {
+            Assert.Equal("SystemMetadata", userDetails.GetAttribute("DataClassification"));
+
+            var merged = Fields(userDetails).Where(f => int.Parse(f.GetAttribute("ID")) >= 774).ToList();
+            Assert.Equal(6, merged.Count);
+
+            // Every one of the six is CustomerContent -- the extension is silent, so they take
+            // ALDataClassification member 0 and NOT the extended table's SystemMetadata.
+            Assert.All(merged, f => Assert.Equal("CustomerContent", f.GetAttribute("DataClassification")));
+
+            // ...and that is a real distinction, not a table where everything is CustomerContent:
+            // field 1 is the table's own and carries the table's classification.
+            var own = Fields(userDetails).Single(f => f.GetAttribute("ID") == "1");
+            Assert.Equal("SystemMetadata", own.GetAttribute("DataClassification"));
+        }
+
+        // No. Series Line 309: the other merged case, and the one that shows Removed survives.
+        var noSeriesLine = bundles
+            .SelectMany(b => b.Objects.Where(o => o.Kind == "MetaTable" && o.Id == 309).Select(o => Root(b, o)))
+            .FirstOrDefault();
+
+        if (noSeriesLine is not null)
+        {
+            var removed = Fields(noSeriesLine)
+                .Where(f => f.GetAttribute("ObsoleteState") == "Removed")
+                .Select(f => int.Parse(f.GetAttribute("ID")))
+                .OrderBy(i => i).ToList();
+
+            Assert.Equal(new[] { 11, 10000, 10001, 10002 }, removed);
+            Assert.All(Fields(noSeriesLine).Where(f => f.GetAttribute("ObsoleteState") == "Removed"),
+                f => Assert.Equal("CustomerContent", f.GetAttribute("DataClassification")));
+        }
+
+        Assert.True(userDetails is not null || noSeriesLine is not null,
+            "neither table 774 nor table 309 was found in any bundle; the merged-field claim in "
+            + "docs/metadata-equivalence.md#the-125-extension-added-fields is no longer checked "
+            + "against anything. Re-derive it rather than deleting this assertion.");
+    }
+
+    /// <summary>
+    /// An <c>ObsoleteState = Moved</c> field is omitted from the emitted table, which is why
+    /// 115 of the 125 extension-added fields per build have no ground truth at all. Table 242
+    /// is the extreme case and the one the "613 of 978 versus 988" reconciliation turns on.
+    /// </summary>
+    [SkippableFact]
+    public void A_moved_field_is_absent_from_the_emitted_table_so_nothing_can_be_observed_about_it()
+    {
+        var bundles = Bundles();
+        Skip.If(bundles.Count == 0, "no metadata ground-truth bundle for this BC build.");
+
+        var sourceCodeSetup = bundles
+            .SelectMany(b => b.Objects.Where(o => o.Kind == "MetaTable" && o.Id == 242).Select(o => Root(b, o)))
+            .FirstOrDefault();
+        Skip.If(sourceCodeSetup is null, "Business Foundation table 242 is not in any bundle for this build.");
+
+        // ObsoleteSourceCodeSetupExt names 107 fields, every one of them Moved. BC emits one.
+        var emitted = Fields(sourceCodeSetup!).ToList();
+        Assert.Single(emitted);
+        Assert.Equal("1", emitted[0].GetAttribute("ID"));
+
+        // The positive half: nothing in this table is emitted carrying Moved. If BC ever starts
+        // emitting Moved fields, the 115 become observable and the doc's arithmetic changes.
+        Assert.DoesNotContain(emitted, f => f.GetAttribute("ObsoleteState") == "Moved");
+    }
+
+    /// <summary>
+    /// The harness compares <c>MetaTable</c> only, and a <c>MetadataRuntimeDeltas</c> document
+    /// carries no <c>Field</c> element — so a tableextension's fields are reachable ONLY
+    /// through the merged table above. This is the negative that makes "40 observations, not
+    /// 500" a fact about the data rather than a choice the harness made.
+    /// </summary>
+    [SkippableFact]
+    public void A_MetadataRuntimeDeltas_document_carries_no_fields()
+    {
+        var bundles = Bundles();
+        Skip.If(bundles.Count == 0, "no metadata ground-truth bundle for this BC build.");
+
+        var deltas = bundles
+            .SelectMany(b => b.Objects.Where(o => o.Kind == "MetadataRuntimeDeltas").Select(o => (b, o)))
+            .ToList();
+        Skip.If(deltas.Count == 0, "no MetadataRuntimeDeltas object in any bundle for this build.");
+
+        foreach (var (bundle, obj) in deltas)
+            Assert.Empty(Fields(Root(bundle, obj)));
+    }
+}

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -2353,7 +2353,8 @@ internal static partial class BcAppSymbolCache
 
     /// <summary>
     /// The field's declared <c>Editable</c>, or null when the symbol file states none — which
-    /// AL reads as true (#3545). Measured over 3,848 field observations on four BC builds:
+    /// AL reads as true (#3545). Measured over 3,848 table-declared field observations on
+    /// four BC builds (plus 40 extension-added ones; #3603 has the populations):
     /// the symbol file states <c>Editable</c> only where it is <c>0</c>, and BC's own emitter
     /// answers <c>1</c> or nothing everywhere it is silent, with zero disagreements. So the
     /// only value worth carrying is the false, and null is passed on unchanged so
@@ -2371,8 +2372,9 @@ internal static partial class BcAppSymbolCache
     /// The enum object a field's <c>TypeDefinition</c> names — <c>(id, name)</c> when
     /// <c>TypeDefinition.Name == "Enum"</c>, <c>(0, null)</c> otherwise. Measured: the
     /// presence of <c>Subtype.Id</c> and the presence of BC's own emitted
-    /// <c>EnumTypeId</c> agree on 3,848 of 3,848 field observations, and the values agree
-    /// wherever both are present (#3545).
+    /// <c>EnumTypeId</c> agree on 3,848 of 3,848 table-declared field observations, and the
+    /// values agree wherever both are present (#3545). #3603 has what that population is and
+    /// what it excludes.
     /// </summary>
     private static (int Id, string? Name) SymbolEnumType(JsonElement typeDefinition)
     {

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -1081,9 +1081,13 @@ public static partial class RecordPatches
     /// extension adds. Called once per parsed object, by every reader.
     ///
     /// <para>Three rules, measured against BC's own emitted metadata for Business Foundation
-    /// and System Application on four BC builds (3,848 field observations, zero
-    /// counterexamples) plus the six extension fields on table 774 that first showed the owner
-    /// is the extension and not the extended table. The two exceptions are not cosmetic:
+    /// and System Application on four BC builds. 3,848 of those observations are the apps'
+    /// TABLE-DECLARED fields; a further 40 (10 per build) are fields a <c>tableextension</c>
+    /// adds, including the six on table 774 that first showed the owner is the extension and
+    /// not the extended table. Zero counterexamples in either set. The remaining 115
+    /// extension-added fields per build are `ObsoleteState = Moved`, which BC omits from the
+    /// emitted table entirely, so nothing can be observed about them (#3603). The two
+    /// exceptions are not cosmetic:
     /// eleven fields sit on tables declaring <c>SystemMetadata</c>, so inheriting
     /// unconditionally answers <c>SystemMetadata</c> where BC answers <c>CustomerContent</c> —
     /// trading one wrong answer for another. Derivation and per-build counts:

--- a/docs/metadata-equivalence.md
+++ b/docs/metadata-equivalence.md
@@ -208,9 +208,21 @@ stays declared in the allowlist until then, with the measurement below recorded 
 re-derives it.
 
 The rules below are measurements, not readings of the AL documentation. Each was checked by
-joining every field of Business Foundation and System Application in `SymbolReference.json`
+joining the fields of Business Foundation and System Application in `SymbolReference.json`
 to the same field in BC's own emitted metadata, on four BC builds — **3,848 field
 observations, zero counterexamples for all three rules**.
+
+<a id="what-the-3848-counts"></a>
+**What those 3,848 are, and what they are not.** They are the **table-declared** fields of the
+150 `MetaTable` objects the two apps emit: 911 + 978 + 978 + 981 across the four builds. They
+are NOT every field the two apps declare. Each build also carries 125 fields added by a
+`tableextension`, and the join reaches only 10 of those per build — 40 observations across the
+four, which is the whole of the difference between 3,848 and the 3,888 a reader who counts
+declared fields arrives at (#3603).
+
+**The rule was separately checked on those 40, and it holds** — zero counterexamples, measured
+the same way. They are not an unmeasured population; they are counted separately because they
+join through a different route, described next.
 
 | | rule |
 |---|---|
@@ -230,8 +242,11 @@ of it.
 BC's emitter states the *effective* classification on each field, not the declared one. The
 rule, and both exceptions, are load-bearing:
 
-1. The field's own `DataClassification`, when it states one — 613 of 978 fields on BC
-   28.1, agreeing with BC on 613 of 613.
+1. The field's own `DataClassification`, when it states one — 613 of the 978 **table-declared**
+   fields on BC 28.1, agreeing with BC on 613 of 613. (978 is the symbol-file population; the
+   988 fields BC emits across the same 150 tables are those 978 plus the 10 extension-added
+   fields BC merges in — see below. Two populations, both correct, counted from opposite
+   sides of the join.)
 2. Otherwise the **owning object's**: the `table` for a field the table declares, the
    **`tableextension`** for a field an extension adds. Not the extended table — System
    Application's extension of `User Details` declares no classification and neither do its
@@ -250,6 +265,45 @@ another rather than fixing anything. Verbatim from System Application's table 91
 table line reads `DataClassification = SystemMetadata`: field 1 `Id` (`Text[250]`, silent) is
 emitted `SystemMetadata`, and field 8 `FieldsJson` (`Blob`, silent) is emitted with no
 `DataClassification` at all.
+
+<a id="the-125-extension-added-fields"></a>
+### The 125 extension-added fields, and why only 10 of them are observable
+
+Measured on BC 28.1.49838.54308 (#3603). The two apps declare six `tableextension` objects
+between them, carrying 125 fields. Every one targets a table in its own app, so this is not a
+cross-app visibility question — the discriminator is `ObsoleteState`:
+
+| extension | target | fields | `ObsoleteState` | merged into the emitted `MetaTable`? |
+|---|---|---:|---|---|
+| `Plan User Details` | `User Details` (774) | 6 | none | **yes** |
+| `NoSeriesLineObsolete` | `No. Series Line` (309) | 4 | `Removed` | **yes** |
+| `NoSeriesObsolete` | `No. Series` (308) | 4 | `Moved` | no |
+| `ObsoleteSourceCodeSetupExt` | `Source Code Setup` (242) | 107 | `Moved` | no |
+| `ObsoleteSourceCodeExt` | `Source Code` (230) | 2 | `Moved` | no |
+| `ObsoleteReturnReasonExt` | `Return Reason` (6635) | 2 | `Moved` | no |
+
+**A `Moved` field is gone from the metadata; a `Removed` field is still in it.** `Moved` means
+the field now lives in another app, so BC's emitter leaves it out of this app's table
+altogether — table 242 emits **1** field against the 107 its extension names. `Removed` means
+the field stays declared and is merely no longer usable, so it is emitted, carrying its
+`ObsoleteState`. That is why 309 emits 18 fields including ids 11 and 10000-10002.
+
+So the 115 unobservable fields are unobservable **because BC emits nothing for them** — there
+is no ground truth to disagree with, on this or any other member. This is a property of what
+Microsoft's own apps happen to declare, not a limit of the harness.
+
+**The rule holds on all 10 that are observable**, expected against emitted, zero
+counterexamples. Six of them are `User Details` 774-779, which is the case that established the
+owner is the `tableextension` and not the extended table: the extension declares no
+classification, the extended table declares `SystemMetadata`, and BC answers `CustomerContent`
+on all six. The other four are `No. Series Line` 11 and 10000-10002, whose extension is also
+silent and which BC likewise answers `CustomerContent`.
+
+**What is therefore still unmeasured, stated plainly:** no field in either app is added by a
+`tableextension` that *declares* a `DataClassification` of its own — all six extensions are
+silent. So rule 2's inheritance is confirmed for a silent extension and **the case of an
+extension declaring a non-default classification has no observation behind it in this
+population**. It is not a counterexample; it is an untested branch.
 
 **BC's six platform-added fields** were wrong on both members and are fixed with them. Their
 values are BC's own, read out of `SystemFieldsHelper` in `Microsoft.Dynamics.Nav.Types`, which

--- a/tests/expectations/metadata-equivalence/allowlist.json
+++ b/tests/expectations/metadata-equivalence/allowlist.json
@@ -301,7 +301,7 @@
     },
     {
       "member": "MetaField.EnumTypeId",
-      "reason": "BC resolves the enum object's id; the runner answers 0. The AL-observable consequence is that an enum-typed field cannot be resolved back to its enum object. #3545 established WHERE the value is \u2014 TypeDefinition.Subtype.Id, agreeing with BC on 3,848 of 3,848 field observations across four builds \u2014 and did not land it: passing enumTypeId makes BC's own FieldDataProvider.GetFieldRecordBuffer resolve that id through NCLMetadata, and the runner registers no metadata object for a precompiled app's enum, so every read of the Field virtual table for Base Application table 1366 threw NavMetadataNotFoundException(\"Enum 8889\") and aborted the corpus app. Registering the metadata is the work; see #3594.",
+      "reason": "BC resolves the enum object's id; the runner answers 0. The AL-observable consequence is that an enum-typed field cannot be resolved back to its enum object. #3545 established WHERE the value is \u2014 TypeDefinition.Subtype.Id, agreeing with BC on 3,848 of 3,848 table-declared field observations across four builds (#3603) \u2014 and did not land it: passing enumTypeId makes BC's own FieldDataProvider.GetFieldRecordBuffer resolve that id through NCLMetadata, and the runner registers no metadata object for a precompiled app's enum, so every read of the Field virtual table for Base Application table 1366 threw NavMetadataNotFoundException(\"Enum 8889\") and aborted the corpus app. Registering the metadata is the work; see #3594.",
       "issue": 3594
     },
     {


### PR DESCRIPTION
Closes #3603

Corpus-NA: an accounting correction to prose plus a measurement over Microsoft's own emitted metadata bundles; it changes no AL-observable runner behaviour, so no corpus test can distinguish before from after.

Written by agent `stma-auto-2`.

#3598 reported "3,848 field observations" under the phrase **"every field of both apps"**. Those
are two different claims and only the first was true. This PR identifies the missing 40, states
the rule for them, and reconciles "613 of 978" against the 988 the bundle carries — outcome 1 of
the two the issue offered, not the narrow-the-claim fallback.

## What the 40 are

**They are the extension-added fields: 10 per build, across 4 builds.** The arithmetic closes
exactly:

| | |
|---|---:|
| table-declared fields, per build (911 / 978 / 978 / 981) | **3,848** |
| extension-added fields the join reaches, 10 per build | **40** |
| total | 3,888 |

3,888 is what a reader counting *declared* fields arrives at, and 911 + 978 + 978 + 981 = 3,848
is what was measured. The gap was never outside the population — it was the extension-added
half of it, counted separately because it joins through a different route and never said so.

## Does the rule hold for them? Yes — zero counterexamples

Measured on BC 28.1.49838.54308 by joining `SymbolReference.json` to the emitted metadata
directly, independently of the harness:

- **978 table-declared fields: 978 joined, 0 counterexamples.**
- **10 extension-added fields: 10 joined, 0 counterexamples.**

Six of the ten are `User Details` 774-779 — the exact case #3598's body cites as having
established that the owner is the `tableextension` and not the extended table. The table
declares `SystemMetadata`, the extension is silent, and BC answers `CustomerContent` on all six.
The other four are `No. Series Line` 11 and 10000-10002, same shape.

So the rule is not merely *assumed* to extend to extension-added fields; it is measured on every
one of them that BC emits anything for.

## Why only 10 of 125, and why that is a fact about the data

The two apps declare **125** extension-added fields across six `tableextension` objects. Every
one targets a table in its own app, so cross-app visibility is not the discriminator.
`ObsoleteState` is:

| extension | target | fields | `ObsoleteState` | emitted? |
|---|---|---:|---|---|
| `Plan User Details` | `User Details` (774) | 6 | none | **yes** |
| `NoSeriesLineObsolete` | `No. Series Line` (309) | 4 | `Removed` | **yes** |
| `NoSeriesObsolete` | `No. Series` (308) | 4 | `Moved` | no |
| `ObsoleteSourceCodeSetupExt` | `Source Code Setup` (242) | 107 | `Moved` | no |
| `ObsoleteSourceCodeExt` | `Source Code` (230) | 2 | `Moved` | no |
| `ObsoleteReturnReasonExt` | `Return Reason` (6635) | 2 | `Moved` | no |

**A `Moved` field is gone from the emitted metadata; a `Removed` field is still in it.** Table
242 is the extreme case: its extension names 107 fields and BC emits **one**. So the 115
unobservable fields are unobservable because there is no ground truth for them to agree or
disagree with — not because the harness declined to look.

## Reconciling "613 of 978" against 988 (issue condition 3)

Both numbers are right; they are counted from opposite sides of the join, and neither was
labelled.

- **978** is the symbol-side population: fields the 150 tables themselves declare. Verified —
  613 of those 978 state their own `DataClassification`, agreeing with BC on 613 of 613.
- **988** is the emitted-side count: `Field` elements across the same 150 `MetaTable`
  documents. Verified directly — Business Foundation 74 + System Application 914 = **988**.

988 − 978 = the same 10 merged extension fields. The doc now says which side each figure is
counted from.

## What I did NOT widen

The measurement covers what it covers, and the doc now says so: **no field in either app is
added by a `tableextension` that declares a `DataClassification` of its own** — all six
extensions are silent. Rule 2's inheritance is therefore confirmed for a *silent* extension,
and the declaring-extension branch has no observation behind it in this population. That is an
untested branch, stated as one, not a counterexample.

Three of the four builds were reproducible on this box (27.3, 28.1, 28.4 carry both platform
apps; the fourth's artifacts have been pruned). 28.1 and 28.4 match the issue's 988 and 991
figures exactly once the 10 is added, which is what ties the identification to the original set.

## A fourth site the issue did not list

The issue named three. `AlRunner/Patches/BcAppSymbolCache.cs` carries the same "3,848" claim
twice more, for `Editable` and `EnumTypeId`, and `allowlist.json` carries it once. All five are
corrected, so nothing is left saying the wider thing.

## Proving test — RED verified for the right reason

`AlRunner.Tests/MetadataEquivalencePopulationTests.cs`, three tests reading the generated bundle
directly. It needs no BC engine, so the engine-bootstrap skip that silences the rest of the
harness cannot silence it.

Each assertion was mutated to a wrong value and confirmed to fail on the real data before being
restored:

- `Assert.Equal(7, merged.Count)` → `Expected: 7, Actual: 6`
- `[11, 10000, 10001]` → `Actual: [11, 10000, 10001, 10002]`
- `Assert.Equal(107, emitted.Count)` → `Expected: 107, Actual: 1`

GREEN: **10 passed, 0 skipped** — the 3 new tests plus all 7 `MetadataEquivalenceHarnessTests`.

**On the skip trap.** `MetadataEquivalenceHarnessTests` skips twice over and still prints
`Passed!` with exit 0. A first run here reported `Passed! Failed: 0, Passed: 1, Skipped: 6` —
six of seven asserting nothing, because `Microsoft.Dynamics.Nav.Ncl` was preloaded before the
Cecil rewrite. The numbers above are from a run with `tools/engine-test-bootstrap.sh` applied
and `-p:_BCVersion=28.1.49838.54308`, where the skip count is **0**. Skip counts are reported
here rather than the summary line, deliberately.

`tools/test_doc_pointers.py`: all checks pass, including the two new anchors.

## Open issues in the same area I did NOT fold in

Scanned the queue for this file cluster. Nothing folds — all three are code fixes, where this is
an accounting correction:

- **#3568** — the other 71 harness members. Spans `BcAppSymbolCache` broadly rather than the two
  doc comments touched here, and closing it needs reader changes this PR deliberately does not
  make.
- **#3491** — whether BC's own derivation can run headless. An architectural question about
  replacing 2,702 lines, not a statement about them.
- **#2417** — `NCLMetaPermissionSet.Assignable`; `status: blocked`, and about permission sets
  rather than fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
