### PR TITLE
fix(testaction): refuse a disabled action's Invoke, and follow an action group's Visible

### DIFF
--- a/AlRunner.Tests/ActionGroupVisibilityChainTests.cs
+++ b/AlRunner.Tests/ActionGroupVisibilityChainTests.cs
@@ -1,0 +1,111 @@
+// ActionGroupVisibilityChainTests — contract tests for
+// AlRunner.Patches.RunnerPageInstance.ActionGroupsIn (issues #3689 / #3339).
+//
+// NOT a claim about what Business Central does. That claim is measured upstream, by corpus
+// codeunit 60583 "TPAR Tests" (StefanMaron/BusinessCentral.AL.Language.Tests#313), on a real
+// service tier: an action inside `group(G) { Visible = false; }` answers Visible() = false,
+// answers Enabled() = true, and is still invokable.
+//
+// What this file pins is OUR OWN half of that fix: which elements of an ancestor path carry an
+// action group's Visible. ActionVisible walks the path BC's own
+// MasterPage.FindControlBaseDefinition hands back, and that path mixes element kinds — the
+// content area, the command bar, action CONTAINERS (AL's `area(Processing)`), control groups
+// and action groups. Only an action group is one an AL author can give a Visible, so only an
+// action group may participate. The live route needs a NavForm over a real compiled page's
+// metadata, which only the page-build pipeline produces, so this seam is where the decision is
+// testable in milliseconds.
+//
+// RED/GREEN, both directions:
+//   * reducing ActionGroupsIn to `Array.Empty<...>()` — the pre-fix behaviour, where an
+//     action's own Visible was the whole answer — fails PicksActionGroups and
+//     PicksEveryActionGroupOnTheWay;
+//   * widening it to return the path unfiltered fails IgnoresElementsThatCarryNoActionGroupVisible,
+//     which is the over-reach a fix chasing "anything above a hidden group" would produce.
+using System.Collections.Generic;
+using System.Linq;
+using AlRunner.Patches;
+using Microsoft.Dynamics.Nav.Types.Metadata;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ActionGroupVisibilityChainTests
+{
+    private static ActionGroupDefinition Group(int id, string? visible)
+        => new() { ID = id, Visible = visible };
+
+    // Positive: an action group in the path is picked up, and its declared Visible travels
+    // with it — the caller reads .Visible off what this returns, so returning the element and
+    // losing the property would be a silent no-op.
+    [Fact]
+    public void PicksActionGroups()
+    {
+        var group = Group(42, "false");
+        var path = new List<ElementDefinition> { group, new ContentAreaDefinition() };
+
+        var picked = RunnerPageInstance.ActionGroupsIn(path).ToList();
+
+        Assert.Single(picked);
+        Assert.Equal(42, picked[0].ID);
+        Assert.Equal("false", picked[0].Visible);
+    }
+
+    // Positive: nesting. A group two levels deep must follow the OUTER group too, so every
+    // action group on the path is returned rather than only the nearest one.
+    [Fact]
+    public void PicksEveryActionGroupOnTheWay()
+    {
+        var path = new List<ElementDefinition>
+        {
+            Group(7, null),          // the immediate group declares nothing
+            Group(8, "false"),       // ...and the one enclosing it is the hidden one
+            new ContentAreaDefinition(),
+        };
+
+        var picked = RunnerPageInstance.ActionGroupsIn(path).ToList();
+
+        Assert.Equal(new[] { 7, 8 }, picked.Select(g => g.ID).ToArray());
+
+        // "true" rather than null on the first: ActionGroupDefinition.Visible normalises an
+        // unset property to the literal "true", which is the AL default and what
+        // EvaluateProperty already reads as visible. Pinned because it is not obvious from the
+        // constructor, and a walk that treated an unset Visible as "declared nothing, skip"
+        // would behave the same only by accident.
+        Assert.Equal(new string?[] { "true", "false" }, picked.Select(g => g.Visible).ToArray());
+    }
+
+    // Negative, and the one that bounds the fix: nothing else on the path participates. An
+    // action CONTAINER is AL's `area(Processing)`, which carries no author-written Visible, and
+    // neither does the content area or a layout control group. Folding them in would invent a
+    // rule no measurement supports.
+    [Fact]
+    public void IgnoresElementsThatCarryNoActionGroupVisible()
+    {
+        var path = new List<ElementDefinition>
+        {
+            new ActionContainerDefinition { ID = 1 },
+            new ContentAreaDefinition(),
+            new ControlGroupDefinition { ID = 2, Visible = "false" },
+        };
+
+        Assert.Empty(RunnerPageInstance.ActionGroupsIn(path));
+    }
+
+    // Negative: an action that is not inside any group has an empty chain, so ActionVisible
+    // falls through to the action's own declaration alone — the behaviour every arm of the
+    // corpus suite outside a group depends on.
+    [Fact]
+    public void AnEmptyPathYieldsNoGroups()
+    {
+        Assert.Empty(RunnerPageInstance.ActionGroupsIn(new List<ElementDefinition>()));
+    }
+
+    // Negative: FindControlBaseDefinition answering null (an id that names no element) reaches
+    // here as a null path. It must not throw — a page whose metadata the runner could not
+    // resolve has to fall back to the action's own Visible, not fail the read.
+    [Fact]
+    public void ANullPathYieldsNoGroups()
+    {
+        Assert.Empty(RunnerPageInstance.ActionGroupsIn(null));
+    }
+}

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -4386,6 +4386,34 @@ internal sealed class LiveNavTestAction : ITestAction
     public void Invoke()
     {
         _testPage.SaveCurrentRow();
+
+        // A DISABLED action's Invoke() does nothing, and does not raise. BC's own
+        // Microsoft.Dynamics.Framework.UI.ActionControl.Invoke opens with
+        // `if (!Enabled) return null;`, and TestActionProxy.Invoke — the ITestAction a real
+        // tier hands NavTestAction — carries no gate of its own, so the refusal is silent all
+        // the way up to AL. Measured on BC 28.4: invoking an action declared Enabled = false
+        // leaves the OnAction trigger unrun, raises nothing, and leaves the page usable (the
+        // next action still runs). Corpus codeunit 60583 "TPAR Tests" pins it, for a literal
+        // Enabled = false and for an Enabled bound to an expression that is currently false.
+        //
+        // Running the trigger anyway was a silent wrong answer: AL got an effect it could not
+        // have obtained on a real tier, so a test asserting the effect passed here and failed
+        // there. Observably equivalent to BC now, with one honest difference — BC says nothing
+        // and this says so on [warn], because the shape it produces (an assertion failing one
+        // step later about a missing effect) is exactly what a reader cannot diagnose.
+        //
+        // SaveCurrentRow stays ahead of the gate: BC's TestActionProxy.Invoke calls
+        // parent.ActivateControl(this) before actionControl.Invoke(), so the row reaches the
+        // server whether or not the trigger fires. Not separately measured.
+        if (!_page.ActionEnabled(_actionId))
+        {
+            Console.Error.WriteLine(
+                $"[warn] TestPage: action {_actionId} is not Enabled, so Invoke() did not run "
+                + "its OnAction trigger — real BC refuses a disabled action silently "
+                + "(ActionControl.Invoke: `if (!Enabled) return null;`)");
+            return;
+        }
+
         _page.RaiseOnAction(_actionId);
     }
 

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -926,11 +926,71 @@ internal sealed partial class RunnerPageInstance
     internal bool ActionEnabled(int actionId)
         => EvaluateProperty(ActionDefinition(actionId)?.Enabled, "Enabled", actionId, atOpen: false);
 
-    // Live, like every other property except a CONTROL's own Visible. An action's own Visible
-    // has not been measured against real BC either way, so it keeps the behaviour it had
-    // rather than inheriting a freeze from a measurement that was not about it.
+    /// <summary>
+    /// Live, like every other property except a CONTROL's own Visible — and it follows the
+    /// enclosing action groups, not just the action's own declaration.
+    ///
+    /// <para>An action inside <c>group(G) { Visible = false; ... }</c> declares no Visible of
+    /// its own, so reading only its own property answered the AL default of true where real BC
+    /// answers false. Measured on BC 28.4: an action in such a group reports
+    /// <c>Visible = false</c> and <c>Enabled = true</c>, and is still invokable — see corpus
+    /// codeunit 60583 "TPAR Tests". Enabled is deliberately NOT walked: the same measurement
+    /// shows a hidden group does not disable the actions inside it, and a group declaring
+    /// <c>Enabled = false</c> has not been measured either way.</para>
+    ///
+    /// <para>Unlike <see cref="ControlVisible"/> an action is never eliminated by this — the
+    /// same measurement shows a hidden action stays on the page and its OnAction still runs.
+    /// This changes what <c>Visible()</c> answers, nothing about reachability.</para>
+    /// </summary>
     internal bool ActionVisible(int actionId)
-        => EvaluateProperty(ActionDefinition(actionId)?.Visible, "Visible", actionId, atOpen: false);
+    {
+        if (!EvaluateProperty(ActionDefinition(actionId)?.Visible, "Visible", actionId, atOpen: false))
+            return false;
+
+        foreach (var ancestor in EnclosingActionGroups(actionId))
+            if (!EvaluateProperty(ancestor.Visible, "Visible", ancestor.ID, atOpen: false))
+                return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// The action groups enclosing <paramref name="actionId"/>.
+    ///
+    /// <para>Actions do not live in the layout tree, so <see cref="ControlVisible"/>'s
+    /// <c>FindParentByControlId</c> walk cannot reach them — that one traverses
+    /// <c>masterPage.ContentArea</c> only. BC publishes a traversal that does cover actions:
+    /// <c>MasterPage.FindControlBaseDefinition(id, out path)</c> searches ContentArea, then
+    /// CommandBar, then InfopartsArea, descending through <c>Actions</c> and
+    /// <c>ActionContainers</c>, and hands back the ancestor path. Using BC's own search keeps
+    /// this from being a second, divergent notion of where an action lives.</para>
+    /// </summary>
+    private IEnumerable<Microsoft.Dynamics.Nav.Types.Metadata.ActionGroupBaseDefinition> EnclosingActionGroups(int actionId)
+    {
+        if (_form is not NavForm form || form.MasterPage is not { } master)
+            return Array.Empty<Microsoft.Dynamics.Nav.Types.Metadata.ActionGroupBaseDefinition>();
+
+        return master.FindControlBaseDefinition(actionId, out var path) == null
+            ? Array.Empty<Microsoft.Dynamics.Nav.Types.Metadata.ActionGroupBaseDefinition>()
+            : ActionGroupsIn(path);
+    }
+
+    /// <summary>
+    /// The elements of an ancestor path that carry an action group's own <c>Visible</c>.
+    ///
+    /// <para>Only an <c>ActionGroupBaseDefinition</c> — AL's <c>group(...)</c> inside
+    /// <c>actions</c> — does. The path also carries the content area, the command bar and
+    /// action CONTAINERS (AL's <c>area(Processing)</c>), none of which an AL author can give a
+    /// <c>Visible</c>, so folding them in would invent a rule no measurement supports.</para>
+    ///
+    /// <para>Internal and static so <c>AlRunner.Tests</c> can pin the filter directly: the live
+    /// route needs a NavForm over a real compiled page's metadata, which only the page-build
+    /// pipeline produces.</para>
+    /// </summary>
+    internal static IEnumerable<Microsoft.Dynamics.Nav.Types.Metadata.ActionGroupBaseDefinition> ActionGroupsIn(
+        IEnumerable<Microsoft.Dynamics.Nav.Types.Metadata.ElementDefinition>? path)
+        => path?.OfType<Microsoft.Dynamics.Nav.Types.Metadata.ActionGroupBaseDefinition>()
+           ?? Array.Empty<Microsoft.Dynamics.Nav.Types.Metadata.ActionGroupBaseDefinition>();
 
     /// <summary>
     /// Whether <paramref name="controlId"/> names a control this page DECLARES at all — the


### PR DESCRIPTION
Closes #3339
Closes #3688
Closes #3689

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/313

Filed-against and implemented by agent `fbk-3` (automated implementation agent).

#3339 asked for a corpus suite before any runner change, because the only evidence for its
hypothesis was IL reading. The suite was written, and **the tier falsified the hypothesis and
found two different gaps instead.** That is the result; the fix follows it, not the issue.

## What the tier measured

BC 28.4 (OnPrem w1, official Microsoft Windows container image), by a probe app whose every test
failed on purpose so its failure text reported what happened rather than what an assertion
expected:

| probe arm | BC 28.4 | runner before |
|---|---|---|
| plain action | `Visible=Yes Enabled=Yes`, trigger ran | same |
| `Visible = false` — `Invoke()` | succeeded, trigger **ran** | same |
| `Visible = false` — `Visible()` / `Enabled()` | No / Yes | same |
| inside `group { Visible = false }` — `Visible()` / `Enabled()` | **No** / Yes | **Yes** / Yes ❌ |
| inside `group { Visible = false }` — `Invoke()` | succeeded, trigger ran | same |
| `Visible = <page variable, false>` | `Visible()=No`, trigger ran | same |
| `Enabled = false` — `Enabled()` / `Visible()` | No / Yes | same |
| `Enabled = false` — `Invoke()` | succeeded, trigger **did not run** | trigger **ran** ❌ |
| `Enabled = <page variable, false>` — `Invoke()` | succeeded, trigger **did not run** | trigger **ran** ❌ |
| a disabled or hidden invoke, then the plain action | the plain action still ran | same |

So `Visible = false` **hides** an action and `Enabled = false` **disables** it, and those are
different things: a hidden action still runs, a disabled one does not run and does not complain.

## 1. #3339 — `GetAction` is not the surface, and BC does not refuse

The issue's hypothesis was that `LiveNavTestPage.GetAction` should refuse an id the page does not
declare, mirroring #3338's `GetField` treatment. Two independent findings say no, and
**`GetAction` is left untouched**:

- **The id-space question cannot be asked from AL.** There is no `TestPage.GetAction(Id)`.
  `TestPage` has `GetField(Id)` taking a page control id (deprecated, AL0667) and no action
  counterpart: the AL compiler's own builtin member table for the `TestPage` type, in
  `Microsoft.Dynamics.Nav.CodeAnalysis.dll` 28.4, lists 30 members including `TestPage_GetField`
  and `TestPage_GetField_Id` and nothing named `TestPage_GetAction`. The published `TestPage`
  method list agrees. An action is reachable from AL only by name, resolved to its id at compile
  time, so every id that reaches `GetAction` is one the page declares.
- **BC does not eliminate a declared action either way.** An action whose `Visible` is the
  compile-time literal `false` — the spelling that dead-code-eliminates a subpage part, which
  #3338's sibling change relies on — is still on the page, still invokable, and its trigger still
  runs. Adding the `GetField` guard here would have introduced a refusal BC does not make.

The IL reading in #3339 was correct about `NavTestPageBase.GetAction` raising
`NavTestActionNotFoundException` on a null from `ITestPage.GetAction`. What was not established
is that anything reachable from AL produces that null — and nothing does. This is the same trap
#3339 names in its own body, arriving one level further down.

## 2. #3688 — `Invoke()` on a disabled action ran the trigger

`LiveNavTestAction.Invoke` dispatched to `RaiseOnAction` unconditionally while reporting
`Enabled = false` through the property beside it. It now gates on `ActionEnabled` and returns.

This is BC's own shape, not an invention:
`Microsoft.Dynamics.Framework.UI.ActionControl.Invoke` opens with `if (!Enabled) return null;`,
and `Microsoft.Dynamics.Nav.Client.TestPageClient.TestActionProxy.Invoke` — the `ITestAction` a
real tier hands `NavTestAction` — checks only that the form is open. The platform has no "this
action is disabled" error text at all, which is why the refusal is silent up to AL.

One deliberate difference from BC, stated because `loud-failures.md` requires the equivalence
claim: BC says nothing, and this writes a `[warn]` naming the action. The AL-observable answer is
identical; the line exists because the shape a silent no-op produces — an assertion failing one
step later about a missing effect — is the one a reader cannot diagnose. It is not a refusal, so
`TestPageRefusalClaimTests`' per-file counters are unchanged (verified, not assumed: that suite
is in the targeted run below).

`SaveCurrentRow()` stays **ahead** of the gate. BC's `TestActionProxy.Invoke` calls
`parent.ActivateControl(this)` before `actionControl.Invoke()`, so the row reaches the server
whether or not the trigger fires. Not separately measured; conservative and noted at the site.

`ExtensionOnlyTestAction` (a precompiled base page, `_page == null`) has no page instance to read
`Enabled` from and is unchanged — stated as the limit rather than papered over with a guess.

## 3. #3689 — `Visible()` ignored the enclosing action group

`ActionVisible` read the action's own declared `Visible` and stopped. An action inside
`group(G) { Visible = false; }` declares none of its own, `null` means "declared nothing", and
that is the AL default of true — so the runner reported it visible where BC reports it hidden.

It now walks the ancestor path and fails on any enclosing action group whose `Visible` evaluates
false. The path comes from BC's own `MasterPage.FindControlBaseDefinition(id, out path)`, which
searches ContentArea, then CommandBar, then InfopartsArea, descending through `Actions` and
`ActionContainers`. `ControlVisible`'s existing walk could not be reused: its
`NavFormMetadataHelper.FindParentByControlId` traverses `masterPage.ContentArea` only and raises
`NavNCLControlMetadataNotFoundException` for an action id. Using BC's search avoids a second,
divergent notion of where an action lives.

**`ActionEnabled` is deliberately not walked.** The same measurement shows a hidden group leaves
`Enabled` true (`P9 INGROUP visible=No enabled=Yes`), and a group declaring `Enabled = false` has
not been measured either way. The corpus test asserts the `Enabled = true` half explicitly, so an
over-reaching fix fails it.

## Fixing the shape

- **Same wrong pattern at another call site?** Yes — `ActionVisible` and `ControlVisible` were
  two answers to one question, and only the control one walked ancestors. Now both do, by
  different traversals because the two trees genuinely are different.
- **Does a sibling make the same assumption?** `ActionEnabled` reads only the action's own
  property, and after this change that is a *measured* answer rather than an unexamined one —
  P9 says a hidden group does not disable what is inside it. Its remaining limit (a group
  declaring `Enabled = false`) is stated at the site.
- **Two paths writing the same state?** `LiveNavTestAction.Invoke` and
  `ExtensionOnlyTestAction.Invoke` both reach a page's OnAction. Only the first can read
  `Enabled`; the second is named as unchanged rather than silently left inconsistent.

## Queue scan, and what is not folded

Open issues touching `MockTestPage.cs` / `RunnerPageInstance.cs` were checked per
`batch-sibling-issues-by-file.md`. **#3258** (`TestPage.View()` / `Edit()`) lands in the same file
and is not folded: its subject is the in-place page-mode switch and `_staticEditableOverride`,
materially different reasoning to review. Its "Visible/Enabled answer true, unmeasured" half is
about *field* controls; this PR settles the action half of that question and leaves the field
half where it was.

## No pin bump

Blocked by intervening commits: the chain behind `main`'s pin (`c9d5f656`) carries work still in
flight, so this PR cannot pin corpus PR #313 without pulling those in. The bump is a separate
catch-up once #313 and the intervening work land. The proving run below is therefore against a
checkout of the corpus branch rather than the submodule.

## What was run

Every runner-side run below is **BC 28.1.49838.53910** (the runner's selected artifact under
`--package-cache`). The 28.4 figures further up are the *container* measurement of real BC and
are a different thing; the two are kept apart deliberately.

- **Corpus codeunit 60583 "TPAR Tests"** (corpus PR #313), against a checkout of that branch:
  **RED 5 pass / 3 fail → GREEN 8 / 8.** The three that moved are
  `TPAR_ActionInsideAGroupDeclaredVisibleFalse_IsHiddenButStillInvokable`,
  `TPAR_ActionDeclaredEnabledFalse_InvokeIsASilentNoOp` and
  `TPAR_ActionWithEnabledBoundToAFalseExpression_InvokeIsASilentNoOp` — one per issue closed
  beyond #3339.
- **`AlRunner.Tests`, filtered** to `ActionGroupVisibilityChainTests`, `TestPageRefusalClaimTests`,
  `RunnerPageInstance*` and `TestPageControlTreeReachabilityTests`: **132 passed, 0 failed.**
- **The new file alone**: 5/5. Reducing `ActionGroupsIn` to `Array.Empty<...>()` — the pre-fix
  behaviour — fails 2 rows; widening it to return the path unfiltered fails a third. Both
  directions are pinned, so neither "never walk" nor "count everything above the action" passes.
- **The full corpus at the pin `c9d5f656`**, with `tests/expectations`: **3112 / 3112**, 0 fail,
  0 error (2 `pass-oos`, 6 `pass-known-gap`, 1 `pass-divergence`).
- **`tests/runner-extras`**, both package caches: **404 / 404**, 0 fail, 0 error. It carries
  `pageext-action-dispatch`, which drives `LiveNavTestPage.GetAction`'s other branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kko97BZZL71nF2nK5aftu4
