### PR TITLE
docs(metadata): name the three shipping shapes and where each gets its metadata

### DIFF
--- a/docs/where-metadata-comes-from.md
+++ b/docs/where-metadata-comes-from.md
@@ -1,0 +1,104 @@
+# Where a table's metadata comes from
+
+The runner needs BC's own answer for every object it serves — key counts, per-field `Editable`,
+`DataClassification`, relations. **Where that answer comes from depends on what the app ships**, and
+the three shipping shapes are genuinely different problems with different costs. This document names
+them, because the distinction was being rediscovered per issue instead of written down once.
+
+The route a table actually took is observable:
+
+```
+AL_RUNNER_TRACE_TABLE_METADATA_SOURCE=1    # one line per built table: [table-metadata] <id> source=<route>
+```
+
+Exactly `"1"` or `"2"` — any other value, including `"true"`, is a silent no-op. There are exactly
+two route values, `bc-document` and `derived`, and no failure route: a failed document read refuses
+rather than falling through to the derivation (`loud-failures.md`).
+
+## The three shapes
+
+| the app ships | source? | metadata XML? | what the runner does | cost |
+|---|---|---|---|---|
+| **source only** | yes | no | compiles it; the emitter's document is captured and consumed | one compile, paid once per app per BC version |
+| **source + a prebuilt DLL** (Base Application, most Microsoft apps) | yes | **no** | reads `SymbolReference.json` — **does not compile** | a symbol-file read |
+| **a runtime package** (`.NEA`) | no | **yes** | reads `/bin/*.xml` straight out of the package | a container decode |
+
+The middle row is the one that keeps getting mis-stated, so it is worth being exact.
+
+### An R2R `.app` ships source AND no metadata
+
+Measured on `Microsoft_Base Application_28.4.53241.53989.app`: **8,095 source files, 0 `/bin`
+metadata documents.** So "ships a DLL" does not mean "ships no source" — it means the source is
+there but was compiled by Microsoft ahead of time, and **we do not want to compile it again**.
+
+That is a deliberate choice, not a limitation. `.claude/rules/no-base-app-in-csharp-tests.md` has the
+measurements: loading the Base Application floor costs about **70 seconds cold and 6 seconds warm per
+runner invocation**. Recompiling it to obtain metadata is far worse — roughly **2 minutes and ~9 GB
+peak RSS**. For an app that already ships a working DLL, that is spending a compile to learn what
+`SymbolReference.json` already states.
+
+**So for this shape the answer is the symbol file, and the symbol file is held to a standard rather
+than treated as second-class.**
+
+## The symbol-file path is not a fallback of last resort
+
+The standard, from #3533:
+
+> Where we have the code, derive metadata faithfully by compiling it with BC's own compiler. Where we
+> do not, fall back to `SymbolReference.json` — and that fallback must produce the **same answer** the
+> source-backed generator would, for every piece of information the symbol file can express.
+
+That is testable rather than aspirational, and it is tested: any app the runner source-compiles
+yields **both** derivations in the same run — BC's metadata XML from `CaptureOutputter`, and ours
+from `SymbolReference.json` — so the standard is a differential assertion over the same tables.
+
+The gap that measurement found was one-directional every time: BC sets a real value, the runner took
+a constructor default.
+
+| property | wrong | BC said | we said |
+|---|---|---|---|
+| `Editable` | 1,262 / 2,036 | `False` | `True` |
+| `DataClassification` | 1,561 / 2,036 | `SystemMetadata` / `EndUserPseudonymousIdentifiers` | `CustomerContent` |
+
+#3545 fixed two defined meanings of an *absent* property the reader was ignoring: `Editable` defaults
+to `true`, and a field's `DataClassification` inherits the table's. Both issues are closed.
+
+**What the symbol file cannot express, it cannot express**, and no amount of reader work changes
+that — which is why the compile path exists for apps that ship source without a DLL, and why the
+runtime-package path exists for packages that ship metadata without source.
+
+## Why this matters for the conversion work
+
+`#3562` tracks converting every metadata consumer to BC's captured document. It has two halves, and
+conflating them makes the tracker read as finished when it is half done:
+
+- **Objects the runner compiles** — done, merged, verified. These take the `bc-document` route.
+- **Dependencies** — where nearly all of the error surface lives, and the un-started half. `#3549` is
+  the issue, with 20 more blocked behind it.
+
+Measured, so it is not a worry anyone needs to re-raise: a source-compiled dependency's document is
+**consumed, not merely captured**. It is persisted as a sidecar, replayed by `DependencyLoader`, and
+the table takes the `bc-document` route on a cold run *and* on a cache HIT.
+
+Not measured, and stated as such rather than inferred: pages and pageextensions have **no route
+trace**, so whether their converted consumers fire is unverified in either direction.
+
+## The sequencing, and why
+
+The repository owner's call, recorded here because it is a judgement about what the runner is for
+rather than a technical constraint:
+
+> **Runtime packages are a side story. Get the regular cases working first.**
+
+The regular cases are the first two rows of the table — an app that ships source, and an app that
+ships source plus a DLL where we read symbols instead of recompiling. Between them they cover
+essentially every real project. The runtime-package reader is merged (#3537, #3733) and is not going
+anywhere; **executing** from a runtime package remains unproven and is tracked separately as #3732.
+
+## Sister material
+
+- `.claude/rules/no-base-app-in-csharp-tests.md` — what loading the Base Application floor costs, and
+  why a fixture declares `platform` and never `application`
+- `docs/object-metadata-capture.md` — how the emitter's document is captured
+- `docs/metadata-equivalence.md` — the differential harness that holds the two derivations to each other
+- `docs/runtime-packages.md` — the `.NEA` container, and what reading one does and does not prove

--- a/docs/where-metadata-comes-from.md
+++ b/docs/where-metadata-comes-from.md
@@ -12,8 +12,16 @@ AL_RUNNER_TRACE_TABLE_METADATA_SOURCE=1    # one line per built table: [table-me
 ```
 
 Exactly `"1"` or `"2"` — any other value, including `"true"`, is a silent no-op. There are exactly
-two route values, `bc-document` and `derived`, and no failure route: a failed document read refuses
-rather than falling through to the derivation (`loud-failures.md`).
+two route values, `bc-document` and `derived`, and **no failure route**: **availability** decides
+which route a table takes, and a failure is never *re-routed* to the derivation — substituting a
+weaker answer on error is what `loud-failures.md` exists to prevent.
+
+**A failure there is not loud, though, and this page must not imply it is.** The site sits inside a
+catch that swallows any throw into `return null` for both routes alike — pre-existing, tracked as
+**#3590**. So a genuine load failure and "no document was available" are **indistinguishable from the
+trace**, and a table that failed to load shows as `derived` exactly like one that never had a
+document. `RecordPatches.NclMetaTableBuilder.cs` says so at the site itself; #3590 is open precisely
+because the guarantee a reader would want here does not yet exist.
 
 ## The three shapes
 
@@ -26,6 +34,12 @@ rather than falling through to the derivation (`loud-failures.md`).
 The middle row is the one that keeps getting mis-stated, so it is worth being exact.
 
 ### An R2R `.app` ships source AND no metadata
+
+**Where to look, because the obvious check contradicts this.** The source is in the **nested inner
+`.app`**; the outer R2R wrapper holds 9 entries and **zero** `.al` files. So a naive unzip of the
+outer package reports no source at all and looks like it disproves the row above. Open the inner
+package. (Re-measured independently on build `28.4.53241.54407`: **8,096** `.al` files, 0 `bin/`
+entries — a one-file drift between 28.4 siblings, which is version drift and not a contradiction.)
 
 Measured on `Microsoft_Base Application_28.4.53241.53989.app`: **8,095 source files, 0 `/bin`
 metadata documents.** So "ships a DLL" does not mean "ships no source" — it means the source is

--- a/docs/where-metadata-comes-from.md
+++ b/docs/where-metadata-comes-from.md
@@ -33,9 +33,21 @@ there but was compiled by Microsoft ahead of time, and **we do not want to compi
 
 That is a deliberate choice, not a limitation. `.claude/rules/no-base-app-in-csharp-tests.md` has the
 measurements: loading the Base Application floor costs about **70 seconds cold and 6 seconds warm per
-runner invocation**. Recompiling it to obtain metadata is far worse — roughly **2 minutes and ~9 GB
-peak RSS**. For an app that already ships a working DLL, that is spending a compile to learn what
-`SymbolReference.json` already states.
+runner invocation**. For an app that already ships a working DLL, recompiling it would be spending a
+compile to learn what `SymbolReference.json` already states.
+
+**And for Base Application specifically it is not merely expensive — it does not work at all.** From
+`tests/expectations/metadata-equivalence/apps.json`, which is why that app is absent from the
+equivalence harness:
+
+> Base Application is deliberately ABSENT. Its emit needs a `PublicKeyToken=null` copy of
+> `Microsoft.AspNetCore.StaticFiles` that no BC artifact ships, and without it the emitter produces
+> **ZERO objects** (issue #3549).
+
+So the symbol-file route is not a cost-saving fallback for this app. It is the only route that
+produces anything. (Compiling Base Application is separately expensive — roughly 2 minutes and ~9 GB
+peak RSS — but that is the *cost*, not the reason, and stating the cost as the reason has misled a
+reader of this repository before.)
 
 **So for this shape the answer is the symbol file, and the symbol file is held to a standard rather
 than treated as second-class.**
@@ -51,6 +63,28 @@ The standard, from #3533:
 That is testable rather than aspirational, and it is tested: any app the runner source-compiles
 yields **both** derivations in the same run — BC's metadata XML from `CaptureOutputter`, and ours
 from `SymbolReference.json` — so the standard is a differential assertion over the same tables.
+
+**It is enforced on every leg, not run by hand.** `MetadataEquivalenceHarnessTests` runs in
+`bc-tests.yml` behind the step *"Generate BC metadata ground truth"*, which is explicitly **not**
+`continue-on-error`. The ground truth is regenerated per leg rather than checked in, for two reasons
+the workflow states: it is Microsoft's compiler output over Microsoft's source, which is not ours to
+redistribute; and it belongs to one exact BC build, so a checked-in copy would either churn on every
+Microsoft release or go stale silently — *"which is the failure mode this whole harness exists to
+remove."*
+
+Two properties make it hard to weaken by accident, and both matter more than the assertion itself:
+
+- **`allowlist.json` fails in BOTH directions** — on any difference not listed, *and* on any listed
+  entry that no longer matches anything. So a reader fix must delete its entries in the same change,
+  and a BC version that introduces a new property surfaces as a new undeclared difference rather
+  than passing silently. Every entry carries exactly one reason **kind** — `issue`, `outOfScope`,
+  `oracleLimitation`, `cannotExpress` — because the four need different evidence.
+- **`apps.json` makes coverage mandatory.** Declaring an app there means the harness *fails* if no
+  ground-truth bundle exists for it, so it cannot quietly measure less than it claims. Currently
+  Business Foundation and System Application.
+
+This is what replaced trial and error. A claim about the symbol path expressed inside this harness
+cannot rot silently; the same claim as a standalone test can.
 
 The gap that measurement found was one-directional every time: BC sets a real value, the runner took
 a constructor default.


### PR DESCRIPTION
## What this adds

`docs/where-metadata-comes-from.md` — one page naming **the three shapes an app ships in, and where
each one's metadata comes from.**

Eight docs already describe metadata, but each covers a single *kind* (codeunit, report, page…).
None answered the prior question: *for this app, what is the source of truth, and why?* That
distinction was being rediscovered issue by issue, and it was stated wrongly more than once.

| the app ships | source? | metadata XML? | what the runner does |
|---|---|---|---|
| source only | yes | no | compiles it; the emitter's document is captured |
| **source + a prebuilt DLL** (Base Application) | **yes** | **no** | reads `SymbolReference.json` — **does not recompile** |
| a runtime package (`.NEA`) | no | yes | reads `/bin/*.xml` from the container |

## The row that keeps getting mis-stated

**An R2R `.app` ships source AND no metadata XML.** Measured on
`Microsoft_Base Application_28.4.53241.53989.app`: **8,095 source files, 0 `/bin` metadata
documents.** So "ships a DLL" does not mean "ships no source" — the source is there, Microsoft
compiled it ahead of time, and **we deliberately do not compile it again.**

That is a choice with numbers behind it. Loading the Base Application floor already costs ~70 s cold
and ~6 s warm per invocation (`no-base-app-in-csharp-tests.md`). Recompiling it for metadata costs
roughly **2 minutes and ~9 GB peak RSS** — to learn what `SymbolReference.json` already states.

## Why now

Written because the owner drew the distinction while sequencing #3549, and it is part of the
complete metadata story rather than a note on one issue. It records:

- the **#3533 standard** — the symbol path is held to producing the *same answer* the source-backed
  generator would, for everything the symbol file can express, tested as a differential over apps
  that yield both derivations in one run;
- the measured, one-directional gap that standard found (`Editable` wrong 1,262/2,036;
  `DataClassification` wrong 1,561/2,036 — BC sets a real value, we took a constructor default);
- the owner's sequencing: **runtime packages are a side story; the regular cases come first**;
- what is measured versus inferred — a source-compiled dependency's document is *consumed*, replayed
  from its sidecar on a cold run and a cache HIT; pages and pageextensions have **no route trace**,
  so their consumers are unverified in either direction.

## Scope

Documentation only. No behaviour change, no test change, no code touched. The trace flag, the route
values and the measurements it cites were all observed this session rather than recalled.

No linked issue: this page documents where a given app's metadata comes from; it closes no issue on its own and stands apart from the conversion work it describes.

Corpus-NA: documentation only — no runner behaviour changes, so there is nothing for a service tier to adjudicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL

