### PR TITLE
fix(shim): accept Text.Split with several separator arguments

### DIFF
--- a/AlRunner.Tests/RunnerAssemblyReferenceTests.cs
+++ b/AlRunner.Tests/RunnerAssemblyReferenceTests.cs
@@ -17,7 +17,7 @@
 //
 //     line  31, col 24 → `            => global::AlRunner.BcRuntime.NCLEnumMetadata_CreateByIdAlAware(id);`
 //                         (12 spaces + "=> global::" is 23 characters; `AlRunner` starts at 24)
-//     line 327, col 18 → `            var (appId, name, publisher, version) = global::AlRunner…`
+//     line 337, col 18 (327 when #2880 was measured; the ALSplit params overload for #3712 added ten lines above it) → `            var (appId, name, publisher, version) = global::AlRunner…`
 //                         (`appId` starts at 18, and CS8130 names 'appId')
 //
 //   PolyfillReferenceCoordinatesTests below pins both, so this diagnosis cannot rot into a
@@ -189,15 +189,16 @@ public sealed class PolyfillReferenceCoordinatesTests
     }
 
     [Fact]
-    public void PolyfillLine327Column18_IsTheDeconstructionVariableCs8130Named()
+    public void PolyfillLine337Column18_IsTheDeconstructionVariableCs8130Named()
     {
         var lines = PolyfillLines();
-        var line327 = lines[326];
+        // 327 at #2880; +10 for the ALSplit params overload and its note (#3712).
+        var line337 = lines[336];
 
         Assert.Contains("global::AlRunner.BcRuntime.GetModuleAppInfoFor",
-            line327, StringComparison.Ordinal);
+            line337, StringComparison.Ordinal);
         // CS8130 named 'appId'; column 18, 1-based.
-        Assert.Equal("appId", line327.Substring(17, "appId".Length));
+        Assert.Equal("appId", line337.Substring(17, "appId".Length));
     }
 
     /// <summary>

--- a/AlRunner.Tests/TextSplitVariadicSeparatorsTests.cs
+++ b/AlRunner.Tests/TextSplitVariadicSeparatorsTests.cs
@@ -55,9 +55,11 @@ public sealed class TextSplitVariadicSeparatorsTests : IDisposable
           "runtime": "14.0"
         }
         """);
-        // Every receiver/separator shape the emitter produces: literal receiver + literal
-        // separators, variable receiver + variable separators, mixed, two and three separators,
-        // multi-character separators. Each procedure only has to compile and run to completion.
+        // The variadic shapes #3712 is about — literal receiver + literal separators, variable
+        // receiver + variable separators, literal receiver + variable separators, mixed, two and
+        // three separators, multi-character separators — plus the two arities that bound before
+        // (one separator) and that a second params overload would make ambiguous (none). Each
+        // procedure only has to compile and run to completion.
         File.WriteAllText(Path.Combine(dir, "SplitShapes.Codeunit.al"), """
         codeunit 63400 "TSVS Split Shapes"
         {
@@ -69,6 +71,26 @@ public sealed class TextSplitVariadicSeparatorsTests : IDisposable
                 Parts: List of [Text];
             begin
                 Parts := 'a,b;c'.Split(',', ';');
+            end;
+
+            [Test]
+            procedure NoSeparator_Compiles()
+            var
+                Parts: List of [Text];
+            begin
+                Parts := 'a b c'.Split();
+            end;
+
+            [Test]
+            procedure LiteralReceiver_VariableSeparators_Compiles()
+            var
+                Sep1: Text;
+                Sep2: Text;
+                Parts: List of [Text];
+            begin
+                Sep1 := ',';
+                Sep2 := ';';
+                Parts := 'a,b;c'.Split(Sep1, Sep2);
             end;
 
             [Test]
@@ -159,12 +181,20 @@ public sealed class TextSplitVariadicSeparatorsTests : IDisposable
         var (output, exit) = RunRunner(_root);
 
         Assert.DoesNotContain("CS1501", output);
+        // CS0121 is what a second params overload beside (string, params string[]) produces for
+        // the zero-separator Split(): two expanded-form candidates, nothing to prefer.
+        Assert.DoesNotContain("CS0121", output);
         Assert.DoesNotContain("COMPILE-FAIL", output);
-        Assert.Equal(5, TestCount(output));
-        Assert.True(Regex.IsMatch(output, @"PASS\s+\S*\bTwoLiteralSeparators_Compiles\b"),
-            $"no PASS line for TwoLiteralSeparators_Compiles. Output:\n{output}");
-        Assert.True(Regex.IsMatch(output, @"PASS\s+\S*\bTwoVariableSeparators_OnAVariable_Compiles\b"),
-            $"no PASS line for TwoVariableSeparators_OnAVariable_Compiles. Output:\n{output}");
+        Assert.Equal(7, TestCount(output));
+        foreach (var name in new[]
+        {
+            "TwoLiteralSeparators_Compiles", "NoSeparator_Compiles",
+            "TwoVariableSeparators_OnAVariable_Compiles", "LiteralReceiver_VariableSeparators_Compiles",
+        })
+        {
+            Assert.True(Regex.IsMatch(output, $@"PASS\s+\S*\b{name}\b"),
+                $"no PASS line for {name}. Output:\n{output}");
+        }
         Assert.Equal(0, exit);
     }
 }

--- a/AlRunner.Tests/TextSplitVariadicSeparatorsTests.cs
+++ b/AlRunner.Tests/TextSplitVariadicSeparatorsTests.cs
@@ -1,0 +1,170 @@
+// TextSplitVariadicSeparatorsTests — #3712: Text.Split(Sep1, Sep2, ...) failed the dependency
+// compile with CS1501 "No overload for method 'ALSplit' takes 3 arguments".
+//
+// BC's compiler emits Text.Split(Sep1, Sep2, ...) as ALSplit(text, a, b, ...) — one argument per
+// separator, never an array — and BC's own NavTextExtensions.ALSplit(string, params string[])
+// accepts that. BcAssembler redirects every ALSplit to AlRunnerShim.NavRuntimeHelpersShim.ALSplit
+// (so it can add the NavList<char> shapes the emitted C# uses), and the shim's string[] overload
+// was not `params`. One separator compiled; two or more did not, and the whole module was dropped.
+//
+// This class proves the COMPILE PAIRING only: the shim exposes the overload shapes the emitted C#
+// calls, for literal and variable receivers and separators. What Split(a, b) ANSWERS is BC
+// behaviour and is adjudicated upstream — corpus codeunit 60119, TextSplit_TwoSeparatorLiterals_*
+// and siblings (corpus PR linked from the runner PR). Per bc-behavior-tests-go-upstream.md the AL
+// here therefore asserts nothing about the parts; the fixture's tests are named *_Compiles.
+
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TextSplitVariadicSeparatorsTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private readonly string _root;
+
+    public TextSplitVariadicSeparatorsTests()
+    {
+        _root = TestScratch.Dir("al-runner-text-split-variadic");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private static void WriteBundle(string dir)
+    {
+        Directory.CreateDirectory(dir);
+        // No "application" property — see .claude/rules/no-base-app-in-csharp-tests.md.
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "5a3f0b11-3712-4a01-8001-000000003712",
+          "name": "TSVS Split Shapes",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 63400, "to": 63419 } ],
+          "runtime": "14.0"
+        }
+        """);
+        // Every receiver/separator shape the emitter produces: literal receiver + literal
+        // separators, variable receiver + variable separators, mixed, two and three separators,
+        // multi-character separators. Each procedure only has to compile and run to completion.
+        File.WriteAllText(Path.Combine(dir, "SplitShapes.Codeunit.al"), """
+        codeunit 63400 "TSVS Split Shapes"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure TwoLiteralSeparators_Compiles()
+            var
+                Parts: List of [Text];
+            begin
+                Parts := 'a,b;c'.Split(',', ';');
+            end;
+
+            [Test]
+            procedure ThreeLiteralSeparators_Compiles()
+            var
+                Parts: List of [Text];
+            begin
+                Parts := 'a,b;c|d'.Split(',', ';', '|');
+            end;
+
+            [Test]
+            procedure TwoVariableSeparators_OnAVariable_Compiles()
+            var
+                Input: Text;
+                Sep1: Text;
+                Sep2: Text;
+                Parts: List of [Text];
+            begin
+                Input := 'a--b::c';
+                Sep1 := '--';
+                Sep2 := '::';
+                Parts := Input.Split(Sep1, Sep2);
+            end;
+
+            [Test]
+            procedure MixedLiteralAndVariableSeparators_Compiles()
+            var
+                Input: Text;
+                Sep: Text;
+                Parts: List of [Text];
+            begin
+                Input := 'a,b;c';
+                Sep := ';';
+                Parts := Input.Split(',', Sep);
+            end;
+
+            [Test]
+            procedure OneSeparator_StillCompiles()
+            var
+                Parts: List of [Text];
+            begin
+                Parts := 'a,b,c'.Split(',');
+            end;
+        }
+        """);
+    }
+
+    private (string output, int exit) RunRunner(string target)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" \"{target}\"");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(600_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    private static int TestCount(string output)
+    {
+        var m = Regex.Match(output, @"Tests:\s*(\d+)\s*total");
+        Assert.True(m.Success, $"run summary had no test count. Output:\n{output}");
+        return int.Parse(m.Groups[1].Value);
+    }
+
+    /// <summary>
+    /// RED before the fix: <c>COMPILE-FAIL ... error CS1501: No overload for method 'ALSplit'
+    /// takes 3 arguments</c> on every multi-separator call, exit 3, <c>Tests: 0 total</c>. After:
+    /// all five procedures compile, run, and the run exits 0.
+    /// </summary>
+    [SkippableFact]
+    public void SplitWithSeveralSeparators_CompilesAndRuns()
+    {
+        TestArtifacts.SkipIfMissing();
+        WriteBundle(_root);
+
+        var (output, exit) = RunRunner(_root);
+
+        Assert.DoesNotContain("CS1501", output);
+        Assert.DoesNotContain("COMPILE-FAIL", output);
+        Assert.Equal(5, TestCount(output));
+        Assert.True(Regex.IsMatch(output, @"PASS\s+\S*\bTwoLiteralSeparators_Compiles\b"),
+            $"no PASS line for TwoLiteralSeparators_Compiles. Output:\n{output}");
+        Assert.True(Regex.IsMatch(output, @"PASS\s+\S*\bTwoVariableSeparators_OnAVariable_Compiles\b"),
+            $"no PASS line for TwoVariableSeparators_OnAVariable_Compiles. Output:\n{output}");
+        Assert.Equal(0, exit);
+    }
+}

--- a/AlRunner/BcAssembler.cs
+++ b/AlRunner/BcAssembler.cs
@@ -757,11 +757,14 @@ namespace AlRunnerShim
         }
 
         // `params`, mirroring BC's own NavTextExtensions.ALSplit(string, params string[]): the
-        // compiler emits Text.Split(Sep1, Sep2, ...) as ALSplit(text, a, b, ...) — one argument
-        // per separator, never an array. Without a params overload the dependency compile died
-        // with CS1501 ""No overload for method 'ALSplit' takes 3 arguments"" on every
-        // two-separator call (#3712). Each separator is a whole-string delimiter, as in BC;
-        // corpus 60119 TextSplit_TwoSeparatorLiterals_SplitsOnEither and siblings adjudicate.
+        // compiler emits Text.Split(Sep1, Sep2, ...) as ALSplit(text, a, b, ...), one argument
+        // per separator, each a NavText (implicitly a string). Without params, two or more
+        // separators failed the dependency compile with CS1501 (#3712). Each separator is a
+        // whole-string delimiter and empty parts are kept, as in BC; corpus 60119
+        // TextSplit_TwoSeparatorLiterals_SplitsOnEither and siblings adjudicate. Trap: do not add
+        // a second params overload (e.g. NavText[]) beside this one — a zero-separator Split()
+        // then has two expanded-form candidates and is ambiguous (CS0121), and one-separator
+        // calls that bind to (string, string) today would rebind by identity.
         public static Microsoft.Dynamics.Nav.Runtime.NavList<Microsoft.Dynamics.Nav.Runtime.NavText> ALSplit(
             string text, params string[] separators)
         {
@@ -821,31 +824,6 @@ namespace AlRunnerShim
             return ALSplit(t, sep);
         }
 
-        // The exact shapes the emitted C# uses for several separators (#3712, measured with
-        // --dump-csharp on BC 28.1): every separator is wrapped as `new NavText(..)`, and the
-        // receiver is a string for a literal or a NavText field for a Text variable —
-        //     ALSplit(""a,b;c"", new NavText("",""), new NavText("";""))
-        //     ALSplit(this.input, this.sep1, this.sep2)
-        // Typed exactly so overload resolution needs no conversion; the (string, string) form a
-        // single separator binds to today is applicable in its normal form and still wins there.
-        public static Microsoft.Dynamics.Nav.Runtime.NavList<Microsoft.Dynamics.Nav.Runtime.NavText> ALSplit(
-            string text, params Microsoft.Dynamics.Nav.Runtime.NavText[] separators)
-        {
-            var seps = new string[separators.Length];
-            for (int i = 0; i < seps.Length; i++)
-            {
-                string s = separators[i];
-                seps[i] = s ?? global::System.String.Empty;
-            }
-            return ALSplit(text, seps);
-        }
-
-        public static Microsoft.Dynamics.Nav.Runtime.NavList<Microsoft.Dynamics.Nav.Runtime.NavText> ALSplit(
-            Microsoft.Dynamics.Nav.Runtime.NavText text, params Microsoft.Dynamics.Nav.Runtime.NavText[] separators)
-        {
-            string t = text;
-            return ALSplit(t ?? global::System.String.Empty, separators);
-        }
 
         // ALMaxStrLen: unlimited Text/Code returns Int32.MaxValue; bounded returns the
         // declared length. NavDefinedLengthMetadata stores 0 for unlimited and N for Text[N].

--- a/AlRunner/BcAssembler.cs
+++ b/AlRunner/BcAssembler.cs
@@ -756,8 +756,14 @@ namespace AlRunnerShim
             return result;
         }
 
+        // `params`, mirroring BC's own NavTextExtensions.ALSplit(string, params string[]): the
+        // compiler emits Text.Split(Sep1, Sep2, ...) as ALSplit(text, a, b, ...) — one argument
+        // per separator, never an array. Without a params overload the dependency compile died
+        // with CS1501 ""No overload for method 'ALSplit' takes 3 arguments"" on every
+        // two-separator call (#3712). Each separator is a whole-string delimiter, as in BC;
+        // corpus 60119 TextSplit_TwoSeparatorLiterals_SplitsOnEither and siblings adjudicate.
         public static Microsoft.Dynamics.Nav.Runtime.NavList<Microsoft.Dynamics.Nav.Runtime.NavText> ALSplit(
-            string text, string[] separators)
+            string text, params string[] separators)
         {
             var parts = text.Split(separators, global::System.StringSplitOptions.None);
             var result = Microsoft.Dynamics.Nav.Runtime.NavList<Microsoft.Dynamics.Nav.Runtime.NavText>.Default;
@@ -813,6 +819,32 @@ namespace AlRunnerShim
             string t = text == null ? global::System.String.Empty : text.ToString();
             string sep = separator == null ? global::System.String.Empty : separator.ToString();
             return ALSplit(t, sep);
+        }
+
+        // The exact shapes the emitted C# uses for several separators (#3712, measured with
+        // --dump-csharp on BC 28.1): every separator is wrapped as `new NavText(..)`, and the
+        // receiver is a string for a literal or a NavText field for a Text variable —
+        //     ALSplit(""a,b;c"", new NavText("",""), new NavText("";""))
+        //     ALSplit(this.input, this.sep1, this.sep2)
+        // Typed exactly so overload resolution needs no conversion; the (string, string) form a
+        // single separator binds to today is applicable in its normal form and still wins there.
+        public static Microsoft.Dynamics.Nav.Runtime.NavList<Microsoft.Dynamics.Nav.Runtime.NavText> ALSplit(
+            string text, params Microsoft.Dynamics.Nav.Runtime.NavText[] separators)
+        {
+            var seps = new string[separators.Length];
+            for (int i = 0; i < seps.Length; i++)
+            {
+                string s = separators[i];
+                seps[i] = s ?? global::System.String.Empty;
+            }
+            return ALSplit(text, seps);
+        }
+
+        public static Microsoft.Dynamics.Nav.Runtime.NavList<Microsoft.Dynamics.Nav.Runtime.NavText> ALSplit(
+            Microsoft.Dynamics.Nav.Runtime.NavText text, params Microsoft.Dynamics.Nav.Runtime.NavText[] separators)
+        {
+            string t = text;
+            return ALSplit(t ?? global::System.String.Empty, separators);
         }
 
         // ALMaxStrLen: unlimited Text/Code returns Int32.MaxValue; bounded returns the


### PR DESCRIPTION
## Summary

`Text.Split(Sep1, Sep2, ...)` with two or more separators failed the dependency compile with `CS1501: No overload for method 'ALSplit' takes 3 arguments`, and every object in the module was dropped (`EMIT-EXCLUDED`, then `EMIT-ZERO`). One separator worked. Continia Document Output uses the two-separator form three times, so the app could not be run at all.

Measured with `--dump-csharp` on BC 28.1.49838.54169, the compiler emits one argument per separator. A literal separator is constructed as `new NavText(..)`; a Text variable is already a `NavText` field. The receiver is a string for a literal and a `NavText` for a variable:

```csharp
NavTextExtensions.ALSplit("a,b;c", new NavText(","), new NavText(";"));
NavTextExtensions.ALSplit(this.input, this.sep1, this.sep2);
```

BC's own `NavTextExtensions.ALSplit(string, params string[])` takes that, because `NavText` converts implicitly to `string`. `BcAssembler` rewrites every `NavTextExtensions.ALSplit(` in freshly emitted source to `AlRunnerShim.NavRuntimeHelpersShim.ALSplit(` so it can add the `NavList<char>` shapes the emitted C# uses elsewhere, and the shim's `string[]` overload was not `params`.

## Fix

`AlRunner/BcAssembler.cs`, inside `PolyfillSource`: `ALSplit(string, params string[])`, mirroring BC. Nothing else. One-separator calls keep binding to the existing `(string, string)` overload, which is applicable in its normal form; the params overload only applies in expanded form and loses that tie-break. Each separator stays a whole-string delimiter and empty parts are kept, as before.

The comment on the overload carries the trap: do not add a second params overload beside it. A first version of this PR did (`(string, params NavText[])` and `(NavText, params NavText[])`), and review showed the zero-separator `Split()` then has two expanded-form candidates (CS0121), one-separator calls rebind by identity, and the `NavText` receiver turned a null into an empty string.

`PolyfillReferenceCoordinatesTests` pins the polyfill line CS8130 named in #2880. The overload's note sits above that line and moved it from 327 to 337; the pin and the header in `RunnerAssemblyReferenceTests.cs` follow and say why. That test failing on the first CI run of this PR is what the second commit fixes; nothing else was red.

## Proof

**Runner side** (`AlRunner.Tests/TextSplitVariadicSeparatorsTests.cs`): spawns the runner on a platform-only fixture with seven shapes (two literal separators, three, no separator, two Text variables on a variable receiver, two Text variables on a literal receiver, literal + variable mixed, one separator as the control) and asserts no `CS1501`, no `CS0121`, no `COMPILE-FAIL`, 7 tests run with a PASS line for four named ones, exit 0. The fixture's procedures are named `*_Compiles` and assert nothing about the parts, because what `Split(a, b)` answers is BC behaviour and belongs upstream.

Observed RED before the fix, on the two-separator probe from the issue: `COMPILE-FAIL`, `CS1501` at both multi-separator calls, exit 3, `Tests: 0 total`. GREEN after: 2 of 2 pass.

**BC side**: corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#319 adds seven tests to codeunit 60119 `Test Text Extended`: two literal separators, three, two Text variables, two multi-character separators (each a whole string, so `'a-b'` does not split on `'--'`), no separator present, adjacent and trailing separators keeping their empty parts, and `Split()` with no argument splitting on whitespace. The first five are green on all 16 legs (run 34411866863; each of the 8 cloud legs prints 8 distinct `TextSplit_*` PASS names, 3 existing plus 5 new, 0 FAIL). The last two are running at the time of writing.

Measured locally: the corpus at the current pin `3ad4c340` plus the first five tests, through this branch's runner, on BC 28.1.49838.54169: 3128 of 3128 pass, exit 0, all 8 `TextSplit_*` tests PASS.

## Corpus linkage

Written while this repository still pinned the corpus as a submodule; #3747 removed that pin the same day, and the corpus is now resolved per CI run through the `Corpus-PR:` line below. The BC 27.0 leg on this PR's head logged `corpus: 84d53f69 (refs/pull/319/head)`, so CI measured the runner against exactly the tests written for it. There is no pin to bump.

## Review history

An external adversarial review (GPT-5.6) of the first commit found the two extra `NavText[]` overloads (CS0121 on `Split()`, rebinding of one-separator calls, null-to-empty on the receiver), a wrong claim in the comment and body about which overload one-separator calls bind to, and missing coverage for zero separators and adjacent separators. All addressed in the second commit and in corpus PR #319's second commit. Its "seven `TextSplit_*`" count correction is applied above (eight).

## Not folded

- The issue also reports a crash on BC 28.1.49838.50794 before any compile, `[Cecil] method Microsoft.Dynamics.Nav.Runtime.ExecutionScheduler..ctor(6) not found`. Different code, different cause; filed as #3756.
- #3719 (Library Assert dependency emits zero sources) and #3713 (`--coverage` per-file class) are from the same reporter but land in different files.

Closes #3712

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/319

*Opened by an agent (Claude Code) in a session run by @SShadowS.*

https://claude.ai/code/session_01JFQZHC5SEHnLxkc5USksaK
