### PR TITLE
fix(rules): the ci-wait.py extraction recipe extracts agent_stdio.py too, and the tool says so when it is missing

### DIFF
--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -129,17 +129,22 @@ Two things it cannot do, so do them yourself:
   ```bash
   git fetch origin main
   d=$(mktemp -d) && mkdir -p "$d/tools"
-  for f in ci-wait.py agent_self_freshness.py; do
+  for f in ci-wait.py agent_self_freshness.py agent_stdio.py; do
     git show "origin/main:tools/$f" > "$d/tools/$f"
   done
   python3 "$d/tools/ci-wait.py" <PR> --timeout 0
   ```
-  **Extract both files, not just `ci-wait.py`** (#3295). A lone copy cannot import its sibling
-  guard, and that used to print a note and judge the PR anyway — so the recipe *recommended
+  **Extract all three files, not just `ci-wait.py`** (#3295, #3658). A lone copy cannot import
+  its sibling guard, and that used to print a note and judge the PR anyway — so the recipe *recommended
   here* was itself a way to reach the one path where nothing checked the running code. It now
   exits 3 instead, so the one-file version of this recipe no longer works at all, which is the
   intended outcome: a tool whose job is to withhold an unsafe verdict must not have a path that
   emits one with the safety check skipped.
+
+  The third file is `agent_stdio.py`, and it is not a guard — without it the copy prints
+  through the console codec, so on a cp1252 box a failing-log tail carrying one non-cp1252
+  character raises `UnicodeEncodeError` and the traceback exits **1**, which is this tool's
+  "a required check failed" code (#3658). A two-file copy says so in a `note:` line on stderr.
 
   Expect two loud `unknown` notes from the copy above — a directory under `/tmp` is not inside
   a git repository, so neither file can check its own freshness. That is fine *here* and only

--- a/tools/ci-wait.py
+++ b/tools/ci-wait.py
@@ -155,6 +155,18 @@ try:
     import agent_stdio as _stdio
 except Exception:  # pragma: no cover - a copy detached from its sibling module
     _stdio = None
+    # A missing display helper is never a refusal and never moves the exit
+    # code -- but it must not be silent either. .claude/rules/ci-verdicts.md
+    # documents extracting this tool out of origin/main into a scratch dir,
+    # and a copy left without this sibling prints through the console codec:
+    # on cp1252 a failing-log tail carrying one non-cp1252 character raises
+    # UnicodeEncodeError, and the traceback exits 1 -- this tool's "a required
+    # check failed" code (#3658). ASCII only, because the console that makes
+    # this note necessary is the console that would fail to print it.
+    print("note: tools/agent_stdio.py could not be imported alongside this copy of "
+          "ci-wait.py -- output is printed with the console encoding, so on a "
+          "non-UTF-8 console it may be lossy or raise while printing. Extract that "
+          "file too (see .claude/rules/ci-verdicts.md).", file=sys.stderr)
 if _stdio is not None:
     # Before any print: stdout is built from the console codec, and cp1252
     # cannot encode the robot emoji in an agent-authored PR body (#3589).

--- a/tools/test_ci_wait.py
+++ b/tools/test_ci_wait.py
@@ -1385,6 +1385,84 @@ check("...and every such recipe extracts the freshness helper alongside it",
       all("agent_self_freshness.py" in b for b in _extracting),
       "\n---\n".join(b for b in _extracting if "agent_self_freshness.py" not in b))
 
+# #3658: the same invariant, one sibling further on. ci-wait.py also imports
+# tools/agent_stdio.py, and a copy without it prints through the console codec
+# -- so on a cp1252 box a failing-log tail carrying one non-cp1252 character
+# raises UnicodeEncodeError and the traceback exits 1, which is this tool's
+# "a required check failed" code. A recipe that omits it hands the reader a
+# copy that can report a crash as a red verdict.
+#
+# Two forms, deliberately: the named list gives a readable failure, and the
+# set derived from ci-wait.py's own imports catches the NEXT sibling nobody
+# adds to the rule file.
+_SIBLINGS = ("ci-wait.py", "agent_self_freshness.py", "agent_stdio.py")
+check("...and every such recipe extracts all three siblings by name",
+      all(all(f in b for f in _SIBLINGS) for b in _extracting),
+      str([b for b in _extracting if not all(f in b for f in _SIBLINGS)]))
+
+import re
+
+_imported = set(re.findall(r"^\s*import (agent_\w+)",
+                           open(os.path.join(HERE, "ci-wait.py"),
+                                encoding="utf-8").read(), re.M))
+check("ci-wait.py imports the siblings the recipe is pinned to",
+      _imported == {"agent_self_freshness", "agent_stdio"}, str(_imported))
+check("...and every extraction recipe names every module ci-wait.py imports",
+      all(all(m + ".py" in b for m in _imported) for b in _extracting),
+      f"imports={sorted(_imported)} blocks={_extracting}")
+
+
+# ---------------------------------------------------------------------------
+# #3658 (2): a copy extracted WITHOUT agent_stdio.py must say so.
+#
+# The import already degrades to a no-op, which is right -- a missing display
+# helper may never be a refusal, and the exit code must not move. But the
+# degradation was silent, so the two-file copy the rule file used to recommend
+# printed through the console codec with nothing saying why its output might
+# be lossy. One note on stderr, in the shape of the freshness `unknown` notes.
+#
+# PYTHONUTF8=1 in the child env so this measures whether the NOTE is printed,
+# not what the host console codec happens to be.
+# ---------------------------------------------------------------------------
+_NOTE_MARK = "agent_stdio.py"
+
+
+def _copy_run(names):
+    """Run a copy of ci-wait.py alongside `names`, with --help (no network)."""
+    with tempfile.TemporaryDirectory() as td:
+        for n in names:
+            shutil.copy(os.path.join(HERE, n), os.path.join(td, n))
+        env = dict(os.environ, PATH=td, PYTHONUTF8="1")
+        return subprocess.run([sys.executable, os.path.join(td, "ci-wait.py"), "--help"],
+                              capture_output=True, text=True, env=env, timeout=120)
+
+
+_two = _copy_run(["ci-wait.py", "agent_self_freshness.py"])
+check("a copy without agent_stdio.py still runs (--help), exit 0",
+      _two.returncode == 0, f"(rc={_two.returncode}) {_two.stdout}{_two.stderr}")
+check("...and prints a note naming the missing helper, on stderr",
+      _NOTE_MARK in _two.stderr and _NOTE_MARK not in _two.stdout,
+      f"stdout={_two.stdout[-400:]} stderr={_two.stderr[-400:]}")
+
+
+def _cp1252_safe(text):
+    try:
+        text.encode("cp1252")
+        return True
+    except UnicodeEncodeError:
+        return False
+
+
+check("...and the note is cp1252-safe, so it cannot crash the box it warns about",
+      _cp1252_safe(_two.stderr), ascii(_two.stderr[-200:]))
+check("...and it is a note, never a verdict",
+      "GREEN" not in _two.stderr and "REFUSING" not in _two.stderr, _two.stderr[-200:])
+
+_three = _copy_run(["ci-wait.py", "agent_self_freshness.py", "agent_stdio.py"])
+check("the three-file copy the rule recommends prints no such note, exit 0",
+      _three.returncode == 0 and _NOTE_MARK not in _three.stderr,
+      f"(rc={_three.returncode}) {_three.stderr[-400:]}")
+
 
 # ---------------------------------------------------------------------------
 # #3309 -- an empty failing-log fetch is a REFUSAL, not an empty log.


### PR DESCRIPTION
Closes #3658

Corpus-NA: tools and rules only; no runner behaviour

Implemented by the `fbk-3` implementation agent, an automated agent acting on the account holder's behalf; the issue was filed by the `fbk` coordinator.

## The defect

`.claude/rules/ci-verdicts.md` § "Run it from a tree you have fetched" tells an agent to extract `ci-wait.py` and `agent_self_freshness.py` out of `origin/main` into a scratch directory. Since PR #3652, `ci-wait.py` also imports `tools/agent_stdio.py` for its UTF-8 stdout reconfiguration, and that import degrades to a **silent** no-op. So the documented two-file copy prints through the console codec: on a cp1252 console a failing-log tail carrying one non-cp1252 character raises `UnicodeEncodeError`, and the traceback exits **1** — `ci-wait.py`'s "a required check failed" code. A crash gets read as a red verdict, on exactly the box #3589 was filed from.

## What changed

- **`.claude/rules/ci-verdicts.md`** — the loop extracts three files, "Extract both files" becomes "Extract all three files", and one short paragraph says why the third matters. Two lines and a clause; the surrounding rule text is untouched. The "Expect two loud `unknown` notes" paragraph stays correct — `agent_stdio.py` carries no freshness check.
- **`tools/test_ci_wait.py`** — the #3295 drift invariant now pins every extraction block against all three siblings **by name**, and additionally against the set derived from `ci-wait.py`'s own `import agent_*` lines, so a fourth sibling nobody adds to the rule file fails the test rather than rotting quietly. Plus three subprocess cases running copies of the tool out of a temp dir.
- **`tools/ci-wait.py`** — when `agent_stdio` cannot be imported, one ASCII `note:` line on **stderr**, in the shape of the freshness `unknown` notes. Never a refusal; the exit code is untouched. The note is deliberately ASCII-only: the console that makes it necessary is the console that would fail to print it.

## RED → GREEN

`python tools/test_ci_wait.py`

RED (before the rule and tool edits) — 3 checks failed:

```
FAILED: 3 check(s): ...and every such recipe extracts all three siblings by name,
...and every extraction recipe names every module ci-wait.py imports,
...and prints a note naming the missing helper, on stderr
```

GREEN after: `all checks passed`.

The three subprocess cases are hermetic — they `shutil.copy` out of `tools/` (never `git show origin/main:`, which would test the pre-merge copy and need a fetched ref in CI), run `--help` so no `gh` and no network are needed, and set `PYTHONUTF8=1` so the claim measured is "is the note printed", not "what codec does the host console have":

| copy | result |
|---|---|
| 1 file (existing #3295 test) | exit 3, refuses to judge — unchanged |
| 2 files (`ci-wait.py` + `agent_self_freshness.py`) | exit 0, `note:` naming `agent_stdio.py` on stderr, cp1252-safe, no verdict word in it |
| 3 files (the recipe as now written) | exit 0, no note |

Also run green: `tools/test_doc_pointers.py` (it does not read this section), `tools/test_agent_stdio.py`, `tools/test_agent_self_freshness.py`, `tools/test_text_encoding.py`.

## Fix the shape, not the reported line

1. **Same wrong pattern at another call site?** `rg --hidden 'git show "origin/main'` over `.claude/`, `docs/` and `tools/` returns exactly one hit — line 133 of `ci-verdicts.md`. There is no second extraction recipe anywhere.
2. **Sibling making the same assumption?** `tools/pr-body.py` and `tools/preflight.py` carry the identical silent `_stdio = None` fallback. Neither has a documented lone-copy extraction recipe, so neither can be reached the way `ci-wait.py` was, and neither is touched here. Worth a follow-up only if such a recipe is ever written for them.
3. **Two paths writing the same state?** The freshness guard and the stdio helper are imported the same way but are deliberately *not* equivalent: a missing freshness guard is a refusal (exit 3), a missing display helper is a note. That asymmetry is intentional and is now asserted — the note may not contain `GREEN` or `REFUSING`.

## Open-issue queue

`gh issue list --state open --limit 200 --search "ci-wait OR agent_stdio OR ci-verdicts OR cp1252 OR UnicodeEncodeError"` returns 14 open issues. Exactly one lands in a file this PR touches: **#3459** — `ci-verdicts.md` §0 quotes its own superseded `--timeout 1` advice in a register agents have twice read as the instruction. Not folded: it is the maintainer's own issue (author `StefanMaron`, unassigned, `documentation`), and this agent does not claim issues it did not file. It is also a different section of the file and a different shape of fix — reframing history, not a recipe that produces a broken copy — so folding it would not have made one coherent diff. Nothing else in the 14 touches `ci-wait.py`, `test_ci_wait.py` or `ci-verdicts.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kko97BZZL71nF2nK5aftu4
