### PR TITLE
test(corpus): record why the pin cannot advance past 3ad4c340

### DIFF
--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -2168,6 +2168,52 @@ that is still open: corpus #273 -> AlRunner#2943 (codeunit 60559) and corpus #27
 
 Written by the fbk-2 agent.
 
+## No bump: the pin stays at `3ad4c340`, re-measured 2026-09-09
+
+Not a bump -- a recorded negative result, so the next agent does not re-run the corpus to
+learn the same thing. Of the two blockers named directly above, **one cleared and one did
+not**, and the one that did not is the one whose position decides everything.
+
+`AlRunner#3593` is now CLOSED, and codeunit 60602 passes here. `AlRunner#2943` is still OPEN,
+and its corpus test -- codeunit 60559 `"TPAROK Tests"`, from corpus #273, commit `123d6dd` --
+is the **first** of the 21 commits between `3ad4c340` and corpus tip `0163b377`. A pin cannot
+skip a predecessor, so a single unfixed gap at position 1 gates the entire range. The "pin the
+newest commit whose predecessors are all satisfied" remedy yields the empty set here; the
+newest such commit is the pin we already have.
+
+Three full-corpus runs (not filtered -- a filtered run cannot see an app-level `EXEC-FAIL`),
+runner `origin/main` at `b5705ee1`, BC 28.4:
+
+| corpus commit | position | tests | pass | fail | exit |
+|---|---|---|---|---|---|
+| `3ad4c340` (current pin) | -- | 3123 | 3123 | 0 | 0 |
+| `123d6dd` (first candidate) | 1 of 21 | 3131 | 3125 | 6 | 1 |
+| `0163b377` (corpus tip) | 21 of 21 | 3242 | 3234 | 8 | 1 |
+
+The current pin's run included `--count-baseline`, and 3123 matches the checked-in baseline
+exactly, so `test-count-baseline.json` is untouched and correct as it stands.
+
+The two failing codeunits at tip, and nothing else:
+
+- **codeunit 60559**, 6 failures, all `AlRunner#2943` -- a TestPage action whose `RunObject`
+  names a report, codeunit, xmlport or query. Raised from
+  `RunnerPageInstance.TryRunActionRunObject`. Note for the implementer that these are not
+  uniformly "make it work": two expect the object to actually run, four expect BC's own
+  refusal text (`The method RunReport is not supported for TestPages.`) rather than the
+  runner's out-of-scope signal.
+- **codeunit 60604**, 2 failures, a gap that was previously untracked and is now
+  **AlRunner#3695** -- a permission set's declared `tabledata` grants are not readable back
+  from the `Permission` table (2000000005). It sits at commit `d34d1c0`, position 11.
+  Distinct from #2886, which is about demo data populating that same table by a different
+  path. Its third test currently passes only vacuously (an empty table trivially satisfies
+  "no `Object Type::Table` rows"), so read it as 0/3 covered, not 1/3.
+
+Both must land before the pin can reach `0163b377`. The 21 commits are all `test(...)`
+additions -- no corpus infrastructure change rides along -- worth +119 tests by static
+`[Test]` count, which the tip run corroborates as 3242 discovered against 3123 today.
+
+Written by an agent (Claude, `stma-auto-2`).
+
 ## runner-extras `testpage-close-message-consumed` 5 -> 8 (#3593)
 
 Three new AL tests in codeunit 65863 "Tcm Close Message Tests", pinning the number of close


### PR DESCRIPTION
**This PR bumps nothing.** It records a measured negative result: the corpus pin
**cannot** advance past `3ad4c340`, and the reason is sharper than the previous note in
`history.md` suggested. Landing this saves the next agent a full-corpus run to rediscover it.

Written by an agent (Claude, `stma-auto-2`).

## What I set out to do

A catch-up pin bump: `3ad4c340` -> corpus tip `0163b377`, 21 commits, all of them `test(...)`
additions. The hypothesis was outcome 1 — every fix these tests prove has already merged, so a
bump alone should be green.

It is not.

## What decided it

Three **full**-corpus runs (never filtered — a filtered run cannot see an app aborting with
`EXEC-FAIL` and 0 of ~3,100 tests), runner `origin/main` at `b5705ee1`, BC 28.4,
`--package-cache ~/.al-runner/platform-apps`. The verdict is the per-app numbers, not the exit
code:

| corpus commit | position in range | tests | pass | fail | exit |
|---|---|---|---|---|---|
| `3ad4c340` (current pin) | — | 3123 | 3123 | 0 | 0 |
| `123d6dd` (first candidate) | **1 of 21** | 3131 | 3125 | **6** | 1 |
| `0163b377` (corpus tip) | 21 of 21 | 3242 | 3234 | **8** | 1 |

The current-pin run also carried `--count-baseline`; it matched the checked-in **3123**
exactly. So `test-count-baseline.json` is already correct and is **untouched** by this PR.

## Why nothing at all is pinnable

`al-language-submodule.md`'s remedy for a blocked range is "pin the newest commit whose
predecessors are all satisfied". Here that set is **empty**, because the blocker is at
**position 1**.

Codeunit 60559 `"TPAROK Tests"` arrives in corpus
[#273](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/273), commit
`123d6dd` — the first commit after the current pin. Its gap, **#2943**, is open. A pin cannot
skip a predecessor, so that one issue gates all 21 commits.

The previous `history.md` entry named two blockers. **One cleared, one did not**, and only the
surviving one's *position* matters:

- **#3593** — CLOSED. Codeunit 60602 passes in my run. Correctly retired.
- **#2943** — OPEN, and first in line.

## The two failing codeunits at tip

**Codeunit 60559 — 6 failures, all #2943.** Raised from
`RunnerPageInstance.TryRunActionRunObject` (`AlRunner/Patches/RunnerPageInstance.ActionRunObject.cs:168`),
whose reason string already names the issue. Worth flagging for whoever implements it, because
it is not a uniform "make it work": **two** tests expect the object to actually run
(`...RunsItOnTheHostsRow`, `...IsHandedTheHostsRow`), and **four** expect BC's own refusal text
(`The method RunReport is not supported for TestPages.`) rather than the runner's out-of-scope
signal. The fix has to discriminate by object kind. Detail posted on #2943.

**Codeunit 60604 — 2 failures, previously untracked.** A permission set's declared `tabledata`
grants are not readable back from the `Permission` table (2000000005). Filed as **#3695**. It
sits at commit `d34d1c0`, position 11. Distinct from #2886, which is about *demo data*
populating the same table by a different path. Its third test passes only **vacuously** — an
empty table trivially satisfies "no `Object Type::Table` rows" — so that codeunit is 0/3
covered, not 1/3.

## Count-baseline delta

**None, deliberately.** No pin move means no count change; 3123 stands and was re-verified
against a live run rather than assumed. For the record, the 21 blocked commits are worth
**+119** tests by static `[Test]` count (3125 -> 3244 at HEAD), which the tip run corroborates
as 3242 discovered against 3123 today.

## Gates

Checked locally against this diff, which is a single `.md` file:

- `check_corpus_pin_forward.sh` (#3683) — *"The tests/al-language pin is unchanged by this
  pull request. Nothing to compare."*
- `check_count_baseline_history.sh` (#3666) — *"This PR does not move the tests/al-language
  pin, so no history.md entry is required."* The entry is added anyway, because the *reasoning
  for where the pin stopped* is exactly what that file is for.
- `check_corpus_linkage.sh` — no AL-observable file in the diff.
- `require-tests` does not trigger (nothing under `AlRunner/`), and no BC legs run on an
  all-markdown diff.

Corpus-NA: no runner behavior changes; this PR adds one `history.md` entry recording a corpus measurement, and moves no pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL



No linked issue: this records a measured negative result — no commit in the range is pinnable, so no pin moved. #2943 and #3695 must stay open.
