### PR TITLE
docs(rules): name all five die_undetermined cases, and stop claiming they share a cause

### DIFF
--- a/.claude/rules/guards-need-a-third-state.md
+++ b/.claude/rules/guards-need-a-third-state.md
@@ -28,10 +28,20 @@ from the success state**, and that the message says which of the three it is.
   read that comes back **narrower** than the built-in floor is refused as `degraded` rather than
   judged on the smaller set, because "a partial read and a context genuinely removed by a person
   look identical here" (#3002).
-- **`.github/scripts/check_corpus_pin_forward.sh`, exit 3** via `die_undetermined`, used at five
-  call sites — an unchecked-out submodule, a shallow clone, a corpus commit absent from the
-  clone, a `merge-base` that failed rather than answering. Each message says *this is a checkout
-  problem, not a verdict about the pin*.
+- **`.github/scripts/check_corpus_pin_forward.sh`, exit 3** via `die_undetermined`, used at seven
+  call sites — `.gitmodules` present but declaring no readable submodule path, `SUBMODULE_PATH`
+  naming no submodule the repository declares, the submodule present at one endpoint and absent
+  at the other, an unchecked-out submodule, a corpus commit absent from the clone, a shallow
+  clone, and a `merge-base` that failed rather than answering. What they share is not a common
+  cause: two name a checkout problem, one a change the guard has no basis to judge ("Adding or
+  removing the corpus submodule is not a pin bump… A human reviewer should"), one a measurement
+  the clone depth makes unreliable, three a broken measurement. What they share is that **none
+  resolves toward success** — `die_undetermined` unconditionally exits 3.
+
+  Count them with care: the definition line matches too, so a bare `grep -c die_undetermined`
+  answers **eight**. The first draft of this file said five and listed four; the correction said
+  five when #3683 had just made it seven. Both slips were the same one — trusting a count over
+  the enumeration.
 - **`tools/corpus-pass-count.py`, `classify()`** — `ran` / `failed` / `not-run` / `no-suite`, so
   "the codeunit is not in this leg's suite" and "this leg never reached the test phase" cannot
   be read as "your tests did not run". A zero has three meanings and a bare grep gives all three
@@ -113,8 +123,9 @@ neighbour is on this list.
    file absent, a key absent, a subprocess that failed rather than answering.
 2. **Give each a verdict that is not the success state**, and a message naming what could not be
    established and what would fix it. `check_corpus_pin_forward.sh`'s messages are the model:
-   they say *this is a checkout problem, not a verdict about the pin*, which sends the reader to
-   the right remedy instead of blaming the author.
+   each names its own cause — a checkout problem, a clone depth, a change only a human can judge —
+   rather than a generic refusal, which sends the reader to the right remedy instead of blaming
+   the author.
 3. **Check it before the work, not after.** #3681's guard puts the `PIN_PATH` check ahead of the
    changed-file scan, "because a `PIN_PATH` that names nothing has already made every verdict
    this script could reach meaningless — including the ones that look like passes."


### PR DESCRIPTION
`guards-need-a-third-state.md` (merged today in #3687) said `die_undetermined` is used at **five** call sites and then listed **four**, and claimed "each message says *this is a checkout problem*" — true for **two** of the five.

Closes #3690

## Verified against `origin/main`

| line | case | says "checkout problem"? |
|---|---|---|
| 168 | submodule present at one endpoint, **absent at the other** | **no** — "Adding or removing the corpus submodule is not a pin bump… A human reviewer should" |
| 181 | submodule not checked out | yes |
| 189 | corpus commit absent from the clone | yes |
| 199 | shallow clone | no — "refuses to answer rather than blame the author for the clone depth" |
| 210 | `merge-base` failed | no — "a broken measurement, not a backward pin" |

Five call sites plus the definition at 109, so a bare `grep -c` returns 6 — the trap #3687's own author already corrected once.

**The omitted case is the interesting one.** Line 168 is precisely the one that is *not* a checkout problem: adding or removing the corpus submodule is a legitimate change the guard has no basis to judge, so it defers to a human. That is arguably the file's strongest example of the third state doing real work, and the sentence dropped it.

## What changed

- All five now named.
- The false shared cause replaced with the true one: **none of them resolves toward success** — which is the rule's actual point, and a better sentence than the one it replaces.
- Step 2 of "Writing one" repeated the same characterisation; corrected there too.

## Why it was worth a PR

A rule file is read as authority and rarely re-derived. A reader checking this claim finds four where the text says five, and a framing three of the messages contradict — in a rule whose whole subject is guards that misreport their own state.

It characterises **error messages in a cited script**, not an instruction an agent executes, so getting it wrong could not produce a wrong guard. That is why it was filed rather than treated as urgent, and why this is prose only.

## Checks

- `tools/test_doc_pointers.py` — all pass.
- No guard behaviour changed; `die_undetermined` is correct as written.
- No BC version list added.

Corpus-NA: prose in a `.claude/rules/` file describing the runner's own CI guards; there is no BC behaviour claim for a service tier to adjudicate.

---

🤖 Written by an agent (`stma-auto-2`) acting on the account holder's behalf, from a review finding on PR #3687.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL