### PR TITLE
fix(query): refuse a failed reflection lookup instead of yielding no filters

### DIFF
--- a/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
+++ b/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
@@ -223,8 +223,10 @@ public sealed class BcInternalsNullForgivingGuardTests
 
         // A ratchet, not a fact about the code: it goes UP when a site is deliberately
         // converted, and a drop means a conversion was undone. 74 -> 75 for the
-        // DataItemTableFilter read in RecordPatches.QueryProjection.cs (#3571).
-        Assert.Equal(75, converted);
+        // DataItemTableFilter read in RecordPatches.QueryProjection.cs (#3571); 75 -> 80 for
+        // the five lookups in that same method's GetSingleDataItemTableFilterTuples, whose
+        // failure used to be a silent `yield break` the caller read as "no filters" (#3647).
+        Assert.Equal(80, converted);
     }
 
     /// <summary>

--- a/AlRunner.Tests/QueryDataItemFilterShapeGapTests.cs
+++ b/AlRunner.Tests/QueryDataItemFilterShapeGapTests.cs
@@ -1,0 +1,367 @@
+// QueryDataItemFilterShapeGapTests — issue #3647.
+//
+// WHAT IS BEING PROVED
+//   GetSingleDataItemTableFilterTuples reaches a single-dataitem query's static
+//   DataItemTableFilter through reflection (#3571). Several of its early exits were
+//   `yield break` on a FAILED REFLECTION LOOKUP, and at the one call site — the
+//   TranslateQueryFilters pass that pushes those tuples into the read request — a
+//   `yield break` is indistinguishable from "this dataitem legitimately has no filters".
+//
+//   So a BC rename of NCLMetaQueryDataItem.TableFiltersAndMarks would have SILENTLY
+//   UNAPPLIED the filter: the query returns more rows than it should, nothing throws, and
+//   a passing test cannot tell the difference unless it asserts the row count. That is the
+//   silent-default shape .claude/rules/loud-failures.md forbids, and BcShapeGapException.cs's
+//   own line puts it on the refusing side — the read could not be PERFORMED.
+//
+//   LATENT, not live. Every BC version this repository tests resolves all four members, and
+//   the live path is covered by the AL bundle in
+//   tests/runner-extras/query-dataitem-filter-precompiled-dep. These arms are about what
+//   happens on the BC version where one of them moves.
+//
+// WHY THE METHOD TAKES ITS TYPES AS PARAMETERS
+//   The reads are against BC types held in RecordPatches statics (_tNCLMetaQuery,
+//   _tFiltersAndMarks, _tFilterFieldDictionary) that only a loaded Ncl.dll populates. Taking
+//   them as parameters is the same idiom PermissionMetadataShapeGapTests drives SetProperty
+//   and BuildIncludeList through: real production code, fakes standing in for a BC type whose
+//   member moved, no BC install required. Poking the statics instead would have left them
+//   poisoned for every other test in the assembly.
+//
+// THE NEGATIVE CONTROLS ARE NOT DECORATION
+//   Four of this method's exits are genuine "nothing to do" answers and MUST stay silent:
+//   the multi-dataitem guard, the sub-query skip, a null TableFiltersAndMarks and a null
+//   Filters. Turning any of them into an error would be a regression that no arm asserting
+//   only "it throws now" could catch. Each has an arm here.
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class QueryDataItemFilterShapeGapTests
+{
+    private const string Surface = "AL query execution (projection and filter push-down)";
+
+    // ══ 1. THE FOUR LOOKUPS THAT MUST REFUSE ═════════════════════════════════════════════
+    //
+    // Each arm removes exactly ONE member and leaves the other three in place, so a fix that
+    // threw unconditionally would still have to name the right member to pass — and the
+    // control arms below would fail it outright.
+
+    [Fact]
+    public void QueryDefinitionLookup_RaisesAShapeGapNamingTheMember_WhenBcRenamesIt()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Drain(typeof(QueryWithoutQueryDefinition), new QueryWithoutQueryDefinition()));
+
+        Assert.Contains("QueryDefinition", ex.Member, StringComparison.Ordinal);
+        Assert.Contains(nameof(QueryWithoutQueryDefinition), ex.Member, StringComparison.Ordinal);
+        Assert.StartsWith("bc-shape-gap: ", ex.Message, StringComparison.Ordinal);
+        Assert.Equal(Surface, ex.Surface);
+    }
+
+    [Fact]
+    public void DataItemsLookup_RaisesAShapeGapNamingTheMember_WhenBcRenamesIt()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Drain(typeof(FakeQuery), new FakeQuery(new DefinitionWithoutDataItems())));
+
+        Assert.Contains("DataItems", ex.Member, StringComparison.Ordinal);
+        Assert.Contains(nameof(DefinitionWithoutDataItems), ex.Member, StringComparison.Ordinal);
+        Assert.StartsWith("bc-shape-gap: ", ex.Message, StringComparison.Ordinal);
+        // The LOOKUP failed, which is a different fact from the property being there and
+        // reading null (the arm below). Without this the two are indistinguishable, and a
+        // `GetProperty(...)?.GetValue(...)` that silently collapses them passes both.
+        Assert.Contains("property not found", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("read as null", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DataItemsReadingNull_RaisesASeparatelyWordedShapeGap_NotTheLookupOne()
+    {
+        // A property that IS there and answers null. BC cannot build a query with no
+        // dataitems, so this is still a refusal — but it must not masquerade as the lookup
+        // having failed, or a reader chases a rename that did not happen.
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Drain(typeof(FakeQuery), new FakeQuery(new DefinitionWhoseDataItemsIsNull())));
+
+        Assert.Contains("DataItems", ex.Member, StringComparison.Ordinal);
+        Assert.Contains("read as null", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("property not found", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TableFiltersAndMarksLookup_RaisesAShapeGapNamingTheMember_WhenBcRenamesIt()
+    {
+        // The member #3647 names: the one whose disappearance drops the filter silently.
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Drain(typeof(FakeQuery),
+                        new FakeQuery(new FakeDefinition(new DataItemWithoutTableFilters()))));
+
+        Assert.Contains("TableFiltersAndMarks", ex.Member, StringComparison.Ordinal);
+        Assert.Contains(nameof(DataItemWithoutTableFilters), ex.Member, StringComparison.Ordinal);
+        Assert.StartsWith("bc-shape-gap: ", ex.Message, StringComparison.Ordinal);
+        Assert.EndsWith(" — see docs/limitations.md#bc-shape-gaps", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ItemsLookup_RaisesAShapeGapNamingTheMember_WhenBcRenamesIt()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Drain(typeof(FakeQuery),
+                        new FakeQuery(new FakeDefinition(new FakeDataItem(new FakeFiltersAndMarks(
+                            new DictionaryWithoutItems())))),
+                        famType: typeof(FakeFiltersAndMarks),
+                        dictType: typeof(DictionaryWithoutItems)));
+
+        Assert.Contains("Items", ex.Member, StringComparison.Ordinal);
+        Assert.Contains(nameof(DictionaryWithoutItems), ex.Member, StringComparison.Ordinal);
+        Assert.StartsWith("bc-shape-gap: ", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DataItemsThatIsNotEnumerable_RaisesAShapeGapNamingWhatItActuallyHeld()
+    {
+        // A member that is PRESENT but holds a shape the runner cannot use is the same
+        // "BC's layout moved" case as an absent one — BcShapeGapException.cs's own line.
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Drain(typeof(FakeQuery), new FakeQuery(new DefinitionWhoseDataItemsIsAnInt())));
+
+        Assert.Contains("DataItems", ex.Member, StringComparison.Ordinal);
+        Assert.Contains("Int32", ex.Message, StringComparison.Ordinal);
+    }
+
+    // ══ 2. NEGATIVE CONTROLS — the exits that must STAY silent ═══════════════════════════
+    //
+    // Every one of these is a genuine "nothing to do" answer. Without them, "absent refuses"
+    // is satisfiable by a change that refuses on everything, which would break the ordinary
+    // no-filter query on every BC version.
+
+    [Fact]
+    public void ADataItemWithNoFiltersAtAll_StillYieldsNothing_AndDoesNotThrow()
+    {
+        // TableFiltersAndMarks resolved and BC answered null. That IS the answer "no filters".
+        var tuples = Drain(typeof(FakeQuery),
+            new FakeQuery(new FakeDefinition(new FakeDataItem(null))));
+
+        Assert.Empty(tuples);
+    }
+
+    [Fact]
+    public void AFiltersAndMarksWhoseFiltersIsNull_StillYieldsNothing_AndDoesNotThrow()
+    {
+        var tuples = Drain(typeof(FakeQuery),
+            new FakeQuery(new FakeDefinition(new FakeDataItem(new FakeFiltersAndMarks(null)))),
+            famType: typeof(FakeFiltersAndMarks),
+            dictType: typeof(FakeFilterFieldDictionary));
+
+        Assert.Empty(tuples);
+    }
+
+    [Fact]
+    public void AMultiDataItemQuery_StillYieldsNothing_BecauseTheJoinPathAppliesThemItself()
+    {
+        var tuples = Drain(typeof(FakeQuery),
+            new FakeQuery(new FakeDefinition(
+                new FakeDataItem(new FakeFiltersAndMarks(new FakeFilterFieldDictionary("a"))),
+                new FakeDataItem(new FakeFiltersAndMarks(new FakeFilterFieldDictionary("b"))))),
+            famType: typeof(FakeFiltersAndMarks),
+            dictType: typeof(FakeFilterFieldDictionary));
+
+        Assert.Empty(tuples);
+    }
+
+    [Fact]
+    public void ASynthesizedSubQueryDataItem_IsSkipped_LeavingTheQuerySingleDataItem()
+    {
+        // #2300's exclusion. The synthesized dataitem must NOT count toward the single-dataitem
+        // test, so this query still yields its one real dataitem's filter.
+        var tuples = Drain(typeof(FakeQuery),
+            new FakeQuery(new FakeDefinition(
+                new FakeDataItem(new FakeFiltersAndMarks(new FakeFilterFieldDictionary("kept"))),
+                new FakeDataItem(new FakeFiltersAndMarks(new FakeFilterFieldDictionary("dropped")))
+                    { SubQueryDefinition = new object() })),
+            famType: typeof(FakeFiltersAndMarks),
+            dictType: typeof(FakeFilterFieldDictionary));
+
+        Assert.Equal(new object[] { "kept" }, tuples);
+    }
+
+    [Fact]
+    public void ANullQueryDefinition_StillYieldsNothing_AndDoesNotThrow()
+    {
+        // The property resolved and answered null — an answer, not a failed read.
+        var tuples = Drain(typeof(FakeQuery), new FakeQuery(null));
+
+        Assert.Empty(tuples);
+    }
+
+    // ══ 3. THE HAPPY PATH, so none of the above is vacuous ═══════════════════════════════
+
+    [Fact]
+    public void ASingleDataItemWithFilters_YieldsExactlyThoseTuples()
+    {
+        var tuples = Drain(typeof(FakeQuery),
+            new FakeQuery(new FakeDefinition(new FakeDataItem(
+                new FakeFiltersAndMarks(new FakeFilterFieldDictionary("first", "second"))))),
+            famType: typeof(FakeFiltersAndMarks),
+            dictType: typeof(FakeFilterFieldDictionary));
+
+        Assert.Equal(new object[] { "first", "second" }, tuples);
+    }
+
+    [Fact]
+    public void ANullEntryInTheItemsArray_IsSkippedRatherThanYielded()
+    {
+        var tuples = Drain(typeof(FakeQuery),
+            new FakeQuery(new FakeDefinition(new FakeDataItem(
+                new FakeFiltersAndMarks(new FakeFilterFieldDictionary("kept", null, "also kept"))))),
+            famType: typeof(FakeFiltersAndMarks),
+            dictType: typeof(FakeFilterFieldDictionary));
+
+        Assert.Equal(new object[] { "kept", "also kept" }, tuples);
+    }
+
+    // ══ 4. WHAT AL CAN DO WITH THE REFUSAL: NOTHING ══════════════════════════════════════
+    //
+    // The point of BcShapeGapException over the RunnerOutOfScopeException flavours. Under
+    // `asserterror`, absorbing this would INVERT the result — real BC reads the filter fine,
+    // so the asserterror fails there and would have passed here.
+
+    [Fact]
+    public void TheRefusal_TearsThroughBothAlSeams_AndIsNotAnAbsorbableOutOfScopeSignal()
+    {
+        object Read() => Drain(typeof(FakeQuery),
+            new FakeQuery(new FakeDefinition(new DataItemWithoutTableFilters())));
+
+        var viaAssertError = Assert.Throws<BcShapeGapException>(
+            () => BcRuntime.NavMethodScope_AssertError(null!, () => Read()));
+        Assert.Contains("TableFiltersAndMarks", viaAssertError.Member, StringComparison.Ordinal);
+
+        var viaTryFunction = Assert.Throws<BcShapeGapException>(
+            () => BcRuntime.NavApplicationObjectBase_TryInvoke(null, () => Read()));
+        Assert.Contains("TableFiltersAndMarks", viaTryFunction.Member, StringComparison.Ordinal);
+
+        // Neither the reporter nor an expect-oos manifest entry may recover it, so a
+        // BC-layout regression can never be declared an expected out-of-scope surface.
+        Assert.False(OutOfScopeMessage.TryParse(viaAssertError.Message, out _));
+        Assert.Null(OutOfScopeMessage.FromException(viaAssertError));
+    }
+
+    // ══ 5. THE REFLECTION PIN: name, arity, uniqueness — liveness is guarded separately ═══
+    //
+    // ReflectionDrivenHelperLivenessTests measures LIVENESS from IL for every RecordPatches
+    // member any test names as a literal, and this file names GetSingleDataItemTableFilterTuples
+    // — so a change that leaves the method declared but stops production reaching it fails
+    // there. What is pinned HERE is the half that guard cannot see: that the member exists,
+    // is unique by name, and takes exactly the four parameters these arms pass.
+
+    [Fact]
+    public void TheHelperIsUniqueByName_AndTakesTheFourParametersTheseArmsDriveItWith()
+    {
+        var candidates = typeof(RecordPatches)
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .Where(m => m.Name == "GetSingleDataItemTableFilterTuples")
+            .ToList();
+
+        Assert.Single(candidates);
+        Assert.Equal(
+            new[] { typeof(object), typeof(Type), typeof(Type), typeof(Type) },
+            candidates[0].GetParameters().Select(p => p.ParameterType).ToArray());
+        Assert.Equal(typeof(IEnumerable<object>), candidates[0].ReturnType);
+    }
+
+    // ══ Plumbing ═════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Drives the real production helper to completion. Draining matters: it is an iterator,
+    /// so nothing in it runs — and nothing throws — until the sequence is enumerated, exactly
+    /// as the production foreach at the call site enumerates it.
+    /// </summary>
+    private static List<object> Drain(Type queryType, object metaAppObj,
+                                      Type? famType = null, Type? dictType = null)
+    {
+        var m = typeof(RecordPatches).GetMethod(
+                    "GetSingleDataItemTableFilterTuples", BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "test setup: RecordPatches.GetSingleDataItemTableFilterTuples not found");
+        try
+        {
+            var seq = (IEnumerable<object>)m.Invoke(null, new object?[]
+            {
+                metaAppObj, queryType,
+                famType ?? typeof(FakeFiltersAndMarks),
+                dictType ?? typeof(FakeFilterFieldDictionary),
+            })!;
+            return seq.ToList();
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            throw tie.InnerException;   // the reflection wrapper is not part of the contract
+        }
+    }
+
+    // ── Fakes standing in for BC's types. Each names the member it is missing. ──
+
+    private sealed class QueryWithoutQueryDefinition
+    {
+    }
+
+    private sealed class FakeQuery
+    {
+        public FakeQuery(object? queryDefinition) => QueryDefinition = queryDefinition;
+        public object? QueryDefinition { get; }
+    }
+
+    private sealed class DefinitionWithoutDataItems
+    {
+    }
+
+    private sealed class DefinitionWhoseDataItemsIsAnInt
+    {
+        public int DataItems => 7;
+    }
+
+    private sealed class DefinitionWhoseDataItemsIsNull
+    {
+        public object? DataItems => null;
+    }
+
+    private sealed class FakeDefinition
+    {
+        public FakeDefinition(params object?[] items) => DataItems = items;
+        public object?[] DataItems { get; }
+    }
+
+    private sealed class DataItemWithoutTableFilters
+    {
+        public object? SubQueryDefinition => null;
+    }
+
+    private sealed class FakeDataItem
+    {
+        public FakeDataItem(object? tableFiltersAndMarks) => TableFiltersAndMarks = tableFiltersAndMarks;
+        public object? TableFiltersAndMarks { get; }
+        public object? SubQueryDefinition { get; init; }
+    }
+
+    private sealed class FakeFiltersAndMarks
+    {
+        public FakeFiltersAndMarks(object? filters) => Filters = filters;
+        public object? Filters { get; }
+    }
+
+    private sealed class DictionaryWithoutItems
+    {
+    }
+
+    private sealed class FakeFilterFieldDictionary
+    {
+        public FakeFilterFieldDictionary(params object?[] items) => Items = items;
+        public object?[] Items { get; }
+    }
+}

--- a/AlRunner/Patches/RecordPatches.QueryProjection.cs
+++ b/AlRunner/Patches/RecordPatches.QueryProjection.cs
@@ -600,7 +600,8 @@ public static partial class RecordPatches
         // The join path reads TableFiltersAndMarks separately, per dataitem, in
         // RecordPatches.QueryJoin.BuildTableFindAllRequest; this pass is the single-dataitem
         // path's equivalent and must not double-apply, hence the single-dataitem guard.
-        foreach (var tuple in GetSingleDataItemTableFilterTuples(metaAppObj!))
+        foreach (var tuple in GetSingleDataItemTableFilterTuples(
+                     metaAppObj!, _tNCLMetaQuery!, _tFiltersAndMarks!, _tFilterFieldDictionary!))
         {
             translatedTuples.Add(tuple);
             anyTranslated = true;
@@ -628,10 +629,6 @@ public static partial class RecordPatches
 
     private static Type? _tNCLMetaQueryColumn;
     private static PropertyInfo? _pNCLMetaQueryColumnFilters; // #2418
-    private static PropertyInfo? _pNclMetaQueryQueryDefinition3;   // #3571
-    private static PropertyInfo? _pQueryDefDataItems3;             // #3571
-    private static PropertyInfo? _pDataItemTableFiltersAndMarks;   // #3571
-    private static PropertyInfo? _pDataItemSubQueryDefinition3;    // #3571
 
     /// <summary>
     /// The <c>(INavFieldMetadata, FilterExpression)</c> tuples of a SINGLE-dataitem query's
@@ -649,49 +646,80 @@ public static partial class RecordPatches
     /// read request (<c>RecordPatches.QueryJoin.BuildTableFindAllRequest</c>). Returning them
     /// here as well would push one dataitem's table-field filter into a request covering
     /// another dataitem's table.</para>
+    ///
+    /// <para>#3647 — a FAILED LOOKUP refuses; an EMPTY ANSWER stays silent. The two were the
+    /// same <c>yield break</c>, and the caller cannot tell them apart, so a BC rename of any
+    /// of these four members would have unapplied the filter and returned MORE ROWS with
+    /// nothing said. Which exit is which, and why, is in
+    /// docs/query-dataitem-table-filter.md#a-failed-lookup-refuses.</para>
+    ///
+    /// <para>The three BC types are parameters rather than reads of the statics so the refusals
+    /// can be driven with fakes standing in for a moved member —
+    /// <c>AlRunner.Tests/QueryDataItemFilterShapeGapTests</c>. Production passes exactly the
+    /// statics the old body read.</para>
     /// </summary>
-    private static IEnumerable<object> GetSingleDataItemTableFilterTuples(object metaAppObj)
+    private static IEnumerable<object> GetSingleDataItemTableFilterTuples(
+        object metaAppObj, Type tQuery, Type tFiltersAndMarks, Type tFilterFieldDictionary)
     {
-        var nclAsm = metaAppObj.GetType().Assembly;
-        const string rt = "Microsoft.Dynamics.Nav.Runtime.";
-        _pNclMetaQueryQueryDefinition3 ??= _tNCLMetaQuery!.GetProperty("QueryDefinition",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-        var queryDef = _pNclMetaQueryQueryDefinition3?.GetValue(metaAppObj);
+        const string surface = "AL query execution (projection and filter push-down)";
+        const BindingFlags anyInstance =
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+        // A null QueryDefinition is an ANSWER (a metaquery carrying no definition); the lookup
+        // failing is not, so only the read is behind the throwing accessor.
+        var queryDef = BcShape.Property(tQuery, "QueryDefinition", anyInstance, surface)
+            .GetValue(metaAppObj);
         if (queryDef == null) yield break;
 
-        _pQueryDefDataItems3 ??= nclAsm.GetType(rt + "NCLMetaQueryDefinition")?
-            .GetProperty("DataItems", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-        if (_pQueryDefDataItems3?.GetValue(queryDef) is not System.Collections.IEnumerable dataItems)
-            yield break;
-
-        var tDataItem = nclAsm.GetType(rt + "NCLMetaQueryDataItem");
-        _pDataItemSubQueryDefinition3 ??= tDataItem?.GetProperty("SubQueryDefinition",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-        _pDataItemTableFiltersAndMarks ??= tDataItem?.GetProperty("TableFiltersAndMarks",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-        if (_pDataItemTableFiltersAndMarks == null) yield break;
+        // Resolved off the value's own runtime type rather than by type NAME. Same member on
+        // BC — the value IS an NCLMetaQueryDefinition — and it removes an assembly-name lookup
+        // that could fail for a second reason (a type that moved namespace) reported as the
+        // same gap. The dataitem lookups below do the same.
+        var tQueryDef = queryDef.GetType();
+        var rawDataItems = BcShape.Property(tQueryDef, "DataItems", anyInstance, surface)
+            .GetValue(queryDef);
+        // Null or non-enumerable both mean the runner could not read BC's dataitem list. There
+        // is no "a query has no dataitems" answer for it to be confused with — BC cannot build
+        // an NCLMetaQuery without one — so neither is silent.
+        if (rawDataItems == null)
+            throw new BcShapeGapException(
+                surface, $"{tQueryDef.Name}.DataItems",
+                "read as null — every query BC builds has at least one dataitem, so the runner "
+                + "cannot tell a legitimately empty list from a member that moved");
+        var dataItems = BcShape.RequiredEnumerable(
+            rawDataItems, $"{tQueryDef.Name}.DataItems", surface,
+            "the runner walks it to find the query's single dataitem");
 
         // #2300's exclusion, for the same reason it exists there: a FlowField-calculation
         // synthesized dataitem is not one of the query's own, and counting it would make a
         // genuinely single-dataitem query look like a join and skip this pass entirely.
+        //
+        // The two per-dataitem lookups are resolved off the dataitem's own runtime type rather
+        // than a type name, so a fake stands in for a moved member without also having to fake
+        // the assembly. On BC that type IS NCLMetaQueryDataItem.
         var real = new List<object>();
+        PropertyInfo? pTableFiltersAndMarks = null;
         foreach (var di in dataItems)
         {
-            if (di == null) continue;
-            if (_pDataItemSubQueryDefinition3?.GetValue(di) != null) continue;
+            if (di == null) continue;   // structural: not a failed read
+            var tDataItem = di.GetType();
+            if (BcShape.Property(tDataItem, "SubQueryDefinition", anyInstance, surface).GetValue(di) != null)
+                continue;               // structural: BC's synthesized sub-dataitem
+            pTableFiltersAndMarks = BcShape.Property(tDataItem, "TableFiltersAndMarks", anyInstance, surface);
             real.Add(di);
         }
+        // Not a failed read: this method is explicitly the SINGLE-dataitem case, and the join
+        // path applies a multi-dataitem query's filters itself (see the para above).
         if (real.Count != 1) yield break;
 
-        var fam = _pDataItemTableFiltersAndMarks.GetValue(real[0]);
-        if (fam == null) yield break;
+        var fam = pTableFiltersAndMarks!.GetValue(real[0]);
+        if (fam == null) yield break;                       // BC's answer: this dataitem has none
         var filters = BcShape.Property(
-            _tFiltersAndMarks!, "Filters", BindingFlags.Public | BindingFlags.Instance,
-            "AL query execution (projection and filter push-down)").GetValue(fam);
-        if (filters == null) yield break;
-        var items = (Array?)_tFilterFieldDictionary!.GetProperty("Items",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(filters);
-        if (items == null) yield break;
+            tFiltersAndMarks, "Filters", BindingFlags.Public | BindingFlags.Instance, surface)
+            .GetValue(fam);
+        if (filters == null) yield break;                   // BC's answer: no filter dictionary
+        var items = (Array?)BcShape.Property(
+            tFilterFieldDictionary, "Items", anyInstance, surface).GetValue(filters);
+        if (items == null) yield break;                     // BC's answer: an empty dictionary
         foreach (var item in items)
             if (item != null) yield return item;
     }

--- a/docs/query-dataitem-table-filter.md
+++ b/docs/query-dataitem-table-filter.md
@@ -161,3 +161,58 @@ is a **table field** of the dataitem's own `RelatedTable`, resolved against that
 - `AlRunner.Tests/BcAppSymbolCacheQueryDataItemFilterTests` — the symbol layer, asserting the
   property text arrives verbatim on root and nested dataitems, with a negative control for a
   dataitem declaring no filter.
+
+## A failed lookup refuses
+
+Issue #3647. `GetSingleDataItemTableFilterTuples` reads four BC members through reflection,
+and its early exits were all the same `yield break`. Two different facts shared it:
+
+- **a failed reflection lookup** — "BC does not have the member I need", and
+- **an empty answer** — "this dataitem legitimately has no filters".
+
+The one call site is a `foreach` that adds whatever it yields, so it cannot tell them apart.
+That made a BC rename of `NCLMetaQueryDataItem.TableFiltersAndMarks` **unapply the filter
+silently**: the query returns more rows than it should, nothing throws, and a test only
+notices if it asserts the row count. `.claude/rules/loud-failures.md` forbids that shape, and
+`AlRunner/Infrastructure/BcShapeGapException.cs` puts a read that could not be *performed* on
+the refusing side.
+
+Latent, not live: every BC version this repository tests resolves all four, and
+`tests/runner-extras/query-dataitem-filter-precompiled-dep` covers the live path. The change
+is about the BC version where one of them moves.
+
+### Which exit is which
+
+| exit | now | why |
+|---|---|---|
+| `QueryDefinition` lookup | **refuses** | the member is absent — BC's layout moved |
+| `QueryDefinition` reads null | silent | an answer: this metaquery carries no definition |
+| `DataItems` lookup | **refuses** | as above, and worded so it cannot be confused with the next row |
+| `DataItems` reads null | **refuses** | BC builds no query without a dataitem, so there is no empty-list answer this could be |
+| `DataItems` holds a non-enumerable | **refuses** | present but uninterpretable is the same "layout moved" case |
+| `SubQueryDefinition` / `TableFiltersAndMarks` lookup | **refuses** | the members #3647 names |
+| `di == null`, sub-query dataitem | silent | structural — #2300's exclusion, not a failed read |
+| `real.Count != 1` | silent | the method is explicitly the single-dataitem case; the join path applies a multi-dataitem query's filters itself |
+| `TableFiltersAndMarks` reads null | silent | BC's answer: this dataitem has no filters |
+| `Filters` reads null | silent | BC's answer: no filter dictionary |
+| `Items` lookup | **refuses** | absent member |
+| `Items` reads null | silent | BC's answer: an empty dictionary |
+
+The refusals raise `BcShapeGapException`, which tears through both AL trapping seams — under
+`asserterror` a swallowed refusal would *invert* the result, since real BC reads the filter
+fine and the asserterror fails there.
+
+### What is not covered
+
+`RecordPatches.QueryJoin.BuildTableFindAllRequest` reads the same
+`TableFiltersAndMarks` for the **join** path and has the same shape, plus a bare `catch`
+that falls back to `FiltersAndMarks.Empty` — so a rename unapplies a join dataitem's filter
+just as silently. Different file and different call path, so it is tracked separately rather
+than folded in.
+
+### What proves it
+
+`AlRunner.Tests/QueryDataItemFilterShapeGapTests` — five arms for the refusals, each removing
+one member and leaving the others, and four negative controls for the exits that must stay
+silent. The method takes its three BC types as parameters so fakes can stand in for a moved
+member without a BC install and without poisoning the `RecordPatches` statics for other tests.


### PR DESCRIPTION
Closes #3647

Corpus-NA: the claim is that the runner's own reflection refuses rather than substituting a default; a corpus test cannot express a lookup failure against a member that resolves on every tier it runs on

`GetSingleDataItemTableFilterTuples` reads four BC members through reflection to apply a
single-dataitem query's static `DataItemTableFilter` (#3571), and its early exits were all the
same `yield break`. Two different facts shared it:

- **a failed reflection lookup** — "BC does not have the member I need", and
- **an empty answer** — "this dataitem legitimately has no filters".

The one call site is a `foreach` that adds whatever it yields, so it cannot tell them apart. A
BC rename of `NCLMetaQueryDataItem.TableFiltersAndMarks` would therefore have **unapplied the
filter silently** — the query returns more rows than it should, nothing throws, and a passing
test cannot notice unless it asserts the row count. That is the shape
`.claude/rules/loud-failures.md` forbids.

**Latent, not live.** Every BC version this repository tests resolves all four members
(confirmed on the `bc284` context: `TableFiltersAndMarks` is a real property on
`NCLMetaQueryDataItem`), and the live path is covered by
`tests/runner-extras/query-dataitem-filter-precompiled-dep`, which still passes 2/2. This is a
trap for the next BC version, not an observable defect now.

## Which exits are now loud, and which stay silent

Five lookups route through the throwing `BcShape.Property` accessor — matching what the
load-bearing `Filters` read in this same method already did, which is why the defect was
latent rather than live. Four genuine "nothing to do" exits stay silent.

| exit | now | why |
|---|---|---|
| `QueryDefinition` lookup | **refuses** | the member is absent — BC's layout moved |
| `QueryDefinition` reads null | silent | an answer: this metaquery carries no definition |
| `DataItems` lookup | **refuses** | absent member, worded so it cannot be confused with the next row |
| `DataItems` reads null | **refuses** | BC builds no query without a dataitem, so there is no empty-list answer this could be |
| `DataItems` holds a non-enumerable | **refuses** | present but uninterpretable is the same "layout moved" case |
| `SubQueryDefinition` lookup | **refuses** | absent member |
| `TableFiltersAndMarks` lookup | **refuses** | the member #3647 names |
| `di == null`, sub-query dataitem | silent | structural — #2300's exclusion, not a failed read |
| `real.Count != 1` | silent | the method is explicitly the single-dataitem case; the join path applies a multi-dataitem query's filters itself |
| `TableFiltersAndMarks` reads null | silent | BC's answer: this dataitem has no filters |
| `Filters` reads null | silent | BC's answer: no filter dictionary |
| `Items` lookup | **refuses** | absent member |
| `Items` reads null | silent | BC's answer: an empty dictionary |

The refusals raise `BcShapeGapException`, which tears through both AL trapping seams. Under
`asserterror` a swallowed refusal would *invert* the result — real BC reads the filter fine, so
the asserterror fails there and would have passed here.

## RED → GREEN, and how I checked the guards are armed rather than quiet

`AlRunner.Tests/QueryDataItemFilterShapeGapTests` — 15 arms. RED baseline: **14 failed, 0
passed** before the fix. GREEN after: **15/15**.

A guard that is merely quiet passes whatever you do to the implementation, so I broke the
implementation five ways and confirmed the right arms fail each time:

| sabotage | arms that failed |
|---|---|
| `TableFiltersAndMarks` lookup back to a silent `yield break` (the exact pre-fix code) | `TableFiltersAndMarksLookup_...`, `TheRefusal_TearsThroughBothAlSeams_...` |
| null `TableFiltersAndMarks` made to throw (over-refusal) | `ADataItemWithNoFiltersAtAll_StillYieldsNothing_AndDoesNotThrow` |
| multi-dataitem guard made to throw **and** the sub-query skip removed | `AMultiDataItemQuery_...`, `ASynthesizedSubQueryDataItem_IsSkipped_...` |
| `Items` lookup back to `GetProperty(...)?.GetValue(...)` | `ItemsLookup_...` |
| `QueryDefinition` lookup back to `GetProperty(...)?.GetValue(...)` | `QueryDefinitionLookup_...` |

The `DataItems` sabotage is worth calling out, because the first version of that arm was **not
armed**: reverting the lookup to `?.GetValue(...)` still refused, just via the null-read branch
instead, and the arm could not tell the two apart. I strengthened it to assert the message says
`property not found` and *not* `read as null`, added a separate arm for the null read asserting
the opposite pair, and re-ran the sabotage — it now fails. That is why there are 15 arms rather
than 14.

The four negative controls are the half that stops the fix turning "absent" into an error, and
sabotages 2 and 3 are what show they are load-bearing rather than decorative.

## The reflection pin: name, arity, uniqueness AND liveness

- **Name, arity, uniqueness** — `TheHelperIsUniqueByName_AndTakesTheFourParametersTheseArmsDriveItWith`
  asserts exactly one declaration by that name, its four parameter types, and its return type.
- **Liveness** — the existing `ReflectionDrivenHelperLivenessTests` measures reachability from
  IL for every `RecordPatches` member any test names as a literal. This file names
  `GetSingleDataItemTableFilterTuples`, so the method is now in that guard's population: if
  production stops *reaching* it, that guard fails even though the member still exists. Ran it;
  it passes, so production genuinely reaches the method today. That is the half static analysis
  cannot see, and it is why the pin is not just an existence check.

## Why the BC types became parameters

The reads are against BC types held in `RecordPatches` statics that only a loaded `Ncl.dll`
populates. Passing them in is the idiom `PermissionMetadataShapeGapTests` already uses for
`SetProperty` / `BuildIncludeList`: real production code, fakes standing in for a moved member,
no BC install. Poking the statics instead would have left them poisoned for every other test in
the assembly. Production passes exactly the three statics the old body read.

Two smaller consequences, both deliberate:

- The `PropertyInfo` caching statics are gone. Caching a lookup resolved against one type and
  reusing it for another would be wrong once the types are parameters, and the lookups happen
  once per query translation — negligible against the surrounding work.
- `DataItems` and the two per-dataitem members now resolve off the value's **own runtime type**
  rather than by type name through the assembly. Same member on BC (the value *is* an
  `NCLMetaQueryDefinition` / `NCLMetaQueryDataItem`), and it removes an assembly-name lookup
  that could fail for a second reason and be reported as the same gap.

## Considered and rejected

I first added a `BcShape.TypeIn(assembly, fullName, ...)` helper for the by-name type lookups,
then removed it when the runtime-type resolution above made it unused — shipping an unexercised
public helper adds surface with no proving test.

I also briefly had production branch on whether the calling assembly was the runner's own, to
pick between a fake and the real type. That is production code testing whether it is under
test; resolving off the value's runtime type removes the need entirely.

## Sibling shapes: one fixed, one filed, two linked

Answering the three "fix the shape" questions explicitly:

1. **Same wrong pattern at another call site?** Yes — `RecordPatches.QueryJoin.cs:259-267`
   reads the same `TableFiltersAndMarks` for the **join** path, with `p?.GetValue(...)`, a bare
   `catch { }` and a `?? FiltersAndMarks.Empty` fallback that is indistinguishable from a
   dataitem genuinely declaring no filter. Same consequence, one path over. **Not folded** —
   different file, different call path, its own fakes to prove — so I filed it as **#3656** with
   the reproducer and the three "done when" conditions.
2. **Sibling function making the same assumption?** `GetStaticColumnFilters`, in this file,
   reads `NCLMetaQuery.ColumnFilters` with the same `?.` shape. Its doc comment states the
   property is *never* null on a real `NCLMetaQuery` — an empty collection when the query
   declares no `ColumnFilter` — so a null there is the same "layout moved" case. I left it
   alone: it is not what #3647 reports, converting it is a separate judgement about a member
   whose null-ness is documented differently, and folding it would have widened this diff past
   the one shape a reviewer is being asked to check. Worth a follow-up if a reviewer disagrees.
3. **Two paths writing the same state with different invariants?** Yes, and that is question 1:
   the single-dataitem pass here and the join pass in `QueryJoin.cs` both apply a dataitem's
   `TableFiltersAndMarks`, and after this change only one of them refuses a failed lookup. #3656
   is what closes that asymmetry.

**Open-issue queue scan** (`.claude/rules/batch-sibling-issues-by-file.md`), for
`QueryProjection` / `QueryJoin` / `GetSingleDataItemTableFilterTuples` / `TableFiltersAndMarks`.
Two same-file issues found; **neither folded**:

- **#3508** — the `NCLMetaQueryColumn` → `NCLMetaField` cast still firing for nested binary
  filter expressions, 47 measured failures. Same file, but the fix is extending
  `RetargetFilterExpression`'s expression-kind coverage, it needs a debug read to identify which
  leaf kind those 47 produce, and its proving test is a full AL bundle. Reviewing it needs
  materially different reasoning from "does this lookup refuse", which is rule 4's stop signal.
- **#3460** — four comment blocks citing a swallowed-refusal example that no longer exists. One
  of the four is in this file; the other three are in `RunnerShapeGaps.cs`,
  `RecordPatches.VirtualTableShapeGap.cs` and `RunnerShapeGapClaimTests.cs`. Pure prose
  deletion spanning four files, none of which this diff otherwise touches.

## What I ran

- `QueryDataItemFilterShapeGapTests` — 15/15, plus the five sabotage runs above.
- Filtered `dotnet test` over the query and shape-gap surfaces (`~Query`, `~BcShape`,
  `~ReflectionDrivenHelperLiveness`, `~BcInternalsNullForgiving`, `~RunnerShapeGap`) — **202
  passed, 0 failed, 2 skipped**.
- `tests/runner-extras/query-dataitem-filter-precompiled-dep` — **2/2**, the AL bundle that
  covers the live path through the exact read this changes.
- `tools/test_doc_pointers.py` — all checks pass, including the new
  `docs/query-dataitem-table-filter.md#a-failed-lookup-refuses` anchor the code comment cites
  (319 pointers checked).

I did not run the full `AlRunner.Tests` suite; per `.claude/rules/local-test-scope.md` the
filtered run over the surface I changed is the right scope, and CI runs the sweep.

## Where the prose went

`docs/query-dataitem-table-filter.md` gains a `## A failed lookup refuses` section carrying the
per-exit table, the "what is not covered" note pointing at #3656, and what proves it. The code
keeps a four-line claim plus the anchor, per `.claude/rules/loud-failures.md` on the form of an
audit justification.

## Test-count baseline

Not touched, deliberately: this PR adds no `[Test]` procedures to any AL suite. Its tests are
C# arms in `AlRunner.Tests`, and the one AL bundle involved is an existing one, run unchanged.

---

Opened by an agent (Claude, `stma-auto-2`) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
