### PR TITLE
fix(permissions): serve the Permission table (2000000005) from BC's own provider

### DIFF
--- a/AlRunner.Tests/PermissionSystemTableOwningAppTests.cs
+++ b/AlRunner.Tests/PermissionSystemTableOwningAppTests.cs
@@ -1,0 +1,120 @@
+// PermissionSystemTableOwningAppTests — the runner-side mechanism behind #3695.
+//
+// WHAT IS BEING PROVED, AND WHAT IS NOT
+//   The BC-behaviour claim — that a permission set's `tabledata` grants are readable back from
+//   the Permission table (2000000005) with their RIMD mask — is adjudicated upstream by corpus
+//   codeunit 60604 "Test Perm. Set Grants", merged in corpus PR #301 and green on all eight
+//   cloud legs. That claim does not belong here and is not duplicated here.
+//
+//   What IS here is the runner-side mechanism the fix turns on, which no corpus test can see:
+//   the reflection helper that finds BC's PRIVATE BASE field `NCLMetaApplicationObject.owningApp`.
+//   Getting that lookup wrong is the difference between BC's permission graph walk running and
+//   BC's permission graph walk raising NullReferenceException on all 47 dependency permission
+//   sets — and it went wrong in exactly one specific way while #3695 was implemented, which is
+//   what the negative arm below pins.
+//
+// THE ARM THAT MATTERS
+//   FlattenHierarchy_DoesNotFindAPrivateBaseField is the control that makes the positive arm
+//   mean something. `BindingFlags.FlattenHierarchy` reads as "search base types too" and does
+//   not surface a PRIVATE base field — measured on .NET 8, and it is what the first version of
+//   SetOwningApp used, so the field lookup returned null and the loud refusal fired instead of
+//   the fix. Without this arm the positive arm would pass just as happily against the broken
+//   lookup, because a field declared on the type ITSELF is found by both.
+using System;
+using System.Reflection;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PermissionSystemTableOwningAppTests
+{
+    // A two-level hierarchy shaped like BC's: NCLMetaPermissionSet derives from
+    // NCLMetaApplicationObject, and `owningApp` is declared PRIVATE on the base.
+    private class BaseWithPrivateField
+    {
+        private object? owningApp;
+        internal object? ReadOwningApp() => owningApp;
+    }
+
+    private sealed class DerivedLikeMetaPermissionSet : BaseWithPrivateField
+    {
+    }
+
+    private sealed class DeclaresItOnItself
+    {
+        private object? owningApp;
+        internal object? ReadOwningApp() => owningApp;
+    }
+
+    private static FieldInfo? FindUpHierarchy(Type type, string name)
+        => (FieldInfo?)typeof(RecordPatches)
+            .GetMethod("FindDeclaredFieldUpHierarchy", BindingFlags.NonPublic | BindingFlags.Static)!
+            .Invoke(null, new object?[] { type, name });
+
+    [Fact]
+    public void FindDeclaredFieldUpHierarchy_FindsAPrivateFieldDeclaredOnABaseType()
+    {
+        var field = FindUpHierarchy(typeof(DerivedLikeMetaPermissionSet), "owningApp");
+
+        Assert.NotNull(field);
+        Assert.Equal("owningApp", field!.Name);
+        // The field it found must be the BASE type's, not something on the derived type —
+        // otherwise "found a field" would not mean "found the one BC's property reads".
+        Assert.Equal(typeof(BaseWithPrivateField), field.DeclaringType);
+
+        // And it must be WRITABLE through, since writing it is the entire point: BC's
+        // NCLMetaApplicationObject.OwningApp getter returns this field and only attempts a
+        // lazy resolution when MetadataAppGroup.GroupId != 0, which the runner's base group's
+        // id is not.
+        var instance = new DerivedLikeMetaPermissionSet();
+        var owner = new object();
+        field.SetValue(instance, owner);
+        Assert.Same(owner, instance.ReadOwningApp());
+    }
+
+    [Fact]
+    public void FindDeclaredFieldUpHierarchy_FindsAPrivateFieldDeclaredOnTheTypeItself()
+    {
+        var field = FindUpHierarchy(typeof(DeclaresItOnItself), "owningApp");
+
+        Assert.NotNull(field);
+        Assert.Equal(typeof(DeclaresItOnItself), field!.DeclaringType);
+    }
+
+    [Fact]
+    public void FindDeclaredFieldUpHierarchy_AnswersNullForAFieldNothingInTheHierarchyDeclares()
+    {
+        // The null is what SetOwningApp turns into a BcShapeGapException naming the member,
+        // rather than a NullReferenceException at the first use somewhere BC's own seam would
+        // swallow. So "returns null" is a contract, not an implementation detail.
+        Assert.Null(FindUpHierarchy(typeof(DerivedLikeMetaPermissionSet), "noSuchFieldAnywhere"));
+    }
+
+    [Fact]
+    public void FlattenHierarchy_DoesNotFindAPrivateBaseField()
+    {
+        // THE NEGATIVE CONTROL. This is not a claim about the runner — it is the .NET
+        // behaviour that made the first version of SetOwningApp fail, and it is asserted here
+        // so the positive arm above cannot be satisfied by re-introducing that lookup.
+        var viaFlatten = typeof(DerivedLikeMetaPermissionSet).GetField("owningApp",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
+            | BindingFlags.FlattenHierarchy);
+
+        Assert.Null(viaFlatten);
+        Assert.NotNull(FindUpHierarchy(typeof(DerivedLikeMetaPermissionSet), "owningApp"));
+    }
+
+    [Fact]
+    public void PermissionSystemTableId_IsTheTableTheFixRoutes()
+    {
+        // The dispatch arm in RecordPatches.cs is keyed on this constant, so a wrong value
+        // routes some other table's data access through BC's PermissionDataProvider — which
+        // would be a silently wrong answer rather than a failure.
+        var id = (int)typeof(RecordPatches)
+            .GetField("PermissionSystemTableId", BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetRawConstantValue()!;
+
+        Assert.Equal(2000000005, id);
+    }
+}

--- a/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
+++ b/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
@@ -425,7 +425,18 @@ public sealed class VirtualTableRefusalClaimTests
         // DateDataProvider, which computes rows per request, so there is no materialised window
         // for a filter to reach past and no skeleton-session read of our own to fail.
         // 75 was READ OUT of this test's own failure message ("Expected: 84, Actual: 75").
-        Assert.Equal(75, total);
+        // +1 (#3695): the Permission (2000000005) populator joined, and contributes exactly ONE
+        // countable refusal — the one in RecordPatches.cs's dispatch chain, guarding a
+        // DataAccessSource with no skeleton session, without which BC's own
+        // PermissionDataProvider cannot be constructed. Its own file,
+        // RecordPatches.PermissionSystemTable.cs, raises two more that this count does not see:
+        // CoveredFiles is a hard-coded list (#3118) and the new file is deliberately not on it,
+        // so those two are outside the scanned set. The delta is therefore +1, not +3.
+        // 76 was READ OUT of this test's own failure message ("Expected: 75, Actual: 76"), and
+        // independently confirmed by counting the same regex across CoveredFiles ∪ SiblingFiles
+        // on origin/main (75) and on this branch (76): the ONLY per-file movement is
+        // RecordPatches.cs, 5 -> 6.
+        Assert.Equal(76, total);
     }
 
 

--- a/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
@@ -463,9 +463,14 @@ public static partial class RecordPatches
 
     private static object? BuildNclMetaPermissionSet(int permissionSetId)
     {
-        var declaration = EnumerateKnownPermissionSets()
-            .Select(p => p.PermissionSet)
-            .FirstOrDefault(p => p.Id == permissionSetId);
+        // The OWNING APP travels with the declaration now (#3695). It used to be projected away
+        // here, and NCLMetaPermissionSet.OwningApp then stayed null for every set the runner
+        // builds: BC resolves it lazily through MetadataAppGroup.GetObjectOwner, and that lazy
+        // is gated on `MetadataAppGroup.GroupId != 0`, which the base group's id is not. See
+        // SetOwningApp below for what dereferences it.
+        var found = EnumerateKnownPermissionSets()
+            .FirstOrDefault(p => p.PermissionSet.Id == permissionSetId);
+        var declaration = found.PermissionSet;
         if (declaration == null) return null;
 
         EnsurePermissionMetadataReflection();
@@ -501,7 +506,68 @@ public static partial class RecordPatches
         if (_fNCLMetaAppObjMetadataLoaded != null)
             FieldPoke.SetInstance(_fNCLMetaAppObjMetadataLoaded, meta, true);
 
+        SetOwningApp(meta, found.OwningAppId, found.OwningAppName);
+
         return meta;
+    }
+
+    private static FieldInfo? _fNCLMetaAppObjOwningApp;
+
+    /// <summary>
+    /// Give the built <c>NCLMetaPermissionSet</c> the same <c>NavAppRuntimeMetadata</c> owner
+    /// BC's own lookup would have found, by writing the backing field its lazy would have
+    /// written.
+    ///
+    /// <para>CLAIM — observably equivalent. BC's <c>NCLMetaApplicationObject.OwningApp</c>
+    /// resolves through <c>MetadataAppGroup.GetObjectOwner</c>, which scans
+    /// <c>OrderedAppMetadata</c> for the app declaring this object — the same
+    /// (app id, app name) pair <see cref="EnumerateKnownPermissionSets"/> already carries for
+    /// this permission set, and the same owner object
+    /// <see cref="GetOrCreateAppOwner"/> hands the app-group summaries. So this writes what
+    /// BC's own resolution answers, not a stand-in for it.</para>
+    ///
+    /// <para>TRAP — the lazy cannot do it here, which is why the field is written rather than
+    /// the property read. The getter is gated on <c>MetadataAppGroup.GroupId != 0</c>, and the
+    /// runner plants <c>NavAppGroup.BaseGroup</c>, whose GroupId IS 0. So the property returns
+    /// the null field forever and never attempts a resolution — silently, since nothing on
+    /// that path reports an unresolved owner.</para>
+    ///
+    /// <para>What dereferences it: <c>MetadataPermissionSetProvider.GetPermissionSet</c>'s
+    /// local <c>CollectReferencedPermissionSetKeys</c> reads
+    /// <c>metaPermissionSet.OwningApp.AppId.Value</c> for every include/exclude edge, so a null
+    /// owner is a NullReferenceException inside BC's own graph walk — measured on all 47
+    /// dependency permission sets before this (#3695).</para>
+    /// </summary>
+    private static void SetOwningApp(object meta, Guid owningAppId, string owningAppName)
+    {
+        // Walked up the hierarchy by hand: `owningApp` is declared PRIVATE on the base
+        // NCLMetaApplicationObject, and BindingFlags.FlattenHierarchy does not surface a
+        // private base field — measured, it returns null here, which this method's own refusal
+        // reported by name on its first run.
+        _fNCLMetaAppObjOwningApp ??= FindDeclaredFieldUpHierarchy(meta.GetType(), "owningApp")
+            ?? throw PermissionMetadataBcShapeGap(
+                "NCLMetaApplicationObject.owningApp",
+                "field not found on the type or any of its bases — a permission set's owning app "
+                + "cannot be supplied, and BC's own permission graph walk dereferences it");
+
+        FieldPoke.SetInstance(_fNCLMetaAppObjOwningApp, meta, GetOrCreateAppOwner(owningAppId, owningAppName));
+    }
+
+    /// <summary>
+    /// The field <paramref name="name"/> declared on <paramref name="type"/> or any of its base
+    /// types, or null. <c>DeclaredOnly</c> per level is what makes a private base field
+    /// reachable at all; <c>FlattenHierarchy</c> does not do it.
+    /// </summary>
+    private static FieldInfo? FindDeclaredFieldUpHierarchy(Type type, string name)
+    {
+        for (var t = type; t != null; t = t.BaseType)
+        {
+            var f = t.GetField(name,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
+                | BindingFlags.DeclaredOnly);
+            if (f != null) return f;
+        }
+        return null;
     }
 
     // ── source-declared permissions: names in, ids out (#2910) ──────────────────────────

--- a/AlRunner/Patches/RecordPatches.PermissionSystemTable.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionSystemTable.cs
@@ -54,13 +54,11 @@
 //   wrapper at most once, so a later Get()/FindSet() on that same variable never re-dispatches
 //   and reads whatever this file last stored. The Aggregate Permission Set sibling closes that
 //   with a per-request redrive prepended to DataAccess.InternalTryGetByPrimaryKeyAsync (#2504),
-//   which is the right shape here too — and it is NOT done here, deliberately, because the
-//   registration lives in AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs, held by another
-//   open pull request while this was written. It costs nothing today: this table's rows derive
-//   from the permission-set inventory, which is fixed for the lifetime of one runner
-//   invocation, so a redrive on an already-open variable can only ever recompute the same rows.
-//   It starts costing something the moment a permission set can be declared mid-run. #3697
-//   tracks it.
+//   which is the right shape here too — and it is NOT done here, deliberately, because it costs
+//   nothing today: this table's rows derive from the permission-set inventory, which is fixed
+//   for the lifetime of one runner invocation, so a redrive on an already-open variable can only
+//   ever recompute the same rows. It starts costing something the moment a permission set can be
+//   declared mid-run. #3705 tracks it.
 //
 // PRECOMPILED-DLL RESPECT
 //   PermissionDataProvider, PermissionDataProviderBase, PermissionProvider, NCLMetadata,

--- a/AlRunner/Patches/RecordPatches.PermissionSystemTable.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionSystemTable.cs
@@ -1,0 +1,326 @@
+// RecordPatches.PermissionSystemTable — managed provider for the "Permission" system
+// virtual table (2000000005), the rows that say what a permission set GRANTS.
+//
+// WHY THIS EXISTS
+//   #2893 made BC's permission METADATA layer resolve — the app group's permission-set
+//   inventory and one NCLMetaPermissionSet per set — and #3609 made a source-compiled set's
+//   grants reach that layer with their object ids and masks already resolved, by reading
+//   BC's own emitted <PermissionSet> document. Both landed, and table 2000000005 was still
+//   empty, because nothing routed it: this file's dispatch arm did not exist, so the
+//   runner's per-table store for 2000000005 was created and never populated.
+//
+//   Measured on the corpus at tip, BC 28.4, before this file: corpus codeunit 60604
+//   "Test Perm. Set Grants" fails
+//     PermissionSet_DeclaredTableDataGrant_IsListedAsAPermissionRow ("at least one Permission
+//       row must exist") and
+//     PermissionSet_TableDataGrant_CarriesTheReadWriteInsertDeleteMask
+//       (NavCSideRecordNotFoundException, Role ID='ALTPERMISSIONSET' Object Type='Table Data'
+//       Object ID='60000'),
+//   while its third test passes VACUOUSLY — it asserts Object Type::Table yields no rows,
+//   which an entirely empty table satisfies. That third test is the negative control for this
+//   file: it only starts doing its job once rows exist, and it goes red if this file files a
+//   tabledata grant under Object Type::Table.
+//
+// WHAT THIS DOES (faithful, managed, R2R-safe)
+//   It drives BC's REAL, unmodified PermissionDataProvider rather than re-deriving what a
+//   permission set grants. Three of its own members, in BC's own order:
+//     GetPermissionSets(null)          -> GetMetadataPermissionSets, which reads the app group
+//                                         inventory EnsurePermissionMetadataPopulated fills;
+//     ComputePermissions(key)          -> PermissionSetGraphWalker.Walk + PermissionComposer,
+//                                         i.e. BC's own include/exclude expansion and
+//                                         extension merge;
+//     GetRecord(key, definition)       -> the ReadOnlyRecordBuffer, with Object Type, Object ID
+//                                         and the five R/I/M/D/X option columns laid out by
+//                                         BC's own PermissionHelper.
+//   So every column value in this table is computed by BC, from data the runner supplied to
+//   BC's metadata layer. The runner contributes the inventory and the dispatch; it computes no
+//   permission of its own. That is the audit justification .claude/rules/loud-failures.md
+//   asks for: an in-scope caller reading this table observes what BC's provider answers,
+//   because it IS what BC's provider answered.
+//
+// WHY ComputePermissions AND NOT GetPermissions
+//   GetPermissions is a memo around ComputePermissions keyed on
+//   session.Database.PermissionSetupMonitor.SetupVersion. The skeleton session has no
+//   Database, so the memo's first line NREs before reaching the computation it caches.
+//   Calling the computation directly is the same answer without the cache — measured: BC's own
+//   PermissionDataProvider.ComputePermissions is `permissionComposer.Compose(
+//   permissionSetGraphWalker.Walk(key), session)`, which reads no Database at all.
+//
+// REBUILT ON EVERY DISPATCH, AND WHAT THAT DOES NOT COVER
+//   The store is cleared and rebuilt on every dispatch (ClearProviderInPlace), so a permission
+//   set that becomes known between two Record variables cannot be missing and a stale row
+//   cannot survive. What it does NOT cover is the second read on ONE already-open Record
+//   variable: real BC's RecordImplementation.InitializeImpl resolves a NavRecord's DataAccess
+//   wrapper at most once, so a later Get()/FindSet() on that same variable never re-dispatches
+//   and reads whatever this file last stored. The Aggregate Permission Set sibling closes that
+//   with a per-request redrive prepended to DataAccess.InternalTryGetByPrimaryKeyAsync (#2504),
+//   which is the right shape here too — and it is NOT done here, deliberately, because the
+//   registration lives in AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs, held by another
+//   open pull request while this was written. It costs nothing today: this table's rows derive
+//   from the permission-set inventory, which is fixed for the lifetime of one runner
+//   invocation, so a redrive on an already-open variable can only ever recompute the same rows.
+//   It starts costing something the moment a permission set can be declared mid-run. #3697
+//   tracks it.
+//
+// PRECOMPILED-DLL RESPECT
+//   PermissionDataProvider, PermissionDataProviderBase, PermissionProvider, NCLMetadata,
+//   NCLMetaTable, ReadOnlyRecordBuffer and TempTableDataProvider are runtime-engine types in
+//   Ncl.dll. Nothing here constructs, rewrites or substitutes an AL-business-logic body.
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using AlRunner.Infrastructure;
+using Microsoft.Dynamics.Nav.Runtime;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    /// <summary>
+    /// A store-wiring refusal on the Permission table. See RecordPatches.VirtualTableShapeGap.cs
+    /// for the three-bucket classification; this is category (2), the same bucket the two
+    /// sibling permission tables' own store-wiring refusals sit in.
+    /// </summary>
+    internal static RunnerOutOfScopeException PermissionSystemTableShapeGap(string detail)
+        => VirtualTableShapeGap("Permission (system table 2000000005)", "permission-system-table", detail);
+
+    /// <summary>
+    /// A BC-internals read behind the Permission table (2000000005) that could not be
+    /// performed — the same classification the sibling permission tables use, so a moved Ncl
+    /// member is reported by name instead of arriving as an anonymous exception the
+    /// <c>asserterror</c> seam absorbs.
+    /// </summary>
+    internal static BcShapeGapException PermissionSystemTableBcShapeGap(string member, string detail)
+        => new("Permission (system table 2000000005)", member, detail);
+
+    internal const int PermissionSystemTableId = 2000000005;
+
+    private static bool _permTableReflectionReady;
+    private static Type? _permTableProviderType;        // Microsoft.Dynamics.Nav.Runtime.PermissionDataProvider
+    private static ConstructorInfo? _permTableProviderCtor;   // .ctor(NavSession, NCLMetadata, PermissionProvider)
+    private static ConstructorInfo? _permTablePermProviderCtor; // PermissionProvider(NCLMetadata)
+    private static MethodInfo? _permTableGetPermissionSets;    // protected IEnumerable<PermissionSetKey> GetPermissionSets(FilterExpression)
+    private static MethodInfo? _permTableComputePermissions;   // protected IEnumerable<NavPermissionDefinition> ComputePermissions(PermissionSetKey)
+    private static MethodInfo? _permTableGetRecord;            // protected ReadOnlyRecordBuffer GetRecord(PermissionSetKey, NavPermissionDefinition)
+    private static PropertyInfo? _permTableSessionNclMetadata; // NavSession.NCLMetadata
+
+    private static bool IsPermissionSystemTable(NCLMetaTable? table)
+        => table != null && table.TableId == PermissionSystemTableId;
+
+    /// <summary>
+    /// Populate the in-memory store behind the Permission (2000000005) data access by driving
+    /// BC's own <c>PermissionDataProvider</c> over every permission set the runner knows.
+    /// </summary>
+    private static void PopulatePermissionSystemTable(object dataAccess, NCLMetaTable metaTable, object session)
+    {
+        // The AllObj block resolved the shared Ncl helpers (buffer ctors,
+        // TempTableDataProvider.Insert). Reuse them rather than resolving a second copy.
+        EnsureAllObjReflection(metaTable);
+        EnsurePermissionSystemTableReflection(metaTable);
+        EnsureDataAccessProviderReflection(dataAccess);
+
+        var store = _pDataAccessDataProvider!.GetValue(dataAccess)
+            ?? throw PermissionSystemTableShapeGap("data access has no in-memory provider");
+
+        ClearProviderInPlace(store);
+
+        // The moment the runner knows the permission-set inventory is complete and something
+        // is asking about permissions. BC's GetMetadataPermissionSets below reads exactly the
+        // app-group inventory this fills, so without it the provider enumerates nothing and
+        // this table is empty for the same reason it was before this file existed.
+        EnsurePermissionMetadataPopulated();
+
+        var nclMetadata = _permTableSessionNclMetadata!.GetValue(session)
+            ?? throw PermissionSystemTableShapeGap(
+                "NavSession.NCLMetadata is null on the skeleton session, so BC's own "
+                + "PermissionDataProvider cannot resolve the permission sets it reads");
+
+        object bcProvider;
+        List<object> permissionSetKeys;
+        try
+        {
+            var permissionProvider = _permTablePermProviderCtor!.Invoke(new object?[] { nclMetadata });
+            bcProvider = _permTableProviderCtor!.Invoke(new object?[] { session, nclMetadata, permissionProvider });
+            // A null FilterExpression means "no App ID filter": BC's own GetMetadataPermissionSets
+            // only evaluates the filter when appIdField is non-null, and this table declares no
+            // App ID field, so the null is the same "every app" answer BC computes for an
+            // unfiltered request rather than a stand-in for one.
+            permissionSetKeys = DrainToList(_permTableGetPermissionSets!.Invoke(bcProvider, new object?[] { null })!);
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
+            throw; // unreachable — satisfies the compiler's flow analysis
+        }
+
+        foreach (var key in permissionSetKeys)
+            InsertPermissionRowsForSet(bcProvider, store, metaTable, key);
+    }
+
+    /// <summary>
+    /// Every Permission row one permission set contributes: BC composes the set's effective
+    /// permissions, and BC lays each one out as a record buffer.
+    ///
+    /// <para>The compose and the per-definition layout are separated deliberately, for the
+    /// reason the Aggregate Permission Set sibling's banner sets out at length: a C# iterator
+    /// that throws out of <c>MoveNext()</c> is terminally finished, so one bad item inside a
+    /// single combined enumeration silently truncates every item after it. Draining the
+    /// composition first and calling <c>GetRecord</c> per item afterwards makes a per-row
+    /// failure an ordinary exception around one ordinary call.</para>
+    /// </summary>
+    private static void InsertPermissionRowsForSet(object bcProvider, object store, NCLMetaTable metaTable, object permissionSetKey)
+    {
+        List<object> definitions;
+        try
+        {
+            // ComputePermissions, not GetPermissions — see the file banner: the latter's memo
+            // reads session.Database, which the skeleton session does not have.
+            definitions = DrainToList(_permTableComputePermissions!.Invoke(bcProvider, new object?[] { permissionSetKey })!);
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
+            throw; // unreachable
+        }
+
+        foreach (var definition in definitions)
+        {
+            object readOnlyBuffer;
+            try
+            {
+                readOnlyBuffer = _permTableGetRecord!.Invoke(bcProvider, new[] { permissionSetKey, definition })!;
+            }
+            catch (TargetInvocationException tie) when (IsRoleIdTooLongForPermissionTable(tie.InnerException))
+            {
+                // "Role ID" on this table is Code[20], and GetRecord calls ModifyLength on the
+                // wider value, whose NavCode constructor throws rather than truncate. A role id
+                // BC's own schema cannot represent in THIS table is a row that exists on no
+                // tier, so it is excluded rather than truncated — truncating would fabricate a
+                // Role ID BC never emits. Same rule, same reason, as the Aggregate Permission
+                // Set sibling's own exclusion.
+                if (Environment.GetEnvironmentVariable("AL_RUNNER_TRACE_PERMISSION_TABLE") == "1")
+                    Console.Error.WriteLine(
+                        $"[permission-table] excluded row: {tie.InnerException!.GetType().Name}: {tie.InnerException.Message}");
+                continue;
+            }
+            catch (TargetInvocationException tie) when (tie.InnerException != null)
+            {
+                ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
+                throw; // unreachable
+            }
+
+            var mutable = _aovCtorMutableBuffer!.Invoke(new object?[] { readOnlyBuffer });
+            try
+            {
+                _aovTtdpInsert!.Invoke(store, new object?[] { 0, mutable, _aovInsertOptionsNone, null });
+            }
+            catch (TargetInvocationException tie) when (
+                tie.InnerException?.GetType().Name == "NavRecordAlreadyExistsException")
+            {
+                // The same (Role ID, Object Type, Object ID) already present. BC's own composer
+                // unions grants across included sets, so two include edges reaching the same
+                // object legitimately produce one row here — dropping the duplicate is what a
+                // table whose primary key is that triple does on any tier.
+            }
+        }
+    }
+
+    private static bool IsRoleIdTooLongForPermissionTable(Exception? ex)
+        => ex?.GetType().Name == "NavNCLStringLengthExceededException";
+
+    private static void EnsurePermissionSystemTableReflection(NCLMetaTable metaTable)
+    {
+        if (_permTableReflectionReady) return;
+
+        const string rt = "Microsoft.Dynamics.Nav.Runtime.";
+
+        _permTableProviderType = ResolveType(rt + "PermissionDataProvider", rt + "PermissionDataProvider")
+            ?? throw PermissionSystemTableBcShapeGap(
+                "PermissionDataProvider",
+                "type not found in Ncl — the Permission table cannot be populated");
+
+        var tNavSession = ResolveType(rt + "NavSession", rt + "NavSession")
+            ?? throw PermissionSystemTableBcShapeGap(
+                "NavSession",
+                "type not found in Ncl — the Permission table cannot be populated");
+        var tNclMetadata = ResolveType(rt + "NCLMetadata", rt + "NCLMetadata")
+            ?? throw PermissionSystemTableBcShapeGap(
+                "NCLMetadata",
+                "type not found in Ncl — the Permission table cannot be populated");
+        var tPermissionProvider = ResolveType(
+            rt + "Permissions.PermissionProvider", rt + "Permissions.PermissionProvider")
+            ?? throw PermissionSystemTableBcShapeGap(
+                "Permissions.PermissionProvider",
+                "type not found in Ncl — the Permission table cannot be populated");
+        var tPermissionSetKey = ResolveType(
+            rt + "Permissions.PermissionSetKey", rt + "Permissions.PermissionSetKey")
+            ?? throw PermissionSystemTableBcShapeGap(
+                "Permissions.PermissionSetKey",
+                "type not found in Ncl — the Permission table cannot be populated");
+        // Permissions.NavPermissionDefinition, NOT Types.NavPermissionDefinition: the "Nav"
+        // prefix reads like a Types-namespace value type and it is not one. Measured on Ncl
+        // 28.1 — the only NavPermissionDefinition in the load chain is under
+        // Microsoft.Dynamics.Nav.Runtime.Permissions, and the Types spelling resolved to
+        // nothing, which is what this file's own refusal reported by name on its first run.
+        var tPermissionDefinition = ResolveType(
+            rt + "Permissions.NavPermissionDefinition", rt + "Permissions.NavPermissionDefinition")
+            ?? throw PermissionSystemTableBcShapeGap(
+                "Permissions.NavPermissionDefinition",
+                "type not found in Ncl — the Permission table cannot be populated");
+        var tFilterExpression = ResolveType(rt + "FilterExpression", rt + "FilterExpression")
+            ?? throw PermissionSystemTableBcShapeGap(
+                "FilterExpression",
+                "type not found in Ncl — the Permission table cannot be populated");
+
+        _permTablePermProviderCtor = tPermissionProvider.GetConstructor(
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            binder: null, types: new[] { tNclMetadata }, modifiers: null)
+            ?? throw PermissionSystemTableBcShapeGap(
+                "PermissionProvider(NCLMetadata)",
+                "constructor not found — the Permission table cannot be populated");
+
+        _permTableProviderCtor = _permTableProviderType.GetConstructor(
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            binder: null, types: new[] { tNavSession, tNclMetadata, tPermissionProvider }, modifiers: null)
+            ?? throw PermissionSystemTableBcShapeGap(
+                "PermissionDataProvider(NavSession, NCLMetadata, PermissionProvider)",
+                "constructor not found — the Permission table cannot be populated");
+
+        // GetPermissionSets and ComputePermissions are declared abstract on
+        // PermissionDataProviderBase and overridden here, so they are resolved on the DERIVED
+        // type: the override is what a virtual dispatch would reach, and resolving the base
+        // declaration would invoke through the same slot but state a member the reader would
+        // have to follow one level to understand.
+        _permTableGetPermissionSets = _permTableProviderType.GetMethod("GetPermissionSets",
+            BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance, binder: null,
+            types: new[] { tFilterExpression }, modifiers: null)
+            ?? throw PermissionSystemTableBcShapeGap(
+                "PermissionDataProvider.GetPermissionSets(FilterExpression)",
+                "method not found — the Permission table cannot be populated");
+
+        _permTableComputePermissions = _permTableProviderType.GetMethod("ComputePermissions",
+            BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance, binder: null,
+            types: new[] { tPermissionSetKey }, modifiers: null)
+            ?? throw PermissionSystemTableBcShapeGap(
+                "PermissionDataProvider.ComputePermissions(PermissionSetKey)",
+                "method not found — the Permission table cannot be populated");
+
+        _permTableGetRecord = _permTableProviderType.GetMethod("GetRecord",
+            BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance, binder: null,
+            types: new[] { tPermissionSetKey, tPermissionDefinition }, modifiers: null)
+            ?? throw PermissionSystemTableBcShapeGap(
+                "PermissionDataProvider.GetRecord(PermissionSetKey, NavPermissionDefinition)",
+                "method not found — the Permission table cannot be populated");
+
+        _permTableSessionNclMetadata = FindBcProperty(tNavSession, "NCLMetadata", out var nNclMetadata)
+            ?? throw PermissionSystemTableBcShapeGap(
+                "NavSession.NCLMetadata",
+                BcPropertyGapDetail("NCLMetadata", nNclMetadata)
+                + " — the Permission table cannot be populated");
+
+        _permTableReflectionReady = true;
+    }
+
+}

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -2178,6 +2178,29 @@ public static partial class RecordPatches
                 return permSetSysDa;
             }
 
+            // ── Permission system virtual table (2000000005) ────────────────────────────
+            // Virtual on the service tier too: PermissionDataProvider computes one row per
+            // permission a permission set grants, from the same metadata inventory the two
+            // tables above read. An empty store made every `Permission.Get(role, type, id)`
+            // answer "does not exist" and every filtered walk come back empty, while the
+            // set's HEADER listed correctly one table over — so a set's grants were
+            // unreadable with nothing reporting a gap (#3695).
+            // See RecordPatches.PermissionSystemTable.cs.
+            if (IsPermissionSystemTable(table))
+            {
+                if (!perTable.TryGetValue(tableId, out var permDa))
+                {
+                    var createdPerm = _mCreateTempDataAccess!.Invoke(self, new object[] { table })!;
+                    permDa = perTable.GetOrAdd(tableId, createdPerm);
+                }
+                var permSession = _fDasSession?.GetValue(self)
+                    ?? throw PermissionSystemTableShapeGap(
+                        "DataAccessSource has no skeleton session, so BC's own "
+                        + "PermissionDataProvider cannot be constructed");
+                PopulatePermissionSystemTable(permDa, table, permSession);
+                return permDa;
+            }
+
             // ── Aggregate Permission Set system virtual table (2000000167) ──────────────
             // Virtual on the service tier too: its rows are the UNION of System-scope
             // (Metadata Permission Set, 2000000250 — just above) and Tenant-scope (Tenant


### PR DESCRIPTION
Closes #3695

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/301

Written by an agent (Claude, `stma-auto-2`).

## The gap

A `permissionset` object's `tabledata` grants were not readable back from the `Permission`
system table (2000000005). The set's *header* listed correctly through "Metadata Permission
Set"; the rows saying what it **grants** were absent entirely, so every
`Permission.Get(role, type, id)` answered "does not exist" and every filtered walk came back
empty — with nothing reporting a gap.

## Two defects, and the second is the interesting one

**1. Table 2000000005 had no dispatch arm.** `NavDataAccessSource_GetDataAccessForTable`'s
if-chain routes each virtual table to a populate function; 2000000005 fell through it, so its
per-table store was created and never populated. The new
`AlRunner/Patches/RecordPatches.PermissionSystemTable.cs` adds the arm and drives BC's **own**
`PermissionDataProvider` — `GetPermissionSets` → `ComputePermissions` → `GetRecord` — rather
than re-deriving what a set grants. Every column value in the table is therefore computed by
BC's `PermissionSetGraphWalker` and `PermissionComposer` from data the runner supplied to BC's
metadata layer. This is the shape #2910 asks for ("Composition must not be re-implemented") and
the model the Aggregate Permission Set sibling already uses.

**2. `NCLMetaPermissionSet.OwningApp` was null on every metadata object the runner builds.**
This is what made the first attempt fail, and it was not visible from the issue. BC resolves
`OwningApp` lazily through `MetadataAppGroup.GetObjectOwner`, and the getter is gated on
`MetadataAppGroup.GroupId != 0` — the base group the runner plants has GroupId **0**, so the
lazy never runs and the field stays null forever, silently. BC's own
`MetadataPermissionSetProvider.GetPermissionSet` then dereferences
`metaPermissionSet.OwningApp.AppId.Value` for every include/exclude edge, so the graph walk
raised `NullReferenceException` on **all 47** dependency permission sets. Measured, not
inferred: a file-based probe over every built metadata object reported `owningApp=NULL` for all
516 builds.

The populator already computed the correct owner for the app-group summaries
(`GetOrCreateAppOwner`) — it simply projected the owning-app identity away before building the
metadata object. It now carries it through and writes the backing field BC's own lazy would
have written, which is the same `NavAppRuntimeMetadata` instance BC's `OrderedAppMetadata` scan
would have found.

## Where the prose went

The audit justification (claim + citation) and the `OwningApp` trap are at the call sites, per
`loud-failures.md`. What is **not** in the code, and is here instead: the two failed attempts —
resolving `NavPermissionDefinition` under `Microsoft.Dynamics.Nav.Types` (it lives under
`...Runtime.Permissions`), and finding `owningApp` with `BindingFlags.FlattenHierarchy` (which
does not surface a **private base** field). Both were caught by this code's own loud refusals
naming the member, rather than by a silent wrong answer — which is the argument for those
refusals existing.

## RED → GREEN

Measured against a private clone of the corpus at tip `cc5cf39`, BC 28.4, with
`--package-cache ~/.al-runner/platform-apps`. The pin cannot advance yet (blocked at position 1
by #2943), so codeunit 60604 will not run in this repository's CI — hence the private clone.

Corpus codeunit 60604 `"Test Perm. Set Grants"`, **0 of 3 → 3 of 3**:

| test | before | after |
|---|---|---|
| `PermissionSet_DeclaredTableDataGrant_IsListedAsAPermissionRow` | FAIL — `Assert.IsFalse failed. the fixture declares tabledata grants, so at least one Permission row must exist` | PASS |
| `PermissionSet_TableDataGrant_CarriesTheReadWriteInsertDeleteMask` | FAIL — `NavCSideRecordNotFoundException: The Permission does not exist. Role ID='ALTPERMISSIONSET', Object Type='Table Data', Object ID='60000'` | PASS |
| `PermissionSet_TableDataGrant_IsNotFiledUnderObjectTypeTable` | "PASS", **vacuously** — an empty table satisfies "no `Object Type::Table` rows" | PASS, **and now armed** |

**Full corpus, not a filtered subset** (the failure mode that matters is an app aborting with
`EXEC-FAIL` and 0 tests, which a filtered run hides):

|  | before | after |
|---|---|---|
| pass | 3242 | **3244** |
| fail | 8 | **6** |
| total | 3250 | 3250 |
| exec-fail | 0 | 0 |

The 6 remaining failures are all codeunit 60559, which is #2943 — a different gap at corpus
commit position 1, untouched by this change.

## Every guard proved ARMED, by sabotage

Not "the tests pass", but "each guard fails the *right* arm when the implementation is broken":

1. **Liveness — the dispatch arm.** The arm was **removed** from `RecordPatches.cs` (not guarded
   out: `grep -c IsPermissionSystemTable` returned **0**, so no `call` remains in IL). Corpus
   went back to exactly the original RED — the two failing, the third passing vacuously.
2. **The `owningApp` hierarchy walk.** Reverted to `BindingFlags.FlattenHierarchy`, the real
   defect. Failed exactly 2 of the 5 unit arms —
   `FindDeclaredFieldUpHierarchy_FindsAPrivateFieldDeclaredOnABaseType` and the negative control
   `FlattenHierarchy_DoesNotFindAPrivateBaseField` — and left the other 3 passing.
3. **Over-population, the arming proof for the third corpus test.** A second row per grant was
   inserted with `Object Type` = Table (1), built from BC's own `objectTypeMetadata`. It failed
   **only** `PermissionSet_TableDataGrant_IsNotFiledUnderObjectTypeTable`, with that test's own
   message, while the other two stayed green. That is what converts "it passes" into "it is a
   live negative control".

Two earlier sabotage attempts were themselves broken (a read-only struct property, a
non-existent `Values` accessor) and produced *inconclusive* results that looked like passes; I
re-did them against BC's real field (`ReadOnlyRecordBuffer.fields`) rather than accept the
answer.

## Also run

- `AlRunner.Tests --filter FullyQualifiedName~Permission` — **108 passed, 0 failed**, 2 skips
  that are pre-existing.
- Both live ratchets plus the liveness guard —
  `BcInternalsNullForgivingGuardTests`, `SilentReflectionLookupRatchetTests`,
  `ReflectionDrivenHelperLivenessTests` — **21 passed, 0 failed**. Neither ratchet baseline was
  touched.

## Fix the shape, not just the reported line

- **Another call site with the same wrong pattern?** Yes, and it is the reason for defect 2:
  `OwningApp` is a property of `NCLMetaApplicationObject`, the base of every built metadata
  object, so the null is not specific to permission sets. It only *bites* here because
  `MetadataPermissionSetProvider` is the only path measured to dereference it. I fixed it where
  the owner is known (the permission-set builder) rather than blanket-poking every metadata
  type, whose owners the runner does not all know.
- **A sibling function making the same assumption?** `BuildNCLMetaTable` and the NCLMetaQuery
  builder construct metadata the same way and leave `owningApp` null too. Nothing measured
  dereferences it on those paths, so changing them would be an unproven edit; noted here rather
  than done silently.
- **Two paths writing the same state with different invariants?** The app-group summaries and
  the metadata objects both carry an owning app, and only the summaries had one. They now agree,
  which is the actual content of defect 2.

## Issue-queue scan — what I did NOT fold, and why

Nine open issues match "permission". None folded; the reasoning per the boundary in
`batch-sibling-issues-by-file.md`:

- **#2910** ("The three `PermissionDataProviderBase` tables 2000000005/251/254 return no rows")
  is the direct parent of this work — its steps 1 and 2 landed in #2910/#3609, and its step 3
  is "route the three tables to BC's own providers". I routed **one** of the three. I did not
  claim or close it for two reasons: it carries a foreign `agent: impl-6` label with
  `status: in-progress`, which `check-open-prs-before-claiming.md` says I may not remove or
  overwrite; and 2000000251/254 need their own proving tests, which do not exist upstream yet.
  This PR leaves it open and strictly smaller. I have commented there with what is now done.
- **#2886** is same-table, different population path — demo data, needing a data source nobody
  has located. The issue itself says it is distinct, and I confirmed that: my change populates
  from permission-set metadata, which `--test-data` cannot affect either way. Not folded.
- **#3249** touches `RecordPatches.PermissionMetadataPopulator.cs`, which I do edit, but is
  about reload/bundle-count invalidation — materially different reasoning to review, and its
  own RED needs a `--server` multi-bundle harness. Not folded.
- #3566, #3352, #3191, #3174, #2417 are different files or different surfaces entirely.

## Deliberately left out

The **per-request redrive** (a prepend to `DataAccess.InternalTryGetByPrimaryKeyAsync`, the
shape the Aggregate Permission Set sibling uses for #2504) is not here. Its registration lives
in `AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs`, which is held by another open PR
(#3686), and colliding there would be worse than the gap. It costs nothing today — this
table's rows derive from the permission-set inventory, which is fixed for the lifetime of one
runner invocation, so a redrive on an already-open Record variable can only recompute identical
rows. It starts costing something only if a permission set can be declared mid-run. Stated in
the file banner and filed as follow-up rather than left silent.

## What I could not prove

The corpus pin is **not** bumped here: it cannot advance past `3ad4c340` while #2943 blocks
position 1, so codeunit 60604 does not run in this repository's CI on this PR. The BC-behaviour
claim is nonetheless already adjudicated — corpus PR #301 merged with all eight cloud legs
green — and my RED → GREEN above is measured against that merged corpus commit from a private
clone. When #2943 lands, the pin bump will pull 60604 in and it will be green by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
