### PR TITLE
fix(query-join): refuse a failed reflection lookup instead of answering FiltersAndMarks.Empty

### DIFF
--- a/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
+++ b/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
@@ -225,8 +225,11 @@ public sealed class BcInternalsNullForgivingGuardTests
         // converted, and a drop means a conversion was undone. 74 -> 75 for the
         // DataItemTableFilter read in RecordPatches.QueryProjection.cs (#3571); 75 -> 80 for
         // the five lookups in that same method's GetSingleDataItemTableFilterTuples, whose
-        // failure used to be a silent `yield break` the caller read as "no filters" (#3647).
-        Assert.Equal(80, converted);
+        // failure used to be a silent `yield break` the caller read as "no filters" (#3647);
+        // 80 -> 81 for the TableFiltersAndMarks read on the JOIN path in
+        // RecordPatches.QueryJoin.cs, whose failure used to answer FiltersAndMarks.Empty —
+        // indistinguishable from a dataitem that genuinely declares no filter (#3656).
+        Assert.Equal(81, converted);
     }
 
     /// <summary>

--- a/AlRunner.Tests/QueryJoinFindRequestShapeGapTests.cs
+++ b/AlRunner.Tests/QueryJoinFindRequestShapeGapTests.cs
@@ -1,0 +1,395 @@
+// QueryJoinFindRequestShapeGapTests — issue #3656.
+//
+// WHAT IS BEING PROVED
+//   BuildTableFindAllRequest builds the per-dataitem read request for a MULTI-DATAITEM (join)
+//   query, and reaches that dataitem's own static DataItemTableFilter through the same BC
+//   member #3647 is about. Its failed reflection lookups used to answer a DEFAULT:
+//
+//       object? filtersAndMarks = null;
+//       try { var p = dataItem.GetType().GetProperty("TableFiltersAndMarks", ...);
+//             filtersAndMarks = p?.GetValue(dataItem); }
+//       catch { filtersAndMarks = null; }
+//       filtersAndMarks ??= StaticMember("FiltersAndMarks", "Empty");
+//
+//   At the one call site — JoinExecutor.ReadDataItemRows — FiltersAndMarks.Empty is exactly
+//   what a dataitem that genuinely declares no filter yields, so an unresolved member is
+//   INDISTINGUISHABLE from a real empty answer. The join then reads the dataitem's table
+//   UNFILTERED and returns MORE ROWS than it should, with nothing thrown.
+//
+//   The `return null` when the FindProviderRequest constructor is not found is worse still:
+//   ReadDataItemRows reads `if (req == null) return result;` and yields ZERO rows for that
+//   dataitem, which collapses the entire join to empty. Silently.
+//
+// THE BARE `catch { }` WAS THE SECOND HALF OF THE DEFECT
+//   `catch { filtersAndMarks = null; }` swallows EVERYTHING the read raises — including a
+//   BcShapeGapException raised beneath it, the one exception type that exists precisely to
+//   tear through both of AL's trapping seams. Converting the lookups to throw without dealing
+//   with the catch would have produced refusals that this very method eats: a guard that is
+//   quiet rather than armed. Arm 4 below is what proves the refusals now escape.
+//
+// LATENT, NOT LIVE. NCLMetaQueryDataItem.TableFiltersAndMarks is a real (internal) property on
+//   every BC version this repository tests — confirmed on the bc284 context, where it reads
+//   `internal FiltersAndMarks TableFiltersAndMarks`. These arms are about the BC version where
+//   it moves.
+//
+// WHY A NULL TableFiltersAndMarks MUST STAY SILENT — measured, not assumed
+//   BC's own NCLMetaQuery.CreateTableFiltersAndMarksFromDataItemFieldFilters (bc284) opens with
+//   `if (fieldFilters.Count == 0) return null;` and ends with `return null;` when no filter
+//   expression was built. So null IS BC's answer for "this dataitem declares no
+//   DataItemTableFilter", and the `?? FiltersAndMarks.Empty` fallback for a SUCCESSFUL read of
+//   null is correct. Converting it would break every join whose dataitems carry no filter,
+//   which is most of them. The negative controls below are what stop that.
+//
+// WHY THE METHOD TAKES ITS BC TYPES AS PARAMETERS
+//   Same idiom as PermissionMetadataShapeGapTests and #3647's QueryDataItemFilterShapeGapTests:
+//   real production code driven with fakes standing in for a BC type whose member moved, no BC
+//   install required. The alternative — poking the RecordPatches statics — would leave them
+//   poisoned for every other test in the assembly.
+using System;
+using System.Linq;
+using System.Reflection;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class QueryJoinFindRequestShapeGapTests
+{
+    private const string Surface = "AL query execution (multi-dataitem join)";
+
+    // ══ 1. THE LOOKUPS THAT MUST REFUSE ══════════════════════════════════════════════════
+    //
+    // Each arm removes exactly ONE member and leaves the others in place, so a fix that threw
+    // unconditionally would still have to name the right member to pass — and the negative
+    // controls in section 2 would fail it outright.
+
+    [Fact]
+    public void TableFiltersAndMarksLookup_RaisesAShapeGapNamingTheMember_WhenBcRenamesIt()
+    {
+        // The member #3656 names: the one whose disappearance drops the join's filter silently.
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Build(dataItem: new DataItemWithoutTableFilters()));
+
+        Assert.Contains("TableFiltersAndMarks", ex.Member, StringComparison.Ordinal);
+        Assert.Contains(nameof(DataItemWithoutTableFilters), ex.Member, StringComparison.Ordinal);
+        Assert.StartsWith("bc-shape-gap: ", ex.Message, StringComparison.Ordinal);
+        Assert.Equal(Surface, ex.Surface);
+        Assert.EndsWith(" — see docs/limitations.md#bc-shape-gaps", ex.Message, StringComparison.Ordinal);
+
+        // The LOOKUP failed. That is a different fact from the property being present and
+        // reading null, which is BC's own "no filters" answer and must NOT throw (section 2).
+        // Without this pair a `GetProperty(...)?.GetValue(...)` that collapses the two would
+        // still pass this arm, which is exactly the unarmed-guard defect #3647 caught in its
+        // own DataItems arm.
+        Assert.Contains("property not found", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FiltersAndMarksEmptyLookup_RaisesAShapeGapNamingTheMember_WhenBcRenamesIt()
+    {
+        // The FALLBACK itself is a reflection lookup. If `FiltersAndMarks.Empty` moves, the old
+        // code fed a null filtersAndMarks into the ctor — a different silent wrong answer for
+        // the same reason.
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Build(famType: typeof(FiltersAndMarksWithoutEmpty)));
+
+        Assert.Contains("Empty", ex.Member, StringComparison.Ordinal);
+        Assert.Contains(nameof(FiltersAndMarksWithoutEmpty), ex.Member, StringComparison.Ordinal);
+        Assert.StartsWith("bc-shape-gap: ", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TableFilterDictionaryEmptyLookup_RaisesAShapeGapNamingTheMember_WhenBcRenamesIt()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Build(tfdType: typeof(TableFilterDictionaryWithoutEmpty)));
+
+        Assert.Contains("Empty", ex.Member, StringComparison.Ordinal);
+        Assert.Contains(nameof(TableFilterDictionaryWithoutEmpty), ex.Member, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheFindProviderRequestConstructorLookup_Refuses_RatherThanReturningNull()
+    {
+        // `return null` here is the WORST of the silent exits: ReadDataItemRows reads it as
+        // "this dataitem has no rows" and collapses the whole join to empty.
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Build(findReqType: typeof(FindRequestWithNoUsableCtor)));
+
+        Assert.Contains(nameof(FindRequestWithNoUsableCtor), ex.Member, StringComparison.Ordinal);
+        Assert.Contains("constructor", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(Surface, ex.Surface);
+    }
+
+    // ══ 2. NEGATIVE CONTROLS — the exits that must STAY silent ═══════════════════════════
+    //
+    // Without these, "a failed lookup refuses" is satisfiable by a change that refuses on
+    // everything, which would break every join whose dataitems carry no DataItemTableFilter —
+    // that is, most joins on every BC version.
+
+    [Fact]
+    public void ADataItemWhoseTableFiltersAndMarksReadsNull_GetsEmpty_AndDoesNotThrow()
+    {
+        // BC's own answer for "no DataItemTableFilter on this dataitem": the property IS there
+        // and returns null (CreateTableFiltersAndMarksFromDataItemFieldFilters, bc284).
+        var req = Build(dataItem: new FakeDataItem(null));
+
+        var built = Assert.IsType<FakeFindProviderRequest>(req);
+        Assert.Same(FakeFiltersAndMarks.Empty, built.FiltersAndMarks);
+    }
+
+    [Fact]
+    public void ADataItemThatDeclaresARealFilter_GetsThatFilter_NotTheEmptyFallback()
+    {
+        // The positive half of the pair above: proves the fallback is a FALLBACK and not what
+        // every dataitem gets. Without this arm a fix that always answered Empty would pass.
+        var real = new object();
+
+        var req = Build(dataItem: new FakeDataItem(real));
+
+        var built = Assert.IsType<FakeFindProviderRequest>(req);
+        Assert.Same(real, built.FiltersAndMarks);
+        Assert.NotSame(FakeFiltersAndMarks.Empty, built.FiltersAndMarks);
+    }
+
+    [Fact]
+    public void TheAbsentMemberAndTheNullRead_AreDistinguishedByWhetherAnythingIsThrownAtAll()
+    {
+        // The pairing that makes the two arms above ARMED rather than merely quiet, stated in
+        // one place so neither half can be weakened alone. #3647's agent found its equivalent
+        // arm unarmed because both of ITS outcomes refused and only the wording separated them;
+        // here they are separated by the strongest discriminator available — one throws and the
+        // other returns a request — so a fix that collapsed them cannot pass both lines.
+        var absent = Record.Exception(() => Build(dataItem: new DataItemWithoutTableFilters()));
+        var readNull = Record.Exception(() => Build(dataItem: new FakeDataItem(null)));
+
+        var gap = Assert.IsType<BcShapeGapException>(absent);
+        Assert.Contains("property not found", gap.Message, StringComparison.Ordinal);
+        Assert.Null(readNull);
+    }
+
+    // ══ 3. THE REST OF THE REQUEST IS STILL BUILT ════════════════════════════════════════
+
+    [Fact]
+    public void TheRequestCarriesTheTableAndTheEmptyGlobalFilters()
+    {
+        var table = new NCLMetaApplicationObject();
+
+        var built = Assert.IsType<FakeFindProviderRequest>(
+            Build(dataItem: new FakeDataItem(null), table: table));
+
+        Assert.Same(table, built.MetaApplicationObject);
+        Assert.Same(FakeTableFilterDictionary.Empty, built.GlobalAndSecurityFilters);
+    }
+
+    // ══ 4. THE BARE `catch` — the half that makes the refusals reachable at all ═══════════
+
+    [Fact]
+    public void AShapeGapRaisedInsideTheRead_ReachesTheCaller_RatherThanBeingSwallowed()
+    {
+        // The issue's condition 3. A getter that itself raises a BcShapeGapException stands in
+        // for a nested reflection read refusing beneath this one. The old `catch { }` ate it
+        // and answered FiltersAndMarks.Empty — a refusal converted back into a silent default,
+        // one frame below where it was raised.
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Build(dataItem: new DataItemWhoseGetterRaisesAShapeGap()));
+
+        Assert.Equal("Nested.Member", ex.Member);
+        Assert.Contains("raised beneath the TableFiltersAndMarks read", ex.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnOrdinaryExceptionFromTheRead_AlsoReachesTheCaller_RatherThanReadingAsNoFilters()
+    {
+        // The catch was not merely too wide for BcShapeGapException — ANY throw from the getter
+        // became "no filters". BC's own getter can throw NavNotSupportedException (a
+        // DataItemTableFilter on a FlowField); swallowing that reported the wrong answer for the
+        // query instead of the error BC raises.
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => Build(dataItem: new DataItemWhoseGetterThrows()));
+
+        Assert.Equal("the getter refused", ex.Message);
+    }
+
+    // ══ 4b. THE ADAPTER'S OWN TYPE LOOKUPS ═══════════════════════════════════════════════
+    //
+    // Join_BuildFindAllRequest resolves the four BC types the builder reads members off. Those
+    // were `nclAsm.GetType(...)!` — the same null-forgiving shape, one frame up: a MOVED TYPE
+    // would hand back null and the NullReferenceException would land inside the builder, on a
+    // line naming a parameter instead of the type that went missing. Driving the adapter with a
+    // provider from an assembly that declares none of them exercises the first of the four.
+
+    [Fact]
+    public void TheAdapterRefuses_NamingTheBcTypeItCouldNotResolve_RatherThanHandingNullOn()
+    {
+        var m = typeof(RecordPatches).GetMethod(
+                    "Join_BuildFindAllRequest", BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "test setup: RecordPatches.Join_BuildFindAllRequest not found");
+
+        // `this` test assembly declares no Microsoft.Dynamics.Nav.Runtime.* type, so every
+        // NclType(...) lookup fails against it — the first one is the one that reports.
+        var ex = Assert.Throws<BcShapeGapException>(() =>
+        {
+            try
+            {
+                m.Invoke(null, new object?[]
+                {
+                    new object(), new FakeDataItem(null), new NCLMetaApplicationObject(),
+                });
+            }
+            catch (TargetInvocationException tie) when (tie.InnerException != null)
+            {
+                throw tie.InnerException;
+            }
+        });
+
+        Assert.Contains("Microsoft.Dynamics.Nav.Runtime.", ex.Member, StringComparison.Ordinal);
+        Assert.Contains("type not found", ex.Message, StringComparison.Ordinal);
+        Assert.Equal(Surface, ex.Surface);
+    }
+
+    // ══ 5. THE REFLECTION PIN: name, arity, uniqueness — liveness is guarded separately ═══
+    //
+    // ReflectionDrivenHelperLivenessTests measures LIVENESS from IL for every RecordPatches
+    // member any test names as a literal, and this file names BuildTableFindAllRequest — so a
+    // change that leaves the method declared but stops production reaching it fails there.
+    // What is pinned HERE is the half that guard cannot see.
+
+    [Fact]
+    public void TheHelperIsUniqueByName_AndTakesTheParametersTheseArmsDriveItWith()
+    {
+        var candidates = typeof(RecordPatches)
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .Where(m => m.Name == "BuildTableFindAllRequest")
+            .ToList();
+
+        Assert.Single(candidates);
+        Assert.Equal(
+            new[] { typeof(object), typeof(object), typeof(object),
+                    typeof(Type), typeof(Type), typeof(Type), typeof(Type) },
+            candidates[0].GetParameters().Select(p => p.ParameterType).ToArray());
+    }
+
+    // ══ Plumbing ═════════════════════════════════════════════════════════════════════════
+
+    private static object? Build(
+        object? dataItem = null, object? table = null,
+        Type? findReqType = null, Type? famType = null,
+        Type? tfdType = null, Type? findTypeEnum = null)
+    {
+        var m = typeof(RecordPatches).GetMethod(
+                    "BuildTableFindAllRequest", BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "test setup: RecordPatches.BuildTableFindAllRequest not found");
+        try
+        {
+            return m.Invoke(null, new object?[]
+            {
+                new object(),                                   // provider — unused by the fakes
+                dataItem ?? new FakeDataItem(null),
+                table ?? new NCLMetaApplicationObject(),
+                findReqType ?? typeof(FakeFindProviderRequest),
+                famType ?? typeof(FakeFiltersAndMarks),
+                tfdType ?? typeof(FakeTableFilterDictionary),
+                findTypeEnum ?? typeof(FakeFindType),
+            });
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            throw tie.InnerException;   // the reflection wrapper is not part of the contract
+        }
+    }
+
+    // ── Fakes standing in for BC's types. Each names the member it is missing. ──
+
+    private enum FakeFindType { Normal = 3, Other = 9 }
+
+    // production reads `lockState` with Enum.ToObject(ps[i].ParameterType, 0), so the fake's
+    // parameter must be an enum exactly as BC's LockState is.
+    private enum FakeLockState { None = 0, Some = 1 }
+
+    private sealed class FakeFiltersAndMarks
+    {
+        public static readonly FakeFiltersAndMarks Empty = new();
+    }
+
+    private sealed class FiltersAndMarksWithoutEmpty
+    {
+    }
+
+    private sealed class FakeTableFilterDictionary
+    {
+        public static readonly FakeTableFilterDictionary Empty = new();
+    }
+
+    private sealed class TableFilterDictionaryWithoutEmpty
+    {
+    }
+
+    private sealed class FakeDataItem
+    {
+        public FakeDataItem(object? tableFiltersAndMarks) => TableFiltersAndMarks = tableFiltersAndMarks;
+        public object? TableFiltersAndMarks { get; }
+    }
+
+    private sealed class DataItemWithoutTableFilters
+    {
+    }
+
+    private sealed class DataItemWhoseGetterThrows
+    {
+        public object? TableFiltersAndMarks => throw new InvalidOperationException("the getter refused");
+    }
+
+    private sealed class DataItemWhoseGetterRaisesAShapeGap
+    {
+        public object? TableFiltersAndMarks => throw new BcShapeGapException(
+            Surface, "Nested.Member",
+            "raised beneath the TableFiltersAndMarks read, standing in for a nested reflection "
+            + "read that refused");
+    }
+
+    /// <summary>
+    /// Stands in for BC's FindProviderRequest: 14 parameters, the second one named so the
+    /// production ctor filter (>= 13 parameters, parameter 1 typed NCLMetaApplicationObject)
+    /// selects it. Parameter NAMES are what production switches on, so they are load-bearing.
+    /// </summary>
+    private sealed class FakeFindProviderRequest
+    {
+        public FakeFindProviderRequest(
+            int companyToken, NCLMetaApplicationObject metaApplicationObject, FakeLockState lockState,
+            object? filtersAndMarks, object? globalAndSecurityFilters, int flowFieldSecurityFiltering,
+            object? autoCalcFields, object? sortingFields, FakeFindType findType,
+            int topNumberOfRowsToReturn, int skipNumberOfRows, int fastNumberOfRowsToReturn,
+            object? timeout, object? fieldLoadInfo)
+        {
+            MetaApplicationObject = metaApplicationObject;
+            FiltersAndMarks = filtersAndMarks;
+            GlobalAndSecurityFilters = globalAndSecurityFilters;
+            FindType = findType;
+        }
+
+        public object? MetaApplicationObject { get; }
+        public object? FiltersAndMarks { get; }
+        public object? GlobalAndSecurityFilters { get; }
+        public FakeFindType FindType { get; }
+    }
+
+    private sealed class FindRequestWithNoUsableCtor
+    {
+        public FindRequestWithNoUsableCtor(int tooFew) { _ = tooFew; }
+    }
+}
+
+/// <summary>
+/// Production selects the FindProviderRequest ctor by testing
+/// <c>GetParameters()[1].ParameterType.Name == "NCLMetaApplicationObject"</c>, so the fake's
+/// second parameter must be a type of exactly that NAME. Declared at namespace scope because a
+/// nested type's <c>Name</c> would still be the simple name but the shape reads more clearly
+/// here; the runner never resolves it by namespace.
+/// </summary>
+internal sealed class NCLMetaApplicationObject
+{
+}

--- a/AlRunner/Patches/RecordPatches.QueryJoin.cs
+++ b/AlRunner/Patches/RecordPatches.QueryJoin.cs
@@ -42,6 +42,9 @@ public static partial class RecordPatches
     // dataitem tables when it executes a join.
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<object, object> _joinSourceByQueryDef = new();
 
+    /// <summary>The AL-visible surface every refusal in this file names.</summary>
+    private const string JoinSurface = "AL query execution (multi-dataitem join)";
+
     // ── lazily-loaded executor handles (resolved by reflection so no compile-time ref to
     //    the AlRunner.QueryJoin assembly leaks Ncl-touching IL into al-runner's startup) ──
     private static Assembly? _joinAsm;
@@ -123,7 +126,30 @@ public static partial class RecordPatches
         => (IEnumerable)_mTtdpFindImpl!.Invoke(provider, new[] { request })!;
 
     private static object? Join_BuildFindAllRequest(object provider, object dataItem, object table)
-        => BuildTableFindAllRequest(provider, dataItem, table);
+    {
+        var nclAsm = provider.GetType().Assembly;
+        const string rt = "Microsoft.Dynamics.Nav.Runtime.";
+
+        // The three BC types the builder reads members off, plus the FindType enum. `!` here
+        // would be the same null-forgiving shape the builder itself no longer has: a type that
+        // MOVED would hand back null and the NullReferenceException would land inside the
+        // builder, on a line naming a parameter rather than the type that went missing.
+        Type NclType(string name) => nclAsm.GetType(rt + name)
+            ?? throw new BcShapeGapException(
+                JoinSurface, rt + name,
+                "type not found in " + nclAsm.GetName().Name + " — the runner builds a join "
+                + "dataitem's read request from it; BC's layout has moved");
+
+        return BuildTableFindAllRequest(
+            provider, dataItem, table,
+            NclType("FindProviderRequest"),
+            NclType("FiltersAndMarks"),
+            NclType("TableFilterDictionary"),
+            _tFindTypeEnum ?? throw new BcShapeGapException(
+                JoinSurface, rt + "FindType",
+                "the FindType enum was not resolved when the query projection reflection was "
+                + "prepared — the runner needs it to ask for a Normal find"));
+    }
 
     private static object Join_MakeReadOnlyRecordBuffer(object metaQuery, Array navValues)
         => _ctorReadOnlyRecordBuffer!.Invoke(new object?[] { metaQuery, navValues })!;
@@ -197,7 +223,7 @@ public static partial class RecordPatches
         EnsureJoinExecutorLoaded();
         var queryDef = BcShape.Property(
             _tNCLMetaQuery!, "QueryDefinition", BindingFlags.Public | BindingFlags.Instance,
-            "AL query execution (multi-dataitem join)")
+            JoinSurface)
             .GetValue(nclMetaQuery)!;
         if (!_joinSourceByQueryDef.TryGetValue(queryDef, out var dataAccessSource))
             throw RunnerShapeGap.Query(
@@ -226,48 +252,78 @@ public static partial class RecordPatches
     // ── FindProviderRequest builder for a full table scan honouring the dataitem's own
     //    filters. Pure reflection; lives here (not in the executor) so the executor needs
     //    no FindProviderRequest knowledge. Ported from the original QueryJoin.cs. ────────
-    private static ConstructorInfo? _ctorFindProviderRequestAll;
-    private static int _normalFindOrdinal = -1;
-
-    private static int NormalFindOrdinal()
+    //
+    //    A FAILED LOOKUP REFUSES; AN EMPTY ANSWER STAYS SILENT (#3656, sibling of #3647).
+    //    Observably equivalent to BC for in-scope AL: on every BC build the runner has seen,
+    //    every member read below resolves, so no refusal fires and the request is the one BC
+    //    would build. What changed is the BC build where one MOVES — that used to answer
+    //    FiltersAndMarks.Empty (an unfiltered join returning too many rows) or null (which
+    //    JoinExecutor.ReadDataItemRows reads as "no rows", collapsing the join to empty),
+    //    both silently. A null TableFiltersAndMarks is BC's own "this dataitem declares no
+    //    DataItemTableFilter" answer — NCLMetaQuery.CreateTableFiltersAndMarksFromDataItem-
+    //    FieldFilters returns null when fieldFilters.Count == 0 — so that one still answers
+    //    Empty. Per-exit table: docs/query-dataitem-table-filter.md#the-join-path-refuses-too
+    private static int NormalFindOrdinal(Type tFindType)
     {
-        if (_normalFindOrdinal < 0)
-        {
-            try { _normalFindOrdinal = Convert.ToInt32(Enum.Parse(_tFindTypeEnum!, "Normal")); }
-            catch { _normalFindOrdinal = 0; }
-        }
-        return _normalFindOrdinal;
+        try { return Convert.ToInt32(Enum.Parse(tFindType, "Normal")); }
+        catch { return 0; }
     }
 
-    private static object? BuildTableFindAllRequest(object provider, object dataItem, object table)
+    private static object? BuildTableFindAllRequest(
+        object provider, object dataItem, object table,
+        Type tFindReq, Type tFiltersAndMarks, Type tTableFilterDictionary, Type tFindType)
     {
-        var nclAsm = provider.GetType().Assembly;
-        const string rt = "Microsoft.Dynamics.Nav.Runtime.";
-        var tFindReq = nclAsm.GetType(rt + "FindProviderRequest")!;
-        _ctorFindProviderRequestAll ??= tFindReq.GetConstructors()
+        var ctor = tFindReq.GetConstructors()
             .FirstOrDefault(c => c.GetParameters().Length >= 13
-                && c.GetParameters()[1].ParameterType.Name == "NCLMetaApplicationObject");
-        if (_ctorFindProviderRequestAll == null) return null;
+                && c.GetParameters()[1].ParameterType.Name == "NCLMetaApplicationObject")
+            ?? throw new BcShapeGapException(
+                JoinSurface, $"{tFindReq.Name}..ctor",
+                "no constructor taking >= 13 parameters whose second is an NCLMetaApplicationObject "
+                + "— the runner builds one to read a join dataitem's table under its own filters; "
+                + "BC's layout for this type has moved");
 
-        object? StaticMember(string typeName, string member)
+        // A static that BC declares as either a field or a property. Absence is a moved member,
+        // never an answer: both of these are `Empty` singletons that always exist on a real Ncl.
+        object StaticMember(Type t, string member)
         {
-            var t = nclAsm.GetType(rt + typeName)!;
-            return t.GetField(member, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)?.GetValue(null)
-                ?? t.GetProperty(member, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)?.GetValue(null);
+            var v = t.GetField(member, BcShape.AnyStatic)?.GetValue(null)
+                 ?? t.GetProperty(member, BcShape.AnyStatic)?.GetValue(null);
+            return v ?? throw new BcShapeGapException(
+                JoinSurface, $"{t.Name}.{member}",
+                "static field or property not found (or reads null) — the runner reads it to "
+                + "supply the join read request's empty filter set; BC's layout for this member "
+                + "has moved");
         }
 
-        object? filtersAndMarks = null;
+        // The read. The bare `catch { filtersAndMarks = null; }` this replaces swallowed
+        // EVERYTHING the getter raised — a BcShapeGapException from a nested read, the one type
+        // that must tear through both AL trapping seams, and BC's own NavNotSupportedException
+        // for a DataItemTableFilter on a FlowField — and answered FiltersAndMarks.Empty one frame
+        // below where it was raised. Nothing is caught now; the only catch left rethrows.
+        var pTableFilters = BcShape.Property(
+            dataItem.GetType(), "TableFiltersAndMarks", BcShape.AnyInstance, JoinSurface);
+        object? filtersAndMarks;
         try
         {
-            var p = dataItem.GetType().GetProperty("TableFiltersAndMarks",
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            filtersAndMarks = p?.GetValue(dataItem);
+            filtersAndMarks = pTableFilters.GetValue(dataItem);
         }
-        catch { filtersAndMarks = null; }
-        filtersAndMarks ??= StaticMember("FiltersAndMarks", "Empty");
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            // Surface the getter's real exception, via ExceptionDispatchInfo and NOT
+            // `throw tie.InnerException` — same reason as ExecuteJoinQuery above: a bare rethrow
+            // resets the stack trace to this frame and erases where the failure came from.
+            // Without this the caller sees a TargetInvocationException whose text names
+            // reflection rather than the member that moved.
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw(tie.InnerException);
+            throw; // unreachable; satisfies definite assignment
+        }
 
-        var emptyTfd = StaticMember("TableFilterDictionary", "Empty");
-        var ps = _ctorFindProviderRequestAll.GetParameters();
+        // Reaching here with null means the READ SUCCEEDED and BC answered null: this dataitem
+        // declares no DataItemTableFilter. That is an answer, so it stays silent.
+        filtersAndMarks ??= StaticMember(tFiltersAndMarks, "Empty");
+
+        var emptyTfd = StaticMember(tTableFilterDictionary, "Empty");
+        var ps = ctor.GetParameters();
         var args = new object?[ps.Length];
         for (int i = 0; i < ps.Length; i++)
         {
@@ -281,7 +337,7 @@ public static partial class RecordPatches
                 "flowFieldSecurityFiltering" => ps[i].ParameterType.IsValueType ? Activator.CreateInstance(ps[i].ParameterType) : null,
                 "autoCalcFields" => null,
                 "sortingFields" => null,
-                "findType" => Enum.ToObject(_tFindTypeEnum!, NormalFindOrdinal()),
+                "findType" => Enum.ToObject(tFindType, NormalFindOrdinal(tFindType)),
                 "topNumberOfRowsToReturn" => 0,
                 "skipNumberOfRows" => 0,
                 "fastNumberOfRowsToReturn" => 0,
@@ -290,6 +346,6 @@ public static partial class RecordPatches
                 _ => ps[i].HasDefaultValue ? ps[i].DefaultValue : (ps[i].ParameterType.IsValueType ? Activator.CreateInstance(ps[i].ParameterType) : null)
             };
         }
-        return _ctorFindProviderRequestAll.Invoke(args);
+        return ctor.Invoke(args);
     }
 }

--- a/docs/query-dataitem-table-filter.md
+++ b/docs/query-dataitem-table-filter.md
@@ -72,7 +72,8 @@ BC's own code, unmodified.
 
 - **Join path** — `RecordPatches.QueryJoin.BuildTableFindAllRequest` reads each dataitem's
   `TableFiltersAndMarks` when it builds that dataitem's own read request. Correct, per
-  dataitem, and unchanged by #3571.
+  dataitem, and unchanged by #3571 — but it used to answer a DEFAULT when the read FAILED,
+  which is what #3656 fixed. See "The join path refuses too" below.
 - **Single-dataitem path** — `RecordPatches.QueryProjection.TranslateQueryFilters` handled
   runtime `SetRange`/`SetFilter` filters and static `ColumnFilters`, and read
   `TableFiltersAndMarks` nowhere.
@@ -149,6 +150,103 @@ column** of the same query, resolved against `columnIdByName`. For `DataItemTabl
 is a **table field** of the dataitem's own `RelatedTable`, resolved against that table's
 `fieldNoByName`. An unresolvable name abandons the build in both cases, matching the
 `ColumnFilter` discipline: running the query unrestricted returns rows real BC excludes.
+
+## The join path refuses too
+
+#3656, the sibling of #3647 one code path over. `BuildTableFindAllRequest` builds the
+per-dataitem read request for a **multi-dataitem (join)** query, and reached the same
+`NCLMetaQueryDataItem.TableFiltersAndMarks` through a lookup whose failure answered a default:
+
+```csharp
+object? filtersAndMarks = null;
+try
+{
+    var p = dataItem.GetType().GetProperty("TableFiltersAndMarks", ...);
+    filtersAndMarks = p?.GetValue(dataItem);
+}
+catch { filtersAndMarks = null; }
+filtersAndMarks ??= StaticMember("FiltersAndMarks", "Empty");
+```
+
+Three separate ways to answer "no filters" for something that is not an empty answer — an
+unresolved property, anything the getter raised, and a fallback indistinguishable from a
+dataitem that genuinely declares none.
+
+### Why the consequence is worse here than a wrong filter
+
+The one call site is `JoinExecutor.ReadDataItemRows`, and it reads **two** of this method's
+answers as ordinary facts:
+
+| the builder answers | ReadDataItemRows does | observable result |
+|---|---|---|
+| a request carrying `FiltersAndMarks.Empty` | reads the dataitem's table unfiltered | the join returns **more rows than it should** |
+| `null` | `if (req == null) return result;` | that dataitem contributes **zero rows**, collapsing the whole join to empty |
+
+Neither throws. A passing test cannot tell the difference unless it asserts the row count,
+which is the silent-default shape `.claude/rules/loud-failures.md` forbids.
+
+### The bare `catch` was the second half of the defect
+
+`catch { filtersAndMarks = null; }` swallowed **everything** the getter raised, including a
+`BcShapeGapException` from a read beneath it — the one exception type that exists to tear
+through both of AL's trapping seams. Converting the lookups to throw without removing that
+catch would have produced refusals this very method ate: a guard that is quiet rather than
+armed.
+
+It also swallowed BC's own errors. `NCLMetaQuery.CreateTableFiltersAndMarksFromDataItemField-`
+`Filters` raises `NavNotSupportedException` for a `DataItemTableFilter` on a FlowField, and the
+getter can reach it; the old code turned that into "no filters" and ran the query, instead of
+reporting the error real BC reports.
+
+Nothing is caught now. The one `catch` that remains rethrows the getter's real exception
+through `ExceptionDispatchInfo`, never a bare `throw tie.InnerException` — the same
+stack-trace-preservation reason `ExecuteJoinQuery` gives a few lines above it. Without the
+unwrap a caller sees a `TargetInvocationException` whose text names reflection rather than the
+member that moved.
+
+### Which exits are now loud, and which stay silent
+
+Five lookups refuse; one exit stays silent, and it is the one that carries most traffic.
+
+| exit | now | why |
+|---|---|---|
+| `FindProviderRequest` type lookup | **refuses** | a moved type; `!` would NRE inside the builder naming a parameter |
+| `FiltersAndMarks` / `TableFilterDictionary` type lookups | **refuses** | same |
+| `FindProviderRequest` ctor not found | **refuses** | used to `return null`, which the executor read as "no rows" |
+| `TableFiltersAndMarks` lookup | **refuses** | the member #3656 names |
+| `FiltersAndMarks.Empty` / `TableFilterDictionary.Empty` statics | **refuses** | `Empty` singletons that always exist on a real Ncl; absence is a moved member |
+| anything the getter raises | **propagates** | was swallowed by the bare `catch` |
+| **`TableFiltersAndMarks` reads null** | **silent** | **BC's own answer** — see below |
+
+The silent row is load-bearing and must stay silent. Measured on the `bc284` context,
+`NCLMetaQuery.CreateTableFiltersAndMarksFromDataItemFieldFilters` opens with
+
+```csharp
+if (fieldFilters.Count == 0) { return null; }
+```
+
+and ends with a second `return null;` when no filter expression was built. So **null is BC's
+answer for "this dataitem declares no `DataItemTableFilter`"** — the ordinary case for most
+join dataitems. Converting it would turn every unfiltered join into an error.
+
+### What proves it
+
+`AlRunner.Tests/QueryJoinFindRequestShapeGapTests` — 12 arms, driving the real production
+helper with fakes standing in for a BC type whose member moved, the same idiom
+`PermissionMetadataShapeGapTests` uses. RED baseline **6 failed / 4 passed**, every failure
+reading `Assert.Throws() Failure: No exception was thrown`; GREEN **12/12**.
+
+The negative controls are what stop the fix becoming a blanket conversion, and they are
+load-bearing rather than decorative: a sabotage that refuses on a *successful* read of null
+breaks `ADataItemWhoseTableFiltersAndMarksReadsNull_GetsEmpty_AndDoesNotThrow` and
+`TheRequestCarriesTheTableAndTheEmptyGlobalFilters`.
+
+`TheAbsentMemberAndTheNullRead_AreDistinguishedByWhetherAnythingIsThrownAtAll` pins the pair in
+one place. #3647's equivalent arm was found *unarmed* because both of its outcomes refused and
+only the message wording separated them; here they are separated by whether anything is thrown
+at all, so a fix collapsing the two cannot pass both lines. Verified in both directions —
+reverting the lookup fails it with `IsType Failure: Value is null`, and over-refusing fails it
+with `Assert.Null Failure: Value is not null`.
 
 ## What proves it
 


### PR DESCRIPTION
Closes #3656

Corpus-NA: the claim is that the runner's own reflection refuses rather than substituting FiltersAndMarks.Empty; a corpus test cannot express a lookup failure against a member that resolves on every tier it runs on

The sibling of #3647 (PR #3657) one code path over, in a different file.
`BuildTableFindAllRequest` builds the per-dataitem read request for a **multi-dataitem
(join)** query and reached the same `NCLMetaQueryDataItem.TableFiltersAndMarks` through a
lookup whose failure answered a default.

**Latent, not live.** `TableFiltersAndMarks` is a real (`internal`) property on every BC
version this repository tests — read off the `bc284` context, where it is
`internal FiltersAndMarks TableFiltersAndMarks`. This is a trap for the next BC version.

## Why the consequence is worse here than a wrong filter

The one call site, `JoinExecutor.ReadDataItemRows`, reads **two** of this method's answers as
ordinary facts:

| the builder answered | ReadDataItemRows did | observable result |
|---|---|---|
| a request carrying `FiltersAndMarks.Empty` | read the dataitem's table unfiltered | the join returns **more rows than it should** |
| `null` | `if (req == null) return result;` | that dataitem contributes **zero rows**, collapsing the whole join to empty |

Neither threw. A passing test cannot tell the difference unless it asserts the row count.

## Silent exits: 7 before, 1 after

Counted as *distinct ways the method could answer without saying anything had gone wrong*.

| # | exit | before | after |
|---|---|---|---|
| 1 | `FindProviderRequest` type lookup (`GetType(...)!`) | NRE naming a parameter, not the type | **refuses** |
| 2 | `FiltersAndMarks` type lookup (`GetType(...)!`) | same | **refuses** |
| 3 | `TableFilterDictionary` type lookup (`GetType(...)!`) | same | **refuses** |
| 4 | ctor not found → `return null` | join collapses to empty | **refuses** |
| 5 | `TableFiltersAndMarks` property lookup → `p?.GetValue` | `Empty`, i.e. "no filters" | **refuses** |
| 6 | `catch { filtersAndMarks = null; }` | `Empty`, swallowing everything | **propagates** |
| 7 | `FiltersAndMarks.Empty` / `TableFilterDictionary.Empty` statics `?.GetValue` | null into the ctor | **refuses** |
| — | **`TableFiltersAndMarks` reads null** | `Empty` | **still `Empty`, deliberately** |

**7 → 1.** The one that stays is the one carrying most of the traffic, and converting it
would have been the blanket conversion this change exists not to be.

### Why that last row must stay silent — measured, not assumed

Decompiled `NCLMetaQuery.CreateTableFiltersAndMarksFromDataItemFieldFilters` on `bc284`:

```csharp
if (fieldFilters.Count == 0) { return null; }
```

with a second `return null;` when no filter expression was built. **Null is BC's own answer
for "this dataitem declares no `DataItemTableFilter`"** — the ordinary case for most join
dataitems. Refusing on it would turn every unfiltered join into an error.

## What I did about the bare `catch`, and how I proved the refusals escape it

`catch { filtersAndMarks = null; }` swallowed **everything** the getter raised. Converting the
lookups to throw while leaving it would have produced refusals this very method ate — a guard
that is quiet rather than armed, which is why the issue calls this one worse than #3647's.

It swallowed two things that matter:

- **`BcShapeGapException` from a read beneath it** — the one type that must tear through both
  AL trapping seams. Under `asserterror` a swallowed refusal *inverts* the result.
- **BC's own errors.** `CreateTableFiltersAndMarksFromDataItemFieldFilters` raises
  `NavNotSupportedException` for a `DataItemTableFilter` on a FlowField, and the getter reaches
  it. The old code turned that into "no filters" and ran the query instead of reporting the
  error real BC reports.

**Removed, not narrowed.** Nothing is caught now. The one `catch` that remains is a
`TargetInvocationException` unwrap that *rethrows* — `PropertyInfo.GetValue` wraps a getter's
exception, and without the unwrap a caller sees a `TargetInvocationException` whose text names
reflection rather than the member that moved. It uses `ExceptionDispatchInfo`, never a bare
`throw tie.InnerException`, for the same stack-trace reason `ExecuteJoinQuery` gives ten lines
above it.

Proved by two arms, both of which failed with **"No exception was thrown"** at RED:

- `AShapeGapRaisedInsideTheRead_ReachesTheCaller_RatherThanBeingSwallowed` — a getter raising a
  `BcShapeGapException`, asserted by `Member` and `Detail`, not merely that something threw.
- `AnOrdinaryExceptionFromTheRead_AlsoReachesTheCaller_RatherThanReadingAsNoFilters` — the
  BC-error half.

Sabotage 3 below restores the bare `catch`, and both arms go red.

## RED → GREEN

`AlRunner.Tests/QueryJoinFindRequestShapeGapTests` — 12 arms, driving the real production
helper with fakes standing in for a BC type whose member moved (the idiom
`PermissionMetadataShapeGapTests` and #3647 both use). No BC install required.

- **RED: 6 failed / 4 passed.** Every failure read `Assert.Throws() Failure: No exception was
  thrown` — the silent-default defect reproduced, not an arity error. The 4 that passed are the
  negative controls plus the pin: they pass on *unfixed* production, which is what a negative
  control must do.
- **GREEN: 12/12.**

The RED baseline was taken against a parameterized-but-otherwise-unchanged production body, so
the failures are behavioural rather than "the signature does not exist yet".

## Every guard verified armed, not merely quiet

Each sabotage reverts one guard on the GREEN tree and must break specific arms.

| # | sabotage | arms that failed |
|---|---|---|
| 1 | `TableFiltersAndMarks` lookup back to `?.GetValue(...)` | `TableFiltersAndMarksLookup_...`, `TheAbsentMemberAndTheNullRead_...` |
| 2 | refuse on a **successful** read of null (blanket conversion) | `ADataItemWhoseTableFiltersAndMarksReadsNull_...`, `TheRequestCarriesTheTable...`, `TheAbsentMemberAndTheNullRead_...` |
| 3 | restore the bare `catch { filtersAndMarks = null; }` | `AShapeGapRaisedInsideTheRead_...`, `AnOrdinaryExceptionFromTheRead_...` |
| 4 | ctor lookup back to `return null` | `TheFindProviderRequestConstructorLookup_...` |
| 5 | `StaticMember` back to the null-forgiving form | `FiltersAndMarksEmptyLookup_...`, `TableFilterDictionaryEmptyLookup_...` |
| 6 | keep the refusal but word a **null read** identically to an absent member | caught by the negative controls |

Sabotage 2 is the one that shows the negative controls are load-bearing rather than
decorative. Sabotage 6 is the #3647 "unarmed arm" shape, checked deliberately.

### The arm that distinguishes the two failure modes

#3647's agent found one of its own arms unarmed: reverting a lookup still refused, via a
*different* branch, and the arm could not tell them apart. I checked for the same hole here.

On this path the two modes are separated by something stronger than message wording — an
absent member **throws** and a null read **returns a request** —
`TheAbsentMemberAndTheNullRead_AreDistinguishedByWhetherAnythingIsThrownAtAll` pins that pair
in one place. Verified in **both** directions, which is what makes it armed:

- under-refusal (sabotage 1) → `Assert.IsType() Failure: Value is null`
- over-refusal (sabotage 2) → `Assert.Null() Failure: Value is not null`

`TableFiltersAndMarksLookup_...` also asserts the message says `property not found`, so the
two cannot be collapsed silently.

## The reflection pin: name, arity, uniqueness AND liveness

- **Name, arity, uniqueness** — `TheHelperIsUniqueByName_AndTakesTheParametersTheseArmsDriveItWith`.
- **Liveness — proved, not assumed.** `ReflectionDrivenHelperLivenessTests` covers every
  `RecordPatches` member a test names as a literal, and this file names
  `BuildTableFindAllRequest`. I checked the guard genuinely picks it up by making production
  stop *reaching* the method while leaving it declared. It failed with exactly:

  > these RecordPatches members are driven by a test through reflection but are not reachable
  > from any production entry point ...: **BuildTableFindAllRequest** (named in
  > QueryJoinFindRequestShapeGapTests.cs)

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes, one frame up. The three
   `nclAsm.GetType(rt + "...")!` type lookups the parameterization moved into
   `Join_BuildFindAllRequest` are the same null-forgiving shape: a **moved type** hands back
   null and the NRE lands inside the builder, on a line naming a parameter rather than the type
   that went missing. Converted, with its own arm
   (`TheAdapterRefuses_NamingTheBcTypeItCouldNotResolve_...`). Fixing only the property lookup
   would have relocated the defect rather than removed it.
2. **Sibling function making the same assumption?** `NormalFindOrdinal` has a bare
   `catch { return 0; }`. **Left alone deliberately** — it is a genuine default question
   (BC's `FindType.Normal` ordinal) rather than a lookup that could not be performed, and its
   fallback is a documented enum value, not a stand-in for missing data. Converting it would be
   the over-conversion this PR argues against.
3. **Two paths writing the same state with different invariants?** That was exactly this issue:
   the single-dataitem pass (#3647) and this join pass both apply a dataitem's
   `TableFiltersAndMarks`, and after #3647 only one of them refused a failed lookup. The
   asymmetry is now closed in both directions.

## Open-issue queue scan

Per `.claude/rules/batch-sibling-issues-by-file.md`, scanned for `QueryJoin` / join / dataitem /
`FiltersAndMarks` / `FindProviderRequest`. **Nothing folded — no open issue lands in
`RecordPatches.QueryJoin.cs`.** No open PR touches that file either, so it is uncontested.

- **#3508** (nested-binary filter cast, 47 failures) — `RecordPatches.QueryProjection.cs`,
  `RetargetFilterExpression`. Different file, held by #3657, and its proving test is a full AL
  bundle. Same reasoning #3657's agent gave.
- **#3523** (join projection slot map recomputed in the filter layer) — `JoinExecutor.cs` plus
  `QueryProjection.cs`, 2-3 days, and a genuinely different review question.
- **#3499** (null `NCLMetaQuery` on `SETFILTER`/`SETRANGE`, 356 failures) — `NavQuery.ALSetFilter`,
  a different file and surface. Adjacent in spirit (a refusal that should exist) but not the
  same code.
- **#3460** (four comments citing a swallowed-refusal example that no longer exists) — I checked
  whether one of them is in my file. **It is not**: the occurrences are in
  `BcShapeGapException.cs`, `ApplicationObjectBasePatches.cs`,
  `RecordPatches.VirtualTableShapeGap.cs`, `RunnerShapeGaps.cs` and
  `RunnerShapeGapClaimTests.cs`. Worth noting on that issue that there are **five** files
  carrying the string, not the four its body claims.

## What I ran

- `QueryJoinFindRequestShapeGapTests` — RED 6/4, GREEN **12/12**, plus the six sabotage runs.
- Filtered `dotnet test` over the changed surface (`~Query`, `~BcShape`, `~RunnerShapeGap`,
  `~BcInternalsNullForgiving`, `~ReflectionDrivenHelperLiveness`) — **199 passed, 0 failed,
  2 skipped**.
- `tests/runner-extras/query-join-aggregation-oos` — **4/4**, the AL bundle whose
  `SetFilterOnAggregateColumn` / `SetFilterOnNonAggregateColumn` arms go straight through
  `BuildTableFindAllRequest` on a real BC build.
- The corpus at the current pin `c9d5f656`, from a private clone rather than the shared
  submodule checkout: `--test Join` **17/17** (including
  `InnerJoin_RuntimeSetFilterOnChildColumn_FiltersJoinedRows` and
  `JoinFlowFilterFlowFieldColumn_FilterSet_NarrowsAggregate`), `--test Query` **36/36**. This is
  what shows the refusals do not fire on a BC build the runner has seen.
- `tools/test_doc_pointers.py` — all checks pass, 320 pointers, including the new
  `docs/query-dataitem-table-filter.md#the-join-path-refuses-too` anchor. It caught the anchor
  while it was still dangling.

I did not run the full `AlRunner.Tests` suite; per `.claude/rules/local-test-scope.md` the
filtered run over the changed surface is the right local scope and CI runs the sweep.

## Where the prose went

The per-exit table, the two-row consequence table, the `bc284` evidence for the silent row and
the sabotage results are in `docs/query-dataitem-table-filter.md` under a new
`## The join path refuses too`. The code keeps a short claim plus the anchor, per
`.claude/rules/loud-failures.md` on the form of an audit justification. I also corrected that
file's existing line calling the join path "correct ... and unchanged by #3571", which was
true about the read and silent about the failure.

## Test-count baseline

Not touched, deliberately: this PR adds **no** `[Test]` procedures to any AL suite. Its tests
are C# arms in `AlRunner.Tests`, and the AL bundles it runs are existing ones, run unchanged.

## The #3657 conflict, already resolved

PR #3657 merged (as `5a49e3ba`) while this was in flight, and it moves the same ratchet line in
`BcInternalsNullForgivingGuardTests.cs`. I rebased onto `e03dbfc1` and resolved it: **80 → 81**,
keeping both entries' history in the comment. The docs file auto-merged, so
`## The join path refuses too` and #3657's `## A failed lookup refuses` both stand.

Everything above was re-run after the rebase rather than carried across it: the shape-gap arms
**33/33** (my 12 alongside #3657's 15 and #3571's, all green together), the wider filtered run
**214 passed / 0 failed / 2 skipped**, the AL bundles **19/19**, and the doc-pointer guard
clean.

---

Opened by an agent (Claude, `stma-auto-2`) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
