### PR TITLE
fix(dep-metadata): dependencies get their table metadata from BC's emitter, not the hand-derivation

### DIFF
--- a/AlRunner.Tests/AppLoaderExtractAlWithPathsTests.cs
+++ b/AlRunner.Tests/AppLoaderExtractAlWithPathsTests.cs
@@ -1,0 +1,166 @@
+// AppLoaderExtractAlWithPathsTests — AppLoader.ExtractAlWithPaths returns a package's AL at its
+// package-relative PATH, which is what makes a shipped app's source writable to disk as a
+// compilation unit (issue #3549).
+//
+// Both differences from ExtractAl were measured, and both presented identically: AL0185
+// "'X' is missing" for objects the app itself declares, which reads as a missing dependency
+// rather than as source the compile never saw.
+//
+//   PATHS   System Application ships an `EmailOutbox.Page.al` AND an `EmailOutbox.Table.al`.
+//           ExtractAl returns `entry.Name` — the base name — so writing that list to one
+//           directory silently drops one of the pair.
+//   SCOPE   ExtractAl also filters to `src/`. Whatever a package keeps outside `src/` is
+//           therefore invisible to it, and an object referenced from there does not resolve.
+//
+// ExtractAl is deliberately unchanged: the Tier-3 source compile wants a flat list of object
+// bodies and has worked on one for a long time. This is an additional reader, not a replacement.
+using System.IO.Compression;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class AppLoaderExtractAlWithPathsTests
+{
+    private static byte[] Navx(byte[] zipBytes)
+    {
+        var result = new byte[8 + zipBytes.Length];
+        result[0] = (byte)'N'; result[1] = (byte)'A'; result[2] = (byte)'V'; result[3] = (byte)'X';
+        BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
+        zipBytes.CopyTo(result, 8);
+        return result;
+    }
+
+    private static byte[] ZipWith(params (string Name, string Content)[] entries)
+    {
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+            foreach (var (name, content) in entries)
+            {
+                var e = zip.CreateEntry(name);
+                using var s = e.Open();
+                s.Write(Encoding.UTF8.GetBytes(content));
+            }
+        return ms.ToArray();
+    }
+
+    private static string WritePackage(string suffix, params (string Name, string Content)[] entries)
+    {
+        var dir = TestScratch.FlatDir("extract-al-with-paths-" + suffix + "-");
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, "Test.app");
+        File.WriteAllBytes(path, Navx(ZipWith(entries)));
+        return path;
+    }
+
+    /// <summary>
+    /// The defect that motivated this reader: two objects whose file names differ only by the
+    /// object-kind segment. Asserted as two DISTINCT paths with their own contents, because the
+    /// symptom of getting it wrong is not an error — it is one file quietly overwriting the
+    /// other and the lost object reported as "missing".
+    /// </summary>
+    [Fact]
+    public void SameBaseNameInDifferentFiles_StaysTwoDistinctEntries()
+    {
+        var app = WritePackage("dup-base",
+            ("NavxManifest.xml", "<Package><App Id=\"" + Guid.NewGuid() + "\" Name=\"N\" Publisher=\"P\" Version=\"1.0.0.0\"/></Package>"),
+            ("src/Email/EmailOutbox.Page.al", "page 1 X {}"),
+            ("src/Email/EmailOutbox.Table.al", "table 1 X {}"));
+
+        var got = AlRunner.AppLoader.ExtractAlWithPaths(app);
+
+        Assert.Equal(2, got.Count);
+        Assert.Contains(got, e => e.Path == "src/Email/EmailOutbox.Page.al" && e.Source == "page 1 X {}");
+        Assert.Contains(got, e => e.Path == "src/Email/EmailOutbox.Table.al" && e.Source == "table 1 X {}");
+
+        // The contrast that makes the claim concrete. ExtractAl returns base names, so the two
+        // files share a stem — write them by stem, as a flattening extractor does, and one
+        // overwrites the other.
+        var flat = AlRunner.AppLoader.ExtractAl(app);
+        Assert.Equal(2, flat.Count);
+        var stems = flat
+            .Select(e => Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(e.Name)))
+            .Distinct()
+            .ToArray();
+        Assert.Equal(new[] { "EmailOutbox" }, stems);
+    }
+
+    /// <summary>
+    /// The <c>src/</c> filter is deliberate and matches <see cref="AlRunner.AppLoader.ExtractAl"/>.
+    ///
+    /// <para>It was widened to "every `.al` in the package" during development and that made
+    /// things worse, which is why this asserts the narrow behaviour rather than the broad one:
+    /// a package's other directories hold entitlements and permission sets referencing objects
+    /// from apps that are NOT being compiled, and including them turned System Application's
+    /// emit from 338 captured documents into AL1024 and zero.</para>
+    ///
+    /// <para>It also costs nothing on the apps this serves — measured on BC 28.1.49838,
+    /// Business Foundation keeps 96/96 and System Application 1,319/1,319 of their `.al` under
+    /// <c>src/</c>.</para>
+    /// </summary>
+    [Fact]
+    public void OnlySrc_IsReturned_MatchingExtractAl()
+    {
+        var app = WritePackage("outside-src",
+            ("NavxManifest.xml", "<Package><App Id=\"" + Guid.NewGuid() + "\" Name=\"N\" Publisher=\"P\" Version=\"1.0.0.0\"/></Package>"),
+            ("src/Thing.Table.al", "table 1 Thing {}"),
+            ("entitlements/Basic.Entitlement.al", "entitlement Basic {}"));
+
+        var got = AlRunner.AppLoader.ExtractAlWithPaths(app);
+        Assert.Single(got);
+        Assert.Equal("src/Thing.Table.al", got[0].Path);
+
+        // The same set as ExtractAl, differing only in how each entry is named.
+        var flat = AlRunner.AppLoader.ExtractAl(app);
+        Assert.Single(flat);
+        Assert.Equal("Thing.Table.al", flat[0].Name);
+    }
+
+    /// <summary>
+    /// The R2R shape Microsoft ships — outer archive, nested <c>.app</c> — resolves to the
+    /// nested package's source, mirroring <see cref="AlRunner.AppLoader.ExtractAl"/>. Business
+    /// Foundation and System Application are both this shape, so a reader that handled only the
+    /// flat one would find no source in either.
+    /// </summary>
+    [Fact]
+    public void ReadsThroughAnR2rNestedPackage()
+    {
+        var inner = Navx(ZipWith(
+            ("NavxManifest.xml", "<Package><App Id=\"" + Guid.NewGuid() + "\" Name=\"N\" Publisher=\"P\" Version=\"1.0.0.0\"/></Package>"),
+            ("src/Deep/Nested.Table.al", "table 7 Nested {}")));
+
+        var dir = TestScratch.FlatDir("extract-al-with-paths-nested-");
+        Directory.CreateDirectory(dir);
+        var app = Path.Combine(dir, "Outer.app");
+        using (var ms = new MemoryStream())
+        {
+            using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                var e = zip.CreateEntry("Inner.app");
+                using var s = e.Open();
+                s.Write(inner);
+            }
+            File.WriteAllBytes(app, Navx(ms.ToArray()));
+        }
+
+        var got = AlRunner.AppLoader.ExtractAlWithPaths(app);
+        Assert.Single(got);
+        Assert.Equal("src/Deep/Nested.Table.al", got[0].Path);
+        Assert.Equal("table 7 Nested {}", got[0].Source);
+    }
+
+    /// <summary>
+    /// A package with no AL answers with an empty list rather than throwing — that is the
+    /// "nothing to produce" half of the availability-vs-failure split #3549 turns on, and it
+    /// must be reachable without an exception for a symbol-only package to stay a quiet no-op.
+    /// </summary>
+    [Fact]
+    public void SymbolOnlyPackage_IsEmptyNotAThrow()
+    {
+        var app = WritePackage("symbol-only",
+            ("NavxManifest.xml", "<Package><App Id=\"" + Guid.NewGuid() + "\" Name=\"N\" Publisher=\"P\" Version=\"1.0.0.0\"/></Package>"),
+            ("SymbolReference.json", "{}"));
+
+        Assert.Empty(AlRunner.AppLoader.ExtractAlWithPaths(app));
+    }
+}

--- a/AlRunner.Tests/DependencyMetadataProducerTests.cs
+++ b/AlRunner.Tests/DependencyMetadataProducerTests.cs
@@ -1,0 +1,184 @@
+// DependencyMetadataProducerTests — the runner-side mechanism behind #3549.
+//
+// WHAT IS PINNED HERE, AND WHAT IS NOT
+//   The BC-behaviour half — that a dependency table's key count and SystemCreatedBy relation
+//   come out as BC's own answer — is not a claim this file can make: it needs BC's compiler and
+//   a loaded runtime. It was proven by running the runner against Business Foundation
+//   (docs/dependency-metadata-from-bc.md records the RED/GREEN and the exact values), and the
+//   route itself is already covered by TableMetadataFromBcDocumentTests.
+//
+//   What IS provable without a BC runtime, and is what a regression would break first, is the
+//   producer's decision logic: which apps it refuses to compile, what its cache key separates,
+//   and — the one that matters most — that the opt-in cannot be switched on by accident.
+//
+//   The availability-vs-failure split (`.claude/rules/loud-failures.md`) is the property this
+//   whole class exists to protect: a dependency with no source must be a quiet 0, and a
+//   dependency whose compile failed must throw. Those two answers must never be spelled the
+//   same way, which is what LoudFailure_And_NoSource_AreDifferentAnswers asserts structurally.
+
+using System;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class DependencyMetadataProducerTests
+{
+    private static AppManifest Manifest(string name, string version = "1.0.0.0") =>
+        new(Publisher: "Microsoft", Name: name, Version: Version.Parse(version),
+            AppId: Guid.Parse("f3552374-a1f2-4356-848e-196002525837"),
+            Dependencies: Array.Empty<DependencyRef>());
+
+    // ---- the opt-in ----------------------------------------------------------------
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("0")]
+    public void FeatureIsOffUnlessExplicitlyEnabled(string? value)
+    {
+        using var _ = new EnvVar("AL_RUNNER_DEP_METADATA_FROM_BC", value);
+        Assert.Null(DependencyLoader.DependencyMetadataAppFilter());
+        Assert.False(DependencyLoader.DependencyMetadataEnabled());
+    }
+
+    /// <summary>
+    /// "1" means every app; an empty filter is how "no filter" is spelled. Asserted as the
+    /// empty collection rather than as "enabled", because a non-null EMPTY filter and a null
+    /// filter are the two states a caller must not confuse — one compiles everything, the other
+    /// compiles nothing.
+    /// </summary>
+    [Fact]
+    public void One_EnablesEveryApp()
+    {
+        using var _ = new EnvVar("AL_RUNNER_DEP_METADATA_FROM_BC", "1");
+        var filter = DependencyLoader.DependencyMetadataAppFilter();
+        Assert.NotNull(filter);
+        Assert.Empty(filter!);
+        Assert.True(DependencyLoader.DependencyMetadataEnabled());
+    }
+
+    /// <summary>
+    /// A named list restricts the producer to those apps. This is not a convenience: BC's
+    /// Compilation.Emit is atomic per module, so one object it cannot emit zeroes the whole
+    /// app — System Application's `Business Chart.Initialize()` does exactly that under the
+    /// runner's .NET probing paths, while Business Foundation compiles clean. See #3745.
+    /// </summary>
+    [Theory]
+    [InlineData("Business Foundation", new[] { "Business Foundation" })]
+    [InlineData("Business Foundation,System Application", new[] { "Business Foundation", "System Application" })]
+    [InlineData(" Business Foundation , System Application ", new[] { "Business Foundation", "System Application" })]
+    public void NamedList_RestrictsToThoseApps(string value, string[] expected)
+    {
+        using var _ = new EnvVar("AL_RUNNER_DEP_METADATA_FROM_BC", value);
+        var filter = DependencyLoader.DependencyMetadataAppFilter();
+        Assert.NotNull(filter);
+        Assert.Equal(expected, filter!);
+    }
+
+    // ---- exclusions ----------------------------------------------------------------
+
+    /// <summary>
+    /// Base Application is excluded because its emit produces ZERO objects without a
+    /// PublicKeyToken=null copy of Microsoft.AspNetCore.StaticFiles that no BC artifact ships —
+    /// a hard blocker, not a cost decision. tests/expectations/metadata-equivalence/apps.json
+    /// records the same exclusion for the same reason.
+    /// </summary>
+    [Fact]
+    public void BaseApplication_IsNeverCompiled()
+    {
+        Assert.True(DependencyMetadataProducer.IsExcluded(Manifest("Base Application")));
+        Assert.True(DependencyMetadataProducer.IsExcluded(Manifest("base application")));
+        Assert.False(DependencyMetadataProducer.IsExcluded(Manifest("Business Foundation")));
+        Assert.False(DependencyMetadataProducer.IsExcluded(Manifest("System Application")));
+    }
+
+    /// <summary>
+    /// An excluded app returns 0 WITHOUT touching the package, so the exclusion cannot be
+    /// defeated by a package that would throw on read. A path that does not exist is the
+    /// cheapest way to prove nothing read it: any code that opened it would throw.
+    /// </summary>
+    [Fact]
+    public void ExcludedApp_ReturnsZeroWithoutReadingThePackage()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), $"no-such-package-{Guid.NewGuid():N}.app");
+        Assert.False(File.Exists(missing));
+        Assert.Equal(0, DependencyMetadataProducer.Ensure(Manifest("Base Application"), missing, compiler: null!));
+    }
+
+    // ---- the cache key -------------------------------------------------------------
+
+    /// <summary>
+    /// The key separates the three things that change the documents: which app, which version
+    /// of it, and which BC build emitted them. The BC version is the one an implementer is
+    /// tempted to leave out, and leaving it out serves one BC build's metadata to another.
+    /// </summary>
+    [Fact]
+    public void CacheKey_SeparatesAppAndVersion()
+    {
+        var a = DependencyMetadataProducer.CacheKey(Manifest("Business Foundation", "28.1.49838.54308"));
+        var b = DependencyMetadataProducer.CacheKey(Manifest("Business Foundation", "28.2.0.0"));
+        Assert.NotEqual(a, b);
+        Assert.Contains("28.1.49838.54308", a);
+        // The selected BC build is part of every key, so two runs against different artifacts
+        // never share an entry.
+        Assert.Contains(AlRunner.Infrastructure.BcArtifacts.SelectedVersion.ToString(), a);
+        Assert.Equal(a, DependencyMetadataProducer.CacheKey(Manifest("Business Foundation", "28.1.49838.54308")));
+    }
+
+    // ---- availability vs failure ---------------------------------------------------
+
+    /// <summary>
+    /// A package with no readable source answers "nothing to produce" (false) rather than
+    /// throwing, and it answers that from the PACKAGE — before any compile — which is what
+    /// keeps "unavailable" from ever being inferred from a failure. #3590 is why that ordering
+    /// is load-bearing: a construction failure that reached the consumer would be
+    /// indistinguishable from a document that was never produced.
+    /// </summary>
+    [Fact]
+    public void HasCompilableSource_IsFalseForAnUnreadablePackage_AndDoesNotThrow()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), $"no-such-package-{Guid.NewGuid():N}.app");
+        Assert.False(DependencyMetadataProducer.HasCompilableSource(missing));
+
+        var notAnApp = Path.Combine(Path.GetTempPath(), $"garbage-{Guid.NewGuid():N}.app");
+        File.WriteAllText(notAnApp, "this is not a NAVX package");
+        try { Assert.False(DependencyMetadataProducer.HasCompilableSource(notAnApp)); }
+        finally { File.Delete(notAnApp); }
+    }
+
+    /// <summary>
+    /// The two outcomes are structurally different — one returns, one throws — so no caller can
+    /// treat a failed compile as an absent document by reading a return value. Asserted on the
+    /// declared signature rather than by running a compile, so it holds without a BC runtime and
+    /// fails loudly if someone converts the throw into a sentinel return.
+    /// </summary>
+    [Fact]
+    public void LoudFailure_And_NoSource_AreDifferentAnswers()
+    {
+        var ensure = typeof(DependencyMetadataProducer)
+            .GetMethod("Ensure", BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Public);
+        Assert.NotNull(ensure);
+        // "How many documents are available" — never a status code with a failure value in it.
+        Assert.Equal(typeof(int), ensure!.ReturnType);
+
+        var loud = typeof(DependencyMetadataProducer)
+            .GetMethod("Loud", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(loud);
+        Assert.Equal(typeof(AlRunner.Infrastructure.DependencyLoadException), loud!.ReturnType);
+    }
+
+    private sealed class EnvVar : IDisposable
+    {
+        private readonly string _name;
+        private readonly string? _old;
+        public EnvVar(string name, string? value)
+        {
+            _name = name;
+            _old = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+        public void Dispose() => Environment.SetEnvironmentVariable(_name, _old);
+    }
+}

--- a/AlRunner.Tests/DependencyMetadataProducerTests.cs
+++ b/AlRunner.Tests/DependencyMetadataProducerTests.cs
@@ -142,10 +142,12 @@ public sealed class DependencyMetadataProducerTests
         var missing = Path.Combine(Path.GetTempPath(), $"no-such-package-{Guid.NewGuid():N}.app");
         Assert.False(DependencyMetadataProducer.HasCompilableSource(missing));
 
-        var notAnApp = Path.Combine(Path.GetTempPath(), $"garbage-{Guid.NewGuid():N}.app");
+        // An owned scratch file: this one IS created, so a killed test host would leak it
+        // (#2743). TestScratch.FilePath creates the owning directory, which is what the
+        // sweep deletes -- so no hand-rolled finally is needed to avoid leaking it.
+        var notAnApp = TestScratch.FilePath("dep-metadata-producer", "garbage.app");
         File.WriteAllText(notAnApp, "this is not a NAVX package");
-        try { Assert.False(DependencyMetadataProducer.HasCompilableSource(notAnApp)); }
-        finally { File.Delete(notAnApp); }
+        Assert.False(DependencyMetadataProducer.HasCompilableSource(notAnApp));
     }
 
     /// <summary>

--- a/AlRunner.Tests/ScratchDirOwnershipGuardTests.cs
+++ b/AlRunner.Tests/ScratchDirOwnershipGuardTests.cs
@@ -67,6 +67,11 @@ public sealed class ScratchDirOwnershipGuardTests
             (1, "a .app path that must not exist, so the loader's miss path is what runs"),
         ["AppLoaderR2rChunkCacheTests.cs"] =
             (1, "a .app path that must not exist"),
+        ["DependencyMetadataProducerTests.cs"] =
+            (2, "two .app paths that must not exist -- one proves an excluded app is never "
+              + "read, one drives HasCompilableSource's miss path; both assert on the absence "
+              + "itself, so creating them would destroy what they measure. This file's one "
+              + "real scratch file IS owned via TestScratch.FilePath"),
         ["RunnerFingerprintTests.cs"] =
             (1, "a .dll path that must not exist"),
         ["TestDataProvisioningTests.cs"] =

--- a/AlRunner/AppLoader.cs
+++ b/AlRunner/AppLoader.cs
@@ -540,6 +540,48 @@ public static class AppLoader
     }
 
     /// <summary>
+    /// The raw text of a package's <c>NavxManifest.xml</c>, including the R2R nested-package
+    /// case, or null when the package carries none.
+    ///
+    /// <para>Distinct from <see cref="ReadManifest"/>, which returns the identity fields the
+    /// runtime models. This exists for a caller that needs an attribute
+    /// <see cref="AppManifest"/> does not carry — <c>Target</c>, <c>Features</c>,
+    /// <c>PreprocessorSymbols</c> — which is what reconstructing a shipped app's COMPILER
+    /// configuration takes (#3549). Adding those to <see cref="AppManifest"/> instead would
+    /// widen a record every dependency load allocates, for a question only the metadata
+    /// producer asks.</para>
+    /// </summary>
+    public static string? ReadNavxManifestXml(string appPath)
+    {
+        using var zip = OpenAppZip(appPath);
+        return ReadNavxManifestXmlFromZip(zip);
+    }
+
+    private static string? ReadNavxManifestXmlFromZip(ZipArchive zip)
+    {
+        var entry = zip.Entries.FirstOrDefault(e =>
+            string.Equals(e.FullName, "NavxManifest.xml", StringComparison.OrdinalIgnoreCase));
+        if (entry != null)
+        {
+            using var s = entry.Open();
+            using var reader = new StreamReader(s);
+            return reader.ReadToEnd();
+        }
+
+        // R2R outer .app — the manifest lives in the nested package, same shape as
+        // ReadManifestFromZip's recursion below.
+        var nested = zip.Entries.FirstOrDefault(e =>
+            e.FullName.EndsWith(".app", StringComparison.OrdinalIgnoreCase) && !e.FullName.Contains('/'));
+        if (nested == null) return null;
+
+        using var ns = nested.Open();
+        using var nms = new MemoryStream();
+        ns.CopyTo(nms);
+        using var innerZip = OpenZipFromNavx(nms.ToArray());
+        return ReadNavxManifestXmlFromZip(innerZip);
+    }
+
+    /// <summary>
     /// Core manifest lookup shared by the streamed (<see cref="OpenAppZip"/>, outer .app)
     /// and byte[]-backed (<see cref="ReadManifestFromBytes"/>, nested .app) entry points —
     /// only the ZipArchive's backing stream differs between callers.
@@ -1257,6 +1299,57 @@ public static class AppLoader
             using var s = entry.Open();
             using var reader = new StreamReader(s, Encoding.UTF8);
             result.Add((entry.Name, reader.ReadToEnd()));
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// A package's `.al` under <c>src/</c>, each at its PACKAGE-RELATIVE PATH.
+    ///
+    /// <para>One deliberate difference from <see cref="ExtractAl"/>, which hands the Tier-3
+    /// source compile a flat list of object bodies and is unchanged (#3549): <b>the path, not
+    /// the base name</b>. A package ships several files with one base name — System Application
+    /// has both an <c>EmailOutbox.Page.al</c> and an <c>EmailOutbox.Table.al</c> — so writing a
+    /// flat list to a directory silently loses one of each such pair, and the lost object is
+    /// then reported as AL0185 "is missing" rather than as source the compile never saw.</para>
+    ///
+    /// <para>The <c>src/</c> filter is the same one <see cref="ExtractAl"/> applies, and it
+    /// costs nothing on Microsoft's apps: measured on BC 28.1.49838, Business Foundation keeps
+    /// 96 of 96 and System Application 1,319 of 1,319 of their `.al` under <c>src/</c>. It is
+    /// kept rather than widened because a package's other directories hold entitlements and
+    /// permission sets that reference objects from apps NOT being compiled, which turns into
+    /// AL1024 against the whole module.</para>
+    /// </summary>
+    public static IReadOnlyList<(string Path, string Source)> ExtractAlWithPaths(string appPath)
+    {
+        var bytes = File.ReadAllBytes(appPath);
+        var direct = ReadAlWithPathsFromNavx(bytes);
+        if (direct.Count > 0) return direct;
+
+        using var zip = OpenZipFromNavx(bytes);
+        var nested = zip.Entries.FirstOrDefault(e =>
+            e.FullName.EndsWith(".app", StringComparison.OrdinalIgnoreCase)
+            && !e.FullName.Contains('/'));
+        if (nested == null) return Array.Empty<(string, string)>();
+
+        using var ns = nested.Open();
+        using var nms = new MemoryStream();
+        ns.CopyTo(nms);
+        return ReadAlWithPathsFromNavx(nms.ToArray());
+    }
+
+    private static List<(string Path, string Source)> ReadAlWithPathsFromNavx(byte[] data)
+    {
+        var result = new List<(string, string)>();
+        using var zip = OpenZipFromNavx(data);
+        foreach (var entry in zip.Entries
+            .Where(e => e.FullName.StartsWith("src/", StringComparison.OrdinalIgnoreCase)
+                     && e.FullName.EndsWith(".al", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(e => e.FullName, StringComparer.Ordinal))
+        {
+            using var s = entry.Open();
+            using var reader = new StreamReader(s, Encoding.UTF8);
+            result.Add((entry.FullName, reader.ReadToEnd()));
         }
         return result;
     }

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -405,29 +405,41 @@ public sealed class DependencyLoader
     private static readonly IReadOnlyList<Assembly> EmptyAssemblies = Array.Empty<Assembly>();
 
     /// <summary>
-    /// Environment switch for #3549's dependency metadata production. OFF by default while the
-    /// chain is proven on one dependency at a time, per the issue's own "one dependency proving
-    /// the whole chain is a sufficient verdict".
-    ///
-    /// <para>Default-off is the honest state rather than caution for its own sake: turning this
-    /// on makes every source-shipping dependency compile once, which is a real provisioning
-    /// cost (Business Foundation 3.0s, System Application 14.5s on BC 28.1) and changes the
-    /// metadata a great many tables answer from. Both belong behind a switch until each app has
-    /// been measured, and `docs/dependency-metadata-from-bc.md` records what has been.</para>
-    ///
-    /// <para>A value other than "1" or "0" is a mistake worth naming rather than silently
-    /// reading as off — an unrecognised value is the shape that makes an opt-in look enabled to
-    /// its author while doing nothing.</para>
+    /// True when #3549's dependency metadata production is switched on at all, for any app.
+    /// <see cref="DependencyMetadataAppFilter"/> is the one that decides WHICH apps, and is
+    /// what callers should use; this exists for the "is the feature on" question alone.
     /// </summary>
     internal static bool DependencyMetadataEnabled()
+        => DependencyMetadataAppFilter() is not null;
+
+    /// <summary>
+    /// Which apps the producer runs for, parsed from the same variable: <c>1</c> means every
+    /// source-shipping dependency, a comma-separated list means exactly those app NAMES, and
+    /// absent/<c>0</c> means the feature is off (null).
+    ///
+    /// <para>OFF by default, and the per-app list is not a convenience — it is what makes the
+    /// feature usable at all today. <c>Compilation.Emit</c> is atomic per module, so ONE object
+    /// BC cannot emit zeroes the entire app's metadata: System Application's
+    /// <c>Business Chart.Initialize()</c> raises <c>BadExpression</c> under the runner's .NET
+    /// probing paths and takes all 1,319 files' output with it, while Business Foundation
+    /// compiles clean and yields 55 documents in ~6.2 s. So naming the app is the difference
+    /// between a dependency whose metadata is BC's own and a run that refuses to start;
+    /// #3745 tracks removing the need for it.</para>
+    ///
+    /// <para>Measurements per app, and the RED/GREEN this was proven with:
+    /// docs/dependency-metadata-from-bc.md.</para>
+    /// </summary>
+    internal static IReadOnlyCollection<string>? DependencyMetadataAppFilter()
     {
         var v = Environment.GetEnvironmentVariable("AL_RUNNER_DEP_METADATA_FROM_BC");
-        if (string.IsNullOrEmpty(v) || v == "0") return false;
-        if (v == "1") return true;
+        if (string.IsNullOrEmpty(v) || v == "0") return null;
+        if (v == "1") return Array.Empty<string>();   // empty = no filter = every app
+        var names = v.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (names.Length > 0) return names;
         Console.Error.WriteLine(
-            $"[dep-metadata] AL_RUNNER_DEP_METADATA_FROM_BC='{v}' is not '1' or '0'; " +
-            "treating as OFF. Set it to 1 to enable BC-emitted dependency metadata (#3549).");
-        return false;
+            $"[dep-metadata] AL_RUNNER_DEP_METADATA_FROM_BC='{v}' is not '1', '0' or an app-name " +
+            "list; treating as OFF (#3549).");
+        return null;
     }
 
     /// <summary>
@@ -439,7 +451,9 @@ public sealed class DependencyLoader
     /// </summary>
     private void EnsureDependencyMetadata(AppManifest m, string appPath)
     {
-        if (!DependencyMetadataEnabled()) return;
+        var filter = DependencyMetadataAppFilter();
+        if (filter is null) return;
+        if (filter.Count > 0 && !filter.Contains(m.Name, StringComparer.OrdinalIgnoreCase)) return;
         DependencyMetadataProducer.Ensure(m, appPath, _compiler);
     }
 

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -405,6 +405,45 @@ public sealed class DependencyLoader
     private static readonly IReadOnlyList<Assembly> EmptyAssemblies = Array.Empty<Assembly>();
 
     /// <summary>
+    /// Environment switch for #3549's dependency metadata production. OFF by default while the
+    /// chain is proven on one dependency at a time, per the issue's own "one dependency proving
+    /// the whole chain is a sufficient verdict".
+    ///
+    /// <para>Default-off is the honest state rather than caution for its own sake: turning this
+    /// on makes every source-shipping dependency compile once, which is a real provisioning
+    /// cost (Business Foundation 3.0s, System Application 14.5s on BC 28.1) and changes the
+    /// metadata a great many tables answer from. Both belong behind a switch until each app has
+    /// been measured, and `docs/dependency-metadata-from-bc.md` records what has been.</para>
+    ///
+    /// <para>A value other than "1" or "0" is a mistake worth naming rather than silently
+    /// reading as off — an unrecognised value is the shape that makes an opt-in look enabled to
+    /// its author while doing nothing.</para>
+    /// </summary>
+    internal static bool DependencyMetadataEnabled()
+    {
+        var v = Environment.GetEnvironmentVariable("AL_RUNNER_DEP_METADATA_FROM_BC");
+        if (string.IsNullOrEmpty(v) || v == "0") return false;
+        if (v == "1") return true;
+        Console.Error.WriteLine(
+            $"[dep-metadata] AL_RUNNER_DEP_METADATA_FROM_BC='{v}' is not '1' or '0'; " +
+            "treating as OFF. Set it to 1 to enable BC-emitted dependency metadata (#3549).");
+        return false;
+    }
+
+    /// <summary>
+    /// Produce or replay BC's metadata documents for one dependency (#3549). See
+    /// <see cref="DependencyMetadataProducer"/> for the availability-vs-failure split; the
+    /// throw is deliberately NOT caught here, because a dependency whose source is present and
+    /// whose emit failed is a broken build, and continuing would answer its tables from the
+    /// weaker derivation under a green run (`.claude/rules/loud-failures.md`).
+    /// </summary>
+    private void EnsureDependencyMetadata(AppManifest m, string appPath)
+    {
+        if (!DependencyMetadataEnabled()) return;
+        DependencyMetadataProducer.Ensure(m, appPath, _compiler);
+    }
+
+    /// <summary>
     /// Load one dependency app. <c>Assemblies</c> is EVERY assembly the app was loaded as and
     /// is non-empty only for the multi-chunk R2R tier; every other tier produces one assembly
     /// and returns it empty, which the caller reads as "just <c>Asm</c>" (#3054).
@@ -412,6 +451,20 @@ public sealed class DependencyLoader
     private (Assembly? Asm, string? Tier3CacheKey, IReadOnlyList<Assembly> Assemblies) LoadOne(
         AppManifest m, string appPath, string bucketRoot)
     {
+        // #3549 — BC's own metadata documents for this dependency, BEFORE the tier choice
+        // below. Tiers 1 and 2 return compiled code without ever running BC's emitter, and the
+        // emitter is what produces the metadata document AlObjectMetadataRegistry captures
+        // (#3548) — so on those tiers every table of this app would otherwise be described by
+        // the runner's SymbolReference hand-derivation and never by BC's own answer. Tier 3
+        // compiles anyway and registers the documents itself, which is why this is a no-op
+        // there (the sidecar is written once and hit thereafter).
+        //
+        // Deliberately ahead of the tiers rather than inside one: the document is about the
+        // app's METADATA, and which tier supplies its CODE does not change what its tables
+        // look like. DependencyMetadataProducer's header has the availability-vs-failure
+        // split this depends on.
+        EnsureDependencyMetadata(m, appPath);
+
         // Tier 1: precompiled DLL.
         var precompiled = FindPrecompiledSidecar(m, bucketRoot);
         if (precompiled != null)

--- a/AlRunner/DependencyMetadataProducer.cs
+++ b/AlRunner/DependencyMetadataProducer.cs
@@ -1,0 +1,242 @@
+// DependencyMetadataProducer — BC's own metadata documents for a dependency that ships
+// source but whose code the runner never compiles (issue #3549, "Producer A").
+//
+// WHY A DEPENDENCY NEEDS ITS OWN PRODUCER
+//   DependencyLoader.LoadOne returns at Tier 1 (precompiled sidecar DLL) or Tier 2 (R2R
+//   `publishedartifacts/*.dll`) whenever compiled code is available — which for Microsoft's
+//   apps it always is. Tier 3, the source compile, is the ONLY tier that runs BC's emitter,
+//   and it is the emitter that produces the metadata document AlObjectMetadataRegistry
+//   captures (#3548). So an R2R dependency's tables are described by the runner's
+//   SymbolReference hand-derivation and never by BC's own answer, even though the package
+//   ships the source BC would need.
+//
+//   Measured on Business Foundation table 230 "Source Code", BC 28.1: the derivation answers
+//   KeyCount=2 and SystemCreatedBy.Relation=0; BC's own document, loaded through
+//   MetaTable.CreateMetaTableFromXml, answers KeyCount=3 and 2000000120. Both are
+//   AL-observable through RecordRef. docs/dependency-metadata-from-bc.md has the measurement
+//   and the per-shape route table.
+//
+// AVAILABILITY DECIDES THE ROUTE — A FAILED COMPILE IS LOUD, NEVER A DOWNGRADE
+//   This is the constraint the issue names as its main risk, and it shapes the whole class.
+//   Producing a document is a COMPILE, so it has two failure modes that must not be conflated:
+//
+//     "no source in the package"  -> nothing to produce. The consumer's availability gate
+//                                    finds no document and keeps the derivation. Correct, and
+//                                    the state every symbol-only package is in (#3533/#3545).
+//     "source present, emit failed" -> a BROKEN BUILD. Silently keeping the derivation here
+//                                    would answer a table's metadata from a weaker source
+//                                    because a compile crashed, under a green test run. That
+//                                    is the silent-default shape .claude/rules/loud-failures.md
+//                                    exists to prevent, so it throws.
+//
+//   The seam that separates them is HasCompilableSource: it is answered from the package
+//   BEFORE any compile is attempted, so "unavailable" is never inferred from a failure.
+//   #3590 is why that ordering is load-bearing rather than stylistic — BuildNCLMetaTable
+//   swallows a construction failure into a cached null with its log line filtered out by
+//   default, so a failure that reached the consumer would be indistinguishable from absence.
+//
+// COST
+//   Once per (app id, app version, BC version), never per run: the documents persist to
+//   AlObjectMetadataRegistry's sidecar format under the `dep-metadata` cache root and are
+//   replayed on every later run. Measured cold on this box, BC 28.1: Business Foundation
+//   (96 AL files, 12 tables) 3.0s; System Application (1,319 AL files, 138 tables) 14.5s.
+//
+// NOT BASE APPLICATION
+//   Base Application ships 8,025 AL files and is deliberately excluded. Its emit needs a
+//   PublicKeyToken=null copy of Microsoft.AspNetCore.StaticFiles that no BC artifact ships,
+//   and without it the emitter produces ZERO objects — a hard blocker, not a cost question.
+//   tests/expectations/metadata-equivalence/apps.json records the same exclusion for the same
+//   reason. EmitProducedNothing below is what turns that into a loud failure rather than an
+//   empty cache entry that would read as "this app has no metadata".
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using AlRunner.Infrastructure;
+
+namespace AlRunner;
+
+/// <summary>
+/// Compiles a source-shipping dependency's AL with BC's own compiler so BC's metadata
+/// documents reach <see cref="AlObjectMetadataRegistry"/>, and persists them per
+/// (app id, app version, BC version).
+/// </summary>
+internal static class DependencyMetadataProducer
+{
+    /// <summary>
+    /// Apps this producer never compiles, by name. Base Application is the only entry and it
+    /// is not a cost decision — see the header. Matched on the manifest name so a differently
+    /// versioned or differently published copy is still excluded.
+    /// </summary>
+    private static readonly HashSet<string> NeverCompile =
+        new(StringComparer.OrdinalIgnoreCase) { "Base Application" };
+
+    /// <summary>
+    /// True when this package carries AL source a compile could consume. Answered from the
+    /// package alone, BEFORE any compile — that is what lets a caller tell "nothing to
+    /// produce" apart from "the compile failed", which the header explains is the one
+    /// distinction this class must never blur.
+    /// </summary>
+    internal static bool HasCompilableSource(string appPath)
+    {
+        try { return AppLoader.ExtractAl(appPath).Count > 0; }
+        catch { return false; }
+    }
+
+    internal static bool IsExcluded(AppManifest m) => NeverCompile.Contains(m.Name);
+
+    /// <summary>
+    /// The identity a dependency's metadata cache entry is stored under. The BC version is
+    /// part of it because the documents are BC's own emitter output for one exact build — a
+    /// key without it would serve one BC version's metadata to another, which is the failure
+    /// the ground-truth generator avoids by keying its bundles the same way.
+    /// </summary>
+    internal static string CacheKey(AppManifest m)
+        => $"{m.AppId:N}_{m.Version}_{AlRunner.Infrastructure.BcArtifacts.SelectedVersion}";
+
+    private static string SidecarPath(AppManifest m)
+        => Path.Combine(
+            AlRunner.Infrastructure.CacheRoots.Resolve("dep-metadata"),
+            CacheKey(m) + ".object-metadata.json");
+
+    /// <summary>
+    /// Make BC's metadata documents for <paramref name="m"/> available in
+    /// <see cref="AlObjectMetadataRegistry"/>, compiling the package's source once if no
+    /// cache entry exists yet. Returns the number of documents now available for this app,
+    /// or 0 when the app has no source to compile (the ordinary symbol-only case).
+    /// </summary>
+    /// <exception cref="DependencyLoadException">
+    /// The package HAS source and the compile or emit failed. Never downgraded to a silent 0 —
+    /// see the header.
+    /// </exception>
+    internal static int Ensure(AppManifest m, string appPath, BcCompiler compiler)
+    {
+        if (IsExcluded(m)) return 0;
+
+        var sidecar = SidecarPath(m);
+        if (File.Exists(sidecar))
+        {
+            try
+            {
+                var replayed = AlObjectMetadataRegistry.LoadSidecar(sidecar);
+                Trace($"cache HIT {m.Name} v{m.Version} — {replayed} document(s)");
+                return replayed;
+            }
+            catch (Exception ex)
+            {
+                // A corrupt entry is a cache problem, not an app problem: delete it and
+                // recompile. Distinct from an emit failure, which is the app's own build
+                // breaking and must not be swallowed.
+                Trace($"cache entry unreadable for {m.Name} ({ex.Message}); recompiling");
+                try { File.Delete(sidecar); } catch { /* best effort */ }
+            }
+        }
+
+        var sources = ReadSource(m, appPath);
+        if (sources.Count == 0) return 0;   // symbol-only: nothing to produce, not a failure
+
+        var keysBefore = new HashSet<string>(AlObjectMetadataRegistry.Keys, StringComparer.Ordinal);
+        var work = Directory.CreateTempSubdirectory($"al-runner-depmeta-{m.AppId:N}-");
+        try
+        {
+            foreach (var (name, src) in sources)
+                File.WriteAllText(Path.Combine(work.FullName, SafeFileName(name)), src);
+
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            try
+            {
+                using (BcCompiler.ScopeCurrentAppIdentity(m.AppId, m.Publisher, m.Version))
+                    compiler.Emit(new[] { work.FullName }, m.Name, work.FullName);
+            }
+            catch (Exception ex)
+            {
+                throw Loud(m, "METADATA-EMIT-FAIL", DependencyLoadException.FlattenException(ex), ex);
+            }
+
+            var produced = AlObjectMetadataRegistry.Keys
+                .Where(k => !keysBefore.Contains(k)).ToArray();
+
+            // The Base Application shape, and the reason this is a throw rather than an empty
+            // cache entry: BC's emitter can return success having produced nothing at all when
+            // a .NET reference does not resolve. Persisting that would record "this app has no
+            // metadata" permanently, and every table would silently keep the derivation.
+            if (produced.Length == 0)
+                throw Loud(m, "METADATA-EMIT-ZERO",
+                    "BC's emitter produced no metadata documents from this app's AL source. " +
+                    "That is a compile failure, not an app without metadata — caching it would " +
+                    "leave every table on the hand-derivation with nothing saying why. " +
+                    "See issue #3549.", null);
+
+            Persist(sidecar, produced, m, sw.ElapsedMilliseconds);
+            return produced.Length;
+        }
+        finally
+        {
+            try { work.Delete(recursive: true); } catch { /* temp cleanup is best effort */ }
+        }
+    }
+
+    private static IReadOnlyList<(string Name, string Source)> ReadSource(AppManifest m, string appPath)
+    {
+        try { return AppLoader.ExtractAl(appPath); }
+        catch (Exception ex)
+        {
+            // Reading the package failed — distinct from the package having no source, which
+            // ExtractAl reports as an empty list rather than a throw.
+            throw Loud(m, "METADATA-SOURCE-UNREADABLE", ex.Message, ex);
+        }
+    }
+
+    private static void Persist(string sidecar, string[] producedKeys, AppManifest m, long emitMs)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(sidecar)!);
+            // Same write-temp-then-move the compiled-deps sidecars use, so a run interrupted
+            // mid-write never leaves a half-file that the next run would read as corrupt.
+            var tmp = sidecar + ".tmp-" + Environment.ProcessId;
+            AlObjectMetadataRegistry.SaveSidecar(tmp, producedKeys);
+            File.Move(tmp, sidecar, overwrite: true);
+            Trace($"WROTE {m.Name} v{m.Version} — {producedKeys.Length} document(s), {emitMs}ms");
+        }
+        catch (Exception ex)
+        {
+            // The documents ARE in the registry; only their persistence failed. Degrading to
+            // "recompile next run" is correct and costs time, not correctness — unlike an
+            // emit failure, which changes the answer.
+            Console.Error.WriteLine(
+                $"[dep-metadata] cache write failed for {m.Name} v{m.Version}: {ex.Message}; " +
+                "documents are available for this run and will be recompiled on the next one");
+        }
+    }
+
+    private static DependencyLoadException Loud(
+        AppManifest m, string stage, string detail, Exception? inner)
+    {
+        Console.Error.WriteLine($"[dep-metadata-fail] {m.Publisher}_{m.Name} v{m.Version}: {stage} — {detail}");
+        return inner == null
+            ? new DependencyLoadException(m.Publisher, m.Name, m.Version.ToString(), stage, detail)
+            : new DependencyLoadException(m.Publisher, m.Name, m.Version.ToString(), stage, detail, inner);
+    }
+
+    /// <summary>
+    /// A source file name from inside the package, reduced to something writable on this
+    /// filesystem. Collisions are made impossible by appending an index rather than by hoping
+    /// the names are unique — a package may ship two `src/Foo.al` under different folders.
+    /// </summary>
+    private static int _fileSeq;
+    private static string SafeFileName(string name)
+    {
+        var baseName = Path.GetFileNameWithoutExtension(name);
+        var safe = new string(baseName.Select(c => char.IsLetterOrDigit(c) ? c : '_').ToArray());
+        if (safe.Length > 80) safe = safe[..80];
+        return $"{safe}_{System.Threading.Interlocked.Increment(ref _fileSeq)}.al";
+    }
+
+    private static void Trace(string message)
+    {
+        var t = Environment.GetEnvironmentVariable("AL_RUNNER_TRACE_DEP_METADATA");
+        if (t == "1" || t == "2") Console.Out.WriteLine($"[dep-metadata] {message}");
+    }
+}

--- a/AlRunner/DependencyMetadataProducer.cs
+++ b/AlRunner/DependencyMetadataProducer.cs
@@ -10,11 +10,11 @@
 //   SymbolReference hand-derivation and never by BC's own answer, even though the package
 //   ships the source BC would need.
 //
-//   Measured on Business Foundation table 230 "Source Code", BC 28.1: the derivation answers
-//   KeyCount=2 and SystemCreatedBy.Relation=0; BC's own document, loaded through
-//   MetaTable.CreateMetaTableFromXml, answers KeyCount=3 and 2000000120. Both are
-//   AL-observable through RecordRef. docs/dependency-metadata-from-bc.md has the measurement
-//   and the per-shape route table.
+//   Measured on Business Foundation table 310 "No. Series Relationship", BC 28.1, read from AL
+//   through RecordRef: the derivation answers SystemCreatedBy.Relation = 0, and BC's own
+//   document — loaded through MetaTable.CreateMetaTableFromXml, which is what adds the platform
+//   system fields and their relations — answers 2000000120, the User table.
+//   docs/dependency-metadata-from-bc.md has the full RED/GREEN and the per-shape route table.
 //
 // AVAILABILITY DECIDES THE ROUTE — A FAILED COMPILE IS LOUD, NEVER A DOWNGRADE
 //   This is the constraint the issue names as its main risk, and it shapes the whole class.
@@ -35,11 +35,17 @@
 //   swallows a construction failure into a cached null with its log line filtered out by
 //   default, so a failure that reached the consumer would be indistinguishable from absence.
 //
-// COST
+// COST, AND WHY IT IS OPT-IN PER APP
 //   Once per (app id, app version, BC version), never per run: the documents persist to
 //   AlObjectMetadataRegistry's sidecar format under the `dep-metadata` cache root and are
-//   replayed on every later run. Measured cold on this box, BC 28.1: Business Foundation
-//   (96 AL files, 12 tables) 3.0s; System Application (1,319 AL files, 138 tables) 14.5s.
+//   replayed on every later run. Business Foundation (96 AL files): ~6.2 s cold, 55 documents.
+//
+//   Emit is atomic per module, so one object BC cannot emit yields ZERO documents for the whole
+//   app rather than a partial result. System Application hits exactly that — BadExpression on
+//   `Business Chart.Initialize()` under the runner's .NET probing paths — which is why
+//   AL_RUNNER_DEP_METADATA_FROM_BC takes app NAMES and not just "on". #3745 is that blocker;
+//   the same app compiles clean in tools/metadata-ground-truth/, which ships .NET reference
+//   shims the runner's probing paths do not.
 //
 // NOT BASE APPLICATION
 //   Base Application ships 8,025 AL files and is deliberately excluded. Its emit needs a
@@ -80,7 +86,7 @@ internal static class DependencyMetadataProducer
     /// </summary>
     internal static bool HasCompilableSource(string appPath)
     {
-        try { return AppLoader.ExtractAl(appPath).Count > 0; }
+        try { return AppLoader.ExtractAlWithPaths(appPath).Count > 0; }
         catch { return false; }
     }
 
@@ -140,8 +146,27 @@ internal static class DependencyMetadataProducer
         var work = Directory.CreateTempSubdirectory($"al-runner-depmeta-{m.AppId:N}-");
         try
         {
-            foreach (var (name, src) in sources)
-                File.WriteAllText(Path.Combine(work.FullName, SafeFileName(name)), src);
+            // Written at the package's OWN relative paths, not flattened into one directory.
+            // Two things break under flattening, and both present as AL0185 "X is missing" for
+            // objects the app itself declares: a package ships several files with one base name
+            // (System Application has an `EmailOutbox.Page.al` and an `EmailOutbox.Table.al`),
+            // and BC resolves a resource — a control add-in's files, a report layout — relative
+            // to the source that references it.
+            foreach (var (path, src) in sources)
+            {
+                var rel = SafeRelativePath(path);
+                var dest = Path.Combine(work.FullName, rel);
+                Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
+                File.WriteAllText(dest, src);
+            }
+
+            // A shipped .app carries NavxManifest.xml, not app.json, and BcCompiler.Emit reads
+            // its compiler inputs — target, features, preprocessor symbols — from an app.json
+            // beside the source. Without one every input silently falls back to its default,
+            // which is not this app's configuration: `Target` in particular decides whether
+            // OnPrem-scoped objects compile at all. Synthesized rather than defaulted so the
+            // compile matches how Microsoft built the package.
+            WriteSynthesizedAppJson(work.FullName, m, appPath);
 
             var sw = System.Diagnostics.Stopwatch.StartNew();
             try
@@ -177,9 +202,75 @@ internal static class DependencyMetadataProducer
         }
     }
 
-    private static IReadOnlyList<(string Name, string Source)> ReadSource(AppManifest m, string appPath)
+    /// <summary>
+    /// Write an app.json describing <paramref name="m"/> next to the extracted source, carrying
+    /// the attributes BC's compiler reads that the runtime <see cref="AppManifest"/> does not
+    /// model — <c>target</c>, <c>features</c>, <c>preprocessorSymbols</c>, <c>runtime</c> —
+    /// taken from the package's own NavxManifest.xml so the compile matches how the package was
+    /// built. An attribute the manifest omits is omitted here too rather than guessed, leaving
+    /// BcCompiler's own default to apply.
+    /// </summary>
+    private static void WriteSynthesizedAppJson(string dir, AppManifest m, string appPath)
     {
-        try { return AppLoader.ExtractAl(appPath); }
+        var attrs = ReadNavxAppAttributes(appPath);
+        string? Attr(string name) => attrs.TryGetValue(name, out var v) && !string.IsNullOrEmpty(v) ? v : null;
+
+        var json = new System.Text.Json.Nodes.JsonObject
+        {
+            ["id"] = m.AppId.ToString(),
+            ["name"] = m.Name,
+            ["publisher"] = m.Publisher,
+            ["version"] = m.Version.ToString(),
+        };
+        if (Attr("Target") is { } target) json["target"] = target;
+        if (Attr("Runtime") is { } runtime) json["runtime"] = runtime;
+        if (Attr("Platform") is { } platform) json["platform"] = platform;
+        if (Attr("ContextSensitiveHelpUrl") is { } help) json["contextSensitiveHelpUrl"] = help;
+        // `Features` and `PreprocessorSymbols` are space/comma-separated attribute lists in the
+        // NAVX manifest and arrays in app.json.
+        if (Attr("Features") is { } features)
+            json["features"] = ToJsonArray(features);
+        if (Attr("PreprocessorSymbols") is { } symbols)
+            json["preprocessorSymbols"] = ToJsonArray(symbols);
+
+        File.WriteAllText(Path.Combine(dir, "app.json"), json.ToJsonString());
+    }
+
+    private static System.Text.Json.Nodes.JsonArray ToJsonArray(string list)
+    {
+        var arr = new System.Text.Json.Nodes.JsonArray();
+        foreach (var part in list.Split(new[] { ' ', ',', ';' }, StringSplitOptions.RemoveEmptyEntries))
+            arr.Add(part);
+        return arr;
+    }
+
+    /// <summary>
+    /// The <c>&lt;App&gt;</c> element's attributes from a package's NavxManifest.xml, including
+    /// the R2R nested-package case. Returns empty rather than throwing when the manifest cannot
+    /// be read: every attribute it supplies has a working default, so an unreadable manifest
+    /// degrades the compile's fidelity but must not be confused with the app having no source
+    /// (the distinction the class header turns on).
+    /// </summary>
+    private static Dictionary<string, string> ReadNavxAppAttributes(string appPath)
+    {
+        var empty = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            var xml = AppLoader.ReadNavxManifestXml(appPath);
+            if (string.IsNullOrEmpty(xml)) return empty;
+            var doc = System.Xml.Linq.XDocument.Parse(xml);
+            var app = doc.Root?.Elements().FirstOrDefault(e => e.Name.LocalName == "App");
+            if (app == null) return empty;
+            foreach (var a in app.Attributes())
+                empty[a.Name.LocalName] = a.Value;
+            return empty;
+        }
+        catch { return empty; }
+    }
+
+    private static IReadOnlyList<(string Path, string Source)> ReadSource(AppManifest m, string appPath)
+    {
+        try { return AppLoader.ExtractAlWithPaths(appPath); }
         catch (Exception ex)
         {
             // Reading the package failed — distinct from the package having no source, which
@@ -221,18 +312,29 @@ internal static class DependencyMetadataProducer
     }
 
     /// <summary>
-    /// A source file name from inside the package, reduced to something writable on this
-    /// filesystem. Collisions are made impossible by appending an index rather than by hoping
-    /// the names are unique — a package may ship two `src/Foo.al` under different folders.
+    /// A package-relative source path, made safe to write under the work directory while
+    /// KEEPING its directory structure and file name — see the extraction loop for why
+    /// flattening breaks the compile.
+    ///
+    /// <para>Package entry names are URL-encoded (`src/User%2520Details/...`), which is
+    /// harmless to write literally and is left as it is: BC resolves object references by
+    /// symbol, not by path, and decoding introduces its own escaping questions for no gain.
+    /// The one thing that must hold is that the result stays inside the work directory, so a
+    /// `..` segment is dropped rather than trusted.</para>
     /// </summary>
-    private static int _fileSeq;
-    private static string SafeFileName(string name)
+    private static string SafeRelativePath(string name)
     {
-        var baseName = Path.GetFileNameWithoutExtension(name);
-        var safe = new string(baseName.Select(c => char.IsLetterOrDigit(c) ? c : '_').ToArray());
-        if (safe.Length > 80) safe = safe[..80];
-        return $"{safe}_{System.Threading.Interlocked.Increment(ref _fileSeq)}.al";
+        var parts = name.Replace('\\', '/').Split('/', StringSplitOptions.RemoveEmptyEntries)
+            .Where(p => p != "." && p != "..")
+            .Select(p => new string(p.Select(c =>
+                Path.GetInvalidFileNameChars().Contains(c) ? '_' : c).ToArray()))
+            .ToArray();
+        return parts.Length == 0
+            ? $"object_{System.Threading.Interlocked.Increment(ref _fileSeq)}.al"
+            : Path.Combine(parts);
     }
+
+    private static int _fileSeq;
 
     private static void Trace(string message)
     {

--- a/docs/dependency-metadata-from-bc.md
+++ b/docs/dependency-metadata-from-bc.md
@@ -1,0 +1,196 @@
+# A dependency's table metadata from BC's own emitter
+
+Issue #3549, "Producer A". The compiled-app half of the metadata chain (#3548, #3552) is
+merged: a table the runner compiles gets its `NCLMetaTable` built by BC from BC's own emitted
+document. This file records the **dependency** half — what was measured, what now works, and
+what is deliberately still switched off.
+
+Everything below was measured on this box against BC **28.1.49838** (engine `28.1.49838.53910`,
+packages `28.1.49838.54308`) unless another build is named.
+
+## The gap, and why it is not visible from the compiled-app path
+
+`DependencyLoader.LoadOne` returns at Tier 1 (a precompiled sidecar DLL) or Tier 2 (R2R
+`publishedartifacts/*.dll`) whenever compiled code is available, which for Microsoft's apps it
+always is. **Tier 3, the source compile, is the only tier that runs BC's emitter** — and the
+emitter is what produces the document `AlObjectMetadataRegistry` captures.
+
+So a dependency's tables were described by the runner's `SymbolReference.json` hand-derivation
+and never by BC's own answer, even though the package ships the source BC would need.
+
+### Measured, AL-observable, on a real Microsoft dependency
+
+Business Foundation table **310 "No. Series Relationship"**, read from AL through `RecordRef`:
+
+| | route | `KeyCount` | `SystemCreatedBy.Relation` | `SystemModifiedBy.Relation` |
+|---|---|---|---|---|
+| before | `derived` | 3 | **0** | **0** |
+| after | `bc-document` | 3 | **2000000120** | **2000000120** |
+
+`2000000120` is the User table — BC's own answer, and the value #3549 names in its acceptance
+criteria. The route is read with `AL_RUNNER_TRACE_TABLE_METADATA_SOURCE=1`.
+
+The mechanism behind the difference: BC's emitted document declares only the AL-declared fields
+and keys, and BC's **loader** (`MetaTable.CreateMetaTableFromXml` → `AssignFromMetaTable`) adds
+the platform system fields and their relations. Taking the document route means BC does that
+work; deriving means the runner does, and the runner does not add the relations.
+
+## Why the whole matrix is not simply switched on
+
+`Compilation.Emit` is **atomic per module**: one object BC cannot emit yields zero documents for
+the entire app, not a partial result. Measured per app:
+
+| app | `.al` files | outcome | documents |
+|---|---|---|---|
+| Business Foundation | 96 | clean, 6.0–6.2 s | **55** (11 tables, 16 codeunits, 13 permission sets, 9 pages, 5 tableextensions, 1 enum) |
+| System Application | 1,319 | **`BadExpression` while emitting `Codeunit System.Visualization."Business Chart"::Initialize()`** | **0** |
+| Base Application | 8,025 | not attempted — see below | — |
+
+So the feature is **opt-in and per-app**, `AL_RUNNER_DEP_METADATA_FROM_BC`:
+
+- unset / `0` — off. Byte-identical to the behaviour before #3549; verified as a regression arm.
+- `1` — every source-shipping dependency.
+- `Business Foundation` (comma-separated names) — exactly those apps.
+
+Naming the app is the difference between a dependency whose metadata is BC's own and a run that
+refuses to start. #3745 tracks removing the need for it.
+
+### System Application: a .NET reference the runner does not resolve
+
+The failure is not in the AL. `tools/metadata-ground-truth/` compiles the same app cleanly
+(1,218 documents in 14.5 s) because it ships **dedicated .NET reference-pack shims** and puts
+them at the head of BC's probing paths — its `CopyDotNetShims` target explains the one it needs
+today, and names this exact shape as "the same shape as the Base Application blocker in #3549".
+`BcCompiler`'s probing paths differ, the DotNet declaration does not bind, and the unbound
+expression reaches the emitter as `BadExpression`.
+
+That is a compile-configuration difference, not a metadata problem, and it is #3745.
+
+### Base Application: a hard blocker, not a cost question
+
+Excluded in code by name, and it is **not** about the ~9 GB peak RSS of compiling it. Its emit
+needs a `PublicKeyToken=null` copy of `Microsoft.AspNetCore.StaticFiles` that no BC artifact
+ships, and without it the emitter produces **zero objects**.
+`tests/expectations/metadata-equivalence/apps.json` records the same exclusion for the same
+reason, and attributes it to this issue.
+
+## Availability decides the route; a failed compile is loud
+
+The constraint #3549 names as its main risk. Producing a document is a compile, so there are two
+failure modes and they must never be spelled the same way:
+
+| | answer |
+|---|---|
+| the package ships no source | return 0. The consumer's availability gate finds no document and keeps the derivation — the ordinary state of every symbol-only package (#3533, #3545). |
+| the package ships source and the compile or emit failed | **throw** `DependencyLoadException`. |
+
+`DependencyMetadataProducer.HasCompilableSource` answers the first question **from the package,
+before any compile is attempted**, which is what keeps "unavailable" from ever being inferred
+from a failure. #3590 is why that ordering is load-bearing rather than stylistic:
+`BuildNCLMetaTable` swallows a construction failure into a cached null with its log line
+filtered out by default, so a failure that reached the consumer would be indistinguishable from
+a document that was never produced.
+
+A **zero-document emit is a throw**, not an empty cache entry: caching it would record "this app
+has no metadata" permanently and leave every table on the derivation with nothing saying why.
+That is what the System Application row above produces, loudly, rather than silently.
+
+A **corrupt cache entry** is neither: it is deleted and recompiled, because it is a cache
+problem rather than the app's build breaking.
+
+## The cache
+
+One entry per **(app id, app version, BC version)** under the `dep-metadata` cache root, in
+`AlObjectMetadataRegistry`'s sidecar format. The BC version is part of the key because the
+documents are one exact build's emitter output; a key without it serves one build's metadata to
+another. Written through a temp file and moved into place, so an interrupted run leaves no
+half-file.
+
+Cost is paid once per app per BC version — a provisioning cost, not a per-run one. Business
+Foundation: 6.0–6.2 s to produce, then a cache hit.
+
+## Verified arms
+
+All against `bfonly` (a bundle whose only dependency is Business Foundation), table 310:
+
+| arm | result |
+|---|---|
+| cold, feature on | `WROTE … 55 document(s), 6248ms`; `bc-document`; `Relation=2000000120` |
+| warm, same cache | `cache HIT … 55 document(s)`; `bc-document`; same values, no recompile |
+| after deleting `dep-metadata/` | recompiled; `bc-document`; same values |
+| cache entry corrupted to non-JSON | `cache entry unreadable … recompiling`; `bc-document`; same values |
+| **feature off (default)** | `derived`; `Relation=0`; no producer activity — today's behaviour exactly |
+
+## A table with a tableextension keeps the derivation, by design
+
+Business Foundation table **230 "Source Code"** stays on `derived` even with the feature on, and
+that is correct rather than a gap: `ObsoleteSourceCodeExt` extends it, and
+`ShouldBuildTableFromBcDocument` deliberately keeps the derivation for a table carrying a
+`modify(...)`-declaring or cross-app extension (#3600). BC's per-app document cannot see another
+app's extension, so the merged view the runner builds is the more complete answer there.
+
+Of Business Foundation's 11 captured tables, 5 carry an extension from the same app (230, 242,
+308, 309, 6635) and the rest take the document route.
+
+## Why this is not a corpus test, measured rather than asserted
+
+The claim "a table's `SystemCreatedBy` relates to User (2000000120)" is plain BC behaviour and
+belongs upstream — and **it is already there and already green**:
+`tests/al-language/record/TestFieldDataClassificationVirtualTable.al`, codeunit 60965,
+`RecordRef_SystemCreatedBy_Relation_IsTheUserTable`.
+
+What this issue fixes is not that claim but the **route** by which the runner answers it, and
+the corpus cannot reach the broken route. Three measurements, not an inference:
+
+1. **A bundle-declared table already answers correctly.** A table declared in the app under
+   test takes `bc-document` and answers `2000000120` on `main`, with the feature off — so the
+   existing corpus test passes today and would still pass with this change reverted. It cannot
+   fail for the reason this issue exists.
+2. **A corpus-shaped precompiled dependency also already answers correctly.** The corpus's one
+   genuine dependency package, `AL Language_AL Internals Test Fixture_1.0.0.0.app` (table 61001
+   `ALT Internal Table`), was run through the runner as a real `.alpackages` dependency: route
+   `bc-document`, `Relation=2000000120`, feature off. It carries **no** `publishedartifacts/*.dll`,
+   so it takes Tier 3 — the source compile — which already runs BC's emitter and captures.
+3. **No package the corpus ships is R2R.** Checked across all six in
+   `tests/al-language/.alpackages/`, including its Base Application and Business Foundation:
+   `R2R=False` for every one, and they carry AL source directly rather than a nested package.
+
+The defect is specific to a dependency the runner loads from **compiled code** (Tier 1/Tier 2),
+which is how BC's own artifacts ship and how every real project consumes Microsoft's apps. The
+corpus has no such dependency, so a corpus test cannot distinguish fixed from broken — which is
+what makes this a `Corpus-NA:` rather than a corpus PR.
+
+Worth stating explicitly, because the opposite conclusion has been reached before on thinner
+evidence (#2518, where a defect assumed precompiled-only reproduced on a source-compiled table
+and corpus PR #165 merged green): the check here is not "the corpus compiles from source, so it
+cannot reach this". It is that the specific assertion **was run** against the corpus's own
+dependency package and came back already-correct.
+
+## Reproducing
+
+```bash
+# ground truth for the harness, and proof the same app compiles cleanly outside the runner
+tools/gen-metadata-ground-truth.sh --artifacts ~/.local/share/al-runner/artifacts/<build>
+
+# the route a table actually took
+AL_RUNNER_TRACE_TABLE_METADATA_SOURCE=1 \
+AL_RUNNER_DEP_METADATA_FROM_BC="Business Foundation" \
+AL_RUNNER_TRACE_DEP_METADATA=1 \
+  dotnet run --project AlRunner -- <bundle> --package-cache ~/.al-runner/platform-apps --cache <private>
+```
+
+`AL_RUNNER_TRACE_TABLE_METADATA_SOURCE=2` additionally dumps per-field `editable`,
+`dataClassification`, `enumTypeId` and `enumTypeName` for both routes, which is how the
+per-field comparison in this file was made.
+
+## Related
+
+- **#3548** — the capture this consumes; **#3552 / #3584** — the compiled-app consumer.
+- **#3568** — the 71 members where the SymbolReference derivation still disagrees with BC's
+  emitter, measured by `MetadataEquivalenceHarnessTests`. `MetaField.Editable` and
+  `MetaField.DataClassification` are **not** among them any more: #3545 (PR #3598) fixed both
+  and deleted their allowlist entries, which is why this file does not claim them.
+- **#3590** — `BuildNCLMetaTable` swallows a construction failure into a cached null.
+- **#3600** — the tableextension guard on the document route.
+- **#3533 / #3545** — the symbol-reference path, which stays correct and necessary for
+  symbol-only packages and is untouched here.


### PR DESCRIPTION
Closes #3549

Corpus-NA: the defect is reachable only through a dependency loaded from COMPILED code (Tier 1/Tier 2), and no package the corpus ships is R2R — measured, see "The corpus answer" below

Producer A of #3549's two producers, per the repo owner's sequencing ("runtime will be a side story; let's get the regular cases working first"). Producer B (runtime packages) is **not** in this PR and is untouched — its reader (#3537) is merged and going nowhere.

## The gap

`DependencyLoader.LoadOne` returns at **Tier 1** (precompiled sidecar DLL) or **Tier 2** (R2R `publishedartifacts/*.dll`) whenever compiled code is available — which for Microsoft's apps it always is. **Tier 3, the source compile, is the only tier that runs BC's emitter**, and the emitter is what produces the document `AlObjectMetadataRegistry` captures (#3548).

So a dependency's tables were described by the runner's `SymbolReference.json` hand-derivation and never by BC's own answer, even though the package ships the source BC would need. Business Foundation carries 96 AL files in a nested package; Base Application 8,025 — confirming the issue's own "source and no metadata, the exact complement of a runtime package".

## RED → GREEN, AL-observable, on a real Microsoft dependency

Business Foundation table **310 "No. Series Relationship"**, read from AL through `RecordRef`, BC 28.1.49838:

| arm | route | `SystemCreatedBy.Relation` | `SystemModifiedBy.Relation` |
|---|---|---|---|
| **RED** (feature off) | `derived` | **0** | **0** |
| **GREEN** (cold) | `bc-document` | **2000000120** | **2000000120** |
| **GREEN** (warm, cache HIT) | `bc-document` | 2000000120 | 2000000120 |
| after deleting `dep-metadata/` | `bc-document` | 2000000120 | 2000000120 |
| cache entry corrupted to non-JSON | `bc-document` | 2000000120 | 2000000120 |
| **regression arm — feature off (default)** | `derived` | **0** | **0** |

`2000000120` is the User table — BC's own answer and the exact value #3549 names. The mechanism: BC's emitted document declares only the AL-declared fields and keys, and BC's **loader** (`MetaTable.CreateMetaTableFromXml` → `AssignFromMetaTable`) adds the platform system fields and their relations. Taking the document route means BC does that work.

The regression arm is the one most likely to be skipped and it is the last row: with the switch unset, the route, the values and the log are byte-identical to `main`.

Would the test still pass against a no-op implementation? No — `0` and `2000000120` are different concrete values on the same field, and the route trace names which code produced each.

## Availability decides the route; a failed compile is loud

The constraint the issue names as its main risk, and it shapes the whole class:

- **no source in the package** → return 0. The consumer's availability gate keeps the derivation. The ordinary state of every symbol-only package (#3533, #3545).
- **source present, compile/emit failed** → **throw** `DependencyLoadException`. Never downgraded.

`HasCompilableSource` answers the first question **from the package, before any compile is attempted**, which is what keeps "unavailable" from ever being inferred from a failure. **#3590 is why that ordering is load-bearing** rather than stylistic: `BuildNCLMetaTable` swallows a construction failure into a cached null with its log line filtered out by default, so a failure reaching the consumer would be indistinguishable from a document that was never produced.

A **zero-document emit throws** rather than caching an empty entry — caching it would record "this app has no metadata" permanently and leave every table on the derivation with nothing saying why. That fired for real during development (System Application, below) and is what stopped a silent degradation. A **corrupt cache entry** is neither case: deleted and recompiled.

`LoudFailure_And_NoSource_AreDifferentAnswers` pins this structurally — one returns, one throws — so no caller can turn a failed compile into an absent document by reading a return value.

## Opt-in per app, and why that is not timidity

`Compilation.Emit` is **atomic per module**: one object BC cannot emit yields zero documents for the entire app.

| app | `.al` | outcome |
|---|---|---|
| Business Foundation | 96 | clean, ~6.2 s, **55 documents** |
| System Application | 1,319 | **`BadExpression` on `Codeunit System.Visualization."Business Chart"::Initialize()`** → 0 |
| Base Application | 8,025 | excluded in code |

`AL_RUNNER_DEP_METADATA_FROM_BC` therefore takes app **names** (`1` = all, `0`/unset = off). Naming the app is the difference between a dependency answering from BC and a run that refuses to start.

**System Application is a runner-side configuration difference, not an AL problem.** `tools/metadata-ground-truth/` compiles the same app from the same package on this box cleanly — 1,218 documents in 14.5 s — because it ships dedicated .NET reference-pack shims and orders probing paths differently. `MetadataGroundTruth.csproj`'s own `CopyDotNetShims` comment documents this failure class for a different member and calls it *"the same shape as the Base Application blocker in #3549"*. Filed as **#3745**; not attempted here because it changes the shared compile path for every compile in the runner — a materially different blast radius.

**Base Application's exclusion is corrected from my brief.** It is not the ~9 GB RSS: its emit needs a `PublicKeyToken=null` copy of `Microsoft.AspNetCore.StaticFiles` that no BC artifact ships, and without it the emitter produces **zero objects**. `tests/expectations/metadata-equivalence/apps.json` records the same exclusion for the same reason and attributes it to this issue. A hard blocker, not a resource question.

## The corpus answer, measured rather than asserted

**`Corpus-NA:`, and the check was run rather than reasoned.** The claim "a table's `SystemCreatedBy` relates to User" is plain BC behaviour and **is already upstream and already green** — codeunit 60965, `RecordRef_SystemCreatedBy_Relation_IsTheUserTable`. What this issue fixes is the **route**, and the corpus cannot reach the broken one:

1. **A bundle-declared table already answers correctly** — `bc-document`, `2000000120`, with the feature off. So the existing corpus test passes today and would still pass with this change reverted.
2. **The corpus's own precompiled dependency also already answers correctly.** `AL Language_AL Internals Test Fixture_1.0.0.0.app` (table 61001) was run through the runner as a real `.alpackages` dependency: `bc-document`, `2000000120`, feature off. It carries no `publishedartifacts/*.dll`, so it takes Tier 3, which already runs the emitter.
3. **No package the corpus ships is R2R** — all six in `tests/al-language/.alpackages/`, including its Base Application and Business Foundation, are plain source packages.

The check deliberately is not "the corpus compiles from source, so it cannot reach this" — that reasoning was wrong before (#2518, where corpus PR #165 merged green on 8 legs). It is that the specific assertion **was run** against the corpus's own dependency package and came back already-correct.

## Open-queue scan

Scanned `area: metadata-conversion` and the metadata files before implementing. Nothing folded, and the reason matters:

- **#3568** (the 71 remaining derivation-vs-emitter members) — read in full before finalising the design, as asked. **`MetaField.Editable` and `MetaField.DataClassification` are no longer among them**: #3545 (PR #3598) fixed both and deleted their allowlist entries, verified against the live `allowlist.json` (71 entries, neither present). So two of my brief's four acceptance arms would have passed for a reason unrelated to this issue, and I did **not** assert them. The arms I kept — the key list and the system-field relations — are `MetaField.Relations.<presence>` (300 differences) and the `MetaKey.*` rows, all still open under #3568 and all still allowlisted.
- **#3590** — cited rather than re-derived; it is exactly why the availability seam is answered before the compile.
- **#3491** — the record of what the hand-derivation does. Untouched: nothing is deleted here, per the issue.
- **#3745** — filed by me from this work.

None lands in these files, so folding any would have made an incoherent diff.

## What I deliberately left out

- **Producer B** (runtime packages) — the owner sequenced it as the side story.
- **Base Application** — a hard blocker (above), not deferred for cost.
- **System Application** — #3745, a shared-compile-path change.
- **Retiring any hand-derivation** — the issue says nothing is deleted here.
- **A wider default.** Off by default, so `BC test matrix passed` measures exactly today's behaviour on every leg; the producer runs only when a name is given.

## Tests

- `DependencyMetadataProducerTests` — the opt-in cannot be switched on by accident, Base Application is never compiled (and its exclusion cannot be defeated by an unreadable package), the cache key separates app/version/BC-build, and failure and absence are structurally different answers.
- `AppLoaderExtractAlWithPathsTests` — paths not base names (the `EmailOutbox.Page.al`/`.Table.al` collision), the `src/` filter is deliberate and measured, the R2R nested shape resolves, and a symbol-only package is empty rather than a throw.

Run: 55 passed (`DependencyMetadataProducerTests` + all `AppLoader*`), plus 265 `~Dependency` tests green. Not run: the full `AlRunner.Tests` sweep, per `local-test-scope.md`.

`docs/dependency-metadata-from-bc.md` carries the measurements, the per-shape route table and the reproduction commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
