### PR TITLE
docs(page-control-field): name the control attribute correctly in two prose sites

### DIFF
--- a/AlRunner/Patches/RecordPatches.PageControlFieldVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.PageControlFieldVirtualTable.cs
@@ -141,7 +141,7 @@ public static partial class RecordPatches
     /// both counts means true.</para>
     ///
     /// <para>Neither of BC's other two rules is reachable from here: these paths carry no
-    /// <c>ExpressionIsAssignable</c> and no page-level <c>Editable</c>, so a control that BC
+    /// <c>SourceExpressionIsAssignable</c> and no page-level <c>Editable</c>, so a control that BC
     /// would force to False through either can only be reached on the document path. That is
     /// a narrower answer rather than a wrong one — a page served from these paths has no
     /// document, so there is nothing to read it from — and it is why this is a separate

--- a/docs/page-control-field-from-bc-document.md
+++ b/docs/page-control-field-from-bc-document.md
@@ -251,8 +251,14 @@ gated on `control.Editable == null`, so a declared value never reaches it. That 
 
 `SolveDocumentControlEditable` in `RecordPatches.PageControlFieldFromBcDocument.cs` implements
 rules 1-3. `SolveParsedControlEditable` in `RecordPatches.PageControlFieldVirtualTable.cs`
-implements rule 2 for the AL-parsed and precompiled-dependency paths, which carry neither an
-`ExpressionIsAssignable` nor a page-level `Editable` to evaluate the other rules against.
+implements rule 2 for the AL-parsed and precompiled-dependency paths, which carry neither a
+`SourceExpressionIsAssignable` nor a page-level `Editable` to evaluate the other rules against.
+
+BC has two near-identical attribute names on **different** elements, and confusing them is what
+made #3659's rule 1 dead code before review caught it: a **control**
+(`ControlDataboundDefinition`) carries `SourceExpressionIsAssignable`, while an `<Expression>`
+entry (`DataFieldDefinition`) carries `ExpressionIsAssignable`. The sample above is an
+`<Expression>`, so its shorter spelling is correct.
 
 **Rule 4 is deliberately not reproduced**, on any path: the runner has no personalization or
 configuration layer, so `SourceAppId` is never `PersonalizationAppId`/`ConfigurationAppId` and


### PR DESCRIPTION
Two comments described a **control** while naming `ExpressionIsAssignable`, which is the `<Expression>` element's attribute. A control carries `SourceExpressionIsAssignable`.

Closes #3667

## Why this is worth a PR rather than a drive-by

That near-collision already cost a real defect, hours ago. PR #3659 originally read `HasAttribute("ExpressionIsAssignable")` on a **control**, copied from an `<Expression> ... ExpressionIsAssignable="1"/>` sample in this very document. The literal could never match, the `||` short-circuited to `true`, and BC's rule 1 — the one that outranks even a declared `Editable` — was unreachable on every page. The record field and doc comment carried the right name; only the string literal was wrong, so the compiler could not see it and it survived a review.

Both sites corrected here describe the **AL-parsed and precompiled-dependency paths**, where rule 1 is *not yet implemented*. Whoever implements it reads exactly these two sentences to learn which attribute to look for — and would have found the wrong name, stated by the very change that fixed the wrong name.

## What changed

| site | was | now |
|---|---|---|
| `AlRunner/Patches/RecordPatches.PageControlFieldVirtualTable.cs:144` | `ExpressionIsAssignable` | `SourceExpressionIsAssignable` |
| `docs/page-control-field-from-bc-document.md:255` | `ExpressionIsAssignable` | `SourceExpressionIsAssignable` |

Plus a short paragraph in the doc stating the distinction, so the next reader does not have to rediscover it: a control (`ControlDataboundDefinition`) carries `SourceExpressionIsAssignable`; an `<Expression>` entry (`DataFieldDefinition`) carries `ExpressionIsAssignable`.

**Verified against BC's own metadata**, not inferred: `ControlDataboundDefinition`'s XML reader has `case "SourceExpressionIsAssignable"` and no `case "ExpressionIsAssignable"`; `DataFieldDefinition`'s has the latter.

## What deliberately did NOT change

The two remaining bare occurrences are **correct** and stay:

- `RecordPatches.PageControlFieldFromBcDocument.cs:232` — the comment #3659 added explaining the distinction.
- `docs/page-control-field-from-bc-document.md:125` — the `<Expression>` sample, which genuinely carries that attribute.

**Prose only. No string literal changed, no behaviour affected** — so there is no RED to write. `tdd.md` decides where a proving test lives, never whether prose is accurate; a behaviour change here would have wanted its own issue.

## Checks

- `tools/test_doc_pointers.py` — all pass, 14 `Doc` values resolve.
- `BcMatrixDocumentationDriftTests` — 5 passed, 0 failed (no BC version list added).

Corpus-NA: prose describing the runner's own reading of BC's page document; there is no BC behaviour claim here for a service tier to adjudicate.

---

🤖 Written by an agent (`stma-auto-2`) acting on the account holder's behalf, from a review finding on PR #3659.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
