### PR TITLE
fix(transaction): count BC's own Begin/EndTransaction so an XmlPort.Import may write under TransactionModel::None

### DIFF
--- a/AlRunner/Infrastructure/NclCecilRewrite.Forms.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Forms.cs
@@ -1446,6 +1446,79 @@ public static partial class NclCecilRewrite
             PrependStaticCall(asm.MainModule, endTransactionMethod, noteTransactionEndHelper, argSlots: 2);
         }
 
+        // 8h. SessionTransactionExtensions.BeginTransaction / EndTransaction /
+        //     BeginTransactionWorldAndTransaction / EndTransactionWorldAndTransaction —
+        //     the TransactionModel::None depth counter (#3580).
+        //
+        //     A `None` test body runs with no transaction, so ALDatabasePatches
+        //     .ThrowIfNoTransactionForWrite refuses a write from it — unless something has
+        //     begun one, which BC's own API bodies routinely do. #3541 bracketed Codeunit.Run
+        //     and #3582 the report and TestPage seams, each in runner-owned C#. XmlPort.Import
+        //     has no runner seam by design (XmlPortPatches.cs: BC's real, unpatched body is the
+        //     right answer), so the count has to come from BC's own transaction calls.
+        //
+        //     Both branches of NavXmlPort.Import(DataError) do exactly that, decompiled Ncl
+        //     28.1.49838.54308: ThrowError calls navSession.BeginTransaction() and closes it
+        //     with navSession.EndTransaction(commit) in a finally; TrapError uses the
+        //     WorldAndTransaction pair the same way. Prepending onto BC's own `finally` call is
+        //     what makes this need no new try/finally IL — the mechanism #3328 warns about.
+        //
+        //     Why this is not #2413. That regression was about COMMIT POINTS: prepending
+        //     RecordPatches.NoteTransactionEnd (block 8g) onto the plain EndTransaction turned
+        //     Query.Open and statement-form XmlPort.Import into commit points, so writes made
+        //     before them survived an asserterror real BC rolls back. NoteBcEndTransaction
+        //     marks nothing and commits nothing; it moves _runTransactionDepth, which is read
+        //     by ThrowIfNoTransactionForWrite and by nothing else, and only while a
+        //     TransactionModel::None body is executing. Every other run in the suite is
+        //     unaffected by construction, and 8g's own prepend is left exactly where #2413 put
+        //     it. The two prepends coexist on EndTransactionWorldAndTransaction.
+        //
+        //     Prepend, not replace: BC's bodies here are one-line forwarders into
+        //     SessionTransactionManager that already run safely today.
+        {
+            var sessTxType3 = asm.MainModule.Types
+                .FirstOrDefault(t => t.FullName == "Microsoft.Dynamics.Nav.Runtime.SessionTransactionExtensions")
+                ?? throw new InvalidOperationException(
+                    "[Cecil] SessionTransactionExtensions type not found — Ncl shape changed; do not commit");
+
+            var noteBeginHelper = typeof(AlRunner.Patches.ALDatabasePatches).GetMethod(
+                nameof(AlRunner.Patches.ALDatabasePatches.NoteBcBeginTransaction),
+                BindingFlags.Public | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "[Cecil] ALDatabasePatches.NoteBcBeginTransaction not found");
+            var noteEndHelper = typeof(AlRunner.Patches.ALDatabasePatches).GetMethod(
+                nameof(AlRunner.Patches.ALDatabasePatches.NoteBcEndTransaction),
+                BindingFlags.Public | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "[Cecil] ALDatabasePatches.NoteBcEndTransaction not found");
+
+            // (method name, parameter count, helper) — the two pairs, matched on the exact
+            // one-line forwarder shape so a renamed or re-signatured Ncl member fails the
+            // build here rather than silently leaving a `None` body unable to write.
+            var depthTargets = new (string Name, int ParamCount, System.Reflection.MethodInfo Helper)[]
+            {
+                ("BeginTransaction", 1, noteBeginHelper),
+                ("EndTransaction", 2, noteEndHelper),
+                ("BeginTransactionWorldAndTransaction", 1, noteBeginHelper),
+                ("EndTransactionWorldAndTransaction", 2, noteEndHelper),
+            };
+
+            foreach (var (name, paramCount, helper) in depthTargets)
+            {
+                var target = sessTxType3.Methods
+                    .FirstOrDefault(m => m.Name == name && m.IsStatic && m.HasBody
+                                         && m.Parameters.Count == paramCount)
+                    ?? throw new InvalidOperationException(
+                        $"[Cecil] SessionTransactionExtensions.{name}(…/{paramCount}) not found — "
+                        + "Ncl shape changed; do not commit");
+
+                // argSlots: 0 — the counter needs neither the session nor the commit flag, and
+                // forwarding arguments it does not read is what #3328's arity mismatches are
+                // made of.
+                PrependStaticCall(asm.MainModule, target, helper, argSlots: 0);
+            }
+        }
+
 
         // 9b. TreeHandler.get_Session — see BcRuntime.TreeHandler_get_Session.
         //     The real body is `=> session`, a readonly field set in the ctor from

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -30,7 +30,7 @@ namespace AlRunner.Infrastructure;
 
 public static partial class NclCecilRewrite
 {
-    private const int CACHE_VERSION = 130;
+    private const int CACHE_VERSION = 131;
 
     // ─────────────────────────────────────────────────────────────────────────
     // Cecil-owned skip registry (JmpHook→Cecil migration enabler).

--- a/AlRunner/Patches/ALDatabasePatches.cs
+++ b/AlRunner/Patches/ALDatabasePatches.cs
@@ -509,10 +509,16 @@ public static class ALDatabasePatches
     /// runs in — BC's pre-body loop, mirrored. Ends the write transaction the same way that
     /// loop does, so a previous test's uncommitted write cannot refuse this test's guarded
     /// <c>Codeunit.Run</c>.</summary>
+    ///
+    /// <remarks>The depth is zeroed here as well as on the way out, because BC's loop ends
+    /// EVERY active transaction before the body: whatever count the surrounding machinery
+    /// left behind cannot be one of the transactions this body is allowed to write inside
+    /// (#3580, now that BC's own Begin/End pair feeds the counter).</remarks>
     public static void EnterNoTransactionScope()
     {
         System.Threading.Volatile.Write(ref _noTransactionScope, true);
         System.Threading.Volatile.Write(ref _inWriteTransaction, false);
+        System.Threading.Volatile.Write(ref _runTransactionDepth, 0);
     }
 
     /// <summary>Leave it. Called for EVERY test, None or not, so the scope can never outlive
@@ -522,6 +528,35 @@ public static class ALDatabasePatches
         System.Threading.Volatile.Write(ref _noTransactionScope, false);
         System.Threading.Volatile.Write(ref _runTransactionDepth, 0);
     }
+
+    /// <summary>BC's own <c>SessionTransactionExtensions.BeginTransaction(NavSession)</c> and
+    /// <c>BeginTransactionWorldAndTransaction(NavSession)</c>, Cecil-prepended (#3580). Every
+    /// BC API whose real Ncl body opens its own transaction reaches one of those two, so this
+    /// is how a construct with no runner seam — <c>XmlPort.Import</c> above all — makes a write
+    /// legal inside a <c>TransactionModel::None</c> body.
+    ///
+    /// <para>Faithful because it counts BC's own decision rather than guessing at one:
+    /// <c>NavXmlPort.Import(DataError)</c> calls <c>navSession.BeginTransaction()</c> on the
+    /// ThrowError branch and <c>BeginTransactionWorldAndTransaction()</c> on the TrapError one,
+    /// each closed by the matching End in a <c>finally</c> (decompiled Ncl 28.1.49838.54308).
+    /// Pinned upstream by corpus 60878 Test12, green on all eight cloud legs.</para>
+    ///
+    /// <para>Not a commit-point change, which is what makes it safe where #2413 was not: the
+    /// only state these two touch is <see cref="_runTransactionDepth"/>, which is read by
+    /// <see cref="ThrowIfNoTransactionForWrite"/> alone and only while
+    /// <see cref="_noTransactionScope"/> is set. Outside a <c>None</c> test body the counter
+    /// changes nothing observable. <see cref="RecordPatches.NoteTransactionEnd"/> stays on
+    /// <c>EndTransactionWorldAndTransaction</c> only, exactly as #2413 left it.</para>
+    /// </summary>
+    public static void NoteBcBeginTransaction() => EnterRunTransaction();
+
+    /// <summary>The other half — BC's <c>EndTransaction(NavSession, bool)</c> /
+    /// <c>EndTransactionWorldAndTransaction(NavSession, bool)</c>. BC calls these from its own
+    /// <c>finally</c>, so the bracket closes on the error path too without any new try/finally
+    /// IL. The <c>commit</c> argument is deliberately not read: whether the nested transaction
+    /// commits is decided elsewhere (see <see cref="RecordPatches.NoteTransactionEnd"/>); the
+    /// only question here is whether one is still open.</summary>
+    public static void NoteBcEndTransaction() => ExitRunTransaction();
 
     /// <summary>The transaction <c>Codeunit.Run</c> begins around the run codeunit — BC's
     /// BeginTransaction on the statement-form branch, BeginTransactionWorldAndTransaction on

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -2143,3 +2143,27 @@ answers `1,3,2`. Before this PR all three read empty.
 Measured 116P/0F/0E on the whole bundle, not computed from the diff.
 
 Written by an agent (Claude, `stma-auto-2`).
+
+## al-language 3112 -> 3123, pin `c9d5f656` -> `3ad4c340` (#3580, corpus #293 and #292)
+
+Folded into the fix PR, not a catch-up bump: `26b0434` is the first commit after the old pin and
+it adds `WriteTxBoundary_Test12_AnXmlPortImportMayWriteUnderNone`, which fails without the
+`SessionTransactionExtensions` transaction-depth prepend this PR adds. Bumping alone would be red
+by construction.
+
+Two corpus commits ride along, both green here at the new pin:
+
+- `26b0434` (corpus #293) -- codeunit 60878 grows from 11 to 15 tests: a report, an xmlport import
+  and a page field validate under `TransactionModel::None`, plus the row-seeding arm the page one
+  opens on. Measured 15/15.
+- `3ad4c34` (corpus #292) -- codeunit 60965, per-field `DataClassification`, the relation columns
+  and `SystemCreatedBy`'s relation. Measured 7/7.
+
+3112 + 11 = 3123, measured on a whole-bundle run at the new pin (3123 pass, 0 fail, 0 error) --
+not computed from the diff. `--strict --count-baseline` then exits 0.
+
+The pin stops at `3ad4c340` rather than at corpus tip because the next commits need runner work
+that is still open: corpus #273 -> AlRunner#2943 (codeunit 60559) and corpus #272 -> AlRunner#3593
+(codeunit 60602). That is `al-language-submodule.md`'s "blocked by an intervening commit".
+
+Written by the fbk-2 agent.

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Schema, semantics and how to bump: README.md in this directory. Per-bump rationale: history.md, never a prose line in here (#2485).",
   "suites": {
     "al-language": {
-      "tests": { "default": 3112 },
+      "tests": { "default": 3123 },
       "appGroups": { "default": 1 }
     },
     "al-language-internals-fixture": { "tests": { "default": 0 }, "appGroups": { "default": 1 } },


### PR DESCRIPTION
Closes #3580

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/293

Under `[TransactionModel(TransactionModel::None)]`, a write performed by an `XmlPort.Import` was refused with BC's own `NavCSideException: A transaction must be started before changes can be made to the database.` Real BC allows it — corpus codeunit 60878 `WriteTxBoundary_Test12_AnXmlPortImportMayWriteUnderNone` (corpus PR #293, merged as `26b0434`) is green on all eight required cloud legs.

## Mechanism: count BC's own transaction calls, rather than build a seam

The issue offered two candidates. This is the second one, narrowed.

`XmlPort.Import` has no runner seam by design — `XmlPortPatches.cs` records the #1800/#1883 decision that BC's real, unpatched `Export`/`Import`/`SetTableView` bodies *are* the right answer, and that decision stands here. So the missing transaction count is taken from BC's own calls instead of from a bracket the runner does not own.

Decompiled `NavXmlPort.Import(DataError)` (Ncl `28.1.49838.54308`):

- `DataError.ThrowError` (`XP.Import();`, result discarded): `navSession.BeginTransaction()` … `finally { navSession.EndTransaction(commit); }`
- `DataError.TrapError` (`Ok := XP.Import(...)`): `navSession.BeginTransactionWorldAndTransaction()` … `finally { navSession.EndTransactionWorldAndTransaction(commit); }`

New Cecil block **8h** (`NclCecilRewrite.Forms.cs`, next to 8g) prepends `ALDatabasePatches.NoteBcBeginTransaction` / `NoteBcEndTransaction` onto those four `SessionTransactionExtensions` forwarders, so `_runTransactionDepth` follows BC's own decision. Because BC already calls the `End` half from its own `finally`, this needs **no new try/finally IL** — the option-1 machinery `AssertHelperArityMatches` warns about (#3328) is not built, and `argSlots: 0` means no arguments are forwarded at all.

## Why this is not #2413

#2413 was about **commit points**: prepending `RecordPatches.NoteTransactionEnd` (block 8g) onto the plain `EndTransaction` turned `Query.Open` and statement-form `XmlPort.Import` into commit points, so writes made *before* them survived an `asserterror` that real BC rolls back. That prepend is left exactly where #2413 put it — on `EndTransactionWorldAndTransaction` only.

The helpers added here mark nothing and commit nothing. They move `_runTransactionDepth`, whose only reader is `ThrowIfNoTransactionForWrite`, which returns early unless `_noTransactionScope` is set. **Outside a `TransactionModel::None` test body the counter changes nothing observable** — that is the whole blast-radius argument for touching a method with 73 callers, and it is why the 73 do not need to be enumerated.

Double-counting is not a hazard either: BC's own pairs are balanced, `Codeunit.Run` does not reach these forwarders at all (the runner replaces `DoRunAsync` outright), and a doubled Enter/Exit would stay balanced regardless. The residual risk is the opposite one — a `Begin` closed by something other than `EndTransaction`, leaving the depth stuck above zero for the rest of that test body. `EnterNoTransactionScope` now zeroes the depth as well as `ExitNoTransactionScope`, mirroring BC's pre-body `while (IsTransactionActive()) EndTransaction(false)` loop, so a leak cannot outlive one test. `CACHE_VERSION` 130 → 131, since the shadow Ncl changes.

## The shape, not just the reported line

- **Another call site with the same wrong pattern?** Yes, and it is fixed here: the `TrapError` branch (`Ok := XP.Import(...)`) makes the same claim through the `WorldAndTransaction` pair, so both pairs are prepended rather than only the one Test12 exercises. Not measured upstream on its own, but it is the same mechanism applied at BC's own second entry point, from BC's own body.
- **A sibling making the same assumption?** Every other BC API whose real body opens its own transaction — `Query.Open`'s `RunOnBeforeOpenTriggerAsync`, `NavForm`, the app installer — now counts too, for free, instead of each needing its own runner bracket later.
- **Two paths writing the same state?** `_runTransactionDepth` had exactly one writer pair before this (`Enter`/`ExitRunTransaction` from `CodeunitPatches`, `NavReportSync`, `MockTestPage`). The new helpers forward to that same pair rather than adding a second counter.

Scanned the open queue for the files this lands in. Nothing folds: **#3586** (page-driven row write under `None` — `Insert` refused, `Modify` never guarded at all) lands in `MockTestPage.cs` / `RecordWritePatches.cs`, not here, and is explicitly waiting on an upstream measurement first. **#2904** (report transaction world) and **#2184** (value-consuming `XmlPort.Import` inside a *write* transaction) are different questions about a different state flag. **#2943** and **#3593** are named below as pin blockers, not as fixes.

## RED → GREEN

Measured against my own corpus clone at `3ad4c34`, `--package-cache ~/.al-runner/platform-apps`:

| | codeunit 60878 |
|---|---|
| RED (before) | **14P/1F** — only Test12, `NavCSideException: A transaction must be started before changes can be made to the database.` from `XmlPort 60413` |
| GREEN (after) | **15/15** |

Whole corpus at the new pin: **3123 pass, 0 fail, 0 error** (`--strict --count-baseline`, exit 4 for the baseline growth alone, which this PR bumps). Codeunit 60965 (corpus #292) 7/7.

Filtered `AlRunner.Tests` — the #2413 regression classes `AssertErrorRollbackNestedTransactionTests` and `TransactionModelCommitRefusalTests` (2/2), and `JmpHookOrphanAuditTests` + `JmpHookInstallIndirectGuardTests` (14/14), both green. The full `AlRunner.Tests` suite runs on the unit legs; it was not run locally.

No new C# mechanism test: the proving test is corpus 60878 Test12, and the pin bump in this PR is what makes CI replay it. Block 8h throws at rewrite time if any of the four Ncl members changes shape, so an orphaned prepend cannot ship quietly.

## Pin fold: `c9d5f656` → `3ad4c340`, baseline 3112 → 3123

Folded rather than a catch-up bump, because `26b0434` is the first commit after the old pin and carries Test12 — the bump alone is red by construction (`al-language-submodule.md`).

Two corpus commits ride along: `26b0434` (corpus #293, codeunit 60878 11 → 15 tests) and `3ad4c34` (corpus #292, codeunit 60965). +11 tests, measured on a whole-bundle run rather than computed from the diff.

The pin stops there rather than at corpus tip — `al-language-submodule.md`'s "blocked by an intervening commit". The next commits need runner work that is still open: corpus #273 → **#2943** (codeunit 60559, maintainer in progress) and corpus #272 → **#3593** (codeunit 60602, `status: ready`, unassigned). Once those land, the remaining bump — including corpus #294 / `c7af7006` — is a catch-up bump and its own PR.

Opened by the **fbk-2** agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kko97BZZL71nF2nK5aftu4
