### PR TITLE
feat(metadata): trace which route produced a page's metadata

### DIFF
--- a/AlRunner.Tests/PageMetadataSourceTraceTests.cs
+++ b/AlRunner.Tests/PageMetadataSourceTraceTests.cs
@@ -1,0 +1,275 @@
+// PageMetadataSourceTraceTests — issue #3750.
+//
+// A RUNNER-MECHANISM test, not a claim about BC. The claim under test is "which of the runner's
+// three routes produced this page's Page Control Field rows", which is not a statement a service
+// tier can adjudicate: all three routes produce the same ROW TYPE and AL cannot see the
+// difference. That is the whole reason the trace has to exist — see
+// .claude/rules/bc-behavior-tests-go-upstream.md for why this one stays here.
+//
+// WHAT MAKES THIS PROVE SOMETHING
+//   The assertion is on the ROUTE, not on a line having been printed. Two properties do that
+//   work, and a trace that hardcoded a single route value fails both:
+//
+//     * one run, two pages, two DIFFERENT routes — an emitted page traced `bc-document` and an
+//       AL-text-only page traced `derived`, from a single enumeration;
+//     * the negative direction per page — the emitted page must NOT be traced `derived` and the
+//       text-only page must NOT be traced `bc-document`.
+//
+//   A `source=bc-document` constant passes neither, and neither does asserting only that some
+//   `[page-metadata]` line appeared.
+//
+// THE LIMIT THIS TEST CANNOT COVER, and does not pretend to
+//   #3590: a document that failed to load is memoised as a null and takes the derivation arm,
+//   so it is indistinguishable from "no document existed" — here and in the trace. There is
+//   deliberately no test asserting a `failed` route, because there deliberately is no such
+//   route. TracePageMetadataSource says the same thing at the site.
+
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class PageMetadataSourceTraceTests : IDisposable
+{
+    private const int EmittedPageId = 90361;
+    private const int EmittedTableId = 90360;
+    private const int TextOnlyPageId = 90371;
+    private const int TextOnlyTableId = 90370;
+
+    private readonly string _root;
+    private readonly BcEngineFixture _engine;
+
+    public PageMetadataSourceTraceTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = TestScratch.Dir("al-runner-page-metadata-source-trace-tests");
+        Directory.CreateDirectory(_root);
+        AlObjectMetadataRegistry.Clear();
+    }
+
+    public void Dispose()
+    {
+        AlObjectMetadataRegistry.Clear();
+        // The parser dictionaries and the row memo are static, so a fixture left behind here
+        // answers for the next class that declares one of these ids.
+        RemoveFromDict("_parsedPages", EmittedPageId);
+        RemoveFromDict("_parsedPages", TextOnlyPageId);
+        RemoveFromDict("_parsedTables", EmittedTableId);
+        RemoveFromDict("_parsedTables", TextOnlyTableId);
+        RemoveMetaTableCacheEntry(EmittedTableId);
+        RemoveMetaTableCacheEntry(TextOnlyTableId);
+        ClearStatic("ClearBcPageControlDocuments");
+        InvalidatePageControlFieldRowCache();
+        Environment.SetEnvironmentVariable("AL_RUNNER_TRACE_PAGE_METADATA_SOURCE", null);
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    /// <summary>The page the runner COMPILES. BC's emitter captures a document for it, so it
+    /// must take the document route.</summary>
+    private const string EmittedAl = """
+        table 90360 "PcfTrace Sample"
+        {
+            DataClassification = CustomerContent;
+            fields
+            {
+                field(1; "Entry No."; Integer) { DataClassification = CustomerContent; }
+                field(2; "Name Field"; Text[50]) { DataClassification = CustomerContent; }
+            }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+
+        page 90361 "PcfTrace Fixture"
+        {
+            PageType = Card;
+            SourceTable = "PcfTrace Sample";
+            layout
+            {
+                area(Content)
+                {
+                    group(G)
+                    {
+                        field(TraceEntryNo; Rec."Entry No.") { ApplicationArea = All; }
+                        field(TraceName; Rec."Name Field") { ApplicationArea = All; }
+                    }
+                }
+            }
+        }
+        """;
+
+    /// <summary>The control page: parsed from AL text and never emitted, so no document is
+    /// captured for it and it must take the derivation. Without this arm the test could not
+    /// tell a working trace from one that answers `bc-document` unconditionally.</summary>
+    private const string TextOnlyAl = """
+        table 90370 "PcfTraceFb Sample"
+        {
+            DataClassification = CustomerContent;
+            fields
+            {
+                field(1; "Entry No."; Integer) { DataClassification = CustomerContent; }
+            }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+
+        page 90371 "PcfTraceFb Fixture"
+        {
+            PageType = Card;
+            SourceTable = "PcfTraceFb Sample";
+            layout
+            {
+                area(Content)
+                {
+                    group(G)
+                    {
+                        field(TraceFbEntryNo; Rec."Entry No.") { ApplicationArea = All; }
+                    }
+                }
+            }
+        }
+        """;
+
+    [SkippableFact]
+    public void Trace_NamesTheRoutePerPage_DocumentForACompiledPage_DerivationForATextOnlyOne()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        // Emit only the first fixture, so exactly one of the two pages has a document. Both
+        // then go through the AL parser, which is what puts both into the same enumeration.
+        var output = new BcCompiler().Emit(new[] { WriteAl("PcfTrace.al", EmittedAl) }, "PcfTraceModule");
+        Assert.True(output.Sources.Count > 0,
+            $"expected the fixture to emit; diagnostics: {string.Join(" | ", output.Diagnostics.Take(10))}");
+        Assert.True(AlObjectMetadataRegistry.TryGet("Page", EmittedPageId, out var xml)
+                    && !string.IsNullOrEmpty(xml),
+            $"page {EmittedPageId}'s document was not captured, so this test could not tell the "
+            + "two routes apart even if the trace worked.");
+
+        ParseAlTableSource(EmittedAl);
+        ParseAlPageSource(EmittedAl);
+        ParseAlTableSource(TextOnlyAl);
+        ParseAlPageSource(TextOnlyAl);
+
+        var lines = EnumerateWithTrace("1");
+
+        // Positive, page by page: the two pages take DIFFERENT routes in one enumeration.
+        Assert.Contains($"[page-metadata] {EmittedPageId} source=bc-document", lines);
+        Assert.Contains($"[page-metadata] {TextOnlyPageId} source=derived", lines);
+
+        // Negative, page by page. This pair is what a hardcoded route fails: a trace that
+        // always said `bc-document` satisfies the first assertion above and fails the second
+        // one here, and a trace that always said `derived` does the mirror image.
+        Assert.DoesNotContain($"[page-metadata] {EmittedPageId} source=derived", lines);
+        Assert.DoesNotContain($"[page-metadata] {TextOnlyPageId} source=bc-document", lines);
+
+        // Exactly one route per page per enumeration — a page traced twice would make the
+        // compiled-vs-precompiled COUNT this trace exists to produce wrong, even with every
+        // assertion above green.
+        Assert.Equal(1, lines.Count(l => l.StartsWith($"[page-metadata] {EmittedPageId} ", StringComparison.Ordinal)));
+        Assert.Equal(1, lines.Count(l => l.StartsWith($"[page-metadata] {TextOnlyPageId} ", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void Trace_IsASilentNoOp_UnlessTheFlagIsExactlyOne()
+    {
+        // The table flag's contract, mirrored: "true" is the value a reader reaches for and it
+        // must do nothing, so a measurement taken with it cannot come back a false zero that
+        // reads as "no pages were built". No BC engine needed — the gate is read before any
+        // route is taken, so an AL-text-only page exercises it.
+        ParseAlTableSource(TextOnlyAl);
+        ParseAlPageSource(TextOnlyAl);
+
+        // Positive: the flag's ONE working value does emit, so the negatives below are about
+        // the gate rather than about the fixture producing no rows.
+        Assert.Contains($"[page-metadata] {TextOnlyPageId} source=derived", EnumerateWithTrace("1"));
+
+        foreach (var value in new[] { null, "", "true", "True", "0", "2", "yes", " 1" })
+        {
+            var lines = EnumerateWithTrace(value);
+            Assert.True(lines.All(l => !l.StartsWith("[page-metadata] ", StringComparison.Ordinal)),
+                $"AL_RUNNER_TRACE_PAGE_METADATA_SOURCE={value ?? "<unset>"} emitted a trace line. "
+                + "Every value other than \"1\" must be a silent no-op.\n"
+                + string.Join("\n", lines.Where(l => l.StartsWith("[page-metadata] ", StringComparison.Ordinal))));
+        }
+    }
+
+    /// <summary>
+    /// Run the real row builder with the flag set to <paramref name="flag"/>, capturing
+    /// <c>Console.Out</c>. Capturing stdout rather than stderr is itself part of the claim:
+    /// the runner re-execs itself, so a stderr diagnostic can vanish, and a test reading the
+    /// wrong stream would pass against a trace nobody could observe in a real run.
+    /// </summary>
+    private static List<string> EnumerateWithTrace(string? flag)
+    {
+        var previous = Console.Out;
+        var captured = new StringWriter(new StringBuilder());
+        Environment.SetEnvironmentVariable("AL_RUNNER_TRACE_PAGE_METADATA_SOURCE", flag);
+        try
+        {
+            Console.SetOut(captured);
+            InvalidatePageControlFieldRowCache();
+            var m = typeof(AlRunner.Patches.RecordPatches).GetMethod("EnumerateKnownPageControlFields",
+                    System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "RecordPatches.EnumerateKnownPageControlFields not found.");
+            m.Invoke(null, null);
+        }
+        finally
+        {
+            Console.SetOut(previous);
+            Environment.SetEnvironmentVariable("AL_RUNNER_TRACE_PAGE_METADATA_SOURCE", null);
+        }
+        return captured.ToString()
+            .Split('\n')
+            .Select(l => l.TrimEnd('\r'))
+            .Where(l => l.Length > 0)
+            .ToList();
+    }
+
+    private string WriteAl(string name, string source)
+    {
+        var dir = Path.Combine(_root, Path.GetFileNameWithoutExtension(name));
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, name), source);
+        return dir;
+    }
+
+    private static void ParseAlPageSource(string source)
+        => typeof(AlRunner.Patches.RecordPatches)
+            .GetMethod("TryParsePageFile",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+            ?.Invoke(null, new object[] { source });
+
+    private static void ParseAlTableSource(string source)
+    {
+        var m = typeof(AlRunner.Patches.RecordPatches).GetMethod("TryParseTableFile",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+            ?? throw new InvalidOperationException("RecordPatches.TryParseTableFile not found.");
+        m.Invoke(null, new object?[] { source, null });
+    }
+
+    private static void InvalidatePageControlFieldRowCache()
+        => typeof(AlRunner.Patches.RecordPatches)
+            .GetField("_pageControlFieldRows",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+            ?.SetValue(null, null);
+
+    private static void ClearStatic(string method)
+        => typeof(AlRunner.Patches.RecordPatches)
+            .GetMethod(method, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+            ?.Invoke(null, null);
+
+    private static void RemoveMetaTableCacheEntry(int tableId)
+    {
+        var f = typeof(AlRunner.Patches.RecordPatches).GetField("_metaTableCache",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        if (f?.GetValue(null) is System.Collections.IDictionary d && d.Contains(tableId))
+            d.Remove(tableId);
+    }
+
+    private static void RemoveFromDict(string field, int id)
+    {
+        var f = typeof(AlRunner.Patches.RecordPatches).GetField(field,
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        if (f?.GetValue(null) is System.Collections.IDictionary d && d.Contains(id)) d.Remove(id);
+    }
+}

--- a/AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs
@@ -119,6 +119,34 @@ public static partial class RecordPatches
         => AlObjectMetadataRegistry.TryGet(BcPageMetadataKind, pageId, out var xml)
            && !string.IsNullOrEmpty(xml);
 
+    /// <summary>
+    /// One line per built page naming which of the three routes produced its Page Control
+    /// Field rows (#3750). Off unless <c>AL_RUNNER_TRACE_PAGE_METADATA_SOURCE</c> is exactly
+    /// <c>"1"</c> — any other value, <c>"true"</c> included, is a silent no-op. Mirrors
+    /// <c>TraceTableMetadataSource</c> (#3552), for the same reason: all three routes produce
+    /// the same ROW TYPE, so nothing downstream can be asked which one ran.
+    ///
+    /// <para><c>Console.Out</c>, never <c>Console.Error</c> — the runner re-execs itself
+    /// (<c>Program.cs</c>), so a stderr diagnostic can vanish and read as a false negative.</para>
+    ///
+    /// <para>There is no failure route, and there must not be one: AVAILABILITY decides which
+    /// route a page takes, so reporting a failure AS a route is the substitution
+    /// <c>.claude/rules/loud-failures.md</c> exists to prevent.</para>
+    ///
+    /// <para><b>The limit this inherits, stated rather than implied away.</b> A failure here is
+    /// not loud. <see cref="TryGetBcPageControlDocument"/> memoises a null on a parse failure
+    /// and the table-side builder swallows a cold-build throw into a cached null the same way
+    /// (pre-existing, <b>#3590</b>). So a page whose document genuinely failed to load and a
+    /// page that never had one are <b>indistinguishable from this trace</b>: both show as the
+    /// derivation route. A trace implying a guarantee #3590 makes impossible would be worse
+    /// than no trace — see docs/where-metadata-comes-from.md.</para>
+    /// </summary>
+    private static void TracePageMetadataSource(int pageId, string source)
+    {
+        if (Environment.GetEnvironmentVariable("AL_RUNNER_TRACE_PAGE_METADATA_SOURCE") != "1") return;
+        Console.Out.WriteLine($"[page-metadata] {pageId} source={source}");
+    }
+
     private static BcPageDocument? TryGetBcPageControlDocument(int pageId)
         => _bcPageControlDocuments.GetOrAdd(pageId, static id =>
         {

--- a/AlRunner/Patches/RecordPatches.PageControlFieldVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.PageControlFieldVirtualTable.cs
@@ -176,8 +176,18 @@ public static partial class RecordPatches
                     && GetPageControlFieldRowsFromBcDocument(page.Id) is { } fromDocument)
                 {
                     rows.AddRange(fromDocument);
+                    // #3750 — emitted here, after the document actually produced rows and
+                    // before they are handed on, so a page whose document did not parse falls
+                    // through to the derivation below and is traced as `derived` rather than
+                    // claiming a route it did not take.
+                    TracePageMetadataSource(page.Id, "bc-document");
                     continue;
                 }
+
+                // #3750 — the fall-through arm: no document was available for this page, OR
+                // one was and did not parse. Those two are indistinguishable from here and
+                // from the trace (#3590); TracePageMetadataSource says so at length.
+                TracePageMetadataSource(page.Id, "derived");
 
                 var tableId = GetSourceTableIdForPage(page.Id);
                 var table = tableId != 0 && _parsedTables.TryGetValue(tableId, out var t) ? t : null;
@@ -206,6 +216,12 @@ public static partial class RecordPatches
             {
                 if (sourceParsedPageIds.Contains(symbol.Id)) continue;
                 if (symbol.Controls == null || symbol.Controls.Count == 0) continue;
+
+                // #3750 — a THIRD route value, which the table trace has no analogue for: a
+                // precompiled dependency's page is served from its SymbolReference.json, not
+                // from AL text and not from a document. Folding it into `derived` would make
+                // the compiled-vs-precompiled split the trace exists to measure unreadable.
+                TracePageMetadataSource(symbol.Id, "symbol");
 
                 var symTable = symbol.SourceTableId != 0 && _parsedTables.TryGetValue(symbol.SourceTableId, out var st)
                     ? st : null;

--- a/docs/object-metadata-from-bc.md
+++ b/docs/object-metadata-from-bc.md
@@ -244,7 +244,13 @@ and is tracked as **#3590**; it is not a claim this page makes about the cold pa
 ```
 AL_RUNNER_TRACE_TABLE_METADATA_SOURCE=1   # one line per built table: id, route
 AL_RUNNER_TRACE_TABLE_METADATA_SOURCE=2   # ...and one line per field
+AL_RUNNER_TRACE_PAGE_METADATA_SOURCE=1    # one line per built page:  id, route (#3750)
 ```
+
+The page flag is the same instrument one object kind over, with three route values rather than
+two — `bc-document`, `derived`, `symbol` — and no level 2. `docs/where-metadata-comes-from.md`
+has the contract, the measured compiled-vs-precompiled split, and the #3590 limit both flags
+inherit.
 
 Level 2 prints `Editable`, `DataClassification`, `EnumTypeId` and `EnumTypeName`. All four live
 on `Types.Metadata.MetaField`, reachable only through the original `MetaTable` the

--- a/docs/where-metadata-comes-from.md
+++ b/docs/where-metadata-comes-from.md
@@ -9,12 +9,19 @@ The route a table actually took is observable:
 
 ```
 AL_RUNNER_TRACE_TABLE_METADATA_SOURCE=1    # one line per built table: [table-metadata] <id> source=<route>
+AL_RUNNER_TRACE_PAGE_METADATA_SOURCE=1     # one line per built page:  [page-metadata]  <id> source=<route>
 ```
 
-Exactly `"1"` or `"2"` — any other value, including `"true"`, is a silent no-op. There are exactly
-two route values, `bc-document` and `derived`, and **no failure route**: **availability** decides
-which route a table takes, and a failure is never *re-routed* to the derivation — substituting a
-weaker answer on error is what `loud-failures.md` exists to prevent.
+Exactly `"1"` or `"2"` for the table flag, exactly `"1"` for the page one — any other value,
+including `"true"`, is a silent no-op in both. A table has two route values, `bc-document` and
+`derived`. A page has **three**: `bc-document`, `derived` (the AL-text derivation) and `symbol` (a
+precompiled dependency's `SymbolReference.json`, the middle row of the table below). The third has no
+table-side analogue and is not folded into `derived`, because the compiled-vs-precompiled split is
+precisely what the page trace exists to measure.
+
+Neither flag has a **failure route**, and neither may grow one: **availability** decides which route
+an object takes, and a failure is never *re-routed* to a derivation — substituting a weaker answer on
+error is what `loud-failures.md` exists to prevent.
 
 **A failure there is not loud, though, and this page must not imply it is.** The site sits inside a
 catch that swallows any throw into `return null` for both routes alike — pre-existing, tracked as
@@ -22,6 +29,13 @@ catch that swallows any throw into `return null` for both routes alike — pre-e
 trace**, and a table that failed to load shows as `derived` exactly like one that never had a
 document. `RecordPatches.NclMetaTableBuilder.cs` says so at the site itself; #3590 is open precisely
 because the guarantee a reader would want here does not yet exist.
+
+**The page trace inherits exactly the same limit, and states it rather than implying it away.**
+`TryGetBcPageControlDocument` memoises a null when the document does not parse, so a page whose
+document genuinely failed to load takes the derivation arm and is traced `derived` — the same value a
+page that never had a document gets. Neither trace can tell you a document loaded *successfully*;
+both tell you only which route was taken. A trace implying the stronger guarantee would be worse than
+no trace.
 
 ## The three shapes
 
@@ -128,8 +142,19 @@ Measured, so it is not a worry anyone needs to re-raise: a source-compiled depen
 **consumed, not merely captured**. It is persisted as a sidecar, replayed by `DependencyLoader`, and
 the table takes the `bc-document` route on a cold run *and* on a cache HIT.
 
-Not measured, and stated as such rather than inferred: pages and pageextensions have **no route
-trace**, so whether their converted consumers fire is unverified in either direction.
+Measured too, since **#3750** gave pages the same instrument. On a bundle declaring the Base
+Application floor and reading the Page Control Field virtual table, one cold run traced **2,759
+pages**: **1** `bc-document` — exactly the one page the bundle source-compiles — and **2,758**
+`symbol`, every precompiled Base Application page. So the split attributes to compiled-vs-precompiled
+on the nose, and `PageControlFieldFromBcDocument` demonstrably **has a live consumer**: the one page
+that had a document took the document route rather than falling through.
+
+Two honest riders on that number. **Zero pages took `derived`** in that run — every source-compiled
+page got a document, so the AL-text arm was never taken; it is reachable and covered by
+`PageMetadataSourceTraceTests`, but this bundle does not exercise it. And per the #3590 limit above, a
+`derived` count can never be read as "no document was available" alone. **Pageextensions still have no
+route trace of their own** — their controls are merged into the base page's rows, so they are counted
+under the base page's route rather than separately.
 
 ## The sequencing, and why
 


### PR DESCRIPTION
Closes #3750

*Opened by an agent (`stma-auto-2`).*

Corpus-NA: a diagnostic trace naming which of the runner's internal routes produced a page's metadata. All three routes produce the same row type and AL cannot see the difference, so there is no observable a service tier could adjudicate — that indistinguishability is precisely why the trace has to exist.

## What this does

Tables can answer *"which route did this take?"* as a count. Pages could not answer it at all, so whether `PageControlFieldFromBcDocument` has a live consumer was unverified **in either direction** — it might have been working perfectly or its output might never have been read.

`AL_RUNNER_TRACE_PAGE_METADATA_SOURCE=1` now emits one line per built page naming its route:

```
[page-metadata] 65901 source=bc-document
[page-metadata] 2000000000 source=symbol
```

The contract is copied from `AL_RUNNER_TRACE_TABLE_METADATA_SOURCE` rather than redesigned: exactly `"1"` (any other value, `"true"` included, is a silent no-op), `Console.Out` and never `Console.Error` (the runner re-execs itself, so a stderr diagnostic can vanish — a previous measurement came back a false negative that way), and **no failure route**, because availability decides which route is taken and reporting a failure *as* a route is the substitution `loud-failures.md` exists to prevent.

**One deliberate divergence from the table trace: pages have three route values, not two.** `bc-document`, `derived` (the AL-text derivation) and `symbol` (a precompiled dependency's `SymbolReference.json`). The third has no table-side analogue, and folding it into `derived` would make the compiled-vs-precompiled split the trace exists to measure unreadable.

## The measurement — the actual deliverable

A throwaway bundle declaring the Base Application floor, reading the Page Control Field virtual table through `RecordRef.Open(2000000192)` so the enumeration runs for every known page. Cold run, private cache, exit 0, 1 test passed:

```
AL_RUNNER_TRACE_PAGE_METADATA_SOURCE=1 dotnet run --project AlRunner -c Release -- \
  <bundle> --package-cache "$HOME/.al-runner/platform-apps" --cache <private-cache>

command grep -E "^\[page-metadata\] " run.log | sed -E 's/.*source=//' | sort | uniq -c
```

| route | pages |
|---|---|
| `bc-document` | **1** |
| `symbol` | **2,758** |
| `derived` | **0** |
| **total** | **2,759** (38,451 rows) |

**Does the split attribute to compiled-vs-precompiled? Yes, exactly.** The single `bc-document` page is id 65901 — the one page the bundle source-compiles. All 2,758 `symbol` pages are precompiled Base Application pages. So `PageControlFieldFromBcDocument` **does have a live consumer**: the one page that had a document took the document route rather than falling through.

Two honest riders, both in the doc as well:

- **Zero pages took `derived`** in that run. That is a finding, not a broken trace — every source-compiled page got a document, so the AL-text arm was never taken. It is reachable and is covered by the unit test below. Confirmed as a real zero two ways (`command grep -c` and `rg -c`) per `verify-execution-not-the-tick.md`.
- **Pageextensions still have no route of their own.** Their controls merge into the base page's rows, so they are counted under the base page's route. Not addressed here.

## The #3590 limit is stated, not implied away

**#3590** swallows a cold-build failure into a cached null, and `TryGetBcPageControlDocument` memoises a null on a parse failure the same way. So **a genuine load failure and "no document was available" are indistinguishable from this trace** — a page that failed to load is traced `derived` exactly like one that never had a document. Neither trace can tell you a document loaded *successfully*; both tell you only which route was taken.

That is written in three places: the `TracePageMetadataSource` doc comment, the `derived` call site, and `docs/where-metadata-comes-from.md`, worded after the table section that already says it. A trace implying a guarantee #3590 makes impossible would be worse than no trace.

## RED → GREEN

`AlRunner.Tests/PageMetadataSourceTraceTests.cs`, run with the in-process BC engine live (`tools/engine-test-bootstrap.sh` + `--settings engine.runsettings`; without it both tests skip and prove nothing).

- **RED**, implementation reverted: both tests fail, `Collection: []` — no `[page-metadata]` line exists at all.
- **GREEN**, implementation restored: `Passed! - Failed: 0, Passed: 2`.

**The assertion is on the route, not on a line having been printed.** Asked directly — *would this still pass if the trace hardcoded one value?* — no, and two properties do that work:

- one enumeration, two pages, two **different** routes: an emitted page traced `bc-document` and an AL-text-only page traced `derived`;
- the negative direction per page: the emitted page must **not** be traced `derived`, and the text-only page must **not** be traced `bc-document`.

A `source=bc-document` constant satisfies the first positive and fails its paired negative; a `derived` constant does the mirror image. There is also an exactly-one-line-per-page assertion, because a page traced twice would corrupt the count the trace exists to produce while every other assertion stayed green.

The second test pins the flag gate across `null`, `""`, `"true"`, `"True"`, `"0"`, `"2"`, `"yes"`, `" 1"` — with a positive `"1"` control first, so the negatives are about the gate rather than about a fixture producing no rows. `"true"` doing nothing is what stops a future measurement coming back a false zero that reads as "no pages were built".

There is deliberately **no** test asserting a `failed` route, because there deliberately is no such route.

## Fix the shape, not just the reported line

- **Another call site with the same wrong pattern?** The route fork is one `foreach` in `EnumerateKnownPageControlFields`; all three arms are traced. `GetPageControlFieldMap` (the `TestPage` consumer) is a *different* consumer of the same symbol data and takes no document route at all, so it has no route to name — out of scope here, not silently skipped.
- **A sibling making the same assumption?** `AL_RUNNER_TRACE_PAGE_METADATA` traces control-tree construction and `AL_RUNNER_TRACE_OBJECT_METADATA` traces registrations — what was *captured*, not what was *consumed*. Neither answers the route question; both left alone.
- **Two paths writing the same state?** Not applicable — the three arms are mutually exclusive within one iteration and each traces exactly once.

## Duplicate search (`search-for-the-same-defect-first.md`)

Searched by mechanism, observable and measurement rather than title, over all 240 open issues: `trace|observab|instrument|measur|unverified|diagnos`, `page.*metadata|metadata.*page`, `route|consumer|distribut`, plus `gh search issues` on six phrasings. **No duplicate.** Nearest neighbours, all genuinely distinct:

- **#3562** — the tracker this serves, not a duplicate of it.
- **#3590** — the swallow that bounds what any trace can prove; stays open and is cited rather than closed here.
- **#2460**, **#3282**, **#3228** — dependency page metadata *content* (missing action tree, registry collision, uncaptured extension controls). All about what the rows say; this is about which route produced them.

## Scope

- Doc updated where it is now false: `docs/where-metadata-comes-from.md` said *"pages and pageextensions have no route trace, so whether their converted consumers fire is unverified in either direction"* — replaced with the measurement above. `tools/test_doc_pointers.py` passes.
- No corpus pin bump (`3ad4c340`, blocked by #2943). Nothing under `tests/al-language/`. No `CHANGELOG.md`.
- `README.md` and `PrintGuide()` list no diagnostic trace flags, so neither needed a change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DbZZqrumg7FXTiV8gaUTL
