### PR TITLE
fix(metadata): make an enum-typed field's enum resolvable, then state its id

### DIFF
--- a/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
+++ b/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
@@ -237,7 +237,14 @@ public sealed class BcInternalsNullForgivingGuardTests
         // so a non-editable field was reported editable (#3669). Three exits in that same
         // method deliberately stay silent, because a null there is BC's own answer; the
         // per-read split is in docs/page-control-field-from-bc-document.md#a-failed-lookup-refuses.
-        Assert.Equal(87, converted);
+        // 87 -> 89 for the PlatformMetadataProvider.Instance and EnumMetadata.Name reads in
+        // EnumMetadataPatches.EnsureSystemEnumsRegistered (#3594). Both used to be `?.`, and a
+        // null from either was indistinguishable from BC legitimately exposing no platform
+        // enums — the first degraded to "there is no inventory", the second registered all 16
+        // under the empty name. The enclosing catch still turns a refusal back into the
+        // documented degradation; what changed is that the shape gap is now named rather than
+        // silently answered.
+        Assert.Equal(89, converted);
     }
 
     /// <summary>

--- a/AlRunner.Tests/FloorOnlyBundleEnumFieldTests.cs
+++ b/AlRunner.Tests/FloorOnlyBundleEnumFieldTests.cs
@@ -83,35 +83,45 @@ public sealed class FloorOnlyBundleEnumFieldTests
     }
 
     /// <summary>
-    /// The opposite direction, on the SAME mechanism: where the enum IS resolvable the id must
-    /// still be stated, so the guard cannot be satisfied by withholding it everywhere.
-    /// <see cref="BcRuntime.CanResolveEnumMetadata"/> is the one decision both directions go
-    /// through, so asserting it answers differently for a registered and an unregistered id
-    /// pins that it is a real lookup rather than a constant.
+    /// The reader half, in both directions. #3594's first attempt withheld an id the registry
+    /// did not know, which masked the real defect: <c>TryParseEnumSymbol</c> dropped every enum
+    /// declaring no <c>Values</c> array, so an enum an app genuinely ships was simply missing.
+    /// Measured on System Application 28.1 — 3 of its 141 enums are written that way, and
+    /// 8889 "Email Connector" is one of them.
+    ///
+    /// <para>Both directions matter and are asserted here: a valueless enum must survive the
+    /// parse WITH its id and name, and an enum WITH values must still carry them. A reader that
+    /// returned an empty symbol for everything would satisfy the first alone.</para>
     /// </summary>
     [Fact]
-    public void CanResolveEnumMetadata_AnswersFalseForUnknown_AndTrueForRegistered()
+    public void EnumDeclaringNoValues_SurvivesTheSymbolParse_AndOneWithValuesKeepsThem()
     {
-        const int unknown = 987654;
-        AlRunner.AlEnumMetadataRegistry.Clear();
-        try
-        {
-            Assert.False(AlRunner.BcRuntime.CanResolveEnumMetadata(unknown),
-                "an id no app declares must not be reported resolvable — stating it is what aborts the bundle.");
+        // A valueless extensible enum, exactly the shape BC ships for 8889.
+        var valueless = System.Text.Json.JsonDocument.Parse("""
+            { "Id": 8889, "Name": "Email Connector",
+              "Properties": [ { "Name": "Extensible", "Value": "1" } ] }
+            """).RootElement;
 
-            AlRunner.AlEnumMetadataRegistry.Register(unknown, "Late Registered",
-                options: new[] { "A", "B" }, indexes: new[] { 0, 1 });
+        var parsedValueless = AlRunner.Patches.BcAppSymbolCache.ParseEnumSymbolForTest(valueless);
 
-            Assert.True(AlRunner.BcRuntime.CanResolveEnumMetadata(unknown),
-                "once the declaring app's symbols are registered the id is resolvable and must be stated.");
+        Assert.NotNull(parsedValueless);
+        Assert.Equal(8889, parsedValueless!.Id);
+        Assert.Equal("Email Connector", parsedValueless.Name);
+        Assert.Empty(parsedValueless.Options);
+        Assert.Empty(parsedValueless.Indexes);
 
-            // Zero is "this field names no enum" and is never resolvable, whatever is registered.
-            Assert.False(AlRunner.BcRuntime.CanResolveEnumMetadata(0),
-                "field.EnumTypeId == 0 means the field is not enum-typed.");
-        }
-        finally
-        {
-            AlRunner.AlEnumMetadataRegistry.Clear();
-        }
+        // ...and the ordinary shape is unaffected, so "accept valueless" did not become
+        // "return an empty symbol for everything".
+        var withValues = System.Text.Json.JsonDocument.Parse("""
+            { "Id": 8888, "Name": "Email Status", "Values": [
+                { "Name": "Draft", "Ordinal": 0 },
+                { "Name": "Queued", "Ordinal": 5 } ] }
+            """).RootElement;
+
+        var parsedWithValues = AlRunner.Patches.BcAppSymbolCache.ParseEnumSymbolForTest(withValues);
+
+        Assert.NotNull(parsedWithValues);
+        Assert.Equal(new[] { "Draft", "Queued" }, parsedWithValues!.Options);
+        Assert.Equal(new[] { 0, 5 }, parsedWithValues.Indexes);
     }
 }

--- a/AlRunner.Tests/FloorOnlyBundleEnumFieldTests.cs
+++ b/AlRunner.Tests/FloorOnlyBundleEnumFieldTests.cs
@@ -1,0 +1,117 @@
+// FloorOnlyBundleEnumFieldTests — issue #3594's regression arm.
+//
+// A bundle whose app.json declares an `application` FLOOR and `dependencies: []` must still
+// run. It resolves the stripped platform packages, which carry NO enum symbols at all, so
+// AlEnumMetadataRegistry never learns the enums of the app that declares them — measured on
+// Fixtures/BcFloorSkip/healthy-suite: 721 enums registered and Base Application's 8889 absent,
+// against zero misses on the corpus, which names Base Application as an explicit dependency.
+//
+// #3594 made the runner state a field's enumTypeId, which is what makes BC resolve it. Stated
+// unconditionally, that turned every floor-only bundle into the exact 0-of-N abort #3594 exists
+// to remove, on a different manifest shape:
+//
+//   EXEC-FAIL: ... GetFieldRecordBuffer threw for table 1366 field:
+//   NavMetadataNotFoundException: The metadata object Enum 8889 was not found.
+//
+// It reached all three BC legs before this test existed. The fix withholds the id where it
+// cannot be backed (BcRuntime.CanResolveEnumMetadata), which is faithful rather than a fake:
+// with no enum id BC builds the plain NCLOptionMetadataWithCaptions from the field's own inline
+// option string, exactly as every such bundle saw before #3594.
+//
+// This is a RUNNER-MECHANISM test. It spawns the runner, because the defect is only observable
+// end to end: the registry contents depend on which packages the bundle resolved, which is a
+// property of the whole load, not of any one call.
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class FloorOnlyBundleEnumFieldTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string Output, int Exit) RunRunner(string relativeFixture)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" \"{Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures", relativeFixture)}\"");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(240_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>
+    /// The regression itself, on the fixture that carried it. Asserts the DISTINGUISHING
+    /// substrings, not merely that the run was green: an abort for some other reason, or a run
+    /// that skipped the bundle and covered nothing, must not pass this.
+    /// </summary>
+    [SkippableTheory]
+    [InlineData("BcFloorSkip/healthy-suite")]
+    [InlineData("CrossMajorNote")]
+    [InlineData("SubscriberScanAudit")]
+    public void FloorOnlyBundle_RunsWithoutAnEnumMetadataAbort(string fixture)
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, exit) = RunRunner(fixture);
+
+        // The exact failure #3594 introduced here, named so a DIFFERENT abort cannot pass by
+        // being green-adjacent.
+        Assert.DoesNotContain("was not found", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("GetFieldRecordBuffer threw", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("EXEC-FAIL", output, StringComparison.Ordinal);
+
+        // ...and the bundle really ran, rather than being skipped into a vacuous green. Every
+        // one of these fixtures declares exactly one test.
+        Assert.Contains("1P/0F/0E", output, StringComparison.Ordinal);
+        Assert.True(exit == 0, $"a floor-only bundle must run green. exit={exit}\n{output}");
+    }
+
+    /// <summary>
+    /// The opposite direction, on the SAME mechanism: where the enum IS resolvable the id must
+    /// still be stated, so the guard cannot be satisfied by withholding it everywhere.
+    /// <see cref="BcRuntime.CanResolveEnumMetadata"/> is the one decision both directions go
+    /// through, so asserting it answers differently for a registered and an unregistered id
+    /// pins that it is a real lookup rather than a constant.
+    /// </summary>
+    [Fact]
+    public void CanResolveEnumMetadata_AnswersFalseForUnknown_AndTrueForRegistered()
+    {
+        const int unknown = 987654;
+        AlRunner.AlEnumMetadataRegistry.Clear();
+        try
+        {
+            Assert.False(AlRunner.BcRuntime.CanResolveEnumMetadata(unknown),
+                "an id no app declares must not be reported resolvable — stating it is what aborts the bundle.");
+
+            AlRunner.AlEnumMetadataRegistry.Register(unknown, "Late Registered",
+                options: new[] { "A", "B" }, indexes: new[] { 0, 1 });
+
+            Assert.True(AlRunner.BcRuntime.CanResolveEnumMetadata(unknown),
+                "once the declaring app's symbols are registered the id is resolvable and must be stated.");
+
+            // Zero is "this field names no enum" and is never resolvable, whatever is registered.
+            Assert.False(AlRunner.BcRuntime.CanResolveEnumMetadata(0),
+                "field.EnumTypeId == 0 means the field is not enum-typed.");
+        }
+        finally
+        {
+            AlRunner.AlEnumMetadataRegistry.Clear();
+        }
+    }
+}

--- a/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
+++ b/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
@@ -225,16 +225,19 @@ public sealed class MetadataEquivalenceHarnessTests
             AssertConstantAnswer(report, Declared("MetaField.CaptionML." + MetadataObjectDiff.PresenceMember),
                 "MetaField.CaptionML", bc: "present", runner: MetadataObjectDiff.Null);
 
-            // Still wrong for a reason that is not a reading defect: the id is known and
-            // stating it needs a metadata object BC can resolve (#3594).
-            AssertConstantAnswer(report, Declared("MetaField.EnumTypeId"), "MetaField.EnumTypeId",
-                bc: null, runner: "0");
-
             // Fixed by #3545, and asserted over EVERY field rather than only the declared
             // ones: the same change corrected BC's six platform-added fields, whose Editable
             // and DataClassification come from SystemFieldsHelper's boilerplate.
             AssertReaderAgrees(report, "MetaField.Editable");
             AssertReaderAgrees(report, "MetaField.DataClassification");
+
+            // Fixed by #3594. Reading the id was never the hard half — stating it was, because
+            // BC then resolves it through NCLMetadata and the runner registered no Enum object
+            // under it. Registering one (a Cecil rewrite of
+            // NCLFieldEnumMetadata.GetEnumMetadataFromMetadataProvider onto
+            // AlEnumMetadataRegistry, plus BC's own 16 platform enums) is what let the value be
+            // stated at all; before it, stating the id aborted the whole corpus app.
+            AssertReaderAgrees(report, "MetaField.EnumTypeId");
         }
     }
 

--- a/AlRunner.Tests/SystemEnumAlSourceParseTests.cs
+++ b/AlRunner.Tests/SystemEnumAlSourceParseTests.cs
@@ -1,0 +1,156 @@
+// SystemEnumAlSourceParseTests — issue #3594.
+//
+// BC's 16 platform ("system") enums are declared by the platform, not by any app, so they
+// appear in no SymbolReference.json and nothing put them in AlEnumMetadataRegistry. A table
+// field typed by one — Base Application table 2000000132 has such a field, enum 2000000002
+// "Entity Text Scenario" — therefore could not resolve its option metadata.
+//
+// BcRuntime.EnsureSystemEnumsRegistered reads them from BC's OWN inventory
+// (PlatformMetadataProvider.GetSystemEnums / GetEnumALCodeById, which returns Microsoft's AL
+// source for the enum) and parses the value declarations out of it. This test pins that PARSE
+// — the one piece of the fix that is the runner's own logic rather than a lookup redirected at
+// BC's data — against the exact shapes BC's own source uses. Measured on BC 28.1: 16 enums,
+// 57 value(...) declarations, 27 of them with a "quoted" name, 73 captions, and three enums
+// declaring no values at all.
+//
+// The BC-behaviour claim (what Field.OptionString / EnumTypeId answer for an enum-typed field)
+// is proven upstream against a live service tier; see the Corpus-PR on #3594.
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class SystemEnumAlSourceParseTests
+{
+    // POSITIVE — the ordinary shape: bare names, explicit ordinals, per-value captions.
+    // Asserted by value, so a parser returning empties or defaults fails.
+    [Fact]
+    public void BareNames_ParseWithOrdinalsAndCaptions()
+    {
+        var (options, ordinals, captions) = BcRuntime.ParseSystemEnumValues(@"
+enum 2000000004 ""Agent Task Status""
+{
+    Extensible = false;
+    Caption = 'Agent Task Status';
+
+    value(0; Paused) { Caption = 'Paused'; }
+    value(1; Ready) { Caption = 'Ready'; }
+    value(2; Scheduled) { Caption = 'Scheduled'; }
+}");
+
+        Assert.Equal(new[] { "Paused", "Ready", "Scheduled" }, options);
+        Assert.Equal(new[] { 0, 1, 2 }, ordinals);
+        Assert.Equal(new string?[] { "Paused", "Ready", "Scheduled" }, captions);
+    }
+
+    // POSITIVE — quoted names, which are 27 of BC's own 57 declarations. The quotes are part
+    // of the syntax, not of the name, so they must not survive into the option string.
+    [Fact]
+    public void QuotedNames_LoseTheQuotesAndKeepTheSpaces()
+    {
+        var (options, ordinals, _) = BcRuntime.ParseSystemEnumValues(@"
+enum 2000000011 ""Agent User Int Request Type""
+{
+    value(0; ""Input Message"") { Caption = 'Input Message'; }
+    value(1; ""Output Message Draft"") { Caption = 'Output Message Draft'; }
+    value(2; ""Page Operation"") { Caption = 'Page Operation'; }
+}");
+
+        Assert.Equal(new[] { "Input Message", "Output Message Draft", "Page Operation" }, options);
+        Assert.Equal(new[] { 0, 1, 2 }, ordinals);
+    }
+
+    // POSITIVE — sparse and out-of-order ordinals are carried as declared, never as a
+    // 0..Count-1 array index. This is the same property AlEnumOptionMetadata exists to keep.
+    [Fact]
+    public void SparseOrdinals_AreCarriedAsDeclared()
+    {
+        var (options, ordinals, _) = BcRuntime.ParseSystemEnumValues(@"
+enum 2000000099 ""Sparse""
+{
+    value(0; Zero) { }
+    value(5; Five) { }
+    value(10; Ten) { }
+}");
+
+        Assert.Equal(new[] { "Zero", "Five", "Ten" }, options);
+        Assert.Equal(new[] { 0, 5, 10 }, ordinals);
+    }
+
+    // POSITIVE — a value with no Caption block records null, meaning "declares none", which is
+    // the convention AlEnumMetadataRegistry.Register and AlEnumOptionMetadata already use: the
+    // consumer then applies AL's own default (the member name). An empty string here would be
+    // a caption BC never declared.
+    [Fact]
+    public void ValueWithoutCaption_RecordsNullNotEmptyString()
+    {
+        var (options, _, captions) = BcRuntime.ParseSystemEnumValues(@"
+enum 2000000098 ""Mixed""
+{
+    value(0; WithCaption) { Caption = 'Has One'; }
+    value(1; NoBody)
+    value(2; EmptyBody) { }
+}");
+
+        Assert.Equal(new[] { "WithCaption", "NoBody", "EmptyBody" }, options);
+        Assert.Equal(new string?[] { "Has One", null, null }, captions);
+    }
+
+    // NEGATIVE — three of BC's sixteen system enums declare no values at all (they are
+    // extensible enums an app is expected to extend). Empty is the CORRECT answer there, and
+    // must not be confused with a parse failure: enum 2000000002 is one of them, and it is the
+    // very enum whose absence aborted the corpus.
+    [Fact]
+    public void EnumDeclaringNoValues_ParsesToEmpty_NotAFailure()
+    {
+        var (options, ordinals, captions) = BcRuntime.ParseSystemEnumValues(@"
+namespace System.Text;
+
+enum 2000000002 ""Entity Text Scenario""
+{
+    Extensible = true;
+    Caption = 'Entity Text Scenario';
+}");
+
+        Assert.Empty(options);
+        Assert.Empty(ordinals);
+        Assert.Empty(captions);
+    }
+
+    // NEGATIVE — the word "value" inside a doc comment must not be read as a declaration. BC's
+    // own sources are heavily doc-commented (73 captions across 16 enums, most preceded by a
+    // /// block), so a parser that skipped comment stripping would invent members here.
+    [Fact]
+    public void DocCommentsMentioningValue_DoNotBecomeMembers()
+    {
+        var (options, ordinals, _) = BcRuntime.ParseSystemEnumValues(@"
+enum 2000000097 ""Commented""
+{
+    /// <summary>
+    /// This mentions value(99; Fake) inside prose and must be ignored.
+    /// </summary>
+    value(0; Real) { Caption = 'Real'; }
+
+    // value(98; AlsoFake)
+    /* value(97; BlockFake) */
+}");
+
+        Assert.Equal(new[] { "Real" }, options);
+        Assert.Equal(new[] { 0 }, ordinals);
+    }
+
+    // NEGATIVE — a caption containing a comment marker survives, because comment stripping must
+    // not run inside a string literal. Opposite pair to the test above: one proves comments are
+    // removed, this one proves the removal stops at a quote.
+    [Fact]
+    public void CommentMarkerInsideACaption_Survives()
+    {
+        var (_, _, captions) = BcRuntime.ParseSystemEnumValues(@"
+enum 2000000096 ""Slashes""
+{
+    value(0; Ratio) { Caption = 'in/out // both'; }
+}");
+
+        Assert.Equal(new string?[] { "in/out // both" }, captions);
+    }
+}

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -106,6 +106,11 @@ public static partial class NclCecilRewrite
         // Library - No. Series.CreateNoSeriesLine validating an enum/option field). Listing
         // its key here makes JmpHook.Apply skip it → single-mechanism (Cecil) → no spin.
         set.Add("Microsoft.Dynamics.Nav.Runtime.NCLEnumMetadata::Create/1");
+        // NCLFieldEnumMetadata.GetEnumMetadataFromMetadataProvider() — #3594. The other route
+        // into enum metadata: an `Enum`-typed FIELD's option metadata, resolved through
+        // NavGlobal.MetadataProvider -> NCLMetadata rather than through Create(int). Rewritten
+        // to the same AlEnumMetadataRegistry (see RewriteNcl, just after the Create(int) block).
+        set.Add("Microsoft.Dynamics.Nav.Runtime.NCLFieldEnumMetadata::GetEnumMetadataFromMetadataProvider/0");
         // get_ApplicationObjectConstructor + Populate + CompileAndLoadClrObject (Batch 7
         // — completes the insert/construction path so ALInsertAsync→get_OldRecord→
         // CreateObjectInstance→{getter,Populate,CompileAndLoadClrObject} is single-mechanism).
@@ -266,6 +271,54 @@ public static partial class NclCecilRewrite
             {
                 Console.Error.WriteLine("[Cecil] WARN: NCLEnumMetadata.Create(int) not found — dependency enum metadata may NRE");
             }
+        }
+
+        // NCLFieldEnumMetadata.GetEnumMetadataFromMetadataProvider() — #3594. The sibling of
+        // the Create(int) rewrite above, for the OTHER route into enum metadata: a table field
+        // declared `Enum "X"` states an EnumTypeId, so BC's own MetaField factory builds an
+        // NCLFieldEnumMetadata, and every accessor on it (OptionString, Options, OrdinalValues,
+        // GetNames, …) funnels through GetAppGroupAwareEnumMetadata into this one virtual. Its
+        // real body goes to NavGlobal.MetadataProvider.GetEnumMetadata(enumId), which resolves
+        // NCLMetadata.TryGetMetaApplicationObject(ObjectType.Enum, id) — a lookup the runner
+        // never populates for Enum objects, so reading the Field virtual table (2000000041) for
+        // any table with an enum-typed field threw NavMetadataNotFoundException and aborted the
+        // whole app. Route it to the same AlEnumMetadataRegistry the Create(int) hook uses.
+        // Derivation and the corpus measurement: docs/field-enum-metadata-resolution.md.
+        {
+            var fieldEnumType = asm.MainModule.GetType(
+                "Microsoft.Dynamics.Nav.Runtime.NCLFieldEnumMetadata")
+                ?? throw new InvalidOperationException(
+                    "[Cecil] NCLFieldEnumMetadata type not found — Ncl shape changed; do not commit");
+
+            var getFromProvider = fieldEnumType.Methods.FirstOrDefault(m =>
+                m.Name == "GetEnumMetadataFromMetadataProvider"
+                && m.HasBody
+                && m.Parameters.Count == 0
+                && m.ReturnType.FullName == "Microsoft.Dynamics.Nav.Runtime.NCLOptionMetadata")
+                ?? throw new InvalidOperationException(
+                    "[Cecil] NCLFieldEnumMetadata.GetEnumMetadataFromMetadataProvider() not found "
+                    + "— Ncl shape changed; do not commit");
+
+            // The helper reads `enumId` off the instance by reflection, because the Id property
+            // is `GetAppGroupAwareEnumMetadata().Id` and would recurse into this very method.
+            // If the field is gone the rewrite is meaningless, so refuse here rather than at
+            // the first AL read.
+            if (!fieldEnumType.Fields.Any(f => f.Name == "enumId" && f.FieldType.FullName == "System.Int32"))
+                throw new InvalidOperationException(
+                    "[Cecil] NCLFieldEnumMetadata.enumId (System.Int32) not found — Ncl shape "
+                    + "changed; the replacement body could not learn which enum a field names. "
+                    + "Do not commit");
+
+            var fieldEnumHelper = typeof(AlRunner.BcRuntime).GetMethod(
+                nameof(AlRunner.BcRuntime.NCLFieldEnumMetadata_GetEnumMetadataFromRegistry),
+                BindingFlags.Public | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "[Cecil] BcRuntime.NCLFieldEnumMetadata_GetEnumMetadataFromRegistry not found");
+
+            ReplaceBodyWithHelper(asm.MainModule, getFromProvider, fieldEnumHelper);
+            Console.Error.WriteLine(
+                "[Cecil] Replaced NCLFieldEnumMetadata.GetEnumMetadataFromMetadataProvider() "
+                + "\u2192 BcRuntime.NCLFieldEnumMetadata_GetEnumMetadataFromRegistry");
         }
 
         // ALCompiler.ToInterface(ITreeObject, NavOption, int) relies on the

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -217,7 +217,15 @@ internal static partial class BcAppSymbolCache
     // an earlier build of this same change (declared-only, same shape) was replayed warm and
     // put 154 of System Application's fields back on CustomerContent while the harness said
     // the reader had been fixed. A wrong answer from cache, wearing a green build.
-    private const int CacheVersion = 35;
+    //
+    // v36: TryParseEnumSymbol stopped dropping an enum that declares no `Values` array (#3594).
+    // Same trap as v35's second half, and it bit the same way: the record SHAPE is unchanged —
+    // an EnumSymbol with an empty option list is shaped exactly like one with a full list — so
+    // PayloadShape cannot see that three enums per System Application payload went from absent
+    // to present. Measured warm on 28.1.49838.54308 before the bump: the harness still reported
+    // 15 MetaField.EnumTypeId differences naming enum 8889, from a payload written by the
+    // previous parse.
+    private const int CacheVersion = 36;
     private static readonly ConcurrentDictionary<string, AppSymbols> ProcessCache = new(StringComparer.OrdinalIgnoreCase);
     // Issue #1820's path -> content-hash memo now lives in
     // RunnerFingerprint._fileContentHashes (#2955), because AppLoader's persisted r2r-chunks
@@ -2256,20 +2264,42 @@ internal static partial class BcAppSymbolCache
             ExternalName: string.IsNullOrWhiteSpace(externalName) ? null : externalName.Trim());
     }
 
+    /// <summary>
+    /// <see cref="TryParseEnumSymbol"/> for AlRunner.Tests. A seam rather than widening the
+    /// parser's own accessibility: the one property worth pinning directly is that an enum
+    /// declaring no <c>Values</c> survives (#3594), and reaching it through a real .app would
+    /// make the test depend on which BC build is provisioned.
+    /// </summary>
+    internal static EnumSymbol? ParseEnumSymbolForTest(JsonElement enumType)
+        => TryParseEnumSymbol(enumType);
+
     private static EnumSymbol? TryParseEnumSymbol(JsonElement enumType)
     {
         if (!enumType.TryGetProperty("Id", out var idProp) || !idProp.TryGetInt32(out var id))
             return null;
         var name = enumType.TryGetProperty("Name", out var nameProp) ? nameProp.GetString() ?? string.Empty : string.Empty;
-        if (!enumType.TryGetProperty("Values", out var values) || values.ValueKind != JsonValueKind.Array)
-            return null;
+        // #3594 — an enum with NO `Values` array is a real enum that declares no values, not an
+        // unreadable symbol. Extensible enums whose members all come from enumextensions are
+        // written exactly this way: measured on System Application 28.1, 3 of its 141 enums
+        // carry no `Values` at all, and enum 8889 "Email Connector" is one of them.
+        //
+        // Returning null here dropped those three from the registry entirely. That was latent
+        // for as long as nothing resolved an enum BY ID — the ordinal/caption consumers only
+        // ever ask about enums they already hold — and became observable the moment MetaField
+        // began stating EnumTypeId, because BC's own metadata names 8889 on five System
+        // Application tables and the runner then had no object under it. An empty value list is
+        // the faithful answer: the enum exists, and it has no members of its own.
+        var hasValues = enumType.TryGetProperty("Values", out var values)
+                        && values.ValueKind == JsonValueKind.Array;
 
         var options = new List<string>();
         var indexes = new List<int>();
         var implementations = new List<List<int>>();
         var captions = new List<string?>();
         var nextOrdinal = 0;
-        foreach (var value in values.EnumerateArray())
+        foreach (var value in hasValues
+                     ? values.EnumerateArray().Cast<JsonElement>()
+                     : Enumerable.Empty<JsonElement>())
         {
             var optionName = value.TryGetProperty("Name", out var optionNameProp)
                 ? optionNameProp.GetString() ?? string.Empty

--- a/AlRunner/Patches/EnumMetadataPatches.cs
+++ b/AlRunner/Patches/EnumMetadataPatches.cs
@@ -746,8 +746,21 @@ public static partial class BcRuntime
                 .GetType("Microsoft.Dynamics.Nav.Runtime.PlatformMetadataProvider");
             var inst = pmpT?.GetProperty("Instance",
                 BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic)?.GetValue(null);
-            var getEnums = pmpT?.GetMethod("GetSystemEnums");
-            var getAl = pmpT?.GetMethod("GetEnumALCodeById");
+            // BcShape.FindMethod, not a name-only GetMethod (#3069): an overload appearing on
+            // either of these would otherwise pick one silently, and BC moving them is exactly
+            // the case this whole method must degrade on rather than guess through. Absence
+            // still returns null, which the guard below treats as "no inventory to read".
+            var getEnums = pmpT == null ? null : AlRunner.Infrastructure.BcShape.FindMethod(
+                pmpT, "GetSystemEnums", BindingFlags.Public | BindingFlags.Instance,
+                "system enum registration", "PlatformMetadataProvider.GetSystemEnums",
+                "BC's own inventory of the platform enums no app declares — see "
+                + "docs/field-enum-metadata-resolution.md",
+                types: Type.EmptyTypes);
+            var getAl = pmpT == null ? null : AlRunner.Infrastructure.BcShape.FindMethod(
+                pmpT, "GetEnumALCodeById", BindingFlags.Public | BindingFlags.Instance,
+                "system enum registration", "PlatformMetadataProvider.GetEnumALCodeById",
+                "the AL source BC ships for one platform enum, parsed for its value declarations",
+                types: new[] { typeof(int) });
             if (inst == null || getEnums == null || getAl == null) return;
             if (getEnums.Invoke(inst, null) is not System.Collections.IDictionary dict) return;
 
@@ -828,6 +841,35 @@ public static partial class BcRuntime
     // Id property: that property is `GetAppGroupAwareEnumMetadata().Id`, which calls the very
     // method this helper replaces, so reading it here would recurse.
     private static FieldInfo? _fFieldEnumMetadataEnumId;
+
+    /// <summary>
+    /// Whether an enum object with this id can be resolved to real values in THIS bundle — i.e.
+    /// whether <see cref="NCLFieldEnumMetadata_GetEnumMetadataFromRegistry"/> would answer
+    /// rather than raise.
+    ///
+    /// <para>The MetaField builder asks before stating a field's <c>enumTypeId</c>, because
+    /// stating it is what makes BC resolve it (#3594). A bundle that never loaded the symbols
+    /// of the app declaring the enum has nothing to resolve: the corpus names Base Application
+    /// as an explicit dependency and so registers its 721 enums, while a bundle declaring only
+    /// an <c>application</c> FLOOR with <c>dependencies: []</c> resolves the stripped platform
+    /// packages, which carry no enum symbols at all. Stating an id that cannot be resolved
+    /// turned the whole bundle into a 0-of-N abort — the exact failure #3594 exists to remove,
+    /// reproduced on a different manifest shape
+    /// (<c>AlRunner.Tests/Fixtures/BcFloorSkip/healthy-suite</c>).</para>
+    ///
+    /// <para>Not stating the id is the FAITHFUL answer for such a bundle, not a silent fake:
+    /// with no enum id the upstream BC factory builds the plain
+    /// <c>NCLOptionMetadataWithCaptions</c> from the field's own inline option string, which is
+    /// exactly what the runner answered before #3594 and what every such bundle has always
+    /// seen. The value is stated wherever it can be backed and withheld where it cannot, rather
+    /// than asserted everywhere and failing where it is unbacked.</para>
+    /// </summary>
+    public static bool CanResolveEnumMetadata(int enumId)
+    {
+        if (enumId == 0) return false;
+        EnsureSystemEnumsRegistered();
+        return AlEnumMetadataRegistry.TryGet(enumId, out _);
+    }
 
     /// <summary>
     /// Replacement for <c>NCLFieldEnumMetadata.GetEnumMetadataFromMetadataProvider()</c> — the

--- a/AlRunner/Patches/EnumMetadataPatches.cs
+++ b/AlRunner/Patches/EnumMetadataPatches.cs
@@ -858,35 +858,6 @@ public static partial class BcRuntime
     private static FieldInfo? _fFieldEnumMetadataEnumId;
 
     /// <summary>
-    /// Whether an enum object with this id can be resolved to real values in THIS bundle — i.e.
-    /// whether <see cref="NCLFieldEnumMetadata_GetEnumMetadataFromRegistry"/> would answer
-    /// rather than raise.
-    ///
-    /// <para>The MetaField builder asks before stating a field's <c>enumTypeId</c>, because
-    /// stating it is what makes BC resolve it (#3594). A bundle that never loaded the symbols
-    /// of the app declaring the enum has nothing to resolve: the corpus names Base Application
-    /// as an explicit dependency and so registers its 721 enums, while a bundle declaring only
-    /// an <c>application</c> FLOOR with <c>dependencies: []</c> resolves the stripped platform
-    /// packages, which carry no enum symbols at all. Stating an id that cannot be resolved
-    /// turned the whole bundle into a 0-of-N abort — the exact failure #3594 exists to remove,
-    /// reproduced on a different manifest shape
-    /// (<c>AlRunner.Tests/Fixtures/BcFloorSkip/healthy-suite</c>).</para>
-    ///
-    /// <para>Not stating the id is the FAITHFUL answer for such a bundle, not a silent fake:
-    /// with no enum id the upstream BC factory builds the plain
-    /// <c>NCLOptionMetadataWithCaptions</c> from the field's own inline option string, which is
-    /// exactly what the runner answered before #3594 and what every such bundle has always
-    /// seen. The value is stated wherever it can be backed and withheld where it cannot, rather
-    /// than asserted everywhere and failing where it is unbacked.</para>
-    /// </summary>
-    public static bool CanResolveEnumMetadata(int enumId)
-    {
-        if (enumId == 0) return false;
-        EnsureSystemEnumsRegistered();
-        return AlEnumMetadataRegistry.TryGet(enumId, out _);
-    }
-
-    /// <summary>
     /// Replacement for <c>NCLFieldEnumMetadata.GetEnumMetadataFromMetadataProvider()</c> — the
     /// single point through which every accessor of an <c>Enum</c>-typed FIELD's option
     /// metadata resolves. <c>OptionString</c>, <c>Options</c>, <c>OrdinalValues</c>,

--- a/AlRunner/Patches/EnumMetadataPatches.cs
+++ b/AlRunner/Patches/EnumMetadataPatches.cs
@@ -744,8 +744,17 @@ public static partial class BcRuntime
         {
             var pmpT = typeof(NCLOptionMetadata).Assembly
                 .GetType("Microsoft.Dynamics.Nav.Runtime.PlatformMetadataProvider");
-            var inst = pmpT?.GetProperty("Instance",
-                BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic)?.GetValue(null);
+            // BcShape.Property, not `GetProperty(...)?` (#3663): a null here would propagate
+            // through `?.` and leave the guard below reading "there is no inventory", which is
+            // the same answer a BC build that genuinely exposes none gives. Those two must not
+            // look alike — one is a rename to react to, the other is nothing to do — so an
+            // absent member refuses loudly and the catch below turns it back into the
+            // documented degradation, with the shape gap named.
+            var inst = pmpT == null ? null : AlRunner.Infrastructure.BcShape.Property(
+                pmpT, "Instance", BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic,
+                "system enum registration",
+                "the PlatformMetadataProvider singleton BC resolves its own platform enums through")
+                .GetValue(null);
             // BcShape.FindMethod, not a name-only GetMethod (#3069): an overload appearing on
             // either of these would otherwise pick one silently, and BC moving them is exactly
             // the case this whole method must degrade on rather than guess through. Absence
@@ -772,9 +781,15 @@ public static partial class BcRuntime
                 // present is the one that came from real symbols.
                 if (AlEnumMetadataRegistry.TryGet(id, out _)) continue;
 
-                var name = de.Value?.GetType()
-                    .GetProperty("Name", BindingFlags.Public | BindingFlags.Instance)
-                    ?.GetValue(de.Value) as string ?? string.Empty;
+                // Same reasoning as the Instance lookup above: a renamed Name property would
+                // otherwise degrade to the empty string, registering all 16 platform enums
+                // under no name at all rather than saying the shape moved.
+                var name = de.Value == null ? string.Empty
+                    : AlRunner.Infrastructure.BcShape.Property(
+                        de.Value.GetType(), "Name", BindingFlags.Public | BindingFlags.Instance,
+                        "system enum registration",
+                        "the display name of one platform enum, carried into AlEnumMetadataRegistry")
+                      .GetValue(de.Value) as string ?? string.Empty;
                 if (getAl.Invoke(inst, new object[] { id }) is not byte[] al || al.Length == 0)
                     continue;
 

--- a/AlRunner/Patches/EnumMetadataPatches.cs
+++ b/AlRunner/Patches/EnumMetadataPatches.cs
@@ -39,6 +39,7 @@ using NavOption = Microsoft.Dynamics.Nav.Runtime.NavOption;
 using NavText = Microsoft.Dynamics.Nav.Runtime.NavText;
 using ITreeObject = Microsoft.Dynamics.Nav.Runtime.ITreeObject;
 using StringHelper = Microsoft.Dynamics.Nav.Runtime.StringHelper;
+using NavMetadataNotFoundException = Microsoft.Dynamics.Nav.Types.NavMetadataNotFoundException;
 
 namespace AlRunner;
 
@@ -697,6 +698,186 @@ public static partial class BcRuntime
             }
         }
         return NCLOptionMetadata.Default;
+    }
+
+    /// <summary>
+    /// BC's own 16 platform ("system") enums — ids 2000000001..2000000017 — registered into
+    /// <see cref="AlEnumMetadataRegistry"/> from <c>PlatformMetadataProvider</c>, which is the
+    /// inventory BC itself resolves them from.
+    ///
+    /// <para>Why this is needed at all: every OTHER enum reaches the registry because some app
+    /// declares it (<c>RecordPatches.AddBcAppPath</c> reads each dependency .app's symbols).
+    /// A system enum is declared by the PLATFORM — it appears in no app's SymbolReference.json,
+    /// so nothing put it in the registry, and a field typed by one could not resolve. Base
+    /// Application table 2000000132 has such a field (enum 2000000002 "Entity Text Scenario").</para>
+    ///
+    /// <para>Source of truth, and why it is BC's own: <c>GetEnumALCodeById</c> returns the AL
+    /// source BC ships for the enum, so the values, ordinals and captions parsed here are
+    /// Microsoft's own declaration rather than anything this runner invents. Measured on BC
+    /// 28.1: 16 enums, 57 <c>value(...)</c> declarations, 73 captions, all in the one shape the
+    /// regex below matches; three of the sixteen declare no values at all (they are extensible
+    /// enums an app is expected to extend), and an empty option set is the correct answer for
+    /// those rather than a reason to refuse.</para>
+    /// </summary>
+    private static int _systemEnumsRegistered;
+
+    private static readonly System.Text.RegularExpressions.Regex _rxSystemEnumValue = new(
+        // value(<ordinal>; <Name>) — the name is bare or "quoted"; an optional { Caption = '...'; }
+        // body follows. Both name forms occur in BC's own source (measured: 27 of 57 quoted).
+        @"value\s*\(\s*(?<ord>-?\d+)\s*;\s*(?:""(?<qname>[^""]*)""|(?<name>[A-Za-z_][A-Za-z0-9_]*))\s*\)"
+        + @"(?<body>\s*\{(?<inner>[^{}]*)\})?",
+        System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    private static readonly System.Text.RegularExpressions.Regex _rxSystemEnumCaption = new(
+        @"Caption\s*=\s*'(?<cap>[^']*)'", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    /// <summary>
+    /// Register BC's platform enums, once per process. Idempotent and never throws: a BC build
+    /// that does not expose this inventory leaves the registry exactly as it was, and a field
+    /// typed by a system enum then fails the same loud way it did before this existed — a
+    /// missing optimisation, not a silent wrong answer.
+    /// </summary>
+    internal static void EnsureSystemEnumsRegistered()
+    {
+        if (System.Threading.Interlocked.Exchange(ref _systemEnumsRegistered, 1) != 0) return;
+        try
+        {
+            var pmpT = typeof(NCLOptionMetadata).Assembly
+                .GetType("Microsoft.Dynamics.Nav.Runtime.PlatformMetadataProvider");
+            var inst = pmpT?.GetProperty("Instance",
+                BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic)?.GetValue(null);
+            var getEnums = pmpT?.GetMethod("GetSystemEnums");
+            var getAl = pmpT?.GetMethod("GetEnumALCodeById");
+            if (inst == null || getEnums == null || getAl == null) return;
+            if (getEnums.Invoke(inst, null) is not System.Collections.IDictionary dict) return;
+
+            foreach (System.Collections.DictionaryEntry de in dict)
+            {
+                if (de.Key is not int id) continue;
+                // Never overwrite a registration an app made: an enumextension on a system enum
+                // is registered separately and merged by TryGet, and a base entry already
+                // present is the one that came from real symbols.
+                if (AlEnumMetadataRegistry.TryGet(id, out _)) continue;
+
+                var name = de.Value?.GetType()
+                    .GetProperty("Name", BindingFlags.Public | BindingFlags.Instance)
+                    ?.GetValue(de.Value) as string ?? string.Empty;
+                if (getAl.Invoke(inst, new object[] { id }) is not byte[] al || al.Length == 0)
+                    continue;
+
+                var (options, ordinals, captions) = ParseSystemEnumValues(
+                    System.Text.Encoding.UTF8.GetString(al));
+                AlEnumMetadataRegistry.Register(id, name, options, ordinals, captions: captions);
+            }
+        }
+        catch
+        {
+            // Reading BC's inventory is best-effort by design (see the doc comment above): the
+            // failure mode without it is the pre-existing loud one, never a wrong value.
+        }
+    }
+
+    /// <summary>
+    /// The <c>value(ord; Name) { Caption = '...'; }</c> declarations of one system enum's AL
+    /// source. A doc comment can carry the word <c>value</c>, so matches are taken only from
+    /// source with comments stripped.
+    /// </summary>
+    internal static (string[] Options, int[] Ordinals, string?[] Captions) ParseSystemEnumValues(string alSource)
+    {
+        var src = StripAlComments(alSource);
+        var options = new List<string>();
+        var ordinals = new List<int>();
+        var captions = new List<string?>();
+        foreach (System.Text.RegularExpressions.Match m in _rxSystemEnumValue.Matches(src))
+        {
+            if (!int.TryParse(m.Groups["ord"].Value, out var ord)) continue;
+            var name = m.Groups["qname"].Success ? m.Groups["qname"].Value : m.Groups["name"].Value;
+            var inner = m.Groups["inner"].Success ? m.Groups["inner"].Value : string.Empty;
+            var cap = _rxSystemEnumCaption.Match(inner);
+            options.Add(name);
+            ordinals.Add(ord);
+            // null means "declares no Caption", the same convention Register/AlEnumOptionMetadata
+            // already use — the consumer then applies AL's own default (the member name).
+            captions.Add(cap.Success ? cap.Groups["cap"].Value : null);
+        }
+        return (options.ToArray(), ordinals.ToArray(), captions.ToArray());
+    }
+
+    /// <summary>Strip <c>//</c> (including <c>///</c>) and <c>/* */</c> comments, leaving string
+    /// literals alone so a caption containing <c>//</c> survives.</summary>
+    private static string StripAlComments(string src)
+    {
+        var sb = new System.Text.StringBuilder(src.Length);
+        bool inStr = false, inLine = false, inBlock = false;
+        for (int i = 0; i < src.Length; i++)
+        {
+            char c = src[i];
+            char n = i + 1 < src.Length ? src[i + 1] : '\0';
+            if (inLine) { if (c == '\n') { inLine = false; sb.Append(c); } continue; }
+            if (inBlock) { if (c == '*' && n == '/') { inBlock = false; i++; } continue; }
+            if (inStr) { sb.Append(c); if (c == '\'') inStr = false; continue; }
+            if (c == '\'') { inStr = true; sb.Append(c); continue; }
+            if (c == '/' && n == '/') { inLine = true; continue; }
+            if (c == '/' && n == '*') { inBlock = true; i++; continue; }
+            sb.Append(c);
+        }
+        return sb.ToString();
+    }
+
+    // NCLFieldEnumMetadata.enumId — `private readonly int`. Read by field, never through the
+    // Id property: that property is `GetAppGroupAwareEnumMetadata().Id`, which calls the very
+    // method this helper replaces, so reading it here would recurse.
+    private static FieldInfo? _fFieldEnumMetadataEnumId;
+
+    /// <summary>
+    /// Replacement for <c>NCLFieldEnumMetadata.GetEnumMetadataFromMetadataProvider()</c> — the
+    /// single point through which every accessor of an <c>Enum</c>-typed FIELD's option
+    /// metadata resolves. <c>OptionString</c>, <c>Options</c>, <c>OrdinalValues</c>,
+    /// <c>GetNames</c> and the rest all funnel through <c>GetAppGroupAwareEnumMetadata</c>,
+    /// which caches per app group and calls this one virtual.
+    ///
+    /// <para>Observably equivalent: the real body is
+    /// <c>NavGlobal.MetadataProvider.GetEnumMetadata(enumId)</c>, which resolves
+    /// <c>NCLMetadata.TryGetMetaApplicationObject(ObjectType.Enum, id)</c> and returns that
+    /// object's declared values, ordinals and captions. <see cref="AlEnumMetadataRegistry"/>
+    /// holds exactly those, for a source-compiled enum and for a precompiled dependency's
+    /// alike — <c>RecordPatches.AddBcAppPath</c> loads every dependency .app's enums into it.
+    /// So this substitutes the lookup's DATA SOURCE, not its outcome: an enum id nothing
+    /// declares still raises BC's own <c>NavMetadataNotFoundException</c>, which is the only
+    /// exception <c>TryGetMetaApplicationObject</c> can answer <c>false</c> for.</para>
+    ///
+    /// <para>Same shape and same reason as
+    /// <c>NCLMetaForm.ApplyAppGroupAwareEnumMetadataToPageExpressions</c> (#1896,
+    /// PageEnumFieldMetadataPatches.cs): a by-id Enum lookup at a consumption point the runner
+    /// never populated. Derivation, the corpus measurement and the residual system-enum gap
+    /// are in docs/field-enum-metadata-resolution.md.</para>
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static NCLOptionMetadata NCLFieldEnumMetadata_GetEnumMetadataFromRegistry(object self)
+    {
+        if (self == null) throw new ArgumentNullException(nameof(self));
+
+        var f = _fFieldEnumMetadataEnumId ??= self.GetType().GetField(
+            "enumId", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException(
+                "[EnumMetadata] NCLFieldEnumMetadata.enumId not found — Ncl shape changed. "
+                + "This helper replaces GetEnumMetadataFromMetadataProvider and has no other "
+                + "way to learn which enum the field names.");
+
+        var enumId = (int)(f.GetValue(self) ?? 0);
+
+        // BC's own platform enums are declared by no app, so nothing else puts them in the
+        // registry. Registered lazily here — the only consumption point that needs them.
+        EnsureSystemEnumsRegistered();
+
+        if (AlEnumMetadataRegistry.TryGet(enumId, out _))
+            return NCLEnumMetadata_CreateByIdAlAware(enumId);
+
+        // Not a fallback to Default: an enum id no app declares is a real metadata failure, and
+        // BC's own type is what lets TryGetMetaApplicationObject answer `false` rather than
+        // propagate. Answering Default here would make an unknown enum silently read as a
+        // valueless one — the silent fake loud-failures.md forbids.
+        throw new NavMetadataNotFoundException(Microsoft.Dynamics.Nav.Types.ObjectType.Enum, enumId);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -577,16 +577,16 @@ public static partial class RecordPatches
                 args[i] = dcVal;
                 continue;
             }
-            // The enum object an `Enum "X"`-typed field names is deliberately NOT passed, even
-            // though ParsedField now carries it. Passing enumTypeId makes BC's own
-            // FieldDataProvider.GetFieldRecordBuffer resolve that id through NCLMetadata, and
-            // for a PRECOMPILED app's enum the runner registers no metadata object for it —
-            // measured on the corpus: every read of the Field virtual table (2000000041) for
-            // Base Application table 1366 then threw NavMetadataNotFoundException("Enum 8889"),
-            // which aborted codeunit 2 Company-Initialize and took the whole corpus app's
-            // 2,900 tests with it. Reading the id is the easy half; making it resolvable is
-            // the work, and it is tracked on #3594 with MetaField.EnumTypeId still declared in
-            // the metadata-equivalence allowlist.
+            // #3594 — the enum object an `Enum "X"`-typed field names. Stating this makes BC's
+            // own FieldDataProvider.GetFieldRecordBuffer resolve the id through NCLMetadata, so
+            // it is only safe once that lookup can answer: BcRuntime's Cecil rewrite of
+            // NCLFieldEnumMetadata.GetEnumMetadataFromMetadataProvider serves it from
+            // AlEnumMetadataRegistry, and EnsureSystemEnumsRegistered adds BC's own platform
+            // enums, which no app declares. Both halves must ship together — stating the id
+            // without them aborted the whole corpus app (0 of 3,112 tests) on the enum of Base
+            // Application table 1366. See docs/field-enum-metadata-resolution.md.
+            if (p.Name == "enumTypeId" && f.EnumTypeId != 0) { args[i] = f.EnumTypeId; continue; }
+            if (p.Name == "enumTypeName" && !string.IsNullOrEmpty(f.EnumTypeName)) { args[i] = f.EnumTypeName; continue; }
             if (p.Name == "fieldClass" && _tFieldClass != null && (f.IsFlowField || f.IsFlowFilter))
             {
                 // #1716 — FlowFilter must reach the metadata as FlowFilter. NCLMetaTable

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -579,23 +579,26 @@ public static partial class RecordPatches
             }
             // #3594 — the enum object an `Enum "X"`-typed field names. Stating this makes BC's
             // own FieldDataProvider.GetFieldRecordBuffer resolve the id through NCLMetadata, so
-            // it is only safe where that lookup can answer. Three things make it answer:
+            // it is only safe once that lookup can answer. Two things make it answer, and both
+            // must be present or a bundle becomes a 0-of-N abort rather than degrading:
             // BcRuntime's Cecil rewrite of NCLFieldEnumMetadata.GetEnumMetadataFromMetadataProvider
-            // serves it from AlEnumMetadataRegistry; EnsureSystemEnumsRegistered adds BC's own
-            // platform enums, which no app declares; and the guard below withholds the id in a
-            // bundle that loaded no symbols for the declaring app. Any one of them missing turns
-            // the bundle into a 0-of-N abort — measured for all three.
+            // serves the id from AlEnumMetadataRegistry, and EnsureSystemEnumsRegistered adds
+            // BC's own platform enums, which no app declares.
+            //
+            // Stated unconditionally, deliberately. An intermediate version of this change
+            // withheld the id when the registry did not know it; that read as prudent and was
+            // wrong twice over — it masked the real defect (BcAppSymbolCache dropped every enum
+            // declaring no `Values`, so 8889 was missing from apps that genuinely ship it) and
+            // it made the runner answer 0 where BC answers a real id, which the
+            // metadata-equivalence harness correctly reported as a reader regression on 17
+            // fields. Fixing the reader removed the need for the guard entirely.
             // See docs/field-enum-metadata-resolution.md.
-            // Stated together or not at all, and only when the enum can actually be resolved in
-            // THIS bundle — see BcRuntime.CanResolveEnumMetadata for why an unresolvable id is
-            // withheld rather than asserted (it aborts the whole bundle) or faked.
-            if (p.Name == "enumTypeId" && AlRunner.BcRuntime.CanResolveEnumMetadata(f.EnumTypeId))
+            if (p.Name == "enumTypeId" && f.EnumTypeId != 0)
             {
                 args[i] = f.EnumTypeId;
                 continue;
             }
-            if (p.Name == "enumTypeName" && !string.IsNullOrEmpty(f.EnumTypeName)
-                && AlRunner.BcRuntime.CanResolveEnumMetadata(f.EnumTypeId))
+            if (p.Name == "enumTypeName" && !string.IsNullOrEmpty(f.EnumTypeName))
             {
                 args[i] = f.EnumTypeName;
                 continue;

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -579,14 +579,27 @@ public static partial class RecordPatches
             }
             // #3594 — the enum object an `Enum "X"`-typed field names. Stating this makes BC's
             // own FieldDataProvider.GetFieldRecordBuffer resolve the id through NCLMetadata, so
-            // it is only safe once that lookup can answer: BcRuntime's Cecil rewrite of
-            // NCLFieldEnumMetadata.GetEnumMetadataFromMetadataProvider serves it from
-            // AlEnumMetadataRegistry, and EnsureSystemEnumsRegistered adds BC's own platform
-            // enums, which no app declares. Both halves must ship together — stating the id
-            // without them aborted the whole corpus app (0 of 3,112 tests) on the enum of Base
-            // Application table 1366. See docs/field-enum-metadata-resolution.md.
-            if (p.Name == "enumTypeId" && f.EnumTypeId != 0) { args[i] = f.EnumTypeId; continue; }
-            if (p.Name == "enumTypeName" && !string.IsNullOrEmpty(f.EnumTypeName)) { args[i] = f.EnumTypeName; continue; }
+            // it is only safe where that lookup can answer. Three things make it answer:
+            // BcRuntime's Cecil rewrite of NCLFieldEnumMetadata.GetEnumMetadataFromMetadataProvider
+            // serves it from AlEnumMetadataRegistry; EnsureSystemEnumsRegistered adds BC's own
+            // platform enums, which no app declares; and the guard below withholds the id in a
+            // bundle that loaded no symbols for the declaring app. Any one of them missing turns
+            // the bundle into a 0-of-N abort — measured for all three.
+            // See docs/field-enum-metadata-resolution.md.
+            // Stated together or not at all, and only when the enum can actually be resolved in
+            // THIS bundle — see BcRuntime.CanResolveEnumMetadata for why an unresolvable id is
+            // withheld rather than asserted (it aborts the whole bundle) or faked.
+            if (p.Name == "enumTypeId" && AlRunner.BcRuntime.CanResolveEnumMetadata(f.EnumTypeId))
+            {
+                args[i] = f.EnumTypeId;
+                continue;
+            }
+            if (p.Name == "enumTypeName" && !string.IsNullOrEmpty(f.EnumTypeName)
+                && AlRunner.BcRuntime.CanResolveEnumMetadata(f.EnumTypeId))
+            {
+                args[i] = f.EnumTypeName;
+                continue;
+            }
             if (p.Name == "fieldClass" && _tFieldClass != null && (f.IsFlowField || f.IsFlowFilter))
             {
                 // #1716 — FlowFilter must reach the metadata as FlowFilter. NCLMetaTable

--- a/docs/field-enum-metadata-resolution.md
+++ b/docs/field-enum-metadata-resolution.md
@@ -104,31 +104,30 @@ entry an app already registered, and never throws: a BC build that does not expo
 inventory leaves the registry untouched, and a field typed by a system enum then fails the same
 loud way it did before. That is a missing optimisation, not a silent wrong answer.
 
-**3. Withhold the id where it cannot be backed.**
-The two steps above cover every enum some app *declares*. They do not cover a bundle that never
-loaded the declaring app's symbols at all, and that turned out to be a whole manifest shape
-rather than an edge case.
+**3. Stop dropping an enum that declares no values.**
+The two steps above cover every enum the registry holds. They do not cover an enum the registry
+never learned, and one whole *class* of enum was being silently discarded at the symbol reader.
 
-A bundle whose `app.json` carries an `application` **floor** with `dependencies: []` resolves
-the stripped platform packages, which carry **no enum symbols whatsoever** — measured on
-`AlRunner.Tests/Fixtures/BcFloorSkip/healthy-suite`: 721 enums registered, Base Application's
-8889 among the absent, against **zero** such misses on the corpus, which names Base Application
-as an explicit dependency and so registers its enums through `RecordPatches.AddBcAppPath`. Four
-fixtures in this repository have that shape (`BcFloorSkip/healthy-suite`,
-`BcFloorSkip/future-suite`, `CrossMajorNote`, `SubscriberScanAudit`).
+`BcAppSymbolCache.TryParseEnumSymbol` began `if (!enumType.TryGetProperty("Values", …)) return
+null;` — so an enum with **no `Values` array at all** was dropped as unreadable. Extensible enums
+whose members all arrive from enumextensions are written exactly that way. Measured on System
+Application 28.1.49838.54308: **3 of its 141 enums** carry no `Values`, and **8889 "Email
+Connector" is one of them** — the very enum this issue is named after, declared by an app that
+genuinely ships it, and absent from the registry all along.
 
-Stating an id that cannot be resolved reproduced the **same 0-of-N abort** on those bundles that
-this whole change exists to remove elsewhere. So `BuildMetaField` asks
-`BcRuntime.CanResolveEnumMetadata(id)` first, and states `enumTypeId`/`enumTypeName` — together
-or not at all — only when the answer is yes.
+That gap was latent for as long as nothing resolved an enum **by id**: the ordinal and caption
+consumers only ever ask about enums they already hold. Stating `EnumTypeId` is what made the
+runner ask, and BC's own metadata names 8889 on five System Application tables.
 
-**Withholding is the faithful answer here, not a silent fake.** With no enum id BC's own factory
-builds the plain `NCLOptionMetadataWithCaptions` from the field's inline option string, which is
-exactly what such a bundle saw before this change and what it still sees. The value is stated
-wherever it can be backed and withheld where it cannot, rather than asserted everywhere and
-failing where it is unbacked. A bundle that *can* resolve the enum is unaffected, which is what
-keeps the guard from being satisfiable by withholding the id everywhere —
-`FloorOnlyBundleEnumFieldTests` asserts both directions.
+An empty option list is the faithful answer here — the enum exists and has no members of its
+own — so the parse now accepts it and keeps the id and name.
+
+**Why there is no "withhold the id" guard.** An intermediate version of this change withheld the
+id whenever the registry did not know it. That read as prudent and was wrong twice over: it
+**masked** this reader gap rather than exposing it, and it made the runner answer `0` where BC
+answers a real id, which `MetadataEquivalenceHarnessTests` correctly reported as a **reader
+regression on 17 fields**. Fixing the reader removed the need for the guard entirely, and the
+floor-only bundles that motivated it pass without it — measured, with the guard deleted.
 
 ## Result
 
@@ -144,8 +143,12 @@ and on `AlRunner.Tests/Fixtures/BcFloorSkip/healthy-suite`, the floor-only shape
 
 | | tests | pass | exec-fail |
 |---|---|---|---|
-| without the resolvability guard | **0** | **0** | **1** |
-| with it | 1 | 1 | 0 |
+| with enum 8889 dropped at the reader | **0** | **0** | **1** |
+| with the parse fixed | 1 | 1 | 0 |
+
+and the metadata-equivalence harness, run with the engine bootstrapped and a matching
+ground-truth bundle: **7 passed, 0 failed, 0 skipped** — the skip count read directly, because
+the summary line prints `Passed!` either way.
 
 and `MetaField.EnumTypeId` moves from a declared difference to an agreeing one, so its entry is
 deleted from `tests/expectations/metadata-equivalence/allowlist.json` and
@@ -164,11 +167,14 @@ distinguishes them:
 |---|---|
 | the Cecil rewrite | corpus aborts on enum **8889**, table 1366 |
 | `EnsureSystemEnumsRegistered` | corpus aborts on enum **2000000002**, table 2000000132 |
-| the resolvability guard | every **floor-only** bundle aborts on enum 8889 — while the corpus stays green |
+| the valueless-enum parse | `FloorOnlyBundleEnumFieldTests` fails; every floor-only bundle aborts on enum 8889 |
 
-That last row is the one worth remembering: the corpus is not a sufficient test bed for this
-change, because the manifest shape that breaks is one the corpus does not have. CI caught it;
-the corpus run could not.
+**No one test bed covers all three**, which is the durable lesson. The corpus stays green through
+the third — it names Base Application explicitly and its bundles resolve real symbols — so a
+change verified only against the corpus reads as safe when it is not. The floor-only fixtures and
+the metadata-equivalence harness are what discriminate, and the harness has to be made to RUN
+(`tools/engine-test-bootstrap.sh` after every build, `--settings engine.runsettings`, and a
+ground-truth bundle matching the build under test) or it skips while printing `Passed!`.
 
 **`enumId` must be read as a field, never through the `Id` property.**
 `NCLFieldEnumBaseMetadata.Id` is `GetAppGroupAwareEnumMetadata().Id`, which calls the very

--- a/docs/field-enum-metadata-resolution.md
+++ b/docs/field-enum-metadata-resolution.md
@@ -63,7 +63,8 @@ rewrite (`AlRunner/Patches/PageEnumFieldMetadataPatches.cs`): a by-id `Enum` loo
 consumption point the runner never populated.
 
 **2. Register BC's own platform enums.**
-The redirect alone is not enough. **System enums** — ids `2000000001`..`2000000017` — are
+The redirect alone is not enough. **System enums** — 16 of them, spanning `2000000001` to
+`2000000017` with `2000000016` absent — are
 declared by the platform, appear in no app's `SymbolReference.json`, and so were in no registry.
 Base Application table `2000000132` has a field typed by enum `2000000002` "Entity Text
 Scenario", which is why the corpus still aborted with the redirect in place, now naming that id
@@ -80,7 +81,7 @@ Measured on BC 28.1.49838.53910:
 
 | | |
 |---|---|
-| system enums exposed | 16 (`2000000001`–`2000000015`, `2000000017`) |
+| system enums exposed | 16 — `2000000001`–`2000000015` and `2000000017`; there is no `2000000016` |
 | `value(...)` declarations across all of them | 57 |
 | declarations using a `"quoted"` name | 27 |
 | `Caption = '...'` occurrences | 73 |
@@ -103,6 +104,32 @@ entry an app already registered, and never throws: a BC build that does not expo
 inventory leaves the registry untouched, and a field typed by a system enum then fails the same
 loud way it did before. That is a missing optimisation, not a silent wrong answer.
 
+**3. Withhold the id where it cannot be backed.**
+The two steps above cover every enum some app *declares*. They do not cover a bundle that never
+loaded the declaring app's symbols at all, and that turned out to be a whole manifest shape
+rather than an edge case.
+
+A bundle whose `app.json` carries an `application` **floor** with `dependencies: []` resolves
+the stripped platform packages, which carry **no enum symbols whatsoever** — measured on
+`AlRunner.Tests/Fixtures/BcFloorSkip/healthy-suite`: 721 enums registered, Base Application's
+8889 among the absent, against **zero** such misses on the corpus, which names Base Application
+as an explicit dependency and so registers its enums through `RecordPatches.AddBcAppPath`. Four
+fixtures in this repository have that shape (`BcFloorSkip/healthy-suite`,
+`BcFloorSkip/future-suite`, `CrossMajorNote`, `SubscriberScanAudit`).
+
+Stating an id that cannot be resolved reproduced the **same 0-of-N abort** on those bundles that
+this whole change exists to remove elsewhere. So `BuildMetaField` asks
+`BcRuntime.CanResolveEnumMetadata(id)` first, and states `enumTypeId`/`enumTypeName` — together
+or not at all — only when the answer is yes.
+
+**Withholding is the faithful answer here, not a silent fake.** With no enum id BC's own factory
+builds the plain `NCLOptionMetadataWithCaptions` from the field's inline option string, which is
+exactly what such a bundle saw before this change and what it still sees. The value is stated
+wherever it can be backed and withheld where it cannot, rather than asserted everywhere and
+failing where it is unbacked. A bundle that *can* resolve the enum is unaffected, which is what
+keeps the guard from being satisfiable by withholding the id everywhere —
+`FloorOnlyBundleEnumFieldTests` asserts both directions.
+
 ## Result
 
 At corpus pin `c9d5f656`, BC 28.1.49838.53910:
@@ -111,7 +138,14 @@ At corpus pin `c9d5f656`, BC 28.1.49838.53910:
 |---|---|---|---|
 | before (baseline) | 3,112 | 3,112 | 0 |
 | stating the id alone | 0 | 0 | **1** |
-| after (both halves) | 3,112 | 3,112 | 0 |
+| after (all three parts) | 3,112 | 3,112 | 0 |
+
+and on `AlRunner.Tests/Fixtures/BcFloorSkip/healthy-suite`, the floor-only shape:
+
+| | tests | pass | exec-fail |
+|---|---|---|---|
+| without the resolvability guard | **0** | **0** | **1** |
+| with it | 1 | 1 | 0 |
 
 and `MetaField.EnumTypeId` moves from a declared difference to an agreeing one, so its entry is
 deleted from `tests/expectations/metadata-equivalence/allowlist.json` and
@@ -123,10 +157,18 @@ supplies the empty string.
 
 ## Two failure modes worth keeping in mind
 
-**The redirect and the system-enum registration are separately load-bearing**, and removing
-either aborts the corpus with a *different* id — 8889 (an app enum, table 1366) without the
-Cecil rewrite, 2000000002 (a platform enum, table 2000000132) without
-`EnsureSystemEnumsRegistered`. That asymmetry is what distinguishes the two guards.
+**All three parts are separately load-bearing**, and each fails differently, which is what
+distinguishes them:
+
+| removed | fails as |
+|---|---|
+| the Cecil rewrite | corpus aborts on enum **8889**, table 1366 |
+| `EnsureSystemEnumsRegistered` | corpus aborts on enum **2000000002**, table 2000000132 |
+| the resolvability guard | every **floor-only** bundle aborts on enum 8889 — while the corpus stays green |
+
+That last row is the one worth remembering: the corpus is not a sufficient test bed for this
+change, because the manifest shape that breaks is one the corpus does not have. CI caught it;
+the corpus run could not.
 
 **`enumId` must be read as a field, never through the `Id` property.**
 `NCLFieldEnumBaseMetadata.Id` is `GetAppGroupAwareEnumMetadata().Id`, which calls the very

--- a/docs/field-enum-metadata-resolution.md
+++ b/docs/field-enum-metadata-resolution.md
@@ -1,0 +1,141 @@
+# Resolving an `Enum`-typed field's option metadata
+
+How the runner answers `MetaField.EnumTypeId` / `EnumTypeName`, and the option metadata BC
+reads alongside them, for a table field declared `Enum "X"`. Issue #3594.
+
+## The two halves, and why they ship together
+
+Reading the value was never the hard part. `TypeDefinition.Subtype.Id` in
+`SymbolReference.json` carries it, and #3545 measured that the presence of `Subtype.Id` and the
+presence of BC's own emitted `EnumTypeId` agree on **3,848 of 3,848** table-declared field
+observations across four BC builds.
+
+Stating it is the hard part. A `MetaField` that declares an `EnumTypeId` makes BC build an
+`NCLFieldEnumMetadata` for the field instead of a plain `NCLOptionMetadataWithCaptions`, and
+every accessor on that object — `OptionString`, `Options`, `OrdinalValues`, `GetNames`,
+`GetCaptionFromIndex` — funnels through one virtual:
+
+```
+NCLFieldEnumBaseMetadata.GetAppGroupAwareEnumMetadata()      // caches per app group
+  -> NCLFieldEnumMetadata.GetEnumMetadataFromMetadataProvider()
+       -> NavGlobal.MetadataProvider.GetEnumMetadata(enumId)
+            -> NCLMetadata.TryGetMetaApplicationObject(ObjectType.Enum, id)
+                 -> throw new NavMetadataNotFoundException(ObjectType.Enum, id)
+```
+
+That last lookup is one the runner never populated for `Enum` objects. Tables, pages, reports,
+queries, xmlports and permission sets all get entries from
+`RecordPatches.NclMetadataCachePopulator`; enums never did, because AL enums are served through
+a different hook entirely (`NCLEnumMetadata.Create(int)` →
+`BcRuntime.NCLEnumMetadata_CreateByIdAlAware`), and nothing on the field path calls it.
+
+So the id was only safe to state once the object it names could be found. Measured on the
+corpus at pin `c9d5f656`, stating it alone:
+
+```
+EXEC-FAIL: out-of-scope: Field (virtual table 2000000041) — not-yet-implemented —
+field-virtual-table: GetFieldRecordBuffer threw for table 1366 field:
+NavMetadataNotFoundException: The metadata object Enum 8889 was not found.
+```
+
+The abort took codeunit 2 `Company-Initialize` with it, so the app reported `EXEC-FAIL` with
+**0 of 3,112 tests run** — a total failure, not a degradation.
+
+## What the fix does
+
+**1. Redirect the lookup at data the runner has.**
+`NCLFieldEnumMetadata.GetEnumMetadataFromMetadataProvider()` is Cecil-rewritten to
+`BcRuntime.NCLFieldEnumMetadata_GetEnumMetadataFromRegistry`, which answers from
+`AlEnumMetadataRegistry` — the same registry `NCLEnumMetadata.Create(int)` already uses, holding
+the values, ordinals, captions and interface implementations of every source-compiled enum and
+of every precompiled dependency's enums (`RecordPatches.AddBcAppPath` loads the latter from each
+`.app`'s symbols).
+
+This substitutes the lookup's **data source**, not its outcome. An enum id nothing declares
+still raises BC's own `NavMetadataNotFoundException` — which is required, not incidental:
+`NCLMetadata.TryGetMetaApplicationObject` is implemented as a `try`/`catch` over that exact
+exception type, so "the object is not there" is only answerable as `false` when it arrives as
+one. Returning `NCLOptionMetadata.Default` instead would make an unknown enum read as a
+valueless one, the silent fake `loud-failures.md` forbids.
+
+Same shape and same cause as #1896's `NCLMetaForm.ApplyAppGroupAwareEnumMetadataToPageExpressions`
+rewrite (`AlRunner/Patches/PageEnumFieldMetadataPatches.cs`): a by-id `Enum` lookup at a
+consumption point the runner never populated.
+
+**2. Register BC's own platform enums.**
+The redirect alone is not enough. **System enums** — ids `2000000001`..`2000000017` — are
+declared by the platform, appear in no app's `SymbolReference.json`, and so were in no registry.
+Base Application table `2000000132` has a field typed by enum `2000000002` "Entity Text
+Scenario", which is why the corpus still aborted with the redirect in place, now naming that id
+rather than 8889.
+
+`BcRuntime.EnsureSystemEnumsRegistered` reads them from BC's own inventory —
+`PlatformMetadataProvider.GetSystemEnums()` for the ids and names, `GetEnumALCodeById(id)` for
+the AL source Microsoft ships for each — and parses the `value(...)` declarations out of that
+source. The values are therefore Microsoft's own declaration, not anything this runner invents.
+
+### What the system-enum population actually is
+
+Measured on BC 28.1.49838.53910:
+
+| | |
+|---|---|
+| system enums exposed | 16 (`2000000001`–`2000000015`, `2000000017`) |
+| `value(...)` declarations across all of them | 57 |
+| declarations using a `"quoted"` name | 27 |
+| `Caption = '...'` occurrences | 73 |
+| enums declaring **no** values | 3 (`2000000001`, `2000000002`, `2000000006`) |
+
+The three that declare nothing are extensible enums an app is expected to extend. An empty
+option set is the correct answer for them, not a parse failure — and `2000000002`, the one that
+aborted the corpus, is among them.
+
+The AL shape is uniform: `value(<ordinal>; <Name>)` with an optional `{ Caption = '...'; }`
+body, the name bare or double-quoted, and no `Locked` or comma-suffixed caption forms in the
+whole population. `BcRuntime.ParseSystemEnumValues` matches exactly that, over source with
+comments stripped — BC's own enum sources are heavily doc-commented, and the word `value`
+appears in prose. `AlRunner.Tests/SystemEnumAlSourceParseTests.cs` pins each of these
+properties, including the two opposite-pair cases: a comment mentioning `value(...)` must not
+become a member, and a comment marker inside a caption string must survive.
+
+Registration is lazy (first field-enum resolution), once per process, never overwrites an
+entry an app already registered, and never throws: a BC build that does not expose this
+inventory leaves the registry untouched, and a field typed by a system enum then fails the same
+loud way it did before. That is a missing optimisation, not a silent wrong answer.
+
+## Result
+
+At corpus pin `c9d5f656`, BC 28.1.49838.53910:
+
+| | tests | pass | exec-fail |
+|---|---|---|---|
+| before (baseline) | 3,112 | 3,112 | 0 |
+| stating the id alone | 0 | 0 | **1** |
+| after (both halves) | 3,112 | 3,112 | 0 |
+
+and `MetaField.EnumTypeId` moves from a declared difference to an agreeing one, so its entry is
+deleted from `tests/expectations/metadata-equivalence/allowlist.json` and
+`MetadataEquivalenceHarnessTests` asserts `AssertReaderAgrees` for it rather than a constant `0`.
+
+`MetaField.EnumTypeName` remains declared under #3568 for an unrelated reason: BC leaves it
+`null` on the ~1,800 fields that are not enum-typed where the runner's `MetaField` constructor
+supplies the empty string.
+
+## Two failure modes worth keeping in mind
+
+**The redirect and the system-enum registration are separately load-bearing**, and removing
+either aborts the corpus with a *different* id — 8889 (an app enum, table 1366) without the
+Cecil rewrite, 2000000002 (a platform enum, table 2000000132) without
+`EnsureSystemEnumsRegistered`. That asymmetry is what distinguishes the two guards.
+
+**`enumId` must be read as a field, never through the `Id` property.**
+`NCLFieldEnumBaseMetadata.Id` is `GetAppGroupAwareEnumMetadata().Id`, which calls the very
+method the rewrite replaces — reading it inside the replacement recurses. The Cecil block
+refuses to install if the `private readonly int enumId` field is not present, because the
+replacement body would otherwise have no way to learn which enum the field names.
+
+## BC-version stability
+
+`NCLFieldEnumMetadata.GetEnumMetadataFromMetadataProvider` is byte-identical between BC 27.0 and
+BC 28.4 — `compare_symbols` reports `signatureChanged: false`, `bodyChanged: false`, zero changed
+blocks — so the rewrite target is not a moving one across the supported range.

--- a/docs/metadata-equivalence.md
+++ b/docs/metadata-equivalence.md
@@ -197,15 +197,16 @@ all stated in `SymbolReference.json`, and the reader read none of them. Together
 classification the Field and Table Metadata virtual tables report, and whether an enum-typed
 field can be resolved back to its enum object at all.
 
-**Two of the three landed.** The enum id did not, and the reason is the useful part: reading it
-was never the problem. Stating `enumTypeId` on the `MetaField` makes BC's own
+**All three landed**, the enum id last and by a different route. Reading it was never the
+problem: stating `enumTypeId` on the `MetaField` makes BC's own
 `FieldDataProvider.GetFieldRecordBuffer` resolve that id through `NCLMetadata`, and the runner
-registers no metadata object for a **precompiled** app's enum — so every read of the Field
-virtual table for Base Application table 1366 threw `NavMetadataNotFoundException("Enum 8889")`,
-which aborted codeunit 2 `Company-Initialize` and reported the corpus app as `EXEC-FAIL` with 0
-of ~2,900 tests run. Registering the metadata is the work, and it is #3594; `MetaField.EnumTypeId`
-stays declared in the allowlist until then, with the measurement below recorded on it so nobody
-re-derives it.
+registered no metadata object for an enum — so every read of the Field virtual table for Base
+Application table 1366 threw `NavMetadataNotFoundException("Enum 8889")`, which aborted codeunit
+2 `Company-Initialize` and reported the corpus app as `EXEC-FAIL` with 0 of 3,112 tests run.
+#3594 made the id resolvable first — a Cecil rewrite of
+`NCLFieldEnumMetadata.GetEnumMetadataFromMetadataProvider` onto `AlEnumMetadataRegistry`, plus
+registration of BC's own 16 platform enums, which no app declares — and only then stated it. See
+[field-enum-metadata-resolution.md](field-enum-metadata-resolution.md).
 
 The rules below are measurements, not readings of the AL documentation. Each was checked by
 joining the fields of Business Foundation and System Application in `SymbolReference.json`
@@ -228,7 +229,7 @@ join through a different route, described next.
 |---|---|
 | `Editable` | stated only where it is `0`; silence means true. So only the false is carried, and `MetaField`'s own null default decides the rest. **Landed.** |
 | field `DataClassification` | see the next section — it is the one with exceptions. **Landed.** |
-| `EnumTypeId` / `EnumTypeName` | `TypeDefinition.Subtype.Id` and `.Name`, when `TypeDefinition.Name == "Enum"`. Presence of the subtype and presence of BC's emitted `EnumTypeId` agree on every observation. **Read, not stated — #3594.** |
+| `EnumTypeId` / `EnumTypeName` | `TypeDefinition.Subtype.Id` and `.Name`, when `TypeDefinition.Name == "Enum"`. Presence of the subtype and presence of BC's emitted `EnumTypeId` agree on every observation. **Landed (#3594)** — stating it required making the id resolvable first. |
 
 **`EnumTypeId`/`EnumTypeName` are not read from AL source either**, independently of #3594. The
 enum's OBJECT ID is not in the type text, and the name alone would produce a pair BC never emits
@@ -320,7 +321,7 @@ builds them by parsing boilerplate XML: `Editable="0"` on all six, and
 | members differing | 74 | 72 |
 | `MetaField.Editable` | 987 | **0** |
 | `MetaField.DataClassification` | 1,564 | **0** |
-| `MetaField.EnumTypeId` | 77 | 77 (#3594) |
+| `MetaField.EnumTypeId` | 77 | 77 — still open at the time of this measurement; closed later by #3594 |
 | `MetaField.EnumTypeName` | 1,888 | 1,888 (#3568) |
 
 No other member moved in either direction, and no new member appeared.

--- a/tests/expectations/metadata-equivalence/allowlist.json
+++ b/tests/expectations/metadata-equivalence/allowlist.json
@@ -300,11 +300,6 @@
       "issue": 3568
     },
     {
-      "member": "MetaField.EnumTypeId",
-      "reason": "BC resolves the enum object's id; the runner answers 0. The AL-observable consequence is that an enum-typed field cannot be resolved back to its enum object. #3545 established WHERE the value is \u2014 TypeDefinition.Subtype.Id, agreeing with BC on 3,848 of 3,848 table-declared field observations across four builds (#3603) \u2014 and did not land it: passing enumTypeId makes BC's own FieldDataProvider.GetFieldRecordBuffer resolve that id through NCLMetadata, and the runner registers no metadata object for a precompiled app's enum, so every read of the Field virtual table for Base Application table 1366 threw NavMetadataNotFoundException(\"Enum 8889\") and aborted the corpus app. Registering the metadata is the work; see #3594.",
-      "issue": 3594
-    },
-    {
       "member": "MetaField.Access",
       "reason": "BC states Internal on fields whose AL declares it; the runner answers Public. The symbol file carries Access.",
       "issue": 3568


### PR DESCRIPTION
Closes #3594

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/312

Opened by an agent (Claude, `agent: stma-auto-2`).

## The problem, and why the obvious fix is worse than nothing

`MetaField.EnumTypeId` was readable long before it was safe to state. #3545 had already
established where the value is — `TypeDefinition.Subtype.Id` in `SymbolReference.json`, agreeing
with BC's own emitted value on **3,848 of 3,848** field observations across four BC builds — and
deliberately did not land it.

Stating the id makes BC build an `NCLFieldEnumMetadata` for the field, and every accessor on
that object funnels through one virtual whose real body resolves the id through `NCLMetadata`:

```
GetAppGroupAwareEnumMetadata() -> GetEnumMetadataFromMetadataProvider()
  -> NavGlobal.MetadataProvider.GetEnumMetadata(enumId)
       -> NCLMetadata.TryGetMetaApplicationObject(ObjectType.Enum, id)   // never populated
```

The runner populates that cache for tables, pages, reports, queries, xmlports and permission
sets — never for enums, because AL enums are served by a different hook entirely
(`NCLEnumMetadata.Create(int)`) that nothing on the field path calls. Reproduced here at corpus
pin `c9d5f656`, stating the id alone:

```
EXEC-FAIL: ... GetFieldRecordBuffer threw for table 1366 field:
NavMetadataNotFoundException: The metadata object Enum 8889 was not found.
```

That aborted codeunit 2 `Company-Initialize` and took the app with it — **0 of 3,112 tests
run**. A total failure, not a degradation.

## The root cause, found last — an enum the reader was silently dropping

Two rounds of CI red on this PR had one cause, and it was not where either round looked.

`BcAppSymbolCache.TryParseEnumSymbol` began `if (!TryGetProperty("Values", …)) return null;`, so
an enum declaring **no `Values` array at all** was discarded as unreadable. Extensible enums
whose members all arrive from enumextensions are written exactly that way. Measured on System
Application 28.1.49838.54308: **3 of its 141 enums**, and **8889 "Email Connector" — the enum
this issue is named after — is one of them.** An app that genuinely ships it, and it was never in
the registry.

The gap was latent for as long as nothing resolved an enum **by id**; the ordinal and caption
consumers only ask about enums they already hold. Stating `EnumTypeId` is what made the runner
ask, and BC names 8889 on five System Application tables. An empty option list is the faithful
answer — the enum exists and has no members of its own — so the parse now accepts it.

**A `CacheVersion` bump was required and is not ceremony** (35 → 36). The record *shape* is
unchanged — an `EnumSymbol` with an empty option list looks exactly like one with a full list —
so `PayloadShape` cannot see that three enums per payload went from absent to present. Measured
warm before the bump: the harness still reported 15 differences, replayed from the old parse.

## The intermediate guard, and why it is gone

The previous push withheld the id whenever the registry did not know it. That read as prudent and
was wrong twice over: it **masked** the reader gap instead of exposing it, and it made the runner
answer `0` where BC answers a real id — which `MetadataEquivalenceHarnessTests` correctly called a
**reader regression on 17 fields**, on 27.5 and 28.4 identically.

With the parse fixed, **the four floor-only fixtures pass without any guard** — measured with it
deleted — so it is deleted rather than kept as dead weight that would mask the next reader gap.
The value is now stated wherever BC states it, which is what the harness demands.

## The earlier floor-only regression, same root cause



The first push of this PR **reintroduced the very failure it removes**, on a different manifest
shape, and went red on all three BC legs. Recorded here because the shape is the interesting
part.

A bundle whose `app.json` declares an `application` **floor** with `dependencies: []` resolves
the stripped platform packages, which carry **no enum symbols at all**. Measured on
`AlRunner.Tests/Fixtures/BcFloorSkip/healthy-suite`: **721 enums registered, Base Application's
8889 absent** — against **zero** such misses on the corpus, which names Base Application as an
explicit dependency and registers its enums through `AddBcAppPath`. Four fixtures here have that
shape. Stating an unresolvable id turned each into the same 0-of-N abort.

The corpus could not have caught this: it does not have that manifest shape. So the fix carries
a third part and a dedicated arm.

## The fix: registration first, statement second

**1. Redirect the lookup** (`AlRunner/Infrastructure/NclCecilRewrite.cs`,
`AlRunner/Patches/EnumMetadataPatches.cs`). `NCLFieldEnumMetadata.GetEnumMetadataFromMetadataProvider()`
is Cecil-rewritten onto `AlEnumMetadataRegistry` — the same registry `NCLEnumMetadata.Create(int)`
already uses, holding every source-compiled enum and every precompiled dependency's enums.

This substitutes the lookup's **data source, not its outcome**: an enum id nothing declares still
raises BC's own `NavMetadataNotFoundException`. That is required rather than incidental —
`TryGetMetaApplicationObject` is a `try`/`catch` over exactly that type, so "not there" is only
answerable as `false` when it arrives as one. Returning `NCLOptionMetadata.Default` would make an
unknown enum read as a valueless one, the silent fake `loud-failures.md` forbids.

Same shape and cause as #1896's `NCLMetaForm.ApplyAppGroupAwareEnumMetadataToPageExpressions`
rewrite: a by-id `Enum` lookup at a consumption point the runner never populated.

**2. Register BC's own platform enums.** The redirect alone is not enough, and this is the part
the issue did not anticipate. **System enums** (ids `2000000001`–`2000000017`) are declared by
the platform, appear in no app's symbols, and so were in no registry. Base Application table
`2000000132` has a field typed by enum `2000000002` "Entity Text Scenario" — with the redirect in
place the corpus still aborted, now naming *that* id.

`EnsureSystemEnumsRegistered` reads them from BC's own inventory
(`PlatformMetadataProvider.GetSystemEnums` for ids and names, `GetEnumALCodeById` for the AL
source Microsoft ships) and parses the `value(...)` declarations out of it, so the values are
Microsoft's own declaration rather than anything invented here. Measured on BC 28.1: **16 enums,
57 value declarations, 27 of them quoted, 73 captions, and 3 enums declaring no values at all** —
including 2000000002, for which empty is the correct answer.

**3. Stop dropping a valueless enum** (`AlRunner/Patches/BcAppSymbolCache.cs`), with the
`CacheVersion` bump that makes the new parse actually reach a warm run.

**4. Only then state it** (`RecordPatches.NclMetaTableBuilder.cs`), and delete the
`MetaField.EnumTypeId` allowlist entry.

## RED → GREEN

Corpus at pin `c9d5f656`, BC 28.1.49838.53910, run from a private clone:

| | tests | pass | exec-fail |
|---|---:|---:|---:|
| baseline (before any change) | 3,112 | 3,112 | 0 |
| **RED** — stating the id alone | **0** | **0** | **1** |
| **GREEN** — both halves | 3,112 | 3,112 | 0 |

The RED was confirmed to fail *for the right reason*: `The metadata object Enum 8889 was not
found`, the exact message #3594 records.

## Both guards are armed, and they are distinguishable

Each sabotage **removes the call** rather than guarding it out, so the IL genuinely loses it:

| sabotage | result |
|---|---|
| remove `EnsureSystemEnumsRegistered()` | corpus `EXEC-FAIL`, 0 tests — **enum 2000000002**, table 2000000132 |
| remove the `ReplaceBodyWithHelper` for the rewrite | corpus `EXEC-FAIL`, 0 tests — **enum 8889**, table 1366 |
| restore the valueless-enum drop | `FloorOnlyBundleEnumFieldTests` fails; every floor-only bundle aborts on enum 8889 |

**No single test bed covers all three, and that is the lesson from two red rounds.** The corpus
stays green through the third — it names Base Application explicitly, so its bundles resolve real
symbols — so a change verified only against the corpus reads as safe when it is not.

`AlRunner.Tests/SystemEnumAlSourceParseTests.cs` (7 tests) pins the AL parse — the one piece
that is the runner's own logic rather than a lookup pointed at BC's data. Also armed by
sabotage: removing comment stripping fails **only** `DocCommentsMentioningValue_DoNotBecomeMembers`;
replacing the declared ordinal with the array index fails **only**
`SparseOrdinals_AreCarriedAsDeclared`. It includes the opposite pair — a comment mentioning
`value(...)` must not become a member, and a comment marker *inside a caption string* must
survive.

## Fixing the shape, not just the reported line

1. **Another call site with the same wrong pattern?** The sibling route into enum metadata,
   `NCLEnumMetadata.Create(int)`, was already redirected at this registry (#1896-era). This PR
   closes the one remaining route — the field path — so both now resolve from one source.
2. **A sibling function making the same assumption?** Yes, and it is why the fix grew:
   `NclMetadataCachePopulator` populates six object types and not `Enum`. Rather than add a
   seventh partial population, the field path is served from the registry that already holds the
   data. `NCLFieldEnumBaseMetadata`'s other accessors need no separate work because all of them
   funnel through the single virtual rewritten here.
3. **Two paths writing the same state with different invariants?** The BC-document route and the
   derivation route both build `NCLMetaField`s, and only the former previously stated an enum id.
   Both now resolve through the same lookup.

**Not folded, and why.** No other open issue lands in these files. `MetaField.EnumTypeName`
stays declared under #3568 for an unrelated reason — BC leaves it `null` on the ~1,800 fields
that are *not* enum-typed where the runner supplies `""`, which is a different defect on a
different population.

## The arm that would have caught it

`AlRunner.Tests/FloorOnlyBundleEnumFieldTests.cs` — the missing test, now present:

- three floor-only fixtures driven **end to end** through the runner
  (`BcFloorSkip/healthy-suite`, `CrossMajorNote`, `SubscriberScanAudit`), asserting the
  *distinguishing* substrings (`was not found`, `GetFieldRecordBuffer threw`, `EXEC-FAIL` all
  absent) plus `1P/0F/0E`, so neither a different abort nor a vacuous skip can pass;
- the parse itself, in **both** directions: a valueless enum survives with its id and name, and
  an enum with values still keeps them — so "accept valueless" cannot degrade into "return an
  empty symbol for everything". Restoring the drop fails this test.

The fixture cases have to spawn the runner: the registry's contents depend on which packages the
bundle resolved, which is a property of the whole load rather than of any one call.

## Two ratchets, converted rather than raised

`BcShapeMethodLookupTests` and `SilentReflectionLookupRatchetTests` both flagged the new
reflection in `EnsureSystemEnumsRegistered`, and both were right: a renamed
`PlatformMetadataProvider.Instance` would have degraded to "there is no inventory", and a renamed
`EnumMetadata.Name` would have registered all 16 platform enums under the empty string — neither
distinguishable from a BC build that legitimately exposes none. All four lookups now go through
`BcShape`, so **no baseline was lowered**; `BcInternalsNullForgivingGuardTests`' converted-site
count moves 87 → 89 in the good direction, with its reason recorded beside the existing entries.

## What I could not prove

- **The corpus tests do not discriminate this fix.** They pass on the runner before and after,
  because a source-compiled enum is served by `FixupEnumFieldOptionMetadata`, a different
  mechanism. They are a real statement about BC that the corpus did not previously make, which
  is why they are still worth merging, but the honest claim is that the *corpus run staying
  green* is what this PR's evidence rests on, plus the two sabotages above. A fixture typed by a
  **precompiled dependency's** enum would discriminate it; one was written and withdrawn because
  that app is consumed prebuilt and it could not be verified locally.
- ~~`MetadataEquivalenceHarnessTests` could not be run locally.~~ **Now resolved, and it was
  the gap that let both red rounds through.** It runs here against the
  `28.1.49838.54308` ground-truth bundle, with `tools/engine-test-bootstrap.sh` re-run after
  every build and `--settings engine.runsettings`: **7 passed, 0 failed, 0 SKIPPED** — read from
  the skip count, never the summary, since it prints `Passed!` either way.
- **The pin is not advanced**, and is not mine to advance (#3580). Corpus #312 has merged, but
  `main`'s pin `3ad4c340` predates it, so the new corpus tests are not pulled in here.

## Prose

Derivation, the full system-enum measurement, and the two failure modes worth remembering are in
`docs/field-enum-metadata-resolution.md`; the code carries one-line pointers to it.
`docs/metadata-equivalence.md` is updated where it recorded this as unresolved, and its #3545
before/after table is annotated rather than rewritten, since I could not re-measure those counts.

## Local verification

All re-run after the rebase onto `cf3756cc`, never carried across it:

- **`MetadataEquivalenceHarnessTests`: 7 passed, 0 failed, 0 skipped** — engine bootstrapped, so
  it genuinely ran; the 17 differences are gone
- **118 passed / 0 failed / 0 skipped** across the fifteen affected test classes, including every
  one of the nine CI reported red in round one
- the four floor-only fixtures: 0 exec-fail each (`future-suite` runs 0 tests by design)
- corpus at pin `3ad4c340` from a private clone: **3,123/3,123**, 0 fail, 0 exec-fail
- `tools/test_doc_pointers.py`: all checks pass
- `.github/scripts/check_corpus_linkage.sh` against this body and diff: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
