### PR TITLE
fix(session-user): decide adoption before dependency install triggers

### DIFF
--- a/AlRunner.Tests/DepInstallTriggerSessionIdentityTests.cs
+++ b/AlRunner.Tests/DepInstallTriggerSessionIdentityTests.cs
@@ -1,0 +1,139 @@
+// DepInstallTriggerSessionIdentityTests — AlRunner#3698.
+//
+// RUNNER-MECHANISM tests. Nothing here is a claim about BC: real Business Central has no
+// session-user seed at all, because the session user is a row in the database long before any
+// extension is installed. What these pin is the runner's own install-seed ORDER, one layer out
+// from #3268: the identity a DEPENDENCY's install code observes is the identity the tests then
+// observe, and the session user is already a row in User (2000000120) while that code runs.
+//
+// THE DEFECT (#3698)
+//   TestExecutor seeded the User row AFTER the #1867 dep-company baseline window, and the
+//   dependency apps' OnInstallAppPerCompany triggers run INSIDE it. So a dependency's install
+//   code looked the session user up in an empty User table — every TableRelation to
+//   User."User Security ID" it wrote refused the id UserSecurityId() itself returned — and the
+//   seed could afterwards move the session onto an adopted row, leaving anything the dependency
+//   had keyed on that id naming a user the session is not.
+//
+// THE RED THESE TESTS ENCODE, measured on this fixture against the pre-fix runner:
+//   4P/1F cold and 4P/1F warm.
+//     FAIL Codeunit70820.DisiDependencyInstallCodeSawTheSessionUsersOwnRow — "dependency install
+//          code looked up UserSecurityId() in User (2000000120) and found no row"
+//   DisiTheSeedWroteExactlyOneRowForTheSessionUser passes in both arms before AND after: it is
+//   here because the FIX introduces a second seed call, and a second INSERT is the way that fix
+//   goes wrong.
+//
+// WHY COLD AND WARM
+//   The observation row is written by a DEPENDENCY install trigger, so it lands inside the
+//   #1867 window and is part of the captured snapshot. On a warm process that window is a
+//   DISK-HIT: the trigger does not run at all and the row arrives from the restored snapshot,
+//   which is the path a fix that only reordered the MISS branch would leave broken
+//   (.claude/rules/local-test-scope.md — a cache-sensitive change needs the second run).
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class DepInstallTriggerSessionIdentityTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    /// <summary>The bundle handed to the runner. Its observer app is the sibling <c>dep</c> dir,
+    /// resolved by BuildSiblingSourceDeps.</summary>
+    private static string BundleDir => Path.Combine(
+        RepoRoot, "AlRunner.Tests", "Fixtures", "DepInstallTriggerSessionIdentity", "main");
+
+    private static (int ExitCode, string StdOut, string StdErr) Run(string cacheDir)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(Path.Combine(RepoRoot, "AlRunner")));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" --package-cache \"").Append(TestArtifacts.PlatformAppsDir()).Append('"');
+        args.Append(' ').Append($"\"{BundleDir}\"");
+        args.Append(' ').Append($"--cache \"{cacheDir}\"");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = args.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        // PERF is what puts the DepCompanyCache MISS/DISK-HIT markers on stderr; without it the
+        // warm arm cannot say which tier answered.
+        psi.Environment["AL_RUNNER_PERF"] = "1";
+
+        var outSb = new StringBuilder();
+        var errSb = new StringBuilder();
+        using var proc = Process.Start(psi)!;
+        proc.OutputDataReceived += (_, e) => { if (e.Data != null) lock (outSb) outSb.AppendLine(e.Data); };
+        proc.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (errSb) errSb.AppendLine(e.Data); };
+        proc.BeginOutputReadLine();
+        proc.BeginErrorReadLine();
+        if (!proc.WaitForExit(300_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException("al-runner did not exit within 300s.");
+        }
+        // WaitForExit(int) returns without draining the async read callbacks; only the
+        // parameterless overload waits for those (#2496).
+        proc.WaitForExit();
+        return (proc.ExitCode, outSb.ToString(), errSb.ToString());
+    }
+
+    private static void AssertEveryTestPassed(string arm, int exit, string stdout, string stderr)
+    {
+        // Asserted by NAME so a green cannot come from the fixture having quietly stopped
+        // running its dependency install trigger.
+        Assert.Contains("PASS  Codeunit70820.DisiTheDependencyRecordedWhatItSaw", stdout);
+        Assert.Contains("PASS  Codeunit70820.DisiDependencyInstallCodeSawTheSessionUsersOwnRow", stdout);
+        Assert.Contains("PASS  Codeunit70820.DisiTheDependencySawTheIdentityTheTestsSee", stdout);
+        Assert.Contains("PASS  Codeunit70820.DisiTheDependencysLookupConsultedTheKey", stdout);
+        Assert.Contains("PASS  Codeunit70820.DisiTheSeedWroteExactlyOneRowForTheSessionUser", stdout);
+        Assert.DoesNotContain("FAIL", stdout);
+        Assert.True(exit == 0,
+            $"{arm}: expected a clean run. exit={exit}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+
+    /// <summary>
+    /// COLD, then WARM in a second process against the same cache root — the two arms of
+    /// .claude/rules/local-test-scope.md's cache-sensitive rule, in one test because the warm
+    /// arm is only meaningful after the cold one has written the entry it hits.
+    /// </summary>
+    [SkippableFact]
+    public void DependencyInstallCodeSeesTheSeededSessionUser_ColdAndOnACachedDepBaseline()
+    {
+        TestArtifacts.SkipIfMissing();
+        // TestScratch.Dir, not a hand-rolled temp combine: a --cache root is the expensive kind
+        // and an OWNED directory is reclaimable by a later runner start (#2706/#2743).
+        var cacheDir = TestScratch.Dir("al-runner-disi");
+        try
+        {
+            var cold = Run(cacheDir);
+            AssertEveryTestPassed("cold", cold.ExitCode, cold.StdOut, cold.StdErr);
+            // The dependency install trigger really ran this time — the arm the warm run below
+            // is being contrasted with.
+            Assert.Contains("InstallBaseline.DepCompanyCache MISS", cold.StdErr);
+            // NEGATIVE CONTROL. This fixture arranges no collision, so nothing may be adopted;
+            // an implementation that reached the settled identity by adopting some row would
+            // satisfy the AL assertions and be wrong.
+            Assert.DoesNotContain("ADOPTED the security id", cold.StdErr);
+
+            var warm = Run(cacheDir);
+            AssertEveryTestPassed("warm", warm.ExitCode, warm.StdOut, warm.StdErr);
+            // WITHOUT this the warm arm is not warm. On a DISK-HIT the dependency install
+            // trigger does not run, so the observation row comes out of the restored baseline —
+            // which is the half of the split a MISS-only fix would leave broken.
+            Assert.Contains("InstallBaseline.DepCompanyCache DISK-HIT", warm.StdErr);
+            Assert.DoesNotContain("InstallBaseline.DepCompanyCache MISS", warm.StdErr);
+            Assert.DoesNotContain("ADOPTED the security id", warm.StdErr);
+        }
+        finally
+        {
+            try { Directory.Delete(cacheDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/AlRunner.Tests/Fixtures/DepInstallTriggerSessionIdentity/dep/DisiInstall.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/DepInstallTriggerSessionIdentity/dep/DisiInstall.Codeunit.al
@@ -1,0 +1,38 @@
+// A DEPENDENCY's OnInstallAppPerCompany, doing what ordinary dependency install code does:
+// reading the session identity and looking the session user up in User (2000000120).
+//
+// It writes no User row and arranges no collision. That is deliberate - this fixture measures
+// what a dependency install trigger OBSERVES, and a trigger that changed the User table would
+// be measuring its own edit instead (AlRunner#3698).
+codeunit 70801 "DISI Installer"
+{
+    Subtype = Install;
+
+    trigger OnInstallAppPerCompany()
+    var
+        Observation: Record "DISI Observation";
+        UserRec: Record User;
+        Nobody: Guid;
+    begin
+        Observation.Init();
+        Observation."Code" := ObservedCodeTok;
+        Observation."Observed Security ID" := UserSecurityId();
+        Observation."Observed User Name" := CopyStr(UserId(), 1, MaxStrLen(Observation."Observed User Name"));
+
+        Observation."Session User Row Existed" := UserRec.Get(UserSecurityId());
+        if Observation."Session User Row Existed" then
+            Observation."Session User Row Name" := UserRec."User Name";
+
+        // Negative control, recorded from INSIDE the install trigger: Get must consult the key
+        // here too, or "Session User Row Existed" would be true for any implementation that
+        // answered true for everything, and the assertion on it would prove nothing.
+        Evaluate(Nobody, NobodyTok);
+        Observation."Nobody Row Existed" := UserRec.Get(Nobody);
+
+        Observation.Insert();
+    end;
+
+    var
+        ObservedCodeTok: Label 'OBSERVED', Locked = true;
+        NobodyTok: Label '{DEADBEEF-1111-2222-3333-444455556666}', Locked = true;
+}

--- a/AlRunner.Tests/Fixtures/DepInstallTriggerSessionIdentity/dep/DisiObservation.Table.al
+++ b/AlRunner.Tests/Fixtures/DepInstallTriggerSessionIdentity/dep/DisiObservation.Table.al
@@ -1,0 +1,22 @@
+// What the dependency's install trigger saw while it ran. Written inside TestExecutor's
+// dep-company baseline window, so on a cache HIT it arrives from the restored snapshot instead
+// of from a fresh trigger run - which is what makes the warm arm of the C# test meaningful.
+table 70800 "DISI Observation"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Code"; Code[10]) { DataClassification = CustomerContent; }
+        field(2; "Observed Security ID"; Guid) { DataClassification = CustomerContent; }
+        field(3; "Observed User Name"; Text[50]) { DataClassification = CustomerContent; }
+        field(4; "Session User Row Existed"; Boolean) { DataClassification = CustomerContent; }
+        field(5; "Session User Row Name"; Text[50]) { DataClassification = CustomerContent; }
+        field(6; "Nobody Row Existed"; Boolean) { DataClassification = CustomerContent; }
+    }
+
+    keys
+    {
+        key(PK; "Code") { Clustered = true; }
+    }
+}

--- a/AlRunner.Tests/Fixtures/DepInstallTriggerSessionIdentity/dep/app.json
+++ b/AlRunner.Tests/Fixtures/DepInstallTriggerSessionIdentity/dep/app.json
@@ -1,0 +1,13 @@
+{
+  "id": "b7f41d92-3c65-4a08-9d17-52e6c8a3b410",
+  "name": "Runner Tests Fixture - Dep Install Trigger Session Identity Observer",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "#3698: a DEPENDENCY install trigger records the session identity it observed, and whether the session user was a row in User (2000000120) at that moment.",
+  "description": "Dependency install triggers run inside TestExecutor's dep-company baseline window. Before #3698 the session-user seed ran after that window, so a dependency's install code saw an empty User table and a session identity that could still change. This app only OBSERVES - it writes no User row and arranges no collision - so the observation it stores is exactly what a real dependency's OnInstallAppPerCompany would have seen. The consuming bundle's tests read the stored row back.",
+  "dependencies": [],
+  "idRanges": [ { "from": 70800, "to": 70819 } ],
+  "platform": "27.0.0.0",
+  "runtime": "15.0",
+  "target": "OnPrem"
+}

--- a/AlRunner.Tests/Fixtures/DepInstallTriggerSessionIdentity/main/DisiTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/DepInstallTriggerSessionIdentity/main/DisiTests.Codeunit.al
@@ -1,0 +1,97 @@
+codeunit 70820 "DISI Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        ObservedCodeTok: Label 'OBSERVED', Locked = true;
+        // What BcRuntime generates for the skeleton session. Nothing here is adopted, so this is
+        // what UserSecurityId() must answer - asserted as a concrete constant rather than as
+        // "not empty", so an implementation returning a default cannot pass.
+        GeneratedSidTok: Label '{C0A1BDFA-0000-0000-0000-545553545553}', Locked = true;
+
+    [Test]
+    procedure DisiTheDependencyRecordedWhatItSaw()
+    var
+        Observation: Record "DISI Observation";
+    begin
+        // PRECONDITION. Without it every assertion below would also pass on a run where the
+        // dependency's install trigger never executed, and would prove nothing at all.
+        if not Observation.Get(ObservedCodeTok) then
+            Error('the dependency''s install trigger must have written the "%1" observation row',
+              ObservedCodeTok);
+        if Observation."Observed User Name" <> UserId() then
+            Error('the dependency saw UserId() = "%1", but UserId() is now "%2"',
+              Observation."Observed User Name", UserId());
+    end;
+
+    [Test]
+    procedure DisiDependencyInstallCodeSawTheSessionUsersOwnRow()
+    var
+        Observation: Record "DISI Observation";
+    begin
+        // THE #3698 DISCRIMINATOR. The session-user seed used to run AFTER the dep-company
+        // baseline window, so a DEPENDENCY install trigger looked the session user up in an
+        // empty User table: every TableRelation to User."User Security ID" it wrote refused the
+        // id UserSecurityId() itself returned, and the identity could still be moved onto an
+        // adopted row afterwards.
+        Observation.Get(ObservedCodeTok);
+        if not Observation."Session User Row Existed" then
+            Error(
+              'dependency install code looked up UserSecurityId() in User (2000000120) and found '
+              + 'no row: the session-user seed had not run yet (AlRunner#3698)');
+        if Observation."Session User Row Name" <> UserId() then
+            Error(
+              'the row the dependency found carried the user name "%1", expected "%2"',
+              Observation."Session User Row Name", UserId());
+    end;
+
+    [Test]
+    procedure DisiTheDependencySawTheIdentityTheTestsSee()
+    var
+        Observation: Record "DISI Observation";
+        GeneratedSid: Guid;
+    begin
+        // The identity is SETTLED by the time dependency install code runs: what it observed is
+        // what the tests observe. Both sides are asserted against the concrete generated id as
+        // well as against each other, so "they agree because nothing was ever set" cannot pass.
+        Evaluate(GeneratedSid, GeneratedSidTok);
+        Observation.Get(ObservedCodeTok);
+        if Observation."Observed Security ID" <> UserSecurityId() then
+            Error(
+              'dependency install code stored %1 as the session identity, but UserSecurityId() is '
+              + 'now %2 - the session user changed after the dependency install triggers ran '
+              + '(AlRunner#3698)',
+              Format(Observation."Observed Security ID"), Format(UserSecurityId()));
+        if UserSecurityId() <> GeneratedSid then
+            Error('with no row to adopt, UserSecurityId() must be the runner-generated %1, but it is %2',
+              GeneratedSidTok, Format(UserSecurityId()));
+    end;
+
+    [Test]
+    procedure DisiTheDependencysLookupConsultedTheKey()
+    var
+        Observation: Record "DISI Observation";
+    begin
+        // NEGATIVE CONTROL for the test above, recorded from inside the same install trigger: a
+        // Get answering true for anything would make "Session User Row Existed" meaningless.
+        Observation.Get(ObservedCodeTok);
+        if Observation."Nobody Row Existed" then
+            Error('User.Get on a security id belonging to nobody must be false, even during install');
+    end;
+
+    [Test]
+    procedure DisiTheSeedWroteExactlyOneRowForTheSessionUser()
+    var
+        UserRec: Record User;
+    begin
+        // Seeding earlier must not seed TWICE. The seed is called at two points now - inside the
+        // dep-company window and again after it - and a second insert would leave two rows under
+        // one user name, a state real BC refuses to hold.
+        if not UserRec.Get(UserSecurityId()) then
+            Error('the session user must be a row in User (2000000120) at test time');
+        UserRec.SetRange("User Name", UserId());
+        if UserRec.Count() <> 1 then
+            Error('expected exactly 1 User row named "%1" but found %2', UserId(), UserRec.Count());
+    end;
+}

--- a/AlRunner.Tests/Fixtures/DepInstallTriggerSessionIdentity/main/app.json
+++ b/AlRunner.Tests/Fixtures/DepInstallTriggerSessionIdentity/main/app.json
@@ -1,0 +1,20 @@
+{
+  "id": "3a08f5c7-91be-4d26-8f43-6c5b71ea2d94",
+  "name": "Runner Tests Fixture - Dep Install Trigger Session Identity",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "#3698: reads back what the sibling DEPENDENCY app's install trigger observed, and asserts the session user was already a row in User (2000000120) with the identity the tests still see.",
+  "description": "AlRunner#3698: the session-user seed ran after the dep-company baseline window, so a DEPENDENCY's install trigger observed an empty User table and an identity the seed could still move onto an adopted row. The dependency here records what it saw; these tests assert the session user's row was present, carried the session user's name, and that the security id install code saw is the one the tests see.",
+  "dependencies": [
+    {
+      "id": "b7f41d92-3c65-4a08-9d17-52e6c8a3b410",
+      "name": "Runner Tests Fixture - Dep Install Trigger Session Identity Observer",
+      "publisher": "AL Runner",
+      "version": "1.0.0.0"
+    }
+  ],
+  "idRanges": [ { "from": 70820, "to": 70839 } ],
+  "platform": "27.0.0.0",
+  "runtime": "15.0",
+  "target": "OnPrem"
+}

--- a/AlRunner.Tests/Fixtures/InstallTriggerSessionIdentity/dep/ItsiSeedInstall.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/InstallTriggerSessionIdentity/dep/ItsiSeedInstall.Codeunit.al
@@ -1,10 +1,15 @@
-// Writes a User (2000000120) row carrying the SESSION user's name under a different security
-// id, from a DEPENDENCY install trigger — i.e. before the runner's session-user seed runs, and
-// before the consuming bundle's own install triggers run.
+// Replaces the session user's row in User (2000000120) with a DIFFERENT user carrying the same
+// name, from a DEPENDENCY install trigger -- i.e. before the consuming bundle's own install
+// triggers run, and before the runner's session-user identity DECISION is made.
 //
 // This is the state a --test-data backup containing its own TESTUSER produces. It is written
 // from AL because a fixture cannot restore a backup, and from a dependency because the ordering
-// under test (AlRunner#3268) is precisely "the bundle's own install code versus the seed".
+// under test (AlRunner#3268) is precisely "the bundle's own install code versus the decision".
+//
+// DELETE-THEN-INSERT, not a bare insert (#3698). The seed's ROW is now written inside
+// TestExecutor's dep-company baseline window, ahead of the dependency install triggers, so the
+// session user is already in the table when this runs and BC refuses a second row under one
+// name. Deleting first is what restoring a backup over the table does.
 codeunit 70760 "ITSI Seed Installer"
 {
     Subtype = Install;
@@ -14,6 +19,15 @@ codeunit 70760 "ITSI Seed Installer"
         UserRec: Record User;
         StandInSid: Guid;
     begin
+        // The #3698 precondition, asserted: dependency install code finds the session user's own
+        // row. Without the delete that follows, the insert below would be refused over the
+        // duplicate name instead of arranging the collision this fixture is about.
+        if not UserRec.Get(UserSecurityId()) then
+            Error(
+              'precondition: the session user %1 must already be a row in User (2000000120) when '
+              + 'a DEPENDENCY install trigger runs (AlRunner#3698)', Format(UserSecurityId()));
+        UserRec.Delete();
+
         Evaluate(StandInSid, StandInSidTok);
         UserRec.Init();
         UserRec."User Security ID" := StandInSid;

--- a/AlRunner.Tests/Fixtures/InstallTriggerSessionIdentity/dep/app.json
+++ b/AlRunner.Tests/Fixtures/InstallTriggerSessionIdentity/dep/app.json
@@ -3,10 +3,15 @@
   "name": "Runner Tests Fixture - Install Trigger Session Identity Seed",
   "publisher": "AL Runner",
   "version": "1.0.0.0",
-  "brief": "#3268: puts a User row carrying the session user's name into 2000000120 from a DEPENDENCY install trigger, so the runner's session-user seed has something to adopt before the consuming bundle's own install code runs.",
-  "description": "The colliding row has to arrive from a dependency rather than from the bundle under test. Dependency install triggers run inside TestExecutor's dep-company baseline window, ahead of the session-user seed; the bundle's own install triggers run after it. Putting the row here is what lets the main app's install trigger observe the SETTLED session identity, which is the whole subject of AlRunner#3268.",
+  "brief": "#3268/#3698: carries the Install codeunit that replaces the session user's User row with a stand-in under the same name, before the runner's identity decision is made.",
+  "description": "The row lives in a dependency because the runner's session-user identity decision runs ahead of a bundle's OWN install triggers (#3268), so a bundle-local trigger could no longer establish the pre-decision state this fixture needs. Since #3698 the seed's ROW is written inside TestExecutor's dep-company baseline window, ahead of the dependency install triggers, so this app deletes that row before inserting its stand-in: a bare insert would be refused over the duplicate user name. The collision the fixture measures is unchanged.",
   "dependencies": [],
-  "idRanges": [ { "from": 70760, "to": 70779 } ],
+  "idRanges": [
+    {
+      "from": 70760,
+      "to": 70779
+    }
+  ],
   "platform": "27.0.0.0",
   "runtime": "15.0",
   "target": "OnPrem"

--- a/AlRunner.Tests/Fixtures/SessionUserRowAlreadyPresent/dep/SuraInstall.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/SessionUserRowAlreadyPresent/dep/SuraInstall.Codeunit.al
@@ -1,15 +1,16 @@
-// Puts the session user's OWN row in User (2000000120) before the runner's seed runs.
+// Puts the fixture's own marker on the session user's row in User (2000000120), before the
+// runner's seed decides the session identity.
 //
-// The ordering is the whole point and it is not incidental. Since #3268 the seed
-// (install-seed-user-row) runs BEFORE a bundle's own Install triggers
-// (install-seed-run-own-install-triggers) and AFTER the DEPENDENCY install triggers, which run
-// inside TestExecutor's dep-company baseline window -- which is why this codeunit lives in a
-// sibling dependency app rather than in the bundle under test. So by the time the seed
-// executes, the row it wants to write is already there and its ALInsert is refused by the
-// PRIMARY KEY on "User Security ID".
+// THE ORDERING, AND WHY IT CHANGED (#3698). The seed's ROW is now written inside TestExecutor's
+// dep-company baseline window, ahead of the DEPENDENCY install triggers, so that dependency
+// install code finds the session user in the table. A dependency can therefore no longer INSERT
+// that row - the seed already did, and BC refuses a second user under one name or one security
+// id, which the runner reproduces. So this codeunit MODIFIES the row instead, which is the state
+// a backup restored over the seeded table leaves behind.
 //
-// That refusal is the benign one. The row the seed exists to guarantee is present, so the run
-// must carry on silently -- and it must not touch the row that is already there.
+// What the fixture measures is unchanged: the seed's second call - the identity DECISION, made
+// after the window on every path - finds a row for the session user's own security id, must take
+// the benign already-present path, and must not touch the row that is there.
 codeunit 70500 "SURA Installer"
 {
     Subtype = Install;
@@ -18,14 +19,19 @@ codeunit 70500 "SURA Installer"
     var
         UserRec: Record User;
     begin
-        UserRec.Init();
-        UserRec."User Security ID" := UserSecurityId();
-        UserRec."User Name" := CopyStr(UserId(), 1, MaxStrLen(UserRec."User Name"));
+        // Asserted rather than tested: without this row the fixture measures nothing, and a
+        // silent miss would turn every test in the bundle into a vacuous pass. It is also the
+        // #3698 precondition - dependency install code sees the session user's row.
+        if not UserRec.Get(UserSecurityId()) then
+            Error(
+              'precondition: the session user %1 must already be a row in User (2000000120) when '
+              + 'a DEPENDENCY install trigger runs (AlRunner#3698)', Format(UserSecurityId()));
+
         // The marker is how the tests tell "the seed left this row alone" from "the seed
         // replaced it": the runner's own seed writes the skeleton NavUser's Full Name, never
         // this string.
         UserRec."Full Name" := InstalledByFixtureTok;
-        UserRec.Insert();
+        UserRec.Modify();
     end;
 
     var

--- a/AlRunner.Tests/Fixtures/SessionUserRowAlreadyPresent/dep/app.json
+++ b/AlRunner.Tests/Fixtures/SessionUserRowAlreadyPresent/dep/app.json
@@ -3,10 +3,15 @@
   "name": "Runner Tests Fixture - Session User Row Already Present Seed",
   "publisher": "AL Runner",
   "version": "1.0.0.0",
-  "brief": "#3268: carries the Install codeunit that puts the session user's own User row in place BEFORE the runner's session-user seed runs.",
-  "description": "The write lives in a dependency because #3268 moved EnsureUserSystemTableRowSeeded ahead of a bundle's OWN install triggers: a bundle-local trigger now runs after the seed and could no longer establish the pre-seed state this control needs. Dependency install triggers still run inside TestExecutor's dep-company baseline window, which is before the seed, so the ordering the fixture is about is unchanged.",
+  "brief": "#2941/#3698: carries the Install codeunit that marks the session user's own User row BEFORE the runner's identity decision is made.",
+  "description": "The write lives in a dependency because the runner's session-user seed runs ahead of a bundle's OWN install triggers (#3268). Since #3698 the seed's ROW is written inside TestExecutor's dep-company baseline window, ahead of the DEPENDENCY install triggers too, so this app can no longer insert that row - the seed already did, and BC refuses a second user under one security id. It MODIFIES the seeded row instead, which is what restoring a backup over the seeded table leaves behind, and the identity decision after the window still has to take the benign already-present path.",
   "dependencies": [],
-  "idRanges": [{ "from": 70500, "to": 70509 }],
+  "idRanges": [
+    {
+      "from": 70500,
+      "to": 70509
+    }
+  ],
   "platform": "27.0.0.0",
   "runtime": "15.0",
   "target": "OnPrem"

--- a/AlRunner.Tests/Fixtures/SessionUserRowNameCollision/dep/SurcInstall.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/SessionUserRowNameCollision/dep/SurcInstall.Codeunit.al
@@ -1,39 +1,26 @@
-// Puts a DIFFERENT user, carrying the session user's NAME, into User (2000000120) before the
-// runner's seed runs.
+// Replaces the session user's row in User (2000000120) with a DIFFERENT user carrying the same
+// name - the state a --test-data backup containing its own TESTUSER produces.
 //
-// TestExecutor runs the DEPENDENCY install triggers -- inside the dep-company baseline window --
-// before RecordPatches.EnsureUserSystemTableRowSeeded, so this row is in place when the seed
-// executes. It has to be a dependency: since #3268 the seed runs ahead of a bundle's own install
-// triggers, and from there BC's uniqueness rule would refuse this insert outright because the
-// session user's row already exists. This is the shape a --test-data backup containing its own
-// TESTUSER produces.
-//
-// WHAT REFUSES A DUPLICATE USER NAME, AND WHERE
-//   On a real tier it is BC's system-table TRIGGER, not an index. Ncl's
-//   SystemTableTriggers.OnBeforeInsertAsync has a `case 2000000120:` arm that validates a unique
-//   user name -- along with the Windows SID, authentication email and application id -- before
-//   the row is written. AlRunner/Patches/UserTableTriggerPatches.cs reproduces that arm (#2983),
-//   so the runner refuses this collision the way BC does. Until it did, the store behind the
-//   User table -- BC's own CreateTempDataAccess -- enforced the primary key and nothing else,
-//   the seed landed anyway, and the run was left holding two rows that share a user name where
-//   BC would hold one.
+// THE ORDERING, AND WHY IT CHANGED (#3698). The seed's ROW is now written inside TestExecutor's
+// dep-company baseline window, ahead of the DEPENDENCY install triggers, so a dependency cannot
+// simply INSERT a same-named user any more: BC refuses a duplicate user name from a TRIGGER
+// (SystemTableTriggers.OnBeforeInsertAsync's `case 2000000120:` arm calls
+// IsUserFieldUniqueAsync(recordBuffer, 2, insert: true), and AlRunner/Patches/UserTableTriggerPatches.cs
+// reproduces it, #2983), and the seeded row is already there. So this codeunit DELETES the
+// seeded row first and inserts the stand-in in its place, which is what restoring a backup over
+// the table does.
 //
 // WHAT THE SEED DOES ABOUT IT: ADOPT (maintainer decision, 2026-09-06)
-//   BC's refusal is right about the ROW, and it leaves open what the SESSION should be. The
-//   runner ADOPTS: it takes this stand-in row's security id as the session's own, so
-//   UserSecurityId() answers {A17E9C42-5B08-4D6F-9E31-0C7A2F84B155} for the rest of the run and
-//   no row is written. The alternative -- refuse, and run as a user present in no row -- is the
-//   state AlRunner#2296 exists to remove, and it was this fixture that measured it.
+//   The seed's second call - the identity DECISION, made after the window on every path - finds
+//   no row for the session's own security id and one carrying its name, so it ADOPTS that row's
+//   security id: UserSecurityId() answers {A17E9C42-5B08-4D6F-9E31-0C7A2F84B155} for the rest of
+//   the run and no row is written. The alternative - refuse, and run as a user present in no row
+//   - is the state AlRunner#2296 exists to remove, and it was this fixture that measured it.
 //
 // WHAT THIS FIXTURE IS FOR
-//   It measures the hazard the #2941 review predicted, end to end, and it has now flipped twice.
-//   SurcTheSessionUserStillGetsItsOwnRow (the seed landing) became
-//   SurcTheSessionUserIsRefusedItsOwnRowOverTheDuplicateName when #2983 added the uniqueness
-//   arm, and that became SurcTheSessionAdoptedTheExistingRowsSecurityId when the maintainer
-//   chose adoption. What it pins from here on is the ADOPTION being complete and loud: the
-//   session resolves to THIS row, no second row is written, UserId() is untouched, the adopted
-//   user keeps its User Property companion row, and the seed says on stderr where the id came
-//   from.
+//   The ADOPTION being complete and loud: the session resolves to THIS row, no second row is
+//   written, UserId() is untouched, the adopted user keeps its User Property companion row, and
+//   the seed says on stderr where the id came from.
 codeunit 70520 "SURC Installer"
 {
     Subtype = Install;
@@ -44,11 +31,19 @@ codeunit 70520 "SURC Installer"
         UserProperty: Record "User Property";
         CollidingSid: Guid;
     begin
+        // Asserted rather than tested: this is the #3698 precondition (dependency install code
+        // finds the session user's row), and without the delete below the insert that follows
+        // would be refused over the duplicate name instead of arranging the collision.
+        if not UserRec.Get(UserSecurityId()) then
+            Error(
+              'precondition: the session user %1 must already be a row in User (2000000120) when '
+              + 'a DEPENDENCY install trigger runs (AlRunner#3698)', Format(UserSecurityId()));
+        UserRec.Delete();
+
         Evaluate(CollidingSid, CollidingSidTok);
         UserRec.Init();
         UserRec."User Security ID" := CollidingSid;
-        // Same NAME as the runner's session user, different security id. This is the collision
-        // BC's OnBeforeInsertAsync case 2000000120: arm would refuse and the runner does not.
+        // Same NAME as the runner's session user, different security id.
         UserRec."User Name" := CopyStr(UserId(), 1, MaxStrLen(UserRec."User Name"));
         UserRec."Full Name" := BackupUserTok;
         UserRec.Insert();

--- a/AlRunner.Tests/Fixtures/SessionUserRowNameCollision/dep/app.json
+++ b/AlRunner.Tests/Fixtures/SessionUserRowNameCollision/dep/app.json
@@ -3,10 +3,15 @@
   "name": "Runner Tests Fixture - Session User Row Name Collision Seed",
   "publisher": "AL Runner",
   "version": "1.0.0.0",
-  "brief": "#3268: carries the Install codeunit that writes the same-named stand-in User row the session adopts.",
-  "description": "The write lives in a dependency because #3268 moved EnsureUserSystemTableRowSeeded ahead of a bundle's OWN install triggers. A bundle-local trigger now runs after the seed, so the session user's row already exists when it runs and BC's own uniqueness rule (which the runner reproduces in UserTableTriggerPatches) refuses the duplicate name outright -- the pre-seed state this fixture needs could not be established from there any more. Dependency install triggers still run inside TestExecutor's dep-company baseline window, ahead of the seed, so the collision the fixture measures is unchanged.",
+  "brief": "#2983/#3698: carries the Install codeunit that replaces the session user's User row with a different user under the same name, before the runner's identity decision is made.",
+  "description": "The write lives in a dependency because the runner's session-user seed runs ahead of a bundle's OWN install triggers (#3268). Since #3698 the seed's ROW is written inside TestExecutor's dep-company baseline window, ahead of the DEPENDENCY install triggers too, so this app DELETES the seeded row and inserts the stand-in in its place - a bare insert would be refused over the duplicate user name, exactly as it would be on a service tier. That is the state a restored backup produces, and it is what the identity decision after the window adopts.",
   "dependencies": [],
-  "idRanges": [{ "from": 70520, "to": 70529 }],
+  "idRanges": [
+    {
+      "from": 70520,
+      "to": 70529
+    }
+  ],
   "platform": "27.0.0.0",
   "runtime": "15.0",
   "target": "OnPrem"

--- a/AlRunner.Tests/SessionUserRowRefusalTests.cs
+++ b/AlRunner.Tests/SessionUserRowRefusalTests.cs
@@ -144,9 +144,16 @@ public sealed class SessionUserRowRefusalTests
 
             // THE DISCRIMINATOR. The pre-fix runner printed the "seeded" line here, because it
             // discarded ALInsert's false and ran its success trace regardless. Asserting the
-            // exact text both ways is what makes this a RED→GREEN rather than a smoke test.
+            // exact text is what makes this a RED→GREEN rather than a smoke test.
             Assert.Contains("UserSystemTable: User row 'TESTUSER' was already present", stderr);
-            Assert.DoesNotContain("UserSystemTable: seeded User row", stderr);
+            // EXACTLY ONE "seeded" line, not none. Since #3698 the seed is called twice per app
+            // group — once inside the dep-company window, which is where that line comes from,
+            // and once after it for the identity decision, which is the call under test here.
+            // A second "seeded" line would be the late call claiming an insert it did not make,
+            // which is the defect this test was written for.
+            var seeded = stderr.Split("UserSystemTable: seeded User row").Length - 1;
+            Assert.True(seeded == 1,
+                $"expected exactly one in-window seed line, saw {seeded}\nstderr:\n{stderr}");
 
             // The benign refusal must not be reported as a failure — this is the negative
             // control on the loud path. An implementation that shouted on every non-insert
@@ -194,7 +201,13 @@ public sealed class SessionUserRowRefusalTests
             // adopting is allowed to be silent about nothing.
             Assert.Contains("ADOPTED the security id", stderr);
             Assert.DoesNotContain("was REFUSED and is NOT present", stderr);
-            Assert.DoesNotContain("UserSystemTable: seeded User row", stderr);
+            // EXACTLY ONE "seeded" line: the in-window seed the dependency then replaces with
+            // its stand-in row (#3698). A second would mean the identity decision after the
+            // window had written a row instead of adopting one, which is the state real BC
+            // refuses to hold and the whole subject of this fixture.
+            var seeded = stderr.Split("UserSystemTable: seeded User row").Length - 1;
+            Assert.True(seeded == 1,
+                $"expected exactly one in-window seed line, saw {seeded}\nstderr:\n{stderr}");
 
             // THE ADOPTION IS VISIBLE, in the terms the objection to adopting demanded: the
             // user, the id taken, the id it replaced, and that it came from the data. A reader

--- a/AlRunner.Tests/SessionUserRowRefusalTests.cs
+++ b/AlRunner.Tests/SessionUserRowRefusalTests.cs
@@ -263,9 +263,10 @@ public sealed class SessionUserRowRefusalTests
     ///
     /// <para>The two fixtures can share a process at all because their object id ranges do not
     /// overlap — 70520-70539 against 70500-70519 — and each declares only its own sibling seed
-    /// app, which #3268 made the place a fixture's pre-seed User write has to live: the
-    /// session-user seed now runs ahead of a bundle's OWN install triggers and after the
-    /// dependency ones.</para>
+    /// app, which is where a fixture's User write has to live: the identity decision runs ahead
+    /// of a bundle's OWN install triggers (#3268) and after the dependency ones, and since #3698
+    /// the seeded ROW is in place before those dependency triggers run, so each seed app
+    /// replaces or modifies that row rather than inserting beside it.</para>
     ///
     /// <para>--watch and --server are the two other multi-bundle modes and reduce to the same
     /// per-bundle reset; this asserts the mechanism through the cheapest of the three. Note that

--- a/AlRunner/Patches/RecordPatches.UserSystemTable.cs
+++ b/AlRunner/Patches/RecordPatches.UserSystemTable.cs
@@ -433,8 +433,12 @@ public static partial class RecordPatches
                 //     in play — and this line is what tells the reader why that exception is
                 //     about to appear.
                 //
-                // _userRowSeededForThisBundle is deliberately NOT set: no row was seeded, and a
-                // flag claiming otherwise is the defect this branch exists to remove.
+                // _userRowSeededForThisBundle is CLEARED here, not merely left unset. Since #3698
+                // this method runs twice per app group, so an earlier call can have set it true
+                // over a row that install code has since deleted — and the flag's stated
+                // invariant is that it is true only while the table holds a row for the session
+                // user's security id. AccessControlSeed reads it.
+                _userRowSeededForThisBundle = false;
                 Console.Error.WriteLine(
                     $"[warn] UserSystemTable: the User row (2000000120) for the session user "
                     + $"'{userName}' ({userSid}) was REFUSED and is NOT present — {refusalDetail}. "

--- a/AlRunner/Patches/RecordPatches.UserSystemTable.cs
+++ b/AlRunner/Patches/RecordPatches.UserSystemTable.cs
@@ -259,8 +259,10 @@ public static partial class RecordPatches
     /// to see), BEFORE the bundle's OWN install triggers — install code that stores
     /// <c>UserSecurityId()</c> must see the identity the tests will see, #3268 — and BEFORE
     /// <c>CaptureInstallBaseline()</c>, so the row is part of the restored baseline.
-    /// Why it cannot move inside the dep-company cached window instead:
-    /// docs/session-user-seed-ordering.md.
+    /// <para>Called TWICE per app group since #3698: inside the dep-company window on a MISS,
+    /// so a dependency's install code finds the row, and again after that window on every path,
+    /// so the identity decision is re-made from whatever the table then holds. The row is
+    /// cacheable; the decision is not. docs/session-user-seed-ordering.md has the ordering.</para>
     /// </summary>
     /// <returns>
     /// Which of the outcomes in <see cref="UserRowSeedOutcome"/> this call reached. The
@@ -269,7 +271,12 @@ public static partial class RecordPatches
     /// </returns>
     internal static UserRowSeedOutcome EnsureUserSystemTableRowSeeded()
     {
-        if (_userRowSeededForThisBundle) return UserRowSeedOutcome.AlreadySeededThisBundle;
+        // #3698: NO short-circuit on _userRowSeededForThisBundle. TestExecutor calls this twice
+        // per app group — once inside the dep-company window for the row, once after it for the
+        // identity decision — and between the two, install code and a --test-data load can both
+        // change what the User table holds. A latch would answer from the first call's state and
+        // skip a decision the second call exists to make; the outcome is decided from the table
+        // each time instead, and re-deciding is a Get on an unchanged table when nothing moved.
         // The flag is no longer set before the work, so the insert below — which re-enters
         // NavRecord and, through UserTableTriggerPatches, a second table — is now inside the
         // window where re-entry would recurse. This guard closes it explicitly rather than

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -588,6 +588,16 @@ public sealed class TestExecutor
                     // "not in the list of allowed tables". Seeded inside this MISS branch so
                     // the rows are part of the captured snapshot a later cache HIT restores.
                     AlRunner.Patches.RecordPatches.EnsurePublishedApplicationDependencyRowsSeeded();
+                    // #3698 — the session user's ROW, before the DEPENDENCY install triggers on
+                    // the next line. A dependency's install code that looks UserSecurityId() up
+                    // in User (2000000120), or writes a row relating to it, must find the row
+                    // there — on a real tier the session user predates every extension install.
+                    // This is the CAPTURE half of the split: the row lands inside the window and
+                    // is part of the snapshot a later HIT restores. The identity DECISION is
+                    // re-made per app group by the second call after this block, because
+                    // adoption is a poke at the skeleton session that no snapshot carries. See
+                    // docs/session-user-seed-ordering.md.
+                    AlRunner.Patches.RecordPatches.EnsureUserSystemTableRowSeeded();
                     InstallTriggerRunner.RunDependenciesOnly();
                     CompanyInitializer.EnsureCompanyInitialized();
                     var initFailure = CompanyInitializer.LastRecordedFailure;
@@ -627,14 +637,11 @@ public sealed class TestExecutor
             }
         }
         // #2296 — the session user's own row in the User system table, and with it the #2983
-        // adoption decision. BEFORE this bundle's own install triggers below (#3268): install
-        // code that stores UserSecurityId() must see the identity the tests will see, and on a
-        // real tier the session user is a row in the database long before any extension is
-        // installed. Seeded after the dep-company block above, never inside it, because
-        // adoption is a poke at the skeleton session rather than a row: a cached snapshot
-        // restores the row on a HIT but cannot re-make the decision, so the decision has to be
-        // re-made per app group outside the cached window. See
-        // docs/session-user-seed-ordering.md.
+        // adoption DECISION, re-made here per app group on every path. The row itself is seeded
+        // one call earlier, inside the dep-company window (#3698), so a dependency's install
+        // code sees it; this call is what a cache HIT needs, because adoption is a poke at the
+        // skeleton session rather than a row and no snapshot carries it. Also before this
+        // bundle's own install triggers below (#3268). See docs/session-user-seed-ordering.md.
         //
         // Still before CaptureInstallBaseline below, the constraint it has always had: the
         // per-codeunit restore puts the store back to that baseline, so a row added after it

--- a/docs/session-user-seed-ordering.md
+++ b/docs/session-user-seed-ordering.md
@@ -8,70 +8,75 @@ the runner reproduces that refusal — so it **adopts** that row's security id a
 own instead (#2983). Adoption makes `UserSecurityId()` a value that came out of the data, which
 is why every adoption prints a `[warn]` line naming both ids.
 
-That leaves one question, which is what this page is about: **when is the adoption decided,
+That leaves one question, which is what this page is about: **when is the identity settled,
 relative to the install code that observes the answer?**
 
-## The order, as of #3268
+## The order, as of #3698
 
 Inside `TestExecutor`'s install-seed stage, in execution order:
 
 1. per-bundle resets (`ResetUserSystemTableForNewBundle` puts the generated id back)
 2. `TestDataProvisioner.Arm()` — the `--test-data` on-demand loader
-3. the **dep-company baseline window** (#1867): on a MISS, the dependency apps' install
-   triggers plus `Company-Initialize`, then `CaptureInstallBaselineSnapshot`; on a HIT or
-   DISK-HIT, `RestoreInstallBaselineSnapshot` and none of that work
-4. **`EnsureUserSystemTableRowSeeded` — the seed, and the adoption decision**
+3. the **dep-company baseline window** (#1867). On a MISS: the dependency apps' Published
+   Application rows, **`EnsureUserSystemTableRowSeeded` — the ROW**, then the dependency apps'
+   install triggers, `Company-Initialize`, and `CaptureInstallBaselineSnapshot`. On a HIT or
+   DISK-HIT: `RestoreInstallBaselineSnapshot` and none of that work.
+4. **`EnsureUserSystemTableRowSeeded` again — the identity DECISION**, re-made per app group on
+   every path from whatever the `User` table now holds
 5. `InstallTriggerRunner.RunTestAssemblyOnly()` — the bundle's **own** install triggers
 6. the Company row, the bundle's Published Application row, the Access Control SUPER row
 7. `CaptureInstallBaseline()` — the baseline every codeunit boundary restores to
 
-Before #3268, step 4 ran between steps 5 and 6. AL that stored `UserSecurityId()` in an install
-trigger therefore stored the runner-generated id, and the seed then moved the session onto an
-adopted row: the stored id named a user the session was no longer, and a `TableRelation` from it
-resolved to the wrong row or to none. That is the defect #3268 describes, and
-`AlRunner.Tests/InstallTriggerSessionIdentityTests` measures it — 3P/2F against the pre-fix
-runner, cold and warm.
+Before #3268, step 4 ran between steps 5 and 6, so the bundle's own install code stored an id
+the seed then changed under it. Before #3698 there was no call at step 3, so a **dependency's**
+install trigger looked the session user up in an empty table and observed an identity that could
+still move. `AlRunner.Tests/InstallTriggerSessionIdentityTests` measures the first;
+`AlRunner.Tests/DepInstallTriggerSessionIdentityTests` measures the second — 4P/1F against the
+pre-#3698 runner, cold and warm.
 
-The new position is also the more BC-faithful one. On a service tier the session user is a row
-in the database long before any extension is installed, so install code cannot observe an
-identity that later changes, and it cannot insert a second user under the session user's name
-either.
+The position is also the more BC-faithful one. On a service tier the session user is a row in
+the database long before any extension is installed, so install code cannot observe an identity
+that later changes, and it cannot insert a second user under the session user's name either.
 
-## Why the seed cannot move inside the dep-company window instead
-
-Moving it one step earlier — ahead of step 3 — would close the same window for a *dependency's*
-install triggers as well. It is not safe, for a reason that is a property of what adoption is:
+## Why the split — the row is cacheable, the decision is not
 
 **Adoption is a poke at the skeleton session, not a row.** `TryAdoptSessionUserSecurityId`
 writes `NavUser.userGuid`; nothing about it is stored in the table. The dep-company snapshot is
 keyed on the dependency set, the runner build and the BC version, and is shared across app
-groups and cached on disk across processes. A snapshot captured with the seed inside that window
-would carry the *row* — so a later HIT would restore a user row whose identity came out of some
-other run's data, while the session poke that made it the session's identity would not happen at
-all. The two would silently disagree, and on the HIT path nothing re-computes the decision.
+groups and cached on disk across processes. So the two halves of the seed cache differently:
 
-Keeping the seed **after** the window means the decision is re-made per app group from whatever
-that group's `User` table actually holds, whether the rows arrived from a MISS's dependency
-triggers, from a restored snapshot, or from a `--test-data` backup loaded on demand. The warm
-arm of `InstallTriggerSessionIdentityTests` is exactly that path: on the second process the
-dependency triggers never run, the stand-in row arrives from the DISK-HIT snapshot, and the
-adoption is decided again against it.
+| | belongs | why |
+|---|---|---|
+| the **row** in `User` (2000000120) | inside the window (step 3) | a table row is exactly what the snapshot carries, and dependency install code has to find it |
+| the **identity decision** | outside it (step 4) | a HIT restores the row without re-making the decision, so on that path nothing would set the session's id |
 
-## What is still open
+`EnsureUserSystemTableRowSeeded` is therefore called at both points and has **no
+already-seeded latch**: it decides its outcome from the table each time. On a MISS the first
+call inserts and the second finds that row present; on a HIT only the second runs, against
+rows that arrived from the snapshot; and where install code or a `--test-data` load replaced
+the row in between, the second call sees the replacement and adopts.
 
-A **dependency's** install trigger (step 3) runs before the seed, so it still observes the
-generated id when the run is going to adopt. Closing that needs the split above — the row
-capture inside the window and the identity decision outside it — rather than a move. Tracked
-separately; #3268 covers the bundle's own install code, which is where the reproducer that
-raised it lives.
+## The adoption timing, and what is not fixture-tested
+
+A collision the runner can adopt comes from data that predates the dependency install triggers
+— in practice a `--test-data` backup carrying its own `TESTUSER`. That case settles at step 3:
+`Arm()` runs at step 2, and the seed's own probe of table 2000000120 is what fires the on-demand
+load, so the rows are there before the decision is made and before any dependency trigger runs.
+
+No fixture measures that, because arranging it needs a real backup. What the fixtures measure
+instead is a collision arranged **by a dependency install trigger**, which then settles at step
+4 — the same path a DISK-HIT takes.
 
 ## Fixtures
 
-Because the seed now precedes a bundle's own install triggers, a fixture that has to establish
-a `User` row **before** the seed writes it from a sibling dependency app instead:
+A fixture that has to establish a `User` row the seed did not write does it from a sibling
+dependency app, and — since the seed's row is written ahead of the dependency triggers — by
+**replacing** the seeded row rather than inserting alongside it. A bare insert is refused, by
+the primary key or by BC's user-name uniqueness rule, exactly as it would be on a service tier.
 
-| fixture | what its `dep` app writes |
+| fixture | what its `dep` app does |
 |---|---|
-| `AlRunner.Tests/Fixtures/SessionUserRowAlreadyPresent` | the session user's own row (the benign already-present refusal, #2941) |
-| `AlRunner.Tests/Fixtures/SessionUserRowNameCollision` | a different user under the session user's name (the adoption, #2983) |
-| `AlRunner.Tests/Fixtures/InstallTriggerSessionIdentity` | the same collision, with the bundle's own install trigger recording the identity it saw (#3268) |
+| `AlRunner.Tests/Fixtures/SessionUserRowAlreadyPresent` | modifies the seeded row (the benign already-present refusal, #2941) |
+| `AlRunner.Tests/Fixtures/SessionUserRowNameCollision` | deletes it and inserts a different user under the session user's name (the adoption, #2983) |
+| `AlRunner.Tests/Fixtures/InstallTriggerSessionIdentity` | the same replacement, with the bundle's own install trigger recording the identity it saw (#3268) |
+| `AlRunner.Tests/Fixtures/DepInstallTriggerSessionIdentity` | only observes: it records whether the session user was a row, and the id it saw (#3698) |


### PR DESCRIPTION
Closes #3698

Corpus-NA: runner session-user seeding order; BC has no adoption step, and on a service tier the session user is a row in the database before any extension installs

Authored by agent `fbk-2` (automated implementation agent).

## What changed

The session-user seed is now called at **two** points in `TestExecutor`'s install-seed stage, and
`RecordPatches.EnsureUserSystemTableRowSeeded` no longer latches on `_userRowSeededForThisBundle`:

| | where | what it does |
|---|---|---|
| **capture** | inside the #1867 dep-company window, on the MISS path, after the dependency Published Application rows and **before** `RunDependenciesOnly()` | writes the `User` (2000000120) row, so it lands in the captured snapshot and dependency install code finds it |
| **decision** | the existing position, after the window, on **every** path | re-makes the #2983 adoption decision from whatever the table then holds |

That is the split #3698 asks for: a row is what a snapshot carries, an adoption is a poke at
`NavUser.userGuid` that no snapshot carries. On a MISS the first call inserts and the second finds
that row present; on a HIT/DISK-HIT only the second runs, against rows restored from the snapshot;
where install code or a `--test-data` load replaced the row in between, the second call adopts.
Removing the latch is what makes the second call a decision rather than a no-op — a latch would
answer from the first call's state and skip exactly the case the second call exists for.

`docs/session-user-seed-ordering.md` is rewritten: the order, the capture/decision table, the
adoption-timing paragraph, and the fixtures table.

## RED to GREEN

New fixture `AlRunner.Tests/Fixtures/DepInstallTriggerSessionIdentity` — a `dep` app whose install
trigger only **observes** (it records `UserSecurityId()`, `UserId()`, whether
`User.Get(UserSecurityId())` found a row and that row's name, plus a Get on an id belonging to
nobody as the negative control), and a `main` app whose tests read the observation back. It does
not arrange a collision, because a trigger that changed the User table would be measuring its own
edit.

Measured with `AL_RUNNER_PERF=1` against the same `--cache` root twice:

```
RED  cold (DepCompanyCache MISS)      4P/1F
RED  warm (DepCompanyCache DISK-HIT)  4P/1F
     FAIL Codeunit70820.DisiDependencyInstallCodeSawTheSessionUsersOwnRow —
       "dependency install code looked up UserSecurityId() in User (2000000120) and found no row:
        the session-user seed had not run yet (AlRunner#3698)"
GREEN cold (MISS)      5P/0F   PERF UserSystemTable: seeded User row 'TESTUSER' → … was already present
GREEN warm (DISK-HIT)  5P/0F   PERF InstallBaseline.DepCompanyCache DISK-HIT … digest=8C301C4218654403
```

`DepInstallTriggerSessionIdentityTests` runs both arms in one test and asserts the `MISS` /
`DISK-HIT` markers, so warm is measured rather than assumed, plus `DoesNotContain("ADOPTED the
security id")` as the negative control — nothing here may reach the settled identity by adopting.

## The three existing fixtures had to change, and that is a finding

`SessionUserRowAlreadyPresent`, `SessionUserRowNameCollision` and `InstallTriggerSessionIdentity`
each arranged their state by having a `dep` install trigger **insert** a `User` row. With the row
seeded before those triggers, every one of them now hits the refusal a service tier would give,
measured:

```
SessionUserRowAlreadyPresent  NavCSideDuplicateKeyException: The record in table User already exists …
SessionUserRowNameCollision   NavNCLUserTableUserNameMustBeUniqueException: The user name must be unique.
InstallTriggerSessionIdentity NavNCLUserTableUserNameMustBeUniqueException: The user name must be unique.
```

`InstallTriggerRunner.InvokeTrigger` rethrows, so each aborted the run. The fixtures arranged a
state real BC cannot reach; they now arrange it the way a restored backup does — SURA **modifies**
the seeded row (its marker still discriminates "left alone" from "overwritten"), SURC and ITSI
**delete** it and insert their stand-in in its place. Every AL assertion in all three is unchanged
and green.

Two C# assertions in `SessionUserRowRefusalTests` changed with them: `DoesNotContain("UserSystemTable:
seeded User row")` became **exactly one** such line — the in-window capture — because a second one
would be the late call claiming an insert it did not make, which is the defect that test was
written for. The discriminator is preserved, not dropped.

The **adoption-before-dependency-triggers** case is not fixture-tested and cannot be without a real
backup: a collision that predates the dependency triggers comes from `--test-data`. Two things
carry it and both are visible in the code — `TestDataProvisioner.Arm()` runs above the cache lookup,
and the seed's own probe of 2000000120 is what fires the on-demand load, so the backup's rows are
there before the decision. Named in `docs/session-user-seed-ordering.md`.

## Fix the shape

1. **Same wrong pattern at another call site?** Yes — filed as #3757, not folded. The `Company`
   (2000000006), bundle `Published Application` and `Access Control` SUPER seeds still run after
   both sets of install triggers, so install code sees none of them. Different files
   (`RecordPatches.CompanySystemTable.cs`, `RecordPatches.AccessControlSeed.cs`), and each needs its
   own answer to the cacheability question this PR had to settle for the User row — the Company row
   is per-app-group state the shared dep-company snapshot must not carry across app groups.
2. **Does a sibling function make the same assumption?** `ResetUserSystemTableForNewBundle` is the
   other half of the per-bundle contract and is unaffected: it restores the generated id before the
   next bundle, and both calls in a bundle now start from that same state.
   `SessionUserRowRefusalTests.AnAdoptionInOneBundleDoesNotLeakIntoTheNextBundlesSessionIdentity`
   still asserts exactly one adoption across two bundles, and is green.
3. **Two code paths writing the same state, same invariant?** This is the question the change is
   about. The MISS path writes the row and decides; the HIT path restores the row and decides. They
   now share one function with no latch, so the invariant — the User table holds a row for the
   session user's *current* security id — is established by the same code on both, rather than by a
   flag on one and nothing on the other. One hole this opened is closed in the same commit range:
   `_userRowSeededForThisBundle` is now **cleared** on the `Refused` branch, not merely left unset.
   With two calls per app group, the early one can have set it true over a row that install code
   then deleted with no same-name replacement, and `RecordPatches.AccessControlSeed` reads that
   flag; with one call that state was unreachable.

## What was run

- `dotnet test AlRunner.Tests --filter` over
  `SessionUser|InstallTrigger|InstallSeed|InstallBaseline|AccessControl|PhaseLog`: **86 passed, 1
  failed**, and that one —
  `RecordPatchesWarmReloadInstallBaselineTests.RestoreInstallBaselineSnapshot_SucceedsWhenTableShapeUnchangedAcrossReload`
  — **fails identically on `origin/main` at f7c4ff67**, this branch's base, so it is pre-existing and
  not caused here. `InstallBaselineDiskCacheTests` and `InstallSeedDepCompanyCacheTests` are green,
  which is #3698's stated #1867 constraint.
- A wider run the fixtures cannot cover, because all four session-user fixtures declare
  `"dependencies": []`: four `tests/runner-extras/` bundles with the real platform closure
  (`microsoft-dependencies`, `install-trigger-seed`, `permission-set-assignment`,
  `microsoft-test-library`) under `AL_RUNNER_NO_DEP_COMPANY_CACHE=1`, so the early seed ran ahead of
  System Application's install codeunits and `Company-Initialize` on every group: **40 PASS, 0 FAIL,
  exit 0**, no `REFUSED` and no `[install-trigger]` line. Re-checked on one of them that the two seed
  lines appear in the expected order around the `DepCompanyCache MISS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kko97BZZL71nF2nK5aftu4
