### PR TITLE
fix(testpage): a property bound to a procedure call answers false, as BC does (AL0573)

### DIFF
--- a/AlRunner.Tests/ProcedureBoundPropertyWarningTests.cs
+++ b/AlRunner.Tests/ProcedureBoundPropertyWarningTests.cs
@@ -1,0 +1,137 @@
+// ProcedureBoundPropertyWarningTests — issue #3731.
+//
+// `Enabled = SomeProcedure()` on an action compiles with warning AL0573 ("Procedure calls is not
+// valid for client expressions"), and real BC never evaluates the expression: the action reads
+// Enabled = false and its OnAction is skipped, though the procedure returns true unconditionally
+// (measured on BC 28.4.53241.0 — issue #3731). The runner now answers false too, which is silent,
+// exactly as BC is silent. The warning is the only thing that tells the AL author their procedure
+// is not being called, so two properties of it are pinned here:
+//
+//   * it survives Log's DEFAULT filter — a line only --verbose shows is not a warning;
+//   * it fires ONCE per (page, element, property), so a bundle opening the same page in ten tests
+//     prints one copy, not ten. The AL side of this (tests/runner-extras/testpage-procedure-bound-property)
+//     cannot assert either: AL cannot read the runner's own stderr.
+using System.Text.RegularExpressions;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Serial: swaps the process-wide Console writers and Log.Verbose. See ConsoleFilterSerialCollection.
+[Collection(ConsoleFilterSerialCollection.Name)]
+public sealed class ProcedureBoundPropertyWarningTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    /// <summary>Run one line through the real Log filter and return what got out.</summary>
+    private static string FilterOnce(string line, bool verbose)
+    {
+        var savedOut = Console.Out;
+        var savedErr = Console.Error;
+        var savedVerbose = Log.Verbose;
+        var sink = new StringWriter();
+        try
+        {
+            Console.SetOut(sink);
+            Console.SetError(sink);
+            Log.Install();
+            Log.Verbose = verbose;
+            Console.Error.WriteLine(line);
+            return sink.ToString();
+        }
+        finally
+        {
+            Log.Verbose = savedVerbose;
+            Console.SetOut(savedOut);
+            Console.SetError(savedErr);
+        }
+    }
+
+    /// <summary>Capture what the real call site writes, by calling it.</summary>
+    private static string EmitOnce(string pageId, int elementId, string propertyName, out bool printed)
+    {
+        var savedErr = Console.Error;
+        var sink = new StringWriter();
+        try
+        {
+            Console.SetError(sink);
+            printed = RunnerPageInstance.WarnOnceAboutDroppedClientExpression(pageId, elementId, propertyName);
+            return sink.ToString();
+        }
+        finally
+        {
+            Console.SetError(savedErr);
+        }
+    }
+
+    [Fact]
+    public void TheWarning_NamesTheProperty_TheElement_AndAL0573()
+    {
+        var line = EmitOnce("65913", 1596877897, "Enabled", out var printed);
+
+        Assert.True(printed, "the first call for a (page, element, property) must print");
+        Assert.Contains("page 65913 element 1596877897", line);
+        Assert.Contains("Enabled is bound to a procedure call", line);
+        Assert.Contains("AL0573", line);
+        // Not a bare "something is wrong": it says what the runner answered and why, so the
+        // author can tell this apart from the property being false for an ordinary reason.
+        Assert.Contains("answers false", line);
+    }
+
+    [Fact]
+    public void TheWarning_SurvivesTheDefaultFilter_AndVerbose()
+    {
+        var line = EmitOnce("65913", 424242, "Enabled", out _).TrimEnd('\r', '\n');
+
+        Assert.Contains(line, FilterOnce(line, verbose: false));
+        Assert.Contains(line, FilterOnce(line, verbose: true));
+    }
+
+    [Fact]
+    public void TheWarning_FiresOncePerElement_NotOncePerRead()
+    {
+        // A distinct element id per test method: the ledger is process-wide by design, so a
+        // shared id would make the "once" assertion depend on test ordering.
+        const int Element = 909090;
+
+        var first = EmitOnce("65913", Element, "Enabled", out var printedFirst);
+        var second = EmitOnce("65913", Element, "Enabled", out var printedSecond);
+
+        Assert.True(printedFirst);
+        Assert.False(printedSecond);
+        Assert.Contains("AL0573", first);
+        Assert.Equal(string.Empty, second);
+
+        // A DIFFERENT element on the same page still gets its own warning — the ledger is not a
+        // per-page latch that hides the second offending action on a page with two.
+        var otherElement = EmitOnce("65913", Element + 1, "Enabled", out var printedOther);
+        Assert.True(printedOther);
+        Assert.Contains($"element {Element + 1}", otherElement);
+
+        // ...and so does the same element under a different property.
+        var otherProperty = EmitOnce("65913", Element, "Visible", out var printedProperty);
+        Assert.True(printedProperty);
+        Assert.Contains("Visible is bound to a procedure call", otherProperty);
+    }
+
+    /// <summary>
+    /// The discriminator the whole fix rests on, asserted against the production source rather
+    /// than restated: an ABSENT property must keep answering true, and only an EMPTY string —
+    /// the shape the compiler writes when it dropped a client expression — may take the new path.
+    /// Collapsing the two back into one `IsNullOrEmpty` check would disable every action whose
+    /// page metadata omits the property.
+    /// </summary>
+    [Fact]
+    public void EvaluateProperty_KeepsNullAndEmptyApart()
+    {
+        var source = File.ReadAllText(
+            Path.Combine(RepoRoot, "AlRunner", "Patches", "RunnerPageInstance.cs"));
+        var body = source[source.IndexOf("private bool EvaluateProperty(", StringComparison.Ordinal)..];
+        body = body[..body.IndexOf("\n    /// <summary>", StringComparison.Ordinal)];
+
+        Assert.Matches(new Regex(@"if \(raw is null\) return true;"), body);
+        Assert.Matches(new Regex(@"if \(raw\.Length == 0\) return ClientExpressionTheCompilerDropped"), body);
+        Assert.DoesNotContain("IsNullOrEmpty(raw)", body);
+    }
+}

--- a/AlRunner.Tests/TestPageRefusalClaimTests.cs
+++ b/AlRunner.Tests/TestPageRefusalClaimTests.cs
@@ -431,7 +431,11 @@ public sealed class TestPageRefusalClaimTests
         // refusal for a spelling BC was never asked about.
         Assert.Equal(6, Regex.Matches(mock, @"throw new AlRunner\.Infrastructure\.BcShapeGapException\(").Count);
 
-        Assert.Equal(4, Regex.Matches(page, @"throw TestPageShapeGap\.").Count);
+        // 5 since #3731: a property whose value arrives as the EMPTY string is one the AL
+        // compiler dropped (a procedure call in a client expression, AL0573). An ACTION's
+        // Enabled answers false there, measured on BC 28.4; every other arm refuses, because no
+        // service tier has been asked what BC answers for it — #3762.
+        Assert.Equal(5, Regex.Matches(page, @"throw TestPageShapeGap\.").Count);
         // 2: the OnLookup-trigger read whose three-valued answer came back "could not determine"
         // (#2946/#2995), and #3447's NavForm.RegisterPageExtension lookup - the method BC's own
         // RaiseOn<trigger>Async loops depend on, so a build that stops declaring it would make
@@ -470,6 +474,7 @@ public sealed class TestPageRefusalClaimTests
         new object[] { "MockTestPage*.cs", "so its OnDrillDown trigger cannot be reached" },
         new object[] { "RunnerPageInstance.cs", "which is not a Boolean" },
         new object[] { "RunnerPageInstance.cs", "which cannot be evaluated:" },
+        new object[] { "RunnerPageInstance.cs", "has not been measured " },
         new object[] { "RunnerPageInstance.cs", "the runner cannot tell which trigger belongs to it" },
     };
 

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -770,10 +770,10 @@ internal sealed partial class RunnerPageInstance
 
     /// <summary>Editable for a data-bound control, combined with the page's own state.</summary>
     internal bool ControlEditable(int controlId)
-        => PageEditable && EvaluateProperty(ControlDefinition(controlId)?.Editable, "Editable", controlId, atOpen: false);
+        => PageEditable && EvaluateProperty(ControlDefinition(controlId)?.Editable, "Editable", controlId, PageElementKind.Control, atOpen: false);
 
     internal bool ControlEnabled(int controlId)
-        => EvaluateProperty(ControlDefinition(controlId)?.Enabled, "Enabled", controlId, atOpen: false);
+        => EvaluateProperty(ControlDefinition(controlId)?.Enabled, "Enabled", controlId, PageElementKind.Control, atOpen: false);
 
     /// <summary>
     /// A control's effective visibility is its own <c>Visible</c> combined with EVERY
@@ -795,7 +795,7 @@ internal sealed partial class RunnerPageInstance
     {
         // atOpen: the control's OWN Visible is the one property real BC does not re-evaluate
         // after the page is open. See SnapshotExpressionValues.
-        if (!EvaluateProperty(ControlDefinition(controlId)?.Visible, "Visible", controlId, atOpen: true))
+        if (!EvaluateProperty(ControlDefinition(controlId)?.Visible, "Visible", controlId, PageElementKind.Control, atOpen: true))
             return false;
 
         if (_form is not NavForm form) return true;
@@ -823,7 +823,7 @@ internal sealed partial class RunnerPageInstance
             // LIVE, unlike the control's own Visible above. Corpus
             // TestPageFieldVisibleGroup_Tests flips a group's Visible expression after the
             // page is open and reads a field inside it as newly visible, green on real BC.
-            if (!EvaluateProperty(group.Visible, "Visible", group.ID, atOpen: false))
+            if (!EvaluateProperty(group.Visible, "Visible", group.ID, PageElementKind.Group, atOpen: false))
                 return false;
 
             currentId = group.ID;
@@ -924,7 +924,7 @@ internal sealed partial class RunnerPageInstance
         => raw != null && (string.Equals(raw, "false", StringComparison.OrdinalIgnoreCase) || raw == "0");
 
     internal bool ActionEnabled(int actionId)
-        => EvaluateProperty(ActionDefinition(actionId)?.Enabled, "Enabled", actionId, atOpen: false);
+        => EvaluateProperty(ActionDefinition(actionId)?.Enabled, "Enabled", actionId, PageElementKind.Action, atOpen: false);
 
     /// <summary>
     /// Live, like every other property except a CONTROL's own Visible — and it follows the
@@ -944,11 +944,11 @@ internal sealed partial class RunnerPageInstance
     /// </summary>
     internal bool ActionVisible(int actionId)
     {
-        if (!EvaluateProperty(ActionDefinition(actionId)?.Visible, "Visible", actionId, atOpen: false))
+        if (!EvaluateProperty(ActionDefinition(actionId)?.Visible, "Visible", actionId, PageElementKind.Action, atOpen: false))
             return false;
 
         foreach (var ancestor in EnclosingActionGroups(actionId))
-            if (!EvaluateProperty(ancestor.Visible, "Visible", ancestor.ID, atOpen: false))
+            if (!EvaluateProperty(ancestor.Visible, "Visible", ancestor.ID, PageElementKind.Group, atOpen: false))
                 return false;
 
         return true;
@@ -1025,9 +1025,15 @@ internal sealed partial class RunnerPageInstance
     /// Resolve one of the boolean control properties. Absent means the AL declared none, and
     /// the AL default for all three is true.
     /// </summary>
-    private bool EvaluateProperty(string? raw, string propertyName, int elementId, bool atOpen)
+    private bool EvaluateProperty(
+        string? raw, string propertyName, int elementId, PageElementKind kind, bool atOpen)
     {
-        if (string.IsNullOrEmpty(raw)) return true;
+        // null is "this element publishes no such property at all". An element that declares
+        // none publishes the AL default as a LITERAL instead — measured on BC 28.1 through this
+        // very seam: an action with no Enabled arrives as "true", one declaring Enabled = Rec.Flag
+        // as "Flag". So an EMPTY string is neither, and cannot be read as "none declared".
+        if (raw is null) return true;
+        if (raw.Length == 0) return ClientExpressionTheCompilerDropped(propertyName, elementId, kind);
 
         // The literal arrives in more than one spelling: the emitted XML carries "true" /
         // "false" on controls and actions and "1" / "0" in the page's Properties block, and
@@ -1079,6 +1085,75 @@ internal sealed partial class RunnerPageInstance
             $"TestPage {propertyName} on page {_pageId} element {elementId}",
             $"the property is bound to expression '{raw}', which cannot be evaluated: {why}");
     }
+
+    /// <summary>
+    /// Which kind of page element a property was read from. An action's Enabled is the one arm a
+    /// service tier measured for a dropped client expression, so the kind is what keeps the
+    /// measured answer from being extended to arms nobody measured.
+    /// </summary>
+    internal enum PageElementKind
+    {
+        Control,
+        Group,
+        Action,
+    }
+
+    /// <summary>
+    /// A property whose value arrives as the EMPTY string: the AL compiler had an expression here
+    /// and dropped it, because a client expression may not call a procedure —
+    /// <c>Enabled = IsAllowed()</c> compiles with AL0573 on an action ("Procedure calls is not
+    /// valid for client expressions ... This warning will become an error in a future release")
+    /// and with error AL0322 on a control, so only the action arms reach this at all.
+    ///
+    /// <para>An ACTION's Enabled answers <b>false</b>, and the OnAction is therefore skipped:
+    /// measured on BC 28.4.53241.0 (onprem w1, container, test toolkit) for a procedure returning
+    /// true unconditionally — issue #3731, proof in
+    /// tests/runner-extras/testpage-procedure-bound-property. That claim cannot go in the corpus:
+    /// AL0573 becomes an error in a future release, so a corpus codeunit carrying this AL is one
+    /// BC minor away from failing every leg's compile.</para>
+    ///
+    /// <para>Every other arm refuses. No service tier has been asked what BC answers for an
+    /// action's Visible, or for a group's, bound to a dropped expression, and borrowing the
+    /// Enabled answer would be a guess presented as a measurement
+    /// (.claude/rules/loud-failures.md). #3762 tracks measuring them.</para>
+    ///
+    /// <para>The answered arm is silent in BC, so the runner is silent too — but it warns once
+    /// per element, because the AL author wrote a procedure call meaning it to be called.</para>
+    /// </summary>
+    private bool ClientExpressionTheCompilerDropped(string propertyName, int elementId, PageElementKind kind)
+    {
+        if (kind != PageElementKind.Action || propertyName != "Enabled")
+            throw TestPageShapeGap.ControlProperty(
+                $"TestPage {propertyName} on page {_pageId} element {elementId}",
+                "the property is bound to a client expression the AL compiler dropped (a procedure "
+                + "call: AL0573), and what real BC answers for this property has not been measured "
+                + "on a service tier — see issue #3762");
+
+        WarnOnceAboutDroppedClientExpression(_pageId.ToString(), elementId, propertyName);
+        return false;
+    }
+
+    /// <summary>
+    /// Once per (page, element, property) for the whole process: a bundle that opens the same page
+    /// in ten tests must not print ten copies. `[warn]` because Log.Install() drops a tagged line
+    /// at default verbosity unless the tag is a severity — see AlRunner.Tests/LoudDiagnosisReachesTheUserTests.
+    /// Returns whether this call was the one that printed, so AlRunner.Tests can pin the "once"
+    /// without a live NavForm.
+    /// </summary>
+    internal static bool WarnOnceAboutDroppedClientExpression(string pageId, int elementId, string propertyName)
+    {
+        if (!_droppedClientExpressionWarned.TryAdd((pageId, elementId, propertyName), true)) return false;
+
+        Console.Error.WriteLine(
+            $"[warn] RunnerPageInstance: page {pageId} element {elementId}: {propertyName} is bound to a "
+            + "procedure call, which AL does not evaluate in a client expression (AL0573), so it "
+            + "answers false here as it does on real BC — the procedure is never called. Bind the "
+            + "property to a page variable a trigger assigns instead.");
+        return true;
+    }
+
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<(string Page, int Element, string Property), bool>
+        _droppedClientExpressionWarned = new();
 
     /// <summary>
     /// The same resolution as <see cref="ResolveExpressionIdentifier"/>, but answering from the

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -2238,3 +2238,23 @@ these red. Each was measured red under its own sabotage.
 Measured 8P/0F/0E on the whole bundle, not computed from the diff.
 
 Written by an agent (Claude, `stma-auto-2`).
+
+## runner-extras `testpage-procedure-bound-property` NEW, 6 (#3731)
+
+A new bundle. A page property bound to a procedure call (`Enabled = IsAllowed()`) compiles with
+warning AL0573 on an action and error AL0322 on a control, and real BC never evaluates the
+expression: the action reads `Enabled` false and its OnAction is skipped, though the procedure
+returns true unconditionally (measured on BC 28.4.53241.0, onprem w1, container, test toolkit —
+issue #3731). The runner answered true.
+
+Six tests: the two arms of the measured claim (`Enabled()` false, `Invoke()` skips the trigger),
+three controls that fail if the fix over-reaches (`Enabled = true`, no `Enabled` declared at all,
+`Enabled = Rec.Flag`), and the refusal an action's `Visible` raises because no service tier has
+been asked what BC answers there.
+
+This claim cannot live in the corpus: AL0573 becomes an error in a future release, so a corpus
+codeunit carrying this AL is one BC minor away from failing every leg's compile.
+
+Measured 6P/0F/0E on the whole bundle, not computed from the diff.
+
+Written by an agent (Claude, `fbk-3`).

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -66,6 +66,7 @@
         "testpage-precompiled-dep-control": { "tests": 2 },
         "testpage-precompiled-member-names": { "tests": 8 },
         "testpage-promoted-actionref": { "tests": 18 },
+        "testpage-procedure-bound-property": { "tests": 6 },
         "testpage-same-value-modify": { "tests": 6 },
         "testpage-trigger-inject-timing": { "tests": 2 },
         "user-system-table-triggers": { "tests": 10 },

--- a/tests/runner-extras/testpage-procedure-bound-property/PpbAssert.Codeunit.al
+++ b/tests/runner-extras/testpage-procedure-bound-property/PpbAssert.Codeunit.al
@@ -1,0 +1,35 @@
+/// Thin standalone assert helper -- no dependency on Library Assert, mirroring
+/// tests/runner-extras/testpage-same-value-modify/TsvmAssert.Codeunit.al -- so this suite needs
+/// no test-toolkit package cache in CI.
+codeunit 65910 "Ppb Assert"
+{
+    procedure AreEqual(Expected: Integer; Actual: Integer; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Assert.AreEqual failed: %1 (expected %2, got %3)', Msg, Expected, Actual);
+    end;
+
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then
+            Error('Assert.IsTrue failed: %1', Msg);
+    end;
+
+    procedure IsFalse(Condition: Boolean; Msg: Text)
+    begin
+        if Condition then
+            Error('Assert.IsFalse failed: %1', Msg);
+    end;
+
+    procedure ExpectedError(Fragment: Text; Msg: Text)
+    var
+        Actual: Text;
+    begin
+        Actual := GetLastErrorText();
+        if Actual = '' then
+            Error('Assert.ExpectedError failed: %1 -- no error was raised at all', Msg);
+        if StrPos(Actual, Fragment) = 0 then
+            Error('Assert.ExpectedError failed: %1 (expected the message to contain ''%2'', got ''%3'')',
+                Msg, Fragment, Actual);
+    end;
+}

--- a/tests/runner-extras/testpage-procedure-bound-property/PpbCard.Page.al
+++ b/tests/runner-extras/testpage-procedure-bound-property/PpbCard.Page.al
@@ -1,0 +1,99 @@
+/// Every property here that names IsAllowed() compiles with
+///     warning AL0573: Procedure calls is not valid for client expressions.
+/// That is the point of the page: real BC does not evaluate such an expression at all, so an
+/// action declaring `Enabled = IsAllowed()` reads false and its OnAction never runs, even though
+/// the procedure returns true unconditionally (measured on BC 28.4.53241.0, issue #3731).
+page 65913 "Ppb Card"
+{
+    PageType = Card;
+    SourceTable = "Ppb Row";
+    ApplicationArea = All;
+    UsageCategory = Administration;
+
+    layout
+    {
+        area(Content)
+        {
+            group(General)
+            {
+                field("No."; Rec."No.") { ApplicationArea = All; }
+                field(FlagProcEnabled; Rec.Flag)
+                {
+                    ApplicationArea = All;
+                }
+            }
+        }
+    }
+
+    actions
+    {
+        area(Processing)
+        {
+            action(AProcEnabled)
+            {
+                ApplicationArea = All;
+                Enabled = IsAllowed();
+
+                trigger OnAction()
+                var
+                    Trace: Record "Ppb Trace";
+                begin
+                    Trace.Log('PROC-ENABLED');
+                end;
+            }
+            action(AProcVisible)
+            {
+                ApplicationArea = All;
+                // Unmeasured on real BC, same as the control above.
+                Visible = IsAllowed();
+
+                trigger OnAction()
+                var
+                    Trace: Record "Ppb Trace";
+                begin
+                    Trace.Log('PROC-VISIBLE');
+                end;
+            }
+            action(ANoProp)
+            {
+                ApplicationArea = All;
+
+                trigger OnAction()
+                var
+                    Trace: Record "Ppb Trace";
+                begin
+                    Trace.Log('NO-PROP');
+                end;
+            }
+            action(ARecFlag)
+            {
+                ApplicationArea = All;
+                Enabled = Rec.Flag;
+
+                trigger OnAction()
+                var
+                    Trace: Record "Ppb Trace";
+                begin
+                    Trace.Log('REC-FLAG');
+                end;
+            }
+            action(ALiteralTrue)
+            {
+                ApplicationArea = All;
+                Enabled = true;
+
+                trigger OnAction()
+                var
+                    Trace: Record "Ppb Trace";
+                begin
+                    Trace.Log('LITERAL-TRUE');
+                end;
+            }
+        }
+    }
+
+    procedure IsAllowed(): Boolean
+    begin
+        exit(true);
+    end;
+}

--- a/tests/runner-extras/testpage-procedure-bound-property/PpbRow.Table.al
+++ b/tests/runner-extras/testpage-procedure-bound-property/PpbRow.Table.al
@@ -1,0 +1,18 @@
+/// One row for the card page to sit on. Flag is here so a control can carry a property whose
+/// expression is an ordinary field read -- the shape #3730 measured -- next to the procedure-call
+/// shape this suite is about.
+table 65911 "Ppb Row"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Flag; Boolean) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/tests/runner-extras/testpage-procedure-bound-property/PpbTests.Codeunit.al
+++ b/tests/runner-extras/testpage-procedure-bound-property/PpbTests.Codeunit.al
@@ -1,0 +1,131 @@
+/// Issue #3731 -- a page property bound to a procedure call.
+///
+/// `Enabled = IsAllowed()` compiles with warning AL0573 ("Procedure calls is not valid for client
+/// expressions ... This warning will become an error in a future release"), and real BC never
+/// evaluates the expression: on BC 28.4.53241.0 (onprem w1, container, test toolkit) the action
+/// reads Enabled = false and its OnAction is skipped, though IsAllowed() returns true
+/// unconditionally. The runner used to resolve the call and answer true, so a test asserting the
+/// action is enabled passed here and failed on a real tier.
+///
+/// WHY THIS IS NOT A CORPUS TEST. AL0573 says the warning becomes an error in a future release,
+/// so a corpus codeunit carrying this shape is one BC minor away from failing the corpus app's
+/// compile on every leg. That is a structural reason, not convenience: the claim is about BC, but
+/// the corpus cannot be made to carry the AL that states it.
+///
+/// The one arm a service tier adjudicated is an ACTION's Enabled. A control's Enabled and an
+/// action's Visible bound to a procedure call are unmeasured, so the runner refuses them loudly
+/// instead of extrapolating (.claude/rules/loud-failures.md), and those refusals are pinned below
+/// so a later measurement has to come back through this file.
+codeunit 65914 "Ppb Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit "Ppb Assert";
+
+    local procedure SeedRow()
+    var
+        Row: Record "Ppb Row";
+        Trace: Record "Ppb Trace";
+    begin
+        Row.DeleteAll();
+        Trace.DeleteAll();
+        Row.Init();
+        Row."No." := 'R1';
+        Row.Flag := true;
+        Row.Insert();
+    end;
+
+    [Test]
+    procedure ActionEnabledBoundToProcedure_AnswersFalse()
+    var
+        Card: TestPage "Ppb Card";
+    begin
+        SeedRow();
+        Card.OpenEdit();
+        // IsAllowed() returns true unconditionally. BC answers false because it never calls it.
+        Assert.IsFalse(Card.AProcEnabled.Enabled(),
+            'an action whose Enabled is bound to a procedure call reads false on real BC (AL0573)');
+        Card.Close();
+    end;
+
+    [Test]
+    procedure ActionEnabledBoundToProcedure_InvokeSkipsTheTrigger()
+    var
+        Card: TestPage "Ppb Card";
+        Trace: Record "Ppb Trace";
+    begin
+        SeedRow();
+        Card.OpenEdit();
+        Card.AProcEnabled.Invoke();
+        Card.Close();
+        Assert.IsFalse(Trace.Ran('PROC-ENABLED'),
+            'the OnAction of a procedure-bound-Enabled action must not run: BC skips it');
+    end;
+
+    [Test]
+    procedure ActionEnabledLiteralTrue_StillInvokes()
+    var
+        Card: TestPage "Ppb Card";
+        Trace: Record "Ppb Trace";
+    begin
+        SeedRow();
+        Card.OpenEdit();
+        Assert.IsTrue(Card.ALiteralTrue.Enabled(), 'Enabled = true still reads true');
+        Card.ALiteralTrue.Invoke();
+        Card.Close();
+        // The control arm: without it, an implementation that answered false for EVERY action
+        // would pass the two tests above.
+        Assert.IsTrue(Trace.Ran('LITERAL-TRUE'),
+            'an action with Enabled = true must still dispatch its OnAction');
+    end;
+
+    [Test]
+    procedure ActionWithNoEnabledDeclared_StillInvokes()
+    var
+        Card: TestPage "Ppb Card";
+        Trace: Record "Ppb Trace";
+    begin
+        // The discriminator this fix rests on: an action declaring NO Enabled publishes the AL
+        // default as a literal ("true"), while one whose expression the compiler dropped
+        // publishes the empty string. If the two ever became the same value, this test goes red
+        // rather than the fix silently disabling every action on every page.
+        SeedRow();
+        Card.OpenEdit();
+        Assert.IsTrue(Card.ANoProp.Enabled(), 'an action declaring no Enabled reads true');
+        Card.ANoProp.Invoke();
+        Card.Close();
+        Assert.IsTrue(Trace.Ran('NO-PROP'), 'an action declaring no Enabled must still dispatch');
+    end;
+
+    [Test]
+    procedure ActionEnabledBoundToASourceTableField_StillFollowsTheRow()
+    var
+        Card: TestPage "Ppb Card";
+        Trace: Record "Ppb Trace";
+    begin
+        // #3730's live-expression path, unchanged by this fix: Flag is true on the seeded row.
+        SeedRow();
+        Card.OpenEdit();
+        Assert.IsTrue(Card.ARecFlag.Enabled(), 'Enabled = Rec.Flag reads the live row');
+        Card.ARecFlag.Invoke();
+        Card.Close();
+        Assert.IsTrue(Trace.Ran('REC-FLAG'), 'Enabled = Rec.Flag on a true row must dispatch');
+    end;
+
+    [Test]
+    procedure ActionVisibleBoundToProcedure_RefusesBecauseBcIsUnmeasured()
+    var
+        Card: TestPage "Ppb Card";
+        Answered: Boolean;
+    begin
+        SeedRow();
+        Card.OpenEdit();
+        asserterror Answered := Card.AProcVisible.Visible();
+        Assert.ExpectedError('out-of-scope:',
+            'an action Visible bound to a procedure call must refuse: no service tier measured it');
+        Assert.ExpectedError('AL0573',
+            'the refusal names the diagnostic that explains why the expression is never evaluated');
+    end;
+}

--- a/tests/runner-extras/testpage-procedure-bound-property/PpbTrace.Table.al
+++ b/tests/runner-extras/testpage-procedure-bound-property/PpbTrace.Table.al
@@ -1,0 +1,35 @@
+/// Which OnAction triggers ran. A tag row is inserted by the trigger, so "the trigger did not
+/// run" is the absence of that row -- a concrete, checkable value rather than a page global the
+/// test could not read after Close.
+table 65912 "Ppb Trace"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; Tag; Code[20]) { }
+    }
+
+    keys
+    {
+        key(PK; Tag) { Clustered = true; }
+    }
+
+    procedure Log(NewTag: Code[20])
+    var
+        Trace: Record "Ppb Trace";
+    begin
+        if Trace.Get(NewTag) then
+            exit;
+        Trace.Init();
+        Trace.Tag := NewTag;
+        Trace.Insert();
+    end;
+
+    procedure Ran(WantedTag: Code[20]): Boolean
+    var
+        Trace: Record "Ppb Trace";
+    begin
+        exit(Trace.Get(WantedTag));
+    end;
+}

--- a/tests/runner-extras/testpage-procedure-bound-property/app.json
+++ b/tests/runner-extras/testpage-procedure-bound-property/app.json
@@ -1,0 +1,18 @@
+{
+  "id": "6b1f0f2a-9c33-4d17-8f21-2a5f4de71c90",
+  "name": "Runner Extras - TestPage Procedure-Bound Property",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Issue #3731: a page property bound to a procedure call (Enabled = SomeProcedure()) compiles with warning AL0573 -- 'Procedure calls is not valid for client expressions' -- and real BC never evaluates it, so an action declaring it reads Enabled = false and its OnAction is skipped. The runner used to resolve the call and answer true.",
+  "description": "This claim cannot go in the al-language corpus: AL0573 states the warning becomes an ERROR in a future release, so a corpus codeunit carrying this shape is one BC minor away from failing the corpus app's compile on every leg. That structural reason -- not convenience -- is why the proof lives here. The measurement behind the answered arm is BC 28.4.53241.0 (onprem w1, container, test toolkit), recorded on issue #3731. The arms BC was not measured on refuse loudly rather than guess (.claude/rules/loud-failures.md).",
+  "dependencies": [],
+  "idRanges": [
+    {
+      "from": 65910,
+      "to": 65919
+    }
+  ],
+  "platform": "27.0.0.0",
+  "runtime": "15.0",
+  "target": "Cloud"
+}


### PR DESCRIPTION
Closes #3731

Opened by agent `fbk-3`.

Corpus-NA: the corpus refuses AL0573-bearing tests; proof lives in tests/runner-extras/testpage-procedure-bound-property

## What real BC does — measured, not reasoned

`Enabled = SomeProcedure()` compiles (warning AL0573: "Procedure calls is not valid for client
expressions ... This warning will become an error in a future release"), and BC never evaluates
the expression. Measured on BC 28.4.53241.0 (onprem w1, container, test toolkit; issue #3731,
found while measuring #3730): the action reads `Enabled` **false** and its `OnAction` is skipped,
though `IsAllowed()` returns `true` unconditionally. The runner answered **true**, so a test
asserting the action is enabled passed here and failed on a real tier.

## The mechanism, which is not what #3731 assumed

#3731 said the runner "resolves the whole property text as a registered source expression". It
does not. Probing `EvaluateProperty` on BC 28.1 through this very seam, the AL compiler never
emits the call text at all — it **drops the expression** and writes the property as the **empty
string**:

| declared in AL | what the metadata carries for `Enabled` |
|---|---|
| nothing at all | `true` — the AL default, as a literal |
| `Enabled = true` | `true` |
| `Enabled = Rec.Flag` | `Flag` |
| `Enabled = IsAllowed()` | **empty string** |

So an empty value is neither "none declared" nor an expression, and the runner's
`IsNullOrEmpty(raw) -> true` folded the dropped-expression case into the none-declared one. That
discriminator is the whole fix, and
`ProcedureBoundPropertyWarningTests.EvaluateProperty_KeepsNullAndEmptyApart` reads the production
source to stop it being folded back — collapsing the two would disable every action on every page
whose metadata omits the property.

## The change

`AlRunner/Patches/RunnerPageInstance.cs`, one seam:

- `EvaluateProperty` now separates `null` (no such property — unchanged, answers true) from the
  empty string (an expression the compiler dropped) and routes the latter to
  `ClientExpressionTheCompilerDropped`, carrying a new `PageElementKind` argument so the seven
  call sites say whether the property came from a control, a group or an action.
- **An action's `Enabled` answers false** — the measured arm — and warns once per
  `(page, element, property)` naming the property, the page, the element and AL0573. BC is silent
  here, so matching BC is faithful (`loud-failures.md`: the answer is observably equivalent); the
  warning exists because the AL author wrote a procedure call meaning it to be called, and nothing
  else in the run would say it is not.
- **Every other arm refuses** with `RunnerOutOfScopeException` (reason `testpage-control-property`),
  naming AL0573 and saying the answer is unmeasured. Filed **#3762** to measure them; that issue
  stays open after this merges.

Not a silent false everywhere: an action's `Visible`, a group's `Visible`, and (if AL ever stops
rejecting them) a control's `Enabled`/`Editable`/`Visible` have never been put in front of a
service tier, and borrowing the `Enabled` answer would be a guess wearing a measurement.

## Why the proof is in `tests/runner-extras/`, structurally

AL0573 states the warning **becomes an error in a future release**, so a corpus codeunit carrying
this AL is one BC minor away from failing the corpus app's compile on every leg — the claim is
about BC, but the corpus cannot be made to carry the AL that states it. This is not "quicker than
upstream": it is the case `bc-behavior-tests-go-upstream.md` calls behaviour not expressible in
the corpus. Two further facts from the RED run support it: on a **control** the same AL is
`error AL0322` in BC 28.1's compiler, not a warning, so that half of the shape does not compile at
all; and the emitted test codeunit crashed on `Unexpected value 'None'` while the page was
excluded, i.e. a corpus app carrying it would take neighbouring objects down with it.

## RED → GREEN

`tests/runner-extras/testpage-procedure-bound-property` (idRanges 65910–65919), 6 tests.

| test | before | after |
|---|---|---|
| `ActionEnabledBoundToProcedure_AnswersFalse` | **FAIL** — answered true | PASS |
| `ActionEnabledBoundToProcedure_InvokeSkipsTheTrigger` | **FAIL** — trigger ran | PASS |
| `ActionVisibleBoundToProcedure_RefusesBecauseBcIsUnmeasured` | **FAIL** — no error raised | PASS |
| `ActionEnabledLiteralTrue_StillInvokes` | PASS | PASS |
| `ActionWithNoEnabledDeclared_StillInvokes` | added after the probe | PASS |
| `ActionEnabledBoundToASourceTableField_StillFollowsTheRow` | added after the probe | PASS |

The last three are the controls: an implementation that answered false for every action, or that
treated "no property declared" as a dropped expression, turns the first two green and one of them
red. `6P/0F/0E` measured on the bundle.

C# side, `AlRunner.Tests`:

- `ProcedureBoundPropertyWarningTests` — the warning names the property, element and AL0573;
  survives Log's **default** filter and `--verbose`; fires **once** per element and per property,
  while a different element or property still gets its own; and the null-vs-empty discriminator
  above. AL cannot assert any of this — it cannot read the runner's own stderr.
- `TestPageRefusalClaimTests` — the deliberate counter for `RunnerPageInstance.cs` goes 4 to 5
  with its reason, and the new refusal joins the marker list, so it cannot be deleted rather than
  corrected.

## The empty-string shape is not one compiler's quirk — measured on four

It is a property of the AL compiler's emit, not of BC, so a single-version measurement would not
have told us what the three PR legs do. The bundle was run against an engine **built for each
version** (`-p:_BCVersion=…`), so none of these is the known-degraded skew of #2008:

| BC | probe: `Enabled = IsAllowed()` / none declared / `Rec.Flag` | bundle |
|---|---|---|
| 27.0.38460.53934 | empty / `true` / `Flag` | **6P/0F/0E** |
| 27.5.46862.53519 | empty / `true` / `Flag` | **6P/0F/0E** |
| 28.1.49838.53910 | empty / `true` / `Flag` | **6P/0F/0E** |
| 28.4.53241.54318 | empty / `true` / `Flag` | **6P/0F/0E** |

Worth recording, because it looked like a real divergence for one run: the bundle **fails on 28.4
artifacts driven by a 28.1-built engine** (2 of 6), and passes once the engine is built for 28.4.
That is #2008's engine/artifact minor skew, which the runner warns about by name; CI builds per
leg, so it does not arise there.

## Regression evidence

All on the current head, after the rebase onto `203ccbb5`:

- `tests/runner-extras` whole tree, `--count-baseline`, BC 28.1.49838.53910: **417P/0F/0E, exit
  0** (the new bundle's 6 are declared in `test-count-baseline.json`, with the rationale in
  `history.md`).
- The corpus at `818ee21b75a01b66a33ea05412fc3b0985a63adf` (master), BC 28.1.49838.53910:
  **3284P/0F/0E**, and not one AL0573 warning in the log — no corpus page reaches the
  empty-property path, which is the measurement behind "this cannot disable something that used
  to work".
- Targeted units: **213 passed** across `ProcedureBoundPropertyWarningTests`,
  `TestPageRefusalClaimTests`, `LoudDiagnosisReachesTheUserTests`, `ConsoleSwapIsolationGuardTests`,
  `RunnerExtrasIdRangeGuardTests` and the count-baseline classes.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — the `IsNullOrEmpty` read was the only reader
   of a property value, but it served all seven call sites, so the same defect was live for a
   control's `Enabled`/`Editable`/`Visible`, a group's `Visible` and an action's `Visible`. All
   seven now go through the kind-aware seam: one answers, six refuse.
2. **Does a sibling function make the same assumption?** `IsLiteralFalse(raw)` reads the same
   values and is correct as it stands — it recognises `"false"`/`"0"` only, so an empty value is
   not eliminating there, which is what compile-time elimination should do. Left alone
   deliberately.
3. **Two paths writing the same state, same invariant?** `ResolveExpressionIdentifierAtOpen` and
   `ResolveExpressionIdentifierLive` are downstream of the new check, so neither can now be handed
   an empty expression text; the at-open snapshot path (corpus 60755's control `Visible`) is
   untouched.

## Open-issue queue scan, same file

Searched the open queue for `RunnerPageInstance`, `EvaluateProperty`, AL0573 and TestPage property
issues. **Nothing folded**, and here is the map:

- **#2596** — a control's `Visible` bound to a source-table field. Same file, different mechanism
  (a *resolvable* expression on the at-open path), and #3734 deliberately left that path alone
  because corpus codeunit 60755 pins it. Folding it in would put two unrelated verdicts in one
  diff.
- **#3762** — filed by this PR for the arms it refuses. Stays open after merge, which is what the
  refusal's own message points at.

## Deliberately left out

- The once-per-element ledger is a process-wide static, so in **server mode** a page reloaded in a
  later request does not warn again, and two bundles that share a page id share one latch. Both
  are the wrong direction only for a warning, never for an answer, and making the ledger
  per-instance would print one copy per page open, which is the noise the ledger exists to stop.
- `docs/limitations.md` is unchanged: the runner now matches BC here rather than falling short of
  it, and the refusing arms already sit under the existing `testpage-shape-gaps` anchor.
- `tools/preflight.py` could not be run on this box — it crashes on Windows in
  `check_stale_scratch` (`os.getuid`), already filed as #3759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kko97BZZL71nF2nK5aftu4
