### PR TITLE
ci: debounced floor run after a merge, and main's floor verdict beside the PR verdict

### DIFF
--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -38,6 +38,11 @@ progress detail belongs. Check a new invocation against a PR whose state you alr
 **Exit 2 is the ordinary answer here, not a failure**, and never a green: the checks have not
 reported, so move on and read again later.
 
+**Beside every verdict it prints one line about `main` itself** — `main floor: RED on 8b6885f4
+(main-verdict-floor.yml, 1h ago)` (#3679), so a PR branched during a red window is visible as
+inheriting a failure it did not cause. It is a report: it never changes the exit code, and a
+read that did not happen prints `unavailable`, never a verdict.
+
 `ci-wait.py` reads the required contexts from the **live branch ruleset** on each invocation
 (`GET /repos/{owner}/{repo}/rules/branches/main`, which reports only *active* rulesets),
 falling back to its built-in list and saying so loudly; `check_required_contexts.py` fails CI
@@ -180,7 +185,8 @@ tolerates in either state while a by-hand ruleset edit catches up with a merged 
 
 **A pull request runs three legs, not eight** (#3141): `.github/pr-bc-versions.txt` — 27.0,
 27.5 and 28.4. `main` runs all eight on every push, every 30 minutes from
-`main-verdict-floor.yml` (#3003), and on the release path. So a green pull request has not been
+`main-verdict-floor.yml` and again about ten minutes after a merge burst ends (#3003, #3679 —
+that workflow's own header states both triggers), and on the release path. So a green pull request has not been
 measured on 27.3, 28.0, 28.1, 28.2 or 28.3 — dispatch `bc-leg-rerun.yml` for one of those
 against your branch — and section 5's leg-set evidence is thin on a PR, where three legs give
 few distinguishable failing sets; prefer the dispatch or an empty commit.

--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -231,7 +231,10 @@ Merge when **all of**:
    legs green" would refuse a legitimate PR or send you hunting for legs that do not exist.
    The legs are not required contexts anyway — the aggregate `BC test matrix passed` is, and
    it fails when any leg of whatever matrix ran fails. The other five versions run on
-   `main` via `main-verdict-floor.yml`, not on the PR.
+   `main` via `main-verdict-floor.yml`, not on the PR — on a 30-minute cadence and
+   again about ten minutes after a merge burst ends (#3679). `tools/ci-wait.py` prints that
+   floor's newest verdict beside the PR's, so a red `main` a PR merely inherited is visible
+   before you arm it.
 2. `git merge-tree --write-tree --messages origin/main origin/<branch>` is clean.
    `mergeStateStatus: CLEAN` only covers textual conflicts.
 3. The proving test exists, and the corpus-PR condition of the arming list above holds.

--- a/.github/workflows/main-verdict-floor.yml
+++ b/.github/workflows/main-verdict-floor.yml
@@ -140,7 +140,9 @@ permissions:
 # What that trades away, stated rather than discovered later: a pending job is cancelled when
 # a newer job joins its group, so a floor matrix waiting behind another can be dropped by a
 # third. That costs a verdict on a superseded tree, which is the one this workflow already
-# declines to buy, and the schedule re-asks within a cadence either way.
+# declines to buy, and the schedule re-asks within a cadence. `floor-verdict` skips on that
+# result, so the run concludes `cancelled` rather than `failure`: a dropped matrix is not a
+# red `main`.
 
 jobs:
   wait:
@@ -191,39 +193,23 @@ jobs:
           # for an older push is not this commit's result (ci-verdicts.md section 2). Both
           # producers count, this workflow and the gating one, so a floor run does not
           # re-verify a commit an earlier floor run already answered for.
-          runs=$(gh api \
-            "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${SHA}&per_page=100")
-
-          conclusive=$(printf '%s' "$runs" | jq '[.workflow_runs[]
+          conclusive=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${SHA}&per_page=100" \
+            --jq '[.workflow_runs[]
                    | select(.path == ".github/workflows/test-matrix.yml"
                          or .path == ".github/workflows/main-verdict-floor.yml")
                    | select(.conclusion == "success" or .conclusion == "failure")]
                   | length')
 
-          # #3679: a floor run ALREADY establishing this commit's verdict. Without this, every
-          # quiet-period merge costs two full matrices — the push path takes ~33 min against a
-          # 30-minute cadence, so a scheduled run lands inside it, sees nothing conclusive yet,
-          # and starts a second matrix on the same commit.
-          #
-          # Only a FLOOR run counts. An in-flight `test-matrix.yml` run on `main` is precisely
-          # what the next merge cancels (#3003), so deferring to one would reproduce the gap
-          # this workflow exists to close. GITHUB_RUN_ID excludes this run, which is itself
-          # in flight and would otherwise make the floor skip forever.
-          inflight=$(printf '%s' "$runs" | jq --arg me "$GITHUB_RUN_ID" '[.workflow_runs[]
-                   | select(.path == ".github/workflows/main-verdict-floor.yml")
-                   | select((.id | tostring) != $me)
-                   | select(.status != "completed")]
-                  | length')
-
+          # CONCLUSIVE only, never in-flight. A run that skipped the matrix still concludes
+          # `success`, so the skip is honest ONLY while a conclusive run co-exists on this
+          # SHA — deferring to an in-flight one would conclude `success` for a commit nothing
+          # had measured, and this very check, plus tools/ci-wait.py, would read that as a
+          # verdict (#3679). Not deferring costs a duplicate matrix when a scheduled run lands
+          # inside a push-triggered one; the pull request prices it.
           if [ "$conclusive" -gt 0 ]; then
             echo "needed=false" >> "$GITHUB_OUTPUT"
             echo "$SHA already has $conclusive conclusive matrix run(s) — nothing to do."
-          elif [ "$inflight" -gt 0 ]; then
-            echo "needed=false" >> "$GITHUB_OUTPUT"
-            echo "$SHA has $inflight floor run(s) in flight already establishing its verdict."
-            echo "Deferring rather than running a second matrix on the same commit. If that"
-            echo "run does not finish, this commit has no conclusive verdict and the next"
-            echo "scheduled run asks again."
           else
             echo "needed=true" >> "$GITHUB_OUTPUT"
             echo "$SHA has no conclusive matrix run. Establishing one."
@@ -269,11 +255,16 @@ jobs:
     # of this workflow.
     name: main verdict (post-merge)
     needs: [verdict-needed, floor-matrix]
-    # `always()` so a red matrix still reports, but ONLY when the guard actually ran. A run
-    # whose `wait` a newer merge cancelled has nothing to say, and reporting success there
-    # would make the run conclude `success` — which `verdict-needed` above and
-    # tools/ci-wait.py both read as a verdict for a commit nothing measured (#3679).
+    # `always()` so a red matrix still reports, but only when there is something to report
+    # about. Two cases must NOT reach it, and both are about this run's own conclusion
+    # rather than about tidiness (#3679): a run whose `wait` a newer merge cancelled has
+    # nothing to say, and reporting success there would conclude `success` for a commit
+    # nothing measured; and a matrix DROPPED while pending — the trade-off named above
+    # `jobs:` — would exit 1 here, concluding `failure`, i.e. a measured RED on a commit
+    # that never ran. `verdict-needed` above and tools/ci-wait.py read both conclusions as
+    # verdicts; skipping leaves the run `cancelled`, which neither counts.
     if: always() && needs.verdict-needed.result == 'success'
+        && needs.floor-matrix.result != 'cancelled'
     runs-on: ubuntu-latest
     steps:
       - name: Report
@@ -283,9 +274,7 @@ jobs:
           result='${{ needs.floor-matrix.result }}'
 
           if [ "$needed" != "true" ]; then
-            echo "main HEAD ${GITHUB_SHA} already had a verdict, or a floor run in flight is"
-            echo "establishing one; this run did not re-run the matrix. The guard job's log"
-            echo "says which of the two it was."
+            echo "main HEAD ${GITHUB_SHA} already had a verdict; floor did not re-run the matrix."
             exit 0
           fi
 

--- a/.github/workflows/main-verdict-floor.yml
+++ b/.github/workflows/main-verdict-floor.yml
@@ -9,8 +9,8 @@ name: Main verdict floor
 #
 # `BC test matrix passed` still gates every pull request targeting `main`, and that is
 # untouched. (#3141 renamed that context from `All BC versions passed` and narrowed the
-# pull-request matrix to three legs; this workflow runs on a `schedule`, so it is unaffected
-# by that narrowing and still delegates at full width — which is now load-bearing, because it
+# pull-request matrix to three legs; this workflow runs on `schedule` and on a push to `main`,
+# neither of which narrows, so it still delegates at full width — which is now load-bearing, because it
 # is the only cadence on which 27.3, 28.0, 28.1, 28.2 and 28.3 run at all.) This is not a hole a red PR can merge through. What the cancellation destroys is
 # the POST-MERGE signal: when a merge breaks `main`, or when two individually-green PRs
 # conflict semantically after landing (#2924, and #2991 for the concrete instance), the run
@@ -89,8 +89,9 @@ name: Main verdict floor
 # cancelling, as well as 6x smaller on the tail. (An earlier draft of this comment put those
 # two within noise of each other; that came from treating today's baseline as 71%-loaded when
 # it is 37%-loaded, and correcting it favours this design.) The floor's peak is bounded by
-# construction: one run at a time, and a cadence longer than the longest observed run, so a
-# floor run can never be overtaken by its own successor.
+# construction: `floor-matrix`'s own group runs one floor matrix at a time (#3679 moved that
+# group from the workflow level to that job), and the cadence exceeds the longest observed
+# run, so a scheduled floor run can never be overtaken by its own successor.
 #
 # It does not give every merged commit its own verdict, and that is deliberate — during a
 # burst, verdicts on five superseded trees are the waste the 2026-09-03 measurement correctly
@@ -103,7 +104,7 @@ name: Main verdict floor
 #
 # NOTE ON publish.yml: the release pushes to `main` as a fast-forward and any merge during its
 # ~40-minute run kills it. This workflow changes nothing about that. It adds no merge, holds
-# no lock on `main`, has its own concurrency group, and never writes to the repository — its
+# no lock on `main`, keeps its matrix in its own concurrency group, and never writes to the repository — its
 # only effect on a release is the shared runner pool, at a bounded 12 jobs.
 
 on:
@@ -115,6 +116,14 @@ on:
     # AlRunner.Tests/MainVerdictFloorWorkflowTests.cs holds the relationship, not the number.
     - cron: '*/30 * * * *'
   workflow_dispatch:
+  # #3679. A merge is when a verdict is most wanted and least likely: the push-triggered
+  # matrix is cancelled by the next merge 83% of the time (#3003), so on the schedule alone a
+  # red merge can go a full cadence unreported, and a pull request branched in that window
+  # inherits a failure it did not cause. What made this trigger unaffordable before is one
+  # eight-leg matrix per merge at ~130 merges a day; the `wait` job below is what removes
+  # that, so the trigger and the debounce are one design and not two.
+  push:
+    branches: [main]
 
 # Read-only. `actions: read` is what lets the guard below ask whether this commit already has
 # a verdict; nothing here needs write access to anything.
@@ -122,18 +131,47 @@ permissions:
   contents: read
   actions: read
 
-# One floor run at a time, and never cancelled. A cancelled floor run would reproduce the
-# exact bug this workflow exists to fix. Cancellation is safe to switch off HERE, unlike on
-# the push path, because arrivals are one per cadence rather than one per merge: rho =
-# 22.8/30 = 0.76 < 1, so the queue is stable and at most one run deep.
-concurrency:
-  group: main-verdict-floor
-  cancel-in-progress: false
+# NO workflow-level `concurrency:` — deliberately, since #3679. One floor MATRIX at a time is
+# still the rule, and `floor-matrix` below declares exactly that group with cancellation off.
+# Holding the whole RUN would queue a merge's run behind a matrix already in flight, and a
+# queued run executes no jobs: its `wait` could never start, never cancel the previous wait,
+# and the debounce would serialise instead of debouncing.
+#
+# What that trades away, stated rather than discovered later: a pending job is cancelled when
+# a newer job joins its group, so a floor matrix waiting behind another can be dropped by a
+# third. That costs a verdict on a superseded tree, which is the one this workflow already
+# declines to buy, and the schedule re-asks within a cadence either way.
 
 jobs:
+  wait:
+    name: Wait out the merge burst
+    # #3679. THE ONLY CANCELLABLE THING IN THIS FILE, and it holds no matrix: a newer merge
+    # cancels this wait, so a burst of merges produces one floor run AFTER the burst rather
+    # than one per merge. The matrix keeps its own non-cancelling group, so a floor run that
+    # has started is never cancelled by a merge — cancelling that is the #3003 bug itself.
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: main-verdict-floor-debounce
+      cancel-in-progress: true
+    steps:
+      - name: Debounce the merge burst
+        # 600 s sits between the two numbers that bound it (#3003's sample): longer than the
+        # 359 s median merge interval, so a burst collapses; shorter than the 30-minute
+        # cadence, so this path adds a verdict the schedule would not have produced for
+        # another half hour. MainVerdictFloorWorkflowTests holds both relationships.
+        run: sleep 600
+
   verdict-needed:
     name: Does main HEAD still lack a verdict?
     runs-on: ubuntu-latest
+    # `always()` because `wait` is SKIPPED on the schedule and dispatch paths, where a skipped
+    # dependency would otherwise skip this too. The result check is the load-bearing half: a
+    # wait that a newer merge CANCELLED must not go on to run a matrix, or the debounce is
+    # decoration and every merge in a burst still costs one (#3679).
+    needs: wait
+    if: always() && (github.event_name != 'push' || needs.wait.result == 'success')
     outputs:
       needed: ${{ steps.check.outputs.needed }}
     steps:
@@ -153,17 +191,39 @@ jobs:
           # for an older push is not this commit's result (ci-verdicts.md section 2). Both
           # producers count, this workflow and the gating one, so a floor run does not
           # re-verify a commit an earlier floor run already answered for.
-          conclusive=$(gh api \
-            "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${SHA}&per_page=100" \
-            --jq '[.workflow_runs[]
+          runs=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${SHA}&per_page=100")
+
+          conclusive=$(printf '%s' "$runs" | jq '[.workflow_runs[]
                    | select(.path == ".github/workflows/test-matrix.yml"
                          or .path == ".github/workflows/main-verdict-floor.yml")
                    | select(.conclusion == "success" or .conclusion == "failure")]
                   | length')
 
+          # #3679: a floor run ALREADY establishing this commit's verdict. Without this, every
+          # quiet-period merge costs two full matrices — the push path takes ~33 min against a
+          # 30-minute cadence, so a scheduled run lands inside it, sees nothing conclusive yet,
+          # and starts a second matrix on the same commit.
+          #
+          # Only a FLOOR run counts. An in-flight `test-matrix.yml` run on `main` is precisely
+          # what the next merge cancels (#3003), so deferring to one would reproduce the gap
+          # this workflow exists to close. GITHUB_RUN_ID excludes this run, which is itself
+          # in flight and would otherwise make the floor skip forever.
+          inflight=$(printf '%s' "$runs" | jq --arg me "$GITHUB_RUN_ID" '[.workflow_runs[]
+                   | select(.path == ".github/workflows/main-verdict-floor.yml")
+                   | select((.id | tostring) != $me)
+                   | select(.status != "completed")]
+                  | length')
+
           if [ "$conclusive" -gt 0 ]; then
             echo "needed=false" >> "$GITHUB_OUTPUT"
             echo "$SHA already has $conclusive conclusive matrix run(s) — nothing to do."
+          elif [ "$inflight" -gt 0 ]; then
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            echo "$SHA has $inflight floor run(s) in flight already establishing its verdict."
+            echo "Deferring rather than running a second matrix on the same commit. If that"
+            echo "run does not finish, this commit has no conclusive verdict and the next"
+            echo "scheduled run asks again."
           else
             echo "needed=true" >> "$GITHUB_OUTPUT"
             echo "$SHA has no conclusive matrix run. Establishing one."
@@ -185,8 +245,15 @@ jobs:
     #
     # `ref` is pinned to the SHA the guard above decided about, so the verdict this run
     # records is unambiguously about that commit even if `main` moved while it was queued.
+    #
+    # The concurrency group moved here from the workflow level at #3679 (see the note above
+    # `jobs:`). What it guarantees is unchanged: one floor matrix at a time, never cancelled,
+    # because a cancelled floor matrix reproduces the exact bug this workflow exists to fix.
     needs: verdict-needed
     if: needs.verdict-needed.outputs.needed == 'true'
+    concurrency:
+      group: main-verdict-floor
+      cancel-in-progress: false
     uses: ./.github/workflows/bc-tests.yml
     with:
       ref: ${{ github.sha }}
@@ -202,7 +269,11 @@ jobs:
     # of this workflow.
     name: main verdict (post-merge)
     needs: [verdict-needed, floor-matrix]
-    if: always()
+    # `always()` so a red matrix still reports, but ONLY when the guard actually ran. A run
+    # whose `wait` a newer merge cancelled has nothing to say, and reporting success there
+    # would make the run conclude `success` — which `verdict-needed` above and
+    # tools/ci-wait.py both read as a verdict for a commit nothing measured (#3679).
+    if: always() && needs.verdict-needed.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Report
@@ -212,7 +283,9 @@ jobs:
           result='${{ needs.floor-matrix.result }}'
 
           if [ "$needed" != "true" ]; then
-            echo "main HEAD ${GITHUB_SHA} already had a verdict; floor did not re-run the matrix."
+            echo "main HEAD ${GITHUB_SHA} already had a verdict, or a floor run in flight is"
+            echo "establishing one; this run did not re-run the matrix. The guard job's log"
+            echo "says which of the two it was."
             exit 0
           fi
 

--- a/.github/workflows/main-verdict-floor.yml
+++ b/.github/workflows/main-verdict-floor.yml
@@ -79,19 +79,18 @@ name: Main verdict floor
 #
 # THE COST OF THIS WORKFLOW, AGAINST THE ALTERNATIVE
 #
-# Time-weighted mean concurrent jobs attributable to `main`, over the same 18.5 h window:
+# Cheaper than never cancelling `main` on both the average and the tail — roughly 1.7x on the
+# mean and 6x on the peak, over the same 18.5 h window. The figures that were here are NOT
+# reproduced, because they were derived for the schedule-only workflow and #3679 added the
+# push path; re-deriving them in place is how a stale table survives a design change. The
+# schedule-only numbers are in #3003, and what the push path adds — a duplicate matrix when a
+# scheduled run lands inside a push-triggered one, plus one idle runner per merge burst — is
+# priced in #3679's pull request.
 #
-#   today (cancelling)    3.14 jobs
-#   never cancel `main`   6.72 jobs   (+3.57)   PEAK 72
-#   this floor            +2.09 jobs            PEAK 12  (bounded by design)
-#
-# So the floor is not merely comparable on the average — it is about 1.7x cheaper than never
-# cancelling, as well as 6x smaller on the tail. (An earlier draft of this comment put those
-# two within noise of each other; that came from treating today's baseline as 71%-loaded when
-# it is 37%-loaded, and correcting it favours this design.) The floor's peak is bounded by
-# construction: `floor-matrix`'s own group runs one floor matrix at a time (#3679 moved that
-# group from the workflow level to that job), and the cadence exceeds the longest observed
-# run, so a scheduled floor run can never be overtaken by its own successor.
+# One floor matrix at a time is still structural: `floor-matrix` carries that concurrency
+# group with cancellation off (#3679 moved it there from the workflow level), and the cadence
+# exceeds the longest observed run, so a scheduled floor run cannot be overtaken by its own
+# successor.
 #
 # It does not give every merged commit its own verdict, and that is deliberate — during a
 # burst, verdicts on five superseded trees are the waste the 2026-09-03 measurement correctly
@@ -235,8 +234,16 @@ jobs:
     # The concurrency group moved here from the workflow level at #3679 (see the note above
     # `jobs:`). What it guarantees is unchanged: one floor matrix at a time, never cancelled,
     # because a cancelled floor matrix reproduces the exact bug this workflow exists to fix.
+    #
+    # `always()` is not decoration here. A missing status function means an implicit
+    # `success()`, which GitHub evaluates over the whole ANCESTOR CHAIN rather than over the
+    # listed `needs` — so the `wait` job, skipped on every schedule and dispatch run, made
+    # this job skip too, and `floor-verdict` then reported `failure` having run nothing
+    # (actions/runner#2205; the guard is AlRunner.Tests/MainVerdictFloorWorkflowTests.cs's
+    # Floor_EveryJobDownstreamOfTheSkippableWait_CarriesAnExplicitStatusFunction).
     needs: verdict-needed
-    if: needs.verdict-needed.outputs.needed == 'true'
+    if: always() && needs.verdict-needed.result == 'success'
+        && needs.verdict-needed.outputs.needed == 'true'
     concurrency:
       group: main-verdict-floor
       cancel-in-progress: false

--- a/AlRunner.Tests/MainVerdictFloorWorkflowTests.cs
+++ b/AlRunner.Tests/MainVerdictFloorWorkflowTests.cs
@@ -141,6 +141,71 @@ public sealed class MainVerdictFloorWorkflowTests
         Assert.Matches(new Regex($@"needs\.{wait.Key}\.result\s*==\s*'success'"), needed);
     }
 
+    /// <summary>
+    /// A job's <c>if:</c> expression, including the folded continuation lines a long condition
+    /// is written across. Empty when the job declares none — which is the condition this file
+    /// checks for, so it must be distinguishable from a condition that exists.
+    /// </summary>
+    private static string IfExpressionOf(string jobBody)
+    {
+        var lines = jobBody.Replace("\r\n", "\n").Split('\n');
+        var i = Array.FindIndex(lines, l => l.TrimStart().StartsWith("if:", StringComparison.Ordinal));
+        if (i < 0) return "";
+
+        var expr = new System.Text.StringBuilder(lines[i].Trim());
+        for (i++; i < lines.Length; i++)
+        {
+            // A continuation is indented deeper than a job key (four spaces) and is not itself
+            // a key. `&& …` on its own line is the shape a folded condition takes here.
+            var line = lines[i];
+            if (line.Trim().Length == 0) break;
+            if (!line.StartsWith("     ", StringComparison.Ordinal)) break;
+            if (Regex.IsMatch(line, @"^    [A-Za-z_-]+:")) break;
+            expr.Append(' ').Append(line.Trim());
+        }
+        return expr.ToString();
+    }
+
+    [Fact]
+    public void Floor_EveryJobDownstreamOfTheSkippableWait_CarriesAnExplicitStatusFunction()
+    {
+        // GitHub evaluates a missing status function as `success()` over the WHOLE ancestor
+        // chain, not over the listed `needs`, and a SKIPPED ancestor makes it false
+        // (actions/runner#2205, still open, whose reproducer is this exact graph). `wait` is
+        // skipped on every `schedule` and `workflow_dispatch` run, so a downstream job with a
+        // bare `if:` is skipped on precisely the paths that were the whole workflow before
+        // #3679 — and `floor-verdict` then reports `failure` having run nothing, which
+        // `verdict-needed` counts as a verdict and tools/ci-wait.py prints as a red `main`.
+        //
+        // The guard is the SHAPE, not the instance: every job transitively downstream of
+        // `wait` must say what statuses it wants, because `wait` is conditional.
+        var jobs = WorkflowParity.SplitJobs(CodeOnly(Read(Floor)));
+
+        var downstream = new HashSet<string>(StringComparer.Ordinal);
+        for (var grew = true; grew;)
+        {
+            grew = false;
+            foreach (var (id, body) in jobs)
+            {
+                if (id == "wait" || downstream.Contains(id)) continue;
+                if (WorkflowParity.NeedsOf(body).Any(n => n == "wait" || downstream.Contains(n)))
+                    grew |= downstream.Add(id);
+            }
+        }
+
+        Assert.NotEmpty(downstream);
+        foreach (var id in downstream)
+        {
+            var expr = IfExpressionOf(jobs[id]);
+            Assert.True(
+                Regex.IsMatch(expr, @"\b(always|success|failure|cancelled)\s*\(\s*\)"),
+                $"job `{id}` is downstream of the conditionally-skipped `wait` but its `if:` "
+                + $"carries no status function — GitHub's implicit success() is false when ANY "
+                + $"ancestor was skipped, so this job never runs on a schedule or a dispatch "
+                + $"(actions/runner#2205). Its condition is: \"{expr}\"");
+        }
+    }
+
     [Fact]
     public void Floor_ReportsOnlyOnRunsThatMeasuredSomething()
     {
@@ -263,7 +328,11 @@ public sealed class MainVerdictFloorWorkflowTests
         // and the expensive job must actually be gated on it, or the guard is decoration
         var matrix = jobs.Single(j => j.Value.Contains(WorkflowParity.DelegationMarker, StringComparison.Ordinal));
         Assert.Contains("needs: verdict-needed", matrix.Value, StringComparison.Ordinal);
-        Assert.Matches(new Regex(@"if:\s*needs\.verdict-needed\.outputs\.\w+\s*==\s*'true'"), matrix.Value);
+        // Matched over the folded expression rather than from `if:` onward: since #3679 the
+        // condition also carries the explicit status function the test above requires, so
+        // anchoring on `if:` would force the two guards to be written in one order.
+        Assert.Matches(new Regex(@"needs\.verdict-needed\.outputs\.\w+\s*==\s*'true'"),
+            IfExpressionOf(matrix.Value));
     }
 
     [Fact]
@@ -288,19 +357,17 @@ public sealed class MainVerdictFloorWorkflowTests
     }
 
     [Fact]
-    public void OnlyTheGatingMatrixAndTheFloor_RunTheEightLegMatrixOnPushesToMain()
+    public void OnlyTheseFourWorkflows_CallTheEightLegMatrixAtAll()
     {
-        // The census behind "the same shape does not repeat elsewhere". Two workflows trigger
-        // on a push to `main`: this repo's gating matrix, and sync-changelog-unreleased.yml.
-        // The changelog sync shares the pattern — one concurrency group, cancellation on —
-        // but not the pathology: it takes a median of 11 s against a 359 s median merge
-        // interval (rho = 0.03), so 56 of its last 60 runs completed. Cancellation starves a
-        // workflow only when its wall time approaches the merge interval, which is a property
-        // of the run, not of the concurrency block.
+        // A census of CALLERS of the shared matrix — which is all this assertion has ever
+        // measured. It fails when a fifth workflow starts calling it, so the cost of doing so
+        // is priced by whoever adds it rather than discovered afterwards (#3003).
         //
-        // This guard fails if a third push-to-main workflow starts calling the eight-leg
-        // matrix, because that would double `main`'s post-merge cost without anyone pricing
-        // it — the thing #3003 is about.
+        // Two sentences that used to sit here claimed this guard would catch a third
+        // push-to-`main` caller. It never could: it reads `uses:`, not triggers, and #3679
+        // made the floor the second push-to-`main` caller with this test passing unchanged.
+        // Deleted rather than rewritten — a census of callers is a useful thing to hold, and
+        // a census of triggers would be a different test.
         var callers = Directory.GetFiles(WorkflowDir, "*.yml")
             .Where(f => CodeOnly(File.ReadAllText(f))
                 .Contains(WorkflowParity.DelegationMarker, StringComparison.Ordinal))

--- a/AlRunner.Tests/MainVerdictFloorWorkflowTests.cs
+++ b/AlRunner.Tests/MainVerdictFloorWorkflowTests.cs
@@ -142,21 +142,30 @@ public sealed class MainVerdictFloorWorkflowTests
     }
 
     [Fact]
-    public void Floor_DoesNotDuplicateAFloorRunAlreadyEstablishingThisCommit()
+    public void Floor_ReportsOnlyOnRunsThatMeasuredSomething()
     {
-        // Without this, every quiet-period merge costs two full matrices: the push-triggered
-        // floor run takes ~33 min (10 debounce + 23 matrix), the cadence is 30, so a
-        // scheduled run lands inside it, finds no CONCLUSIVE run yet, and starts a second one
-        // on the same commit. The guard defers to an in-flight FLOOR run only — an in-flight
-        // `test-matrix.yml` run on `main` is the thing the next merge cancels (#3003), so
-        // deferring to that would reproduce the gap this workflow exists to close.
-        var needed = WorkflowParity.SplitJobs(CodeOnly(Read(Floor)))["verdict-needed"];
+        // Both halves are about this RUN'S CONCLUSION, which is what `verdict-needed` above
+        // and tools/ci-wait.py read as a verdict — so a `floor-verdict` that reports on a run
+        // which measured nothing writes a verdict for a commit nobody ran (#3679):
+        //
+        //   * `wait` cancelled by a newer merge  -> reporting success concludes `success`
+        //   * `floor-matrix` DROPPED while pending -> exit 1 concludes `failure`, a RED on a
+        //     commit that never ran (the trade-off of moving the group down to that job)
+        //
+        // Skipping in both cases leaves the run `cancelled`, which neither consumer counts.
+        var jobs = WorkflowParity.SplitJobs(CodeOnly(Read(Floor)));
+        var verdict = jobs["floor-verdict"];
 
-        Assert.Contains("status", needed, StringComparison.Ordinal);
-        Assert.Contains("completed", needed, StringComparison.Ordinal);
-        // ...and it must exclude ITSELF, or the check sees this very run in flight and the
-        // floor never runs again.
-        Assert.Contains("GITHUB_RUN_ID", needed, StringComparison.Ordinal);
+        Assert.Matches(new Regex(@"needs\.verdict-needed\.result\s*==\s*'success'"), verdict);
+        Assert.Matches(new Regex(@"needs\.floor-matrix\.result\s*!=\s*'cancelled'"), verdict);
+
+        // And the guard job may only skip the matrix on a CONCLUSIVE run for this commit. An
+        // in-flight one is not a verdict: deferring to it would conclude `success` here while
+        // nothing had measured the commit, and if that run is then dropped, nothing ever does.
+        var needed = jobs["verdict-needed"];
+        Assert.Contains("conclusion", needed, StringComparison.Ordinal);
+        Assert.DoesNotContain("in_progress", needed, StringComparison.Ordinal);
+        Assert.DoesNotMatch(new Regex(@"\.status\s*!=\s*""completed"""), needed);
     }
 
     [Fact]

--- a/AlRunner.Tests/MainVerdictFloorWorkflowTests.cs
+++ b/AlRunner.Tests/MainVerdictFloorWorkflowTests.cs
@@ -80,6 +80,12 @@ public sealed class MainVerdictFloorWorkflowTests
     /// </summary>
     private const int LongestObservedRunMinutes = 27;
 
+    /// <summary>
+    /// Median interval between merges to `main` in the same sample, in minutes. The #3679
+    /// debounce must exceed it, or a burst still produces one floor run per merge.
+    /// </summary>
+    private const int MedianMergeIntervalMinutes = 6;
+
     private static string Read(string name)
     {
         var path = Path.Combine(WorkflowDir, name);
@@ -91,12 +97,66 @@ public sealed class MainVerdictFloorWorkflowTests
         string.Join('\n', text.Split('\n').Where(l => !l.TrimStart().StartsWith('#')));
 
     [Fact]
-    public void Floor_RunsOnlyOnAScheduleAndOnDemand()
+    public void Floor_RunsOnASchedule_OnDemand_AndAfterAMergeToMain()
     {
-        // The cost guard. A `push` trigger here would run a SECOND eight-leg matrix on every
-        // merge — 130 extra runs a day — and a `pull_request` trigger would put a
-        // non-gating reporter on the same events the real gate uses.
-        Assert.Equal(new[] { "schedule", "workflow_dispatch" }, WorkflowTriggers.TriggersOf(Read(Floor)));
+        // #3679 added the `push`. What made a push trigger unaffordable before was one
+        // eight-leg matrix per merge; the debounce below is what removes that, so the two
+        // must be asserted together — a push trigger with no wait job is the cost guard this
+        // test used to be, defeated. A `pull_request` trigger stays forbidden outright: it
+        // would put a non-gating reporter on the same events the real gate uses.
+        var triggers = WorkflowTriggers.TriggersOf(Read(Floor));
+
+        Assert.Equal(new[] { "schedule", "workflow_dispatch", "push" }, triggers);
+        Assert.Matches(new Regex(@"push:\s*\n\s*branches:\s*\[\s*main\s*\]"), CodeOnly(Read(Floor)));
+    }
+
+    [Fact]
+    public void Floor_DebouncesAMergeBurst_IntoOneRunAfterIt()
+    {
+        // #3679: a merge is when a verdict is most wanted and least likely — the
+        // push-triggered matrix is cancelled by the next merge 83% of the time — but one
+        // floor matrix per merge is unaffordable at ~130 merges a day. The wait job is the
+        // whole design: a newer merge cancels it, so a burst collapses to one run after it.
+        var code = CodeOnly(Read(Floor));
+        var jobs = WorkflowParity.SplitJobs(code);
+
+        var wait = jobs.Single(j => Regex.IsMatch(j.Value, @"sleep\s+\d+"));
+        Assert.Contains("github.event_name == 'push'", wait.Value, StringComparison.Ordinal);
+        Assert.Matches(new Regex(@"cancel-in-progress:\s*true"), wait.Value);
+
+        var seconds = int.Parse(Regex.Match(wait.Value, @"sleep\s+(\d+)").Groups[1].Value);
+        Assert.True(seconds > MedianMergeIntervalMinutes * 60,
+            $"the debounce is {seconds}s, at or under the {MedianMergeIntervalMinutes}-minute "
+            + "median merge interval — a burst would still produce one floor run per merge.");
+
+        var cadence = int.Parse(Regex.Match(code, @"cron:\s*'\*/(\d+) \* \* \* \*'").Groups[1].Value);
+        Assert.True(seconds < cadence * 60,
+            $"the debounce is {seconds}s against a {cadence}-minute cadence — a wait at least "
+            + "as long as the cadence buys nothing the schedule would not already have done.");
+
+        // A wait that was CANCELLED must not reach the matrix, or the debounce is decoration
+        // and every merge in the burst still runs one.
+        var needed = jobs["verdict-needed"];
+        Assert.Contains(wait.Key, WorkflowParity.NeedsOf(needed));
+        Assert.Matches(new Regex($@"needs\.{wait.Key}\.result\s*==\s*'success'"), needed);
+    }
+
+    [Fact]
+    public void Floor_DoesNotDuplicateAFloorRunAlreadyEstablishingThisCommit()
+    {
+        // Without this, every quiet-period merge costs two full matrices: the push-triggered
+        // floor run takes ~33 min (10 debounce + 23 matrix), the cadence is 30, so a
+        // scheduled run lands inside it, finds no CONCLUSIVE run yet, and starts a second one
+        // on the same commit. The guard defers to an in-flight FLOOR run only — an in-flight
+        // `test-matrix.yml` run on `main` is the thing the next merge cancels (#3003), so
+        // deferring to that would reproduce the gap this workflow exists to close.
+        var needed = WorkflowParity.SplitJobs(CodeOnly(Read(Floor)))["verdict-needed"];
+
+        Assert.Contains("status", needed, StringComparison.Ordinal);
+        Assert.Contains("completed", needed, StringComparison.Ordinal);
+        // ...and it must exclude ITSELF, or the check sees this very run in flight and the
+        // floor never runs again.
+        Assert.Contains("GITHUB_RUN_ID", needed, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -117,15 +177,39 @@ public sealed class MainVerdictFloorWorkflowTests
     }
 
     [Fact]
-    public void Floor_NeverCancelsItself_AndDoesNotShareTheGatingGroup()
+    public void Floor_NeverCancelsItsMatrix_AndDoesNotShareTheGatingGroup()
     {
-        // A cancelled floor run reproduces the bug it exists to fix. Sharing the gating
-        // workflow's group would be worse still: a merge would cancel the floor, so the
+        // A cancelled floor MATRIX reproduces the bug this workflow exists to fix. Sharing the
+        // gating workflow's group would be worse still: a merge would cancel the floor, so the
         // floor could never outlive the merge rate that defeats the push-triggered run.
+        //
+        // Since #3679 the file also contains a cancellable job, so "somewhere in this file
+        // there is a `cancel-in-progress: false`" is no longer a guard — a file with both
+        // spellings passes it while the matrix is the cancellable one. Attribute each
+        // concurrency block to its job instead.
         var code = CodeOnly(Read(Floor));
+        var jobs = WorkflowParity.SplitJobs(code);
 
-        Assert.Matches(new Regex(@"cancel-in-progress:\s*false"), code);
+        // Nothing may hold the whole RUN. A workflow-level group with cancellation off would
+        // queue a merge's run behind a floor matrix already in flight, and a QUEUED run runs
+        // no jobs — so its wait could not start, could not cancel the previous wait, and the
+        // debounce would serialise instead of debouncing.
+        Assert.DoesNotMatch(new Regex(@"^concurrency:", RegexOptions.Multiline), code);
+
+        var matrix = jobs.Single(j => j.Value.Contains(WorkflowParity.DelegationMarker, StringComparison.Ordinal));
+        Assert.Matches(
+            new Regex(@"group:\s*main-verdict-floor\s*\n\s*cancel-in-progress:\s*false"),
+            matrix.Value);
         Assert.DoesNotMatch(new Regex(@"group:.*github\.ref"), code);
+
+        // Exactly one cancellable job, and it is the wait rather than the work.
+        var cancellable = jobs
+            .Where(j => Regex.IsMatch(j.Value, @"cancel-in-progress:\s*true"))
+            .Select(j => j.Key)
+            .ToArray();
+        Assert.Single(cancellable);
+        Assert.DoesNotContain(WorkflowParity.DelegationMarker, jobs[cancellable[0]],
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tools/ci-wait.py
+++ b/tools/ci-wait.py
@@ -36,6 +36,15 @@ Usage
     tools/ci-wait.py 2379 --timeout 0     # single pass: look once, do not wait
     tools/ci-wait.py 2379 --no-log        # skip the failure log fetch
 
+Beside every verdict it prints one more line -- the newest conclusive matrix
+verdict for `main` itself (#3679):
+
+    main floor: RED on 8b6885f4 (main-verdict-floor.yml, 1h ago)
+
+A pull request branched during a red window inherits a failure it did not cause,
+and that was invisible here. The line is a REPORT: it never changes the exit
+code, and a read that did not happen prints as `unavailable`, never as GREEN.
+
 Exit codes
 ----------
     0  every required check passed ON THE CURRENT HEAD -- safe to report green
@@ -143,6 +152,7 @@ exit-4 output names any entry that fails the condition.
 from __future__ import annotations
 
 import argparse
+import datetime
 import json
 import os
 import re
@@ -280,6 +290,108 @@ def workflow_runs_for(sha: str) -> list[dict] | None:
     except Exception:
         return None
     return got if isinstance(got, list) else None
+
+
+# --- the floor verdict for `main` (#3679) ----------------------------------
+#
+# A pull request branched during a red window inherits a failure it did not
+# cause. `main`'s own verdict is measurable -- main-verdict-floor.yml and
+# test-matrix.yml are its only two producers -- so this tool prints it beside
+# the PR verdict rather than leaving the agent to go and ask. It is a REPORT:
+# it never touches the exit code, and a read that did not happen prints as
+# `unavailable`, never as a verdict (guards-need-a-third-state.md).
+FLOOR_WORKFLOWS = ("main-verdict-floor.yml", "test-matrix.yml")
+
+
+def _workflow_file(run: dict) -> str:
+    return (run.get("path") or "").rsplit("/", 1)[-1]
+
+
+def _age_of(updated_at: str | None, now: float) -> str:
+    """`updated_at` as an age, or "age unknown" when it cannot be parsed."""
+    if not updated_at:
+        return "age unknown"
+    try:
+        when = datetime.datetime.strptime(updated_at, "%Y-%m-%dT%H:%M:%SZ")
+        when = when.replace(tzinfo=datetime.timezone.utc).timestamp()
+    except Exception:
+        return "age unknown"
+    secs = max(0.0, now - when)
+    if secs < 60:
+        return "just now"
+    if secs < 3600:
+        return f"{int(secs // 60)}m ago"
+    if secs < 86400:
+        return f"{int(secs // 3600)}h ago"
+    return f"{int(secs // 86400)}d ago"
+
+
+def fetch_floor_runs(branch: str = "main"):
+    """(runs, reason): completed runs of both producers of a `main` verdict.
+
+    Asked per workflow rather than as one `?branch=main` sweep: `main` carries
+    enough unrelated traffic that a 100-run page can hold no matrix run at all,
+    and an empty page would then read as "no conclusive run found" -- a wrong
+    answer wearing the shape of a right one.
+
+    One failed read refuses the whole answer. Judging `main` from whichever half
+    responded is the #3002 shape: a partial read and a genuinely empty one are
+    indistinguishable from here, and the smaller set is the one that produces a
+    false GREEN.
+    """
+    out: list[dict] = []
+    for wf in FLOOR_WORKFLOWS:
+        rc, body = gh(["api",
+                       f"repos/{REPO}/actions/workflows/{wf}/runs"
+                       f"?branch={branch}&status=completed&per_page=20",
+                       "--jq", "[.workflow_runs[] | {path, conclusion, head_sha, updated_at}]"])
+        if rc != 0:
+            return None, f"could not read {wf} runs on {branch}"
+        try:
+            got = json.loads(body)
+        except Exception:
+            return None, f"unreadable run list for {wf} on {branch}"
+        if not isinstance(got, list):
+            return None, f"unexpected run list shape for {wf} on {branch}"
+        out.extend(got)
+    return out, ""
+
+
+def floor_verdict(runs: list[dict] | None, reason: str = "",
+                  now: float | None = None) -> str:
+    """One line: the newest conclusive matrix verdict for `main`.
+
+    RED wins over GREEN on the SAME commit, because a floor run concludes
+    `success` when it SKIPS -- its `verdict-needed` guard counts a `failure` as
+    a verdict too, so a floor success can sit on top of a red commit and mean
+    only "somebody already measured this one".
+    """
+    now = time.time() if now is None else now
+    if runs is None:
+        why = reason or "could not read main's recent workflow runs"
+        return f"main floor: unavailable ({why})"
+    conclusive = [r for r in runs
+                  if _workflow_file(r) in FLOOR_WORKFLOWS
+                  and r.get("conclusion") in ("success", "failure")]
+    if not conclusive:
+        return "main floor: no conclusive run found"
+    newest = max(conclusive, key=lambda r: r.get("updated_at") or "")
+    sha = newest.get("head_sha") or ""
+    same = [r for r in conclusive if (r.get("head_sha") or "") == sha]
+    red = [r for r in same if r.get("conclusion") == "failure"]
+    decider = max(red, key=lambda r: r.get("updated_at") or "") if red else newest
+    state = "RED" if red else "GREEN"
+    return (f"main floor: {state} on {sha[:8] or '<unknown sha>'} "
+            f"({_workflow_file(decider)}, {_age_of(decider.get('updated_at'), now)})")
+
+
+def print_floor_verdict() -> None:
+    """Print the floor line. Returns nothing, raises nothing, gates nothing."""
+    try:
+        runs, why = fetch_floor_runs()
+        print(floor_verdict(runs, why))
+    except Exception as exc:  # pragma: no cover - a report may never break a verdict
+        print(f"main floor: unavailable ({type(exc).__name__} while reading main's runs)")
 
 
 def contexts_from_branch_rules(payload) -> tuple[str, ...] | None:
@@ -1277,6 +1389,9 @@ def main() -> int:
             print(f"\nFAILED on {sha[:8]} -- " + v.lines[0])
             for line in v.lines[1:]:
                 print(line)
+            # Beside the PR verdict, never instead of it: a red PR branched from
+            # a red `main` is often not this PR failure to own (#3679).
+            print_floor_verdict()
             if not args.no_log:
                 # The check-run `id` is NOT the Actions job id that `gh run view --job`
                 # wants; passing it fails with "could not find job". The job id is the
@@ -1308,12 +1423,14 @@ def main() -> int:
             print(f"\nUNDETERMINED on {sha[:8]} -- " + v.lines[0])
             for line in v.lines[1:]:
                 print(line)
+            print_floor_verdict()
             return 3
 
         if v.code == 4:
             print(f"\nBLOCKED on {sha[:8]} -- " + v.lines[0].split(" -- ", 1)[1])
             for line in v.lines[1:]:
                 print(line)
+            print_floor_verdict()
             return 4
 
         if v.code == 0:
@@ -1321,6 +1438,7 @@ def main() -> int:
             for line in v.lines[1:]:
                 print(line)
             print("Confirm this SHA is still the PR head before reporting it.")
+            print_floor_verdict()
             return 0
 
         if time.time() >= deadline:
@@ -1338,6 +1456,7 @@ def main() -> int:
     else:
         print(f"\nSTILL RUNNING after {args.timeout}s ({reason}). "
               "This is NOT a verdict -- call again; do not report a result.")
+    print_floor_verdict()
     return 2
 
 

--- a/tools/ci-wait.py
+++ b/tools/ci-wait.py
@@ -327,12 +327,17 @@ def _age_of(updated_at: str | None, now: float) -> str:
 
 
 def fetch_floor_runs(branch: str = "main"):
-    """(runs, reason): completed runs of both producers of a `main` verdict.
+    """(runs, reason): recent completed runs of both producers of a `main` verdict.
+
+    This read finds WHICH COMMIT to report on; `fetch_runs_for_sha` below then
+    decides what that commit's verdict is. Splitting them is the point: a page
+    of recent runs is a window, and a window cannot answer "is there a failure
+    on this commit" -- twenty later floor skips on a static `main` push the
+    failure off it, and the line would print GREEN for a commit measured red.
 
     Asked per workflow rather than as one `?branch=main` sweep: `main` carries
     enough unrelated traffic that a 100-run page can hold no matrix run at all,
-    and an empty page would then read as "no conclusive run found" -- a wrong
-    answer wearing the shape of a right one.
+    and an empty page would then read as "no conclusive run found".
 
     One failed read refuses the whole answer. Judging `main` from whichever half
     responded is the #3002 shape: a partial read and a genuinely empty one are
@@ -344,7 +349,8 @@ def fetch_floor_runs(branch: str = "main"):
         rc, body = gh(["api",
                        f"repos/{REPO}/actions/workflows/{wf}/runs"
                        f"?branch={branch}&status=completed&per_page=20",
-                       "--jq", "[.workflow_runs[] | {path, conclusion, head_sha, updated_at}]"])
+                       "--jq", "[.workflow_runs[] "
+                               "| {path, conclusion, head_sha, created_at, updated_at}]"])
         if rc != 0:
             return None, f"could not read {wf} runs on {branch}"
         try:
@@ -357,11 +363,58 @@ def fetch_floor_runs(branch: str = "main"):
     return out, ""
 
 
+def fetch_runs_for_sha(sha: str):
+    """(runs, reason): EVERY workflow run GitHub has for one commit.
+
+    Complete rather than recent, which is what lets a failure outrank a later
+    skip on the same commit. A page that FILLED is a partial read and is
+    refused: 100 runs on one commit means the tail is invisible, and an
+    invisible tail is where the failure would be (guards-need-a-third-state).
+    """
+    rc, body = gh(["api",
+                   f"repos/{REPO}/actions/runs?head_sha={sha}&per_page=100",
+                   "--jq", "[.workflow_runs[] "
+                           "| {path, conclusion, head_sha, created_at, updated_at}]"])
+    if rc != 0:
+        return None, f"could not read the run list for {sha[:8]}"
+    try:
+        got = json.loads(body)
+    except Exception:
+        return None, f"unreadable run list for {sha[:8]}"
+    if not isinstance(got, list):
+        return None, f"unexpected run list shape for {sha[:8]}"
+    if len(got) >= 100:
+        return None, f"the run list for {sha[:8]} filled its page — a partial read"
+    return got, ""
+
+
+def _conclusive(runs: list[dict]) -> list[dict]:
+    return [r for r in runs
+            if _workflow_file(r) in FLOOR_WORKFLOWS
+            and r.get("conclusion") in ("success", "failure")]
+
+
+def _commit_order(run: dict) -> str:
+    """The key that tracks COMMIT order, not completion order.
+
+    `created_at` is the merge for a push run and the tick whose `github.sha` was
+    HEAD for a scheduled one, so it orders runs the way commits are ordered.
+    `updated_at` is when a run FINISHED: a floor matrix that queued in the
+    shared `main-verdict-floor` group finishes late, so ordering by it can pick
+    an older commit's verdict and print it as the state of `main`.
+    """
+    return run.get("created_at") or run.get("updated_at") or ""
+
+
 def floor_verdict(runs: list[dict] | None, reason: str = "",
-                  now: float | None = None) -> str:
+                  now: float | None = None, sha_fetch=None) -> str:
     """One line: the newest conclusive matrix verdict for `main`.
 
-    RED wins over GREEN on the SAME commit, because a floor run concludes
+    Two steps, because they answer different questions: `runs` (a recent window)
+    says WHICH commit was measured last, and `sha_fetch` reads that commit
+    completely to say what its verdict is.
+
+    RED wins over GREEN on the same commit, because a floor run concludes
     `success` when it SKIPS -- its `verdict-needed` guard counts a `failure` as
     a verdict too, so a floor success can sit on top of a red commit and mean
     only "somebody already measured this one".
@@ -370,16 +423,22 @@ def floor_verdict(runs: list[dict] | None, reason: str = "",
     if runs is None:
         why = reason or "could not read main's recent workflow runs"
         return f"main floor: unavailable ({why})"
-    conclusive = [r for r in runs
-                  if _workflow_file(r) in FLOOR_WORKFLOWS
-                  and r.get("conclusion") in ("success", "failure")]
+    conclusive = _conclusive(runs)
     if not conclusive:
         return "main floor: no conclusive run found"
-    newest = max(conclusive, key=lambda r: r.get("updated_at") or "")
-    sha = newest.get("head_sha") or ""
-    same = [r for r in conclusive if (r.get("head_sha") or "") == sha]
+
+    sha = max(conclusive, key=_commit_order).get("head_sha") or ""
+    fetch = sha_fetch or fetch_runs_for_sha
+    same, why = fetch(sha)
+    if same is None:
+        return f"main floor: unavailable ({why or 'the per-commit read failed'})"
+    same = [r for r in _conclusive(same) if (r.get("head_sha") or "") == sha]
+    if not same:
+        return (f"main floor: unavailable (the per-commit read found no conclusive "
+                f"run for {sha[:8] or '<unknown sha>'})")
+
     red = [r for r in same if r.get("conclusion") == "failure"]
-    decider = max(red, key=lambda r: r.get("updated_at") or "") if red else newest
+    decider = max(red or same, key=_commit_order)
     state = "RED" if red else "GREEN"
     return (f"main floor: {state} on {sha[:8] or '<unknown sha>'} "
             f"({_workflow_file(decider)}, {_age_of(decider.get('updated_at'), now)})")

--- a/tools/test_ci_wait.py
+++ b/tools/test_ci_wait.py
@@ -1599,6 +1599,137 @@ check("#3589: the excerpt keeps the emoji as UTF-8", ROBOT_UTF8 in _child.stdout
 check("#3589: the excerpt keeps the em dash as UTF-8, not as cp1252 0x97",
       DASH_UTF8 in _child.stdout and DASH_CP1252 not in _child.stdout, _detail)
 
+# --------------------------------------------------------------------------
+# #3679 -- the floor verdict for `main`, printed beside the PR verdict.
+#
+# A PR branched during a red window inherits a failure it did not cause, and
+# nothing in this tool said so. The claim proved here is narrow and is the whole
+# point: the line reports a verdict about `main`, it NEVER changes the PR's exit
+# code, and a network failure comes out as "unavailable", never as GREEN.
+# --------------------------------------------------------------------------
+import datetime as _dt
+
+# updated_at is UTC and so is this clock, or the age would be measured against
+# the local zone and the test would pass or fail by geography.
+_NOW = _dt.datetime(2026, 9, 9, 12, 0, 0, tzinfo=_dt.timezone.utc).timestamp()
+
+
+def _fr(path, conclusion, sha, updated):
+    return {"path": f".github/workflows/{path}", "conclusion": conclusion,
+            "head_sha": sha, "updated_at": updated}
+
+
+def _line(runs, reason=""):
+    return cw.floor_verdict(runs, reason, _NOW)
+
+
+_green = _line([_fr("main-verdict-floor.yml", "success", "1a2b3c4d5e6f", "2026-09-09T11:48:00Z")])
+check("#3679: a successful floor run on main reads GREEN with the sha and workflow",
+      _green.startswith("main floor: GREEN on 1a2b3c4d")
+      and "main-verdict-floor.yml" in _green, _green)
+check("#3679: ...and carries an age, so a stale floor is visible as stale",
+      "12m" in _green, _green)
+
+_red = _line([_fr("test-matrix.yml", "failure", "aaaaaaaabbbb", "2026-09-09T11:00:00Z")])
+check("#3679: a failed matrix run on main reads RED",
+      _red.startswith("main floor: RED on aaaaaaaa"), _red)
+check("#3679: ...and its age is reported in hours", "1h" in _red, _red)
+
+# The newest conclusive run decides, not the first in the list.
+_newer = _line([_fr("test-matrix.yml", "failure", "old00000", "2026-09-09T09:00:00Z"),
+                _fr("main-verdict-floor.yml", "success", "new00000", "2026-09-09T11:55:00Z")])
+check("#3679: the NEWEST conclusive run decides the verdict",
+      _newer.startswith("main floor: GREEN on new00000"), _newer)
+
+# A floor run concludes `success` when it SKIPS -- the commit already had a
+# verdict, and that verdict can be a FAILURE. Red wins on the same commit, or
+# the line would report green for a commit measured red.
+_skip = _line([_fr("test-matrix.yml", "failure", "deadbeef1234", "2026-09-09T11:30:00Z"),
+               _fr("main-verdict-floor.yml", "success", "deadbeef1234", "2026-09-09T11:40:00Z")])
+check("#3679: a floor run that SKIPPED a red commit does not turn it green",
+      _skip.startswith("main floor: RED on deadbeef"), _skip)
+
+# Cancelled and in-progress runs are not verdicts, in either direction.
+_none = _line([_fr("test-matrix.yml", "cancelled", "ccccccc0", "2026-09-09T11:59:00Z"),
+               _fr("main-verdict-floor.yml", None, "ccccccc0", "2026-09-09T11:59:30Z")])
+check("#3679: cancelled/unfinished runs yield no verdict, never a green one",
+      _none == "main floor: no conclusive run found", _none)
+
+# An unrelated workflow that happens to run on main is not a matrix verdict.
+_other = _line([_fr("sync-changelog-unreleased.yml", "success", "eeeeeeee", "2026-09-09T11:59:00Z")])
+check("#3679: a non-matrix workflow on main is not read as a floor verdict",
+      _other == "main floor: no conclusive run found", _other)
+
+# The third state: a read that did not happen is never a verdict.
+_unavail = _line(None, "gh api failed for main-verdict-floor.yml")
+check("#3679: an unreadable run list is 'unavailable', not GREEN and not RED",
+      _unavail.startswith("main floor: unavailable")
+      and "GREEN" not in _unavail and "RED" not in _unavail, _unavail)
+check("#3679: ...and names the reason it could not tell",
+      "main-verdict-floor.yml" in _unavail, _unavail)
+
+# The fetch half: both workflows are asked, on main, and one failure refuses.
+_calls = []
+
+
+def _floor_gh(ok=(0, "[]"), fail_on=None):
+    def _gh(args, attempts=4):
+        _calls.append(list(args))
+        if fail_on and fail_on in args[1]:
+            return 1, "dial tcp: lookup api.github.com: no such host"
+        return ok
+    return _gh
+
+
+_old_gh = cw.gh
+try:
+    _calls.clear()
+    cw.gh = _floor_gh(ok=(0, '[{"path": ".github/workflows/main-verdict-floor.yml",'
+                             ' "conclusion": "success", "head_sha": "abcdef1234",'
+                             ' "updated_at": "2026-09-09T11:59:00Z"}]'))
+    _runs, _why = cw.fetch_floor_runs()
+    check("#3679: the fetch asks for BOTH producers of a main verdict",
+          any("main-verdict-floor.yml" in a[1] for a in _calls)
+          and any("test-matrix.yml" in a[1] for a in _calls), repr(_calls))
+    check("#3679: ...scoped to the main branch",
+          all("branch=main" in a[1] for a in _calls if a[0] == "api"), repr(_calls))
+    check("#3679: ...and returns what it read", _runs is not None and len(_runs) == 2, repr(_runs))
+
+    _calls.clear()
+    cw.gh = _floor_gh(fail_on="test-matrix.yml")
+    _runs, _why = cw.fetch_floor_runs()
+    check("#3679: one failed read refuses rather than answering from half the data",
+          _runs is None and "test-matrix.yml" in _why, f"{_runs!r} {_why!r}")
+    check("#3679: ...and that refusal prints as unavailable",
+          cw.floor_verdict(_runs, _why).startswith("main floor: unavailable"),
+          cw.floor_verdict(_runs, _why))
+
+    # print_floor_verdict() must never raise and never return an exit code.
+    _calls.clear()
+    cw.gh = _floor_gh(ok=(1, "boom"))
+    _buf = io.StringIO()
+    _stdout = sys.stdout
+    sys.stdout = _buf
+    try:
+        _ret = cw.print_floor_verdict()
+    finally:
+        sys.stdout = _stdout
+    check("#3679: printing the floor line returns nothing (it cannot change an exit code)",
+          _ret is None, repr(_ret))
+    check("#3679: ...and a broken gh prints unavailable, on one line",
+          _buf.getvalue().startswith("main floor: unavailable")
+          and len(_buf.getvalue().rstrip().splitlines()) == 1, repr(_buf.getvalue()))
+finally:
+    cw.gh = _old_gh
+
+# main() must actually print it next to the verdict, on every path that reached
+# GitHub -- a helper nobody calls is the #3679 defect with extra steps.
+_main_src = open(os.path.join(HERE, "ci-wait.py"), encoding="utf-8").read()
+check("#3679: main() prints the floor line on every verdict path",
+      _main_src.count("print_floor_verdict()") >= 5,
+      f"only {_main_src.count('print_floor_verdict()')} call site(s)")
+
+
 print()
 if FAILURES:
     print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")

--- a/tools/test_ci_wait.py
+++ b/tools/test_ci_wait.py
@@ -1603,24 +1603,42 @@ check("#3589: the excerpt keeps the em dash as UTF-8, not as cp1252 0x97",
 # #3679 -- the floor verdict for `main`, printed beside the PR verdict.
 #
 # A PR branched during a red window inherits a failure it did not cause, and
-# nothing in this tool said so. The claim proved here is narrow and is the whole
-# point: the line reports a verdict about `main`, it NEVER changes the PR's exit
-# code, and a network failure comes out as "unavailable", never as GREEN.
+# nothing in this tool said so. Three claims are proved here, and the last two
+# are what the first round of review found missing:
+#
+#   * the line reports a verdict about `main`, never changes the PR's exit code,
+#     and turns a failed read into "unavailable" rather than a verdict;
+#   * it is ordered by `created_at` -- COMMIT order. `updated_at` is when a run
+#     FINISHED, so a matrix that queued behind another can conclude after a
+#     later commit's and make the line report the older commit as `main`;
+#   * the decision is taken over a COMPLETE per-commit read. A red on the
+#     deciding SHA can sit behind twenty later floor skips, so a branch-listing
+#     page is a window, not the set.
 # --------------------------------------------------------------------------
 import datetime as _dt
 
-# updated_at is UTC and so is this clock, or the age would be measured against
-# the local zone and the test would pass or fail by geography.
+# updated_at/created_at are UTC and so is this clock, or the age would be
+# measured against the local zone and the test would pass or fail by geography.
 _NOW = _dt.datetime(2026, 9, 9, 12, 0, 0, tzinfo=_dt.timezone.utc).timestamp()
 
 
-def _fr(path, conclusion, sha, updated):
+def _fr(path, conclusion, sha, updated, created=None):
     return {"path": f".github/workflows/{path}", "conclusion": conclusion,
-            "head_sha": sha, "updated_at": updated}
+            "head_sha": sha, "updated_at": updated,
+            "created_at": created or updated}
 
 
-def _line(runs, reason=""):
-    return cw.floor_verdict(runs, reason, _NOW)
+def _line(runs, reason="", per_sha=None):
+    """floor_verdict over `runs`, with the per-commit read faked from the same list.
+
+    Passing the same list back is what the old single-list behaviour was; the
+    tests that care about the difference pass `per_sha` explicitly.
+    """
+    def _fetch(sha):
+        if per_sha is not None:
+            return per_sha
+        return [r for r in (runs or []) if r.get("head_sha") == sha], ""
+    return cw.floor_verdict(runs, reason, _NOW, sha_fetch=_fetch)
 
 
 _green = _line([_fr("main-verdict-floor.yml", "success", "1a2b3c4d5e6f", "2026-09-09T11:48:00Z")])
@@ -1641,6 +1659,21 @@ _newer = _line([_fr("test-matrix.yml", "failure", "old00000", "2026-09-09T09:00:
 check("#3679: the NEWEST conclusive run decides the verdict",
       _newer.startswith("main floor: GREEN on new00000"), _newer)
 
+# ...and "newest" is COMMIT order, not completion order. A floor matrix that
+# queued in the shared group finishes late, so a run for the OLDER commit can
+# have the LATER updated_at. Ordering by that would report the older commit --
+# green, in this fixture -- as the state of a `main` whose HEAD is red.
+_inverted = _line([
+    # older commit, but it finished last
+    _fr("main-verdict-floor.yml", "success", "older000", updated="2026-09-09T11:58:00Z",
+        created="2026-09-09T11:00:00Z"),
+    # newer commit, finished first
+    _fr("test-matrix.yml", "failure", "newer000", updated="2026-09-09T11:30:00Z",
+        created="2026-09-09T11:20:00Z"),
+])
+check("#3679: ordering is by created_at (commit order), not by completion time",
+      _inverted.startswith("main floor: RED on newer000"), _inverted)
+
 # A floor run concludes `success` when it SKIPS -- the commit already had a
 # verdict, and that verdict can be a FAILURE. Red wins on the same commit, or
 # the line would report green for a commit measured red.
@@ -1648,6 +1681,16 @@ _skip = _line([_fr("test-matrix.yml", "failure", "deadbeef1234", "2026-09-09T11:
                _fr("main-verdict-floor.yml", "success", "deadbeef1234", "2026-09-09T11:40:00Z")])
 check("#3679: a floor run that SKIPPED a red commit does not turn it green",
       _skip.startswith("main floor: RED on deadbeef"), _skip)
+
+# ...and that red only has to exist ON THE COMMIT, not on the page that was
+# read to find the commit. Twenty floor skips on a static `main` push the
+# failure off a 20-run window; the per-commit read is what finds it.
+_page = [_fr("main-verdict-floor.yml", "success", "cafe0000",
+             f"2026-09-09T11:{m:02d}:00Z") for m in range(30, 50)]
+_beyond = _line(_page, per_sha=(_page + [
+    _fr("test-matrix.yml", "failure", "cafe0000", "2026-09-09T09:00:00Z")], ""))
+check("#3679: a RED beyond the branch-listing page is still found, per commit",
+      _beyond.startswith("main floor: RED on cafe0000"), _beyond)
 
 # Cancelled and in-progress runs are not verdicts, in either direction.
 _none = _line([_fr("test-matrix.yml", "cancelled", "ccccccc0", "2026-09-09T11:59:00Z"),
@@ -1668,6 +1711,13 @@ check("#3679: an unreadable run list is 'unavailable', not GREEN and not RED",
 check("#3679: ...and names the reason it could not tell",
       "main-verdict-floor.yml" in _unavail, _unavail)
 
+# ...and so is a per-commit read that failed, even though the branch listing
+# answered. Half an answer about one commit is not a verdict about it.
+_half = _line([_fr("main-verdict-floor.yml", "success", "12345678", "2026-09-09T11:50:00Z")],
+              per_sha=(None, "the per-commit run list for 12345678 could not be read"))
+check("#3679: a failed per-commit read is unavailable, not the branch listing's guess",
+      _half.startswith("main floor: unavailable") and "12345678" in _half, _half)
+
 # The fetch half: both workflows are asked, on main, and one failure refuses.
 _calls = []
 
@@ -1686,6 +1736,7 @@ try:
     _calls.clear()
     cw.gh = _floor_gh(ok=(0, '[{"path": ".github/workflows/main-verdict-floor.yml",'
                              ' "conclusion": "success", "head_sha": "abcdef1234",'
+                             ' "created_at": "2026-09-09T11:40:00Z",'
                              ' "updated_at": "2026-09-09T11:59:00Z"}]'))
     _runs, _why = cw.fetch_floor_runs()
     check("#3679: the fetch asks for BOTH producers of a main verdict",
@@ -1693,6 +1744,8 @@ try:
           and any("test-matrix.yml" in a[1] for a in _calls), repr(_calls))
     check("#3679: ...scoped to the main branch",
           all("branch=main" in a[1] for a in _calls if a[0] == "api"), repr(_calls))
+    check("#3679: ...asking for created_at, the key the ordering needs",
+          all("created_at" in a[3] for a in _calls if a[0] == "api"), repr(_calls))
     check("#3679: ...and returns what it read", _runs is not None and len(_runs) == 2, repr(_runs))
 
     _calls.clear()
@@ -1703,6 +1756,26 @@ try:
     check("#3679: ...and that refusal prints as unavailable",
           cw.floor_verdict(_runs, _why).startswith("main floor: unavailable"),
           cw.floor_verdict(_runs, _why))
+
+    # The per-commit read: one commit, a full page, and a page that FILLED is a
+    # partial read rather than a complete answer.
+    _calls.clear()
+    cw.gh = _floor_gh(ok=(0, "[]"))
+    _got, _why = cw.fetch_runs_for_sha("abc123")
+    check("#3679: the per-commit read asks by head_sha, not by branch",
+          any("head_sha=abc123" in a[1] and "branch=" not in a[1] for a in _calls), repr(_calls))
+    check("#3679: ...over a full page", any("per_page=100" in a[1] for a in _calls), repr(_calls))
+    check("#3679: ...and an empty answer is an answer, not a refusal",
+          _got == [] and not _why, f"{_got!r} {_why!r}")
+
+    _calls.clear()
+    _full = "[" + ",".join(['{"path":".github/workflows/test-matrix.yml","conclusion":"success",'
+                            '"head_sha":"abc123","created_at":"2026-09-09T11:00:00Z",'
+                            '"updated_at":"2026-09-09T11:00:00Z"}'] * 100) + "]"
+    cw.gh = _floor_gh(ok=(0, _full))
+    _got, _why = cw.fetch_runs_for_sha("abc123")
+    check("#3679: a per-commit page that FILLED is a partial read, not a verdict",
+          _got is None and _why, f"{_got!r} {_why!r}")
 
     # print_floor_verdict() must never raise and never return an exit code.
     _calls.clear()
@@ -1722,13 +1795,77 @@ try:
 finally:
     cw.gh = _old_gh
 
-# main() must actually print it next to the verdict, on every path that reached
-# GitHub -- a helper nobody calls is the #3679 defect with extra steps.
-_main_src = open(os.path.join(HERE, "ci-wait.py"), encoding="utf-8").read()
-check("#3679: main() prints the floor line on every verdict path",
-      _main_src.count("print_floor_verdict()") >= 5,
-      f"only {_main_src.count('print_floor_verdict()')} call site(s)")
 
+# --------------------------------------------------------------------------
+# ...and main() must actually print it, on every path that reached GitHub, with
+# the exit code unchanged. This used to be a substring COUNT over the source --
+# which counted the `def` line, so it tolerated four call sites out of five and
+# would have passed with a whole verdict path silently unannotated.
+# --------------------------------------------------------------------------
+class _FreshStub:
+    """Stands in for tools/agent_self_freshness.py: this copy is not stale.
+
+    `__file__` is part of the interface main() uses -- it assesses the guard
+    module's own file as well as ci-wait.py's (#3296) -- so the stub carries one.
+    """
+    notes: list = []
+    refuse = False
+    state = "fresh"
+    __file__ = os.path.join(HERE, "agent_self_freshness.py")
+
+    @staticmethod
+    def assess(path, remote_check=False):
+        return _FreshStub
+
+
+def _drive_main(code, extra_argv=()):
+    """Run main() with everything below classify() faked. Returns (rc, stdout)."""
+    saved = {name: getattr(cw, name) for name in
+             ("_freshness", "head_sha", "resolve_required_contexts", "workflow_runs_for",
+              "required_checks", "classify", "fetch_floor_runs", "fetch_runs_for_sha")}
+    argv = sys.argv
+    buf = io.StringIO()
+    out = sys.stdout
+    try:
+        cw._freshness = _FreshStub
+        cw.head_sha = lambda pr: "0123456789abcdef0123456789abcdef01234567"
+        cw.resolve_required_contexts = lambda *a, **k: (cw.RULESET_CONTEXTS, "ok", [])
+        cw.workflow_runs_for = lambda sha: [{"id": 1, "name": "Test Matrix",
+                                             "status": "completed", "conclusion": "success"}]
+        cw.required_checks = lambda sha: []
+        # The headline carries " -- " because main()'s exit-4 branch splits on it;
+        # a fixture that omits it makes that path raise instead of reporting.
+        cw.classify = lambda *a, **k: cw.Verdict(
+            code, ["state -- one required check reported"], None,
+            "nothing has reported yet")
+        cw.fetch_floor_runs = lambda branch="main": (
+            [_fr("main-verdict-floor.yml", "failure", "8b6885f4aaaa", "2026-09-09T11:00:00Z")], "")
+        cw.fetch_runs_for_sha = lambda sha: (
+            [_fr("main-verdict-floor.yml", "failure", "8b6885f4aaaa", "2026-09-09T11:00:00Z")], "")
+        sys.argv = ["ci-wait.py", "3740", "--timeout", "0", "--no-log", *extra_argv]
+        sys.stdout = buf
+        rc = cw.main()
+    finally:
+        sys.stdout = out
+        sys.argv = argv
+        for name, value in saved.items():
+            setattr(cw, name, value)
+    return rc, buf.getvalue()
+
+
+for _code, _want_rc, _headline in ((0, 0, "GREEN"), (1, 1, "FAILED"),
+                                   (3, 3, "UNDETERMINED"), (4, 4, "BLOCKED"),
+                                   (None, 2, "NOT YET REPORTED")):
+    _rc, _text = _drive_main(_code)
+    _floor = [l for l in _text.splitlines() if l.startswith("main floor:")]
+    check(f"#3679: main() exit {_want_rc} ({_headline}) prints the floor line exactly once",
+          len(_floor) == 1, f"rc={_rc} lines={_floor!r}")
+    check(f"#3679: ...and the floor line does not change exit {_want_rc}",
+          _rc == _want_rc, f"rc={_rc} out={_text[-300:]!r}")
+    check(f"#3679: ...and it reports main's own state, not the PR's",
+          _floor and _floor[0].startswith("main floor: RED on 8b6885f4"), repr(_floor))
+    check(f"#3679: ...beside the PR verdict, not instead of it",
+          _headline in _text, _text[-300:])
 
 print()
 if FAILURES:


### PR DESCRIPTION
Closes #3679

*Opened by an automated implementation agent (`fbk-1`, Claude Code session run by FBakkensen).*

`main`'s floor only ran on a cadence, so a merge that broke `main` could go a full 30 minutes unreported, and a pull request branched inside that window inherited a failure it did not cause. Two halves, both from the issue.

## 1. `main-verdict-floor.yml`: a debounced run after a merge

- `push: branches: [main]` added; `schedule` (`*/30`) and `workflow_dispatch` are untouched.
- A new `wait` job — push-only, `sleep 600`, its own concurrency group with `cancel-in-progress: true`. It is the **only** cancellable thing in the file, and it holds no matrix, so a newer merge cancels the *wait* and a burst of merges collapses to one floor run after the burst instead of one per merge.
- `verdict-needed` gains `needs: wait` and `if: always() && (github.event_name != 'push' || needs.wait.result == 'success')`, so a wait a newer merge cancelled cannot go on to run a matrix.

**Why the workflow-level `concurrency:` block had to move to `floor-matrix`.** Held at the workflow level, a merge's run would *queue* behind a floor matrix already in flight, and a queued run executes no jobs — so its `wait` could never start, never cancel the previous wait, and the debounce would serialise instead of debouncing. The guarantee is unchanged (`group: main-verdict-floor`, `cancel-in-progress: false`, one floor matrix at a time, never cancelled); only its scope is.

## 2. `tools/ci-wait.py`: the floor verdict beside the PR verdict

One line after every verdict, on all five exit paths:

```
main floor: RED on 8b6885f4 (main-verdict-floor.yml, 1h ago)
main floor: no conclusive run found
main floor: unavailable (the run list for 87879acb filled its page — a partial read)
```

- It **never** changes the exit code and returns nothing; `print_floor_verdict()` swallows exceptions.
- **Two reads, because they answer different questions.** A recent per-workflow listing (`branch=main`) says *which commit* was measured last, ordered by **`created_at`** — commit order. Then that commit is read **completely** (`actions/runs?head_sha=…&per_page=100`) to decide its verdict. A page that filled is refused as partial rather than answered.
- A read that did not happen is `unavailable`, never a verdict (`guards-need-a-third-state.md`); one failed producer refuses the whole answer rather than judging `main` from half the data (the #3002 shape).
- **RED wins over GREEN on the same commit.** A floor run concludes `success` when it *skips*, and its guard counts a `failure` as a verdict too — so a floor success can sit on top of a red commit and mean only "somebody already measured this one".

## The invariant that constrained the design, and the four ways drafts broke it

**Both consumers read a floor run's CONCLUSION as a verdict** — `verdict-needed` counts `success`/`failure` for that SHA, and so does the new ci-wait line. So a run that measured nothing must conclude neither, and a verdict must be *about* the commit it names. Four violations were found in review and fixed; each is pinned by a test that is RED against the commit before it.

- **The schedule path stopped running the matrix and reported `failure`.** `floor-matrix` carried no status function, and GitHub's implicit `success()` is evaluated over the whole **ancestor chain**, not the listed `needs` — so the conditionally-skipped `wait` job skipped the matrix on every `schedule` and `workflow_dispatch` run, and `floor-verdict` then exited 1 having measured nothing (actions/runner#2205). That would have stopped the eight-leg cadence outright — 27.3, 28.0, 28.1, 28.2 and 28.3 run nowhere else since #3141 — and emitted a false RED that this PR's own detector would repeat to every agent. Fixed with an explicit `always() && needs.verdict-needed.result == 'success' && …`, and `Floor_EveryJobDownstreamOfTheSkippableWait_CarriesAnExplicitStatusFunction` pins the **shape**: every job downstream of the conditional `wait` must declare its status function.
- **A deferral concluded GREEN.** An earlier draft let `verdict-needed` skip when another floor run was in flight on the same SHA. That run concludes `success` while nothing has measured the commit; if the deferred-to matrix is then dropped while pending, the SHA is green forever with nothing behind it. Removed: **only a CONCLUSIVE run for the SHA may skip the matrix.**
- **A dropped matrix concluded RED.** Moving the concurrency group down to `floor-matrix` makes it a pending *job* rather than a pending *run*, so a drop reaches `floor-verdict`, which exits 1. It now carries `&& needs.floor-matrix.result != 'cancelled'`, so the run concludes `cancelled`, which neither consumer counts.
- **The floor line could name the wrong commit, or miss a red on the right one.** Ordering by `updated_at` (completion) reports an older commit's verdict when its matrix queued and finished late; deciding red-vs-green inside a 20-run window misses a failure sitting behind twenty later floor skips on a static `main`. Fixed by `created_at` ordering plus the complete per-commit read described above.

## Settled by running it, not by reading it

Nothing on this PR parses `main-verdict-floor.yml`: it has no `pull_request` trigger, there is no actionlint here, and job-level `concurrency:` on a `uses:` job appears nowhere else in the repository. So the file was **dispatched against this branch** (run `34400920456`, `workflow_dispatch`, head `af38d0b1`), and its job graph settles four things at once:

```
Does main HEAD still lack a verdict? = completed/success
Wait out the merge burst            = completed/skipped
floor-matrix / resolve-versions     = pending        <- created, NOT skipped
```

The file parses (so job-level `concurrency:` on a reusable-workflow call is accepted); `wait` is skipped on the dispatch path as designed; `verdict-needed` runs anyway through its `always()`; and **`floor-matrix` is reached** — which is exactly what the implicit `success()` prevented before the fix. The run was cancelled once the graph was visible rather than spending an eight-leg matrix on the shared queue.

## What this costs, stated rather than hidden

- **No deferral to an in-flight run.** A push-triggered floor run takes ~33 min (10 debounce + 23 matrix) against a 30-minute cadence, so a scheduled run can land inside it and start a second matrix on the same commit — ~75 job-minutes. The same happens against a *surviving* gating `test-matrix.yml` run. That is the price of a conclusion that means what it says; the cheaper alternatives are a self-cancelling deferral (needs `actions: write`) or making both consumers verify the matrix job actually ran. Worth a follow-up if the job-minutes show up.
- **Where the push path buys a verdict the gating run would not:** merges spaced wider than the 10-minute debounce but closer than a matrix run (~23 min). Under sustained merging tighter than 10 minutes the waits keep cancelling each other and the schedule remains the floor, exactly as before.
- **Two ways a run still concludes `failure` having measured nothing, named rather than fixed.** An infrastructure failure in `wait`, and a transient `gh api` failure in `verdict-needed` (`set -euo pipefail`, no retry) — both leave the run `failure` with no matrix behind it, counted by the guard and printed as a red `main`. The `verdict-needed` half predates this PR; what is new is a consumer putting it in front of every agent. `continue-on-error` would convert it into the worse false GREEN, so nothing here changes; a retry around that one `gh api` call is the honest follow-up.

## RED → GREEN

- `tools/test_ci_wait.py`: 40 checks for this feature. RED was `AttributeError: no attribute 'floor_verdict'`, then `TypeError: unexpected keyword argument 'sha_fetch'` for the per-commit read. The five exit paths are now driven through `main()` itself with the fakes, asserting one floor line **and** an unchanged exit code on each — the previous check counted a substring in the source, including the `def` line, so it tolerated four call sites out of five. All checks pass. Live smoke against this repository returned `main floor: RED on 8b6885f4 (main-verdict-floor.yml, 1h ago)` while `main` was red, and `main floor: GREEN on 87879acb (main-verdict-floor.yml, 13m ago)` after it recovered.
- `AlRunner.Tests/MainVerdictFloorWorkflowTests.cs`: RED was 4 failures on the first round (trigger list, debounce job absent, concurrency attribution, the reporting guard) and 1 on the second (`floor-matrix` carrying no status function — the message named the job and quoted its condition). GREEN: 27/27, plus `PullRequestMatrixScopeTests` and `ReleaseTestParityTests` — 39/39.
- `tools/test_ci_wait.py`, `test_doc_pointers.py`, `test_matrix_docs_drift.py`, `test_line_endings.py`, `test_text_encoding.py`, `test_comment_density.py` all pass; `check_required_contexts.py` (offline half) passes. `test_pr_body.py` and `test_preflight.py` fail on this Windows box on untouched `main` and were not run.

## Fixing the shape, not the reported line

- **Two guards in the same test file had stopped guarding.** `Floor_NeverCancelsItself` asserted only that `cancel-in-progress: false` appeared *somewhere*, which a file making the **matrix** the cancellable one would have passed; each concurrency block is now attributed to its job. And the census test claimed it would catch a third push-to-`main` caller of the eight-leg matrix — it never could, because it reads `uses:`, not triggers, and this PR made the floor the second such caller with the test passing unchanged. Those two sentences are deleted and the test renamed to what it measures.
- **Stale header claims corrected**: "runs on a `schedule`, so it is unaffected by that narrowing" (it now also runs on a push, which likewise does not narrow — `GATING_EVENT` narrows on `pull_request` only), the peak-bound sentence, and the cost table, whose figures were derived for the schedule-only design and are now cited to #3003 rather than re-derived in place.
- **Open-issue scan**: no other open issue's fix lands in `main-verdict-floor.yml` or `tools/ci-wait.py`. Nothing folded in.

## Deliberately not done

- The "Tests updated" gate is not triggered: the diff touches no non-`.md` path under `AlRunner/`. No `no-tests-needed` label needed.
- The 10-minute wait costs one idle runner job per merge burst (~1 concurrent, since each new merge cancels the previous wait).
- No corpus linkage line: the diff touches none of the paths `check_corpus_linkage.sh` gates, and nothing here is a claim about BC's behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXnG1GjZMwpnnRHAcrGzUH
