### PR TITLE
feat(hooks): block git stash, backgrounded CI waits and bare grep over AlRunner C#

### DIFF
--- a/.claude/hooks/prefer-code-navigation.py
+++ b/.claude/hooks/prefer-code-navigation.py
@@ -21,14 +21,38 @@ The cost driver is the NUMBER of round trips, not the size of any one result --
 the whole conversation is re-sent on every call, so 500 small reads cost far
 more than 50 targeted ones.
 
-This hook is ADVISORY. It never blocks a call; it prints one short reminder so
-an agent does not have to remember, or discover, the cheaper path. It fires for
-reads and searches aimed at C# under AlRunner/, which is where the navigation
-tools answer better than the shell does.
+It fires for reads and searches aimed at C# under AlRunner/, which is where the
+navigation tools answer better than the shell does, and it has two strengths
+(#3707):
+
+  * in an IMPL or REVIEWER context it BLOCKS (exit 2, stderr fed back);
+  * anywhere else -- the coordinator session in the main checkout -- it stays
+    advisory, exit 0, because grep over the C# tree is sometimes exactly right
+    there and a hook that blocks legitimate work gets switched off wholesale.
+
+A context is an agent context when AL_RUNNER_AGENT_ID / CLAUDE_AGENT_ID is set,
+or when the payload's cwd or the command itself names a `.claude/worktrees/`
+path. AL_RUNNER_HOOK_CONTEXT=coordinator overrides all of that, and a
+`# hook:allow-grep` marker in the command downgrades one single call.
+
+Tested by tools/test_prefer_code_navigation.py (firing) and
+tools/test_agent_workflow_hooks.py (blocking, context and the escape hatch).
+CI globs tools/test_*.py only, which is why neither suite lives beside the hook.
 """
 import json
+import os
 import re
 import sys
+
+BLOCK = 2
+ALLOW = 0
+
+# Both separators, because the cwd arrives Windows-shaped on a Windows box and
+# POSIX-shaped in CI, and the same hook has to recognise each.
+WORKTREE_PATH = re.compile(r'[\\/]\.claude[\\/]worktrees[\\/]')
+# One call's opt-out. Without one, an agent whose grep really is the right tool
+# has no move except to stop using the hook.
+ALLOW_MARKER = re.compile(r'#\s*hook:allow-grep\b')
 
 # `command grep` is the spelling CLAUDE.md mandates here, so it must match too.
 TEXT_SEARCH = re.compile(r'(?:^|[|;&]\s*)\s*(?:command\s+)?(?:grep|rg|ag)\b')
@@ -46,8 +70,16 @@ TARGETS_CS = re.compile(r'AlRunner[\w./-]*|--include[= ]\S*\.cs|\*\.cs|\.cs\b')
 NOT_A_SYMBOL_LOOKUP = re.compile(
     r'\.(log|json|trx|txt|md|xml|al)\b|/tmp/|scratchpad|git log|gh \w|dmesg|journalctl')
 
+ADVISORY_HEADER = "Code-navigation reminder (advisory, nothing was blocked).\n"
+BLOCK_HEADER = (
+    "BLOCKED: shell read/search over AlRunner/*.cs in an agent context\n"
+    "(CLAUDE.md, 'Code navigation: use these before grepping').\n"
+    "WHY: the cost is the NUMBER of round trips -- every call re-sends the whole\n"
+    "conversation -- and a grep hit over 81,000 lines of C# costs several follow-up reads to\n"
+    "interpret, with comment and string false positives you then discount by hand.\n"
+    "Append `# hook:allow-grep` to this command if the shell really is the right tool here.\n"
+)
 MESSAGE = (
-    "Code-navigation reminder (advisory, nothing was blocked).\n"
     "For reading or searching AlRunner/*.cs, these answer in ONE call what a sequence of\n"
     "sed/cat/head/grep approximates, and without comment/string false positives:\n"
     "  tools/lsp-query.py symbol  <Name>      # definition\n"
@@ -63,27 +95,37 @@ MESSAGE = (
 )
 
 
+def is_agent_context(cwd: str, cmd: str, env) -> bool:
+    """Whether this call is an impl or reviewer agent's, so the hook blocks."""
+    if (env.get("AL_RUNNER_HOOK_CONTEXT") or "").strip().lower() == "coordinator":
+        return False
+    if (env.get("AL_RUNNER_AGENT_ID") or env.get("CLAUDE_AGENT_ID") or "").strip():
+        return True
+    return bool(WORKTREE_PATH.search(cwd) or WORKTREE_PATH.search(cmd))
+
+
 def main() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
-        return 0
+        return ALLOW
     if payload.get("tool_name") != "Bash":
-        return 0
+        return ALLOW
     cmd = (payload.get("tool_input") or {}).get("command", "") or ""
 
     searching = bool(TEXT_SEARCH.search(cmd)) and bool(TARGETS_CS.search(cmd))
     reading = bool(READ_VERB.search(cmd)) and bool(NAMES_CS_FILE.search(cmd))
     if not (searching or reading):
-        return 0
+        return ALLOW
     if WRITES_CS.search(cmd):
-        return 0
+        return ALLOW
     if NOT_A_SYMBOL_LOOKUP.search(cmd):
-        return 0
-    print(MESSAGE, file=sys.stderr)
-    # Exit 0: advisory only. Never block -- grep over C# is sometimes exactly right,
-    # and a hook that blocks would cost more than the greps it prevents.
-    return 0
+        return ALLOW
+
+    blocking = (is_agent_context(payload.get("cwd") or "", cmd, os.environ)
+                and not ALLOW_MARKER.search(cmd))
+    print((BLOCK_HEADER if blocking else ADVISORY_HEADER) + MESSAGE, file=sys.stderr)
+    return BLOCK if blocking else ALLOW
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/prefer-code-navigation.py
+++ b/.claude/hooks/prefer-code-navigation.py
@@ -45,7 +45,8 @@ marker in the command, which always wins.
 
 Tested by tools/test_prefer_code_navigation.py (firing) and
 tools/test_agent_workflow_hooks.py (blocking, context and the escape hatch).
-CI globs tools/test_*.py only, which is why neither suite lives beside the hook.
+Both live in tools/ because that is the directory pr-gate.yml's tools-tests job
+globs; a suite beside the hook is only run if something delegates to it.
 """
 import json
 import os
@@ -55,8 +56,9 @@ import sys
 BLOCK = 2
 ALLOW = 0
 
-# The payload's own answer, measured on harness 2.1.266. `orchestrator` is not
-# here: the coordinator's own greps stay advisory.
+# The payload's own answer, measured on harness 2.1.266 for `impl-agent`;
+# `reviewer` is here by analogy with it and has not been measured. `orchestrator`
+# is not here: the coordinator's own greps stay advisory.
 BLOCKING_AGENT_TYPES = {"impl-agent", "reviewer"}
 # Both separators, because the cwd arrives Windows-shaped on a Windows box and
 # POSIX-shaped in CI, and the same hook has to recognise each.

--- a/.claude/hooks/prefer-code-navigation.py
+++ b/.claude/hooks/prefer-code-navigation.py
@@ -30,10 +30,18 @@ navigation tools answer better than the shell does, and it has two strengths
     advisory, exit 0, because grep over the C# tree is sometimes exactly right
     there and a hook that blocks legitimate work gets switched off wholesale.
 
-A context is an agent context when AL_RUNNER_AGENT_ID / CLAUDE_AGENT_ID is set,
-or when the payload's cwd or the command itself names a `.claude/worktrees/`
-path. AL_RUNNER_HOOK_CONTEXT=coordinator overrides all of that, and a
-`# hook:allow-grep` marker in the command downgrades one single call.
+The context comes from the payload's own `agent_type`, measured on harness
+2.1.266: a dispatched subagent's payload carries `agent_type: "impl-agent"` and a
+`cwd` of the PROJECT ROOT -- not of the agent's worktree -- so a cwd test alone
+would never fire for the agents this hook is for. `AL_RUNNER_AGENT_ID` /
+`CLAUDE_AGENT_ID`, and a `.claude/worktrees/` path in the cwd or the command,
+are kept as secondary signals for a loop that runs as its own session.
+
+`AL_RUNNER_HOOK_CONTEXT=coordinator` downgrades a session to advisory but
+deliberately does NOT outrank `agent_type`: the environment is inherited by
+every subagent the session dispatches, so letting it win would disarm the hook
+for exactly the agents it guards. The per-call escape is a `# hook:allow-grep`
+marker in the command, which always wins.
 
 Tested by tools/test_prefer_code_navigation.py (firing) and
 tools/test_agent_workflow_hooks.py (blocking, context and the escape hatch).
@@ -47,6 +55,9 @@ import sys
 BLOCK = 2
 ALLOW = 0
 
+# The payload's own answer, measured on harness 2.1.266. `orchestrator` is not
+# here: the coordinator's own greps stay advisory.
+BLOCKING_AGENT_TYPES = {"impl-agent", "reviewer"}
 # Both separators, because the cwd arrives Windows-shaped on a Windows box and
 # POSIX-shaped in CI, and the same hook has to recognise each.
 WORKTREE_PATH = re.compile(r'[\\/]\.claude[\\/]worktrees[\\/]')
@@ -95,12 +106,15 @@ MESSAGE = (
 )
 
 
-def is_agent_context(cwd: str, cmd: str, env) -> bool:
+def is_agent_context(payload: dict, cmd: str, env) -> bool:
     """Whether this call is an impl or reviewer agent's, so the hook blocks."""
+    if str(payload.get("agent_type") or "").strip().lower() in BLOCKING_AGENT_TYPES:
+        return True
     if (env.get("AL_RUNNER_HOOK_CONTEXT") or "").strip().lower() == "coordinator":
         return False
     if (env.get("AL_RUNNER_AGENT_ID") or env.get("CLAUDE_AGENT_ID") or "").strip():
         return True
+    cwd = payload.get("cwd") or ""
     return bool(WORKTREE_PATH.search(cwd) or WORKTREE_PATH.search(cmd))
 
 
@@ -122,7 +136,7 @@ def main() -> int:
     if NOT_A_SYMBOL_LOOKUP.search(cmd):
         return ALLOW
 
-    blocking = (is_agent_context(payload.get("cwd") or "", cmd, os.environ)
+    blocking = (is_agent_context(payload, cmd, os.environ)
                 and not ALLOW_MARKER.search(cmd))
     print((BLOCK_HEADER if blocking else ADVISORY_HEADER) + MESSAGE, file=sys.stderr)
     return BLOCK if blocking else ALLOW

--- a/.claude/hooks/refuse-stash-and-ci-waits.py
+++ b/.claude/hooks/refuse-stash-and-ci-waits.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""PreToolUse REFUSAL: `git stash` in any form, and a backgrounded CI wait.
+
+Both are absolute rules with no legitimate exception, which is what makes them
+safe to block rather than advise: `refs/stash` is shared by every worktree of
+this repository (`.claude/rules/no-git-stash-with-worktrees.md`), and a
+backgrounded child process dies when the turn ends
+(`.claude/rules/no-backgrounding-long-commands.md`). Neither refusal is scoped
+to an agent context, because neither shape is correct in any session.
+
+What is deliberately NOT refused, so the coordinator keeps working: a
+backgrounded command that is not a CI wait -- a detached runner, build or test
+sweep -- and any CI-wait shape run in the FOREGROUND. Only the pairing of
+`run_in_background` with a CI wait is refused.
+
+Exit 2 is what blocks a PreToolUse call and feeds stderr back to the model;
+exit 0 allows it. There is no third state here: this hook reads the command
+string it was handed, so it cannot fail to measure. A payload it cannot parse
+allows the call rather than blocking on a guess.
+
+Tested by tools/test_agent_workflow_hooks.py (that directory is what CI globs).
+"""
+import json
+import re
+import sys
+
+BLOCK = 2
+ALLOW = 0
+
+# A command line is a sequence of segments. Only what a segment *starts with*
+# decides anything, so `command grep -rn "git stash" .claude/rules` -- a search
+# of the docs -- is not read as running it.
+SEGMENT_SPLIT = re.compile(r'\|\||&&|[;|\n&()`]|\$\(')
+# Leading noise a real invocation carries: keywords, env assignments, wrappers.
+LEADING_NOISE = re.compile(
+    r'^(?:\s*(?:then|else|elif|do|done|fi|if|while|until|for|!|time|exec|nohup|'
+    r'sudo|command|builtin|\w+=\S*)\s+)+')
+
+GIT_OPTS = r'(?:\s+(?:-[A-Za-z]\s+\S+|-[A-Za-z]\S*|--[\w-]+(?:=\S+)?))*'
+GIT_STASH = re.compile(r'^git\b' + GIT_OPTS + r'\s+stash\b')
+
+CI_WAIT_RUN_WATCH = re.compile(r'^(?:python3?\s+)?gh\b.*\brun\s+watch\b')
+CI_WAIT_PR_CHECKS = re.compile(r'^(?:python3?\s+)?gh\b.*\bpr\s+checks\b.*--watch\b')
+CI_WAIT_TOOL = re.compile(r'^(?:python3?\s+)?\S*ci-wait\.py\b')
+TIMEOUT_ZERO = re.compile(r'--timeout(?:=|\s+)0(?:\s|$)')
+SLEEPS = re.compile(r'^sleep\b')
+POLLS_CI = re.compile(
+    r'^(?:python3?\s+)?gh\b.*(?:\brun\s+(?:view|list)\b|\bpr\s+checks\b'
+    r'|\bapi\b.*actions/runs)')
+
+STASH_MESSAGE = (
+    "BLOCKED: `git stash` (.claude/rules/no-git-stash-with-worktrees.md).\n"
+    "WHY: refs/stash belongs to the REPOSITORY, not to a worktree. Every\n"
+    ".claude/worktrees/<id>-issue-<N> directory is a worktree of this same repository, so\n"
+    "your push and another loop's pop share one stack -- including `git stash list`, whose\n"
+    "output interleaves entries you did not create and whose stash@{0} shifts under you.\n"
+    "There is no per-worktree stash and no pathspec or -m form that makes one.\n"
+    "USE INSTEAD:\n"
+    "  git commit ...                          # on your own branch: free, and nobody can pop it\n"
+    "  git diff HEAD > /tmp/mine.patch         # set aside; `git diff` alone captures nothing\n"
+    "  git apply /tmp/mine.patch               #   once staged. Untracked files: copy by hand.\n"
+    "  git checkout <rev> -- <path>            # RED baseline -- COMMIT FIRST; it writes the\n"
+    "                                          #   index too, so re-read `git diff --cached`."
+)
+
+CI_WAIT_MESSAGE = (
+    "BLOCKED: a CI wait with run_in_background\n"
+    "(.claude/rules/no-backgrounding-long-commands.md, .claude/rules/ci-verdicts.md §0).\n"
+    "WHY: a backgrounded command is a child of this turn and dies with the turn -- no\n"
+    "notification arrives, and nothing you were waiting for is ever reported. Waiting on CI\n"
+    "at all is the wrong shape besides: a workflow run completes whether or not anyone is\n"
+    "watching, so push, open the PR, and read the verdict on your next pass.\n"
+    "USE INSTEAD:\n"
+    "  tools/ci-wait.py <PR> --timeout 0       # one pass, one answer, about a second\n"
+    "                                          #   exit 2 = not reported yet; read again later\n"
+    "Local work that really is long runs in the FOREGROUND with a generous timeout, and you\n"
+    "push before starting it. Backgrounding a detached runner or build is not refused here."
+)
+
+
+def segments(cmd: str) -> list:
+    out = []
+    for raw in SEGMENT_SPLIT.split(cmd):
+        seg = LEADING_NOISE.sub("", raw.strip()).strip()
+        if seg:
+            out.append(seg)
+    return out
+
+
+def stash_segment(segs: list):
+    for seg in segs:
+        if GIT_STASH.match(seg):
+            return seg
+    return None
+
+
+def ci_wait_reason(segs: list):
+    """The CI-wait shape in these segments, or None."""
+    sleeping = any(SLEEPS.match(s) for s in segs)
+    polling = any(POLLS_CI.match(s) for s in segs)
+    for seg in segs:
+        if CI_WAIT_RUN_WATCH.match(seg):
+            return "`gh run watch` blocks until the run finishes"
+        if CI_WAIT_PR_CHECKS.match(seg):
+            return "`gh pr checks --watch` blocks until the checks finish"
+        if CI_WAIT_TOOL.match(seg) and not TIMEOUT_ZERO.search(seg):
+            return "ci-wait.py without `--timeout 0` polls until its deadline"
+    if sleeping and polling:
+        return "a sleep loop polling CI is a hand-rolled wait"
+    return None
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return ALLOW
+    if payload.get("tool_name") != "Bash":
+        return ALLOW
+    tool_input = payload.get("tool_input") or {}
+    cmd = tool_input.get("command", "") or ""
+    segs = segments(cmd)
+
+    seg = stash_segment(segs)
+    if seg:
+        print(STASH_MESSAGE, file=sys.stderr)
+        print(f"Refused segment: {seg}", file=sys.stderr)
+        return BLOCK
+
+    if tool_input.get("run_in_background"):
+        reason = ci_wait_reason(segs)
+        if reason:
+            print(CI_WAIT_MESSAGE, file=sys.stderr)
+            print(f"Refused because {reason}.", file=sys.stderr)
+            return BLOCK
+    return ALLOW
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/refuse-stash-and-ci-waits.py
+++ b/.claude/hooks/refuse-stash-and-ci-waits.py
@@ -18,7 +18,7 @@ exit 0 allows it. There is no third state here: this hook reads the command
 string it was handed, so it cannot fail to measure. A payload it cannot parse
 allows the call rather than blocking on a guess.
 
-Tested by tools/test_agent_workflow_hooks.py (that directory is what CI globs).
+Tested by tools/test_agent_workflow_hooks.py (tools/ is what pr-gate.yml globs).
 """
 import json
 import re

--- a/.claude/hooks/shared-scratchpad-guard.py
+++ b/.claude/hooks/shared-scratchpad-guard.py
@@ -18,10 +18,9 @@ the obvious case), and a hook that blocks legitimate work gets switched off,
 taking the warning with it. The refusal that CAN block lives in
 `tools/agent_scratchpad.py check`, where a caller opts into it explicitly.
 
-Tested by .claude/hooks/test_shared_scratchpad_guard.py. NOTE that no CI job runs
-.claude/hooks/test_*.py -- `pr-gate.yml`'s tools-tests job globs `tools/test_*.py`
-only -- so the logic this hook depends on lives in tools/agent_scratchpad.py,
-which that glob does cover.
+Tested by tools/test_shared_scratchpad_guard.py. The suite lives there rather than
+beside the hook because `pr-gate.yml`'s tools-tests job globs `tools/test_*.py`
+only, so a test next to the hook gates nothing (#3707).
 """
 import json
 import os

--- a/.claude/hooks/shared-scratchpad-guard.py
+++ b/.claude/hooks/shared-scratchpad-guard.py
@@ -20,7 +20,8 @@ taking the warning with it. The refusal that CAN block lives in
 
 Tested by tools/test_shared_scratchpad_guard.py. The suite lives there rather than
 beside the hook because `pr-gate.yml`'s tools-tests job globs `tools/test_*.py`
-only, so a test next to the hook gates nothing (#3707).
+only, so a test next to the hook gates nothing unless something delegates to it
+(#3707).
 """
 import json
 import os

--- a/.claude/rules/no-backgrounding-long-commands.md
+++ b/.claude/rules/no-backgrounding-long-commands.md
@@ -28,6 +28,11 @@ One mechanism — a child process of your turn dies with your turn — in three 
 - **The harness backgrounding it FOR you**, with a message saying you will be notified. That
   promise does not hold for anything started inside your own turn.
 
+A `PreToolUse` hook refuses `run_in_background` on a CI wait —
+`.claude/hooks/refuse-stash-and-ci-waits.py`, which reads `gh run watch`,
+`gh pr checks --watch`, `ci-wait.py` without `--timeout 0`, and a sleep loop polling CI as
+that shape; a backgrounded local run that is not a CI wait is still yours to judge (#3707).
+
 **If you are about to end a turn while local work you launched is still running, that is the
 bug.** Correct shapes, in order of preference: run it in the foreground; push first so the loss
 is survivable; or genuinely abandon it and say so. "Start it, end the turn, and wait" is not on

--- a/.claude/rules/no-git-stash-with-worktrees.md
+++ b/.claude/rules/no-git-stash-with-worktrees.md
@@ -10,6 +10,9 @@ warns you.
 Do not run `git stash`, `git stash pop`, `git stash apply`, or `git stash drop` in this
 repository — not in a worktree, not in the top-level checkout.
 
+A `PreToolUse` hook refuses every form of it — `.claude/hooks/refuse-stash-and-ci-waits.py`,
+`git stash list` included, in every session (#3707).
+
 The obvious workarounds do not help: `git stash push --` with a pathspec and `-m` names still
 write to the shared `refs/stash`, `git stash list` interleaves every agent's entries with yours,
 and `stash@{0}` shifts under you when another agent pushes. There is no per-worktree stash.

--- a/.claude/rules/no-git-stash-with-worktrees.md
+++ b/.claude/rules/no-git-stash-with-worktrees.md
@@ -1,9 +1,8 @@
 # Never use `git stash` — the stash is shared across every worktree
 
 `refs/stash` belongs to the **repository**, not to a worktree, so every agent's
-`.claude/worktrees/*` directory pushes and pops the same single stack. One agent's
-`git stash pop` has restored another agent's changes into its own worktree, and nothing in git
-warns you.
+`.claude/worktrees/*` directory pushes and pops one stack. One agent's `git stash pop` has
+restored another agent's changes into its worktree; nothing in git warns you.
 
 ## The rule
 
@@ -13,60 +12,42 @@ repository — not in a worktree, not in the top-level checkout.
 A `PreToolUse` hook refuses every form of it — `.claude/hooks/refuse-stash-and-ci-waits.py`,
 `git stash list` included, in every session (#3707).
 
-The obvious workarounds do not help: `git stash push --` with a pathspec and `-m` names still
-write to the shared `refs/stash`, `git stash list` interleaves every agent's entries with yours,
-and `stash@{0}` shifts under you when another agent pushes. There is no per-worktree stash.
+The workarounds do not help: a pathspec or an `-m` name still writes the shared `refs/stash`,
+`git stash list` interleaves every agent's entries, and `stash@{0}` shifts under you. There is
+no per-worktree stash.
 
 ## What to use instead
 
 | Goal | Use |
 |---|---|
-| Temporarily revert one file to compare RED vs GREEN | **Commit first.** Then `git checkout <rev> -- <path>`, and `git checkout HEAD -- <path>` to restore. On uncommitted work the restore step **deletes** the change — use the patch row instead. Read the two failure modes below before running either half. |
+| Temporarily revert one file to compare RED vs GREEN | **Commit first**, then `git checkout <rev> -- <path>`. On uncommitted work the restore step **deletes** the change — use the patch row instead, and read the two failure modes below. |
 | Set aside changes you will bring back | `git diff HEAD > /tmp/mine.patch`, then `git apply /tmp/mine.patch`. `git diff HEAD`, not `git diff` — plain `git diff` captures **nothing** once the change is staged. Neither captures untracked files; copy those by hand. |
-| Keep work safe across a crash or reboot | Commit it on your own branch. Free, and nobody else can pop it. |
-| Move to another branch with changes in hand | You should not need to — each agent owns one worktree on one branch. |
+| Keep work safe across a crash or reboot | Commit it on your own branch; nobody else can pop it. |
+| Move to another branch with changes in hand | You should not need to — one agent, one worktree, one branch. |
 
 Committing early is the preferred answer to all of these.
 
 ## The RED-baseline recipe has two ways to destroy work
 
-Both are properties of `git checkout` (measured on git 2.55.0), and mode 2 is silent — it
-produces a PR carrying a green CI verdict for code that is not what CI measured:
+Both are properties of `git checkout` (git 2.55.0). `git checkout HEAD -- <path>` with your fix
+uncommitted **deletes the fix**, with no stash or reflog entry. And `git checkout <rev> --
+<paths>` writes the **index**, so those paths stay staged as pre-fix content and a later
+`git commit` commits the revert — silent, and it ships code CI never measured.
 
-1. **The restore step is not a restore.** `git checkout HEAD -- <path>` sets the file to
-   whatever `HEAD` says, so with your fix still uncommitted it throws the fix away, with no
-   stash entry and no reflog entry to recover from.
-2. **`git checkout <rev> -- <paths>` writes the index, not just the working tree**, leaving
-   those paths **staged** as pre-fix content. Read `git status`: a path you restored from a copy
-   reads `MM`, one you did not reads `M `. `git commit` then commits the index — the revert —
-   and `git commit -a` commits the working tree, right for paths you restored and still pre-fix
-   for any you did not.
-
-So, around any `git checkout <rev> -- <paths>`:
-
-1. **Copy the affected files outside the repository before you revert** —
-   `mkdir -p /tmp/red-baseline && cp <paths> /tmp/red-baseline/` — so the restore is verifiable
-   instead of hopeful.
-2. Restore, then `git add` those paths again; the revert staged them and the restore does not
-   necessarily unstage them.
-3. Read `git diff --cached` and confirm it is your fix, not the revert.
-4. Never `git commit -a` straight after a RED baseline.
+So: copy the affected files outside the repository first, `git add` them again after restoring,
+read `git diff --cached` to confirm it is your fix rather than the revert, and never
+`git commit -a` straight after a RED baseline. Worked modes: the incidents file.
 
 ## Polling loops must not match themselves
 
-`pgrep -f <pattern>` matches the polling shell's own command line **and every ancestor** whose
-command line contains the pattern, including the outer tool shell, so
-`while pgrep -f "dotnet run"; do ...; done` never terminates. Filtering `$$` out does not rescue
-it, and fails twice over: `grep -v $$` is a substring filter, so with a PID of `123` it also
-drops `1234` and `4123`, and `grep -vx` fixes that half while leaving the ancestor half. Use
-`$!` on a job you started, or `wait`. Whether to wait at all is
-`no-backgrounding-long-commands.md`'s call, not this rule's.
+`pgrep -f <pattern>` matches the polling shell's own command line **and every ancestor**
+carrying the pattern, so `while pgrep -f "dotnet run"; do ...; done` never terminates, and
+filtering `$$` out does not rescue it (why not: the incidents file). Use `$!` or `wait`.
 
 ## Sister rules
 
 - `branch-and-pr.md` — one branch per agent, one open PR per agent
-- `tdd.md` — the RED → GREEN cycle the revert recipe above exists to serve
-- `no-backgrounding-long-commands.md` — why the answer to "is it done yet" is a foreground
-  wait for local work, and for CI is not to wait at all
+- `tdd.md` — the RED → GREEN cycle the revert recipe serves
+- `no-backgrounding-long-commands.md` — wait in the foreground locally; never wait on CI
 
 History: docs/incidents/no-git-stash-with-worktrees.md

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/refuse-stash-and-ci-waits.py\""
+          },
+          {
+            "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/prefer-code-navigation.py\""
           },
           {

--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -405,6 +405,11 @@ Otherwise the next agent starts from the wrong premise — which has happened he
 - **`grep` is a shell function.** It rejects `-E` and `--include` with
   `error: unknown option '-G'` **and exits 0 with no output**, which reads exactly like "no
   matches". Use `command grep` or `rg` before believing an empty result.
+- **`export AL_RUNNER_HOOK_CONTEXT=coordinator` in the shell that launches `claude`** if this
+  session greps `AlRunner/**/*.cs` itself: `.claude/hooks/prefer-code-navigation.py` blocks that
+  read in an agent context and stays advisory for a coordinator. It is read from the hook
+  process's environment, so exporting it inside a Bash command does nothing, and a dispatched
+  subagent's own `agent_type` still outranks it (#3707).
 - **Always pass a private `--cache <dir>`** to runner invocations. The shared
   `~/.cache/al-runner` is not keyed on the runner binary, so a concurrent agent's payload can
   make a fix look like it did nothing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,9 +63,11 @@ tools/context-pack.py <Name> [<Name>...]   # definition + source + call sites fo
 ```
 
 Prefer it whenever you have more than one symbol to resolve; that is the whole point of it.
-A `PreToolUse` hook (`.claude/hooks/prefer-code-navigation.py`) prints a reminder when a
-shell search targets `AlRunner/**/*.cs`. It is advisory and never blocks — grep stays right
-for logs, JSON, TRX, markdown and `.al` sources.
+A `PreToolUse` hook (`.claude/hooks/prefer-code-navigation.py`) acts when a shell read or
+search targets `AlRunner/**/*.cs`: it **blocks** in an impl or reviewer context (a
+`.claude/worktrees/` cwd, or `AL_RUNNER_AGENT_ID` set) and stays an advisory reminder
+elsewhere, so the coordinator keeps grep (#3707). Append `# hook:allow-grep` to override one
+call. Grep stays right everywhere for logs, JSON, TRX, markdown and `.al` sources.
 
 **1. Knowledge graph — this is the one a subagent has.**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,10 +64,9 @@ tools/context-pack.py <Name> [<Name>...]   # definition + source + call sites fo
 
 Prefer it whenever you have more than one symbol to resolve; that is the whole point of it.
 A `PreToolUse` hook (`.claude/hooks/prefer-code-navigation.py`) acts when a shell read or
-search targets `AlRunner/**/*.cs`: it **blocks** in an impl or reviewer context (a
-`.claude/worktrees/` cwd, or `AL_RUNNER_AGENT_ID` set) and stays an advisory reminder
-elsewhere, so the coordinator keeps grep (#3707). Append `# hook:allow-grep` to override one
-call. Grep stays right everywhere for logs, JSON, TRX, markdown and `.al` sources.
+search targets `AlRunner/**/*.cs`: it **blocks** when the PreToolUse payload's `agent_type` is
+`impl-agent` or `reviewer` and stays an advisory reminder elsewhere, so the coordinator keeps
+grep (#3707). Append `# hook:allow-grep` to override one call. Grep stays right everywhere for logs, JSON, TRX, markdown and `.al` sources.
 
 **1. Knowledge graph — this is the one a subagent has.**
 

--- a/docs/agent-scratchpad.md
+++ b/docs/agent-scratchpad.md
@@ -112,7 +112,7 @@ made the easy one to get, and the shared one is made to refuse.
 ## Testing note
 
 `tools/test_agent_scratchpad.py` is picked up by `pr-gate.yml`'s `tools-tests`
-job, which globs `tools/test_*.py`. **No CI job globs `.claude/hooks/test_*.py`**
-— so `test_prefer_code_navigation.py` had never run in CI — and that suite
-therefore delegates to every `.claude/hooks/test_*.py`, which makes them gate by
-the same discovery argument without a workflow change.
+job, which globs `tools/test_*.py`. **No CI job globs `.claude/hooks/test_*.py`**,
+so the hooks' own suites live in `tools/` too — `test_shared_scratchpad_guard.py`
+and `test_prefer_code_navigation.py` — and `test_agent_scratchpad.py` asserts
+that `.claude/hooks/` stays empty of suites, since one placed there gates nothing.

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -867,7 +867,7 @@ def pr_map(slug: Optional[str]) -> tuple[dict, str]:
     if not slug or not shutil.which("gh"):
         return {}, "unavailable"
     r = run_retry(["gh", "pr", "list", "--repo", slug, "--state", "all", "--limit", "300",
-                   "--json", "number,headRefName,state,headRefOid,mergedAt"], timeout=90)
+                   "--json", "number,headRefName,state,headRefOid,mergedAt,labels"], timeout=90)
     if not r.ok:
         return {}, f"gh pr list failed: {(r.err or r.out).strip()[:200]}"
     try:
@@ -911,6 +911,88 @@ def collect_worktrees(repo: str, prs: dict, measure: bool = True) -> list[tuple]
         d = disposition(wt, pr=pr, dirty=dirty, unpushed=unpushed, is_current=is_current)
         rows.append((wt, pr, dirty, unpushed, d, exists))
     return rows
+
+
+WORKTREE_DIR = re.compile(r'[\\/]\.claude[\\/]worktrees[\\/]')
+
+
+def agent_label(pr: Optional[dict]) -> Optional[str]:
+    for label in (pr or {}).get("labels") or []:
+        name = (label.get("name") if isinstance(label, dict) else str(label)) or ""
+        if name.startswith("agent:"):
+            return name.split(":", 1)[1].strip()
+    return None
+
+
+def judge_branch_ownership(*, cwd: str, branch: Optional[str], pr: Optional[dict],
+                           agent_id: Optional[str]) -> CheckResult:
+    """Whether the branch you are standing on already heads another loop's PR (#3707).
+
+    The `agent:` label on the OPEN pull request is the only signal here that names
+    a loop: the assignee cannot, because every loop pushes under one account
+    (`check-open-prs-before-claiming.md`). Two loops can hold one identity, so the
+    branch is what keeps their commits apart, and a second loop committing on it
+    lands its work on the first one's PR (#3014).
+
+    Three answers, not two (`guards-need-a-third-state.md`): PASS when the branch
+    is measurably yours or unclaimed, FAIL when it measurably is not, and WARN --
+    never PASS -- when the comparison could not be made at all.
+    """
+    name = "branch-ownership"
+    cmd = "git rev-parse --abbrev-ref HEAD + gh pr list --json headRefName,labels"
+    if not WORKTREE_DIR.search(cwd.replace("\\", "/")) and not WORKTREE_DIR.search(cwd):
+        return CheckResult(name=name, status="PASS", command=cmd,
+                           summary="not standing in an agent worktree; nothing to compare")
+    if not branch:
+        return CheckResult(
+            name=name, status="WARN", command=cmd,
+            summary="detached HEAD in an agent worktree - no branch, so no pull request "
+                    "to compare against",
+            remedy="Check out the branch this worktree belongs to before working in it.")
+    state = str((pr or {}).get("state") or "").upper()
+    if not pr or state != "OPEN":
+        return CheckResult(name=name, status="PASS", command=cmd,
+                           summary=f"no open pull request heads {branch}")
+    owner = agent_label(pr)
+    if owner is None:
+        return CheckResult(
+            name=name, status="WARN", command=cmd,
+            summary=f"PR #{pr.get('number')} heads {branch} but carries no `agent:` label, "
+                    f"so which loop owns it cannot be established",
+            remedy=f"Read PR #{pr.get('number')} and label it `agent: <id>`, or confirm by "
+                   f"hand that the branch is yours, before committing on it.")
+    if not agent_id:
+        return CheckResult(
+            name=name, status="WARN", command=cmd,
+            summary=f"PR #{pr.get('number')} heads {branch} and is owned by `agent: {owner}`, "
+                    f"but this run declared no identity to compare it against",
+            remedy="Re-run with --agent-id <your-identity> (or set AL_RUNNER_AGENT_ID); "
+                   "without one, a foreign claim and your own look identical.")
+    if owner == agent_id:
+        return CheckResult(name=name, status="PASS", command=cmd,
+                           summary=f"PR #{pr.get('number')} heads {branch} and is yours "
+                                   f"(`agent: {owner}`)")
+    return CheckResult(
+        name=name, status="FAIL", command=cmd,
+        summary=f"{branch} already heads OPEN PR #{pr.get('number')}, owned by "
+                f"`agent: {owner}` and not by `agent: {agent_id}`",
+        remedy=f"Stop: committing here pushes onto another loop's PR branch, and its Test "
+               f"Matrix then reports on the mixture (#3014). Take your own worktree at "
+               f".claude/worktrees/<your-id>-issue-<N> on branch agent/<your-id>/issue-<N>, "
+               f"and say on PR #{pr.get('number')} that you found its branch checked out "
+               f"elsewhere.")
+
+
+def check_branch_ownership(repo: str, prs: dict, agent_id: Optional[str],
+                           cwd: Optional[str] = None) -> CheckResult:
+    here = cwd or os.getcwd()
+    r = run(["git", "-C", here, "rev-parse", "--abbrev-ref", "HEAD"], timeout=30)
+    branch = r.out.strip() if r.ok else ""
+    if branch in ("HEAD", ""):
+        branch = None
+    return judge_branch_ownership(cwd=here, branch=branch,
+                                  pr=prs.get(branch) if branch else None,
+                                  agent_id=agent_id)
 
 
 def check_worktrees(rows: list[tuple], repo: str, pr_status: str) -> CheckResult:
@@ -2720,6 +2802,10 @@ def main(argv: Optional[list[str]] = None) -> int:
                     help="remove worktrees whose PR is MERGED and whose tree is clean")
     ap.add_argument("--dry-run", action="store_true", help="with --reap, only say what it would do")
     ap.add_argument("--identity", default=None, help="agent identity used for the push probe ref")
+    ap.add_argument("--agent-id", default=None,
+                    help="the loop's identity (fbk-3, impl-2, ...), compared against the "
+                         "`agent:` label of any open PR heading this worktree's branch; "
+                         "defaults to $AL_RUNNER_AGENT_ID")
     ap.add_argument("--scratch-root", default=None,
                     help="directory to scan for stale scratch (default: the system temp dir)")
     ap.add_argument("--stale-hours", type=float, default=6.0,
@@ -2776,6 +2862,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     import tempfile
     scratch_root = args.scratch_root or tempfile.gettempdir()
     identity = args.identity or default_identity()
+    agent_id = args.agent_id or os.environ.get("AL_RUNNER_AGENT_ID") or None
     per_worker = (PER_WORKER_BYTES_WITH_TEST_DATA if args.with_test_data
                   else PER_WORKER_BYTES_NO_TEST_DATA)
     per_worker_label = ("with --test-data" if args.with_test_data else "without test data")
@@ -2803,6 +2890,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         check_headroom(scratch_root, repo, mounts, mem, per_worker, per_worker_label),
         check_budget(skip_fallback=args.skip_budget_fallback),
         check_worktrees(rows, repo, pr_status),
+        check_branch_ownership(repo, prs, agent_id),
         check_stale_scratch(scratch_root, rows, args.stale_hours),
         classify_checkout(lags),
         check_push(repo, identity),

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -867,7 +867,7 @@ def pr_map(slug: Optional[str]) -> tuple[dict, str]:
     if not slug or not shutil.which("gh"):
         return {}, "unavailable"
     r = run_retry(["gh", "pr", "list", "--repo", slug, "--state", "all", "--limit", "300",
-                   "--json", "number,headRefName,state,headRefOid,mergedAt,labels"], timeout=90)
+                   "--json", "number,headRefName,state,headRefOid,mergedAt"], timeout=90)
     if not r.ok:
         return {}, f"gh pr list failed: {(r.err or r.out).strip()[:200]}"
     try:
@@ -925,7 +925,8 @@ def agent_label(pr: Optional[dict]) -> Optional[str]:
 
 
 def judge_branch_ownership(*, cwd: str, branch: Optional[str], pr: Optional[dict],
-                           agent_id: Optional[str]) -> CheckResult:
+                           agent_id: Optional[str],
+                           lookup_status: str = "ok") -> CheckResult:
     """Whether the branch you are standing on already heads another loop's PR (#3707).
 
     The `agent:` label on the OPEN pull request is the only signal here that names
@@ -949,6 +950,14 @@ def judge_branch_ownership(*, cwd: str, branch: Optional[str], pr: Optional[dict
             summary="detached HEAD in an agent worktree - no branch, so no pull request "
                     "to compare against",
             remedy="Check out the branch this worktree belongs to before working in it.")
+    if lookup_status != "ok":
+        return CheckResult(
+            name=name, status="WARN", command=cmd,
+            summary=f"the open pull requests for {branch} could not be read "
+                    f"({lookup_status}), so whether another loop owns this branch is "
+                    f"unmeasured",
+            remedy="Authenticate gh (`gh auth status`) and re-run; an unreadable pull-request "
+                   "list is not evidence that the branch is free.")
     state = str((pr or {}).get("state") or "").upper()
     if not pr or state != "OPEN":
         return CheckResult(name=name, status="PASS", command=cmd,
@@ -983,16 +992,42 @@ def judge_branch_ownership(*, cwd: str, branch: Optional[str], pr: Optional[dict
                f"elsewhere.")
 
 
-def check_branch_ownership(repo: str, prs: dict, agent_id: Optional[str],
-                           cwd: Optional[str] = None) -> CheckResult:
+def open_pr_for_branch(slug: Optional[str], branch: str) -> tuple[Optional[dict], str]:
+    """The OPEN pull request whose head is `branch`, asked for by name.
+
+    Deliberately not `pr_map()`: that is `--state all --limit 300` over a
+    repository with thousands of pull requests, so an open PR older than the 300
+    newest is simply absent from it -- and absent reads as "nobody owns this
+    branch", the false PASS this check exists to prevent. `--head` reads the
+    pull-request list rather than the search index, which is why a PR opened
+    seconds earlier is found (#3717).
+    """
+    if not slug:
+        return None, "no repository slug"
+    if not shutil.which("gh"):
+        return None, "gh is not installed"
+    r = run_retry(["gh", "pr", "list", "--repo", slug, "--state", "open",
+                   "--head", branch, "--json", "number,state,labels"], timeout=60)
+    if not r.ok:
+        return None, f"gh pr list failed: {(r.err or r.out).strip()[:160]}"
+    try:
+        prs = json.loads(r.out)
+    except ValueError:
+        return None, "gh pr list returned unparseable JSON"
+    return (prs[0] if prs else None), "ok"
+
+
+def check_branch_ownership(repo: str, agent_id: Optional[str],
+                           cwd: Optional[str] = None, lookup=None) -> CheckResult:
     here = cwd or os.getcwd()
     r = run(["git", "-C", here, "rev-parse", "--abbrev-ref", "HEAD"], timeout=30)
     branch = r.out.strip() if r.ok else ""
     if branch in ("HEAD", ""):
-        branch = None
-    return judge_branch_ownership(cwd=here, branch=branch,
-                                  pr=prs.get(branch) if branch else None,
-                                  agent_id=agent_id)
+        return judge_branch_ownership(cwd=here, branch=None, pr=None, agent_id=agent_id)
+    ask = lookup or (lambda b: open_pr_for_branch(repo_slug(repo), b))
+    pr, status = ask(branch)
+    return judge_branch_ownership(cwd=here, branch=branch, pr=pr, agent_id=agent_id,
+                                  lookup_status=status)
 
 
 def check_worktrees(rows: list[tuple], repo: str, pr_status: str) -> CheckResult:
@@ -2890,7 +2925,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         check_headroom(scratch_root, repo, mounts, mem, per_worker, per_worker_label),
         check_budget(skip_fallback=args.skip_budget_fallback),
         check_worktrees(rows, repo, pr_status),
-        check_branch_ownership(repo, prs, agent_id),
+        check_branch_ownership(repo, agent_id),
         check_stale_scratch(scratch_root, rows, args.stale_hours),
         classify_checkout(lags),
         check_push(repo, identity),

--- a/tools/test_agent_scratchpad.py
+++ b/tools/test_agent_scratchpad.py
@@ -233,26 +233,21 @@ def test_cli_refuses_rather_than_defaulting_without_an_identity() -> None:
         check("nothing is printed to stdout", out == "", out)
 
 
-def test_the_hook_suite_runs_here_because_no_CI_job_globs_it() -> None:
-    """`.claude/hooks/test_*.py` is discovered by NOTHING.
+def test_no_test_suite_lives_where_nothing_globs_it() -> None:
+    """A suite under `.claude/hooks/` gates nothing on its own.
 
-    `pr-gate.yml`'s tools-tests job globs `tools/test_*.py` only, so
-    `.claude/hooks/test_prefer_code_navigation.py` has never run in CI and
-    neither would the new hook's suite. That is the same defect the tools-tests
-    job was created to fix, one directory over: a test file that exists, passes
-    locally, and gates nothing.
-
-    Rather than edit a workflow -- this box's token has no `workflow` scope, so a
-    PR touching .github/workflows/ cannot be merged from here -- this delegates
-    from a suite the glob DOES pick up. Any .claude/hooks/test_*.py now gates the
-    day it lands, by the same discovery argument, with no workflow change.
+    `pr-gate.yml`'s tools-tests job globs `tools/test_*.py` only. #3420 covered
+    that by delegating from here; #3707 moved the hook suites into `tools/`
+    instead, so they are discovered directly and delegating would run them
+    twice. What is left to assert is that nobody puts one back.
     """
-    hooks = sorted(pathlib.Path(HERE).parent.joinpath(".claude", "hooks").glob("test_*.py"))
-    check("hook suites are discovered", len(hooks) >= 2, f"found {[h.name for h in hooks]}")
-    for h in hooks:
-        r = subprocess.run([sys.executable, str(h)], capture_output=True, text=True)
-        check(f"{h.name} passes", r.returncode == 0,
-              (r.stdout + r.stderr)[-600:])
+    root = pathlib.Path(HERE).parent
+    strays = sorted(root.joinpath(".claude", "hooks").glob("test_*.py"))
+    check("no suite hides under .claude/hooks", not strays,
+          f"move to tools/: {[s.name for s in strays]}")
+    for name in ("test_prefer_code_navigation.py", "test_shared_scratchpad_guard.py"):
+        check(f"{name} is globbed by tools-tests",
+              root.joinpath("tools", name).is_file(), name)
 
 
 def main() -> int:

--- a/tools/test_agent_workflow_hooks.py
+++ b/tools/test_agent_workflow_hooks.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Unit tests for the two BLOCKING PreToolUse hooks (#3707).
 
-Both hooks live in `.claude/hooks/`, and no CI job globs that directory --
-`pr-gate.yml`'s tools-tests job runs `tools/test_*.py` only. So the tests for
-them live here, and drive the real scripts as subprocesses with a JSON
-PreToolUse payload on stdin, which is the only interface the harness uses.
+Both hooks live in `.claude/hooks/`, which `pr-gate.yml`'s tools-tests job does
+not glob -- it runs `tools/test_*.py` only. So the tests for them live here,
+where that job discovers them directly, and drive the real scripts as
+subprocesses with a JSON PreToolUse payload on stdin, the only interface the
+harness uses.
 
 What "blocking" means, and why the assertions are on exit code 2 specifically:
 a PreToolUse hook that exits 2 has its stderr fed back to the model and the tool

--- a/tools/test_agent_workflow_hooks.py
+++ b/tools/test_agent_workflow_hooks.py
@@ -44,13 +44,16 @@ def check(name: str, cond: bool, detail: str = "") -> None:
 
 
 def fire(hook: str, command: str, *, background: bool = False, cwd: str = "",
-         tool: str = "Bash", env_extra: dict | None = None) -> subprocess.CompletedProcess:
+         tool: str = "Bash", env_extra: dict | None = None,
+         agent_type: str = "") -> subprocess.CompletedProcess:
     tool_input: dict = {"command": command}
     if background:
         tool_input["run_in_background"] = True
     payload = {"tool_name": tool, "tool_input": tool_input}
     if cwd:
         payload["cwd"] = cwd
+    if agent_type:
+        payload["agent_type"] = agent_type
     env = dict(os.environ)
     # The invoking session's own identity must never leak into a case asserting
     # what happens WITHOUT one.
@@ -164,6 +167,22 @@ NAV_BLOCKED = [
 for name, cmd in NAV_BLOCKED:
     ok, d = blocks(NAV, cmd, "context-pack.py", cwd=WORKTREE)
     check(name, ok, d)
+
+# The signal the payload itself carries, measured on harness 2.1.266: a dispatched
+# subagent's payload has agent_type="impl-agent" and a cwd of the PROJECT ROOT, so
+# a cwd test alone would never fire for the agents this hook exists for.
+for _t in ("impl-agent", "reviewer"):
+    ok, d = blocks(NAV, "cat AlRunner/BcRuntime.cs", "context-pack.py",
+                   cwd=MAIN_CHECKOUT, agent_type=_t)
+    check("agent_type=" + _t + " blocks even from the project root", ok, d)
+
+r = fire(NAV, "cat AlRunner/BcRuntime.cs", cwd=MAIN_CHECKOUT, agent_type="impl-agent",
+         env_extra={"AL_RUNNER_HOOK_CONTEXT": "coordinator"})
+check("a coordinator env var inherited by a dispatched agent does NOT disarm the block",
+      r.returncode == 2, f"exit={r.returncode}")
+
+r = fire(NAV, "cat AlRunner/Program.cs", cwd=MAIN_CHECKOUT, agent_type="orchestrator")
+check("agent_type=orchestrator stays advisory", r.returncode == 0, f"exit={r.returncode}")
 
 ok, d = blocks(NAV, "cat AlRunner/BcRuntime.cs", "context-pack.py",
                env_extra={"AL_RUNNER_AGENT_ID": "fbk-9"})

--- a/tools/test_agent_workflow_hooks.py
+++ b/tools/test_agent_workflow_hooks.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Unit tests for the two BLOCKING PreToolUse hooks (#3707).
+
+Both hooks live in `.claude/hooks/`, and no CI job globs that directory --
+`pr-gate.yml`'s tools-tests job runs `tools/test_*.py` only. So the tests for
+them live here, and drive the real scripts as subprocesses with a JSON
+PreToolUse payload on stdin, which is the only interface the harness uses.
+
+What "blocking" means, and why the assertions are on exit code 2 specifically:
+a PreToolUse hook that exits 2 has its stderr fed back to the model and the tool
+call is refused; exit 1 is a non-blocking error the model never sees. Asserting
+"non-zero" would pass on a hook that does not actually block.
+
+Run: python3 tools/test_agent_workflow_hooks.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+HOOKS = os.path.join(ROOT, ".claude", "hooks")
+REFUSE = os.path.join(HOOKS, "refuse-stash-and-ci-waits.py")
+NAV = os.path.join(HOOKS, "prefer-code-navigation.py")
+
+# Synthetic, never this checkout: the suite itself runs from an agent worktree
+# during development and from the main checkout in CI, so deriving either cwd
+# from __file__ would make the coordinator cases pass or fail by location.
+MAIN_CHECKOUT = "/home/runner/work/BusinessCentral.AL.Runner/BusinessCentral.AL.Runner"
+WORKTREE = MAIN_CHECKOUT + "/.claude/worktrees/fbk-9-issue-1234"
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        FAILURES.append(name)
+
+
+def fire(hook: str, command: str, *, background: bool = False, cwd: str = "",
+         tool: str = "Bash", env_extra: dict | None = None) -> subprocess.CompletedProcess:
+    tool_input: dict = {"command": command}
+    if background:
+        tool_input["run_in_background"] = True
+    payload = {"tool_name": tool, "tool_input": tool_input}
+    if cwd:
+        payload["cwd"] = cwd
+    env = dict(os.environ)
+    # The invoking session's own identity must never leak into a case asserting
+    # what happens WITHOUT one.
+    for k in ("AL_RUNNER_AGENT_ID", "CLAUDE_AGENT_ID", "AL_RUNNER_HOOK_CONTEXT"):
+        env.pop(k, None)
+    env.update(env_extra or {})
+    return subprocess.run([sys.executable, hook], input=json.dumps(payload),
+                          capture_output=True, text=True, env=env)
+
+
+def blocks(hook: str, command: str, must_say: str, **kw):
+    r = fire(hook, command, **kw)
+    ok = r.returncode == 2 and must_say in r.stderr
+    return ok, f"exit={r.returncode} stderr={r.stderr.strip()[:160]!r}"
+
+
+def allows(hook: str, command: str, **kw):
+    r = fire(hook, command, **kw)
+    return r.returncode == 0, f"exit={r.returncode} stderr={r.stderr.strip()[:160]!r}"
+
+
+print("git stash -- blocked in every form, in every context")
+STASH_BLOCKED = [
+    ("bare git stash", "git stash"),
+    ("git stash push with a pathspec", "git stash push -- AlRunner/Program.cs"),
+    ("git stash pop", "git stash pop"),
+    ("git stash apply", "git stash apply stash@{0}"),
+    ("git stash drop", "git stash drop"),
+    ("git stash list (a stack shared with every other loop)", "git stash list"),
+    ("git -C <worktree> stash", "git -C .claude/worktrees/fbk-1-issue-1 stash"),
+    ("stash after &&", "git add -A && git stash"),
+    ("stash in a later segment", "echo hi; git stash save wip"),
+]
+for name, cmd in STASH_BLOCKED:
+    ok, d = blocks(REFUSE, cmd, "refs/stash")
+    check(name, ok, d)
+
+r = fire(REFUSE, "git stash")
+check("the stash refusal names the patch alternative", "git diff HEAD >" in r.stderr,
+      r.stderr[:200])
+check("the stash refusal cites the rule",
+      "no-git-stash-with-worktrees" in r.stderr, r.stderr[:200])
+
+print("\ngit stash -- shapes that must NOT be blocked")
+STASH_ALLOWED = [
+    ("grepping the docs for the phrase", "command grep -rn 'git stash' .claude/rules"),
+    ("rg for the phrase", "rg --hidden 'git stash' ."),
+    ("echoing a sentence about it", "echo 'never run git stash here'"),
+    ("an ordinary git command", "git status --short"),
+    ("a branch whose name contains stash", "git checkout -b agent/fbk-1/stash-docs"),
+]
+for name, cmd in STASH_ALLOWED:
+    ok, d = allows(REFUSE, cmd)
+    check(name, ok, d)
+
+print("\nbackgrounded CI waits -- blocked")
+CI_WAIT_BLOCKED = [
+    ("gh run watch", "gh run watch 12345"),
+    ("gh pr checks --watch", "gh pr checks 3707 --watch"),
+    ("ci-wait.py with a positive timeout", "tools/ci-wait.py 3707 --timeout 900"),
+    ("ci-wait.py with no timeout at all", "python3 tools/ci-wait.py 3707"),
+    ("a sleep loop polling gh run view",
+     "while true; do gh run view 123 --json status; sleep 30; done"),
+    ("a sleep loop polling gh pr checks",
+     "for i in 1 2 3; do gh pr checks 3707; sleep 60; done"),
+]
+for name, cmd in CI_WAIT_BLOCKED:
+    ok, d = blocks(REFUSE, cmd, "--timeout 0", background=True)
+    check(name, ok, d)
+
+r = fire(REFUSE, "gh run watch 1", background=True)
+check("the CI-wait refusal explains that a backgrounded child dies with the turn",
+      "dies with the turn" in r.stderr, r.stderr[:200])
+check("the CI-wait refusal cites the rule",
+      "no-backgrounding-long-commands" in r.stderr, r.stderr[:200])
+
+print("\nbackgrounded work that is NOT a CI wait -- allowed (detached runner runs)")
+BACKGROUND_ALLOWED = [
+    ("a detached runner run", "al-runner run --bundle app.json --out results.trx"),
+    ("a detached dotnet run", "dotnet run --project AlRunner -c Release -- run --bundle x.json"),
+    ("a detached test sweep", "dotnet test AlRunner.Tests --filter FullyQualifiedName~Foo"),
+    ("gh run view as a single read", "gh run view 123 --json conclusion"),
+    ("ci-wait.py --timeout 0 is one pass, not a wait", "tools/ci-wait.py 3707 --timeout 0"),
+]
+for name, cmd in BACKGROUND_ALLOWED:
+    ok, d = allows(REFUSE, cmd, background=True)
+    check(name, ok, d)
+
+print("\nthe same CI-wait shapes in the FOREGROUND -- allowed (only backgrounding is refused)")
+for name, cmd in [
+    ("foreground gh run watch", "gh run watch 12345"),
+    ("foreground ci-wait with a timeout", "tools/ci-wait.py 3707 --timeout 600"),
+]:
+    ok, d = allows(REFUSE, cmd)
+    check(name, ok, d)
+
+print("\nnon-Bash tools are never the business of either hook")
+for hook in (REFUSE, NAV):
+    r = fire(hook, "git stash", tool="Read")
+    check(f"{os.path.basename(hook)} ignores a non-Bash tool", r.returncode == 0,
+          f"exit={r.returncode}")
+
+print("\ncode navigation -- BLOCKS in an agent context")
+NAV_BLOCKED = [
+    ("grep over the C# tree", "command grep -rn 'GetDataAccessForTableCore' AlRunner"),
+    ("rg over the C# tree", "rg -n 'IsProcessingOnly' --glob '*.cs' AlRunner"),
+    ("sed a range out of a C# file", "sed -n '600,680p' AlRunner/Patches/NavReportSync.cs"),
+    ("cat a C# file", "cat AlRunner/Patches/RecordPatches.cs"),
+    ("head a C# file", "head -60 AlRunner/BcRuntime.cs"),
+]
+for name, cmd in NAV_BLOCKED:
+    ok, d = blocks(NAV, cmd, "context-pack.py", cwd=WORKTREE)
+    check(name, ok, d)
+
+ok, d = blocks(NAV, "cat AlRunner/BcRuntime.cs", "context-pack.py",
+               env_extra={"AL_RUNNER_AGENT_ID": "fbk-9"})
+check("AL_RUNNER_AGENT_ID alone puts the hook in blocking mode", ok, d)
+
+ok, d = blocks(NAV, "cat " + WORKTREE + "/AlRunner/BcRuntime.cs", "context-pack.py")
+check("a worktree path in the command puts the hook in blocking mode", ok, d)
+
+ok, d = blocks(NAV, "cat AlRunner/BcRuntime.cs", "context-pack.py",
+               cwd=WORKTREE.replace("/", "\\"))
+check("a Windows-separator cwd is recognised too", ok, d)
+
+print("\ncode navigation -- ADVISORY outside an agent context, never blocking there")
+for name, cmd in [
+    ("the coordinator greps the C# tree", "command grep -rn 'Foo' AlRunner"),
+    ("the coordinator reads a C# file", "cat AlRunner/Program.cs"),
+]:
+    r = fire(NAV, cmd, cwd=MAIN_CHECKOUT)
+    check(name, r.returncode == 0 and "context-pack.py" in r.stderr,
+          f"exit={r.returncode} fired={'context-pack.py' in r.stderr}")
+
+r = fire(NAV, "cat AlRunner/Program.cs", cwd=WORKTREE,
+         env_extra={"AL_RUNNER_HOOK_CONTEXT": "coordinator"})
+check("AL_RUNNER_HOOK_CONTEXT=coordinator downgrades the block to a reminder",
+      r.returncode == 0 and "context-pack.py" in r.stderr,
+      f"exit={r.returncode} stderr={r.stderr[:120]!r}")
+
+print("\ncode navigation -- the escape hatch, and what stays allowed in an agent context")
+r = fire(NAV, "command grep -rn 'Foo' AlRunner   # hook:allow-grep", cwd=WORKTREE)
+check("an explicit # hook:allow-grep marker downgrades the block",
+      r.returncode == 0, f"exit={r.returncode}")
+
+NAV_ALLOWED = [
+    ("grepping a log", "command grep -n 'error' /tmp/run.log"),
+    ("grepping a TRX", "command grep -c 'outcome' results.trx"),
+    ("reading a results JSON", "cat scratchpad/results.json"),
+    ("searching markdown", "rg --hidden 'clean status' .claude"),
+    ("searching AL sources", "command grep -n 'SaveAsXml' tests/al-language/foo.al"),
+    ("build output trimmed with tail", "dotnet build AlRunner -c Release | tail -5"),
+    ("writing a C# file with a heredoc", "cat > AlRunner/New.cs <<EOF\nclass X {}\nEOF"),
+    ("git log over the C# tree", "git log --oneline -5 -- AlRunner"),
+]
+for name, cmd in NAV_ALLOWED:
+    ok, d = allows(NAV, cmd, cwd=WORKTREE)
+    check(name, ok, d)
+
+print("\nboth hooks are actually registered -- a hook nothing invokes blocks nothing")
+settings = json.load(open(os.path.join(ROOT, ".claude", "settings.json"), encoding="utf-8"))
+registered = [h.get("command", "")
+              for entry in settings.get("hooks", {}).get("PreToolUse", [])
+              if entry.get("matcher") == "Bash"
+              for h in entry.get("hooks", [])]
+for script in ("refuse-stash-and-ci-waits.py", "prefer-code-navigation.py"):
+    check("settings.json registers " + script,
+          any(script in c for c in registered), str(registered))
+
+print()
+if FAILURES:
+    print(f"{len(FAILURES)} failing check(s)")
+    sys.exit(1)
+print("all checks passed")

--- a/tools/test_prefer_code_navigation.py
+++ b/tools/test_prefer_code_navigation.py
@@ -10,11 +10,12 @@ Exits 0 when every case passes, 1 on the first failure.
 """
 
 import json
+import os
 import pathlib
 import subprocess
 import sys
 
-HOOK = pathlib.Path(__file__).resolve().parent / "prefer-code-navigation.py"
+HOOK = pathlib.Path(__file__).resolve().parent.parent / ".claude" / "hooks" / "prefer-code-navigation.py"
 
 CASES = []
 
@@ -56,8 +57,15 @@ def run():
     failures = 0
     for name, command, should_fire, tool in CASES:
         payload = json.dumps({"tool_name": tool, "tool_input": {"command": command}})
+        # Strip any agent identity the invoking session carries: these cases
+        # assert the ADVISORY behaviour, which a set AL_RUNNER_AGENT_ID turns
+        # into a block (#3707).
+        env = dict(os.environ)
+        for k in ("AL_RUNNER_AGENT_ID", "CLAUDE_AGENT_ID", "AL_RUNNER_HOOK_CONTEXT"):
+            env.pop(k, None)
         r = subprocess.run(
-            [sys.executable, str(HOOK)], input=payload, capture_output=True, text=True
+            [sys.executable, str(HOOK)], input=payload, capture_output=True, text=True,
+            env=env
         )
         fired = "Code-navigation reminder" in r.stderr
         ok = (fired == should_fire) and r.returncode == 0

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -1977,6 +1977,95 @@ finally:
     shutil.rmtree(_pin_tmp, ignore_errors=True)
 
 
+# -------------------------------------------------- a branch that already heads
+# someone else's pull request (#3707)
+#
+# Two loops can hold one identity, and a worktree path built from the identity
+# alone renders the same directory for both, so one loop's commits land on the
+# other's PR branch. The `agent:` label on the OPEN pull request heading this
+# branch is the one signal that names a loop; the assignee cannot, because every
+# loop pushes under the same account (check-open-prs-before-claiming.md).
+
+def _pr(number, labels, state="OPEN"):
+    return {"number": number, "state": state,
+            "labels": [{"name": n} for n in labels]}
+
+
+_WT = "/repo/BusinessCentral.AL.Runner/.claude/worktrees/fbk-3-issue-3707"
+_MAIN = "/repo/BusinessCentral.AL.Runner"
+
+_foreign = pf.judge_branch_ownership(cwd=_WT, branch="agent/fbk-3/issue-3707",
+                                     pr=_pr(3742, ["agent: fbk-7"]), agent_id="fbk-3")
+check("a branch heading another loop's open PR is a FAIL",
+      _foreign.status == "FAIL", _foreign.summary)
+check("...and the refusal names the pull request and the label that owns it",
+      "3742" in _foreign.summary and "fbk-7" in _foreign.summary, _foreign.summary)
+
+_own = pf.judge_branch_ownership(cwd=_WT, branch="agent/fbk-3/issue-3707",
+                                 pr=_pr(3742, ["agent: fbk-3"]), agent_id="fbk-3")
+check("your own open PR is a PASS", _own.status == "PASS", _own.summary)
+
+_none = pf.judge_branch_ownership(cwd=_WT, branch="agent/fbk-3/issue-3707",
+                                  pr=None, agent_id="fbk-3")
+check("no open PR on the branch is a PASS", _none.status == "PASS", _none.summary)
+
+_closed = pf.judge_branch_ownership(cwd=_WT, branch="agent/fbk-9/issue-1",
+                                    pr=_pr(1, ["agent: fbk-7"], state="MERGED"),
+                                    agent_id="fbk-3")
+check("a MERGED PR by another loop does not refuse", _closed.status == "PASS",
+      _closed.summary)
+
+_outside = pf.judge_branch_ownership(cwd=_MAIN, branch="main",
+                                     pr=_pr(3742, ["agent: fbk-7"]), agent_id="fbk-3")
+check("the main checkout is never refused, whatever PR exists",
+      _outside.status == "PASS", _outside.summary)
+
+# The third state: distinct from PASS, and it says which of the three it is
+# (guards-need-a-third-state.md). Neither of these may resolve toward success.
+_noid = pf.judge_branch_ownership(cwd=_WT, branch="agent/fbk-3/issue-3707",
+                                  pr=_pr(3742, ["agent: fbk-7"]), agent_id=None)
+check("no identity to compare against is undetermined, not a PASS",
+      _noid.status == "WARN", _noid.summary)
+check("...and it names the flag that would settle it",
+      "--agent-id" in (_noid.remedy + _noid.summary), _noid.remedy)
+
+_nolabel = pf.judge_branch_ownership(cwd=_WT, branch="agent/fbk-3/issue-3707",
+                                     pr=_pr(3742, []), agent_id="fbk-3")
+check("an open PR carrying no agent: label is undetermined, not a PASS",
+      _nolabel.status == "WARN", _nolabel.summary)
+
+_detached = pf.judge_branch_ownership(cwd=_WT, branch=None, pr=None, agent_id="fbk-3")
+check("a detached HEAD in a worktree is undetermined, not a PASS",
+      _detached.status == "WARN", _detached.summary)
+
+# End to end against a real repository: the branch has to be READ, and reading it
+# from the wrong directory is exactly the mistake this check exists to catch.
+_own_tmp = tempfile.mkdtemp(prefix="preflight-ownership-")
+try:
+    subprocess.run(["git", "init", "-q", "-b", "main", _own_tmp], check=True,
+                   capture_output=True)
+    _g(_own_tmp, "config", "user.email", "t@example.invalid")
+    _g(_own_tmp, "config", "user.name", "T")
+    open(os.path.join(_own_tmp, "F"), "w").write("x")
+    _g(_own_tmp, "add", "F")
+    _g(_own_tmp, "commit", "-qm", "init")
+    _wt_path = os.path.join(_own_tmp, ".claude", "worktrees", "fbk-9-issue-77")
+    _g(_own_tmp, "worktree", "add", "-q", "-b", "agent/fbk-9/issue-77", _wt_path)
+
+    _prs = {"agent/fbk-9/issue-77": _pr(4242, ["agent: fbk-1"])}
+    _res = pf.check_branch_ownership(_own_tmp, _prs, agent_id="fbk-9", cwd=_wt_path)
+    check("the real worktree's branch is read and refused for the right PR",
+          _res.status == "FAIL" and "4242" in _res.summary, _res.summary)
+    _res_ok = pf.check_branch_ownership(_own_tmp, _prs, agent_id="fbk-1", cwd=_wt_path)
+    check("...and the loop that owns that PR may stand in it",
+          _res_ok.status == "PASS", _res_ok.summary)
+    _res_main = pf.check_branch_ownership(_own_tmp, _prs, agent_id="fbk-9", cwd=_own_tmp)
+    check("...while the main checkout of the same repository is a PASS",
+          _res_main.status == "PASS", _res_main.summary)
+finally:
+    shutil.rmtree(_own_tmp, ignore_errors=True)
+
+
 print()
 if FAILURES:
     print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -2034,6 +2034,16 @@ _nolabel = pf.judge_branch_ownership(cwd=_WT, branch="agent/fbk-3/issue-3707",
 check("an open PR carrying no agent: label is undetermined, not a PASS",
       _nolabel.status == "WARN", _nolabel.summary)
 
+# The lookup itself failing must not read as "the branch is free" -- an
+# unauthenticated gh, or a repository whose open PRs could not be listed, is the
+# third state and not a PASS.
+_blind = pf.judge_branch_ownership(cwd=_WT, branch="agent/fbk-3/issue-3707", pr=None,
+                                   agent_id="fbk-3", lookup_status="gh is not installed")
+check("an unreadable pull-request list is undetermined, not a PASS",
+      _blind.status == "WARN", _blind.summary)
+check("...and it says the list could not be read", "could not be read" in _blind.summary,
+      _blind.summary)
+
 _detached = pf.judge_branch_ownership(cwd=_WT, branch=None, pr=None, agent_id="fbk-3")
 check("a detached HEAD in a worktree is undetermined, not a PASS",
       _detached.status == "WARN", _detached.summary)
@@ -2052,16 +2062,31 @@ try:
     _wt_path = os.path.join(_own_tmp, ".claude", "worktrees", "fbk-9-issue-77")
     _g(_own_tmp, "worktree", "add", "-q", "-b", "agent/fbk-9/issue-77", _wt_path)
 
-    _prs = {"agent/fbk-9/issue-77": _pr(4242, ["agent: fbk-1"])}
-    _res = pf.check_branch_ownership(_own_tmp, _prs, agent_id="fbk-9", cwd=_wt_path)
+    _asked = []
+
+    def _lookup(branch):
+        _asked.append(branch)
+        return (_pr(4242, ["agent: fbk-1"]), "ok")
+
+    _res = pf.check_branch_ownership(_own_tmp, agent_id="fbk-9", cwd=_wt_path,
+                                     lookup=_lookup)
     check("the real worktree's branch is read and refused for the right PR",
           _res.status == "FAIL" and "4242" in _res.summary, _res.summary)
-    _res_ok = pf.check_branch_ownership(_own_tmp, _prs, agent_id="fbk-1", cwd=_wt_path)
+    check("...and the pull request was asked for BY BRANCH, not looked up in a window",
+          _asked == ["agent/fbk-9/issue-77"], str(_asked))
+    _res_ok = pf.check_branch_ownership(_own_tmp, agent_id="fbk-1", cwd=_wt_path,
+                                        lookup=_lookup)
     check("...and the loop that owns that PR may stand in it",
           _res_ok.status == "PASS", _res_ok.summary)
-    _res_main = pf.check_branch_ownership(_own_tmp, _prs, agent_id="fbk-9", cwd=_own_tmp)
+    _res_main = pf.check_branch_ownership(_own_tmp, agent_id="fbk-9", cwd=_own_tmp,
+                                          lookup=_lookup)
     check("...while the main checkout of the same repository is a PASS",
           _res_main.status == "PASS", _res_main.summary)
+    _res_blind = pf.check_branch_ownership(
+        _own_tmp, agent_id="fbk-9", cwd=_wt_path,
+        lookup=lambda b: (None, "gh pr list failed: network unreachable"))
+    check("...and a failed lookup from the worktree is a WARN, never a PASS",
+          _res_blind.status == "WARN", _res_blind.summary)
 finally:
     shutil.rmtree(_own_tmp, ignore_errors=True)
 

--- a/tools/test_shared_scratchpad_guard.py
+++ b/tools/test_shared_scratchpad_guard.py
@@ -14,7 +14,7 @@ import pathlib
 import subprocess
 import sys
 
-HOOK = pathlib.Path(__file__).resolve().parent / "shared-scratchpad-guard.py"
+HOOK = pathlib.Path(__file__).resolve().parent.parent / ".claude" / "hooks" / "shared-scratchpad-guard.py"
 SP = "/tmp/claude-1000/-home-stefan-Documents-Repos-Comunity-BusinessCentral-AL-Runner/2a9b731a/scratchpad"
 
 CASES = []

--- a/tools/test_shared_scratchpad_guard.py
+++ b/tools/test_shared_scratchpad_guard.py
@@ -7,7 +7,7 @@ scratchpads -- the ones that caused #2980 must fire, and the ordinary reads that
 happen on every task must not, because a hook that cries on everything gets
 ignored and then it is not a mechanism at all.
 
-Usage: python3 .claude/hooks/test_shared_scratchpad_guard.py
+Usage: python3 tools/test_shared_scratchpad_guard.py
 """
 import json
 import pathlib


### PR DESCRIPTION
Closes #3707

Part of #3673 (retrospective stage S2). Written by an automated agent, impl agent `fbk-3`.

Corpus-NA: agent-workflow hooks and a preflight check; no runner behaviour changes, and no AL is observable from any of it

Four guards that were prose-only rules, turned into things that refuse.

## What changed

**1. `.claude/hooks/refuse-stash-and-ci-waits.py` (new, blocking).**

- **`git stash` in any form, in every session.** Not scoped to an agent context, because
  `no-git-stash-with-worktrees.md` forbids it "not in a worktree, not in the top-level
  checkout". **`git stash list` is refused too** — the rule names it as misleading rather than
  merely useless (it interleaves every loop's entries and `stash@{0}` shifts under you), so
  there is no read-only form worth carving out. The refusal prints the patch/commit
  alternatives and the RED-baseline recipe.
- **`run_in_background` on a CI wait**: `gh run watch`, `gh pr checks --watch`, `ci-wait.py`
  without `--timeout 0`, and a `sleep` loop polling `gh run view` / `gh pr checks` /
  `gh api .../actions/runs`. The pairing is what is refused: the same shapes run in the
  **foreground** are allowed, and a backgrounded command that is not a CI wait — a detached
  runner, build or `dotnet test` — is allowed, which is how the coordinator's detached runs
  stay possible without a context test.
- False positives were the design risk, so nothing is matched inside a command: the line is
  split into segments and only what a segment *starts with* counts. `command grep -rn 'git
  stash' .claude/rules` and `echo 'never run git stash here'` are allowed, and there are tests
  for both.

**2. `.claude/hooks/prefer-code-navigation.py` upgraded, not replaced.** It now **blocks**
(exit 2) a shell read or search over `AlRunner/**/*.cs` in an impl or reviewer context and
stays the same advisory reminder everywhere else. Scoping — this is the one item that needs a
context, because grep over the C# tree is legitimately right in the coordinator session.

**The signal is the payload's own `agent_type`, measured rather than guessed** (see "How the
context signal was measured" below): a dispatched subagent's PreToolUse payload carries
`agent_type: "impl-agent"` **and a `cwd` of the project root**, not of the agent's worktree,
so the cwd heuristic this issue suggested would never have fired for the agents the hook is
for.

| signal, in this order | effect |
|---|---|
| payload `agent_type` is `impl-agent` or `reviewer` | **blocks** |
| `AL_RUNNER_HOOK_CONTEXT=coordinator` | advisory |
| `AL_RUNNER_AGENT_ID` / `CLAUDE_AGENT_ID` set | blocks |
| payload `cwd`, or the command, names `.claude/worktrees/` (either separator) | blocks |
| anything else — the coordinator, `agent_type: orchestrator` | advisory, exit 0 |

`agent_type` deliberately outranks the coordinator env var: the environment is inherited by
every subagent a session dispatches, so letting it win would disarm the hook for exactly the
agents it guards. There is a test for that. Both env vars are read from the **hook process's**
environment — the one that launched `claude` — so `export
AL_RUNNER_HOOK_CONTEXT=coordinator && grep ...` inside a Bash command changes nothing.

`# hook:allow-grep` in the command downgrades one call. That escape is deliberate: the
neighbouring `shared-scratchpad-guard.py` argues in its own docstring that a blocker with no
escape gets switched off wholesale, taking the warning with it. Everything the hook already
excluded stays excluded — logs, JSON, TRX, markdown, `.al`, writes to `.cs`, `git log`.

**3. `tools/preflight.py` — a new `branch-ownership` check.** `judge_branch_ownership()` is
pure and unit-tested like `disposition()`; `check_branch_ownership()` reads the branch and
asks for the open PR **by name**, `gh pr list --state open --head <branch>`. It deliberately
does not consult `pr_map()`: that is `--state all --limit 300` over a repository with
thousands of PRs — a live call returned 298 branches, so the window is effectively full — and
an open PR older than the newest 300 would be absent from it, which reads as "nobody owns this
branch". That is the false PASS this check exists to prevent. `--head` reads the PR list rather
than the search index, so a PR opened seconds earlier is found (#3717). The `agent:` label on
the open PR is the only signal that names a loop, because every loop pushes under one account
(`check-open-prs-before-claiming.md`). Four states, per `guards-need-a-third-state.md`:

| situation | verdict |
|---|---|
| cwd not under `.claude/worktrees/` | PASS — nothing to compare |
| no open PR heads this branch, or it is MERGED/CLOSED | PASS |
| open PR whose `agent:` label is yours | PASS |
| **open PR labelled for another loop** | **FAIL** — names the PR, the owning label, and what to do |
| no `--agent-id` / `$AL_RUNNER_AGENT_ID` | **WARN**, naming the flag — never PASS |
| open PR with no `agent:` label, or detached HEAD | **WARN** — never PASS |
| **the PR list could not be read** (no `gh`, call failed, unparseable) | **WARN**, naming `gh auth status` — never PASS |

FAIL maps to `overall_exit` 1, which is preflight refusing to start. **Follow-up wiring, not
done here:** nothing invokes `preflight.py` with `--agent-id` yet, so from a worktree the
result today is the WARN row; the callers to teach are `autonomous-cycle` and
`orchestrating-a-session`, and until one of them passes it the FAIL path is reachable only by
hand or through `$AL_RUNNER_AGENT_ID`. Filed as **#3746** rather than left in this body.

**4. `.claude/hooks/test_*.py` moved to `tools/`.** `pr-gate.yml`'s `tools-tests` job globs
`tools/test_*.py` only. **Correction to an earlier version of this body, which said the two hook
suites gated nothing:** they did gate, indirectly — #3420 added
`test_the_hook_suite_runs_here_because_no_CI_job_globs_it` to `tools/test_agent_scratchpad.py`,
which ran every `.claude/hooks/test_*.py` as a subprocess precisely because the glob does not
reach that directory. What this PR changes is that the suites are `git mv`d into `tools/`, so
they are **discovered directly** rather than through one delegator a future edit could drop. The
delegator is therefore removed — it now finds an empty directory, and re-running the moved suites
from there would run them twice. It is replaced by
`test_no_test_suite_lives_where_nothing_globs_it`, which asserts `.claude/hooks/` stays empty of
`test_*.py` and that both moved files exist under `tools/`: the invariant that survives the move.
New tests for this PR are in `tools/test_agent_workflow_hooks.py` for the same discovery reason.

## RED → GREEN

- `tools/test_agent_workflow_hooks.py`: **RED** 40 failing checks (hook A absent; hook B
  advisory in every context). **GREEN** all 59. Blocked shapes assert `exit == 2`
  specifically — the code that blocks a PreToolUse call and feeds stderr back — plus a phrase
  from the refusal (`refs/stash`, `--timeout 0`), so a hook that crashed with exit 2 would not
  count as a block. That mattered: in the RED run the missing script exited 2 from Python's
  own `can't open file`, and the message assertions are what kept those checks red.
- Allowed shapes assert `exit == 0`, including the coordinator cases, the foreground CI waits,
  the detached runner runs, and the eight non-C# search shapes.
- One check asserts `.claude/settings.json` registers both hooks. A hook nothing invokes blocks
  nothing, and that is invisible from the script alone.
- `tools/test_preflight.py` +17 checks, including a **real throwaway repository** with a real
  `git worktree` on `agent/fbk-9/issue-77`, so the branch is read rather than passed in, and an
  injected lookup that records what it was asked for — proving the PR is fetched **by branch**
  rather than found in a window. RED: `judge_branch_ownership` / `check_branch_ownership`
  absent. GREEN: 17/17. Four of those checks exist only to hold the third state open: an
  unreadable PR list, a missing identity, an unlabelled PR and a detached HEAD each WARN, and
  none of them PASSes.
- End-to-end against the live repository, which is the strongest proof here: standing in this
  PR's own worktree, against real `gh`, `--agent-id fbk-7` returns
  `FAIL: agent/fbk-3/issue-3707 already heads OPEN PR #3742, owned by agent: fbk-3`,
  `--agent-id fbk-3` returns PASS, and no identity returns WARN. Re-run unchanged after the
  lookup was switched from the windowed map to the `--head` query.

**How the context signal was measured, including the false zero on the way.**

- A payload probe was added temporarily to the **main checkout's** registered hook, run once,
  and reverted (`git status --short .claude/hooks/` empty afterwards, checked both times). The
  **first** probe reported no dump, and I nearly wrote "hooks do not fire for subagents" into
  this body. That was a false zero of exactly the kind `CLAUDE.md` warns about: the probe wrote
  to a `/c/Users/...` MSYS path that native Windows Python cannot open, inside a swallowing
  `except Exception: pass`. Re-run with a `C:/...` path and no `except`, it produced a dump
  immediately.
- What the dump says, on harness `2.1.266`: the payload carries `session_id`,
  `transcript_path`, `cwd`, `permission_mode`, `tool_name`, `tool_input`, `tool_use_id`,
  **`agent_id`** and **`agent_type`** — `agent_type` was `impl-agent` for this session — and
  `cwd` was the **project root**, not this agent's worktree. So hooks do fire for dispatched
  subagents, `agent_type` is the right discriminator, and a cwd-only test would have shipped a
  hook that never blocked anything. Re-check the field set on a harness upgrade; the secondary
  signals are kept so a harness that stops sending `agent_type` degrades to the old heuristic
  rather than to nothing.
- `tools/test_preflight.py` **cannot run on Windows**, and that is pre-existing: `origin/main`'s
  unmodified copy raises `AttributeError` at line 125 (`mount_for_path("/tmp/x/y", ...)`
  returning `None`) on this box. The 13 new checks were therefore run locally through a
  throwaway driver that loads the same module and executes the same block; the committed suite
  runs in CI on Linux. Not fixed here — it is a separate defect in a file three other open
  issues also want to change.

## Fix the shape, not just the reported line

1. **The same wrong pattern at another call site?** Yes, and it is item 4 above: hook tests
   living in a directory CI does not glob. Both existing suites moved.
2. **Does a sibling function make the same assumption?** `shared-scratchpad-guard.py` is the
   other advisory hook and is deliberately **left advisory**: reading another agent's
   scratchpad on purpose is legitimate work (diagnosing a collision), so its blocking form
   already exists as an opt-in refusal in `tools/agent_scratchpad.py check`. Blocking it would
   be the failure mode this PR's escape hatch exists to avoid.
3. **Two code paths writing the same state, same invariant?** Yes, and this is where the
   design changed after review. `check_worktrees` reads PR state from `pr_map()` and asks
   `state != "MERGED"`; the new check asks `state == "OPEN"`, which is not its complement — a
   CLOSED-unmerged PR is neither reapable nor an owner — so the two are spelled explicitly
   rather than one derived from the other. The invariant they do **not** share is
   completeness: `pr_map()` is windowed, which `check_worktrees` tolerates (an unknown PR makes
   a worktree unreapable, the safe direction) and this check cannot (an unknown PR would make a
   branch look free, the unsafe direction). Hence the separate `--head` query rather than a
   second consumer of the same window.

## Queue scan — what shares the file and was not folded

`tools/preflight.py` has three other open issues, all deliberately left: **#3335** (`--reap`
reads submodule pointer drift as uncommitted work — `disposition()`), **#3264** (a `bc260`
decompiler expectation that can never clear — `classify_decompiler`), **#3361** (two corpus-check
assertions comparing a call against itself). None touches the code this PR adds, each needs its
own diagnosis and RED baseline, and folding three unrelated preflight bugs into a
retrospective-proposal PR is exactly the incoherent diff `batch-sibling-issues-by-file.md`
point 4 says to split. **#3275** is adjacent rather than same-file: it observes that a second
agent-running account now exists, which is the doc-level half of the assumption the new check
leans on — the check compares `agent:` labels, which the impl-agent contract already namespaces
per account, so it stays correct either way.

## Where the prose went

Both hooks carry a module docstring stating what they refuse and why, plus the scoping table
for the navigation hook; the derivation and the measurements stay here in the PR body and in
`docs/incidents/`, per `loud-failures.md` § "The justification is a claim plus a citation".
`CLAUDE.md` and the two rules each gained one line naming its hook — claim plus citation, no
incident narrative.

## Not touched

`.github/workflows/*` (the issue says none is needed, and the `tools/test_*.py` glob means the
new suite gates the day it lands). `CHANGELOG.md`. `tests/al-language/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kko97BZZL71nF2nK5aftu4
