### PR TITLE
fix(page-control-field): refuse a failed Editable lookup instead of answering 'editable'

### DIFF
--- a/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
+++ b/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
@@ -231,8 +231,13 @@ public sealed class BcInternalsNullForgivingGuardTests
         // indistinguishable from a dataitem that genuinely declares no filter (#3656);
         // 81 -> 82 for GetStaticColumnFilters' ColumnFilters lookup in
         // RecordPatches.QueryProjection.cs, the sibling of those five and the same silent
-        // `yield break` (#3660).
-        Assert.Equal(82, converted);
+        // `yield break` (#3660); 82 -> 87 for the five reads in ReadMetaFieldEditable in
+        // RecordPatches.PageControlFieldFromBcDocument.cs, whose failure used to answer
+        // `true` — a load-bearing "this field is editable" rather than a neutral sentinel,
+        // so a non-editable field was reported editable (#3669). Three exits in that same
+        // method deliberately stay silent, because a null there is BC's own answer; the
+        // per-read split is in docs/page-control-field-from-bc-document.md#a-failed-lookup-refuses.
+        Assert.Equal(87, converted);
     }
 
     /// <summary>

--- a/AlRunner.Tests/PageControlFieldEditableShapeGapTests.cs
+++ b/AlRunner.Tests/PageControlFieldEditableShapeGapTests.cs
@@ -1,0 +1,415 @@
+// PageControlFieldEditableShapeGapTests — issue #3669.
+//
+// WHAT IS BEING PROVED
+//   GetMetaFieldEditable answers the bound field's Editable for the "Page Control Field"
+//   (2000000192) virtual table. It reaches BC's own Types.Metadata.MetaField through five
+//   chained `?.` reflection lookups, and every failure path answered `true`.
+//
+//   `true` there is not a neutral sentinel. It is a real, load-bearing answer about a field:
+//   SolveDocumentControlEditable's rule 2 renders it as the AL-visible "True", so a field BC
+//   reports NON-editable would be reported editable, silently, on the BC version where any of
+//   metadataAppGroupMetaTable / Item / Fields / Id / Editable moves. That is worse than an
+//   empty list — it is a plausible wrong value, the shape .claude/rules/loud-failures.md
+//   forbids and BcShapeGapException.cs's own line puts on the refusing side.
+//
+//   LATENT, not live: every BC version this repository tests resolves all five members.
+//   These arms are about the version where one of them moves.
+//
+// WHICH READS REFUSE, AND WHY THAT IS NOT A MECHANICAL ANSWER
+//   The judgement is per read, and getting it wrong in the other direction would break an
+//   ordinary page on EVERY BC version rather than only a future one. What decides it is
+//   whether a null can be BC's own answer, and for three of the five that was settled by
+//   measuring the member's TYPE off Microsoft.Dynamics.Nav.Types.dll (28.1.49838.54308):
+//
+//     MetaTable.Fields   ImmutableArray<MetaField> — a STRUCT. GetValue boxes it; it is
+//                        never null. A null/non-enumerable read can therefore only be a
+//                        failed lookup.                                        REFUSES
+//     MetaField.Id       System.Int32  — never null.                           REFUSES
+//     MetaField.Editable System.Boolean — never null.                          REFUSES
+//
+//   The two field/property LOOKUPS refuse for the ordinary reason: the member is absent.
+//
+//     metadataAppGroupMetaTable   field lookup                                 REFUSES
+//     MetadataExtension`1.Item    property lookup                              REFUSES
+//
+//   Their VALUES do not, and that is the half a mechanical conversion gets wrong. Both are
+//   reference-typed, and BC's own GetMetaTableOriginal() is literally
+//   `return metadataAppGroupMetaTable?.Item;` (Ncl 28.1) — BC treats a null there as an
+//   ANSWER and its callers take name-based fallbacks. The runner's own
+//   AssignMetaTableOriginal is best-effort by design and documents that BC "keeps its
+//   existing fallbacks rather than the table failing to build". Refusing on those values
+//   would turn every table whose original MetaTable was never assigned into an error.
+//
+// THE NEGATIVE CONTROLS ARE THE POINT, NOT DECORATION
+//   "A failed lookup refuses" is satisfiable by a change that refuses on everything. Three
+//   exits must stay silent — an unassigned metadataAppGroupMetaTable, an Item reading null,
+//   and the foreach completing without finding the field number (a table that genuinely has
+//   no such field, which is BC's `field?.Editable ?? true`). Each has an arm here.
+//
+// WHY RUNNER-LOCAL AND NOT THE CORPUS
+//   No AL statement can rename a private BC field, so a service tier has nothing to
+//   adjudicate — the subject is the runner's own refusal contract. What BC ANSWERS for
+//   Editable is already pinned upstream by corpus codeunit 60424 (PR #310, merged).
+//   Same reasoning as BcShapeGapConventionTests and QueryDataItemFilterShapeGapTests.
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PageControlFieldEditableShapeGapTests
+{
+    private const string Surface = "Page Control Field (system table 2000000192)";
+
+    // ══ 1. THE FIVE LOOKUPS THAT MUST REFUSE ═════════════════════════════════════════════
+    //
+    // Each arm removes exactly ONE member and leaves the others in place, so an
+    // implementation that threw unconditionally would still have to name the right member to
+    // pass — and section 2's controls would fail it outright.
+
+    [Fact]
+    public void MetadataAppGroupMetaTableLookup_RaisesAShapeGapNamingTheMember_WhenBcRenamesIt()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Editable(new MetaTableWithoutTheAppGroupField(), fieldNo: 1));
+
+        Assert.EndsWith(".metadataAppGroupMetaTable", ex.Member, StringComparison.Ordinal);
+        Assert.Contains(nameof(MetaTableWithoutTheAppGroupField), ex.Member, StringComparison.Ordinal);
+        Assert.StartsWith("bc-shape-gap: ", ex.Message, StringComparison.Ordinal);
+        Assert.Equal(Surface, ex.Surface);
+        Assert.EndsWith(" — see docs/limitations.md#bc-shape-gaps", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ItemLookup_RaisesAShapeGapNamingTheMember_WhenBcRenamesIt()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Editable(new FakeNclMetaTable(new ExtensionWithoutItem()), fieldNo: 1));
+
+        Assert.EndsWith(".Item", ex.Member, StringComparison.Ordinal);
+        Assert.Contains(nameof(ExtensionWithoutItem), ex.Member, StringComparison.Ordinal);
+        Assert.StartsWith("bc-shape-gap: ", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FieldsLookup_RaisesAShapeGapNamingTheMember_WhenBcRenamesIt()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Editable(
+                new FakeNclMetaTable(new FakeExtension(new MetaTableWithoutFields())),
+                fieldNo: 1));
+
+        Assert.EndsWith(".Fields", ex.Member, StringComparison.Ordinal);
+        Assert.Contains(nameof(MetaTableWithoutFields), ex.Member, StringComparison.Ordinal);
+        Assert.StartsWith("bc-shape-gap: ", ex.Message, StringComparison.Ordinal);
+        // Condition 2 of #3669. The LOOKUP failing is a different fact from the member being
+        // there and holding something unusable (the arm below). Asserting only "it throws"
+        // passes when the OTHER branch throws, so each arm asserts its own distinguishing
+        // substring PRESENT and the other one ABSENT.
+        Assert.Contains("property not found", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("cannot be enumerated", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FieldsHoldingSomethingUnusable_RaisesASeparatelyWordedShapeGap_NotTheLookupOne()
+    {
+        // Present, and holding a shape the runner cannot walk. BcShapeGapException.cs's own
+        // line puts this on the same refusing side as an absent member; folding the two into
+        // one branch is how #2786's silent skip happened.
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Editable(
+                new FakeNclMetaTable(new FakeExtension(new MetaTableWhoseFieldsIsAnInt())),
+                fieldNo: 1));
+
+        Assert.EndsWith(".Fields", ex.Member, StringComparison.Ordinal);
+        Assert.Contains("Int32", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("cannot be enumerated", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("property not found", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void IdLookup_RaisesAShapeGapNamingTheMember_WhenBcRenamesIt()
+    {
+        // MetaField.Id is System.Int32 on BC, so GetValue can never answer null — an
+        // unreadable Id is a moved member and nothing else.
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Editable(FakeTableWith(new FieldWithoutId()), fieldNo: 1));
+
+        // The MEMBER half, not merely the string "Id" somewhere in Member: the declaring
+        // type's own name contains "Id" for these fakes, so `Contains("Id")` alone is
+        // satisfied by a refusal naming `.Editable` on a type called FieldWhoseIdIsAString.
+        // Measured — a sabotage swapping the Id refusal's member for Editable passed the
+        // weaker assertion. This is condition 2 of #3669 at its sharpest.
+        Assert.EndsWith(".Id", ex.Member, StringComparison.Ordinal);
+        Assert.Contains(nameof(FieldWithoutId), ex.Member, StringComparison.Ordinal);
+        Assert.StartsWith("bc-shape-gap: ", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(".Editable", ex.Member, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void IdHoldingANonInteger_RaisesAShapeGapNamingWhatItActuallyHeld()
+    {
+        // The member kept its name and changed its type. Answering `true` here is the
+        // original defect in its most deceptive form: every field silently misses the
+        // fieldNo test and the method falls out of the loop reporting editable.
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Editable(FakeTableWith(new FieldWhoseIdIsAString()), fieldNo: 1));
+
+        Assert.EndsWith(".Id", ex.Member, StringComparison.Ordinal);
+        Assert.DoesNotContain(".Editable", ex.Member, StringComparison.Ordinal);
+        Assert.Contains("String", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EditableLookup_RaisesAShapeGapNamingTheMember_WhenBcRenamesIt()
+    {
+        // The member #3669 is named for: MetaField.Editable is System.Boolean on BC, so a
+        // null read is a moved member. Answering `true` reports a non-editable field as
+        // editable — the wrong value this whole file exists to stop.
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Editable(FakeTableWith(new FieldWithoutEditable(1)), fieldNo: 1));
+
+        Assert.EndsWith(".Editable", ex.Member, StringComparison.Ordinal);
+        Assert.Contains(nameof(FieldWithoutEditable), ex.Member, StringComparison.Ordinal);
+        Assert.StartsWith("bc-shape-gap: ", ex.Message, StringComparison.Ordinal);
+        // The Id read on the same object SUCCEEDED, so this must not be reported as the Id
+        // gap — the other half of condition 2 for this pair.
+        Assert.DoesNotContain(".Id", ex.Member, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EditableHoldingANonBoolean_RaisesAShapeGapNamingWhatItActuallyHeld()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Editable(FakeTableWith(new FieldWhoseEditableIsAString(1)), fieldNo: 1));
+
+        Assert.EndsWith(".Editable", ex.Member, StringComparison.Ordinal);
+        Assert.DoesNotContain(".Id", ex.Member, StringComparison.Ordinal);
+        Assert.Contains("String", ex.Message, StringComparison.Ordinal);
+    }
+
+    // ══ 2. NEGATIVE CONTROLS — the exits that must STAY silent ═══════════════════════════
+    //
+    // Over-converting is worse than the defect: it breaks an ordinary page on every BC
+    // version instead of only a future one. Each of these is a genuine answer, not a failed
+    // read, and each would fail an implementation that refused on every null.
+
+    [Fact]
+    public void AFieldTheTableDoesNotCarry_AnswersTrue_WithoutThrowing()
+    {
+        // Condition 3 of #3669. The foreach completing without matching is BC's own
+        // `field?.Editable ?? true` — a real "this table has no such field", not a failed
+        // read. The five reads all SUCCEEDED here.
+        Assert.True(Editable(FakeTableWith(new FakeMetaField(1, editable: false)), fieldNo: 99));
+    }
+
+    [Fact]
+    public void AnUnassignedMetadataAppGroupMetaTable_AnswersTrue_WithoutThrowing()
+    {
+        // The field is THERE and holds null. AssignMetaTableOriginal is best-effort by
+        // design, and BC's own GetMetaTableOriginal() is `metadataAppGroupMetaTable?.Item` —
+        // so null is an answer BC itself produces and falls back from.
+        Assert.True(Editable(new FakeNclMetaTable(null), fieldNo: 1));
+    }
+
+    [Fact]
+    public void AnItemReadingNull_AnswersTrue_WithoutThrowing()
+    {
+        // Same reasoning one level down: MetadataExtension`1.Item is reference-typed and
+        // BC's own `?.` chain treats a null Item as no original MetaTable.
+        Assert.True(Editable(new FakeNclMetaTable(new FakeExtension(null)), fieldNo: 1));
+    }
+
+    [Fact]
+    public void ANullEntryInTheFieldsSequence_IsSkippedRatherThanRead()
+    {
+        // Structural, not a failed read: a null element cannot be interrogated, and the real
+        // field sitting after it must still be found.
+        Assert.False(Editable(
+            FakeTableWith(null, new FakeMetaField(1, editable: false)), fieldNo: 1));
+    }
+
+    // ══ 3. THE HAPPY PATH, so nothing above is vacuous ═══════════════════════════════════
+
+    [Fact]
+    public void ANonEditableField_AnswersFalse_AndAnEditableOneTrue()
+    {
+        // The value this method exists to carry, in both directions. Without this pair every
+        // arm above is satisfiable by a method that always throws or always answers true.
+        Assert.False(Editable(FakeTableWith(new FakeMetaField(7, editable: false)), fieldNo: 7));
+        Assert.True(Editable(FakeTableWith(new FakeMetaField(7, editable: true)), fieldNo: 7));
+    }
+
+    [Fact]
+    public void TheMatchingFieldDecides_NotTheFirstOne()
+    {
+        // Pins that the fieldNo test actually selects. A method ignoring it and reading the
+        // first entry would answer true here.
+        Assert.False(Editable(
+            FakeTableWith(new FakeMetaField(1, editable: true), new FakeMetaField(2, editable: false)),
+            fieldNo: 2));
+    }
+
+    [Fact]
+    public void AnImmutableArrayOfFields_IsWalked_LikeTheStructBcActuallyHolds()
+    {
+        // BC's MetaTable.Fields is ImmutableArray<MetaField>, a struct that boxes to an
+        // IEnumerable rather than ever being null — the measurement this file's header
+        // records, and the reason the Fields read refuses on null at all. A fake handing back
+        // a List would not exercise that.
+        var fields = ImmutableArray.Create<object>(new FakeMetaField(3, editable: false));
+        Assert.False(Editable(new FakeNclMetaTable(new FakeExtension(new MetaTableWithFields(fields))),
+                              fieldNo: 3));
+    }
+
+    // ══ 4. WHAT AL CAN DO WITH THE REFUSAL: NOTHING ══════════════════════════════════════
+    //
+    // The point of BcShapeGapException over either RunnerOutOfScopeException flavour. Under
+    // `asserterror` an absorbed refusal INVERTS the result: real BC reads Editable fine, so
+    // the asserterror fails there and would have passed here.
+
+    [Fact]
+    public void TheRefusal_TearsThroughBothAlSeams_AndIsNotAnAbsorbableOutOfScopeSignal()
+    {
+        object Read() => Editable(FakeTableWith(new FieldWithoutEditable(1)), fieldNo: 1);
+
+        var viaAssertError = Assert.Throws<BcShapeGapException>(
+            () => BcRuntime.NavMethodScope_AssertError(null!, () => Read()));
+        Assert.Contains("Editable", viaAssertError.Member, StringComparison.Ordinal);
+
+        var viaTryFunction = Assert.Throws<BcShapeGapException>(
+            () => BcRuntime.NavApplicationObjectBase_TryInvoke(null, () => Read()));
+        Assert.Contains("Editable", viaTryFunction.Member, StringComparison.Ordinal);
+
+        Assert.False(OutOfScopeMessage.TryParse(viaAssertError.Message, out _));
+        Assert.Null(OutOfScopeMessage.FromException(viaAssertError));
+    }
+
+    // ══ 5. THE REFLECTION PIN: name, arity, uniqueness ═══════════════════════════════════
+    //
+    // ReflectionDrivenHelperLivenessTests measures LIVENESS from IL for every RecordPatches
+    // member a test names as a literal, and this file names ReadMetaFieldEditable — so a
+    // change leaving it declared but unreached by production fails there. Pinned HERE is the
+    // half that guard cannot see: it exists, is unique by name, and takes what these arms pass.
+
+    [Fact]
+    public void TheHelperIsUniqueByName_AndTakesTheTwoParametersTheseArmsDriveItWith()
+    {
+        var candidates = typeof(RecordPatches)
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .Where(m => m.Name == "ReadMetaFieldEditable")
+            .ToList();
+
+        Assert.Single(candidates);
+        Assert.Equal(
+            new[] { typeof(object), typeof(int) },
+            candidates[0].GetParameters().Select(p => p.ParameterType).ToArray());
+        Assert.Equal(typeof(bool), candidates[0].ReturnType);
+    }
+
+    // ══ Plumbing ═════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Drives the real production helper. The NCLMetaTable is taken as <c>object</c> so a fake
+    /// can stand in for a BC type whose member moved — the idiom
+    /// QueryDataItemFilterShapeGapTests and PermissionMetadataShapeGapTests already use. The
+    /// per-(table, field) memo is deliberately NOT in the path under test: it is keyed by
+    /// table id, and these arms drive many different shapes for one nominal table.
+    /// </summary>
+    private static bool Editable(object meta, int fieldNo)
+    {
+        var m = typeof(RecordPatches).GetMethod(
+                    "ReadMetaFieldEditable", BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "test setup: RecordPatches.ReadMetaFieldEditable not found");
+        try
+        {
+            return (bool)m.Invoke(null, new object?[] { meta, fieldNo })!;
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            throw tie.InnerException;   // the reflection wrapper is not part of the contract
+        }
+    }
+
+    private static object FakeTableWith(params object?[] fields)
+        => new FakeNclMetaTable(new FakeExtension(new MetaTableWithFields(fields)));
+
+    // ── Fakes standing in for BC's types. Each names the member it is missing. ──
+
+    private sealed class MetaTableWithoutTheAppGroupField
+    {
+    }
+
+    private sealed class FakeNclMetaTable
+    {
+        public FakeNclMetaTable(object? extension) => metadataAppGroupMetaTable = extension;
+
+        // The name BC declares, private instance, exactly as NCLMetaTable holds it.
+#pragma warning disable IDE0044, CS0169, IDE1006
+        private readonly object? metadataAppGroupMetaTable;
+#pragma warning restore IDE0044, CS0169, IDE1006
+    }
+
+    private sealed class ExtensionWithoutItem
+    {
+    }
+
+    private sealed class FakeExtension
+    {
+        public FakeExtension(object? item) => Item = item;
+        public object? Item { get; }
+    }
+
+    private sealed class MetaTableWithoutFields
+    {
+    }
+
+    private sealed class MetaTableWhoseFieldsIsAnInt
+    {
+        public int Fields => 7;
+    }
+
+    private sealed class MetaTableWithFields
+    {
+        public MetaTableWithFields(IEnumerable fields) => Fields = fields;
+        public IEnumerable Fields { get; }
+    }
+
+    private sealed class FakeMetaField
+    {
+        public FakeMetaField(int id, bool editable) { Id = id; Editable = editable; }
+        public int Id { get; }
+        public bool Editable { get; }
+    }
+
+    private sealed class FieldWithoutId
+    {
+        public bool Editable => true;
+    }
+
+    private sealed class FieldWhoseIdIsAString
+    {
+        public string Id => "1";
+        public bool Editable => true;
+    }
+
+    private sealed class FieldWithoutEditable
+    {
+        public FieldWithoutEditable(int id) => Id = id;
+        public int Id { get; }
+    }
+
+    private sealed class FieldWhoseEditableIsAString
+    {
+        public FieldWhoseEditableIsAString(int id) => Id = id;
+        public int Id { get; }
+        public string Editable => "yes";
+    }
+}

--- a/AlRunner.Tests/SilentReflectionLookupRatchetTests.cs
+++ b/AlRunner.Tests/SilentReflectionLookupRatchetTests.cs
@@ -96,7 +96,13 @@ public sealed class SilentReflectionLookupRatchetTests
     /// ratchet movement is the guard working as specified, not a defect in it — the 2 sites in
     /// QueryJoin and 3 in QueryProjection are counted here on purpose.</para>
     /// </summary>
-    private const int Baseline = 125;
+    // 125 -> 120: the five GetMetaFieldEditable lookups in
+    // RecordPatches.PageControlFieldFromBcDocument.cs, converted by #3685 (issue #3669) — the
+    // sites this ratchet caught on first contact and recorded rather than converted. The figure
+    // is the guard's own answer on the merge tree, not a subtraction: a conversion of this shape
+    // may legitimately move the count by less than the number of sites converted (test 15), so
+    // the number comes from running it.
+    private const int Baseline = 120;
 
     // ── The assertions ──────────────────────────────────────────────────────────────────
 
@@ -283,20 +289,24 @@ public sealed class SilentReflectionLookupRatchetTests
         ("AlRunner/Patches/RecordPatches.ObjectMetadataSystemTable.cs", "tNavEnvironment", "GetProperty", "\"Instance\"", 1),
         // RecordPatches.PageTriggerMetadata.cs — 1
         ("AlRunner/Patches/RecordPatches.PageTriggerMetadata.cs", "objId.GetType()", "GetProperty", "\"ObjectType\"", 1),
-        // RecordPatches.PageControlFieldFromBcDocument.cs — 5
+        // RecordPatches.PageControlFieldFromBcDocument.cs — 0, converted by #3685 (issue #3669)
         //
-        // #3659, merged the same day this ratchet landed, and the reason the guard exists.
-        // GetMetaFieldEditable walks five reflection hops to BC's original Types.Metadata.
-        // MetaField and answers `true` — EDITABLE — on every one of them failing. That is not a
-        // neutral default: it is a plausible invented answer a caller cannot tell from BC
-        // genuinely saying editable. Recorded, not converted: the defaulting rule is the
-        // method's stated design and changing it is that method's own decision, not this
-        // ratchet's. See docs/silent-reflection-lookup-ratchet.md#the-first-thing-it-caught.
-        new("AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs", "meta.GetType()", "GetField", "\"metadataAppGroupMetaTable\"", 1),
-        new("AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs", "metaTable?.GetType()", "GetProperty", "\"Fields\"", 1),
-        new("AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs", "original?.GetType()", "GetProperty", "\"Item\"", 1),
-        new("AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs", "t", "GetProperty", "\"Editable\"", 1),
-        new("AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs", "t", "GetProperty", "\"Id\"", 1),
+        // This is the entry the ratchet was built to produce and the one it has now discharged,
+        // so the shape of the exchange is worth keeping. #3659 merged the same day this guard
+        // landed; GetMetaFieldEditable walked five reflection hops to BC's original
+        // Types.Metadata.MetaField and answered `true` — EDITABLE — on every one of them
+        // failing, a plausible invented answer a caller cannot tell from BC genuinely saying
+        // editable. The guard RECORDED all five rather than converting them, deliberately:
+        // overruling a method's stated defaulting rule is that method's decision, not this
+        // ratchet's.
+        //
+        // #3669 made that decision per read, and the split is not five-for-five. Five lookups
+        // now refuse through BcShape; THREE exits in the same method stay silent and are not
+        // ratchet sites, because a null there is BC's own answer rather than a failed read —
+        // BC's NCLMetaTable.GetMetaTableOriginal() is literally `metadataAppGroupMetaTable?.Item`.
+        // docs/page-control-field-from-bc-document.md#a-failed-lookup-refuses has the
+        // exit-by-exit table and the measured member types that decide it.
+        //
         // RecordPatches.QueryJoin.cs — 2
         ("AlRunner/Patches/RecordPatches.QueryJoin.cs", "t", "GetField", "member", 1),
         ("AlRunner/Patches/RecordPatches.QueryJoin.cs", "t", "GetProperty", "member", 1),

--- a/AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs
@@ -56,6 +56,7 @@
 //   the same NCLMetaTable the runner already builds. No BC method body is rewritten and no
 //   AL business logic is touched.
 using System.Xml;
+using AlRunner.Infrastructure;
 
 namespace AlRunner.Patches;
 
@@ -505,38 +506,113 @@ public static partial class RecordPatches
     /// the reason that trace exists at all
     /// (docs/object-metadata-from-bc.md#reading-the-values-back).</para>
     ///
-    /// <para>A table whose structure does not expose it answers true rather than throwing:
-    /// this is a defaulting rule, and true is the value BC itself substitutes when it has no
-    /// field. Reflection is cached per (table, field) because the virtual table asks about
-    /// every control on every known page.</para>
+    /// <para>A table that genuinely has no such field answers true — BC's own
+    /// <c>field?.Editable ?? true</c>. A member the runner could not READ refuses instead
+    /// (#3669): true is a load-bearing answer about a field here, not a neutral sentinel, so
+    /// substituting it for a failed lookup reports a non-editable field as editable. The
+    /// per-read split is in <see cref="ReadMetaFieldEditable"/>. Reflection is cached per
+    /// (table, field) because the virtual table asks about every control on every known
+    /// page.</para>
     /// </summary>
     private static bool GetMetaFieldEditable(int tableId, int fieldNo)
         => _bcMetaFieldEditable.GetOrAdd((tableId, fieldNo), static key =>
         {
             var meta = GetOrBuildNCLMetaTable(key.TableId);
+            // The runner's OWN build declining to produce a metatable is a fact about the
+            // runner's state, not about BC's layout, so it stays silent — BcShapeGapException.cs
+            // draws that line explicitly.
             if (meta == null) return true;
-
-            var original = meta.GetType()
-                .GetField("metadataAppGroupMetaTable",
-                    System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
-                ?.GetValue(meta);
-            var metaTable = original?.GetType()
-                .GetProperty("Item", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
-                ?.GetValue(original);
-            if (metaTable?.GetType()
-                    .GetProperty("Fields", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
-                    ?.GetValue(metaTable) is not System.Collections.IEnumerable fields)
-                return true;
-
-            foreach (var f in fields)
-            {
-                if (f == null) continue;
-                var t = f.GetType();
-                if (t.GetProperty("Id")?.GetValue(f) is not int id || id != key.FieldNo) continue;
-                return t.GetProperty("Editable")?.GetValue(f) is not bool e || e;
-            }
-            return true;
+            return ReadMetaFieldEditable(meta, key.FieldNo);
         });
+
+    /// <summary>
+    /// <see cref="GetMetaFieldEditable"/>'s reflection walk, over the NCLMetaTable's original
+    /// <c>Types.Metadata.MetaTable</c>. Split out and taking <paramref name="meta"/> as
+    /// <c>object</c> so the refusals below can be driven with fakes standing in for a moved
+    /// member, without a BC install — the idiom
+    /// <c>AlRunner.Tests/PageControlFieldEditableShapeGapTests</c> uses, after
+    /// QueryDataItemFilterShapeGapTests. Production passes exactly the NCLMetaTable the old
+    /// body read.
+    ///
+    /// <para>#3669 — a FAILED LOOKUP refuses; BC's OWN ANSWER stays silent. Every exit used to
+    /// be <c>true</c>, and <c>true</c> here is not a neutral sentinel: SolveEditable's rule 2
+    /// renders it as the AL-visible "True", so a field BC reports non-editable would be
+    /// reported editable on the BC version where any of these members moves. Which exit is
+    /// which, and the member types that decide it, are in
+    /// docs/page-control-field-from-bc-document.md#a-failed-lookup-refuses.</para>
+    /// </summary>
+    private static bool ReadMetaFieldEditable(object meta, int fieldNo)
+    {
+        const string surface = "Page Control Field (system table 2000000192)";
+        var tMeta = meta.GetType();
+
+        // The field LOOKUP refuses; its VALUE reading null does not. BC's own
+        // GetMetaTableOriginal() is `metadataAppGroupMetaTable?.Item` (Ncl 28.1), so a null
+        // there is an answer BC itself produces and falls back from, and the runner's
+        // AssignMetaTableOriginal is best-effort by the same design.
+        var original = BcShape.Field(
+                tMeta, "metadataAppGroupMetaTable",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+                surface)
+            .GetValue(meta);
+        if (original == null) return true;
+
+        // Same split one level down: MetadataExtension`1.Item is reference-typed and BC's `?.`
+        // chain treats a null Item as "no original MetaTable".
+        var metaTable = BcShape.Property(
+                original.GetType(), "Item",
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance,
+                surface)
+            .GetValue(original);
+        if (metaTable == null) return true;
+
+        // MetaTable.Fields is ImmutableArray<MetaField> — a STRUCT, so GetValue boxes it and it
+        // is never null. Neither a null nor a non-enumerable read can be BC answering; both
+        // mean the runner could not perform the read.
+        var tMetaTable = metaTable.GetType();
+        var rawFields = BcShape.Property(
+                tMetaTable, "Fields",
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance,
+                surface)
+            .GetValue(metaTable);
+        if (rawFields == null)
+            throw new BcShapeGapException(
+                surface, $"{tMetaTable.Name}.Fields",
+                "read as null — BC declares it as a non-nullable ImmutableArray<MetaField>, so "
+                + "the runner cannot tell an empty field list from a member that moved");
+        var fields = BcShape.RequiredEnumerable(
+            rawFields, $"{tMetaTable.Name}.Fields", surface,
+            "the runner walks it to find the bound field's Editable");
+
+        foreach (var f in fields)
+        {
+            if (f == null) continue;   // structural: a null element cannot be interrogated
+            var t = f.GetType();
+
+            // Id is System.Int32 and Editable is System.Boolean on BC, so neither GetValue can
+            // answer null. A non-int Id is the most deceptive form of the original defect:
+            // every field misses the fieldNo test and the walk falls out reporting editable.
+            var rawId = BcShape.Property(t, "Id", surface).GetValue(f);
+            if (rawId is not int id)
+                throw new BcShapeGapException(
+                    surface, $"{t.Name}.Id",
+                    $"holds {(rawId == null ? "null" : "a " + rawId.GetType().Name)}, not the "
+                    + "Int32 BC declares — the runner compares it against the bound field number");
+            if (id != fieldNo) continue;
+
+            var rawEditable = BcShape.Property(t, "Editable", surface).GetValue(f);
+            if (rawEditable is not bool e)
+                throw new BcShapeGapException(
+                    surface, $"{t.Name}.Editable",
+                    $"holds {(rawEditable == null ? "null" : "a " + rawEditable.GetType().Name)},"
+                    + " not the Boolean BC declares — it is the value this column reports");
+            return e;
+        }
+
+        // BC's own `field?.Editable ?? true`: the walk completing is a real "this table has no
+        // such field", not a failed read. Converting it would error every unbound control.
+        return true;
+    }
 
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<(int TableId, int FieldNo), bool>
         _bcMetaFieldEditable = new();

--- a/docs/page-control-field-from-bc-document.md
+++ b/docs/page-control-field-from-bc-document.md
@@ -285,6 +285,59 @@ in this file as resting on a reflection measurement rather than a tier verdict, 
 filed to settle it. That is the process working — the cost was one wrong column shipped in the
 meantime, not a wrong claim left standing.
 
+<a id="a-failed-lookup-refuses"></a>
+
+### Reading the field's `Editable`: a failed lookup refuses, BC's own answer stays silent
+
+Rule 2 above resolves an undeclared `Editable` against the bound field's own `Editable`. That
+value is not on `NCLMetaField` — it lives on the original `Types.Metadata.MetaField` hanging
+off the NCLMetaTable's private `metadataAppGroupMetaTable`, so `GetMetaFieldEditable` reaches
+it through five reflection lookups.
+
+Every one of those used to answer `true` on failure (#3669). That is not a neutral sentinel
+here: rule 2 renders the value as the AL-visible `"True"`, so a field BC reports non-editable
+would be reported **editable** on the BC version where any of the five members moves — a
+plausible wrong value, which is worse than an empty one, and the shape
+`.claude/rules/loud-failures.md` forbids. Latent, not live: every BC version this repository
+tests resolves all five.
+
+The conversion is per read, because getting it wrong in the other direction breaks an ordinary
+page on **every** BC version rather than only a future one. What decides each case is whether a
+null can be BC's own answer. Measured off `Microsoft.Dynamics.Nav.Types.dll` and
+`Microsoft.Dynamics.Nav.Ncl.dll` at 28.1.49838.54308, via `MetadataLoadContext`:
+
+| read | BC's declared type | a null means | verdict |
+|---|---|---|---|
+| `NCLMetaTable.metadataAppGroupMetaTable` (lookup) | `MetadataExtension<MetaTable>` | the field is gone | **refuses** |
+| …its **value** | reference type | never assigned | silent |
+| `MetadataExtension\`1.Item` (lookup) | — | the property is gone | **refuses** |
+| …its **value** | `MetaTable`, reference type | no original MetaTable | silent |
+| `MetaTable.Fields` | `ImmutableArray<MetaField>` — a **struct** | impossible; boxes, never null | **refuses** |
+| `MetaField.Id` | `System.Int32` | impossible | **refuses** |
+| `MetaField.Editable` | `System.Boolean` | impossible | **refuses** |
+| the `foreach` completing | — | the table has no such field | silent |
+
+The three struct/value-typed members are the load-bearing half: `GetValue` on them cannot
+return null, so a null read can only be a lookup that failed, and there is no BC answer for it
+to be confused with. `Fields` being an `ImmutableArray` is also why a **non-enumerable** read
+refuses rather than folding into the null branch — a member that is present and holds an
+uninterpretable shape is the same "BC's layout moved" case, and folding the two is how #2786's
+silent skip happened.
+
+The three silent exits are BC's own answers, not failed reads, and the citation for the first
+two is BC's own code: `NCLMetaTable.GetMetaTableOriginal()` is literally
+`return metadataAppGroupMetaTable?.Item;` (Ncl 28.1), so BC treats a null at either level as an
+answer and its callers take name-based fallbacks. The runner's `AssignMetaTableOriginal` is
+best-effort by the same design — its own comment says BC "keeps its existing fallbacks rather
+than the table failing to build". Refusing there would turn every table whose original MetaTable
+was never assigned into an error. The third is BC's `field?.Editable ?? true`.
+
+`ReadMetaFieldEditable` takes the metatable as `object` so each refusal can be driven with a
+fake standing in for a moved member, without a BC install — the idiom of #3657 and #3664.
+`AlRunner.Tests/PageControlFieldEditableShapeGapTests` has an arm per refusal, each asserting
+the member name *and* the absence of the sibling branch's wording, plus a negative control per
+silent exit.
+
 <a id="option-and-enum"></a>
 
 ## `OptionString`, and why an Enum field takes the same branch

--- a/docs/silent-reflection-lookup-ratchet.md
+++ b/docs/silent-reflection-lookup-ratchet.md
@@ -70,25 +70,25 @@ the whole claim of #3663, demonstrated on live code within a day of the issue be
 ## The measurement
 
 Every `GetProperty` / `GetMethod` / `GetField` / `GetConstructor` / `GetNestedType` call in
-`AlRunner/Patches/**/*.cs` (171 files), classified by what happens to the null a failed lookup
+`AlRunner/Patches/**/*.cs` (172 files), classified by what happens to the null a failed lookup
 returns. Comments and string literals are blanked before scanning, so prose describing a shape
 is not counted as one.
 
 | | count |
 |---|---:|
-| lookups scanned | 744 |
+| lookups scanned | 738 |
 | — excluded as not-reflection (`JsonElement`, `StackFrame`) | 21 |
-| **considered** | **723** |
-| **silent — the null is absorbed** | **125** |
+| **considered** | **717** |
+| **silent — the null is absorbed** | **120** |
 | loud — `?? throw` | 105 |
 | null-forgiving `!` — a different ratchet's population (#3051) | 26 |
 | chain — `?? <another lookup>`, an alternate member *name* | 13 |
 | explicit `!= null` test at the expression | 2 |
-| stored to a variable, or otherwise consumed; the failure path is a property of the method, not of the expression | 452 |
+| stored to a variable, or otherwise consumed; the failure path is a property of the method, not of the expression | 451 |
 
-The buckets sum to 723, and 723 + 21 excluded = 744.
+The buckets sum to 717, and 717 + 21 excluded = 738.
 
-The 125 sit in **42 files**. The heaviest:
+The 120 sit in **41 files**. The heaviest:
 
 | file | silent sites |
 |---|---:|
@@ -138,7 +138,7 @@ off.
 #3663 measured 745 lookups and reported **167 loud / 339 silent / 239 unclear**, and said
 plainly that its classifier was a heuristic and 339 should be read as an order of magnitude.
 Re-deriving it produced 740 lookups at the time — the five-lookup gap is #3647 and #3660, both
-fixed that same day — so the *scan* reproduces. (The tree has since moved to 744/723/125; the
+fixed that same day — so the *scan* reproduces. (The tree has since moved to 738/717/120; the
 comparison below uses the figures as measured against #3663's own tree, so the two sides are
 like for like.) The *classification* does not, and the reason is specific
 and worth recording:
@@ -237,7 +237,7 @@ by the same amount, and name the site in the PR body.
 
 ## What this guard does not claim
 
-It does **not** claim all 125 are bugs. Per #3663 and `BcShapeGapException`'s own header, some
+It does **not** claim all 120 are bugs. Per #3663 and `BcShapeGapException`'s own header, some
 fraction are correct as they stand, and telling which is which needs the per-site adjudication
 #3657 spent its review on — in that one method, four exits turned out to be genuine answers
 that had to stay silent, and getting one wrong in that direction breaks an ordinary query on


### PR DESCRIPTION
Closes #3669

Corpus-NA: the claim is about the runner's own reflection refusing rather than substituting a default; no AL statement can rename a private BC field, so a service tier has nothing to adjudicate. What BC answers for Editable is already pinned upstream by corpus codeunit 60424 (PR #310, merged).

`GetMetaFieldEditable` answers the bound field's `Editable` for the Page Control Field
(2000000192) virtual table, reaching BC's own `Types.Metadata.MetaField` through five chained
`?.` reflection lookups. **Every failure path answered `true`.**

`true` there is not a neutral sentinel. `SolveDocumentControlEditable`'s rule 2 renders it as
the AL-visible `"True"`, so a field BC reports non-editable would be reported **editable**,
silently, on the BC version where any of the five members moves — a plausible wrong value,
which is worse than an empty one. Latent, not live: every BC version this repository tests
resolves all five.

## The per-read judgement, which is the actual job

Converting mechanically would break an ordinary page on **every** BC version rather than only a
future one, so each null was classified by whether it can be BC's own answer. Three of the
eight were settled by measuring the member's declared type off
`Microsoft.Dynamics.Nav.Types.dll` / `Ncl.dll` at 28.1.49838.54308 through a
`MetadataLoadContext` probe, not by reading the code:

| read | BC's declared type | a null means | verdict |
|---|---|---|---|
| `NCLMetaTable.metadataAppGroupMetaTable` (lookup) | `MetadataExtension<MetaTable>` | the field is gone | **refuses** |
| …its **value** | reference type | never assigned | **silent** |
| `MetadataExtension\`1.Item` (lookup) | — | the property is gone | **refuses** |
| …its **value** | `MetaTable`, reference type | no original MetaTable | **silent** |
| `MetaTable.Fields` | `ImmutableArray<MetaField>` — a **struct** | impossible; boxes, never null | **refuses** |
| `MetaField.Id` | `System.Int32` | impossible | **refuses** |
| `MetaField.Editable` | `System.Boolean` | impossible | **refuses** |
| the `foreach` completing | — | the table has no such field | **silent** |

The five refusals are the load-bearing half: on the three value-typed members `GetValue`
cannot return null, so a null read can only be a lookup that failed and there is no BC answer
to confuse it with. `Fields` being an `ImmutableArray` is also why a **non-enumerable** read
refuses separately rather than folding into the null branch — a member that is present and
holds an uninterpretable shape is the same "BC's layout moved" case, and folding the two is how
#2786's silent skip happened.

**The three silent exits are BC's own answers**, and the citation for two of them is BC's own
code: `NCLMetaTable.GetMetaTableOriginal()` is literally `return metadataAppGroupMetaTable?.Item;`
(Ncl 28.1), so BC treats a null at either level as an answer and its callers take name-based
fallbacks. The runner's `AssignMetaTableOriginal` is best-effort by the same design — its own
comment says BC "keeps its existing fallbacks rather than the table failing to build". Refusing
there would turn every table whose original MetaTable was never assigned into an error. The
third is BC's `field?.Editable ?? true`.

Routed through the existing throwing `BcShape.Field` / `BcShape.Property` /
`BcShape.RequiredEnumerable` accessors — the spelling of #3657 and #3664, not a fourth one. The
walk is split into `ReadMetaFieldEditable` taking the metatable as `object` so each refusal can
be driven with a fake standing in for a moved member, without a BC install and without poisoning
the `RecordPatches` statics for other tests in the assembly.

## RED → GREEN

RED was taken in two steps so the failure is attributable. With the helper extracted but the
**old body** intact: **9 failed, 8 passed** — the 9 refusal arms failed with
`Assert.Throws() Failure: No exception was thrown`, which is the defect itself, while the 8
negative-control and happy-path arms passed, proving the conversion must not disturb them.
After the conversion: **17/17 green**.

## Every guard verified ARMED, not merely quiet

14 sabotages, each reverting one decision; liveness sabotages **remove the call** rather than
guarding it, so nothing passes on IL that is still present.

| sabotage | arm that failed |
|---|---|
| `metadataAppGroupMetaTable` lookup back to silent `?.` | `MetadataAppGroupMetaTableLookup_…` |
| `Item` lookup back to silent `?.` | `ItemLookup_…` |
| `Fields` lookup back to silent `?.` | `FieldsLookup_…` |
| non-enumerable `Fields` folded into the null branch | `FieldsHoldingSomethingUnusable_…` |
| `Id` line reverted to the exact pre-fix silent line | `IdLookup_…`, `IdHoldingANonInteger_…` |
| `Editable` line reverted to the exact pre-fix silent line | `EditableLookup_…`, `EditableHoldingANonBoolean_…`, `TheRefusal_TearsThrough…` |
| `Fields` lookup refusal reworded as the non-enumerable one | `FieldsLookup_…` |
| **over-convert**: missing field refuses | `AFieldTheTableDoesNotCarry_AnswersTrue_WithoutThrowing` |
| **over-convert**: null `metadataAppGroupMetaTable` value refuses | `AnUnassignedMetadataAppGroupMetaTable_…` |
| **over-convert**: null `Item` value refuses | `AnItemReadingNull_…` |
| always answer `true` | 4 happy-path arms |
| one conversion undone (ratchet) | `TheConvertedSites_AreStillConverted` 87 → 86 |

**One sabotage found a real hole in my own tests, and it is condition 2 exactly.** An
implementation whose `Id` refusal names `Editable` instead **passed** the first draft: the arm
asserted `Contains("Id")`, and `"FieldWhoseIdIsAString.Editable"` contains `"Id"` through the
declaring type's name. The member assertions are now `EndsWith(".Id")` / `EndsWith(".Editable")`
plus `DoesNotContain` of the sibling, and the sabotage now fails the right arm. Same tightening
applied to `.Item`, `.Fields` and `.metadataAppGroupMetaTable`.

The two failure modes are distinguished in both directions where they share a branch: the
`Fields` lookup arm asserts `"property not found"` present **and** `"cannot be enumerated"`
absent; the non-enumerable arm asserts the converse.

## The three shape questions

1. **Same wrong pattern at another call site in this file?** No. `ReadMetaFieldEditable` was
   the only reflection walk here; the other reads go through the parsed document.
2. **Does a sibling function make the same assumption?** `DescribeMetaFields` in
   `RecordPatches.NclMetaTableFromBcDocument.cs` walks the *same* structure with the same `?.`
   chain — deliberately left alone. It is a diagnostic behind `AL_RUNNER_TRACE_TABLE_METADATA_SOURCE=2`
   whose only output is trace lines, so a failed lookup there produces *fewer log lines*, never a
   wrong answer about a field. That is the "read succeeded and the answer was unwelcome" side of
   `BcShapeGapException.cs`'s line, and converting it would make a trace flag able to abort a run.
3. **Two paths writing the same state with different invariants?** `SolveParsedControlEditable`
   (`RecordPatches.PageControlFieldVirtualTable.cs`) answers the same column for the AL-parsed
   and precompiled-dependency paths, but reads the parsed table rather than BC's `MetaField` —
   no reflection, so no silent-lookup exposure. Not touched (it is #3670's file, now merged).

`PrimaryKeyTableNo` in `RecordPatches.FieldFindIntercept.cs` has a similar-looking
`GetProperty("Fields")?.GetValue(...)`, but on `RecordId.Fields` (an `IList`) in a different
subsystem and a different file — **not folded**, since `batch-sibling-issues-by-file.md` makes
same-file the test.

## Issue-queue scan — nothing folded, and why

Searched the open queue for `PageControlFieldFromBcDocument`, `GetMetaFieldEditable`,
`SolveDocumentControlEditable`, `2000000192` and "Page Control Field". Only #3562 (a tracking
issue for the document-conversion programme) and #3355 (the auto-updated corpus-pin tracker)
came back — neither is a same-file defect with a fix to fold. #3663 is the umbrella issue this
shape belongs to and stays open by design.

## The #3668 hand-off, now made here

#3668 has merged (`a4318626`), so the allowlist edit it deferred is this PR's. Rebased onto
`f8720984`; its allowlist recorded these five sites rather than converting them, and #3669 made
that decision, so the entries come out and `Baseline` drops **125 → 120**.

**The number is the guard's own answer, not a subtraction.** Running it reported all five as
`found 0` and named 120 itself. That matters because a conversion of this shape may legitimately
move the count by *less* than the number of sites converted — #3668's own test 15
(`ARefusalOneStatementAway_DoesNotMakeTheLookupsLoud`) pins that, and #3664 and #3665 both
converted without moving it. Here it happened to be five-for-five; the guard confirmed that
rather than my assuming it.

**Validated on the real merge tree, not the branch head** — the head-only run is exactly how
#3668's own baseline went stale. `git merge-tree --write-tree origin/main HEAD` materialised into
a separate checkout and run there: **37/37** for the three guards, **145 passed / 0 failed** over
the wider filtered set.

Also folded in, because this PR's own diff makes it wrong: the ratchet doc's totals table read
744/723/452. Converting five lookups removes reflection calls, so the scanned and considered
totals move too — leaving it would have been stale in this PR's favour. Re-measured by driving
the guard's **own** private `Scan`/`Blank`/`Excluded`/`IsSilent` through reflection, so every
bucket reproduces the shipped classifier: 738 / 21 excluded / 717 considered / **120 silent**
across 41 files / 105 loud / 26 null-forgiving / 13 chain / 2 explicit / 451 stored. The buckets
still sum to 717 and 717 + 21 = 738, so the table's stated invariant holds. No test asserts these
figures, which is why they drifted.

## Where the prose went

The derivation — the measured member types, BC's `GetMetaTableOriginal()` body, and the
exit-by-exit table — is in `docs/page-control-field-from-bc-document.md#a-failed-lookup-refuses`,
with a one-line pointer at the code. `tools/test_doc_pointers.py` caught that anchor dangling
before the doc section existed, and passes now (328 pointers).

## What I could not prove

- **No BC version where these members have actually moved.** All five resolve on every version
  this repository tests, so the refusals are latent by construction and no test can observe one
  against real BC. The arms drive fakes; that is the claim's limit and the reason it is
  runner-local.
- **The `AnImmutableArrayOfFields_…` arm uses a real `ImmutableArray<object>`**, not BC's
  `ImmutableArray<MetaField>` — enough to pin the boxes-to-`IEnumerable`-never-null property the
  refusal rests on, not the exact generic instantiation.

## Tests run locally

- `PageControlFieldEditableShapeGapTests` — 17/17 (the RED → GREEN).
- Filtered pass over `PageControlField`, `ReflectionDrivenHelperLiveness`, `BcShapeGap`,
  `SilentReflection`, `BcInternalsNullForgiving`, `RunnerShapeGapClaim`,
  `BcMatrixDocumentationDrift` — **145 passed, 0 failed, 13 skipped**, run on the merge tree.
- `BcMatrixDocumentationDriftTests` — 5 passed, 1 skipped (the new doc text cites one artifact
  build as a measurement, not a matrix claim).
- `tools/test_doc_pointers.py` — all checks pass.

Not run: the full `AlRunner.Tests` suite, per `.claude/rules/local-test-scope.md`.

Filed by an agent (Claude, `stma-auto-2`) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
