### PR TITLE
fix(flowfields): refuse by name when the computed-provider guard cannot read its own discriminator

### DIFF
--- a/AlRunner.Tests/FlowFieldComputedProviderGuardTests.cs
+++ b/AlRunner.Tests/FlowFieldComputedProviderGuardTests.cs
@@ -1,0 +1,170 @@
+// FlowFieldComputedProviderGuardTests — the computed-provider guard must not be able to
+// FALL THROUGH into the store path it exists to protect (#3622).
+//
+// The reported defect, and why it is not the one this file pins
+// -------------------------------------------------------------
+// #3622 reports `CalcFields` over a FlowField whose CalcFormula source is the Integer virtual
+// table (2000000026) crashing with a raw ArgumentException:
+//
+//     Field 'primaryKeySortingFields' defined on type
+//     'Microsoft.Dynamics.Nav.Runtime.TempTableDataProvider' is not a field on the target
+//     object which is of type 'Microsoft.Dynamics.Nav.Runtime.IntegerDataProvider'.
+//
+// That exact crash was measured on 0ef9bf72~1 and is GONE on 0ef9bf72 (#3597), which added the
+// computed-provider branch in CalcFlowFieldValuesCore. It is fixed, and this file does not
+// re-assert it — what the Integer table answers for such a formula is BC's claim and is pinned
+// upstream against a real service tier by corpus codeunit 60779
+// (record/TestDateVirtualTableFlowField.al, FlowField_CountOverInteger_*), whose fixture
+// DVT Flow Row field 8 is precisely the `count(Integer where(Number = field(...)))` shape.
+//
+// What is NOT fixed is the guard's own reachability, which is what this file pins.
+//
+// The residual defect
+// -------------------
+// The branch that routes a computed provider to BC's own path is conditional on a reflection
+// handle being non-null:
+//
+//     if (_tTempTableDataProvider != null && !_tTempTableDataProvider.IsInstanceOfType(srcTtdp))
+//
+// so if that Type lookup ever fails, the guard evaluates false, control falls THROUGH it, and
+// forty lines later reaches
+//
+//     var sortingFields = _fTtdpPrimaryKeySortingFields?.GetValue(srcTtdp);
+//
+// against the very IntegerDataProvider the guard was there to divert — reproducing #3622's
+// ArgumentException verbatim. The `?.` absorbs a MISSING handle and then hands the surviving
+// one an instance of the wrong type, so the null-check protects nothing that matters here.
+//
+// This is the `bc-shape-gap` shape, not an out-of-scope one: the surface is in scope and
+// implemented, and the only way to reach the fall-through is for BC's own layout to stop
+// matching what the reflection was written against. `.claude/rules/loud-failures.md` and
+// AlRunner/Infrastructure/BcShapeGapException.cs put that squarely on BcShapeGapException —
+// a bug report about the runner against a specific BC build.
+//
+// Why a refusal is the whole answer here, and computing is not the better one
+// --------------------------------------------------------------------------
+// The brief for #3622 asked whether the sorting step could simply be made not to apply, so a
+// FlowField over Integer would compute instead of refusing. Measured against Ncl 28.1
+// (bc-decompiler, Microsoft.Dynamics.Nav.Runtime):
+//
+//   IntegerDataProvider declares SIX members — .ctor, CountValuesWithinRange,
+//   GetValuesWithinRangeForKeyField, FirstRecordKey, LastRecordKey, TableId. It has no
+//   `primaryKeySortingFields` field AND no `Filter` method. Its base VirtualDataProvider has
+//   no `Filter` either.
+//
+// So the store path below the guard is not a sorting step that could be skipped — it is
+// `TempTableDataProvider.Filter`, a method these providers do not have, reading rows from a
+// store they do not keep. Removing the sorting assumption would leave the very next line with
+// nothing to call. Computing the aggregate is already what the guard DOES, by handing the
+// formula to FlowFieldsHelper.CalcSingleFieldFromVirtualTableAsync — BC's own path for this
+// shape. The correct answer for the fall-through is therefore to make it unreachable and name
+// the gap if BC's layout ever moves, not to reimplement a second aggregation route.
+using System.Reflection;
+using AlRunner.Infrastructure;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class FlowFieldComputedProviderGuardTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static string Source => File.ReadAllText(
+        Path.Combine(RepoRoot, "AlRunner", "Patches", "FlowFieldPatches.cs"));
+
+    private static Assembly Ncl => typeof(NCLMetaTable).Assembly;
+
+    /// <summary>
+    /// The three handles the store path needs must be obtained through a THROWING accessor, so
+    /// a BC layout change refuses by name instead of falling through to #3622's
+    /// ArgumentException.
+    /// <para>Asserted against the real Ncl assembly rather than against the source text: this
+    /// calls BcShape itself with the same arguments the patch uses, so it fails if the member
+    /// is gone AND if the accessor stops throwing. A source scan could only see the spelling.</para>
+    /// </summary>
+    [Fact]
+    public void TheThreeTempTableDataProviderHandles_AreObtainedThroughAThrowingAccessor()
+    {
+        var ttdp = Ncl.GetType("Microsoft.Dynamics.Nav.Runtime.TempTableDataProvider");
+        Assert.True(ttdp != null,
+            "TempTableDataProvider is absent from this BC build — the store path's own type is "
+            + "gone, which is itself the gap this test is about.");
+
+        // BcShape.RequiredField walks the hierarchy and throws BcShapeGapException naming the
+        // member. If BC ever drops the field, this is the refusal the runner must produce.
+        var f = BcShape.RequiredField(ttdp!, "primaryKeySortingFields",
+            "AL FlowField calculation", "test probe");
+        Assert.Equal("primaryKeySortingFields", f.Name);
+
+        // The negative arm: the SAME accessor, asked for a member that is not there, must
+        // refuse by name rather than answer null. This is what makes the positive arm above
+        // evidence of a throwing accessor rather than of a member that happens to exist.
+        var gap = Assert.Throws<BcShapeGapException>(() => BcShape.RequiredField(
+            ttdp!, "primaryKeySortingFieldsThatDoNotExist",
+            "AL FlowField calculation", "test probe"));
+        Assert.Contains("primaryKeySortingFieldsThatDoNotExist", gap.Member);
+    }
+
+    /// <summary>
+    /// The guard that diverts a computed provider must not be conditional on a reflection
+    /// handle. `_tTempTableDataProvider != null && !IsInstanceOfType(...)` reads false when the
+    /// lookup failed, and false means "fall through into the store path" — the one outcome the
+    /// guard exists to prevent (#3622).
+    /// </summary>
+    [Fact]
+    public void TheComputedProviderGuard_DoesNotFallThroughWhenItsOwnTypeLookupFailed()
+    {
+        var src = Source;
+
+        Assert.DoesNotContain("_tTempTableDataProvider != null && !_tTempTableDataProvider.IsInstanceOfType", src);
+
+        // And the positive half: the divert must still be there. Deleting the guard outright
+        // would satisfy the assertion above while restoring the crash, so the liveness arm
+        // names the call the divert is FOR.
+        Assert.Contains("_mCalcSingleFieldFromVirtualTable", src);
+        Assert.Contains("IsInstanceOfType", src);
+    }
+
+    /// <summary>
+    /// The store path's own reads must not be null-absorbing. `_f?.GetValue(x)` on a missing
+    /// handle yields null and lets the call proceed with a wrong-typed receiver; that is how
+    /// #3622's ArgumentException is reached with the guard bypassed.
+    /// </summary>
+    [Fact]
+    public void TheStorePathReads_DoNotAbsorbAMissingHandle()
+    {
+        var src = Source;
+
+        Assert.DoesNotContain("_fTtdpPrimaryKeySortingFields?.GetValue(", src);
+        Assert.DoesNotContain("_mTtdpFilter?.Invoke(", src);
+    }
+
+    /// <summary>
+    /// The claim underneath the whole design decision, asserted against BC's own metadata
+    /// rather than restated in a comment: IntegerDataProvider carries neither of the two
+    /// members the store path below the guard uses. This is why the fall-through cannot be
+    /// repaired by relaxing the sorting step — there is no Filter to call afterwards.
+    /// </summary>
+    [Fact]
+    public void IntegerDataProvider_HasNeitherPrimaryKeySortingFieldsNorFilter()
+    {
+        var integer = Ncl.GetType("Microsoft.Dynamics.Nav.Runtime.IntegerDataProvider");
+        Assert.True(integer != null, "IntegerDataProvider is absent from this BC build");
+
+        const BindingFlags All = BindingFlags.Public | BindingFlags.NonPublic
+                                 | BindingFlags.Instance | BindingFlags.Static
+                                 | BindingFlags.FlattenHierarchy;
+
+        Assert.Null(integer!.GetField("primaryKeySortingFields", All));
+        Assert.Empty(integer.GetMethods(All).Where(m => m.Name == "Filter"));
+
+        // The control: the type the store path IS written against has both, so the two
+        // assertions above are about IntegerDataProvider specifically and not about a
+        // BindingFlags set that finds nothing anywhere.
+        var ttdp = Ncl.GetType("Microsoft.Dynamics.Nav.Runtime.TempTableDataProvider");
+        Assert.NotNull(ttdp!.GetField("primaryKeySortingFields", All));
+        Assert.NotEmpty(ttdp.GetMethods(All).Where(m => m.Name == "Filter"));
+    }
+}

--- a/AlRunner/Patches/FlowFieldPatches.cs
+++ b/AlRunner/Patches/FlowFieldPatches.cs
@@ -1132,7 +1132,21 @@ public static class FlowFieldPatches
             // virtual table the runner serves — AllObj, Field, Page Metadata, … — is materialised
             // into a TempTableDataProvider and is answered correctly by the code below; routing
             // those through BC's helper too would be a much wider change than the defect needs.
-            if (_tTempTableDataProvider != null && !_tTempTableDataProvider.IsInstanceOfType(srcTtdp))
+            // The discriminator is asked of a handle that must EXIST. Gating this on
+            // `_tTempTableDataProvider != null` read false when the Type lookup had failed, and
+            // false here means "fall through into the store path" — which then reaches
+            // `primaryKeySortingFields` against the very computed provider this branch exists to
+            // divert, reproducing #3622's ArgumentException with the guard bypassed. A missing
+            // handle is a BC-layout gap, so it refuses by name (#3622).
+            var tTtdpNow = _tTempTableDataProvider
+                ?? throw new BcShapeGapException(
+                    "AL FlowField calculation", "TempTableDataProvider",
+                    "type not found — it is the discriminator that decides whether a CalcFormula's "
+                    + "source table is served by a stored-row provider or by a computed one. "
+                    + "Without it the runner cannot tell the two apart, and reading the store path's "
+                    + "`primaryKeySortingFields` off a computed provider throws a raw "
+                    + "ArgumentException instead of answering (#3622)");
+            if (!tTtdpNow.IsInstanceOfType(srcTtdp))
             {
                 if (_mCalcSingleFieldFromVirtualTable == null)
                     throw new RunnerOutOfScopeException(
@@ -1250,10 +1264,30 @@ public static class FlowFieldPatches
             // Enumerate source rows via TempTableDataProvider.Filter to mirror the runner's
             // CalcNumeric path (company-scoped, key-ordered, current in-memory rows).
             IEnumerable? rows = null;
+
+            // Resolved OUTSIDE the try, deliberately. Both handles must exist, and `?.` absorbed
+            // a missing one and let the OTHER run against a receiver the guard above would have
+            // diverted — the second half of #3622. A null sorting-field list is not a neutral
+            // default; it is the runner having failed to read BC's layout. They sit outside
+            // because the catch below reports "BC's filter machinery rejected the conditions",
+            // which a layout gap is not.
+            var fSorting = _fTtdpPrimaryKeySortingFields
+                ?? throw new BcShapeGapException(
+                    "AL FlowField calculation", "TempTableDataProvider.primaryKeySortingFields",
+                    "field not found — it supplies the key order the source rows of a CalcFormula "
+                    + "are walked in. Passing null instead would ask BC's Filter to enumerate with "
+                    + "no sort order at all (#3622)");
+            var mFilter = _mTtdpFilter
+                ?? throw new BcShapeGapException(
+                    "AL FlowField calculation", "TempTableDataProvider.Filter(5 args)",
+                    "method not found — it is the only route the runner has to the source rows of a "
+                    + "CalcFormula over a stored-row table. Without it the aggregate would be "
+                    + "computed over no rows and answer 0 for every formula (#3622)");
+
             try
             {
-                var sortingFields = _fTtdpPrimaryKeySortingFields?.GetValue(srcTtdp);
-                rows = _mTtdpFilter?.Invoke(srcTtdp, new object?[]
+                var sortingFields = fSorting.GetValue(srcTtdp);
+                rows = mFilter.Invoke(srcTtdp, new object?[]
                 {
                     companyToken,
                     srcFiltersAndMarks,


### PR DESCRIPTION
Closes #3622

Corpus-NA: the BC-behaviour claim is already pinned upstream by corpus codeunit 60779 (record/TestDateVirtualTableFlowField.al, FlowField_CountOverInteger_*), whose fixture DVT Flow Row field 8 is exactly the count(Integer where(Number = field(...))) shape this issue reports; what remains here is a runner-internal reflection guard with no AL-observable behaviour change on any BC build the runner has seen.

*Opened by agent `stma-auto-2` (automated implementation agent).*

## What the issue reported, and what was actually left to fix

#3622 reports `CalcFields` over a FlowField whose `CalcFormula` source is the Integer virtual
table (2000000026) crashing with a raw `ArgumentException`:

```
Field 'primaryKeySortingFields' defined on type 'Microsoft.Dynamics.Nav.Runtime.TempTableDataProvider'
is not a field on the target object which is of type 'Microsoft.Dynamics.Nav.Runtime.IntegerDataProvider'.
```

**That exact crash was already fixed, by #3597, nine hours after the issue was filed.** Measured,
not inferred — the issue's own minimal reproducer, run as a probe bundle against two builds:

| build | `CalcFields_ClosedRange` | `CalcFields_OpenHighEnd` | `CalcFields_NoFilterAtAll` |
|---|---|---|---|
| `0ef9bf72~1` (`aafabb62`, pre-#3597) | **FAIL** — the ArgumentException above, verbatim | FAIL | FAIL |
| `66791cf9` (current `main`) | PASS, answers 10 | PASS, answers 11 | PASS, answers 2000000001 |

`0ef9bf72` (#3597) is where `CalcSingleFieldFromVirtualTable` first appears in
`FlowFieldPatches.cs` — 0 occurrences at its parent, 12 at that commit. The Date virtual-table
fix carried the Integer case with it, because the branch it added discriminates on the
*provider*, and `IntegerDataProvider` and `DateDataProvider` are both computed providers.

So this PR does not re-fix the reported crash. It fixes the reason that crash can come back.

## The residual defect: a guard that falls through when its own lookup fails

The branch #3597 added is conditional on a reflection handle being non-null:

```csharp
if (_tTempTableDataProvider != null && !_tTempTableDataProvider.IsInstanceOfType(srcTtdp))
```

If that `Type` lookup ever fails, the condition reads **false** — and false here means "fall
through into the store path", which is the one outcome the guard exists to prevent. Forty lines
later that path reaches

```csharp
var sortingFields = _fTtdpPrimaryKeySortingFields?.GetValue(srcTtdp);
rows = _mTtdpFilter?.Invoke(srcTtdp, ...);
```

against the very `IntegerDataProvider` the guard was there to divert — reproducing #3622's
`ArgumentException` verbatim, with the fix for it bypassed. The `?.` on those two reads makes it
worse rather than safer: it absorbs a *missing* handle and then hands the surviving one a
receiver of the wrong type.

Three lookups, one shape: a failed read of BC's own layout being absorbed into an ordinary value.

## Which of the two answers this is, and the evidence

The brief asked whether a named refusal is right here, or whether a FlowField over `Integer`
should compute once the wrong assumption is removed — on the reading that the *sorting* step is
what should not apply to a computed provider.

**Computing is already what happens, and a refusal is right for the fall-through.** The evidence
is BC's own metadata, read with `bc-decompiler` against Ncl 28.1:

- `IntegerDataProvider` declares **six** members: `.ctor`, `CountValuesWithinRange`,
  `GetValuesWithinRangeForKeyField`, `FirstRecordKey`, `LastRecordKey`, `TableId`. No
  `primaryKeySortingFields` **and no `Filter`**.
- Its base `VirtualDataProvider` has no `Filter` either.

So the store path below the guard is not a sorting step that could be skipped — it is
`TempTableDataProvider.Filter`, a method these providers do not have, reading rows from a store
they do not keep. Relaxing the sorting assumption would leave the very next line with nothing to
call. The aggregate *is* computed, by the guard handing the formula to BC's own
`FlowFieldsHelper.CalcSingleFieldFromVirtualTableAsync` — which is why all three probe arms
answer correctly today.

That makes the fall-through a `bc-shape-gap` in the sense of
`AlRunner/Infrastructure/BcShapeGapException.cs`: the surface is in scope **and implemented**,
and the only way to reach it is for BC's layout to stop matching what the reflection was written
against. A bug report about the runner against a specific BC build — not a scope claim, and not
a second aggregation route worth building.

## The change

Three lookups converted from absorbing to refusing, in `CalcFlowFieldValuesCore`:

- `_tTempTableDataProvider` — the discriminator is now required, so a missing handle refuses
  instead of selecting the store path by default.
- `_fTtdpPrimaryKeySortingFields`, `_mTtdpFilter` — resolved before the `try`, each with its own
  `BcShapeGapException` naming the member and what its absence would otherwise cause.

They sit **outside** the surrounding `try` deliberately: that catch reports "BC's filter
machinery rejected the resolved conditions", which a layout gap is not, and it would have
printed that line over a refusal that means something else.

`Register()` is untouched — it runs at startup for every invocation, so throwing there would
refuse runs that never calculate a FlowField. The refusal belongs at the use site, which is
where the fall-through actually happens.

## RED → GREEN, and how each guard was proved armed

`AlRunner.Tests/FlowFieldComputedProviderGuardTests.cs`, 4 tests. RED first: 2 failed for the
right reason (each naming the exact absorbing expression), 2 passed — those two assert BC's own
layout and are the premise, so they are green in both states by construction.

Every arm was then sabotaged individually, and each failed **only** its own arm — never a
different one:

| sabotage | arm that failed | others |
|---|---|---|
| restore `_tTempTableDataProvider != null && !…IsInstanceOfType` | `TheComputedProviderGuard_DoesNotFallThroughWhenItsOwnTypeLookupFailed` | 3 pass |
| **liveness**: rename `_mCalcSingleFieldFromVirtualTable` away (the divert call REMOVED) | same arm | 3 pass |
| restore `_fTtdpPrimaryKeySortingFields?.GetValue(` | `TheStorePathReads_DoNotAbsorbAMissingHandle` | 3 pass |
| restore `_mTtdpFilter?.Invoke(` | same arm | 3 pass |

The liveness sabotage **removes the call** rather than merely perturbing it, so the arm cannot
pass on an implementation where the divert was deleted outright — deleting the guard would
otherwise satisfy a pure `DoesNotContain` assertion while restoring the crash.

`TheThreeTempTableDataProviderHandles_AreObtainedThroughAThrowingAccessor` carries its own
negative arm: the same `BcShape.RequiredField` asked for a member that does not exist must throw
`BcShapeGapException` **naming that member**, so the positive arm is evidence of a throwing
accessor rather than of a member that happens to be present.

Needle polarity was checked rather than assumed — all three negative needles are absent in the
fixed tree and present in each corresponding sabotage, which is what the four rows above measure.

## Measurements

**Full corpus, all 3 apps, pin `3ad4c340`** (not a filtered subset — an app aborting with
`EXEC-FAIL` and 0 tests is the failure mode a filter hides):

| | tests | pass | fail | error | exec-fail |
|---|---|---|---|---|---|
| before (`origin/main`, patch reverted, rebuilt) | 3152 | 3152 | 0 | 0 | 0 |
| after | 3152 | 3152 | 0 | 0 | 0 |

3152, not the 3123 in the brief — re-derived rather than trusted, and it matches the reviewer's
clean-clone figure. `tools/corpus-pin.py` reported all three readings agreeing at `3ad4c340`
before either run; the submodule was initialised in this worktree rather than `git checkout`-ed.

Targeted C#: `FlowField|IntegerVirtualTable|DateVirtualTable` 39 passed / 3 skipped;
`SilentReflectionLookupRatchetTests` + `BcInternalsNullForgivingGuardTests` +
`BcShapeNullForgivingLookupTests` 45 passed.

**Neither ratchet moved, and neither should have.** `SilentReflectionLookupRatchetTests` is
expression-local by design and counts *lookup* expressions (`x.GetProperty(…)`), not *uses* of an
already-cached handle (`_f?.GetValue(…)`). The three sites converted here are the second shape,
so `Baseline = 120` is still the guard's own answer on this tree — lowering it would have been
wrong. That shape having no ratchet is worth noting rather than fixing here.

## The pin, and why it does not move

`tests/al-language` stays at `3ad4c340`. #2943 sits at position 1 in the corpus range, so the pin
cannot advance, and the corpus test that adjudicates this claim (codeunit 60779) is therefore not
yet replayed by this repository's CI. That is expected and is not a gap this PR can close — the
corpus legs are the adjudication, and they are already green upstream.

## What I did NOT fold, and why

Scanned the open queue for FlowField / CalcFields / virtual-table issues. **Nothing folds** —
none lands in `FlowFieldPatches.cs`, which is the same-file test in
`.claude/rules/batch-sibling-issues-by-file.md`:

| issue | where its fix lands | why not folded |
|---|---|---|
| #3513 | `RecordPatches.DateMissingSpans` | date arithmetic range check; different file, different mechanism |
| #3502 | `RecordPatches.AlSourceParser.cs` | `const()` qualified-option parsing, not calculation |
| #3367 | `RecordPatches.AlSourceParser.cs` | parser-level `where()` refusals dropped silently |
| #3578 | `RecordPatches` Get replacement | `SetAutoCalcFields` on `Get`; touches the caller, not this path |
| #3382 | `BcAppSymbolCache.CollectReportDataItems` | dependency-report wire format |

#3367 is the closest relative — the same "a failed read is absorbed into an ordinary value"
shape, one property over — and it is deliberately left alone because it is a different file with
its own reasoning, exactly as its own body says about #3326.

## What I could not prove

- **The refusals cannot be triggered on any BC build the runner has on disk**, because
  `primaryKeySortingFields`, `Filter` and `TempTableDataProvider` are all present on 28.1. What
  is proved is that the *code path* refuses instead of absorbing, via the four sabotages; what
  is not proved is a live `BcShapeGapException` reaching AL, and it cannot be without a BC build
  that has moved these members.
- **No behaviour change is observable from AL on 28.1** — which is the intended outcome, and why
  the corpus count is identical before and after rather than improved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
