### PR TITLE
fix(reload): clear the app-identity memos and the permission-metadata latch on reload

### DIFF
--- a/AlRunner.Tests/BuiltMetadataCacheBundleBoundaryTests.cs
+++ b/AlRunner.Tests/BuiltMetadataCacheBundleBoundaryTests.cs
@@ -26,6 +26,8 @@
 // Not a claim about Business Central in either case: the subject is the lifetime of a runner
 // cache across the runner's own bundle-reload boundary.
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using AlRunner.Patches;
 using Xunit;
@@ -155,6 +157,233 @@ public sealed class BuiltMetadataCacheBundleBoundaryTests : IDisposable
         // says it mirrors — is cleared on the first line of the same method.
         Assert.Empty(TableExtensionTypeCache());
     }
+
+    // ── #3226: the two memos on the INPUT side of the profile / permission-set re-parse ──────
+    //
+    // ResetForReload clears _parsedProfiles and _parsedPermissionSets so an edited bundle's
+    // declarations are re-read. _owningAppByDir (directory -> nearest app.json identity) and
+    // _appOwnerCache (app id -> NavAppRuntimeMetadata) sit in front of that re-read and were
+    // cleared by nothing, so a --watch cycle that edits app.json re-parsed every declaration
+    // and attributed it to the PREVIOUS identity.
+
+    private const string OwningAppIdOne = "e2c8a4b1-3226-4a11-9c7e-000000032261";
+    private const string OwningAppIdTwo = "e2c8a4b1-3226-4a11-9c7e-000000032262";
+
+    [Fact]
+    public void AnAppJsonRenamedBetweenBundles_IsReReadRatherThanServedFromTheDirectoryMemo()
+    {
+        var dir = Path.Combine(_root, "renamed-app");
+        Directory.CreateDirectory(dir);
+        var profile = WriteProfile(dir, "BMCB Rename Profile");
+        var permissionSet = WritePermissionSet(dir, PermissionSetId + 10, "BMCB Rename Set");
+
+        WriteAppJson(dir, OwningAppIdOne, "BMCB Owner One");
+        ParseOneSourceFile(profile);
+        ParseOneSourceFile(permissionSet);
+        Assert.Equal("BMCB Owner One", ProfileNamed("BMCB Rename Profile").AppName);
+        Assert.Equal("BMCB Owner One", PermissionSetNamed("BMCB Rename Set").AppName);
+
+        // The bundle boundary, then the edit a --watch cycle picks up: same app id, new name.
+        RecordPatches.ResetForReload();
+        WriteAppJson(dir, OwningAppIdOne, "BMCB Owner Two");
+        ParseOneSourceFile(profile);
+        ParseOneSourceFile(permissionSet);
+
+        Assert.Equal("BMCB Owner Two", ProfileNamed("BMCB Rename Profile").AppName);
+        Assert.Equal("BMCB Owner Two", PermissionSetNamed("BMCB Rename Set").AppName);
+    }
+
+    [Fact]
+    public void AnAppJsonReIdentifiedBetweenBundles_IsReReadRatherThanServedFromTheDirectoryMemo()
+    {
+        var dir = Path.Combine(_root, "reidentified-app");
+        Directory.CreateDirectory(dir);
+        var profile = WriteProfile(dir, "BMCB Reid Profile");
+        var permissionSet = WritePermissionSet(dir, PermissionSetId + 11, "BMCB Reid Set");
+
+        WriteAppJson(dir, OwningAppIdOne, "BMCB Owner One");
+        ParseOneSourceFile(profile);
+        ParseOneSourceFile(permissionSet);
+        Assert.Equal(Guid.Parse(OwningAppIdOne), ProfileNamed("BMCB Reid Profile").AppId);
+
+        RecordPatches.ResetForReload();
+        WriteAppJson(dir, OwningAppIdTwo, "BMCB Owner One");
+        ParseOneSourceFile(profile);
+        ParseOneSourceFile(permissionSet);
+
+        // Both dictionaries are keyed by (AppId, Name), so a stale id is not merely a wrong
+        // column — it is a wrong primary key, and All Profile's own key is (Scope, App ID,
+        // Profile ID). Assert the new id is there AND the old one is gone: a surviving
+        // bundle-1 entry would satisfy the first half on its own.
+        Assert.Equal(Guid.Parse(OwningAppIdTwo), ProfileNamed("BMCB Reid Profile").AppId);
+        Assert.Equal(Guid.Parse(OwningAppIdTwo), PermissionSetNamed("BMCB Reid Set").AppId);
+        Assert.DoesNotContain(RecordPatches.ParsedProfiles,
+            p => p.AppId == Guid.Parse(OwningAppIdOne));
+        Assert.DoesNotContain(RecordPatches.ParsedPermissionSets,
+            p => p.AppId == Guid.Parse(OwningAppIdOne));
+    }
+
+    [Fact]
+    public void ADeclarationWithNoAppJsonAboveIt_IsStillDroppedAfterTheReload_Control()
+    {
+        // The control for the two cases above: clearing the directory memo must re-run the
+        // walk-up, not weaken it. #2357's rule is that a declaration whose owning app.json
+        // cannot be found is DROPPED rather than attributed to an invented app id, and a memo
+        // that no longer answers must not turn that drop into an attribution. Passes before and
+        // after the fix — it is here so a future "just default the identity" cannot land quietly.
+        var orphan = Path.Combine(_root, "no-manifest");
+        Directory.CreateDirectory(orphan);
+        var orphanProfile = WriteProfile(orphan, "BMCB Orphan Profile");
+        var orphanSet = WritePermissionSet(orphan, PermissionSetId + 12, "BMCB Orphan Set");
+
+        // A sibling that DOES have a manifest, so "dropped" is distinguishable from "the sweep
+        // never ran": the two are parsed by the same loop in the same state.
+        var owned = Path.Combine(_root, "with-manifest");
+        Directory.CreateDirectory(owned);
+        WriteAppJson(owned, OwningAppIdOne, "BMCB Owner One");
+        var ownedProfile = WriteProfile(owned, "BMCB Owned Profile");
+
+        foreach (var f in new[] { orphanProfile, orphanSet, ownedProfile }) ParseOneSourceFile(f);
+        RecordPatches.ResetForReload();
+        foreach (var f in new[] { orphanProfile, orphanSet, ownedProfile }) ParseOneSourceFile(f);
+
+        Assert.Contains(RecordPatches.ParsedProfiles, p => p.ProfileId == "BMCB Owned Profile");
+        Assert.DoesNotContain(RecordPatches.ParsedProfiles, p => p.ProfileId == "BMCB Orphan Profile");
+        Assert.DoesNotContain(RecordPatches.ParsedPermissionSets, p => p.Name == "BMCB Orphan Set");
+    }
+
+    [Fact]
+    public void TheAppOwnerMetadataBuiltInBundleOne_DoesNotSurviveTheReload()
+    {
+        // Seeded rather than driven, for the same reason the tableextension case below is:
+        // GetOrCreateAppOwner constructs a real NavAppRuntimeMetadata by reflection over Ncl,
+        // which a plain unit-test host has not bootstrapped. The claim is the reset contract.
+        //
+        // Not redundant with the two behavioural cases: this cache is keyed by app id ALONE
+        // while carrying the name, so a bundle that renames an app without changing its id
+        // gets a correctly re-resolved (id, name) out of the directory walk-up and then a
+        // NavAppRuntimeMetadata still carrying bundle 1's name.
+        var cache = AppOwnerCache();
+        cache[Guid.Parse(OwningAppIdOne)] = new object();
+        Assert.True(cache.Contains(Guid.Parse(OwningAppIdOne)));
+
+        RecordPatches.ResetForReload();
+
+        Assert.Empty(AppOwnerCache());
+    }
+
+    [Fact]
+    public void ThePopulatedPermissionSetCount_DoesNotSurviveTheReload()
+    {
+        // EnsurePermissionMetadataPopulated short-circuits on
+        // `known.Count == _permMetaPopulatedForCount`, and nothing reset that latch. Without
+        // this, the clear above is unobservable on the app-group path: bundle 2 declaring the
+        // same NUMBER of permission sets under a renamed app never re-enters the populate at
+        // all, so NavAppGroup.BaseGroup keeps bundle 1's summaries and their owner.
+        PopulatedCountField().SetValue(null, 7);
+
+        RecordPatches.ResetForReload();
+
+        Assert.Equal(-1, (int)PopulatedCountField().GetValue(null)!);
+    }
+
+    // ── #3249: the count guard and the name index in the SAME file, both process-lifetime ────
+    //
+    // Folded in here because the fix lands in ResetPermissionSetMetadataForReload beside the
+    // #3226 clears, in the same lock, in the same file. The count half is asserted by
+    // ThePopulatedPermissionSetCount_DoesNotSurviveTheReload above; these two are the name
+    // index, and they are behavioural rather than seeded — #3249 was filed asking whether an
+    // engine-free seam existed for them, and it does: PermissionSetIdByName /
+    // PermissionSetNameById read EnumerateKnownPermissionSets, which is _parsedPermissionSets
+    // plus the registered .app paths and reaches no BC reflection at all.
+
+    [Fact]
+    public void ThePermissionSetNameIndex_ResolvesBundleTwosIdsRatherThanBundleOnes()
+    {
+        var dir = Path.Combine(_root, "name-index");
+        Directory.CreateDirectory(dir);
+        WriteAppJson(dir, OwningAppIdOne, "BMCB Owner One");
+
+        // Bundle 1: one set named "BMCB Shared Set" at 79950.
+        var setPath = Path.Combine(dir, "Shared.PermissionSet.al");
+        File.WriteAllText(setPath,
+            "permissionset 79950 \"BMCB Shared Set\"\n{\n    Assignable = true;\n}\n");
+        ParseOneSourceFile(setPath);
+        Assert.Equal(79950, IdByName()["BMCB Shared Set"]);
+        Assert.Equal("BMCB Shared Set", NameById()[79950]);
+
+        // Bundle 2: the same name at a DIFFERENT id, plus one the first bundle never declared.
+        RecordPatches.ResetForReload();
+        File.WriteAllText(setPath,
+            "permissionset 79951 \"BMCB Shared Set\"\n{\n    Assignable = true;\n}\n"
+            + "permissionset 79952 \"BMCB Second Set\"\n{\n    Assignable = true;\n}\n");
+        ParseOneSourceFile(setPath);
+
+        // The read this feeds is IncludedPermissionSets resolution: a name in bundle 2's
+        // include list resolving to bundle 1's object id is a silent wrong answer, and a name
+        // bundle 1 never saw is missing from the memo entirely.
+        var byName = IdByName();
+        Assert.Equal(79951, byName["BMCB Shared Set"]);
+        Assert.Equal(79952, byName["BMCB Second Set"]);
+        Assert.Equal("BMCB Shared Set", NameById()[79951]);
+        Assert.DoesNotContain(79950, NameById().Keys);
+    }
+
+    private static Dictionary<string, int> IdByName()
+        => (Dictionary<string, int>)typeof(RecordPatches).GetMethod("PermissionSetIdByName",
+               BindingFlags.NonPublic | BindingFlags.Static)!.Invoke(null, null)!;
+
+    private static Dictionary<int, string> NameById()
+        => (Dictionary<int, string>)typeof(RecordPatches).GetMethod("PermissionSetNameById",
+               BindingFlags.NonPublic | BindingFlags.Static)!.Invoke(null, null)!;
+
+    private static void WriteAppJson(string dir, string id, string name)
+        => File.WriteAllText(Path.Combine(dir, "app.json"),
+            "{\n"
+            + $"  \"id\": \"{id}\",\n"
+            + $"  \"name\": \"{name}\",\n"
+            + "  \"publisher\": \"AL Runner\",\n"
+            + "  \"version\": \"1.0.0.0\"\n"
+            + "}\n");
+
+    private static string WriteProfile(string dir, string profileName)
+    {
+        var path = Path.Combine(dir, profileName.Replace(" ", "") + ".Profile.al");
+        File.WriteAllText(path,
+            $"profile \"{profileName}\"\n{{\n    Caption = '{profileName}';\n    Enabled = true;\n}}\n");
+        return path;
+    }
+
+    private static string WritePermissionSet(string dir, int id, string setName)
+    {
+        var path = Path.Combine(dir, setName.Replace(" ", "") + ".PermissionSet.al");
+        File.WriteAllText(path,
+            $"permissionset {id} \"{setName}\"\n{{\n    Caption = '{setName}';\n    Assignable = true;\n}}\n");
+        return path;
+    }
+
+    private static RecordPatches.ParsedAlProfile ProfileNamed(string profileId)
+        => Assert.Single(RecordPatches.ParsedProfiles.Where(p => p.ProfileId == profileId));
+
+    private static RecordPatches.ParsedAlPermissionSet PermissionSetNamed(string name)
+        => Assert.Single(RecordPatches.ParsedPermissionSets.Where(p => p.Name == name));
+
+    /// <summary>Read by reflection for the same reason <see cref="TableExtensionTypeCache"/> is:
+    /// nothing reports it, and "it was cleared" cannot be inferred from a later lookup.</summary>
+    private static IDictionary AppOwnerCache()
+    {
+        var field = typeof(RecordPatches).GetField("_appOwnerCache",
+                        BindingFlags.NonPublic | BindingFlags.Static)
+                    ?? throw new InvalidOperationException(
+                        "RecordPatches._appOwnerCache not found — this test tracks that field.");
+        return (IDictionary)field.GetValue(null)!;
+    }
+
+    private static FieldInfo PopulatedCountField()
+        => typeof(RecordPatches).GetField("_permMetaPopulatedForCount",
+               BindingFlags.NonPublic | BindingFlags.Static)
+           ?? throw new InvalidOperationException(
+               "RecordPatches._permMetaPopulatedForCount not found — this test tracks that field.");
 
     /// <summary>
     /// Run the production per-file source sweep over one .al file. Called instead of

--- a/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
@@ -411,7 +411,10 @@ public static partial class RecordPatches
 
     /// <summary>
     /// Drop the built-<c>NCLMetaPermissionSet</c> cache on a bundle reload, called from
-    /// <see cref="RecordPatches.ResetForReload"/> next to the other built-metadata caches.
+    /// <see cref="RecordPatches.ResetForReload"/> next to the other built-metadata caches —
+    /// together with the four other pieces of permission-metadata state this file memoizes for
+    /// the process (#3226, #3249): the app-owner cache, the populate latch and the two name
+    /// indexes, each with its reason at the line.
     /// <para>
     /// Every entry is derived from <see cref="EnumerateKnownPermissionSets"/>, i.e. from
     /// <c>_parsedPermissionSets</c>, which that same method clears — so without this the
@@ -424,7 +427,39 @@ public static partial class RecordPatches
     /// </summary>
     internal static void ResetPermissionSetMetadataForReload()
     {
-        lock (_permMetaGate) _metaPermissionSetCache.Clear();
+        lock (_permMetaGate)
+        {
+            _metaPermissionSetCache.Clear();
+            // #3226: the app-identity state on the INPUT side goes with it, under the same lock
+            // that guards every read and write of both.
+            //
+            // _appOwnerCache is keyed by app id ALONE while CARRYING the name, so a --watch
+            // cycle that renames an app.json without changing its id resolves the fresh
+            // (id, name) out of ResolveOwningApp and is then handed back the previous cycle's
+            // NavAppRuntimeMetadata, still naming the old app. Cleared rather than re-keyed on
+            // (id, name): within one cycle an app id resolves through one app.json to one name,
+            // so the id-only key is correct there, and re-keying would keep every dead
+            // NavAppRuntimeMetadata alive for the life of the process. Reasoning in #3226's PR.
+            _appOwnerCache.Clear();
+            // The latch in front of EnsurePermissionMetadataPopulated, without which the clear
+            // above is unobservable on the app-group path: it short-circuits on
+            // `known.Count == _permMetaPopulatedForCount`, so a bundle declaring the same NUMBER
+            // of permission sets under a renamed app never re-enters the populate at all and
+            // NavAppGroup.BaseGroup keeps the previous bundle's summaries and their owner.
+            // Safe to reset: the method's own contract is "idempotent and re-runnable", and it
+            // installs a fresh lazy on every run.
+            _permMetaPopulatedForCount = -1;
+            // #3249's second half, and it must go with the line above rather than be left to
+            // the invalidation inside EnsurePermissionMetadataPopulated: that one runs AFTER
+            // the count guard, so the two failures compounded — the guard short-circuited and
+            // the memo it would have dropped survived with it. Both are built from
+            // EnumerateKnownPermissionSets, i.e. from _parsedPermissionSets plus the registered
+            // .app set, both of which ResetForReload discards. Stale, an IncludedPermissionSets
+            // name resolves to the previous bundle's object id, and a set only the new bundle
+            // declares does not resolve at all.
+            _permissionSetIdByName = null;
+            _permissionSetNameById = null;
+        }
     }
 
     /// <summary>The number of permission-set ids currently memoized (including the ids

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -418,6 +418,14 @@ public static partial class RecordPatches
         // able to go stale across a --server reload.
         _parsedProfiles.Clear();
         _parsedPermissionSets.Clear();
+        // #3226: and the directory -> owning-app memo the two lines above re-read THROUGH.
+        // ResolveOwningApp answers "the nearest app.json at or above this directory" once per
+        // directory and keeps it for the life of the process, so a --watch cycle that edits
+        // app.json's name or id re-parsed every profile, permission set and table-metadata
+        // source and attributed all of them to the PREVIOUS identity — the clear above without
+        // this one only re-reads the declarations, not who owns them. Cost: one app.json
+        // walk-up per source directory per cycle (measured in #3226's PR body).
+        _owningAppByDir.Clear();
         _metaFormCache.Clear();
         // #1957: the "already (successfully|un-)loaded" bookkeeping is a statement about
         // the NCLMetaForm instances _metaFormCache.Clear() just discarded — it must go


### PR DESCRIPTION
Closes #3226
Closes #3249

Corpus-NA: runner-internal reload memoisation; not observable on a service tier

Implemented by the automated implementation agent `fbk-2` on the account holder's behalf.

## What was wrong

`ResetForReload` clears `_parsedProfiles` and `_parsedPermissionSets` so an edited bundle's declarations are re-read. Four statics sat around that re-read and were cleared by nothing, on any path:

| static | file | what went stale |
|---|---|---|
| `_owningAppByDir` | `RecordPatches.AlProfileParser.cs` | directory → nearest `app.json` identity, memoised for the process |
| `_appOwnerCache` | `RecordPatches.PermissionMetadataPopulator.cs` | app id → `NavAppRuntimeMetadata`, keyed by id while carrying the name |
| `_permMetaPopulatedForCount` | same file | a count used as a generation, in front of `EnsurePermissionMetadataPopulated` |
| `_permissionSetIdByName` / `_permissionSetNameById` | same file | role-id ↔ object-id, invalidated only *behind* that count guard |

A `--watch` cycle (or a `--server` request) that edits `app.json`'s `name` or `id` therefore re-parsed every profile and permission set and attributed all of them to the **previous** identity — the declaration clear re-reads the declarations, not who owns them. #3226 has the shape; #3249 is the same shape two fields over in the same file, filed separately by another agent.

## The fix

- `RecordPatches.cs` — `_owningAppByDir.Clear()` beside the `_parsedProfiles` / `_parsedPermissionSets` clears it feeds.
- `ResetPermissionSetMetadataForReload` — `_appOwnerCache.Clear()`, `_permMetaPopulatedForCount = -1`, and both name indexes nulled, all inside the existing `_permMetaGate` lock that guards every read and write of them. That method is already called from `ResetForReload`.

**Why `_permMetaPopulatedForCount` had to come too, and is not scope creep.** Clearing `_appOwnerCache` alone is unobservable on the app-group path: `EnsurePermissionMetadataPopulated` returns early on `known.Count == _permMetaPopulatedForCount`, so a bundle declaring the same *number* of permission sets under a renamed app never re-enters the populate and `NavAppGroup.BaseGroup` keeps the previous bundle's summaries and their owner. The same guard is what kept the two name indexes alive, since their only invalidation sits after it.

## Decision: clear `_appOwnerCache`, do not re-key it on `(id, name)`

#3226 asks which is the more faithful fix. **Clear.** Within one cycle an app id resolves through one `app.json` to one name, so the id-only key is correct *inside* a bundle and the staleness is purely a reload-boundary fact — which is where every neighbouring fix in this method puts it. Re-keying would be a second mechanism for one fact, and it would keep every dead `NavAppRuntimeMetadata` alive for the life of the process instead of dropping it at the boundary that replaced it. It also would not have helped on its own: `_owningAppByDir` has to be cleared regardless (its key is a directory and its value is file content, so no key can fix it), and once it is, the fresh `(id, name)` reaches `GetOrCreateAppOwner` and only the id-keyed memo is left answering with the old name.

## Cost of the extra `app.json` walk-up per cycle

#3226 asks for a number rather than an assumption. Measured by driving `ResolveOwningApp` over every `.al` path in a tree with `_owningAppByDir` cleared before each pass — i.e. exactly the work the new clear adds — 20 passes per figure, warm OS cache, throwaway harness (not committed):

| tree | files / distinct dirs | added cost per reload cycle |
|---|---|---|
| `tests/runner-extras/standalone-suites/profile-object-emit-crash` (the profile bundle) | 3 / 1 | **0.3 – 0.8 ms** |
| whole `tests/runner-extras` | 235 / 91 | **20 – 68 ms** (5 runs: 20.2, 23.1, 45.8, 62.4, 68.1) |

Context measured in the same runs: the per-file parse sweep this walk-up precedes costs **101 – 144 ms** over the same 235 files. So the added cost is a fraction of the re-parse that has to happen anyway, and a realistic single-app bundle pays well under a millisecond. The spread is machine load on a busy box (other agents were building), not variance in the work — the ordering between the two columns is stable across every run.

## The three shape questions

1. **Same wrong pattern at another call site?** `ResolveOwningApp` has two more callers than the issue names — `RecordPatches.AlSourceParser.cs:876` and `:951`, which resolve the owning app for the table-metadata-source guard (#3600's same-app vs cross-app `tableextension` distinction). They were stale for the same reason and are fixed by the same clear. No test added for them: the same memo, the same boundary, one mechanism.
2. **Sibling making the same assumption?** Yes — that is #3249, folded in above, and both halves of it are in this PR with their own RED.
3. **Two paths writing the same state with different invariants?** The name-index invalidation is exactly that: `EnsurePermissionMetadataPopulated` nulls both indexes at line 158 while nothing on the reload path did, and the count guard above it meant the one that did could be skipped. Both now happen at the boundary.

**Not folded, and why.** #2886 (Permission system table 2000000005 returns no demo-data rows) is `status: needs-input` and is a data-seeding question, not a cache-lifetime one. #3562 is the metadata-conversion tracking issue and touches this file only incidentally. #2939 is already closed.

## RED → GREEN

`AlRunner.Tests/BuiltMetadataCacheBundleBoundaryTests` (engine-free; the class is already in `RecordPatchesSerialCollection`):

| test | RED before | GREEN after |
|---|---|---|
| `AnAppJsonRenamedBetweenBundles_...` | `BMCB Owner One` where `BMCB Owner Two` was written | passes |
| `AnAppJsonReIdentifiedBetweenBundles_...` | old app id, on both the profile and the permission set | passes |
| `TheAppOwnerMetadataBuiltInBundleOne_DoesNotSurviveTheReload` | entry survives the reload | passes |
| `ThePopulatedPermissionSetCount_DoesNotSurviveTheReload` | `7`, expected `-1` | passes |
| `ThePermissionSetNameIndex_ResolvesBundleTwosIdsRatherThanBundleOnes` | `79950` where bundle 2 declares `79951` | passes |
| `ADeclarationWithNoAppJsonAboveIt_IsStillDroppedAfterTheReload_Control` | **passes before and after** — the control | passes |

The control is deliberate: #2357's rule is that a declaration whose `app.json` cannot be found is DROPPED rather than attributed to an invented app id, so clearing the memo must re-run the walk-up rather than weaken it. It parses an orphan file and a manifest-owning sibling in the same call, so "dropped" is distinguishable from "the sweep never ran".

`ThePermissionSetNameIndex_...` answers the open design question #3249 was filed with. That issue says both fields are only reachable past BC reflection and that a "the field is null" assertion would prove the setter rather than the defect. There is an engine-free seam: `PermissionSetIdByName` / `PermissionSetNameById` read `EnumerateKnownPermissionSets`, which is `_parsedPermissionSets` plus the registered `.app` paths and touches no BC reflection — so the test declares a set at one id in bundle 1 and the same name at a different id in bundle 2 and asserts bundle 2's ids, which is the behavioural claim.

Verified locally: `dotnet test AlRunner.Tests --filter FullyQualifiedName~BuiltMetadataCacheBundleBoundaryTests` — 9/9 pass; before the fix, 5 of them failed with the messages above. A wider filtered run over `PermissionSet|Profile|WarmReload|ParserStaticsIsolationGuard|BaseAppFloorFixtureGuard` was 96/99, and the same 3 (`SkeletonProfilePageMetadataCacheTests` ×2, `RecordPatchesWarmReloadInstallBaselineTests` ×1) fail identically on unmodified `origin/main` on this host — they need a bootstrapped BC engine a plain `dotnet test` host does not stand up.

## Prose

No comment block over ten lines was added to `AlRunner/`; the reasoning that would have gone into one is in this body. Nothing moved to `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kko97BZZL71nF2nK5aftu4
