### PR TITLE
ci(gates): refuse a submodule path that names nothing, in both gate scripts that hardcoded one

### DIFF
--- a/.github/scripts/check_corpus_pin_forward.sh
+++ b/.github/scripts/check_corpus_pin_forward.sh
@@ -27,12 +27,43 @@
 #     exactly the older revision. The tests that would have gone red are the
 #     ones being removed.
 #
-# Caught for real on PR #3181, which was green and CLEAN while about to drop
-# corpus #199 and #201. That PR did nothing wrong: it bumped the pin forward
-# from the main that existed when it was written, and main's pin advanced
-# afterwards. Nothing rebased it and nothing told it to. That is why this is a
-# guard rather than a note in a rules file -- it is a merge-order accident, not
-# an authoring mistake, and it gets likelier as more agents run in parallel.
+# WHAT THIS GUARD HAS AND HAS NOT DEMONSTRATED (#3299)
+# ----------------------------------------------------
+# This header used to say the shape was "caught for real on PR #3181, green and
+# CLEAN while about to drop corpus #199 and #201." That is false, and it is
+# corrected here rather than deleted, because a guard justified by a catch that
+# did not happen is worse than one justified by nothing -- the next reader
+# trusts it more, not less. Measured against the live repository:
+#
+#   * #3181's base pin is b0c6248a at BOTH readings of "base": its frozen
+#     event-payload base c0fda77e, and the main it actually merged onto,
+#     9fe2b1d2. Its head pin 7394c15f is strictly FORWARD of b0c6248a, three
+#     corpus commits ahead.
+#   * At #3181's first commit 6cbdfff5 the pin was b0c6248a, identical to base --
+#     the untouched case.
+#   * So this script exits 0 on #3181 at every revision it ever had, on either
+#     reading of base. Running it against those endpoints is a five-second check
+#     and it was never done before the claim was written.
+#   * Corpus #199 (b0c6248a) and #201 (ae64da1b) are both ancestors of b0c6248a,
+#     so they were already pinned at #3181's base and remained pinned at its
+#     head. Nothing was about to be dropped.
+#   * main's pin has only ever moved forward: 6e198a97 -> b0c6248a -> 7394c15f.
+#
+# So: the backward-pin shape is real, it is a merge-order accident rather than
+# an authoring mistake, and it gets likelier as more agents run in parallel --
+# which is why it is a guard rather than a note in a rules file. It has no
+# real-world instance to point at yet. If one occurs, cite it here; do not
+# reintroduce one that did not.
+#
+# A SECOND, SEPARATE LIMIT, which is true and was raised in the same review:
+# BASE_SHA comes from github.event.pull_request.base.sha, which GitHub freezes
+# at the pull request's last event and does NOT advance when the base branch
+# does. So the verdict is point-in-time: it is measured against the base as of
+# the PR's most recent push or synchronise, not against main at the moment of
+# merge. A pin that was forward when the PR was last touched can be behind by
+# the time it merges, and this guard will not re-fire on its own -- only a new
+# event (a push, a rebase, a synchronise) refreshes the base. On #3181 both
+# readings happened to agree; that is not guaranteed in general.
 #
 # THE FOUR VERDICTS, AND WHY THERE ARE FOUR RATHER THAN THREE
 # -----------------------------------------------------------
@@ -86,16 +117,19 @@
 #   HEAD_SHA  - github.event.pull_request.head.sha
 #
 # Optional:
-#   SUBMODULE_PATH - defaults to tests/al-language
+#   SUBMODULE_PATH - defaults to tests/al-language. It must name a submodule the
+#                    endpoint commits' .gitmodules actually declares; one that
+#                    does not is refused with exit 3 rather than passed (#3299).
 #
 # Exit codes
-#   0  the pin is unchanged, or it moved strictly forward
+#   0  the pin is unchanged, or it moved strictly forward -- or the repository
+#      declares no submodule at all, which has nothing to un-pin
 #   1  the pin moved backward, or the two pins have diverged
 #   2  the check could not run: a missing input, or an endpoint that is not a
 #      commit SHA present in this checkout
-#   3  the answer cannot be determined from this checkout -- the corpus history
-#      needed to compare the two pins is not present. NOT a pass and NOT a
-#      backward-pin verdict.
+#   3  the answer cannot be determined -- the corpus history needed to compare
+#      the two pins is not present, or SUBMODULE_PATH names nothing this
+#      repository declares. NOT a pass and NOT a backward-pin verdict.
 
 set -uo pipefail
 
@@ -157,9 +191,62 @@ read_pin() {
 base_pin="$(read_pin "$BASE_SHA")" || base_pin=""
 head_pin="$(read_pin "$HEAD_SHA")" || head_pin=""
 
+# --- Neither endpoint carries the pin: two very different situations ---------
+#
+# #3299. Until this was written, both of them exited 0 with the same sentence,
+# which made the ONE path in this script that can pass without measuring
+# anything also the path a typo lands on. SUBMODULE_PATH's default is a string;
+# nothing tied it to what .gitmodules declares, so renaming the submodule -- or
+# mistyping the default -- would have given every pull request a green tick
+# forever, reporting the same "there is no corpus pin to compare" a genuinely
+# submodule-free repository gets.
+#
+# The two are told apart by asking what the ENDPOINT COMMITS declare, never the
+# working tree: .gitmodules on disk belongs to whatever is checked out, which is
+# refs/pull/N/merge under actions/checkout, and #3261's lesson applies to this
+# read exactly as it does to the pins themselves.
+#
+#   .gitmodules absent at BOTH endpoints -> 0. A repository that genuinely
+#     declares no submodule has nothing to un-pin, and turning that into a hard
+#     error would trade this defect for a different one. That constraint is why
+#     the fix is a discrimination rather than an unconditional assertion.
+#   .gitmodules present, declaring submodules, none of them SUBMODULE_PATH -> 3,
+#     naming what it DOES declare, so a typo is visible in the message rather
+#     than left for the reader to infer from an absence.
+#   .gitmodules present but unreadable -> 3. Not folded into the row above: an
+#     absent file is the legitimate pass and an unreadable one is a broken
+#     measurement, and collapsing them would put the broken case back on the
+#     exit-0 path this section exists to take it off.
+
+# Does commit $1 carry a .gitmodules at all? Asked separately from reading it,
+# because the two answers must not be conflated: "the file is not there" is the
+# submodule-free repository, and every OTHER reason `git config --blob` produces
+# nothing is a broken measurement. Collapsing them would put the broken case back
+# on the exit-0 path this whole section exists to take it off.
+has_gitmodules() {
+  git cat-file -e "$1:.gitmodules" 2>/dev/null
+}
+
+declared_paths() {
+  # Every path .gitmodules declares at commit $1, one per line.
+  git config --blob "$1:.gitmodules" --get-regexp '^submodule\..*\.path$' 2>/dev/null \
+    | awk '{ $1 = ""; sub(/^ /, ""); print }'
+}
+
 if [ -z "$base_pin" ] && [ -z "$head_pin" ]; then
-  echo "Neither $BASE_SHA nor $HEAD_SHA carries a $SUBMODULE_PATH submodule; there is no corpus pin to compare."
-  exit 0
+  if ! has_gitmodules "$BASE_SHA" && ! has_gitmodules "$HEAD_SHA"; then
+    echo "Neither $BASE_SHA nor $HEAD_SHA carries a .gitmodules, so this repository declares no submodule and there is no corpus pin to compare. Nothing is being un-pinned."
+    exit 0
+  fi
+
+  declared="$(printf '%s\n%s\n' "$(declared_paths "$BASE_SHA")" "$(declared_paths "$HEAD_SHA")" \
+    | awk 'NF' | sort -u)"
+
+  if [ -z "$declared" ]; then
+    die_undetermined "SUBMODULE_PATH='$SUBMODULE_PATH' carries no gitlink at either endpoint, and .gitmodules is present but declares no submodule path that this script could read. That is a broken measurement, not a verdict: a guard that passes here would be passing without having checked anything."
+  fi
+
+  die_undetermined "SUBMODULE_PATH='$SUBMODULE_PATH' is not a submodule this repository declares. .gitmodules at these endpoints declares: $(printf '%s' "$declared" | tr '\n' ' '). Neither endpoint carries a gitlink at '$SUBMODULE_PATH', so this guard measured NOTHING -- and a guard that passes when it measured nothing is the green-tick-meaning-nothing-was-read failure it exists to prevent. Fix SUBMODULE_PATH (or this script's default) to name a declared submodule path."
 fi
 
 # One side carrying no submodule is a structural change to the repository, not a

--- a/.github/scripts/check_count_baseline_history.sh
+++ b/.github/scripts/check_count_baseline_history.sh
@@ -84,10 +84,20 @@
 #   PR_BODY        - the pull request's body/description
 #   CHANGED_FILES  - the PR's changed paths, one per line
 #
+# Optional:
+#   PIN_PATH       - the submodule gitlink whose movement fires this guard.
+#                    Defaults to tests/al-language, and must name a submodule
+#                    .gitmodules declares; one that does not is refused with
+#                    exit 3 rather than silently never firing (#3681).
+#
 # Exit codes
 #   0  no pin bump, or the entry is present, or a well-formed opt-out
 #   1  the pin moved and neither an entry nor a usable opt-out is present
 #   2  the check could not run (a required input was not passed at all)
+#   3  the answer cannot be determined -- PIN_PATH names no submodule this
+#      repository declares, so no changed path could ever match it and every
+#      verdict below would be vacuous. NOT a pass and NOT a missing-entry
+#      verdict; the remedy is a constant in this file, not a history entry.
 
 set -uo pipefail
 
@@ -104,8 +114,62 @@ if [ -z "${PR_BODY+set}" ]; then
   exit 2
 fi
 
-PIN_PATH="tests/al-language"
+# PIN_PATH is overridable for the same reason SUBMODULE_PATH is in
+# check_corpus_pin_forward.sh: a constant nothing can vary is a constant nothing
+# can test, and this one decides whether the guard fires at all.
+PIN_PATH="${PIN_PATH:-tests/al-language}"
 HISTORY_PATH="tests/expectations/count-baseline/history.md"
+
+# --- PIN_PATH must name a submodule this repository declares (#3681) ----------
+#
+# The same defect as #3299, one file over, and it disarms this gate completely.
+# PIN_PATH is compared for exact equality against each changed path; if it names
+# nothing -- a renamed submodule, a typo -- no path can ever equal it, pin_moved
+# is never set, and this script prints "does not move the tests/al-language pin"
+# and exits 0 on every pull request, forever, with a green tick. Nothing says the
+# gate stopped firing.
+#
+# The check is made BEFORE the changed-file scan, not after, because a PIN_PATH
+# that names nothing has already made every verdict this script could reach
+# meaningless -- including the ones that look like passes. It gets exit 3, the
+# cannot-determine code check_corpus_pin_forward.sh and tools/ci-wait.py use, so
+# it is never confusable with the missing-entry failure (exit 1): those need
+# different remedies, and sending an author to write a history entry when the
+# real problem is a constant in this file wastes the one thing the message is
+# for.
+#
+# Two things this must NOT do, both learned from #3299:
+#
+#   * It must not hard-error a repository that genuinely declares no submodule.
+#     There, a corpus pin bump is not a thing that can occur, so no history entry
+#     can be owed and this guard has nothing to say -- pass.
+#   * It must not conflate "no .gitmodules" with "could not read .gitmodules".
+#     The first is that legitimate pass; the second is a broken measurement, and
+#     folding them puts the broken case back on the exit-0 path.
+#
+# The read is from the working tree's HEAD rather than from an event-payload
+# commit, and that is a deliberate narrowing rather than an oversight about
+# #3261. This job passes no BASE_SHA, and unlike a PIN it does not need one: the
+# question is only "does this repository declare a submodule at this path",
+# whose answer is the same at base, head and the merge ref in every case that is
+# not itself a submodule add or removal -- and a submodule add or removal is a
+# structural change a human reviews, which check_corpus_pin_forward.sh already
+# refuses to judge (exit 3) on its own endpoints.
+if git cat-file -e HEAD:.gitmodules 2>/dev/null; then
+  declared_pin_paths="$(git config --blob HEAD:.gitmodules \
+      --get-regexp '^submodule\..*\.path$' 2>/dev/null \
+    | awk '{ $1 = ""; sub(/^ /, ""); print }' | awk 'NF' | sort -u)"
+
+  if [ -z "$declared_pin_paths" ]; then
+    echo "::error::check_count_baseline_history.sh: .gitmodules is present but no submodule path could be read from it, so whether PIN_PATH='$PIN_PATH' names a real submodule cannot be established. That is a broken measurement, not a verdict -- a pass here would be a pass without having checked anything." >&2
+    exit 3
+  fi
+
+  if ! printf '%s\n' "$declared_pin_paths" | command grep -qxF "$PIN_PATH"; then
+    echo "::error::check_count_baseline_history.sh: PIN_PATH='$PIN_PATH' is not a submodule this repository declares. .gitmodules declares: $(printf '%s' "$declared_pin_paths" | tr '\n' ' '). No changed path can ever equal '$PIN_PATH', so this gate would report that no pin bump occurred on EVERY pull request -- a green tick with nothing behind it. Fix PIN_PATH (or this script's default) to name a declared submodule path." >&2
+    exit 3
+  fi
+fi
 
 # --- Did the pin move, and was an entry written? -----------------------------
 #

--- a/.github/scripts/test_check_corpus_pin_forward.sh
+++ b/.github/scripts/test_check_corpus_pin_forward.sh
@@ -89,7 +89,14 @@ trap 'rm -rf "$TMP"' EXIT
 #             D1            a divergent branch, no ancestry either way with C2
 #
 # C1 stands for the pin main carried when a PR branched; C2 for the pin main
-# carries now. The #3181 shape is head=C1, base=C2.
+# carries now. The backward shape is head=C1, base=C2.
+#
+# The commit subjects below name corpus #199 and #201 because those were the two
+# corpus PRs the original header wrongly claimed were about to be dropped by
+# PR #3181 (#3299 -- they were ancestors of #3181's base pin and were never at
+# risk). They are kept as fixture labels ONLY: the construction here is a
+# synthetic corpus with a synthetic backward pin, and nothing about it depends on
+# what those real corpus PRs contain. Do not read them as provenance.
 
 CORPUS="$TMP/corpus"
 git init -q -b master "$CORPUS"
@@ -165,7 +172,7 @@ pin_to() {
 }
 
 BASE_AT_C2=$(pin_to "$C2")     # main today: the newer pin
-HEAD_AT_C1=$(pin_to "$C1")     # a PR still carrying the older pin  -- the #3181 shape
+HEAD_AT_C1=$(pin_to "$C1")     # a PR still carrying the older pin -- the backward shape
 HEAD_AT_C2=$(pin_to "$C2")     # a PR that did not touch the pin
 HEAD_AT_D1=$(pin_to "$D1")     # a PR carrying a divergent corpus commit
 BASE_AT_C1=$(pin_to "$C1")     # main at the older pin, for the forward-bump case
@@ -184,10 +191,15 @@ assert_rc "a genuine forward bump passes" 0 \
   BASE_SHA="$BASE_AT_C1" HEAD_SHA="$HEAD_AT_C2"
 assert_output_has "a forward bump names the direction it verified" "ancestor"
 
-# The centre of the suite: #3181's real shape, reconstructed. The head pin is an
+# The centre of the suite: the backward shape, constructed. The head pin is an
 # ancestor of the base pin, so merging it would un-pin every corpus commit in
 # between -- suites already validated against a real service tier.
-assert_rc "a BACKWARD pin fails (#3181's shape: head pin is an ancestor of base pin)" 1 \
+#
+# This construction is sound and is the defect the guard exists to catch. It is
+# NOT a reconstruction of a pull request that happened: the suite used to call it
+# "#3181's real shape", and #3181 moved its pin forward (#3299). No real-world
+# instance of the backward shape has occurred yet.
+assert_rc "a BACKWARD pin fails (head pin is an ancestor of base pin)" 1 \
   BASE_SHA="$BASE_AT_C2" HEAD_SHA="$HEAD_AT_C1"
 assert_output_has "the backward failure is a GitHub error annotation" "::error::"
 # head=C1, base=C2, so the corpus commit that would be un-pinned is C2 -- the
@@ -342,6 +354,89 @@ git -C "$SUPER" checkout -q --detach "$BASE_AT_C2"
 assert_rc "a backward pin is still caught whatever is checked out" 1 \
   BASE_SHA="$BASE_AT_C2" HEAD_SHA="$HEAD_AT_C1"
 git -C "$SUPER" checkout -q main
+
+# --- SUBMODULE_PATH that names nothing (#3299) -------------------------------
+#
+# The gap this closes: the script's default is a hardcoded string, and until
+# #3299 nothing tied it to what .gitmodules declares. Rename the submodule, or
+# mistype the default, and read_pin returns empty at BOTH endpoints, the script
+# prints "there is no corpus pin to compare" and exits 0 -- forever, on every
+# pull request, with a green tick. That is the same green-run-that-measured-
+# nothing shape this script spends exit 3 refusing everywhere else, and it is
+# the one path where it produced it.
+#
+# The discrimination has to be made from the ENDPOINT COMMITS, not the working
+# tree, for the same #3261 reason every other read here does: .gitmodules on
+# disk belongs to whatever is checked out. A repository that genuinely declares
+# no submodules must stay a pass -- turning that into a hard error would trade
+# one defect for another.
+#
+#   .gitmodules declares SUBMODULE_PATH, no gitlink anywhere -> 3, and say so
+#   .gitmodules exists but declares something else            -> 3, name what it does declare
+#   no .gitmodules at either endpoint                         -> 0, genuinely submodule-free
+
+assert_rc "a SUBMODULE_PATH matching nothing is CANNOT-DETERMINE, not a silent pass" 3 \
+  SUBMODULE_PATH=tests/al-langauge BASE_SHA="$BASE_AT_C2" HEAD_SHA="$HEAD_AT_C1"
+assert_output_has "the mis-set path is named in the message" "tests/al-langauge"
+assert_output_has "the message names what .gitmodules DOES declare, so the typo is visible" \
+  "tests/al-language"
+
+# The same refusal must apply to a path that is not merely misspelled but absent
+# from the repository altogether -- e.g. a default left behind by a rename.
+assert_rc "a wholly unknown SUBMODULE_PATH is refused too" 3 \
+  SUBMODULE_PATH=vendor/some-other-corpus BASE_SHA="$BASE_AT_C2" HEAD_SHA="$HEAD_AT_C2"
+
+# ...and it must be annotated, not merely non-zero: a silent 3 in the CI log is
+# only half a fix.
+if [ "$LAST_OUTPUT" != "${LAST_OUTPUT/::error::/}" ]; then
+  ok "the mis-set-path refusal is annotated in the CI log"
+else
+  bad "the mis-set-path refusal produced no ::error:: annotation. Got: $LAST_OUTPUT"
+fi
+
+# The default must not be a string nobody checks. Asserted against THIS
+# repository's real .gitmodules, from the repository root rather than the
+# fixture, because that is the file the shipped default has to agree with.
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+default_path="$(command sed -n 's/^SUBMODULE_PATH="\${SUBMODULE_PATH:-\(.*\)}"$/\1/p' "$SCRIPT")"
+check_eq "the script has exactly one parseable SUBMODULE_PATH default" \
+  "1" "$(printf '%s\n' "$default_path" | command grep -c .)"
+if git -C "$REPO_ROOT" config --blob HEAD:.gitmodules --get-regexp '^submodule\..*\.path$' 2>/dev/null \
+     | awk '{print $2}' | command grep -qxF "$default_path"; then
+  ok "the shipped SUBMODULE_PATH default ('$default_path') is a path .gitmodules really declares"
+else
+  bad "the shipped SUBMODULE_PATH default ('$default_path') is not declared in this repository's .gitmodules -- the guard would pass every PR while measuring nothing"
+fi
+
+# --- A repository that genuinely has no submodule ----------------------------
+#
+# The constraint on the fix above: refusing an unknown path must not turn a
+# checkout with no submodules at all into a hard error. There is nothing to
+# compare there and nothing being un-pinned, so 0 is the honest answer -- and
+# the message must not imply a measurement was made.
+
+NOSUB="$TMP/no-submodule"
+git init -q -b main "$NOSUB"
+git -C "$NOSUB" config user.email test@example.com
+git -C "$NOSUB" config user.name Test
+echo "a repository with no submodules" > "$NOSUB/README.md"
+git -C "$NOSUB" add -A && git -C "$NOSUB" commit -qm "root"
+NOSUB_A=$(git -C "$NOSUB" rev-parse HEAD)
+echo "another commit" >> "$NOSUB/README.md"
+git -C "$NOSUB" commit -qam "second"
+NOSUB_B=$(git -C "$NOSUB" rev-parse HEAD)
+
+if [ -e "$NOSUB/.gitmodules" ]; then
+  bad "fixture setup: the no-submodule repository unexpectedly has a .gitmodules"
+else
+  ok "the no-submodule fixture genuinely declares no submodules"
+fi
+
+SUPER="$NOSUB"
+assert_rc "a repository that genuinely declares no submodule still passes" 0 \
+  BASE_SHA="$NOSUB_A" HEAD_SHA="$NOSUB_B"
+assert_output_has "the submodule-free pass says there is nothing to compare" "no corpus pin"
+SUPER="$SUPER_REAL"
 
 # --- Prove, not pass: both stub directions must be caught --------------------
 #

--- a/.github/scripts/test_check_count_baseline_history.sh
+++ b/.github/scripts/test_check_count_baseline_history.sh
@@ -34,9 +34,15 @@ pass=0
 fail=0
 
 assert_exit() {
-  local desc="$1" expected_rc="$2" files="$3" body="${4-}"
+  local desc="$1" expected_rc="$2" files="$3" body="${4-}" extra_env="${5-}"
   local rc
-  CHANGED_FILES="$files" PR_BODY="$body" "$SCRIPT" >/dev/null 2>&1
+  # $5 carries an optional VAR=value for the cases that vary PIN_PATH. Passed
+  # through `env` rather than exported, so one case cannot leak into the next.
+  if [ -n "$extra_env" ]; then
+    CHANGED_FILES="$files" PR_BODY="$body" env "$extra_env" "$SCRIPT" >/dev/null 2>&1
+  else
+    CHANGED_FILES="$files" PR_BODY="$body" "$SCRIPT" >/dev/null 2>&1
+  fi
   rc=$?
   if [ "$rc" = "$expected_rc" ]; then
     echo "ok   - $desc"
@@ -253,6 +259,108 @@ fi
 # must fire rather than error -- the omission is still an omission.
 assert_exit "an empty body on a pin bump still fires" 1 \
   "$(printf '%s\n%s\n' "$PIN" "$BASELINE")" ""
+
+# --- PIN_PATH must name a submodule .gitmodules declares (#3681) --------------
+#
+# The same defect as #3299, one file over. PIN_PATH was a hardcoded constant with
+# nothing tying it to what .gitmodules declares. Rename the submodule -- or
+# mistype the constant -- and no changed path ever equals it, pin_moved is never
+# set, the script prints "does not move the tests/al-language pin" and exits 0 on
+# every pull request, forever, with a green tick. The gate stops firing and
+# nothing says so.
+#
+# The section below already asserted that the PATH exists in the tree. That is a
+# weaker claim and it does not close this: it checks the path is there, not that
+# PIN_PATH IS that path, and not that a mismatch is refused AT RUNTIME. With the
+# constant typo'd, that assertion still passes -- it looks up "tests/al-language"
+# from its own $PIN variable, which the script never reads -- while a real pin
+# bump with no history entry sails through at exit 0. Measured before this was
+# written.
+#
+# PIN_PATH is therefore overridable, for the same reason SUBMODULE_PATH is in
+# check_corpus_pin_forward.sh: a constant nothing can vary is a constant nothing
+# can test.
+
+assert_exit "a PIN_PATH matching no declared submodule is refused, not passed" 3 \
+  "$(printf '%s\n%s\n' "$PIN" "$BASELINE")" "" "PIN_PATH=tests/al-langauge"
+
+# It must be the REFUSAL that fires, not the ordinary missing-entry failure --
+# those need different remedies (fix the constant vs. write a history entry), and
+# reporting one as the other sends the author to the wrong file.
+out=$(CHANGED_FILES="$(printf '%s\n%s\n' "$PIN" "$BASELINE")" PR_BODY="" \
+      PIN_PATH=tests/al-langauge "$SCRIPT" 2>&1)
+if printf '%s' "$out" | command grep -qF 'tests/al-langauge' \
+   && printf '%s' "$out" | command grep -qF 'tests/al-language' \
+   && printf '%s' "$out" | command grep -qF '::error::'; then
+  echo "ok   - the refusal is annotated and names both the mis-set path and what .gitmodules declares"
+  pass=$((pass + 1))
+else
+  echo "FAIL - the mis-set-PIN_PATH refusal should be an ::error:: naming both paths. Got: $out"
+  fail=$((fail + 1))
+fi
+
+# The refusal must not depend on the diff looking like a bump: a PIN_PATH that
+# names nothing has already made every verdict from this script meaningless, so
+# it is refused before the changed-file scan reaches a conclusion either way.
+assert_exit "a mis-set PIN_PATH is refused even on a diff that would otherwise pass" 3 \
+  "README.md" "" "PIN_PATH=vendor/some-other-corpus"
+
+# The shipped default is the thing that actually ships, so assert it directly
+# against .gitmodules rather than only against a path existing on disk.
+REPO_ROOT_EARLY="$(cd "$SCRIPT_DIR/../.." && pwd)"
+default_pin="$(command sed -n 's/^PIN_PATH="\${PIN_PATH:-\(.*\)}"$/\1/p' "$SCRIPT")"
+if [ "$(printf '%s\n' "$default_pin" | command grep -c .)" = "1" ]; then
+  echo "ok   - the script has exactly one parseable PIN_PATH default"
+  pass=$((pass + 1))
+else
+  echo "FAIL - PIN_PATH's default is not parseable as a single overridable value; got '$default_pin'"
+  fail=$((fail + 1))
+fi
+if git -C "$REPO_ROOT_EARLY" config --blob HEAD:.gitmodules \
+     --get-regexp '^submodule\..*\.path$' 2>/dev/null \
+     | awk '{print $2}' | command grep -qxF "$default_pin"; then
+  echo "ok   - the shipped PIN_PATH default ('$default_pin') is a path .gitmodules really declares"
+  pass=$((pass + 1))
+else
+  echo "FAIL - the shipped PIN_PATH default ('$default_pin') is not declared in .gitmodules -- the gate would pass every PR while measuring nothing"
+  fail=$((fail + 1))
+fi
+
+# --- ...and a repository with no submodule at all must still work -------------
+#
+# The constraint #3299 sets, applied identically here: refusing an undeclared
+# PIN_PATH must not turn a checkout that genuinely declares no submodule into a
+# hard error. There the answer was a pass, because there was nothing to un-pin.
+# Here it is a pass for a different and stronger reason: with no submodule, a
+# corpus pin bump is not a thing that can occur, so no history entry can be owed
+# and the guard has nothing to say. Run from a real submodule-free repository so
+# the claim is measured rather than asserted about a code path.
+
+NOSUB="$(mktemp -d)"
+trap 'rm -rf "$NOSUB"' EXIT
+git init -q -b main "$NOSUB"
+git -C "$NOSUB" config user.email test@example.com
+git -C "$NOSUB" config user.name Test
+echo "a repository with no submodules" > "$NOSUB/README.md"
+git -C "$NOSUB" add -A && git -C "$NOSUB" commit -qm root
+
+if [ -e "$NOSUB/.gitmodules" ]; then
+  echo "FAIL - fixture setup: the no-submodule repository unexpectedly has a .gitmodules"
+  fail=$((fail + 1))
+else
+  echo "ok   - the no-submodule fixture genuinely declares no submodules"
+  pass=$((pass + 1))
+fi
+
+rc=0
+(cd "$NOSUB" && CHANGED_FILES="README.md" PR_BODY="" bash "$SCRIPT" >/dev/null 2>&1) || rc=$?
+if [ "$rc" = "0" ]; then
+  echo "ok   - a repository that declares no submodule is a pass, not a hard error"
+  pass=$((pass + 1))
+else
+  echo "FAIL - a submodule-free repository should pass, got exit $rc -- the fix traded one defect for another"
+  fail=$((fail + 1))
+fi
 
 # --- The paths this guard names must exist -----------------------------------
 #

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -308,6 +308,16 @@ jobs:
     # reason. The changed-file list comes from the local checkout via git, not
     # from api.github.com.
     #
+    # PIN_PATH, the gitlink whose movement fires this, is checked against
+    # .gitmodules before anything else (#3681). It used to be a bare constant
+    # nothing verified, so a submodule rename or a typo would have made no
+    # changed path ever match it -- the gate reporting "no pin bump" on every
+    # pull request, green, forever, with nothing saying it had stopped firing.
+    # An undeclared PIN_PATH is now exit 3, distinct from the missing-entry
+    # failure because the remedy is a constant in the script rather than a
+    # history entry. A repository declaring no submodule at all stays a pass:
+    # there, a pin bump cannot occur, so no entry can be owed.
+    #
     # Scoping, and why it is the PIN and not the count: see the header of
     # check_count_baseline_history.sh. Short version, measured on main at
     # e03dbfc1 -- of the last 12 commits touching test-count-baseline.json, 10

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -219,11 +219,23 @@ jobs:
     # they stop existing, and the next green run reports success over a smaller
     # set.
     #
-    # Caught for real on PR #3181, green and CLEAN while about to drop corpus
-    # #199 and #201. That PR did nothing wrong: it bumped the pin forward from
-    # the main that existed when it was written, and main's pin advanced
-    # afterwards. It is a merge-order accident, which is why it needs a guard
-    # rather than a rule -- and it gets likelier as more agents run in parallel.
+    # This comment used to claim the shape was "caught for real on PR #3181,
+    # green and CLEAN while about to drop corpus #199 and #201". It is corrected
+    # rather than deleted (#3299): #3181's base pin was b0c6248a at both its
+    # frozen event-payload base and the main it merged onto, its head pin
+    # 7394c15f is three corpus commits FORWARD of that, and corpus #199 and #201
+    # are ancestors of b0c6248a -- pinned at base, still pinned at head. The
+    # guard exits 0 on #3181 at every revision it ever had. The backward-pin
+    # shape is real and is a merge-order accident rather than an authoring
+    # mistake, which is why it needs a guard rather than a rule and why it gets
+    # likelier as more agents run in parallel; it simply has no real-world
+    # instance yet. check_corpus_pin_forward.sh's header has the measurements.
+    #
+    # One real limit, from the same review: BASE_SHA below is
+    # github.event.pull_request.base.sha, which GitHub freezes at the PR's last
+    # event and does not advance with the base branch. The verdict is therefore
+    # point-in-time -- a pin forward when the PR was last pushed can be behind by
+    # the time it merges, and only a new event re-measures it.
     #
     # It gates, so by the rule of thumb at the top of this file it must not be
     # able to fail for an environmental reason. Two things make that true, and


### PR DESCRIPTION
Closes #3299
Closes #3681

**One defect in two places.** Two `pr-gate.yml` gate scripts each decided which submodule to look at from a hardcoded string that nothing tied to `.gitmodules`. In both, a submodule rename or a typo in the constant makes the guard pass every pull request forever with a green tick, having measured nothing — the exact shape both scripts exist to refuse. The second instance is a copy of the first, written by someone who could not see the first was wrong.

Also corrects a false provenance claim that #3299 raised, carried in three places (#3299 only — this does not bleed into #3681's scope).

Corpus-NA: CI plumbing only. This changes two shell guards' exit codes and some comment blocks; it asserts nothing about Business Central and no service tier can adjudicate it. (The gate does not fire on this diff — no non-`.md` `AlRunner/` path — declared anyway so the reasoning is on the record.)

## The mechanism, once

Both scripts now ask what the repository **declares** before trusting their constant, with the same three-way discrimination:

| | verdict |
|---|---|
| `.gitmodules` absent — the repository genuinely declares no submodule | **0**, unchanged |
| `.gitmodules` present, declaring submodules, none of them the configured path | **3**, naming what it *does* declare |
| `.gitmodules` present but unreadable | **3**, deliberately not folded into row 1 |

Row 1 is the constraint both issues set: refusing an undeclared path must not turn a legitimately submodule-free checkout into a hard error. That is why the fix is a discrimination rather than an unconditional assertion, and it is asserted in both suites against a **real submodule-free git repository** rather than argued about a code path.

Row 3 exists because collapsing "the file is not there" with "reading it failed" would put the broken measurement straight back on the exit-0 path this change exists to take it off.

Exit 3 in both, matching `check_corpus_pin_forward.sh`'s existing cannot-determine code and `tools/ci-wait.py`'s. It must not be exit 1: the remedy is a constant in the script, not the thing exit 1 tells the author to go fix.

---

## #3299 — `check_corpus_pin_forward.sh`

`SUBMODULE_PATH` defaulted to a hardcoded `tests/al-language`. When neither endpoint carried a gitlink there, the script printed `there is no corpus pin to compare` and **exited 0** — the one path in a script that spends a whole exit code refusing exactly this.

The read is from the **endpoint commits**, never the working tree: `.gitmodules` on disk belongs to whatever is checked out, which under `actions/checkout` is `refs/pull/N/merge`, so #3261's lesson applies to this read as much as to the pins themselves.

**RED** — new suite against `origin/main`'s script, in an isolated arena so the worktree was never disturbed:

```
FAIL - a SUBMODULE_PATH matching nothing is CANNOT-DETERMINE, not a silent pass: expected '3', got '0'
FAIL - the message names what .gitmodules DOES declare, so the typo is visible
FAIL - a wholly unknown SUBMODULE_PATH is refused too: expected '3', got '0'
FAIL - the mis-set-path refusal produced no ::error:: annotation
passed: 41, failed: 4        suite exit 1
```

**GREEN** — same suite, this branch: `passed: 45, failed: 0`, exit 0.

Live, same endpoints, one character different:

```
# origin/main
SUBMODULE_PATH=tests/al-langauge -> "there is no corpus pin to compare."          EXIT=0
# this branch
SUBMODULE_PATH=tests/al-langauge -> ::error:: ... .gitmodules at these endpoints
    declares: tests/al-language ... this guard measured NOTHING                   EXIT=3
```

## #3681 — `check_count_baseline_history.sh`

`PIN_PATH="tests/al-language"` was compared for exact equality against each changed path. Mistype it and `pin_moved` is never set: the script prints `does not move the tests/al-language pin` and exits 0. **On a real #3588-shaped diff** — pin plus baseline, no history entry, the exact omission this gate was built for:

```
# origin/main's script, constant typo'd
This PR does not move the tests/al-language pin, so no history.md entry is required.   EXIT=0
# this branch
::error:: PIN_PATH='tests/al-langauge' is not a submodule this repository declares.
    .gitmodules declares: tests/al-language. No changed path can ever equal
    'tests/al-langauge', so this gate would report that no pin bump occurred on
    EVERY pull request -- a green tick with nothing behind it.                        EXIT=3
```

**The suite's existing check does not close this**, which is worth stating because it looks like it might. It asserts `$PIN` *exists in the tree*. That is a weaker claim: it checks the path is there, not that `PIN_PATH` **is** that path, and not that a mismatch is refused **at runtime**. With the constant typo'd it still passes — it looks up its own `$PIN` variable, which the script never reads — while the disarm above sails through at exit 0.

`PIN_PATH` is now overridable, for the reason `SUBMODULE_PATH` already is: a constant nothing can vary is a constant nothing can test.

The check runs **before** the changed-file scan, because a `PIN_PATH` naming nothing has already made every verdict below it vacuous — including the ones that look like passes. Asserted: a mis-set `PIN_PATH` is refused even on a diff that would otherwise have passed.

**RED** — new suite against `origin/main`'s script:

```
FAIL - a PIN_PATH matching no declared submodule is refused, not passed: expected exit 3, got 1
FAIL - the mis-set-PIN_PATH refusal should be an ::error:: naming both paths
FAIL - a mis-set PIN_PATH is refused even on a diff that would otherwise pass: expected exit 3, got 0
FAIL - PIN_PATH's default is not parseable as a single overridable value; got ''
FAIL - the shipped PIN_PATH default ('') is not declared in .gitmodules
passed: 47, failed: 5        suite exit 1
```

**GREEN** — same suite, this branch: `passed: 52, failed: 0`, exit 0.

**This gate is live and protecting the repository**, so I verified it is unharmed rather than only that the new cases pass: it still fires on #3588's real shape (exit 1), still passes with a history entry, and still passes with a well-formed `Count-Baseline-History-NA` opt-out.

## The default assertions have teeth

Both suites assert their shipped default is a path `.gitmodules` really declares. That passes today by construction, so I proved each one fails when it should — a fixture whose `.gitmodules` declares `tests/corpus-renamed` instead:

```
FAIL - the shipped SUBMODULE_PATH default ('tests/al-language') is not declared in this repository's .gitmodules
FAIL - the shipped PIN_PATH default ('tests/al-language') is not declared in .gitmodules
```

That is the rename scenario both issues described, caught at the point the rename lands rather than silently never again.

## Shared helper: duplicated, deliberately

**No helper was extracted.** Two reasons, and this was a real decision rather than a tidy-up skipped:

1. **No script in `.github/scripts/` sources another.** Every gate script is self-contained; sharing here is done by *invoking a subprocess* (`pr_changed_files.sh`, used by two jobs). Extracting a sourced helper would introduce the first `source` dependency between gate scripts, and each of these scripts is required to be able to run standalone from its own suite.
2. **The two read `.gitmodules` from different sources**, which is the part a helper would have to be parameterised over — exactly the difference that matters. `check_corpus_pin_forward.sh` reads from the two **event-payload endpoint commits**, because it also reads the pins from there and #3261 forbids reading either from `HEAD`. `check_count_baseline_history.sh` reads from **`HEAD`**, because its job passes no `BASE_SHA`.

That second point is a deliberate narrowing, not an oversight about #3261, and I've said so at the call site: the question there is only *does this repository declare a submodule at this path*, whose answer is identical at base, head and the merge ref in every case that is not itself a submodule add or removal — and a submodule add or removal is a structural change a human reviews, which `check_corpus_pin_forward.sh` already refuses to judge (exit 3) on its own endpoints.

If a third instance appears, that is the point to extract one, with three call sites to shape it against.

## The fold, and why it is still one coherent change

The coordinator asked me to judge whether folding breaks the rule's actual limit. **It does not.** The diff is 5 files, and the two script changes are the *same mechanism* applied twice with one documented difference. A reviewer checks one three-way discrimination and then confirms it appears twice, rather than reading two near-identical PRs a week apart and writing the same review notes on both.

**Reasoning on the record**, since this is a departure from the same-file default: `batch-sibling-issues-by-file.md` normally would **not** fold two `.github/scripts/*.sh` sharing one `pr-gate.yml` — #3591/#3666 declined to fold #3299 for exactly that reason and I agree with that call, since this PR touches `pr-gate.yml` only for comments. What makes this different is that it is not two adjacent issues; it is one defect in two places, where splitting would mean writing and reviewing the same `.gitmodules` check twice.

## #3299's second finding — the #3181 provenance claim is wrong

The script header, the `pr-gate.yml` job comment and the test fixtures all said the shape was *"caught for real on PR #3181, green and CLEAN while about to drop corpus #199 and #201."*

**I verified this against the live repository rather than taking the issue's word for it.** It does not hold:

- **#3181's base pin is `b0c6248a` on both readings of "base"** — its frozen event-payload base `c0fda77e`, and the `main` it actually merged onto, `9fe2b1d2` (merge commit `d6e61b89`'s first parent). Read with `git ls-tree <sha> tests/al-language`.
- **Its head pin `7394c15f` is strictly forward**, three corpus commits ahead; `git merge-base --is-ancestor b0c6248a 7394c15f` returns 0 in a non-shallow corpus clone.
- **At #3181's first commit `6cbdfff5` the pin was `b0c6248a`** — identical to base, the untouched case.
- **Running the guard itself** against all four (base, head) pairings gives exit 0 every time: two `unchanged`, two `moves forward ... 3 corpus commit(s) ahead`. It was never going to fire on #3181.
- **Corpus #199 (`b0c6248a`) and #201 (`ae64da1b`) are both ancestors of `b0c6248a`** — already pinned at #3181's base, still pinned at its head. Nothing was about to be dropped.
- `main`'s pin has only ever moved forward.

All three sites now say what the guard has and has not demonstrated: the backward-pin shape is real, it is a merge-order accident rather than an authoring mistake — which is why it is a guard and not a note in a rules file, and why it gets likelier as more agents run in parallel — and **it has no real-world instance to point at yet**. The header adds: if one occurs, cite it; do not reintroduce one that did not.

**Corrected rather than deleted, deliberately.** A guard justified by a catch that did not happen is worse than one justified by nothing, because the next reader trusts it more — so the correction stays visible where the false claim was.

**The test fixtures keep their construction unchanged.** Only the attribution moved: `"#3181's real shape, reconstructed"` becomes `"the backward shape, constructed"`, with a note that the `#199`/`#201` commit subjects survive as fixture labels only, from the claim that named them, with nothing in the construction depending on what those corpus PRs contain.

**Kept, because it is true and separate:** `BASE_SHA` is `github.event.pull_request.base.sha`, which GitHub freezes at the PR's last event and does not advance with the base branch. The verdict is point-in-time — a pin that was forward when the PR was last pushed can be behind by the time it merges, and only a new event re-measures it. Documented in both the script header and the workflow comment. On #3181 both readings happened to agree; that is not guaranteed in general.

## Not done, and stated

- **Neither job is added to `PENDING_REQUIRED_CONTEXTS`, and the ruleset is untouched.** For what it is worth the case for gating is stronger than it was — before this, both jobs could report green while measuring nothing, which is a poor property for a required check — but that is a human's call (#3002), not mine.
- **#3363** names #3299 as one of four instances of "a guard's could-not-determine spelled as its success state", and is discharged by a **rule file** rather than by either script. Not folded, for its own stated reason. #3681 is arguably a fifth instance and strengthens that issue's case; I did not edit it.
- `require-tests` does not fire (no `AlRunner/` paths). The corpus-linkage and count-baseline-history gates were both run locally against this diff and both pass.

## Ran locally

Every `.github/scripts/test_*.sh` (9 suites) and `test_*.py` (6 suites) — all pass. That is what `pr-gate.yml`'s glob-discovered job runs, so both new suites gate the day this lands with no workflow edit.

- `test_check_corpus_pin_forward.sh` — 45/45 here; 41/45 with 4 failures against `origin/main`'s script
- `test_check_count_baseline_history.sh` — 52/52 here; 47/52 with 5 failures against `origin/main`'s script
- `check_pr_check_triggers.sh`, `check_corpus_linkage.sh`, `check_count_baseline_history.sh` against this diff — all pass
- `bash -n` on all four shell files; `yaml.safe_load` on `pr-gate.yml`

I did not run `dotnet test AlRunner.Tests` — no C# changed and nothing in this diff is reachable from it.

## What I could not prove

The **row-3 branch** in each script — `.gitmodules` present but yielding no readable submodule path — is reasoned, not measured. I could not construct a `.gitmodules` that `git cat-file -e` finds and `git config --blob` then reads as declaring zero paths without hand-writing a corrupt blob, which would test git's parser rather than this code. It is there because folding it into row 1 would put a broken measurement back on the exit-0 path, and its cost if unreachable is one dead branch; I would rather state that than quietly let the two collapse.

---

*Opened by automated implementation agent `stma-auto-2` on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
