### PR TITLE
test(runner-extras): pin the precompiled implicit-return defect behind #3347's four Azure ML failures

### DIFF
--- a/AlRunner.Tests/ExpectationManifestWiringTests.cs
+++ b/AlRunner.Tests/ExpectationManifestWiringTests.cs
@@ -339,7 +339,7 @@ public sealed class ExpectationManifestWiringTests : IDisposable
             + $"--test GreenPath_KnownGapDeclared \"{SuitePath}\"");
 
         AssertCount(output, "pass-known-gap:", 1);
-        Assert.Contains("all 1 entries matched a discovered test", output, StringComparison.Ordinal);
+        Assert.Contains("all 1 entry in scope for this run matched a discovered test", output, StringComparison.Ordinal);
         Assert.DoesNotContain("UNMATCHED", output, StringComparison.Ordinal);
         Assert.True(exit == 0, $"a matched entry must not fail the run. exit={exit}\n{output}");
     }
@@ -390,6 +390,87 @@ public sealed class ExpectationManifestWiringTests : IDisposable
         Assert.Contains("declares no test method 'GreenPath_PlainPas'", output, StringComparison.Ordinal);
         Assert.Contains("GreenPath_PlainPass", output, StringComparison.Ordinal);
         Assert.True(exit == 5, $"expected exit 5, got {exit}\n{output}");
+    }
+
+    // ── Suite scoping (#3347) ────────────────────────────────────────────────────
+    //
+    // The pure tests over the scoping predicate live in ExpectationMatchAuditTests. These
+    // two are the end-to-end proof that the scope reaches the EXIT CODE, which is what
+    // actually broke: PR #3711's two entries named a tests/runner-extras/ codeunit, the
+    // corpus step is the only invocation passing --expectations-require-match, and all
+    // three BC legs failed with exit 5 on entries that were correct — while the same two
+    // entries matched and reclassified normally in the runner-extras step of the same leg.
+
+    /// <summary>Writes a one-entry manifest carrying a Suites scope, and returns its directory.</summary>
+    private string OneEntryManifestScopedTo(
+        string name, string codeunitName, string method, string suite)
+    {
+        var dir = Path.Combine(_scratchRoot, name);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "known-gaps-fixture.json"), $$"""
+        [
+          {
+            "codeunitId": 60810,
+            "CodeunitName": "{{codeunitName}}",
+            "Method": "{{method}}",
+            "Mode": "expect-fail-known-gap",
+            "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3347",
+            "Suites": ["{{suite}}"]
+          }
+        ]
+        """);
+        return dir;
+    }
+
+    /// <summary>
+    /// A wrong entry scoped to a suite this run did not cover must NOT fail the run. Wrong
+    /// on purpose — the same misspelled CodeunitName that reaches exit 5 unscoped two tests
+    /// above — so the green can only come from the scope, never from the entry being right.
+    /// </summary>
+    [SkippableFact]
+    public void RequireMatch_AnEntryScopedToAnotherSuite_DoesNotFailThisRun()
+    {
+        TestArtifacts.SkipIfMissing();
+        var dir = OneEntryManifestScopedTo(
+            "scope-elsewhere", "Expct Fixture Test", "GreenPath_PlainPass", "tests/runner-extras");
+
+        var (output, exit) = RunRunner(
+            $"--expectations \"{dir}\" --expectations-require-match "
+            + $"--test GreenPath_PlainPass \"{SuitePath}\"");
+
+        Assert.DoesNotContain("UNMATCHED", output, StringComparison.Ordinal);
+        // The green must not silently absorb it: a skipped entry is named, and the count
+        // reports what was actually looked at rather than the manifest's size.
+        Assert.Contains("all 0 entries in scope for this run matched a discovered test", output, StringComparison.Ordinal);
+        Assert.Contains("1 scoped to another suite, not audited here", output, StringComparison.Ordinal);
+        Assert.Contains("Expct Fixture Test.GreenPath_PlainPass", output, StringComparison.Ordinal);
+        Assert.True(exit == 0,
+            $"an entry scoped to a suite this run did not cover must not fail it. exit={exit}\n{output}");
+    }
+
+    /// <summary>
+    /// The negative that stops the scope from becoming a blanket exemption: the same wrong
+    /// entry, scoped to a suite this run DOES cover, still reaches exit 5 with the sharp
+    /// diagnostic. Without this pair, an implementation that skipped every scoped entry
+    /// would pass the test above.
+    /// </summary>
+    [SkippableFact]
+    public void RequireMatch_AnEntryScopedToTheSuiteThisRunCovers_StillFailsTheRun()
+    {
+        TestArtifacts.SkipIfMissing();
+        var dir = OneEntryManifestScopedTo(
+            "scope-here", "Expct Fixture Test", "GreenPath_PlainPass",
+            "AlRunner.Tests/Fixtures/ExpectationsBundle");
+
+        var (output, exit) = RunRunner(
+            $"--expectations \"{dir}\" --expectations-require-match "
+            + $"--test GreenPath_PlainPass \"{SuitePath}\"");
+
+        AssertCount(output, "  fail:", 0);
+        Assert.Contains("UNMATCHED", output, StringComparison.Ordinal);
+        Assert.Contains("object id 60810 was loaded as \"Expct Fixture Tests\"", output, StringComparison.Ordinal);
+        Assert.True(exit == 5,
+            $"a scoped entry is still audited by the run that covers its suite. exit={exit}\n{output}");
     }
 
     /// <summary>
@@ -449,7 +530,7 @@ public sealed class ExpectationManifestWiringTests : IDisposable
     //   entry "Ghost Resume Tests"."RanInAnEarlierAttempt", carried, --merge-results
     //     → exit 5, "no codeunit named ... was loaded in this run"
     // and after:
-    //     → exit 0, "all 1 entries matched a discovered test"
+    //     → exit 0, "all 1 entry in scope for this run matched a discovered test"
     //
     // The codeunit is deliberately one the run's OWN bundle does not contain, so the
     // test cannot pass on the final attempt's own discovery — which is what a version of
@@ -519,7 +600,7 @@ public sealed class ExpectationManifestWiringTests : IDisposable
         AssertCount(output, "  pass:", 1);
         AssertCount(output, "  fail:", 0);
         Assert.DoesNotContain("UNMATCHED", output, StringComparison.Ordinal);
-        Assert.Contains("all 1 entries matched a discovered test", output, StringComparison.Ordinal);
+        Assert.Contains("all 1 entry in scope for this run matched a discovered test", output, StringComparison.Ordinal);
         Assert.True(exit == 0,
             $"an entry whose test ran in an earlier resume attempt must not fail the run. "
             + $"exit={exit}\n{output}");

--- a/AlRunner.Tests/ExpectationMatchAuditTests.cs
+++ b/AlRunner.Tests/ExpectationMatchAuditTests.cs
@@ -166,6 +166,133 @@ public sealed class ExpectationMatchAuditTests
         Assert.Empty(manifest.FindUnmatchedEntries());
     }
 
+    // ── Suite scoping (#3347) ────────────────────────────────────────────────────
+    //
+    // The audit's claim is "this invocation was expected to discover a test for every
+    // entry". That held only while every entry named a corpus test: the manifest
+    // directory is shared by every invocation in this repo, and only the full-corpus CI
+    // step passes --expectations-require-match. The first entry naming a
+    // tests/runner-extras/ codeunit made the claim false — the corpus step can never
+    // load that codeunit, so it reported a correct entry as matching nothing and failed
+    // the leg with exit 5 (measured on PR #3711, all three BC legs).
+    //
+    // The optional "Suites" field is the entry saying which suite roots can cover it.
+    // Absent = audited by every invocation, which is what every pre-existing entry
+    // wants and gets. Present = audited only by an invocation that ran a matching root.
+
+    private static ExpectationManifest LoadOneEntryManifestWithSuites(
+        string codeunitName, string method, string suitesJson)
+    {
+        var dir = TestScratch.Dir("al-runner-match-audit-suites");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "known-gaps-fixture.json"), $$"""
+        [
+          {
+            "codeunitId": 60810,
+            "CodeunitName": "{{codeunitName}}",
+            "Method": "{{method}}",
+            "Mode": "expect-fail-known-gap",
+            "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3123",
+            "Suites": {{suitesJson}}
+          }
+        ]
+        """);
+        try { return ExpectationManifest.LoadFromDirectory(dir); }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    [Fact]
+    public void AnEntryScopedToAnotherSuite_IsNotAuditedByThisRun()
+    {
+        // The #3711 shape exactly: the entry names a runner-extras codeunit and the run
+        // is the corpus. Nothing here could have loaded it, so reporting it as unmatched
+        // accuses a correct entry of a typo.
+        var manifest = LoadOneEntryManifestWithSuites(
+            "Precompiled Implicit Return", "PrecompiledBooleanMethodWithNoExit_ReturnsFalse",
+            "[\"tests/runner-extras\"]");
+        manifest.NoteDiscoveredTestCodeunit(TheFixtureCodeunit());
+
+        Assert.Empty(manifest.FindUnmatchedEntries(new[] { "tests/al-language/tests/al-language" }));
+    }
+
+    [Fact]
+    public void AnEntryScopedToTheSuiteThisRunCovers_IsStillAudited()
+    {
+        // The negative that makes the test above mean something: scoping must not become
+        // a blanket exemption. The run DID cover this suite, so a wrong method name is
+        // still reported — the whole point of the audit.
+        var manifest = LoadOneEntryManifestWithSuites(
+            "Expct Fixture Tests", "GreenPath_KnownGapDeclare",
+            "[\"tests/runner-extras\"]");
+        manifest.NoteDiscoveredTestCodeunit(TheFixtureCodeunit());
+
+        var unmatched = manifest.FindUnmatchedEntries(
+            new[] { "tests/runner-extras/precompiled-implicit-return-3347" });
+
+        var u = Assert.Single(unmatched);
+        Assert.Contains("declares no test method", u.Diagnostic, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnEntryScopedToTheSuiteThisRunCovers_AndCorrect_Matches()
+    {
+        // The control for the pair above: same scope, correct entry, no report.
+        var manifest = LoadOneEntryManifestWithSuites(
+            "Expct Fixture Tests", "GreenPath_KnownGapDeclared",
+            "[\"tests/runner-extras\"]");
+        manifest.NoteDiscoveredTestCodeunit(TheFixtureCodeunit());
+
+        Assert.Empty(manifest.FindUnmatchedEntries(
+            new[] { "tests/runner-extras/precompiled-implicit-return-3347" }));
+    }
+
+    [Fact]
+    public void AnUnscopedEntry_IsAuditedByEveryRun()
+    {
+        // Back-compat, and the reason the field is optional: every entry that existed
+        // before #3347 carries no Suites and must keep being audited exactly as before.
+        var manifest = LoadOneEntryManifest("Expct Fixture Test", "GreenPath_KnownGapDeclared");
+        manifest.NoteDiscoveredTestCodeunit(TheFixtureCodeunit());
+
+        var unmatched = manifest.FindUnmatchedEntries(new[] { "tests/al-language/tests/al-language" });
+
+        var u = Assert.Single(unmatched);
+        Assert.Contains("Check CodeunitName for a typo", u.Diagnostic, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SuiteScoping_MatchesOnAPathSegment_NotASubstring()
+    {
+        // "tests/runner-extras" must not be satisfied by a root that merely CONTAINS
+        // those characters in a longer segment. Otherwise a typo'd scope silently
+        // exempts an entry from every run, which is the failure this whole audit exists
+        // to prevent, reintroduced through its own escape hatch.
+        var manifest = LoadOneEntryManifestWithSuites(
+            "Expct Fixture Tests", "GreenPath_KnownGapDeclare",
+            "[\"tests/runner-extras\"]");
+        manifest.NoteDiscoveredTestCodeunit(TheFixtureCodeunit());
+
+        // Covered: the root IS the scope, and a root BELOW it.
+        Assert.Single(manifest.FindUnmatchedEntries(new[] { "tests/runner-extras" }));
+        Assert.Single(manifest.FindUnmatchedEntries(new[] { "tests/runner-extras/some-bundle" }));
+
+        // Not covered: a sibling whose name merely starts with the scope's last segment.
+        Assert.Empty(manifest.FindUnmatchedEntries(new[] { "tests/runner-extras-isolation-disabled" }));
+    }
+
+    [Fact]
+    public void NoRootsGiven_AuditsEveryEntry_ScopedOrNot()
+    {
+        // A caller that cannot say which roots it ran must not get a quieter audit than
+        // one that can. The parameterless overload keeps the pre-#3347 behaviour.
+        var manifest = LoadOneEntryManifestWithSuites(
+            "Precompiled Implicit Return", "PrecompiledBooleanMethodWithNoExit_ReturnsFalse",
+            "[\"tests/runner-extras\"]");
+        manifest.NoteDiscoveredTestCodeunit(TheFixtureCodeunit());
+
+        Assert.Single(manifest.FindUnmatchedEntries());
+    }
+
     // ── Carried resume attempts (#3168) ──────────────────────────────────────────
     //
     // NoteDiscoveredTestCodeunit is called by the executor IN THIS PROCESS. A resumed

--- a/AlRunner/Infrastructure/ExpectationManifest.cs
+++ b/AlRunner/Infrastructure/ExpectationManifest.cs
@@ -63,9 +63,66 @@ public sealed record ExpectationEntry(
     string? Issue,              // required when Mode == ExpectFailKnownGap; forbidden for ExpectDivergence
     string? Doc,                // required when Mode == ExpectDivergence
     string? Note,
-    string SourceFile)          // the .json this entry came from, for diagnostics
+    string SourceFile,          // the .json this entry came from, for diagnostics
+    // #3347: the suite roots that can cover this entry, or empty = every run.
+    // See ExpectationManifest.FindUnmatchedEntries and docs/expectations.md#suites--which-runs-are-answerable-for-an-entry-3347.
+    IReadOnlyList<string>? Suites = null)
 {
     public bool MatchesAll => Method == "*";
+
+    /// <summary>
+    /// True when a run over <paramref name="runRoots"/> could have loaded this entry's test,
+    /// so the match audit may hold that run responsible for it (#3347).
+    ///
+    /// An entry with no <c>Suites</c> is answerable by every run — the pre-#3347 behaviour and
+    /// what all ten corpus entries want. So is any entry when the caller passes no roots at
+    /// all: a caller that cannot say what it ran must not get a quieter audit than one that can.
+    /// </summary>
+    public bool IsAnsweredBy(IReadOnlyList<string>? runRoots)
+    {
+        if (Suites == null || Suites.Count == 0) return true;
+        if (runRoots == null || runRoots.Count == 0) return true;
+        foreach (var scope in Suites)
+            foreach (var root in runRoots)
+                if (PathScope.Covers(scope, root)) return true;
+        return false;
+    }
+}
+
+/// <summary>
+/// Whether one repo-relative path denotes the same suite tree as another (#3347).
+/// </summary>
+internal static class PathScope
+{
+    /// <summary>
+    /// True when <paramref name="root"/> IS <paramref name="scope"/> or sits beneath it.
+    ///
+    /// Two constraints a simplification here would break. Do NOT reduce this to a string
+    /// <c>StartsWith</c>: <c>tests/runner-extras</c> would then cover
+    /// <c>tests/runner-extras-isolation-disabled</c>, a different suite under different
+    /// flags, and a scope matching more than it names is the untracked-gap hole the audit
+    /// exists to close. Do NOT anchor the match at segment 0: a bundle root arrives however
+    /// the caller spelled it, relative or absolute, so anchoring makes an entry's scope
+    /// depend on the caller's working directory.
+    /// See docs/expectations.md#suites--which-runs-are-answerable-for-an-entry-3347.
+    /// </summary>
+    public static bool Covers(string scope, string root)
+    {
+        var s = Split(scope);
+        var r = Split(root);
+        if (s.Length == 0 || r.Length < s.Length) return false;
+        for (int start = 0; start + s.Length <= r.Length; start++)
+        {
+            var all = true;
+            for (int i = 0; i < s.Length && all; i++)
+                all = string.Equals(s[i], r[start + i], StringComparison.OrdinalIgnoreCase);
+            if (all) return true;
+        }
+        return false;
+    }
+
+    private static string[] Split(string path) =>
+        path.Replace('\\', '/').Split('/', StringSplitOptions.RemoveEmptyEntries);
 }
 
 /// <summary>
@@ -215,7 +272,27 @@ public sealed class ExpectationManifest
     /// <c>--expectations-require-match</c>, which is opted into only by an invocation
     /// that really is expected to cover every entry.
     /// </summary>
-    public IReadOnlyList<UnmatchedExpectation> FindUnmatchedEntries()
+    public IReadOnlyList<UnmatchedExpectation> FindUnmatchedEntries() => FindUnmatchedEntries(null);
+
+    /// <summary>
+    /// The entries this run has no standing to audit, because their <c>Suites</c> scope names
+    /// no root it ran (#3347). Reported alongside a green audit so "all N matched" can never
+    /// silently stand for "some were skipped" — the number a green audit accounts for has to
+    /// be the number it actually looked at.
+    /// </summary>
+    public IReadOnlyList<ExpectationEntry> EntriesOutOfScopeFor(IReadOnlyList<string>? runRoots)
+        => Entries
+            .Where(e => e.Mode != ExpectationMode.AcceptPartialCompanyInit && !e.IsAnsweredBy(runRoots))
+            .ToList();
+
+    /// <inheritdoc cref="FindUnmatchedEntries()"/>
+    /// <param name="runRoots">
+    /// The suite roots this invocation ran, or null when the caller cannot say (#3347). An
+    /// entry declaring <c>Suites</c> none of these roots covers is skipped, because no run
+    /// over these roots could have loaded its test and reporting it would accuse a correct
+    /// entry of a typo. Passing null audits every entry, as before.
+    /// </param>
+    public IReadOnlyList<UnmatchedExpectation> FindUnmatchedEntries(IReadOnlyList<string>? runRoots)
     {
         DiscoveredTestCodeunit[] discovered;
         lock (_discoveredLock) discovered = _discovered.ToArray();
@@ -226,6 +303,9 @@ public sealed class ExpectationManifest
             // #3561: not a test expectation - see the constructor. Its own drift check is the
             // end-of-run one in Program.cs ("the codeunit completed, remove the entry").
             if (entry.Mode == ExpectationMode.AcceptPartialCompanyInit) continue;
+            // #3347: this run does not cover the suite the entry names, so it has no standing
+            // to call the entry unmatched. The run that DOES cover it still audits it.
+            if (!entry.IsAnsweredBy(runRoots)) continue;
             // Mirrors LookupExpectation: entries may be written against the AL object
             // name OR the CLR type name, and "*" matches every test method.
             var named = discovered
@@ -381,6 +461,27 @@ public sealed class ExpectationManifest
             return v.ValueKind == JsonValueKind.String ? v.GetString() : null;
         }
 
+        IReadOnlyList<string>? OptStringArray(string name)
+        {
+            if (!el.TryGetProperty(name, out var v)) return null;
+            if (v.ValueKind != JsonValueKind.Array)
+                throw new InvalidOperationException(
+                    $"{relName}[{idx}]: '{name}' must be a JSON array of repo-relative suite root paths");
+            var list = new List<string>();
+            foreach (var item in v.EnumerateArray())
+            {
+                if (item.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(item.GetString()))
+                    throw new InvalidOperationException(
+                        $"{relName}[{idx}]: every '{name}' element must be a non-empty string");
+                list.Add(item.GetString()!.Trim());
+            }
+            if (list.Count == 0)
+                throw new InvalidOperationException(
+                    $"{relName}[{idx}]: '{name}' is present but empty. An empty scope would exempt the "
+                    + "entry from every audit — omit the field to be audited everywhere instead.");
+            return list;
+        }
+
         var codeunitId = ReqInt("codeunitId");
         var codeunitName = Req("CodeunitName");
         var method = Req("Method");
@@ -389,6 +490,9 @@ public sealed class ExpectationManifest
         var issue = Opt("Issue");
         var docAnchor = Opt("Doc");
         var note = Opt("Note");
+        // #3347. Which suite roots can cover this entry. Optional; absent = every run, which
+        // is what every entry written before #3347 means and gets.
+        var suites = OptStringArray("Suites");
 
         var mode = modeRaw switch
         {
@@ -453,7 +557,7 @@ public sealed class ExpectationManifest
         }
 
         return new ExpectationEntry(
-            codeunitId, codeunitName, method, mode, reason, issue, docAnchor, note, relName);
+            codeunitId, codeunitName, method, mode, reason, issue, docAnchor, note, relName, suites);
     }
 
     /// <summary>

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -4244,7 +4244,15 @@ if (expectationsRequireMatch)
         if (carriedResults.Count > 0)
             expectations.NoteDiscoveredFromCarriedResults(carriedResults.SelectMany(b => b.Tests));
 
-        var unmatched = expectations.FindUnmatchedEntries();
+        // #3347: hand the audit the roots this invocation ran, so an entry declaring a
+        // Suites scope none of them covers is skipped rather than reported. The manifest
+        // directory is shared by every invocation in this repo and only the corpus step
+        // passes this flag, so before this the first entry naming a runner-extras codeunit
+        // failed the corpus leg with exit 5 for an entry that was entirely correct.
+        var unmatched = expectations.FindUnmatchedEntries(bundles);
+        var audited = expectations.Entries.Count
+            - expectations.CompanyInitAcceptances.Count
+            - expectations.EntriesOutOfScopeFor(bundles).Count;
         if (unmatched.Count > 0)
         {
             expectationsMatchFailure = true;
@@ -4261,10 +4269,21 @@ if (expectationsRequireMatch)
         }
         else
         {
-            // Never mute about its scope: a green audit says how much it accounted for.
+            // Never mute about its scope: a green audit says how much it accounted for, and
+            // #3347 made "how much" smaller than "every entry". An entry scoped to a suite
+            // this run did not cover was not checked, so counting it as matched would be the
+            // vacuous green this message exists to rule out — it is reported separately, by
+            // name, so a scope that quietly exempts an entry from EVERY run is visible in the
+            // log of the run that should have owned it.
+            var outOfScope = expectations.EntriesOutOfScopeFor(bundles);
             Console.Error.WriteLine(
-                $"[expectations] match audit: all {expectations.Entries.Count} entries matched a "
-                + "discovered test.");
+                $"[expectations] match audit: all {audited} entr"
+                + $"{(audited == 1 ? "y" : "ies")} in scope for this run matched a discovered test"
+                + (outOfScope.Count == 0
+                    ? "."
+                    : $"; {outOfScope.Count} scoped to another suite, not audited here ("
+                      + string.Join(", ", outOfScope.Select(e => $"{e.CodeunitName}.{e.Method}"))
+                      + ")."));
         }
     }
 }

--- a/AlRunner/ProgramSupport/CliText.cs
+++ b/AlRunner/ProgramSupport/CliText.cs
@@ -694,8 +694,9 @@ internal static partial class ProgramSupport
         w.WriteLine("                          company-init exit 0->2 escalation (never 1/3/4/5, unlike");
         w.WriteLine("                          --no-strict-exit). The abort is still reported everywhere.");
         w.WriteLine("  --expectations-require-match");
-        w.WriteLine("                          Assert that this RUN discovers a test for EVERY entry in");
-        w.WriteLine("                          the active manifest, and fail (exit 5) on any that");
+        w.WriteLine("                          Assert that this RUN discovers a test for every entry in");
+        w.WriteLine("                          the active manifest IN SCOPE FOR IT, and fail (exit 5) on");
+        w.WriteLine("                          any that");
         w.WriteLine("                          matched nothing, naming the file, the codeunit and the");
         w.WriteLine("                          method. Without it such an entry is silently inert: one");
         w.WriteLine("                          wrong letter in CodeunitName or Method untracks a declared");
@@ -707,7 +708,11 @@ internal static partial class ProgramSupport
         w.WriteLine("                          every entry is actually true. After a watchdog resume the");
         w.WriteLine("                          final attempt folds the earlier attempts carried in with");
         w.WriteLine("                          --merge-results into what it audits, so the claim is about");
-        w.WriteLine("                          the run and not one process (#3168).");
+        w.WriteLine("                          the run and not one process (#3168). An entry may also");
+        w.WriteLine("                          narrow itself with \"Suites\": [...], naming the suite roots");
+        w.WriteLine("                          that can cover it; a run over none of them skips it rather");
+        w.WriteLine("                          than calling it unmatched, and a green audit counts only");
+        w.WriteLine("                          what it looked at and names what it skipped (#3347).");
         w.WriteLine("  --count-baseline PATH   Load a per-suite test/app-group expected-count manifest");
         w.WriteLine("                          (schema: AlRunner/Infrastructure/CountBaseline.cs) and");
         w.WriteLine("                          fail the run (exit 4) if a suite's count does not exactly");

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -90,6 +90,52 @@ The residual, deliberately: an entry with **both** a wrong `CodeunitName` and a 
 loaded. And an entry naming a codeunit no run covers is never audited at all, because
 no invocation can honestly assert it should have been.
 
+### `Suites` — which runs are answerable for an entry (#3347)
+
+"Only the full-corpus step passes the flag, because only there is *every entry is
+covered* true" held only while every entry named a `tests/al-language` test. The first
+entry naming a `tests/runner-extras/` codeunit made it false, and the corpus leg failed
+with exit 5 on an entry that was entirely correct — the corpus run cannot load a
+runner-extras codeunit, so it had no standing to call the entry unmatched. Measured on
+PR #3711: all three BC legs, `2 of 12 entries matched no test`, while the same two
+entries matched and reclassified normally in the runner-extras step of the same leg.
+
+An entry may therefore declare the suite roots that can cover it:
+
+```json
+"Suites": ["tests/runner-extras/precompiled-implicit-return-3347"]
+```
+
+- **Absent** — audited by every run. This is what all ten pre-#3347 entries mean, and
+  the default: adding the field is opting *out* of runs that could never see the test,
+  never opting out of the audit.
+- **Present** — audited only by a run whose bundle roots include one the scope covers.
+  The run that *does* cover it audits it in full: a one-letter typo in a scoped entry
+  still fails that run with the sharp `declares no test method` diagnostic.
+- **Present but empty** — refused at load. An empty scope would exempt the entry from
+  every audit, which is the untracked-gap hole the audit exists to close, arriving
+  through the audit's own escape hatch.
+
+Paths are compared **segment by segment**, never as substrings, so
+`tests/runner-extras` does not cover `tests/runner-extras-isolation-disabled` — a
+different suite run under different flags. The scope is sought anywhere in the root's
+segments rather than only at its head, because a bundle root reaches the runner however
+the caller spelled it: `tests/runner-extras/x` from the repo root and an absolute
+`/home/runner/work/…/tests/runner-extras/x` are the same suite, and anchoring at
+segment 0 would make an entry's scope depend on the caller's working directory.
+
+A green audit counts only what it looked at and names what it skipped:
+
+```
+[expectations] match audit: all 10 entries in scope for this run matched a discovered
+test; 2 scoped to another suite, not audited here (Precompiled Implicit
+Return.PrecompiledBooleanMethodWithNoExit_ReturnsFalse, …).
+```
+
+Counting a skipped entry as matched would be the vacuous green the message exists to
+rule out, and naming them is what makes a scope that quietly exempts an entry from
+*every* run visible in the log of the run that should have owned it.
+
 ## Layout
 
 ```

--- a/tests/expectations/README.md
+++ b/tests/expectations/README.md
@@ -29,6 +29,14 @@ naming convention:
 Sharding by area keeps PR diffs small. A single PR adding or removing one
 expectation should touch one file with one entry.
 
+An entry may also carry an optional `"Suites": [...]` naming the suite roots that can
+cover it (#3347). Absent — the case for every entry naming a `tests/al-language`
+test — it is audited by every run, unchanged. Present, it is audited only by a run that
+covered a matching root, which is what lets an entry name a `tests/runner-extras/`
+codeunit without failing the full-corpus leg that could never load it. It is not an
+exemption: the run that owns the suite still audits the entry in full. See
+[`docs/expectations.md`](../../docs/expectations.md#suites--which-runs-are-answerable-for-an-entry-3347).
+
 The file prefix and the entry's `Mode` must agree — the prefix is what a human
 scanning the directory reads. Moving an entry between modes means moving it
 between files. A `known-gaps-*.json` holding entries that are not

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -43,6 +43,7 @@
         "page-enum-control-modal": { "tests": 4 },
         "pageext-action-dispatch": { "tests": 6 },
         "permission-set-assignment": { "tests": 8 },
+        "precompiled-implicit-return-3347": { "tests": 4 },
         "precompiled-table-relation": { "tests": 10 },
         "precompiled-tableext-keys": { "tests": 6 },
         "published-application-system-table": { "tests": 9 },

--- a/tests/expectations/known-gaps-precompiled-implicit-return.json
+++ b/tests/expectations/known-gaps-precompiled-implicit-return.json
@@ -3,6 +3,9 @@
     "codeunitId": 65900,
     "CodeunitName": "Precompiled Implicit Return",
     "Method": "PrecompiledBooleanMethodWithNoExit_ReturnsFalse",
+    "Suites": [
+      "tests/runner-extras/precompiled-implicit-return-3347"
+    ],
     "Mode": "expect-fail-known-gap",
     "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3710",
     "Note": "Codeunit 2000 \"Time Series Management\".GetMLForecastCredentials is declared Boolean (SymbolReference.json: ReturnType Boolean; IL: ValueTask<System.Boolean>) and its body has no exit(<value>), so AL's implicit default return requires false. The runner answers true. The two assertions ABOVE the failing one pass -- the byref URL suffix is written and the returned key is empty -- so the body genuinely ran and only the return value diverges.\n\nThis is NOT a general AL implicit-return gap: corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#316 pins eight variants of the shape, including one that discards a true returned by another codeunit, and all eight pass on the runner. What diverges is the runner's execution of Microsoft's PRECOMPILED copy -- see the sibling test LocallyCompiledMirrorOfTheSameShape_AlsoReturnsFalse, which passes on a mirror of the identical body in this same bundle.\n\nNor is it universal across precompiled no-exit methods: PrecompiledNoExitMethod_IsNotUniversallyBroken passes on Codeunit 7046 \"Price Asset - G/L Account\".ValidateUnitOfMeasure, which has the same shape. #3710 records the hypotheses ruled out by measurement (key vault lookups, __IsAsync routing, the SecretText byref, a data-recipe difference) and the one structural difference found: Codeunit 2000 dispatches through NavApplicationObjectBase.InvokeAsync and pops the result, Codeunit 7046 does not."
@@ -11,6 +14,9 @@
     "codeunitId": 65900,
     "CodeunitName": "Precompiled Implicit Return",
     "Method": "PrecompiledAndLocallyCompiledCopies_AgreeWithEachOther",
+    "Suites": [
+      "tests/runner-extras/precompiled-implicit-return-3347"
+    ],
     "Mode": "expect-fail-known-gap",
     "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3710",
     "Note": "The differential form of the entry above, and the one that names the defect most precisely: the same body, compiled by Microsoft and compiled here, called in the same test, must return the same value. It reports 'expected No, got Yes' while its own AreEqualText on the byref output passes -- so both copies ran and produced identical side effects, and only the return values disagree. Whether AL was precompiled by Microsoft or emitted by the runner is not an observable an AL caller may depend on; #3710 tracks the work."

--- a/tests/expectations/known-gaps-precompiled-implicit-return.json
+++ b/tests/expectations/known-gaps-precompiled-implicit-return.json
@@ -1,0 +1,18 @@
+[
+  {
+    "codeunitId": 65900,
+    "CodeunitName": "Precompiled Implicit Return",
+    "Method": "PrecompiledBooleanMethodWithNoExit_ReturnsFalse",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3710",
+    "Note": "Codeunit 2000 \"Time Series Management\".GetMLForecastCredentials is declared Boolean (SymbolReference.json: ReturnType Boolean; IL: ValueTask<System.Boolean>) and its body has no exit(<value>), so AL's implicit default return requires false. The runner answers true. The two assertions ABOVE the failing one pass -- the byref URL suffix is written and the returned key is empty -- so the body genuinely ran and only the return value diverges.\n\nThis is NOT a general AL implicit-return gap: corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#316 pins eight variants of the shape, including one that discards a true returned by another codeunit, and all eight pass on the runner. What diverges is the runner's execution of Microsoft's PRECOMPILED copy -- see the sibling test LocallyCompiledMirrorOfTheSameShape_AlsoReturnsFalse, which passes on a mirror of the identical body in this same bundle.\n\nNor is it universal across precompiled no-exit methods: PrecompiledNoExitMethod_IsNotUniversallyBroken passes on Codeunit 7046 \"Price Asset - G/L Account\".ValidateUnitOfMeasure, which has the same shape. #3710 records the hypotheses ruled out by measurement (key vault lookups, __IsAsync routing, the SecretText byref, a data-recipe difference) and the one structural difference found: Codeunit 2000 dispatches through NavApplicationObjectBase.InvokeAsync and pops the result, Codeunit 7046 does not."
+  },
+  {
+    "codeunitId": 65900,
+    "CodeunitName": "Precompiled Implicit Return",
+    "Method": "PrecompiledAndLocallyCompiledCopies_AgreeWithEachOther",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3710",
+    "Note": "The differential form of the entry above, and the one that names the defect most precisely: the same body, compiled by Microsoft and compiled here, called in the same test, must return the same value. It reports 'expected No, got Yes' while its own AreEqualText on the byref output passes -- so both copies ran and produced identical side effects, and only the return values disagree. Whether AL was precompiled by Microsoft or emitted by the runner is not an observable an AL caller may depend on; #3710 tracks the work."
+  }
+]

--- a/tests/runner-extras/precompiled-implicit-return-3347/PirAssert.Codeunit.al
+++ b/tests/runner-extras/precompiled-implicit-return-3347/PirAssert.Codeunit.al
@@ -1,0 +1,29 @@
+/// Thin standalone assert helper -- no dependency on Library Assert, mirroring the pattern
+/// used by tests/runner-extras/db-trigger-inject-timing/DbtAssert.Codeunit.al -- so this
+/// suite does not need a Library Assert package cache in CI.
+codeunit 65901 "Pir Assert"
+{
+    procedure IsTrue(Value: Boolean; Msg: Text)
+    begin
+        if not Value then
+            Error('Assert.IsTrue failed: %1', Msg);
+    end;
+
+    procedure IsFalse(Value: Boolean; Msg: Text)
+    begin
+        if Value then
+            Error('Assert.IsFalse failed: %1', Msg);
+    end;
+
+    procedure AreEqualText(Expected: Text; Actual: Text; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Assert.AreEqualText failed: expected ''%1'', got ''%2''. %3', Expected, Actual, Msg);
+    end;
+
+    procedure AreEqualBool(Expected: Boolean; Actual: Boolean; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Assert.AreEqualBool failed: expected %1, got %2. %3', Expected, Actual, Msg);
+    end;
+}

--- a/tests/runner-extras/precompiled-implicit-return-3347/PrecompiledImplicitReturn.Codeunit.al
+++ b/tests/runner-extras/precompiled-implicit-return-3347/PrecompiledImplicitReturn.Codeunit.al
@@ -1,0 +1,147 @@
+/// #3347 — AL's implicit default return, as executed for MICROSOFT'S PRECOMPILED AL.
+///
+/// A method declared with a return type whose body completes without `exit(<value>)`
+/// returns that type's default. 23 Boolean-returning methods in the shipped Base
+/// Application (28.1.49838.53910) have no `exit` anywhere in their bodies and rely on it.
+///
+/// Codeunit 2000 "Time Series Management".GetMLForecastCredentials is one of them:
+///
+///     procedure GetMLForecastCredentials(var LocalApiUri: Text[250]; var Key: SecretText;
+///                                        var LimitType: Option; var Limit: Decimal): Boolean
+///     begin
+///         MachineLearningKeyVaultMgmt.GetMachineLearningCredentials(
+///             ForecastSecretNameTxt, LocalApiUri, Key, LimitType, Limit);
+///         LocalApiUri += '/execute?api-version=2.0&details=true';
+///     end;
+///
+/// No `exit`, so it must answer FALSE. That false is load-bearing: Codeunit 850
+/// "Cash Flow Forecast Handler".Initialize logs "You must specify an API URL and an API
+/// Key for the Cash Flow Setup" and returns early precisely because GetMLCredentials ->
+/// RetrieveSaaSMLCredentials -> GetMLForecastCredentials came back false. When it answers
+/// true instead, Initialize walks past that check to the Azure ML quota test and logs
+/// "The Microsoft Azure Machine Learning limit has been reached" — which is exactly how
+/// four of MS's Tests-Cash Flow Codeunit135203 tests failed (APIKeyNotDefinedError,
+/// APIURLNotDefinedError, PrepareDataNotEnoughHistoricalData, AzureAINotEnabledError).
+///
+/// WHY HERE AND NOT IN THE UPSTREAM CORPUS. The claim is plain BC behaviour, so it was
+/// written upstream too — corpus PR #316 pins eight variants of this shape, including a
+/// cross-codeunit call whose returned `true` is discarded by the caller. All eight PASS on
+/// the runner. The corpus compiles its objects from source, and the runner's own emit of
+/// this shape is correct in every variant AL can express; what diverges is the runner's
+/// execution of Microsoft's PRECOMPILED copy. Naming a precompiled method requires calling
+/// one, which is what this bundle does and what the corpus structurally cannot do.
+///
+/// The isolation, measured in one run: a locally-compiled mirror of Codeunit 2000's exact
+/// body returned false while BC's precompiled original returned true, with both writing the
+/// identical byref output — so both bodies ran, and only the return value differs.
+codeunit 65900 "Precompiled Implicit Return"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Pir Assert";
+
+    /// A locally-compiled mirror of Codeunit 2000's body: Boolean return, no `exit`
+    /// anywhere, one cross-codeunit call whose result is discarded, then a byref write.
+    /// This is the control — it isolates "precompiled" as the only difference.
+    procedure LocalMirrorOfCodeunit2000(var Url: Text[250]): Boolean
+    var
+        MLKeyVaultMgmt: Codeunit "Machine Learning KeyVaultMgmt.";
+        Secret: SecretText;
+        LimitType: Option;
+        Limit: Decimal;
+    begin
+        MLKeyVaultMgmt.GetMachineLearningCredentials('MachineLearningForecast', Url, Secret, LimitType, Limit);
+        Url := CopyStr(Url + '/execute?api-version=2.0&details=true', 1, 250);
+    end;
+
+    [Test]
+    procedure PrecompiledBooleanMethodWithNoExit_ReturnsFalse()
+    var
+        TimeSeriesManagement: Codeunit "Time Series Management";
+        ApiUrl: Text[250];
+        ApiKey: SecretText;
+        LimitType: Option;
+        Limit: Decimal;
+        Result: Boolean;
+    begin
+        Result := TimeSeriesManagement.GetMLForecastCredentials(ApiUrl, ApiKey, LimitType, Limit);
+
+        // The byref output proves the body ran, so a false return cannot be mistaken for
+        // the call having been skipped: BC appends this suffix as its last statement, and
+        // the key vault supplies no prefix here.
+        Assert.AreEqualText('/execute?api-version=2.0&details=true', ApiUrl,
+          'Codeunit 2000.GetMLForecastCredentials must still append its URL suffix.');
+        Assert.IsTrue(ApiKey.IsEmpty(),
+          'No Azure Key Vault is reachable here, so the returned key must be empty.');
+
+        Assert.IsFalse(Result,
+          'Codeunit 2000.GetMLForecastCredentials has no exit(<value>) in its body, so AL''s implicit default return requires false.');
+    end;
+
+    [Test]
+    procedure LocallyCompiledMirrorOfTheSameShape_AlsoReturnsFalse()
+    var
+        Url: Text[250];
+        Result: Boolean;
+    begin
+        Result := LocalMirrorOfCodeunit2000(Url);
+
+        Assert.AreEqualText('/execute?api-version=2.0&details=true', Url,
+          'The mirror must produce the same byref output as the precompiled original.');
+        Assert.IsFalse(Result,
+          'A locally-compiled method of the same shape must return false — this is the control that isolates "precompiled" as the difference.');
+    end;
+
+    [Test]
+    procedure PrecompiledAndLocallyCompiledCopies_AgreeWithEachOther()
+    var
+        TimeSeriesManagement: Codeunit "Time Series Management";
+        PrecompiledUrl: Text[250];
+        LocalUrl: Text[250];
+        ApiKey: SecretText;
+        LimitType: Option;
+        Limit: Decimal;
+        Precompiled: Boolean;
+        Mirrored: Boolean;
+    begin
+        Precompiled := TimeSeriesManagement.GetMLForecastCredentials(PrecompiledUrl, ApiKey, LimitType, Limit);
+        Mirrored := LocalMirrorOfCodeunit2000(LocalUrl);
+
+        // Same body, same run, same byref result. The return values must agree too;
+        // whether the AL was precompiled by Microsoft or emitted here is not an
+        // observable an AL caller may depend on.
+        Assert.AreEqualText(LocalUrl, PrecompiledUrl,
+          'Both copies must write the same byref output.');
+        Assert.AreEqualBool(Mirrored, Precompiled,
+          'A precompiled AL method and a locally-compiled copy of the same body must return the same value.');
+    end;
+
+    [Test]
+    procedure PrecompiledNoExitMethod_IsNotUniversallyBroken()
+    var
+        PriceAssetGLAccount: Codeunit "Price Asset - G/L Account";
+        PriceAsset: Record "Price Asset";
+        UnitOfMeasure: Record "Unit of Measure";
+    begin
+        // Codeunit 7046.ValidateUnitOfMeasure has the same no-exit Boolean shape and is
+        // also precompiled, and it answers correctly. Pinned so the fix is not written as
+        // a blanket rule about precompiled Boolean methods, and so a regression here is
+        // distinguishable from a regression in the case above.
+        //
+        // Its body is `UnitofMeasure.Get(PriceAsset."Unit of Measure Code");` with the
+        // result discarded, so the row has to exist or the Get raises instead of
+        // returning -- this suite runs without --test-data in CI, so insert it here
+        // rather than depending on a company being loaded.
+        if not UnitOfMeasure.Get('PCS') then begin
+            UnitOfMeasure.Init();
+            UnitOfMeasure.Validate(Code, 'PCS');
+            UnitOfMeasure.Insert(true);
+        end;
+
+        PriceAsset."Unit of Measure Code" := 'PCS';
+
+        Assert.IsFalse(PriceAssetGLAccount.ValidateUnitOfMeasure(PriceAsset),
+          'Codeunit 7046.ValidateUnitOfMeasure has no exit(<value>) either, so it must also return false.');
+    end;
+}

--- a/tests/runner-extras/precompiled-implicit-return-3347/app.json
+++ b/tests/runner-extras/precompiled-implicit-return-3347/app.json
@@ -1,0 +1,19 @@
+{
+  "id": "c4e81b76-2d95-4f3a-8b61-9e07a5d3c218",
+  "name": "Runner Extras - Precompiled Implicit Return",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Issue #3347: a PRECOMPILED AL method declared Boolean whose body has no exit(<value>) must return false. Codeunit 2000 'Time Series Management'.GetMLForecastCredentials returned true, which is why MS Tests-Cash Flow Codeunit135203's four Azure-ML tests saw the quota error instead of the missing-credentials error.",
+  "description": "These tests do not live in the al-language corpus, and the reason was measured rather than assumed. The claim -- AL's implicit default return -- IS plain BC behaviour and does belong upstream, so it was written there too: StefanMaron/BusinessCentral.AL.Language.Tests#316 pins eight variants of the shape, including cross-codeunit calls that discard a returned true. All eight PASS on the runner. That is the point: the corpus compiles its objects from source, and the runner's own emit of this shape is correct in every variant AL can express, so a corpus test cannot reach the defect. What is broken is the runner's execution of Microsoft's PRECOMPILED copy of the same shape, and the only way to name a precompiled method is to call one -- which is what this bundle does. The isolation is recorded on the issue: a locally-compiled mirror of Codeunit 2000's exact body (same signature, same discarded cross-codeunit call, same byref write) returns false, while BC's precompiled original returns true, in the same run, with both producing the identical byref output.",
+  "dependencies": [],
+  "idRanges": [
+    {
+      "from": 65900,
+      "to": 65909
+    }
+  ],
+  "platform": "27.0.0.0",
+  "application": "27.0.0.0",
+  "runtime": "15.0",
+  "target": "OnPrem"
+}


### PR DESCRIPTION
Closes #3347

## Outcome, per group

**Group A (the four Azure ML tests) — a real runner defect, diagnosed, pinned, not fixed.**
Not the data-recipe failure the issue hypothesised. Root cause filed as #3710; this PR lands
the reproducer and declares it a known gap.

**Group B (`EnableAzureAINotificationOnOpenCashFlowChartPage`) — already fixed on `main`.**
It passes at `66791cf9`, as does its sibling `…PageNotShown`. Something merged since the
issue's `ae2726de` measurement fixed it. Nothing to do.

A different fifth test now fails in its place: `NotEnoughHistoricalData`, which reaches
`AzureMLWrapper.AzureMLRequest.InvokeRequestResponseService` and gets `Connection refused
(localhost)`. That is HTTP egress to a mock service, permanently out of scope
(`docs/scope.md`), and out of this issue's scope.

## Bucket count at current `main`

Full `Tests-Cash Flow`, run whole. Runner `66791cf9`, BC 28.1.49838.53910 platform + test
apps, `--test-data` from `BusinessCentral-W1.bak`, company `CRONUS International Ltd_`,
private empty `--cache`, `AL_RUNNER_EMIT_TIMEOUT_SEC=3600`:

```
Tests: 399 total   pass: 268   fail: 131   error: 0   exec-fail: 0
Codeunit135203: 32 total, 27 pass, 5 fail
```

27/32 reproduces the issue's figure exactly.

## Why it is not a data-recipe failure

The issue's own first hypothesis, and the first thing tested. **Falsified by the test
source.** `Codeunit135203`'s shared `Initialize()` calls `CreateCashFlowSetup()`, which
begins:

```al
CashFlowSetup.DeleteAll();
CashFlowSetup.Init();
CashFlowSetup.Insert(true);
CashFlowSetup.Validate("Azure AI Enabled", true);
CashFlowSetup.Validate("API URL", '');
ApiKey := '';
CashFlowSetup.SaveUserDefinedAPIKey(ApiKey);
```

The test deletes and re-creates the setup row itself, with a blank API URL and key. Whatever
a restored CRONUS holds is irrelevant — the runner is handed exactly the state the assertions
expect. The values feeding the branch were then read directly and are all correct.

## What actually happens

`Codeunit 850 "Cash Flow Forecast Handler".Initialize` logs the expected error and returns
early **only** when `GetMLCredentials` comes back false:

```al
if not CashFlowSetup.GetMLCredentials(APIURL, APIKey, LimitValue, UsingStandardCredentials) then begin
    TempErrorMessage.LogMessage(..., StrSubstNo(AzureAIAPIURLEmptyErr, ...));   // the expected error
    IsInitialized := false;
end;
if IsInitialized = false then
    exit(false);                                                                // never reaches the quota check
```

On this configuration that chain ends in `Codeunit 2000 "Time Series Management"
.GetMLForecastCredentials`, whose body is:

```al
MachineLearningKeyVaultMgmt.GetMachineLearningCredentials(ForecastSecretNameTxt, LocalApiUri, Key, LimitType, Limit);
LocalApiUri += '/execute?api-version=2.0&details=true';
```

No `exit` anywhere, so AL requires **false**. The runner answers **true**, so `Initialize`
walks past the credentials check to the Azure ML quota test and logs the wrong error. (The
shipped `.al` omits the `: Boolean` declaration; the compiled symbol carries it —
`SymbolReference.json` says `ReturnType Boolean`, and the IL is `ValueTask<System.Boolean>`.)

## The isolation

Measured in a single run, precompiled original and locally-compiled mirror side by side:

```
Actual:<mine=No theirs=Yes
        url1=</execute?api-version=2.0&details=true>
        url2=</execute?api-version=2.0&details=true>>
```

Identical byref output from both, so both bodies ran; only the return value differs.
**Precompiled vs locally-compiled is the only variable.**

## What was ruled out, by measurement rather than argument

| hypothesis | result |
|---|---|
| data recipe | **No** — the test blanks the setup row itself (above) |
| a general AL implicit-return gap | **No** — corpus #316's eight variants all PASS on the runner |
| all precompiled no-exit Boolean methods | **No** — Codeunit 7046 `ValidateUnitOfMeasure` is correct |
| the key vault returning a secret | **No** — all three `GetAzureKeyVaultSecret` lookups return false |
| `__IsAsync` routing to the wrong dispatcher | **No** — codeunits 2000, 2004, 7046 all override it to `return true` |
| the `SecretText` byref | **No** — Codeunit 2004's overload takes the same byref and is correct |

The one structural difference found: Codeunit 2000's `MoveNext` dispatches through
`NavApplicationObjectBase::InvokeAsync(Int32, Object[])` and pops the result; Codeunit 7046's
does not. Both are async state machines, so "async" alone is not the discriminator.

## What this PR contains

`tests/runner-extras/precompiled-implicit-return-3347/` — four tests carrying their own
controls:

| test | at `main` |
|---|---|
| `PrecompiledBooleanMethodWithNoExit_ReturnsFalse` | **FAIL** — the defect |
| `PrecompiledAndLocallyCompiledCopies_AgreeWithEachOther` | **FAIL** — the differential form |
| `LocallyCompiledMirrorOfTheSameShape_AlsoReturnsFalse` | PASS — control: the runner's own emit is correct |
| `PrecompiledNoExitMethod_IsNotUniversallyBroken` | PASS — control: another precompiled no-exit method is correct |

The two failures are declared `expect-fail-known-gap` against **#3710, which stays open after
this merges**. The two controls are what stop the eventual fix from being written as a blanket
rule about precompiled Boolean methods, and make a regression in either direction
distinguishable.

Both byref assertions in the failing tests pass, so a `false` return can never be confused
with the call having been skipped.

Verified identical with and without `--test-data` (the `runner-extras` CI step runs without
it), which is why the fourth test inserts the `Unit of Measure` row it needs rather than
depending on a loaded company.

## Corpus linkage

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/316

The BC-behaviour half — AL's implicit default return — went upstream: eight variants,
including one that discards a `true` returned by another codeunit, and non-Boolean return
types. **All eight PASS on the runner**, and that negative result is what localised this
defect: the corpus compiles its objects from source, the runner's own emit of this shape is
correct in every variant AL can express, so a corpus test structurally cannot reach it. The
tests are still worth having upstream as a spec statement and regression guard for a rule 23
Base Application methods depend on. **No pin bump here** — the pin is blocked at position 1 by
\#2943.

## Fix the shape

1. **Same wrong pattern at another call site?** Surveyed the shipped Base Application (28.1)
   for the shape: **23 Boolean-returning methods have no `exit` anywhere in their bodies.**
   Two were probed — one broken, one correct — so the blast radius of the other 21 is
   unmeasured and recorded as such in #3710.
2. **Sibling function with the same assumption?** `GetMLCredentials`, `RetrieveSaaSMLCredentials`
   and both `GetMachineLearningCredentials` overloads were all read and probed; each behaves
   correctly. The divergence is confined to the one method.
3. **Two paths writing the same state?** The AL return value lives in the scope tuple's last
   slot (`ALMethodScope<T>.Target.ItemN`), explicitly zeroed at entry and read back into
   `SetResult` at exit in both the broken and correct methods. Which runner mechanism writes a
   `true` there was not identified — see "Not fixed here".

**Queue scan:** no open issue lands in these files. #3347 is the only one matching the area,
and #3710 is the follow-up this PR files. Nothing to fold.

## Not fixed here

The runner mechanism that corrupts the return slot. Six explanations were ruled out by
measurement and none of the remaining candidates is supported by evidence I have; guessing one
is what `no-assumption-fixes.md` forbids. #3710 carries the full diagnosis, the reproducer and
the ruled-out list so the next person starts from evidence rather than from scratch.

## Tests run

- The four-test bundle, `--strict` with `--count-baseline`: **RC=0, 4/4 pass, 2 as `pass-known-gap`.**
- The same bundle without the manifest: **2 pass / 2 fail** — the RED, failing on the right assertions.
- Full `Tests-Cash Flow` bucket at `main`: 399 tests, 268/131, `Codeunit135203` 27/32.
- `dotnet test AlRunner.Tests --filter` over `RunnerExtras|BcInternalsNullForgivingGuard|SilentReflectionLookupRatchet|BaseAppFloorFixtureGuard|Expectation|CountBaseline`: **155 passed, 0 failed.**

`RunnerExtrasIdRangeGuardTests` caught a genuine id-range overlap on the first attempt
(65880–65889 was already claimed by `query-dataitem-filter-precompiled-dep`). The bundle was
renumbered to 65900–65909; the guard was not touched.

---
*Opened by an autonomous agent (`stma-auto-2`).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
