### PR TITLE
fix(nav-app-extra): refuse a partial BC provider answer instead of latching it as complete

### DIFF
--- a/AlRunner.Tests/NavAppExtraProviderLatchTests.cs
+++ b/AlRunner.Tests/NavAppExtraProviderLatchTests.cs
@@ -1,0 +1,295 @@
+// NavAppExtraProviderLatchTests — the NAV App Extra (2000000157) provider handout: what a
+// PARTIAL answer from BC's own provider does, and what two concurrent handouts do (#3315).
+//
+// WHY THIS IS A RUNNER-SIDE MECHANISM TEST AND NOT AN AL BUNDLE
+//   Every claim here is about C# control flow inside
+//   AlRunner/Patches/RecordPatches.NavAppExtraVirtualTable.cs: whether a mid-enumeration
+//   throw from Ncl's NavAppExtraDataProvider latches the store as answered, whether the
+//   ConditionalWeakTable that records the latch survives concurrent handouts, and whether
+//   the reflection ready-flag is published before the members it promises. No AL statement
+//   can make BC's provider throw after yielding rows — measured, it yields 0 rows in this
+//   runner and the loaded-module fallback is what answers — so no bundle under
+//   tests/runner-extras/ can drive any of it. Same shape as VirtualTableRefusalClaimTests.
+//
+// WHAT WAS WRONG (all three on main as of fe8a8f26, none reachable today)
+//   1. `if (inserted > 0) latch` cannot tell a COMPLETE BC answer from a partial one. Three
+//      rows then a throw latched the store, skipped the fallback, and left the apps BC never
+//      reached reading `false` for both Published Application FlowFields — the exact wrong
+//      answer #3072 and #3308 exist to remove, on a path that logged nothing.
+//   2. ConditionalWeakTable.Add after a TryGetValue throws ArgumentException on a duplicate
+//      key, so two concurrent handouts for one store race into an unexplained failure.
+//   3. TryEnsureNavAppExtraReflection set _naeReflectionReady = true BEFORE resolving the
+//      ctor and the method, so a caller arriving in that window read "ready", found nulls,
+//      and silently skipped BC's own provider.
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class NavAppExtraProviderLatchTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    // ── helpers ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Yields <paramref name="rows"/> row objects and then throws, the way a lazy
+    /// BC provider enumeration fails: after the caller has already taken rows from it.</summary>
+    private static IEnumerable YieldThenThrow(int rows, Exception fault)
+    {
+        for (var i = 0; i < rows; i++) yield return new object();
+        throw fault;
+    }
+
+    private static IEnumerable Yield(int rows)
+    {
+        for (var i = 0; i < rows; i++) yield return new object();
+    }
+
+    private static object Invoke(string name, params object?[] args)
+    {
+        var m = typeof(RecordPatches).GetMethod(
+            name, BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+        Assert.True(m != null, $"RecordPatches.{name} not found — renamed or removed.");
+        try
+        {
+            return m!.Invoke(null, args)!;
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            throw tie.InnerException;
+        }
+    }
+
+    private static (int Inserted, Exception? Fault) Consume(IEnumerable rows, Action<object>? insert = null)
+    {
+        var outcome = Invoke("ConsumeNavAppExtraProviderRows", rows, insert ?? (_ => { }));
+        var t = outcome.GetType();
+        return ((int)t.GetProperty("Inserted", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)!.GetValue(outcome)!,
+                (Exception?)t.GetProperty("Fault", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)!.GetValue(outcome));
+    }
+
+    private static string Decide(IEnumerable rows)
+    {
+        var outcome = Invoke("ConsumeNavAppExtraProviderRows", rows, (Action<object>)(_ => { }));
+        var decide = typeof(RecordPatches).GetMethod(
+            "DecideNavAppExtraBcAnswer", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+        Assert.True(decide != null, "RecordPatches.DecideNavAppExtraBcAnswer not found.");
+        return decide!.Invoke(null, new[] { outcome })!.ToString()!;
+    }
+
+    // ── 1. a partial BC answer must not latch ───────────────────────────────────────────
+
+    [Fact]
+    public void PartialProviderAnswer_IsRefused_NotLatchedAsComplete()
+    {
+        var fault = new InvalidOperationException("the metadata retriever went away mid-enumeration");
+        var seen = new List<object>();
+
+        var (inserted, captured) = Consume(YieldThenThrow(3, fault), seen.Add);
+
+        // The rows BC did produce were taken, and the exception that ended the enumeration is
+        // carried out rather than discarded — all three catch blocks used to swallow it whole.
+        Assert.Equal(3, inserted);
+        Assert.Equal(3, seen.Count);
+        Assert.Same(fault, captured);
+
+        // And the decision: a partial answer is NOT a complete one. Latching it here is the
+        // defect — it skips the loaded-module fallback for every app BC never reached.
+        Assert.Equal("Refuse", Decide(YieldThenThrow(3, fault)));
+    }
+
+    [Fact]
+    public void PartialProviderAnswer_UnwrapsAReflectionWrapper_SoTheMessageNamesTheRealFault()
+    {
+        var real = new NotSupportedException("NavAppGroup is BaseGroup");
+        var (inserted, captured) = Consume(YieldThenThrow(1, new TargetInvocationException(real)));
+
+        Assert.Equal(1, inserted);
+        Assert.Same(real, captured);
+    }
+
+    [Fact]
+    public void FaultBeforeAnyRow_FallsBackRatherThanRefusing()
+    {
+        // The negative arm, and the one that keeps the fix from being "refuse on any throw".
+        // Nothing was inserted, so the store is untouched and the loaded-module list can
+        // answer the whole table — which is what already happens on every BC build measured.
+        var (inserted, captured) = Consume(YieldThenThrow(0, new InvalidOperationException("boom")));
+
+        Assert.Equal(0, inserted);
+        Assert.NotNull(captured);
+        Assert.Equal("FallBack", Decide(YieldThenThrow(0, new InvalidOperationException("boom"))));
+    }
+
+    [Fact]
+    public void CompleteNonEmptyAnswer_Latches_AndCompleteEmptyAnswerFallsBack()
+    {
+        Assert.Equal("Latch", Decide(Yield(4)));
+        Assert.Equal("FallBack", Decide(Yield(0)));
+    }
+
+    [Fact]
+    public void TheRefusalNamesTheProvider_TheFault_AndHowManyRowsArrived()
+    {
+        var message = (string)Invoke(
+            "NavAppExtraPartialAnswerDetail", 3, new InvalidOperationException("retriever vanished"));
+
+        Assert.Contains("NavAppExtraDataProvider.GetAllItems", message, StringComparison.Ordinal);
+        Assert.Contains("InvalidOperationException", message, StringComparison.Ordinal);
+        Assert.Contains("retriever vanished", message, StringComparison.Ordinal);
+        Assert.Contains("3 row", message, StringComparison.Ordinal);
+        Assert.Contains("3315", message, StringComparison.Ordinal);
+    }
+
+    // ── 2a. the latch must survive concurrent handouts ──────────────────────────────────
+
+    [Fact]
+    public void MarkingTheStoreAnswered_IsSafeUnderConcurrentHandouts()
+    {
+        var store = new object();
+
+        // ConditionalWeakTable.Add throws ArgumentException on a duplicate key, and the
+        // TryGetValue in front of it is not a lock: 64 handouts for one store hit it together.
+        var faults = new System.Collections.Concurrent.ConcurrentBag<Exception>();
+        Parallel.For(0, 64, _ =>
+        {
+            try { Invoke("MarkNavAppExtraBcProviderAnswered", store); }
+            catch (Exception ex) { faults.Add(ex); }
+        });
+
+        Assert.True(faults.IsEmpty,
+            "marking the store answered threw under concurrency: "
+            + string.Join("; ", faults.Select(e => e.GetType().Name + ": " + e.Message).Distinct()));
+
+        // And it really recorded the latch, so the test cannot pass by doing nothing.
+        var field = typeof(RecordPatches).GetField(
+            "_naeBcProviderAnswered", BindingFlags.Static | BindingFlags.NonPublic)!;
+        var table = (System.Runtime.CompilerServices.ConditionalWeakTable<object, object>)field.GetValue(null)!;
+        Assert.True(table.TryGetValue(store, out _));
+    }
+
+    // ── 2b. the reflection latch must be published AFTER the members it promises ────────
+
+    [Fact]
+    public void ReflectionReadyFlag_IsSetOnlyAfterTheMembersAreResolved()
+    {
+        var readyField = typeof(RecordPatches).GetField(
+            "_naeReflectionReady", BindingFlags.Static | BindingFlags.NonPublic)!;
+        var typeField = typeof(RecordPatches).GetField(
+            "_naeProviderType", BindingFlags.Static | BindingFlags.NonPublic)!;
+        var ctorField = typeof(RecordPatches).GetField(
+            "_naeProviderCtor", BindingFlags.Static | BindingFlags.NonPublic)!;
+        var methodField = typeof(RecordPatches).GetField(
+            "_naeGetAllItems", BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        var savedReady = readyField.GetValue(null);
+        var savedType = typeField.GetValue(null);
+        var savedCtor = ctorField.GetValue(null);
+        var savedMethod = methodField.GetValue(null);
+        var probeField = typeof(RecordPatches).GetField(
+            "NavAppExtraReflectionProbe", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)!;
+        var probe = (System.Threading.AsyncLocal<Action?>)probeField.GetValue(null)!;
+
+        object? readyDuringResolution = null;
+        try
+        {
+            readyField.SetValue(null, false);
+            typeField.SetValue(null, null);
+            ctorField.SetValue(null, null);
+            methodField.SetValue(null, null);
+            probe.Value = () => readyDuringResolution = readyField.GetValue(null);
+
+            Invoke("TryEnsureNavAppExtraReflection");
+        }
+        finally
+        {
+            probe.Value = null;
+            readyField.SetValue(null, savedReady);
+            typeField.SetValue(null, savedType);
+            ctorField.SetValue(null, savedCtor);
+            methodField.SetValue(null, savedMethod);
+        }
+
+        Assert.NotNull(readyDuringResolution);
+        Assert.False((bool)readyDuringResolution!,
+            "_naeReflectionReady was already true while the ctor and method were still being "
+            + "resolved — a concurrent caller in that window reads 'ready', finds nulls, and "
+            + "silently skips BC's own provider.");
+    }
+
+    // ── 2c. a row's identity must be a property of the app, not of insertion order ──────
+
+    [Fact]
+    public void RowIdentity_IsTheSameForOneApp_WhateverOrderItWasInsertedIn()
+    {
+        var app = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+        var first = (object[])Invoke("NavAppExtraSystemIdArgs", app);
+        var second = (object[])Invoke("NavAppExtraSystemIdArgs", app);
+
+        Assert.Equal(first, second);
+        Assert.Equal(2000000157, first[0]);
+    }
+
+    [Fact]
+    public void RowIdentity_DiffersBetweenApps_SoTwoAppsCannotShareASystemId()
+    {
+        var ids = new[]
+        {
+            Guid.Parse("11111111-2222-3333-4444-555555555555"),
+            Guid.Parse("437dbf0e-84ff-417a-965d-ed2bb9650972"),   // System Application
+            Guid.Parse("63ca2fa4-4f03-4f2b-a480-172fef340d3f"),   // Base Application
+            Guid.Empty,
+        }.Select(g => string.Join(",", ((object[])Invoke("NavAppExtraSystemIdArgs", g)).Select(o => o!.ToString())))
+         .ToList();
+
+        Assert.Equal(ids.Count, ids.Distinct().Count());
+    }
+
+    // ── the same latch shape, everywhere it is written ──────────────────────────────────
+
+    [Fact]
+    public void NoLatchTable_StillUsesAdd_WhichThrowsOnADuplicateKey()
+    {
+        // Question 1 of "fix the shape, not just the reported line": the NAV App Extra latch
+        // was not the only one. Every ConditionalWeakTable<object, object> under
+        // AlRunner/Patches/ is a "has this store/provider been populated" latch guarded by a
+        // TryGetValue that is not a lock, and five of them wrote it with Add — Feature Key,
+        // Session, Time Zone, Windows Language and All Profile. AddOrUpdate is the same
+        // one-token change in each. Asserted over the field names rather than a fixed file
+        // list, so a NEW latch written with Add fails here without anyone remembering to.
+        var patches = Directory.GetFiles(
+            Path.Combine(RepoRoot, "AlRunner", "Patches"), "*.cs", SearchOption.AllDirectories);
+
+        // The one exclusion, and it is measured rather than defensive:
+        // RunObjectMetadataPopulateOnce holds `lock (_omsPopulatedByProvider)` across its
+        // TryGetValue and its Add, so no second caller can reach the Add with the key already
+        // present. That is a different — and equally correct — answer to the same question.
+        var lockGuarded = new[] { "_omsPopulatedByProvider" };
+
+        var offenders = new List<string>();
+        foreach (var file in patches)
+        {
+            var src = File.ReadAllText(file);
+            var fields = Regex.Matches(src, @"ConditionalWeakTable<object, object>\s+(_\w+)")
+                .Select(m => m.Groups[1].Value).ToList();
+            foreach (var f in fields.Where(f => !lockGuarded.Contains(f)))
+                foreach (Match hit in Regex.Matches(src, Regex.Escape(f) + @"\.Add\("))
+                    offenders.Add($"{Path.GetFileName(file)}: {f}.Add(");
+        }
+
+        Assert.True(offenders.Count == 0,
+            "ConditionalWeakTable.Add throws ArgumentException when two concurrent handouts "
+            + "race past the TryGetValue in front of it; use AddOrUpdate. Offenders: "
+            + string.Join(", ", offenders.Distinct()));
+    }
+}

--- a/AlRunner.Tests/NavAppExtraProviderLatchTests.cs
+++ b/AlRunner.Tests/NavAppExtraProviderLatchTests.cs
@@ -34,6 +34,10 @@ using Xunit;
 
 namespace AlRunner.Tests;
 
+// Joins the serial collection: two tests here mutate RecordPatches statics — the reflection
+// ready-flag and its three resolved members, restored in a finally — and a parallel class must
+// not observe them nulled.
+[Collection(RecordPatchesSerialCollection.Name)]
 public sealed class NavAppExtraProviderLatchTests
 {
     private static readonly string RepoRoot = Path.GetFullPath(
@@ -291,5 +295,87 @@ public sealed class NavAppExtraProviderLatchTests
             "ConditionalWeakTable.Add throws ArgumentException when two concurrent handouts "
             + "race past the TryGetValue in front of it; use AddOrUpdate. Offenders: "
             + string.Join(", ", offenders.Distinct()));
+    }
+
+    [Fact]
+    public void ARefusedStore_ReplaysTheSameRefusalOnEveryLaterHandout()
+    {
+        // The rows BC inserted before it threw stay in the store and nothing can take them
+        // out, so a later handout must not be allowed to fall back and put the runner's own
+        // rows alongside them — both insert paths swallow NavRecordAlreadyExistsException, so
+        // that mixing would be silent.
+        var store = new object();
+        var outcomeType = typeof(RecordPatches).GetNestedType(
+            "NavAppExtraProviderOutcome", BindingFlags.NonPublic | BindingFlags.Public)!;
+        var outcome = Activator.CreateInstance(
+            outcomeType,
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
+            binder: null,
+            args: new object?[] { 3, new InvalidOperationException("retriever vanished"), "enumerating its rows" },
+            culture: null)!;
+
+        Assert.Null(Record.Exception(() => Invoke("ThrowIfNavAppExtraBcProviderRefused", store)));
+
+        Invoke("MarkNavAppExtraBcProviderRefused", store, outcome);
+
+        var again = Assert.Throws<AlRunner.Infrastructure.RunnerOutOfScopeException>(
+            () => Invoke("ThrowIfNavAppExtraBcProviderRefused", store));
+        Assert.Equal("NAV App Extra (virtual table 2000000157)", again.Api);
+        Assert.Contains("stopped after 3 row", again.Reason, StringComparison.Ordinal);
+        Assert.Contains("retriever vanished", again.Reason, StringComparison.Ordinal);
+
+        // A store marked ANSWERED is not a refused one, so the ordinary latch still lets the
+        // handout through rather than throwing at everything.
+        var answered = new object();
+        Invoke("MarkNavAppExtraBcProviderAnswered", answered);
+        Assert.Null(Record.Exception(() => Invoke("ThrowIfNavAppExtraBcProviderRefused", answered)));
+    }
+
+    [Fact]
+    public void TheFallBackWarning_IsTaggedWarn_AndNamesTheStageAndTheFault()
+    {
+        var text = (string)Invoke(
+            "NavAppExtraProviderFaultWarning", "calling GetAllItems",
+            new NotSupportedException("no metadata retriever"));
+
+        // `[warn]`, not a component tag: Log's default filter is what decides whether this is
+        // seen at all (#2461, #3068).
+        Assert.StartsWith("[warn] ", text, StringComparison.Ordinal);
+        Assert.Contains("NavAppExtraDataProvider", text, StringComparison.Ordinal);
+        Assert.Contains("calling GetAllItems", text, StringComparison.Ordinal);
+        Assert.Contains("NotSupportedException", text, StringComparison.Ordinal);
+        Assert.Contains("no metadata retriever", text, StringComparison.Ordinal);
+        Assert.Contains("3315", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheFallBackWarning_IsWrittenOncePerProcessPerFault_NotPerHandout()
+    {
+        // This runs on EVERY data-access handout for 2000000157. A warning repeated per
+        // handout is a warning nobody reads.
+        var stage = "a stage no other test uses " + Guid.NewGuid();
+        var fault = new InvalidTimeZoneException("probe");
+
+        var saved = Console.Error;
+        var captured = new System.IO.StringWriter();
+        try
+        {
+            Console.SetError(captured);
+            Invoke("WarnOnceNavAppExtraProviderFault", stage, fault);
+            Invoke("WarnOnceNavAppExtraProviderFault", stage, fault);
+            Invoke("WarnOnceNavAppExtraProviderFault", stage, new InvalidTimeZoneException("again"));
+        }
+        finally
+        {
+            Console.SetError(saved);
+        }
+
+        var lines = captured.ToString()
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+            .Where(l => l.Contains(stage, StringComparison.Ordinal))
+            .ToList();
+
+        Assert.Single(lines);
+        Assert.Contains("InvalidTimeZoneException", lines[0], StringComparison.Ordinal);
     }
 }

--- a/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
+++ b/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
@@ -436,7 +436,16 @@ public sealed class VirtualTableRefusalClaimTests
         // independently confirmed by counting the same regex across CoveredFiles ∪ SiblingFiles
         // on origin/main (75) and on this branch (76): the ONLY per-file movement is
         // RecordPatches.cs, 5 -> 6.
-        Assert.Equal(76, total);
+        // +1 (#3315): the NAV App Extra populator gained one, for a PARTIAL answer from BC's own
+        // NavAppExtraDataProvider — rows already inserted, then a mid-enumeration throw. That
+        // used to latch the store as answered and skip the loaded-module fallback, so every app
+        // BC never reached read false for both Published Application FlowFields with nothing
+        // logged. It cannot be topped up (this file does not read the runtime package id out of
+        // BC's pre-built buffers), so it refuses. A throw with NO rows inserted is NOT a refusal
+        // and deliberately does not appear here: the fallback answers the whole table, on a
+        // `[warn]`.
+        // 77 was READ OUT of this test's own failure message ("Expected: 76, Actual: 77").
+        Assert.Equal(77, total);
     }
 
 

--- a/AlRunner/Patches/RecordPatches.AllProfileVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AllProfileVirtualTable.cs
@@ -129,7 +129,7 @@ public static partial class RecordPatches
             ?? throw AllProfileShapeGap("data access has no in-memory provider");
 
         if (_apvPopulatedProviders.TryGetValue(provider, out _)) return;
-        _apvPopulatedProviders.Add(provider, new object());
+        _apvPopulatedProviders.AddOrUpdate(provider, new object());
 
         foreach (var row in EnumerateKnownProfiles())
             InsertVirtualRow(provider, metaTable, AllProfileSystemIdArgs(row),

--- a/AlRunner/Patches/RecordPatches.FeatureKeyVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.FeatureKeyVirtualTable.cs
@@ -166,7 +166,7 @@ public static partial class RecordPatches
                 + "that BC ships no features. Silently answering empty would put back exactly "
                 + "the wrong-legacy-path bug this fixes. See AlRunner#2585");
 
-        _fkPopulatedProviders.Add(store, new object());
+        _fkPopulatedProviders.AddOrUpdate(store, new object());
     }
 
     /// <summary>

--- a/AlRunner/Patches/RecordPatches.NavAppExtraVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.NavAppExtraVirtualTable.cs
@@ -111,6 +111,7 @@
 using System.Collections.Concurrent;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using AlRunner.Infrastructure;
 using Microsoft.Dynamics.Nav.Runtime;
 
@@ -157,7 +158,21 @@ public static partial class RecordPatches
     // metadata, which the runner does not add to mid-run.
     private static readonly ConditionalWeakTable<object, object> _naeBcProviderAnswered = new();
 
-    private static bool _naeReflectionReady;
+    /// <summary>
+    /// Test seam: invoked once, midway through <see cref="TryEnsureNavAppExtraReflection"/>,
+    /// between reading the ready flag and resolving the ctor and method. Nothing in the
+    /// product sets it. It exists because "the ready flag is published before the members it
+    /// promises" is not observable from outside — a second caller arriving in that window
+    /// sees "ready", reads nulls and silently skips BC's own provider — and no AL statement,
+    /// BC build or thread schedule can be relied on to open that window on demand (#3187 is
+    /// the same latch-before-work shape one file over).
+    /// </summary>
+    internal static readonly AsyncLocal<Action?> NavAppExtraReflectionProbe = new();
+
+    // volatile: the flag is a promise about the three fields below it, so it is written LAST
+    // and with release semantics. It used to be written FIRST, which let a second caller read
+    // "ready", find nulls, and silently skip BC's own provider (#3315 — the #3187 shape).
+    private static volatile bool _naeReflectionReady;
     private static Type? _naeProviderType;          // Microsoft.Dynamics.Nav.Runtime.NavAppExtraDataProvider
     private static ConstructorInfo? _naeProviderCtor;   // .ctor(NavSession)
     private static MethodInfo? _naeGetAllItems;     // protected IEnumerable<ReadOnlyRecordBuffer> GetAllItems(out bool)
@@ -198,8 +213,26 @@ public static partial class RecordPatches
         {
             var outcome = TryPopulateNavAppExtraFromBcProvider(store, session);
             inserted = outcome.Inserted;
-            if (DecideNavAppExtraBcAnswer(outcome) == NavAppExtraBcAnswer.Latch)
-                MarkNavAppExtraBcProviderAnswered(store);
+
+            switch (DecideNavAppExtraBcAnswer(outcome))
+            {
+                case NavAppExtraBcAnswer.Latch:
+                    MarkNavAppExtraBcProviderAnswered(store);
+                    break;
+
+                case NavAppExtraBcAnswer.Refuse:
+                    throw NavAppExtraShapeGap(
+                        NavAppExtraPartialAnswerDetail(outcome.Inserted, outcome.Fault!));
+
+                default:
+                    // Nothing of BC's reached the table, so the fallback below answers all of
+                    // it. Say so when a throw is why, ONCE per process per (stage, exception
+                    // type): this runs on every handout, and a warning repeated per handout is
+                    // a warning nobody reads.
+                    if (outcome.Fault != null)
+                        WarnOnceNavAppExtraProviderFault(outcome.Stage ?? "using BC's own provider", outcome.Fault);
+                    break;
+            }
         }
 
         // 2. The runner's own app list, topped up on every handout. Reached when BC's
@@ -237,12 +270,14 @@ public static partial class RecordPatches
         {
             provider = _naeProviderCtor!.Invoke(new object?[] { session });
         }
-        catch
+        catch (Exception ex)
         {
             // The provider reads the session's tenant and app group in its base constructor.
             // On the skeleton session that can throw; it is not a shape gap, it is the case
-            // the loaded-module fallback exists for.
-            return NavAppExtraProviderOutcome.NoRows;
+            // the loaded-module fallback exists for. Carried out rather than discarded so the
+            // caller can say so once — this was a bare `catch { return 0; }` and nothing was
+            // written anywhere (#3315).
+            return NavAppExtraProviderOutcome.Faulted("constructing it on the skeleton session", ex);
         }
 
         object? rows;
@@ -250,9 +285,9 @@ public static partial class RecordPatches
         {
             rows = _naeGetAllItems!.Invoke(provider, new object?[] { false });
         }
-        catch
+        catch (Exception ex)
         {
-            return NavAppExtraProviderOutcome.NoRows;
+            return NavAppExtraProviderOutcome.Faulted("calling GetAllItems", ex);
         }
 
         if (rows is not System.Collections.IEnumerable enumerable) return NavAppExtraProviderOutcome.NoRows;
@@ -268,18 +303,25 @@ public static partial class RecordPatches
     /// </summary>
     internal readonly struct NavAppExtraProviderOutcome
     {
-        internal NavAppExtraProviderOutcome(int inserted, Exception? fault)
+        internal NavAppExtraProviderOutcome(int inserted, Exception? fault, string? stage = null)
         {
             Inserted = inserted;
             Fault = fault;
+            Stage = stage;
         }
 
         internal int Inserted { get; }
 
-        /// <summary>Non-null when the row enumeration ended in a throw.</summary>
+        /// <summary>Non-null when the provider call or the row enumeration ended in a throw.</summary>
         internal Exception? Fault { get; }
 
+        /// <summary>Which step threw, for the warning text. Null when nothing threw.</summary>
+        internal string? Stage { get; }
+
         internal static NavAppExtraProviderOutcome NoRows => new(0, null);
+
+        internal static NavAppExtraProviderOutcome Faulted(string stage, Exception fault)
+            => new(0, UnwrapNavAppExtraFault(fault), stage);
     }
 
     /// <summary>What the caller does with a BC-provider outcome.</summary>
@@ -316,7 +358,8 @@ public static partial class RecordPatches
         }
         catch (Exception ex)
         {
-            return new NavAppExtraProviderOutcome(inserted, UnwrapNavAppExtraFault(ex));
+            return new NavAppExtraProviderOutcome(
+                inserted, UnwrapNavAppExtraFault(ex), "enumerating its rows");
         }
 
         return new NavAppExtraProviderOutcome(inserted, null);
@@ -326,15 +369,53 @@ public static partial class RecordPatches
         => ex is TargetInvocationException tie && tie.InnerException != null ? tie.InnerException : ex;
 
     /// <summary>
-    /// Classify a BC-provider outcome. Behaviour-preserving extraction of the call site's
-    /// former `if (inserted > 0) latch`.
+    /// Classify a BC-provider outcome. Only a COMPLETE non-empty answer latches: latching a
+    /// partial one skips the fallback for every app BC never reached, and both FlowFields then
+    /// read false for those apps with nothing logged and an unchanged exit code — the wrong
+    /// answer #3072 and #3308 exist to remove, reintroduced on a silent path (#3315).
     /// </summary>
     internal static NavAppExtraBcAnswer DecideNavAppExtraBcAnswer(in NavAppExtraProviderOutcome outcome)
-        => outcome.Inserted > 0 ? NavAppExtraBcAnswer.Latch : NavAppExtraBcAnswer.FallBack;
+        => outcome.Fault == null
+            ? (outcome.Inserted > 0 ? NavAppExtraBcAnswer.Latch : NavAppExtraBcAnswer.FallBack)
+            : (outcome.Inserted > 0 ? NavAppExtraBcAnswer.Refuse : NavAppExtraBcAnswer.FallBack);
 
-    /// <summary>Record that BC's own provider has answered for this store.</summary>
+    /// <summary>
+    /// Why a partial BC answer is refused rather than topped up. The alternative is a table
+    /// that looks populated and is missing rows — see .claude/rules/loud-failures.md.
+    /// </summary>
+    internal static string NavAppExtraPartialAnswerDetail(int inserted, Exception fault)
+        => $"BC's own NavAppExtraDataProvider.GetAllItems stopped after {inserted} row(s) with "
+        + $"{fault.GetType().Name}: {fault.Message}. Those rows are in the table already and "
+        + "cannot be topped up — this file does not read the runtime package id out of BC's "
+        + "own pre-built buffers, so adding the runner's rows for the apps BC never reached "
+        + "would collide on the primary key for the apps it did. Latching a partial answer "
+        + "instead would leave every app BC never reached reading false for Published "
+        + "Application's Tenant Visible and PerTenant Or Installed, silently. "
+        + "See AlRunner#3315";
+
+    /// <summary>The fell-back-with-a-fault warning text. Built here so a test can pin it.</summary>
+    internal static string NavAppExtraProviderFaultWarning(string stage, Exception fault)
+        => "[warn] NAV App Extra (virtual table 2000000157): BC's own NavAppExtraDataProvider "
+        + $"failed while {stage} ({fault.GetType().Name}: {fault.Message}), so none of its rows "
+        + "reached the table. The runner's loaded-module list answers the whole table instead, "
+        + "which is the path every measured BC build already takes. See AlRunner#3315.";
+
+    private static readonly ConcurrentDictionary<string, byte> _naeWarnedFaults = new();
+
+    private static void WarnOnceNavAppExtraProviderFault(string stage, Exception fault)
+    {
+        if (!_naeWarnedFaults.TryAdd(stage + "|" + fault.GetType().FullName, 0)) return;
+        Console.Error.WriteLine(NavAppExtraProviderFaultWarning(stage, fault));
+    }
+
+    /// <summary>
+    /// Record that BC's own provider has answered for this store. <c>AddOrUpdate</c>, not
+    /// <c>Add</c>: the <c>TryGetValue</c> in front of the call site is not a lock, and
+    /// <c>ConditionalWeakTable.Add</c> throws <c>ArgumentException</c> on a duplicate key, so
+    /// two concurrent handouts for one store used to surface an unexplained failure (#3315).
+    /// </summary>
     internal static void MarkNavAppExtraBcProviderAnswered(object store)
-        => _naeBcProviderAnswered.Add(store, new object());
+        => _naeBcProviderAnswered.AddOrUpdate(store, new object());
 
     /// <summary>
     /// Build one row per app the runner loaded, from the same <c>BcRuntime.RegisteredModules()</c>
@@ -361,12 +442,36 @@ public static partial class RecordPatches
 
             var packageId = AppPackageIdentity.PackageIdFor(m.AppId);
             InsertVirtualRow(store, metaTable,
-                new object[] { NavAppExtraVirtualTableId, seeded.Count, 0, 0 },
+                NavAppExtraSystemIdArgs(runtimePackageId),
                 field => BuildNavAppExtraValue(field, runtimePackageId, packageId));
             inserted++;
         }
 
         return inserted;
+    }
+
+    /// <summary>
+    /// The virtual-record identity of one NAV App Extra row: what BC's own
+    /// <c>GetSystemPopulatedVirtualRecordValues</c> derives the row's SystemId from. Folded out
+    /// of the app's OWN runtime package id, so one app keeps one identity however many handouts
+    /// it takes and in whatever order its row is inserted. The ledger's COUNT used to stand in
+    /// that slot, which is a property of insertion order and nondeterministic under concurrent
+    /// handouts (#3315). Same shape as the two permission-set populators' hashed role key.
+    /// </summary>
+    internal static object[] NavAppExtraSystemIdArgs(Guid runtimePackageId)
+    {
+        var b = runtimePackageId.ToByteArray();
+        var i0 = BitConverter.ToInt32(b, 0);
+        var i1 = BitConverter.ToInt32(b, 4);
+        var i2 = BitConverter.ToInt32(b, 8);
+        var i3 = BitConverter.ToInt32(b, 12);
+        return new object[]
+        {
+            NavAppExtraVirtualTableId,
+            (i0 ^ i3) & 0x7fffffff,
+            i1 & 0x7fffffff,
+            i2 & 0x7fffffff,
+        };
     }
 
     /// <summary>
@@ -410,11 +515,12 @@ public static partial class RecordPatches
     private static bool TryEnsureNavAppExtraReflection()
     {
         if (_naeReflectionReady) return _naeProviderCtor != null && _naeGetAllItems != null;
-        _naeReflectionReady = true;
 
         var navNcl = AppDomain.CurrentDomain.GetAssemblies()
             .FirstOrDefault(a => a.GetName().Name == "Microsoft.Dynamics.Nav.Ncl");
         _naeProviderType = navNcl?.GetType("Microsoft.Dynamics.Nav.Runtime.NavAppExtraDataProvider");
+
+        NavAppExtraReflectionProbe.Value?.Invoke();
 
         _naeProviderCtor = _naeProviderType?.GetConstructors(
                 BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
@@ -442,6 +548,11 @@ public static partial class RecordPatches
             "it is the row set BC's own provider computes for this table, so the runner "
             + "cannot pick an overload on the table's behalf",
             new[] { typeof(bool).MakeByRefType() });
+
+        // LAST. Everything the flag promises is resolved above it, so a caller arriving
+        // concurrently either repeats the resolution — idempotent, every step is a lookup — or
+        // reads a flag whose promise already holds.
+        _naeReflectionReady = true;
 
         return _naeProviderCtor != null && _naeGetAllItems != null;
     }

--- a/AlRunner/Patches/RecordPatches.NavAppExtraVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.NavAppExtraVirtualTable.cs
@@ -110,6 +110,7 @@
 
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using AlRunner.Infrastructure;
@@ -209,6 +210,14 @@ public static partial class RecordPatches
         var seeded = _naeSeededByStore.GetValue(store, static _ => new ConcurrentDictionary<Guid, byte>());
         var inserted = 0;
 
+        // A store whose FIRST handout refused stays refused. The rows BC managed to insert
+        // before it threw are still in the store and nothing can take them out, so a later
+        // handout falling back would put the runner's rows alongside a partial BC row set --
+        // the mixing this refuses, arrived at one handout later and silently, because both
+        // insert paths swallow NavRecordAlreadyExistsException. Same device as
+        // RunObjectMetadataPopulateOnce: the original refusal is replayed with its own stack.
+        ThrowIfNavAppExtraBcProviderRefused(store);
+
         if (!_naeBcProviderAnswered.TryGetValue(store, out _))
         {
             var outcome = TryPopulateNavAppExtraFromBcProvider(store, session);
@@ -221,6 +230,12 @@ public static partial class RecordPatches
                     break;
 
                 case NavAppExtraBcAnswer.Refuse:
+                    // Recorded first, thrown second, and deliberately in that order: the throw
+                    // keeps the literal factory-call spelling that
+                    // VirtualTableRefusalClaimTests counts, so this refusal cannot be deleted
+                    // later without that ratchet noticing. (That count scans raw file text, so
+                    // do not write the spelling into a comment either — it counts there too.)
+                    MarkNavAppExtraBcProviderRefused(store, outcome);
                     throw NavAppExtraShapeGap(
                         NavAppExtraPartialAnswerDetail(outcome.Inserted, outcome.Fault!));
 
@@ -416,6 +431,25 @@ public static partial class RecordPatches
     /// </summary>
     internal static void MarkNavAppExtraBcProviderAnswered(object store)
         => _naeBcProviderAnswered.AddOrUpdate(store, new object());
+
+    /// <summary>
+    /// Record the refusal so every later handout for this store replays it rather than falling
+    /// back onto a store that already holds BC's partial rows.
+    /// </summary>
+    internal static void MarkNavAppExtraBcProviderRefused(object store, in NavAppExtraProviderOutcome outcome)
+        => _naeBcProviderAnswered.AddOrUpdate(store, ExceptionDispatchInfo.Capture(
+            NavAppExtraShapeGap(NavAppExtraPartialAnswerDetail(outcome.Inserted, outcome.Fault!))));
+
+    /// <summary>
+    /// Replay a recorded refusal. <c>ExceptionDispatchInfo.Throw</c> rather than <c>throw</c>,
+    /// so the message still points at the handout that actually found the partial answer.
+    /// </summary>
+    internal static void ThrowIfNavAppExtraBcProviderRefused(object store)
+    {
+        if (_naeBcProviderAnswered.TryGetValue(store, out var prior)
+            && prior is ExceptionDispatchInfo refused)
+            refused.Throw();
+    }
 
     /// <summary>
     /// Build one row per app the runner loaded, from the same <c>BcRuntime.RegisteredModules()</c>

--- a/AlRunner/Patches/RecordPatches.NavAppExtraVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.NavAppExtraVirtualTable.cs
@@ -196,8 +196,10 @@ public static partial class RecordPatches
 
         if (!_naeBcProviderAnswered.TryGetValue(store, out _))
         {
-            inserted = TryPopulateNavAppExtraFromBcProvider(store, session);
-            if (inserted > 0) _naeBcProviderAnswered.Add(store, new object());
+            var outcome = TryPopulateNavAppExtraFromBcProvider(store, session);
+            inserted = outcome.Inserted;
+            if (DecideNavAppExtraBcAnswer(outcome) == NavAppExtraBcAnswer.Latch)
+                MarkNavAppExtraBcProviderAnswered(store);
         }
 
         // 2. The runner's own app list, topped up on every handout. Reached when BC's
@@ -226,9 +228,9 @@ public static partial class RecordPatches
     /// retriever is empty, or it threw), which is the expected case in the runner and is
     /// handled by the caller rather than raised here.
     /// </summary>
-    private static int TryPopulateNavAppExtraFromBcProvider(object store, object session)
+    private static NavAppExtraProviderOutcome TryPopulateNavAppExtraFromBcProvider(object store, object session)
     {
-        if (!TryEnsureNavAppExtraReflection()) return 0;
+        if (!TryEnsureNavAppExtraReflection()) return NavAppExtraProviderOutcome.NoRows;
 
         object provider;
         try
@@ -240,7 +242,7 @@ public static partial class RecordPatches
             // The provider reads the session's tenant and app group in its base constructor.
             // On the skeleton session that can throw; it is not a shape gap, it is the case
             // the loaded-module fallback exists for.
-            return 0;
+            return NavAppExtraProviderOutcome.NoRows;
         }
 
         object? rows;
@@ -250,32 +252,89 @@ public static partial class RecordPatches
         }
         catch
         {
-            return 0;
+            return NavAppExtraProviderOutcome.NoRows;
         }
 
-        if (rows is not System.Collections.IEnumerable enumerable) return 0;
+        if (rows is not System.Collections.IEnumerable enumerable) return NavAppExtraProviderOutcome.NoRows;
 
+        return ConsumeNavAppExtraProviderRows(enumerable, buffer => InsertPreBuiltVirtualRow(store, buffer));
+    }
+
+    /// <summary>
+    /// What BC's own provider produced on one handout: how many rows were inserted, and the
+    /// exception that ended the enumeration if one did. Enumeration is lazy in BC's provider,
+    /// so a throw arrives mid-loop rather than out of the <c>GetAllItems</c> call, which is why
+    /// "how many arrived" and "did it finish" are two facts rather than one count.
+    /// </summary>
+    internal readonly struct NavAppExtraProviderOutcome
+    {
+        internal NavAppExtraProviderOutcome(int inserted, Exception? fault)
+        {
+            Inserted = inserted;
+            Fault = fault;
+        }
+
+        internal int Inserted { get; }
+
+        /// <summary>Non-null when the row enumeration ended in a throw.</summary>
+        internal Exception? Fault { get; }
+
+        internal static NavAppExtraProviderOutcome NoRows => new(0, null);
+    }
+
+    /// <summary>What the caller does with a BC-provider outcome.</summary>
+    internal enum NavAppExtraBcAnswer
+    {
+        /// <summary>A complete BC answer: latch the store, skip the loaded-module fallback.</summary>
+        Latch,
+
+        /// <summary>BC's provider produced nothing usable; the loaded-module list answers.</summary>
+        FallBack,
+
+        /// <summary>A PARTIAL BC answer. Refuse — see DecideNavAppExtraBcAnswer.</summary>
+        Refuse,
+    }
+
+    /// <summary>
+    /// Drain BC's own row enumerable into the store, recording a mid-enumeration throw rather
+    /// than discarding it. Split out from the provider call so the partial-answer path can be
+    /// driven directly by a test: no AL statement and no BC build can make BC's provider throw
+    /// after yielding rows, and BC's provider produces 0 rows in this runner anyway.
+    /// </summary>
+    internal static NavAppExtraProviderOutcome ConsumeNavAppExtraProviderRows(
+        System.Collections.IEnumerable rows, Action<object> insert)
+    {
         var inserted = 0;
         try
         {
-            foreach (var buffer in enumerable)
+            foreach (var buffer in rows)
             {
                 if (buffer == null) continue;
-                InsertPreBuiltVirtualRow(store, buffer);
+                insert(buffer);
                 inserted++;
             }
         }
-        catch
+        catch (Exception ex)
         {
-            // Enumeration is lazy in BC's provider, so a throw can arrive here rather than
-            // above. Rows already inserted stay: they are BC's own and are not wrong. The
-            // caller tops the table up from the loaded-module list only when NOTHING arrived,
-            // so a partial BC answer is never mixed with a synthesised one.
-            return inserted;
+            return new NavAppExtraProviderOutcome(inserted, UnwrapNavAppExtraFault(ex));
         }
 
-        return inserted;
+        return new NavAppExtraProviderOutcome(inserted, null);
     }
+
+    private static Exception UnwrapNavAppExtraFault(Exception ex)
+        => ex is TargetInvocationException tie && tie.InnerException != null ? tie.InnerException : ex;
+
+    /// <summary>
+    /// Classify a BC-provider outcome. Behaviour-preserving extraction of the call site's
+    /// former `if (inserted > 0) latch`.
+    /// </summary>
+    internal static NavAppExtraBcAnswer DecideNavAppExtraBcAnswer(in NavAppExtraProviderOutcome outcome)
+        => outcome.Inserted > 0 ? NavAppExtraBcAnswer.Latch : NavAppExtraBcAnswer.FallBack;
+
+    /// <summary>Record that BC's own provider has answered for this store.</summary>
+    internal static void MarkNavAppExtraBcProviderAnswered(object store)
+        => _naeBcProviderAnswered.Add(store, new object());
 
     /// <summary>
     /// Build one row per app the runner loaded, from the same <c>BcRuntime.RegisteredModules()</c>

--- a/AlRunner/Patches/RecordPatches.QueryJoin.cs
+++ b/AlRunner/Patches/RecordPatches.QueryJoin.cs
@@ -208,8 +208,10 @@ public static partial class RecordPatches
     /// <summary>Record which DataAccessSource owns the tables for this join query.</summary>
     private static void StashJoinSource(object queryDefinition, object dataAccessSource)
     {
-        _joinSourceByQueryDef.Remove(queryDefinition);
-        _joinSourceByQueryDef.Add(queryDefinition, dataAccessSource);
+        // AddOrUpdate, not Remove-then-Add: the same replace, without the window between the
+        // two calls in which a concurrent reader sees no entry and a concurrent writer makes
+        // the Add throw ArgumentException (#3315).
+        _joinSourceByQueryDef.AddOrUpdate(queryDefinition, dataAccessSource);
     }
 
     /// <summary>

--- a/AlRunner/Patches/RecordPatches.SessionVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.SessionVirtualTable.cs
@@ -176,7 +176,7 @@ public static partial class RecordPatches
             new object[] { SessionVirtualTableId, row.ConnectionId, 0, 0 },
             field => BuildSessionValue(field, row));
 
-        _sessionPopulatedProviders.Add(provider, new object());
+        _sessionPopulatedProviders.AddOrUpdate(provider, new object());
     }
 
     /// <summary>

--- a/AlRunner/Patches/RecordPatches.TimeZoneVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.TimeZoneVirtualTable.cs
@@ -132,7 +132,7 @@ public static partial class RecordPatches
                 field => BuildTimeZoneValue(field, number, zone));
         }
 
-        _tzPopulatedProviders.Add(provider, new object());
+        _tzPopulatedProviders.AddOrUpdate(provider, new object());
     }
 
     /// <summary>

--- a/AlRunner/Patches/RecordPatches.WindowsLanguageVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.WindowsLanguageVirtualTable.cs
@@ -147,7 +147,7 @@ public static partial class RecordPatches
                 field => BuildWindowsLanguageValue(field, culture, languageId));
         }
 
-        _wlPopulatedProviders.Add(provider, new object());
+        _wlPopulatedProviders.AddOrUpdate(provider, new object());
     }
 
     private static object? BuildWindowsLanguageValue(NCLMetaField field, CultureInfo culture, int languageId)

--- a/AlRunner/Patches/RunnerFormInit.cs
+++ b/AlRunner/Patches/RunnerFormInit.cs
@@ -47,9 +47,9 @@ public static class RunnerFormInit
     public static void MarkRealInit(object form)
     {
         if (form == null) return;
-        _realInitForms.TryGetValue(form, out _);
-        _realInitForms.Remove(form);
-        _realInitForms.Add(form, Marker);
+        // AddOrUpdate: one atomic write, where Remove-then-Add left a window in which the Add
+        // could throw ArgumentException against a concurrent marker (#3315).
+        _realInitForms.AddOrUpdate(form, Marker);
     }
 
     /// <summary>
@@ -161,8 +161,7 @@ public static class RunnerFormInit
     public static void MarkSourceExpressionsWanted(object form)
     {
         if (form == null) return;
-        _sourceExpressionForms.Remove(form);
-        _sourceExpressionForms.Add(form, Marker);
+        _sourceExpressionForms.AddOrUpdate(form, Marker);
     }
 
     /// <summary>Whether <see cref="MarkSourceExpressionsWanted"/> was called for this form.


### PR DESCRIPTION
Closes #3315

Corpus-NA: runner-internal provider latch, exception handling and concurrency; BC's own NavAppExtraDataProvider is never partial on a service tier, and the corpus already pins the rows this touches (arms below)

Review findings on #3308, items 1 and 2. Item 3 (a wrong SHA in a commit body) is not fixable
by editing anything and the issue's own correction says it never reached `CHANGELOG.md`.

## What was wrong, and what it now does

### 1. A partial provider answer latched as complete

`TryPopulateNavAppExtraFromBcProvider` ended with `catch { return inserted; }` and the call
site latched on `inserted > 0`. Three rows out of ten, then a throw, and the store reads as
answered: the loaded-module fallback is skipped and the seven apps BC never reached read
`false` for both `Published Application` FlowFields — with no exception surfaced, nothing
logged and an unchanged exit code. That is the wrong answer #3072 and #3308 exist to remove,
reintroduced on a silent path.

Both halves of the issue's "either fix works" are now used, split on what the store contains:

| BC's provider | verdict | why |
|---|---|---|
| clean, ≥1 row | latch, fallback skipped | a complete BC answer, unchanged |
| clean, 0 rows | fall back | the measured case on every BC build so far |
| **throws after ≥1 row** | **refuse** — `NavAppExtraShapeGap` naming `NavAppExtraDataProvider.GetAllItems`, the exception type and message, and the row count | the rows are already in the table and cannot be topped up: this file does not read the runtime package id out of BC's pre-built buffers, so the runner's own rows for the apps BC never reached would collide on the primary key for the apps it did |
| **throws before any row** | fall back, `[warn]` once per (stage, exception type) | nothing of BC's reached the table, so the loaded-module list can legitimately answer all of it |

**A refused store stays refused.** BC's partial rows are in the store and nothing can take
them out, so refusing only the first handout was not enough: the next one re-ran the provider,
and a 0-row or fault-before-any-row answer then routed to the fallback, putting the runner's
rows alongside BC's partial ones one handout later — silently, because both insert paths
swallow `NavRecordAlreadyExistsException`. The refusal is recorded on the store as an
`ExceptionDispatchInfo` and replayed on every later handout, the device
`RunObjectMetadataPopulateOnce` already uses two files over.

All three `catch` blocks stop discarding the exception; each carries it out with the stage it
came from, and `TargetInvocationException` is unwrapped so a message names the real fault
rather than the reflection wrapper. The warning is emitted once per process per (stage,
exception type) — this runs on every data-access handout, and a warning repeated per handout
is a warning nobody reads.

### 2. The concurrency defects

- `_naeBcProviderAnswered.Add(store, …)` after a `TryGetValue` → **`AddOrUpdate`**.
  `ConditionalWeakTable.Add` throws `ArgumentException` on a duplicate key and the
  `TryGetValue` in front of it is not a lock.
- `TryEnsureNavAppExtraReflection` set `_naeReflectionReady = true` **before** resolving the
  ctor and the method (the #3187 latch-before-work shape). The flag is now written **last**
  and is `volatile`, so a caller arriving mid-resolution either repeats the resolution —
  idempotent, every step is a lookup — or reads a flag whose promise already holds. Second
  benefit: a `BcShape.FindMethod` ambiguity refusal is no longer converted into a permanent
  silent "not ready" for the rest of the process.
- `seeded.Count` as a row-identity element → **folded out of the app's own runtime package
  id** (`(i0 ^ i3, i1, i2)`, each masked non-negative), the same shape as the two
  permission-set populators' hashed role key. The count is a property of insertion order and
  nondeterministic under concurrent handouts.

**This one change is AL-observable** and is called out deliberately: the `SystemId` of a
runner-synthesised `NAV App Extra` row changes from insertion-order-derived to
guid-derived. No corpus test and no `runner-extras` test reads that `SystemId`; what the
corpus does assert — that the rows exist, one per app, and that both FlowFields compute
`true` — is unchanged and re-measured below. Which rows appear does **not** change.

## RED → GREEN

New `AlRunner.Tests/NavAppExtraProviderLatchTests.cs`, 13 tests. It is a runner-side
mechanism test because no AL statement can make BC's provider throw after yielding rows —
measured, it yields 0 rows in this runner — so no bundle under `tests/runner-extras/` can
drive any of it. The first commit on this branch is a **behaviour-preserving** extraction
(`ConsumeNavAppExtraProviderRows` / `DecideNavAppExtraBcAnswer` /
`MarkNavAppExtraBcProviderAnswered` / `NavAppExtraSystemIdArgs`) so every RED below is a
wrong verdict rather than a missing symbol.

```
RED  (extraction only, semantics unchanged): 3 passed, 6 failed   (of the first nine)
GREEN (as committed):                        13 passed, 0 failed
```

The counts do not add up to the same total on purpose: the sibling-latch ratchet was written
after those nine and RED'd on its own (9 offenders across 7 files), and the three tests
covering the refusal replay and the warning text came with the follow-up commit.

The three that passed in both arms are the negative controls, and they are the reason the fix
cannot be "refuse on any throw": a fault before any row still falls back, a clean empty answer
still falls back, and a clean non-empty answer still latches.

| test | RED |
|---|---|
| `PartialProviderAnswer_IsRefused_NotLatchedAsComplete` | `Expected: "Refuse" / Actual: "Latch"` |
| `TheRefusalNamesTheProvider_TheFault_AndHowManyRowsArrived` | no such refusal existed |
| `MarkingTheStoreAnswered_IsSafeUnderConcurrentHandouts` (64 parallel) | `ArgumentException` |
| `ReflectionReadyFlag_IsSetOnlyAfterTheMembersAreResolved` | the probe observed the flag already `true` mid-resolution |
| `RowIdentity_IsTheSameForOneApp_…` / `…DiffersBetweenApps_…` | identity took the ledger count |
| `NoLatchTable_StillUsesAdd_WhichThrowsOnADuplicateKey` | 9 offenders across 7 files |
| `ARefusedStore_ReplaysTheSameRefusalOnEveryLaterHandout` | a refused store fell back on the next handout |
| `TheFallBackWarning_IsTaggedWarn_…` / `…_IsWrittenOncePerProcessPerFault_…` | nothing was written at all |

**Why `RunnerOutOfScopeException` and not `BcShapeGapException`.** Every refusal in this file
already routes through the `NavAppExtraShapeGap` factory, and `VirtualTableRefusalClaimTests`
holds that factory to the `not-yet-implemented` contract — an AL `[TryFunction]` must not read
it as `false`. A second refusal type in one file would give one table two different claims
depending on which line raised.

The reflection-latch test uses an `internal static AsyncLocal<Action?>
NavAppExtraReflectionProbe` invoked once, midway through the resolution. Nothing in the
product sets it. A re-entrancy probe was rejected: in `AlRunner.Tests` Ncl may or may not be
loaded, so a re-entrant caller returns `false` in both arms and proves nothing; observing the
flag itself is deterministic either way.

## Fix the shape, not the reported line

**1. Same wrong pattern at another call site?** Yes — five, found by scanning every
`ConditionalWeakTable<object, object>` in `AlRunner/Patches/` rather than by grepping the
symptom. `_fkPopulatedProviders`, `_sessionPopulatedProviders`, `_tzPopulatedProviders`,
`_wlPopulatedProviders` and `_apvPopulatedProviders` are all a `TryGetValue`-guarded latch
written with `Add`. One-token change each. Two more (`_joinSourceByQueryDef`,
`_realInitForms` / `_sourceExpressionForms`) spelled the same replace as `Remove(x); Add(x,v)`,
which is `AddOrUpdate` with a window in it; converted, and the redundant discarded
`TryGetValue` in `MarkRealInit` went with it. **One is deliberately NOT converted and is
excluded by name in the ratchet with its reason:** `RunObjectMetadataPopulateOnce` holds
`lock (_omsPopulatedByProvider)` across its `TryGetValue` and its `Add`, which is a different
and equally correct answer to the same question.

**2. Does a sibling function make the same assumption?** The `Faulted`-with-rows shape exists
only here: `FeatureKeyVirtualTable` — the file this populator was modelled on — already throws
on a ctor or `GetAllItems` failure and enumerates without a `catch`, so it has no partial-latch
path to fix. `WindowsLanguage` and `TimeZone` take BC's rows the same way, also without a
swallowing `catch`.

**3. Do two paths writing the same state hold the same invariant?** Yes, and this is the one
the fix rests on. The loaded-module ledger (`_naeSeededByStore`) tops up per app id; the BC
latch (`_naeBcProviderAnswered`) is all-or-nothing, because BC's buffers are opaque here. A
partial BC answer is exactly the state where those two invariants cannot both hold — which is
why it refuses rather than mixing.

**Nothing else in the open-issue queue lands in this file.** #2961 (`NAV App Installed App`,
2000000153) is the nearest neighbour in subject and is a different table in a different file,
with an unsurveyed reader scope its own body records; left open and unclaimed.

## What was run

- `NavAppExtraProviderLatchTests` — RED 3P/6F, GREEN 10P/0F (above).
- `VirtualTableRefusalClaimTests` + `SilentReflectionLookupRatchetTests` +
  `BcInternalsNullForgivingGuardTests` + the `FeatureKey` / `TimeZone` / `ObjectMetadata` /
  `RunnerFormInit` / `QueryJoin` classes: **201 passed, 0 failed.**
- `NavAppExtraProviderLatchTests` + `VirtualTableRefusalClaimTests` +
  `SilentReflectionLookupRatchetTests` + `ParserStaticsIsolationGuardTests` after the
  follow-up commit: **145 passed, 0 failed.**
- `AllFortyEightRefusalsStillExist…`: **76 → 77**, the number read out of the test's own
  failure message, not computed. The new refusal is the partial-answer one; the
  fall-back-with-a-fault path deliberately adds none, because it is a `[warn]`, not a refusal.
- `tests/runner-extras/published-application-system-table`: **9/9 pass**, unchanged before and
  after, and again after the follow-up commit — the guid-derived `SystemId` does not move the
  per-app row assertions.
- The corpus's OnPrem app at the current pin `3ad4c340`
  (`tests/al-language/tests/al-language-onprem`, which this repo's CI enumerates and runs):
  **29/29 pass**, including corpus #228's four arms —
  `PublishedApplication_CalcFields_TenantVisible_IsTrueForThisApp`,
  `…_PerTenantOrInstalled_IsTrueForThisApp`, `…_BothFlowFields_AlsoTrueForTheOtherApp` and
  `…_Installed_IsTrueForThisApp`. Worth recording against the issue's own text: those arms are
  **no longer unguarded here** — the pin has since moved past `17b015ef`, so this repository's
  CI does replay them. No pin bump in this PR.

Not run: the full `AlRunner.Tests` suite and the Cloud corpus app — nothing in this diff
reaches either beyond the classes named above, per `.claude/rules/local-test-scope.md`.

---
*Implemented by an agent (`fbk-3`) acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kko97BZZL71nF2nK5aftu4
