### PR TITLE
fix(testpage): evaluate a live property expression against the current row (#3693 regression)

### DIFF
--- a/AlRunner.Tests/LivePropertyExpressionTests.cs
+++ b/AlRunner.Tests/LivePropertyExpressionTests.cs
@@ -11,6 +11,8 @@
 // Option compared against ORDINALS, which is how the AL compiler writes such a comparison into
 // the page metadata.
 using System;
+using System.Diagnostics;
+using System.Text;
 using AlRunner.Patches;
 using Xunit;
 
@@ -117,4 +119,255 @@ public class LivePropertyExpressionTests
             if (raw == null) { resolved = null; return false; }
             return RunnerPageInstance.TryComparableFieldValue(raw, out resolved);
         };
+}
+
+// FlowFieldBoundLivePropertyTests — the narrowing the live resolver applies BEFORE it reads a
+// field: a FlowField is not a live-resolvable identifier, and must reach the caller's refusal
+// rather than an invented answer.
+//
+// WHY A BUNDLE AND NOT A UNIT ARM
+//   The guard lives in RunnerPageInstance.TryResolveSourceTableField, which needs the page's
+//   record and BC's own NCLMetaField — no unit arm reaches it, and one written against the
+//   narrowing helper alone would prove an enum comparison while leaving the wiring (that the
+//   call site consults FieldClass at all) untested. That wiring is the defect.
+//
+// WHAT THE FIXTURE ESTABLISHES
+//   'HasKid' is a FlowField whose formula is TRUE on the row the page is on — one child row is
+//   inserted for it. An uncalculated FlowField's ClientObject is nonetheless false, which
+//   narrows cleanly to bool, so without the guard the runner answers Enabled = false on a row
+//   where the condition holds and Invoke() skips OnAction: a silent wrong answer, the failure
+//   class .claude/rules/loud-failures.md forbids. What real BC answers for a FlowField-bound
+//   Enabled is UNMEASURED — no corpus arm and no container run in #3730 covers it — so the
+//   runner refuses rather than calculating.
+//
+// THE CONTROL ARM
+//   NormalBooleanBoundEnabled_StillFollowsTheRow, on the same page and the same row, must keep
+//   PASSING. Without it the guard could be satisfied by refusing every field, which would undo
+//   #3730 entirely and still turn the first arm green.
+public sealed class FlowFieldBoundLivePropertyTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private readonly string _root;
+
+    public FlowFieldBoundLivePropertyTests()
+    {
+        _root = TestScratch.Dir("al-runner-flowfield-live-property");
+        Directory.CreateDirectory(_root);
+        WriteFixture(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private static void WriteFixture(string dir)
+    {
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "d3f2a1b0-3730-4c5d-9e6f-000000003730",
+          "name": "FlowField Live Property Fixture",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62480, "to": 62489 } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(dir, "FfeObjects.al"), """
+        table 62480 "FFE Row"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; PK; Code[10]) { }
+                field(2; Flag; Boolean) { }
+                field(3; Value; Text[30]) { }
+                field(4; HasKid; Boolean)
+                {
+                    FieldClass = FlowField;
+                    CalcFormula = exist("FFE Child" where(Parent = field(PK)));
+                }
+            }
+            keys { key(K; PK) { Clustered = true; } }
+        }
+
+        table 62481 "FFE Child"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "Entry No."; Integer) { }
+                field(2; Parent; Code[10]) { }
+            }
+            keys { key(K; "Entry No.") { Clustered = true; } }
+        }
+
+        page 62482 "FFE Card"
+        {
+            PageType = Card;
+            SourceTable = "FFE Row";
+            ApplicationArea = All;
+            UsageCategory = Administration;
+
+            layout
+            {
+                area(Content)
+                {
+                    field(ValueCtl; Rec.Value) { ApplicationArea = All; }
+                }
+            }
+
+            actions
+            {
+                area(Processing)
+                {
+                    action(FlowFieldEnabled)
+                    {
+                        ApplicationArea = All;
+                        Enabled = Rec.HasKid;
+                        trigger OnAction()
+                        begin
+                        end;
+                    }
+                    action(NormalEnabled)
+                    {
+                        ApplicationArea = All;
+                        Enabled = Rec.Flag;
+                        trigger OnAction()
+                        begin
+                        end;
+                    }
+                }
+            }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(dir, "FfeTests.Codeunit.al"), """
+        codeunit 62483 "FFE Tests"
+        {
+            Subtype = Test;
+
+            local procedure InitializeRowWithAChild(var Row: Record "FFE Row")
+            var
+                Child: Record "FFE Child";
+            begin
+                Row.DeleteAll();
+                Child.DeleteAll();
+                Row.Init();
+                Row.PK := 'ROW1';
+                Row.Flag := true;
+                Row.Value := 'Filled';
+                Row.Insert();
+                Child.Init();
+                Child."Entry No." := 1;
+                Child.Parent := 'ROW1';
+                Child.Insert();
+            end;
+
+            // Reports whatever Enabled() answered, so the runner's refusal and a silently
+            // invented answer are told apart in the output instead of both reading as "failed".
+            [Test]
+            procedure FlowFieldBoundEnabled_IsRefusedNotAnsweredFalse()
+            var
+                Row: Record "FFE Row";
+                Card: TestPage "FFE Card";
+            begin
+                InitializeRowWithAChild(Row);
+                Card.OpenEdit();
+                Card.GoToRecord(Row);
+                if Card.ValueCtl.Value() <> 'Filled' then
+                    Error('the page must be on the row just inserted');
+                Error('OBSERVED Enabled=%1', Card.FlowFieldEnabled.Enabled());
+            end;
+
+            // The control: a Normal Boolean field on the same page and the same row still
+            // answers the row, so the guard above cannot be a blanket refusal.
+            [Test]
+            procedure NormalBooleanBoundEnabled_StillFollowsTheRow()
+            var
+                Row: Record "FFE Row";
+                Card: TestPage "FFE Card";
+            begin
+                InitializeRowWithAChild(Row);
+                Card.OpenEdit();
+                Card.GoToRecord(Row);
+                if not Card.NormalEnabled.Enabled() then
+                    Error('a Normal Boolean field bound to Enabled must follow the row (#3730)');
+            end;
+        }
+        """);
+    }
+
+    private (string output, int exit) RunRunner()
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" \"{_root}\"");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(300_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>The reported header line for one test plus its indented continuation lines —
+    /// what a developer reads, and the only place the refusal exists.</summary>
+    private static string BlockFor(string output, string testMethod)
+    {
+        var lines = output.Replace("\r\n", "\n").Split('\n');
+        var block = new StringBuilder();
+        var inBlock = false;
+        foreach (var line in lines)
+        {
+            var isHeader = line.StartsWith("FAIL ", StringComparison.Ordinal)
+                        || line.StartsWith("PASS ", StringComparison.Ordinal)
+                        || line.StartsWith("ERROR", StringComparison.Ordinal)
+                        || line.StartsWith("SKIP ", StringComparison.Ordinal);
+            if (isHeader)
+            {
+                if (inBlock) break;
+                inBlock = line.Contains($".{testMethod} (", StringComparison.Ordinal);
+                if (inBlock) block.AppendLine(line);
+                continue;
+            }
+            if (inBlock) block.AppendLine(line);
+        }
+        Assert.True(block.Length > 0,
+            $"no reported block for '{testMethod}' — the fixture did not run as expected. Full output:\n{output}");
+        return block.ToString();
+    }
+
+    [SkippableFact]
+    public void AFlowFieldBoundEnabled_IsRefusedByName_AndANormalFieldStillAnswersTheRow()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, _) = RunRunner();
+
+        var refused = BlockFor(output, "FlowFieldBoundEnabled_IsRefusedNotAnsweredFalse");
+        Assert.Contains("out-of-scope", refused, StringComparison.Ordinal);
+        Assert.Contains("HasKid", refused, StringComparison.Ordinal);
+        // The defect, pinned: an answer at all — Yes or No — means the runner resolved an
+        // uncalculated FlowField and invented a verdict for a shape nobody has measured.
+        Assert.DoesNotContain("OBSERVED Enabled=", refused, StringComparison.Ordinal);
+
+        var control = BlockFor(output, "NormalBooleanBoundEnabled_StillFollowsTheRow");
+        Assert.StartsWith("PASS ", control, StringComparison.Ordinal);
+    }
 }

--- a/AlRunner.Tests/LivePropertyExpressionTests.cs
+++ b/AlRunner.Tests/LivePropertyExpressionTests.cs
@@ -10,6 +10,9 @@
 // shapes the corpus arms use once a resolver answers field names at all — including an
 // Option compared against ORDINALS, which is how the AL compiler writes such a comparison into
 // the page metadata.
+//
+// FlowFieldBoundLivePropertyTests at the bottom of this file is the exception: it spawns the
+// runner over a generated bundle, for the reason its own header gives.
 using System;
 using System.Diagnostics;
 using System.Text;

--- a/AlRunner.Tests/LivePropertyExpressionTests.cs
+++ b/AlRunner.Tests/LivePropertyExpressionTests.cs
@@ -1,0 +1,120 @@
+// LivePropertyExpressionTests — the C# half of issue #3730.
+//
+// The AL-observable claim (an action's Enabled, and a control's Enabled/Editable, bound to a
+// source-table field follow the CURRENT ROW, while a control's Visible does not) belongs to real
+// BC and is adjudicated upstream by corpus codeunit 60436 "TPAE Tests".
+//
+// What is provable here without a loaded BC runtime is the C# contract that fix rests on: the
+// narrowing RunnerPageInstance applies to a field's ClientObject before it reaches
+// PageControlExpression, and the fact that PageControlExpression really does evaluate the three
+// shapes the corpus arms use once a resolver answers field names at all — including an
+// Option compared against ORDINALS, which is how the AL compiler writes such a comparison into
+// the page metadata.
+using System;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class LivePropertyExpressionTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    [InlineData("Filled")]
+    [InlineData("")]
+    [InlineData(1)]
+    [InlineData(0)]
+    public void TryComparableFieldValue_PassesThroughAShapeCompareCanOrder(object clientObject)
+    {
+        Assert.True(RunnerPageInstance.TryComparableFieldValue(clientObject, out var value));
+        Assert.Equal(clientObject, value);
+    }
+
+    [Fact]
+    public void TryComparableFieldValue_PassesThroughDecimalAndTheOtherNumericWidths()
+    {
+        Assert.True(RunnerPageInstance.TryComparableFieldValue(12.5m, out var dec));
+        Assert.Equal(12.5m, dec);
+
+        Assert.True(RunnerPageInstance.TryComparableFieldValue((long)7, out var lng));
+        Assert.Equal((long)7, lng);
+    }
+
+    // The negative direction, and the one that matters: a shape the evaluator's Compare has no
+    // ordering for must be REFUSED, so EvaluateProperty raises naming the expression rather than
+    // handing Compare an operand it would have to invent an answer for.
+    [Fact]
+    public void TryComparableFieldValue_RefusesAShapeCompareCannotOrder()
+    {
+        Assert.False(RunnerPageInstance.TryComparableFieldValue(Guid.NewGuid(), out var guid));
+        Assert.Null(guid);
+
+        Assert.False(RunnerPageInstance.TryComparableFieldValue(new object(), out var opaque));
+        Assert.Null(opaque);
+
+        Assert.False(RunnerPageInstance.TryComparableFieldValue(null, out var missing));
+        Assert.Null(missing);
+    }
+
+    // The three property texts the corpus arms produce, evaluated through the real parser with a
+    // resolver that answers field names — the composition the #3730 fix creates. The metadata
+    // spellings here are the compiler's own (see PageControlExpression's file header): a bare
+    // field name for a Boolean, a quoted comparison for Text, and ORDINALS for an Option.
+    [Theory]
+    [InlineData("Flag", true, true)]
+    [InlineData("Flag", false, false)]
+    public void ABareBooleanFieldNameEvaluatesToTheFieldsValue(string text, bool flag, bool expected)
+    {
+        Assert.True(PageControlExpression.TryEvaluateBoolean(
+            text, Resolver(flag, "Filled", 1), out var evaluated, out var why), why);
+        Assert.Equal(expected, evaluated);
+    }
+
+    [Theory]
+    [InlineData("Filled", true)]
+    [InlineData("", false)]
+    public void ATextComparisonEvaluatesAgainstTheFieldsValue(string value, bool expected)
+    {
+        Assert.True(PageControlExpression.TryEvaluateBoolean(
+            "Value <> ''", Resolver(true, value, 1), out var evaluated, out var why), why);
+        Assert.Equal(expected, evaluated);
+    }
+
+    [Theory]
+    [InlineData(1, true)]
+    [InlineData(2, true)]
+    [InlineData(0, false)]
+    public void AnOptionComparisonEvaluatesAgainstTheFieldsOrdinal(int ordinal, bool expected)
+    {
+        Assert.True(PageControlExpression.TryEvaluateBoolean(
+            "( LineType = 1 ) or ( LineType = 2 )",
+            Resolver(true, "Filled", ordinal), out var evaluated, out var why), why);
+        Assert.Equal(expected, evaluated);
+    }
+
+    // And the refusal survives the composition: a field the resolver does not answer must still
+    // come back as a failure, never as a default, so #3693's Invoke()-time Enabled check cannot
+    // silently invent an answer for a shape nobody has measured.
+    [Fact]
+    public void AnUnresolvedIdentifierIsStillAFailure()
+    {
+        Assert.False(PageControlExpression.TryEvaluateBoolean(
+            "Unknown", Resolver(true, "Filled", 1), out _, out var why));
+        Assert.Contains("Unknown", why);
+    }
+
+    private static PageControlExpression.ResolveIdentifier Resolver(bool flag, string value, int lineType)
+        => (string name, bool quoted, out object? resolved) =>
+        {
+            object? raw = name switch
+            {
+                "Flag" => flag,
+                "Value" => value,
+                "LineType" => lineType,
+                _ => null,
+            };
+            if (raw == null) { resolved = null; return false; }
+            return RunnerPageInstance.TryComparableFieldValue(raw, out resolved);
+        };
+}

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -1081,19 +1081,6 @@ internal sealed partial class RunnerPageInstance
     }
 
     /// <summary>
-    /// Resolve one identifier inside a control-property expression.
-    ///
-    /// Registered source expressions only. A page global is registered in the page's
-    /// source-expression table under the emitted name the metadata carries, and that is the one
-    /// source this resolves against.
-    ///
-    /// A source-table FIELD reference is deliberately NOT resolved here: this overload serves the
-    /// AT-OPEN path only, where real BC reads such an expression as if the field held its type
-    /// default, whatever row the page is on (corpus codeunit 60755, green on 8 legs — issue
-    /// #2596). <see cref="ResolveExpressionIdentifierLive"/> is the one that reads the record, and
-    /// the split between the two is what keeps both answers faithful.
-    /// </summary>
-    /// <summary>
     /// The same resolution as <see cref="ResolveExpressionIdentifier"/>, but answering from the
     /// open-time snapshot. Used only for a control's own Visible — the one property real BC
     /// does not re-evaluate after the page is open.
@@ -1130,9 +1117,13 @@ internal sealed partial class RunnerPageInstance
     /// field's type default on every row (corpus codeunit 60755) — which is why that one property
     /// goes through <see cref="ResolveExpressionIdentifierAtOpen"/> and never reaches here.</para>
     ///
-    /// <para>Before this, every such expression raised RunnerOutOfScopeException. That was
-    /// unreachable from Invoke() until #3693 made Invoke() consult Enabled, at which point it
-    /// turned every action with a Rec-bound Enabled un-invokable — issue #3730.</para>
+    /// <para>Before this, every such expression raised RunnerOutOfScopeException, which #3693
+    /// turned into an un-invokable action — issue #3730.</para>
+    ///
+    /// <para>Ordering: a registered source expression is tried before a source-table field, so a
+    /// page global sharing a field's name shadows the field. AL tells them apart by the
+    /// <c>Rec.</c> prefix, which the metadata drops; whether BC resolves the same way here is
+    /// UNMEASURED.</para>
     /// </summary>
     private bool ResolveExpressionIdentifierLive(string name, bool quoted, out object? value)
     {
@@ -1148,9 +1139,10 @@ internal sealed partial class RunnerPageInstance
     /// PageControlExpression needs, because the compiler writes an option comparison into the
     /// metadata with the member already lowered to a number (<c>Kind = 1</c>).</para>
     ///
-    /// <para>False for a name the source table does not carry, and false for a value shape the
-    /// expression evaluator cannot compare, so the caller raises its refusal naming the
-    /// expression rather than inventing an answer (.claude/rules/loud-failures.md).</para>
+    /// <para>False for a name the source table does not carry, false for a FlowField or
+    /// FlowFilter, and false for a value shape the expression evaluator cannot compare, so the
+    /// caller raises its refusal naming the expression rather than inventing an answer
+    /// (.claude/rules/loud-failures.md).</para>
     /// </summary>
     private bool TryResolveSourceTableField(string name, out object? value)
     {
@@ -1160,6 +1152,15 @@ internal sealed partial class RunnerPageInstance
         foreach (var field in RecordPatches.GetAllFields(_record.MetaTable) ?? Enumerable.Empty<NCLMetaField>())
         {
             if (!string.Equals(field.FieldName, name, StringComparison.OrdinalIgnoreCase)) continue;
+
+            // GetAllFields is BC's NCLMetaTable.AllFields, FlowFields and FlowFilters included.
+            // An UNCALCULATED FlowField's ClientObject is its type default, which narrows
+            // cleanly below — so without this the runner would answer Enabled = false on a row
+            // whose CalcFormula holds. What BC answers for a FlowField-bound live property is
+            // unmeasured (no corpus arm covers it), so refuse rather than calculate: see
+            // AlRunner.Tests/LivePropertyExpressionTests.cs's FlowField arm.
+            if (field.FieldClass != Microsoft.Dynamics.Nav.Types.Metadata.FieldClass.Normal)
+                return false;
 
             return TryComparableFieldValue(_record.GetFieldValue(field.FieldNo)?.ClientObject, out value);
         }

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -1161,28 +1161,43 @@ internal sealed partial class RunnerPageInstance
         {
             if (!string.Equals(field.FieldName, name, StringComparison.OrdinalIgnoreCase)) continue;
 
-            var client = _record.GetFieldValue(field.FieldNo)?.ClientObject;
-            switch (client)
-            {
-                case bool:
-                case string:
-                case int:
-                case long:
-                case short:
-                case byte:
-                case decimal:
-                case double:
-                case float:
-                    value = client;
-                    return true;
-                default:
-                    // A shape the evaluator's Compare cannot order (a Guid, a Blob, a Media...).
-                    // Refusing here is the honest answer: the caller names the expression.
-                    return false;
-            }
+            return TryComparableFieldValue(_record.GetFieldValue(field.FieldNo)?.ClientObject, out value);
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// A field's <c>ClientObject</c> narrowed to the shapes PageControlExpression's Compare can
+    /// order: Boolean, Text/Code, and the numeric family — which is also where an Option/Enum
+    /// arrives, as its ordinal, since the compiler lowers a member comparison to a number
+    /// (<c>Kind = 1</c>).
+    ///
+    /// <para>Anything else — a Guid, a Blob, a Media, a DateFormula — is refused rather than
+    /// passed through, so the caller raises its refusal naming the expression instead of handing
+    /// the evaluator an operand it would have to invent an ordering for
+    /// (.claude/rules/loud-failures.md). Internal so AlRunner.Tests can pin the narrowing without
+    /// a live NavForm.</para>
+    /// </summary>
+    internal static bool TryComparableFieldValue(object? clientObject, out object? value)
+    {
+        switch (clientObject)
+        {
+            case bool:
+            case string:
+            case int:
+            case long:
+            case short:
+            case byte:
+            case decimal:
+            case double:
+            case float:
+                value = clientObject;
+                return true;
+            default:
+                value = null;
+                return false;
+        }
     }
 
     /// <summary>

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -1068,7 +1068,7 @@ internal sealed partial class RunnerPageInstance
         // the measured shapes and the grammar.
         if (PageControlExpression.TryEvaluateBoolean(
                 raw,
-                atOpen ? ResolveExpressionIdentifierAtOpen : ResolveExpressionIdentifier,
+                atOpen ? ResolveExpressionIdentifierAtOpen : ResolveExpressionIdentifierLive,
                 out var evaluated, out var why))
             return evaluated;
 
@@ -1087,15 +1087,11 @@ internal sealed partial class RunnerPageInstance
     /// source-expression table under the emitted name the metadata carries, and that is the one
     /// source this resolves against.
     ///
-    /// A source-table FIELD reference is deliberately NOT resolved here, even though the metadata
-    /// carries the field name and the record is right there. Measured on all 8 BC versions
-    /// (corpus PR #125's measurement pass): real BC evaluates such an expression as if the field
-    /// held its type default, whatever row the page is on — opening a card on a row with
-    /// Flag = true and on a row with Flag = false produced byte-identical readings of
-    /// `Visible = Rec.Flag`, `Visible = not Rec.Flag` and `Visible = Rec.Value &lt;&gt; ''`.
-    /// Reading the live record would therefore answer something BC does not answer, and a value
-    /// this runner made up is worse than the loud refusal the caller raises instead
-    /// (.claude/rules/loud-failures.md). Issue #2596 tracks it, with the transcripts.
+    /// A source-table FIELD reference is deliberately NOT resolved here: this overload serves the
+    /// AT-OPEN path only, where real BC reads such an expression as if the field held its type
+    /// default, whatever row the page is on (corpus codeunit 60755, green on 8 legs — issue
+    /// #2596). <see cref="ResolveExpressionIdentifierLive"/> is the one that reads the record, and
+    /// the split between the two is what keeps both answers faithful.
     /// </summary>
     /// <summary>
     /// The same resolution as <see cref="ResolveExpressionIdentifier"/>, but answering from the
@@ -1118,6 +1114,74 @@ internal sealed partial class RunnerPageInstance
         }
 
         value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Identifier resolution for the LIVE properties — an action's Enabled and Visible, and a
+    /// control's Enabled and Editable. A registered source expression first, then a field on the
+    /// page's source table, read off the record the page is currently on.
+    ///
+    /// <para>Measured on BC 28.4.53241.0 (container, test toolkit) and pinned upstream by corpus
+    /// codeunit 60436 "TPAE Tests": all four of those properties follow the current row. An action
+    /// declaring <c>Enabled = Rec.Flag</c> reports true and runs its OnAction on a row whose Flag
+    /// is true, and reports false and skips it on a row whose Flag is false; a control's Enabled
+    /// and Editable answer the same way. A control's own <c>Visible</c> does NOT — it reads the
+    /// field's type default on every row (corpus codeunit 60755) — which is why that one property
+    /// goes through <see cref="ResolveExpressionIdentifierAtOpen"/> and never reaches here.</para>
+    ///
+    /// <para>Before this, every such expression raised RunnerOutOfScopeException. That was
+    /// unreachable from Invoke() until #3693 made Invoke() consult Enabled, at which point it
+    /// turned every action with a Rec-bound Enabled un-invokable — issue #3730.</para>
+    /// </summary>
+    private bool ResolveExpressionIdentifierLive(string name, bool quoted, out object? value)
+    {
+        if (ResolveExpressionIdentifier(name, quoted, out value)) return true;
+        return TryResolveSourceTableField(name, out value);
+    }
+
+    /// <summary>
+    /// One source-table field, by the name the metadata carries, off the record the page is on.
+    ///
+    /// <para>The value is the field's <c>ClientObject</c>: a Boolean arrives as <c>bool</c>, a
+    /// Text/Code as <c>string</c>, and an Option/Enum as its ORDINAL — which is the shape
+    /// PageControlExpression needs, because the compiler writes an option comparison into the
+    /// metadata with the member already lowered to a number (<c>Kind = 1</c>).</para>
+    ///
+    /// <para>False for a name the source table does not carry, and false for a value shape the
+    /// expression evaluator cannot compare, so the caller raises its refusal naming the
+    /// expression rather than inventing an answer (.claude/rules/loud-failures.md).</para>
+    /// </summary>
+    private bool TryResolveSourceTableField(string name, out object? value)
+    {
+        value = null;
+        if (_record?.MetaTable == null) return false;
+
+        foreach (var field in RecordPatches.GetAllFields(_record.MetaTable) ?? Enumerable.Empty<NCLMetaField>())
+        {
+            if (!string.Equals(field.FieldName, name, StringComparison.OrdinalIgnoreCase)) continue;
+
+            var client = _record.GetFieldValue(field.FieldNo)?.ClientObject;
+            switch (client)
+            {
+                case bool:
+                case string:
+                case int:
+                case long:
+                case short:
+                case byte:
+                case decimal:
+                case double:
+                case float:
+                    value = client;
+                    return true;
+                default:
+                    // A shape the evaluator's Compare cannot order (a Guid, a Blob, a Media...).
+                    // Refusing here is the honest answer: the caller names the expression.
+                    return false;
+            }
+        }
+
         return false;
     }
 


### PR DESCRIPTION
Closes #3730

Opened by agent `fbk-3`.

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/318

## The regression

#3693 made `TestAction.Invoke()` consult the action's `Enabled` before dispatching `OnAction` —
right, and measured. But `Enabled` goes through `RunnerPageInstance.EvaluateProperty`, which
**refuses** any property expression reading a field on the page's SourceTable (#2596). That
refusal was unreachable from `Invoke()` before #3693; after it, every action declaring
`Enabled = Rec.<Field>` became un-invokable:

```
RunnerOutOfScopeException: out-of-scope: TestPage Enabled on page N element M
  - not-yet-implemented - testpage-control-property: the property is bound to expression
    'Value <> ''', which cannot be evaluated: 'Value' is not a name the page publishes a binding for
  at RunnerPageInstance.EvaluateProperty -> RunnerPageInstance.ActionEnabled -> LiveNavTestAction.Invoke
```

The reviewer flagged exactly this risk on #3693.

## What real BC does — measured, not reasoned

BC 28.4.53241.0 (onprem w1) in a container, through the test toolkit, on two rows — one where
every expression under test is true, one where every one is false:

| shape | true row | false row |
|---|---|---|
| action `Enabled = Rec.<Boolean>` | `Enabled()` true, `OnAction` runs | false, `OnAction` skipped, nothing raised |
| action `Enabled = Rec.<Text> <> ''` | true, runs | false, skipped |
| action `Enabled = (Rec.<Option> = One) or (Rec.<Option> = Two)` | true, runs | false, skipped |
| control `Enabled = Rec.<Boolean>` | true | false |
| control `Editable = Rec.<Boolean>` | true | false |

So these four properties are evaluated **live against the current row**. Corpus PR #318 pins all
six rows upstream (codeunit 60436 `TPAE Tests`, 8 tests, all Success on 28.4 before the PR was
opened).

This does **not** contradict corpus codeunit 60755 (`TPCF Tests`, green on 8 legs), which measures
a *control's `Visible`* — a different property on a different element, frozen at the field's type
default. The runner already routes that one through `ResolveExpressionIdentifierAtOpen`, and this
change deliberately leaves that path alone, so 60755's assertions are untouched.

## The change

`AlRunner/Patches/RunnerPageInstance.cs`, one seam:

- `EvaluateProperty(atOpen: false)` now resolves identifiers through a new
  `ResolveExpressionIdentifierLive`: registered source expressions first (unchanged), then a
  source-table field read off the record the page is on.
- `ResolveExpressionIdentifierAtOpen` and the base `ResolveExpressionIdentifier` are unchanged, so
  a control's `Visible` keeps answering exactly as it does today.
- `TryComparableFieldValue` narrows a field's `ClientObject` to the shapes
  `PageControlExpression.Compare` can order — Boolean, Text/Code, and the numeric family, which is
  where an Option/Enum arrives as its **ordinal**, the form the compiler lowers a member comparison
  to (`Kind = 1`). Anything else (Guid, Blob, Media) is refused, so the caller still raises naming
  the expression rather than inventing an operand.

**The rejected alternative:** "if the expression cannot be evaluated, invoke anyway (BC defaults to
enabled)". The container measurement kills it — BC genuinely skips the trigger on a row where the
expression is false, so a default-true fallback would reintroduce the exact silent wrong answer
#3693 removed. It is in the PR body rather than the code because it is a choice between options, not
something the next editor of that line needs.

## RED -> GREEN

The corpus arms of PR #318, run as a local bundle against this runner
(`--package-cache platform-apps + test-apps`):

| | `origin/main` (`8b6885f4`) | this branch |
|---|---|---|
| the 8 `TPAE` arms | **0 pass, 8 fail** — every one a `RunnerOutOfScopeException` refusal | **8 pass, 0 fail** |

Bisect of the regression itself, same 14-test bundle:

| | `f58e01af` (before #3693) | `662f3775` (after) | this branch |
|---|---|---|---|
| `Invoke()` only, `Enabled = Rec.Flag`, Flag true | PASS | **FAIL — refusal** | PASS |
| `Invoke()` only, text comparison, filled row | PASS | **FAIL — refusal** | PASS |
| `Invoke()` only, option comparison, row where it holds | PASS | **FAIL — refusal** | PASS |
| `Invoke()` only, `Enabled = Rec.Flag`, Flag false | FAIL (trigger ran) | PASS | PASS |

So #3693's real fix (last row) is preserved and its refusal is removed.

`AlRunner.Tests/LivePropertyExpressionTests.cs` pins the C# contract the fix rests on without a
loaded BC runtime: the narrowing in both directions (a Guid, an opaque object and null are
**refused**, not passed through), and the three metadata expression texts evaluating correctly
through the real parser once a resolver answers field names — including the option comparison
against ordinals. `dotnet test --filter "TestPageRefusalClaim|PageControlExpression|LivePropertyExpression"`:
155 passed, 0 failed.

## Scope, and what is deliberately left out

- **No pin bump.** Corpus PR #318 has not merged, and the pin chain is blocked by #2943 anyway.
  The bump folds into a later PR.
- **#2596 stays open.** This closes its live half; its own claim — a control's `Visible` — remains
  the type-default gap corpus 60755 measures. Commented there.
- **#3731 is not folded.** `Enabled = SomeProcedure()` compiles with `warning AL0573` and reads
  **false** on BC 28.4, while the runner answers true. Different mechanism (the whole-property-text
  fast path, not identifier resolution), and it cannot be pinned upstream because AL0573 becomes a
  compile error in a future release — a corpus codeunit carrying that shape is one BC minor away
  from failing every leg. Filed separately with the measurement.
- **The three sibling questions.** (1) The same wrong pattern elsewhere: `EvaluateProperty` is the
  single site every property read goes through, so there is no second call site with the shape.
  (2) Sibling functions with the same assumption: `ActionVisible` walks enclosing groups through the
  same `EvaluateProperty`, so it is fixed by the same change; `ControlVisible` shares the assumption
  deliberately and must keep it (60755). (3) Two paths writing one invariant: the at-open snapshot
  and the live read are the two, and the split between them is now explicit rather than implicit in
  one resolver serving both.
- **Queue scan.** Open issues landing in `RunnerPageInstance.cs`: #2596 (linked above, half closed,
  half deliberately not) and #3731 (filed by this work, deliberately not folded). Nothing else in the
  open queue lands in this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kko97BZZL71nF2nK5aftu4
