### PR TITLE
fix(tools): print through UTF-8 so a tool cannot die on the console codec

### DIFF
--- a/tools/agent-cost.py
+++ b/tools/agent-cost.py
@@ -35,6 +35,16 @@ import os
 import re
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+try:
+    import agent_stdio as _stdio
+except Exception:  # pragma: no cover - a copy detached from its sibling module
+    _stdio = None
+if _stdio is not None:
+    # Before any print: stdout is built from the console codec, and cp1252
+    # cannot encode the robot emoji in an agent-authored PR body (#3589).
+    _stdio.enable_utf8_stdio()
+
 KINDS = [
     ("context-pack", r"context-pack\.py"),
     ("lsp-query", r"lsp-query\.py"),

--- a/tools/agent_scratchpad.py
+++ b/tools/agent_scratchpad.py
@@ -59,6 +59,16 @@ import os
 import re
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+try:
+    import agent_stdio as _stdio
+except Exception:  # pragma: no cover - a copy detached from its sibling module
+    _stdio = None
+if _stdio is not None:
+    # Before any print: stdout is built from the console codec, and cp1252
+    # cannot encode the robot emoji in an agent-authored PR body (#3589).
+    _stdio.enable_utf8_stdio()
+
 # Every private directory carries this prefix, so `scan` can tell an owned
 # directory from a bare one without a registry, and a human reading the
 # scratchpad can attribute a stray file to the agent that wrote it.

--- a/tools/agent_stdio.py
+++ b/tools/agent_stdio.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Make stdout/stderr UTF-8 so a tool cannot die while PRINTING (#3589).
+
+`sys.stdout` is built by the interpreter before any tool code runs, from the
+console code page or `PYTHONIOENCODING`, and no `encoding=` argument inside a
+tool reaches it. On this repository's Windows boxes that codec is cp1252 for
+both a pipe and a file redirect, so:
+
+  * `print()` of any text carrying a character cp1252 cannot encode raises
+    `UnicodeEncodeError`. Measured twice on 2026-09-09: `pr-body.py` died on
+    the robot emoji in a PR body's Claude Code footer AFTER its write had
+    already landed and verified -- so the caller saw a crash for a successful
+    edit -- and `ci-wait.py` died printing a failing-log excerpt.
+  * a character cp1252 CAN encode goes out as a cp1252 byte: an em dash as the
+    single byte 0x97, which a caller reading the tool's output as UTF-8 (the
+    normal shape for `subprocess.run(..., encoding="utf-8")`) cannot decode.
+
+Both are fixed by the same reconfiguration, and both directions are asserted in
+`tools/test_agent_stdio.py`. `errors="replace"` is the second half: after this,
+an unencodable character is a `?`, never an exception -- a tool that has done
+the work must never lose its answer on the way to the terminal.
+
+This is the display counterpart to #3434's fix, which named UTF-8 on the
+subprocess decodes and file reads/writes (`tools/test_text_encoding.py` guards
+that shape). It is deliberately its own module so every tool gets the same one
+line, imported the same way the `agent_self_freshness` guard is.
+"""
+from __future__ import annotations
+
+import sys
+
+
+def enable_utf8_stdio() -> None:
+    """Reconfigure sys.stdout/sys.stderr to UTF-8 with errors="replace".
+
+    Never raises. A stream can legitimately be `None` (pythonw), lack
+    `reconfigure` (a `StringIO` installed by a test harness, or any non-
+    `TextIOWrapper` substitute), or refuse it -- and a helper that threw in any
+    of those states would take down the harnesses that import these tools.
+    Idempotent, so calling it from an imported module and again from a caller
+    costs nothing.
+    """
+    for name in ("stdout", "stderr"):
+        stream = getattr(sys, name, None)
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            # A stream that will not be reconfigured is left as it was: the
+            # tool then behaves exactly as it did before this module existed,
+            # which is worse than UTF-8 but is never worse than not running.
+            pass

--- a/tools/ci-wait.py
+++ b/tools/ci-wait.py
@@ -152,6 +152,14 @@ import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 try:
+    import agent_stdio as _stdio
+except Exception:  # pragma: no cover - a copy detached from its sibling module
+    _stdio = None
+if _stdio is not None:
+    # Before any print: stdout is built from the console codec, and cp1252
+    # cannot encode the robot emoji in an agent-authored PR body (#3589).
+    _stdio.enable_utf8_stdio()
+try:
     import agent_self_freshness as _freshness
 except Exception:  # pragma: no cover - a copy detached from its sibling module
     _freshness = None

--- a/tools/comment-density.py
+++ b/tools/comment-density.py
@@ -31,6 +31,16 @@ import os
 import sys
 from dataclasses import dataclass, asdict
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+try:
+    import agent_stdio as _stdio
+except Exception:  # pragma: no cover - a copy detached from its sibling module
+    _stdio = None
+if _stdio is not None:
+    # Before any print: stdout is built from the console codec, and cp1252
+    # cannot encode the robot emoji in an agent-authored PR body (#3589).
+    _stdio.enable_utf8_stdio()
+
 SKIP_DIRS = {"obj", "bin", "graphify-out", ".git", "node_modules"}
 
 

--- a/tools/context-pack.py
+++ b/tools/context-pack.py
@@ -34,6 +34,16 @@ import re
 import subprocess
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+try:
+    import agent_stdio as _stdio
+except Exception:  # pragma: no cover - a copy detached from its sibling module
+    _stdio = None
+if _stdio is not None:
+    # Before any print: stdout is built from the console codec, and cp1252
+    # cannot encode the robot emoji in an agent-authored PR body (#3589).
+    _stdio.enable_utf8_stdio()
+
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 LSP_QUERY = os.path.join(REPO, "tools", "lsp-query.py")
 

--- a/tools/corpus-pass-count.py
+++ b/tools/corpus-pass-count.py
@@ -42,10 +42,21 @@ Run: tools/corpus-pass-count.py 34079169063 TestPart_
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import subprocess
 import sys
 import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+try:
+    import agent_stdio as _stdio
+except Exception:  # pragma: no cover - a copy detached from its sibling module
+    _stdio = None
+if _stdio is not None:
+    # Before any print: stdout is built from the console codec, and cp1252
+    # cannot encode the robot emoji in an agent-authored PR body (#3589).
+    _stdio.enable_utf8_stdio()
 
 CORPUS = "StefanMaron/BusinessCentral.AL.Language.Tests"
 

--- a/tools/corpus-pin-advance.py
+++ b/tools/corpus-pin-advance.py
@@ -89,6 +89,16 @@ import re
 import subprocess
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+try:
+    import agent_stdio as _stdio
+except Exception:  # pragma: no cover - a copy detached from its sibling module
+    _stdio = None
+if _stdio is not None:
+    # Before any print: stdout is built from the console codec, and cp1252
+    # cannot encode the robot emoji in an agent-authored PR body (#3589).
+    _stdio.enable_utf8_stdio()
+
 CORPUS_REMOTE = "https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests"
 SUBMODULE_PATH = "tests/al-language"
 

--- a/tools/corpus-pin.py
+++ b/tools/corpus-pin.py
@@ -87,6 +87,16 @@ import os
 import subprocess
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+try:
+    import agent_stdio as _stdio
+except Exception:  # pragma: no cover - a copy detached from its sibling module
+    _stdio = None
+if _stdio is not None:
+    # Before any print: stdout is built from the console codec, and cp1252
+    # cannot encode the robot emoji in an agent-authored PR body (#3589).
+    _stdio.enable_utf8_stdio()
+
 SUBMODULE_PATH = "tests/al-language"
 CORPUS_REMOTE = "https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests"
 

--- a/tools/lsp-query.py
+++ b/tools/lsp-query.py
@@ -42,6 +42,16 @@ Usage:
 from __future__ import annotations
 import json, os, subprocess, sys, time
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+try:
+    import agent_stdio as _stdio
+except Exception:  # pragma: no cover - a copy detached from its sibling module
+    _stdio = None
+if _stdio is not None:
+    # Before any print: stdout is built from the console codec, and cp1252
+    # cannot encode the robot emoji in an agent-authored PR body (#3589).
+    _stdio.enable_utf8_stdio()
+
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SOLUTION = os.path.join(REPO, "AlRunner.slnx")
 READY_TIMEOUT = 120

--- a/tools/pr-body.py
+++ b/tools/pr-body.py
@@ -126,6 +126,14 @@ from typing import Callable
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 try:
+    import agent_stdio as _stdio
+except Exception:  # pragma: no cover - a copy detached from its sibling module
+    _stdio = None
+if _stdio is not None:
+    # Before any print: stdout is built from the console codec, and cp1252
+    # cannot encode the robot emoji in an agent-authored PR body (#3589).
+    _stdio.enable_utf8_stdio()
+try:
     import agent_self_freshness as _freshness
 except Exception:  # pragma: no cover - a copy detached from its sibling module
     _freshness = None

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -60,6 +60,14 @@ from typing import Any, Iterable, Optional
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 try:
+    import agent_stdio as _stdio
+except Exception:  # pragma: no cover - a copy detached from its sibling module
+    _stdio = None
+if _stdio is not None:
+    # Before any print: stdout is built from the console codec, and cp1252
+    # cannot encode the robot emoji in an agent-authored PR body (#3589).
+    _stdio.enable_utf8_stdio()
+try:
     import agent_self_freshness as _freshness
 except Exception:  # pragma: no cover - a copy detached from its sibling module
     _freshness = None

--- a/tools/test_agent_stdio.py
+++ b/tools/test_agent_stdio.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Every tools/ CLI prints GitHub-sourced text without dying on the console codec (#3589).
+
+`sys.stdout` is built by the interpreter before any of this code runs, from the
+console code page or `PYTHONIOENCODING`. On this Windows box that is cp1252 for
+both a pipe and a file redirect, so `print()` of a PR body carrying the robot
+emoji every agent-authored footer contains raises `UnicodeEncodeError` -- measured
+twice in one day, once in `pr-body.py` AFTER the write had already landed (so the
+caller saw a crash for a successful edit) and once in `ci-wait.py` while printing
+a failing-log excerpt.
+
+Two halves, both needed:
+  * a shape guard, so the next tool added here cannot reintroduce it silently;
+  * a behavioural check per CLI, in a child interpreter -- the only portable
+    lever, since `PYTHONIOENCODING` is read before `main()` exists.
+
+Run: python3 tools/test_agent_stdio.py
+"""
+from __future__ import annotations
+
+import ast
+import importlib.util
+import io
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location("agent_stdio", os.path.join(HERE, "agent_stdio.py"))
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+ast_stdio = _mod
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        FAILURES.append(name)
+
+
+# --------------------------------------------------------------------------
+# The helper itself: a no-op on anything it cannot reconfigure, never a raise.
+# A helper that throws would take down every test harness that imports a tool.
+# --------------------------------------------------------------------------
+print("agent_stdio.enable_utf8_stdio is safe on every stream shape")
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def reconfigure(self, **kw) -> None:
+        self.calls.append(kw)
+
+
+class _NoReconfigure:
+    pass
+
+
+class _Raiser:
+    def reconfigure(self, **kw):
+        raise io.UnsupportedOperation("not seekable")
+
+
+def with_streams(out, err):
+    saved = (sys.stdout, sys.stderr)
+    sys.stdout, sys.stderr = out, err
+    try:
+        return ast_stdio.enable_utf8_stdio()
+    finally:
+        sys.stdout, sys.stderr = saved
+
+
+rec_out, rec_err = _Recorder(), _Recorder()
+with_streams(rec_out, rec_err)
+check("reconfigures stdout as UTF-8 with errors=replace",
+      rec_out.calls == [{"encoding": "utf-8", "errors": "replace"}], str(rec_out.calls))
+check("reconfigures stderr as UTF-8 with errors=replace",
+      rec_err.calls == [{"encoding": "utf-8", "errors": "replace"}], str(rec_err.calls))
+
+ok = True
+for out, err in ((_NoReconfigure(), _Recorder()), (_Raiser(), _Recorder()),
+                 (None, None), (_Recorder(), _Raiser())):
+    try:
+        with_streams(out, err)
+    except Exception as e:  # pragma: no cover - the failure this asserts against
+        ok = False
+        check("no-op stream shape %s raised" % type(out).__name__, False, repr(e))
+check("a stream without reconfigure, one that raises, and None are all no-ops", ok)
+
+second = _Recorder()
+with_streams(second, _Recorder())
+with_streams(second, _Recorder())
+check("calling it twice is harmless", len(second.calls) == 2, str(second.calls))
+
+
+# --------------------------------------------------------------------------
+# Shape guard: every executable tool calls it at module level, before any print.
+# --------------------------------------------------------------------------
+print("\nevery tools/ CLI calls enable_utf8_stdio() at module level")
+
+# agent_stdio.py is the helper; agent_self_freshness.py is import-only (no
+# `__main__` block and no print of its own -- it returns notes for its caller to
+# print), so the guard below does not reach either, by construction rather than
+# by allowlist.
+SELF = ("agent_stdio.py",)
+
+
+def has_main_block(tree: ast.Module) -> bool:
+    for node in tree.body:
+        if (isinstance(node, ast.If) and isinstance(node.test, ast.Compare)
+                and isinstance(node.test.left, ast.Name) and node.test.left.id == "__name__"):
+            return True
+    return False
+
+
+def calls_enable(tree: ast.Module) -> bool:
+    """A module-level call to agent_stdio.enable_utf8_stdio(), guarded or not."""
+    for node in tree.body:
+        for sub in ast.walk(node):
+            if not isinstance(sub, ast.Call):
+                continue
+            f = sub.func
+            if isinstance(f, ast.Attribute) and f.attr == "enable_utf8_stdio":
+                return True
+    return False
+
+
+scanned = 0
+for fn in sorted(os.listdir(HERE)):
+    if not fn.endswith(".py") or fn.startswith("test_") or fn in SELF:
+        continue
+    path = os.path.join(HERE, fn)
+    with open(path, encoding="utf-8") as fh:
+        tree = ast.parse(fh.read(), filename=path)
+    if not has_main_block(tree):
+        continue
+    scanned += 1
+    check(f"{fn} calls enable_utf8_stdio() at module level", calls_enable(tree))
+check("the guard actually scanned the tools (not zero files)", scanned >= 8, f"scanned={scanned}")
+
+
+# --------------------------------------------------------------------------
+# Behavioural: each CLI, imported under a cp1252 stdout, prints U+1F916 and
+# U+2014 as UTF-8 bytes instead of raising. This is line 1269 of ci-wait.py
+# (`print("\n".join(tail))` over a GitHub log) and line 749/753 of pr-body.py
+# (`print(d)` over a PR body), reduced to the one thing that decides it.
+# --------------------------------------------------------------------------
+print("\nunder PYTHONIOENCODING=cp1252, importing a tool makes print() survive")
+
+CHILD = r'''
+import importlib.util, sys
+pre = (sys.stdout.encoding or "").lower().replace("-", "")
+if pre != "cp1252":
+    # PYTHONIOENCODING is honoured on every platform, so this is a broken test
+    # environment, never a reason to skip -- a skip here would make the whole
+    # check unable to fail.
+    sys.stderr.write("PRECONDITION-FAIL: stdout encoding is %s\n" % pre)
+    raise SystemExit(3)
+spec = importlib.util.spec_from_file_location("tool_under_test", sys.argv[1])
+mod = importlib.util.module_from_spec(spec)
+# Registered before execution: a dataclass defined in a module absent from
+# sys.modules raises in dataclasses' own type resolution (preflight.py,
+# comment-density.py), which would be a harness artifact, not a finding.
+sys.modules["tool_under_test"] = mod
+spec.loader.exec_module(mod)
+print("robot \U0001f916 dash \u2014 end")
+sys.stdout.flush()
+'''
+assert CHILD.isascii(), "CHILD must survive an ASCII argv"
+
+ROBOT = b"\xf0\x9f\xa4\x96"
+DASH = b"\xe2\x80\x94"
+CP1252_DASH = b"\x97"
+
+TOOLS = ["pr-body.py", "ci-wait.py", "preflight.py", "corpus-pin.py",
+         "corpus-pass-count.py", "corpus-pin-advance.py", "context-pack.py",
+         "lsp-query.py", "agent_scratchpad.py", "agent-cost.py", "comment-density.py"]
+
+env = dict(os.environ, PYTHONIOENCODING="cp1252", PYTHONUTF8="0")
+for tool in TOOLS:
+    child = subprocess.run([sys.executable, "-c", CHILD, os.path.join(HERE, tool)],
+                           capture_output=True, env=env)
+    detail = ascii(child.stdout[-200:]) + " " + ascii(child.stderr[-400:])
+    check(f"{tool}: exit 0 under a cp1252 stdout", child.returncode == 0, detail)
+    check(f"{tool}: the robot emoji reaches stdout as UTF-8",
+          ROBOT in child.stdout, detail)
+    check(f"{tool}: the em dash reaches stdout as UTF-8, not as cp1252 0x97",
+          DASH in child.stdout and CP1252_DASH not in child.stdout, detail)
+
+print()
+if FAILURES:
+    print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")
+    sys.exit(1)
+print("all checks passed")

--- a/tools/test_ci_wait.py
+++ b/tools/test_ci_wait.py
@@ -1484,6 +1484,43 @@ check("#3309: ci-verdicts.md records that an empty --log-failed is not an empty 
       "ci-verdicts.md does not mention the escape-sequence refusal")
 
 
+# --------------------------------------------------------------------------
+# #3589: the failing-log excerpt main() prints is GitHub's text, not ours, and
+# printing it died on this box with UnicodeEncodeError while reporting a red PR
+# -- a tool that has done the work must not lose its answer on the way to the
+# terminal. The child below reproduces that print site under the codec that
+# decides it; PYTHONIOENCODING is read before main() exists, so a child
+# interpreter is the only lever.
+# --------------------------------------------------------------------------
+CP1252_CHILD = r'''
+import importlib.util, sys
+pre = (sys.stdout.encoding or "").lower().replace("-", "")
+if pre != "cp1252":
+    # PYTHONIOENCODING is honoured on every platform, so anything else here is a
+    # broken test environment, never a reason to skip.
+    sys.stderr.write("PRECONDITION-FAIL: stdout encoding is %s" % pre)
+    raise SystemExit(3)
+spec = importlib.util.spec_from_file_location("ci_wait", sys.argv[1])
+cw = importlib.util.module_from_spec(spec)
+sys.modules["ci_wait"] = cw
+spec.loader.exec_module(cw)
+tail = ["--- failing log (tail) ---", "  \U0001f916 step failed \u2014 see above"]
+print("\n".join(tail))
+'''
+assert CP1252_CHILD.isascii(), "CP1252_CHILD must survive an ASCII argv"
+ROBOT_UTF8 = "\U0001f916".encode("utf-8")
+DASH_UTF8 = "—".encode("utf-8")
+DASH_CP1252 = "—".encode("cp1252")
+_env = dict(os.environ, PYTHONIOENCODING="cp1252", PYTHONUTF8="0")
+_child = subprocess.run([sys.executable, "-c", CP1252_CHILD, os.path.join(HERE, "ci-wait.py")],
+                        capture_output=True, env=_env)
+_detail = ascii(_child.stdout[-200:]) + " " + ascii(_child.stderr[-400:])
+check("#3589: a failing-log excerpt prints under a cp1252 stdout, exit 0",
+      _child.returncode == 0, _detail)
+check("#3589: the excerpt keeps the emoji as UTF-8", ROBOT_UTF8 in _child.stdout, _detail)
+check("#3589: the excerpt keeps the em dash as UTF-8, not as cp1252 0x97",
+      DASH_UTF8 in _child.stdout and DASH_CP1252 not in _child.stdout, _detail)
+
 print()
 if FAILURES:
     print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")

--- a/tools/test_pr_body.py
+++ b/tools/test_pr_body.py
@@ -774,6 +774,46 @@ else:
     check("non-UTF-8 locale (%s): the body file keeps the em dash" % verdict["encoding"],
           verdict["written"].strip() == EM, ascii(verdict["written"]))
 
+# --------------------------------------------------------------------------
+# #3589: the whole tool, end to end, under a stdout the console codec owns.
+# `print(d)` at the two --dry-run / writing sites encodes the PR BODY, and a
+# body carrying the robot emoji of the Claude Code footer killed the tool on
+# this box AFTER the write had landed and verified -- so the caller saw a crash
+# for a successful edit. A child interpreter is the only lever: PYTHONIOENCODING
+# is read by the interpreter before main() exists.
+# --------------------------------------------------------------------------
+CP1252_CHILD = r'''
+import importlib.util, json, sys
+pre = (sys.stdout.encoding or "").lower().replace("-", "")
+if pre != "cp1252":
+    # PYTHONIOENCODING is honoured on every platform, so anything else here is a
+    # broken test environment, never a reason to skip.
+    sys.stderr.write("PRECONDITION-FAIL: stdout encoding is %s" % pre)
+    raise SystemExit(3)
+spec = importlib.util.spec_from_file_location("pr_body", sys.argv[1])
+pb = importlib.util.module_from_spec(spec)
+sys.modules["pr_body"] = pb
+spec.loader.exec_module(pb)
+pb._freshness = None       # no origin/main question here; this is about printing
+body = "footer \U0001f916 with an em dash \u2014 in it. " * 12   # over the --min-bytes floor
+pb.gh = lambda args, attempts=4: (0, json.dumps({"body": body}, ensure_ascii=False))
+raise SystemExit(pb.main(["1", "--repo", "R", "--dry-run", "--append", "tail"]))
+'''
+assert CP1252_CHILD.isascii(), "CP1252_CHILD must survive an ASCII argv"
+ROBOT_UTF8 = "\U0001f916".encode("utf-8")
+DASH_UTF8 = "—".encode("utf-8")
+DASH_CP1252 = "—".encode("cp1252")
+_env = dict(os.environ, PYTHONIOENCODING="cp1252", PYTHONUTF8="0")
+_child = subprocess.run([sys.executable, "-c", CP1252_CHILD, os.path.join(HERE, "pr-body.py")],
+                        capture_output=True, env=_env)
+_detail = ascii(_child.stdout[-200:]) + " " + ascii(_child.stderr[-400:])
+check("#3589: --dry-run exits 0 with a cp1252 stdout and an emoji in the body",
+      _child.returncode == 0, _detail)
+check("#3589: the printed diff carries the emoji as UTF-8",
+      ROBOT_UTF8 in _child.stdout, _detail)
+check("#3589: the printed diff carries the em dash as UTF-8, not as cp1252 0x97",
+      DASH_UTF8 in _child.stdout and DASH_CP1252 not in _child.stdout, _detail)
+
 print()
 if FAILURES:
     print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")


### PR DESCRIPTION
Closes #3589

Corpus-NA: tools-only change; no runner behaviour, no AL surface, nothing a service tier can adjudicate

Filed and implemented by agent `fbk-3` (automated implementation agent).

## The defect

`sys.stdout` is built by the interpreter from the console code page or `PYTHONIOENCODING`
before any tool code runs, so no `encoding=` argument inside a tool reaches it. Measured on
this Windows box (Python 3.14), the codec is `cp1252` for a pipe **and** for a file redirect:

```
$ python -c "import sys;print(sys.stdout.encoding)" | cat      -> cp1252
$ python -c "import sys;print(sys.stdout.encoding)" > file     -> cp1252
```

Two symptoms, one cause:

- **The tool dies while printing.** `pr-body.py` line 749 `print(d)` raised
  `UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f916'` — the robot emoji
  every agent-authored PR body carries in its Claude Code footer. It fired **after** the write
  had landed and verified, so the caller saw a crash for a successful edit. `ci-wait.py` died
  the same way on `print("\n".join(tail))`, a failing-log excerpt, while reporting a red PR.
- **A UTF-8-reading caller cannot decode the output.** An em dash goes out as the single cp1252
  byte `0x97`, so `subprocess.run(..., encoding="utf-8")` around the tool raises
  `UnicodeDecodeError`.

`PYTHONIOENCODING=utf-8` works around both, which is what makes this fixable in one place.

## The fix

`tools/agent_stdio.py` — one function, `enable_utf8_stdio()`, reconfiguring `sys.stdout` and
`sys.stderr` to `encoding="utf-8", errors="replace"`. It never raises: a stream can be `None`
(pythonw), lack `reconfigure` (a `StringIO` installed by a test harness), or refuse, and a
helper that threw in any of those states would take down the harnesses that import these
tools. Idempotent.

Called at module level in every `tools/` CLI, imported in the same shape as the
`agent_self_freshness` guard next to it (`sys.path.insert` + `try: import ... except`), so a
copy detached from its siblings degrades instead of failing.

This is the display counterpart to #3434 / PR #3587, which named UTF-8 on the **subprocess
decodes and file reads/writes**. `sys.stdout` is neither, and the AST guard added there does
not look at `print` — correctly, a print site is not a subprocess text decode.

## Fixing the shape, not the reported line

The issue names `pr-body.py`, and asked whether `ci-wait.py`, `preflight.py` and
`corpus-pass-count.py` share it. Rather than check the four named, the new shape guard
enumerates every executable tool and the behavioural probe measures each one. **Eleven of
eleven were affected**, all folded here:

`pr-body.py`, `ci-wait.py`, `preflight.py`, `corpus-pin.py`, `corpus-pass-count.py`,
`corpus-pin-advance.py`, `context-pack.py`, `lsp-query.py`, `agent_scratchpad.py`,
`agent-cost.py`, `comment-density.py`.

`tools/agent_self_freshness.py` is the one file in `tools/` deliberately **not** touched: it
has no `__main__` block and prints nothing of its own — it returns `notes` for its caller to
print, and those callers are all fixed. The shape guard skips it by construction (no
`__main__`), not by allowlist, so a `__main__` added there later is caught.

## RED -> GREEN

RED, against `origin/main`'s tools (a pristine `git archive origin/main tools` copy, the new
tests dropped in), the two end-to-end cases:

```
FAIL #3589: --dry-run exits 0 with a cp1252 stdout and an emoji in the body
  ... File ".../pr-body.py", line 749, in main
        print(d)
      UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f916' in position 78
FAIL #3589: a failing-log excerpt prints under a cp1252 stdout, exit 0
  ... print("\n".join(tail))
      UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f916' in position 30
```

and `tools/test_agent_stdio.py` on the same tree: **44 failing checks** — 11 shape checks plus
3 behavioural checks against each of the 11 CLIs.

GREEN, in this branch:

```
$ python tools/test_agent_stdio.py
  ok   reconfigures stdout as UTF-8 with errors=replace
  ok   a stream without reconfigure, one that raises, and None are all no-ops
  ok   pr-body.py calls enable_utf8_stdio() at module level                (x11)
  ok   pr-body.py: exit 0 under a cp1252 stdout                            (x11)
  ok   pr-body.py: the robot emoji reaches stdout as UTF-8                 (x11)
  ok   pr-body.py: the em dash reaches stdout as UTF-8, not as cp1252 0x97 (x11)
all checks passed

$ python tools/test_ci_wait.py
  ok   #3589: a failing-log excerpt prints under a cp1252 stdout, exit 0
  ok   #3589: the excerpt keeps the emoji as UTF-8
  ok   #3589: the excerpt keeps the em dash as UTF-8, not as cp1252 0x97
all checks passed

$ python tools/test_pr_body.py
  ok   #3589: --dry-run exits 0 with a cp1252 stdout and an emoji in the body
  ok   #3589: the printed diff carries the emoji as UTF-8
  ok   #3589: the printed diff carries the em dash as UTF-8, not as cp1252 0x97
```

The `pr-body.py` case drives the real `main(["1", "--repo", "R", "--dry-run", "--append",
"tail"])` with `gh` stubbed, so it exercises the reported print site rather than a stand-in.

**Both directions are asserted**, per `tdd.md`: the emoji must arrive as the UTF-8 bytes
`f0 9f a4 96` (a no-op implementation crashes instead), and the em dash must arrive as
`e2 80 94` with the cp1252 byte `97` **absent** (a no-op implementation emits `97`). The
child asserts `sys.stdout.encoding == cp1252` before importing the tool and **fails** —
never skips — if the environment did not honour `PYTHONIOENCODING`, so the check cannot
pass vacuously on a UTF-8 box.

## Suites run

All thirteen `tools/test_*.py`, on this Windows box. Twelve report all checks passed. Two
carry failures, **both pre-existing and both reproduced on `origin/main` before this change**:

| suite | state |
|---|---|
| `test_pr_body.py` | 7 `parity (...)` failures — the bash `check_closing_reference.sh` port disagreeing with the Python one under Git Bash here. Identical set on `origin/main`. |
| `test_preflight.py` | `AttributeError: 'NoneType' object has no attribute 'mountpoint'` at line 125, a Linux-path assumption (`/tmp/x/y`). Identical on `origin/main`. |

No C# changed, so no AL suite is in scope for this diff.

## Deliberately left out

- **Not changed to keep the console codec with `errors="replace"` only.** That stops the crash
  and leaves the second symptom — a UTF-8-reading caller still cannot decode `0x97`. On a real
  Windows *console* Python uses UTF-8 via `_WindowsConsoleIO` (PEP 528; not measured here); the cp1252 case measured
  above is a pipe or a redirect, which is exactly where the mojibake concern does not apply.
- **No `PYTHONIOENCODING` wrapper or launcher.** The fix has to hold for a tool invoked
  directly by an agent, which is how all of these are invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kko97BZZL71nF2nK5aftu4
