### PR TITLE
chore(tools): pass --agent-id so preflight's branch-ownership check can FAIL

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -91,7 +91,10 @@ Before your first commit, check the directory, the branch, and who holds the bra
 git rev-parse --show-toplevel        # the worktree you meant to be in
 git rev-parse --abbrev-ref HEAD      # MUST equal agent/<AGENT-ID>/issue-<N>
 gh pr list --state open --head agent/<AGENT-ID>/issue-<N> --json number,title,isDraft --repo StefanMaron/BusinessCentral.AL.Runner
+tools/preflight.py --agent-id <AGENT-ID>   # from the worktree: its `branch-ownership` row
 ```
+
+The fourth command is the one that reads the `agent:` label rather than just the PR's existence, and it is the only place preflight's `branch-ownership` check can reach a verdict at all — from the main checkout it has nothing to compare and PASSes (#3746). `--agent-id` is not optional: with no identity a foreign claim and your own look identical, so the check WARNs instead of refusing. Pass it as an argument, never as an exported `AL_RUNNER_AGENT_ID`, because shell state does not survive between tool calls. FAIL there means the branch already heads another loop's open PR — stop, exactly as the paragraph below says.
 
 A branch naming an issue other than yours belongs to another task — stop and report, whatever the prefix says: `agent/<AGENT-ID>/` records who created a branch, and a second agent committing there is a push no check refuses.
 

--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -136,14 +136,23 @@ These numbers come from a single session and review time varies with PR size. Re
 A fresh or drifted box does not announce that it is broken; it produces numbers that look fine.
 Every check below exists because its absence has silently corrupted a result.
 
-**Run `tools/preflight.py`.** It is this section, executable, with a real exit code — 0 all
-passed, 1 something failed and this box would produce untrustworthy results, 2 warnings under
-`--strict`, 3 it could not complete. `--json` for a box profile, `--reap` to remove worktrees
-whose PR is merged and whose tree is clean, `--with-corpus` to include step 1. The prose below
-stays as the specification and the reasoning; the script is how it actually gets run, because a
-check a busy coordinator can decline is not a check — one skipped step 5 across an evening of
-~20 agents and filled a 7.7 GB tmpfs, after which every shell on the box failed without naming
-the cause.
+**Run `tools/preflight.py --agent-id <AGENT-ID>`.** It is this section, executable, with a
+real exit code — 0 all passed, 1 something failed and this box would produce untrustworthy
+results, 2 warnings under `--strict`, 3 it could not complete. `--json` for a box profile,
+`--reap` to remove worktrees whose PR is merged and whose tree is clean, `--with-corpus` to
+include step 1.
+
+**`--agent-id` is what lets the `branch-ownership` check answer at all** — with no identity it
+can only WARN (#3746), so every documented invocation carries it. It travels as an argument
+and not as an exported `AL_RUNNER_AGENT_ID` because shell state does not survive between tool
+calls (`impl-agent.md`): an `export` is gone by the next command and the check drops back to
+WARN without saying so. From the main checkout there is nothing to compare and the check
+PASSes; it earns its keep from a worktree, which is where `impl-agent.md` runs it.
+
+The prose below stays as the specification and the reasoning; the script is how it actually
+gets run, because a check a busy coordinator can decline is not a check — one skipped step 5
+across an evening of ~20 agents and filled a 7.7 GB tmpfs, after which every shell on the box
+failed without naming the cause.
 
 Two things about the verdicts it produces, because both change what "stop" means:
 

--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -440,6 +440,9 @@ Otherwise the next agent starts from the wrong premise — which has happened he
   `search_members` → `memberId` → `get_decompiled_source` / `find_callers`.
   `compare_symbols` diffs a method between BC versions, which is how a Cecil rewrite that
   stopped being reached gets caught.
+- `tools/preflight.py --agent-id <AGENT-ID>` — the box check, with the identity it needs. Without
+  it the `branch-ownership` check can only WARN (#3746). From this checkout it PASSes, having
+  nothing to compare; it refuses from a worktree, so brief agents to run it there.
 - `tools/agent-cost.py <tasks-dir>` — where a session's agents actually spent their calls.
   Measured once: 85% of Bash calls were shell read/search and the navigation tools were used
   3 times in 3,237 calls. Re-measure rather than assuming it improved.

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -22,6 +22,7 @@ import importlib.util
 import io
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -2089,6 +2090,46 @@ try:
           _res_blind.status == "WARN", _res_blind.summary)
 finally:
     shutil.rmtree(_own_tmp, ignore_errors=True)
+
+# -------------------------------------------------- BEGIN agent-id-wiring (#3746)
+# The identity the ownership check needs has to be IN the documented invocation.
+#
+# judge_branch_ownership can only reach its FAIL row when the run declared an
+# identity; a `--agent-id` nothing passes leaves the check producing the WARN row
+# from every worktree, which is the state #3742 shipped in. The identity travels
+# as an ARGUMENT rather than an exported AL_RUNNER_AGENT_ID because shell state
+# does not survive between an agent's tool calls (impl-agent.md), so an `export`
+# is gone by the next command and the check drops back to WARN without saying so.
+
+_DOCUMENTED_INVOCATION = re.compile(
+    r"tools/preflight\.py(?:\s+--\S+)*\s+--agent-id\s+<AGENT-ID>")
+
+for _doc in (".claude/skills/autonomous-cycle/SKILL.md",
+             ".claude/skills/orchestrating-a-session/SKILL.md",
+             ".claude/agents/impl-agent.md"):
+    # utf-8 explicitly: these files carry em-dashes, and the Windows default
+    # codec turns reading one into a failure that looks like a drifted document.
+    with open(os.path.join(os.path.dirname(HERE), _doc), encoding="utf-8") as _fh:
+        _text = _fh.read()
+    check(f"{_doc} documents the preflight run WITH --agent-id",
+          bool(_DOCUMENTED_INVOCATION.search(_text)),
+          "no `tools/preflight.py [flags] --agent-id <AGENT-ID>` invocation in this file")
+
+# The other direction, so a rename cannot leave three documents pointing at a
+# flag that no longer exists: ask preflight's own parser, not the source text.
+_help_out = io.StringIO()
+_help_rc = None
+_saved_stdout, sys.stdout = sys.stdout, _help_out
+try:
+    pf.main(["--help"])
+except SystemExit as _exc:
+    _help_rc = _exc.code
+finally:
+    sys.stdout = _saved_stdout
+check("...and --agent-id is still a real flag on preflight.py itself",
+      _help_rc == 0 and "--agent-id" in _help_out.getvalue(),
+      f"rc={_help_rc} help={_help_out.getvalue()[:160]!r}")
+# -------------------------------------------------- END agent-id-wiring (#3746)
 
 
 print()


### PR DESCRIPTION
Closes #3746

Corpus-NA: agent tooling; no runner behaviour

Written by an automated agent, impl agent `fbk-2`.

`branch-ownership` landed in #3742 able to refuse a worktree standing on another loop's PR
branch. Nothing told it which loop it was — no caller passed `--agent-id`, no loop exported
`AL_RUNNER_AGENT_ID` — so from a worktree it produced its WARN row instead of a verdict. This
puts the identity into the documented invocation in the three definitions that run preflight.

**Argument, not `export`.** `impl-agent.md` states that shell state does not survive between
tool calls, so an `export AL_RUNNER_AGENT_ID=...` in one call is gone by the next and the check
drops back to WARN *without saying so* — the exact failure being removed. `--agent-id` on the
command line cannot be lost that way. The reason is written once, next to the autonomous-cycle
invocation, and referenced from the other two.

**Where it earns its keep: `impl-agent.md`.** The check PASSes outside a worktree, so the
coordinator's run from the main checkout can never reach the FAIL row. The edit that makes it
bite is the fourth line added to "Isolate your working tree"'s pre-first-commit block, run from
the worktree — the existing three commands establish that a PR exists; only preflight compares
its `agent:` label against yours. The hand-rolled block stays: preflight does not assert that
the branch equals `agent/<AGENT-ID>/issue-<N>`, which those commands do.

**Premise correction.** The issue says both skills invoke `preflight.py`;
`orchestrating-a-session/SKILL.md` had **no** preflight mention at all before this PR. It gets a
"Tooling you should be using" bullet carrying the flag, and the bullet says plainly that from
that checkout the check PASSes for want of anything to compare — so a coordinator does not read
a PASS there as evidence about a worktree.

## RED → GREEN

The drift test (`tools/test_preflight.py`, block `agent-id-wiring (#3746)`) asserts each of the
three documents contains a `tools/preflight.py [flags] --agent-id <AGENT-ID>` invocation, and —
the other direction — asks preflight's own parser via `main(["--help"])` that `--agent-id` is
still a real flag, so a rename cannot leave three documents pointing at nothing.

RED, before the doc edits: three FAILs, one ok.

```
  FAIL .claude/skills/autonomous-cycle/SKILL.md documents the preflight run WITH --agent-id
  FAIL .claude/skills/orchestrating-a-session/SKILL.md documents the preflight run WITH --agent-id
  FAIL .claude/agents/impl-agent.md documents the preflight run WITH --agent-id
  ok   ...and --agent-id is still a real flag on preflight.py itself
```

GREEN, after: all four ok.

Both runs went through a throwaway loader that execs only that block, because
`tools/test_preflight.py` as a whole cannot complete on this Windows box (pre-existing, at the
mountpoint assertions) — the same technique #3742 used for its own additions. The block runs
normally under the `tools/ unit tests` context on Linux.

## The wiring proved against a real service, not a fixture

The verdict logic already had fixture coverage for all four states, so the new evidence is the
wiring. Real run from this PR's own worktree, real `gh pr list` through `open_pr_for_branch`,
real slug, against this PR (#3758, labelled `agent: fbk-2`):

```
slug: StefanMaron/BusinessCentral.AL.Runner
--agent-id fbk-9  -> FAIL: agent/fbk-2/issue-3746 already heads OPEN PR #3758, owned by `agent: fbk-2` and not by `agent: fbk-9`
--agent-id fbk-2  -> PASS: PR #3758 heads agent/fbk-2/issue-3746 and is yours (`agent: fbk-2`)
--agent-id None   -> WARN: PR #3758 heads agent/fbk-2/issue-3746 and is owned by `agent: fbk-2`, but this run declared no identity to compare it against
```

FAIL with an identity where the same run WARNs without one — the verdict the check exists to
give, now reachable from the documented invocation.

`main()` was checked first for the trap that would have made this doc-only change inert:
`check_branch_ownership`'s `cwd` defaults to `os.getcwd()`, not to the `repo` variable that
`main()` reassigns to the common root, so a worktree run does read the worktree's branch. No
code change needed.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** Every place `preflight.py` is invoked in
   `.claude/` and `docs/` was enumerated (`rg --hidden -n "preflight\.py"`): 11 mentions, of
   which three are invocations a loop actually runs (the two edited skills plus `impl-agent.md`)
   and the rest describe `--reap`, `--with-corpus` or exit 3 in prose. All three invocations now
   carry the flag, and the drift test holds all three.
2. **A sibling with the same assumption?** `--identity` (the push-probe ref) has the same
   defaulting shape but is not a comparison against anyone else's claim, so a missing value
   costs nothing there. `check_worktrees` reads PR state and not the `agent:` label, so it has no
   identity to be missing.
3. **Two paths writing the same state?** One path only: `agent_id = args.agent_id or
   os.environ.get("AL_RUNNER_AGENT_ID") or None`. Both routes now feed a check that treats
   absence as WARN rather than PASS, so neither can resolve toward success.

## Not folded, and why

Three other open preflight issues land in `tools/preflight.py`, not in the documents this PR
edits, and each needs different reasoning to review: #3335 (`--reap` reads submodule pointer
drift as uncommitted work), #3361 (the corpus check compares a call against itself), #3264 (a
`bc260` context that can never be present). Folding them in would make one diff out of four
unrelated verdicts.

Filed while here: **#3759** — a full `preflight.py` run cannot complete on Windows at all
(`os.getuid()` in `check_stale_scratch`), which is why the proof above drives the check through
a loader rather than through `main()`.

PR #3747 is open and touches all three of these documents as part of a much larger change; this
diff is four small hunks and will rebase cleanly or trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kko97BZZL71nF2nK5aftu4
