### PR TITLE
feat(app-loader): read a runtime package, instead of silently answering false about one

### DIFF
--- a/AlRunner.Tests/AppLoaderNeaRuntimePackageTests.cs
+++ b/AlRunner.Tests/AppLoaderNeaRuntimePackageTests.cs
@@ -1,0 +1,255 @@
+// AppLoaderNeaRuntimePackageTests — AppLoader reads a runtime package (#3537).
+//
+// A runtime package is a `.app` whose NAVX payload is a `.NEA` container rather than a bare ZIP,
+// so every one of AppLoader's readers used to answer wrongly about one. Two failure modes, and
+// the silent one is the worse:
+//
+//   ExtractCSharp / ExtractAl  threw InvalidDataException("End of Central Directory record
+//                              could not be found") — the ZIP reader hitting RC4 bytes.
+//   IsR2R / HasAlSource        answered `false` through `catch { return false; }`, which reads
+//                              as "this package carries no implementation" and drops it from
+//                              DependencyResolver's scan set with no diagnosis at all.
+//
+// The format is fixed and carries no secret: `.NEA` + a big-endian version, then RC4 with a
+// 6-byte key that ships in Microsoft.Dynamics.Nav.CodeAnalysis as
+// `Packaging.Nea.NeaStream.Key`. Under that one layer is an ordinary ZIP, which is why peeling
+// it is all this takes. Measured identical on three genuine third-party runtime packages of one
+// app built by three different BC compilers (27.5.46862, 28.1.49838, 28.4.53241): same header,
+// same key, 26 `/bin/*.xml` + 18 `/bin/*.cs` + `SymbolReference.json` + zero AL source in each.
+// docs/runtime-packages.md has the layout and the measurement.
+using System.IO.Compression;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class AppLoaderNeaRuntimePackageTests
+{
+    private static string NewTempDir(string suffix)
+    {
+        var dir = TestScratch.FlatDir("app-loader-nea-tests-" + suffix + "-");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static byte[] Utf8(string s) => Encoding.UTF8.GetBytes(s);
+
+    private static string ManifestXml(Guid appId, string name) => $"""
+        <?xml version="1.0" encoding="utf-8"?>
+        <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+          <App Id="{appId}" Name="{name}" Publisher="Pub" Version="2.3.4.5"
+               Application="28.0.0.0" Platform="28.0.0.0"/>
+          <Dependencies/>
+        </Package>
+        """;
+
+    private static byte[] ZipWith(params (string Name, byte[] Content)[] entries)
+    {
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+            foreach (var (name, content) in entries)
+            {
+                var e = zip.CreateEntry(name);
+                using var s = e.Open();
+                s.Write(content);
+            }
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// The `.NEA` obfuscation BC's own writer applies, reproduced here so the fixture is a real
+    /// runtime package rather than a mock of one. Independent of the production decoder on
+    /// purpose: a test that encoded with the same code it decodes with would pass even if both
+    /// halves were wrong together.
+    /// </summary>
+    private static byte[] NeaEncode(byte[] plain)
+    {
+        byte[] key = [0x0F, 0x0B, 0x51, 0x89, 0xB8, 0x78];
+        var s = new byte[256];
+        for (int i = 0; i < 256; i++) s[i] = (byte)i;
+        for (int i = 0, j = 0; i < 256; i++)
+        {
+            j = (j + s[i] + key[i % key.Length]) & 0xFF;
+            (s[i], s[j]) = (s[j], s[i]);
+        }
+        var body = new byte[plain.Length];
+        for (int n = 0, i = 0, j = 0; n < plain.Length; n++)
+        {
+            i = (i + 1) & 0xFF;
+            j = (j + s[i]) & 0xFF;
+            (s[i], s[j]) = (s[j], s[i]);
+            body[n] = (byte)(plain[n] ^ s[(s[i] + s[j]) & 0xFF]);
+        }
+        byte[] header = [0x2E, 0x4E, 0x45, 0x41, 0x00, 0x00, 0x00, 0x01];
+        var result = new byte[header.Length + body.Length];
+        header.CopyTo(result, 0);
+        body.CopyTo(result, header.Length);
+        return result;
+    }
+
+    /// <summary>The 40-byte NAVX header BC writes, followed by the payload at offset 40.</summary>
+    private static byte[] Navx(byte[] payload, Guid appId)
+    {
+        var result = new byte[40 + payload.Length];
+        "NAVX"u8.CopyTo(result);
+        BitConverter.TryWriteBytes(result.AsSpan(4, 4), 40u);
+        BitConverter.TryWriteBytes(result.AsSpan(8, 4), 2u);
+        appId.ToByteArray().CopyTo(result, 12);
+        BitConverter.TryWriteBytes(result.AsSpan(28, 8), (long)payload.Length);
+        "NAVX"u8.CopyTo(result.AsSpan(36, 4));
+        payload.CopyTo(result, 40);
+        return result;
+    }
+
+    private const string TableMetadataXml =
+        """<MetaTable MetadataVersion="130000" ID="60001" Name="Probe Table"/>""";
+    private const string GeneratedCSharp =
+        "namespace Probe { public sealed class Table60001 { public int Answer() { return 42; } } }";
+
+    /// <summary>Writes a runtime package: NAVX → .NEA → ZIP with /bin content and no AL source.</summary>
+    private static string WriteRuntimePackage(string dir, Guid appId, string name)
+    {
+        var zip = ZipWith(
+            ("NavxManifest.xml", Utf8(ManifestXml(appId, name))),
+            ("SymbolReference.json", Utf8("""{"AppId":"probe"}""")),
+            ("bin/TAB60001.xml", Utf8(TableMetadataXml)),
+            ("bin/TAB60001.cs", Utf8(GeneratedCSharp)));
+        var path = Path.Combine(dir, name + ".app");
+        File.WriteAllBytes(path, Navx(NeaEncode(zip), appId));
+        return path;
+    }
+
+    /// <summary>The same content as an ordinary package, so each assertion has a control.</summary>
+    private static string WritePlainPackage(string dir, Guid appId, string name)
+    {
+        var zip = ZipWith(
+            ("NavxManifest.xml", Utf8(ManifestXml(appId, name))),
+            ("SymbolReference.json", Utf8("""{"AppId":"probe"}""")),
+            ("bin/TAB60001.xml", Utf8(TableMetadataXml)),
+            ("bin/TAB60001.cs", Utf8(GeneratedCSharp)));
+        var path = Path.Combine(dir, name + ".app");
+        File.WriteAllBytes(path, Navx(zip, appId));
+        return path;
+    }
+
+    [Fact]
+    public void ReadManifest_AnswersTheRealIdentityOfANeaRuntimePackage()
+    {
+        var dir = NewTempDir("manifest");
+        var appId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+        var path = WriteRuntimePackage(dir, appId, "RuntimePkg");
+
+        AppLoader.ResetManifestMemoForTests();
+        var manifest = AppLoader.ReadManifest(path);
+
+        Assert.NotNull(manifest);
+        Assert.Equal("RuntimePkg", manifest!.Name);
+        Assert.Equal("Pub", manifest.Publisher);
+        Assert.Equal(new Version(2, 3, 4, 5), manifest.Version);
+        Assert.Equal(appId, manifest.AppId);
+    }
+
+    [Fact]
+    public void ExtractCSharp_ReturnsTheGeneratedCodeShippedInTheRuntimePackage()
+    {
+        var dir = NewTempDir("cs");
+        var path = WriteRuntimePackage(dir, Guid.NewGuid(), "RuntimePkgCs");
+
+        var sources = AppLoader.ExtractCSharp(path);
+
+        var one = Assert.Single(sources);
+        Assert.Contains("Table60001", one.Code);
+        Assert.Contains("return 42;", one.Code);
+    }
+
+    [Fact]
+    public void HasSymbolReference_IsTrueForARuntimePackageThatShipsOne()
+    {
+        var dir = NewTempDir("symref");
+        var path = WriteRuntimePackage(dir, Guid.NewGuid(), "RuntimePkgSym");
+
+        Assert.True(AppLoader.HasSymbolReference(path));
+    }
+
+    /// <summary>
+    /// The silent half of the defect. A runtime package genuinely ships no AL source, so `false`
+    /// is the right ANSWER — but before the fix it was reached by swallowing an
+    /// InvalidDataException, which returned the same `false` for a package the runner could not
+    /// read at all. Pinning the reachable-and-correct path is what stops that from regressing
+    /// into an unreadable package being reported as a readable one with nothing in it.
+    /// </summary>
+    [Fact]
+    public void HasAlSource_IsFalseForARuntimePackageBecauseItShipsNoneNotBecauseItIsUnreadable()
+    {
+        var dir = NewTempDir("alsrc");
+        var path = WriteRuntimePackage(dir, Guid.NewGuid(), "RuntimePkgNoAl");
+
+        Assert.False(AppLoader.HasAlSource(path));
+        // Readable: the same package answers every other question truthfully.
+        Assert.True(AppLoader.HasSymbolReference(path));
+        Assert.Single(AppLoader.ExtractCSharp(path));
+        Assert.Empty(AppLoader.ExtractAl(path));
+    }
+
+    [Fact]
+    public void IsR2R_IsFalseForARuntimePackageWhichCarriesNoPublishedArtifacts()
+    {
+        var dir = NewTempDir("r2r");
+        var path = WriteRuntimePackage(dir, Guid.NewGuid(), "RuntimePkgNoR2r");
+
+        Assert.False(AppLoader.IsR2R(path));
+    }
+
+    /// <summary>
+    /// Equivalence: wrapping the identical ZIP in `.NEA` must change no answer AppLoader gives.
+    /// Without this, a decoder that silently produced different content would still pass every
+    /// assertion above.
+    /// </summary>
+    [Fact]
+    public void ANeaPackageAndAPlainPackageWithTheSameContentAnswerIdentically()
+    {
+        var dir = NewTempDir("equiv");
+        var appId = Guid.Parse("66666666-7777-8888-9999-aaaaaaaaaaaa");
+        var nea = WriteRuntimePackage(dir, appId, "EquivNea");
+        var plain = WritePlainPackage(dir, appId, "EquivPlain");
+
+        AppLoader.ResetManifestMemoForTests();
+        var mNea = AppLoader.ReadManifest(nea);
+        var mPlain = AppLoader.ReadManifest(plain);
+
+        Assert.NotNull(mNea);
+        Assert.NotNull(mPlain);
+        Assert.Equal(mPlain!.AppId, mNea!.AppId);
+        Assert.Equal(mPlain.Publisher, mNea.Publisher);
+        Assert.Equal(mPlain.Version, mNea.Version);
+        Assert.Equal(AppLoader.HasSymbolReference(plain), AppLoader.HasSymbolReference(nea));
+        Assert.Equal(AppLoader.IsR2R(plain), AppLoader.IsR2R(nea));
+        Assert.Equal(AppLoader.HasAlSource(plain), AppLoader.HasAlSource(nea));
+        Assert.Equal(
+            AppLoader.ExtractCSharp(plain).Select(s => s.Code).ToArray(),
+            AppLoader.ExtractCSharp(nea).Select(s => s.Code).ToArray());
+    }
+
+    /// <summary>
+    /// The negative direction: a file that begins with the `.NEA` magic but whose body is not a
+    /// decodable ZIP must NOT be reported as an empty-but-fine package. `ReadManifest` returning
+    /// null is how AppLoader says "unreadable", and ReportUnreadablePackage prints the diagnosis.
+    /// </summary>
+    [Fact]
+    public void ACorruptNeaPayloadIsReportedUnreadableRatherThanAsAnEmptyPackage()
+    {
+        var dir = NewTempDir("corrupt");
+        byte[] header = [0x2E, 0x4E, 0x45, 0x41, 0x00, 0x00, 0x00, 0x01];
+        var garbage = new byte[256];
+        new Random(1234).NextBytes(garbage);
+        var payload = new byte[header.Length + garbage.Length];
+        header.CopyTo(payload, 0);
+        garbage.CopyTo(payload, header.Length);
+        var path = Path.Combine(dir, "Corrupt.app");
+        File.WriteAllBytes(path, Navx(payload, Guid.NewGuid()));
+
+        AppLoader.ResetManifestMemoForTests();
+        Assert.Null(AppLoader.ReadManifest(path));
+        Assert.False(AppLoader.HasSymbolReference(path));
+    }
+}

--- a/AlRunner.Tests/AppLoaderNeaRuntimePackageTests.cs
+++ b/AlRunner.Tests/AppLoaderNeaRuntimePackageTests.cs
@@ -119,6 +119,25 @@ public sealed class AppLoaderNeaRuntimePackageTests
         return path;
     }
 
+    private static readonly byte[] FontBytes = Utf8("PROBE-FONT-BYTES-v1");
+
+    /// <summary>
+    /// A package carrying a <c>/resources/</c> part, written either plain or `.NEA`-wrapped from
+    /// the identical ZIP. NavAppResourcePatches reads this part to answer NavApp.GetResource, and
+    /// it is on the dependency path (DependencyLoader sets AppPath from a resolved dependency
+    /// .app), so a runtime package must answer it the same way an ordinary one does.
+    /// </summary>
+    private static string WriteResourcePackage(string dir, Guid appId, string name, bool nea)
+    {
+        var zip = ZipWith(
+            ("NavxManifest.xml", Utf8(ManifestXml(appId, name))),
+            ("PackagedResources.json", Utf8("""{"Resources":["fonts/Probe.ttf"]}""")),
+            ("resources/fonts/Probe.ttf", FontBytes));
+        var path = Path.Combine(dir, name + ".app");
+        File.WriteAllBytes(path, Navx(nea ? NeaEncode(zip) : zip, appId));
+        return path;
+    }
+
     /// <summary>The same content as an ordinary package, so each assertion has a control.</summary>
     private static string WritePlainPackage(string dir, Guid appId, string name)
     {
@@ -251,5 +270,53 @@ public sealed class AppLoaderNeaRuntimePackageTests
         AppLoader.ResetManifestMemoForTests();
         Assert.Null(AppLoader.ReadManifest(path));
         Assert.False(AppLoader.HasSymbolReference(path));
+    }
+
+    /// <summary>
+    /// The THIRD reader copy (#3537 review). NavAppResourcePatches opened a ZipArchive over the
+    /// raw NAVX payload through its own private NavxZipOffset, so it could not see through a
+    /// `.NEA` container — and the failure was silent in the shape loud-failures.md names: the
+    /// InvalidDataException was caught, logged to Console.Error (off the visible path, since the
+    /// runner re-execs itself), and an EMPTY dictionary returned as if complete. A runtime
+    /// package's resources then reported as absent from the app rather than as unreadable.
+    ///
+    /// Asserting a specific count and the specific bytes is what makes this prove something: a
+    /// test that only checked "no throw" would have passed against the broken reader, which
+    /// returned zero resources without throwing.
+    /// </summary>
+    [Fact]
+    public void PackageResources_AreReadFromANeaRuntimePackageNotReportedAbsent()
+    {
+        var dir = NewTempDir("res-nea");
+        var path = WriteResourcePackage(dir, Guid.NewGuid(), "ResNea", nea: true);
+
+        var resources = Patches.NavAppResourcePatches.ReadPackageResourcesForTests(path);
+
+        var one = Assert.Single(resources);
+        Assert.Equal("fonts/Probe.ttf", one.Key);
+        Assert.Equal(FontBytes, one.Value);
+    }
+
+    /// <summary>
+    /// The equivalence control for the same reader: identical ZIP content, one plain and one
+    /// `.NEA`, must produce identical resource dictionaries. Without this a decoder that produced
+    /// silently different bytes would still satisfy the count assertion above.
+    /// </summary>
+    [Fact]
+    public void PackageResources_AnswerIdenticallyForANeaAndAPlainPackageWithTheSameContent()
+    {
+        var dir = NewTempDir("res-equiv");
+        var appId = Guid.Parse("bbbbbbbb-cccc-dddd-eeee-ffffffffffff");
+        var nea = WriteResourcePackage(dir, appId, "ResEquivNea", nea: true);
+        var plain = WriteResourcePackage(dir, appId, "ResEquivPlain", nea: false);
+
+        var fromNea = Patches.NavAppResourcePatches.ReadPackageResourcesForTests(nea);
+        var fromPlain = Patches.NavAppResourcePatches.ReadPackageResourcesForTests(plain);
+
+        Assert.Single(fromPlain);          // the control is itself non-empty
+        Assert.Equal(fromPlain.Keys.OrderBy(k => k, StringComparer.Ordinal),
+                     fromNea.Keys.OrderBy(k => k, StringComparer.Ordinal));
+        foreach (var (name, bytes) in fromPlain)
+            Assert.Equal(bytes, fromNea[name]);
     }
 }

--- a/AlRunner/AppLoader.cs
+++ b/AlRunner/AppLoader.cs
@@ -1148,10 +1148,11 @@ public static class AppLoader
     /// <summary>
     /// True if the bytes at <paramref name="offset"/> begin a .NEA container.
     ///
-    /// <para>Internal rather than private because <c>BcAppSymbolCache</c> keeps its own
-    /// NAVX reader — it reads <c>SymbolReference.json</c>, which a runtime package ships and
-    /// which #3549 consumes — and a second copy of the RC4 would be a second place for the
-    /// format to drift.</para>
+    /// <para>Internal rather than private because two other files keep their own NAVX readers
+    /// and both must see through this layer: <c>BcAppSymbolCache</c> reads
+    /// <c>SymbolReference.json</c> (which a runtime package ships, and #3549 consumes), and
+    /// <c>NavAppResourcePatches</c> reads <c>/resources/*</c> on the dependency path. A further
+    /// copy of the RC4 would be a further place for the format to drift.</para>
     /// </summary>
     internal static bool IsNeaContainer(byte[] bytes, int offset)
         => offset >= 0

--- a/AlRunner/AppLoader.cs
+++ b/AlRunner/AppLoader.cs
@@ -943,9 +943,8 @@ public static class AppLoader
         var direct = ReadAlFromNavx(bytes);
         if (direct.Count > 0) return direct;
 
-        // R2R nested case.
-        using var zipStream = new MemoryStream(bytes, NavxZipOffset(bytes), bytes.Length - NavxZipOffset(bytes));
-        using var zip = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        // R2R nested case. Through OpenZipFromNavx so a .NEA payload decodes here too (#3537).
+        using var zip = OpenZipFromNavx(bytes);
         var nested = zip.Entries.FirstOrDefault(e =>
             e.FullName.EndsWith(".app", StringComparison.OrdinalIgnoreCase)
             && !e.FullName.Contains('/'));
@@ -972,9 +971,8 @@ public static class AppLoader
         var direct = ReadLayoutsFromNavx(bytes);
         if (direct.Count > 0) return direct;
 
-        // R2R nested case.
-        using var zipStream = new MemoryStream(bytes, NavxZipOffset(bytes), bytes.Length - NavxZipOffset(bytes));
-        using var zip = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        // R2R nested case. Through OpenZipFromNavx so a .NEA payload decodes here too (#3537).
+        using var zip = OpenZipFromNavx(bytes);
         var nested = zip.Entries.FirstOrDefault(e =>
             e.FullName.EndsWith(".app", StringComparison.OrdinalIgnoreCase)
             && !e.FullName.Contains('/'));
@@ -987,10 +985,8 @@ public static class AppLoader
 
     private static List<(string FileName, byte[] Bytes)> ReadLayoutsFromNavx(byte[] data)
     {
-        var offset = NavxZipOffset(data);
         var result = new List<(string, byte[])>();
-        using var ms = new MemoryStream(data, offset, data.Length - offset, writable: false);
-        using var zip = new ZipArchive(ms, ZipArchiveMode.Read);
+        using var zip = OpenZipFromNavx(data);
         foreach (var entry in zip.Entries
             .Where(e => e.FullName.StartsWith("layout/", StringComparison.OrdinalIgnoreCase)
                      && (e.FullName.EndsWith(".rdlc", StringComparison.OrdinalIgnoreCase)
@@ -1029,6 +1025,16 @@ public static class AppLoader
         try
         {
             var offset = ReadNavxOffsetFromStream(fs);
+            // A runtime package puts a .NEA container where an ordinary .app puts the zip
+            // (#3537). Decoding it costs a buffer of the whole payload, so it is done only
+            // when the magic says so and never on the ordinary path this method exists to
+            // keep streaming.
+            if (PayloadIsNeaContainer(fs, offset))
+            {
+                var decoded = DecodeNeaPayload(fs, offset);
+                fs.Dispose();
+                return new ZipArchive(new MemoryStream(decoded, writable: false), ZipArchiveMode.Read);
+            }
             var view = new NavxZipView(fs, offset);
             return new ZipArchive(view, ZipArchiveMode.Read, leaveOpen: false);
         }
@@ -1116,9 +1122,115 @@ public static class AppLoader
         }
     }
 
+    // ── .NEA runtime-package container (#3537) ───────────────────────────────
+    //
+    // A runtime package is an ordinary NAVX .app whose payload, instead of starting at
+    // `PK\x03\x04`, starts with this 8-byte header and then an RC4 stream. Under that one
+    // layer is a plain zip, which is why decoding it here makes every reader in this file
+    // answer about a runtime package without any of them changing.
+    //
+    // The key is not a secret and this is not encryption: it is a fixed 6-byte value that
+    // ships in the clear inside Microsoft.Dynamics.Nav.CodeAnalysis, as
+    // `Packaging.Nea.NeaStream.Key`, alongside `NeaStream.Header`. BC's own reader
+    // (`NeaStreamReader.IsSupported`) takes no key argument for exactly that reason.
+    //
+    // Reimplemented here rather than called through NavAppPackageReader deliberately.
+    // AppLoader runs on the cold-artifact-cache provisioning path, where
+    // Microsoft.Dynamics.Nav.CodeAnalysis is not yet resolvable — the failure AffectedObjectId's
+    // doc comment records, which took 20 of 22 provisioning tests down. Six lines of RC4 keep
+    // this file's zero-BC-assembly property intact. docs/runtime-packages.md § "The container"
+    // has the format, the cross-version measurement and why a reader is preferred to a writer.
+    private static ReadOnlySpan<byte> NeaHeader => [0x2E, 0x4E, 0x45, 0x41, 0x00, 0x00, 0x00, 0x01];
+    /// <summary>Bytes of the .NEA header, i.e. where the RC4 body starts. See <see cref="IsNeaContainer"/>.</summary>
+    internal const int NeaHeaderLength = 8;
+    private static ReadOnlySpan<byte> NeaKey => [0x0F, 0x0B, 0x51, 0x89, 0xB8, 0x78];
+
+    /// <summary>
+    /// True if the bytes at <paramref name="offset"/> begin a .NEA container.
+    ///
+    /// <para>Internal rather than private because <c>BcAppSymbolCache</c> keeps its own
+    /// NAVX reader — it reads <c>SymbolReference.json</c>, which a runtime package ships and
+    /// which #3549 consumes — and a second copy of the RC4 would be a second place for the
+    /// format to drift.</para>
+    /// </summary>
+    internal static bool IsNeaContainer(byte[] bytes, int offset)
+        => offset >= 0
+        && bytes.Length - offset >= NeaHeader.Length
+        && bytes.AsSpan(offset, NeaHeader.Length).SequenceEqual(NeaHeader);
+
+    /// <summary>
+    /// The same question against a seekable stream, leaving the position where it found it so
+    /// the ordinary streaming path is unaffected when the answer is false.
+    /// </summary>
+    private static bool PayloadIsNeaContainer(Stream s, long offset)
+    {
+        var saved = s.Position;
+        try
+        {
+            if (s.Length - offset < NeaHeader.Length) return false;
+            s.Position = offset;
+            Span<byte> probe = stackalloc byte[8];
+            int total = 0;
+            while (total < probe.Length)
+            {
+                int n = s.Read(probe.Slice(total));
+                if (n == 0) return false;
+                total += n;
+            }
+            return probe.SequenceEqual(NeaHeader);
+        }
+        finally { s.Position = saved; }
+    }
+
+    /// <summary>Reads the whole .NEA body from <paramref name="s"/> and decodes it to zip bytes.</summary>
+    private static byte[] DecodeNeaPayload(Stream s, long offset)
+    {
+        s.Position = offset + NeaHeader.Length;
+        using var buffered = new MemoryStream();
+        s.CopyTo(buffered);
+        var body = buffered.GetBuffer();
+        return NeaDecode(body, 0, (int)buffered.Length);
+    }
+
+    /// <summary>Decodes a .NEA body to the plain zip bytes underneath. See
+    /// <see cref="IsNeaContainer"/> for why this is internal.</summary>
+    internal static byte[] NeaDecode(byte[] bytes, int start)
+        => NeaDecode(bytes, start, bytes.Length - start);
+
+    /// <summary>
+    /// RC4 over <paramref name="count"/> bytes from <paramref name="start"/>, with the fixed key
+    /// above. Symmetric, so this is both BC's encode and its decode.
+    /// </summary>
+    private static byte[] NeaDecode(byte[] bytes, int start, int count)
+    {
+        if (count < 0) count = 0;
+        Span<byte> s = stackalloc byte[256];
+        for (int i = 0; i < 256; i++) s[i] = (byte)i;
+        var key = NeaKey;
+        for (int i = 0, j = 0; i < 256; i++)
+        {
+            j = (j + s[i] + key[i % key.Length]) & 0xFF;
+            (s[i], s[j]) = (s[j], s[i]);
+        }
+        var result = new byte[count];
+        for (int n = 0, i = 0, j = 0; n < count; n++)
+        {
+            i = (i + 1) & 0xFF;
+            j = (j + s[i]) & 0xFF;
+            (s[i], s[j]) = (s[j], s[i]);
+            result[n] = (byte)(bytes[start + n] ^ s[(s[i] + s[j]) & 0xFF]);
+        }
+        return result;
+    }
+
     private static ZipArchive OpenZipFromNavx(byte[] bytes)
     {
         var offset = NavxZipOffset(bytes);
+        if (IsNeaContainer(bytes, offset))
+        {
+            var decoded = NeaDecode(bytes, offset + NeaHeaderLength);
+            return new ZipArchive(new MemoryStream(decoded, writable: false), ZipArchiveMode.Read);
+        }
         var ms = new MemoryStream(bytes, offset, bytes.Length - offset, writable: false);
         return new ZipArchive(ms, ZipArchiveMode.Read);
     }
@@ -1134,10 +1246,8 @@ public static class AppLoader
 
     private static List<(string Name, string Source)> ReadAlFromNavx(byte[] data)
     {
-        var offset = NavxZipOffset(data);
         var result = new List<(string, string)>();
-        using var ms = new MemoryStream(data, offset, data.Length - offset, writable: false);
-        using var zip = new ZipArchive(ms, ZipArchiveMode.Read);
+        using var zip = OpenZipFromNavx(data);
         foreach (var entry in zip.Entries
             .Where(e => e.FullName.StartsWith("src/", StringComparison.OrdinalIgnoreCase)
                      && e.FullName.EndsWith(".al", StringComparison.OrdinalIgnoreCase))

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -2516,6 +2516,15 @@ internal static partial class BcAppSymbolCache
             && bytes[2] == (byte)'V' && bytes[3] == (byte)'X'
                 ? (int)BitConverter.ToUInt32(bytes, 4)
                 : 0;
+        // A runtime package's payload is a .NEA container, not a bare zip (#3537). This
+        // reader is the one that reaches SymbolReference.json, which a runtime package does
+        // ship, so it has to see through that layer as well as AppLoader's does. The decode
+        // itself lives in AppLoader so the format has one implementation.
+        if (AlRunner.AppLoader.IsNeaContainer(bytes, offset))
+        {
+            var decoded = AlRunner.AppLoader.NeaDecode(bytes, offset + AlRunner.AppLoader.NeaHeaderLength);
+            return new ZipArchive(new MemoryStream(decoded, writable: false), ZipArchiveMode.Read);
+        }
         var ms = new MemoryStream(bytes, offset, bytes.Length - offset, writable: false);
         return new ZipArchive(ms, ZipArchiveMode.Read);
     }

--- a/AlRunner/Patches/NavAppResourcePatches.cs
+++ b/AlRunner/Patches/NavAppResourcePatches.cs
@@ -108,7 +108,7 @@ public static class NavAppResourcePatches
         /// /resources/ parts). Resource name = package path minus "resources/",
         /// case-sensitive exactly like BC's PackagedResourceManifest dictionary.
         /// </summary>
-        private static Dictionary<string, byte[]> ReadPackageResources(string appPath)
+        internal static Dictionary<string, byte[]> ReadPackageResources(string appPath)
         {
             var result = new Dictionary<string, byte[]>(StringComparer.Ordinal);
             try
@@ -126,7 +126,20 @@ public static class NavAppResourcePatches
         private static void ReadResourcesFromNavx(byte[] navxBytes, Dictionary<string, byte[]> into, bool allowNested)
         {
             var offset = NavxZipOffset(navxBytes);
-            using var ms = new MemoryStream(navxBytes, offset, navxBytes.Length - offset, writable: false);
+            // A runtime package's payload is a .NEA container, not a bare zip (#3537). Peel it
+            // through AppLoader's helpers rather than repeating the header and RC4 key here, so
+            // the format keeps ONE implementation across the runner's three .app readers. Without
+            // this, ZipArchive hits the RC4 bytes, the InvalidDataException is swallowed by
+            // ReadPackageResources' catch, and an empty dictionary is returned as if complete —
+            // reporting a runtime package's resources as ABSENT rather than as unreadable, which
+            // is the silent-wrong-answer shape .claude/rules/loud-failures.md forbids. Live on the
+            // dependency path: DependencyLoader.RegisterDependencyAssembly sets AppPath from a
+            // resolved dependency .app.
+            using var ms = AlRunner.AppLoader.IsNeaContainer(navxBytes, offset)
+                ? new MemoryStream(
+                    AlRunner.AppLoader.NeaDecode(navxBytes, offset + AlRunner.AppLoader.NeaHeaderLength),
+                    writable: false)
+                : new MemoryStream(navxBytes, offset, navxBytes.Length - offset, writable: false);
             using var zip = new ZipArchive(ms, ZipArchiveMode.Read);
             bool any = false;
             foreach (var entry in zip.Entries)
@@ -162,6 +175,15 @@ public static class NavAppResourcePatches
             return 0;
         }
     }
+
+    /// <summary>
+    /// Test seam over the real <c>/resources/</c> reader — the same method
+    /// <see cref="AppResourceStore.TryRead"/> calls, not a copy of it. Exists because the reader
+    /// had no test at all, which is how a runtime package silently reporting zero resources
+    /// survived (#3537).
+    /// </summary>
+    internal static Dictionary<string, byte[]> ReadPackageResourcesForTests(string appPath)
+        => AppResourceStore.ReadPackageResources(appPath);
 
     // Assembly → resource store. Assemblies are process-wide (Assembly.Load(byte[])),
     // so entries stay valid across bundles; re-registration updates in place.

--- a/docs/runtime-packages.md
+++ b/docs/runtime-packages.md
@@ -1,0 +1,139 @@
+# Runtime packages (`.NEA`)
+
+A **runtime package** is a `.app` Business Central produces when an extension is published
+without its source: no `/src/*.al`, but the complete output of the AL compile — BC's own
+generated C# and BC's own materialized object metadata. It is another package distribution
+format, not a lesser one. A customer is handed one, deploys it, and runs tests against it on a
+service tier.
+
+This document records what one contains, how the runner reads it, and what has and has not been
+measured. Issue #3537 is the origin; #3531 has the first readability measurements.
+
+## The container
+
+An ordinary `.app` is a 40-byte NAVX header whose payload, at the offset the header names, is a
+plain ZIP. A runtime package has the identical NAVX header and puts a **`.NEA` container** at
+that offset instead.
+
+```
+offset 0    'N','A','V','X'                       (magic)
+offset 4    LE uint32 = 40                        (payload offset)
+offset 8    LE uint32 = 2                         (format version)
+offset 12   16 bytes                              (app GUID)
+offset 28   LE uint64                             (payload length)
+offset 36   'N','A','V','X'                       (trailing magic)
+offset 40   payload
+```
+
+At offset 40:
+
+| package | first bytes | meaning |
+|---|---|---|
+| ordinary `.app` | `50 4B 03 04` (`PK\x03\x04`) | a ZIP |
+| runtime package | `2E 4E 45 41 00 00 00 01` (`.NEA` + version 1) | a `.NEA` container |
+
+After the 8-byte `.NEA` header the remaining bytes are **RC4** with a fixed 6-byte key,
+`0F 0B 51 89 B8 78`. Decode that and what you have is an ordinary ZIP — the same shape the
+runner already reads.
+
+**This is obfuscation, not encryption, and nothing here is a secret.** Both constants ship in
+the clear inside `Microsoft.Dynamics.Nav.CodeAnalysis`, as
+`Packaging.Nea.NeaStream.Header` and `Packaging.Nea.NeaStream.Key`, and BC's own reader
+(`Packaging.Nea.NeaStreamReader.IsSupported`) takes no key argument at all. #3531 first read the
+resulting high-entropy bytes as encryption; they are not.
+
+### Why the runner reimplements the decode instead of calling BC
+
+`NavAppPackageReader` is public and would answer all of this. `AppLoader` does not use it, on
+purpose.
+
+`AppLoader` runs on the cold-artifact-cache provisioning path, where
+`Microsoft.Dynamics.Nav.CodeAnalysis` is **not yet resolvable** — that is the failure recorded in
+`AlRunner/AffectedObjectId.cs`'s doc comment, where merely naming a type from that assembly in
+`Program.cs` took 20 of 22 provisioning tests down with an unhandled `FileNotFoundException` and
+no managed stack. Six lines of RC4 keep `AppLoader`'s zero-BC-assembly property intact, and the
+format is a fixed constant rather than something that has to track a BC version.
+
+The decode lives in `AppLoader` and `BcAppSymbolCache` calls into it, so there is one
+implementation rather than two copies of the same constants.
+
+## What is inside one
+
+Measured on three genuine third-party runtime packages of one app
+(`365 business API 17.13.1.27844`, from the public feed at
+`https://pkgs.dev.azure.com/365businessdev/Public/_packaging/MSDyn365BCRuntimeApps/nuget/v3/index.json`),
+each built by a **different** BC compiler:
+
+| built by | `/bin/*.xml` | `/bin/*.cs` | `/src/*.al` | `SymbolReference.json` |
+|---|---|---|---|---|
+| 27.5.46862 | 26 | 18 | 0 | yes |
+| 28.1.49838 | 26 | 18 | 0 | yes |
+| 28.4.53241 | 26 | 18 | 0 | yes |
+
+`/bin/TAB<id>.xml` is a fully materialized `MetaTable` document
+(`MetadataVersion="130000"`) — the shape `MetaTable.CreateMetaTableFromXml` consumes.
+`/bin/<Prefix><id>.cs` is the generated C#, post-AL-compile and pre-C#-compile: the same input
+BC's own service tier Roslyn-compiles into its assembly cache.
+
+**A runtime package and a Microsoft shipped app are exact complements.** Measured on
+`Microsoft_Base Application_28.4.53241.53989.app`: 8,095 AL source files and **zero** `/bin`
+metadata documents. So a shipped app must be compiled to produce metadata, and a runtime package
+already contains it.
+
+## What the runner answers about one
+
+Every `AppLoader` reader funnels through two places — `OpenAppZip` (path, streaming) and
+`OpenZipFromNavx` (bytes, for the nested R2R case) — so decoding at those two points is what
+makes all of them work. Measured before and after, on the three real packages above:
+
+| | before | after |
+|---|---|---|
+| `ReadManifest` | `null` | the real identity |
+| `HasSymbolReference` | `false` | `true` |
+| `ExtractCSharp` | throws `InvalidDataException` | 18 sources |
+| `ExtractAl` | throws `InvalidDataException` | 0, correctly |
+| `IsR2R` | `false` | `false`, correctly |
+
+The two `false` answers in the "before" column are the more dangerous half, and neither announced
+itself: `IsR2R` and `HasAlSource` reach their answer through `catch { return false; }`, so a
+package the runner could not read at all was reported as one that simply carries no
+implementation — which drops it from `DependencyResolver`'s scan set with no diagnosis.
+`ReadManifest` returning `null` at least routes to `ReportUnreadablePackage`.
+
+## The metadata property set (settles #3531's open question)
+
+#3531 observed four attributes absent from both a 15.0 and a 22.0 package and asked whether that
+was the generator's doing or version drift. Counted over the `/bin/TAB*.xml` documents of the
+three current packages above, identically on all three:
+
+| attribute | present |
+|---|---|
+| `AllowInCustomizations` | **5/5** |
+| `ValidateTableRelation` | 5/5 |
+| `DataClassification` | 5/5 |
+| `Editable` | 5/5 |
+| `EnumTypeId` | 2/5 (only where a field is an enum) |
+| `TestRelations` | 0/5 |
+| `ValidateRelation` | 0/5 |
+| `PlatformDefinedFieldsAdded` | 0/5 |
+
+So the caveat was wrong in two different ways. `AllowInCustomizations` **was** version drift — it
+is present in every current package. And `TestRelations` and `ValidateRelation` were never
+missing: current BC spells that attribute `ValidateTableRelation`, so counting the other two
+spellings was counting names that do not exist. `PlatformDefinedFieldsAdded` is genuinely absent.
+
+## What is not shown
+
+- **Executing tests from a runtime package end to end is not wired up.** Reading one is;
+  consuming its `/bin/*.cs` as the compile input instead of an AL emit is a separate change
+  (#3732 tracks it). The proof that the mechanism works is in #3537's own thread: 45
+  dependency-free bundles, 44 of them producing identical results from the package alone.
+- **Only the container format is claimed to be version-stable.** Header and key are byte-identical
+  across the 27.5, 28.1 and 28.4 builds measured. The *generated C#* inside pins to the BC version
+  that produced it, and running a package across a BC minor has not been measured.
+- **The three packages measured are one app.** They cover three BC compilers, not three shapes of
+  app: no PermissionSet, Profile, Entitlement or DotNet package objects were exercised, and no
+  package carrying report layouts was.
+- **`/bin/ENUM*.xml` omits per-value `Implementation`**, which `AlEnumMetadataRegistry.Register`
+  needs, and `/layout/LayoutManifest.xml` carries no `DefaultRenderingLayout`, so
+  `AlReportLayoutInfo.IsDefault` has no source in the package. Both are recorded in #3537.

--- a/docs/runtime-packages.md
+++ b/docs/runtime-packages.md
@@ -54,8 +54,23 @@ purpose.
 no managed stack. Six lines of RC4 keep `AppLoader`'s zero-BC-assembly property intact, and the
 format is a fixed constant rather than something that has to track a BC version.
 
-The decode lives in `AppLoader` and `BcAppSymbolCache` calls into it, so there is one
-implementation rather than two copies of the same constants.
+The runner carries the header and the key as **literals** in `AppLoader` — not resolved from BC
+at run time. Reflecting them out of `Microsoft.Dynamics.Nav.CodeAnalysis` is how they were
+*verified* (BC's own `NeaStreamWriter` was executed over a known plaintext, and an independent
+RC4 reproduced its output byte for byte), but doing that at run time would reintroduce exactly the
+assembly dependency the previous paragraph rules out.
+
+The decode lives in `AppLoader`, and both other `.app` readers — `BcAppSymbolCache`
+(`SymbolReference.json`) and `NavAppResourcePatches` (`/resources/*`) — call into it, so the
+format has one implementation rather than three copies of the same constants.
+
+**If Microsoft ever changed these constants**, a changed *header* is loud: `IsNeaContainer`
+answers `false`, the ZIP reader hits bytes that are not a ZIP, and the reader raises
+`InvalidDataException`. A changed *key* under an unchanged header is the quieter case — a corrupt
+ZIP, loud through `ExtractCSharp` but reaching `IsR2R`/`HasAlSource` as `catch { return false; }`.
+No guard is built for that: the constants are byte-identical across all eleven BC builds measured
+(27.0 through 28.4), and BC's own reader has no version negotiation — `NeaStreamReader.IsSupported`
+takes no key argument and its private overload assigns `NeaStream.Key` unconditionally.
 
 ## What is inside one
 

--- a/tools/test_matrix_docs_drift.py
+++ b/tools/test_matrix_docs_drift.py
@@ -155,6 +155,9 @@ NOT_A_MATRIX_CLAIM = [
     ("docs/testpage-write-buffer.md", "27.0 27.3 27.5",
      "the legs that raised \"The record that you tried to open is not available.\" on "
      "the same write sequence, corpus run 34328827788 -- the other measured half"),
+    ("docs/runtime-packages.md", "27.5 28.1 28.4",
+     "the three BC compilers that built the three genuine third-party runtime packages measured "
+     "for #3537 -- a historical measurement of which builds were compared, not the matrix"),
 ]
 
 


### PR DESCRIPTION
Closes #3537

Corpus-NA: runner packaging infrastructure. The change is a container decode in the runner's own `.app` reader — it asserts nothing about what Business Central does, and a service tier has no way to observe it. The BC-behaviour facts it rests on (the `.NEA` header, the RC4 key) were verified against Microsoft's own shipped assembly, not inferred.

Opened by an agent (`agent: stma-auto-2`) on the account holder's behalf.

## What this lands

A runtime package is a `.app` whose NAVX payload is a **`.NEA` container** rather than a bare
zip. Every `AppLoader` reader answered wrongly about one, in two ways — and the silent way is
the worse:

| | before | after |
|---|---|---|
| `ReadManifest` | `null` | the real identity |
| `HasSymbolReference` | **`false`** | `true` |
| `ExtractCSharp` | throws `InvalidDataException` | 18 sources |
| `ExtractAl` | throws `InvalidDataException` | `0`, correctly |
| `DependencyResolver.Resolve` | `0` — never reached | `1` |

`IsR2R` and `HasAlSource` reach their answer through `catch { return false; }`, so a package the
runner could not read **at all** was reported as one that simply carries no implementation. That
drops it from `DependencyResolver`'s scan set with no diagnosis — the anti-pattern
`loud-failures.md` names explicitly. `ReadManifest` at least routed to `ReportUnreadablePackage`.

## How it is measured

The table above is **not** from the hermetic fixture. It is three genuine third-party runtime
packages of one app (`365 business API 17.13.1.27844`), each built by a **different BC compiler**
— 27.5.46862, 28.1.49838, 28.4.53241 — pulled from the public feed named in #3537's own thread,
run through the real test host, with `CacheRoots.DisableForRun()` so the shared content-keyed
manifest index could not answer for the package.

That last detail is load-bearing and I nearly published the wrong number without it: a first
pre-fix run reported `ReadManifest` **working**, because a post-fix run had already written that
package's content hash into the shared on-disk index. Cold, with a private cache root, pre-fix is
`manifest=NULL, symref=False, csharp=InvalidDataException`, exactly as the hermetic RED predicted.

## The mechanism

An ordinary `.app` puts `PK\x03\x04` at the NAVX payload offset; a runtime package puts
`2E 4E 45 41 00 00 00 01` — `.NEA` plus a version — and then **RC4 with a fixed 6-byte key**,
`0F 0B 51 89 B8 78`. Under that one layer is a plain zip.

**This is obfuscation, not encryption, and no secret is involved.** Both constants ship in the
clear inside `Microsoft.Dynamics.Nav.CodeAnalysis` as `Packaging.Nea.NeaStream.Header` and
`.Key`, and BC's own `NeaStreamReader.IsSupported` takes no key argument for that reason. #3531
read the resulting high-entropy bytes as encryption; they are not.

**The runner carries both as hardcoded literals** — `AppLoader.cs:1143` and `:1146` are
`ReadOnlySpan<byte>` literals, and nothing is resolved from BC at run time. Reflecting them out of
`Microsoft.Dynamics.Nav.CodeAnalysis` is how they were *verified*, not how they are obtained;
doing it at run time would reintroduce exactly the assembly dependency the next section rules out.

Header and key are **byte-identical across all three BC builds** measured, and a reviewer
independently confirmed them identical across **all eleven builds on this box (27.0–28.4)**, so
the container format is version-stable. That is a claim about the container only — see the limits
below. On drift: a changed *header* fails loudly (`IsNeaContainer` answers `false`, the ZIP reader
raises `InvalidDataException`); a changed *key* under an unchanged header is the quieter case, but
with eleven builds identical and no version negotiation anywhere in BC's own reader, that is worth
one sentence in `docs/runtime-packages.md` rather than a guard, and it now has one.

## Why the decode is reimplemented instead of calling `NavAppPackageReader`

`NavAppPackageReader` is public and would answer all of this. Using it here would be a bug.

`AppLoader` runs on the **cold-artifact-cache provisioning path**, where
`Microsoft.Dynamics.Nav.CodeAnalysis` is not yet resolvable. That is the failure recorded in
`AlRunner/AffectedObjectId.cs`'s doc comment: merely *naming* a type from that assembly in
`Program.cs` took 20 of 22 provisioning tests down with an unhandled `FileNotFoundException` and
no managed stack. Six lines of RC4 keep `AppLoader`'s zero-BC-assembly property intact, against a
format that is a fixed constant rather than something tracking a BC version.

## Fixing the shape, not the reported line

The issue pointed at one method. Three widenings, each measured rather than assumed:

1. **Every reader, not one.** All `.app` reading in `AppLoader` funnels through two chokepoints —
   `OpenAppZip` (streaming, by path) and `OpenZipFromNavx` (by bytes, the nested-R2R case).
   Decoding at those two makes all ten call sites work. Four further call sites were building
   `new ZipArchive(new MemoryStream(bytes, NavxZipOffset(bytes), …))` **by hand** instead of using
   the helper — `ExtractAl`, `ExtractReportLayouts`, `ReadAlFromNavx`, `ReadLayoutsFromNavx`.
   Routing them through it fixed the last red test and removed the duplication. `ExtractAl` was
   the one the tests caught; the other three were the same shape, unreported.
2. **Two siblings with their own copies — the runner had THREE `.app` readers, not one.**
   `BcAppSymbolCache` keeps a second, independent `OpenZipFromNavx`, and it is the one that reads
   `SymbolReference.json`, which is precisely what #3549's Producer B consumes from a runtime
   package. `NavAppResourcePatches` keeps a third, with its own private `NavxZipOffset`, and it
   reads `/resources/*` to answer `NavApp.GetResource`. Fixing only `AppLoader` would have left
   the path this issue exists to unblock still broken; the third copy was found in review, and
   its failure is the silent shape again — the `InvalidDataException` is caught, logged to
   `Console.Error` (off the visible path, since the runner re-execs itself) and an **empty
   dictionary returned as if complete**, so a runtime package's resources report as *absent from
   the app* rather than as *unreadable*. It is live on the dependency path:
   `DependencyLoader.cs:394` → `RegisterDependencyAssembly` sets `AppPath` from a resolved
   dependency `.app`. All three now call the one decode instead of carrying their own constants.

   **Enumerated rather than assumed, after the third was missed.** Every `new ZipArchive` in
   `AlRunner/` (8 sites, agreed by `rg`, `command grep -rn` and a Python walk) and every
   `System.IO.Compression` importer over `.app` bytes: `AppLoader` (4 sites, 2 chokepoints),
   `BcAppSymbolCache` (2), `NavAppResourcePatches` (1, this fix) and `InProcessAppPackager` (1),
   which is a **writer** in `ZipArchiveMode.Create` and never reads a package. Exactly three
   files compute a NAVX offset, and all three now decode. Everything else that reads a package —
   `PrebuiltShadowCheck`, `TestDataProvisioner`, `RecordPatches.BcAppFallback` — goes through
   `AppLoader.ExtractAl` / `ReadPackageMeta`. **There is no fourth.**
3. **Both writers of the same invariant.** The stream-based and byte-based probes answer the same
   question, so they share the header constant instead of each spelling it.

## Scope: what is deliberately NOT here

**Executing tests from a runtime package is not wired up** — filed as #3732 with the full design.
The bytes are now readable; nothing yet consumes `/bin/*.cs` as the compile input instead of an AL
emit. That is a change at a different seam (`BcAssembler`, not `BcCompiler`) and it brings its own
question — `ApplyPolyfillRedirects` would begin applying to a vendor's emitter output — which
deserves its own review rather than riding along here.

The mechanism itself is already proven: #3537's thread records 45 dependency-free bundles
regenerated as runtime packages and run from the package alone with AL source removed, **44 of 45
producing identical results**. This PR lands the reader that half of that needs, and the honest
answer to "why not both" is that one PR closing both would be two changes a reviewer cannot hold
at once.

## This settles #3531's open question, and corrects it twice

#3531 saw four attributes absent from a 15.0 and a 22.0 package and asked: generator, or version
drift? Counted over the `/bin/TAB*.xml` of the three current packages, identical on all three:

| attribute | present |
|---|---|
| `AllowInCustomizations` | **5/5** |
| `ValidateTableRelation` | 5/5 |
| `TestRelations` | 0/5 |
| `ValidateRelation` | 0/5 |
| `PlatformDefinedFieldsAdded` | 0/5 |

`AllowInCustomizations` **was** version drift. `TestRelations` and `ValidateRelation` were never
missing at all — current BC spells that attribute `ValidateTableRelation`, so #3531 was counting
two names that do not exist. `PlatformDefinedFieldsAdded` is genuinely absent. This reproduces
coord-1's correction independently, on third-party packages instead of a locally generated one.

## Limits I am claiming nothing beyond

- **Container format is version-stable; the generated C# is not claimed to be.** The `.cs` pins to
  the BC version that produced it, and running a package **across** a BC minor remains unmeasured
  — the second unknown #3537 named, still open, carried into #3732.
- **Three packages, one app.** Three BC compilers, not three shapes of app: no PermissionSet,
  Profile, Entitlement or DotNet package objects, and none carrying report layouts.
- `/bin/ENUM*.xml` omits per-value `Implementation` that `AlEnumMetadataRegistry.Register` needs,
  and `/layout/LayoutManifest.xml` carries no `DefaultRenderingLayout`. Both recorded in #3732.

## Tests

RED first: 7 tests, **5 failed / 2 passed** before the fix. The two that passed are the controls
whose correct answer happens to be `false` (`IsR2R`, and the corrupt-payload negative), so the
suite is not trivially red. **7/7 after.**

The third-copy fix has its own RED → GREEN, added in review. Two tests drive the **real**
`ReadPackageResources` (via a narrow internal seam, not a copy of it) over two packages with
identical content, one plain and one `.NEA`. Before the fix: **2 failed / 7 passed** —
`Assert.Single() Failure: The collection was empty` and `Expected: ["fonts/Probe.ttf"] Actual:
[]`. The `.NEA` package answered **0** resources where the plain control answered **1**, and it
did so *without throwing*, which is why "does not crash" would have proved nothing and the test
asserts a specific count and the specific bytes. After: **9/9.**

The fixture builds a real `.NEA` — 40-byte NAVX header, `.NEA` header, RC4 body — with its own
encoder, deliberately **not** sharing code with the decoder under test, so both halves being
wrong together cannot pass. Coverage is both directions: a `.NEA` and a plain package with
identical content must answer identically (so a decoder returning different bytes fails), and a
`.NEA` whose body is garbage must be reported **unreadable** rather than as an empty-but-fine
package.

Suites actually run, on this commit:

- `AppLoaderNeaRuntimePackageTests` — 9/9 (7 original + 2 for the third reader copy)
- `AppLoader` + `AppPackage` + `BcAppSymbolCache` + `NavAppResource` + `Dependency` +
  `SilentReflectionLookupRatchet` + doc/comment guards — **397 passed, 0 failed**
- Provisioning + Dependency + Manifest + Symbol + Package — **721 passed, 0 failed**, 12 skipped
- `tests/runner-extras/object-system-table` end to end — 3/3, ordinary AL path unaffected
- the whole `tools/test_*.py` suite (what CI's `tools/ unit tests` job globs) — **14/14 green**,
  including `test_matrix_docs_drift.py`, which was red on the previous head

## Queue scan

Nothing folded. `#3549` (dependency metadata from BC's emitter) is what this unblocks but lands in
`RecordPatches.BcAppFallback.cs` / `BcAppSymbolCache.cs` metadata derivation, not the container
layer. `#2214` is a tracking issue that deliberately stays open; its stated blocking measurement —
"nobody has published a runtime package end to end" — is now discharged offline via
`NavAppPackageWriter.CreateNeaPackage`, which needs no WCF admin endpoint, and I have commented
there rather than closing it. `#2211` (read a service instance directory) is route A to this
route B and is genuinely separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
