### PR TITLE
docs(rules): name the class -- every guard needs a third state, distinct from success

### DIFF
--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -524,3 +524,5 @@ narrowly-scoped tool, not an addition to `ci-wait.py`.
 - `branch-and-pr.md` — branch naming, `Closes #N`, the assignee boundary
 - `verify-execution-not-the-tick.md` — the corpus-side companion: a green leg does not
   prove the tests you added executed, and the check for that false-zeros
+- `guards-need-a-third-state.md` — why exit 3 exists at all, and the four other guards
+  that did or do resolve "could not tell" toward success

--- a/.claude/rules/guards-need-a-third-state.md
+++ b/.claude/rules/guards-need-a-third-state.md
@@ -1,0 +1,144 @@
+# Every guard needs a third state, and it must not be spelled as its success state
+
+A check has three answers, not two: *the thing is fine*, *the thing is broken*, and **I could
+not tell**. Collapsing the third into the first produces a confident wrong verdict instead of a
+loud one — a green tick asserting something nobody measured.
+
+**This is not a missing pattern here.** The repository already has the vocabulary in three
+places, and this rule exists because it is applied inconsistently, so each new instance gets
+filed as an isolated bug instead of as the class it belongs to.
+
+| the answer | the code |
+|---|---|
+| measured, and fine | 0 |
+| measured, and broken | 1 |
+| **could not measure** | **3** |
+
+The number is a convention, not the point; `tools/corpus-pass-count.py` spells the third state
+as a per-leg label rather than an exit code. What is not negotiable is that it is **distinct
+from the success state**, and that the message says which of the three it is.
+
+## The three that get this right — copy one of them
+
+- **`tools/ci-wait.py`, exit 3.** "Could not determine state (auth, network, no checks
+  reported, the required-context set could not be established without narrowing it, or THIS
+  FILE is behind `origin/main`)." Two of its internals are worth reading as models:
+  `rollup_is_final` returns `True`/`False`/**`None`**, with `None` documented as "deliberately
+  distinct from False: an unknown must never be resolved toward GREEN (#2807)"; and a ruleset
+  read that comes back **narrower** than the built-in floor is refused as `degraded` rather than
+  judged on the smaller set, because "a partial read and a context genuinely removed by a person
+  look identical here" (#3002).
+- **`.github/scripts/check_corpus_pin_forward.sh`, exit 3** via `die_undetermined`, used at five
+  call sites — an unchecked-out submodule, a shallow clone, a corpus commit absent from the
+  clone, a `merge-base` that failed rather than answering. Each message says *this is a checkout
+  problem, not a verdict about the pin*.
+- **`tools/corpus-pass-count.py`, `classify()`** — `ran` / `failed` / `not-run` / `no-suite`, so
+  "the codeunit is not in this leg's suite" and "this leg never reached the test phase" cannot
+  be read as "your tests did not run". A zero has three meanings and a bare grep gives all three
+  the same answer.
+
+## The worked example: three-way discrimination (#3299, #3681, PR #3683)
+
+The pattern to copy, because it shows the part that is easy to get wrong. Both gate scripts
+hardcoded a submodule path that nothing tied to what `.gitmodules` declares. A rename or a typo
+would make `SUBMODULE_PATH` match nothing — and both scripts reported that as their success
+state, so every pull request would get a green tick forever with nothing behind it.
+
+The fix is not an unconditional assertion. It is a discrimination over three cases:
+
+| at the endpoint commits | verdict | why |
+|---|---|---|
+| `.gitmodules` **absent** at both | **0 — pass** | a repository that genuinely declares no submodule has nothing to un-pin |
+| present, declaring paths, **none matching** the configured one | **3**, naming what it *does* declare | a typo is visible in the message rather than inferred from an absence |
+| present but **unreadable** | **3**, deliberately *not* folded into row 1 | an absent file is the legitimate pass; an unreadable one is a broken measurement |
+
+**That third row is the whole rule in one place.** Folding it into the first would put the
+broken case back on the exit-0 path the change exists to take it off.
+
+The `.gitmodules` read is against the **endpoint commits**, never the working tree, for the same
+reason the pins are (#3261) — under `actions/checkout` the working tree is `refs/pull/N/merge`.
+
+## The constraint that stops the fix trading one defect for another
+
+**A genuinely absent thing must stay a pass. Only an *unmeasurable* one becomes the third
+state.** Row 1 above is not a concession; it is the constraint, and a fix that hard-errors a
+submodule-free repository has swapped a false green for a false red.
+
+The same constraint has a second, sharper form in `tools/agent_self_freshness.py`, which splits
+"could not establish" into three (#3296) and refuses only one of them:
+
+- **detached** — the file is not in a git repository, because the caller extracted it there.
+  That extraction is the remedy the module prints, and "a remedy that refuses itself is not a
+  remedy."
+- **identical** — no merge base (shallow clone), but the file is byte-identical to
+  `origin/main`'s blob. Identity is provenance.
+- **unvouched** — everything else. Only this refuses.
+
+So the split is by **what remedy the message must send the reader to**, not by how uncertain the
+check feels. A missing *local* `origin/main` ref is deliberately excluded from `unvouched`: CI
+checks out with `fetch-depth 1`, so that ref never exists on any run while the remote answers
+fine, and conflating the two refused every CI run in the first version of that fix.
+
+## The instances, and their states as of 2026-09-09
+
+The class was visible only because six issues were reviewed in one pass; each had been filed
+separately as its own defect.
+
+| issue | the "could not tell" case | was reported as | state |
+|---|---|---|---|
+| #3296 | `agent_self_freshness` cannot establish provenance | full GREEN, exit 0 | **closed**, fixed |
+| #3351 | `ci-wait.py --timeout 0` — no poll could occur | exit 2, a verdict-shaped non-verdict | **closed**, fixed |
+| #3299 | `SUBMODULE_PATH` matches nothing | exit 0, identical output to a real forward-bump | **open**, fixed in PR #3683 |
+| #3681 | `check_count_baseline_history.sh`'s `PIN_PATH` matches nothing | exit 0, "does not move the pin", on every PR forever | **open**, fixed in PR #3683 |
+| #3361 (part 2) | a leg summary lost its `fail` key | zero failures | **open** |
+
+**#3681 is the argument for writing this down.** `check_count_baseline_history.sh` landed on
+`main` the morning of 2026-09-09 (#3666) as a guard against a corpus pin bump that silently
+writes no history entry — and shipped with a silent never-fire path of its own, filed the same
+day at 11:03Z. A guard authored to catch a silent omission reproduced the shape it was built to
+catch, two days after two instances of it had been fixed. Naming the class is what makes the
+fifth instance a lookup instead of a rediscovery.
+
+**#3361 part 2 is the outstanding one**, and its own body records the honest qualifier: that
+spot is currently backstopped by a `summary.get("pass") != want` comparison a few lines down
+where a `None` fails loudly, so it is not reachable as a false pass **today**. It is still
+written the opposite way from every neighbour in that function, where an uncomputable value is
+an explicit refusal rather than a silent zero. A guard that is safe only by accident of a
+neighbour is on this list.
+
+## Writing one
+
+1. **Enumerate the ways the measurement can fail to happen**, separately from the ways the
+   subject can be broken. Missing input, unreachable network, a pattern matching nothing, a
+   file absent, a key absent, a subprocess that failed rather than answering.
+2. **Give each a verdict that is not the success state**, and a message naming what could not be
+   established and what would fix it. `check_corpus_pin_forward.sh`'s messages are the model:
+   they say *this is a checkout problem, not a verdict about the pin*, which sends the reader to
+   the right remedy instead of blaming the author.
+3. **Check it before the work, not after.** #3681's guard puts the `PIN_PATH` check ahead of the
+   changed-file scan, "because a `PIN_PATH` that names nothing has already made every verdict
+   this script could reach meaningless — including the ones that look like passes."
+4. **Keep the genuinely-absent case a pass**, per the constraint above.
+5. **Prove the third state fires.** A refusal path with no test is indistinguishable from a
+   never-fire path, which is the defect itself. Both scripts in PR #3683 gained cases in their
+   `test_*.sh` siblings; `pr-gate.yml` discovers those by glob, so a correctly-named test gates
+   the day it lands.
+
+## The same shape one level down
+
+At the *tool-use* level this class is already documented, which is why the guards are the gap:
+`CLAUDE.md` has `grep -E` exiting 0 after rejecting a flag, and `rg` skipping dot-directories;
+`verify-execution-not-the-tick.md` has five more, including `gh api .../logs` writing nothing
+and exiting 0 on a log carrying ANSI colour. **A zero from a pattern you chose is not
+evidence** — there, and in anything you write.
+
+## Sister rules
+
+- `ci-verdicts.md` — exit 3 in practice: what it means when `ci-wait.py` returns it, and why
+  a narrowed ruleset read is refused rather than judged
+- `verify-execution-not-the-tick.md` — five false zeros in the corpus-execution check, the
+  tool-use half of this class
+- `loud-failures.md` — the runtime companion: a surface the runner cannot support throws
+  loudly rather than returning a default
+- `no-assumption-fixes.md` — a zero you cannot attribute is not a diagnosis
+- `file-issues-for-gaps.md` — a sixth instance gets filed, not silently worked around

--- a/.claude/rules/loud-failures.md
+++ b/.claude/rules/loud-failures.md
@@ -128,3 +128,5 @@ so the pattern is established rather than proposed.
 - `.claude/rules/no-assumption-fixes.md` — never fix without understanding the AL pattern.
 - `.claude/rules/file-issues-for-gaps.md` — gaps go to issues + `tests/expectations/`, never silent workarounds.
 - `.claude/rules/tdd.md` — every fix needs a RED → GREEN.
+- `.claude/rules/guards-need-a-third-state.md` — the build-time companion: a guard that
+  could not measure must say so, never return its success code.

--- a/.claude/rules/verify-execution-not-the-tick.md
+++ b/.claude/rules/verify-execution-not-the-tick.md
@@ -108,3 +108,5 @@ for exactly that reason.
 - `ask-the-corpus-before-claiming-bc-behavior.md` — a corpus test green on a real service
   tier is evidence only if it *ran*
 - `no-assumption-fixes.md` — a zero you cannot attribute is not a diagnosis
+- `guards-need-a-third-state.md` — the same class in the guards this repository writes
+  itself: a check that cannot measure must not report its success state


### PR DESCRIPTION
Closes #3363

Adds `.claude/rules/guards-need-a-third-state.md`.

**The invariant:** every guard needs a third state — *I could not tell* — and it must not be
spelled as its success state.

## Why a rule file and not a code change

The issue's strongest point is that this is **not a missing pattern**. The repository already
has the vocabulary in three places, and I verified each against the source rather than taking
the issue's word for it:

- `tools/ci-wait.py` exit 3 — "could not determine state". Two internals are the models worth
  copying: `rollup_is_final` returns `True`/`False`/**`None`**, documented as "an unknown must
  never be resolved toward GREEN (#2807)"; and a ruleset read narrower than the built-in floor
  is refused as `degraded` rather than judged on the smaller set (#3002).
- `.github/scripts/check_corpus_pin_forward.sh` exit 3 via `die_undetermined`, at **five** call
  sites (I wrote "six" first and corrected it after counting).
- `tools/corpus-pass-count.py` `classify()` — `ran` / `failed` / `not-run` / `no-suite`.

So the defect is inconsistent application of an established convention, and the deliverable is
the rule those five instances share. **No guard's behaviour changes in this PR.**

## The worked example

PR #3683's three-way discrimination is reproduced as the pattern to copy, because it shows the
part that is easy to get wrong — including the third row, which is the whole rule in one place:

| at the endpoint commits | verdict |
|---|---|
| `.gitmodules` absent at both | **0 — pass**; a submodule-free repo has nothing to un-pin |
| present, declaring paths, none matching | **3**, naming what it *does* declare |
| present but **unreadable** | **3**, deliberately *not* folded into row 1 |

The rule states the constraint that stops the fix trading one defect for another: **a genuinely
absent thing must stay a pass; only an *unmeasurable* one becomes the third state.** It also
carries the sharper form of the same constraint from `agent_self_freshness.py` (#3296), where
"could not establish" splits three ways and only `unvouched` refuses — the split being by *what
remedy the message must send the reader to*, not by how uncertain the check feels.

## Instances cited, with states I verified today (2026-09-09)

| issue | state as verified | how cited |
|---|---|---|
| #3296 | **CLOSED** | fixed; its three-way `unknown` split is quoted as the constraint's sharper form |
| #3351 | **CLOSED** | fixed |
| #3299 | **OPEN**, fix in PR #3683 (OPEN, not merged) | the worked example |
| #3681 | **OPEN**, fix in PR #3683 | the timing argument |
| #3361 part 2 | **OPEN** | **cited as outstanding, not fixed** |

I confirmed #3683 is unmerged by reading my own base: `PIN_PATH="tests/al-language"` is still a
bare constant and `has_gitmodules` does not exist in `check_corpus_pin_forward.sh` at
`f8720984`. So "open, fixed in PR #3683" is a statement about the branch, not about `main`.

**#3681 is the argument for writing this down.** `check_count_baseline_history.sh` landed on
`main` this morning (#3666, commit `f58e01af`, dated 2026-09-09) as a guard against a corpus pin
bump that silently writes no history entry — and shipped with a silent never-fire path of its
own, filed the same day at 11:03Z. A guard authored to catch a silent omission reproduced the
shape it was built to catch, **two days** after two instances of it had been fixed. I wrote
"four days" first and corrected it against the actual close dates.

**#3361 part 2 is cited, not fixed**, per the brief. Its own body records the honest qualifier I
reproduced: that spot is backstopped by a `summary.get("pass") != want` comparison a few lines
down where a `None` fails loudly, so it is not reachable as a false pass *today* — it is still
written the opposite way from every neighbour in that function.

## What I did not fold, and why

Scanned the open-issue queue for same-file siblings per `batch-sibling-issues-by-file.md`.
**Nothing folds**, and the reason is structural rather than a judgement call: this PR's only
substantive file is a new `.claude/rules/*.md`, and no open issue lands there.

- **#3361 part 2** — `tools/preflight.py`. A different file, and the brief explicitly says to
  cite rather than fix. Folding it would also have made this PR change guard behaviour, which
  the issue asks it not to do.
- **#3299, #3681** — `.github/scripts/*.sh`, both held by PR #3683, which is ARMED. I read those
  files and edited neither.
- **#3619** (`agent_scratchpad.py`'s id-sharing guard) is arguably a *sixth* instance of the
  class, but it was already filed, so there was nothing new to file. I did not fold it: it is a
  different file and needs its own behaviour change.

**No sixth unfiled instance found**, so nothing was filed. I was looking — the brief's
instruction was to file rather than fix — and the nearest candidate (#3619) turned out to
already exist.

## Checks run

- `tools/test_doc_pointers.py` — **pass** (mandated; 6 surfaces, all non-empty).
- All 13 `tools/test_*.py` — **pass**, including `test_comment_density.py` and
  `test_line_endings.py`, the two a prose change could plausibly trip.
- All 15 `.github/scripts/test_*.{py,sh}` — **pass**.
- `check_corpus_linkage.sh` against this diff — exit 0, "no file in this diff can change what AL
  observes", so no `Corpus-PR:`/`Corpus-NA:` line is required.
- `Tests updated` does not fire: no changed path matches `^AlRunner/` minus `.md`. No
  `docs-only` label needed and no invented test added.
- **No BC version list** in the new file, so `BcMatrixDocumentationDriftTests` is not implicated
  and no `NotAMatrixClaim` entry is needed.

## What I could not prove

The rule's claim that naming a class prevents the next instance is an argument from the #3681
timing, not a measurement — it is stated as such in the file rather than as an established
effect.

---

Written by an agent (`stma-auto-2`) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
