### PR TITLE
fix(page-control-field): run BC's own SolveEditable, not the raw document attribute

### DIFF
--- a/AlRunner.Tests/PageControlFieldDocumentTests.cs
+++ b/AlRunner.Tests/PageControlFieldDocumentTests.cs
@@ -45,9 +45,13 @@ public sealed class PageControlFieldDocumentTests : IDisposable
         // The AL parser's dictionaries and the delta memo are static, so a fixture left
         // behind here would answer for the NEXT class's page of the same id. Both are
         // dropped for the same reason the runtime drops them on a --watch reload.
+        RemoveParsedPage(90321);
         RemoveParsedPage(90331);
         RemoveParsedPageExtension(90333);
+        RemoveFromDict("_parsedTables", 90320);
+        RemoveMetaTableCacheEntry(90320);
         ClearBcPageExtensionControls();
+        ClearBcPageControlDocuments();
         try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
     }
 
@@ -57,8 +61,28 @@ public sealed class PageControlFieldDocumentTests : IDisposable
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
             ?.Invoke(null, null);
 
+    private static void ClearBcPageControlDocuments()
+        => typeof(AlRunner.Patches.RecordPatches)
+            .GetMethod("ClearBcPageControlDocuments",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+            ?.Invoke(null, null);
+
     private static void RemoveParsedPage(int id) => RemoveFromDict("_parsedPages", id);
     private static void RemoveParsedPageExtension(int id) => RemoveFromDict("_parsedPageExtensions", id);
+
+    /// <summary>
+    /// Drop the built NCLMetaTable for the fixture table. It is memoised for the process, so
+    /// a table left behind answers for the next class that declares 90320 — and #3653's
+    /// assertions read the bound field's Editable THROUGH it, so a stale entry would decide
+    /// the result.
+    /// </summary>
+    private static void RemoveMetaTableCacheEntry(int tableId)
+    {
+        var f = typeof(AlRunner.Patches.RecordPatches).GetField("_metaTableCache",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        if (f?.GetValue(null) is System.Collections.IDictionary d && d.Contains(tableId))
+            d.Remove(tableId);
+    }
 
     private static void RemoveFromDict(string field, int id)
     {
@@ -267,6 +291,240 @@ public sealed class PageControlFieldDocumentTests : IDisposable
         // Visible IS stated on this control even though it is defaulted, which is why the
         // reader must not infer "absent means declared-default" from Visible's presence.
         Assert.Equal("true", plain.GetAttribute("Visible"));
+    }
+
+    // ---------------------------------------------------------------------------------
+    // #3653 — what the ROW reports for an undeclared Editable, which is a different
+    // question from what the DOCUMENT states (the test above).
+    //
+    // The document omits the attribute; #3604 read that absence as the answer and reported
+    // ''. A real BC service tier reports True, identically on all eight cloud legs (corpus
+    // PR #310, run 34329910568). BC does not read the deserialized field: MergePageAndTable
+    // runs PropertiesSolveHelper.SolveEditable over every control first, and that RESOLVES
+    // the null against the bound field's own Editable before any reader sees it. See
+    // docs/page-control-field-from-bc-document.md#solveeditable.
+    //
+    // These are runner-mechanism tests. The behavioural claim is the corpus's; what they pin
+    // is that the runner reproduces BC's solver rather than the raw attribute.
+    // ---------------------------------------------------------------------------------
+
+    [SkippableFact]
+    public void PageControlFieldRows_UndeclaredEditable_ResolvesToTheBoundFieldsEditable()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        EmitMainFixtureThroughTheParser();
+
+        var rows = PageControlFieldRowsFor(90321);
+        var bare = rows.Single(r => r.ControlName == "Entry No.");
+
+        // Positive, and the whole RED: "Entry No." declares no Editable and is bound to a
+        // field that declares none either, so SolveEditable's null branch answers the field's
+        // own Editable — true — rendered by Boolean.ToString(InvariantCulture). The capital T
+        // is not incidental: it is what the tier reported (Actual:<True>), and it is what
+        // distinguishes BC's solver from a "true" substituted by the runner.
+        Assert.Equal("True", bare.Editable);
+
+        // Negative: a DECLARED Editable is not overwritten by the solver. SolveEditable's
+        // null branch is gated on control.Editable == null, so a declared value survives —
+        // this is corpus test DeclaredEditableFalse_RoundTripsAsFalse's claim, held here on
+        // the runner side so a fix that defaulted every row to True would be caught.
+        Assert.Equal("false", rows.Single(r => r.ControlName == "PcfDocEditable").Editable);
+    }
+
+    [SkippableFact]
+    public void PageControlFieldRows_EnabledAndVisible_AreNotTouchedByTheSolver()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        EmitMainFixtureThroughTheParser();
+
+        var rows = PageControlFieldRowsFor(90321);
+        var bare = rows.Single(r => r.ControlName == "Entry No.");
+
+        // The sibling half of #3653, and the reason the fix is not "resolve all three the
+        // same way": no method on PropertiesSolveHelper writes Enabled or Visible, so those
+        // two keep the deserializer's [DefaultValue("true")] — lower-case "true", the
+        // attribute default, NOT the "True" that Boolean.ToString produces. The two spellings
+        // are what make this test able to tell the two mechanisms apart at all, and both are
+        // pinned green on a real tier by corpus codeunit 60424.
+        Assert.Equal("true", bare.Enabled);
+        Assert.Equal("true", bare.Visible);
+
+        // Negative: a declared value is reported verbatim on these columns too.
+        Assert.Equal("false", rows.Single(r => r.ControlName == "PcfDocHidden").Visible);
+    }
+
+    [Fact]
+    public void ParsedAndDependencyPaths_AnswerEditableTheSameWayTheDocumentPathDoes()
+    {
+        // The fold in #3653. Both fallback paths — a source-compiled page whose document was
+        // never captured, and a page from a precompiled dependency .app — substituted the
+        // lower-case attribute default "true" for an undeclared Editable, where the document
+        // path (and BC) answer "True". One column meaning two different things depending on
+        // which path served the page is the defect #3631 named for Sequence: AL cannot see
+        // which path it got, so the two must agree.
+        //
+        // No BC engine needed — this is the defaulting rule itself, not a document read.
+        Assert.Equal("True", SolveParsedEditable(null, null));
+
+        // The bound field's own declared Editable is what an undeclared control resolves to,
+        // so a field declared Editable = false makes the CONTROL report False without the
+        // control declaring anything. This is the arm that proves the field is really
+        // consulted rather than a constant being returned.
+        Assert.Equal("False", SolveParsedEditable(null, false));
+        Assert.Equal("True", SolveParsedEditable(null, true));
+
+        // Negative: a DECLARED expression is reported verbatim and is never overwritten —
+        // including a variable name, which is why the column is Text and not Boolean.
+        Assert.Equal("false", SolveParsedEditable("false", null));
+        Assert.Equal("true", SolveParsedEditable("true", false));
+        Assert.Equal("MyEditableVar", SolveParsedEditable("MyEditableVar", false));
+    }
+
+    [Fact]
+    public void ParsedPathWiring_ReportsTheSolvedEditable_NotTheRawAttributeDefault()
+    {
+        // The helper test above pins the RULE; this pins that the AL-parsed path actually
+        // CALLS it. Without this, replacing the call site with `?? "true"` again would keep
+        // that test green — the exact shape of a fix that passes its own unit test and leaves
+        // the defect in the column a caller reads.
+        //
+        // No emit and no BC engine: this page is parsed from AL text only, so
+        // HasBcPageMetadataDocument is false for it and the fallback path is the one that
+        // builds its rows — which is precisely the path under test.
+        const string Al = """
+            table 90340 "PcfFb Sample"
+            {
+                DataClassification = CustomerContent;
+                fields
+                {
+                    field(1; "Entry No."; Integer) { DataClassification = CustomerContent; }
+                    field(2; "Locked Field"; Text[30]) { Editable = false; DataClassification = CustomerContent; }
+                }
+                keys { key(PK; "Entry No.") { Clustered = true; } }
+            }
+
+            page 90341 "PcfFb Fixture"
+            {
+                PageType = Card;
+                SourceTable = "PcfFb Sample";
+                layout
+                {
+                    area(Content)
+                    {
+                        group(G)
+                        {
+                            field(FbBare; Rec."Entry No.") { ApplicationArea = All; }
+                            field(FbLocked; Rec."Locked Field") { ApplicationArea = All; }
+                            field(FbDeclared; Rec."Entry No.") { ApplicationArea = All; Editable = false; }
+                        }
+                    }
+                }
+            }
+            """;
+
+        ParseAlTableSource(Al);
+        ParseAlSource("TryParsePageFile", Al);
+        try
+        {
+            var rows = AllKnownPageControlFieldRows()
+                .Where(r => r.PageNo == 90341)
+                .ToDictionary(r => r.ControlName, r => r.Editable);
+
+            Assert.True(rows.Count >= 3,
+                $"expected page 90341's controls to be enumerated; got {rows.Count} row(s). "
+                + "The AL-parsed fallback path did not produce this page's rows at all.");
+
+            // Positive: an undeclared Editable on a field that declares none resolves to
+            // "True" — BC's Boolean.ToString, not the lower-case "true" this path used to
+            // substitute. This assertion is what a re-introduced `?? "true"` fails.
+            Assert.Equal("True", rows["FbBare"]);
+
+            // The field is consulted, not a constant returned: the same undeclared control
+            // over a field declared Editable = false answers "False".
+            Assert.Equal("False", rows["FbLocked"]);
+
+            // Negative: a declared value survives verbatim, lower-case as written.
+            Assert.Equal("false", rows["FbDeclared"]);
+        }
+        finally
+        {
+            RemoveParsedPage(90341);
+            RemoveFromDict("_parsedTables", 90340);
+            InvalidatePageControlFieldRowCache();
+        }
+    }
+
+    /// <summary>
+    /// Every row the virtual table would report, from the real builder
+    /// (<c>EnumerateKnownPageControlFields</c>) — so the AL-parsed and dependency branches are
+    /// exercised as the populate path runs them, not as a helper called in isolation.
+    /// </summary>
+    private static List<(int PageNo, string ControlName, string Editable)> AllKnownPageControlFieldRows()
+    {
+        var m = typeof(AlRunner.Patches.RecordPatches).GetMethod("EnumerateKnownPageControlFields",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+            ?? throw new InvalidOperationException(
+                "RecordPatches.EnumerateKnownPageControlFields not found.");
+
+        InvalidatePageControlFieldRowCache();
+        var raw = (System.Collections.IEnumerable)m.Invoke(null, null)!;
+        var view = new List<(int, string, string)>();
+        foreach (var row in raw)
+        {
+            var t = row.GetType();
+            view.Add(((int)t.GetProperty("PageNo")!.GetValue(row)!,
+                      (string)t.GetProperty("ControlName")!.GetValue(row)!,
+                      (string)t.GetProperty("Editable")!.GetValue(row)!));
+        }
+        return view;
+    }
+
+    /// <summary>
+    /// Drop the memoised row list. It is keyed on (registration epoch, parsed-page count), and
+    /// removing a page in the finally block above leaves that count where it started — so
+    /// without this the NEXT caller is served this test's rows.
+    /// </summary>
+    private static void InvalidatePageControlFieldRowCache()
+    {
+        var f = typeof(AlRunner.Patches.RecordPatches).GetField("_pageControlFieldRows",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        f?.SetValue(null, null);
+    }
+
+    private static string SolveParsedEditable(string? declared, bool? fieldEditable)
+    {
+        var m = typeof(AlRunner.Patches.RecordPatches).GetMethod("SolveParsedControlEditable",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+            ?? throw new InvalidOperationException(
+                "RecordPatches.SolveParsedControlEditable not found — #3653's fold onto the "
+                + "AL-parsed and dependency paths has been renamed or removed.");
+        return (string)m.Invoke(null, new object?[] { declared, fieldEditable })!;
+    }
+
+    /// <summary>
+    /// Emit the main fixture AND drive the AL source parser over it, so
+    /// <c>GetOrBuildNCLMetaTable</c> can resolve the bound field. A bare
+    /// <see cref="EmitAndReadDocument"/> captures the document but leaves
+    /// <c>_parsedTables</c> empty, and SolveEditable's field branch would then see a null
+    /// field and answer True by its OTHER arm — passing for the wrong reason.
+    /// </summary>
+    private void EmitMainFixtureThroughTheParser()
+    {
+        EmitAndReadDocument();
+        ParseAlSource("TryParsePageFile", FixtureAl);
+        ParseAlTableSource(FixtureAl);
+    }
+
+    private static void ParseAlTableSource(string source)
+    {
+        var m = typeof(AlRunner.Patches.RecordPatches).GetMethod("TryParseTableFile",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+            ?? throw new InvalidOperationException("RecordPatches.TryParseTableFile not found.");
+        m.Invoke(null, new object?[] { source, null });
     }
 
     [SkippableFact]
@@ -524,12 +782,14 @@ public sealed class PageControlFieldDocumentTests : IDisposable
             int I(string n) => (int)t.GetProperty(n)!.GetValue(row)!;
             view.Add(new PageControlFieldRowView(
                 I("ControlId"), S("ControlName"), I("TableNo"), I("FieldNo"),
-                S("SourceExpression"), I("Sequence")));
+                S("SourceExpression"), I("Sequence"),
+                S("Enabled"), S("Editable"), S("Visible")));
         }
         return view;
     }
 
     private sealed record PageControlFieldRowView(
         int ControlId, string ControlName, int TableNo, int FieldNo,
-        string SourceExpression, int Sequence);
+        string SourceExpression, int Sequence,
+        string Enabled, string Editable, string Visible);
 }

--- a/AlRunner.Tests/PageControlFieldDocumentTests.cs
+++ b/AlRunner.Tests/PageControlFieldDocumentTests.cs
@@ -266,7 +266,7 @@ public sealed class PageControlFieldDocumentTests : IDisposable
     }
 
     [SkippableFact]
-    public void EmittedDocument_OmitsDefaultedProperties_AndEditableHasNoDefaultToOmitTo()
+    public void EmittedDocument_OmitsDefaultedProperties_StatingNeitherEnabledNorEditable()
     {
         TestArtifacts.SkipIf(!_engine.Ready,
             _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
@@ -277,13 +277,14 @@ public sealed class PageControlFieldDocumentTests : IDisposable
         Assert.Equal("false", Named(controls, "PcfDocHidden").GetAttribute("Visible"));
         Assert.Equal("false", Named(controls, "PcfDocEditable").GetAttribute("Editable"));
 
-        // Negative, and the asymmetry the fix turns on: an UNDECLARED property is absent from
-        // the document, so what the column reports is whatever BC's deserializer supplies.
-        // ControlDefinition carries [DefaultValue("true")] on Enabled and Visible and NONE on
-        // Editable, so Enabled/Visible read "true" and Editable reads "". Substituting "true"
-        // for all three — which the AL derivation did — is therefore wrong for exactly one of
-        // them. See docs/page-control-field-from-bc-document.md#the-three-property-defaults;
-        // #3625 tracks getting the Editable half in front of a real tier.
+        // Negative: an UNDECLARED property is absent from the document. This is a statement
+        // about the DOCUMENT only, and the renaming of this method is #3653's doing: what the
+        // COLUMN reports for an absent Editable is decided afterwards by BC's
+        // SolveEditable pass, not by the absence measured here, and a tier answered True
+        // where reading the absence alone predicted ''
+        // (docs/page-control-field-from-bc-document.md#solveeditable). The assertions
+        // themselves are unchanged and still load-bearing: the solver's null branch is
+        // reachable only because the attribute really is omitted.
         var plain = Named(controls, "Entry No.");
         Assert.False(plain.HasAttribute("Enabled"));
         Assert.False(plain.HasAttribute("Editable"));

--- a/AlRunner.Tests/PageControlFieldDocumentTests.cs
+++ b/AlRunner.Tests/PageControlFieldDocumentTests.cs
@@ -47,6 +47,10 @@ public sealed class PageControlFieldDocumentTests : IDisposable
         // dropped for the same reason the runtime drops them on a --watch reload.
         RemoveParsedPage(90321);
         RemoveParsedPage(90331);
+        RemoveParsedPage(90351);
+        RemoveParsedPage(90352);
+        RemoveFromDict("_parsedTables", 90350);
+        RemoveMetaTableCacheEntry(90350);
         RemoveParsedPageExtension(90333);
         RemoveFromDict("_parsedTables", 90320);
         RemoveMetaTableCacheEntry(90320);
@@ -356,6 +360,126 @@ public sealed class PageControlFieldDocumentTests : IDisposable
 
         // Negative: a declared value is reported verbatim on these columns too.
         Assert.Equal("false", rows.Single(r => r.ControlName == "PcfDocHidden").Visible);
+    }
+
+    /// <summary>
+    /// The two SolveEditable rules that override a DECLARED value, each on the smallest page
+    /// that can trigger it. Both shapes were confirmed present in BC's own emitted document
+    /// before these tests were written: a constant-bound control carries
+    /// <c>SourceExpressionIsAssignable="0"</c>, and a page declaring <c>Editable = false</c>
+    /// carries <c>Editable="0"</c> on its <c>&lt;Properties&gt;</c>.
+    ///
+    /// <para>Every control here declares <c>Editable = true</c>. That is what makes the arms
+    /// load-bearing: the answer can only be <c>False</c> if the rule fired, since neither the
+    /// declaration nor rule 2 could have produced it.</para>
+    /// </summary>
+    private const string OverrideFixtureAl = """
+        table 90350 "PcfAsg Sample"
+        {
+            DataClassification = CustomerContent;
+            fields
+            {
+                field(1; "Entry No."; Integer) { DataClassification = CustomerContent; }
+            }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+
+        page 90351 "PcfAsg Fixture"
+        {
+            PageType = Card;
+            SourceTable = "PcfAsg Sample";
+            layout
+            {
+                area(Content)
+                {
+                    group(G)
+                    {
+                        field(AsgBare; Rec."Entry No.") { ApplicationArea = All; }
+                        field(AsgConst; 'literal text') { ApplicationArea = All; Editable = true; }
+                    }
+                }
+            }
+        }
+
+        page 90352 "PcfAsg NonEditable"
+        {
+            PageType = Card;
+            SourceTable = "PcfAsg Sample";
+            Editable = false;
+            layout
+            {
+                area(Content)
+                {
+                    group(G)
+                    {
+                        field(NeDeclaredTrue; Rec."Entry No.") { ApplicationArea = All; Editable = true; }
+                    }
+                }
+            }
+        }
+        """;
+
+    private void EmitOverrideFixture()
+    {
+        File.WriteAllText(Path.Combine(_root, "PcfAsg.al"), OverrideFixtureAl);
+        var output = new BcCompiler().Emit(new[] { _root }, "PcfAsgModule");
+        Assert.True(output.Sources.Count > 0,
+            $"Expected the fixture to emit; diagnostics: {string.Join(" | ", output.Diagnostics.Take(10))}");
+    }
+
+    [SkippableFact]
+    public void PageControlFieldRows_NonAssignableSourceExpression_IsFalse_EvenWhenDeclaredTrue()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        EmitOverrideFixture();
+
+        var rows = PageControlFieldRowsFor(90351).ToDictionary(r => r.ControlName, r => r.Editable);
+
+        // SolveEditable rule 1. "AsgConst" is bound to a string literal, so BC emits
+        // SourceExpressionIsAssignable="0" on it — and rule 1 returns False BEFORE the
+        // declared-value branch is reached, so the control's own `Editable = true` loses.
+        //
+        // This arm fails three ways, which is the point of it: with rule 1 deleted (the
+        // declaration wins, "true"), with the attribute name misspelled as
+        // ExpressionIsAssignable (HasAttribute never matches, so rule 1 cannot fire and the
+        // declaration wins again — the defect this test was added to catch), and against the
+        // pre-#3653 runner.
+        Assert.Equal("False", rows["AsgConst"]);
+
+        // Negative: rule 1 is not a blanket override. The assignable control on the SAME page
+        // takes rule 2 and answers True, so a fix that returned False unconditionally — or one
+        // that read the attribute's ABSENCE as false — is caught here rather than passing.
+        Assert.Equal("True", rows["AsgBare"]);
+    }
+
+    [SkippableFact]
+    public void PageControlFieldRows_NonEditablePage_ForcesFalse_EvenWhenTheControlDeclaresTrue()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        EmitOverrideFixture();
+
+        var rows = PageControlFieldRowsFor(90352).ToDictionary(r => r.ControlName, r => r.Editable);
+
+        // SolveEditable rule 3. Page 90352 declares Editable = false, which BC emits as
+        // Editable="0" on <Properties> — note the 0/1 spelling, not true/false, which is why
+        // the parse goes through BcPropertyIsFalse rather than bool.TryParse. The control
+        // declares Editable = true and is overridden to False.
+        //
+        // Fails with rule 3 deleted (the declaration survives as "true"), and fails if the
+        // page-level attribute is parsed with bool.TryParse — "0" would not parse, the page
+        // would read editable, and the rule would not fire.
+        Assert.Equal("False", rows["NeDeclaredTrue"]);
+
+        // Negative: page 90351 is identical except that it does NOT declare Editable = false,
+        // and its Rec-bound control answers True. So the override above is the PAGE property
+        // doing the work — not the declaration being discarded, and not every control on
+        // every page being forced.
+        Assert.Equal("True",
+            PageControlFieldRowsFor(90351).Single(r => r.ControlName == "AsgBare").Editable);
     }
 
     [Fact]

--- a/AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs
@@ -29,8 +29,13 @@
 //     TableNo            BC states the page's source table on EVERY row, including one with
 //                        no source field.
 //
-//   docs/page-control-field-from-bc-document.md has the emitted document, the reflection
-//   measurements behind the three attribute defaults, and what is deliberately left alone.
+//   Editable is a fifth, and it does not come from the document at all: BC's
+//   SolvePropertiesDefaulting pass overwrites it before the provider reads it, so the value
+//   is computed here by SolveDocumentControlEditable rather than read off the attribute
+//   (#3653 — a tier answered True where reading the absent attribute predicted '').
+//
+//   docs/page-control-field-from-bc-document.md has the emitted document, the SolveEditable
+//   chain, and what is deliberately left alone.
 //
 // WHY THE XML AND NOT THE MERGED MetaPageDefinition EnsureRealPageMetadata BUILDS
 //   Written down rather than rediscovered, because it is the same trap #3607 hit one table

--- a/AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs
@@ -77,7 +77,7 @@ public static partial class RecordPatches
     /// document omits it. Null is a distinct state from <c>""</c> here and must stay one:
     /// SolveEditable's whole shape is <c>if (control.Editable == null)</c>, so collapsing the
     /// two is what made an undeclared Editable answer <c>''</c> (#3653).</param>
-    /// <param name="SourceExpressionIsAssignable">BC's <c>ExpressionIsAssignable</c>, default
+    /// <param name="SourceExpressionIsAssignable">BC's <c>SourceExpressionIsAssignable</c>, default
     /// true (<c>[DefaultValue(true)]</c> on <c>ControlDataboundDefinition</c>). False forces
     /// Editable to False regardless of what the control declares.</param>
     private sealed record BcPageControl(
@@ -227,8 +227,15 @@ public static partial class RecordPatches
                     DeclaredEditable: e.HasAttribute("Editable") ? e.GetAttribute("Editable") : null,
                     Visible: ReadBcAttrOrDefault(e, "Visible", "true"),
                     Sequence: sequence++,
-                    SourceExpressionIsAssignable: !e.HasAttribute("ExpressionIsAssignable")
-                        || !BcPropertyIsFalse(e.GetAttribute("ExpressionIsAssignable"))));
+                    // SourceExpressionIsAssignable, NOT ExpressionIsAssignable. Both names
+                    // are real and they are different elements: DataFieldDefinition (an
+                    // <Expression> entry) carries ExpressionIsAssignable, while a CONTROL
+                    // carries SourceExpressionIsAssignable. Reading the shorter name here
+                    // makes HasAttribute never match, the `||` short-circuit answer true for
+                    // every control, and rule 1 unreachable — measured, and shipped in the
+                    // first cut of #3653.
+                    SourceExpressionIsAssignable: !e.HasAttribute("SourceExpressionIsAssignable")
+                        || !BcPropertyIsFalse(e.GetAttribute("SourceExpressionIsAssignable"))));
             }
 
             CollectBcPageControls(e, into, ref sequence);
@@ -359,6 +366,14 @@ public static partial class RecordPatches
         // Rule 3 — a non-editable PAGE forces a control that does not already read false to
         // False. Note BC compares with PropertyIsFalse rather than string equality, so a
         // control declaring "NO" or "0" is already false and is left alone.
+        //
+        // BC FALLS THROUGH here and this RETURNS, which is a deliberate structural
+        // divergence and is observably equivalent: the only thing rule 4 can do is assign
+        // the same "False" this line already assigned, and its guard
+        // (!PropertyIsFalse(control.Editable)) is false by construction once it has. Since
+        // rule 4 is not reproduced at all (see the method summary), the early return also
+        // cannot skip work that would otherwise happen. If rule 4 is ever implemented, this
+        // must become a fall-through again.
         if (!BcPropertyIsFalse(control.DeclaredEditable) && !pageEditable) return "False";
 
         // Otherwise the declared expression stands verbatim — including a variable NAME,

--- a/AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs
@@ -68,18 +68,30 @@ public static partial class RecordPatches
     /// <c>ControlDefinition.IsBoundToTableField(out fieldNo)</c> is
     /// <c>int.TryParse(DataColumnName, out fieldNo)</c> and nothing else.
     /// </summary>
+    /// <param name="DeclaredEditable">The raw <c>Editable</c> attribute, or null when the
+    /// document omits it. Null is a distinct state from <c>""</c> here and must stay one:
+    /// SolveEditable's whole shape is <c>if (control.Editable == null)</c>, so collapsing the
+    /// two is what made an undeclared Editable answer <c>''</c> (#3653).</param>
+    /// <param name="SourceExpressionIsAssignable">BC's <c>ExpressionIsAssignable</c>, default
+    /// true (<c>[DefaultValue(true)]</c> on <c>ControlDataboundDefinition</c>). False forces
+    /// Editable to False regardless of what the control declares.</param>
     private sealed record BcPageControl(
         int ControlId, string ControlName, string DataColumnName,
-        string Enabled, string Editable, string Visible, int Sequence);
+        string Enabled, string? DeclaredEditable, string Visible, int Sequence,
+        bool SourceExpressionIsAssignable = true);
 
     /// <summary>The subset of BC's page document this table reads.
     /// <paramref name="Expressions"/> is <c>page.Expressions</c> — the
     /// <c>DataFieldDefinition</c> list BC looks an unbound control's source expression up in,
     /// keyed by the control's <c>DataColumnName</c>.</summary>
+    /// <param name="PageEditable"><c>PageProperties.Editable</c>, default true
+    /// (<c>[DefaultValue(true)]</c>). A non-editable PAGE forces every control that does not
+    /// already say False to False — SolveEditable's third rule.</param>
     private sealed record BcPageDocument(
         int SourceTableId,
         List<BcPageControl> Controls,
-        Dictionary<string, (string SourceExpression, string OptionString, bool IsOption)> Expressions);
+        Dictionary<string, (string SourceExpression, string OptionString, bool IsOption)> Expressions,
+        bool PageEditable = true);
 
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<int, BcPageDocument?>
         _bcPageControlDocuments = new();
@@ -128,6 +140,7 @@ public static partial class RecordPatches
         var controls = new List<BcPageControl>();
         var expressions = new Dictionary<string, (string, string, bool)>(StringComparer.Ordinal);
         int sourceTableId = 0;
+        var pageEditable = true;
 
         foreach (XmlNode node in root.ChildNodes)
         {
@@ -135,6 +148,11 @@ public static partial class RecordPatches
             switch (e.Name)
             {
                 case "Properties":
+                    // The document writes Editable="1"/"0" here rather than true/false, which
+                    // is why this goes through BcPropertyIsFalse (BC's own PropertyHelper
+                    // accepts NO/FALSE/0) instead of bool.TryParse.
+                    if (e.HasAttribute("Editable"))
+                        pageEditable = !BcPropertyIsFalse(e.GetAttribute("Editable"));
                     foreach (XmlNode p in e.ChildNodes)
                         if (p is XmlElement so && so.Name == "SourceObject")
                             sourceTableId = ReadBcAttrInt(so, "SourceTable");
@@ -161,7 +179,7 @@ public static partial class RecordPatches
             }
         }
 
-        return new BcPageDocument(sourceTableId, controls, expressions);
+        return new BcPageDocument(sourceTableId, controls, expressions, pageEditable);
     }
 
     /// <summary>
@@ -194,17 +212,18 @@ public static partial class RecordPatches
                     ControlId: ReadBcAttrInt(e, "ID"),
                     ControlName: e.GetAttribute("Name"),
                     DataColumnName: e.GetAttribute("DataColumnName"),
-                    // Enabled and Visible carry [DefaultValue("true")] on
-                    // ControlDefinition, so BC's deserializer supplies "true" when the
-                    // attribute is absent. Editable carries NO DefaultValue and defaults to
-                    // null, which BC renders as the empty string through
-                    // NavText.CreateTruncated — so absent means "" here, not "true". Measured
-                    // by reflection over Microsoft.Dynamics.Nav.Types 28.1; see
-                    // docs/page-control-field-from-bc-document.md#the-three-property-defaults.
+                    // Enabled and Visible carry [DefaultValue("true")] on ControlDefinition,
+                    // so BC's deserializer supplies "true" when the attribute is absent and
+                    // NOTHING later rewrites them — no method on PropertiesSolveHelper writes
+                    // either one. Editable is the odd one out and is deliberately left null
+                    // here rather than defaulted: what it answers is decided by
+                    // SolveDocumentControlEditable below, not by the document.
                     Enabled: ReadBcAttrOrDefault(e, "Enabled", "true"),
-                    Editable: e.GetAttribute("Editable"),
+                    DeclaredEditable: e.HasAttribute("Editable") ? e.GetAttribute("Editable") : null,
                     Visible: ReadBcAttrOrDefault(e, "Visible", "true"),
-                    Sequence: sequence++));
+                    Sequence: sequence++,
+                    SourceExpressionIsAssignable: !e.HasAttribute("ExpressionIsAssignable")
+                        || !BcPropertyIsFalse(e.GetAttribute("ExpressionIsAssignable"))));
             }
 
             CollectBcPageControls(e, into, ref sequence);
@@ -274,6 +293,74 @@ public static partial class RecordPatches
         return result;
     }
 
+    /// <summary>
+    /// <c>Types.Metadata.PropertyHelper.PropertyIsFalse</c>: a property expression counts as
+    /// false when it trims to <c>NO</c>, <c>FALSE</c> or <c>0</c>, case-insensitively.
+    /// Anything else — including a variable name — is not false.
+    /// </summary>
+    private static bool BcPropertyIsFalse(string? property)
+    {
+        if (property == null) return false;
+        var p = property.Trim();
+        return p.Equals("NO", StringComparison.OrdinalIgnoreCase)
+            || p.Equals("FALSE", StringComparison.OrdinalIgnoreCase)
+            || p.Equals("0", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// What <c>Editable</c> reports for one control, reproducing
+    /// <c>Types.Metadata.PropertiesSolveHelper.SolveEditable</c> (BC 28.1).
+    ///
+    /// <para>The claim: for an in-scope caller this is observably equivalent to what BC's
+    /// provider reads, because BC does not read the deserialized property either — the
+    /// solver has already overwritten it. <c>MetadataProvider.GetMasterPageForDesigner</c>
+    /// (which <c>GetControlsOnPage</c> calls) runs <c>MergePageAndTable</c> →
+    /// <c>SolvePropertiesDefaulting</c> → <c>SolvePropertiesDefaultingControls</c> →
+    /// <c>ControlDataboundDefinition.SolveProperties</c> → <c>SolveEditable</c> over every
+    /// control before returning, so <c>control.Editable</c> is never null by the time
+    /// <c>array[7]</c> is assigned. Adjudicated on a real service tier: corpus codeunit
+    /// 60424 answered <c>True</c> for an undeclared Editable on all eight cloud legs
+    /// (PR #310, run 34329910568), against the <c>''</c> a raw attribute read produced
+    /// (#3653). See docs/page-control-field-from-bc-document.md#solveeditable.</para>
+    ///
+    /// <para>The trap for a later editor: the four rules below are ORDERED and the first two
+    /// return. Reordering them, or collapsing "attribute absent" and "attribute empty" into
+    /// one state, reintroduces #3653 — a declared <c>Editable = false</c> must survive, and
+    /// only a genuinely absent one resolves against the field.</para>
+    ///
+    /// <para>Two of BC's four rules are deliberately not reproduced, because neither input
+    /// exists here: <c>TableAllowInCustomizations</c>/<c>AllowInCustomizations</c> and the
+    /// personalization/configuration <c>SourceAppId</c> checks. The runner has no
+    /// personalization or configuration layer at all — a page is served as compiled — so
+    /// those rules cannot fire, and reproducing them would mean inventing the state they
+    /// read. If personalization ever lands, this is one of its call sites.</para>
+    /// </summary>
+    private static string SolveDocumentControlEditable(
+        BcPageControl control, bool fieldEditable, bool fieldResolved, bool pageEditable)
+    {
+        // Rule 1 — a non-assignable source expression is never editable, and this outranks
+        // even a declared value. BC: `if (!control.SourceExpressionIsAssignable) { … return; }`
+        if (!control.SourceExpressionIsAssignable) return "False";
+
+        // Rule 2 — the undeclared case, and the whole of #3653. BC resolves the null against
+        // the BOUND FIELD's own Editable, falling back to true when there is no field, and
+        // renders it with Boolean.ToString(InvariantCulture) — hence "True"/"False" with a
+        // capital, not the lower-case "true" the Enabled/Visible attribute default carries.
+        // The two spellings are observably different to AL, so this is not cosmetic.
+        if (control.DeclaredEditable == null)
+            return (fieldResolved ? fieldEditable : true)
+                .ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        // Rule 3 — a non-editable PAGE forces a control that does not already read false to
+        // False. Note BC compares with PropertyIsFalse rather than string equality, so a
+        // control declaring "NO" or "0" is already false and is left alone.
+        if (!BcPropertyIsFalse(control.DeclaredEditable) && !pageEditable) return "False";
+
+        // Otherwise the declared expression stands verbatim — including a variable NAME,
+        // which is why this column is Text and not Boolean.
+        return control.DeclaredEditable;
+    }
+
     private static int ReadBcAttrInt(XmlElement e, string name)
         => int.TryParse(e.GetAttribute(name), out var v) ? v : 0;
 
@@ -320,6 +407,11 @@ public static partial class RecordPatches
             var isBound = int.TryParse(c.DataColumnName, out var fieldNo);
             var sourceExpression = string.Empty;
             var optionString = string.Empty;
+            // SolveEditable's `field` argument: the SAME MetaField the SourceExpression /
+            // OptionString branch below resolves, so "the field was found" is one fact here
+            // and cannot disagree between the two readings.
+            var fieldResolved = false;
+            var fieldEditable = true;
 
             if (isBound)
             {
@@ -332,6 +424,8 @@ public static partial class RecordPatches
                     var field = FindMetaFieldById(doc.SourceTableId, fieldNo);
                     if (field != null)
                     {
+                        fieldResolved = true;
+                        fieldEditable = GetMetaFieldEditable(doc.SourceTableId, fieldNo);
                         sourceExpression = field.FieldName ?? string.Empty;
                         // BC gates this on `f.Type == NavType.Option`, so the guard is the
                         // field's NavType and not "does the field carry option metadata".
@@ -362,7 +456,9 @@ public static partial class RecordPatches
             rows.Add(new PageControlFieldRow(
                 pageId, c.ControlId, c.ControlName,
                 doc.SourceTableId, isBound ? fieldNo : 0,
-                c.Enabled, c.Editable, c.Visible,
+                c.Enabled,
+                SolveDocumentControlEditable(c, fieldEditable, fieldResolved, doc.PageEditable),
+                c.Visible,
                 sourceExpression, optionString, c.Sequence));
         }
 
@@ -376,6 +472,62 @@ public static partial class RecordPatches
     /// object that carries tableextension-added fields and the resolved option metadata for an
     /// Enum-typed field; the parsed table carries neither.
     /// </summary>
+    /// <summary>
+    /// The bound field's <c>Editable</c>, the value SolveEditable's null branch resolves
+    /// against. Defaults to true — AL's own field default, and BC's <c>field?.Editable ?? true</c>.
+    ///
+    /// <para><c>NCLMetaField</c> does not expose it: measured over Ncl 28.1's 83 properties and
+    /// 34 fields, there is no editable member of any accessibility, and the constructor does
+    /// not retain the <c>MetaField</c> it was built from. So the only readable copy is the
+    /// original <c>Types.Metadata.MetaField</c> hanging off the NCLMetaTable's
+    /// <c>metadataAppGroupMetaTable</c> — the same route
+    /// <c>RecordPatches.NclMetaTableFromBcDocument.DescribeMetaFields</c> already uses, and
+    /// the reason that trace exists at all
+    /// (docs/object-metadata-from-bc.md#reading-the-values-back).</para>
+    ///
+    /// <para>A table whose structure does not expose it answers true rather than throwing:
+    /// this is a defaulting rule, and true is the value BC itself substitutes when it has no
+    /// field. Reflection is cached per (table, field) because the virtual table asks about
+    /// every control on every known page.</para>
+    /// </summary>
+    private static bool GetMetaFieldEditable(int tableId, int fieldNo)
+        => _bcMetaFieldEditable.GetOrAdd((tableId, fieldNo), static key =>
+        {
+            var meta = GetOrBuildNCLMetaTable(key.TableId);
+            if (meta == null) return true;
+
+            var original = meta.GetType()
+                .GetField("metadataAppGroupMetaTable",
+                    System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                ?.GetValue(meta);
+            var metaTable = original?.GetType()
+                .GetProperty("Item", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
+                ?.GetValue(original);
+            if (metaTable?.GetType()
+                    .GetProperty("Fields", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
+                    ?.GetValue(metaTable) is not System.Collections.IEnumerable fields)
+                return true;
+
+            foreach (var f in fields)
+            {
+                if (f == null) continue;
+                var t = f.GetType();
+                if (t.GetProperty("Id")?.GetValue(f) is not int id || id != key.FieldNo) continue;
+                return t.GetProperty("Editable")?.GetValue(f) is not bool e || e;
+            }
+            return true;
+        });
+
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<(int TableId, int FieldNo), bool>
+        _bcMetaFieldEditable = new();
+
+    /// <summary>
+    /// Drop the per-field Editable memo on a <c>--watch</c>/<c>--server</c> reload, for the
+    /// same reason <see cref="ClearBcPageControlDocuments"/> exists: table and field ids
+    /// repeat across reloads, so an entry from the previous bundle is a wrong answer.
+    /// </summary>
+    internal static void ClearBcMetaFieldEditable() => _bcMetaFieldEditable.Clear();
+
     private static Microsoft.Dynamics.Nav.Runtime.NCLMetaField? FindMetaFieldById(int tableId, int fieldNo)
     {
         var meta = GetOrBuildNCLMetaTable(tableId);

--- a/AlRunner/Patches/RecordPatches.PageControlFieldVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.PageControlFieldVirtualTable.cs
@@ -129,6 +129,27 @@ public static partial class RecordPatches
         };
     }
 
+    /// <summary>
+    /// <c>Editable</c> for a control whose source is AL text or a dependency's symbol file,
+    /// rather than BC's emitted document. Same rules as
+    /// <c>SolveDocumentControlEditable</c> — see that method for the mechanism and the tier
+    /// verdict behind it (#3653) — reduced to the two inputs these paths have.
+    ///
+    /// <para><paramref name="declared"/> is null when the control declares no Editable, which
+    /// is the state BC's solver resolves; <paramref name="fieldEditable"/> is the bound
+    /// field's own declared Editable, itself null when the FIELD declares none, and null on
+    /// both counts means true.</para>
+    ///
+    /// <para>Neither of BC's other two rules is reachable from here: these paths carry no
+    /// <c>ExpressionIsAssignable</c> and no page-level <c>Editable</c>, so a control that BC
+    /// would force to False through either can only be reached on the document path. That is
+    /// a narrower answer rather than a wrong one — a page served from these paths has no
+    /// document, so there is nothing to read it from — and it is why this is a separate
+    /// method instead of a call into the document one.</para>
+    /// </summary>
+    private static string SolveParsedControlEditable(string? declared, bool? fieldEditable)
+        => declared ?? (fieldEditable ?? true).ToString(System.Globalization.CultureInfo.InvariantCulture);
+
     private static List<PageControlFieldRow> EnumerateKnownPageControlFields()
     {
         var generation = (BcAppRegistrationEpoch, _parsedPages.Count);
@@ -167,7 +188,14 @@ public static partial class RecordPatches
                     rows.Add(new PageControlFieldRow(
                         page.Id, c.ControlId, c.ControlName,
                         pField != null ? tableId : 0, pField?.FieldId ?? 0,
-                        c.EnabledExpr ?? "true", c.EditableExpr ?? "true", c.VisibleExpr ?? "true",
+                        c.EnabledExpr ?? "true",
+                        // #3653 — the same solver the document path runs, for the same reason
+                        // #3631 gave for Sequence: one column may not mean two different
+                        // things depending on which path served the page, because AL cannot
+                        // see which it got. `?? "true"` here was the lower-case attribute
+                        // default; BC's SolveEditable produces "True"/"False".
+                        SolveParsedControlEditable(c.EditableExpr, pField?.Editable),
+                        c.VisibleExpr ?? "true",
                         c.SourceExpressionText, string.Empty, c.Sequence));
                 }
             }
@@ -187,7 +215,17 @@ public static partial class RecordPatches
                     var (tableNo, fieldNo) = ResolveDependencyControlField(c.SourceExpression, symbol.SourceTableId, symTable);
                     rows.Add(new PageControlFieldRow(
                         symbol.Id, c.Id, c.Name, tableNo, fieldNo,
-                        c.EnabledExpr ?? "true", c.EditableExpr ?? "true", c.VisibleExpr ?? "true",
+                        c.EnabledExpr ?? "true",
+                        // #3653, same statement as the source-parsed path above. The bound
+                        // field comes from the dependency's own parsed table when
+                        // ResolveDependencyControlField resolved one; an unresolved control
+                        // takes SolveEditable's no-field arm and answers True, which is BC's
+                        // `field?.Editable ?? true`.
+                        SolveParsedControlEditable(c.EditableExpr,
+                            fieldNo != 0
+                                ? symTable?.Fields.FirstOrDefault(f => f.FieldId == fieldNo)?.Editable
+                                : null),
+                        c.VisibleExpr ?? "true",
                         // A dependency page's SymbolReference.json does not state the source
                         // field's option members, and DependencyPageMetadataXml.EmitPageXml
                         // reconstructs no <Controls> element to read them from, so this stays

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -298,6 +298,10 @@ public static partial class RecordPatches
         // #3605: and the pageextension deltas that merge into those documents, which are keyed
         // by the EXTENSION's id — a separate id space, so a separate memo to drop.
         ClearBcPageExtensionControls();
+        // #3653: and the per-field Editable those rows resolve against. It is keyed by
+        // (table, field) and read through the rebuilt NCLMetaTable, so a stale entry outlives
+        // the very table it describes.
+        ClearBcMetaFieldEditable();
         // #3121: every table is rebuilt from scratch below, so carrying the previous bundle's
         // pending CalcFormula rebuilds forward only buys a wasted repopulate pass on the next
         // .app registration.

--- a/docs/page-control-field-from-bc-document.md
+++ b/docs/page-control-field-from-bc-document.md
@@ -163,38 +163,121 @@ approximation of one, and it stops being true the moment a BC release adds a sub
 is why it is written down here rather than left implicit at the call site.
 
 <a id="the-three-property-defaults"></a>
+<a id="solveeditable"></a>
 
-## The three property defaults, and why `Editable` is not `"true"`
+## The three property defaults, and why `Editable` answers `True` where the others answer `true`
 
 `Enabled`, `Editable` and `Visible` are **text** columns carrying the declared property
 expression, so a control with `Visible = NoFieldVisible` reports the variable's name. The
 question this section answers is narrower: what does BC report when the property is *absent*
 from the document, which is the common case?
 
-The document omits an attribute when the property is at its default, so the answer is whatever
-BC's deserializer supplies. Measured by instantiating `ControlDefinition` through reflection
-and reading each property off a fresh instance:
+**It does not answer alike, and the casing is the tell.** Measured on a real service tier —
+corpus codeunit 60424 against fixture page 60425, run
+[`34329910568`](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/310),
+identically on 27.0, 27.3, 27.5, 28.0, 28.1, 28.2, 28.3 and 28.4:
 
-| property | `DefaultValueAttribute` | value on a fresh instance |
-|---|---|---|
-| `Enabled` | yes | `"true"` |
-| `Visible` | yes | `"true"` |
-| `Editable` | **no** | **`null`** |
+| column, control declaring none of the three | BC answers |
+|---|---|
+| `Enabled` | `true` |
+| `Visible` | `true` |
+| `Editable` | **`True`** |
 
-`Enabled` and `Visible` therefore default to `"true"`, which is what the AL derivation already
-substituted and what corpus codeunit 60921 pins for `Visible`. `Editable` does **not**: BC
-passes the null straight to `NavText.CreateTruncated`, which renders it as the empty string.
-The AL derivation substituted `"true"` there too, so this change makes `Editable` answer `""`
-for a control that does not declare it.
+Two different mechanisms produce those two spellings, and separating them is the whole of
+this section.
 
-**That last cell is measured from BC's own type, not from a service tier.** No corpus test
-pins `Editable` today — codeunit 60921 pins `Visible` only, and corpus PR #300's codeunit
-60426 asserts `Editable` nowhere. So the claim rests on the reflection measurement above plus
-BC's decompiled `array[7] = NavText.CreateTruncated(len, control.Editable)`, and not on a real
-tier having answered it. It is the honest reading of both, and it is the kind of claim
-`.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md` says to name rather than to
-assert quietly. A corpus test asserting `Editable` on an undeclared control is the follow-up
-that would settle it; #3625 tracks it.
+### `Enabled` and `Visible`: the deserializer's own default, verbatim
+
+Both are declared on `UIElementDefinition` and carry `[DefaultValue("true")]` — a **string**
+literal. The document omits an attribute at its default, the deserializer substitutes that
+string, and nothing afterwards rewrites it: no method on `PropertiesSolveHelper` writes either
+property. So the lower-case `"true"` a caller sees is the attribute's own text, copied through.
+
+### `Editable`: resolved afterwards by `SolveEditable`, and rendered from a `Boolean`
+
+`Editable` is declared on `ControlDataboundDefinition` and carries **no**
+`DefaultValueAttribute`, so a freshly deserialized control really does read `null` — and
+`NavText.CreateTruncated` really does render null as `""`. Both facts are true and neither
+decides the answer, because **BC's provider never reads that null.**
+
+`GetControlsOnPage` obtains its page from `MetadataProvider.GetMasterPageForDesigner`, and the
+chain below runs to completion before a single row is built:
+
+```
+GetMasterPageForDesigner
+  -> GetMasterPageWithoutConfiguration
+       -> MergePageAndTable
+            -> PropertiesSolveHelper.SolvePropertiesDefaulting
+                 -> SolvePropertiesDefaultingControls        // per control, with its MetaField
+                      -> ControlDataboundDefinition.SolveProperties
+                           -> PropertiesSolveHelper.SolveEditable   // writes control.Editable
+```
+
+`SolveEditable` (`Microsoft.Dynamics.Nav.Types` 28.1) is the specification, four rules in
+order, the first two returning:
+
+```csharp
+control.TableEditable = field?.Editable ?? true;
+control.TableAllowInCustomizations = field?.AllowInCustomizations ?? AllowInCustomizations.ToBeClassified;
+
+if (!control.SourceExpressionIsAssignable) {                       // 1
+    control.Editable = false.ToString(CultureInfo.InvariantCulture); return; }
+
+if (control.Editable == null) {                                    // 2  <- the undeclared case
+    control.Editable = (field != null ? field.Editable : true)
+                          .ToString(CultureInfo.InvariantCulture);  return; }
+
+if (!PropertyHelper.PropertyIsFalse(control.Editable)              // 3
+    && masterPage?.PageProperties?.Editable == false)
+    control.Editable = false.ToString(CultureInfo.InvariantCulture);
+
+if (!PropertyHelper.PropertyIsFalse(control.Editable)              // 4
+    && control.TableAllowInCustomizations != AllowInCustomizations.AsReadWrite) {
+    // personalization / configuration SourceAppId, or "Editable" in Personalized/ConfiguredProperties
+    control.Editable = false.ToString(CultureInfo.InvariantCulture); }
+```
+
+Rule 2 is the one that answers the question, and it explains the capital directly:
+`Boolean.ToString(InvariantCulture)` returns `"True"`, not `"true"`. So the value **and** its
+spelling both come from the same place — a `Boolean` being formatted, rather than a string
+literal being copied. `Entry No.` on fixture page 60425 declares no `Editable` and neither
+does the field it binds to, so `field.Editable` is `true` and the column reports `True`.
+
+Rule 2 also explains why a declared `Editable = false` round-trips unchanged: the branch is
+gated on `control.Editable == null`, so a declared value never reaches it. That is corpus test
+`Record_PageControlField_DeclaredEditableFalse_RoundTripsAsFalse`, green throughout.
+
+### What the runner reproduces, and what it does not
+
+`SolveDocumentControlEditable` in `RecordPatches.PageControlFieldFromBcDocument.cs` implements
+rules 1-3. `SolveParsedControlEditable` in `RecordPatches.PageControlFieldVirtualTable.cs`
+implements rule 2 for the AL-parsed and precompiled-dependency paths, which carry neither an
+`ExpressionIsAssignable` nor a page-level `Editable` to evaluate the other rules against.
+
+**Rule 4 is deliberately not reproduced**, on any path: the runner has no personalization or
+configuration layer, so `SourceAppId` is never `PersonalizationAppId`/`ConfigurationAppId` and
+`PersonalizedProperties`/`ConfiguredProperties` are never populated. The rule cannot fire, and
+reproducing it would mean inventing the state it reads. If personalization ever lands, those
+two methods are its call sites.
+
+### How this was got wrong, and what generalizes
+
+The reading this section replaces was: `Editable` has no `DefaultValueAttribute`, so a fresh
+`ControlDefinition` reads `null`, so `CreateTruncated` renders `''`. Every step of that is
+true and the conclusion was false, because a **fresh reflected instance is not the object the
+provider reads** — something ran in between and overwrote the field.
+
+The general form, worth carrying to the next virtual-table column: *reading a default off a
+freshly constructed instance answers what the constructor does, never what a caller observes.*
+The question to ask instead is what runs between deserialization and the read, and BC's
+answer here — a whole property-defaulting pass, `SolvePropertiesDefaulting` — was two call
+levels above the provider method already being read.
+
+**And the check that would have caught it costs one PR**:
+`.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md`. The claim was correctly flagged
+in this file as resting on a reflection measurement rather than a tier verdict, and #3625 was
+filed to settle it. That is the process working — the cost was one wrong column shipped in the
+meantime, not a wrong claim left standing.
 
 <a id="option-and-enum"></a>
 


### PR DESCRIPTION
Closes #3653

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/310

`Page Control Field` (2000000192) reported `''` for a control declaring no `Editable`.
A real BC service tier reports `True` — corpus codeunit 60424 against fixture page 60425,
run [`34329910568`](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/310),
identically on all eight cloud legs.

## The mechanism

`PropertiesSolveHelper.SolveEditable`. BC's provider never reads the deserialized property,
because a whole property-defaulting pass overwrites it first:

```
GetControlsOnPage -> MetadataProvider.GetMasterPageForDesigner
  -> GetMasterPageWithoutConfiguration -> MergePageAndTable
       -> PropertiesSolveHelper.SolvePropertiesDefaulting
            -> SolvePropertiesDefaultingControls          // per control, with its MetaField
                 -> ControlDataboundDefinition.SolveProperties
                      -> PropertiesSolveHelper.SolveEditable    // writes control.Editable
```

Four rules, in order, the first two returning:

1. `!SourceExpressionIsAssignable` -> `False`, outranking even a declared value.
2. **`Editable == null`** -> `(field?.Editable ?? true).ToString(InvariantCulture)`.
3. declared, not already false, on a page with `Editable = false` -> `False`.
4. personalization / configuration -> `False`.

Rule 2 is the answer, and it explains the **capital T** as well as the value:
`Boolean.ToString` returns `"True"`, not `"true"`. `Entry No.` declares no `Editable` and
neither does the field it binds to, so the column reports `True`.

Rule 2 is also why a declared `Editable = false` round-trips: the branch is gated on `null`,
so a declared value never reaches it. Corpus
`Record_PageControlField_DeclaredEditableFalse_RoundTripsAsFalse` stayed green throughout.

**Rules 1-3 are reproduced; rule 4 deliberately is not** — the runner has no personalization
or configuration layer, so `SourceAppId` is never those app ids and
`PersonalizedProperties`/`ConfiguredProperties` are never populated. The rule cannot fire, and
reproducing it would mean inventing the state it reads. Named at both call sites as the place
personalization would land.

Rule 3 `return`s where BC falls through to rule 4. Observably equivalent — rule 4 can only
assign the same `"False"`, and its guard is false by construction once rule 3 has — but it is a
deliberate structural divergence from the method being mirrored, so it is now stated at the
line, with the condition under which it must become a fall-through again.

### Why the original reading was wrong

Every step of it was true — `Editable` really carries no `DefaultValueAttribute`, a fresh
instance really reads `null`, `CreateTruncated` really renders `null` as `''`. The invalid step
was inferring a column's answer from a **freshly reflected instance**, which measures what the
constructor does and not what a caller observes. The thing that runs in between was two call
levels above the provider method already being read.

## The three siblings, checked

| column | solve-phase treatment | answer | verdict |
|---|---|---|---|
| `Enabled` | **none** — no `PropertiesSolveHelper` method writes it | `true`, the `[DefaultValue("true")]` string copied verbatim | already correct |
| `Visible` | **none**, same | `true`, same | already correct |
| `Editable` | `SolveEditable` rewrites it | `True`, a formatted `Boolean` | **fixed here** |

Enumerated all 47 members of `PropertiesSolveHelper` (BC 28.1): nothing writes `Enabled` or
`Visible`. `SolveOptionString` was the one near miss — it writes `control.OptionCaption`, not
the `OptionString` column this table reads, which comes from the metafield or the expression.
So `Editable` is the only one of this table's columns the solve phase touches, and the two
spellings are what let a test tell the two mechanisms apart at all.

## Folded in (same file)

The AL-parsed and precompiled-dependency paths substituted the lower-case attribute default
`"true"` for an undeclared `Editable`, so the column meant **two different things depending on
which path served the page** — exactly the defect #3631 named for `Sequence`, where AL cannot
see which path it got. Both now run the same rule (`SolveParsedControlEditable`, rule 2 only:
neither path carries an `ExpressionIsAssignable` or a page-level `Editable` to evaluate the
others against — a narrower answer, not a wrong one).

No open issue covers those two paths, so this closes only #3653; the fold is the "fix the
shape, not the reported line" half. Nothing else in the queue lands in these files.

## RED -> GREEN

### The review round: rule 1 was dead code, and no test could tell

The first cut read the attribute as `ExpressionIsAssignable`. **Both names are real and they
are different elements** — `DataFieldDefinition` (an `<Expression>` entry) carries
`ExpressionIsAssignable`; a *control* carries `SourceExpressionIsAssignable`. That is how it
survived: the record field and the doc comment used the right name, only the two string
literals were wrong. `HasAttribute` never matched, the `||` short-circuited to `true` for every
control, and rule 1 was unreachable.

**The worse half was the coverage.** Deleting rule 1, deleting rule 3, or correcting the typo
each left the suite at 15/15 — three behaviours, one result. A guard that cannot separate the
bug from the fix is not armed, and a green CI leg would not have caught this.

Both shapes were confirmed in BC's own emitted document before fixing, not assumed:

```
<Controls xsi:type="ControlDefinition" Name="AsgConst" DataColumnName="Control875617979"
          SourceExpressionIsAssignable="0" ... Editable="true" />
<Properties ... Editable="0" PageType="Card" ...>          <!-- page declaring Editable = false -->
```

Note the `0`/`1` spelling on both, which is why each goes through `BcPropertyIsFalse` rather
than `bool.TryParse` — a `bool.TryParse` would fail to parse `"0"`, read the page as editable,
and silently disarm rule 3.

Two arms added, one per rule, each on a control declaring `Editable = true` so the answer can
only be `False` if the rule fired. **Mutation-verified, each failing under deletion of exactly
its own rule:**

| mutation | result |
|---|---|
| rule 1 deleted | `..._NonAssignableSourceExpression_...` fails — 1 of 17 |
| rule 3 deleted | `..._NonEditablePage_ForcesFalse_...` fails — 1 of 17 |
| **the original typo reintroduced** | `..._NonAssignableSourceExpression_...` fails, `Expected: "False" / Actual: "true"` — 1 of 17 |

The third row is the one that matters: that same mutation used to leave the suite fully green.

Two new engine tests in `PageControlFieldDocumentTests`:

- `PageControlFieldRows_UndeclaredEditable_ResolvesToTheBoundFieldsEditable` — **RED**
  `Expected: "True" / Actual: ""`, the same failure shape the tier reported. GREEN after.
  Negative arm: a declared `false` still reports `false`.
- `PageControlFieldRows_EnabledAndVisible_AreNotTouchedByTheSolver` — passed before **and**
  after, pinning the two spellings apart so a fix that resolved all three alike is caught.

Two new `[Fact]`s for the fold, needing no engine:

- `ParsedAndDependencyPaths_AnswerEditableTheSameWayTheDocumentPathDoes` — the rule, including
  the arm proving the bound field is really consulted (a field declared `Editable = false`
  makes an undeclared control report `False`).
- `ParsedPathWiring_ReportsTheSolvedEditable_NotTheRawAttributeDefault` — drives the real
  `EnumerateKnownPageControlFields`, so the call site is pinned and not only the helper.
  **Mutation-checked**: restoring `?? "true"` at that call site fails it with
  `Expected: "True" / Actual: "true"`, while the helper test alone stays green.

## What was run

- `dotnet test AlRunner.Tests --filter FullyQualifiedName~PageControlField` — **17 passed,
  0 skipped, 0 failed**, after `tools/engine-test-bootstrap.sh --configuration Debug` and with
  `--settings engine.runsettings`. The skip count is the number to read: without both of those
  the engine collection skips silently and `dotnet test` still prints `Passed!`.
- The **corpus suite against this runner**, from a clone of `master` **after #310 merged**:
  `al-runner <corpus> --package-cache ~/.al-runner/platform-apps --filter Record_PageControlField_`
  -> **18 total, 18 pass, 0 fail**, including the merged `IsTrueCapitalized` assertion and all
  four siblings.
- `python3 tools/test_doc_pointers.py` -> all checks pass (320 pointers, 64 links, 13 anchors).

Not run: the full `AlRunner.Tests` suite, and the rest of the corpus. This change is confined
to one virtual table's `Editable` column.

## Docs

`docs/page-control-field-from-bc-document.md`'s "three property defaults" section asserted the
refuted reading and **named itself** as resting on reflection rather than a tier verdict, with
#3625 filed to settle it. Rewritten against the measurement and around the mechanism: the
`SolveEditable` chain, its four rules, which three the runner reproduces, and why the two
spellings differ. Anchor `#solveeditable` added; `#the-three-property-defaults` kept so
existing pointers resolve.

`EmittedDocument_OmitsDefaultedProperties_AndEditableHasNoDefaultToOmitTo` renamed — its second
clause asserted the refuted inference. Its assertions are unchanged and still load-bearing:
the solver's null branch is reachable only because the attribute really is omitted.

## Corpus PR #310 — merged

Merged at `b6a43e7c`, 8/8 cloud legs green, execution verified.
`UndeclaredEditable_IsEmpty` -> `UndeclaredEditable_IsTrueCapitalized`, asserting `'True'` and
citing run `34329910568` in the comment. The inversion is correct only because the tier said
so, and the comment states the tier's answer rather than the runner's. #3625 is closed.

**No pin bump here.** `master` is 21 commits ahead of the pin `c9d5f656` and #310 is only the
newest; bumping would drag in 20 unrelated commits whose runner-side fixes are not all landed.
That is `al-language-submodule.md`'s "blocked by an intervening commit" case — the merged
corpus PR is the proof, and the pin advances on its own schedule.

---

Opened by an agent (Claude, `stma-auto-2`) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
