### PR TITLE
ci(count-baseline): fail a corpus pin bump that writes no history.md entry

### DIFF
--- a/.github/scripts/check_count_baseline_history.sh
+++ b/.github/scripts/check_count_baseline_history.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Requires a PR that bumps the al-language corpus pin to record WHY, in
+# tests/expectations/count-baseline/history.md (#3591).
+#
+# tests/expectations/count-baseline/README.md has required this since the file
+# existed: "Bumped the corpus pin -- edit al-language's tests.default to the
+# number the run reported, and add an entry to history.md under ## al-language
+# saying which upstream PRs came in and that you measured it rather than
+# computed it." Nothing enforced it. AlRunner.Tests/CountBaselineMergeShapeTests.cs
+# is the only thing that reads history.md, and it validates a section's SHAPE if
+# one is written -- so an omission is invisible to it, and nothing in .github/ or
+# tools/ looked at the file at all.
+#
+# PR #3588 is the instance: it bumped the pin, passed all 13 required checks
+# green, and had no entry. A reviewer caught it, and it was fixed afterwards by
+# 26ddc371.
+#
+# WHY THE ENTRY IS NOT DECORATION
+# -------------------------------
+# The reasoning for where a bump STOPPED is the thing the next agent needs, and
+# history.md is where they look. On #3588 that reasoning -- corpus #293 brings a
+# test the runner fails until #3580 lands -- existed only in the PR body, and a
+# PR body is not reachable from a checkout. Six months on, `git log` and the
+# working tree are what remain; a review comment is not.
+#
+# WHAT FIRES IT, AND WHY IT IS THE PIN AND NOT THE COUNT
+# ------------------------------------------------------
+# The trigger is the tests/al-language gitlink moving. That is narrower than
+# "test-count-baseline.json changed", and the narrowing is measured rather than
+# preferred. On main at e03dbfc1, of the last 12 commits touching
+# test-count-baseline.json, 10 carried a history.md change and 2 did not:
+#
+#   b071a9d4  fix(query): honour DataItemTableFilter ... (#3630)
+#   01338b5e  fix(testpage): report the close BC actually performs ... (#3595)
+#
+# Neither was a violation. Both added one runner-extras GROUP line
+# ("query-dataitem-filter-precompiled-dep", "testpage-close-message-consumed")
+# and neither moved the submodule pin. The README asks for a history entry under
+# "Bumped the corpus pin"; adding a runner-extras group line is a different row
+# of the same table and carries no such requirement, because the group name and
+# its count are self-describing in a way a corpus count is not. Firing on those
+# would be the noisy direction check_corpus_linkage.sh warns about -- a guard
+# that nags on a legitimate shape gets pasted past, and then it protects
+# nothing.
+#
+# In the other direction the rule is absolute, so this guard is too: of the 31
+# commits moving the pin since history.md was created (c133aa97, #2879), 31
+# carried an entry. There is no observed legitimate silent bump.
+#
+# The pin firing on its own -- without a baseline edit -- is deliberate. The
+# requirement attaches to the bump, not to the count moving, and a bump that
+# leaves the count unchanged is the case whose reasoning is LEAST recoverable
+# from the diff: nothing in it says how far the pin went or why it stopped
+# there.
+#
+# WHY AN OPT-OUT EXISTS WHEN NOTHING OBSERVED NEEDS ONE
+# -----------------------------------------------------
+# 31 of 31 says unconditional would be correct today. What argues for the hatch
+# is NOT that it is cheap -- "one sentence when it is needed" would justify a
+# hatch on any guard at all, so it decides nothing. It is that the expensive
+# failure is UNRECOVERABLE BY THE AUTHOR: an unconditional guard meeting a
+# legitimate silent bump leaves exactly one way past it, writing a history entry
+# that says nothing. That is this guard forcing a junk entry into the very file
+# it exists to keep meaningful -- corrupting its own asset -- and the author
+# cannot avoid it. A guard whose failure mode degrades the thing it protects
+# needs a way out even before anything has needed one.
+#
+#   Count-Baseline-History-NA: <reason>
+#
+# Same idiom, and the same mandatory non-placeholder reason, as
+# check_corpus_linkage.sh's Corpus-NA and check_closing_reference.sh's
+# "No linked issue:" hatch. A bare marker is the same as no guard.
+#
+# WHAT THIS DOES NOT CHECK
+# ------------------------
+# Whether the entry is any GOOD. Not whether it names the upstream PRs, not
+# whether it is under ## al-language, not whether the number in it matches the
+# baseline. Told to judge that, CI gets it wrong in both directions and the
+# author writes to the checker instead of to the reader. Shape is
+# CountBaselineMergeShapeTests's job; a human reviewer judges content. This asks
+# only that there is something for them to read.
+#
+# Inputs (environment variables, both required, either may be empty):
+#   PR_BODY        - the pull request's body/description
+#   CHANGED_FILES  - the PR's changed paths, one per line
+#
+# Exit codes
+#   0  no pin bump, or the entry is present, or a well-formed opt-out
+#   1  the pin moved and neither an entry nor a usable opt-out is present
+#   2  the check could not run (a required input was not passed at all)
+
+set -uo pipefail
+
+# "Unset" and "set but empty" are deliberately different. An empty CHANGED_FILES
+# is a legitimate state; an UNSET one means the caller never computed it, and a
+# guard handed nothing checks nothing and passes green -- the failure
+# pr_commit_messages.sh and check_corpus_linkage.sh both refuse.
+if [ -z "${CHANGED_FILES+set}" ]; then
+  echo "::error::check_count_baseline_history.sh: CHANGED_FILES is required (it may be empty, but it must be passed)." >&2
+  exit 2
+fi
+if [ -z "${PR_BODY+set}" ]; then
+  echo "::error::check_count_baseline_history.sh: PR_BODY is required (it may be empty, but it must be passed)." >&2
+  exit 2
+fi
+
+PIN_PATH="tests/al-language"
+HISTORY_PATH="tests/expectations/count-baseline/history.md"
+
+# --- Did the pin move, and was an entry written? -----------------------------
+#
+# Exact string equality per line, never a prefix or a substring match.
+# tests/al-language is a gitlink, so git names it as exactly that one path and
+# never with anything after it: a path UNDER it is either a stale diff or a file
+# in some other tree, and a prefix match would read every corpus source file as
+# a pin bump. The same equality protects the history path from
+# .../history.md.bak and friends.
+pin_moved=""
+history_written=""
+
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  # Strip a trailing CR, for a list that reached us through a CRLF round trip.
+  # Only the CR: pr_changed_files.sh emits bare `git diff --name-only` output,
+  # so a leading or trailing SPACE cannot occur in production and trimming one
+  # would be untested code guarding an unreachable case.
+  f="${f%$'\r'}"
+  case "$f" in
+    "$PIN_PATH")     pin_moved="1" ;;
+    "$HISTORY_PATH") history_written="1" ;;
+  esac
+done <<< "$CHANGED_FILES"
+
+if [ -z "$pin_moved" ]; then
+  echo "This PR does not move the tests/al-language pin, so no history.md entry is required."
+  exit 0
+fi
+
+if [ -n "$history_written" ]; then
+  echo "The corpus pin moves and $HISTORY_PATH carries an entry."
+  exit 0
+fi
+
+# --- The pin moved with no entry: is there a usable opt-out? -----------------
+
+found_marker=""
+found_reason=""
+
+while IFS= read -r line; do
+  # The marker and its reason share ONE line, the marker starts the line
+  # (leading whitespace aside), and nothing may precede it. That is the
+  # canonical-line rule check_closing_reference.sh and check_corpus_linkage.sh
+  # both apply, and it is not pedantry: every shape it rejects -- bolded,
+  # backticked, mid-sentence, split across two lines -- went red on a real PR
+  # for the Corpus-PR marker in a single day (#3330). A declaration has to stand
+  # where a reviewer reads it.
+  if [[ "$line" =~ ^[[:space:]]*[Cc]ount-[Bb]aseline-[Hh]istory-[Nn][Aa]:[[:space:]]*(.*)$ ]]; then
+    found_marker="1"
+    reason="${BASH_REMATCH[1]}"
+    reason="$(printf '%s' "$reason" | command sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    # A fixed placeholder list, not a quality bar. It catches a marker with
+    # nothing behind it and judges no prose.
+    case "$(printf '%s' "$reason" | tr '[:upper:]' '[:lower:]')" in
+      ""|"n/a"|"na"|"none"|"no"|"-"|"--"|"."|"?"|"tbd"|"todo"|"x") ;;
+      *) found_reason="1" ;;
+    esac
+  fi
+done <<< "$PR_BODY"
+
+if [ -n "$found_reason" ]; then
+  echo "The corpus pin moves with no history.md entry, and the PR body declares why."
+  exit 0
+fi
+
+REMEDY="Do ONE of these:
+  Add an entry to $HISTORY_PATH under '## al-language' -- which upstream PRs came
+    in, the count you MEASURED rather than computed, and, if the bump stopped
+    short of corpus master, why it stopped where it did. That last part is the
+    one the next agent cannot get anywhere else.
+  Count-Baseline-History-NA: <reason>
+    -- on its own line in the PR body, if this bump genuinely has nothing to
+       record. Be specific; the reason is what a reviewer reads. 'n/a' is not one."
+
+if [ -n "$found_marker" ]; then
+  echo "::error::This PR moves the corpus pin with no $HISTORY_PATH entry, and its 'Count-Baseline-History-NA:' line carries no usable reason. The reason is the entire point of the opt-out -- a bare marker gets pasted in reflexively, which is the same as having no guard. $REMEDY" >&2
+  exit 1
+fi
+
+echo "::error::This PR moves the tests/al-language corpus pin and writes no entry in $HISTORY_PATH. tests/expectations/count-baseline/README.md requires one on every pin bump, and nothing else records the reasoning: CountBaselineMergeShapeTests validates a section's shape if one is written, so an omission is invisible to it, and a PR body is not reachable from a checkout. PR #3588 is why this check exists -- it bumped the pin, passed all 13 required checks, and had no entry. $REMEDY" >&2
+exit 1

--- a/.github/scripts/test_check_count_baseline_history.sh
+++ b/.github/scripts/test_check_count_baseline_history.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# Tests for check_count_baseline_history.sh -- the pin-bump history entry guard
+# (#3591).
+#
+# The decisive case is FIRST and named for the PR it replays. A guard that has
+# never been seen to fire on the real omission it was built for is not armed,
+# whatever else it asserts, so PR #3588's actual pre-fix diff shape --
+# tests/al-language plus test-count-baseline.json, no history.md -- is pinned
+# here as its own case rather than left implicit in a generic "missing entry"
+# test.
+#
+# The other half carries equal weight. This guard fires on the al-language pin
+# bump and NOTHING else, because the README requires the entry for exactly that
+# case ("Bumped the corpus pin -- ... and add an entry to history.md"). Measured
+# on main at e03dbfc1: of the last 12 commits touching test-count-baseline.json,
+# 10 carried a history.md change and 2 did not, and BOTH of those two
+# (b071a9d4, 01338b5e) added a runner-extras GROUP line and never touched the
+# submodule pin. Neither was a violation. So a runner-extras-only baseline edit
+# must pass, and the skip cases below are what keeps this guard from nagging on
+# the two-in-twelve shape that is legitimately silent.
+#
+# Run directly: bash .github/scripts/test_check_count_baseline_history.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check_count_baseline_history.sh"
+
+BASELINE="tests/expectations/count-baseline/test-count-baseline.json"
+HISTORY="tests/expectations/count-baseline/history.md"
+PIN="tests/al-language"
+
+pass=0
+fail=0
+
+assert_exit() {
+  local desc="$1" expected_rc="$2" files="$3" body="${4-}"
+  local rc
+  CHANGED_FILES="$files" PR_BODY="$body" "$SCRIPT" >/dev/null 2>&1
+  rc=$?
+  if [ "$rc" = "$expected_rc" ]; then
+    echo "ok   - $desc"
+    pass=$((pass + 1))
+  else
+    echo "FAIL - $desc: expected exit $expected_rc, got $rc"
+    fail=$((fail + 1))
+  fi
+}
+
+# --- The case this guard exists for ------------------------------------------
+#
+# PR #3588 bumped the pin, passed all 13 required checks green, and had no
+# history.md entry. Caught by a reviewer, not by CI; fixed afterwards by
+# 26ddc371. This is that diff, byte for byte in path terms.
+#
+# Reconstructing it means taking the squash 325b24ec's paths and SUBTRACTING
+# history.md. That is not a shortcut for walking to a parent commit, and it is
+# worth knowing why before anyone tries: 26ddc371 is a branch commit whose
+# parent is 64990eed, and it is NOT an ancestor of 325b24ec -- the squash
+# discarded the branch history, so no parent walk from main reaches the pre-fix
+# state at all. Subtraction is the only reconstruction available, which is
+# exactly why the pre-fix shape is pinned here as literal paths rather than
+# derived from git at test time.
+
+assert_exit "#3588's actual omission fires the guard (pin + baseline, no history)" 1 \
+  "$(printf '%s\n%s\n' "$PIN" "$BASELINE")"
+
+# The same omission with the paths in the other order, because reading only the
+# first path would miss it.
+assert_exit "the omission fires with the paths reversed" 1 \
+  "$(printf '%s\n%s\n' "$BASELINE" "$PIN")"
+
+# The realistic shape of a fix PR that folds in its pin bump: lots of unrelated
+# files, the pin and the baseline among them, no history entry.
+assert_exit "a fold-in fix PR omitting the entry fires" 1 \
+  "$(printf 'AlRunner/Patches/RecordPatches.DateVirtualTable.cs\nAlRunner.Tests/DateVirtualTableTests.cs\n%s\n%s\ndocs/scope.md\n' "$PIN" "$BASELINE")"
+
+# A pin bump that does not touch the baseline at all is still a pin bump, and
+# the README's requirement is attached to the bump, not to the count moving.
+# Every one of the 31 pin bumps since history.md existed moved both.
+assert_exit "a pin bump with no baseline edit and no history entry fires" 1 "$PIN"
+
+# --- The same bumps, done correctly ------------------------------------------
+
+assert_exit "#3588 with its history entry passes" 0 \
+  "$(printf '%s\n%s\n%s\n' "$PIN" "$BASELINE" "$HISTORY")"
+assert_exit "a fold-in fix PR with its entry passes" 0 \
+  "$(printf 'AlRunner/Patches/RecordPatches.DateVirtualTable.cs\n%s\n%s\n%s\n' "$PIN" "$BASELINE" "$HISTORY")"
+assert_exit "a pin bump with only a history entry passes" 0 \
+  "$(printf '%s\n%s\n' "$PIN" "$HISTORY")"
+
+# A REVERT moves the gitlink like any other change, so it needs an entry like
+# any other change -- arguably more, since "why did the pin go back" is the
+# least recoverable reasoning of all. The guard cannot tell a revert from a bump
+# and is not supposed to; this pins that it does not accidentally special-case
+# one. (check_corpus_pin_forward.sh is what refuses a BACKWARD pin; the two
+# guards are independent and a revert meets both.)
+assert_exit "a revert of a pin bump still needs an entry" 1 \
+  "$(printf '%s\n%s\n' "$PIN" "$BASELINE")"
+assert_exit "a revert of a pin bump with its entry passes" 0 \
+  "$(printf '%s\n%s\n%s\n' "$PIN" "$BASELINE" "$HISTORY")"
+
+# The pin and its entry buried in a large diff. Reading only the first or last
+# few paths would get this wrong in either direction, so both the trigger and
+# the satisfying path are placed away from the ends.
+assert_exit "a large diff carrying both the pin and its entry passes" 0 \
+  "$(for i in $(seq 1 20); do echo "AlRunner/Patches/File$i.cs"; done
+     printf '%s\n' "$PIN"
+     for i in $(seq 21 30); do echo "AlRunner.Tests/Test$i.cs"; done
+     printf '%s\n' "$HISTORY"
+     for i in $(seq 31 40); do echo "docs/doc$i.md"; done)"
+assert_exit "a large diff carrying the pin but no entry fires" 1 \
+  "$(for i in $(seq 1 20); do echo "AlRunner/Patches/File$i.cs"; done
+     printf '%s\n' "$PIN"
+     for i in $(seq 21 40); do echo "AlRunner.Tests/Test$i.cs"; done)"
+
+# --- The two measured exceptions, which must stay silent ---------------------
+#
+# b071a9d4 and 01338b5e, the two of the last twelve that carried no history
+# change. Both added one runner-extras group line and neither moved the pin.
+# The README asks for a history entry under "Bumped the corpus pin"; adding or
+# removing a runner-extras group line is a different row of that table with no
+# such requirement. Firing here would be the noisy failure that gets pasted
+# past, so these are pinned as decisions.
+
+assert_exit "b071a9d4's shape: a runner-extras group line, no pin move, passes" 0 \
+  "$(printf 'AlRunner/Patches/RecordPatches.QueryJoin.cs\ntests/runner-extras/query-dataitem-filter-precompiled-dep/app.json\n%s\n' "$BASELINE")"
+assert_exit "01338b5e's shape: a runner-extras group line, no pin move, passes" 0 \
+  "$(printf 'AlRunner/Patches/MockTestPage.cs\n%s\n' "$BASELINE")"
+assert_exit "a baseline edit alone, with no pin move, passes" 0 "$BASELINE"
+
+# --- Everything else stays quiet ---------------------------------------------
+
+assert_exit "an empty diff is skipped" 0 ""
+assert_exit "an unrelated code PR is skipped" 0 \
+  "$(printf 'AlRunner/Patches/MockTestPage.cs\nAlRunner.Tests/MockTestPageTests.cs\n')"
+assert_exit "a docs-only PR is skipped" 0 "docs/limitations.md"
+assert_exit "a history.md edit on its own is skipped" 0 "$HISTORY"
+assert_exit "an expectations manifest edit is skipped" 0 "tests/expectations/known-gaps-ui.json"
+assert_exit "the count-baseline README is not the baseline" 0 \
+  "tests/expectations/count-baseline/README.md"
+
+# A path that merely CONTAINS the submodule path as a prefix is not the pin.
+# tests/al-language is a gitlink: git reports it as exactly that one path, never
+# with anything after it, so a path underneath it is either a stale diff or a
+# different file -- and a prefix match would make every corpus file look like a
+# pin bump.
+assert_exit "a path under the submodule is not the pin gitlink" 0 \
+  "tests/al-language/tests/al-language/app.json"
+# The mirror: a sibling directory sharing the prefix.
+assert_exit "a sibling path sharing the pin's prefix is not the pin" 0 \
+  "tests/al-language-notes/README.md"
+# And for the baseline, the same shape.
+assert_exit "a longer path sharing the baseline's prefix is not the baseline" 0 \
+  "tests/expectations/count-baseline/test-count-baseline.json.bak"
+
+# --- The opt-out ---------------------------------------------------------------
+#
+# Measured on main at e03dbfc1: 31 of 31 pin bumps since history.md was created
+# (c133aa97, #2879) carried an entry, so nothing observed needs this. It exists
+# because the cost of being wrong is asymmetric -- an unconditional guard that
+# meets a legitimate silent bump blocks a merge with no way past it except
+# writing a sentence that says nothing, which is the reflexive-paste failure in
+# the other direction. Same mandatory-reason idiom as check_corpus_linkage.sh's
+# Corpus-NA, for the same reason: a bare marker is the same as no guard.
+
+assert_exit "the opt-out with a real reason passes" 0 \
+  "$(printf '%s\n%s\n' "$PIN" "$BASELINE")" \
+  "Count-Baseline-History-NA: the pin moves only to un-skip a test the previous bump had already described"
+assert_exit "the opt-out keyword is case-insensitive" 0 \
+  "$(printf '%s\n%s\n' "$PIN" "$BASELINE")" \
+  "count-baseline-history-na: spelled out properly, and this is the reason"
+assert_exit "leading whitespace before the opt-out is tolerated" 0 \
+  "$(printf '%s\n%s\n' "$PIN" "$BASELINE")" \
+  "   Count-Baseline-History-NA: a real reason, indented"
+assert_exit "the opt-out among other body prose passes" 0 \
+  "$(printf '%s\n%s\n' "$PIN" "$BASELINE")" \
+  "Closes #1
+
+Count-Baseline-History-NA: a real reason, in a normal body
+
+More prose after it."
+
+assert_exit "the opt-out with no reason fails" 1 \
+  "$(printf '%s\n%s\n' "$PIN" "$BASELINE")" "Count-Baseline-History-NA:"
+assert_exit "the opt-out with only whitespace fails" 1 \
+  "$(printf '%s\n%s\n' "$PIN" "$BASELINE")" "Count-Baseline-History-NA:      "
+assert_exit "the opt-out with a placeholder reason fails (n/a)" 1 \
+  "$(printf '%s\n%s\n' "$PIN" "$BASELINE")" "Count-Baseline-History-NA: n/a"
+assert_exit "the opt-out with a placeholder reason fails (none)" 1 \
+  "$(printf '%s\n%s\n' "$PIN" "$BASELINE")" "Count-Baseline-History-NA: none"
+assert_exit "the opt-out with a placeholder reason fails (TBD)" 1 \
+  "$(printf '%s\n%s\n' "$PIN" "$BASELINE")" "Count-Baseline-History-NA: TBD"
+
+# The canonical-line requirement, same reasoning as check_corpus_linkage.sh and
+# check_closing_reference.sh: a declaration stands on its own line where a
+# reviewer reads it, and the marker and its reason share that line. Every one of
+# these shapes went red on a real PR for the Corpus-PR marker (#3330); they are
+# pinned here so this marker cannot drift away from that behaviour.
+assert_exit "the opt-out buried mid-sentence does not count" 1 \
+  "$(printf '%s\n%s\n' "$PIN" "$BASELINE")" \
+  "I considered a Count-Baseline-History-NA: line but wrote the entry instead."
+assert_exit "a bold opt-out marker is not the marker" 1 \
+  "$(printf '%s\n%s\n' "$PIN" "$BASELINE")" \
+  "**Count-Baseline-History-NA:** a real enough reason"
+assert_exit "the opt-out marker inside backticks does not count" 1 \
+  "$(printf '%s\n%s\n' "$PIN" "$BASELINE")" \
+  "The \`Count-Baseline-History-NA:\` marker would apply here, arguably."
+assert_exit "the marker and its reason on two separate lines do not count" 1 \
+  "$(printf '%s\n%s\n' "$PIN" "$BASELINE")" \
+  "Count-Baseline-History-NA:
+the reason lives down here"
+
+# The opt-out is scoped to this guard and must not be satisfied by another
+# guard's marker, nor satisfy one.
+assert_exit "a Corpus-NA line does not satisfy this guard" 1 \
+  "$(printf '%s\n%s\n' "$PIN" "$BASELINE")" \
+  "Corpus-NA: CI plumbing; this asserts nothing about BC"
+
+# Writing the entry makes the opt-out irrelevant rather than contradictory: a PR
+# that does both is honouring the rule, and there is nothing to complain about.
+assert_exit "an entry plus an opt-out is not a conflict" 0 \
+  "$(printf '%s\n%s\n%s\n' "$PIN" "$BASELINE" "$HISTORY")" \
+  "Count-Baseline-History-NA: belt and braces"
+
+# --- Usage errors are not passes ---------------------------------------------
+#
+# A guard handed nothing checks nothing and exits 0, which is a green tick
+# meaning nobody read anything. check_corpus_linkage.sh and
+# pr_commit_messages.sh both refuse that; so does this.
+
+rc=0
+PR_BODY="x" "$SCRIPT" >/dev/null 2>&1 || rc=$?
+if [ "$rc" = "2" ]; then
+  echo "ok   - a missing CHANGED_FILES is a usage error, not a pass"
+  pass=$((pass + 1))
+else
+  echo "FAIL - a missing CHANGED_FILES should exit 2, got $rc"
+  fail=$((fail + 1))
+fi
+
+rc=0
+CHANGED_FILES="$PIN" "$SCRIPT" >/dev/null 2>&1 || rc=$?
+if [ "$rc" = "2" ]; then
+  echo "ok   - a missing PR_BODY is a usage error, not a pass"
+  pass=$((pass + 1))
+else
+  echo "FAIL - a missing PR_BODY should exit 2, got $rc"
+  fail=$((fail + 1))
+fi
+
+# An EMPTY body is a legitimate state (a PR with no description at all), and it
+# must fire rather than error -- the omission is still an omission.
+assert_exit "an empty body on a pin bump still fires" 1 \
+  "$(printf '%s\n%s\n' "$PIN" "$BASELINE")" ""
+
+# --- The paths this guard names must exist -----------------------------------
+#
+# The guard matches three literal paths. If one is renamed and the guard is not,
+# it silently stops firing -- the same silent-pass failure it was built to close,
+# one level up. Assert them against the working tree.
+
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+for p in "$BASELINE" "$HISTORY" "$PIN"; do
+  if [ -e "$REPO_ROOT/$p" ]; then
+    echo "ok   - the guard's path $p exists in the tree"
+    pass=$((pass + 1))
+  else
+    echo "FAIL - the guard names $p, which is not in the tree -- rename, or the guard is dead"
+    fail=$((fail + 1))
+  fi
+done
+
+# And the README sentence the guard enforces must still say so. If that
+# requirement is dropped, this guard should go with it, not outlive it.
+if command grep -qi 'add an entry to' "$REPO_ROOT/tests/expectations/count-baseline/README.md" \
+   && command grep -qi 'history\.md' "$REPO_ROOT/tests/expectations/count-baseline/README.md"; then
+  echo "ok   - the count-baseline README still requires a history.md entry"
+  pass=$((pass + 1))
+else
+  echo "FAIL - the count-baseline README no longer requires a history.md entry; this guard should be removed with it"
+  fail=$((fail + 1))
+fi
+
+echo
+echo "passed: $pass, failed: $fail"
+[ "$fail" -eq 0 ]

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -274,6 +274,68 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: bash .github/scripts/check_corpus_pin_forward.sh
 
+  require-count-baseline-history:
+    name: A corpus pin bump must record why in history.md
+    runs-on: ubuntu-latest
+    # #3591. tests/expectations/count-baseline/README.md has required an entry
+    # in history.md on every pin bump since the file existed, and nothing
+    # enforced it. CountBaselineMergeShapeTests validates a section's SHAPE if
+    # one is written, so an omission is invisible to it; nothing in .github/ or
+    # tools/ read the file at all. PR #3588 bumped the pin, passed all 13
+    # required checks green, and had no entry -- caught by a reviewer.
+    #
+    # The entry is not decoration. For a bump that deliberately stops short of
+    # corpus master, the reasoning for WHERE IT STOPPED is what the next agent
+    # needs, and history.md is where they look. On #3588 that reasoning lived
+    # only in the PR body, which is not reachable from a checkout.
+    #
+    # This is the same shape as require-corpus-linkage above -- a presence
+    # check over the PR's changed paths, with a mandatory-reason opt-out -- and
+    # it is offline for the same reason: it gates, so by the rule of thumb at
+    # the top of this file it must not be able to fail for an environmental
+    # reason. The changed-file list comes from the local checkout via git, not
+    # from api.github.com.
+    #
+    # Scoping, and why it is the PIN and not the count: see the header of
+    # check_count_baseline_history.sh. Short version, measured on main at
+    # e03dbfc1 -- of the last 12 commits touching test-count-baseline.json, 10
+    # carried a history change and 2 did not, and both of those two added a
+    # runner-extras group line without moving the pin, so neither was a
+    # violation. Of the 31 commits moving the pin since history.md was created,
+    # 31 carried an entry. Replayed against all 31, this guard fires on none of
+    # them, and against #3588's real pre-fix diff it fires.
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Same reason as require-corpus-linkage: both endpoints of the diff
+          # must be present as objects, and the PR head is only reachable with
+          # the full history fetched.
+          fetch-depth: 0
+
+      - name: Collect the PR's changed files
+        id: changed
+        # BASE...HEAD from the event payload, never the checked-out HEAD -- the
+        # #3261 collapse the require-corpus-linkage comment above explains in
+        # full. Sharing pr_changed_files.sh keeps both endpoints under
+        # test_pr_changed_files.sh rather than repeating the shape inline.
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          files=$(bash .github/scripts/pr_changed_files.sh)
+          {
+            echo "files<<CHANGED_FILES_EOF"
+            printf '%s\n' "$files"
+            echo "CHANGED_FILES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check a pin bump records its reasoning in history.md
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          CHANGED_FILES: ${{ steps.changed.outputs.files }}
+        run: bash .github/scripts/check_count_baseline_history.sh
+
   verify-trigger-list:
     name: pull_request trigger lists must keep their load-bearing event types
     runs-on: ubuntu-latest

--- a/tests/expectations/count-baseline/README.md
+++ b/tests/expectations/count-baseline/README.md
@@ -94,3 +94,24 @@ whole bump, with `git merge-file`, and fails if they conflict. It also fails on 
 enough to be a conflict magnet, and checks that the `groups` keys are exactly the app-group
 directories on disk — so a new suite whose baseline entry was forgotten fails in seconds
 locally instead of on eight CI legs.
+
+That holds the *shape* of a `history.md` section if one is written. It cannot see an omission,
+and for a long time nothing could: PR #3588 bumped the pin, passed all 13 required checks
+green, and wrote no entry at all — caught by a reviewer, not by CI (#3591).
+
+`.github/scripts/check_count_baseline_history.sh`, run by `pr-gate.yml`, closes that. It fires
+when a PR moves the `tests/al-language` gitlink and does not touch `history.md`. The trigger is
+the **pin**, not this file: adding or removing a `runner-extras` group line needs no entry —
+the group name and its count say what changed — and of the last 12 commits touching
+`test-count-baseline.json` when the guard was written, the 2 that carried no `history.md`
+change were both exactly that, and neither was a violation. Of the 31 commits that moved the
+pin since `history.md` existed, all 31 carried an entry.
+
+If a bump genuinely has nothing to record, say so on its own line in the PR body — the reason
+is mandatory, and a placeholder is refused:
+
+```
+Count-Baseline-History-NA: <why this bump has nothing to record>
+```
+
+It checks only that an entry *exists*. Whether it is a good one is a reviewer's call.


### PR DESCRIPTION
Closes #3591

The count-baseline README has required an entry in `history.md` on every corpus pin bump since the file existed. Nothing enforced it. `CountBaselineMergeShapeTests` validates a section's *shape if one is written*, so an omission is invisible to it, and nothing in `.github/` or `tools/` read the file at all. PR #3588 bumped the pin, passed all 13 required checks green, and had no entry — caught by a reviewer, then fixed by `26ddc371`.

New guard: `.github/scripts/check_count_baseline_history.sh`, run by a new `pr-gate.yml` job (`A corpus pin bump must record why in history.md`).

## The two measurements the issue asked for, re-derived

**1. The 10/2 figure, and what the 2 actually are.** Re-derived independently on `main` at `e03dbfc1` rather than taken from the issue: of the last 12 commits touching `test-count-baseline.json`, **10 carried a `history.md` change and 2 did not**. The issue's number is correct.

The two are `b071a9d4` (#3630) and `01338b5e` (#3595), and **neither is a violation**. Each adds exactly one `runner-extras` **group line** — `"query-dataitem-filter-precompiled-dep": { "tests": 2 }` and `"testpage-close-message-consumed": { "tests": 5 }` — and **neither moves the submodule pin**. The README attaches the `history.md` requirement to one specific row of its "How to bump it" table, *"Bumped the corpus pin"*. Adding or removing a runner-extras group line is a different row and carries no such requirement, reasonably: the group name and its count are self-describing in a way a corpus count is not.

That is what set the trigger. The guard fires on **the `tests/al-language` gitlink moving**, not on `test-count-baseline.json` changing. Firing on the baseline file would have nagged both of those legitimate commits — the noisy direction `check_corpus_linkage.sh`'s header warns about, where a guard gets pasted past and then protects nothing.

**2. Can a legitimate bump have nothing to say?** Nothing observed says yes. `history.md` was created by `c133aa97` (#2879); of the **31** commits that have moved the pin since, **31 carried an entry**. So the rule is absolute in practice and the check could be unconditional.

There is an opt-out anyway, and what decides it is not that a hatch is cheap — "one sentence when it is needed" would justify *any* unused hatch, so it discriminates nothing. What decides it is that the expensive failure is **unrecoverable by the author**. An unconditional guard meeting a genuinely silent bump leaves exactly one way past: writing a `history.md` entry that says nothing. That is the guard forcing a junk entry into the very file it exists to keep meaningful — **it corrupts its own asset**, and the author cannot avoid it. A guard whose failure mode degrades the thing it protects needs a way out even when nothing has yet needed one.

(This argument is the reviewer's, and it is better than the one that stood here; recorded because the weaker version would have justified a hatch on any guard at all.)

```
Count-Baseline-History-NA: <reason>
```

Mandatory non-placeholder reason, same idiom as `Corpus-NA:` and `check_closing_reference.sh`'s "No linked issue:" hatch, and the same canonical-line rule — marker and reason on one line, nothing before the marker. Bold, backticked, mid-sentence and split-across-two-lines forms are all rejected and pinned as cases, because every one of those went red on a real PR for the `Corpus-PR` marker in a single day (#3330).

## Proof it fires on #3588's actual omission

This is the decisive check, not "does deleting the guard fail a test". `#3588`'s squash `325b24ec` touched three paths; `26ddc371` inside it added the `history.md` one. Removing that path reconstructs the diff the PR actually had when it went green.

```
pre-fix  (tests/al-language, test-count-baseline.json)                  -> exit 1  FIRES
post-fix (+ tests/expectations/count-baseline/history.md)               -> exit 0  passes
```

Run with **#3588's real PR body** fetched from the API, not a synthetic one, confirming the real body contains nothing that accidentally satisfies the opt-out.

Both shapes are pinned as the first cases in the test file, named for the PR.

**Replayed against history, from real diffs rather than hand-typed paths:**

| replay | result |
|---|---|
| all **31** pin bumps since `history.md` existed | fires on **0** |
| the two measured exceptions `b071a9d4`, `01338b5e` | passes both |
| last **150** commits on `main` | fires on **0** |

So the guard fires on the one real omission and on nothing else in the recorded history.

## Where it went, and why not in `CountBaselineMergeShapeTests`

The issue is right that this is a **presence** question, not a **shape** one. `CountBaselineMergeShapeTests` reads the checked-in files; it cannot see a PR's diff, which is the only place an omission exists. So it went to `pr-gate.yml`, next to `require-forward-corpus-pin` — same domain, and structurally the same job as `require-corpus-linkage`: changed paths from `pr_changed_files.sh` (the `BASE...HEAD` form, so the #3261 collapse cannot recur), body from the event payload, offline apart from the checkout so it cannot go red for an environmental reason.

`.github/scripts/test_*.sh` is discovered by glob in the `github-scripts-tests` job, so the new suite gates the day it lands with no workflow edit.

## Not made a required context

The job is deliberately in **neither** `DEFAULT_REQUIRED_CONTEXTS` nor `PENDING_REQUIRED_CONTEXTS` in `check_required_contexts.py`. Promoting a context before the ruleset requires it makes `tools/ci-wait.py` answer exit 3 for every agent in the repository (#3002). `check_required_contexts.py` passes as-is with the job present.

**It should gate** — a failure means a real defect in the PR, it is offline, and it takes about a second — but that is a ruleset edit only an administrator can make.

## Two things it deliberately does not do

- **Judge the entry.** Not whether it names the upstream PRs, not whether it is under `## al-language`, not whether its number matches the baseline. Told to judge content, CI gets it wrong in both directions and authors write to the checker. It asks only that there is something for a reviewer to read.
- **Prefix-match.** Paths are compared for exact equality per line. `tests/al-language` is a gitlink, so git names it as exactly that path and never with anything after it; a prefix match would read every corpus source file as a pin bump. Pinned as cases both ways, including a sibling directory sharing the prefix.

## Test coverage

41 assertions, `.github/scripts/test_check_count_baseline_history.sh`. RED was 37 failures with the script absent (exit 127); GREEN is 41/41. The suite also asserts the three paths the guard names still exist in the tree and that the README still states the requirement — if either is renamed away, the guard should die with it rather than silently stop firing, which is the same failure it was built to close one level up.

Also ran: the full `.github/scripts/` suite (15 suites, all green), the full `tools/` suite (13 suites, all green), `check_required_contexts.py`, and YAML validity of `pr-gate.yml`.

## Not folded, and why

**#3299** (`check_corpus_pin_forward.sh` has a silent never-fire path; its "#3181" provenance claim is wrong) is the nearest neighbour — `status: ready`, unassigned, no open PR, adjacent domain, and it touches `pr-gate.yml` too. **Not folded.** The fix lands in a *different* script and its *different* test file; the only shared file is `pr-gate.yml`, which every gate job in the repository touches, so sharing it is not the "same tight cluster" test. And the two need materially different reasoning to review: this PR adds a guard, #3299 corrects an existing guard's behaviour *and* retracts a factual claim from three places. It remains cleanly claimable.

Scanned and not applicable: **#3350**, **#3130** (`--count-baseline` runtime behaviour, in `AlRunner/`); **#2803** (the baseline's numeric fields auto-merging wrongly — `CountBaselineMergeShapeTests` territory, a shape question); **#3416**, **#3355**, **#3478** (corpus pin *advance* tooling under `tools/`).

## Not proven

- **The job has never run on real GitHub Actions.** Every assertion here is local: the script logic under its unit suite, and the workflow wiring by reading `pr-gate.yml` and validating the YAML. The `pr_changed_files.sh` step is the same one `require-corpus-linkage` already uses in production, which is why it was reused rather than written fresh, but *this job's* copy of it is unexercised until this PR's own gate run.
- **The opt-out has no real-world instance.** 31 of 31 says nothing has needed it. It is a judgement about asymmetric cost, argued in the script header, not a measurement — and if it is judged wrong, deleting the marker branch and its cases is a small, contained change.

Corpus-NA: CI plumbing only; this guard reads a PR's changed paths and body and asserts nothing whatever about Business Central behaviour. The corpus-linkage gate does not trigger on this diff either — it touches no non-`.md` path under `AlRunner/` — verified locally with `check_corpus_linkage.sh`.

---

🤖 Written by an automated implementation agent (`stma-auto-2`) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
