### PR TITLE
fix(suites): compile a suite from its root when .al files sit outside src/, app*/ and test/

### DIFF
--- a/AlRunner.Tests/SuiteRootAlFilesTests.cs
+++ b/AlRunner.Tests/SuiteRootAlFilesTests.cs
@@ -175,6 +175,22 @@ public sealed class SuiteRootAlFilesTests : IDisposable
         Assert.Equal(new[] { Path.Combine(_root, "src") }, paths);
     }
 
+    /// <summary>
+    /// The shape every real bundle has: a <c>.alpackages/</c> of symbol .app files beside
+    /// <c>src/</c>. A sibling folder with no <c>.al</c> in it is not a reason to widen.
+    /// </summary>
+    [Fact]
+    public void SiblingDirWithoutAl_DoesNotWidenThePaths()
+    {
+        Touch(Path.Combine(_root, "app.json"), "{}");
+        Touch(Path.Combine(_root, ".alpackages", "Microsoft_Application_28.0.0.0.app"), "not al");
+        Touch(Path.Combine(_root, "src", "A.al"));
+
+        var paths = ProgramSupport.CollectSuitePaths(_root);
+
+        Assert.Equal(new[] { Path.Combine(_root, "src") }, paths);
+    }
+
     // ── end to end, spawning the runner ──────────────────────────────────────────────────
 
     private static void WriteManifest(string dir, string appId, int idFrom, string name)

--- a/AlRunner.Tests/SuiteRootAlFilesTests.cs
+++ b/AlRunner.Tests/SuiteRootAlFilesTests.cs
@@ -1,0 +1,383 @@
+// SuiteRootAlFilesTests — #3611 / #3714: a suite's .al files outside src/, app*/ and test/
+// were silently dropped from the compile.
+//
+// CollectSuitePaths hands the emitter a list of folders. It added the suite root ONLY when
+// none of the conventional folders (src/, app*/, test/) existed — the "flat bundle" fallback.
+// So one src/ folder switched the root scan off, and every .al file beside it (at the root,
+// or in a sibling folder such as ControlAddin/) never reached BcCompiler.Emit:
+//
+//   root test codeunit + src/ helper   → "Tests: 0 total", exit 0        (#3611 case 5)
+//   root helper + src/ test codeunit   → AL0185 'Probe Helper' is missing (#3611 case 4)
+//   src/A.al + ControlAddin/B.al       → B.al ignored, even when broken    (#3714)
+//
+// The register-source-dirs loops in Program.cs made the same src/-else-root choice for
+// RecordPatches, so a TABLE at the root was invisible to the in-memory table provider even
+// once its file compiled. The root-table fact below is what distinguishes that half.
+//
+// alc compiles every one of these layouts at 0 errors; the convention was inherited from the
+// legacy bucket trees and was never a contract. The fix: a suite whose .al files are not all
+// under the conventional folders is compiled from its root, like a flat bundle. Suites that
+// DO keep everything under src/ (and src/+test/) are unchanged — the exact-list facts below
+// pin that, so the fix cannot churn every existing suite's cache key.
+
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class SuiteRootAlFilesTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private readonly string _root;
+
+    public SuiteRootAlFilesTests()
+    {
+        _root = TestScratch.Dir("al-runner-suite-root-al");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    // ── CollectSuitePaths, in-process ────────────────────────────────────────────────────
+
+    private static void Touch(string path, string content = "")
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, content);
+    }
+
+    private static bool IsUnder(string file, string dir)
+    {
+        var rel = Path.GetRelativePath(dir, file);
+        return rel != ".." && !rel.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+            && !Path.IsPathRooted(rel);
+    }
+
+    /// <summary>
+    /// The property the emitter needs from CollectSuitePaths: every .al file under the suite
+    /// lies under at least one returned folder. Names the files that do not, so a failure
+    /// says which layout dropped what.
+    /// </summary>
+    private static void AssertEveryAlFileCovered(string suite, IReadOnlyList<string> paths)
+    {
+        var all = Directory.EnumerateFiles(suite, "*.al", SearchOption.AllDirectories).ToList();
+        Assert.NotEmpty(all);
+        var dropped = all.Where(f => !paths.Any(p => IsUnder(f, p))).ToList();
+        Assert.True(dropped.Count == 0,
+            $"CollectSuitePaths returned [{string.Join(", ", paths)}], which drops: "
+            + string.Join(", ", dropped.Select(d => Path.GetRelativePath(suite, d))));
+        Assert.All(paths, p => Assert.True(IsUnder(p, suite) || p == suite,
+            $"path {p} is outside the suite {suite}"));
+    }
+
+    [Fact]
+    public void RootAlFileBesideSrc_IsCovered()
+    {
+        Touch(Path.Combine(_root, "app.json"), "{}");
+        Touch(Path.Combine(_root, "Helper.Codeunit.al"));
+        Touch(Path.Combine(_root, "src", "Tests.Codeunit.al"));
+
+        AssertEveryAlFileCovered(_root, ProgramSupport.CollectSuitePaths(_root));
+    }
+
+    [Fact]
+    public void SiblingDirBesideSrc_IsCovered()
+    {
+        Touch(Path.Combine(_root, "app.json"), "{}");
+        Touch(Path.Combine(_root, "src", "A.al"));
+        Touch(Path.Combine(_root, "ControlAddin", "B.al"));
+
+        AssertEveryAlFileCovered(_root, ProgramSupport.CollectSuitePaths(_root));
+    }
+
+    [Fact]
+    public void RootAlFileBesideAppDir_IsCovered()
+    {
+        Touch(Path.Combine(_root, "app.json"), "{}");
+        Touch(Path.Combine(_root, "app", "A.al"));
+        Touch(Path.Combine(_root, "B.al"));
+
+        AssertEveryAlFileCovered(_root, ProgramSupport.CollectSuitePaths(_root));
+    }
+
+    [Fact]
+    public void RootAlFileBesideTestDir_IsCovered()
+    {
+        Touch(Path.Combine(_root, "app.json"), "{}");
+        Touch(Path.Combine(_root, "test", "A.al"));
+        Touch(Path.Combine(_root, "B.al"));
+
+        AssertEveryAlFileCovered(_root, ProgramSupport.CollectSuitePaths(_root));
+    }
+
+    /// <summary>
+    /// Regression pin: an app that keeps everything under src/ still gets exactly [src].
+    /// ComputeAlCacheKey hashes the folder-relative layout, so widening this list would miss
+    /// every existing suite's cache once for no gain.
+    /// </summary>
+    [Fact]
+    public void SrcOnly_StillReturnsExactlySrc()
+    {
+        Touch(Path.Combine(_root, "app.json"), "{}");
+        Touch(Path.Combine(_root, "src", "A.al"));
+        Touch(Path.Combine(_root, "src", "deep", "B.al"));
+
+        var paths = ProgramSupport.CollectSuitePaths(_root);
+
+        Assert.Equal(new[] { Path.Combine(_root, "src") }, paths);
+    }
+
+    [Fact]
+    public void SrcAndTest_StillReturnsExactlySrcThenTest()
+    {
+        Touch(Path.Combine(_root, "app.json"), "{}");
+        Touch(Path.Combine(_root, "src", "A.al"));
+        Touch(Path.Combine(_root, "test", "B.al"));
+
+        var paths = ProgramSupport.CollectSuitePaths(_root);
+
+        Assert.Equal(new[] { Path.Combine(_root, "src"), Path.Combine(_root, "test") }, paths);
+    }
+
+    [Fact]
+    public void Flat_StillReturnsExactlyTheSuiteRoot()
+    {
+        Touch(Path.Combine(_root, "app.json"), "{}");
+        Touch(Path.Combine(_root, "A.al"));
+        Touch(Path.Combine(_root, "collections", "B.al"));
+
+        var paths = ProgramSupport.CollectSuitePaths(_root);
+
+        Assert.Equal(new[] { _root }, paths);
+    }
+
+    /// <summary>
+    /// A file that is not AL beside src/ must NOT flip the suite to root-scanning: only .al
+    /// files count. Otherwise every suite with a README at its root would churn its cache key.
+    /// </summary>
+    [Fact]
+    public void NonAlFileBesideSrc_DoesNotWidenThePaths()
+    {
+        Touch(Path.Combine(_root, "app.json"), "{}");
+        Touch(Path.Combine(_root, "README.md"), "# not AL");
+        Touch(Path.Combine(_root, "src", "A.al"));
+
+        var paths = ProgramSupport.CollectSuitePaths(_root);
+
+        Assert.Equal(new[] { Path.Combine(_root, "src") }, paths);
+    }
+
+    // ── end to end, spawning the runner ──────────────────────────────────────────────────
+
+    private static void WriteManifest(string dir, string appId, int idFrom, string name)
+    {
+        Directory.CreateDirectory(dir);
+        // No "application" property — see .claude/rules/no-base-app-in-csharp-tests.md.
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{appId}}",
+          "name": "{{name}}",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": {{idFrom}}, "to": {{idFrom + 19}} } ],
+          "runtime": "14.0"
+        }
+        """);
+    }
+
+    private static string HelperCodeunit(int id, string tag) => $$"""
+        codeunit {{id}} "SRAF Helper {{tag}}"
+        {
+            procedure Answer(): Integer
+            begin
+                exit(42);
+            end;
+        }
+        """;
+
+    private static string TestCodeunit(int id, string tag) => $$"""
+        codeunit {{id}} "SRAF Tests {{tag}}"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure HelperAnswers{{tag}}()
+            var
+                H: Codeunit "SRAF Helper {{tag}}";
+            begin
+                // 42 is not a default: a helper that never compiled cannot satisfy this.
+                if H.Answer() <> 42 then
+                    Error('SRAF Helper %1 answered %2, expected 42', '{{tag}}', H.Answer());
+            end;
+        }
+        """;
+
+    private (string output, int exit) RunRunner(string target)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" \"{target}\"");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(600_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>Reads "Tests:  N total" out of the run summary.</summary>
+    private static int TestCount(string output)
+    {
+        var m = Regex.Match(output, @"Tests:\s*(\d+)\s*total");
+        Assert.True(m.Success, $"run summary had no test count. Output:\n{output}");
+        return int.Parse(m.Groups[1].Value);
+    }
+
+    private static void AssertPassed(string output, string testName)
+    {
+        // The reporter prints "PASS  Codeunit63301.HelperAnswers (7ms)" — object-qualified,
+        // any run of spaces, optional timing — so anchor on the method name, not the prefix.
+        Assert.True(Regex.IsMatch(output, $@"PASS\s+\S*\b{Regex.Escape(testName)}\b"),
+            $"no PASS line for {testName}. Output:\n{output}");
+    }
+
+    /// <summary>
+    /// #3611 case 5 — the silent one. The test codeunit sits at the root, its helper under
+    /// src/. Before the fix: "Tests: 0 total", exit 0, and a CI pipeline reports success
+    /// having run nothing.
+    /// </summary>
+    [SkippableFact]
+    public void TestAtRoot_HelperInSrc_RunsTheTest()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        WriteManifest(_root, "5a3f0b11-3611-4a01-8001-000000003611", 63300, "SRAF Inverse");
+        Touch(Path.Combine(_root, "Tests.Codeunit.al"), TestCodeunit(63301, "Inverse"));
+        Touch(Path.Combine(_root, "src", "Helper.Codeunit.al"), HelperCodeunit(63300, "Inverse"));
+
+        var (output, exit) = RunRunner(_root);
+
+        Assert.Equal(1, TestCount(output));
+        AssertPassed(output, "HelperAnswersInverse");
+        Assert.Equal(0, exit);
+    }
+
+    /// <summary>
+    /// #3611 case 4 — the loud one. Helper at the root, the test under src/. Before the fix:
+    /// AL0185 'SRAF Helper Nested' is missing, EMIT-ZERO, and a diagnosis that points at
+    /// dependencies rather than at layout.
+    /// </summary>
+    [SkippableFact]
+    public void HelperAtRoot_TestInSrc_RunsTheTest()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        WriteManifest(_root, "5a3f0b11-3611-4a02-8002-000000003611", 63310, "SRAF Nested");
+        Touch(Path.Combine(_root, "Helper.Codeunit.al"), HelperCodeunit(63310, "Nested"));
+        Touch(Path.Combine(_root, "src", "Tests.Codeunit.al"), TestCodeunit(63311, "Nested"));
+
+        var (output, exit) = RunRunner(_root);
+
+        Assert.DoesNotContain("AL0185", output);
+        Assert.Equal(1, TestCount(output));
+        AssertPassed(output, "HelperAnswersNested");
+        Assert.Equal(0, exit);
+    }
+
+    /// <summary>
+    /// #3714 — a sibling folder beside src/ (the Continia Document Output shape:
+    /// ControlAddin/ next to src/). Its file is deliberately broken. Before the fix the
+    /// folder was never read, so the bundle compiled clean and exited 0 with an object
+    /// missing. After: the compile fails and the diagnostic names the ignored file.
+    /// </summary>
+    [SkippableFact]
+    public void BrokenAlInSiblingDirBesideSrc_FailsTheCompileNamingTheFile()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        WriteManifest(_root, "5a3f0b11-3714-4a03-8003-000000003714", 63320, "SRAF Sibling");
+        Touch(Path.Combine(_root, "src", "Helper.Codeunit.al"), HelperCodeunit(63320, "Sibling"));
+        Touch(Path.Combine(_root, "src", "Tests.Codeunit.al"), TestCodeunit(63321, "Sibling"));
+        Touch(Path.Combine(_root, "ControlAddin", "Broken.Codeunit.al"),
+            "codeunit 63322 \"SRAF Broken Sibling\" { this is not AL }");
+
+        var (output, exit) = RunRunner(_root);
+
+        Assert.Contains("Broken.Codeunit.al", output);
+        Assert.Equal(3, exit);
+    }
+
+    /// <summary>
+    /// The register-source-dirs half. A TABLE at the root, used by a test under src/. Emitting
+    /// the root file is necessary but not sufficient: RecordPatches only knows tables from the
+    /// folders Program.cs registered, and those loops made the same src/-else-root choice.
+    /// Insert-then-Get of a non-default value proves the table exists in the in-memory
+    /// provider, not merely in the compiled module.
+    /// </summary>
+    [SkippableFact]
+    public void TableAtRoot_UsedFromSrcTest_IsRegisteredForRecords()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        WriteManifest(_root, "5a3f0b11-3611-4a04-8004-000000003611", 63330, "SRAF Root Table");
+        Touch(Path.Combine(_root, "Probe.Table.al"), """
+        table 63330 "SRAF Root Probe"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "Code"; Code[20]) { }
+                field(2; "Value"; Integer) { }
+            }
+            keys { key(PK; "Code") { Clustered = true; } }
+        }
+        """);
+        Touch(Path.Combine(_root, "src", "Tests.Codeunit.al"), """
+        codeunit 63331 "SRAF Root Table Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure RootTableRoundTrips()
+            var
+                Probe: Record "SRAF Root Probe";
+            begin
+                Probe.Init();
+                Probe.Code := 'X';
+                Probe.Value := 42;
+                Probe.Insert();
+                Clear(Probe);
+                if not Probe.Get('X') then
+                    Error('row X not found after Insert');
+                if Probe.Value <> 42 then
+                    Error('Value was %1, expected 42', Probe.Value);
+            end;
+        }
+        """);
+
+        var (output, exit) = RunRunner(_root);
+
+        Assert.Equal(1, TestCount(output));
+        AssertPassed(output, "RootTableRoundTrips");
+        Assert.Equal(0, exit);
+    }
+}

--- a/AlRunner.Tests/SuiteRootAlFilesTests.cs
+++ b/AlRunner.Tests/SuiteRootAlFilesTests.cs
@@ -119,9 +119,11 @@ public sealed class SuiteRootAlFilesTests : IDisposable
     }
 
     /// <summary>
-    /// Regression pin: an app that keeps everything under src/ still gets exactly [src].
-    /// ComputeAlCacheKey hashes the folder-relative layout, so widening this list would miss
-    /// every existing suite's cache once for no gain.
+    /// Regression pin: an app that keeps everything under src/ still gets exactly [src] — the
+    /// widening is reserved for suites that need it, so the emitter, the RecordPatches
+    /// registration and the per-call cost of every existing src/ suite are untouched.
+    /// (ComputeAlCacheKey hashes the .al files relative to their common directory, not this
+    /// list, so the key would survive a widening anyway; the pin is about the paths.)
     /// </summary>
     [Fact]
     public void SrcOnly_StillReturnsExactlySrc()
@@ -189,6 +191,114 @@ public sealed class SuiteRootAlFilesTests : IDisposable
         var paths = ProgramSupport.CollectSuitePaths(_root);
 
         Assert.Equal(new[] { Path.Combine(_root, "src") }, paths);
+    }
+
+    [Fact]
+    public void AppDirOnly_StillReturnsExactlyTheAppDir()
+    {
+        Touch(Path.Combine(_root, "app.json"), "{}");
+        Touch(Path.Combine(_root, "app", "A.al"));
+
+        var paths = ProgramSupport.CollectSuitePaths(_root);
+
+        Assert.Equal(new[] { Path.Combine(_root, "app") }, paths);
+    }
+
+    [Fact]
+    public void TestDirOnly_StillReturnsExactlyTheTestDir()
+    {
+        Touch(Path.Combine(_root, "test", "A.al"));
+
+        var paths = ProgramSupport.CollectSuitePaths(_root);
+
+        Assert.Equal(new[] { Path.Combine(_root, "test") }, paths);
+    }
+
+    /// <summary>
+    /// Legacy bucket layout with the suite AS the bucket root: <c>_shared/</c> holds AL and is
+    /// appended by CollectSuitePaths itself, so it is not "outside" and must not widen.
+    /// </summary>
+    [Fact]
+    public void SharedDirUnderTheSuite_IsCoveredNotOutside()
+    {
+        Touch(Path.Combine(_root, "app.json"), "{}");
+        Touch(Path.Combine(_root, "src", "A.al"));
+        Touch(Path.Combine(_root, "_shared", "Assert.al"));
+
+        var paths = ProgramSupport.CollectSuitePaths(_root, bucketRoot: _root);
+
+        Assert.Equal(new[] { Path.Combine(_root, "src"), Path.Combine(_root, "_shared") }, paths);
+    }
+
+    /// <summary>
+    /// A dot-directory is never an AL source root and can be huge (.git). AL under one does not
+    /// widen the suite; the predicate does not even walk it.
+    /// </summary>
+    [Fact]
+    public void AlUnderADotDirectory_DoesNotWidenThePaths()
+    {
+        Touch(Path.Combine(_root, "app.json"), "{}");
+        Touch(Path.Combine(_root, "src", "A.al"));
+        Touch(Path.Combine(_root, ".git", "stray.al"));
+
+        var paths = ProgramSupport.CollectSuitePaths(_root);
+
+        Assert.Equal(new[] { Path.Combine(_root, "src") }, paths);
+    }
+
+    /// <summary>
+    /// A suite's sub-directories are part of that suite by design, nested app.json or not
+    /// (Suites.cs: "a suite's own sub-directories are part of that suite, never separate
+    /// buckets"). A flat suite has always compiled such a child; a src/ suite now does the same
+    /// instead of silently dropping it.
+    /// </summary>
+    [Fact]
+    public void NestedAppInASiblingDir_IsPartOfThisSuite_LikeAFlatSuite()
+    {
+        Touch(Path.Combine(_root, "app.json"), "{}");
+        Touch(Path.Combine(_root, "src", "A.al"));
+        Touch(Path.Combine(_root, "fixtures", "child", "app.json"), "{}");
+        Touch(Path.Combine(_root, "fixtures", "child", "src", "C.al"));
+
+        var paths = ProgramSupport.CollectSuitePaths(_root);
+
+        Assert.Equal(new[] { _root }, paths);
+    }
+
+    private static bool TryMakeUnreadable(string path)
+    {
+        try { File.SetUnixFileMode(path, UnixFileMode.None); }
+        catch { return false; }
+        try { Directory.GetDirectories(path); return false; }
+        catch (UnauthorizedAccessException) { return true; }
+        catch (IOException) { return true; }
+    }
+
+    /// <summary>
+    /// A sibling the predicate cannot read is "could not tell", not "no AL there": the suite
+    /// widens to its root rather than quietly returning [src] with a helper possibly hidden
+    /// behind the permission bits. (Same third-state rule as the guards: an unmeasurable case
+    /// must not resolve to the answer that runs fewer tests.)
+    /// </summary>
+    [SkippableFact]
+    public void UnreadableSiblingDir_WidensToTheRoot()
+    {
+        Touch(Path.Combine(_root, "app.json"), "{}");
+        Touch(Path.Combine(_root, "src", "A.al"));
+        var locked = Path.Combine(_root, "locked");
+        Directory.CreateDirectory(Path.Combine(locked, "inner"));
+        Skip.IfNot(TryMakeUnreadable(locked), "permission bits do not bite here (Windows, or running as root)");
+        try
+        {
+            var paths = ProgramSupport.CollectSuitePaths(_root);
+
+            Assert.Equal(new[] { _root }, paths);
+        }
+        finally
+        {
+            try { File.SetUnixFileMode(locked, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute); }
+            catch { }
+        }
     }
 
     // ── end to end, spawning the runner ──────────────────────────────────────────────────

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2638,7 +2638,11 @@ foreach (var bundle in bundles)
         foreach (var suite in suites)
         {
             var s = Path.Combine(suite, "src");
-            if (Directory.Exists(s))
+            if (SuiteHasAlOutsideConventionalDirs(suite))
+                // #3611/#3714: AL beside src/ (a root table, a ControlAddin/ folder) — the
+                // compile reads the whole root (CollectSuitePaths), so the table parsers must too.
+                dirsToRegister.Add(suite);
+            else if (Directory.Exists(s))
                 dirsToRegister.Add(s);
             else if (!Directory.Exists(Path.Combine(suite, "test")))
                 // Flat bundle: register the suite root so table parsers can find .al files.
@@ -5165,7 +5169,10 @@ return strictExitCode ? computedExitCode : 0;
         foreach (var suite in suites)
         {
             var s = Path.Combine(suite, "src");
-            if (Directory.Exists(s)) dirsToRegister.Add(s);
+            // #3611/#3714: same decision as the CLI loop above — AL beside src/ means the
+            // table parsers read the whole root, as the compile does.
+            if (SuiteHasAlOutsideConventionalDirs(suite)) dirsToRegister.Add(suite);
+            else if (Directory.Exists(s)) dirsToRegister.Add(s);
             else if (!Directory.Exists(Path.Combine(suite, "test")))
                 dirsToRegister.Add(suite);
             allPaths.AddRange(CollectSuitePaths(suite, bucketRoot));

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2638,7 +2638,7 @@ foreach (var bundle in bundles)
         foreach (var suite in suites)
         {
             var s = Path.Combine(suite, "src");
-            if (SuiteHasAlOutsideConventionalDirs(suite))
+            if (SuiteHasAlOutsideConventionalDirs(suite, bucketRoot))
                 // #3611/#3714: AL beside src/ (a root table, a ControlAddin/ folder) — the
                 // compile reads the whole root (CollectSuitePaths), so the table parsers must too.
                 dirsToRegister.Add(suite);
@@ -5171,7 +5171,7 @@ return strictExitCode ? computedExitCode : 0;
             var s = Path.Combine(suite, "src");
             // #3611/#3714: same decision as the CLI loop above — AL beside src/ means the
             // table parsers read the whole root, as the compile does.
-            if (SuiteHasAlOutsideConventionalDirs(suite)) dirsToRegister.Add(suite);
+            if (SuiteHasAlOutsideConventionalDirs(suite, bucketRoot)) dirsToRegister.Add(suite);
             else if (Directory.Exists(s)) dirsToRegister.Add(s);
             else if (!Directory.Exists(Path.Combine(suite, "test")))
                 dirsToRegister.Add(suite);

--- a/AlRunner/ProgramSupport/Dependencies.cs
+++ b/AlRunner/ProgramSupport/Dependencies.cs
@@ -349,15 +349,18 @@ internal static partial class ProgramSupport
     internal static List<string> CollectSuitePaths(string suite, string? bucketRoot = null)
     {
         var all = ConventionalSourceDirs(suite);
+        var shared = SharedDirOf(bucketRoot);
         // #3611/#3714: src/, app*/ and test/ are a convention inherited from the legacy bucket
         // trees, not a contract — alc compiles every .al under the project root, whatever the
         // folder is called. A suite with any .al file OUTSIDE those folders is compiled from its
         // root, exactly like a flat bundle, so a root-level codeunit or a sibling folder such as
         // ControlAddin/ can no longer vanish from the compile (silently, when the dropped file
         // was the test codeunit: "Tests: 0 total", exit 0). A suite that keeps everything under
-        // the conventional folders returns exactly what it always did, so its ComputeAlCacheKey
-        // input does not move. The register-source-dirs loops in Program.cs ask
-        // SuiteHasAlOutsideConventionalDirs for the same decision — keep the two in step.
+        // the conventional folders returns exactly the list it always did. The register-source-
+        // dirs loops in Program.cs ask the same predicate, so compile and table parsers widen
+        // together. Trap: a suite's sub-directories are part of that suite by design, nested
+        // app.json or not (Suites.cs, EnumerateSuitesBelow) — widening therefore absorbs a
+        // nested app the way a flat suite always has; it is not a reason to refuse.
         if (all.Count == 0)
         {
             // Flat bundle: neither src/ nor app*/ nor test/ — the suite root is the one folder,
@@ -365,17 +368,21 @@ internal static partial class ProgramSupport
             if (AlRunner.Infrastructure.SafeDirectoryScan.Files(suite, "*.al").Count > 0)
                 all.Add(suite);
         }
-        else if (HasAlOutside(suite, all))
+        else if (SuiteHasAlOutsideConventionalDirs(suite, bucketRoot, all))
         {
             all.Clear();
             all.Add(suite);
         }
-        if (bucketRoot != null)
-        {
-            var shared = Path.Combine(bucketRoot, "_shared");
-            if (Directory.Exists(shared)) all.Add(shared);
-        }
+        if (shared != null) all.Add(shared);
         return all;
+    }
+
+    /// <summary><c>&lt;bucketRoot&gt;/_shared</c> when a bucket root is given and the folder exists.</summary>
+    private static string? SharedDirOf(string? bucketRoot)
+    {
+        if (bucketRoot == null) return null;
+        var shared = Path.Combine(bucketRoot, "_shared");
+        return Directory.Exists(shared) ? shared : null;
     }
 
     /// <summary>
@@ -396,42 +403,83 @@ internal static partial class ProgramSupport
     }
 
     /// <summary>
-    /// True when some <c>.al</c> file under <paramref name="suite"/> is not under any of the
-    /// conventional <paramref name="dirs"/>. Only <c>.al</c> files count — an app.json, a README
-    /// or a <c>.alpackages/</c> beside <c>src/</c> must not widen the compile.
+    /// True when some <c>.al</c> file under <paramref name="suite"/> is not under any of
+    /// <paramref name="covered"/> (the conventional folders, plus the bucket's <c>_shared</c>
+    /// when that sits inside the suite). Only <c>.al</c> files count — an app.json, a README or
+    /// a <c>.alpackages/</c> beside <c>src/</c> must not widen the compile.
     /// <para>
-    /// Deliberately never walks the conventional folders themselves: a <c>.al</c> outside them is
-    /// either directly at the root or somewhere under a top-level folder that is not one of them,
-    /// so the check is one top-level listing plus a walk of the non-conventional siblings only.
-    /// For the common src/-only suite that is a listing of the root and nothing more; the old
-    /// "scan the whole suite and subtract" shape re-walked src/ on every call (PR #3739 review).
+    /// Never walks the covered folders themselves: a <c>.al</c> outside them is either directly
+    /// at the root or under a top-level folder that is not one of them. So the cost is two
+    /// top-level listings of the root (files, then directories) plus a walk of each
+    /// non-covered, non-hidden sibling — for the common src/-only suite, no walk at all. The
+    /// earlier shape scanned the whole suite and subtracted, re-walking src/ on every call
+    /// (PR #3739 review).
+    /// </para>
+    /// <para>
+    /// Dot-directories (<c>.git</c>, <c>.alpackages</c>, <c>.vscode</c>) are skipped: none is an
+    /// AL source root, and <c>.git</c> can hold tens of thousands of files. A sibling the walk
+    /// could not read is a "could not tell", never a "no": the suite widens to its root, and the
+    /// directory is named once on stdout (the #2206 pattern), because the emitter's own root scan
+    /// will skip it just the same and anything under it is not compiled.
     /// </para>
     /// </summary>
-    private static bool HasAlOutside(string suite, IReadOnlyList<string> dirs)
+    private static bool HasAlOutside(string suite, IReadOnlyList<string> covered)
     {
         if (AlRunner.Infrastructure.SafeDirectoryScan.Files(suite, "*.al", SearchOption.TopDirectoryOnly).Count > 0)
             return true;
         foreach (var top in AlRunner.Infrastructure.SafeDirectoryScan.Directories(suite, "*", SearchOption.TopDirectoryOnly))
         {
+            if (Path.GetFileName(top).StartsWith('.')) continue;
             // Path.GetRelativePath compares the way the platform does (case-insensitive on
-            // Windows), which is how Directory.Exists/EnumerateDirectories matched `dirs`.
-            if (dirs.Any(d => Path.GetRelativePath(d, top) == ".")) continue;
-            if (AlRunner.Infrastructure.SafeDirectoryScan.Files(top, "*.al").Count > 0) return true;
+            // Windows), which is how Directory.Exists/EnumerateDirectories matched `covered`.
+            if (covered.Any(d => Path.GetRelativePath(d, top) == ".")) continue;
+            var hits = AlRunner.Infrastructure.SafeDirectoryScan.Files(top, "*.al", out var unreadable);
+            if (hits.Count > 0) return true;
+            if (unreadable.Count > 0)
+            {
+                WarnUnreadableOnce(suite, unreadable);
+                return true;
+            }
         }
         return false;
     }
 
+    private static readonly HashSet<string> _warnedUnreadable = new(StringComparer.Ordinal);
+
+    private static void WarnUnreadableOnce(string suite, IReadOnlyList<string> unreadable)
+    {
+        lock (_warnedUnreadable)
+        {
+            foreach (var dir in unreadable)
+            {
+                if (!_warnedUnreadable.Add(dir)) continue;
+                Console.WriteLine(
+                    $"[warn] {suite}: cannot read {dir}. The suite is compiled from its root, but any "
+                    + ".al file under that directory is NOT compiled (issue #2206 pattern; fix the permissions).");
+            }
+        }
+    }
+
     /// <summary>
     /// #3611/#3714: does this suite carry <c>.al</c> files outside <c>src/</c>, <c>app*/</c> and
-    /// <c>test/</c>? When it does, <see cref="CollectSuitePaths"/> compiles it from its root, and
-    /// the RecordPatches source-dir registration in Program.cs must register the root too — a
+    /// <c>test/</c> (and outside the bucket's <c>_shared</c>, which <see cref="CollectSuitePaths"/>
+    /// appends anyway)? When it does, <see cref="CollectSuitePaths"/> compiles it from its root,
+    /// and the RecordPatches source-dir registration in Program.cs must register the root too — a
     /// table at the root that compiled but was never parsed into the in-memory provider is the
-    /// same defect one layer down.
+    /// same defect one layer down. False for a flat suite: there is nothing to widen.
     /// </summary>
-    internal static bool SuiteHasAlOutsideConventionalDirs(string suite)
+    /// <param name="conventional">
+    /// The result of <see cref="ConventionalSourceDirs"/> when the caller already has it; computed
+    /// here otherwise.
+    /// </param>
+    internal static bool SuiteHasAlOutsideConventionalDirs(
+        string suite, string? bucketRoot = null, IReadOnlyList<string>? conventional = null)
     {
-        var dirs = ConventionalSourceDirs(suite);
-        return dirs.Count > 0 && HasAlOutside(suite, dirs);
+        var dirs = conventional ?? ConventionalSourceDirs(suite);
+        if (dirs.Count == 0) return false;
+        var shared = SharedDirOf(bucketRoot);
+        var covered = shared == null ? dirs : dirs.Append(shared).ToList();
+        return HasAlOutside(suite, covered);
     }
 
     // Deterministic cache key for the bundled-mode emit:

--- a/AlRunner/ProgramSupport/Dependencies.cs
+++ b/AlRunner/ProgramSupport/Dependencies.cs
@@ -348,23 +348,84 @@ internal static partial class ProgramSupport
 
     internal static List<string> CollectSuitePaths(string suite, string? bucketRoot = null)
     {
-        var all = new List<string>();
-        var s = Path.Combine(suite, "src");
-        var t = Path.Combine(suite, "test");
-        if (Directory.Exists(s)) all.Add(s);
-        foreach (var app in Directory.EnumerateDirectories(suite, "app*"))
-            all.Add(app);
-        if (Directory.Exists(t)) all.Add(t);
-        // Flat bundle: if neither src/ nor test/ exist, include the suite root so
-        // the emitter can recurse into it and find all .al files.
-        if (all.Count == 0 && AlRunner.Infrastructure.SafeDirectoryScan.Files(suite, "*.al").Any())
-            all.Add(suite);
+        var all = ConventionalSourceDirs(suite);
+        // #3611/#3714: src/, app*/ and test/ are a convention inherited from the legacy bucket
+        // trees, not a contract — alc compiles every .al under the project root, whatever the
+        // folder is called. A suite with any .al file OUTSIDE those folders is compiled from its
+        // root, exactly like a flat bundle, so a root-level codeunit or a sibling folder such as
+        // ControlAddin/ can no longer vanish from the compile (silently, when the dropped file
+        // was the test codeunit: "Tests: 0 total", exit 0). A suite that keeps everything under
+        // the conventional folders returns exactly what it always did, so its ComputeAlCacheKey
+        // input does not move. The register-source-dirs loops in Program.cs ask
+        // SuiteHasAlOutsideConventionalDirs for the same decision — keep the two in step.
+        var alFiles = AlRunner.Infrastructure.SafeDirectoryScan.Files(suite, "*.al");
+        if (all.Count == 0 || HasAlOutside(alFiles, all))
+        {
+            all.Clear();
+            if (alFiles.Count > 0) all.Add(suite);
+        }
         if (bucketRoot != null)
         {
             var shared = Path.Combine(bucketRoot, "_shared");
             if (Directory.Exists(shared)) all.Add(shared);
         }
         return all;
+    }
+
+    /// <summary>
+    /// The folders the legacy bucket layout put AL in — <c>src/</c>, every <c>app*/</c>, and
+    /// <c>test/</c> — in the order <see cref="CollectSuitePaths"/> has always returned them.
+    /// Empty for a flat suite.
+    /// </summary>
+    private static List<string> ConventionalSourceDirs(string suite)
+    {
+        var dirs = new List<string>();
+        var s = Path.Combine(suite, "src");
+        var t = Path.Combine(suite, "test");
+        if (Directory.Exists(s)) dirs.Add(s);
+        foreach (var app in Directory.EnumerateDirectories(suite, "app*"))
+            dirs.Add(app);
+        if (Directory.Exists(t)) dirs.Add(t);
+        return dirs;
+    }
+
+    /// <summary>
+    /// True when at least one of <paramref name="alFiles"/> (every <c>.al</c> under the suite)
+    /// is not under any of <paramref name="dirs"/>. Only <c>.al</c> files are ever passed in —
+    /// an app.json, a README or a <c>.alpackages/</c> beside <c>src/</c> must not widen the compile.
+    /// </summary>
+    private static bool HasAlOutside(IReadOnlyList<string> alFiles, IReadOnlyList<string> dirs)
+    {
+        foreach (var file in alFiles)
+        {
+            var covered = false;
+            foreach (var d in dirs)
+            {
+                var rel = Path.GetRelativePath(d, file);
+                if (rel != ".." && !rel.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+                    && !Path.IsPathRooted(rel))
+                {
+                    covered = true;
+                    break;
+                }
+            }
+            if (!covered) return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// #3611/#3714: does this suite carry <c>.al</c> files outside <c>src/</c>, <c>app*/</c> and
+    /// <c>test/</c>? When it does, <see cref="CollectSuitePaths"/> compiles it from its root, and
+    /// the RecordPatches source-dir registration in Program.cs must register the root too — a
+    /// table at the root that compiled but was never parsed into the in-memory provider is the
+    /// same defect one layer down.
+    /// </summary>
+    internal static bool SuiteHasAlOutsideConventionalDirs(string suite)
+    {
+        var dirs = ConventionalSourceDirs(suite);
+        return dirs.Count > 0
+            && HasAlOutside(AlRunner.Infrastructure.SafeDirectoryScan.Files(suite, "*.al"), dirs);
     }
 
     // Deterministic cache key for the bundled-mode emit:

--- a/AlRunner/ProgramSupport/Dependencies.cs
+++ b/AlRunner/ProgramSupport/Dependencies.cs
@@ -358,11 +358,17 @@ internal static partial class ProgramSupport
         // the conventional folders returns exactly what it always did, so its ComputeAlCacheKey
         // input does not move. The register-source-dirs loops in Program.cs ask
         // SuiteHasAlOutsideConventionalDirs for the same decision — keep the two in step.
-        var alFiles = AlRunner.Infrastructure.SafeDirectoryScan.Files(suite, "*.al");
-        if (all.Count == 0 || HasAlOutside(alFiles, all))
+        if (all.Count == 0)
+        {
+            // Flat bundle: neither src/ nor app*/ nor test/ — the suite root is the one folder,
+            // provided it holds any .al at all.
+            if (AlRunner.Infrastructure.SafeDirectoryScan.Files(suite, "*.al").Count > 0)
+                all.Add(suite);
+        }
+        else if (HasAlOutside(suite, all))
         {
             all.Clear();
-            if (alFiles.Count > 0) all.Add(suite);
+            all.Add(suite);
         }
         if (bucketRoot != null)
         {
@@ -390,26 +396,27 @@ internal static partial class ProgramSupport
     }
 
     /// <summary>
-    /// True when at least one of <paramref name="alFiles"/> (every <c>.al</c> under the suite)
-    /// is not under any of <paramref name="dirs"/>. Only <c>.al</c> files are ever passed in —
-    /// an app.json, a README or a <c>.alpackages/</c> beside <c>src/</c> must not widen the compile.
+    /// True when some <c>.al</c> file under <paramref name="suite"/> is not under any of the
+    /// conventional <paramref name="dirs"/>. Only <c>.al</c> files count — an app.json, a README
+    /// or a <c>.alpackages/</c> beside <c>src/</c> must not widen the compile.
+    /// <para>
+    /// Deliberately never walks the conventional folders themselves: a <c>.al</c> outside them is
+    /// either directly at the root or somewhere under a top-level folder that is not one of them,
+    /// so the check is one top-level listing plus a walk of the non-conventional siblings only.
+    /// For the common src/-only suite that is a listing of the root and nothing more; the old
+    /// "scan the whole suite and subtract" shape re-walked src/ on every call (PR #3739 review).
+    /// </para>
     /// </summary>
-    private static bool HasAlOutside(IReadOnlyList<string> alFiles, IReadOnlyList<string> dirs)
+    private static bool HasAlOutside(string suite, IReadOnlyList<string> dirs)
     {
-        foreach (var file in alFiles)
+        if (AlRunner.Infrastructure.SafeDirectoryScan.Files(suite, "*.al", SearchOption.TopDirectoryOnly).Count > 0)
+            return true;
+        foreach (var top in AlRunner.Infrastructure.SafeDirectoryScan.Directories(suite, "*", SearchOption.TopDirectoryOnly))
         {
-            var covered = false;
-            foreach (var d in dirs)
-            {
-                var rel = Path.GetRelativePath(d, file);
-                if (rel != ".." && !rel.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal)
-                    && !Path.IsPathRooted(rel))
-                {
-                    covered = true;
-                    break;
-                }
-            }
-            if (!covered) return true;
+            // Path.GetRelativePath compares the way the platform does (case-insensitive on
+            // Windows), which is how Directory.Exists/EnumerateDirectories matched `dirs`.
+            if (dirs.Any(d => Path.GetRelativePath(d, top) == ".")) continue;
+            if (AlRunner.Infrastructure.SafeDirectoryScan.Files(top, "*.al").Count > 0) return true;
         }
         return false;
     }
@@ -424,8 +431,7 @@ internal static partial class ProgramSupport
     internal static bool SuiteHasAlOutsideConventionalDirs(string suite)
     {
         var dirs = ConventionalSourceDirs(suite);
-        return dirs.Count > 0
-            && HasAlOutside(AlRunner.Infrastructure.SafeDirectoryScan.Files(suite, "*.al"), dirs);
+        return dirs.Count > 0 && HasAlOutside(suite, dirs);
     }
 
     // Deterministic cache key for the bundled-mode emit:


### PR DESCRIPTION
## Summary

`CollectSuitePaths` (`AlRunner/ProgramSupport/Dependencies.cs`) handed the emitter `src/`, every `app*/` and `test/`, and fell back to the suite root only when none of those existed. One `src/` folder therefore switched the root scan off, and every `.al` file beside it never reached `BcCompiler.Emit`:

- root test codeunit + `src/` helper: `Tests: 0 total`, exit 0 (#3611 case 5, the silent one)
- root helper + `src/` test codeunit: `AL0185: Codeunit 'Probe Helper' is missing`, EMIT-ZERO (#3611 case 4)
- `src/A.al` + `ControlAddin/B.al`: B.al never read, so a broken B.al still exits 0 (#3714)

This is also why `src/` and `app/` trigger it while `sub/` and `source/` do not: only those names are in the conventional list.

The two register-source-dirs loops in `Program.cs` (the CLI bundle loop and server mode) made the same `src/`-else-root choice for `RecordPatches`, so a table at the root was invisible to the in-memory table provider even once its file compiled.

`alc` compiles all of these layouts at 0 errors. The convention came from the legacy bucket trees (v2 cutover, `146bdbbb`) and is not documented anywhere as a contract.

## Fix

A suite whose `.al` files are not all under the conventional folders is compiled from its root, like a flat bundle, and its root is registered for the table parsers. `SuiteHasAlOutsideConventionalDirs` is the one predicate; `CollectSuitePaths` calls it, and so do both register loops, with the bucket root so the legacy `_shared/` folder counts as covered.

Suites that keep everything under `src/` (or `src/` + `test/`, `app*/` only, `test/` only) return exactly the list they did before. Only `.al` files count: a README, `app.json` or `.alpackages/` beside `src/` does not widen the compile.

The decision never walks the conventional folders: two top-level listings of the root, then a walk of each non-covered, non-hidden sibling. For a `src/`-only suite that is no walk at all. Dot-directories (`.git`, `.alpackages`, `.vscode`) are skipped. A sibling the walk cannot read is treated as "could not tell": the suite widens to its root and the directory is named once on stdout, following the #2206 pattern for unreadable directories; the emitter's own root scan skips it just the same, so anything under it is still not compiled and the warning says so.

A suite's sub-directories are part of that suite by design (`Suites.cs`: "a suite's own sub-directories are part of that suite, never separate buckets"). A flat suite has always compiled a nested child app; a `src/` suite with a nested child under a sibling folder now does the same instead of silently dropping it. Pinned as a fact so the choice is visible.

A scan of `tests/runner-extras/`, `AlRunner.Tests/Fixtures/` and `tests/archive/` found no suite with the affected shape.

## Proof: `AlRunner.Tests/SuiteRootAlFilesTests.cs`, 19 facts

In-process facts on `CollectSuitePaths`. RED before the fix, each naming the dropped file:

- `RootAlFileBesideSrc_IsCovered`, `SiblingDirBesideSrc_IsCovered`, `RootAlFileBesideAppDir_IsCovered`, `RootAlFileBesideTestDir_IsCovered`

Exact-list pins for the unchanged layouts, green before and after:

- `SrcOnly_StillReturnsExactlySrc`, `SrcAndTest_StillReturnsExactlySrcThenTest`, `AppDirOnly_StillReturnsExactlyTheAppDir`, `TestDirOnly_StillReturnsExactlyTheTestDir`, `Flat_StillReturnsExactlyTheSuiteRoot`, `NonAlFileBesideSrc_DoesNotWidenThePaths`, `SiblingDirWithoutAl_DoesNotWidenThePaths`, `AlUnderADotDirectory_DoesNotWidenThePaths`
- `SharedDirUnderTheSuite_IsCoveredNotOutside` (suite == bucket root, `_shared/` holds AL): stays `[src, _shared]`
- `NestedAppInASiblingDir_IsPartOfThisSuite_LikeAFlatSuite`: documents the by-design widening
- `UnreadableSiblingDir_WidensToTheRoot`: `SkippableFact` on Unix permission bits, skips on Windows, so it was not observed red locally; it runs on the Linux legs

Runner-spawn facts, platform-only fixtures (no `application` floor):

- #3611: `TestAtRoot_HelperInSrc_RunsTheTest` (RED: `Tests: 0 total`), `HelperAtRoot_TestInSrc_RunsTheTest` (RED: AL0185)
- #3714: `BrokenAlInSiblingDirBesideSrc_FailsTheCompileNamingTheFile` (RED: exit 0, the file never named)
- the register-source-dirs half: `TableAtRoot_UsedFromSrcTest_IsRegisteredForRecords`, insert-then-get of 42 on a root-level table from a `src/` test. Measured in isolation with only the `CollectSuitePaths` change and `Program.cs` at `origin/main`: the test runs and FAILs at runtime (`FAIL Codeunit63331.RootTableRoundTrips`), so the compile half alone is not enough. Green with both halves.

Measured locally on Windows against BC 28.1.49838.54169: the first 12 facts were 8 red before and 12 green after; the class is now 18 green and 1 skipped (the Unix permissions fact). `SiblingSymbolsAppRootManifestTests`, `NestedBundleManifestDiscoveryTests`, `InaccessibleDirectoryScanTests`, `PerSuiteAlDiagnosticFailureTests`, `CorpusAppEnumerationWorkflowTests`, `BaseAppFloorFixtureGuardTests` and `TestArtifactsGateTests` stay green.

## Review history

Copilot flagged the first version's full-suite scan per call; the predicate was rewritten to the top-level shape above. An external adversarial review (GPT-5.6) then found the `_shared` regression, the unreadable-sibling silent path, the stale "one listing" comment, the two-copies-of-the-predicate wording, and the missing `app*`-only / `test/`-only pins; all addressed in the third commit. Its nested-app finding is answered by the design note above rather than a code change.

## Not folded

- #3738, filed from this work: both `SuiteEnumerationTests` facts fail on a Windows box because the test regex expects the runner's em dash and the console codec delivers `-`. Pre-existing and unrelated to this change; the captured output shows enumeration is correct.
- Pre-existing asymmetry between what the compile includes and what `RecordPatches` registers for the conventional layouts (`test/`-only registers nothing; `src/` + `test/` registers only `src/`; `_shared/` is never registered). This PR keeps those decisions as they were and only adds the root-widening branch to both sides. Filed as #3754.
- #3719, #3713 and #3712 are from the same reporter but land in different files (dependency emit, coverage source map, `Text.Split` overloads).

Closes #3611
Closes #3714

Corpus-NA: bundle-layout discovery is runner-specific, deciding which folders of a bundle the runner compiles; no BC behaviour is asserted, so there is nothing for a service tier to adjudicate.

*Opened by an agent (Claude Code) in a session run by @SShadowS.*

https://claude.ai/code/session_01JFQZHC5SEHnLxkc5USksaK
