### PR TITLE
fix(testpage): flush the page's PARTS before the handler-driven close raises OnQueryClosePage

### DIFF
--- a/AlRunner.Tests/HandlerDrivenClosePartFlushOrderTests.cs
+++ b/AlRunner.Tests/HandlerDrivenClosePartFlushOrderTests.cs
@@ -1,0 +1,88 @@
+// HandlerDrivenClosePartFlushOrderTests — issue #3701.
+//
+// The defect: #3672 made a [ModalPageHandler]'s built-in OK().Invoke() attempt the close
+// (LiveNavTestPage.AttemptHandlerDrivenClose), but that attempt raised OnQueryClosePage while a
+// row typed into a PART was still only a buffer. Invoke() flushes the page's own row and nothing
+// else, so a page that reads its part in OnQueryClosePage saw one row too few and a page that
+// materialises its part contents on OK saved nothing.
+//
+// The BC-behaviour claim — that pressing OK saves the typed part row BEFORE OnQueryClosePage
+// runs — is not asserted here. It is measured on a real service tier by corpus codeunit 60663
+// "Opf Ok Part Flush Tests" (StefanMaron/BusinessCentral.AL.Language.Tests#315), and confirmed
+// in a BC 28.4.53241.0 container before that PR was opened.
+//
+// What IS asserted here is the runner-internal mechanism that makes it true, and it is an
+// ORDERING, which no return value exposes: inside AttemptHandlerDrivenClose, the call to
+// FlushParts must come before the call to RaiseOnClosePage. A regression that dropped the flush,
+// or moved it after the raise, restores the exact defect while every unit-level return value
+// stays the same — so the order is read out of the IL, which is where it lives.
+using System.Linq;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class HandlerDrivenClosePartFlushOrderTests
+{
+    private static MethodDefinition AttemptHandlerDrivenClose()
+    {
+        // Any type from the runner assembly locates the image; LiveNavTestPage itself is
+        // internal, and this test reads it through Cecil rather than through the type system.
+        var path = typeof(AlRunner.TestExecutor).Assembly.Location;
+        var module = ModuleDefinition.ReadModule(path);
+        var type = module.GetTypes().Single(t => t.FullName == "AlRunner.LiveNavTestPage");
+        return type.Methods.Single(m => m.Name == "AttemptHandlerDrivenClose");
+    }
+
+    private static int IndexOfCallTo(MethodDefinition method, string calleeName)
+    {
+        var body = method.Body.Instructions;
+        for (var i = 0; i < body.Count; i++)
+        {
+            if (body[i].OpCode != OpCodes.Call && body[i].OpCode != OpCodes.Callvirt) continue;
+            if (body[i].Operand is MethodReference callee && callee.Name == calleeName) return i;
+        }
+        return -1;
+    }
+
+    // The regression row. Both calls must be present, and the flush must come first.
+    [Fact]
+    public void AttemptHandlerDrivenClose_FlushesParts_BeforeItRaisesOnClosePage()
+    {
+        var method = AttemptHandlerDrivenClose();
+
+        var flush = IndexOfCallTo(method, "FlushParts");
+        var raise = IndexOfCallTo(method, "RaiseOnClosePage");
+
+        Assert.True(flush >= 0,
+            "AttemptHandlerDrivenClose must call FlushParts — without it a row the handler typed "
+            + "into a part is still a buffer when OnQueryClosePage runs (#3701).");
+        Assert.True(raise >= 0,
+            "AttemptHandlerDrivenClose must still raise OnQueryClosePage — that is the close "
+            + "attempt #3672 added.");
+        Assert.True(flush < raise,
+            $"FlushParts must be called BEFORE RaiseOnClosePage (found FlushParts at IL index "
+            + $"{flush} and RaiseOnClosePage at {raise}). Flushing afterwards is the #3701 defect "
+            + "with the call present.");
+    }
+
+    // The row that stops the assertion above from being satisfied by an unconditional flush at
+    // the top of the method: the flush belongs after the guards, so a page the TEST opened, a
+    // torn-down page, and a non-confirming result still take no action at all.
+    [Fact]
+    public void AttemptHandlerDrivenClose_FlushesPartsOnlyAfterItsGuards()
+    {
+        var method = AttemptHandlerDrivenClose();
+
+        var flush = IndexOfCallTo(method, "FlushParts");
+        var wasClosedFromAl = IndexOfCallTo(method, "WasClosedFromAl");
+
+        Assert.True(wasClosedFromAl >= 0,
+            "the guard reading WasClosedFromAl must still be in AttemptHandlerDrivenClose.");
+        Assert.True(flush > wasClosedFromAl,
+            $"FlushParts (IL index {flush}) must come after the guards (WasClosedFromAl at "
+            + $"{wasClosedFromAl}) — a page the test opened, or one already closed from AL, must "
+            + "not be touched by this route.");
+    }
+}

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -1965,8 +1965,14 @@ internal class LiveNavTestPage : MockITestPage
         // above flushes only this page's own row, so without this the trigger sees a part one
         // row short and a page that materialises its part contents on OK saves nothing (#3701).
         // Measured on a real service tier: corpus codeunit 60663 "Opf Ok Part Flush Tests"
-        // (StefanMaron/BusinessCentral.AL.Language.Tests#315). Same order as Close()/Dispose():
-        // parts first, because a part's OnValidate can touch the header.
+        // (StefanMaron/BusinessCentral.AL.Language.Tests#315).
+        //
+        // Order here is row THEN parts -- the reverse of Close()/Dispose()/SaveCurrentRow(),
+        // which flush parts first so a part's OnValidate still finds an unflushed header. Both
+        // orders are safe because each flush latches: FlushPendingNewRow/FlushPendingModify
+        // clear their flag on entry, so the later Close()/Dispose() pass writes nothing twice.
+        // Do not delete Invoke()'s FlushRow() on the strength of this call -- FlushParts() does
+        // not write the host page's own row, and no test here would catch its loss.
         FlushParts();
 
         // Both refusals leave the form OPEN and raise nothing here, which is what makes

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -1960,6 +1960,15 @@ internal class LiveNavTestPage : MockITestPage
         // has been asked, so it keeps the behaviour it had.
         if (result is not (FormResult.OK or FormResult.LookupOK)) return;
 
+        // BC's client sends the row being edited -- INCLUDING a row typed into a part -- before
+        // it drives the close, so OnQueryClosePage reads a part that already holds it. Invoke()
+        // above flushes only this page's own row, so without this the trigger sees a part one
+        // row short and a page that materialises its part contents on OK saves nothing (#3701).
+        // Measured on a real service tier: corpus codeunit 60663 "Opf Ok Part Flush Tests"
+        // (StefanMaron/BusinessCentral.AL.Language.Tests#315). Same order as Close()/Dispose():
+        // parts first, because a part's OnValidate can touch the header.
+        FlushParts();
+
         // Both refusals leave the form OPEN and raise nothing here, which is what makes
         // FormRunModal's own attempt run -- and that second attempt is where the second message
         // delivery, and the Action::None, come from. They are one branch on purpose: unlike

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -1967,12 +1967,12 @@ internal class LiveNavTestPage : MockITestPage
         // Measured on a real service tier: corpus codeunit 60663 "Opf Ok Part Flush Tests"
         // (StefanMaron/BusinessCentral.AL.Language.Tests#315).
         //
-        // Order here is row THEN parts -- the reverse of Close()/Dispose()/SaveCurrentRow(),
-        // which flush parts first so a part's OnValidate still finds an unflushed header. Both
-        // orders are safe because each flush latches: FlushPendingNewRow/FlushPendingModify
-        // clear their flag on entry, so the later Close()/Dispose() pass writes nothing twice.
-        // Do not delete Invoke()'s FlushRow() on the strength of this call -- FlushParts() does
-        // not write the host page's own row, and no test here would catch its loss.
+        // Order here is row THEN parts: Invoke() above has already flushed this page's own row.
+        // Close()/Dispose()/SaveCurrentRow() are parts-then-row because a part's OnValidate can
+        // touch the header. The repeat pass is a no-op -- FlushPendingNewRow/FlushPendingModify
+        // clear their flag on entry -- so nothing is written twice. Do not delete Invoke()'s
+        // FlushRow() on the strength of this call: FlushParts() does not write the host row, and
+        // no test here would catch its loss.
         FlushParts();
 
         // Both refusals leave the form OPEN and raise nothing here, which is what makes


### PR DESCRIPTION
Closes #3701

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/315

## The defect

#3672 made a `[ModalPageHandler]`'s built-in `OK().Invoke()` attempt the close
(`LiveNavTestPage.AttemptHandlerDrivenClose`). `RecordingBuiltInAction.Invoke()` flushes only the
page's **own** row — every other close point (`Close()`, `Dispose()`, `SaveCurrentRow()`) calls
`FlushParts(); FlushRow();` — so the new attempt raised `OnQueryClosePage` while a row the handler
had typed into a **ListPart** was still a buffer. A page that materialises its part contents on
OK, the ordinary "write what the user entered when they press OK" shape, therefore saved nothing.

The fix is one call, placed after the existing guards and before the raise, restoring the ordering
this route had before #3672 while keeping the close attempt #3672 added.

## Bisect

Found by a private downstream AL suite, clean at `f58e01af` and 8 failures at `7d40783c`.

| runner commit | the affected test codeunit |
|---|---|
| `a4318626` (parent of #3672) | 22P / 0F |
| `f8720984` (#3672) | 14P / 8F |

Every one of the 8 is a page reading its ListPart in `OnQueryClosePage` after a handler typed rows
into it.

## What real BC does — measured

The reproducer was compiled and run against a real BC service tier (BC 28.4.53241.0 OnPrem
container, `Run-TestsInBcContainer`) before the corpus PR was opened:

```
  Codeunit 60015 Opf Ok Part Flush Tests Success (0.322 seconds)
    Testfunction OkInvokeSavesThePartRowBeforeQueryClosePageRuns Success (0.223 seconds)
    Testfunction OkInvokeWithNothingTypedLeavesThePartEmpty Success (0.046 seconds)
    Testfunction OkInvokeSavesEveryTypedPartRowInOrder Success (0.053 seconds)
```

So BC saves the typed part row before `OnQueryClosePage`, and the runner at `f8720984` did not.
The delivery-count question #3672 was about is not involved: this close is **allowed**, there is
no message, and the only observable is what the trigger could see.

## RED → GREEN

Against corpus branch `agent/fbk-3/issue-3701` (the PR above), run with this runner:

| | before | after |
|---|---|---|
| corpus codeunit 60663 "Opf Ok Part Flush Tests" | **1P / 2F** | **3P / 0F** |
| `AlRunner.Tests` `HandlerDrivenClosePartFlushOrderTests` (2 tests) | **2F** under sabotage (flush removed) | **2P** |

The #3672 constraint, re-run on this build:

| | result |
|---|---|
| `tests/runner-extras/testpage-close-message-consumed` | 8P / 0F |
| corpus codeunit 60602 "QCM Query Close Msg Tests" | 5P / 0F |
| corpus codeunit 60276 "MQC Tests" | 9P / 0F |

The private suite's affected codeunit is back to 0 failures on this build (result in the issue
thread).

## Where the proving test lives

The BC-behaviour claim is upstream (corpus 60663, three arms incl. a negative control that types
nothing and a two-row arm so the count cannot be met by a fixed `1`), verified on a container
before opening. Its pin is **not** bumped here — the corpus chain is blocked ahead of it — so the
runner-side proving test is a mechanism test: `HandlerDrivenClosePartFlushOrderTests` reads the IL
of `AttemptHandlerDrivenClose` and asserts `FlushParts` is called, that it precedes
`RaiseOnClosePage`, and that it sits after the guards. The order is what the defect was, and no
return value exposes it.

## Fix the shape, not the reported line

1. **Same wrong pattern elsewhere?** `Invoke()` is the only close point that flushed the row
   without the parts; `Close()`, `Dispose()` and `SaveCurrentRow()` all call both.
2. **A sibling with the same assumption — yes, and it is deliberately left.**
   `LiveNavTestPage.Close()` raises `OnQueryClosePage` *before* its own `FlushParts(); FlushRow();`,
   so `Card.OpenEdit(); Card.Lines.New(); …; Card.Close();` has the same ordering question on the
   explicit-close route. That is **pre-existing, not a #3672 regression**, and no service tier has
   been asked about it yet — the corpus arms here measure the OK-press route only. Filed as a
   follow-up rather than changed unmeasured: #3708.
3. **Two paths writing the same state?** Both close paths now go through `RaiseOnClosePage`; what
   differs is only the flush ordering, which is point 2.

**Open-issue queue scan** for `MockTestPage.cs` / TestPage-close: nothing else open lands in this
file. #3593 is closed by #3672.

---

Written by an agent (Claude, `fbk-3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kko97BZZL71nF2nK5aftu4
