### PR TITLE
fix(asserterror): tear through a corrupt-dependency symbol read instead of swallowing it

### DIFF
--- a/AlRunner.Tests/AssertErrorSymbolReadCatchabilityTests.cs
+++ b/AlRunner.Tests/AssertErrorSymbolReadCatchabilityTests.cs
@@ -1,0 +1,273 @@
+// AssertErrorSymbolReadCatchabilityTests — what AL's error-trapping seams do with a
+// BcAppSymbolReadException (issue #3241).
+//
+// THE DEFECT
+//   MethodScopePatches.NavMethodScope_AssertError — the Cecil-bound replacement for
+//   NavMethodScope::AssertError/1 — rethrew only BcShapeGapException and caught everything
+//   else. #3239 converted ten dependency-symbol reads from silent swallows to
+//   BcAppSymbolReadException, several of them on AL-entered paths (GetInsertAllowedForPage,
+//   IsPageShapeKnown, TryGetAnyPageType, the virtual-table walks). So `asserterror` around a
+//   TestPage operation over a corrupt dependency package CAUGHT the refusal and the test
+//   PASSED: on real BC the read succeeds and the asserterror fails ("expected an error"), so
+//   swallowing here inverts the result rather than merely hiding a gap.
+//
+//   The RED for every "TearsThrough" row below is that the call returned normally.
+//
+// WHY THE SUBJECT IS PROVEN HERE AND NOT AS AN AL BUNDLE
+//   The reachable shape is poison-AFTER-registration, and it is in-process by construction:
+//   RecordPatches.AddBcAppPath parses table symbols eagerly, so a package that is already
+//   corrupt on disk refuses at registration and Program.cs exits 1 before any AL runs
+//   (RecordPatchesBcAppSymbolReadFailureTests). Only a package that was readable when it was
+//   registered and unreadable when a lazy read drains it can reach an `asserterror` at all.
+//   These rows drive the REAL NavMethodScope_AssertError over the REAL
+//   RecordPatches.GetInsertAllowedForPage / IsPageShapeKnown against exactly that state.
+//
+//   Nothing here is a claim about Business Central — no AL statement can corrupt a dependency
+//   package, so a service tier has nothing to adjudicate. Same reasoning as
+//   BcShapeGapConventionTests and AssertErrorOutOfScopeCatchabilityTests
+//   (.claude/rules/bc-behavior-tests-go-upstream.md).
+//
+// THE CONTROLS
+//   Every tear-through row is paired with something the seam must STILL catch — a plain BC
+//   error and a permanent out-of-scope refusal — so no row can pass by a seam that stopped
+//   catching anything, and the healthy arm proves the poisoned arm is measuring the poison
+//   rather than a pipeline that never reads the .app.
+//
+// No Base Application floor (.claude/rules/no-base-app-in-csharp-tests.md).
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Reflection;
+using System.Text;
+using AlRunner;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// RecordPatchesSerialCollection: calls RecordPatches.ResetForReload() directly (#1696).
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class AssertErrorSymbolReadCatchabilityTests : IDisposable
+{
+    private readonly string _root;
+
+    public AssertErrorSymbolReadCatchabilityTests()
+    {
+        _root = TestScratch.Dir("al-runner-3241-tests");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private const string AppGuid = "c3241a00-3241-4a32-9a32-000000003241";
+
+    // Process-wide unique among AlRunner.Tests statics — RecordPatches' dependency state is
+    // process-global, so an id another fixture also declares could answer from its payload.
+    private const int TableId = 88324101;
+    private const int PageId = 88324103;
+
+    // ── the fixture ──────────────────────────────────────────────────────────────────────
+
+    // Poison technique, unchanged from DependencySymbolReadFailureTests (#3143): the root
+    // "AppId" as a JSON NUMBER. BcAppSymbolCache.Parse calls ReadAppIdentity LAST, after every
+    // container has been collected, so this is a parse that dies part-way AFTER the data the
+    // sites want — not a whole-file failure any path would notice. The different LENGTH is
+    // what gives the content-hash memo and the symbol cache a new key.
+    private static string SymbolReference(bool poison)
+    {
+        var appId = poison ? "\"AppId\": 3241" : $"\"AppId\": \"{AppGuid}\"";
+        return $$"""
+            {
+              "RuntimeVersion": "15.1",
+              {{appId}},
+              "Name": "Bug3241 Symbol App",
+              "Tables": [
+                {
+                  "Id": {{TableId}},
+                  "Name": "Bug3241 Table",
+                  "Properties": [ { "Name": "Caption", "Value": "Bug3241 Table" } ],
+                  "Fields": [ { "Id": 1, "Name": "Code", "TypeDefinition": { "Name": "Code" } } ]
+                }
+              ],
+              "Pages": [
+                {
+                  "Id": {{PageId}},
+                  "Name": "Bug3241 Page",
+                  "Properties": [
+                    { "Name": "PageType", "Value": "List" },
+                    { "Name": "SourceTable", "Value": "{{TableId}}" },
+                    { "Name": "InsertAllowed", "Value": "false" }
+                  ]
+                }
+              ]
+            }
+            """;
+    }
+
+    private static void WriteApp(string path, string symbolReferenceJson)
+    {
+        using var zip = new FileStream(path, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(symbolReferenceJson);
+    }
+
+    private string RegisterHealthy(string fileName)
+    {
+        var appPath = Path.Combine(_root, fileName);
+        WriteApp(appPath, SymbolReference(poison: false));
+        RecordPatches.ResetForReload();
+        RecordPatches.AddBcAppPath(appPath);
+        return appPath;
+    }
+
+    /// <summary>
+    /// Register a healthy .app, then rewrite it on disk into the poisoned shape — the only
+    /// state that can reach an AL `asserterror` at all (see this file's header).
+    /// </summary>
+    private string RegisterThenPoison(string fileName = "dep3241.app")
+    {
+        var appPath = RegisterHealthy(fileName);
+        WriteApp(appPath, SymbolReference(poison: true));
+        File.SetLastWriteTimeUtc(appPath, File.GetLastWriteTimeUtc(appPath).AddSeconds(5));
+        return appPath;
+    }
+
+    private static BcAppSymbolReadException Refusal() =>
+        new("/artifacts/Some.Publisher_Some App_1.0.0.0.app", "table symbols",
+            new InvalidOperationException("The requested operation requires an element of type 'String'."));
+
+    private const string AssertErrorTypeName =
+        "Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLAssertErrorException";
+
+    // ── the defect, over the real AL-entered read ────────────────────────────────────────
+
+    [Fact]
+    public void AssertError_TearsThrough_WhenAnAlEnteredPageReadHitsACorruptDependency()
+    {
+        var appPath = RegisterThenPoison();
+
+        // RED: this returned normally — NavMethodScope_AssertError caught the refusal, so the
+        // AL `asserterror` PASSED on a read real BC performs fine.
+        var ex = Assert.Throws<BcAppSymbolReadException>(
+            () => BcRuntime.NavMethodScope_AssertError(
+                null!, () => RecordPatches.GetInsertAllowedForPage(PageId)));
+
+        Assert.Contains("symbol-read-fail", ex.Message);
+        Assert.Contains(Path.GetFileName(appPath), ex.Message);
+        Assert.Equal(appPath, ex.AppPath);
+    }
+
+    [Fact]
+    public void AssertError_TearsThrough_WhenAnAlEnteredPageShapeProbeHitsACorruptDependency()
+    {
+        RegisterThenPoison("dep3241-shape.app");
+
+        // The sibling read on the same AL-entered path: IsPageShapeKnown answered `false`
+        // before #3239 and is caught by `asserterror` before this fix.
+        var ex = Assert.Throws<BcAppSymbolReadException>(
+            () => BcRuntime.NavMethodScope_AssertError(
+                null!, () => RecordPatches.IsPageShapeKnown(PageId)));
+
+        Assert.Contains("pages and pageextensions", ex.Message);
+    }
+
+    [Fact]
+    public void AssertError_Fails_WhenTheSameReadSucceeds()
+    {
+        // The positive control for both rows above: with the .app healthy the body completes,
+        // and the asserterror replacement's own failure signal is what comes back — so the
+        // poisoned rows are measuring the poison, not a pipeline that never reads the .app.
+        RegisterHealthy("healthy3241.app");
+
+        Assert.False(RecordPatches.GetInsertAllowedForPage(PageId),
+            "the fixture page declares InsertAllowed = false");
+
+        var ex = Record.Exception(
+            () => BcRuntime.NavMethodScope_AssertError(
+                null!, () => RecordPatches.GetInsertAllowedForPage(PageId)));
+
+        Assert.NotNull(ex);
+        Assert.Equal(AssertErrorTypeName, ex!.GetType().FullName);
+    }
+
+    // ── the same claim, raised directly and wrapped ──────────────────────────────────────
+
+    [Fact]
+    public void AssertError_TearsThrough_WhenTheRefusalIsRaisedDirectly()
+    {
+        var raised = Refusal();
+        var ex = Assert.Throws<BcAppSymbolReadException>(
+            () => BcRuntime.NavMethodScope_AssertError(null!, () => throw raised));
+        Assert.Same(raised, ex);
+    }
+
+    [Fact]
+    public void AssertError_TearsThrough_WhenTheRefusalArrivesWrapped()
+    {
+        // A refusal raised behind MethodBase.Invoke comes back inside a
+        // TargetInvocationException, and BC's own RemapToALExceptionAndThrow can rewrap it
+        // again — an `is` test would miss both, which is why the seam asks Find().
+        var raised = Refusal();
+        var ex = Assert.Throws<TargetInvocationException>(
+            () => BcRuntime.NavMethodScope_AssertError(
+                null!, () => throw new TargetInvocationException(raised)));
+        Assert.Same(raised, ex.InnerException);
+    }
+
+    // ── the controls: the seam still catches what it is supposed to ──────────────────────
+
+    [Fact]
+    public void AssertError_StillPasses_WhenTheBodyRaisesAnOrdinaryError()
+    {
+        // Returning normally IS the pass signal. Without this row, "the seam stopped catching
+        // anything at all" would satisfy every tear-through row above.
+        BcRuntime.NavMethodScope_AssertError(
+            null!, () => throw new InvalidOperationException("Bug3241 ordinary AL error"));
+    }
+
+    [Fact]
+    public void AssertError_StillPasses_WhenTheBodyRaisesAPermanentOutOfScopeRefusal()
+    {
+        // #2871's contract, deliberately untouched — the discrimination is by TYPE, so a fix
+        // that widened the filter to "anything the runner raises" would fail here.
+        BcRuntime.NavMethodScope_AssertError(
+            null!, () => throw new RunnerOutOfScopeException("NavFile.Upload", "browser-roundtrip", "file-storage"));
+    }
+
+    // ── the other AL trapping seam ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void TryInvoke_TearsThrough_WhenTheRefusalArrivesWrapped()
+    {
+        // NavApplicationObjectBase_TryInvoke's ordering matters for the same reason as the
+        // asserterror seam's: bare, the refusal already reached the final `throw`; remapped
+        // into a trappable NavBaseException it would have been swallowed into `false`.
+        var raised = Refusal();
+        var ex = Assert.Throws<TargetInvocationException>(
+            () => BcRuntime.NavApplicationObjectBase_TryInvoke(
+                null, () => throw new TargetInvocationException(raised)));
+        Assert.Same(raised, ex.InnerException);
+    }
+
+    [Fact]
+    public void TryInvoke_StillTraps_APermanentRefusal()
+    {
+        // The control: without it, "tears through" would be satisfied by a TryInvoke that
+        // trapped nothing at all.
+        Assert.False(BcRuntime.NavApplicationObjectBase_TryInvoke(
+            null, () => throw new RunnerOutOfScopeException("NavFile.Upload", "browser-roundtrip", "file-storage")));
+    }
+
+    [Fact]
+    public void TryInvoke_StillAnswersTrue_WhenTheBodySucceeds()
+    {
+        Assert.True(BcRuntime.NavApplicationObjectBase_TryInvoke(null, () => { }));
+    }
+}

--- a/AlRunner.Tests/ExpectationClassifierTests.cs
+++ b/AlRunner.Tests/ExpectationClassifierTests.cs
@@ -244,4 +244,85 @@ public class ExpectationClassifierTests
         Assert.Equal(ExpectationResult.FailManifestDrift, c.Result);
         Assert.Contains("Declare it expect-oos", c.Diagnostic);
     }
+
+    // ── a corrupt dependency package may never be declared expected (#3241) ───
+
+    private static BcAppSymbolReadException SymbolRead(Exception inner) =>
+        new("/artifacts/Some.Publisher_Some App_1.0.0.0.app", "table symbols", inner);
+
+    [Fact]
+    public void ExpectOos_SymbolReadFailureWrappingAMatchingOosReason_IsDriftNotPassOos()
+    {
+        // THE RED, and why this type needed its own branch rather than riding on the shape
+        // gap's structural unabsorbability: BcAppSymbolReadException wraps whatever failed the
+        // read, and OutOfScopeMessage.FromException walks that chain to depth 16. So a
+        // corrupt package whose inner failure happened to be an out-of-scope refusal with the
+        // entry's own anchor classified as PassOos — the run went green over a dependency the
+        // runner could not read at all.
+        var c = ExpectationClassifier.Classify(
+            Failed(SymbolRead(new RunnerOutOfScopeException(
+                "HttpClient.Get", "external-http", "docs/scope.md#external-http"))),
+            Oos("external-http"));
+
+        Assert.Equal(ExpectationResult.FailManifestDrift, c.Result);
+        Assert.Contains("could not read", c.Diagnostic);
+        Assert.Contains("Some.Publisher_Some App_1.0.0.0.app", c.Diagnostic);
+        Assert.Contains("table symbols", c.Diagnostic);
+    }
+
+    [Fact]
+    public void ExpectOos_SymbolReadFailure_DiagnosticDoesNotAdviseRaisingAnOosRefusal()
+    {
+        // With an ordinary inner failure the entry already could not absorb it — what was
+        // wrong was the ADVICE. The no-signal branch tells the author to make the throw site
+        // raise RunnerOutOfScopeException, which is exactly wrong for a package the runner
+        // cannot read: nothing about the throw site is at fault.
+        var c = ExpectationClassifier.Classify(
+            Failed(SymbolRead(new InvalidOperationException(
+                "The requested operation requires an element of type 'String'."))),
+            Oos("external-http"));
+
+        Assert.Equal(ExpectationResult.FailManifestDrift, c.Result);
+        Assert.DoesNotContain("raise RunnerOutOfScopeException", c.Diagnostic);
+        Assert.Contains("Repair or re-provision", c.Diagnostic);
+    }
+
+    [Fact]
+    public void ExpectDivergence_SymbolReadFailure_IsDriftNotPassDivergence()
+    {
+        var c = ExpectationClassifier.Classify(
+            Failed(SymbolRead(new InvalidOperationException("unreadable"))),
+            Divergence("task-scheduler-create-task"));
+
+        Assert.Equal(ExpectationResult.FailManifestDrift, c.Result);
+        Assert.Contains("no answer at all", c.Diagnostic);
+    }
+
+    [Fact]
+    public void ExpectFailKnownGap_SymbolReadFailure_StillAbsorbs()
+    {
+        // The control on the two refusals above: expect-fail-known-gap means "must fail, and
+        // this open issue tracks it", so it is unaffected — a fix that refused the type
+        // everywhere would fail here.
+        var known = new ExpectationEntry(
+            60000, "Cu", "M", ExpectationMode.ExpectFailKnownGap, null, "#3241", null, null, File);
+        var c = ExpectationClassifier.Classify(
+            Failed(SymbolRead(new InvalidOperationException("unreadable"))), known);
+
+        Assert.Equal(ExpectationResult.PassKnownGap, c.Result);
+    }
+
+    [Fact]
+    public void NoEntry_SymbolReadFailureWrappingAnOosRefusal_IsAPlainFailNotUndeclaredOos()
+    {
+        // The undeclared-OOS branch would tell a reviewer to add an expect-oos entry for a
+        // surface that was never touched.
+        var c = ExpectationClassifier.Classify(
+            Failed(SymbolRead(new RunnerOutOfScopeException(
+                "HttpClient.Get", "external-http", "docs/scope.md#external-http"))),
+            null);
+
+        Assert.Equal(ExpectationResult.Fail, c.Result);
+        Assert.Null(c.Diagnostic);
+    }
 }

--- a/AlRunner/Infrastructure/BcAppSymbolReadException.cs
+++ b/AlRunner/Infrastructure/BcAppSymbolReadException.cs
@@ -9,6 +9,11 @@
 // produce meaningful results, so it stops here instead — the same posture as
 // DependencyLoadException for a dependency that fails to compile.
 //
+// It tears through BOTH of AL's error-trapping seams — `asserterror` and [TryFunction] —
+// the same posture BcShapeGapException takes, and for the same reason: on real BC the read
+// succeeds, so swallowing the refusal INVERTS the result rather than merely hiding a gap
+// (#3241). Find() below is what the two seams ask.
+//
 // See: .claude/rules/loud-failures.md.
 
 namespace AlRunner.Infrastructure;
@@ -29,6 +34,35 @@ public sealed class BcAppSymbolReadException : Exception
     {
         AppPath = appPath;
         Surface = surface;
+    }
+
+    /// <summary>
+    /// The symbol-read refusal anywhere in <paramref name="ex"/>'s inner-exception chain,
+    /// else null.
+    ///
+    /// <para>A chain walk, not an <c>is</c> test, for the same reason as
+    /// <see cref="BcShapeGapException.Find"/>: a refusal raised behind
+    /// <see cref="System.Reflection.MethodBase.Invoke(object, object[])"/> arrives wrapped in
+    /// a <see cref="System.Reflection.TargetInvocationException"/>, and BC's own
+    /// <c>RemapToALExceptionAndThrow</c> can rewrap it again. The AL trapping seams
+    /// (<c>MethodScopePatches.NavMethodScope_AssertError</c>,
+    /// <c>ApplicationObjectBasePatches.NavApplicationObjectBase_TryInvoke</c>) ask this
+    /// before anything else so a corrupt dependency package cannot be swallowed into a green
+    /// <c>asserterror</c> or a <c>[TryFunction]</c> answering false (#3241).</para>
+    /// </summary>
+    public static BcAppSymbolReadException? Find(Exception? ex)
+    {
+        const int MaxDepth = 16;   // guard against self-referential inner chains
+        var e = ex;
+        for (var d = 0; e != null && d < MaxDepth; d++, e = e.InnerException)
+        {
+            if (e is BcAppSymbolReadException read) return read;
+            if (e is AggregateException agg)
+                foreach (var inner in agg.InnerExceptions)
+                    if (inner is not null && !ReferenceEquals(inner, e) && Find(inner) is { } nested)
+                        return nested;
+        }
+        return null;
     }
 
     // No leading `[tag]`: Log's default-verbosity filter drops lines that START with a

--- a/AlRunner/Infrastructure/BcShapeGapException.cs
+++ b/AlRunner/Infrastructure/BcShapeGapException.cs
@@ -204,8 +204,9 @@ internal static class BcShape
     /// <para>What this is for: <see cref="Type.GetMethod(string, BindingFlags)"/> throws
     /// <see cref="AmbiguousMatchException"/> the moment Microsoft ships a second method of that
     /// name. That is a bare framework exception carrying no member name, and
-    /// <c>MethodScopePatches.NavMethodScope_AssertError</c> rethrows only
-    /// <see cref="BcShapeGapException"/> — so under an AL <c>asserterror</c> it is ABSORBED and
+    /// <c>MethodScopePatches.NavMethodScope_AssertError</c> rethrows only the runner's own
+    /// refusal types (this one and <c>BcAppSymbolReadException</c>, #3241) — so under an AL
+    /// <c>asserterror</c> a bare framework exception is ABSORBED and
     /// the asserterror PASSES, on a call real BC performs fine. Enumerating cannot throw, so
     /// every outcome here is the method, <c>null</c>, or a refusal that names the member
     /// (#3069, and #3062 for the same repair inside the permission slice).</para>

--- a/AlRunner/Infrastructure/ExpectationManifest.cs
+++ b/AlRunner/Infrastructure/ExpectationManifest.cs
@@ -527,10 +527,22 @@ public static class ExpectationClassifier
         // RunnerOutOfScopeException") is exactly wrong for a layout gap.
         var shapeGap = outcome.Passed ? null : BcShapeGapException.Find(outcome.Exception);
 
+        // Nor is a corrupt/unreadable dependency package (#3241). Unlike a shape gap this one
+        // is NOT already structurally unabsorbable: BcAppSymbolReadException wraps whatever
+        // failed the read, and OutOfScopeMessage.FromException walks that chain — so an inner
+        // RunnerOutOfScopeException whose reason anchor matched the entry classified the
+        // corrupt package as PassOos. Found first, so the read failure wins over the signal.
+        var symbolRead = outcome.Passed ? null : BcAppSymbolReadException.Find(outcome.Exception);
+
         if (entry == null)
         {
             // No manifest entry — normal pass/fail. Unexpected OOS surfaces as a
             // distinct fail with diagnostic so reviewers know to add an entry.
+            // A corrupt dependency package wrapping an out-of-scope inner failure is not an
+            // undeclared OOS surface — advising a reviewer to add an expect-oos entry for a
+            // surface that was never touched would be worse than saying nothing (#3241).
+            if (symbolRead != null)
+                return new Classification(ExpectationResult.Fail, null);
             if (signal is { } undeclared)
             {
                 return new Classification(
@@ -547,6 +559,14 @@ public static class ExpectationClassifier
                 return new Classification(ExpectationResult.Skipped, null);
 
             case ExpectationMode.ExpectOos:
+                if (symbolRead != null)
+                    return new Classification(
+                        ExpectationResult.FailManifestDrift,
+                        $"Manifest declares expect-oos (reason: {entry.Reason}) but the runner could not "
+                        + $"read {Path.GetFileName(symbolRead.AppPath)}'s {symbolRead.Surface} from its "
+                        + "SymbolReference.json. That is not a scope boundary, it is a dependency package "
+                        + "the runner cannot read on this machine, so it must not be declared expected. "
+                        + $"Repair or re-provision the .app: {symbolRead.AppPath}");
                 if (shapeGap != null)
                     return new Classification(
                         ExpectationResult.FailManifestDrift,
@@ -598,6 +618,14 @@ public static class ExpectationClassifier
                 // out-of-scope throw is a different claim with its own mode, and
                 // conflating them would let expect-divergence quietly absorb new OOS
                 // surfaces that expect-oos is supposed to declare.
+                if (symbolRead != null)
+                    return new Classification(
+                        ExpectationResult.FailManifestDrift,
+                        $"Manifest declares expect-divergence (reason: {entry.Reason}) but the runner could "
+                        + $"not read {Path.GetFileName(symbolRead.AppPath)}'s {symbolRead.Surface} from its "
+                        + "SymbolReference.json. A divergence is an answer the runner gives on purpose; an "
+                        + "unreadable dependency package is no answer at all. Repair or re-provision the "
+                        + $".app: {symbolRead.AppPath}");
                 if (shapeGap != null)
                     return new Classification(
                         ExpectationResult.FailManifestDrift,

--- a/AlRunner/Patches/ApplicationObjectBasePatches.cs
+++ b/AlRunner/Patches/ApplicationObjectBasePatches.cs
@@ -193,6 +193,10 @@ public static partial class BcRuntime
             // trappable, and BC's own RemapToALExceptionAndThrow can hand it back wrapped in a
             // NavBaseException that the next clause would swallow. See BcShapeGapException.cs.
             if (AlRunner.Infrastructure.BcShapeGapException.Find(ex) != null) throw;
+            // Same posture for a corrupt dependency package, and the ordering matters for the
+            // same reason: bare it would reach `throw` below anyway, remapped into a trappable
+            // NavBaseException it would not (#3241). See BcAppSymbolReadException.Find.
+            if (AlRunner.Infrastructure.BcAppSymbolReadException.Find(ex) != null) throw;
             // Rethrow untrappable errors; swallow trappable NavBaseExceptions.
             if (ex is Microsoft.Dynamics.Nav.Types.Exceptions.NavBaseException nbe && !nbe.UntrappableError)
                 return false;
@@ -274,6 +278,7 @@ public static partial class BcRuntime
         {
             // Same ordering as TryInvoke, and for the same reason — see there.
             if (AlRunner.Infrastructure.BcShapeGapException.Find(ex) != null) throw;
+            if (AlRunner.Infrastructure.BcAppSymbolReadException.Find(ex) != null) throw;
             if (ex is Microsoft.Dynamics.Nav.Types.Exceptions.NavBaseException nbe && !nbe.UntrappableError)
                 return new System.Threading.Tasks.ValueTask<bool>(false);
             // Same permanent-OOS trap as TryInvoke — see IsPermanentOutOfScope.

--- a/AlRunner/Patches/MethodScopePatches.cs
+++ b/AlRunner/Patches/MethodScopePatches.cs
@@ -468,6 +468,13 @@ public static partial class BcRuntime
             // (invoked below) can rewrap it too. An `is` test would miss both.
             throw;
         }
+        catch (Exception ex) when (AlRunner.Infrastructure.BcAppSymbolReadException.Find(ex) != null)
+        {
+            // A corrupt dependency package is the same claim — the runner could not read
+            // something it needs, on a path real BC completes — so swallowing it here inverts
+            // the result exactly as the clause above describes (#3241). Wrapped or bare.
+            throw;
+        }
         catch (Exception ex)
         {
             // Real BC's own AssertError body (decompiled) is:

--- a/AlRunner/Patches/RecordPatches.NavAppExtraVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.NavAppExtraVirtualTable.cs
@@ -364,8 +364,8 @@ public static partial class RecordPatches
 
         // BcShape.FindMethod, not Type.GetMethod (#3069). A bare-name lookup throws
         // AmbiguousMatchException the day Microsoft ships a second GetAllItems overload on
-        // this provider, and MethodScopePatches.NavMethodScope_AssertError rethrows only
-        // BcShapeGapException while absorbing everything else — so that throw would be
+        // this provider, and MethodScopePatches.NavMethodScope_AssertError rethrows only the
+        // runner's own refusal types while absorbing everything else — so that throw would be
         // SWALLOWED under an AL `asserterror`, passing it on a call real BC performs fine.
         //
         // The signature is pinned to the one BC's own provider declares —

--- a/AlRunner/Patches/RecordPatches.PageMetadataSourceObject.cs
+++ b/AlRunner/Patches/RecordPatches.PageMetadataSourceObject.cs
@@ -140,8 +140,8 @@ public static partial class RecordPatches
             var type = typeof(NCLMetadata).Assembly.GetType("Microsoft.Dynamics.Nav.Runtime.PageDataProvider");
             // BcShape.FindMethod, not Type.GetMethod (#3069). A bare-name lookup throws
             // AmbiguousMatchException the day Microsoft ships a second overload of this name,
-            // and MethodScopePatches.NavMethodScope_AssertError rethrows only
-            // BcShapeGapException and absorbs everything else — so that throw would be
+            // and MethodScopePatches.NavMethodScope_AssertError rethrows only the runner's
+            // own refusal types and absorbs everything else — so that throw would be
             // SWALLOWED under an AL `asserterror`, passing it on a call real BC performs fine.
             // FindMethod refuses with the right type instead, and still answers null on
             // absence, which ReadSourceTableView already turns into a named refusal.

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -230,6 +230,24 @@ raising `RunnerOutOfScopeException` that would be exactly wrong here.
 written the gap down. Settled in
 [#2946](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2946).
 
+**A fourth type, and `expect-oos` may never absorb that one either.**
+`BcAppSymbolReadException` — message prefix `symbol-read-fail ` — means a
+registered dependency `.app` has a `SymbolReference.json` the runner could not
+read to completion. Same argument, one step further out: it is not a statement
+about the runner's scope at all, it is a statement about the package on this
+machine, so it can be true on one leg and false on the next. It differs from a
+shape gap in one way that mattered: it **wraps** whatever failed the read, and
+`OutOfScopeMessage.FromException` walks that chain, so a corrupt package whose
+inner failure happened to carry an out-of-scope signal with the entry's own
+anchor classified as `pass-oos`. `expect-oos` and `expect-divergence` now refuse
+it explicitly, naming the `.app` and the surface; with no entry at all it is a
+plain failure rather than an "undeclared out-of-scope" report about a surface
+nothing touched. `expect-fail-known-gap` still absorbs it. It also tears through
+both AL trapping seams — `asserterror` and `[TryFunction]` — for the same reason
+a shape gap does: on real BC the read succeeds, so swallowing it inverts the
+result. Settled in
+[#3241](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3241).
+
 New Cecil throw sites therefore have to put the **`docs/scope.md` anchor first
 in the reason slot**, and the API name in the API slot. A message shaped
 `out-of-scope: report-rendering-external — RDLC layout processing …` puts a


### PR DESCRIPTION
Closes #3241

`asserterror` around an AL-entered read of a corrupt dependency package turned the failure into a **green** test. `NavMethodScope_AssertError` rethrew only `BcShapeGapException`; the `BcAppSymbolReadException` #3239 introduced was caught, so the asserterror passed — the opposite of what real BC answers, because the read succeeds there. That is a result inversion, not a hidden gap.

Corpus-NA: asserterror over a runner-side symbol-read failure; BC has no corrupt-package read path in a test

## Which of the two candidate fixes, and why

The issue offered "derive `BcAppSymbolReadException : BcShapeGapException`" or "add the type to the rethrow filter". **Option 2**, because the blast radius of option 1 is enumerable and bad:

- `BcShapeGapException` is `sealed`. Deriving means unsealing it.
- The two message contracts are mutually exclusive. `BcShapeGapConventionTests` pins the `bc-shape-gap: ` prefix; `DependencySymbolReadFailureTests` and `PermissionSetSymbolReadFailureTests` pin that the symbol-read message has *no* leading tag and starts `symbol-read-fail `.
- `Surface`/`Member`/`Detail` do not map onto `(appPath, surface, inner)`.
- `BcShapeGapException.Find` is asked at three catch sites plus `ExpectationManifest.cs`. Deriving would make every one of them absorb a package read, and the classifier would then tell the author to "fix the reflection target" for a corrupt `.app` — advice that is exactly wrong.

So: a `BcAppSymbolReadException.Find` chain walk mirroring `BcShapeGapException.Find` (depth 16, `AggregateException` branch), asked at the seams.

## What changed

1. **`BcAppSymbolReadException.Find`** — the wrapped case is the reachable one. A refusal raised behind `MethodBase.Invoke` arrives inside a `TargetInvocationException`, and BC's own `RemapToALExceptionAndThrow` can rewrap it; an `is` test misses both.
2. **`MethodScopePatches.NavMethodScope_AssertError`** — a filtered `catch` beside the shape-gap clause. This is the fix the issue asked for.
3. **`ApplicationObjectBasePatches`, `TryInvoke` and `TryInvokeAsync`** — the sibling seam (question 2 of "fix the shape, not the reported line"). **Honest scope note:** a *bare* refusal already reached the final `throw` there, so this edit only changes the case where BC remaps it into a trappable `NavBaseException` — an ordering pin, not a measured RED. The `BcShapeGapException` line it sits next to exists for the same reason.
4. **`ExpectationManifest` classifier** — refuses `expect-oos` and `expect-divergence`, and does not report a symbol read as an *undeclared* out-of-scope surface when there is no entry at all. `expect-fail-known-gap` still absorbs it.
5. **`docs/expectations.md`** — the "may never be absorbed by `expect-oos`" statement now covers this second type, with what makes it different from a shape gap. That is where the derivation went; the code carries the claim and the issue number.

**The classifier half was not already structurally safe, unlike the shape gap.** `BcAppSymbolReadException` **wraps** whatever failed the read, and `OutOfScopeMessage.FromException` walks that chain to depth 16 — so a corrupt package whose inner failure happened to be a `RunnerOutOfScopeException` with the entry's own reason anchor classified as `pass-oos`. That is the RED for `ExpectOos_SymbolReadFailureWrappingAMatchingOosReason_IsDriftNotPassOos`.

## RED to GREEN

`dotnet test AlRunner.Tests --filter "…AssertErrorSymbolReadCatchabilityTests|…ExpectationClassifierTests"`, with the four production files reverted to `origin/main` and the tests unchanged:

```
RED   Failed: 8, Passed: 27, Total: 35
  AssertError_TearsThrough_WhenAnAlEnteredPageReadHitsACorruptDependency
  AssertError_TearsThrough_WhenAnAlEnteredPageShapeProbeHitsACorruptDependency
  AssertError_TearsThrough_WhenTheRefusalIsRaisedDirectly
  AssertError_TearsThrough_WhenTheRefusalArrivesWrapped
  ExpectOos_SymbolReadFailureWrappingAMatchingOosReason_IsDriftNotPassOos
  ExpectOos_SymbolReadFailure_DiagnosticDoesNotAdviseRaisingAnOosRefusal
  ExpectDivergence_SymbolReadFailure_IsDriftNotPassDivergence
  NoEntry_SymbolReadFailureWrappingAnOosRefusal_IsAPlainFailNotUndeclaredOos
  (all four AssertError rows: "Assert.Throws() Failure: No exception was thrown")

GREEN Failed: 0, Passed: 35
```

Then, over the whole affected surface — `AssertErrorSymbolRead`, `ExpectationClassifier`, `ExpectationManifest*`, `AssertErrorOutOfScopeCatchability`, `BcShapeGapConvention`, `DependencySymbolReadFailure`, `DependencyAppSymbolWalkSourceGuard`, `*NullForgivingGuard`: **154 passed, 0 failed** (3 m 22 s).

The RED baseline was taken by copying the four files outside the repository first and restoring from the copies, per `no-git-stash-with-worktrees.md`; `git diff --cached` was read afterwards to confirm the staged content is the fix and not the revert.

**Negative controls, in the same class** — without them "tears through" would be satisfied by a seam that stopped catching anything: a plain `InvalidOperationException` is still caught (the asserterror passes), a permanent `RunnerOutOfScopeException` is still caught, `TryInvoke` still traps a permanent refusal into `false`, and the healthy-`.app` arm shows the same call completing so `NavNCLAssertErrorException` comes back — which proves the poisoned rows measure the poison rather than a pipeline that never reads the `.app`.

## Why the proving test is C#, not an AL bundle

The reachable shape is **poison-after-registration**, and it is in-process by construction. `RecordPatches.AddBcAppPath` parses table symbols eagerly, so an `.app` already corrupt on disk refuses at registration and `Program.cs` exits 1 before any AL runs (`RecordPatchesBcAppSymbolReadFailureTests`). Only a package readable when registered and unreadable when a lazy read drains it can reach an `asserterror` at all — the `--watch` window. The new tests drive the **real** `NavMethodScope_AssertError` over the **real** `RecordPatches.GetInsertAllowedForPage` / `IsPageShapeKnown` against exactly that state, using #3143's fixture technique (root `"AppId"` as a JSON number, which dies in `ReadAppIdentity` after every container has been collected).

Nothing here is a claim about Business Central — no AL statement can corrupt a dependency package, so a service tier has nothing to adjudicate. Same placement reasoning as `BcShapeGapConventionTests` and `AssertErrorOutOfScopeCatchabilityTests`.

**What "fails loudly" now means, concretely:** the refusal escapes the AL method into the per-test outcome, so it is a named per-test FAIL carrying the `.app` path and the surface — not a silent green. `Program.cs`'s `catch (BcAppSymbolReadException)` still exits 1 for the registration-time path, which this does not touch.

## Queue scan, and what was deliberately not folded

Open issues touching these files: none. #2994 (`agent: stma-auto-1`) sweeps remaining reflection guards onto `BcShapeGapException` — a different file set, and claimed. #2871 remains open and **untouched**: whether AL should be able to swallow a `RunnerOutOfScopeException` is a maintainer decision, and `AssertErrorOutOfScopeCatchabilityTests` plus a control arm here both still pin today's answer.

**Two stale comments left alone on purpose.** `AlRunner/Patches/MockTestPage.cs:3673` and `:3772` say `NavMethodScope_AssertError` "rethrows only `BcShapeGapException`", which this makes imprecise. Another agent is mid-edit in that file (regression #3701), so touching it would manufacture a conflict. The three equivalent lines outside it — in `BcShapeGapException.cs`, `RecordPatches.NavAppExtraVirtualTable.cs` and `RecordPatches.PageMetadataSourceObject.cs` — are corrected here, in a word each.

---

*Authored by `fbk-2`, an automated implementation agent acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kko97BZZL71nF2nK5aftu4
