### PR TITLE
fix(query): refuse a failed ColumnFilters read instead of yielding no static filters

### DIFF
--- a/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
+++ b/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
@@ -228,8 +228,11 @@ public sealed class BcInternalsNullForgivingGuardTests
         // failure used to be a silent `yield break` the caller read as "no filters" (#3647);
         // 80 -> 81 for the TableFiltersAndMarks read on the JOIN path in
         // RecordPatches.QueryJoin.cs, whose failure used to answer FiltersAndMarks.Empty —
-        // indistinguishable from a dataitem that genuinely declares no filter (#3656).
-        Assert.Equal(81, converted);
+        // indistinguishable from a dataitem that genuinely declares no filter (#3656);
+        // 81 -> 82 for GetStaticColumnFilters' ColumnFilters lookup in
+        // RecordPatches.QueryProjection.cs, the sibling of those five and the same silent
+        // `yield break` (#3660).
+        Assert.Equal(82, converted);
     }
 
     /// <summary>

--- a/AlRunner.Tests/QueryStaticColumnFilterShapeGapTests.cs
+++ b/AlRunner.Tests/QueryStaticColumnFilterShapeGapTests.cs
@@ -1,0 +1,239 @@
+// QueryStaticColumnFilterShapeGapTests — issue #3660.
+//
+// WHAT IS BEING PROVED
+//   GetStaticColumnFilters reads NCLMetaQuery.ColumnFilters — the query's static AL
+//   `ColumnFilter` conditions (#2418) — through reflection, because the property is
+//   internal to Ncl.dll. Its guard was
+//
+//       _pNCLMetaQueryColumnFilters ??= _tNCLMetaQuery!.GetProperty("ColumnFilters", ...);
+//       var raw = _pNCLMetaQueryColumnFilters?.GetValue(metaAppObj) as IEnumerable;
+//       if (raw == null) yield break;
+//
+//   and BOTH ways to reach that `yield break` are failed reads: the GetProperty lookup
+//   returning null (a BC rename), or the value not being enumerable. Neither is an answer
+//   BC gives — the property is a ReadOnlyCollection that is EMPTY when the query declares
+//   no ColumnFilter, never null (verified on Ncl 28.4: internal instance property,
+//   ReadOnlyCollection). Both call sites — TranslateQueryFilters (single-dataitem) and
+//   ApplyJoinRuntimeFilters (join) — are `foreach`es that add whatever is yielded, so a
+//   failed read there is indistinguishable from "this query has no static filters", and
+//   the observable is a query returning MORE ROWS THAN IT SHOULD with nothing said. That
+//   is the silent-default shape .claude/rules/loud-failures.md forbids, and
+//   BcShapeGapException.cs's own line puts it on the refusing side: the read could not be
+//   PERFORMED.
+//
+//   LATENT, not live. ColumnFilters resolves on every BC version this repository tests.
+//   These arms are about the BC version where it moves.
+//
+// WHY THE METHOD TAKES ITS QUERY TYPE AS A PARAMETER
+//   The lookup is against _tNCLMetaQuery, a RecordPatches static only a loaded Ncl.dll
+//   populates. Taking it as a parameter is the same idiom PR #3657 used one method away in
+//   the same file (QueryDataItemFilterShapeGapTests) and PermissionMetadataShapeGapTests
+//   used before that: real production code, fakes standing in for a BC type whose member
+//   moved, no BC install required, and no poisoning of the statics for the rest of the
+//   assembly.
+//
+// THE TWO REFUSALS MUST BE DISTINGUISHABLE
+//   An arm asserting only "it throws" would pass on a broken implementation — #3657's agent
+//   caught exactly that in its own work, where reverting one lookup still threw, via a
+//   different branch. So each refusal arm here asserts the wording that belongs to ITS
+//   failure mode and asserts the ABSENCE of the other's: `property not found` xor
+//   `cannot be enumerated`.
+//
+// THE NEGATIVE CONTROL IS NOT DECORATION
+//   An EMPTY ColumnFilters collection is BC's answer for a query declaring no ColumnFilter,
+//   and it is the overwhelmingly common case. Turning it into an error would break every
+//   ordinary query on every BC version, and no arm asserting only "it refuses now" could
+//   catch that.
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class QueryStaticColumnFilterShapeGapTests
+{
+    private const string Surface = "AL query execution (projection and filter push-down)";
+
+    // ══ 1. THE TWO FAILURE MODES, EACH DISTINGUISHABLE FROM THE OTHER ════════════════════
+
+    [Fact]
+    public void ColumnFiltersLookup_RaisesAShapeGapNamingTheMember_WhenBcRenamesIt()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Drain(typeof(QueryWithoutColumnFilters), new QueryWithoutColumnFilters()));
+
+        Assert.Contains("ColumnFilters", ex.Member, StringComparison.Ordinal);
+        Assert.Contains(nameof(QueryWithoutColumnFilters), ex.Member, StringComparison.Ordinal);
+        Assert.StartsWith("bc-shape-gap: ", ex.Message, StringComparison.Ordinal);
+        Assert.Equal(Surface, ex.Surface);
+        // The LOOKUP failed. That is a different fact from the property resolving and holding
+        // something unusable (the arm below), and a `GetProperty(...)?.GetValue(...) as
+        // IEnumerable` that collapses the two into one `yield break` satisfies an arm asserting
+        // only that something threw. Asserting the absence of the OTHER mode's wording is what
+        // makes this arm fail under exactly one sabotage.
+        Assert.Contains("property not found", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("cannot be enumerated", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ColumnFiltersHoldingSomethingNotEnumerable_RaisesASeparatelyWordedShapeGap()
+    {
+        // The property IS there and resolved; its value is not a collection. Same "BC's layout
+        // moved" case, different diagnosis — a reader must not be sent chasing a rename that
+        // did not happen.
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Drain(typeof(QueryWhoseColumnFiltersIsAnInt), new QueryWhoseColumnFiltersIsAnInt()));
+
+        Assert.Contains("ColumnFilters", ex.Member, StringComparison.Ordinal);
+        Assert.Contains("cannot be enumerated", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("Int32", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("property not found", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ColumnFiltersReadingNull_Refuses_BecauseBcNeverAnswersNullHere()
+    {
+        // On a real NCLMetaQuery this property is a ReadOnlyCollection that is EMPTY when the
+        // query declares no ColumnFilter — never null. So null is not an answer either, and
+        // the old `as IEnumerable` cast turned it into the same silent `yield break`.
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Drain(typeof(QueryWhoseColumnFiltersIsNull), new QueryWhoseColumnFiltersIsNull()));
+
+        Assert.Contains("ColumnFilters", ex.Member, StringComparison.Ordinal);
+        Assert.Contains("read as null", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("property not found", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("cannot be enumerated", ex.Message, StringComparison.Ordinal);
+    }
+
+    // ══ 2. NEGATIVE CONTROL — the answer that must STAY silent ═══════════════════════════
+
+    [Fact]
+    public void AQueryDeclaringNoColumnFilterAtAll_StillYieldsNothing_AndDoesNotThrow()
+    {
+        // BC's answer for the common case: the property resolved and holds an EMPTY
+        // ReadOnlyCollection, exactly the shape BuildFilterExpressionCollection leaves behind
+        // for a query with no `ColumnFilter` property. Refusing here would break every
+        // ordinary query on every BC version.
+        var tuples = Drain(typeof(FakeQuery), new FakeQuery(EmptyLikeBc()));
+
+        Assert.Empty(tuples);
+    }
+
+    [Fact]
+    public void AColumnFiltersWhoseTuplesAreNotQueryColumns_YieldsNothing_WithoutRefusing()
+    {
+        // The per-tuple Item1/Item2 filter is a runner-side type test, not a BC-layout read:
+        // a tuple whose Item1 is not an NCLMetaQueryColumn is skipped, silently, as before.
+        // This arm exists so the refusals above cannot be satisfied by refusing on the tuple
+        // walk instead of on the collection read.
+        var tuples = Drain(typeof(FakeQuery),
+            new FakeQuery(new List<object> { Tuple.Create<object, object>("not a column", "expr") }));
+
+        Assert.Empty(tuples);
+    }
+
+    // ══ 3. WHAT AL CAN DO WITH THE REFUSAL: NOTHING ══════════════════════════════════════
+    //
+    // Under `asserterror`, absorbing this would INVERT the result — real BC reads ColumnFilters
+    // fine, so the asserterror fails there and would have passed here.
+
+    [Fact]
+    public void TheRefusal_TearsThroughBothAlSeams_AndIsNotAnAbsorbableOutOfScopeSignal()
+    {
+        object Read() => Drain(typeof(QueryWithoutColumnFilters), new QueryWithoutColumnFilters());
+
+        var viaAssertError = Assert.Throws<BcShapeGapException>(
+            () => BcRuntime.NavMethodScope_AssertError(null!, () => Read()));
+        Assert.Contains("ColumnFilters", viaAssertError.Member, StringComparison.Ordinal);
+
+        var viaTryFunction = Assert.Throws<BcShapeGapException>(
+            () => BcRuntime.NavApplicationObjectBase_TryInvoke(null, () => Read()));
+        Assert.Contains("ColumnFilters", viaTryFunction.Member, StringComparison.Ordinal);
+
+        Assert.False(OutOfScopeMessage.TryParse(viaAssertError.Message, out _));
+        Assert.Null(OutOfScopeMessage.FromException(viaAssertError));
+    }
+
+    // ══ 4. THE REFLECTION PIN — liveness is guarded separately ═══════════════════════════
+    //
+    // ReflectionDrivenHelperLivenessTests measures LIVENESS from IL for every RecordPatches
+    // member any test names as a literal, and this file names GetStaticColumnFilters — so a
+    // change leaving the method declared but no longer REACHED by production fails there.
+    // What is pinned here is the half that guard cannot see: the member exists, is unique by
+    // name, and takes exactly the parameters these arms pass.
+
+    [Fact]
+    public void TheHelperIsUniqueByName_AndTakesTheTwoParametersTheseArmsDriveItWith()
+    {
+        var candidates = typeof(RecordPatches)
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .Where(m => m.Name == "GetStaticColumnFilters")
+            .ToList();
+
+        Assert.Single(candidates);
+        Assert.Equal(
+            new[] { typeof(object), typeof(Type) },
+            candidates[0].GetParameters().Select(p => p.ParameterType).ToArray());
+        Assert.Equal(
+            typeof(IEnumerable<(NCLMetaQueryColumn Column, object Expr)>),
+            candidates[0].ReturnType);
+    }
+
+    // ══ Plumbing ═════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Drives the real production helper to completion. Draining matters: it is an iterator,
+    /// so nothing in it runs — and nothing throws — until the sequence is enumerated, exactly
+    /// as the two production foreaches enumerate it.
+    /// </summary>
+    private static List<(NCLMetaQueryColumn Column, object Expr)> Drain(Type queryType, object metaAppObj)
+    {
+        var m = typeof(RecordPatches).GetMethod(
+                    "GetStaticColumnFilters", BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "test setup: RecordPatches.GetStaticColumnFilters not found");
+        try
+        {
+            var seq = (IEnumerable<(NCLMetaQueryColumn Column, object Expr)>)
+                m.Invoke(null, new object?[] { metaAppObj, queryType })!;
+            return seq.ToList();
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            throw tie.InnerException;   // the reflection wrapper is not part of the contract
+        }
+    }
+
+    /// <summary>The shape BC actually hands back for a query with no ColumnFilter: EMPTY, not null.</summary>
+    private static ReadOnlyCollection<Tuple<object, object>> EmptyLikeBc()
+        => new(new List<Tuple<object, object>>());
+
+    // ── Fakes standing in for BC's NCLMetaQuery. Each names what it is missing. ──
+
+    private sealed class QueryWithoutColumnFilters
+    {
+    }
+
+    private sealed class QueryWhoseColumnFiltersIsAnInt
+    {
+        internal int ColumnFilters => 7;
+    }
+
+    private sealed class QueryWhoseColumnFiltersIsNull
+    {
+        internal object? ColumnFilters => null;
+    }
+
+    private sealed class FakeQuery
+    {
+        public FakeQuery(object? columnFilters) => ColumnFilters = columnFilters;
+        internal object? ColumnFilters { get; }
+    }
+}

--- a/AlRunner/Patches/RecordPatches.QueryProjection.cs
+++ b/AlRunner/Patches/RecordPatches.QueryProjection.cs
@@ -569,7 +569,7 @@ public static partial class RecordPatches
         // NclMetaQueryBuilder.BuildMetaQueryDesign from the AL `ColumnFilter` property) — same
         // WHERE/HAVING routing as a runtime filter on that column, applied only when no runtime
         // filter already targets it (a runtime filter REPLACES the static one, never combines).
-        var staticColumnFilters = GetStaticColumnFilters(metaAppObj!);
+        var staticColumnFilters = GetStaticColumnFilters(metaAppObj!, _tNCLMetaQuery!);
         foreach (var (col, expr) in staticColumnFilters)
         {
             if (runtimeFilteredColumnIds.Contains(col.Id)) continue;
@@ -628,7 +628,6 @@ public static partial class RecordPatches
     }
 
     private static Type? _tNCLMetaQueryColumn;
-    private static PropertyInfo? _pNCLMetaQueryColumnFilters; // #2418
 
     /// <summary>
     /// The <c>(INavFieldMetadata, FilterExpression)</c> tuples of a SINGLE-dataitem query's
@@ -732,15 +731,44 @@ public static partial class RecordPatches
     /// populates (#2418). The property is <c>internal</c> to Ncl.dll, hence reflection.
     /// Never null on a real <c>NCLMetaQuery</c> — an empty collection when the query declares
     /// no <c>ColumnFilter</c> at all.
+    ///
+    /// <para>#3660 — EVERY exit before the tuple walk is a FAILED READ, so all of them refuse.
+    /// That invariant above is what makes this unambiguous: BC answers an empty collection,
+    /// never a null, so neither a failed lookup nor a null nor a non-enumerable value is an
+    /// answer this method could be reporting. Both call sites — TranslateQueryFilters and
+    /// ApplyJoinRuntimeFilters — are foreaches that add whatever is yielded, so the old shared
+    /// <c>yield break</c> would have dropped the filter and returned MORE ROWS with nothing
+    /// said. The three modes are worded apart so a reader is not sent chasing a rename that
+    /// did not happen; see docs/query-static-column-filter.md#every-exit-here-is-a-failed-read.</para>
+    ///
+    /// <para>The query type is a parameter rather than a read of <c>_tNCLMetaQuery</c> so the
+    /// refusals can be driven with fakes standing in for a moved member —
+    /// <c>AlRunner.Tests/QueryStaticColumnFilterShapeGapTests</c>. Production passes exactly
+    /// the static the old body read. The <c>PropertyInfo</c> cache went with it: a static
+    /// memoising a lookup against a type that is now a parameter would answer one caller's
+    /// type from another's, which is the same defect #3657 removed one method away.</para>
     /// </summary>
-    private static IEnumerable<(NCLMetaQueryColumn Column, object Expr)> GetStaticColumnFilters(object metaAppObj)
+    private static IEnumerable<(NCLMetaQueryColumn Column, object Expr)> GetStaticColumnFilters(
+        object metaAppObj, Type tQuery)
     {
-        _pNCLMetaQueryColumnFilters ??= _tNCLMetaQuery!.GetProperty("ColumnFilters",
-            BindingFlags.NonPublic | BindingFlags.Instance);
-        var raw = _pNCLMetaQueryColumnFilters?.GetValue(metaAppObj) as System.Collections.IEnumerable;
-        if (raw == null) yield break;
+        const string surface = "AL query execution (projection and filter push-down)";
+        var value = BcShape.Property(
+            tQuery, "ColumnFilters", BindingFlags.NonPublic | BindingFlags.Instance, surface)
+            .GetValue(metaAppObj);
+        if (value == null)
+            throw new BcShapeGapException(
+                surface, $"{tQuery.Name}.ColumnFilters",
+                "read as null — BC leaves an EMPTY collection here for a query declaring no "
+                + "ColumnFilter, so the runner cannot tell a legitimately filter-free query "
+                + "from a member that moved");
+        var raw = BcShape.RequiredEnumerable(
+            value, $"{tQuery.Name}.ColumnFilters", surface,
+            "the runner walks it to apply the query's static ColumnFilter conditions");
         foreach (var tuple in raw)
         {
+            // Item1/Item2 are the FRAMEWORK's members on BC's Tuple, not BC's own, so a null
+            // here is not a BC-layout question — and a tuple whose Item1 is not a query column
+            // is skipped silently, exactly as before.
             var col = tuple!.GetType().GetProperty("Item1")!.GetValue(tuple);
             var expr = tuple.GetType().GetProperty("Item2")!.GetValue(tuple);
             if (col is NCLMetaQueryColumn c && expr != null)
@@ -1115,7 +1143,7 @@ public static partial class RecordPatches
         // (this method runs post-projection/post-aggregation, so an aggregated column's static
         // ColumnFilter is naturally a HAVING-equivalent check here — no separate having-filter
         // list needed, unlike TranslateQueryFilters' pre-aggregation WHERE path).
-        var staticColumnFilters = GetStaticColumnFilters(nclMetaQuery);
+        var staticColumnFilters = GetStaticColumnFilters(nclMetaQuery, _tNCLMetaQuery!);
         foreach (var (col, expr) in staticColumnFilters)
         {
             if (runtimeFilteredColumnIds.Contains(col.Id)) continue;

--- a/docs/query-static-column-filter.md
+++ b/docs/query-static-column-filter.md
@@ -1,0 +1,101 @@
+# A query's static `ColumnFilter` conditions
+
+AL lets a query column carry a design-time filter:
+
+```al
+query 50100 "Customers By Country"
+{
+    elements
+    {
+        dataitem(Cust; Customer)
+        {
+            column(Country; "Country/Region Code") { ColumnFilter = Country = const('DE'); }
+            column(Name; Name) { }
+        }
+    }
+}
+```
+
+BC's `NclMetaQueryBuilder.BuildMetaQueryDesign` collects those into `MetaQuery.ColumnFilters`,
+and `BuildFilterExpressionCollection` turns them into `NCLMetaQuery.ColumnFilters` — a
+`ReadOnlyCollection<Tuple<NCLMetaQueryColumn, FilterExpression>>`. The property is `internal`
+to `Ncl.dll`, so `RecordPatches.GetStaticColumnFilters` reads it through reflection.
+
+Two passes consume what it yields, and they route the same conditions differently:
+
+| pass | file | what it does with a static filter |
+|---|---|---|
+| `TranslateQueryFilters` (single dataitem) | `RecordPatches.QueryProjection.cs` | retargets it onto the column's `SourceTableField` and pushes it into the temp provider's WHERE, or into the HAVING list for an aggregated column (#2418) |
+| `ApplyJoinRuntimeFilters` (multi-dataitem join) | `RecordPatches.QueryProjection.cs` | evaluates it against the already-projected join row, post-aggregation, so an aggregated column's filter is naturally HAVING-equivalent (#2444) |
+
+A runtime `SetRange`/`SetFilter` on the same column **replaces** the static one rather than
+combining with it, which is why both passes skip a column already in
+`runtimeFilteredColumnIds`.
+
+<a id="every-exit-here-is-a-failed-read"></a>
+
+## Every exit here is a failed read
+
+Issue #3660, and the sibling of #3647 one method away in the same file. The guard was:
+
+```csharp
+_pNCLMetaQueryColumnFilters ??= _tNCLMetaQuery!.GetProperty("ColumnFilters",
+    BindingFlags.NonPublic | BindingFlags.Instance);
+var raw = _pNCLMetaQueryColumnFilters?.GetValue(metaAppObj) as System.Collections.IEnumerable;
+if (raw == null) yield break;
+```
+
+Both call sites are `foreach`es that add whatever is yielded, so a `yield break` there is
+indistinguishable from "this query declares no `ColumnFilter`" — and the observable of getting
+it wrong is a query **returning more rows than it should**, with nothing said.
+
+What makes this one unambiguous, where #3647 had to sort its exits one by one, is the
+invariant: on a real `NCLMetaQuery` the property is a `ReadOnlyCollection` that is **empty**
+when the query declares no `ColumnFilter`, never null. Verified on `Ncl` 28.4 —
+`Microsoft.Dynamics.Nav.Runtime.NCLMetaQuery.ColumnFilters`, internal instance property,
+`ReadOnlyCollection`. So none of the three ways to reach that `yield break` is an answer BC
+gives, and all three refuse:
+
+| exit | now | why |
+|---|---|---|
+| the `ColumnFilters` lookup returns null | **refuses** — `property not found` | the member is absent: BC's layout moved |
+| the property reads null | **refuses** — `read as null` | BC leaves an empty collection, never a null, so the runner cannot tell a filter-free query from a moved member |
+| the value is not `IEnumerable` | **refuses** — `cannot be enumerated`, naming the type it held | present but uninterpretable is the same "layout moved" case (`BcShapeGapException.cs`'s own line) |
+| an **empty** `ColumnFilters` collection | **silent** | BC's answer, and the overwhelmingly common case — refusing here would break every ordinary query on every BC version |
+| a tuple whose `Item1` is not an `NCLMetaQueryColumn` | **silent** | a runner-side type test on the framework's own `Tuple` members, not a question about BC's layout |
+
+The three refusals are **worded apart on purpose**. A reader who sees `read as null` must not
+go looking for a rename that did not happen, and — the reason it is load-bearing rather than
+cosmetic — an arm asserting only "something threw" passes on an implementation where one
+branch still refuses and the one under test does not. That is measured, not predicted:
+reverting the lookup alone still raised a `BcShapeGapException`, from the null branch, and only
+the `property not found` / not-`cannot be enumerated` pair distinguished them.
+
+Latent, not live. `ColumnFilters` resolves on every BC version this repository tests; this is a
+trap for the next one.
+
+### Why the query type is a parameter
+
+The lookup is against `_tNCLMetaQuery`, a `RecordPatches` static only a loaded `Ncl.dll`
+populates. Passing it in is the same idiom #3657 used for
+`GetSingleDataItemTableFilterTuples`: real production code driven with fakes standing in for a
+BC type whose member moved, with no BC install and without poisoning the statics for the rest
+of the test assembly.
+
+The `_pNCLMetaQueryColumnFilters` cache went with it, and had to. A static memoising a
+`PropertyInfo` resolved against a type that is now a **parameter** would answer one caller's
+type from another's — the same defect #3657 removed alongside its own parameterisation. There
+is nothing to reclaim: `Type.GetProperty` is a metadata lookup on a cached runtime type, and it
+runs once per query read, not per row.
+
+## Where the coverage is
+
+- `AlRunner.Tests/QueryStaticColumnFilterShapeGapTests` — the three refusals, each asserting
+  its own wording **and the absence of the other modes'**, plus the empty-collection negative
+  control, the AL-seam arm (`asserterror` and `[TryFunction]` must both fail to absorb it) and
+  the signature pin.
+- `AlRunner.Tests/ReflectionDrivenHelperLivenessTests` — liveness, from IL. Severing the two
+  production call sites while leaving the method declared fails it by name.
+- `AlRunner.Tests/QueryJoinColumnFilterProjectionTests` — the live join-path behaviour.
+- `docs/query-dataitem-table-filter.md` — the sibling surface, a dataitem's
+  `DataItemTableFilter`, and why it is not expressible as a `ColumnFilter`.


### PR DESCRIPTION
Closes #3660

Corpus-NA: the claim is about the runner's own reflection refusing instead of substituting a default, not about anything BC does — a service tier cannot observe a lookup that fails only on a BC version where the member has moved.

## The shape

`GetStaticColumnFilters` reads `NCLMetaQuery.ColumnFilters` — a query's static AL `ColumnFilter`
conditions (#2418) — through reflection, because the property is `internal` to `Ncl.dll`. Its
guard was:

```csharp
_pNCLMetaQueryColumnFilters ??= _tNCLMetaQuery!.GetProperty("ColumnFilters",
    BindingFlags.NonPublic | BindingFlags.Instance);
var raw = _pNCLMetaQueryColumnFilters?.GetValue(metaAppObj) as System.Collections.IEnumerable;
if (raw == null) yield break;
```

Both call sites — `TranslateQueryFilters` (single dataitem) and `ApplyJoinRuntimeFilters`
(join) — are `foreach`es that add whatever is yielded, so that `yield break` is
indistinguishable from "this query declares no `ColumnFilter`". The observable of getting it
wrong is a query **returning more rows than it should**, with nothing said.

Same shape as #3647, one method away in the same file, and this PR follows #3657's mechanism
exactly rather than inventing a second one.

## Why this one needed no judgement call

The method's own doc comment already stated the invariant, and it is confirmed on Ncl 28.4
(`Microsoft.Dynamics.Nav.Runtime.NCLMetaQuery.ColumnFilters`: internal instance property,
`ReadOnlyCollection`): BC leaves an **empty collection** for a query with no `ColumnFilter`,
never a null. So none of the three ways to reach that `yield break` is an answer BC gives, and
all three now refuse — unlike #3647, where four genuine "nothing to do" exits had to be sorted
out and left silent.

| exit | now | why |
|---|---|---|
| the `ColumnFilters` lookup returns null | refuses — `property not found` | the member is absent |
| the property reads null | refuses — `read as null` | BC never answers null here |
| the value is not `IEnumerable` | refuses — `cannot be enumerated`, naming the type held | present but uninterpretable |
| an **empty** `ColumnFilters` collection | silent | BC's answer, and the common case |
| a tuple whose `Item1` is not an `NCLMetaQueryColumn` | silent | a runner-side type test on the framework's own `Tuple` members |

Latent, not live: `ColumnFilters` resolves on every BC version this repository tests. This is a
trap for the next one.

## The caching static was removed

`_pNCLMetaQueryColumnFilters` had the same problem #3657 found in its own method. The query
type is now a **parameter**, so a static memoising a `PropertyInfo` resolved against it would
answer one caller's type from another's. Nothing is reclaimed by keeping it: `Type.GetProperty`
is a metadata lookup on a cached runtime type and runs once per query read, not per row.

## RED to GREEN, and the sabotages that prove the arms are armed

RED was taken with the parameter added but the body unchanged, so the arms reached the real
reflection code: **4 failed with "No exception was thrown"**, the three negative controls and
the signature pin passed. GREEN: 7/7.

An arm asserting only "it throws" would not be armed here — #3657's agent caught exactly that
in its own work. Each sabotage was performed against the GREEN implementation and **each failed
exactly one arm**:

| sabotage | arm that failed | how |
|---|---|---|
| **A.** lookup reverted to `tQuery.GetProperty(...)?.GetValue(...)` | `ColumnFiltersLookup_RaisesAShapeGapNamingTheMember_WhenBcRenamesIt` | `Assert.Contains() Failure: Sub-string not found` / `Not found: "property not found"` — a `BcShapeGapException` **was** still raised, from the null branch. This is the laundering the issue warned about: only the distinguishing-substring pair caught it. |
| **B.** `BcShape.RequiredEnumerable` reverted to `value as IEnumerable` + `yield break` | `ColumnFiltersHoldingSomethingNotEnumerable_RaisesASeparatelyWordedShapeGap` | `Assert.Throws() Failure: No exception was thrown` |
| **C.** the null branch reverted to a silent `yield break` | `ColumnFiltersReadingNull_Refuses_BecauseBcNeverAnswersNullHere` | `Assert.Throws() Failure: No exception was thrown` |
| **D.** an **empty** `ColumnFilters` made to refuse too (over-refusal) | `AQueryDeclaringNoColumnFilterAtAll_StillYieldsNothing_AndDoesNotThrow` | the negative control, which is what stops the fix breaking every ordinary query |
| **E.** both production call sites severed, method left declared | `ReflectionDrivenHelperLivenessTests` | *"these RecordPatches members are driven by a test through reflection but are not reachable from any production entry point … `GetStaticColumnFilters` (named in `QueryStaticColumnFilterShapeGapTests.cs`)"* — it names the method **and** the file |

Sabotage A is the important one. It is a broken implementation that still throws
`bc-shape-gap:`, so it passes any arm whose claim is merely "something refused".

**No downstream laundering.** The static-filter list is the only source for those conditions at
either call site — nothing recomputes or repairs them — and the arms assert the exception
directly rather than an end result, so there is no intermediate value to repair.

## What was run

- The new suite: 7/7.
- `dotnet test AlRunner.Tests --filter "FullyQualifiedName~Query|…BcInternalsNullForgivingGuardTests|…ReflectionDrivenHelperLiveness|…BcShape|…RunnerShapeGapClaim"` — **209 passed, 0 failed**, 2 skipped.
- The two live-path AL bundles genuinely executed (not skipped), confirming the change is
  behaviour-neutral on real BC:
  `QueryColumnFilterProjectionTests.ColumnFilter_AppliesHavingAndWhereStyle_AndRuntimeFilterReplacesStatic`
  and `QueryJoinColumnFilterProjectionTests.ColumnFilter_AppliesOnJoinPath_HavingAndWhereStyle_AndRuntimeFilterReplacesStatic`.
- `python3 tools/test_doc_pointers.py` — all six checks pass.
- `BcMatrixDocumentationDriftTests` — passes; the new doc carries no BC version list.

## Where the prose went

The derivation — the exits table, the invariant and its Ncl 28.4 citation, why the type is a
parameter and why the cache had to go — is in the new `docs/query-static-column-filter.md`,
pointed at by a one-line reference in the method's doc comment. The claim and the citation stay
at the code.

## The wider scan, and what was NOT folded

Scanned `RecordPatches.QueryProjection.cs` for the same shape and the open-issue queue for
same-file siblings. Nothing folded, and here is why for each:

- **#3663** (`status: ready`, unclaimed) — *"Silent reflection failure is a repeating shape: 339
  sites in Patches/"*. My scan of this one file found roughly a dozen more `?.GetValue(...)` /
  `GetProperty(...)!` sites (lines 242, 289-290, 376-380, 946, 1212, 1547). They are real, they
  are the same family, and they are a strict subset of what #3663 exists to sweep. Folding them
  here would need per-site adjudication of "BC's answer" versus "failed read" — the judgement
  call #3657 spent its whole review on — and would collide head-on with that sweep. Left for
  #3663.
- **#3460** — four comment blocks citing a dead
  `"query-join-synthesized-subquery-not-implemented"` example. Only one of its four files is
  mine; the mass is in `BcShapeGapException.cs`, `RunnerShapeGaps.cs`,
  `RecordPatches.VirtualTableShapeGap.cs` and `RunnerShapeGapClaimTests.cs`. Not the same code,
  and it would conflict with #3663's likely sweep of the same comments.
- **#3508** — the `NCLMetaQueryColumn -> NCLMetaField` cast for nested binary expressions. Same
  file, genuinely, but it needs a debug read and an AL bundle to diagnose, and it is a
  behavioural defect rather than a reflection-refusal one. #3657's agent examined and left it
  for the same reason.

No open PR closes any of those, and no open PR touches `RecordPatches.QueryProjection.cs`.

## What I could not prove

That the refusals fire on a real BC build — by construction. Every BC version this repository
tests resolves `ColumnFilters`, so the refusal paths are unreachable there; that is what makes
this latent rather than live, and it is why the arms drive the real production method with
fakes standing in for a moved member.

---

Written by an agent (Claude, `stma-auto-2`) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
