### PR TITLE
fix(testpage): the handler's OK().Invoke() is a close attempt, so a refused RunModal close delivers its message twice

### DIFF
--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -814,6 +814,9 @@ internal class LiveNavTestPage : MockITestPage
                 _page.DiscardPendingNewRow();
             else
                 _page.FlushRow();
+
+            // On BC this invoke IS the close attempt -- see AttemptHandlerDrivenClose.
+            _page.AttemptHandlerDrivenClose(_result);
         }
 
         public bool Visible => true;
@@ -1876,6 +1879,78 @@ internal class LiveNavTestPage : MockITestPage
         _page?.ForceCloseForm();
     }
     public override void Dispose() { FlushParts(); FlushRow(); }
+
+    /// <summary>
+    /// The close attempt a built-in OK/LookupOK invoked from a <c>[ModalPageHandler]</c> /
+    /// <c>[PageHandler]</c> makes, which the runner did not make at all before #3593.
+    ///
+    /// <para>On BC the handler's <c>OK().Invoke()</c> is a CLIENT action: pressing OK drives the
+    /// logical form's close, so <c>OnQueryClosePage</c> is raised right there, before the round
+    /// trip that opened the page gets control back. The runner's <c>Invoke()</c> only recorded a
+    /// result, so the ONLY close attempt on this route was the one
+    /// <see cref="AlRunner.Patches.RunnerModalDispatch.FormRunModal"/> makes afterwards.</para>
+    ///
+    /// <para>The observable consequence, and the reason this is a defect rather than an internal
+    /// detail: a close BC REFUSES is attempted twice, so an <c>OnQueryClosePage</c> that raises
+    /// an AL error consumed by a <c>[MessageHandler]</c> delivers that message TWICE on the
+    /// RunModal route. Measured on a real service tier by corpus codeunit 60602 "QCM Query Close
+    /// Msg Tests" (StefanMaron/BusinessCentral.AL.Language.Tests#272, merged bd168356), green on
+    /// all eight cloud legs and confirmed by the Windows nightly reference tier, whose modal arms
+    /// assert a delivery count of 2 while its TestPage arm asserts 1.</para>
+    ///
+    /// <para>ONE mechanism produces both counts, which is why this is not a counter. A successful
+    /// attempt here CLOSES the form, so <c>FormRunModal</c>'s own <c>IsFormOpen</c> gate skips its
+    /// attempt and the trigger is raised exactly once -- the result corpus codeunit 60276 "MQC
+    /// Tests" measured for an allowed close, and the one the runner already matched. A REFUSED
+    /// attempt leaves the form open, so that gate lets the second attempt through and the message
+    /// is delivered twice. Delivering twice unconditionally would break the allowed-close case.</para>
+    ///
+    /// <para>Restricted to a page the TEST DID NOT OPEN (<c>!_opened</c>, written only by
+    /// <see cref="MarkOpened"/>). A page the test opened itself is the test's to close: BC's
+    /// client does not press its OK button, and <c>Card.OpenNew(); Card.OK().Invoke();</c>
+    /// followed by further calls on the same variable is ordinary AL that must keep working.
+    /// That route's close attempt is <see cref="Close"/>, which is unchanged.</para>
+    ///
+    /// <para>A refusal is SWALLOWED here rather than raised, and that is the faithful answer, not
+    /// a convenience: BC's own close handler returns "close refused" to the client without
+    /// raising anything the handler can see (the message has already been shown), and the handler
+    /// carries on to its own end. What the caller of <c>RunModal()</c> observes is then decided by
+    /// <c>FormRunModal</c>'s second attempt, which reaches the same refusal and drops the
+    /// handler's result -- so <c>Action::None</c> still comes out of the refused path, unchanged.
+    /// The one thing that must NOT be swallowed is a refusal whose message had nowhere to go:
+    /// with no <c>[MessageHandler]</c> declared, BC's own "Unhandled UI: Message …" comes out of
+    /// <see cref="AlRunner.Patches.RunnerFormCloseHandler"/> rather than being returned, and that
+    /// is a real test failure which propagates.</para>
+    /// </summary>
+    private void AttemptHandlerDrivenClose(FormResult result)
+    {
+        // The test opened this page itself, so closing it is the test's call, not the client's.
+        if (_opened) return;
+
+        // Nothing to raise a trigger on, or AL already closed the page from under the handler
+        // (CurrPage.Close() from an OnAction) -- in which case the close has happened and its
+        // triggers have run exactly once already (issue #3091).
+        if (_page == null || _tornDown || RunnerPageInstance.WasClosedFromAl(_page.Form)) return;
+
+        // Only the CONFIRMING built-ins close the page on BC. A Cancel that reached here would
+        // be a second question -- what a cancelled modal's close attempt does -- which no tier
+        // has been asked, so it keeps the behaviour it had.
+        if (result is not (FormResult.OK or FormResult.LookupOK)) return;
+
+        // Both refusals leave the form OPEN and raise nothing here, which is what makes
+        // FormRunModal's own attempt run -- and that second attempt is where the second message
+        // delivery, and the Action::None, come from. They are one branch on purpose: unlike
+        // Close(), which must tell them apart because a veto there is a scope boundary
+        // (testpage-close-veto), this route's observable outcome is produced downstream either
+        // way, and it is the outcome the route already had before #3593.
+        if (!_page.RaiseOnClosePage(result, out _)) return;
+
+        // The close succeeded, so BC's own form state has to agree -- otherwise IsOpen stays
+        // true and FormRunModal runs the whole sequence a second time, which is exactly the
+        // double-raise issue #3091 fixed. ForceClose raises nothing: the triggers have just run.
+        _opened = false;
+        _page.ForceCloseForm();
+    }
 
     private void FlushParts()
     {

--- a/AlRunner/Patches/RunnerFormCloseHandler.cs
+++ b/AlRunner/Patches/RunnerFormCloseHandler.cs
@@ -73,10 +73,12 @@
 //   passes on the same leg of the same run. What unwinds it there is the framework tearing down
 //   a PROPAGATED error; a consumed message propagates nothing, so nothing unwinds.
 //
-//   NOT reproduced, and tracked in #3593: BC delivers this message TWICE on the RunModal route,
-//   because its round trip attempts the close twice (the handler's OK().Invoke() is itself a
-//   close attempt on BC and is not one here). The runner delivers once on both routes, which
-//   matches BC on the TestPage route only.
+//   BC delivers this message TWICE on the RunModal route and once on the TestPage route,
+//   because the modal round trip attempts the close twice: the handler's OK().Invoke() is itself
+//   a close attempt (LiveNavTestPage.AttemptHandlerDrivenClose), and FormRunModal attempts it
+//   again on a form the refusal left open. Both counts are reproduced since #3593. The asymmetry
+//   is load-bearing -- an ALLOWED close still raises the trigger exactly once, because the first
+//   attempt succeeds and closes the form.
 using System.Reflection;
 
 namespace AlRunner.Patches;

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1520,11 +1520,20 @@ https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues.
   reads back `Action::None`, and `TestPage.Close()` returns with the page still open and
   drivable.
 
-  **Still not reproduced on this surface, and tracked separately:** BC delivers the close-time
-  message **twice** on the `RunModal` route and once on the `TestPage.Close()` route, because
-  its round trip attempts the close twice. The runner attempts it once on both, so a
-  `[MessageHandler]` that counts deliveries sees one where BC would show two
-  ([#3593](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3593)).
+  The **delivery count** differs by route and is reproduced since
+  ([#3593](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3593)). BC delivers
+  the close-time message **twice** on the `RunModal` route and **once** on `TestPage.Close()`,
+  because the modal round trip attempts the close twice: on BC the handler's `OK().Invoke()` is
+  itself a close attempt, and the round trip attempts it again on a form the refusal left open.
+  The runner made only the second of those attempts, so a `[MessageHandler]` counting deliveries
+  saw one where BC shows two. `LiveNavTestPage.AttemptHandlerDrivenClose` now makes the first.
+
+  Only a *refused* close is delivered twice, and that asymmetry is what the fix has to preserve:
+  an allowed close still raises `OnQueryClosePage` exactly **once**, because the first attempt
+  succeeds and closes the form, so the round trip's own attempt finds nothing to do — the result
+  corpus codeunit 60276 "MQC Tests" measured on a real tier. A page the *test* opened is
+  unaffected in either direction: BC's client never presses its OK button, so
+  `Card.OpenNew(); …; Card.OK().Invoke();` remains a row commit and not a close.
 
 <a id="virtual-table-shape-gaps"></a>
 

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -2143,3 +2143,24 @@ answers `1,3,2`. Before this PR all three read empty.
 Measured 116P/0F/0E on the whole bundle, not computed from the diff.
 
 Written by an agent (Claude, `stma-auto-2`).
+
+## runner-extras `testpage-close-message-consumed` 5 -> 8 (#3593)
+
+Three new AL tests in codeunit 65863 "Tcm Close Message Tests", pinning the number of close
+attempts each route makes rather than only what a close reports.
+
+`RunModalWhenQueryCloseAllows_RaisesTheTriggerExactlyOnce` and
+`TestPageCloseWhenQueryCloseAllows_RaisesTheTriggerExactlyOnce` drive a new page 65864
+"Tcm Allow Card" whose `OnQueryClosePage` allows the close and counts its own raises; both assert
+exactly one. `TestPageOwnOkInvoke_DoesNotCloseThePageTheTestOpened` asserts that a page the TEST
+opened is not closed by its own `OK().Invoke()` — the trigger is not raised at all, and the page is
+still drivable afterwards.
+
+All three are the negative side of the delivery-count assertion this PR adds to the existing
+`RunModalAfterQueryCloseError_MessageConsumed_ReturnsToTheCaller` arm: a fix that attempted the
+close twice unconditionally, or that closed a test-opened page, turns that arm green and one of
+these red. Each was measured red under its own sabotage.
+
+Measured 8P/0F/0E on the whole bundle, not computed from the diff.
+
+Written by an agent (Claude, `stma-auto-2`).

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -66,7 +66,7 @@
         "tableext-eviction-subscriber-timing-dep": { "tests": 0 },
         "task-scheduler-oos": { "tests": 8 },
         "temporary-virtual-table-isolation": { "tests": 6 },
-        "testpage-close-message-consumed": { "tests": 5 },
+        "testpage-close-message-consumed": { "tests": 8 },
         "testpage-lookup-tablerelation-oos": { "tests": 3 },
         "testpage-precompiled-dep-control": { "tests": 2 },
         "testpage-precompiled-member-names": { "tests": 8 },

--- a/tests/runner-extras/testpage-close-message-consumed/TcmAllowCard.Page.al
+++ b/tests/runner-extras/testpage-close-message-consumed/TcmAllowCard.Page.al
@@ -1,0 +1,47 @@
+/// <summary>
+/// The counterpart to "Tcm Error Card": an OnQueryClosePage that ALLOWS the close, and counts
+/// how many times it was raised. The card above refuses every close, so it can only ever
+/// measure the refused path; this one measures the allowed one, which is where the constraint
+/// on #3593 lives.
+///
+/// Why the count has to be observable at all. #3593 adds a close attempt to the RunModal round
+/// trip so a refused close is delivered twice, matching BC. Corpus codeunit 60276 "MQC Tests"
+/// measured on a real service tier that the same OK().Invoke() shape raises OnQueryClosePage
+/// exactly ONCE when the trigger allows the close -- so the extra attempt must be reachable only
+/// after a refusal. A runner that simply attempted the close twice would satisfy the refused-path
+/// arm and break this one, which is the point of having both.
+///
+/// The count is written to a table rather than held in a page global because the page instance
+/// the round trip builds is not one the test holds afterwards.
+/// </summary>
+page 65864 "Tcm Allow Card"
+{
+    PageType = Card;
+    SourceTable = "Tcm Row";
+    ApplicationArea = All;
+    UsageCategory = None;
+
+    layout
+    {
+        area(Content)
+        {
+            field("No."; Rec."No.") { ApplicationArea = All; }
+            field("Set ID"; Rec."Set ID") { ApplicationArea = All; }
+        }
+    }
+
+    trigger OnQueryClosePage(CloseAction: Action): Boolean
+    var
+        Row: Record "Tcm Row";
+    begin
+        if not Row.Get('QCP') then begin
+            Row.Init();
+            Row."No." := 'QCP';
+            Row."Set ID" := 0;
+            Row.Insert();
+        end;
+        Row."Set ID" := Row."Set ID" + 1;
+        Row.Modify();
+        exit(true);
+    end;
+}

--- a/tests/runner-extras/testpage-close-message-consumed/TcmTests.Codeunit.al
+++ b/tests/runner-extras/testpage-close-message-consumed/TcmTests.Codeunit.al
@@ -172,10 +172,115 @@ codeunit 65863 "Tcm Close Message Tests"
         // Reaching this line at all is the #3179 half; the rest is what came back.
         Assert.IsTrue(Row.Get('SEEN'),
             'the [MessageHandler] must have consumed the close-time message on the RunModal route too');
+        Assert.AreEqual(2, Row."Set ID",
+            'the RunModal route must deliver the close-time message TWICE, where the TestPage route above delivers it once -- the handler''s OK().Invoke() is itself a close attempt, and the round trip then attempts the close again (#3593)');
         Assert.IsTrue(StrPos(Row."Last Text", CloseRefusedTxt) > 0,
             'the handler must receive the trigger''s own error text on the RunModal route');
         Assert.AreEqual(Format(Action::None), Format(Result),
             'RunModal must report an Action once control returns, and a refused close completed none');
+    end;
+
+    // CLAIM 6, and the CONSTRAINT on claim 5: the second close attempt is reachable ONLY after
+    // a refusal.
+    //
+    // Claim 5 above pins that the RunModal route delivers a REFUSED close's message twice,
+    // which the runner reaches by making the handler's OK().Invoke() attempt the close before
+    // the round trip attempts it again. That change would be wrong if it made every RunModal
+    // round trip raise OnQueryClosePage twice: corpus codeunit 60276 "MQC Tests" measured on a
+    // real service tier that this exact OK().Invoke() shape raises the trigger exactly ONCE
+    // when it allows the close, and the runner already matched that before #3593.
+    //
+    // So this arm is the negative side of the pair, and it is not decoration -- a fix that
+    // attempted the close unconditionally twice turns claim 5 green and this one red. The
+    // page's trigger returns true, so the first attempt SUCCEEDS and there is nothing left for
+    // a second to do.
+    //
+    // A concrete count, not a liveness check: asserting merely that the trigger ran would pass
+    // against two raises just as well as against one.
+    [Test]
+    [HandlerFunctions('TcmAllowOkHandler')]
+    procedure RunModalWhenQueryCloseAllows_RaisesTheTriggerExactlyOnce()
+    var
+        Row: Record "Tcm Row";
+        Card: Page "Tcm Allow Card";
+        Result: Action;
+    begin
+        Initialize();
+
+        Result := Card.RunModal();
+
+        Assert.IsTrue(Row.Get('QCP'),
+            'OnQueryClosePage must be raised at all on a RunModal round trip the handler closes with OK');
+        Assert.AreEqual(1, Row."Set ID",
+            'a RunModal round trip whose OnQueryClosePage ALLOWS the close must raise it exactly once -- corpus 60276 measured that on a real tier, and the second attempt #3593 adds must be reachable only after a refusal');
+        Assert.AreEqual(Format(Action::OK), Format(Result),
+            'the close succeeded, so RunModal must report the action the [ModalPageHandler] chose rather than None');
+    end;
+
+    // The TestPage twin of the arm above: this route has one close attempt and must keep it,
+    // whatever the RunModal route does. Its refused-close counterpart is claim 1, which asserts
+    // one delivery -- the two together are why a fix cannot buy the RunModal count by changing
+    // the shared close path.
+    [Test]
+    procedure TestPageCloseWhenQueryCloseAllows_RaisesTheTriggerExactlyOnce()
+    var
+        Row: Record "Tcm Row";
+        Card: TestPage "Tcm Allow Card";
+    begin
+        Initialize();
+
+        Card.OpenEdit();
+        Card.Close();
+
+        Assert.IsTrue(Row.Get('QCP'),
+            'OnQueryClosePage must be raised when the test closes a TestPage itself');
+        Assert.AreEqual(1, Row."Set ID",
+            'TestPage.Close() must raise OnQueryClosePage exactly once -- this route has a single close attempt and #3593 does not touch it');
+    end;
+
+    // CLAIM 7, and the OTHER constraint on claim 5: a page the TEST opened is the test's to
+    // close, and its OK().Invoke() is not a client close.
+    //
+    // #3593 makes the built-in OK invoked from a [ModalPageHandler] attempt the close, because
+    // on BC that invoke is the client pressing OK. It must NOT do so for a page the test opened
+    // itself: BC's client never presses that page's OK button, and
+    // Card.OpenNew(); ...SetValue(...); Card.OK().Invoke(); followed by more calls on the same
+    // variable is ordinary AL that predates this issue by a long way.
+    //
+    // Two independent observations, so the arm cannot pass on a technicality. The trigger must
+    // NOT have been raised at all -- OK().Invoke() on this route is a row commit, not a close --
+    // and the page must still be drivable afterwards, which a page whose close ran would not be:
+    // #3593's success path calls ForceCloseForm, and a subsequent field read on a form BC has
+    // closed does not answer 99.
+    //
+    // Removing the guard turns this arm red and leaves every other arm in this bundle, and the
+    // whole al-language corpus at the current pin, green -- measured, which is why the arm is
+    // here rather than assumed unnecessary.
+    [Test]
+    procedure TestPageOwnOkInvoke_DoesNotCloseThePageTheTestOpened()
+    var
+        Row: Record "Tcm Row";
+        Card: TestPage "Tcm Allow Card";
+    begin
+        Initialize();
+
+        Card.OpenEdit();
+        Card."Set ID".SetValue(99);
+        Card.OK().Invoke();
+
+        Assert.IsTrue(not Row.Get('QCP'),
+            'OK().Invoke() on a page the TEST opened must not attempt the close -- BC''s client does not press that page''s OK button, so OnQueryClosePage must not have been raised');
+        Assert.AreEqual('99', Format(Card."Set ID".Value()),
+            'the page the test opened must still be drivable after its own OK().Invoke() -- a close would have torn the form down, and a torn-down form cannot answer this value');
+    end;
+
+    // Invoked by the allowed-close arm. Same OK().Invoke() shape as TcmOkHandler, against a page
+    // whose trigger permits the close -- so the two handlers differ only in which page they
+    // drive, which is what makes the delivery counts a statement about the refusal.
+    [ModalPageHandler]
+    procedure TcmAllowOkHandler(var Card: TestPage "Tcm Allow Card")
+    begin
+        Card.OK().Invoke();
     end;
 
     // Invoked by the modal arm above. Chooses OK deliberately: the close is refused regardless,


### PR DESCRIPTION
Closes #3593

Corpus-NA: the BC claim is already merged upstream as corpus codeunit 60602 "QCM Query Close Msg Tests" (BusinessCentral.AL.Language.Tests#272, bd168356), whose modal arms assert a delivery count of 2 and whose TestPage arm asserts 1 — this PR makes the runner match it, and adds no new BC-behaviour claim

*Implemented by an agent (Claude, `stma-auto-2`).*

## The defect

BC's `RunModal` round trip attempts a page's close **twice**, so an `OnQueryClosePage` raising an AL error consumed by a `[MessageHandler]` shows the message twice. The runner attempted it once.

The mechanism is in the issue title: on BC the handler's `OK().Invoke()` **is** a close attempt — the test client presses OK, which drives the logical form's close and raises `OnQueryClosePage` right there, before the round trip that opened the page gets control back. The runner's `RecordingBuiltInAction.Invoke()` only recorded a `FormResult` and flushed the row, so the only close attempt on that route was the one `RunnerModalDispatch.FormRunModal` makes afterwards.

## Delivery count, before and after

Measured on this branch with a `[MessageHandler]` that counts, BC 28.1:

| route | BC | before | after |
|---|---|---|---|
| `Modal.RunModal()` + `[ModalPageHandler]` doing `OK().Invoke()`, close **refused** | 2 | **1** | **2** |
| `Card.OpenEdit(); Card.Close()`, close **refused** | 1 | 1 | **1** |
| `Modal.RunModal()` + `OK().Invoke()`, close **allowed** (`OnQueryClosePage` raises) | 1 | 1 | **1** |
| `Card.OpenEdit(); Card.Close()`, close **allowed** | 1 | 1 | **1** |
| `Card.OpenEdit(); Card.OK().Invoke()` — page the **test** opened | 0 | 0 | **0** |

Only the first row moves.

## One mechanism, not a counter

`LiveNavTestPage.AttemptHandlerDrivenClose` makes the attempt BC's client makes, and both counts fall out of it:

- the attempt **succeeds** → it closes the form (`ForceCloseForm`), so `FormRunModal`'s own `IsFormOpen` gate skips its attempt and the trigger is raised **once**. That is what corpus 60276 "MQC Tests" measured for an allowed close, and what the runner already matched;
- the attempt is **refused** → the form stays open, so that gate lets the second attempt through and the message is delivered **twice**.

Delivering twice unconditionally would have satisfied the issue's headline and broken 60276. That is a measured claim, not a caution — see sabotage B below.

## Why it does not touch the `TestPage` route

Restricted to a page the test did **not** open (`!_opened`, written only by `MarkOpened`, which runs only for a test-opened page). BC's client never presses the OK button of a page the test opened, and `Card.OpenNew(); …SetValue(…); Card.OK().Invoke();` followed by more calls on the same variable is ordinary AL. `LiveNavTestPage.Close()` is unchanged.

A refusal is swallowed rather than raised, which is BC's own behaviour: its close handler returns "refused" to the client having already shown the message, and the handler runs on. What the caller of `RunModal()` sees is still decided by `FormRunModal`'s second attempt, which reaches the same refusal and drops the handler's result — so `Action::None` still comes out of the refused path, unchanged. A refusal whose message had nowhere to go is *not* swallowed: with no `[MessageHandler]`, BC's own "Unhandled UI: Message …" propagates out of `RunnerFormCloseHandler`.

## RED → GREEN

RED, before the fix, in `tests/runner-extras/testpage-close-message-consumed`:

```
FAIL  Codeunit65863.RunModalAfterQueryCloseError_MessageConsumed_ReturnsToTheCaller
      Expected 2 but got 1: the RunModal route must deliver the close-time message TWICE …
```

with the `TestPage` arm passing at 1 in the same run — the asymmetry the issue describes, not merely "a message arrived".

GREEN: 8/8 on that bundle, 407/407 across all of `tests/runner-extras`, and 3112/3112 on the al-language corpus at the current pin `c9d5f656` (a private clone; the pin cannot advance, #3580). The corpus run includes 60276 "MQC Tests" and 60296 "MQC Self Close Tests" — the codeunits a naive double-attempt breaks.

## Every guard is armed, each by a different arm

Each sabotage was applied to the shipping source, rebuilt, and run:

| sabotage | fails |
|---|---|
| **A** — remove the `AttemptHandlerDrivenClose(_result)` call entirely (the call is *removed*, not neutered, so nothing is left in IL) | `RunModalAfterQueryCloseError_…` — `Expected 2 but got 1` |
| **B** — keep the attempt but never close the form on success, i.e. the naive unconditional double-attempt | `RunModalWhenQueryCloseAllows_RaisesTheTriggerExactlyOnce` — `Expected 1 but got 2` |
| **C** — remove the `if (_opened) return;` test-opened guard | `TestPageOwnOkInvoke_DoesNotCloseThePageTheTestOpened` |

Sabotage B is the one worth reading: it turns the headline arm **green** and is caught only by the negative arm. Sabotage C is worth reading too — it was caught by an arm added *after* measuring that neither the rest of this bundle nor the entire corpus at the current pin noticed the guard's removal. Without it the `_opened` guard would have shipped unproven.

## Three new AL tests (count baseline 5 → 8)

- `RunModalWhenQueryCloseAllows_RaisesTheTriggerExactlyOnce` — the allowed-close constraint, on a new page 65864 "Tcm Allow Card" whose `OnQueryClosePage` counts its own raises;
- `TestPageCloseWhenQueryCloseAllows_RaisesTheTriggerExactlyOnce` — the same on the `TestPage` route;
- `TestPageOwnOkInvoke_DoesNotCloseThePageTheTestOpened` — two independent observations: the trigger is not raised at all, and the page is still drivable afterwards.

`test-count-baseline.json` bumps by exactly 3, matching the `[Test]` procedures added; `history.md` records why.

## Fix the shape — the three questions

1. **Same wrong pattern at another call site?** `RaiseOnClosePage` has exactly two call sites: `LiveNavTestPage.Close()` and the new method. `Close()` is correct at one attempt for its route and is untouched.
2. **Sibling function with the same assumption?** `RequestPageTestPage.RecordingBuiltInAction.Invoke()` is the same shape and is **not** affected: a report request page has no `OnQueryClosePage`, and there is no close-trigger path in that file at all. Verified rather than assumed.
3. **Two paths writing the same state, same invariant?** Both close paths now write `_opened = false` then `ForceCloseForm()` on success — deliberately identical, since a form left `IsOpen` after its triggers ran is the #3091 double-raise. One difference is deliberate: `Close()` also calls `FlushParts()`, which the modal route has never done (it goes through `FormRunModal`'s `TryCloseForm`, not `Close()`). That is pre-existing and unchanged here; adding a part flush to the modal close would be a behaviour change no service tier has adjudicated, so it is not folded in.

## Folded, and not folded

Nothing folded. The open-issue queue has no other issue whose fix lands in `MockTestPage.cs`'s close path — #3237 is a `[ConfirmHandler]` question, #2184 is an unmeasured XmlPort/Report transaction question. #3179, which this was split out of, is **closed** and is not reopened.

## Documentation

`docs/limitations.md` and `RunnerFormCloseHandler.cs`'s header both stated this was "not reproduced" and named #3593; both now state the reproduced behaviour and the asymmetry that constrains it.

## Conflict note

PR #3671 also edits `tests/expectations/count-baseline/{test-count-baseline.json,history.md}`, on different entries (its `al-language` pin-bump count vs this PR's `runner-extras` bundle entry). No semantic conflict; `history.md` may need a trivial append rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
