### PR TITLE
ci(corpus): refuse to arm auto-merge while the cited corpus PR is not mergeable

### DIFF
--- a/.claude/rules/bc-behavior-tests-go-upstream.md
+++ b/.claude/rules/bc-behavior-tests-go-upstream.md
@@ -39,13 +39,18 @@ Step 3 is the one that is never optional. Full detail, including escape hatches:
    Mandatory — a test becomes part of the corpus only by merging into that repo's `master`. The
    orchestrator merges it, not the authoring agent, once the corpus's required BC legs are green
    (`verify-execution-not-the-tick.md` § "Which legs were ever going to run it" says which of the
-   sixteen those are, and which of them ever run your tests).
+   sixteen those are, and which of them ever run your tests). While it is open,
+   `pr-gate.yml`'s `A cited corpus PR must be able to merge` job reads it through
+   `.github/scripts/corpus_pr_state.py` and fails your runner PR if that corpus PR cannot merge —
+   a red or unreported required leg, a conflict, a draft, or closed unmerged (#3674).
 4. **Once that PR merges, this repository measures it on its next run** — there is no pin
    to bump (#3737). Until it merges, cite it with a `Corpus-PR:` line and CI resolves the
    corpus at your corpus PR's branch head, so the runner PR is measured against exactly the
    tests it is being written for.
 5. **Then merge the runner change here.** The order is the merge bar, not a formality: a PR
-   asserting BC behaviour merges after the corpus PR it cites (`orchestrating-a-session`).
+   asserting BC behaviour merges after the corpus PR it cites (`orchestrating-a-session`), whose
+   arming list holds out for `MERGED` from that same script — CI passing on a merely *mergeable*
+   corpus PR is not the bar, because the pair lands in one coordinator step.
 
 **No local BC container is not a blocker** — open the corpus PR and let its CI adjudicate (step
 2). **No verdict available at all** (corpus CI broken, BC legs failing for unrelated reasons,

--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -43,6 +43,17 @@ reported, so move on and read again later.
 inheriting a failure it did not cause. It is a report: it never changes the exit code, and a
 read that did not happen prints `unavailable`, never a verdict.
 
+**And one line per corpus PR the body cites** — `corpus PR #226: NOT-MERGEABLE (head 321ac71a)`
+(#3674), from `.github/scripts/corpus_pr_state.py`, the same module `pr-gate.yml`'s
+`A cited corpus PR must be able to merge` job runs. Same contract as the floor line: a report,
+never an exit code, `unavailable` on a read that did not happen and `UNREADABLE` on a malformed
+declaration. **That gate is a status check, so it evaluates on push, `edited` and `labeled` and
+not when the corpus PR moves** — a corpus PR that goes green or merges later leaves a stale red
+until something re-triggers it, and editing the body or applying `status: review-ready` is the
+cheap re-trigger. It is deliberately not in the branch ruleset (it reads `api.github.com`), so
+that stale red does not block a merge; the arming list in `orchestrating-a-session` is what
+holds out for `MERGED`.
+
 `ci-wait.py` reads the required contexts from the **live branch ruleset** on each invocation
 (`GET /repos/{owner}/{repo}/rules/branches/main`, which reports only *active* rulesets),
 falling back to its built-in list and saying so loudly; `check_required_contexts.py` fails CI

--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -152,9 +152,13 @@ Arm **only** when all of these hold. Any one missing means report it to the coor
   ~40-minute run kills it).
 - `git merge-tree --write-tree --messages origin/<base> origin/<branch>` is clean.
 - **Every `Corpus-PR:` line in the body names a merged corpus PR**; a PR touching an AL-observable path with neither a `Corpus-PR:` nor a
-  `Corpus-NA:` line is held (the linkage gate, `bc-behavior-tests-go-upstream.md`): `gh pr view <M> --repo StefanMaron/BusinessCentral.AL.Language.Tests --json
-  state,mergedAt --jq '"\(.state) \(.mergedAt)"'` prints `MERGED` and a date before the arm
-  command runs. Any other answer means reporting that corpus PR's number instead of arming.
+  `Corpus-NA:` line is held (the linkage gate, `bc-behavior-tests-go-upstream.md`). The read is
+  `PR_BODY="$(gh pr view <N> --json body --jq .body)" python3 .github/scripts/corpus_pr_state.py`,
+  which answers one of `NONE` / `MERGED` / `MERGEABLE` / `NOT-MERGEABLE` / `CLOSED-UNMERGED` /
+  `UNREADABLE` per cited corpus PR — `tools/ci-wait.py` prints the same line beside its verdict
+  (#3674). **Only `NONE` and `MERGED` arm.** `MERGEABLE` is a corpus PR still to merge: merge it
+  first, in this same step, then re-read. Anything else means reporting that corpus PR's number
+  instead of arming.
 - No *other* PR in the same batch conflicts with it. Where two do — historically two submodule pin bumps to
   different revisions, say — arm only the one that must merge first and report the ordering.
 - **The newest comment on the PR whose last line begins `Verdict:` reads `Verdict: MERGE` with a

--- a/.github/scripts/check_required_contexts.py
+++ b/.github/scripts/check_required_contexts.py
@@ -223,7 +223,8 @@ PENDING_REQUIRED_CONTEXTS: list[str] = [
     # an environmental reason out of the ruleset. Listing it here still buys the
     # analysis: produced by a pull_request workflow, and not cancellable on the
     # head commit. Promoting it needs an argument that its network read cannot
-    # block merges, which #3674's PR body says it does not have.
+    # block merges, and no such argument exists today -- #3674's PR body sets
+    # out why, including the stale-red window when the corpus PR moves.
     "A cited corpus PR must be able to merge",
 ]
 

--- a/.github/scripts/check_required_contexts.py
+++ b/.github/scripts/check_required_contexts.py
@@ -216,6 +216,15 @@ PENDING_REQUIRED_CONTEXTS: list[str] = [
     # workflow, not cancellable on the head commit -- which is the whole point of
     # the seam.
     "A PR closing a gap issue must not leave its known-gap entry behind",
+    # #3674's gate: pr-gate.yml's corpus-pr-mergeable job. Listed here rather
+    # than promoted, and NOT because a ruleset edit is pending -- it reads
+    # api.github.com to ask the corpus repository about a pull request, and the
+    # rule of thumb at the top of pr-gate.yml keeps a check that can go red for
+    # an environmental reason out of the ruleset. Listing it here still buys the
+    # analysis: produced by a pull_request workflow, and not cancellable on the
+    # head commit. Promoting it needs an argument that its network read cannot
+    # block merges, which #3674's PR body says it does not have.
+    "A cited corpus PR must be able to merge",
 ]
 
 REPO = "StefanMaron/BusinessCentral.AL.Runner"

--- a/.github/scripts/corpus_pr_state.py
+++ b/.github/scripts/corpus_pr_state.py
@@ -181,6 +181,26 @@ def _linkage(mode: str, body: str, script: str) -> tuple[str | None, str]:
     return p.stdout, ""
 
 
+def marker_lines_only(body: str) -> str:
+    """`body` reduced to the lines that could possibly carry the marker.
+
+    A PREFILTER, not a parser. Both extraction modes of check_corpus_linkage.sh
+    anchor on `^[[:space:]]*Corpus-PR:`, so every line either of them can match
+    contains `corpus-pr:` case-insensitively; keeping exactly those lines cannot
+    change either mode's output, including the counts the refusal below compares.
+    Lines it keeps that the script then ignores (a mid-sentence mention, say) are
+    harmless -- a superset is safe in the direction that matters.
+
+    It exists because that script spawns two `grep` processes PER LINE, which is
+    milliseconds on the Linux runner and about 0.4s each on Windows: measured
+    2026-09-10 on this box, a 200-line body took 87.7s to parse and the same body
+    reduced to its one marker line took 1.2s. Without this, tools/ci-wait.py
+    would take a minute to print one line beside a verdict it answers in a
+    second, and the sweep over 68 bodies would take hours.
+    """
+    return "\n".join(l for l in body.splitlines() if "corpus-pr:" in l.lower())
+
+
 def corpus_pr_numbers(body: str, script: str | None = None
                       ) -> tuple[list[int] | None, str]:
     """(the corpus PR numbers this body declares, reason) -- None means REFUSED.
@@ -190,6 +210,7 @@ def corpus_pr_numbers(body: str, script: str | None = None
     back looking like "no declaration", because that is a pass.
     """
     script = script or LINKAGE
+    body = marker_lines_only(body)
     urls_out, why = _linkage("--print-corpus-pr-urls", body, script)
     if urls_out is None:
         return None, why

--- a/.github/scripts/corpus_pr_state.py
+++ b/.github/scripts/corpus_pr_state.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""What happened to the corpus pull request this PR body cites? (#3674)
+
+check_corpus_linkage.sh checks that a `Corpus-PR:` line was DECLARED. Nothing
+checked what became of the pull request it names, and the retrospective measured
+the consequence: 4 of 68 post-gate declarations merged while their corpus PR was
+still open (#3428/#3430 landed 19.6 h and 18.6 h before corpus #272/#273), and
+four merged runner PRs (#2318, #2638, #2778, #2837) cite corpus PRs #85, #137
+and #153 that closed WITHOUT merging -- so those surfaces never received a
+service-tier verdict and nothing flags them today.
+
+This module is the mechanical read, and it is the ONLY one: pr-gate.yml runs it
+as a script, tools/ci-wait.py imports it and prints its lines beside the PR
+verdict, and tools/corpus-citation-sweep.py uses it over merged PRs. One answer,
+three callers.
+
+THE SIX ANSWERS
+---------------
+    NONE             the body declares no corpus PR (the ordinary case)
+    MERGED           the corpus PR merged; a real service tier adjudicated it
+    MERGEABLE        open, no conflict, every REQUIRED leg green
+    NOT-MERGEABLE    open with a red or unreported required leg, conflicting,
+                     behind, or still a draft -- or closed... no: see below
+    CLOSED-UNMERGED  closed without merging; the claim has no verdict at all
+    UNREADABLE       the measurement did not happen (guards-need-a-third-state.md)
+
+WHY MERGEABLE IS A PASS AND NOT A FAILURE
+-----------------------------------------
+The issue was written when the runner repository still pinned the corpus, and it
+asked for a gate that fails while the corpus PR is merely OPEN. #3737 dropped the
+pin, so a runner PR now measures the head of the corpus PR it names and the two
+land in the SAME coordinator step. Failing on an open-and-green corpus PR would
+therefore fail every well-formed PR for the whole window between opening it and
+merging it -- the noisy direction check_corpus_linkage.sh's header warns about,
+where the guard gets pasted past. What is left, and what has actually gone wrong,
+is a corpus PR that CANNOT merge: red or unreported required legs, a conflict, or
+one that closed unmerged.
+
+The ARMING bar is stricter and stays stricter: `orchestrating-a-session`'s arming
+list requires MERGED before auto-merge is armed, because by then the coordinator
+has merged the corpus PR itself. CI cannot require that -- the runner PR's checks
+run long before the coordinator gets there -- so the two bars are deliberately
+different, and this module reports the state rather than one verdict for both.
+
+WHAT DECIDES `mergeable_state`
+------------------------------
+GitHub's own answer, not a leg count of our own. `blocked` is what a REQUIRED
+status check that is red or has not reported produces, which on the corpus is one
+of the eight cloud legs; `unstable` is a non-required check failing, which on the
+corpus is one of the eight OnPrem legs, and the merge bar accepts that. Measured
+2026-09-10 through the REST API, which is the same call
+.github/actions/resolve-corpus-ref/action.yml already makes cross-repo with
+`github.token`:
+
+    #319  open   merged=false mergeable=true  mergeable_state=clean
+    #305  closed merged=true  mergeable=null  mergeable_state=unknown
+    #85   closed merged=false mergeable=true  mergeable_state=blocked
+    #137  closed merged=false mergeable=true  mergeable_state=blocked
+    #153  closed merged=false mergeable=true  mergeable_state=blocked
+
+Two things that mapping has to get right, and both are pinned in
+test_corpus_pr_state.py. A merged PR reports `mergeable: null` and
+`mergeable_state: unknown`, so `merged` must be read FIRST or every merged corpus
+PR reads UNREADABLE. And #85/#137/#153 still report `mergeable_state: blocked`
+long after closing, so `state` must be read before `mergeable_state` or a
+withdrawn corpus PR reads as a merely-red one.
+
+`mergeable: null` is GitHub's documented "the merge commit is still being
+computed, ask again", so it is retried here and only becomes UNREADABLE after the
+retries.
+
+WHY THE `Corpus-PR:` REGEX IS NOT IN THIS FILE
+----------------------------------------------
+check_corpus_linkage.sh owns it, and owning it once is the point: the shape it
+accepts is the shape authors are told to write, and a second parser here would
+disagree with the gate silently -- a body the gate calls well-formed that this
+module does not see would report NONE, which is a pass. So both of that script's
+extraction modes are invoked rather than reimplemented, exactly as
+resolve_corpus_ref.sh does. The marker-count-versus-URL-count comparison is the
+same five lines as in resolve_corpus_ref.sh; it is duplicated rather than shared
+because that script answers a different question (which ONE corpus a run
+measures, refusing two) and returning per-PR answers here would change its
+contract.
+
+Usage
+-----
+    PR_BODY="$(gh pr view <N> --json body --jq .body)" \
+        python3 .github/scripts/corpus_pr_state.py
+
+Reads PR_BODY from the environment. It may be empty, but it must be passed: an
+unset body means the caller never read one, and a body nobody read declares
+nothing, which would pass every pull request in the repository.
+
+Exit codes
+----------
+    0  every cited corpus PR is MERGED or MERGEABLE, or none is cited
+    1  at least one is NOT-MERGEABLE or CLOSED-UNMERGED
+    2  usage -- PR_BODY was not passed at all
+    3  at least one could not be read, and none of them failed outright
+
+Exit 1 outranks exit 3 when both occur: a definite failure is a verdict and the
+unreadable one is a refusal, and every line is printed either way, so nothing is
+hidden by the ordering.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+
+CORPUS_REPO = "StefanMaron/BusinessCentral.AL.Language.Tests"
+HERE = os.path.dirname(os.path.abspath(__file__))
+LINKAGE = os.path.join(HERE, "check_corpus_linkage.sh")
+
+# A definite failure, a refusal, and a pass. Ordered so `max` over the codes a
+# body produced picks exit 1 over exit 3 over 0.
+_RANK = {"NONE": 0, "MERGED": 0, "MERGEABLE": 0, "UNREADABLE": 3,
+         "NOT-MERGEABLE": 1, "CLOSED-UNMERGED": 1}
+
+
+@dataclass
+class Entry:
+    """One corpus pull request, as this module sees it."""
+
+    number: int
+    state: str
+    head: str = ""
+    detail: str = ""
+
+
+def format_line(entry: Entry) -> str:
+    """The one line every caller prints. tools/ci-wait.py prints exactly this."""
+    head = entry.head[:8] if entry.head else ""
+    where = f"head {head}" if head else "head unknown"
+    tail = f" -- {entry.detail}" if entry.detail else ""
+    return f"corpus PR #{entry.number}: {entry.state} ({where}){tail}"
+
+
+def _bash() -> str | None:
+    """The bash that runs check_corpus_linkage.sh, or None.
+
+    On CI this is just `bash`. On a Windows agent box python may be launched from
+    PowerShell, where Git's bash is often not on PATH even though git is -- so the
+    two standard Git-for-Windows locations are tried before giving up. Giving up
+    is a refusal, never an empty answer.
+    """
+    found = shutil.which("bash")
+    if found:
+        return found
+    for candidate in (r"C:\Program Files\Git\bin\bash.exe",
+                      r"C:\Program Files\Git\usr\bin\bash.exe"):
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def _linkage(mode: str, body: str, script: str) -> tuple[str | None, str]:
+    """One extraction mode of check_corpus_linkage.sh. (stdout, reason-if-failed)."""
+    if not os.path.isfile(script):
+        return None, (f"cannot find check_corpus_linkage.sh at {script}; it owns the "
+                      "Corpus-PR regex, and refusing is the point -- a copy of that "
+                      "regex here would answer while disagreeing with the gate")
+    shell = _bash()
+    if shell is None:
+        return None, ("no bash found to run check_corpus_linkage.sh, which owns the "
+                      "Corpus-PR regex; refusing rather than parsing the body here")
+    env = dict(os.environ)
+    env["PR_BODY"] = body
+    try:
+        p = subprocess.run([shell, script, mode], capture_output=True, text=True,
+                           encoding="utf-8", errors="replace", env=env)
+    except Exception as exc:  # noqa: BLE001 - a broken invocation is a refusal
+        return None, f"could not run check_corpus_linkage.sh {mode}: {exc!r}"
+    if p.returncode != 0:
+        return None, (f"check_corpus_linkage.sh {mode} exited {p.returncode}: "
+                      f"{(p.stderr or '').strip()[:200]}")
+    return p.stdout, ""
+
+
+def corpus_pr_numbers(body: str, script: str | None = None
+                      ) -> tuple[list[int] | None, str]:
+    """(the corpus PR numbers this body declares, reason) -- None means REFUSED.
+
+    An empty list is an answer: this body declares nothing. None is not -- a
+    malformed `Corpus-PR:` line, or a parse that could not run, must never come
+    back looking like "no declaration", because that is a pass.
+    """
+    script = script or LINKAGE
+    urls_out, why = _linkage("--print-corpus-pr-urls", body, script)
+    if urls_out is None:
+        return None, why
+    markers_out, why = _linkage("--print-corpus-pr-marker-lines", body, script)
+    if markers_out is None:
+        return None, why
+
+    urls = [u for u in urls_out.splitlines() if u.strip()]
+    markers = [m for m in markers_out.splitlines() if m.strip()]
+    if len(markers) > len(urls):
+        bad = "; ".join(m.strip() for m in markers)
+        return None, (f"this body carries {len(markers)} 'Corpus-PR:' line(s) but only "
+                      f"{len(urls)} of them is a well-formed corpus pull request URL, so "
+                      f"the state of the corpus PR you named cannot be read. Write it as "
+                      f"one line: Corpus-PR: https://github.com/{CORPUS_REPO}/pull/<N>. "
+                      f"Lines carrying the marker: {bad}")
+
+    numbers: list[int] = []
+    for url in urls:
+        tail = url.strip().rstrip("/").rsplit("/", 1)[-1]
+        if not tail.isdigit():
+            return None, (f"could not read a pull request number out of {url!r}, which "
+                          "check_corpus_linkage.sh called well-formed -- that is a "
+                          "disagreement between the two, not something a body can cause")
+        numbers.append(int(tail))
+    return numbers, ""
+
+
+def classify(payload) -> tuple[str, str]:
+    """(state, detail) for one corpus pull request payload. Pure.
+
+    Order is load-bearing and both orderings below are measured, not assumed:
+    `merged` before anything else (a merged PR reports mergeable=null), and
+    `state` before `mergeable_state` (a closed-unmerged PR keeps reporting
+    `blocked` indefinitely).
+    """
+    if not isinstance(payload, dict):
+        return "UNREADABLE", "the corpus PR payload was not an object"
+    if "state" not in payload or "merged" not in payload:
+        return "UNREADABLE", ("the corpus PR payload carries no state/merged fields, so "
+                              "nothing about it was actually measured")
+
+    if payload.get("merged") is True:
+        return "MERGED", "a real BC service tier adjudicated this claim"
+
+    state = str(payload.get("state") or "").lower()
+    if state == "closed":
+        return "CLOSED-UNMERGED", (
+            "it closed WITHOUT merging, so no service tier ever adjudicated this claim. "
+            "Reopen it, or open a new corpus PR and cite that one")
+    if state != "open":
+        return "UNREADABLE", f"unexpected pull request state {state!r}"
+
+    mergeable = payload.get("mergeable")
+    mstate = str(payload.get("mergeable_state") or "").lower()
+
+    if mergeable is None:
+        return "UNREADABLE", ("GitHub has not finished computing this corpus PR's merge "
+                              "state (mergeable: null); ask again")
+    if mergeable is False:
+        return "NOT-MERGEABLE", "it conflicts with the corpus master branch"
+
+    if mstate in ("clean", "has_hooks"):
+        return "MERGEABLE", "open, no conflict, every required BC leg green"
+    if mstate == "unstable":
+        return "MERGEABLE", ("open and mergeable; a check that is NOT required is failing "
+                             "-- on the corpus that is one of the eight OnPrem legs, which "
+                             "the merge bar does not gate on")
+    if mstate == "dirty":
+        return "NOT-MERGEABLE", "it conflicts with the corpus master branch"
+    if mstate == "blocked":
+        return "NOT-MERGEABLE", ("a required BC leg is red or has not reported yet, so no "
+                                 "service tier has adjudicated this claim green")
+    if mstate == "behind":
+        return "NOT-MERGEABLE", "it is behind the corpus master branch and must be updated"
+    if mstate == "draft" or payload.get("draft") is True:
+        return "NOT-MERGEABLE", "it is still a draft"
+    return "UNREADABLE", (f"GitHub answered mergeable_state {mstate!r}, which this script "
+                          "does not know how to read; refusing to guess")
+
+
+def _gh(args: list[str]) -> tuple[int, str]:
+    p = subprocess.run(["gh", *args], capture_output=True, text=True,
+                       encoding="utf-8", errors="replace")
+    out = (p.stdout or "") + (p.stderr or "")
+    # mise prints a banner on stdout; drop it so the JSON parses (CLAUDE.md).
+    out = "\n".join(l for l in out.split("\n") if not l.startswith("mise "))
+    return p.returncode, out.strip()
+
+
+def fetch_pull(number: int, run=None, attempts: int = 3, sleep=time.sleep
+               ) -> tuple[dict | None, str]:
+    """(payload, reason) for one corpus pull request. None means the read failed.
+
+    Retries a `mergeable: null`, which is GitHub still computing the merge commit
+    rather than an answer. Everything else is returned as read.
+    """
+    run = run or _gh
+    jq = ('{state:.state, merged:.merged, draft:.draft, mergeable:.mergeable, '
+          'mergeable_state:.mergeable_state, head:.head.sha}')
+    last = ""
+    for i in range(max(1, attempts)):
+        rc, out = run(["api", f"repos/{CORPUS_REPO}/pulls/{number}", "--jq", jq])
+        if rc != 0:
+            return None, (f"could not read corpus pull request #{number} from "
+                          f"{CORPUS_REPO}: {out[:200]}")
+        try:
+            payload = json.loads(out)
+        except Exception:
+            return None, (f"could not parse the API answer for corpus pull request "
+                          f"#{number}: {out[:200]}")
+        if not isinstance(payload, dict):
+            return None, f"unexpected payload shape for corpus pull request #{number}"
+        if payload.get("mergeable") is not None or payload.get("merged") is True \
+                or str(payload.get("state") or "").lower() != "open":
+            return payload, ""
+        last = "mergeable was still null"
+        if i + 1 < max(1, attempts):
+            sleep(2 * (i + 1))
+    return payload, last
+
+
+def states_for_body(body: str, fetch=None, script: str | None = None
+                    ) -> tuple[list[Entry], str]:
+    """(one Entry per cited corpus PR, refusal reason).
+
+    A non-empty reason with an empty list means the body could not be read at
+    all -- a malformed declaration, or a parse that could not run. That is the
+    third state, not "nothing declared".
+    """
+    fetch = fetch or fetch_pull
+    numbers, why = corpus_pr_numbers(body, script=script)
+    if numbers is None:
+        return [], why
+    entries: list[Entry] = []
+    for number in numbers:
+        payload, read_why = fetch(number)
+        if payload is None:
+            entries.append(Entry(number, "UNREADABLE", "", read_why))
+            continue
+        state, detail = classify(payload)
+        if state == "UNREADABLE" and read_why:
+            detail = f"{detail} ({read_why})"
+        entries.append(Entry(number, state, str(payload.get("head") or ""), detail))
+    return entries, ""
+
+
+def main(argv: list[str], fetch=None) -> int:
+    if "PR_BODY" not in os.environ:
+        print("::error::corpus_pr_state.py: PR_BODY is required (it may be empty, but it "
+              "must be passed). A body nobody read declares nothing, which would pass "
+              "every pull request in the repository.", file=sys.stderr)
+        return 2
+
+    body = os.environ["PR_BODY"]
+    entries, why = states_for_body(body, fetch=fetch)
+    if why:
+        print(f"::error::corpus PR: UNREADABLE -- {why}", file=sys.stderr)
+        return 3
+    if not entries:
+        print("corpus PR: NONE -- this body declares no Corpus-PR line, so there is no "
+              "corpus pull request to wait for.")
+        return 0
+
+    worst = 0
+    for entry in entries:
+        line = format_line(entry)
+        rank = _RANK.get(entry.state, 3)
+        if rank == 0:
+            print(line)
+        else:
+            print(f"::error::{line}", file=sys.stderr)
+        # 1 outranks 3: a definite failure is a verdict, a refusal is not.
+        worst = 1 if (worst == 1 or rank == 1) else max(worst, rank)
+
+    if worst == 1:
+        print("\nThis pull request cites a corpus pull request that cannot merge as it "
+              "stands. .claude/rules/bc-behavior-tests-go-upstream.md: the corpus PR is "
+              "what puts the claim in front of a real BC service tier, and a runner PR "
+              "merged ahead of it ships a claim nothing adjudicated (#3674). Fix the "
+              "corpus PR, or change the declaration to the corpus PR that carries the "
+              "proving test.", file=sys.stderr)
+    elif worst == 3:
+        print("\nThe corpus pull request could not be read, so this check has no verdict "
+              "-- it is not a pass. Re-run it once GitHub answers.", file=sys.stderr)
+    return worst
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/scripts/test_corpus_pr_state.py
+++ b/.github/scripts/test_corpus_pr_state.py
@@ -155,6 +155,47 @@ _nums, _why = cps.corpus_pr_numbers(GOOD, script=os.path.join(HERE, "no_such_scr
 check("with check_corpus_linkage.sh missing it refuses -- proof the regex is not duplicated here",
       _nums is None and "check_corpus_linkage.sh" in (_why or ""), f"{_nums!r} {_why!r}")
 
+# --- the prefilter, which must change no answer ------------------------------
+#
+# check_corpus_linkage.sh spawns two greps PER LINE, so a real PR body is parsed
+# in a minute on Windows and in milliseconds on the runner. Reducing the body to
+# its marker lines is what makes ci-wait.py's line cheap -- and it is only safe
+# because both extraction modes anchor on the marker at line start, so a line
+# neither can match cannot change either answer.
+FILLER = "\n".join(f"some prose line {i}" for i in range(30))
+
+check("the prefilter keeps a marker line",
+      cps.marker_lines_only(FILLER + "\n" + GOOD + "\n" + FILLER) == GOOD,
+      repr(cps.marker_lines_only(FILLER + "\n" + GOOD)))
+check("...case-insensitively",
+      cps.marker_lines_only("corpus-pr: x") == "corpus-pr: x",
+      repr(cps.marker_lines_only("corpus-pr: x")))
+check("...and keeps a MALFORMED marker line, so the refusal below still fires",
+      "228" in cps.marker_lines_only(
+          FILLER + "\nCorpus-PR: [#228](https://x/pull/228)\n"),
+      repr(cps.marker_lines_only(FILLER + "\nCorpus-PR: [#228](https://x/pull/228)")))
+check("...and drops a body with nothing to parse",
+      cps.marker_lines_only(FILLER + "\nCorpus-NA: tooling only\n") == "",
+      repr(cps.marker_lines_only(FILLER)))
+
+_padded, _why = cps.corpus_pr_numbers(FILLER + "\n" + GOOD + "\n" + FILLER + "\n")
+check("a marker buried in 60 lines of prose reads exactly as the compact body does",
+      _padded == [226] and not _why, f"{_padded!r} {_why!r}")
+
+# A mid-sentence mention is one of the six near-misses the gate refuses. It
+# survives the prefilter -- a superset -- and the script still does not count it,
+# so the well-formed line beside it is the only declaration.
+_mixed, _why = cps.corpus_pr_numbers(
+    "The `Corpus-PR:` for this is #226, see below.\n" + GOOD + "\n")
+check("a mid-sentence 'Corpus-PR:' mention beside a good line does not refuse the body",
+      _mixed == [226] and not _why, f"{_mixed!r} {_why!r}")
+
+_bad, _why = cps.corpus_pr_numbers(
+    FILLER + "\nCorpus-PR: [#228](https://github.com/StefanMaron/"
+    "BusinessCentral.AL.Language.Tests/pull/228)\n" + FILLER)
+check("a malformed line buried in prose still refuses",
+      _bad is None and _why, f"{_bad!r} {_why!r}")
+
 # ===========================================================================
 # The whole answer for a body, and the line it prints
 # ===========================================================================

--- a/.github/scripts/test_corpus_pr_state.py
+++ b/.github/scripts/test_corpus_pr_state.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Unit tests for corpus_pr_state.py (#3674).
+
+Every payload below is the shape `GET /repos/{o}/{r}/pulls/{n}` returns, and the
+five named ones were MEASURED on 2026-09-10 against the corpus repository rather
+than imagined -- #319 open and clean, #305 merged, and #85 / #137 / #153 closed
+without merging. The mapping from `mergeable_state` to a verdict is the part of
+this module that can be wrong in a way nothing else notices, so it is pinned
+against real answers.
+
+Run: python3 .github/scripts/test_corpus_pr_state.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+_spec = importlib.util.spec_from_file_location(
+    "corpus_pr_state", os.path.join(HERE, "corpus_pr_state.py"))
+cps = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = cps
+_spec.loader.exec_module(cps)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        FAILURES.append(name)
+
+
+def payload(**kw):
+    base = {"state": "open", "merged": False, "draft": False,
+            "mergeable": True, "mergeable_state": "clean", "head": "0" * 40}
+    base.update(kw)
+    return base
+
+
+print("corpus_pr_state.py -- classifying one corpus pull request")
+
+# --- the five measured payloads ---------------------------------------------
+MEASURED = {
+    319: payload(state="open", merged=False, mergeable=True,
+                 mergeable_state="clean", head="321ac71a04c4797723dd7c90875a315b42f5b356"),
+    305: payload(state="closed", merged=True, mergeable=None,
+                 mergeable_state="unknown", head="45b2b2a38491109fb8495cb37e9caa4615fde57e"),
+    85: payload(state="closed", merged=False, mergeable=True,
+                mergeable_state="blocked", head="957bced842e753f7f40d184bbe3b8267acaa509f"),
+    137: payload(state="closed", merged=False, mergeable=True,
+                 mergeable_state="blocked", head="9638c7a4d7d85692c3ec83229812a0af5addfa96"),
+    153: payload(state="closed", merged=False, mergeable=True,
+                 mergeable_state="blocked", head="b31bd4f428b9f5b9b4d128bfdfe59c239278063b"),
+}
+
+check("an open corpus PR whose required legs are green is MERGEABLE (measured on #319)",
+      cps.classify(MEASURED[319])[0] == "MERGEABLE", str(cps.classify(MEASURED[319])))
+check("a merged corpus PR is MERGED even though its mergeable fields read unknown "
+      "(measured on #305)",
+      cps.classify(MEASURED[305])[0] == "MERGED", str(cps.classify(MEASURED[305])))
+for _n in (85, 137, 153):
+    check(f"corpus #{_n}, closed without merging, is CLOSED-UNMERGED -- not read off "
+          "mergeable_state, which still says 'blocked'",
+          cps.classify(MEASURED[_n])[0] == "CLOSED-UNMERGED", str(cps.classify(MEASURED[_n])))
+
+# --- the rest of the mergeable_state space ----------------------------------
+check("open + blocked is NOT-MERGEABLE (a required BC leg is red or has not reported)",
+      cps.classify(payload(mergeable_state="blocked"))[0] == "NOT-MERGEABLE",
+      str(cps.classify(payload(mergeable_state="blocked"))))
+check("...and the reason names the required legs rather than saying 'blocked'",
+      "leg" in cps.classify(payload(mergeable_state="blocked"))[1].lower(),
+      str(cps.classify(payload(mergeable_state="blocked"))))
+check("open + dirty is NOT-MERGEABLE, and says conflict",
+      cps.classify(payload(mergeable=False, mergeable_state="dirty"))[0] == "NOT-MERGEABLE"
+      and "conflict" in cps.classify(payload(mergeable=False,
+                                             mergeable_state="dirty"))[1].lower(),
+      str(cps.classify(payload(mergeable=False, mergeable_state="dirty"))))
+check("mergeable=false alone is NOT-MERGEABLE even when mergeable_state looks fine",
+      cps.classify(payload(mergeable=False, mergeable_state="clean"))[0] == "NOT-MERGEABLE",
+      str(cps.classify(payload(mergeable=False, mergeable_state="clean"))))
+check("open + behind is NOT-MERGEABLE",
+      cps.classify(payload(mergeable_state="behind"))[0] == "NOT-MERGEABLE",
+      str(cps.classify(payload(mergeable_state="behind"))))
+check("a draft corpus PR is NOT-MERGEABLE",
+      cps.classify(payload(draft=True, mergeable_state="draft"))[0] == "NOT-MERGEABLE",
+      str(cps.classify(payload(draft=True, mergeable_state="draft"))))
+check("open + has_hooks is MERGEABLE (clean, with a webhook configured)",
+      cps.classify(payload(mergeable_state="has_hooks"))[0] == "MERGEABLE",
+      str(cps.classify(payload(mergeable_state="has_hooks"))))
+# The corpus runs 16 legs and requires 8; a red OnPrem leg leaves the PR
+# mergeable with a non-passing check, which is `unstable`. Reading that as
+# NOT-MERGEABLE would refuse a corpus PR the merge bar accepts.
+check("open + unstable is MERGEABLE -- the failing check is not a required one",
+      cps.classify(payload(mergeable_state="unstable"))[0] == "MERGEABLE",
+      str(cps.classify(payload(mergeable_state="unstable"))))
+check("...and says so, so nobody reads it as all sixteen legs green",
+      "required" in cps.classify(payload(mergeable_state="unstable"))[1].lower(),
+      str(cps.classify(payload(mergeable_state="unstable"))))
+
+# --- the third state (guards-need-a-third-state.md) --------------------------
+check("mergeable=null is UNREADABLE, never NOT-MERGEABLE -- GitHub is still computing it",
+      cps.classify(payload(mergeable=None, mergeable_state="unknown"))[0] == "UNREADABLE",
+      str(cps.classify(payload(mergeable=None, mergeable_state="unknown"))))
+check("a mergeable_state GitHub has not documented is UNREADABLE, not a guess",
+      cps.classify(payload(mergeable_state="something_new"))[0] == "UNREADABLE",
+      str(cps.classify(payload(mergeable_state="something_new"))))
+check("a payload missing the fields is UNREADABLE",
+      cps.classify({})[0] == "UNREADABLE", str(cps.classify({})))
+check("a payload that is not a mapping at all is UNREADABLE",
+      cps.classify(None)[0] == "UNREADABLE", str(cps.classify(None)))
+check("an unexpected `state` is UNREADABLE",
+      cps.classify(payload(state="weird"))[0] == "UNREADABLE",
+      str(cps.classify(payload(state="weird"))))
+
+# ===========================================================================
+# Reading the declarations out of a body -- delegated, never re-parsed
+# ===========================================================================
+print("\ncorpus_pr_state.py -- which corpus PRs a body declares")
+
+GOOD = "Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/226"
+GOOD2 = "Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/227"
+
+_nums, _why = cps.corpus_pr_numbers("Closes #1\n\n" + GOOD + "\n")
+check("one well-formed Corpus-PR line yields its number", _nums == [226] and not _why,
+      f"{_nums!r} {_why!r}")
+
+# resolve_corpus_ref.sh refuses two, because a RUN measures one corpus. This
+# module answers per corpus PR, so two is an ordinary answer here.
+_nums, _why = cps.corpus_pr_numbers(GOOD + "\n" + GOOD2 + "\n")
+check("two well-formed lines yield both numbers (unlike the resolver, which must pick one)",
+      _nums == [226, 227] and not _why, f"{_nums!r} {_why!r}")
+
+_nums, _why = cps.corpus_pr_numbers("Closes #1\n\nCorpus-NA: tooling only\n")
+check("a body with no Corpus-PR line yields no numbers, and that is not an error",
+      _nums == [] and not _why, f"{_nums!r} {_why!r}")
+
+_nums, _why = cps.corpus_pr_numbers(
+    "Corpus-PR: [#228](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/228)\n")
+check("a MALFORMED Corpus-PR line refuses rather than reading as no declaration",
+      _nums is None and _why, f"{_nums!r} {_why!r}")
+check("...and the refusal quotes the line, so the author can see what was wrong",
+      _nums is None and "228" in (_why or ""), f"{_why!r}")
+
+# The regex lives in check_corpus_linkage.sh and nowhere else. Point this at a
+# path that does not exist and it must refuse -- a module carrying its own copy
+# would answer anyway, which is the silent second-source failure
+# resolve_corpus_ref.sh's header describes.
+_nums, _why = cps.corpus_pr_numbers(GOOD, script=os.path.join(HERE, "no_such_script.sh"))
+check("with check_corpus_linkage.sh missing it refuses -- proof the regex is not duplicated here",
+      _nums is None and "check_corpus_linkage.sh" in (_why or ""), f"{_nums!r} {_why!r}")
+
+# ===========================================================================
+# The whole answer for a body, and the line it prints
+# ===========================================================================
+print("\ncorpus_pr_state.py -- the per-body answer")
+
+
+def faker(by_number, calls=None):
+    """A stand-in for the gh read: number -> payload, or None for a failed read."""
+    def _fetch(number, **kw):
+        if calls is not None:
+            calls.append(number)
+        got = by_number.get(number)
+        if got is None:
+            return None, f"could not read corpus pull request #{number}"
+        return got, ""
+    return _fetch
+
+
+_entries, _why = cps.states_for_body(GOOD, fetch=faker({226: MEASURED[319]}))
+check("a body declaring one corpus PR gets one entry", len(_entries) == 1 and not _why,
+      f"{_entries!r} {_why!r}")
+check("...carrying the state and the corpus PR's head",
+      _entries[0].state == "MERGEABLE" and _entries[0].head.startswith("321ac71a"),
+      repr(_entries[0]))
+check("...and formats as one line naming the number, the state and eight sha characters",
+      cps.format_line(_entries[0]).startswith("corpus PR #226: MERGEABLE (head 321ac71a)"),
+      cps.format_line(_entries[0]))
+
+_failed, _ = cps.states_for_body(GOOD, fetch=faker({}))
+check("a failed read is UNREADABLE, never a state", _failed[0].state == "UNREADABLE",
+      repr(_failed[0]))
+check("...and its line says so without inventing a head",
+      "UNREADABLE" in cps.format_line(_failed[0])
+      and "head unknown" in cps.format_line(_failed[0]), cps.format_line(_failed[0]))
+
+# ===========================================================================
+# Exit codes
+# ===========================================================================
+print("\ncorpus_pr_state.py -- exit codes")
+
+
+def run_main(body, by_number, unset_body=False):
+    saved_body = os.environ.get("PR_BODY")
+    if unset_body:
+        os.environ.pop("PR_BODY", None)
+    else:
+        os.environ["PR_BODY"] = body
+    buf = io.StringIO()
+    out, err = sys.stdout, sys.stderr
+    try:
+        sys.stdout = buf
+        sys.stderr = buf
+        rc = cps.main(["corpus_pr_state.py"], fetch=faker(by_number))
+    finally:
+        sys.stdout, sys.stderr = out, err
+        if saved_body is None:
+            os.environ.pop("PR_BODY", None)
+        else:
+            os.environ["PR_BODY"] = saved_body
+    return rc, buf.getvalue()
+
+
+_rc, _out = run_main("Closes #1\n", {})
+check("a body with no declaration passes", _rc == 0, f"rc={_rc} {_out!r}")
+check("...and says NONE rather than printing nothing", "NONE" in _out, _out)
+
+_rc, _out = run_main(GOOD, {226: MEASURED[305]})
+check("a MERGED corpus PR passes", _rc == 0, f"rc={_rc} {_out!r}")
+
+_rc, _out = run_main(GOOD, {226: MEASURED[319]})
+check("an open corpus PR whose required legs are green passes -- it lands in the same "
+      "coordinator step as this PR", _rc == 0, f"rc={_rc} {_out!r}")
+
+_rc, _out = run_main(GOOD, {226: MEASURED[153]})
+check("a corpus PR closed without merging FAILS", _rc == 1, f"rc={_rc} {_out!r}")
+check("...and the message says what to do about it",
+      "reopen" in _out.lower() or "open a new" in _out.lower(), _out)
+
+_rc, _out = run_main(GOOD, {226: payload(mergeable_state="blocked")})
+check("a corpus PR with a red or unreported required leg FAILS", _rc == 1, f"rc={_rc} {_out!r}")
+
+_rc, _out = run_main(GOOD, {226: payload(mergeable=None, mergeable_state="unknown")})
+check("an unreadable corpus PR is exit 3, never a pass", _rc == 3, f"rc={_rc} {_out!r}")
+
+# A definite failure beside an unreadable one is still a definite failure: exit 1
+# is a verdict, exit 3 is a refusal, and hiding the verdict behind the refusal
+# would lose the actionable half.
+_rc, _out = run_main(GOOD + "\n" + GOOD2,
+                     {226: MEASURED[153], 227: payload(mergeable=None,
+                                                       mergeable_state="unknown")})
+check("a definite failure outranks an unreadable sibling", _rc == 1, f"rc={_rc} {_out!r}")
+check("...and both lines are printed, so neither is lost",
+      "#226" in _out and "#227" in _out, _out)
+
+_rc, _out = run_main(
+    "Corpus-PR: [#228](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/228)",
+    {})
+check("a malformed declaration is exit 3, not a pass", _rc == 3, f"rc={_rc} {_out!r}")
+
+_rc, _out = run_main("", {}, unset_body=True)
+check("an UNSET PR_BODY is a usage error (2), not a body that declares nothing",
+      _rc == 2, f"rc={_rc} {_out!r}")
+
+# ===========================================================================
+# The gh call itself
+# ===========================================================================
+print("\ncorpus_pr_state.py -- the read")
+
+_calls: list = []
+
+
+def _runner(results):
+    def _run(args):
+        _calls.append(list(args))
+        return results[min(len(_calls) - 1, len(results) - 1)]
+    return _run
+
+
+_calls.clear()
+_got, _why = cps.fetch_pull(226, run=_runner([(0, '{"state":"open","merged":false,'
+                                                 '"draft":false,"mergeable":true,'
+                                                 '"mergeable_state":"clean","head":"abc"}')]),
+                            sleep=lambda s: None)
+check("the read asks the corpus repository, by pull number",
+      _got is not None and any("BusinessCentral.AL.Language.Tests/pulls/226" in " ".join(a)
+                               for a in _calls), f"{_got!r} {_calls!r}")
+
+_calls.clear()
+_got, _why = cps.fetch_pull(
+    226,
+    run=_runner([(0, '{"state":"open","merged":false,"draft":false,"mergeable":null,'
+                     '"mergeable_state":"unknown","head":"abc"}'),
+                 (0, '{"state":"open","merged":false,"draft":false,"mergeable":true,'
+                     '"mergeable_state":"clean","head":"abc"}')]),
+    sleep=lambda s: None)
+check("a null `mergeable` is retried rather than reported -- GitHub computes it "
+      "asynchronously", len(_calls) > 1 and cps.classify(_got)[0] == "MERGEABLE",
+      f"{len(_calls)} call(s) {_got!r}")
+
+_calls.clear()
+_got, _why = cps.fetch_pull(226, run=_runner([(1, "gh: not found")]), sleep=lambda s: None)
+check("a failed gh call returns no payload and a reason", _got is None and _why,
+      f"{_got!r} {_why!r}")
+
+_calls.clear()
+_got, _why = cps.fetch_pull(226, run=_runner([(0, "not json at all")]), sleep=lambda s: None)
+check("an unparseable answer is a failed read, not an empty payload",
+      _got is None and _why, f"{_got!r} {_why!r}")
+
+print()
+if FAILURES:
+    print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")
+    sys.exit(1)
+print("all checks passed")

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -212,6 +212,53 @@ jobs:
           CHANGED_FILES: ${{ steps.changed.outputs.files }}
         run: bash .github/scripts/check_corpus_linkage.sh
 
+  corpus-pr-mergeable:
+    name: A cited corpus PR must be able to merge
+    permissions:
+      contents: read
+      pull-requests: read   # gh api on the CORPUS repo, which is public
+    runs-on: ubuntu-latest
+    # #3674. The job above checks that a `Corpus-PR:` line was DECLARED, never
+    # what became of the pull request it names. Measured over the 68 post-gate
+    # declarations: four runner PRs merged while their corpus PR was still open,
+    # and four merged runner PRs (#2318, #2638, #2778, #2837) cite corpus PRs
+    # #85, #137 and #153 that closed WITHOUT merging -- so those claims have no
+    # service-tier verdict and nothing said so.
+    #
+    # What it fails on is deliberately narrower than the issue proposed: a corpus
+    # PR that CANNOT merge (a red or unreported required leg, a conflict, a
+    # draft, or closed unmerged). An open-and-green corpus PR PASSES, because
+    # since #3737 the runner PR is measured against that PR's head and the two
+    # land in the same coordinator step -- failing on merely-open would fail
+    # every well-formed PR for its whole review window, which is the
+    # paste-past-it direction check_corpus_linkage.sh's header warns about.
+    # The stricter MERGED bar belongs to arming, and lives in
+    # `orchestrating-a-session`'s arming list, read through tools/ci-wait.py.
+    #
+    # It reads api.github.com, so by the rule of thumb at the top of this file it
+    # is NOT ready to be a required context, and it is deliberately not in the
+    # branch ruleset: it is listed in PENDING_REQUIRED_CONTEXTS in
+    # check_required_contexts.py, which analyses it like a required one (produced
+    # by a pull_request workflow, not cancellable on the head commit) without
+    # gating on it. Two things would have to change before promoting it -- see
+    # that list and the PR body of #3674.
+    #
+    # `edited` and `labeled` in this workflow's trigger list are what re-evaluate
+    # it after the corpus PR moves: editing the body, or the coordinator's
+    # `status: review-ready` label, re-runs this job on the same commit. That is
+    # why no `concurrency` block may be added here (see the header).
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check the cited corpus PR can merge
+        env:
+          # The body from the event payload, like require-corpus-linkage above:
+          # `edited` is in this workflow's trigger list, so a body changed after
+          # the last push re-runs this job with the new body.
+          PR_BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/corpus_pr_state.py
+
   verify-trigger-list:
     name: pull_request trigger lists must keep their load-bearing event types
     runs-on: ubuntu-latest

--- a/tools/ci-wait.py
+++ b/tools/ci-wait.py
@@ -153,6 +153,7 @@ from __future__ import annotations
 
 import argparse
 import datetime
+import importlib.util
 import json
 import os
 import re
@@ -451,6 +452,92 @@ def print_floor_verdict() -> None:
         print(floor_verdict(runs, why))
     except Exception as exc:  # pragma: no cover - a report may never break a verdict
         print(f"main floor: unavailable ({type(exc).__name__} while reading main's runs)")
+
+
+# --------------------------------------------------------------------------
+# The corpus pull request this PR's body cites (#3674)
+#
+# The linkage gate checks that a `Corpus-PR:` line was declared, never what
+# became of the pull request it names -- and four merged runner PRs cite corpus
+# PRs that closed without ever merging, so those claims have no service-tier
+# verdict and nothing said so. This line is what a reviewer sees before arming
+# auto-merge; the arming list in `orchestrating-a-session` reads it.
+#
+# The state itself is NOT computed here. .github/scripts/corpus_pr_state.py is
+# the one source of truth -- pr-gate.yml runs it as a script, this imports it --
+# so the line printed beside a verdict and the check that blocks a merge cannot
+# answer differently.
+# --------------------------------------------------------------------------
+CORPUS_PR_STATE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               "..", ".github", "scripts", "corpus_pr_state.py")
+
+_UNSET = object()
+
+
+def load_corpus_pr_state(path: str | None = None):
+    """Import .github/scripts/corpus_pr_state.py, or None. Never raises.
+
+    None is the answer for a copy of this tool sitting outside a checkout -- the
+    /tmp three-file recipe in `ci-verdicts.md` produces exactly that -- and it
+    prints as `unavailable`, never as a state.
+    """
+    target = os.path.abspath(path or CORPUS_PR_STATE)
+    try:
+        spec = importlib.util.spec_from_file_location("corpus_pr_state_for_ci_wait", target)
+        if spec is None or spec.loader is None:
+            return None
+        mod = importlib.util.module_from_spec(spec)
+        # Registered BEFORE exec_module: that module declares a @dataclass, and
+        # dataclasses resolves annotations through sys.modules[cls.__module__],
+        # which is None for an unregistered module -- the import then fails with
+        # an AttributeError inside dataclasses.py and the line prints
+        # `unavailable` for a module sitting right there.
+        sys.modules[spec.name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+    except Exception:  # pragma: no cover - any import failure is "unavailable"
+        return None
+
+
+def pr_body(pr: str) -> tuple[str | None, str]:
+    """(this PR's body, reason) -- None means the read failed, not an empty body."""
+    rc, out = gh(["pr", "view", pr, "--repo", REPO, "--json", "body", "--jq", ".body"])
+    if rc != 0:
+        detail = (out or "").strip().splitlines()
+        return None, (detail[-1] if detail else f"gh pr view {pr} failed")
+    # `--jq .body` prints the four characters `null` for an empty body; no regex
+    # in check_corpus_linkage.sh matches it, but saying so here keeps the empty
+    # case identical to a body that genuinely declares nothing.
+    return ("" if out.strip() == "null" else out), ""
+
+
+def corpus_state_lines(pr: str, body_fetch=None, module=_UNSET) -> list[str]:
+    """The corpus-PR line(s) for this PR. Always at least one, never raises."""
+    if module is _UNSET:
+        module = load_corpus_pr_state()
+    if module is None:
+        return ["corpus PR: unavailable (.github/scripts/corpus_pr_state.py could not be "
+                "imported beside this copy of ci-wait.py, so the cited corpus PR was "
+                "never read)"]
+    try:
+        body, why = (body_fetch or pr_body)(pr)
+        if body is None:
+            return [f"corpus PR: unavailable ({why or 'could not read this PR body'})"]
+        entries, refusal = module.states_for_body(body)
+        if refusal:
+            return [f"corpus PR: UNREADABLE -- {refusal}"]
+        if not entries:
+            return ["corpus PR: none declared"]
+        return [module.format_line(entry) for entry in entries]
+    except Exception as exc:  # a report may never break a verdict
+        return [f"corpus PR: unavailable ({type(exc).__name__} while reading the "
+                "cited corpus PR)"]
+
+
+def print_corpus_pr_states(pr: str) -> None:
+    """Print the corpus line(s). Returns nothing, raises nothing, gates nothing."""
+    for line in corpus_state_lines(pr):
+        print(line)
 
 
 def contexts_from_branch_rules(payload) -> tuple[str, ...] | None:
@@ -1451,6 +1538,7 @@ def main() -> int:
             # Beside the PR verdict, never instead of it: a red PR branched from
             # a red `main` is often not this PR failure to own (#3679).
             print_floor_verdict()
+            print_corpus_pr_states(args.pr)
             if not args.no_log:
                 # The check-run `id` is NOT the Actions job id that `gh run view --job`
                 # wants; passing it fails with "could not find job". The job id is the
@@ -1483,6 +1571,7 @@ def main() -> int:
             for line in v.lines[1:]:
                 print(line)
             print_floor_verdict()
+            print_corpus_pr_states(args.pr)
             return 3
 
         if v.code == 4:
@@ -1490,6 +1579,7 @@ def main() -> int:
             for line in v.lines[1:]:
                 print(line)
             print_floor_verdict()
+            print_corpus_pr_states(args.pr)
             return 4
 
         if v.code == 0:
@@ -1498,6 +1588,7 @@ def main() -> int:
                 print(line)
             print("Confirm this SHA is still the PR head before reporting it.")
             print_floor_verdict()
+            print_corpus_pr_states(args.pr)
             return 0
 
         if time.time() >= deadline:
@@ -1516,6 +1607,7 @@ def main() -> int:
         print(f"\nSTILL RUNNING after {args.timeout}s ({reason}). "
               "This is NOT a verdict -- call again; do not report a result.")
     print_floor_verdict()
+    print_corpus_pr_states(args.pr)
     return 2
 
 

--- a/tools/corpus-citation-sweep.py
+++ b/tools/corpus-citation-sweep.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Which MERGED runner PRs cite a corpus PR that never merged? (#3674)
+
+The gate this ships beside (`pr-gate.yml`'s corpus-pr-mergeable job) stops the
+next one. This answers the other half of the same question, backwards: over pull
+requests that already merged, whose cited corpus PR is not MERGED today — so
+whose BC claim no service tier ever adjudicated.
+
+It is a sweep, not a gate. Run it, read the list, and file one catch-up issue per
+SURFACE (`.github/ISSUE_TEMPLATE/runner-gap.md`), after checking the open queue
+for one that already covers it (`file-issues-for-gaps.md`). Several runner PRs
+can cite one corpus PR and one surface; that is one issue, not three.
+
+    tools/corpus-citation-sweep.py                 # the last 400 merged PRs
+    tools/corpus-citation-sweep.py --limit 1000
+
+WHAT IT DOES NOT PARSE
+----------------------
+The `Corpus-PR:` regex lives in .github/scripts/check_corpus_linkage.sh and is
+reached through .github/scripts/corpus_pr_state.py, the same module the gate and
+tools/ci-wait.py use. The one thing this file decides for itself is a PREFILTER:
+a body is handed to that parser only if it contains the marker text at all,
+case-insensitively. That can only skip bodies in which every mode of the real
+parser would find nothing — the marker is a literal prefix of both its regexes —
+and it exists because the parser is a subprocess per body and most bodies carry
+no declaration.
+
+Exit codes
+----------
+    0  every cited corpus PR merged
+    1  at least one merged runner PR cites a corpus PR that did not
+    3  a read failed, so the sweep is incomplete and its zero means nothing
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = "StefanMaron/BusinessCentral.AL.Runner"
+STATE_MODULE = os.path.abspath(
+    os.path.join(HERE, "..", ".github", "scripts", "corpus_pr_state.py"))
+
+
+def load_state_module(path: str | None = None):
+    """Import corpus_pr_state.py, or None."""
+    target = os.path.abspath(path or STATE_MODULE)
+    try:
+        spec = importlib.util.spec_from_file_location("corpus_pr_state_for_sweep", target)
+        if spec is None or spec.loader is None:
+            return None
+        mod = importlib.util.module_from_spec(spec)
+        # Before exec_module: the module declares a @dataclass, which resolves
+        # annotations through sys.modules[cls.__module__].
+        sys.modules[spec.name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+    except Exception:
+        return None
+
+
+def has_marker(body: str | None) -> bool:
+    """The prefilter. A superset of what the real parser can match."""
+    return "corpus-pr:" in (body or "").lower()
+
+
+def unmerged_citations(prs, numbers_for, state_for):
+    """[(runner PR, corpus number, state, detail)] for every citation not MERGED.
+
+    `numbers_for(body)` -> (numbers|None, why); `state_for(number)` -> Entry-like
+    with `.state` and `.detail`. Both are injected so this stays a pure decision
+    over data, which is what the unit tests drive.
+    """
+    findings = []
+    for pr in prs:
+        body = pr.get("body") or ""
+        if not has_marker(body):
+            continue
+        numbers, why = numbers_for(body)
+        if numbers is None:
+            findings.append((pr, None, "UNREADABLE", why))
+            continue
+        for number in numbers:
+            entry = state_for(number)
+            if entry.state != "MERGED":
+                findings.append((pr, number, entry.state, entry.detail))
+    return findings
+
+
+def gh_json(args: list[str]):
+    p = subprocess.run(["gh", *args], capture_output=True, text=True,
+                       encoding="utf-8", errors="replace")
+    out = "\n".join(l for l in (p.stdout or "").split("\n") if not l.startswith("mise "))
+    if p.returncode != 0:
+        return None, ((p.stderr or out).strip() or "gh failed")
+    try:
+        return json.loads(out), ""
+    except Exception as exc:
+        return None, f"could not parse gh output: {exc!r}"
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--limit", type=int, default=400,
+                    help="how many merged pull requests to sweep (newest first)")
+    args = ap.parse_args(argv[1:])
+
+    module = load_state_module()
+    if module is None:
+        print("could not import .github/scripts/corpus_pr_state.py; the sweep cannot "
+              "read a body without the parser it owns. This is not an empty result.",
+              file=sys.stderr)
+        return 3
+
+    prs, why = gh_json(["pr", "list", "--repo", REPO, "--state", "merged",
+                        "--limit", str(args.limit), "--json",
+                        "number,title,body,mergedAt,url"])
+    if prs is None:
+        print(f"could not list merged pull requests: {why}", file=sys.stderr)
+        return 3
+    print(f"swept {len(prs)} merged pull request(s) on {REPO}")
+
+    cache: dict = {}
+
+    def state_for(number: int):
+        if number not in cache:
+            payload, read_why = module.fetch_pull(number)
+            if payload is None:
+                cache[number] = module.Entry(number, "UNREADABLE", "", read_why)
+            else:
+                state, detail = module.classify(payload)
+                cache[number] = module.Entry(number, state,
+                                             str(payload.get("head") or ""), detail)
+        return cache[number]
+
+    findings = unmerged_citations(prs, module.corpus_pr_numbers, state_for)
+
+    cited = sum(1 for pr in prs if has_marker(pr.get("body")))
+    print(f"{cited} of them declare a Corpus-PR line")
+    if not findings:
+        print("every cited corpus pull request has merged.")
+        return 0
+
+    print("\nmerged runner PRs whose cited corpus PR did NOT merge:")
+    for pr, number, state, detail in findings:
+        where = f"corpus #{number}" if number else "corpus PR unreadable"
+        print(f"  runner #{pr['number']} ({pr.get('mergedAt', '')[:10]}) -> {where}: "
+              f"{state} -- {detail}")
+        print(f"      {pr.get('title', '')}")
+    print("\nFile one catch-up issue per SURFACE, not per runner PR "
+          "(.github/ISSUE_TEMPLATE/runner-gap.md), after searching the open queue "
+          "for one that already covers it.")
+    # Same ordering as the gate: a definite finding is a verdict and outranks a
+    # refusal, so exit 3 only when EVERY finding is one the sweep could not read.
+    definite = [f for f in findings if f[2] != "UNREADABLE"]
+    return 1 if definite else 3
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tools/corpus-citation-sweep.py
+++ b/tools/corpus-citation-sweep.py
@@ -41,6 +41,17 @@ import subprocess
 import sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
+
+sys.path.insert(0, HERE)
+try:
+    import agent_stdio as _stdio
+except Exception:  # pragma: no cover - a copy detached from its sibling module
+    _stdio = None
+if _stdio is not None:
+    # Before any print: stdout is built from the console codec, and this tool
+    # prints PR titles, which carry whatever an author wrote (#3589).
+    _stdio.enable_utf8_stdio()
+
 REPO = "StefanMaron/BusinessCentral.AL.Runner"
 STATE_MODULE = os.path.abspath(
     os.path.join(HERE, "..", ".github", "scripts", "corpus_pr_state.py"))

--- a/tools/test_ci_wait.py
+++ b/tools/test_ci_wait.py
@@ -1822,7 +1822,11 @@ def _drive_main(code, extra_argv=()):
     """Run main() with everything below classify() faked. Returns (rc, stdout)."""
     saved = {name: getattr(cw, name) for name in
              ("_freshness", "head_sha", "resolve_required_contexts", "workflow_runs_for",
-              "required_checks", "classify", "fetch_floor_runs", "fetch_runs_for_sha")}
+              "required_checks", "classify", "fetch_floor_runs", "fetch_runs_for_sha",
+              # #3674: stubbed for the same reason the floor fetches are -- left
+              # real it would make a live `gh pr view` call from this suite on
+              # every CI run, and the assertion below would be about the network.
+              "corpus_state_lines")}
     argv = sys.argv
     buf = io.StringIO()
     out = sys.stdout
@@ -1842,6 +1846,8 @@ def _drive_main(code, extra_argv=()):
             [_fr("main-verdict-floor.yml", "failure", "8b6885f4aaaa", "2026-09-09T11:00:00Z")], "")
         cw.fetch_runs_for_sha = lambda sha: (
             [_fr("main-verdict-floor.yml", "failure", "8b6885f4aaaa", "2026-09-09T11:00:00Z")], "")
+        cw.corpus_state_lines = lambda pr: [
+            "corpus PR #226: NOT-MERGEABLE (head 321ac71a) -- a required BC leg is red"]
         sys.argv = ["ci-wait.py", "3740", "--timeout", "0", "--no-log", *extra_argv]
         sys.stdout = buf
         rc = cw.main()
@@ -1866,6 +1872,113 @@ for _code, _want_rc, _headline in ((0, 0, "GREEN"), (1, 1, "FAILED"),
           _floor and _floor[0].startswith("main floor: RED on 8b6885f4"), repr(_floor))
     check(f"#3679: ...beside the PR verdict, not instead of it",
           _headline in _text, _text[-300:])
+    _corpus = [l for l in _text.splitlines() if l.startswith("corpus PR")]
+    check(f"#3674: main() exit {_want_rc} ({_headline}) prints the corpus PR line exactly once",
+          len(_corpus) == 1, f"rc={_rc} lines={_corpus!r}")
+    check(f"#3674: ...and the corpus line does not change exit {_want_rc}",
+          _rc == _want_rc, f"rc={_rc} out={_text[-300:]!r}")
+
+# --------------------------------------------------------------------------
+# #3674 -- the state of the corpus PR this PR's body cites, printed beside the
+# verdict.
+#
+# The linkage gate checks that a `Corpus-PR:` line was DECLARED, never what
+# became of the pull request it names. Four merged runner PRs cite corpus PRs
+# that closed without merging, and four more merged while their corpus PR was
+# still open. This line is what an agent and a reviewer see before arming.
+#
+# Three claims, and the last is the one that keeps this suite offline: the state
+# comes from .github/scripts/corpus_pr_state.py rather than from a second parser
+# here; a read that fails says `unavailable` rather than reporting a state; and
+# nothing about the line can change the PR's exit code.
+# --------------------------------------------------------------------------
+_CORPUS_URL = "https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/226"
+
+
+class _CorpusStub:
+    """Stands in for corpus_pr_state.py -- the module ci-wait.py must delegate to."""
+
+    def __init__(self, entries=(), why=""):
+        self.entries = list(entries)
+        self.why = why
+        self.bodies: list[str] = []
+
+    def states_for_body(self, body, **kw):
+        self.bodies.append(body)
+        return self.entries, self.why
+
+    @staticmethod
+    def format_line(entry):
+        return f"corpus PR #{entry['number']}: {entry['state']} (head {entry['head'][:8]})"
+
+
+def _entry(number, state, head=""):
+    return {"number": number, "state": state, "head": head}
+
+
+_stub = _CorpusStub([_entry(226, "MERGEABLE", "321ac71a04c4797723dd7c90875a315b42f5b356")])
+_lines = cw.corpus_state_lines("3740",
+                               body_fetch=lambda pr: (f"Closes #1\n\nCorpus-PR: {_CORPUS_URL}", ""),
+                               module=_stub)
+check("#3674: the corpus state comes back as one line naming the PR, the state and the head",
+      _lines == ["corpus PR #226: MERGEABLE (head 321ac71a)"], repr(_lines))
+check("#3674: ...and the body it classified is the one that was read",
+      _stub.bodies and _CORPUS_URL in _stub.bodies[0], repr(_stub.bodies))
+
+_lines = cw.corpus_state_lines("3740",
+                               body_fetch=lambda pr: ("Closes #1\n", ""),
+                               module=_CorpusStub([]))
+check("#3674: a body with no Corpus-PR line says so rather than printing nothing",
+      _lines == ["corpus PR: none declared"], repr(_lines))
+
+_lines = cw.corpus_state_lines("3740", body_fetch=lambda pr: (None, "gh pr view failed"),
+                               module=_CorpusStub([_entry(226, "MERGED")]))
+check("#3674: a failed body read is unavailable, never a state",
+      len(_lines) == 1 and _lines[0].startswith("corpus PR: unavailable")
+      and "gh pr view failed" in _lines[0], repr(_lines))
+
+_lines = cw.corpus_state_lines("3740", body_fetch=lambda pr: ("body", ""), module=None)
+check("#3674: with corpus_pr_state.py not importable the line is unavailable -- which is "
+      "what a copy extracted to /tmp gets, and it must not read as a verdict",
+      len(_lines) == 1 and _lines[0].startswith("corpus PR: unavailable"), repr(_lines))
+
+_lines = cw.corpus_state_lines("3740", body_fetch=lambda pr: ("body", ""),
+                               module=_CorpusStub([], why="malformed Corpus-PR line"))
+check("#3674: a malformed declaration reports UNREADABLE, not 'none declared'",
+      len(_lines) == 1 and "UNREADABLE" in _lines[0]
+      and "malformed" in _lines[0], repr(_lines))
+
+
+class _Boom:
+    @staticmethod
+    def states_for_body(body, **kw):
+        raise RuntimeError("kaboom")
+
+
+_lines = cw.corpus_state_lines("3740", body_fetch=lambda pr: ("body", ""), module=_Boom)
+check("#3674: an exception inside the resolver is unavailable, never an exception out of here",
+      len(_lines) == 1 and _lines[0].startswith("corpus PR: unavailable"), repr(_lines))
+
+_buf = io.StringIO()
+_stdout = sys.stdout
+try:
+    sys.stdout = _buf
+    _ret = cw.print_corpus_pr_states("3740")
+finally:
+    sys.stdout = _stdout
+check("#3674: printing the corpus line returns nothing (it cannot change an exit code)",
+      _ret is None, repr(_ret))
+
+# The module really is the one under .github/scripts, not a lookalike: loading it
+# from this checkout must yield the six states the gate uses.
+_real = cw.load_corpus_pr_state()
+check("#3674: ci-wait.py loads the SAME module the gate runs",
+      _real is not None and hasattr(_real, "states_for_body")
+      and hasattr(_real, "format_line"), repr(_real))
+check("#3674: ...and that module classifies a merged corpus PR as MERGED",
+      _real is not None
+      and _real.classify({"state": "closed", "merged": True})[0] == "MERGED",
+      repr(_real.classify({"state": "closed", "merged": True}) if _real else None))
 
 print()
 if FAILURES:

--- a/tools/test_corpus_citation_sweep.py
+++ b/tools/test_corpus_citation_sweep.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/corpus-citation-sweep.py (#3674).
+
+The sweep's decision is one function over data -- which merged runner PRs cite a
+corpus PR that is not MERGED -- so that is what is driven here, with the parser
+and the network read injected. The prefilter gets its own checks: it is the only
+thing in that file that looks at a body itself, and a prefilter that drops a body
+the real parser would have matched is a silent false zero.
+
+Run: python3 tools/test_corpus_citation_sweep.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location(
+    "corpus_citation_sweep", os.path.join(HERE, "corpus-citation-sweep.py"))
+sweep = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = sweep
+_spec.loader.exec_module(sweep)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        FAILURES.append(name)
+
+
+class _Entry:
+    def __init__(self, state, detail=""):
+        self.state = state
+        self.detail = detail
+
+
+URL = "https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/153"
+
+print("corpus-citation-sweep.py -- the prefilter")
+
+check("a body carrying the marker is handed to the parser",
+      sweep.has_marker(f"Closes #1\n\nCorpus-PR: {URL}\n"))
+check("...case-insensitively, because the gate's regex is",
+      sweep.has_marker("corpus-pr: whatever"))
+check("...and a MALFORMED marker line is still handed over -- refusing to read it "
+      "is the parser's job, not the prefilter's",
+      sweep.has_marker("Corpus-PR: [#228](https://example.invalid/pull/228)"))
+check("a body with no marker is skipped", not sweep.has_marker("Closes #1\n"))
+check("...and a Corpus-NA declaration is not a marker",
+      not sweep.has_marker("Corpus-NA: tooling only"))
+check("an empty or missing body is not a marker",
+      not sweep.has_marker("") and not sweep.has_marker(None))
+
+print("\ncorpus-citation-sweep.py -- the finding")
+
+PRS = [
+    {"number": 2318, "title": "a", "mergedAt": "2026-09-01T00:00:00Z",
+     "body": f"Closes #1\n\nCorpus-PR: {URL}\n"},
+    {"number": 3428, "title": "b", "mergedAt": "2026-09-08T00:00:00Z",
+     "body": "Corpus-PR: https://github.com/StefanMaron/"
+             "BusinessCentral.AL.Language.Tests/pull/272\n"},
+    {"number": 3000, "title": "c", "mergedAt": "2026-09-02T00:00:00Z",
+     "body": "Corpus-NA: tooling only\n"},
+]
+
+STATES = {153: _Entry("CLOSED-UNMERGED", "closed without merging"),
+          272: _Entry("MERGED", "adjudicated")}
+
+
+def _numbers(body):
+    import re
+    return [int(m) for m in re.findall(r"/pull/(\d+)", body)], ""
+
+
+_found = sweep.unmerged_citations(PRS, _numbers, lambda n: STATES[n])
+check("a merged runner PR citing a closed-unmerged corpus PR is a finding",
+      [(f[0]["number"], f[1], f[2]) for f in _found]
+      == [(2318, 153, "CLOSED-UNMERGED")], repr(_found))
+check("...and one citing a MERGED corpus PR is not",
+      all(f[0]["number"] != 3428 for f in _found), repr(_found))
+check("...and a body with no declaration never reaches the parser",
+      all(f[0]["number"] != 3000 for f in _found), repr(_found))
+
+# An open corpus PR on an ALREADY MERGED runner PR is a finding too: the runner
+# change shipped and nothing has adjudicated it yet. That is #3428/#3430's shape,
+# and it is why this sweep asks for MERGED rather than for mergeable.
+_open = sweep.unmerged_citations(
+    [PRS[0]], _numbers, lambda n: _Entry("MERGEABLE", "open, legs green"))
+check("a merged runner PR whose corpus PR is still OPEN is a finding",
+      len(_open) == 1 and _open[0][2] == "MERGEABLE", repr(_open))
+
+# A body the parser refuses is reported, never dropped: dropping it is the silent
+# zero the whole sweep exists to avoid.
+_refused = sweep.unmerged_citations(
+    [PRS[0]], lambda body: (None, "malformed Corpus-PR line"), lambda n: _Entry("MERGED"))
+check("a body the parser refuses is reported as UNREADABLE, not skipped",
+      len(_refused) == 1 and _refused[0][2] == "UNREADABLE"
+      and _refused[0][1] is None, repr(_refused))
+
+print()
+if FAILURES:
+    print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")
+    sys.exit(1)
+print("all checks passed")


### PR DESCRIPTION
Closes #3674

Corpus-NA: CI and agent tooling only. Nothing here can change what AL observes — no file under `AlRunner/` is touched.

The corpus-linkage gate checks that a `Corpus-PR:` line was **declared**, never what became of the pull request it names. This adds the mechanical read of that pull request's state, uses it in three places, and sweeps the history for citations that never merged.

## What changed

**`.github/scripts/corpus_pr_state.py`** — one source of truth. Reads `PR_BODY`, finds every `Corpus-PR:` line, and answers per corpus PR one of `NONE` / `MERGED` / `MERGEABLE` / `NOT-MERGEABLE` / `CLOSED-UNMERGED` / `UNREADABLE`, with the corpus PR's head SHA. Exit 0 pass, 1 a definite failure, 2 usage (`PR_BODY` unset), 3 could not measure (`guards-need-a-third-state.md`). Exit 1 outranks exit 3 when both occur, and every line is printed either way, so the actionable half is never hidden behind a refusal.

It does **not** carry a second `Corpus-PR:` regex: both extraction modes of `check_corpus_linkage.sh` are invoked, as `resolve_corpus_ref.sh` does. The marker-count-versus-URL-count comparison is ~5 lines duplicated from `resolve_corpus_ref.sh` — deliberately, because that script answers a different question (which ONE corpus a run measures, refusing two) and returning per-PR answers would change its contract. A test points the module at a missing script and asserts it refuses, which is what proves the regex is not duplicated here.

**`pr-gate.yml`: `A cited corpus PR must be able to merge`** — runs that script on the event-payload body, like `require-corpus-linkage` beside it.

**`tools/ci-wait.py`** — prints `corpus PR #226: MERGEABLE (head 321ac71a) -- …` beside the verdict on all five exit paths, importing the same module. Same contract as #3679's floor line: never changes the exit code, `unavailable` on a read that did not happen, `UNREADABLE` on a malformed declaration.

**`tools/corpus-citation-sweep.py`** — the one-off sweep, plus its unit tests.

**Docs** — one sentence each in `bc-behavior-tests-go-upstream.md` (steps 3 and 5), the arming list in `orchestrating-a-session`, and `ci-verdicts.md`.

## The decision the issue asked for: it is NOT ready to be a required context

Listed in `PENDING_REQUIRED_CONTEXTS` in `check_required_contexts.py`, which analyses it exactly like a required one (produced by a `pull_request` workflow, not cancellable on the head commit) without gating. **Not promoted, and not because a ruleset edit is pending — because the evidence says it should not gate yet:**

1. **It reads `api.github.com`, cross-repo.** `pr-gate.yml`'s own header draws the line there: a check that can go red for an environmental reason stays advisory, which is why the live-ruleset drift check lives in `pr-check.yml`. This one asks the *corpus* repository about a pull request.
2. **A status check evaluates on push / `edited` / `labeled`, never when the corpus PR moves.** A corpus PR that goes green or merges later leaves a stale red until something re-triggers it. The re-trigger is cheap and already exists — `edited` (any body rewrite, including `tools/pr-body.py`'s Step-4 rewrite) and `labeled` (the coordinator's `status: review-ready`) are both in `pr-gate.yml`'s trigger list, enforced by `verify-trigger-list` — but "cheap re-trigger available" is a weaker claim than "cannot block a merge for something the author did not do".
3. **Promoting early is separately harmful**: a name in `ci-wait.py`'s `RULESET_CONTEXTS` that the live ruleset does not require makes `ci-wait.py` answer exit 3 for every PR in the repository (#3002/#3165). No name moved into that tuple here.

So the *blocking* half of #3674 is the arming list, not CI: `orchestrating-a-session` now says only `NONE` and `MERGED` arm, and names this script as the read. `MERGEABLE` means "merge the corpus PR first, in this same step, then re-read".

**Why CI passes on `MERGEABLE` at all.** The issue's own last section reshaped the trigger to "not mergeable" after #3737 dropped the pin: a runner PR is now measured against the head of the corpus PR it cites, and the two land in one coordinator step. Failing on merely-open would fail every well-formed PR for its entire review window — the paste-past-it direction `check_corpus_linkage.sh`'s header warns about.

## RED → GREEN

- `.github/scripts/test_corpus_pr_state.py` — written first, RED with `FileNotFoundError` (no module). 55 checks green now. The mapping is pinned against **measured** REST payloads, not imagined ones (2026-09-10): #319 `open/clean`, #305 `merged` with `mergeable: null`, #85 / #137 / #153 `closed merged=false` still reporting `mergeable_state: blocked`. Those two are why the order is load-bearing and tested: read `merged` first or every merged corpus PR reads UNREADABLE; read `state` before `mergeable_state` or a withdrawn corpus PR reads as a merely-red one.
- `tools/test_ci_wait.py` — RED with `AttributeError: module 'ci_wait' has no attribute 'corpus_state_lines'`, then green: one corpus line on each of the five exit paths with the code unchanged, `unavailable` for a failed body read, for a module that will not import (the `/tmp` three-file recipe in `ci-verdicts.md`) and for an exception inside the resolver, `UNREADABLE` for a malformed declaration, and a check that the module `ci-wait.py` loads is the one the gate runs.
- `tools/test_corpus_citation_sweep.py` — the finding function and the prefilter.
- Locally green: every `.github/scripts/test_*.py` and `test_*.sh`, and every `tools/test_*.py` except `test_pr_body.py` and `test_preflight.py`, which fail on this Windows box on untouched `main`.

**Live smoke**, end to end: corpus #153 → `CLOSED-UNMERGED` rc=1, #319 → `MERGEABLE` rc=0, #305 → `MERGED` rc=0, a body with no line → `NONE` rc=0; and `tools/ci-wait.py 3761 --timeout 0` printing `corpus PR: none declared` beside its verdict.

## A performance defect this surfaced, and the fix

`check_corpus_linkage.sh` spawns two `grep` processes **per line** of the body. Milliseconds on the Linux runner; **measured 0.4s each on this Windows box**, so a 200-line PR body took **87.7 seconds** to parse — which would have made `ci-wait.py` take a minute to print one line beside a verdict it answers in a second, and made the sweep take hours (the first sweep run was killed after 30 minutes).

Fix: `marker_lines_only()` reduces the body to lines containing `corpus-pr:` case-insensitively before handing it over. That is a **prefilter, not a parser** — both extraction modes anchor on `^[[:space:]]*Corpus-PR:`, so every line either can match contains that substring, and keeping a superset cannot change either mode's output or the counts the refusal compares. Same body: 87.7s → 1.2s. Four tests pin the equivalence, including a marker buried in 60 lines of prose, a mid-sentence near-miss beside a good line, and a malformed line buried in prose still refusing. The shell script is untouched.

## The one-off sweep, and the issues filed

`tools/corpus-citation-sweep.py --limit 2000`, run over **all 1570 merged PRs** on this repository:

```
swept 1570 merged pull request(s) on StefanMaron/BusinessCentral.AL.Runner
86 of them declare a Corpus-PR line
```

**No merged PR's declared corpus PR failed to merge.** Two bodies carry a declaration the gate's regex refuses, and both name a corpus PR that did merge, so neither is a missing verdict:

- #3585 — `Corpus-PR: StefanMaron/BusinessCentral.AL.Language.Tests#293` (the `owner/repo#N` shorthand, in the very PR that documented it as rejected). Corpus #293 merged.
- #3569 — a well-formed URL followed by ` (merged; codeunit 60368 is pinned at …)` on the same line. Corpus #280 merged.

**The four PRs the issue names carry no `Corpus-PR:` line at all** — #2318, #2638, #2778 and #2837 all predate the linkage gate (#3255) and cite their corpus PRs in prose. So the sweep cannot see them, and that is the honest limit of it: *it is only as good as the declarations, and the pre-gate era has none.* They were resolved by hand instead, and three catch-up issues are filed, one per surface rather than one per PR:

- **#3764** — `Sid()` / `ALDatabase.ALSid` (runner #2318, corpus #85 closed unmerged with no recorded reason). Note the twist: the Linux tier *patches* that method, so the corpus CI may be unable to adjudicate it at all and the Windows nightly is the authority.
- **#3765** — `ALCompiler.DotNetToNavInStream` (runner #2638, corpus #137 closed unmerged ~7 hours after the runner PR merged). Three named BC-behaviour assertions have never run on a service tier; the runner-side Cecil-binding test pins the mechanism, not the claim.
- **#3766** — Object Metadata `2000000071` (runner #2778 and #2837, corpus #153 **withdrawn** after eight red legs whose failure was `You cannot open record 2000000071 from a RecordRef data type when you are using target Cloud`). The measurement says the claim is not expressible *from the corpus app as it stands*; the open decision is an OnPrem corpus app versus recording it permanently with that run id as its citation. Distinct from #3236, which is about the payload refusal being disarmed.

None of those three surfaces is fixed here, deliberately.

## Fix the shape, not just the reported line

1. **Does the same wrong pattern appear at another call site?** Yes, and it is now one module rather than three readers: the arming list's hand-rolled `gh pr view … --json state,mergedAt` recipe, the CI check, and `ci-wait.py` all read through `corpus_pr_state.py`. The arming list keeps the stricter `MERGED` bar; the difference between the two bars is written down rather than left to be inferred.
2. **Does a sibling function make the same assumption?** `.github/actions/resolve-corpus-ref` asks the corpus PR its state for a different purpose — *which ref to check out* — and already refuses a closed-unmerged one with exit 3. It is deliberately not merged into this module: it runs inside the composite action with `github.token`, resolves exactly one corpus, and its three-way refusal is `guards-need-a-third-state.md`'s live worked example. What this module adds is the mergeability question, which that action has no reason to ask.
3. **If two code paths write the same state, do they maintain the same invariant?** The two places that decide *whether a corpus PR is settled* are CI and arming, and they now share the classifier while keeping different thresholds on purpose (`MERGEABLE` vs `MERGED`), each stated in the file that applies it.

**From the open-issue queue** (`batch-sibling-issues-by-file.md`), nothing folds — no open issue's fix lands in `corpus_pr_state.py`, `ci-wait.py` or `pr-gate.yml`. The nearby ones and why they stay separate: **#3361** (preflight corpus check, two assertions comparing a call against itself) is `preflight.py`; **#3389** (reading a corpus PR's leg set) is about interpreting corpus runs, not about a PR's state; **#3478** and **#3416** are pin-era issues that #3737 has overtaken; **#3482** is a citation going stale in an `AlRunner/` justification.

## What I deliberately left out

- **No promotion into the branch ruleset**, per the argument above. If a maintainer wants it to gate, the change is two list edits plus the by-hand ruleset edit, in that order — and the re-trigger caveat has to be accepted first.
- **No retroactive body edits** on #3585 or #3569; both cite corpus PRs that merged, so nothing is missing.
- **No fix for the three surfaces** in #3764 / #3765 / #3766.
- **`check_corpus_linkage.sh` is untouched.** Its per-line grep loop is the real cost, and rewriting the regex owner to fix a Windows-only slowness would put the gate's own behaviour at risk for a caller's convenience. The prefilter sits in the caller, where being wrong can only cost lines the script would have ignored anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXnG1GjZMwpnnRHAcrGzUH
