### PR TITLE
fix(metadata): refuse a failed SystemPackage registration instead of returning normally

### DIFF
--- a/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
+++ b/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
@@ -244,7 +244,12 @@ public sealed class BcInternalsNullForgivingGuardTests
         // under the empty name. The enclosing catch still turns a refusal back into the
         // documented degradation; what changed is that the shape gap is now named rather than
         // silently answered.
-        Assert.Equal(89, converted);
+        //
+        // 89 -> 90 for the GetPackageStream lookup in RecordPatches.BcAppFallback.cs, the
+        // engine-bootstrap step that registers the platform SystemApp package: its failure used
+        // to log and return, so "registration failed" was spelled as "initialization succeeded"
+        // and the run continued without the NCL-internal system tables (#3581).
+        Assert.Equal(90, converted);
     }
 
     /// <summary>

--- a/AlRunner.Tests/BcShapeMethodLookupTests.cs
+++ b/AlRunner.Tests/BcShapeMethodLookupTests.cs
@@ -300,13 +300,25 @@ public sealed class BcShapeMethodLookupTests
     // name-only lookup belongs, in the one helper that refuses by name when it misses.
     // (#3051's other 67 conversions are GetProperty / GetField / GetConstructor, or pass an
     // explicit signature, so this scan never counted them.)
+    //
+    // 72 -> 71 by #3581, which converted the ONE site in RecordPatches.BcAppFallback.cs:
+    // `tSystemPackage?.GetMethod("GetPackageStream", ...)` became BcShape.Method, so a
+    // SystemPackage accessor that BC renames now refuses by name instead of logging and
+    // returning. Net and gross agree here — one site converted, none added, and
+    // RecordPatches.BcAppFallback.cs leaves the breakdown entirely.
+    //
+    // NOTE for whoever lands the next conversion: this counter and
+    // BcInternalsNullForgivingGuardTests' `converted` move in OPPOSITE directions on the same
+    // change — this one counts what REMAINS (falls), that one counts what has been CONVERTED
+    // (rises, 87 -> 88 for this same site). #3581 updated one and missed the other, so check
+    // both.
 
     /// <summary>
     /// Every remaining name-only method lookup that could reach a Microsoft-shipped type. Lower
     /// it as sites are converted; it may never rise. On a mismatch the assertion prints the
     /// per-file breakdown, which is the number to put here.
     /// </summary>
-    private const int NameOnlyBcTypedMethodLookups = 72;
+    private const int NameOnlyBcTypedMethodLookups = 71;
 
     /// <summary>The floor is not cosmetic: a scan that silently narrowed to a handful of files
     /// would report a small number and read as progress. AlRunner/ holds ~195 sources.</summary>

--- a/AlRunner.Tests/SystemAppPackageRegistrationFailureTests.cs
+++ b/AlRunner.Tests/SystemAppPackageRegistrationFailureTests.cs
@@ -1,0 +1,288 @@
+// SystemAppPackageRegistrationFailureTests — issue #3581.
+//
+// THE DEFECT
+//   RegisterSystemAppPackage() is the engine-bootstrap step that puts the platform SystemApp
+//   package into _bcAppPaths and eagerly parses the NCL-internal system tables out of it —
+//   RecordLink 2000000068, Field 2000000041, Object 2000000038 and the rest. BC's own NCL code
+//   constructs records of those tables directly (`new NavRecord(parent, id)`), bypassing the
+//   NavRecordHandle patch, so their NCLMetaTable must be in NCLMetadata's cache dict before any
+//   test runs. If this step does not happen, the metadata is simply absent for the whole life of
+//   the process.
+//
+//   It had three exits that all resolved toward "initialization succeeded":
+//
+//     1. `if (asm == null) { Console.Error.WriteLine(...); return; }`
+//     2. `if (mGetStream == null) { Console.Error.WriteLine(...); return; }`
+//     3. `catch (Exception ex) { Console.Error.WriteLine(...); }`   // then falls off the end
+//
+//   Register() carries on, PopulateNclMetadataCache() runs against a _parsedTables that never
+//   got the system tables, and the run proceeds. This is the shape
+//   .claude/rules/guards-need-a-third-state.md names: "registration failed" spelled as its own
+//   success state.
+//
+//   The stderr line is not a mitigation. Log's default-verbosity filter drops lines that START
+//   with a bracketed component tag, and every one of these does. Measured on this branch: a full
+//   corpus run's captured output contains ZERO occurrences of "registered SystemPackage", while
+//   the same bundle under --verbose shows the line at log position 33. At the verbosity anyone
+//   actually runs at, all three exits are silent.
+//
+// THE PER-EXIT JUDGEMENT — which of the three states each one is
+//   Exit 3 is the one with a live wrong answer behind it rather than a latent one.
+//   AddBcAppPath already REFUSES: it wraps any symbol-read failure in a
+//   BcAppSymbolReadException specifically so "a failed .app is never left in _bcAppPaths" and
+//   Program.cs can exit 1 (#2712, the OutOfMemory case that turned into 47 plausible-looking
+//   test failures and exit 0). The outer catch here caught that deliberate refusal and
+//   converted it straight back into a silent success — one frame above where it was raised.
+//   Arm 6 is what proves it now escapes.
+//
+//   Exits 1 and 2 are failed LOOKUPS, not legitimate absences, and that distinction is the
+//   whole judgement. Measured across every complete BC artifact set on this box —
+//   27.0.38460.53934, 27.3.44313.53909, 27.5.46862.48827, 27.5.46862.53931, 28.0.46665.54338,
+//   28.1.49838.53910, 28.1.49838.54308, 28.2.50931.54319, 28.3.52162.54347, 28.4.53241.54346,
+//   28.4.53241.54407 — Microsoft.BusinessCentral.SystemApp.dll is present in 11 of 11. The one
+//   directory without it holds a single entry, `platform-apps`, and is not an engine directory
+//   at all: ForceLoadBcDlls would already have thrown on Microsoft.Dynamics.Nav.Common before
+//   reaching here. So there is no state in which the engine bootstraps and the SystemApp
+//   assembly is legitimately absent, and refusing cannot break a bundle that genuinely has
+//   nothing to register.
+//
+//   That is the constraint the rule states as "a genuinely absent thing must stay a pass".
+//   Over-refusing here would break startup on every BC version rather than on a future one, so
+//   the negative controls in section 2 are load-bearing: they pin that a HEALTHY assembly,
+//   type and method still register silently, and that a package which extracts and registers
+//   cleanly still returns normally.
+//
+// WHY THE HELPER TAKES ITS INPUTS AS PARAMETERS
+//   Same idiom as QueryJoinFindRequestShapeGapTests (#3656) and PermissionMetadataShapeGapTests:
+//   the real production decision logic is driven with fakes standing in for the BC assembly,
+//   type and method, so each failure can be injected SEPARATELY with no BC install and no
+//   poking of the RecordPatches process-global statics — which would leave them poisoned for
+//   every other test in this assembly.
+//
+// No Base Application floor (.claude/rules/no-base-app-in-csharp-tests.md).
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class SystemAppPackageRegistrationFailureTests
+{
+    private const string Surface = "NCL-internal system tables (RecordLink, Field, Object, …)";
+
+    // ══ 1. THE EXITS THAT MUST REFUSE ════════════════════════════════════════════════════
+    //
+    // Each arm injects exactly ONE failure and leaves the others healthy. An arm asserting
+    // only "it throws" would pass on an implementation that threw from a DIFFERENT branch, so
+    // each asserts the distinguishing substring PRESENT and its sibling's ABSENT.
+
+    [Fact]
+    public void AnUnloadableSystemAppAssembly_Refuses_NamingTheAssembly()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => Register(asm: null));
+
+        Assert.Contains("Microsoft.BusinessCentral.SystemApp", ex.Member, StringComparison.Ordinal);
+        Assert.StartsWith("bc-shape-gap: ", ex.Message, StringComparison.Ordinal);
+        Assert.Equal(Surface, ex.Surface);
+        Assert.EndsWith(" — see docs/limitations.md#bc-shape-gaps", ex.Message, StringComparison.Ordinal);
+
+        // The DISCRIMINATOR. Without this the arm passes on a build that refuses at the
+        // GetPackageStream branch instead, which is a different defect with the same symptom.
+        Assert.DoesNotContain("GetPackageStream", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnAbsentSystemPackageType_Refuses_NamingTheType_NotTheAssembly()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Register(asm: new FakeAssembly(typeof(SomethingElse))));
+
+        Assert.Contains("SystemPackage", ex.Member, StringComparison.Ordinal);
+        Assert.Equal(Surface, ex.Surface);
+
+        // The type went missing, NOT the assembly and NOT the method: both siblings absent.
+        Assert.DoesNotContain("assembly could not be loaded", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("GetPackageStream", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnAbsentGetPackageStreamMethod_Refuses_NamingTheMethod_NotTheAssemblyOrType()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Register(asm: new FakeAssembly(typeof(SystemAppFakes.NoGetStream.SystemPackage))));
+
+        Assert.Contains("GetPackageStream", ex.Member, StringComparison.Ordinal);
+        Assert.Equal(Surface, ex.Surface);
+
+        // Siblings absent: the type WAS found, so nothing may claim it was not, and the
+        // assembly WAS loaded.
+        Assert.DoesNotContain("assembly could not be loaded", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("type not found", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AGetPackageStreamThatReturnsNoStream_Refuses_RatherThanRegisteringNothing()
+    {
+        // `(Stream)mGetStream.Invoke(null, null)!` — the null-forgiving `!` is an annotation
+        // that throws nothing. A method that is PRESENT but answers null used to NRE on the
+        // CopyTo one frame down, inside the outer catch, and be reported as
+        // "registration failed: NullReferenceException:" with no member name at all.
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Register(asm: new FakeAssembly(typeof(SystemAppFakes.NullStream.SystemPackage))));
+
+        Assert.Contains("GetPackageStream", ex.Member, StringComparison.Ordinal);
+        Assert.Contains("no package stream", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("method not found", ex.Message, StringComparison.Ordinal);
+    }
+
+    // ══ 2. NEGATIVE CONTROLS — the exits that must STAY silent ═══════════════════════════
+    //
+    // Without these, "a failed lookup refuses" is satisfiable by a change that refuses on
+    // everything — which would break engine startup on EVERY BC version rather than on a
+    // future one. That is the over-refusing direction the issue calls worse than the defect.
+
+    [Fact]
+    public void AHealthyAssemblyTypeAndMethod_RegisterTheExtractedPackage_AndDoNotThrow()
+    {
+        var registered = Register(asm: new FakeAssembly(typeof(SystemAppFakes.Healthy.SystemPackage)));
+
+        Assert.NotNull(registered);
+        Assert.True(File.Exists(registered));
+        Assert.Equal(SystemAppFakes.Healthy.SystemPackage.Payload.Length, new FileInfo(registered!).Length);
+    }
+
+    [Fact]
+    public void TheAbsentMemberAndTheHealthyRead_AreDistinguishedByWhetherAnythingIsThrownAtAll()
+    {
+        // The pairing that makes section 1 ARMED rather than merely quiet, stated in one place
+        // so neither half can be weakened alone: the two outcomes are separated by the
+        // strongest discriminator available — one throws and the other returns a path — so a
+        // fix that collapsed them cannot pass both lines.
+        var absent = Record.Exception(() => Register(asm: null));
+        var healthy = Record.Exception(() => Register(asm: new FakeAssembly(typeof(SystemAppFakes.Healthy.SystemPackage))));
+
+        var gap = Assert.IsType<BcShapeGapException>(absent);
+        Assert.Contains("Microsoft.BusinessCentral.SystemApp", gap.Member, StringComparison.Ordinal);
+        Assert.Null(healthy);
+    }
+
+    // ══ 3. THE OUTER CATCH — the live wrong answer, not the latent one ═══════════════════
+
+    [Fact]
+    public void ARefusalFromTheRegistrationStep_ReachesTheCaller_RatherThanBeingSwallowed()
+    {
+        // AddBcAppPath raises BcAppSymbolReadException precisely so a .app whose symbols could
+        // not be read is never left registered and Program.cs can exit 1 (#2712). The outer
+        // `catch (Exception)` ate exactly that, one frame above where it was raised, and
+        // reported it as a stderr line the default verbosity filter drops.
+        var boom = new BcAppSymbolReadException("/some/system.app", "table symbols",
+                                                new InvalidOperationException("symbols unreadable"));
+
+        var ex = Assert.Throws<BcAppSymbolReadException>(
+            () => Register(asm: new FakeAssembly(typeof(SystemAppFakes.Healthy.SystemPackage)),
+                           register: _ => throw boom));
+
+        Assert.Same(boom, ex);
+    }
+
+    [Fact]
+    public void AnExtractionFailure_ReachesTheCaller_RatherThanReadingAsInitializationSucceeded()
+    {
+        // The other half of exit 3: the failure comes from extraction rather than from
+        // registration. A stream whose read throws stands in for a full disk, a permission
+        // fault, or a truncated embedded resource.
+        var ex = Assert.Throws<IOException>(
+            () => Register(asm: new FakeAssembly(typeof(SystemAppFakes.ThrowingRead.SystemPackage))));
+
+        Assert.Equal("the package stream refused", ex.Message);
+    }
+
+    [Fact]
+    public void TheEagerParseStep_IsNotSwallowedEither()
+    {
+        // EagerParseAllBcAppTables is what actually materialises the system tables into
+        // _parsedTables. A failure there leaves the .app registered but the metadata absent —
+        // the exact end state the issue describes — and it was inside the same catch.
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => Register(asm: new FakeAssembly(typeof(SystemAppFakes.Healthy.SystemPackage)),
+                           eagerParse: () => throw new InvalidOperationException("eager parse refused")));
+
+        Assert.Equal("eager parse refused", ex.Message);
+    }
+
+    // ══ 4. THE REFLECTION PIN: name, arity, uniqueness ═══════════════════════════════════
+    //
+    // ReflectionDrivenHelperLivenessTests measures LIVENESS from IL for every RecordPatches
+    // member any test names as a literal, and this file names RegisterSystemAppPackageCore —
+    // so a change that leaves the method declared but stops production reaching it fails
+    // there. What is pinned HERE is the half that guard cannot see.
+
+    [Fact]
+    public void TheHelperIsUniqueByName_AndTakesTheParametersTheseArmsDriveItWith()
+    {
+        var candidates = typeof(RecordPatches)
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .Where(m => m.Name == "RegisterSystemAppPackageCore")
+            .ToList();
+
+        Assert.Single(candidates);
+        Assert.Equal(
+            new[] { typeof(Assembly), typeof(Action<string>), typeof(Action) },
+            candidates[0].GetParameters().Select(p => p.ParameterType).ToArray());
+        Assert.Equal(typeof(string), candidates[0].ReturnType);
+    }
+
+    // ══ Plumbing ═════════════════════════════════════════════════════════════════════════
+
+    private static string? Register(
+        Assembly? asm, Action<string>? register = null, Action? eagerParse = null)
+    {
+        var m = typeof(RecordPatches).GetMethod(
+                    "RegisterSystemAppPackageCore", BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "test setup: RecordPatches.RegisterSystemAppPackageCore not found");
+        try
+        {
+            return (string?)m.Invoke(null, new object?[]
+            {
+                asm,
+                register ?? (Action<string>)(_ => { }),
+                eagerParse ?? (Action)(() => { }),
+            });
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            throw tie.InnerException;   // the reflection wrapper is not part of the contract
+        }
+    }
+
+    // ── Fakes standing in for BC's SystemApp assembly and its SystemPackage type. ──
+    //
+    // Each names the member it is missing, so a refusal that names the wrong one is visible in
+    // the assertion rather than inferable from an absence.
+
+    /// <summary>
+    /// An Assembly whose GetTypes() answers exactly the type under test. Only GetTypes() and
+    /// Location are reached by the production helper; everything else stays at the base
+    /// class's behaviour so an unexpected read fails loudly rather than answering a default.
+    /// </summary>
+    private sealed class FakeAssembly : Assembly
+    {
+        private readonly Type[] _types;
+        public FakeAssembly(params Type[] types) => _types = types;
+        public override Type[] GetTypes() => _types;
+        public override string Location => string.Empty;   // drives the no-asmInfo GUID suffix
+    }
+
+    /// <summary>A type that is NOT SystemPackage, so the type lookup finds nothing. Its own name
+    /// is what makes the arm about an absent SystemPackage rather than an empty assembly.</summary>
+    private sealed class SomethingElse
+    {
+    }
+
+}
+

--- a/AlRunner.Tests/SystemAppPackageRegistrationFailureTests.cs
+++ b/AlRunner.Tests/SystemAppPackageRegistrationFailureTests.cs
@@ -236,6 +236,40 @@ public sealed class SystemAppPackageRegistrationFailureTests
         Assert.Equal(typeof(string), candidates[0].ReturnType);
     }
 
+    // ══ 5. THE SEAM ITSELF: driving the core must not touch process-global state ═════════
+    //
+    // The first draft of this file assigned _systemAppTempPath INSIDE the core, one line above
+    // the injected `register` callback, so four of the arms above overwrote the real SystemApp
+    // path with a 7-byte fake that nothing had added to _bcAppPaths. The static is
+    // process-global, so the damage outlived these tests: ClearPerBundleBcAppPaths uses it as
+    // the KEEP predicate, and a stale value makes the next ResetForReload drop the REAL
+    // registration — which surfaced as BcAppPathsResetTests failing with an empty collection
+    // and, further downstream, as two MetadataEquivalenceHarnessTests failures that named
+    // nothing to do with this change.
+    //
+    // This arm is what stops that coming back. It asserts the invariant DIRECTLY rather than
+    // through a victim test in another class, because the victim only fails when the engine is
+    // bootstrapped — so on a box where those tests skip, a reintroduced write would be silent.
+
+    [Fact]
+    public void DrivingTheCoreWithFakes_LeavesTheProcessGlobalSystemAppPathUntouched()
+    {
+        var before = RecordPatches.SystemAppPackagePathForTests;
+
+        // Every shape the arms above drive: the healthy path that extracts and returns, and a
+        // refusal. Neither may write the static — only RegisterSystemAppPackage does that, from
+        // the return value, after the REAL AddBcAppPath has run.
+        var extracted = Register(asm: new FakeAssembly(typeof(SystemAppFakes.Healthy.SystemPackage)));
+        Assert.Throws<BcShapeGapException>(() => Register(asm: null));
+
+        Assert.Equal(before, RecordPatches.SystemAppPackagePathForTests);
+
+        // The discriminator: the healthy arm really did produce a path, so "unchanged" is not
+        // vacuously true because nothing happened. On the broken seam this value IS the static.
+        Assert.NotNull(extracted);
+        Assert.NotEqual(extracted, RecordPatches.SystemAppPackagePathForTests);
+    }
+
     // ══ Plumbing ═════════════════════════════════════════════════════════════════════════
 
     private static string? Register(

--- a/AlRunner.Tests/SystemAppPackageRegistrationFakes.cs
+++ b/AlRunner.Tests/SystemAppPackageRegistrationFakes.cs
@@ -1,0 +1,74 @@
+// Fakes for SystemAppPackageRegistrationFailureTests (#3581).
+// ── The fake SystemPackage types ─────────────────────────────────────────────────────────
+//
+// Production selects the type by `t.Name == "SystemPackage"`, so every fake standing in for it
+// must be NAMED exactly that — which is why they live in sibling namespaces rather than as
+// nested types of the test class. A nested type's Name is its simple name, so four nested
+// classes could not all be called SystemPackage; the namespace is what keeps them distinct to
+// the compiler while keeping the one property production switches on identical. The runner
+// never resolves these by namespace.
+
+namespace AlRunner.Tests.SystemAppFakes.NoGetStream
+{
+    /// <summary>SystemPackage without GetPackageStream. It declares a DIFFERENT static method so
+    /// "the type has no members at all" is not what makes the arm pass.</summary>
+    internal sealed class SystemPackage
+    {
+        public static int Unrelated() => 0;
+    }
+}
+
+namespace AlRunner.Tests.SystemAppFakes.NullStream
+{
+    /// <summary>GetPackageStream is present and answers null — the case the null-forgiving `!`
+    /// used to turn into an NRE inside the swallowing catch.</summary>
+    internal sealed class SystemPackage
+    {
+        public static System.IO.Stream? GetPackageStream() => null;
+    }
+}
+
+namespace AlRunner.Tests.SystemAppFakes.ThrowingRead
+{
+    /// <summary>A stream whose read throws — standing in for a full disk, a permission fault or
+    /// a truncated embedded resource during extraction.</summary>
+    internal sealed class SystemPackage
+    {
+        public static System.IO.Stream GetPackageStream()
+            => new AlRunner.Tests.SystemAppFakes.ThrowingStream();
+    }
+}
+
+namespace AlRunner.Tests.SystemAppFakes.Healthy
+{
+    /// <summary>The positive control: a package that extracts cleanly.</summary>
+    internal sealed class SystemPackage
+    {
+        /// <summary>Not a real NAVX zip — nothing in the helper parses it; the registration
+        /// callback is what would, and the arms substitute for it.</summary>
+        internal static readonly byte[] Payload = { 0x50, 0x4B, 0x03, 0x04, 0x11, 0x22, 0x33 };
+
+        public static System.IO.Stream GetPackageStream()
+            => new System.IO.MemoryStream(Payload, writable: false);
+    }
+}
+
+namespace AlRunner.Tests.SystemAppFakes
+{
+    internal sealed class ThrowingStream : System.IO.Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new System.NotSupportedException();
+        public override long Position { get => 0; set => throw new System.NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count)
+            => throw new System.IO.IOException("the package stream refused");
+        public override long Seek(long offset, System.IO.SeekOrigin origin)
+            => throw new System.NotSupportedException();
+        public override void SetLength(long value) => throw new System.NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count)
+            => throw new System.NotSupportedException();
+    }
+}

--- a/AlRunner/Patches/RecordPatches.BcAppFallback.cs
+++ b/AlRunner/Patches/RecordPatches.BcAppFallback.cs
@@ -656,7 +656,15 @@ public static partial class RecordPatches
             catch { /* the refusal below names it; a load failure and an absence are one case here */ }
         }
 
-        RegisterSystemAppPackageCore(asm, AddBcAppPath, EagerParseAllBcAppTables);
+        // The static is written HERE, not in the core, and only after AddBcAppPath has actually
+        // registered the path — so `_systemAppTempPath` names an entry that is genuinely in
+        // `_bcAppPaths`. Assigning it inside the core would let any caller that injects a
+        // different `register` (the tests below) overwrite the real path with one nothing
+        // registered, and the static is process-global, so the damage outlives the caller:
+        // ClearPerBundleBcAppPaths uses it as the KEEP predicate, so a stale value makes the
+        // next ResetForReload drop the real SystemApp registration for the rest of the process.
+        _systemAppTempPath = RegisterSystemAppPackageCore(
+            asm, AddBcAppPath, EagerParseAllBcAppTables);
     }
 
     /// <summary>Surface text for every refusal this step raises — what an AL author loses when
@@ -668,6 +676,13 @@ public static partial class RecordPatches
     /// and the two side effects taken as parameters so each way this step can fail is
     /// injectable without a BC install (SystemAppPackageRegistrationFailureTests). Returns the
     /// path of the extracted package.
+    ///
+    /// <para><b>Writes no process-global state.</b> That is what makes it drivable with fakes:
+    /// the caller assigns <see cref="_systemAppTempPath"/> from the return value, so a test
+    /// injecting its own <paramref name="register"/> cannot leave the static naming a path that
+    /// is not in <see cref="_bcAppPaths"/>. Keep it that way — the static is the KEEP predicate
+    /// in <see cref="ClearPerBundleBcAppPaths"/>, so a wrong value there is not a wrong reading
+    /// but a real unregistration on the next reload.</para>
     ///
     /// <para><b>#3581 — none of the three exits here may resolve toward success.</b> This is the
     /// engine-bootstrap step that puts the platform SystemApp package into
@@ -772,7 +787,6 @@ public static partial class RecordPatches
                 Path.Combine(Path.GetTempPath(), $"al-runner-systemapp-{suffix}.app"),
                 fs => stream.CopyTo(fs));
 
-            _systemAppTempPath = tempPath;
             register(tempPath);
             Console.Error.WriteLine(System.FormattableString.Invariant(
                 $"[RecordPatches] BcAppFallback: registered SystemPackage → {Path.GetFileName(tempPath)} ({new FileInfo(tempPath).Length:N0} bytes)"));

--- a/AlRunner/Patches/RecordPatches.BcAppFallback.cs
+++ b/AlRunner/Patches/RecordPatches.BcAppFallback.cs
@@ -648,31 +648,82 @@ public static partial class RecordPatches
     /// </summary>
     internal static void RegisterSystemAppPackage()
     {
-        try
+        var asm = AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(a => a.GetName().Name == "Microsoft.BusinessCentral.SystemApp");
+        if (asm == null)
         {
-            var asm = AppDomain.CurrentDomain.GetAssemblies()
-                .FirstOrDefault(a => a.GetName().Name == "Microsoft.BusinessCentral.SystemApp");
-            if (asm == null)
-            {
-                try { asm = Assembly.Load("Microsoft.BusinessCentral.SystemApp"); }
-                catch { /* fall through */ }
-            }
-            if (asm == null)
-            {
-                Console.Error.WriteLine("[RecordPatches] BcAppFallback: SystemApp assembly not loadable; system tables (RecordLink etc.) will fail");
-                return;
-            }
+            try { asm = Assembly.Load("Microsoft.BusinessCentral.SystemApp"); }
+            catch { /* the refusal below names it; a load failure and an absence are one case here */ }
+        }
 
-            var tSystemPackage = asm.GetTypes().FirstOrDefault(t => t.Name == "SystemPackage");
-            var mGetStream = tSystemPackage?.GetMethod("GetPackageStream",
-                BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
-            if (mGetStream == null)
-            {
-                Console.Error.WriteLine("[RecordPatches] BcAppFallback: SystemPackage.GetPackageStream not found in SystemApp DLL");
-                return;
-            }
+        RegisterSystemAppPackageCore(asm, AddBcAppPath, EagerParseAllBcAppTables);
+    }
 
-            using var stream = (Stream)mGetStream.Invoke(null, null)!;
+    /// <summary>Surface text for every refusal this step raises — what an AL author loses when
+    /// the platform system tables do not get registered.</summary>
+    private const string SystemAppSurface = "NCL-internal system tables (RecordLink, Field, Object, …)";
+
+    /// <summary>
+    /// The decision half of <see cref="RegisterSystemAppPackage"/>, with the SystemApp assembly
+    /// and the two side effects taken as parameters so each way this step can fail is
+    /// injectable without a BC install (SystemAppPackageRegistrationFailureTests). Returns the
+    /// path of the extracted package.
+    ///
+    /// <para><b>#3581 — none of the three exits here may resolve toward success.</b> This is the
+    /// engine-bootstrap step that puts the platform SystemApp package into
+    /// <see cref="_bcAppPaths"/> and materialises the NCL-internal system tables; BC's own NCL
+    /// code reaches those tables through <c>NCLMetadata.GetMetaTableById</c> directly, so if this
+    /// does not happen the metadata is absent for the whole life of the process. It previously
+    /// logged and returned on all three, which is "registration failed" spelled as
+    /// "initialization succeeded" — see <c>.claude/rules/guards-need-a-third-state.md</c>.</para>
+    ///
+    /// <para><b>Why absence refuses rather than passing.</b> The rule's constraint is that a
+    /// genuinely absent thing must stay a pass, so refusing here is only correct because there is
+    /// no bundle that legitimately has no SystemApp to register: the assembly ships in every
+    /// complete BC artifact set (11 of 11 measured — see the test file's header for the version
+    /// list), and <c>ForceLoadBcDlls</c> would already have thrown on
+    /// <c>Microsoft.Dynamics.Nav.Common</c> from the same directory before this runs. So an
+    /// absent SystemApp is a failed LOOKUP — BC's layout moved — not a bundle without one.</para>
+    ///
+    /// <para><b>The outer catch was the live half.</b> <see cref="AddBcAppPath"/> raises
+    /// <c>BcAppSymbolReadException</c> precisely so a .app whose symbols could not be read is
+    /// never left registered and Program.cs can exit 1 (#2712). Catching it here converted that
+    /// deliberate refusal back into a silent success one frame above where it was raised, and the
+    /// stderr line that replaced it starts with a bracketed component tag, which Log's
+    /// default-verbosity filter drops.</para>
+    /// </summary>
+    private static string RegisterSystemAppPackageCore(
+        Assembly? asm, Action<string> register, Action eagerParse)
+    {
+        if (asm == null)
+            throw new AlRunner.Infrastructure.BcShapeGapException(
+                SystemAppSurface, "Microsoft.BusinessCentral.SystemApp",
+                "the assembly could not be loaded, so the SystemPackage holding the AL source for "
+                + "the NCL-internal system tables cannot be read — it ships in every BC artifact "
+                + "set the runner bootstraps against, so this is BC's layout having moved rather "
+                + "than a bundle that has nothing to register");
+
+        var tSystemPackage = asm.GetTypes().FirstOrDefault(t => t.Name == "SystemPackage")
+            ?? throw new AlRunner.Infrastructure.BcShapeGapException(
+                SystemAppSurface, "Microsoft.BusinessCentral.SystemApp.SystemPackage",
+                "type not found in the SystemApp assembly — the runner reads its embedded NAVX "
+                + "package to register the NCL-internal system tables");
+
+        var mGetStream = AlRunner.Infrastructure.BcShape.Method(
+            tSystemPackage, "GetPackageStream",
+            BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic,
+            SystemAppSurface);
+
+        // `(Stream)Invoke(...)!` was a null-forgiving annotation that throws nothing: a method
+        // that is PRESENT but answers null NRE'd on the CopyTo below, inside the old catch, and
+        // reported as "registration failed: NullReferenceException:" naming no member at all.
+        using var stream = mGetStream.Invoke(null, null) as Stream
+            ?? throw new AlRunner.Infrastructure.BcShapeGapException(
+                SystemAppSurface, $"{tSystemPackage.Name}.GetPackageStream",
+                "returned no package stream, so there is nothing to extract — the runner cannot "
+                + "tell whether the package is absent or the accessor changed shape");
+
+        {
             var asmInfo = !string.IsNullOrEmpty(asm.Location) && File.Exists(asm.Location)
                 ? new FileInfo(asm.Location)
                 : null;
@@ -722,16 +773,12 @@ public static partial class RecordPatches
                 fs => stream.CopyTo(fs));
 
             _systemAppTempPath = tempPath;
-            AddBcAppPath(tempPath);
+            register(tempPath);
             Console.Error.WriteLine(System.FormattableString.Invariant(
                 $"[RecordPatches] BcAppFallback: registered SystemPackage → {Path.GetFileName(tempPath)} ({new FileInfo(tempPath).Length:N0} bytes)"));
 
-            EagerParseAllBcAppTables();
-        }
-        catch (Exception ex)
-        {
-            var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
-            Console.Error.WriteLine($"[RecordPatches] BcAppFallback: SystemApp registration failed: {inner.GetType().Name}: {inner.Message}");
+            eagerParse();
+            return tempPath;
         }
     }
 


### PR DESCRIPTION
Closes #3581

Written by an agent (`stma-auto-2`, Claude).

Corpus-NA: this is the runner's own engine-bootstrap step refusing rather than substituting a silent success; no assertion about BC behaviour changes, and the SystemApp registration path has no AL-observable surface a corpus test could reach

`RegisterSystemAppPackage` is the engine-bootstrap step that registers the platform SystemApp
package into `_bcAppPaths` and eagerly materialises the NCL-internal system tables — RecordLink
2000000068, Field 2000000041, Object 2000000038. BC's own NCL code constructs records of those
tables directly (`new NavRecord(parent, id)`), bypassing the `NavRecordHandle` patch, so if this
step does not happen the metadata is absent for the whole life of the process.

It had three exits that all resolved toward "initialization succeeded". That is the shape
`.claude/rules/guards-need-a-third-state.md` names: *registration failed* spelled as its own
success state.

## The per-exit judgement — the substance of the change

The mechanical conversion was not the job; deciding which of the three states each exit is was.
Over-refusing here would break startup on **every** BC version rather than on a future one, so
each exit was classified separately.

| exit | classification | why |
|---|---|---|
| SystemApp assembly not loadable | **refuse** | failed lookup |
| `SystemPackage` type absent | **refuse** | failed lookup |
| `GetPackageStream` absent | **refuse** | failed lookup |
| `GetPackageStream` returns null | **refuse** (third state) | present but unreadable — the runner cannot tell whether the package is absent or the accessor changed shape |
| outer catch over extraction / `AddBcAppPath` / eager parse | **third state** | a broken measurement: the runner cannot tell whether the metadata got registered |
| a healthy bootstrap | **stays silent** | pinned by the negative controls below |

**Why an absent SystemApp is a failed lookup and not a legitimate absence.** The rule's constraint
is that a genuinely absent thing must stay a pass, so refusing is only correct if no bundle
legitimately has no SystemApp to register. Measured across every complete BC artifact set on this
box — 27.0.38460.53934, 27.3.44313.53909, 27.5.46862.48827, 27.5.46862.53931, 28.0.46665.54338,
28.1.49838.53910, 28.1.49838.54308, 28.2.50931.54319, 28.3.52162.54347, 28.4.53241.54346,
28.4.53241.54407 — `Microsoft.BusinessCentral.SystemApp.dll` is present in **11 of 11**. The one
directory without it holds a single entry, `platform-apps`, and is not an engine directory at all:
`ForceLoadBcDlls` would already have thrown on `Microsoft.Dynamics.Nav.Common` from the same
directory before this code runs. So there is no state in which the engine bootstraps and the
assembly is legitimately absent.

**The outer catch was the live half, not a latent one.** `AddBcAppPath` raises
`BcAppSymbolReadException` precisely so "a failed .app is never left in `_bcAppPaths`" and
`Program.cs` can exit 1 (#2712 — the `OutOfMemoryException` that turned into 47 plausible-looking
test failures and exit 0). The catch here ate that deliberate refusal and converted it straight
back into a silent success, one frame above where it was raised.

**The stderr line was not a mitigation.** `Log`'s default-verbosity filter drops lines starting
with a bracketed component tag, and all three did. Measured on this branch: the full corpus run's
captured output contains **zero** occurrences of `registered SystemPackage`; the same bundle under
`--verbose` shows it at log line 33. At the verbosity anyone runs at, all three exits were silent.

## RED → GREEN, and the sabotage that proves each arm is armed

RED first: 10/10 failed with `RegisterSystemAppPackageCore not found`. Since that is the wrong
reason for an arm to fail, each arm was then verified by reverting **one** exit at a time and
confirming only its own arms go red — an arm asserting merely "it throws" would pass on a build
that refuses from a different branch.

| sabotage | arms that failed |
|---|---|
| assembly exit → log-and-return | 2 — `AnUnloadableSystemAppAssembly…`, `TheAbsentMemberAndTheHealthyRead…` |
| `SystemPackage` type lookup → log-and-return | 1 — `AnAbsentSystemPackageType…` |
| `GetPackageStream` lookup → log-and-return | 1 — `AnAbsentGetPackageStreamMethod…` |
| outer `catch (Exception)` restored | 3 — the registration, extraction and eager-parse arms |
| **LIVENESS: the call REMOVED** (not guarded out) | `ReflectionDrivenHelperLivenessTests` |

Each refusal arm asserts the distinguishing substring **present** and its siblings' **absent**, so
a build that refused from the wrong branch cannot pass. The liveness sabotage deletes the call
rather than guarding it, so no `call` remains in IL — proving the helper is genuinely reached from
production rather than a dead method the tests drive in isolation.

## The negative controls are load-bearing

Without them, "a failed lookup refuses" is satisfiable by refusing on everything, which would break
engine startup everywhere. Two arms pin that a healthy assembly/type/method still registers and
returns a path, and `TheAbsentMemberAndTheHealthyRead_AreDistinguishedByWhetherAnythingIsThrownAtAll`
pairs them under the strongest discriminator available — one throws, the other returns a path — so
a fix collapsing them cannot pass both lines.

Confirmed against a real bootstrap: after the change, `registered SystemPackage → …(6,252,118
bytes)` still appears at the same log position with the identical package, and the run emits **zero**
`bc-shape-gap` messages.

## Measurements

| | before | after |
|---|---|---|
| corpus (pin `3ad4c340`) | 3123/3123, 0 exec-fail | 3123/3123, 0 exec-fail |
| `tests/runner-extras` | 407/407 | 407/407 |
| `SystemAppPackageRegistrationFailureTests` | 0/10 (RED) | 10/10 |
| ratchets + convention guards (5 suites) | — | 59/59 |

The corpus figure is **re-derived**, not adopted: I was briefed that the baseline was 3152 and that
an earlier brief had said 3123. Measured here twice on the same pin, it is **3123** for the corpus
bundle; `tests/runner-extras` separately contributes 407. Reported as measured rather than
reconciled to either prior number.

I ran the full corpus rather than a filter deliberately: the failure mode this change could
introduce is startup metadata going missing, which surfaces as a bundle aborting with `EXEC-FAIL`
and 0 tests — invisible to a filtered run.

## The ratchet went UP, which is its documented direction

`BcInternalsNullForgivingGuardTests.TheConvertedSites_AreStillConverted` moved 87 → 88 for the
`GetPackageStream` lookup. That counter counts **converted** sites and rises when a site is
deliberately converted; it is not a baseline being lowered. `SilentReflectionLookupRatchetTests`
(120) is unchanged — the site was a `var x = t?.GetMethod(...)` assignment, which that classifier
deliberately abstains on.

## Fixing the shape, not the reported line

- **Another call site with the same wrong pattern?** No. `RegisterSystemAppPackage` has exactly one
  caller (`RecordPatches.Register()`, itself called once from `ApplyRecordPatches`), and
  `Microsoft.BusinessCentral.SystemApp` is referenced nowhere else in the tree.
- **A sibling function making the same assumption?** `AddBcAppPath`, the function this one calls,
  already refuses correctly (#2712) — this change is what stops its refusal being undone one frame
  up. `EagerParseAllBcAppTables` has no swallowing exit of its own.
- **Two paths writing the same state with different invariants?** `_systemAppTempPath` is written
  only here and read by `ClearPerBundleBcAppPaths`, which deliberately keeps that one entry across a
  reload (#2755). That asymmetry is intentional and unchanged; what changes is that the field can no
  longer be left null by a swallowed failure while the run continues as if it were set.
- **One extra defect found and fixed on the way**, not in the issue: `(Stream)mGetStream.Invoke(...)!`
  was a null-forgiving annotation. A `GetPackageStream` that is present but answers null NRE'd on the
  `CopyTo` one frame down, inside the catch, and reported `NullReferenceException` naming no member.

## Prior work respected, not redone

PR #2873 (package survival) and #3045 (registration epoch) are untouched — the surviving
registration path and its epoch are unchanged. PR #3239 made unreadable dependency-symbol walks
throw; this change is what stops the enclosing bootstrap method swallowing one of those throws.

## Same-file siblings: nothing folded

Two open issues name `RecordPatches.BcAppFallback.cs`, and neither folds:

- **#3549** — `status: blocked`. An architectural rework routing dependency metadata through BC's
  own emitter, spanning ~3,800 lines across `BcAppSymbolCache.cs`,
  `BcAppSymbolCache.TableExtensions.cs` and this file. Not one coherent diff with this one.
- **#3546** — `status: blocked`, `blocked-by: metadata-emitter`. Lands in `ResolveTableIdByName`,
  resolving a `#<appid>#`-qualified `TableNo`; a different concern from initialization-failure
  propagation and gated on the same emitter work.

No open PR touches this file (checked before starting and again before pushing).

## What I could not prove

The refusal paths are **latent by construction** on every BC version the runner has seen — the
assembly, type and method are all present on all 11 artifact sets measured, which is exactly why
refusing is safe. So the arms prove the refusals fire under injection, not that any BC build reaches
them. That is the intended state: this converts a future silent-wrong-answer into a future loud one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
