### PR TITLE
fix(table-metadata): answer NCLMetaTable's Is<Trigger>Defined flags from the table and its tableextensions

### DIFF
--- a/AlRunner.Tests/Fixtures/TableTriggerMetadata/TtmOwn.Table.al
+++ b/AlRunner.Tests/Fixtures/TableTriggerMetadata/TtmOwn.Table.al
@@ -1,0 +1,15 @@
+// A table declaring its own OnRename and nothing else, with no tableextension over it: the
+// base-table arm of the computation on its own.
+table 70741 "TTM Own"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+    }
+
+    keys { key(PK; "No.") { Clustered = true; } }
+
+    trigger OnRename()
+    begin
+    end;
+}

--- a/AlRunner.Tests/Fixtures/TableTriggerMetadata/TtmPlain.Table.al
+++ b/AlRunner.Tests/Fixtures/TableTriggerMetadata/TtmPlain.Table.al
@@ -1,0 +1,12 @@
+// A table declaring NO triggers of its own, so every bit its metadata reports came from
+// "TTM Plain Ext" (70742).
+table 70740 "TTM Plain"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Payload; Integer) { }
+    }
+
+    keys { key(PK; "No.") { Clustered = true; } }
+}

--- a/AlRunner.Tests/Fixtures/TableTriggerMetadata/TtmPlainExt.TableExt.al
+++ b/AlRunner.Tests/Fixtures/TableTriggerMetadata/TtmPlainExt.TableExt.al
@@ -1,0 +1,19 @@
+// Declares three of the four write triggers a tableextension can contribute, and NOT the
+// rename pair - so an implementation answering "all five bits" wholesale fails.
+tableextension 70742 "TTM Plain Ext" extends "TTM Plain"
+{
+    trigger OnBeforeInsert()
+    begin
+        Payload := Payload + 1;
+    end;
+
+    trigger OnAfterModify()
+    begin
+        Payload := Payload + 1;
+    end;
+
+    trigger OnBeforeDelete()
+    begin
+        Payload := Payload + 1;
+    end;
+}

--- a/AlRunner.Tests/Fixtures/TableTriggerMetadata/TtmTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/TableTriggerMetadata/TtmTests.Codeunit.al
@@ -1,0 +1,20 @@
+// Touches each table once so the runner builds its NCLMetaTable and the audit records a line.
+codeunit 70743 "TTM Tests"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure TouchTheTablesSoTheirMetadataIsBuilt()
+    var
+        Plain: Record "TTM Plain";
+        Own: Record "TTM Own";
+    begin
+        Plain.Init();
+        Plain."No." := 'A1';
+        Plain.Insert(true);
+
+        Own.Init();
+        Own."No." := 'B1';
+        Own.Insert(true);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/TableTriggerMetadata/app.json
+++ b/AlRunner.Tests/Fixtures/TableTriggerMetadata/app.json
@@ -1,0 +1,12 @@
+{
+  "id": "3ad9f6c1-70b2-4e8d-9c33-51b7ad20e4f9",
+  "name": "Runner Tests Fixture - Table Trigger Metadata",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Issue #3556: NCLMetaTable's five Is<Trigger>Defined flags must answer true exactly when the table - or a tableextension over it - declares the trigger.",
+  "description": "Runner-mechanism fixture. The flags themselves are table METADATA with no AL surface; what AL observes is which triggers a write dispatches, and that belongs upstream (corpus PR 307). This bundle pins the runner's own computation: AL_RUNNER_TABLE_TRIGGER_AUDIT=1 prints the mask per table and TableTriggerMetadataTests asserts the exact set. Declares no application floor.",
+  "dependencies": [],
+  "platform": "1.0.0.0",
+  "idRanges": [ { "from": 70740, "to": 70759 } ],
+  "runtime": "14.0"
+}

--- a/AlRunner.Tests/TableTriggerMetadataTests.cs
+++ b/AlRunner.Tests/TableTriggerMetadataTests.cs
@@ -1,0 +1,98 @@
+// TableTriggerMetadataTests — issue #3556.
+//
+// NCLMetaTable carries five Is<Trigger>Defined flags, and BC's own write path branches on them:
+// NavRecord.ALInsert/ALModify/ALDelete/ALRename run the extension OnBefore<X> loop, the base
+// table's own On<X> trigger and the extension On<X> loop INSIDE
+// `if (runApplicationTrigger && metaTable.Is<X>TriggerDefined)`.
+//
+// What AL can observe is which triggers a write dispatches, and that is BC behaviour — it is
+// pinned upstream by corpus codeunit 60433 (corpus PR #307), not here. This test pins the
+// runner's own computation of the mask, which has no AL surface: AL_RUNNER_TABLE_TRIGGER_AUDIT=1
+// prints one line per table and this asserts the exact set.
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TableTriggerMetadataTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static readonly string FixtureDir =
+        Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures", "TableTriggerMetadata");
+
+    private static (int ExitCode, string StdOut, string StdErr) Run(string cacheDir)
+    {
+        var sb = new StringBuilder(TestBuildConfig.RunArgs(Path.Combine(RepoRoot, "AlRunner")));
+        sb.Append(' ').Append($"\"{FixtureDir}\"");
+        sb.Append(' ').Append($"--cache \"{cacheDir}\"");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = sb.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        psi.Environment["AL_RUNNER_TABLE_TRIGGER_AUDIT"] = "1";
+
+        var outSb = new StringBuilder();
+        var errSb = new StringBuilder();
+        using var proc = Process.Start(psi)!;
+        proc.OutputDataReceived += (_, e) => { if (e.Data != null) lock (outSb) outSb.AppendLine(e.Data); };
+        proc.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (errSb) errSb.AppendLine(e.Data); };
+        proc.BeginOutputReadLine();
+        proc.BeginErrorReadLine();
+        if (!proc.WaitForExit(180_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException("al-runner did not exit within 180s.");
+        }
+        // WaitForExit(int) does not drain the async output callbacks; the parameterless
+        // overload does. See #2496.
+        proc.WaitForExit();
+        return (proc.ExitCode, outSb.ToString(), errSb.ToString());
+    }
+
+    [Fact]
+    public void EveryTableTriggerFlagAnswersForTheTriggersItsTableAndTableextensionsDeclare()
+    {
+        var cacheDir = TestScratch.Dir("al-runner-ttm-tests");
+        try
+        {
+            var (exit, stdout, stderr) = Run(cacheDir);
+
+            Assert.True(exit == 0,
+                $"the fixture test must pass. exit={exit}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            // The defect this issue is about. Table 70740 declares NO trigger of its own, so
+            // every bit here came from tableextension 70742 — which declares OnBeforeInsert
+            // (Insert), OnAfterModify (Modify AND the separate OnAfterModify bit) and
+            // OnBeforeDelete (Delete), and deliberately NOT the rename pair. An implementation
+            // answering "all five bits" wholesale fails on the missing Rename; one that ignores
+            // extensions, which is what the runner did before this fix, reports none of them.
+            Assert.Contains(
+                "[table-trigger-audit] table=70740 clr=Record70740 ext=TableExtension70742"
+                + " triggers=Insert,Modify,Delete,OnAfterModify",
+                stdout);
+
+            // The base-table arm on its own: table 70741 declares OnRename and nothing else,
+            // and has no tableextension. Rename alone, so a fix that reached the extension arm
+            // by widening the base arm fails here.
+            Assert.Contains(
+                "[table-trigger-audit] table=70741 clr=Record70741 ext=- triggers=Rename",
+                stdout);
+
+            Assert.DoesNotContain("FAIL", stdout);
+        }
+        finally
+        {
+            try { Directory.Delete(cacheDir, recursive: true); } catch { /* best-effort cleanup */ }
+        }
+    }
+}

--- a/AlRunner/Infrastructure/NclCecilRewrite.Records.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Records.cs
@@ -1771,6 +1771,46 @@ public static partial class NclCecilRewrite
         // The (ITreeObject, int, SecurityFiltering, NCLMetaQuery) overload chains to
         // : this(parent, securityFiltering, metaQuery) so it inherits the fix.
 
+        // === NCLMetaTable.get_DefinedTriggers — #3556 ===
+        // The private property behind IsInsertTriggerDefined / IsModifyTriggerDefined /
+        // IsOnAfterModifyTriggerDefined / IsDeleteTriggerDefined / IsRenameTriggerDefined. BC's
+        // body reflects over the table's own Record{id} class AND over every NCLTableExtension in
+        // orderedExtensionObjects; the runner hand-builds this metatable and carries none, so a
+        // trigger a TABLEEXTENSION declares read false — and NavRecord.ALInsert/ALModify/ALDelete/
+        // ALRename then skipped the whole OnBefore/On block on the write. The replacement runs
+        // BC's own declaration check against the runner's tableextension registry — see
+        // RecordPatches.TableTriggerMetadata.cs.
+        //
+        // Same TRAP as the NCLMetaForm twin (NclCecilRewrite.Forms.cs, 8b2b): the helper returns
+        // System.Int32 while the target returns the private TableTriggers enum, and
+        // ReplaceBodyWithHelper emits no conversion for a VALUE-type return. Valid only while the
+        // enum's underlying type is int32, which the guard below asserts rather than assumes.
+        {
+            var metaTableType = asm.MainModule.GetType("Microsoft.Dynamics.Nav.Runtime.NCLMetaTable")
+                ?? throw new InvalidOperationException(
+                    "[Cecil] NCLMetaTable type not found — Ncl shape changed; do not commit");
+
+            var getter = metaTableType.Methods
+                .FirstOrDefault(m => m.Name == "get_DefinedTriggers" && m.HasBody && m.Parameters.Count == 0)
+                ?? throw new InvalidOperationException(
+                    "[Cecil] NCLMetaTable.get_DefinedTriggers not found — Ncl shape changed; do not commit");
+
+            var enumType = getter.ReturnType.Resolve();
+            if (enumType == null || !enumType.IsEnum
+                || enumType.Fields.FirstOrDefault(f => f.Name == "value__")?.FieldType.FullName != "System.Int32")
+                throw new InvalidOperationException(
+                    "[Cecil] NCLMetaTable.get_DefinedTriggers no longer returns an Int32-backed enum "
+                    + "— do not commit");
+
+            var helper = typeof(AlRunner.Patches.RecordPatches).GetMethod(
+                nameof(AlRunner.Patches.RecordPatches.NCLMetaTable_get_DefinedTriggers),
+                BindingFlags.Public | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "[Cecil] RecordPatches.NCLMetaTable_get_DefinedTriggers not found");
+
+            ReplaceBodyWithHelper(asm.MainModule, getter, helper);
+            Console.Error.WriteLine("[Cecil] Rewrote NCLMetaTable.get_DefinedTriggers → RecordPatches.NCLMetaTable_get_DefinedTriggers");
+        }
     }
 
     private static void AddRecordsOwned(HashSet<string> set)
@@ -1805,6 +1845,10 @@ public static partial class NclCecilRewrite
         // to RecordPatches.NCLMetaTable_ComputeReferencingRelations over the runner's
         // metatable cache (BC's body reads the null ObjectLoader and NREs).
         set.Add("Microsoft.Dynamics.Nav.Runtime.NCLMetaTable::ComputeReferencingRelations/2");
+        // Table-trigger metadata (#3556) — Cecil-forwarded to
+        // RecordPatches.NCLMetaTable_get_DefinedTriggers so a tableextension's declared
+        // OnBefore/On/OnAfter triggers set the flags BC's write path branches on.
+        set.Add("Microsoft.Dynamics.Nav.Runtime.NCLMetaTable::get_DefinedTriggers/0");
         // DataAccessSource + TempTableDataProvider
         set.Add("Microsoft.Dynamics.Nav.Runtime.DataAccessSource::GetDataAccessForTable/2");
         // NavRecord::UpdateReferencesOnRenameAsync/2 is deliberately NOT here: BC's real

--- a/AlRunner/Patches/RecordPatches.PageTriggerMetadata.cs
+++ b/AlRunner/Patches/RecordPatches.PageTriggerMetadata.cs
@@ -56,7 +56,7 @@ public static partial class RecordPatches
         foreach (var trigger in _pageTriggerNames!)
         {
             if (IsTriggerImplemented(typeof(Microsoft.Dynamics.Nav.Runtime.NavForm),
-                                     pageClrType, trigger.Key, isPublic: false))
+                                     pageClrType, trigger.Key, isPublic: false, PageTriggerSurface))
             {
                 mask |= trigger.Value;
                 continue;
@@ -64,7 +64,7 @@ public static partial class RecordPatches
             if (_pageOnlyTriggers.Contains(trigger.Key)) continue;
             foreach (var extType in extensionTypes)
                 if (IsTriggerImplemented(typeof(Microsoft.Dynamics.Nav.Runtime.Extensions.NavFormExtension),
-                                         extType, trigger.Key, isPublic: true))
+                                         extType, trigger.Key, isPublic: true, PageTriggerSurface))
                 {
                     mask |= trigger.Value;
                     break;
@@ -81,58 +81,68 @@ public static partial class RecordPatches
     }
 
     /// <summary>
-    /// BC's own declaration check, transcribed rather than called.
+    /// BC's own declaration check, transcribed rather than called — shared by the page flags
+    /// (#3447) and the table flags (#3556).
     ///
     /// <para>Calling BC's <c>NCLMetaApplicationObject.IsTriggerImplemented</c> is not portable
     /// across the versions this runner supports: the <b>static</b>
     /// <c>(Type, string, bool)</c> overload the extension arm needs — the runner holds an
-    /// extension's Type, not an NCLPageExtension instance — exists on 27.5 and 28.x and does NOT
-    /// exist on 27.0, which declares only the instance <c>(string, bool)</c> form reading its own
-    /// receiver. Resolving it and answering "no triggers" when it is absent is what made every
-    /// flag false on the 27.0 leg of PR #3557 while 28.x passed.</para>
+    /// extension's Type, not an NCLPageExtension / NCLTableExtension instance — exists on 27.5
+    /// and 28.x and does NOT exist on 27.0, which declares only the instance <c>(string, bool)</c>
+    /// form reading its own receiver. Resolving it and answering "no triggers" when it is absent
+    /// is what made every flag false on the 27.0 leg of PR #3557 while 28.x passed.</para>
     ///
     /// <para>The body below is BC's <c>CheckTrigger</c> local function, whose decision is
     /// identical on 27.0, 27.5 and 28.4: look the name up, then the <c>…Async</c> spelling, and
     /// answer whether the resolved method was declared somewhere OTHER than
     /// <paramref name="platformBase"/>. Not a transcription character for character — the guard
     /// before the throw is the runner's, and it is what decides that an absent name is a BC-shape
-    /// gap rather than an ordinary "this page declares nothing".</para>
+    /// gap rather than an ordinary "this object declares nothing".</para>
     /// </summary>
-    private static bool IsTriggerImplemented(Type platformBase, Type clrType, string triggerName, bool isPublic)
-        => CheckTrigger(platformBase, clrType, triggerName, isPublic)
-        || CheckTrigger(platformBase, clrType, triggerName + "Async", isPublic);
+    internal readonly record struct TriggerSurface(string Surface, string Subject, string Doc);
 
-    private static bool CheckTrigger(Type platformBase, Type clrType, string name, bool isPublic)
+    private static readonly TriggerSurface PageTriggerSurface = new(
+        "page trigger metadata", "page", "docs/page-rowset-triggers.md#page-trigger-metadata");
+
+    private static bool IsTriggerImplemented(
+        Type platformBase, Type clrType, string triggerName, bool isPublic, TriggerSurface surface)
+        => CheckTrigger(platformBase, clrType, triggerName, isPublic, surface)
+        || CheckTrigger(platformBase, clrType, triggerName + "Async", isPublic, surface);
+
+    private static bool CheckTrigger(
+        Type platformBase, Type clrType, string name, bool isPublic, TriggerSurface surface)
     {
         var flags = BindingFlags.Instance | (isPublic ? BindingFlags.Public : BindingFlags.NonPublic);
-        var method = LookupTrigger(clrType, name, flags);
+        var method = LookupTrigger(clrType, name, flags, surface);
         if (method != null) return method.DeclaringType != platformBase;
 
         // BC throws here, and so must this: the lookup searches the whole hierarchy, so a null
         // means platformBase itself no longer declares the trigger — the shape this computation
         // rests on. Answering false instead would silently report "declares nothing" for every
-        // page in the run, which is #3447 reappearing with no signal.
-        if (LookupTrigger(clrType, name + "Async", flags) != null
-         || LookupTrigger(platformBase, name, flags) != null) return false;
+        // object in the run, which is #3447 reappearing with no signal.
+        if (LookupTrigger(clrType, name + "Async", flags, surface) != null
+         || LookupTrigger(platformBase, name, flags, surface) != null) return false;
 
         throw new AlRunner.Infrastructure.BcShapeGapException(
-            "page trigger metadata", $"{platformBase.Name}.{name}",
+            surface.Surface, $"{platformBase.Name}.{name}",
             $"neither {name} nor {name}Async resolves on {clrType.Name}, so the runner cannot say "
-            + "which page triggers this page declares — see docs/page-rowset-triggers.md#page-trigger-metadata");
+            + $"which {surface.Subject} triggers this {surface.Subject} declares — see {surface.Doc}");
     }
 
     /// <summary>
-    /// One BC-typed method lookup for the whole file, through <see cref="BcShape"/> (#3069): a
-    /// trigger name that grows a second declaration must arrive as a named gap, not as an
-    /// <c>AmbiguousMatchException</c> an <c>asserterror</c> can absorb. No <c>types:</c> filter —
-    /// the twelve triggers have twelve different signatures and BC resolves them by name too.
+    /// One BC-typed method lookup for both trigger-metadata computations, through
+    /// <see cref="BcShape"/> (#3069): a trigger name that grows a second declaration must arrive
+    /// as a named gap, not as an <c>AmbiguousMatchException</c> an <c>asserterror</c> can absorb.
+    /// No <c>types:</c> filter — the triggers have different signatures and BC resolves them by
+    /// name too.
     /// </summary>
-    private static MethodInfo? LookupTrigger(Type declaring, string name, BindingFlags flags)
+    private static MethodInfo? LookupTrigger(
+        Type declaring, string name, BindingFlags flags, TriggerSurface surface)
         => BcShape.FindMethod(declaring, name, flags,
-            surface: "page trigger metadata", member: $"{declaring.Name}.{name}",
-            detail: "the runner asks which page triggers this page declares, and two declarations "
-                  + "of one trigger name leave no way to say which body BC would have counted — "
-                  + "see docs/page-rowset-triggers.md#page-trigger-metadata");
+            surface: surface.Surface, member: $"{declaring.Name}.{name}",
+            detail: $"the runner asks which {surface.Subject} triggers this {surface.Subject} declares, "
+                  + "and two declarations of one trigger name leave no way to say which body BC "
+                  + $"would have counted — see {surface.Doc}");
 
     /// <summary>The compiled <c>PageExtension{id}</c> classes extending this page, in id order.</summary>
     private static List<Type> PageExtensionTypesFor(object metaForm, out bool allResolved)

--- a/AlRunner/Patches/RecordPatches.TableTriggerMetadata.cs
+++ b/AlRunner/Patches/RecordPatches.TableTriggerMetadata.cs
@@ -1,0 +1,253 @@
+// RecordPatches.TableTriggerMetadata — NCLMetaTable's five Is<Trigger>Defined flags (#3556).
+//
+// The table twin of RecordPatches.PageTriggerMetadata.cs (#3447), and it decides more: BC's own
+// NavRecord.ALInsert/ALModify/ALDelete/ALRename run the ext.OnBefore<X> loop, the base table's
+// own On<X> trigger and the ext.On<X> loop INSIDE `if (runApplicationTrigger &&
+// metaTable.Is<X>TriggerDefined)`. The ext.OnAfter<X> loop sits outside it, guarded by
+// runApplicationTrigger alone — which is why, before this, a tableextension's OnAfterInsert ran
+// and its OnBeforeInsert did not. See docs/table-trigger-metadata.md.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    private static readonly TriggerSurface TableTriggerSurface = new(
+        "table trigger metadata", "table", "docs/table-trigger-metadata.md");
+
+    private static readonly ConditionalWeakTable<object, StrongBox<int>> _definedTableTriggersCache = new();
+
+    // BC's TableTriggers bit → the trigger names that set it, in BC's own order
+    // (NCLMetaTable.DefinedTriggers, identical body on 27.0, 27.5 and 28.4). The base-table arm
+    // reads the middle name of each triple off NavRecord; the extension arm reads all three off
+    // NavRecordExtension. OnAfterModify is a bit of its own with a single name, and no base-table
+    // arm at all — BC never sets it from the table's own class.
+    private static readonly (string Bit, string? BaseName, string[] ExtensionNames)[] _tableTriggerBits =
+    {
+        ("Insert",        "OnInsert", new[] { "OnBeforeInsert", "OnInsert", "OnAfterInsert" }),
+        ("Modify",        "OnModify", new[] { "OnBeforeModify", "OnModify", "OnAfterModify" }),
+        ("OnAfterModify", null,       new[] { "OnAfterModify" }),
+        ("Delete",        "OnDelete", new[] { "OnBeforeDelete", "OnDelete", "OnAfterDelete" }),
+        ("Rename",        "OnRename", new[] { "OnBeforeRename", "OnRename", "OnAfterRename" }),
+    };
+
+    private static Dictionary<string, int>? _tableTriggerBitValues;
+
+    /// <summary>
+    /// Replacement for the private <c>NCLMetaTable.get_DefinedTriggers</c>, the single source of
+    /// <c>IsInsertTriggerDefined</c>, <c>IsModifyTriggerDefined</c>,
+    /// <c>IsOnAfterModifyTriggerDefined</c>, <c>IsDeleteTriggerDefined</c> and
+    /// <c>IsRenameTriggerDefined</c>. Returns the <c>TableTriggers</c> bitmask as its underlying
+    /// <see cref="int"/>.
+    /// </summary>
+    /// <remarks>
+    /// Observably equivalent to BC's own body — the same five bits, the same trigger names in the
+    /// same order, the same <c>…Async</c> fallback and <c>DeclaringType</c> comparison — for a
+    /// table whose tableextensions BC would have loaded. Two deliberate differences, both because
+    /// the runner hand-builds this metatable rather than loading it: the extension list is the
+    /// UNION of BC's own <c>orderedExtensionObjects</c> and the runner's tableextension registry
+    /// (the registry alone is what the runner fills, and the union keeps a BC-loaded metatable
+    /// answering exactly as BC would); and the answer is cached only once every extension's
+    /// compiled class resolves, because BC's unconditional cache would freeze an answer taken
+    /// before the test assembly loaded.
+    /// Verified against a real service tier by corpus codeunit 60433 (corpus PR #307), 6/6 on
+    /// BC 28.4.53241.0. See docs/table-trigger-metadata.md.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int NCLMetaTable_get_DefinedTriggers(object self)
+    {
+        if (self == null) return 0;
+        if (_definedTableTriggersCache.TryGetValue(self, out var cached)) return cached.Value;
+
+        var recordClrType = NCLMetaApplicationObject_get_ApplicationObjectClrType(self);
+        if (recordClrType == null) return 0;
+
+        var bits = EnsureTableTriggerBitValues(self.GetType());
+
+        int mask = 0;
+        var extensionTypes = TableExtensionTypesFor(self, out var allExtensionsResolved);
+        foreach (var (bit, baseName, extensionNames) in _tableTriggerBits)
+        {
+            var value = bits[bit];
+            if (baseName != null
+                && IsTriggerImplemented(typeof(Microsoft.Dynamics.Nav.Runtime.NavRecord),
+                                        recordClrType, baseName, isPublic: false, TableTriggerSurface))
+            {
+                mask |= value;
+                continue;
+            }
+            foreach (var extType in extensionTypes)
+            {
+                if (!extensionNames.Any(n => IsTriggerImplemented(
+                        typeof(Microsoft.Dynamics.Nav.Runtime.Extensions.NavRecordExtension),
+                        extType, n, isPublic: true, TableTriggerSurface)))
+                    continue;
+                mask |= value;
+                break;
+            }
+        }
+
+        TableTriggerAudit.Record(self, recordClrType, extensionTypes, mask, bits);
+        if (allExtensionsResolved) _definedTableTriggersCache.AddOrUpdate(self, new StrongBox<int>(mask));
+        return mask;
+    }
+
+    /// <summary>
+    /// The five <c>TableTriggers</c> bit values, read off BC's own enum by NAME rather than
+    /// assumed to be 1/2/4/8/0x10 — a renumbering would otherwise silently move which flag a bit
+    /// answers.
+    /// </summary>
+    private static Dictionary<string, int> EnsureTableTriggerBitValues(Type metaTableType)
+    {
+        if (_tableTriggerBitValues != null) return _tableTriggerBitValues;
+
+        Type? enumType = null;
+        for (var t = metaTableType; t != null && enumType == null; t = t.BaseType)
+            enumType = t.GetProperty("DefinedTriggers",
+                BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)?.PropertyType;
+
+        if (enumType == null || !enumType.IsEnum)
+            throw new BcShapeGapException(
+                "table trigger metadata", "NCLMetaTable.DefinedTriggers",
+                "BC no longer declares the private DefinedTriggers property whose enum names the "
+                + "table-trigger bits, so the runner cannot compute the Is<Trigger>Defined flags");
+
+        var values = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var v in Enum.GetValues(enumType))
+        {
+            var name = v.ToString();
+            if (!string.IsNullOrEmpty(name)) values[name!] = Convert.ToInt32(v);
+        }
+
+        foreach (var (bit, _, _) in _tableTriggerBits)
+            if (!values.ContainsKey(bit))
+                throw new BcShapeGapException(
+                    "table trigger metadata", $"NCLMetaTable.TableTriggers.{bit}",
+                    $"BC's table-trigger enum no longer declares {bit}, so the runner cannot say "
+                    + "which writes need trigger dispatch — see docs/table-trigger-metadata.md");
+
+        _tableTriggerBitValues = values;
+        return values;
+    }
+
+    /// <summary>
+    /// The compiled <c>TableExtension{id}</c> classes extending this table: BC's own
+    /// <c>orderedExtensionObjects</c> (empty on a runner-built metatable, populated on a
+    /// BC-loaded one) unioned with the runner's tableextension registry — the same
+    /// <c>_extensionIdsByBaseTable</c> / <see cref="FindTableExtensionType"/> pair that
+    /// <see cref="RegisterParsedTableExtensions"/> instantiates from, so the flag and the
+    /// extension instances a write dispatches to cannot disagree about which extensions exist.
+    /// </summary>
+    private static List<Type> TableExtensionTypesFor(object metaTable, out bool allResolved)
+    {
+        var types = new List<Type>();
+        allResolved = true;
+        if (!TryGetMetaObjectNumber(metaTable, out _, out var tableId)) return types;
+
+        foreach (var loaded in BcLoadedTableExtensionTypes(metaTable))
+            if (!types.Contains(loaded)) types.Add(loaded);
+
+        if (!_parsedTables.TryGetValue(tableId, out var parsed)) return types;
+        if (!_extensionIdsByBaseTable.TryGetValue(parsed.TableName.ToLowerInvariant(), out var extIds))
+            return types;
+
+        foreach (var extensionId in extIds)
+        {
+            var t = FindTableExtensionType(extensionId);
+            if (t != null) { if (!types.Contains(t)) types.Add(t); continue; }
+
+            allResolved = false;
+            // Loud, once per (table, extension): the flags would otherwise report this table as
+            // declaring fewer triggers than it does, and a false Is<X>TriggerDefined does not
+            // merely mislead a metadata reader — BC skips the whole trigger block on the write.
+            if (_unresolvedTableExtensionTypesWarned.Add((tableId, extensionId)))
+                Console.Out.WriteLine(
+                    $"[warn] RecordPatches: table {tableId}: tableextension {extensionId} extends it, but no "
+                    + $"compiled TableExtension{extensionId} type is loaded, so the triggers it declares are "
+                    + "missing from this table's Is<Trigger>Defined flags");
+        }
+        return types;
+    }
+
+    private static readonly HashSet<(int Table, int Extension)> _unresolvedTableExtensionTypesWarned = new();
+
+    /// <summary>
+    /// The CLR types behind BC's own <c>orderedExtensionObjects</c>, if anything filled it. A
+    /// private field on a base type is not found through inheritance by <c>GetField</c>, so the
+    /// type chain is walked by hand — same shape as <see cref="TryGetMetaObjectNumber"/>.
+    /// </summary>
+    private static IEnumerable<Type> BcLoadedTableExtensionTypes(object metaTable)
+    {
+        FieldInfo? field = null;
+        for (var t = metaTable.GetType(); t != null && field == null; t = t.BaseType)
+            field = t.GetField("orderedExtensionObjects",
+                BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+        if (field?.GetValue(metaTable) is not System.Collections.IEnumerable list) yield break;
+        foreach (var ext in list)
+        {
+            if (ext == null) continue;
+            var t = NCLMetaApplicationObject_get_ApplicationObjectClrType(ext);
+            if (t != null) yield return t;
+        }
+    }
+}
+
+/// <summary>
+/// Opt-in AUDIT of what <see cref="RecordPatches.NCLMetaTable_get_DefinedTriggers"/> answered,
+/// one line per table, written when the process exits — an inspection channel like
+/// <c>AL_RUNNER_HOOK_AUDIT</c>, not a diagnosis, so it is not <c>[warn]</c>-tagged and reports no
+/// problem. Off unless <c>AL_RUNNER_TABLE_TRIGGER_AUDIT=1</c>.
+///
+/// <para>Written straight to the process's stdout HANDLE: the test phase redirects
+/// <see cref="Console"/>, so a <c>Console.Out</c> write from here is swallowed.</para>
+/// </summary>
+internal static class TableTriggerAudit
+{
+    private static readonly bool Enabled =
+        Environment.GetEnvironmentVariable("AL_RUNNER_TABLE_TRIGGER_AUDIT") == "1";
+
+    private static readonly object Gate = new();
+    private static readonly SortedDictionary<int, string> Lines = new();
+    private static bool _flushRegistered;
+
+    internal static void Record(
+        object metaTable, Type recordClrType, List<Type> extensionTypes, int mask,
+        Dictionary<string, int> bits)
+    {
+        if (!Enabled) return;
+        if (!RecordPatches.TryGetMetaObjectNumber(metaTable, out _, out var tableId)) return;
+
+        var defined = bits.Where(b => b.Value != 0 && (mask & b.Value) == b.Value && b.Key != "Unknown")
+                          .OrderBy(b => b.Value).Select(b => b.Key).ToArray();
+        var line = $"[table-trigger-audit] table={tableId} clr={recordClrType.Name}"
+                 + $" ext={(extensionTypes.Count == 0 ? "-" : string.Join(",", extensionTypes.Select(t => t.Name)))}"
+                 + $" triggers={(defined.Length == 0 ? "-" : string.Join(",", defined))}";
+
+        lock (Gate)
+        {
+            Lines[tableId] = line;
+            if (_flushRegistered) return;
+            _flushRegistered = true;
+            AppDomain.CurrentDomain.ProcessExit += (_, _) => Flush();
+        }
+    }
+
+    private static void Flush()
+    {
+        lock (Gate)
+        {
+            try
+            {
+                using var stdout = new System.IO.StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true };
+                foreach (var line in Lines.Values) stdout.WriteLine(line);
+            }
+            catch { }
+        }
+    }
+}

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -2511,6 +2511,11 @@ public static partial class RecordPatches
             // this arm a pageextension receiver fell to the table default and resolved
             // Record{id}, so BC's own CheckTrigger threw "OnOpenPage missing on Record{id}".
             "PageExtension" => FindClrTypeByName($"PageExtension{id}"),
+            // TableExtension{id} — the table twin (#3556). BC reads this property on an
+            // NCLTableExtension too (NCLMetaTable.DefinedTriggers walks orderedExtensionObjects
+            // and asks each one), and without an arm such a receiver fell to the table default
+            // and resolved Record{extId} — a different object, usually absent.
+            "TableExtension" => FindTableExtensionType(id),
             "Report"   => FindClrTypeByName($"Report{id}"),
             "CodeUnit" => FindClrTypeByName($"Codeunit{id}"),
             _          => FindRecordType(id),

--- a/docs/table-trigger-metadata.md
+++ b/docs/table-trigger-metadata.md
@@ -1,0 +1,73 @@
+# Table trigger metadata — `NCLMetaTable`'s five `Is<Trigger>Defined` flags
+
+Issue #3556. The table twin of [page trigger metadata](page-rowset-triggers.md#page-trigger-metadata) (#3447), and it decides more: these flags do not merely answer a metadata reader, they decide whether BC dispatches a table's write triggers at all.
+
+## What BC does
+
+`IsInsertTriggerDefined`, `IsModifyTriggerDefined`, `IsOnAfterModifyTriggerDefined`, `IsDeleteTriggerDefined` and `IsRenameTriggerDefined` are each `(DefinedTriggers & TableTriggers.X) != 0`, and `NCLMetaTable.DefinedTriggers` is **reflection**, not a read of the table metadata document (`Microsoft.Dynamics.Nav.Ncl.dll`, identical body on 27.0, 27.5 and 28.4):
+
+```csharp
+tableTriggers |= IsTriggerImplemented<NavRecord>("OnInsert", isPublic: false) ? 1 : 0;   // …Modify, Delete, Rename
+foreach (NCLTableExtension ext in orderedExtensionObjects)
+{
+    if ((tableTriggers & Insert) == 0 && (ext.IsTriggerImplemented<NavRecordExtension>("OnBeforeInsert", true)
+        || ext.IsTriggerImplemented<NavRecordExtension>("OnInsert", true)
+        || ext.IsTriggerImplemented<NavRecordExtension>("OnAfterInsert", true)))
+        tableTriggers |= Insert;
+    // …Modify, the separate OnAfterModify bit, Delete, Rename — same shape
+}
+```
+
+Two properties of that body are what the runner has to reproduce and are easy to get wrong:
+
+- **`OnAfterModify` is a bit of its own**, set only by an extension declaring `OnAfterModify`, and the base-table arm never sets it. It gates `NavRecord.PerformJITLoadIfNecessaryAsync`, not a trigger.
+- **Any one of the three names sets the bit.** An extension declaring only `OnAfterInsert` sets `Insert`, which is what makes the flag "does this write need the trigger pipeline", not "does someone declare this exact trigger".
+
+## Why a false flag skips a trigger, and why only half of them
+
+`NavRecord.ALInsertAsync` (and its Modify / Delete / Rename siblings) puts the extension `OnBefore<X>` loop, the base table's own `On<X>` trigger and the extension `On<X>` loop **inside** the flag's guard, and leaves the `OnAfter<X>` loop **outside** it:
+
+```csharp
+if (runApplicationTrigger && metaTable.IsInsertTriggerDefined)
+{
+    if (orderedTableExtensions.Count > 0) await …ForEachAsync(ext => ext.OnBeforeInsert(), …);
+    if (__IsAsync) await OnInsertAsync(); else OnInsert();
+    if (orderedTableExtensions.Count > 0) await …ForEachAsync(ext => ext.OnInsert(), …);
+}
+await NavGlobalTriggers.InsertAsync(this, runGlobalTrigger);
+bool result = await recordImplementation.InsertRecordAsync(errorLevel);
+if (result)
+{
+    if (runApplicationTrigger)
+        if (orderedTableExtensions.Count > 0) await …ForEachAsync(ext => ext.OnAfterInsert(), …);
+    …
+}
+```
+
+That asymmetry is the whole observable shape of the defect. With the flag false, a tableextension's `OnAfterInsert` ran and its `OnBeforeInsert` did not — measured on the runner before the fix, on a table declaring no trigger of its own: `OnBeforeInsert,OnAfterInsert` expected, `OnAfterInsert` observed, and the same for Modify, Delete and Rename. On a base table that *does* declare `OnInsert`, the flag was already true and the extension's `OnBeforeInsert` ran, which is what pins the flag as the discriminator rather than extension dispatch being broken.
+
+## What the runner does
+
+`NCLMetaTable.get_DefinedTriggers` is Cecil-replaced (`AlRunner/Patches/RecordPatches.TableTriggerMetadata.cs`, installed from `AlRunner/Infrastructure/NclCecilRewrite.Records.cs`). `NCLMetaTable` lives in `Ncl.dll`, the runtime engine, so `precompiled-dll-respect.md` allows it; no AL-business-logic body is touched.
+
+The replacement keeps BC's algorithm — the same five bits read **by name** off BC's own enum, the same trigger-name triples in the same order, the same `…Async` fallback and `DeclaringType` comparison, transcribed through the `CheckTrigger` helper shared with the page twin. Three things differ, all because the runner hand-builds this metatable rather than loading it:
+
+| | why |
+|---|---|
+| the extension list is the **union** of BC's own `orderedExtensionObjects` and the runner's tableextension registry | the runner fills the registry and never that list; the union keeps a BC-loaded metatable answering exactly as BC would |
+| the extension list is the **same** `_extensionIdsByBaseTable` / `FindTableExtensionType` pair `RegisterParsedTableExtensions` instantiates from | the flag and the extension instances a write dispatches to cannot then disagree about which extensions exist |
+| the answer is cached only once **every** extension's compiled class resolves | BC caches unconditionally on first read; the runner resolves those types lazily from the loaded assemblies, so an unconditional cache would freeze an answer taken before the test assembly loaded |
+
+A tableextension whose compiled class never resolves produces one `[warn]` line per (table, extension) rather than a quietly smaller mask. `NCLMetaApplicationObject.ApplicationObjectClrType` gained a `TableExtension` arm at the same time: BC reads that property on an `NCLTableExtension` too, and without an arm such a receiver fell to the table default and resolved `Record{extId}`.
+
+## Evidence
+
+- **Real BC**: corpus codeunit 60433, `tests/al-language/tableextensiontrigger/` (corpus PR [#307](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/307)) — six arms, 6/6 on BC 28.4.53241.0 in a container before the PR was opened.
+- **Runner mechanism**: `AlRunner.Tests/TableTriggerMetadataTests.cs` over fixture `TableTriggerMetadata`, asserting the exact mask per table from `AL_RUNNER_TABLE_TRIGGER_AUDIT=1`.
+
+`AL_RUNNER_TABLE_TRIGGER_AUDIT=1` prints one line per table at process exit — an inspection channel like `AL_RUNNER_HOOK_AUDIT`, not a diagnosis:
+
+```
+[table-trigger-audit] table=70740 clr=Record70740 ext=TableExtension70742 triggers=Insert,Modify,Delete,OnAfterModify
+[table-trigger-audit] table=70741 clr=Record70741 ext=- triggers=Rename
+```


### PR DESCRIPTION
Closes #3556

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/307

## The measurement the issue asked for

#3556 was filed unmeasured — "it may well already work through a different runner mechanism, in which case this issue closes with that measurement recorded". It does not. Measured on `aa34c8a3` with a bundle whose base table declares no triggers and whose tableextension declares all eight before/after triggers, each appending its name to a log table read back in AL:

| arm | expected | runner, before |
|---|---|---|
| `Insert(true)` | `OnBeforeInsert,OnAfterInsert` | **`OnAfterInsert`** |
| `Modify(true)` | `OnBeforeModify,OnAfterModify` | **`OnAfterModify`** |
| `Delete(true)` | `OnBeforeDelete,OnAfterDelete` | **`OnAfterDelete`** |
| `Rename` | `OnBeforeRename,OnAfterRename` | **`OnAfterRename`** |
| base table has its own `OnInsert` | `ExtOnBeforeInsert,BaseOnInsert,ExtOnAfterInsert` | pass |
| `Insert(false)` | nothing | pass |

The `OnAfter*` half running while the `OnBefore*` half does not is the fingerprint, and the fifth row is what identifies the cause rather than guessing it: with the base table declaring its own `OnInsert`, the flag is already true and the extension's `OnBeforeInsert` runs. So the flag is the discriminator; extension dispatch itself was never broken.

## What BC does, and why the halves differ

`NCLMetaTable.DefinedTriggers` is reflection over the table's own `Record{id}` class **and** over every `NCLTableExtension` in `orderedExtensionObjects` (`Microsoft.Dynamics.Nav.Ncl.dll`, identical body on 27.0, 27.5 and 28.4). `NavRecord.ALInsertAsync` and its three siblings then put the extension `OnBefore<X>` loop, the base table's own `On<X>` trigger and the extension `On<X>` loop **inside** `if (runApplicationTrigger && metaTable.Is<X>TriggerDefined)`, and leave the `OnAfter<X>` loop **outside** it, guarded by `runApplicationTrigger` alone. A false flag therefore skips exactly the first three and keeps the fourth — which is the table above, line for line.

The full decompiled bodies, the two easy-to-miss properties of BC's computation (`OnAfterModify` is a bit of its own with no base-table arm; any one of the three names sets the bit) and the runner's three deliberate differences are in **`docs/table-trigger-metadata.md`** — that is where the derivation went, with a one-line pointer at the patch.

## The change

1. **`NCLMetaTable.get_DefinedTriggers` is Cecil-replaced** (`AlRunner/Patches/RecordPatches.TableTriggerMetadata.cs`, installed from `NclCecilRewrite.Records.cs`). BC's algorithm kept: the five bits read **by name** off BC's own enum rather than assumed to be 1/2/4/8/0x10, the same trigger-name triples in the same order, the same `…Async` fallback and `DeclaringType` comparison. `NCLMetaTable` is in `Ncl.dll`, the runtime engine — `precompiled-dll-respect.md` allows it, and no AL-business-logic body is touched.
2. **The extension list is the union of BC's own `orderedExtensionObjects` and the runner's registry.** The runner fills only the registry; the union means a metatable BC did load answers exactly as BC would, rather than being narrowed by the replacement.
3. **The registry read is the same `_extensionIdsByBaseTable` / `FindTableExtensionType` pair `RegisterParsedTableExtensions` instantiates from**, so the flag and the extension instances a write dispatches to cannot disagree about which extensions exist. That is the third "fix the shape" question answered rather than left open.
4. **`ApplicationObjectClrType` gains a `TableExtension` arm** — the sibling gap. BC reads that property on an `NCLTableExtension` too, and the switch had no arm for it, so such a receiver fell to the table default and resolved `Record{extId}`. Exactly the shape #3557 found on the page side, one type over.
5. **`AL_RUNNER_TABLE_TRIGGER_AUDIT=1`** prints one line per table at process exit — an opt-in inspection channel like `AL_RUNNER_HOOK_AUDIT`, not a diagnosis, so deliberately not `[warn]`-tagged. A tableextension whose compiled class never resolves *is* `[warn]`, once per (table, extension), because the alternative is a quietly smaller mask.
6. **The page twin's `IsTriggerImplemented` / `CheckTrigger` / `LookupTrigger` are now shared** by both computations through a `TriggerSurface` record, so the two cannot drift and the `BcShape.FindMethod` ratchet gains no new site (`BcShapeMethodLookupTests` green at 72).

## RED to GREEN

**RED** (the Cecil rewrite gated off behind a temporary env check, so BC's own body runs; the gate was removed before committing and the file restored from a copy taken first):

- measurement bundle: **2 pass, 4 fail**, the four rows above.
- `TableTriggerMetadataTests`: `Failed: 1, Passed: 0` — no `[table-trigger-audit]` line at all.

**GREEN**: measurement bundle **6P/0F**, `TableTriggerMetadataTests` passing, audit output:

```
[table-trigger-audit] table=65001 clr=Record65001 ext=TableExtension65004 triggers=Insert,Modify,Delete,Rename,OnAfterModify
[table-trigger-audit] table=65002 clr=Record65002 ext=TableExtension65005 triggers=Insert
```

## Where the proving tests live

- **BC behaviour → upstream.** Corpus PR **#307** adds `tests/al-language/tableextensiontrigger/` — the same six arms, codeunit 60433. **Container-verified before opening**: BC 28.4.53241.0 (OnPrem w1), 6/6 `Success`. CI since agreed: **all 16 legs green**, and `tools/corpus-pass-count.py 34323966500 Tableextension` reports **6 distinct PASS on each of the 8 cloud legs** (the 8 OnPrem legs run a 29-test suite that does not include it). No corpus test declared a table trigger inside a `tableextension` before this one.
- **Runner mechanism → here.** `AlRunner.Tests/TableTriggerMetadataTests.cs` over fixture `TableTriggerMetadata` (ids 70740-70759, `platform` only, no application floor) asserts the exact mask per table. Two directions: a table declaring nothing whose extension declares `OnBeforeInsert` / `OnAfterModify` / `OnBeforeDelete` and **not** the rename pair, so an implementation answering "all five bits" fails; and a table declaring only its own `OnRename` with no extension, so a fix that widened the base arm fails.

**No pin bump.** `main`'s pin is `c9d5f656` and the corpus tip is blocked-by-intervening — corpus #293 needs #3580, #272 needs #3593, #273 needs #2943 — so this commit sits behind them too and cannot be pinned yet. The corpus PR merging is what makes the claim adjudicated; our CI replaying it waits on **#3580** and the rest.

## Runs on this head

| run | result |
|---|---|
| full corpus at the pin `c9d5f656`, CI's flags (`--strict --expectations-require-match --count-baseline`), all three apps | **3141 total, 3141 pass, 0 fail, 0 error** — of which 3 `pass-oos`, 6 `pass-known-gap`, 1 `pass-divergence`, all unchanged. No `[warn] … no compiled TableExtension` line anywhere in the run, so every extension resolved and every mask was cached. |
| `tests/runner-extras --strict` | **399P/0F/0E**, exit 0 |
| `dotnet test --filter TableTriggerMetadataTests\|PageTriggerMetadataTests\|BcShapeMethodLookupTests\|BcMatrixDocumentationDriftTests\|LoudDiagnosisReachesTheUserTests\|TestPageRefusalClaimTests`, re-run after the rebase | 157 passed, 0 failed, 1 skipped |

The corpus run is here rather than optional: `RecordPatches` on the write path is the "run wider anyway" case, and flipping this flag changes behaviour for every table carrying a tableextension.

## Not folded, and what I looked at

- **Open-issue scan for this area** (`NCLMetaTable`, `RecordPatches`, trigger dispatch): nothing else lands in `RecordPatches.TableTriggerMetadata.cs`, `NclCecilRewrite.Records.cs`'s new block or the `ApplicationObjectClrType` switch. #3447's own follow-ups are page-side. Nothing folded, and that is the finding rather than an omission.
- **Precompiled (dependency) tableextensions are unmeasured**, exactly as on the page side. The union in change 2 is what covers them in principle — a BC-loaded metatable keeps its own list — but `no-base-app-in-csharp-tests.md` forbids an `application` floor in an `AlRunner.Tests` fixture, so this is stated rather than asserted. The full corpus, which does declare a Base Application dependency, is green either way.
- **`IsOnAfterModifyTriggerDefined` has no AL-observable of its own.** It gates `NavRecord.PerformJITLoadIfNecessaryAsync`, a partial-record load. The bit is computed and audited; nothing in the corpus arm turns on it alone.

---

*PR by agent `fbk-2`, an AL Runner implementation agent.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kko97BZZL71nF2nK5aftu4
