### PR TITLE
fix(testpage): answer the in-place page-mode switch, and Visible/Enabled from what a service tier measured

### DIFF
--- a/AlRunner.Tests/BuiltInPageModeActionRuleTests.cs
+++ b/AlRunner.Tests/BuiltInPageModeActionRuleTests.cs
@@ -6,7 +6,7 @@ namespace AlRunner.Tests;
 /// <summary>
 /// The measured table behind <c>TestPage.View()</c> / <c>TestPage.Edit()</c>, one assertion per
 /// row. The claims themselves are BC's, adjudicated by a real service tier — corpus codeunit
-/// 60479 "TPMS Tests" (StefanMaron/BusinessCentral.AL.Language.Tests#317, 10 arms on BC
+/// 60479 "TPMS Tests" (StefanMaron/BusinessCentral.AL.Language.Tests#317, 9 arms, 9/9 on BC
 /// 28.4.53241.0) and 60461 "TPVE Tests" (upstream #203). These pin the runner's own decision
 /// function against them, which is what the upstream arms cannot do until the corpus pin moves
 /// (the chain is blocked on issue #2943), and what no BC-runtime test does cheaply.
@@ -72,8 +72,9 @@ public class BuiltInPageModeActionRuleTests
     [InlineData("InPlaceSwitch", false, false, true)]  // Edit on a read-only page
     [InlineData("InPlaceSwitch", true, true, true)]    // View on an editable page
     [InlineData("InPlaceSwitch", false, true, false)]  // Edit, already editable
-    // View on a page that is already read-only, incl. one declaring Editable = false
-    // (60479 RoCardPageHandler asserts IsFalse on View().Enabled() there).
+    // View on a page that is already read-only, incl. one declaring Editable = false --
+    // asserted upstream in 60479's RoCardPageHandler, adjudicated by #317's cloud legs rather
+    // than by the 28.4 container run, which predates that assertion.
     [InlineData("InPlaceSwitch", true, false, false)]  // View, already read-only
     // A list with no card: View is enabled, Edit is not.
     [InlineData("NoTarget", true, true, true)]

--- a/AlRunner.Tests/BuiltInPageModeActionRuleTests.cs
+++ b/AlRunner.Tests/BuiltInPageModeActionRuleTests.cs
@@ -6,7 +6,7 @@ namespace AlRunner.Tests;
 /// <summary>
 /// The measured table behind <c>TestPage.View()</c> / <c>TestPage.Edit()</c>, one assertion per
 /// row. The claims themselves are BC's, adjudicated by a real service tier — corpus codeunit
-/// 60479 "TPMS Tests" (StefanMaron/BusinessCentral.AL.Language.Tests#317, 9/9 on BC
+/// 60479 "TPMS Tests" (StefanMaron/BusinessCentral.AL.Language.Tests#317, 10 arms on BC
 /// 28.4.53241.0) and 60461 "TPVE Tests" (upstream #203). These pin the runner's own decision
 /// function against them, which is what the upstream arms cannot do until the corpus pin moves
 /// (the chain is blocked on issue #2943), and what no BC-runtime test does cheaply.
@@ -72,6 +72,8 @@ public class BuiltInPageModeActionRuleTests
     [InlineData("InPlaceSwitch", false, false, true)]  // Edit on a read-only page
     [InlineData("InPlaceSwitch", true, true, true)]    // View on an editable page
     [InlineData("InPlaceSwitch", false, true, false)]  // Edit, already editable
+    // View on a page that is already read-only, incl. one declaring Editable = false
+    // (60479 RoCardPageHandler asserts IsFalse on View().Enabled() there).
     [InlineData("InPlaceSwitch", true, false, false)]  // View, already read-only
     // A list with no card: View is enabled, Edit is not.
     [InlineData("NoTarget", true, true, true)]

--- a/AlRunner.Tests/BuiltInPageModeActionRuleTests.cs
+++ b/AlRunner.Tests/BuiltInPageModeActionRuleTests.cs
@@ -1,0 +1,117 @@
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// The measured table behind <c>TestPage.View()</c> / <c>TestPage.Edit()</c>, one assertion per
+/// row. The claims themselves are BC's, adjudicated by a real service tier — corpus codeunit
+/// 60479 "TPMS Tests" (StefanMaron/BusinessCentral.AL.Language.Tests#317, 9/9 on BC
+/// 28.4.53241.0) and 60461 "TPVE Tests" (upstream #203). These pin the runner's own decision
+/// function against them, which is what the upstream arms cannot do until the corpus pin moves
+/// (the chain is blocked on issue #2943), and what no BC-runtime test does cheaply.
+///
+/// The negative half is the point: before issue #3258 both properties answered a hardcoded
+/// true and two of the shapes were refused outright, so an implementation that answers "true,
+/// always" passes nothing here.
+/// </summary>
+public class BuiltInPageModeActionRuleTests
+{
+    // ── Which shape the action is ───────────────────────────────────────────────────────────
+
+    [Theory]
+    // A resolvable CardPageId wins whatever the host is, and for both modes (corpus 60461).
+    [InlineData(60458, "List", true, true, "OpenCard")]
+    [InlineData(60458, "List", false, true, "OpenCard")]
+    [InlineData(60458, "Card", false, true, "OpenCard")]
+    // A list with nothing to open still has both actions; they do nothing (60479
+    // PlainListWithoutCardPageIdOffersBothActionsAndEnablesOnlyView).
+    [InlineData(0, "List", true, true, "NoTarget")]
+    [InlineData(0, "List", false, true, "NoTarget")]
+    [InlineData(0, "ListPart", false, true, "NoTarget")]
+    // Not a list, no card: the page already open changes mode (60479, both in-place arms).
+    [InlineData(0, "Card", true, true, "InPlaceSwitch")]
+    [InlineData(0, "Card", false, true, "InPlaceSwitch")]
+    [InlineData(0, "Document", false, true, "InPlaceSwitch")]
+    // Editable = false: View still exists, Edit does not (60479's file header).
+    [InlineData(0, "Card", true, false, "InPlaceSwitch")]
+    [InlineData(0, "Card", false, false, "RefuseNoEditAction")]
+    // Unknown PageType cannot be told apart from either, so it is refused rather than guessed.
+    [InlineData(0, null, true, true, "RefuseUnknownPageType")]
+    [InlineData(0, null, false, true, "RefuseUnknownPageType")]
+    public void ResolveShape_AnswersTheShapeTheServiceTierMeasured(
+        int cardPageId, string? pageType, bool viewMode, bool declaredEditable,
+        string expected)
+        // The enum is internal, and an xUnit theory method must be public, so the expected value
+        // travels as its name rather than as the value itself.
+        => Assert.Equal(
+            expected,
+            BuiltInPageModeActionRule.ResolveShape(cardPageId, pageType, viewMode, declaredEditable).ToString());
+
+    [Fact]
+    public void ResolveShape_DoesNotRefuseAnEditActionOnAReadOnlyCardWhenACardPageIdResolves()
+    {
+        // The read-only rule is about the HOST's own Editable, never the target card's: a list
+        // whose card is read-only keeps its Edit action and expresses the refusal through
+        // Enabled (60479 ListWhoseCardIsReadOnlyLeavesTheEditActionVisibleButNotEnabled). The
+        // runner used to throw here, which is half of what #3258 was filed for.
+        Assert.Equal(
+            BuiltInPageModeShape.OpenCard,
+            BuiltInPageModeActionRule.ResolveShape(60475, "List", viewMode: false, declaredPageEditable: false));
+        Assert.True(
+            BuiltInPageModeActionRule.Enabled(
+                BuiltInPageModeActionKind.OpenCard, viewMode: true, hostEditableNow: true, cardModifyAllowed: false),
+            "the View half of the same list stays enabled and does open that card, read-only");
+    }
+
+    // ── Whether it can be invoked ───────────────────────────────────────────────────────────
+
+    [Theory]
+    // In place: enabled only when the requested mode differs from the current one
+    // (CanSwitchViewMode). Rows 1-2 are the switch arms, 3-4 the "already in that mode" arms.
+    [InlineData("InPlaceSwitch", false, false, true)]  // Edit on a read-only page
+    [InlineData("InPlaceSwitch", true, true, true)]    // View on an editable page
+    [InlineData("InPlaceSwitch", false, true, false)]  // Edit, already editable
+    [InlineData("InPlaceSwitch", true, false, false)]  // View, already read-only
+    // A list with no card: View is enabled, Edit is not.
+    [InlineData("NoTarget", true, true, true)]
+    [InlineData("NoTarget", false, true, false)]
+    public void Enabled_FollowsTheModeThePageIsIn(
+        string kind, bool viewMode, bool hostEditableNow, bool expected)
+        => Assert.Equal(
+            expected,
+            BuiltInPageModeActionRule.Enabled(
+                System.Enum.Parse<BuiltInPageModeActionKind>(kind), viewMode, hostEditableNow, null));
+
+    [Theory]
+    // Opening a card: View always; Edit only when that card allows modification.
+    [InlineData(true, true, true)]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(false, false, false)]
+    [InlineData(false, null, true)]   // unknown card keeps the permissive answer
+    [InlineData(true, null, true)]
+    public void Enabled_OnACardOpeningActionFollowsTheCardsOwnModifyAllowed(
+        bool viewMode, bool? cardModifyAllowed, bool expected)
+        => Assert.Equal(
+            expected,
+            BuiltInPageModeActionRule.Enabled(
+                BuiltInPageModeActionKind.OpenCard, viewMode, hostEditableNow: true, cardModifyAllowed));
+
+    [Fact]
+    public void Enabled_IsNotAConstant()
+    {
+        // The regression guard for what #3258 reported: Visible and Enabled both answered a
+        // hardcoded true. Any implementation that answers one value everywhere fails here.
+        var answers = new[]
+        {
+            BuiltInPageModeActionRule.Enabled(BuiltInPageModeActionKind.InPlaceSwitch, false, true, null),
+            BuiltInPageModeActionRule.Enabled(BuiltInPageModeActionKind.InPlaceSwitch, false, false, null),
+            BuiltInPageModeActionRule.Enabled(BuiltInPageModeActionKind.NoTarget, false, true, null),
+            BuiltInPageModeActionRule.Enabled(BuiltInPageModeActionKind.OpenCard, false, true, false),
+            BuiltInPageModeActionRule.Enabled(BuiltInPageModeActionKind.OpenCard, true, true, false),
+        };
+        Assert.Contains(true, answers);
+        Assert.Contains(false, answers);
+    }
+}

--- a/AlRunner/Patches/BuiltInPageModeAction.cs
+++ b/AlRunner/Patches/BuiltInPageModeAction.cs
@@ -32,30 +32,48 @@
 //       it falls back to the card page id in the builder context (a list page's CardPageId),
 //       then FormState.CardPageId, and only then — when the parent form is NOT a List — to the
 //       parent page's OWN id.
-//     * IsModifyAllowedInCard — the Edit action is not created at all when the card does not
-//       allow modification, which is why Edit() can legitimately answer null.
+//     * IsModifyAllowedInCard — whether the card allows modification. BC does NOT drop the
+//       Edit action when it does not: the action is still there and still Visible, and BC
+//       expresses "you cannot use it here" through Enabled instead (corpus 60479
+//       ListWhoseCardIsReadOnlyLeavesTheEditActionVisibleButNotEnabled). This file said the
+//       opposite until #3258, and the runner refused that shape on the strength of it.
 //     * NavOpenTaskPageAction.FindFormState / CreateForm — the ROW and the MODE. `new
 //       FormState(ViewMode)` carries the requested mode onto the target, and the parent
 //       binding manager's CurrentRow bookmark is stamped onto it, so the card opens on the
 //       row the list is standing on.
 //
-//   And the service tier has adjudicated the result: corpus codeunit 60461 "TPVE Tests"
+//   And the service tier has adjudicated the result twice. Corpus codeunit 60461 "TPVE Tests"
 //   (StefanMaron/BusinessCentral.AL.Language.Tests#203) drives a List with CardPageId, parks it
 //   on its second row, invokes each action, and asserts that the card opens exactly once, on
 //   that row, that the [PageHandler] ran, and that View gives the handler a read-only page
-//   while Edit gives it an editable one.
+//   while Edit gives it an editable one. Corpus codeunit 60479 "TPMS Tests" (upstream #317,
+//   9/9 on BC 28.4.53241.0) adds every shape where NO card opens:
+//
+//     shape                                   | Visible | Enabled | Invoke
+//     ----------------------------------------|---------|---------|---------------------------
+//     Card opened read-only, Edit()            | true    | true    | the page becomes editable
+//     Card opened editable, View()             | true    | true    | the page becomes read-only
+//     Card already in the requested mode       | true    | FALSE   | nothing at all
+//     List with no CardPageId, View()          | true    | true    | nothing opens
+//     List with no CardPageId, Edit()          | true    | FALSE   | nothing opens
+//     List whose card is read-only, Edit()     | true    | FALSE   | nothing opens
+//     List whose card is read-only, View()     | true    | true    | that card opens, read-only
+//     List whose card is editable, both        | true    | true    | that card opens (60461)
+//
+//   Visible is true in every single row. Enabled is where BC says "not here" — which is the
+//   correction #3258 was filed to get: both properties used to answer a hardcoded true, and
+//   the two no-card shapes were refused outright.
 //
 // WHAT THIS FILE IMPLEMENTS
-//   Exactly the measured shape: a page that declares a resolvable CardPageId opens that card,
-//   on the host's current row, in the requested mode, through BC's own NavForm front door —
-//   so handler lookup, TestPage.Trap() and the "Unhandled UI" refusal stay BC's.
+//   All of the above. The in-place switch moves LiveNavTestPage's own editability
+//   (SwitchViewModeInPlace) rather than driving BC's PageModeAggregator.ChangePageMode: that
+//   type lives in Microsoft.Dynamics.Nav.Client.UI.dll and operates on a client LogicalForm,
+//   which the runner never builds — its whole action layer is its own.
 //
-// WHAT IT REFUSES, LOUDLY
-//   The in-place variant, where ResolveCardFormId lands on the host page's own id and
-//   NavOpenTaskPageAction.InvokeCore switches THAT page's mode instead of opening anything
-//   (UseCurrentForm -> PageModeAggregator.ChangePageMode). No corpus test measures it, the
-//   runner models a TestPage's editability as a value fixed at open time, and answering it by
-//   opening a second copy of the page would be a silent wrong answer. Issue #3258.
+// WHAT IS STILL REFUSED
+//   A page declaring Editable = false, asked for Edit(). BC has no such action and raises a
+//   bare NullReferenceException out of NavTestAction; the runner refuses by name instead. See
+//   LiveNavTestPage.BuiltInPageModeActionFor.
 using Microsoft.Dynamics.Nav.Runtime;
 using Microsoft.Dynamics.Nav.Types;
 
@@ -103,9 +121,22 @@ internal static class RunnerPendingPageOpenMode
     }
 }
 
+/// <summary>Which of BC's three shapes a built-in page-mode action is. See this file's header.</summary>
+internal enum BuiltInPageModeActionKind
+{
+    /// <summary>Opens the host's CardPageId card (corpus 60461).</summary>
+    OpenCard,
+
+    /// <summary>A list with no card to open: the action exists and does nothing.</summary>
+    NoTarget,
+
+    /// <summary>A non-list host: the page already open changes mode.</summary>
+    InPlaceSwitch,
+}
+
 /// <summary>
-/// A page's built-in View / Edit action, wired to the page it actually opens. See this file's
-/// header for what BC's own client does and where each rule below is read from.
+/// A page's built-in View / Edit action. See this file's header for what BC's own client does
+/// and where each row of the table is measured.
 /// </summary>
 internal sealed class BuiltInPageModeAction : ITestAction
 {
@@ -113,57 +144,110 @@ internal sealed class BuiltInPageModeAction : ITestAction
     private readonly NavRecord? _record;
     private readonly int _targetPageId;
     private readonly bool _viewMode;
+    private readonly BuiltInPageModeActionKind _kind;
 
-    internal BuiltInPageModeAction(LiveNavTestPage host, NavRecord? record, int targetPageId, bool viewMode)
+    internal BuiltInPageModeAction(
+        LiveNavTestPage host, NavRecord? record, int targetPageId, bool viewMode,
+        BuiltInPageModeActionKind kind)
     {
         _host = host;
         _record = record;
         _targetPageId = targetPageId;
         _viewMode = viewMode;
+        _kind = kind;
     }
 
     /// <summary>
-    /// Save the current row, then open the card on it — the same order
-    /// <see cref="LiveNavTestAction"/> uses, and BC's: <c>LogicalAction.RequiresSave</c> is set
-    /// to true in <c>NavOpenTaskPageAction</c>'s constructor, so a real client sends the row it
-    /// is standing on to the server before the action runs.
+    /// Save the current row, then do whatever this action's shape does. The save is BC's order
+    /// too: <c>LogicalAction.RequiresSave</c> is set to true in <c>NavOpenTaskPageAction</c>'s
+    /// constructor, so a real client sends the row it is standing on to the server first.
+    ///
+    /// <para>A DISABLED action does nothing, and does not raise. That is not the runner being
+    /// permissive: it is what a real service tier does with every one of these — corpus 60479
+    /// EditActionOnAnAlreadyEditableCardIsVisibleButNotEnabledAndDoesNothing, its View mirror,
+    /// and ListWhoseCardIsReadOnlyLeavesTheEditActionVisibleButNotEnabled each invoke one and
+    /// assert that the page's mode is unchanged and that nothing opened. Under
+    /// loud-failures.md this is the observably-equivalent answer, not a swallowed failure:
+    /// BC's own <c>LogicalAction.CanInvoke</c> gate produces no effect and no error.</para>
     /// </summary>
     public void Invoke()
     {
         _host.SaveCurrentRow();
 
-        // The mode has to be in place BEFORE the form opens: OnOpenPage is AL that can read
-        // CurrPage.Editable, and the [PageHandler] reads it through TestPage.Editable().
-        RunnerPendingPageOpenMode.Arm(_targetPageId, readOnly: _viewMode);
-        try
+        if (!Enabled) return;
+
+        switch (_kind)
         {
-            // The host's current row, which is what BC stamps onto the target's form state as
-            // `parentBindingManager.CurrentRow.Bookmark` — the runner's equivalent of a
-            // bookmark is handing BC's own page-run front door the record itself, exactly as
-            // an action's `RunPageOnRec` already does (RunnerPageInstance.ActionRunObject).
-            RunnerPageInstance.RunPageThroughBcFrontDoor(_targetPageId, _record);
-        }
-        finally
-        {
-            RunnerPendingPageOpenMode.Disarm();
+            case BuiltInPageModeActionKind.InPlaceSwitch:
+                // Nothing opens: the page already on screen changes mode. BC reaches this
+                // through NavOpenTaskPageAction.InvokeCore's UseCurrentForm branch.
+                _host.SwitchViewModeInPlace(_viewMode);
+                return;
+
+            case BuiltInPageModeActionKind.NoTarget:
+                // A list with no CardPageId: BC resolves no target form and the invoke has no
+                // effect (corpus 60479 PlainListWithoutCardPageIdOffersBothActionsAndEnablesOnlyView
+                // asserts neither card opened).
+                return;
+
+            default:
+                // The mode has to be in place BEFORE the form opens: OnOpenPage is AL that can
+                // read CurrPage.Editable, and the [PageHandler] reads it through
+                // TestPage.Editable().
+                RunnerPendingPageOpenMode.Arm(_targetPageId, readOnly: _viewMode);
+                try
+                {
+                    // The host's current row, which is what BC stamps onto the target's form
+                    // state as `parentBindingManager.CurrentRow.Bookmark` — the runner's
+                    // equivalent of a bookmark is handing BC's own page-run front door the
+                    // record itself, exactly as an action's `RunPageOnRec` already does
+                    // (RunnerPageInstance.ActionRunObject).
+                    RunnerPageInstance.RunPageThroughBcFrontDoor(_targetPageId, _record);
+                }
+                finally
+                {
+                    RunnerPendingPageOpenMode.Disarm();
+                }
+                return;
         }
     }
 
     /// <summary>
-    /// True, and the reason is structural rather than a default: in BC these two properties
-    /// answer <c>LogicalAction.CanInvoke</c>, whereas whether the action EXISTS at all is
-    /// decided earlier, by ActionBuilder — and that is the half this runner models, in
-    /// <see cref="LiveNavTestPage.BuiltInPageModeActionFor"/>. An action that got this far was
-    /// created by the builder's own rules.
-    ///
-    /// <para>What is NOT modelled: CanInvoke additionally refuses a multi-row selection
-    /// (<c>IsMultipleSelectionDisabledAction</c>), and consults the action's FilterContext and
-    /// any already-open form for the same page. None of those has a runner equivalent — the
-    /// runner has no selection model and no window list — and no corpus test reads
-    /// <c>Visible</c>/<c>Enabled</c> on a built-in page-mode action. Issue #3258.</para>
+    /// True in every shape a service tier has been asked about — see the table in this file's
+    /// header, where Visible is true on all eight rows. The action's EXISTENCE is what
+    /// LiveNavTestPage.BuiltInPageModeActionFor decides; anything that got this far exists.
     /// </summary>
     public bool Visible => true;
 
-    /// <inheritdoc cref="Visible"/>
-    public bool Enabled => true;
+    /// <summary>
+    /// BC's <c>LogicalAction.CanInvoke</c>, for the conditions that have an answer here:
+    ///
+    /// <list type="bullet">
+    /// <item><b>In place</b> — enabled only when the requested mode differs from the page's
+    /// current one, which is <c>NavOpenTaskPageAction.CanSwitchViewMode</c>: Edit applies to a
+    /// page that is currently read-only, View to one that is currently editable.</item>
+    /// <item><b>No target</b> — View is enabled, Edit is not. A list with no CardPageId has no
+    /// editable card to reach.</item>
+    /// <item><b>Open a card</b> — View always; Edit only when that card allows modification
+    /// (<c>ActionBuilder.IsModifyAllowedInCard</c>). Unknown keeps the permissive answer, the
+    /// rule every TryGetAny* caller uses: refusing on a lookup miss would answer from the
+    /// runner's own inventory rather than from the page.</item>
+    /// </list>
+    ///
+    /// <para>Computed per read rather than at construction, because a switch moves it: AL that
+    /// reads Enabled, invokes, and reads again must see the second answer.</para>
+    ///
+    /// <para>CanInvoke's remaining conditions have no runner equivalent and need none — each
+    /// collapses to its permissive value BY CONSTRUCTION, not by assumption.
+    /// <c>IsMultipleSelectionDisabledAction</c> refuses a multi-row selection and the runner
+    /// drives exactly one row; <c>FindExistingForm</c> refuses when a form for the same page is
+    /// already open and RunnerTestClientSession.OpenFormsCount is 0 by design. So the three
+    /// rules above are the whole gate here, and the eight measured rows agree with them.</para>
+    /// </summary>
+    public bool Enabled => _kind switch
+    {
+        BuiltInPageModeActionKind.InPlaceSwitch => _viewMode ? _host.StaticEditableNow : !_host.StaticEditableNow,
+        BuiltInPageModeActionKind.NoTarget => _viewMode,
+        _ => _viewMode || RecordPatches.TryGetAnyPageModifyAllowed(_targetPageId) != false,
+    };
 }

--- a/AlRunner/Patches/BuiltInPageModeAction.cs
+++ b/AlRunner/Patches/BuiltInPageModeAction.cs
@@ -1,78 +1,33 @@
 // BuiltInPageModeAction — AL's `SomePage.View()` and `SomePage.Edit()` on a TestPage.
 //
-// THE GAP (issue #3185)
-//   Both raised "InvalidOperationException: The UISessionManager was expected to be
-//   initialized." from TestPageClientSession.GetTestLogicalDispatcher(), before any page could
-//   open. Two independent causes, and the first one hid the second:
+// THE CLAIM
+//   Nothing in the application declares these actions; the CLIENT supplies them, and BC's
+//   TestPageProxy.View()/Edit() is a lookup rather than an effect. Across every shape BC
+//   distinguishes, Visible is TRUE — including the shapes where nothing happens. Enabled is
+//   the channel BC says "not here" through. Both properties answered a hardcoded true, and the
+//   two no-card shapes were refused outright, until issue #3258.
 //
-//   1. NavTestPageBase.ALView()/ALEdit() wrap their result in TestClientProxy<ITestAction>
-//      .Proxy(...), which needs the client's dispatcher. NclCecilRewrite step 4 strips that
-//      call from NavTestPageBase — but it used to strip it from a hard-coded list of six
-//      method names, and NavTestPageBase has EIGHT Proxy call sites. ALView and ALEdit were
-//      the two the list did not name. That step now sweeps the whole type.
+//   Measured, not read off the builder: corpus codeunit 60479 "TPMS Tests"
+//   (StefanMaron/BusinessCentral.AL.Language.Tests#317, 10 arms on BC 28.4.53241.0) and 60461
+//   "TPVE Tests" (upstream #203). Row by row the table is pinned as assertions in
+//   AlRunner.Tests/BuiltInPageModeActionRuleTests.cs; the builder walk behind it
+//   (ActionBuilder.ResolveCardFormId / IsModifyAllowedInCard, BC 28.1) and the #3185 history
+//   are in this change's pull request.
 //
-//   2. Underneath it, ITestPage.View()/Edit() answered `new MockITestAction()`, whose Invoke()
-//      is a literal no-op. So even with the proxy gone, invoking either did nothing at all.
-//      This file is that half.
+// THE TRAP
+//   The read-only rule reads the HOST page's own Editable, never the target card's.
+//   ResolveCardFormId falls back to the parent page's OWN id only when that parent is not a
+//   List — so a list whose card is read-only keeps its Edit action, Visible and not Enabled,
+//   while a Card declaring Editable = false has no Edit action at all.
 //
-// WHAT REAL BC DOES, AND HOW THAT WAS ESTABLISHED
-//   Nothing in the application declares these actions; the CLIENT supplies them. The
-//   reference implementation is Microsoft.Dynamics.Nav.Client.TestPageClient.TestPageProxy
-//   (BC 28.1), and it is a lookup, not an effect:
-//
-//     public ITestAction View()  => the first ActionControl whose Action is a
-//         NavOpenTaskPageAction { IsPageModeAction: not false } with ViewMode == PageMode.View,
-//         wrapped in a TestActionProxy — or NULL when the page has none.
-//
-//   Edit() is the same with PageMode.Edit. Those actions are created by
-//   Microsoft.Dynamics.Nav.Client.FormBuilder.ActionBuilder, from MenuActionType.View /
-//   MenuActionType.Edit, and everything this file needs is in three of its methods:
-//
-//     * ResolveCardFormId — the TARGET. For a system menu action `actionDef.TargetID` is 0, so
-//       it falls back to the card page id in the builder context (a list page's CardPageId),
-//       then FormState.CardPageId, and only then — when the parent form is NOT a List — to the
-//       parent page's OWN id.
-//     * IsModifyAllowedInCard — whether the card allows modification. BC does NOT drop the
-//       Edit action when it does not: the action is still there and still Visible, and BC
-//       expresses "you cannot use it here" through Enabled instead (corpus 60479
-//       ListWhoseCardIsReadOnlyLeavesTheEditActionVisibleButNotEnabled). This file said the
-//       opposite until #3258, and the runner refused that shape on the strength of it.
-//     * NavOpenTaskPageAction.FindFormState / CreateForm — the ROW and the MODE. `new
-//       FormState(ViewMode)` carries the requested mode onto the target, and the parent
-//       binding manager's CurrentRow bookmark is stamped onto it, so the card opens on the
-//       row the list is standing on.
-//
-//   And the service tier has adjudicated the result twice. Corpus codeunit 60461 "TPVE Tests"
-//   (StefanMaron/BusinessCentral.AL.Language.Tests#203) drives a List with CardPageId, parks it
-//   on its second row, invokes each action, and asserts that the card opens exactly once, on
-//   that row, that the [PageHandler] ran, and that View gives the handler a read-only page
-//   while Edit gives it an editable one. Corpus codeunit 60479 "TPMS Tests" (upstream #317,
-//   9/9 on BC 28.4.53241.0) adds every shape where NO card opens:
-//
-//     shape                                   | Visible | Enabled | Invoke
-//     ----------------------------------------|---------|---------|---------------------------
-//     Card opened read-only, Edit()            | true    | true    | the page becomes editable
-//     Card opened editable, View()             | true    | true    | the page becomes read-only
-//     Card already in the requested mode       | true    | FALSE   | nothing at all
-//     List with no CardPageId, View()          | true    | true    | nothing opens
-//     List with no CardPageId, Edit()          | true    | FALSE   | nothing opens
-//     List whose card is read-only, Edit()     | true    | FALSE   | nothing opens
-//     List whose card is read-only, View()     | true    | true    | that card opens, read-only
-//     List whose card is editable, both        | true    | true    | that card opens (60461)
-//
-//   Visible is true in every single row. Enabled is where BC says "not here" — which is the
-//   correction #3258 was filed to get: both properties used to answer a hardcoded true, and
-//   the two no-card shapes were refused outright.
-//
-// WHAT THIS FILE IMPLEMENTS
-//   All of the above. The in-place switch moves LiveNavTestPage's own editability
-//   (SwitchViewModeInPlace) rather than driving BC's PageModeAggregator.ChangePageMode: that
-//   type lives in Microsoft.Dynamics.Nav.Client.UI.dll and operates on a client LogicalForm,
-//   which the runner never builds — its whole action layer is its own.
+//   The in-place switch moves LiveNavTestPage's own editability (SwitchViewModeInPlace) rather
+//   than driving BC's PageModeAggregator.ChangePageMode: that type operates on a client
+//   LogicalForm, which the runner never builds.
 //
 // WHAT IS STILL REFUSED
-//   A page declaring Editable = false, asked for Edit(). BC has no such action and raises a
-//   bare NullReferenceException out of NavTestAction; the runner refuses by name instead. See
+//   A page declaring Editable = false, asked for Edit() — a deliberate divergence, since BC
+//   raises a bare NullReferenceException that names nothing. See
+//   docs/limitations.md#testpage-page-mode-no-edit-action and
 //   LiveNavTestPage.BuiltInPageModeActionFor.
 using Microsoft.Dynamics.Nav.Runtime;
 using Microsoft.Dynamics.Nav.Types;
@@ -213,8 +168,8 @@ internal sealed class BuiltInPageModeAction : ITestAction
     }
 
     /// <summary>
-    /// True in every shape a service tier has been asked about — see the table in this file's
-    /// header, where Visible is true on all eight rows. The action's EXISTENCE is what
+    /// True in every shape a service tier has been asked about — corpus 60479 (upstream #317)
+    /// and 60461 (#203) assert it on every one. The action's EXISTENCE is what
     /// LiveNavTestPage.BuiltInPageModeActionFor decides; anything that got this far exists.
     /// </summary>
     public bool Visible => true;

--- a/AlRunner/Patches/BuiltInPageModeAction.cs
+++ b/AlRunner/Patches/BuiltInPageModeAction.cs
@@ -8,7 +8,7 @@
 //   two no-card shapes were refused outright, until issue #3258.
 //
 //   Measured, not read off the builder: corpus codeunit 60479 "TPMS Tests"
-//   (StefanMaron/BusinessCentral.AL.Language.Tests#317, 10 arms on BC 28.4.53241.0) and 60461
+//   (StefanMaron/BusinessCentral.AL.Language.Tests#317, 9 arms, 9/9 on BC 28.4.53241.0) and 60461
 //   "TPVE Tests" (upstream #203). Row by row the table is pinned as assertions in
 //   AlRunner.Tests/BuiltInPageModeActionRuleTests.cs; the builder walk behind it
 //   (ActionBuilder.ResolveCardFormId / IsModifyAllowedInCard, BC 28.1) and the #3185 history

--- a/AlRunner/Patches/BuiltInPageModeAction.cs
+++ b/AlRunner/Patches/BuiltInPageModeAction.cs
@@ -244,10 +244,9 @@ internal sealed class BuiltInPageModeAction : ITestAction
     /// already open and RunnerTestClientSession.OpenFormsCount is 0 by design. So the three
     /// rules above are the whole gate here, and the eight measured rows agree with them.</para>
     /// </summary>
-    public bool Enabled => _kind switch
-    {
-        BuiltInPageModeActionKind.InPlaceSwitch => _viewMode ? _host.StaticEditableNow : !_host.StaticEditableNow,
-        BuiltInPageModeActionKind.NoTarget => _viewMode,
-        _ => _viewMode || RecordPatches.TryGetAnyPageModifyAllowed(_targetPageId) != false,
-    };
+    public bool Enabled => BuiltInPageModeActionRule.Enabled(
+        _kind, _viewMode, _host.StaticEditableNow,
+        _kind == BuiltInPageModeActionKind.OpenCard
+            ? RecordPatches.TryGetAnyPageModifyAllowed(_targetPageId)
+            : null);
 }

--- a/AlRunner/Patches/BuiltInPageModeActionRule.cs
+++ b/AlRunner/Patches/BuiltInPageModeActionRule.cs
@@ -2,16 +2,15 @@
 // inputs — which shape the action is, and whether it is enabled.
 //
 // They live apart from BuiltInPageModeAction and LiveNavTestPage for the reason
-// TestPageNewRowLineRule and LiveNavTestPage.OffersBuiltInAction do: every row of the table in
-// BuiltInPageModeAction.cs's header is a measured claim about real BC, and a claim that can
-// only be exercised by standing up a BC runtime and a TestPage is a claim nothing pins
-// cheaply. Here each row is one assertion (AlRunner.Tests/BuiltInPageModeActionRuleTests.cs).
+// TestPageNewRowLineRule and LiveNavTestPage.OffersBuiltInAction do: every value below is a
+// measured claim about real BC, and a claim that can only be exercised by standing up a BC
+// runtime and a TestPage is a claim nothing pins cheaply. Here each one is an assertion
+// (AlRunner.Tests/BuiltInPageModeActionRuleTests.cs).
 //
-// Every value below is measured on a real service tier — corpus codeunit 60479 "TPMS Tests"
-// (StefanMaron/BusinessCentral.AL.Language.Tests#317, 9/9 on BC 28.4.53241.0) and 60461
-// "TPVE Tests" (upstream #203) — not read off BC's UI builder. The builder read is in
-// BuiltInPageModeAction.cs's header and explains the measurements; it does not stand in for
-// them, and where the two disagreed the measurement won (issue #3258).
+// Measured on a real service tier — corpus codeunit 60479 "TPMS Tests"
+// (StefanMaron/BusinessCentral.AL.Language.Tests#317) and 60461 "TPVE Tests" (upstream #203) —
+// not read off BC's UI builder. The builder read explains the measurements and does not stand
+// in for them; where the two disagreed the measurement won (issue #3258).
 namespace AlRunner.Patches;
 
 /// <summary>Which of BC's shapes a built-in page-mode action is, or why there is none.</summary>

--- a/AlRunner/Patches/BuiltInPageModeActionRule.cs
+++ b/AlRunner/Patches/BuiltInPageModeActionRule.cs
@@ -1,0 +1,86 @@
+// The two decisions behind a page's built-in View / Edit action, as pure functions of their
+// inputs — which shape the action is, and whether it is enabled.
+//
+// They live apart from BuiltInPageModeAction and LiveNavTestPage for the reason
+// TestPageNewRowLineRule and LiveNavTestPage.OffersBuiltInAction do: every row of the table in
+// BuiltInPageModeAction.cs's header is a measured claim about real BC, and a claim that can
+// only be exercised by standing up a BC runtime and a TestPage is a claim nothing pins
+// cheaply. Here each row is one assertion (AlRunner.Tests/BuiltInPageModeActionRuleTests.cs).
+//
+// Every value below is measured on a real service tier — corpus codeunit 60479 "TPMS Tests"
+// (StefanMaron/BusinessCentral.AL.Language.Tests#317, 9/9 on BC 28.4.53241.0) and 60461
+// "TPVE Tests" (upstream #203) — not read off BC's UI builder. The builder read is in
+// BuiltInPageModeAction.cs's header and explains the measurements; it does not stand in for
+// them, and where the two disagreed the measurement won (issue #3258).
+namespace AlRunner.Patches;
+
+/// <summary>Which of BC's shapes a built-in page-mode action is, or why there is none.</summary>
+internal enum BuiltInPageModeShape
+{
+    /// <summary>The host declares a resolvable CardPageId: the action opens that card.</summary>
+    OpenCard,
+
+    /// <summary>A list with no card to open: the action exists and does nothing.</summary>
+    NoTarget,
+
+    /// <summary>A non-list host: the page already open changes mode.</summary>
+    InPlaceSwitch,
+
+    /// <summary>
+    /// The host's PageType is unknown here, so the runner cannot tell NoTarget from
+    /// InPlaceSwitch — and those two differ in whether the page's editability moves.
+    /// </summary>
+    RefuseUnknownPageType,
+
+    /// <summary>
+    /// Edit() on a host declaring <c>Editable = false</c>. BC creates no action and raises a
+    /// bare NullReferenceException out of NavTestAction; the runner refuses by name.
+    /// </summary>
+    RefuseNoEditAction,
+}
+
+internal static class BuiltInPageModeActionRule
+{
+    /// <summary>
+    /// Which shape the action is. <paramref name="pageType"/> is null when the host page is in
+    /// neither the parsed-AL nor the dependency-symbol inventory.
+    /// </summary>
+    internal static BuiltInPageModeShape ResolveShape(
+        int cardPageId, string? pageType, bool viewMode, bool declaredPageEditable)
+    {
+        if (cardPageId > 0) return BuiltInPageModeShape.OpenCard;
+        if (pageType == null) return BuiltInPageModeShape.RefuseUnknownPageType;
+
+        // BC's ResolveCardFormId falls back to the host page's own id only when the host is not
+        // a List. Measured for PageType = List and for PageType = Card; the other list-shaped
+        // types follow the same declaration family rather than a separate measurement.
+        if (pageType.StartsWith("List", System.StringComparison.OrdinalIgnoreCase))
+            return BuiltInPageModeShape.NoTarget;
+
+        if (!viewMode && !declaredPageEditable) return BuiltInPageModeShape.RefuseNoEditAction;
+
+        return BuiltInPageModeShape.InPlaceSwitch;
+    }
+
+    /// <summary>
+    /// Whether the action can be invoked — BC's <c>LogicalAction.CanInvoke</c> for the
+    /// conditions that have an answer in the runner. <paramref name="cardModifyAllowed"/> is
+    /// null when the card is not in this run's inventory, which keeps the permissive answer
+    /// rather than refusing on a lookup miss.
+    /// </summary>
+    internal static bool Enabled(
+        BuiltInPageModeActionKind kind, bool viewMode, bool hostEditableNow, bool? cardModifyAllowed)
+        => kind switch
+        {
+            // NavOpenTaskPageAction.CanSwitchViewMode: Edit applies to a page that is currently
+            // read-only, View to one that is currently editable.
+            BuiltInPageModeActionKind.InPlaceSwitch => viewMode ? hostEditableNow : !hostEditableNow,
+
+            // A list with no CardPageId has no editable card to reach.
+            BuiltInPageModeActionKind.NoTarget => viewMode,
+
+            // ActionBuilder.IsModifyAllowedInCard, which BC surfaces as Enabled rather than by
+            // withholding the action.
+            _ => viewMode || cardModifyAllowed != false,
+        };
+}

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -735,15 +735,15 @@ internal class LiveNavTestPage : MockITestPage
     public override ITestAction Edit() => BuiltInPageModeActionFor(viewMode: false);
 
     /// <summary>
-    /// The built-in page-mode action for one of the two modes, resolved the way BC's own UI
-    /// builder resolves it (<c>ActionBuilder.ResolveCardFormId</c> /
-    /// <c>IsModifyAllowedInCard</c>, BC 28.1) — see BuiltInPageModeAction.cs for the full read.
+    /// The built-in page-mode action for one of the two modes. Which of BC's three shapes it
+    /// is — open a card, switch this page's own mode, or do nothing — is decided here, and
+    /// each shape is measured on a real service tier: corpus codeunit 60479 "TPMS Tests"
+    /// (StefanMaron/BusinessCentral.AL.Language.Tests#317) plus 60461 "TPVE Tests" for the
+    /// card-opening one. BuiltInPageModeAction.cs carries the table.
     ///
-    /// <para>Refuses by name rather than answering null, which is what
-    /// <c>TestPageProxy.View()/Edit()</c> do for a page that has no such action: BC's
-    /// <c>NavTestAction</c> takes that null without checking it, so AL's <c>.Invoke()</c>
-    /// would surface as a bare NullReferenceException inside Ncl with nothing naming the
-    /// page or the reason.</para>
+    /// <para>The action EXISTS in every one of those shapes: BC answers Visible = true
+    /// throughout and expresses "this does not apply here" through Enabled instead. So the
+    /// only refusals left below are the two shapes where BC has no action object at all.</para>
     /// </summary>
     private ITestAction BuiltInPageModeActionFor(bool viewMode)
     {
@@ -753,41 +753,79 @@ internal class LiveNavTestPage : MockITestPage
         var actionName = viewMode ? "View" : "Edit";
         var cardPageId = RecordPatches.TryGetAnyCardPageId(_pageId);
 
-        // No resolvable CardPageId. BC's ResolveCardFormId then falls back to the HOST page's
-        // own id whenever the host is not a List, and NavOpenTaskPageAction.InvokeCore takes
-        // its UseCurrentForm branch: the action switches the OPEN page's mode in place through
-        // PageModeAggregator.ChangePageMode, opening nothing. That is a real AL shape —
-        // SubscriptionBilling's ContractRenewalTest does
-        // `if not Card.Editable then Card.Edit().Invoke();` inside a [ModalPageHandler] — and it
-        // is NOT what this class implements. Answering it by opening a second copy of the page
-        // would be a silent wrong answer (two OnOpenPage runs where BC has none), so it
-        // refuses. On a List with no CardPageId the builder creates no action at all.
-        if (cardPageId <= 0)
+        // A resolvable CardPageId: BC's ResolveCardFormId lands on that card and the action
+        // opens it (corpus 60461). Whether the EDIT half of that can be invoked is decided by
+        // the card, not here — see BuiltInPageModeAction.Enabled.
+        if (cardPageId > 0)
+            return new BuiltInPageModeAction(
+                this, _record, cardPageId, viewMode, BuiltInPageModeActionKind.OpenCard);
+
+        var pageType = RecordPatches.TryGetAnyPageType(_pageId);
+
+        // Null means the page is in neither source's inventory, so the runner cannot tell which
+        // of BC's two no-CardPageId shapes applies — a list's do-nothing action, or a non-list's
+        // in-place switch. They differ in whether the page's editability moves, which is exactly
+        // what the caller is about to read, so picking one would be a silent wrong answer.
+        if (pageType == null)
             throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
                 $"TestPage.{actionName}() on page {_pageId}",
-                $"not-yet-implemented — page {_pageId} declares no CardPageId this run can "
-                + $"resolve, so its built-in {actionName} action is not a page open. On a page "
-                + "that is not a list BC switches the OPEN page's own mode in place "
-                + "(NavOpenTaskPageAction.UseCurrentForm -> PageModeAggregator.ChangePageMode), "
-                + "which the runner does not model; on a list with no CardPageId BC's builder "
-                + "creates no such action at all. Tracked by issue #3258");
+                $"not-yet-implemented — page {_pageId} declares no CardPageId and its PageType is "
+                + "not in this run's inventory, so the runner cannot tell whether BC would switch "
+                + "this page's mode in place (not a List) or do nothing (a List). Tracked by "
+                + "issue #3735");
 
-        // BC's IsModifyAllowedInCard: with a card page id in context, the Edit action is
-        // created only when that CARD allows modification — so a read-only card has a View
-        // action and no Edit action. Unknown (the card is not in this run's inventory) keeps
-        // the permissive answer, the same rule TryGetAnyPageType's callers use: refusing on a
-        // lookup miss would refuse pages on the strength of the runner's own inventory.
-        if (!viewMode && RecordPatches.TryGetAnyPageModifyAllowed(cardPageId) == false)
+        // BC's ResolveCardFormId falls back to the host page's OWN id only when the host is not
+        // a List; on a list with nothing to open the action exists, is Visible, and does
+        // nothing. Measured for PageType = List (corpus 60479
+        // PlainListWithoutCardPageIdOffersBothActionsAndEnablesOnlyView) and for PageType = Card
+        // (the in-place arms below); the other list-shaped types follow the same declaration
+        // family rather than a separate measurement.
+        if (pageType.StartsWith("List", StringComparison.OrdinalIgnoreCase))
+            return new BuiltInPageModeAction(
+                this, _record, targetPageId: 0, viewMode, BuiltInPageModeActionKind.NoTarget);
+
+        // A page declaring Editable = false has no built-in Edit action at all, and BC does not
+        // report that as an AL error: TestPage.Edit() hands back a NavTestAction wrapping a null
+        // client action, so .Invoke() and .Visible() each raise a bare NullReferenceException
+        // from NavTestAction.ALInvoke()/ALVisible() — caught by neither asserterror nor a
+        // [TryFunction] (measured on BC 28.4.53241.0 both ways; corpus 60479's file header
+        // records it, which is why no arm there asserts it). Refusing by name is a DELIBERATE
+        // divergence from that: a bare NRE inside Ncl names neither the page nor the reason.
+        if (!viewMode && !DeclaredPageEditable)
             throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
                 $"TestPage.Edit() on page {_pageId}",
-                $"not-yet-implemented — the CardPageId target, page {cardPageId}, does not allow "
-                + "modification (Editable = false or ModifyAllowed = false), and BC's own UI "
-                + "builder creates no Edit action for such a card "
-                + "(ActionBuilder.IsModifyAllowedInCard), so real BC has nothing to invoke here "
-                + "either. Tracked by issue #3258");
+                $"testpage-page-mode-no-edit-action — page {_pageId} declares Editable = false, so "
+                + "BC's UI builder creates no built-in Edit action for it and real BC raises a bare "
+                + "System.NullReferenceException from NavTestAction.ALInvoke(). The runner refuses "
+                + "by name instead of reproducing an exception that names nothing");
 
-        return new BuiltInPageModeAction(this, _record, cardPageId, viewMode);
+        // Not a list, no card: the page already open changes mode. See
+        // BuiltInPageModeAction.Invoke.
+        return new BuiltInPageModeAction(
+            this, _record, targetPageId: 0, viewMode, BuiltInPageModeActionKind.InPlaceSwitch);
     }
+
+    /// <summary>The page's declared <c>Editable</c>, true for a page with no metadata here.</summary>
+    internal bool DeclaredPageEditable => _page?.PageEditable ?? true;
+
+    /// <summary>This page's current static editability — what <c>TestPage.Editable()</c> answers.</summary>
+    internal bool StaticEditableNow => _staticEditable;
+
+    /// <summary>
+    /// The in-place half of a built-in page-mode action: the page already open changes mode,
+    /// nothing opens, and OnOpenPage does not run again (corpus 60479
+    /// CardOpenedReadOnlyIsMadeEditableInPlaceByItsEditAction asserts the open count stays 1).
+    ///
+    /// <para>It writes the same field, by the same formula, that <see cref="MarkOpened"/> writes
+    /// for a page the test opened — which is what makes the switch work for a page a
+    /// [ModalPageHandler] was handed too, where that field starts null
+    /// (ResolveStaticEditable takes the override in preference to everything else). BC does this
+    /// through PageModeAggregator.ChangePageMode on a client LogicalForm; that type lives in
+    /// Microsoft.Dynamics.Nav.Client.UI.dll and acts on a form the runner never builds, so there
+    /// is no BC machinery here to reuse.</para>
+    /// </summary>
+    internal void SwitchViewModeInPlace(bool viewMode)
+        => _staticEditableOverride = !viewMode && DeclaredPageEditable;
 
     private sealed class RecordingBuiltInAction : ITestAction
     {

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -780,7 +780,7 @@ internal class LiveNavTestPage : MockITestPage
             // neither asserterror nor a [TryFunction] (measured on BC 28.4.53241.0 both ways;
             // corpus 60479's file header records it, which is why no arm there asserts it).
             // Refusing by name is a DELIBERATE divergence: a bare NRE inside Ncl names neither
-            // the page nor the reason.
+            // the page nor the reason. See docs/limitations.md#testpage-page-mode-no-edit-action.
             case BuiltInPageModeShape.RefuseNoEditAction:
                 throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
                     $"TestPage.Edit() on page {_pageId}",

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -753,56 +753,55 @@ internal class LiveNavTestPage : MockITestPage
         var actionName = viewMode ? "View" : "Edit";
         var cardPageId = RecordPatches.TryGetAnyCardPageId(_pageId);
 
-        // A resolvable CardPageId: BC's ResolveCardFormId lands on that card and the action
-        // opens it (corpus 60461). Whether the EDIT half of that can be invoked is decided by
-        // the card, not here — see BuiltInPageModeAction.Enabled.
-        if (cardPageId > 0)
-            return new BuiltInPageModeAction(
-                this, _record, cardPageId, viewMode, BuiltInPageModeActionKind.OpenCard);
+        // The decision itself is a pure function of these four inputs, so every row of the
+        // measured table is pinned without a BC runtime — BuiltInPageModeActionRule.cs.
+        var shape = BuiltInPageModeActionRule.ResolveShape(
+            cardPageId, RecordPatches.TryGetAnyPageType(_pageId), viewMode, DeclaredPageEditable);
 
-        var pageType = RecordPatches.TryGetAnyPageType(_pageId);
+        switch (shape)
+        {
+            // Null PageType means the page is in neither source's inventory, so the runner
+            // cannot tell which of BC's two no-CardPageId shapes applies — a list's do-nothing
+            // action, or a non-list's in-place switch. They differ in whether the page's
+            // editability moves, which is exactly what the caller is about to read, so picking
+            // one would be a silent wrong answer.
+            case BuiltInPageModeShape.RefuseUnknownPageType:
+                throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                    $"TestPage.{actionName}() on page {_pageId}",
+                    $"not-yet-implemented — page {_pageId} declares no CardPageId and its PageType "
+                    + "is not in this run's inventory, so the runner cannot tell whether BC would "
+                    + "switch this page's mode in place (not a List) or do nothing (a List). "
+                    + "Tracked by issue #3735");
 
-        // Null means the page is in neither source's inventory, so the runner cannot tell which
-        // of BC's two no-CardPageId shapes applies — a list's do-nothing action, or a non-list's
-        // in-place switch. They differ in whether the page's editability moves, which is exactly
-        // what the caller is about to read, so picking one would be a silent wrong answer.
-        if (pageType == null)
-            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                $"TestPage.{actionName}() on page {_pageId}",
-                $"not-yet-implemented — page {_pageId} declares no CardPageId and its PageType is "
-                + "not in this run's inventory, so the runner cannot tell whether BC would switch "
-                + "this page's mode in place (not a List) or do nothing (a List). Tracked by "
-                + "issue #3735");
+            // A page declaring Editable = false has no built-in Edit action at all, and BC does
+            // not report that as an AL error: TestPage.Edit() hands back a NavTestAction wrapping
+            // a null client action, so .Invoke() and .Visible() each raise a bare
+            // NullReferenceException from NavTestAction.ALInvoke()/ALVisible() — caught by
+            // neither asserterror nor a [TryFunction] (measured on BC 28.4.53241.0 both ways;
+            // corpus 60479's file header records it, which is why no arm there asserts it).
+            // Refusing by name is a DELIBERATE divergence: a bare NRE inside Ncl names neither
+            // the page nor the reason.
+            case BuiltInPageModeShape.RefuseNoEditAction:
+                throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                    $"TestPage.Edit() on page {_pageId}",
+                    $"testpage-page-mode-no-edit-action — page {_pageId} declares Editable = false, "
+                    + "so BC's UI builder creates no built-in Edit action for it and real BC raises "
+                    + "a bare System.NullReferenceException from NavTestAction.ALInvoke(). The "
+                    + "runner refuses by name instead of reproducing an exception that names "
+                    + "nothing");
 
-        // BC's ResolveCardFormId falls back to the host page's OWN id only when the host is not
-        // a List; on a list with nothing to open the action exists, is Visible, and does
-        // nothing. Measured for PageType = List (corpus 60479
-        // PlainListWithoutCardPageIdOffersBothActionsAndEnablesOnlyView) and for PageType = Card
-        // (the in-place arms below); the other list-shaped types follow the same declaration
-        // family rather than a separate measurement.
-        if (pageType.StartsWith("List", StringComparison.OrdinalIgnoreCase))
-            return new BuiltInPageModeAction(
-                this, _record, targetPageId: 0, viewMode, BuiltInPageModeActionKind.NoTarget);
+            case BuiltInPageModeShape.OpenCard:
+                return new BuiltInPageModeAction(
+                    this, _record, cardPageId, viewMode, BuiltInPageModeActionKind.OpenCard);
 
-        // A page declaring Editable = false has no built-in Edit action at all, and BC does not
-        // report that as an AL error: TestPage.Edit() hands back a NavTestAction wrapping a null
-        // client action, so .Invoke() and .Visible() each raise a bare NullReferenceException
-        // from NavTestAction.ALInvoke()/ALVisible() — caught by neither asserterror nor a
-        // [TryFunction] (measured on BC 28.4.53241.0 both ways; corpus 60479's file header
-        // records it, which is why no arm there asserts it). Refusing by name is a DELIBERATE
-        // divergence from that: a bare NRE inside Ncl names neither the page nor the reason.
-        if (!viewMode && !DeclaredPageEditable)
-            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                $"TestPage.Edit() on page {_pageId}",
-                $"testpage-page-mode-no-edit-action — page {_pageId} declares Editable = false, so "
-                + "BC's UI builder creates no built-in Edit action for it and real BC raises a bare "
-                + "System.NullReferenceException from NavTestAction.ALInvoke(). The runner refuses "
-                + "by name instead of reproducing an exception that names nothing");
+            case BuiltInPageModeShape.NoTarget:
+                return new BuiltInPageModeAction(
+                    this, _record, targetPageId: 0, viewMode, BuiltInPageModeActionKind.NoTarget);
 
-        // Not a list, no card: the page already open changes mode. See
-        // BuiltInPageModeAction.Invoke.
-        return new BuiltInPageModeAction(
-            this, _record, targetPageId: 0, viewMode, BuiltInPageModeActionKind.InPlaceSwitch);
+            default:
+                return new BuiltInPageModeAction(
+                    this, _record, targetPageId: 0, viewMode, BuiltInPageModeActionKind.InPlaceSwitch);
+        }
     }
 
     /// <summary>The page's declared <c>Editable</c>, true for a page with no metadata here.</summary>

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -684,6 +684,26 @@ the exact value will see different results.
 | `Commit()` | Commits current transaction | Establishes a rollback commit-point — see "Transaction semantics" above; not a no-op |
 | `FilterGroup(n)` | Scoped filter groups | Tracked — BC's own `NavRecord` filter state runs here. Pinned upstream by `record/TestFilterContracts.al` (`FilterGroup2_CombinesWithFilterGroup0_AsAND`, `Reset_AfterFilterGroup2_ClearsBothGroups`) and measured 2026-09-07: a group-2 `SetRange` intersected with a group-0 `SetFilter` answered the intersection, and `GetFilters` reported only group 0, as on BC. This row said "no-op" until the 2026-09 audit |
 
+### `TestPage.Edit()` on a page declaring `Editable = false` — refused by name, not by NRE
+
+<a id="testpage-page-mode-no-edit-action"></a>
+
+BC's UI builder creates no built-in Edit action for a page that declares `Editable = false`, and
+BC does not report that as an AL error: `TestPage.Edit()` hands back a `NavTestAction` wrapping a
+null client action, so `.Invoke()` and `.Visible()` each raise a bare
+`System.NullReferenceException` out of `NavTestAction`, caught by neither `asserterror` nor a
+`[TryFunction]` (measured on BC 28.4.53241.0 both ways).
+
+The runner deliberately answers differently: it throws `RunnerOutOfScopeException` with reason
+`testpage-page-mode-no-edit-action`, naming the page id and the declaration that caused it. A
+bare NRE inside `Ncl` names neither, so reproducing it faithfully would trade a diagnosable
+failure for an undiagnosable one. AL that expects a `NullReferenceException` here sees a
+different exception type; AL that expects the call to work sees the same failure either way.
+
+The rest of the built-in page-mode surface — `View()`/`Edit()` `Visible`, `Enabled` and `Invoke`
+across every shape BC distinguishes — is faithful, and is pinned upstream by corpus codeunits
+60479 (`BusinessCentral.AL.Language.Tests#317`) and 60461 (`#203`).
+
 ### Permission-set assignment — answered from `Access Control`, including the session user's own SUPER row
 
 <a id="permission-set-assignment"></a>


### PR DESCRIPTION
Closes #3258

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/317

`TestPage.View()` / `TestPage.Edit()` had two unmeasured halves left after #3185: the in-place
mode switch was refused with `not-yet-implemented`, and `Visible`/`Enabled` both answered a
hardcoded `true`. The issue asked for a service-tier verdict first. This is that verdict, and
the runner change that follows it.

## What a real service tier says

Corpus codeunit 60479 "TPMS Tests" (upstream PR above), **9/9 on BC 28.4.53241.0** in a local
container before the PR was opened. Every row below is measured, not read off BC's UI builder:

| shape | `Visible` | `Enabled` | `Invoke` |
|---|---|---|---|
| Card opened `OpenView()`, `Edit()` | true | true | the page becomes editable, in place |
| Card opened `OpenEdit()`, `View()` | true | true | the page becomes read-only, in place |
| Card already in the requested mode | true | **false** | nothing: no error, no mode change |
| List with no `CardPageId`, `View()` | true | true | nothing opens |
| List with no `CardPageId`, `Edit()` | true | **false** | nothing opens |
| List whose card is read-only, `Edit()` | true | **false** | nothing opens |
| List whose card is read-only, `View()` | true | true | that card opens, read-only |
| List whose card is editable, both | true | true | that card opens (60461) |

Three of those contradict what the issue and the code assumed:

- **`Visible` is true everywhere; `Enabled` is BC's whole "not here" channel.** The issue
  expected the *existence* of the action to carry it.
- **A list with no `CardPageId` still has both actions.** `BuiltInPageModeActionFor` said BC's
  builder "creates no such action at all".
- **A list whose card declares `Editable = false` still has an Edit action** — visible,
  disabled, and a no-op when invoked. The runner refused that shape outright.

The in-place switch is confirmed by the card's own `OnOpenPage` counter staying at **1** across
the switch, which is what separates it from opening a second copy of the page. One arm drives
the exact shape the issue named (`if not Page.Editable then Page.Edit().Invoke()` inside a
`[ModalPageHandler]`): the handler records `Yes;No;Yes` across `View()` then `Edit()`, with the
open count still 1.

**Not asserted upstream, deliberately, and recorded in the corpus file header instead:** a Card
whose own `Editable = false` has no built-in Edit action, and BC raises a bare
`System.NullReferenceException` from `NavTestAction.ALInvoke()`/`ALVisible()`. Measured
uncatchable by both `asserterror` and a `[TryFunction]`, so no arm can pass on it. On that same
page only `View().Visible()` was read (true) and not `View().Enabled()`; the runner answers false
there, which follows the measured rule for a page already read-only but is itself unmeasured.

## What changed in the runner

- `AlRunner/Patches/BuiltInPageModeActionRule.cs` (new) — `ResolveShape` and `Enabled` as pure
  functions, so each measured row is one assertion rather than something only a live BC runtime
  can exercise. Same shape as `TestPageNewRowLineRule` and `OffersBuiltInAction`.
- `MockTestPage.cs` — `BuiltInPageModeActionFor` routes through it; `SwitchViewModeInPlace`
  writes `_staticEditableOverride` by the same formula `MarkOpened` uses, which is why the
  switch also works on a page a `[ModalPageHandler]` was handed (there the override starts null
  and `ResolveStaticEditable` takes it in preference to everything else).
- `BuiltInPageModeAction.cs` — three shapes (`OpenCard` / `NoTarget` / `InPlaceSwitch`);
  `Enabled` computed per read, because a switch moves it; a disabled action's `Invoke` does
  nothing, which is what the tier does with every one of them.

**"Through BC's own machinery" was checked and is not available here.**
`PageModeAggregator.ChangePageMode` and `NavOpenTaskPageAction.CanSwitchViewMode` both live in
`Microsoft.Dynamics.Nav.Client.UI.dll` (confirmed by scanning the 28.1 artifacts) and act on a
client `LogicalForm` the runner never builds — its action layer is its own. So the switch moves
the runner's editability state, and `CanSwitchViewMode` is reproduced as the `Enabled` rule the
tier measured rather than called.

**`CanInvoke`'s unmodellable conditions need no `BcShapeGapException`**, and the reason is
structural rather than optimistic: `IsMultipleSelectionDisabledAction` refuses a multi-row
selection and the runner drives exactly one row; `FindExistingForm` refuses when a form for the
same page is already open and `RunnerTestClientSession.OpenFormsCount` is 0 by design. Both
collapse to their permissive value by construction, and the eight measured rows agree.

## What is still refused, and why

- **Edit() on a page declaring `Editable = false`** — `RunnerOutOfScopeException` naming the
  page. A deliberate divergence: BC's answer is a bare NRE inside Ncl that names neither the
  page nor the reason.
- **A page whose `PageType` is unknown to this run** — the two no-`CardPageId` shapes go
  opposite ways on it and differ in whether editability moves, so guessing would be a silent
  wrong answer on the property the AL is about to read. Filed as **#3735**, which stays open.

## RED → GREEN

Measured against the corpus branch in a private clone (`--package-cache
$HOME/.al-runner/platform-apps`, own `--cache`), since the pin cannot move yet:

- **RED**, before the fix: `7 fail / 2 pass` of the 9 arms — six `RunnerOutOfScopeException`s
  from `BuiltInPageModeActionFor` and the modal-handler arm failing inside `InvokeHandler`. The
  two that passed are the shapes #3185 already implemented.
- **GREEN**, after: `9 pass / 0 fail`, re-confirmed after the decision-seam refactor and again
  after merging `origin/main`.

Regression:

- **Full pinned corpus (`3ad4c340`): 3123 pass / 0 fail / 0 error** — including 60461 "TPVE
  Tests" and every `testpage/` codeunit touched by #3693 and #3709. Measured on commit
  `1856370a`, so **before** the decision-seam refactor and before `origin/main` was merged in;
  what was repeated on the current head is the 9 corpus arms and the unit tests below. CI runs
  the corpus on every leg, which is where that gap closes.
- `dotnet test AlRunner.Tests --filter "…BuiltInPageModeActionRuleTests|…TestPageRefusalClaimTests"`:
  **113 passed**, on the current head after the merge. `TestPageRefusalClaimTests`'s counters are unchanged and were
  not edited: the two refusals removed and the two added are direct
  `new RunnerOutOfScopeException` throws carrying no `docs/scope.md` citation, so
  `MockTestPage_KeepsExactlyItsFivePermanentCitations` still counts five.

## Pin, and the open-issue scan

**No pin bump.** Corpus PR #317 is unmerged, and the pin chain is blocked by #2943 regardless —
so this lands with the runner-side seam tests as its in-repo proof, and the upstream arms as the
BC-behaviour proof. The bump belongs to whoever unblocks the chain.

Scanning the open queue for the two files this touches (`MockTestPage.cs`,
`BuiltInPageModeAction.cs`) turned up nothing else that lands in them: #3131 (built-in `Cancel`
on NavigatePage/ConfirmationDialog) — state: CLOSED, and the live TestPage work — #3730's
`EvaluateProperty`/`ActionEnabled` regression from #3693 — is a different function in
`RunnerPageInstance.cs`, deliberately left alone here. Nothing folded in.

---
Opened by an agent (`fbk-2`) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kko97BZZL71nF2nK5aftu4
