### PR TITLE
fix(company-seed): decide the once-per-bundle latch per exit, not on line 2

### DIFF
--- a/AlRunner.Tests/CompanySystemTableSeedLatchTests.cs
+++ b/AlRunner.Tests/CompanySystemTableSeedLatchTests.cs
@@ -1,0 +1,272 @@
+// CompanySystemTableSeedLatchTests — AlRunner#3187.
+//
+// RUNNER-MECHANISM tests. Nothing here is a claim about Business Central: that the Company
+// system table holds a row for the current company is plain BC behaviour and is adjudicated
+// upstream (corpus codeunit 60700, #2329). What these pin is the runner's own once-per-bundle
+// latch on the seed that writes it.
+//
+// THE DEFECT
+//   EnsureCompanySystemTableRowSeeded set its flag on its FIRST line, before doing any work:
+//
+//       if (_companyRowSeededForThisBundle) return;
+//       _companyRowSeededForThisBundle = true;   // <-- before the work
+//
+//   So the flag meant "someone started", not "the row is there". A throw out of the seed left
+//   it latched, and a later call returned early having done nothing, against a table the
+//   method reports as seeded. The sibling seeder next door carries the opposite in a comment,
+//   because #2941's review rejected exactly this pattern there.
+//
+// WHY IT IS NOT A ONE-LINE MOVE, AND WHAT THESE TESTS ENCODE
+//   Two of the exits mean "there is nothing to seed", and moving one assignment to the end of
+//   the method would turn them from "do not retry" into "retry on every call". So the fix
+//   decides PER EXIT, and each of these tests pins one row of that decision:
+//
+//     NoCompanyTable        settled  -> latches, not retried  (NoCompanyMetatable_...)
+//     NoDataAccessSource    not-yet  -> reported, retried     (NoDataAccessSourceYet_...)
+//     NoCompanyIdentity     not-yet  -> reported, retried     (NoCompanyIdentityYet_...)
+//     Inserted              settled  -> latches               (...RetriesAndInserts, 2nd call)
+//     AlreadyPresent        settled  -> latches, not retried  (AnAlreadyPresentRow_...)
+//     threw                 not-yet  -> reported, retried     (AThrownSeed_...)
+//
+// WHY A DELEGATE SEAM AND NOT A FIXTURE RUN
+//   The three BC-typed steps — NCLMetaTable, the DataAccessSource, BC's own provider Insert —
+//   cannot be constructed in a unit test, and there is no supported way to make the real
+//   Insert refuse from outside the process. EnsureCompanySystemTableRowSeededCore takes them
+//   as parameters; production passes the real ones. No environment variable is involved and
+//   nothing behaves differently in production, which is the same shape SeededRowColumnsTests
+//   uses to drive the production resolution logic over a plain tuple.
+//
+// WHY THE RED IS REAL
+//   These tests were run against the refactor with the OLD policy restored (the settled
+//   predicate answering true for every outcome, which is what latching on line 2 amounts to):
+//   the three retry tests failed with the second call returning AlreadySeededThisBundle and no
+//   second attempt made. Restoring the per-exit predicate turned them green.
+using System.Reflection;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Serial: drives process-wide static seed state and swaps Console.Error to read the [warn]
+// lines the production call sites emit. See ConsoleFilterSerialCollection.
+[Collection(ConsoleFilterSerialCollection.Name)]
+public sealed class CompanySystemTableSeedLatchTests : IDisposable
+{
+    private readonly TextWriter _savedErr = Console.Error;
+
+    public CompanySystemTableSeedLatchTests()
+        => AlRunner.Patches.RecordPatches.ResetCompanySystemTableForNewBundle();
+
+    public void Dispose()
+    {
+        Console.SetError(_savedErr);
+        AlRunner.Patches.RecordPatches.ResetCompanySystemTableForNewBundle();
+    }
+
+    /// <summary>
+    /// BC's own already-exists refusal is matched by TYPE NAME in the seed, so a local type of
+    /// the same name drives that branch exactly as the real one does.
+    /// </summary>
+    private sealed class NavRecordAlreadyExistsException : Exception
+    {
+        internal NavRecordAlreadyExistsException(string message) : base(message) { }
+    }
+
+    private sealed class ProviderRefusedException : Exception
+    {
+        internal ProviderRefusedException(string message) : base(message) { }
+    }
+
+    /// <summary>One seed's steps, with a record of what the seed actually did.</summary>
+    private sealed class Seed
+    {
+        internal object? Meta = new object();
+        internal object? Source = new object();
+        internal (string? Name, object? Id) Identity = ("CRONUS", Guid.Empty);
+        internal Exception? InsertThrows;
+
+        internal int MetaLookups;
+        internal int InsertAttempts;
+        internal readonly List<string> RowsWritten = new();
+
+        internal AlRunner.Patches.RecordPatches.CompanyRowSeedOutcome Run()
+            => AlRunner.Patches.RecordPatches.EnsureCompanySystemTableRowSeededCore(
+                resolveMeta: () => { MetaLookups++; return Meta; },
+                resolveSource: () => Source,
+                readIdentity: () => Identity,
+                insertRow: (_, _, name, _) =>
+                {
+                    InsertAttempts++;
+                    if (InsertThrows != null) throw InsertThrows;
+                    RowsWritten.Add(name);
+                });
+    }
+
+    private static (T Result, string Stderr) CapturingStderr<T>(Func<T> body)
+    {
+        var saved = Console.Error;
+        var sink = new StringWriter();
+        try
+        {
+            Console.SetError(sink);
+            return (body(), sink.ToString());
+        }
+        finally
+        {
+            Console.SetError(saved);
+        }
+    }
+
+    // ---------------------------------------------------------------- the reported defect
+
+    [Fact]
+    public void AThrownSeed_DoesNotLatch_AndTheNextCallRetriesAndWritesTheRow()
+    {
+        var seed = new Seed { InsertThrows = new ProviderRefusedException("the provider refused") };
+
+        var (first, _) = CapturingStderr(seed.Run);
+
+        Assert.Equal(AlRunner.Patches.RecordPatches.CompanyRowSeedOutcome.Failed, first);
+        Assert.Empty(seed.RowsWritten);
+
+        // The second call is the whole point of #3187: pre-fix it returned early on a latched
+        // flag and never attempted the insert again.
+        seed.InsertThrows = null;
+        var second = seed.Run();
+
+        Assert.Equal(AlRunner.Patches.RecordPatches.CompanyRowSeedOutcome.Inserted, second);
+        Assert.Equal(2, seed.InsertAttempts);
+        Assert.Equal(new[] { "CRONUS" }, seed.RowsWritten);
+        Assert.False(
+            AlRunner.Patches.RecordPatches.CompanySeedIsSettled(first),
+            "a seed that threw wrote no row, so it must not settle the question for the bundle");
+        Assert.Equal(
+            AlRunner.Patches.RecordPatches.CompanyRowSeedOutcome.Inserted,
+            AlRunner.Patches.RecordPatches.CompanySeedOutcomeForThisBundle);
+
+        // ...and having written it, it now settles: a third call does no work.
+        Assert.Equal(
+            AlRunner.Patches.RecordPatches.CompanyRowSeedOutcome.AlreadySeededThisBundle,
+            seed.Run());
+        Assert.Equal(2, seed.InsertAttempts);
+    }
+
+    [Fact]
+    public void AThrownSeed_IsLoud_NamingTheExceptionTypeAndMessageAtWarn()
+    {
+        var seed = new Seed
+        {
+            // Wrapped, because the real Insert is invoked by reflection and every genuine
+            // failure arrives inside a TargetInvocationException. The unwrap is what puts the
+            // real type name and message on the line rather than "TargetInvocationException:
+            // Exception has been thrown by the target of an invocation."
+            InsertThrows = new TargetInvocationException(
+                new ProviderRefusedException("Company: primary key is not writable")),
+        };
+
+        var (outcome, stderr) = CapturingStderr(seed.Run);
+
+        Assert.Equal(AlRunner.Patches.RecordPatches.CompanyRowSeedOutcome.Failed, outcome);
+        Assert.Contains("[warn] CompanySystemTable: could not seed the Company row (2000000006)", stderr);
+        Assert.Contains("ProviderRefusedException: Company: primary key is not writable", stderr);
+        Assert.Contains("Company.Get(CompanyName()) will fail", stderr);
+        Assert.DoesNotContain("TargetInvocationException", stderr);
+    }
+
+    // ---------------------------------------------------------------- the settled exits
+
+    [Fact]
+    public void NoCompanyMetatableInTheBundle_Settles_AndIsNotRetried()
+    {
+        var seed = new Seed { Meta = null };
+
+        var (first, stderr) = CapturingStderr(seed.Run);
+
+        Assert.Equal(AlRunner.Patches.RecordPatches.CompanyRowSeedOutcome.NoCompanyTable, first);
+        Assert.True(AlRunner.Patches.RecordPatches.CompanySeedIsSettled(first));
+        // Nothing to seed is not a failure, so nothing is reported.
+        Assert.Equal("", stderr);
+        Assert.Equal(1, seed.MetaLookups);
+
+        Assert.Equal(
+            AlRunner.Patches.RecordPatches.CompanyRowSeedOutcome.AlreadySeededThisBundle,
+            seed.Run());
+        // The call count is the claim: a bundle whose closure has no Company metatable must not
+        // re-ask per app group.
+        Assert.Equal(1, seed.MetaLookups);
+        Assert.Equal(0, seed.InsertAttempts);
+    }
+
+    [Fact]
+    public void AnAlreadyPresentRow_Settles_AndIsNotRetried_AndIsNotReported()
+    {
+        var seed = new Seed
+        {
+            InsertThrows = new NavRecordAlreadyExistsException("record already exists"),
+        };
+
+        var (first, stderr) = CapturingStderr(seed.Run);
+
+        Assert.Equal(AlRunner.Patches.RecordPatches.CompanyRowSeedOutcome.AlreadyPresent, first);
+        Assert.True(AlRunner.Patches.RecordPatches.CompanySeedIsSettled(first));
+        Assert.Equal("", stderr);
+
+        Assert.Equal(
+            AlRunner.Patches.RecordPatches.CompanyRowSeedOutcome.AlreadySeededThisBundle,
+            seed.Run());
+        Assert.Equal(1, seed.InsertAttempts);
+    }
+
+    // ---------------------------------------------------------------- the not-yet exits
+
+    [Fact]
+    public void NoDataAccessSourceYet_DoesNotLatch_AndTheNextCallRetriesAndWritesTheRow()
+    {
+        var seed = new Seed { Source = null };
+
+        var (first, stderr) = CapturingStderr(seed.Run);
+
+        Assert.Equal(AlRunner.Patches.RecordPatches.CompanyRowSeedOutcome.NoDataAccessSource, first);
+        Assert.Contains("[warn] CompanySystemTable: the skeleton session has no DataAccessSource yet", stderr);
+        Assert.Equal(0, seed.InsertAttempts);
+
+        seed.Source = new object();
+        Assert.Equal(AlRunner.Patches.RecordPatches.CompanyRowSeedOutcome.Inserted, seed.Run());
+        Assert.Equal(new[] { "CRONUS" }, seed.RowsWritten);
+        Assert.False(AlRunner.Patches.RecordPatches.CompanySeedIsSettled(first));
+    }
+
+    [Fact]
+    public void NoCompanyIdentityYet_DoesNotLatch_AndTheNextCallRetriesAndWritesTheRow()
+    {
+        var seed = new Seed { Identity = (null, null) };
+
+        var (first, stderr) = CapturingStderr(seed.Run);
+
+        Assert.Equal(AlRunner.Patches.RecordPatches.CompanyRowSeedOutcome.NoCompanyIdentity, first);
+        Assert.Contains("[warn] CompanySystemTable: the skeleton NavCompany exposes no company name", stderr);
+        Assert.Equal(0, seed.InsertAttempts);
+
+        seed.Identity = ("CRONUS", Guid.Empty);
+        Assert.Equal(AlRunner.Patches.RecordPatches.CompanyRowSeedOutcome.Inserted, seed.Run());
+        Assert.Equal(new[] { "CRONUS" }, seed.RowsWritten);
+        Assert.False(AlRunner.Patches.RecordPatches.CompanySeedIsSettled(first));
+    }
+
+    // ---------------------------------------------------------------- the per-bundle reset
+
+    [Fact]
+    public void ResetForANewBundle_ClearsASettledOutcome_SoTheNextBundleSeedsItsOwnRow()
+    {
+        var seed = new Seed();
+        Assert.Equal(AlRunner.Patches.RecordPatches.CompanyRowSeedOutcome.Inserted, seed.Run());
+        Assert.Equal(
+            AlRunner.Patches.RecordPatches.CompanyRowSeedOutcome.AlreadySeededThisBundle,
+            seed.Run());
+
+        AlRunner.Patches.RecordPatches.ResetCompanySystemTableForNewBundle();
+
+        Assert.Null(AlRunner.Patches.RecordPatches.CompanySeedOutcomeForThisBundle);
+        Assert.Equal(AlRunner.Patches.RecordPatches.CompanyRowSeedOutcome.Inserted, seed.Run());
+        Assert.Equal(new[] { "CRONUS", "CRONUS" }, seed.RowsWritten);
+    }
+}

--- a/AlRunner/Patches/RecordPatches.CompanySystemTable.cs
+++ b/AlRunner/Patches/RecordPatches.CompanySystemTable.cs
@@ -52,27 +52,113 @@ public static partial class RecordPatches
 {
     internal const int CompanySystemTableId = 2000000006;
 
-    private static bool _companyRowSeededForThisBundle;
+    /// <summary>
+    /// Which exit <see cref="EnsureCompanySystemTableRowSeeded"/> reached (AlRunner#3187). The
+    /// production call site ignores it; the point of naming the exits is that
+    /// <see cref="CompanySeedIsSettled"/> can decide the once-per-bundle latch PER EXIT, which
+    /// a single bool set at the top of the method could not.
+    /// </summary>
+    internal enum CompanyRowSeedOutcome
+    {
+        /// <summary>A settled outcome was already reached for this bundle; nothing ran.</summary>
+        AlreadySeededThisBundle,
+        /// <summary>No Company metatable in this bundle's closure — nothing to seed, ever.</summary>
+        NoCompanyTable,
+        /// <summary>The skeleton session has no DataAccessSource YET. Reported, and retried.</summary>
+        NoDataAccessSource,
+        /// <summary>The skeleton NavCompany exposes no company name YET. Reported, and retried.</summary>
+        NoCompanyIdentity,
+        /// <summary>The row was written by this call.</summary>
+        Inserted,
+        /// <summary>The row was already there (BC's own already-exists refusal).</summary>
+        AlreadyPresent,
+        /// <summary>The seed threw. Reported at <c>[warn]</c>, NOT latched, retried.</summary>
+        Failed,
+    }
 
-    internal static void ResetCompanySystemTableForNewBundle() => _companyRowSeededForThisBundle = false;
+    private static CompanyRowSeedOutcome? _companySeedOutcomeForThisBundle;
+    private static bool _companyRowSeedInProgress;
+
+    /// <summary>The last outcome this bundle reached, or null before the first call.</summary>
+    internal static CompanyRowSeedOutcome? CompanySeedOutcomeForThisBundle
+        => _companySeedOutcomeForThisBundle;
+
+    /// <summary>
+    /// Whether an outcome settles the question for this bundle, so a later call may return
+    /// early. #3187: only the three outcomes that answer "the row is there, or there is no row
+    /// to write in this bundle at all" settle it. A report and a throw are NOT-YET answers —
+    /// latching either one makes the flag mean "someone started" rather than "the row is
+    /// there", which is the silent-wrong-answer .claude/rules/loud-failures.md forbids.
+    /// </summary>
+    internal static bool CompanySeedIsSettled(CompanyRowSeedOutcome outcome)
+        => outcome is CompanyRowSeedOutcome.Inserted
+                   or CompanyRowSeedOutcome.AlreadyPresent
+                   or CompanyRowSeedOutcome.NoCompanyTable;
+
+    internal static void ResetCompanySystemTableForNewBundle()
+        => _companySeedOutcomeForThisBundle = null;
 
     /// <summary>
     /// Insert the runner's own company into the Company system table (2000000006), once per
     /// bundle. Call AFTER install triggers and company initialization and BEFORE
     /// <c>CaptureInstallBaseline()</c>, so the row is part of the restored baseline.
     /// </summary>
-    internal static void EnsureCompanySystemTableRowSeeded()
-    {
-        if (_companyRowSeededForThisBundle) return;
-        _companyRowSeededForThisBundle = true;
+    internal static CompanyRowSeedOutcome EnsureCompanySystemTableRowSeeded()
+        => EnsureCompanySystemTableRowSeededCore(
+            resolveMeta: () => EnsureTableInMetadataCache(CompanySystemTableId),
+            resolveSource: ResolveSkeletonDataAccessSource,
+            readIdentity: ReadSkeletonCompanyIdentity,
+            insertRow: (meta, source, name, id) =>
+                InsertCompanyRow((NCLMetaTable)meta, source, name, id));
 
-        var meta = EnsureTableInMetadataCache(CompanySystemTableId);
+    /// <summary>
+    /// The seed with its four BC-typed steps handed in, so the once-per-bundle policy above can
+    /// be driven by a test: <c>NCLMetaTable</c>, the DataAccessSource and BC's own provider
+    /// Insert cannot be constructed in a unit test, and cannot be made to throw in one either.
+    /// The steps are the seam — there is no environment variable, and nothing here behaves
+    /// differently in production. See CompanySystemTableSeedLatchTests.
+    /// </summary>
+    internal static CompanyRowSeedOutcome EnsureCompanySystemTableRowSeededCore(
+        Func<object?> resolveMeta,
+        Func<object?> resolveSource,
+        Func<(string? Name, object? Id)> readIdentity,
+        Action<object, object, string, object?> insertRow)
+    {
+        if (_companySeedOutcomeForThisBundle is { } previous && CompanySeedIsSettled(previous))
+            return CompanyRowSeedOutcome.AlreadySeededThisBundle;
+        // The latch is no longer set before the work, so a re-entrant call would now run the
+        // seed a second time inside itself. Nothing reaches it today — this row goes straight
+        // to the in-memory provider and runs no AL — but the sibling User seeder closed the
+        // same window explicitly when it made this move (#2941), and the cost is one bool.
+        if (_companyRowSeedInProgress) return CompanyRowSeedOutcome.AlreadySeededThisBundle;
+        _companyRowSeedInProgress = true;
+        try
+        {
+            var outcome = SeedCompanyRowCore(resolveMeta, resolveSource, readIdentity, insertRow);
+            _companySeedOutcomeForThisBundle = outcome;
+            return outcome;
+        }
+        finally
+        {
+            _companyRowSeedInProgress = false;
+        }
+    }
+
+    private static CompanyRowSeedOutcome SeedCompanyRowCore(
+        Func<object?> resolveMeta,
+        Func<object?> resolveSource,
+        Func<(string? Name, object? Id)> readIdentity,
+        Action<object, object, string, object?> insertRow)
+    {
+        var meta = resolveMeta();
         if (meta == null)
             // A bundle with no Company metatable has no company concept to seed — the same
-            // shape as CompanyInitializer's "no Base App in this bundle" early return.
-            return;
+            // shape as CompanyInitializer's "no Base App in this bundle" early return. SETTLED:
+            // a closure does not gain a metatable part-way through its own bundle, so a retry
+            // could only re-answer the same question.
+            return CompanyRowSeedOutcome.NoCompanyTable;
 
-        var source = ResolveSkeletonDataAccessSource();
+        var source = resolveSource();
         if (source == null)
         {
             // #3068: `[warn]`, not `[CompanySystemTable]` — Log.cs suppresses component tags at
@@ -85,33 +171,46 @@ public static partial class RecordPatches
                 "[warn] CompanySystemTable: the skeleton session has no DataAccessSource yet, so the "
                 + "Company row (2000000006) was not seeded — Company.Get(CompanyName()) will fail. "
                 + "See AlRunner#2329.");
-            return;
+            // NOT settled (#3187): "yet" is the whole content of this branch.
+            return CompanyRowSeedOutcome.NoDataAccessSource;
         }
 
-        var (companyName, companyId) = ReadSkeletonCompanyIdentity();
+        var (companyName, companyId) = readIdentity();
         if (companyName == null)
         {
             Console.Error.WriteLine(
                 "[warn] CompanySystemTable: the skeleton NavCompany exposes no company name, so the "
                 + "Company row (2000000006) was not seeded — Company.Get(CompanyName()) will fail. "
                 + "See AlRunner#2329.");
-            return;
+            return CompanyRowSeedOutcome.NoCompanyIdentity;
         }
 
         try
         {
-            InsertCompanyRow(meta, source, companyName, companyId);
+            insertRow(meta, source, companyName, companyId);
             PerfTrace.Log($"CompanySystemTable: seeded Company row '{companyName}'");
+            return CompanyRowSeedOutcome.Inserted;
         }
         catch (Exception ex)
         {
             var inner = ex is TargetInvocationException tie && tie.InnerException != null ? tie.InnerException : ex;
             if (inner.GetType().Name == "NavRecordAlreadyExistsException")
-                return; // already present — nothing to do, and not a failure.
+            {
+                PerfTrace.Log($"CompanySystemTable: Company row '{companyName}' was already present");
+                return CompanyRowSeedOutcome.AlreadyPresent; // already present — not a failure.
+            }
+            // #3187: reported, and NOT settled. Reported rather than rethrown because this
+            // seeder's caller makes that choice deliberately — the row is seeded per app group
+            // OUTSIDE the persisted install-baseline snapshot, so this line fires on every run
+            // rather than once on the run that poisons a cache, and a missing row takes the
+            // tests that read it RED by itself. The argument is stated in full in
+            // SeededRowColumns.cs's header ("WHY IT THROWS RATHER THAN REPORTING"); what #3187
+            // changes is only that a run which reported this may try again.
             Console.Error.WriteLine(
                 $"[warn] CompanySystemTable: could not seed the Company row (2000000006): "
                 + $"{inner.GetType().Name}: {inner.Message} — Company.Get(CompanyName()) will fail. "
                 + "See AlRunner#2329.");
+            return CompanyRowSeedOutcome.Failed;
         }
     }
 


### PR DESCRIPTION
Closes #3187

Agent-authored (`fbk-2`).

`EnsureCompanySystemTableRowSeeded` set its once-per-bundle flag on its **first line**, before
doing any work, so the flag meant "someone started" rather than "the row is there". A throw out
of the seed left it latched and a later call returned early having done nothing, against a table
the method reports as seeded. The sibling `EnsurePublishedApplicationBundleRowSeeded` carries the
opposite in a comment, because #2941's review rejected exactly this pattern next door.

Corpus-NA: runner-internal seeding latch; no BC-observable surface

## Not a one-line move — the decision is per exit

Moving one assignment to the end of the method would turn the two "nothing to seed" exits from
"do not retry" into "retry on every call". So the bool is replaced by a stored
`CompanyRowSeedOutcome?` plus an explicit predicate, `CompanySeedIsSettled`:

| exit | settled? | behaviour |
|---|---|---|
| a settled outcome already stored | — | return `AlreadySeededThisBundle`, no work |
| `NoCompanyTable` — no Company metatable in the closure | **settled** | latches; a closure does not gain a metatable part-way through its own bundle |
| `NoDataAccessSource` — the skeleton session has none *yet* | not-yet | `[warn]`, retried on the next call |
| `NoCompanyIdentity` — the skeleton NavCompany exposes no name *yet* | not-yet | `[warn]`, retried |
| `Inserted` | **settled** | latches |
| `AlreadyPresent` (BC's own already-exists refusal) | **settled** | latches, not reported — not a failure |
| threw → `Failed` | not-yet | `[warn]` naming the unwrapped exception type and message, retried |

Storing the outcome rather than a bool is what makes the `NoCompanyTable` latch honest: a field
named `_companyRowSeededForThisBundle` set on that exit would claim a row that is not there.

**A throw is reported, not rethrown, and that is deliberate.** `SeededRowColumns.cs`'s header
records the decision for this specific seeder ("The Company seeder is the one place that reports
instead, and its caller — not this type — makes that choice"): the row is seeded per app group
*outside* the persisted install-baseline snapshot, so the line fires on every run rather than
once on the run that poisons a cache, and a missing row takes the tests that read it RED by
itself. #3187 is about the latch; changing report-vs-refuse would be a separate decision. The
`[warn]` line keeps its literal `Console.Error.WriteLine` call site, which is what
`LoudDiagnosisReachesTheUserTests` reads out of the source.

**Re-entry guard added.** With the latch no longer set on line 2, a re-entrant call would run the
seed inside itself. Nothing reaches it today (this row goes straight to the in-memory provider and
runs no AL), but the User seeder closed the same window explicitly when it made this move, and the
cost is one bool.

## RED → GREEN

The seam is `EnsureCompanySystemTableRowSeededCore`, which takes the four BC-typed steps
(`NCLMetaTable` lookup, DataAccessSource, skeleton identity, provider Insert) as delegates —
none of them constructible in a unit test, and none makeable-to-throw from outside the process.
Production passes the real ones; no environment variable, nothing behaves differently in
production. Same shape as `SeededRowColumnsTests`.

RED was produced by restoring the old policy inside the refactored shape (the settled predicate
answering `true` for every outcome, which is what latching on line 2 amounts to):

```
Failed  NoCompanyIdentityYet_DoesNotLatch_AndTheNextCallRetriesAndWritesTheRow
  Assert.Equal() Failure: Values differ   Expected: Inserted  Actual: AlreadySeededThisBundle
Failed  AThrownSeed_DoesNotLatch_AndTheNextCallRetriesAndWritesTheRow
  Assert.Equal() Failure: Values differ   Expected: Inserted  Actual: AlreadySeededThisBundle
Failed  NoDataAccessSourceYet_DoesNotLatch_AndTheNextCallRetriesAndWritesTheRow
  Assert.Equal() Failure: Values differ   Expected: Inserted  Actual: AlreadySeededThisBundle
Failed!  - Failed: 3, Passed: 4, Total: 7
```

GREEN with the per-exit predicate: `Passed! - Failed: 0, Passed: 7, Total: 7`.

The settled exits are pinned by **call count**, not by a return value: `NoCompanyMetatable_...`
asserts the metatable is looked up exactly once across two calls, so "latch it and stop asking" is
a claim the test can fail. `AnAlreadyPresentRow_...` drives BC's already-exists branch through a
local type of the same name (the seed matches by type name) and asserts nothing is reported.

## Sibling audit

- **`RecordPatches.UserSystemTable.cs` — already the accepted shape, no change.** It latches only
  in the outcome switch (`Inserted`, `AdoptedExistingRow`, `AlreadyPresent`), a refusal does not
  latch, and it already carries the `_userRowSeedInProgress` re-entry guard. Its `NoUserTable` and
  `NoSessionIdentity` exits do **not** latch, which is consistent with the not-yet rows above; for
  `NoUserTable` that costs one metatable lookup per app group and cannot make a wrong claim,
  because that flag's stated invariant is "the row is there".
- **`RecordPatches.PublishedApplicationSystemTable.cs`** — latches after the work, with the
  comment that made this issue. Unchanged.
- The only other caller of the Company seed is `TestExecutor.cs:654`, which ignores the return
  value; nothing outside the file read the old bool.

## Open-issue scan

No other open issue lands in `RecordPatches.CompanySystemTable.cs`. #3015, whose review split this
one out, is closed. Nothing folded in.

## Local verification

- `CompanySystemTableSeedLatchTests` — 7/7 (RED → GREEN above).
- `LoudDiagnosisReachesTheUserTests`, `SeededRowColumnsTests`, `SilentReflectionLookupRatchetTests`
  — 67/67, the guards that read this file's `[warn]` call sites and its column ledger.
- `InstallSeedDepCompanyCacheTests` — 3/3 (87 s), a real runner subprocess over the install-seed
  path, so the production seed is exercised end to end and not only through the seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kko97BZZL71nF2nK5aftu4
