### PR TITLE
test(page-mode): pin that every live TestPage knows its PageType; the #3735 refusal is unreachable

### DIFF
--- a/AlRunner.Tests/LiveTestPagePageTypeKnownTests.cs
+++ b/AlRunner.Tests/LiveTestPagePageTypeKnownTests.cs
@@ -18,6 +18,22 @@
 //   A page in neither gets MockITestPage, whose View()/Edit() are the base mock's and never
 //   reach BuiltInPageModeActionFor at all.
 //
+//   THERE IS A THIRD CONSTRUCTION ROUTE, and it is gated differently.
+//   RunnerTestClientSession.GetPage — the [PageHandler]/[ModalPageHandler] route — builds a
+//   LiveNavTestPage with no IsPageShapeKnown/TryGetAnyPageType check at all; its only gate is
+//   form construction (CodeunitPatches.FindFormType), a CLR-type inventory that is NOT
+//   contained in the symbol inventory by construction, because the two have different
+//   lifetimes: ResetForReload clears _sourceDirs and _parsedPages and ClearPerBundleBcAppPaths
+//   drops _bcAppPaths, while loaded assemblies are process-wide and
+//   BcRuntime.IsStaleBundleAssembly excludes only superseded generations of a registered name.
+//   What keeps that route unreachable is one step earlier: BC selects the handler from its
+//   `TestPage "X"` parameter type, so the page has to resolve in THIS bundle's compile, and
+//   every compile symbol source is also a registration source (Program.cs). That is a
+//   MAINTAINED invariant, not a structural one — #3611/#3714 are the record of the compile's
+//   file set and the registered source dirs having drifted apart before. Program.cs wiring is
+//   not unit-pinnable here; the rows below pin the part that is, including that the dependency
+//   reader's own skip keeps both predicates on the same side.
+//
 //   So the refusal STAYS as a guard on a state no AL can reach today, and the diagnosis is what
 //   #3735 wanted: BC's own captured emitter metadata (docs/object-metadata-capture.md) is not
 //   the second source, because it exists only for objects THIS run compiles — a subset of
@@ -49,6 +65,7 @@ public class LiveTestPagePageTypeKnownTests
     private const int NoPageTypePropId = 88373502;  // no PageType property at all
     private const int BlankPageTypeId = 88373503;   // PageType present but empty
     private const int NoSourceNoTypeId = 88373504;  // neither property — the recordless shape
+    private const int NamelessPageId = 88373505;    // declared with an EMPTY Name — the reader skips it
     private const int UndeclaredPageId = 88373509;  // no loaded .app declares it
 
     // 2000000120 is table "User", the same real table DependencyPageShapeResolutionTests uses,
@@ -84,6 +101,14 @@ public class LiveTestPagePageTypeKnownTests
               "Id": 88373504,
               "Name": "LTP No Source No Type",
               "Properties": []
+            },
+            {
+              "Id": 88373505,
+              "Name": "",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "SourceTable", "Value": "2000000120" }
+              ]
             }
           ]
         }
@@ -144,6 +169,7 @@ public class LiveTestPagePageTypeKnownTests
     [InlineData(NoPageTypePropId, true)]
     [InlineData(BlankPageTypeId, true)]
     [InlineData(NoSourceNoTypeId, true)]
+    [InlineData(NamelessPageId, false)]
     [InlineData(UndeclaredPageId, false)]
     public void PageTypeIsNonNull_ExactlyWhenThePageShapeIsKnown(int pageId, bool known)
         => WithLoadedDependency(() =>
@@ -190,6 +216,34 @@ public class LiveTestPagePageTypeKnownTests
             recordBuilt: false,
             pageShapeKnown: RecordPatches.IsPageShapeKnown(pageId),
             pageDeclaresSourceTable: RecordPatches.ResolvePageDeclaresSourceTableForAnyPage(pageId));
+
+    /// <summary>
+    /// The dependency reader SKIPS a page entry it cannot parse — BcAppSymbolCache
+    /// .TryParsePageSymbol returns null for a missing/non-positive Id or an empty Name, and the
+    /// caller drops it. That is the one way an id present in a registered .app's own
+    /// SymbolReference.json can still be absent from the symbol inventory, so it is the
+    /// candidate for the CLR-type-inventory containment the third construction route
+    /// (RunnerTestClientSession.GetPage) rests on.
+    /// <para>Measured, both halves: the skip leaves the two predicates on the SAME side — it
+    /// cannot produce a shape-known page with a null PageType, which is what would make the
+    /// refusal reachable — and the entry it drops is exactly one the AL compiler cannot name
+    /// either, so no [PageHandler]/[ModalPageHandler] can be typed over it. Asserted against
+    /// the page's stated PageType ("List") rather than any value, so a reader that started
+    /// accepting the nameless entry fails here rather than passing silently.</para>
+    /// </summary>
+    [Fact]
+    public void ANamelessDependencyPageEntry_IsAbsentFromBothInventories()
+        => WithLoadedDependency(() =>
+        {
+            Assert.False(RecordPatches.IsPageParsed(NamelessPageId),
+                "the fixture pages must NOT be AL-source-parsed, or this proves nothing");
+            Assert.False(RecordPatches.IsPageShapeKnown(NamelessPageId));
+            Assert.Null(RecordPatches.TryGetAnyPageType(NamelessPageId));
+            // Not merely "unknown": the entry states PageType List and SourceTable 2000000120,
+            // so a reader that stopped skipping it would answer both of those instead of null.
+            Assert.Equal(0, RecordPatches.ResolveSourceTableIdForAnyPage(NamelessPageId));
+            Assert.Equal(TestPageClientKind.NavigationMock, ClientKindFor(NamelessPageId));
+        });
 
     /// <summary>
     /// The last link: the client an unknown page actually gets answers View()/Edit() out of the

--- a/AlRunner.Tests/LiveTestPagePageTypeKnownTests.cs
+++ b/AlRunner.Tests/LiveTestPagePageTypeKnownTests.cs
@@ -21,18 +21,20 @@
 //   THERE IS A THIRD CONSTRUCTION ROUTE, and it is gated differently.
 //   RunnerTestClientSession.GetPage — the [PageHandler]/[ModalPageHandler] route — builds a
 //   LiveNavTestPage with no IsPageShapeKnown/TryGetAnyPageType check at all; its only gate is
-//   form construction (CodeunitPatches.FindFormType), a CLR-type inventory that is NOT
-//   contained in the symbol inventory by construction, because the two have different
-//   lifetimes: ResetForReload clears _sourceDirs and _parsedPages and ClearPerBundleBcAppPaths
-//   drops _bcAppPaths, while loaded assemblies are process-wide and
-//   BcRuntime.IsStaleBundleAssembly excludes only superseded generations of a registered name.
-//   What keeps that route unreachable is one step earlier: BC selects the handler from its
-//   `TestPage "X"` parameter type, so the page has to resolve in THIS bundle's compile, and
-//   every compile symbol source is also a registration source (Program.cs). That is a
-//   MAINTAINED invariant, not a structural one — #3611/#3714 are the record of the compile's
-//   file set and the registered source dirs having drifted apart before. Program.cs wiring is
-//   not unit-pinnable here; the rows below pin the part that is, including that the dependency
-//   reader's own skip keeps both predicates on the same side.
+//   form construction. What keeps it out of the refusal is one step earlier: BC selects the
+//   handler from its `TestPage "X"` parameter type, so the page has to resolve in THIS bundle's
+//   compile, and every compile symbol source is also a registration source.
+//
+//   That was NOT true when this file was written, and #3763 fixed it: the two
+//   register-source-dirs loops in Program.cs re-derived the suite's folder set and registered
+//   src/ only, so a page under test/ or app2/ compiled and was never parsed (a test/-only suite
+//   registered nothing at all). Both loops now call ProgramSupport.SuiteRegistrationDirs, which
+//   IS CollectSuitePaths — the same set by construction. SuiteRootAlFilesTests pins that half,
+//   end to end, including a [ModalPageHandler] driving a page declared under test/. One symbol
+//   source is still unmatched and unpinned: BcCompiler._usePackageCacheFallback (issue #3769).
+//   See docs/page-shape-inventory.md for the routes, the lifetimes and the residual; the rows
+//   below pin the two-inventory half, including that the dependency reader's own skip keeps
+//   both predicates on the same side.
 //
 //   So the refusal STAYS as a guard on a state no AL can reach today, and the diagnosis is what
 //   #3735 wanted: BC's own captured emitter metadata (docs/object-metadata-capture.md) is not

--- a/AlRunner.Tests/LiveTestPagePageTypeKnownTests.cs
+++ b/AlRunner.Tests/LiveTestPagePageTypeKnownTests.cs
@@ -1,0 +1,207 @@
+// LiveTestPagePageTypeKnownTests — issue #3735.
+//
+// THE QUESTION
+//   BuiltInPageModeActionRule.ResolveShape answers RefuseUnknownPageType when
+//   RecordPatches.TryGetAnyPageType(pageId) is null, and LiveNavTestPage.BuiltInPageModeActionFor
+//   turns that into a RunnerOutOfScopeException. #3735 asked for a second source for that
+//   PageType — and, first, for a reproducer, because no test could produce a page the runner
+//   drives live while knowing nothing about its type.
+//
+// THE ANSWER: there is no such page, and this file pins why.
+//   TryGetAnyPageType is null for exactly the ids IsPageShapeKnown answers false for — both
+//   read _parsedPages and then a loaded dependency .app's page symbols, and NEITHER source can
+//   yield a null PageType, because both apply AL's absent-property default of "Card"
+//   (RecordPatches.AlPageParser.cs's ParsedPage construction; BcAppSymbolCache.TryParsePageSymbol's
+//   `IsNullOrWhiteSpace(pageType) ? "Card"`). And both routes to a live client require one of
+//   those two inventories: LiveOverRecord needs a source table, which TestPageFactory.TryBuild
+//   resolves through the same two lookups, and LiveRecordless needs pageShapeKnown outright.
+//   A page in neither gets MockITestPage, whose View()/Edit() are the base mock's and never
+//   reach BuiltInPageModeActionFor at all.
+//
+//   So the refusal STAYS as a guard on a state no AL can reach today, and the diagnosis is what
+//   #3735 wanted: BC's own captured emitter metadata (docs/object-metadata-capture.md) is not
+//   the second source, because it exists only for objects THIS run compiles — a subset of
+//   _parsedPages. A precompiled dependency page never passes through Compilation.Emit. The
+//   source that would widen the inventory is a runtime-package reader (#3537).
+//
+// WHAT WOULD MAKE THE REFUSAL REACHABLE, which is what these rows guard
+//   Either half of the co-extensiveness breaking: a third inventory feeding IsPageShapeKnown or
+//   TestPageFactory.TryBuild without also feeding TryGetAnyPageType, or either existing source
+//   passing an absent PageType property through as null instead of defaulting it.
+//
+// No Base Application floor (.claude/rules/no-base-app-in-csharp-tests.md).
+
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Same reason as DependencyPageShapeResolutionTests: BcAppSymbolCache.Get() resolves through
+// the process-global CacheRoots override.
+[Collection(CacheRootsSerialCollection.Name)]
+public class LiveTestPagePageTypeKnownTests
+{
+    // Ids distinct from every other fixture's: RecordPatches' dependency-page state is
+    // process-global, so a shared id could answer from someone else's payload.
+    private const int TypedPageId = 88373501;       // PageType = List, SourceTable declared
+    private const int NoPageTypePropId = 88373502;  // no PageType property at all
+    private const int BlankPageTypeId = 88373503;   // PageType present but empty
+    private const int NoSourceNoTypeId = 88373504;  // neither property — the recordless shape
+    private const int UndeclaredPageId = 88373509;  // no loaded .app declares it
+
+    // 2000000120 is table "User", the same real table DependencyPageShapeResolutionTests uses,
+    // so the SourceTable rows resolve against a table that genuinely exists.
+    private const string SymbolReference = """
+        {
+          "RuntimeVersion": "15.1",
+          "Pages": [
+            {
+              "Id": 88373501,
+              "Name": "LTP Typed List",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "SourceTable", "Value": "2000000120" }
+              ]
+            },
+            {
+              "Id": 88373502,
+              "Name": "LTP No PageType Property",
+              "Properties": [
+                { "Name": "SourceTable", "Value": "2000000120" }
+              ]
+            },
+            {
+              "Id": 88373503,
+              "Name": "LTP Blank PageType",
+              "Properties": [
+                { "Name": "PageType", "Value": "" },
+                { "Name": "SourceTable", "Value": "2000000120" }
+              ]
+            },
+            {
+              "Id": 88373504,
+              "Name": "LTP No Source No Type",
+              "Properties": []
+            }
+          ]
+        }
+        """;
+
+    private static string WriteApp(string dir, string symbolReferenceJson)
+    {
+        var appPath = Path.Combine(dir, Guid.NewGuid().ToString("N") + ".app");
+        using var zip = new FileStream(appPath, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(symbolReferenceJson);
+        return appPath;
+    }
+
+    private static void WithLoadedDependency(Action body)
+    {
+        var dir = TestScratch.Dir("al-runner-3735-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, SymbolReference));
+            body();
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Every page id a dependency declares answers a CONCRETE PageType, whether or not the
+    /// property is there — the arm that fails if either source ever passes an absent property
+    /// through as null. "Card" is AL's own default, not a runner invention.
+    /// </summary>
+    [Theory]
+    [InlineData(TypedPageId, "List")]
+    [InlineData(NoPageTypePropId, "Card")]
+    [InlineData(BlankPageTypeId, "Card")]
+    [InlineData(NoSourceNoTypeId, "Card")]
+    public void DependencyPage_AnswersAConcretePageType_EvenWithThePropertyAbsent(
+        int pageId, string expected)
+        => WithLoadedDependency(() =>
+        {
+            Assert.False(RecordPatches.IsPageParsed(pageId),
+                "the fixture pages must NOT be AL-source-parsed, or this proves nothing");
+            Assert.Equal(expected, RecordPatches.TryGetAnyPageType(pageId));
+        });
+
+    /// <summary>
+    /// The co-extensiveness itself: null PageType and unknown shape are the same set. A third
+    /// inventory wired into one predicate and not the other breaks this row before it can make
+    /// the refusal reachable.
+    /// </summary>
+    [Theory]
+    [InlineData(TypedPageId, true)]
+    [InlineData(NoPageTypePropId, true)]
+    [InlineData(BlankPageTypeId, true)]
+    [InlineData(NoSourceNoTypeId, true)]
+    [InlineData(UndeclaredPageId, false)]
+    public void PageTypeIsNonNull_ExactlyWhenThePageShapeIsKnown(int pageId, bool known)
+        => WithLoadedDependency(() =>
+        {
+            Assert.Equal(known, RecordPatches.IsPageShapeKnown(pageId));
+            Assert.Equal(known, RecordPatches.TryGetAnyPageType(pageId) != null);
+        });
+
+    /// <summary>
+    /// The LiveOverRecord precondition. TestPageFactory.TryBuild builds a record only when a
+    /// source table resolves, and it resolves one through the SAME two lookups TryGetAnyPageType
+    /// reads — so a resolvable source table implies a known PageType, and an unknown page
+    /// resolves none. Concrete table id, not "non-zero": a resolver answering a default fails.
+    /// </summary>
+    [Fact]
+    public void AResolvableSourceTable_ImpliesAKnownPageType()
+        => WithLoadedDependency(() =>
+        {
+            Assert.Equal(2000000120, RecordPatches.ResolveSourceTableIdForAnyPage(TypedPageId));
+            Assert.NotNull(RecordPatches.TryGetAnyPageType(TypedPageId));
+
+            Assert.Equal(0, RecordPatches.ResolveSourceTableIdForAnyPage(UndeclaredPageId));
+            Assert.Null(RecordPatches.TryGetAnyPageType(UndeclaredPageId));
+        });
+
+    /// <summary>
+    /// The LiveRecordless precondition: it is <c>pageShapeKnown</c> itself, so a page whose
+    /// PageType is unknown cannot take that route either — it lands on the navigation mock.
+    /// Both live kinds are asserted here so a rule change that widened the mock case into a
+    /// live one would fail rather than silently make the refusal reachable.
+    /// </summary>
+    [Fact]
+    public void WithoutARecord_OnlyAKnownPageIsDrivenLive()
+        => WithLoadedDependency(() =>
+        {
+            Assert.Equal(TestPageClientKind.LiveRecordless, ClientKindFor(NoSourceNoTypeId));
+            Assert.Equal(TestPageClientKind.NavigationMock, ClientKindFor(UndeclaredPageId));
+        });
+
+    // Computed exactly the way CodeunitPatches.CreateTestPageClient computes it, with
+    // recordBuilt false — the branch a page with no resolvable source table takes.
+    private static TestPageClientKind ClientKindFor(int pageId)
+        => TestPageClientConstructionRule.Resolve(
+            recordBuilt: false,
+            pageShapeKnown: RecordPatches.IsPageShapeKnown(pageId),
+            pageDeclaresSourceTable: RecordPatches.ResolvePageDeclaresSourceTableForAnyPage(pageId));
+
+    /// <summary>
+    /// The last link: the client an unknown page actually gets answers View()/Edit() out of the
+    /// base mock, so <c>LiveNavTestPage.BuiltInPageModeActionFor</c> — and therefore #3735's
+    /// refusal — is never entered for it. The user-visible signal for such a page is the
+    /// <c>[warn] … navigation mock</c> line CodeunitPatches.CreateTestPageClient prints.
+    /// </summary>
+    [Fact]
+    public void TheClientAnUnknownPageGets_AnswersViewAndEditFromTheMock()
+    {
+        var mock = new MockITestPage();
+        Assert.IsType<MockITestAction>(mock.View());
+        Assert.IsType<MockITestAction>(mock.Edit());
+    }
+}

--- a/AlRunner.Tests/SuiteRootAlFilesTests.cs
+++ b/AlRunner.Tests/SuiteRootAlFilesTests.cs
@@ -506,4 +506,291 @@ public sealed class SuiteRootAlFilesTests : IDisposable
         AssertPassed(output, "RootTableRoundTrips");
         Assert.Equal(0, exit);
     }
+
+    // -- #3735: registration mirrors the compile, folder for folder ----------------------
+
+    /// <summary>
+    /// The unit half. <c>SuiteRegistrationDirs</c> is what Program.cs's two register-source-dirs
+    /// loops hand <c>RecordPatches.AddSourceDirs</c>, and it must be the folder set the compile
+    /// reads - not a second derivation of it. Concrete list, in order, for the layout that used
+    /// to break: the old loops answered <c>[src]</c> here and dropped <c>app/</c>,
+    /// <c>app2/</c> and <c>test/</c> on the floor.
+    /// </summary>
+    [Fact]
+    public void SuiteRegistrationDirs_CoversEveryConventionalFolder_NotJustSrc()
+    {
+        Touch(Path.Combine(_root, "app.json"), "{}");
+        Touch(Path.Combine(_root, "src", "A.al"));
+        Touch(Path.Combine(_root, "app", "B.al"));
+        Touch(Path.Combine(_root, "app2", "C.al"));
+        Touch(Path.Combine(_root, "test", "D.al"));
+
+        Assert.Equal(
+            new[]
+            {
+                Path.Combine(_root, "src"), Path.Combine(_root, "app"),
+                Path.Combine(_root, "app2"), Path.Combine(_root, "test"),
+            },
+            ProgramSupport.SuiteRegistrationDirs(_root));
+    }
+
+    /// <summary>
+    /// A <c>test/</c>-only suite registered NOTHING before - the branch that fell through both
+    /// the src/ arm and the flat-bundle arm - while the compile returned <c>[test]</c>.
+    /// </summary>
+    [Fact]
+    public void SuiteRegistrationDirs_TestOnlySuite_RegistersTest()
+    {
+        Touch(Path.Combine(_root, "test", "A.al"));
+
+        Assert.Equal(new[] { Path.Combine(_root, "test") },
+            ProgramSupport.SuiteRegistrationDirs(_root));
+    }
+
+    /// <summary>
+    /// The drift pin itself: over every layout this file exercises, the registered set IS the
+    /// compiled set. A future editor who widens one and not the other fails here - which is the
+    /// failure #3611/#3714 and #3735 each shipped once.
+    /// </summary>
+    [Theory]
+    [InlineData("src")]
+    [InlineData("test")]
+    [InlineData("src+test")]
+    [InlineData("src+app+app2+test")]
+    [InlineData("flat")]
+    [InlineData("root-al-beside-src")]
+    [InlineData("sibling-dir-beside-src")]
+    [InlineData("shared")]
+    public void RegisteredDirs_AreExactlyTheCompiledDirs(string layout)
+    {
+        Touch(Path.Combine(_root, "app.json"), "{}");
+        switch (layout)
+        {
+            case "src": Touch(Path.Combine(_root, "src", "A.al")); break;
+            case "test": Touch(Path.Combine(_root, "test", "A.al")); break;
+            case "src+test":
+                Touch(Path.Combine(_root, "src", "A.al"));
+                Touch(Path.Combine(_root, "test", "B.al"));
+                break;
+            case "src+app+app2+test":
+                Touch(Path.Combine(_root, "src", "A.al"));
+                Touch(Path.Combine(_root, "app", "B.al"));
+                Touch(Path.Combine(_root, "app2", "C.al"));
+                Touch(Path.Combine(_root, "test", "D.al"));
+                break;
+            case "flat": Touch(Path.Combine(_root, "A.al")); break;
+            case "root-al-beside-src":
+                Touch(Path.Combine(_root, "src", "A.al"));
+                Touch(Path.Combine(_root, "B.al"));
+                break;
+            case "sibling-dir-beside-src":
+                Touch(Path.Combine(_root, "src", "A.al"));
+                Touch(Path.Combine(_root, "ControlAddin", "B.al"));
+                break;
+            case "shared":
+                Touch(Path.Combine(_root, "src", "A.al"));
+                Touch(Path.Combine(_root, "_shared", "Assert.al"));
+                break;
+            default: throw new ArgumentOutOfRangeException(nameof(layout), layout, null);
+        }
+
+        var bucketRoot = layout == "shared" ? _root : null;
+        var compiled = ProgramSupport.CollectSuitePaths(_root, bucketRoot);
+
+        Assert.NotEmpty(compiled);
+        Assert.Equal(compiled, ProgramSupport.SuiteRegistrationDirs(_root, bucketRoot));
+    }
+
+    /// <summary>
+    /// The end-to-end shape #3735 turned on: a PAGE declared under <c>test/</c> in a suite with
+    /// no <c>src/</c>. It compiled, but nothing registered <c>test/</c>, so the page was absent
+    /// from the runner's object inventory and <c>Page.RunModal</c> answered
+    /// "An object with that ID does not exist in the current application" (measured on
+    /// ea27ed9f). Past that, the third LiveNavTestPage route - RunnerTestClientSession.GetPage,
+    /// via [ModalPageHandler], which applies no shape gate - would have reached
+    /// BuiltInPageModeActionRule.RefuseUnknownPageType.
+    /// <para>The assertion is the mode switch itself, before and after, not "did not throw":
+    /// a Card opened modally starts editable, and its built-in View action makes the page
+    /// already on screen read-only (corpus codeunit 60479 "TPMS Tests" measures that shape on a
+    /// real service tier). An implementation that answered a default for either boolean fails.
+    /// </para>
+    /// </summary>
+    [SkippableFact]
+    public void PageUnderTestDir_IsDrivenLiveByAModalPageHandler()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        WriteManifest(_root, "7c1a0b22-3735-4b01-9001-000000003735", 63340, "SRAF Test Only");
+        Touch(Path.Combine(_root, "test", "Objects.al"), ModeProbeObjects("H", 63341, 63342));
+        Touch(Path.Combine(_root, "test", "Tests.al"), ModeProbeTests("H", 63343));
+
+        var (output, exit) = RunRunner(_root);
+
+        Assert.DoesNotContain("does not exist in the current application", output);
+        Assert.Equal(1, TestCount(output));
+        AssertPassed(output, "ModeActionResolvesForAPageDeclaredOutsideSrc");
+        Assert.Equal(0, exit);
+    }
+
+    /// <summary>
+    /// The same, one folder over: the page under <c>app2/</c> beside a <c>src/</c> that does
+    /// exist - so the old loops registered <c>[src]</c> and dropped the page anyway.
+    /// </summary>
+    [SkippableFact]
+    public void PageUnderAppDir_BesideSrc_IsDrivenLiveByAModalPageHandler()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        WriteManifest(_root, "7c1a0b22-3735-4b02-9002-000000003735", 63360, "SRAF App2 Page");
+        Touch(Path.Combine(_root, "app2", "Objects.al"), ModeProbeObjects("A", 63361, 63362));
+        Touch(Path.Combine(_root, "src", "Tests.al"), ModeProbeTests("A", 63363));
+
+        var (output, exit) = RunRunner(_root);
+
+        Assert.DoesNotContain("does not exist in the current application", output);
+        Assert.Equal(1, TestCount(output));
+        AssertPassed(output, "ModeActionResolvesForAPageDeclaredOutsideSrc");
+        Assert.Equal(0, exit);
+    }
+
+    /// <summary>
+    /// The table half of the same branch - the sibling of
+    /// <see cref="TableAtRoot_UsedFromSrcTest_IsRegisteredForRecords"/> for a suite whose only
+    /// folder is <c>test/</c>. Insert-then-Get of a non-default value, so a provider that
+    /// answered zero rows or a defaulted field fails.
+    /// </summary>
+    [SkippableFact]
+    public void TableUnderTestDir_IsRegisteredForRecords()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        WriteManifest(_root, "7c1a0b22-3735-4b03-9003-000000003735", 63370, "SRAF Test Table");
+        Touch(Path.Combine(_root, "test", "Probe.Table.al"), """
+        table 63370 "SRAF Test Probe"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "Code"; Code[20]) { }
+                field(2; "Value"; Integer) { }
+            }
+            keys { key(PK; "Code") { Clustered = true; } }
+        }
+        """);
+        Touch(Path.Combine(_root, "test", "Tests.al"), """
+        codeunit 63371 "SRAF Test Table Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure TestDirTableRoundTrips()
+            var
+                Probe: Record "SRAF Test Probe";
+            begin
+                Probe.Init();
+                Probe.Code := 'X';
+                Probe.Value := 42;
+                Probe.Insert();
+                Clear(Probe);
+                if not Probe.Get('X') then
+                    Error('row X not found after Insert');
+                if Probe.Value <> 42 then
+                    Error('Value was %1, expected 42', Probe.Value);
+            end;
+        }
+        """);
+
+        var (output, exit) = RunRunner(_root);
+
+        Assert.Equal(1, TestCount(output));
+        AssertPassed(output, "TestDirTableRoundTrips");
+        Assert.Equal(0, exit);
+    }
+
+    // A SingleInstance probe plus a sourceless Card page. The probe is how a [ModalPageHandler]
+    // reports what it saw: the handler is gone by the time the test resumes (corpus codeunit
+    // 60473 "TPMS Open Probe" makes the same move). Raw Error(), never Codeunit Assert - the
+    // toolkit would pull a Base Application floor (.claude/rules/no-base-app-in-csharp-tests.md).
+    private static string ModeProbeObjects(string tag, int probeId, int pageId) => $$"""
+        codeunit {{probeId}} "SRAF Probe {{tag}}"
+        {
+            SingleInstance = true;
+
+            var
+                Runs: Integer;
+                Before: Boolean;
+                After: Boolean;
+
+            procedure Reset()
+            begin
+                Runs := 0;
+                Before := false;
+                After := false;
+            end;
+
+            procedure Note(EditableBefore: Boolean; EditableAfter: Boolean)
+            begin
+                Runs += 1;
+                Before := EditableBefore;
+                After := EditableAfter;
+            end;
+
+            procedure GetRuns(): Integer
+            begin
+                exit(Runs);
+            end;
+
+            procedure GetBefore(): Boolean
+            begin
+                exit(Before);
+            end;
+
+            procedure GetAfter(): Boolean
+            begin
+                exit(After);
+            end;
+        }
+
+        page {{pageId}} "SRAF Mode Card {{tag}}"
+        {
+            PageType = Card;
+            ApplicationArea = All;
+        }
+        """;
+
+    private static string ModeProbeTests(string tag, int codeunitId) => $$"""
+        codeunit {{codeunitId}} "SRAF Mode Tests {{tag}}"
+        {
+            Subtype = Test;
+
+            [Test]
+            [HandlerFunctions('ModeHandler')]
+            procedure ModeActionResolvesForAPageDeclaredOutsideSrc()
+            var
+                Probe: Codeunit "SRAF Probe {{tag}}";
+            begin
+                Probe.Reset();
+                Page.RunModal(Page::"SRAF Mode Card {{tag}}");
+                if Probe.GetRuns() <> 1 then
+                    Error('handler ran %1 time(s), expected 1', Probe.GetRuns());
+                if not Probe.GetBefore() then
+                    Error('a Card opened modally must start out editable');
+                if Probe.GetAfter() then
+                    Error('the built-in View action must make the open page read-only');
+            end;
+
+            [ModalPageHandler]
+            procedure ModeHandler(var Card: TestPage "SRAF Mode Card {{tag}}")
+            var
+                Probe: Codeunit "SRAF Probe {{tag}}";
+                EditableBefore: Boolean;
+            begin
+                EditableBefore := Card.Editable();
+                // Before #3735 this raised RunnerOutOfScopeException - the page's PageType was
+                // unknown, because nothing had parsed the folder it is declared in.
+                Card.View().Invoke();
+                Probe.Note(EditableBefore, Card.Editable());
+            end;
+        }
+        """;
 }

--- a/AlRunner.Tests/SuiteRootAlFilesTests.cs
+++ b/AlRunner.Tests/SuiteRootAlFilesTests.cs
@@ -535,6 +535,35 @@ public sealed class SuiteRootAlFilesTests : IDisposable
     }
 
     /// <summary>
+    /// The order is part of the answer, not an accident of the filesystem. The list is both the
+    /// compile's path list and the <c>AddSourceDirs</c> registration list, and
+    /// <c>Directory.EnumerateDirectories</c> returns <c>app*/</c> in filesystem order - NTFS
+    /// sorted, ext4 not - which is why the concrete-list assertion above passed on Windows and
+    /// failed on the BC 27.5 Linux leg. <c>app10/</c> before <c>app2/</c> is what makes this an
+    /// ordinal sort rather than a numeric one. It cannot go RED on NTFS; the Linux legs are where
+    /// it bites.
+    /// </summary>
+    [Fact]
+    public void SuiteRegistrationDirs_OrdersAppFolders_Ordinally()
+    {
+        Touch(Path.Combine(_root, "app.json"), "{}");
+        Touch(Path.Combine(_root, "src", "A.al"));
+        Touch(Path.Combine(_root, "app2", "B.al"));
+        Touch(Path.Combine(_root, "app10", "C.al"));
+        Touch(Path.Combine(_root, "app", "D.al"));
+        Touch(Path.Combine(_root, "test", "E.al"));
+
+        Assert.Equal(
+            new[]
+            {
+                Path.Combine(_root, "src"), Path.Combine(_root, "app"),
+                Path.Combine(_root, "app10"), Path.Combine(_root, "app2"),
+                Path.Combine(_root, "test"),
+            },
+            ProgramSupport.SuiteRegistrationDirs(_root));
+    }
+
+    /// <summary>
     /// A <c>test/</c>-only suite registered NOTHING before - the branch that fell through both
     /// the src/ arm and the flat-bundle arm - while the compile returned <c>[test]</c>.
     /// </summary>
@@ -551,6 +580,13 @@ public sealed class SuiteRootAlFilesTests : IDisposable
     /// The drift pin itself: over every layout this file exercises, the registered set IS the
     /// compiled set. A future editor who widens one and not the other fails here - which is the
     /// failure #3611/#3714 and #3735 each shipped once.
+    /// <para>
+    /// What it cannot catch: since the fix, <c>SuiteRegistrationDirs</c> IS
+    /// <c>CollectSuitePaths</c>, so this compares one function against itself and would stay
+    /// green through any change either makes - including the filesystem-dependent
+    /// <c>app*/</c> order that reddened the BC 27.5 and 28.4 legs. It pins that the two never
+    /// diverge again, not what either answers; the concrete-list tests above pin that.
+    /// </para>
     /// </summary>
     [Theory]
     [InlineData("src")]

--- a/AlRunner/Patches/MockTestPage.LivePage.Actions.cs
+++ b/AlRunner/Patches/MockTestPage.LivePage.Actions.cs
@@ -277,15 +277,37 @@ internal partial class LiveNavTestPage
             // one would be a silent wrong answer.
             //
             // NO AL CAN REACH THIS TODAY (#3735), and it stays as the guard that keeps it that
-            // way. Both routes to a live client require an inventory that also states a
-            // PageType: LiveOverRecord needs a source table, which TestPageFactory.TryBuild
-            // resolves through the same two lookups TryGetAnyPageType reads, and LiveRecordless
-            // needs IsPageShapeKnown outright — so a page in neither gets MockITestPage, whose
-            // View()/Edit() never enter this method, and CreateTestPageClient's `[warn] …
-            // navigation mock` line is the user-visible signal instead. What would widen the
-            // inventory is a runtime-package metadata reader (#3537); BC's captured emitter
-            // metadata cannot, because it exists only for objects this run compiles.
-            // Pinned by AlRunner.Tests/LiveTestPagePageTypeKnownTests.cs.
+            // way. ALL THREE routes that construct a LiveNavTestPage are covered, but not by
+            // one argument — the third rests on a weaker invariant, which is the thing a later
+            // editor would get wrong:
+            //
+            //   1-2. CodeunitPatches.CreateTestPageClient, via TestPageClientConstructionRule.
+            //        LiveOverRecord needs a source table, which TestPageFactory.TryBuild
+            //        resolves through the same two lookups TryGetAnyPageType reads;
+            //        LiveRecordless needs IsPageShapeKnown outright. A page in neither gets
+            //        MockITestPage, whose View()/Edit() never enter this method, and
+            //        CreateTestPageClient's `[warn] … navigation mock` line says so.
+            //   3.   RunnerTestClientSession.GetPage — the [PageHandler]/[ModalPageHandler]
+            //        route — applies NO shape gate at all. Its only gate is form construction
+            //        (FindFormType, CodeunitPatches), a CLR-type inventory that is NOT
+            //        contained in the symbol inventory by construction: the symbol side is
+            //        per-bundle (ResetForReload clears _sourceDirs and _parsedPages;
+            //        ClearPerBundleBcAppPaths drops _bcAppPaths) while loaded assemblies are
+            //        process-wide and BcRuntime.IsStaleBundleAssembly excludes only superseded
+            //        generations. What keeps it unreachable is one step earlier: BC picks the
+            //        handler from its `TestPage "X"` parameter type, so the page must resolve
+            //        in THIS bundle's compile, and every compile symbol source is also a
+            //        registration source (Program.cs — one `ordered` list feeds both
+            //        DependencyLoader.LoadAll and AddBcAppPath; the layered-workspace packages
+            //        SetExtraSymbolDirs adds are resolved as declared dependencies; the
+            //        registered source dirs mirror the compile's CollectSuitePaths). That last
+            //        one is MAINTAINED, not structural, and #3611/#3714 are the record of the
+            //        two sets having drifted apart before — so widening what the compiler can
+            //        see without widening what RecordPatches registers makes this reachable.
+            //
+            // What would widen the inventory is a runtime-package metadata reader (#3537); BC's
+            // captured emitter metadata cannot, because it exists only for objects this run
+            // compiles. Pinned by AlRunner.Tests/LiveTestPagePageTypeKnownTests.cs.
             case BuiltInPageModeShape.RefuseUnknownPageType:
                 throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
                     $"TestPage.{actionName}() on page {_pageId}",

--- a/AlRunner/Patches/MockTestPage.LivePage.Actions.cs
+++ b/AlRunner/Patches/MockTestPage.LivePage.Actions.cs
@@ -275,6 +275,17 @@ internal partial class LiveNavTestPage
             // action, or a non-list's in-place switch. They differ in whether the page's
             // editability moves, which is exactly what the caller is about to read, so picking
             // one would be a silent wrong answer.
+            //
+            // NO AL CAN REACH THIS TODAY (#3735), and it stays as the guard that keeps it that
+            // way. Both routes to a live client require an inventory that also states a
+            // PageType: LiveOverRecord needs a source table, which TestPageFactory.TryBuild
+            // resolves through the same two lookups TryGetAnyPageType reads, and LiveRecordless
+            // needs IsPageShapeKnown outright — so a page in neither gets MockITestPage, whose
+            // View()/Edit() never enter this method, and CreateTestPageClient's `[warn] …
+            // navigation mock` line is the user-visible signal instead. What would widen the
+            // inventory is a runtime-package metadata reader (#3537); BC's captured emitter
+            // metadata cannot, because it exists only for objects this run compiles.
+            // Pinned by AlRunner.Tests/LiveTestPagePageTypeKnownTests.cs.
             case BuiltInPageModeShape.RefuseUnknownPageType:
                 throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
                     $"TestPage.{actionName}() on page {_pageId}",

--- a/AlRunner/Patches/MockTestPage.LivePage.Actions.cs
+++ b/AlRunner/Patches/MockTestPage.LivePage.Actions.cs
@@ -276,38 +276,23 @@ internal partial class LiveNavTestPage
             // editability moves, which is exactly what the caller is about to read, so picking
             // one would be a silent wrong answer.
             //
-            // NO AL CAN REACH THIS TODAY (#3735), and it stays as the guard that keeps it that
-            // way. ALL THREE routes that construct a LiveNavTestPage are covered, but not by
-            // one argument — the third rests on a weaker invariant, which is the thing a later
-            // editor would get wrong:
-            //
-            //   1-2. CodeunitPatches.CreateTestPageClient, via TestPageClientConstructionRule.
-            //        LiveOverRecord needs a source table, which TestPageFactory.TryBuild
-            //        resolves through the same two lookups TryGetAnyPageType reads;
-            //        LiveRecordless needs IsPageShapeKnown outright. A page in neither gets
-            //        MockITestPage, whose View()/Edit() never enter this method, and
-            //        CreateTestPageClient's `[warn] … navigation mock` line says so.
-            //   3.   RunnerTestClientSession.GetPage — the [PageHandler]/[ModalPageHandler]
-            //        route — applies NO shape gate at all. Its only gate is form construction
-            //        (FindFormType, CodeunitPatches), a CLR-type inventory that is NOT
-            //        contained in the symbol inventory by construction: the symbol side is
-            //        per-bundle (ResetForReload clears _sourceDirs and _parsedPages;
-            //        ClearPerBundleBcAppPaths drops _bcAppPaths) while loaded assemblies are
-            //        process-wide and BcRuntime.IsStaleBundleAssembly excludes only superseded
-            //        generations. What keeps it unreachable is one step earlier: BC picks the
-            //        handler from its `TestPage "X"` parameter type, so the page must resolve
-            //        in THIS bundle's compile, and every compile symbol source is also a
-            //        registration source (Program.cs — one `ordered` list feeds both
-            //        DependencyLoader.LoadAll and AddBcAppPath; the layered-workspace packages
-            //        SetExtraSymbolDirs adds are resolved as declared dependencies; the
-            //        registered source dirs mirror the compile's CollectSuitePaths). That last
-            //        one is MAINTAINED, not structural, and #3611/#3714 are the record of the
-            //        two sets having drifted apart before — so widening what the compiler can
-            //        see without widening what RecordPatches registers makes this reachable.
-            //
-            // What would widen the inventory is a runtime-package metadata reader (#3537); BC's
-            // captured emitter metadata cannot, because it exists only for objects this run
-            // compiles. Pinned by AlRunner.Tests/LiveTestPagePageTypeKnownTests.cs.
+            // NO AL IS KNOWN TO REACH THIS TODAY (#3735), and it stays as the guard that keeps it that
+            // way. THE TRAP, for whoever edits near here: two of the three routes that build a
+            // LiveNavTestPage gate on the page's shape, and the third does not.
+            // RunnerTestClientSession.GetPage — the [PageHandler]/[ModalPageHandler] route —
+            // applies no shape check at all; what keeps it out of this case is that BC picks the
+            // handler by its `TestPage "X"` parameter type, so the page must resolve in THIS
+            // bundle's compile, and every symbol source the compile has is also a registration
+            // source. The suite's own folders are that by construction since #3735
+            // (ProgramSupport.SuiteRegistrationDirs IS CollectSuitePaths); widening what the
+            // compiler can see without widening what RecordPatches registers puts this case back
+            // in reach, which is what #3611/#3714 and #3735 each shipped once.
+            // One source is still unmatched and unpinned: BcCompiler._usePackageCacheFallback
+            // (issue #3769).
+            // see docs/page-shape-inventory.md#route-3 — the routes, the two inventories, the
+            // per-bundle vs process-wide lifetimes, and the residual.
+            // Pinned by AlRunner.Tests/LiveTestPagePageTypeKnownTests.cs and
+            // AlRunner.Tests/SuiteRootAlFilesTests.cs.
             case BuiltInPageModeShape.RefuseUnknownPageType:
                 throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
                     $"TestPage.{actionName}() on page {_pageId}",

--- a/AlRunner/Patches/RecordPatches.AlPageParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlPageParser.cs
@@ -338,6 +338,12 @@ public static partial class RecordPatches
     /// <para>Issue #2931's consumer is RunnerPageInstance.TargetPageOpensModally: whether an
     /// action's RunObject target opens as a dialog is decided by the TARGET's PageType, so this
     /// is asked about a page other than the one being driven.</para>
+    /// <para><b>Null here is co-extensive with <see cref="IsPageShapeKnown"/> being false</b>
+    /// (#3735): both read these same two sources, and neither can yield a null PageType,
+    /// because each applies AL's absent-property default of "Card". A third source added to
+    /// one and not the other breaks that, and makes
+    /// BuiltInPageModeActionRule.RefuseUnknownPageType reachable — pinned by
+    /// AlRunner.Tests/LiveTestPagePageTypeKnownTests.cs.</para>
     /// </summary>
     internal static string? TryGetAnyPageType(int pageId)
     {

--- a/AlRunner/Patches/TestPageFactory.cs
+++ b/AlRunner/Patches/TestPageFactory.cs
@@ -39,12 +39,8 @@ internal static class TestPageFactory
         // PageType (#3735). A third source added here without being added there would make
         // BuiltInPageModeActionRule's RefuseUnknownPageType reachable — pinned by
         // AlRunner.Tests/LiveTestPagePageTypeKnownTests.cs.
-        //
-        // That is TWO of the three routes that construct a LiveNavTestPage. The third,
-        // RunnerTestClientSession.GetPage (the [PageHandler]/[ModalPageHandler] route), never
-        // calls this method and applies no shape gate at all; it rests on a DIFFERENT and
-        // weaker invariant — compile-time handler typing — stated in full at the refusal site,
-        // MockTestPage.LivePage.Actions.cs's RefuseUnknownPageType case.
+        // The third construction route, RunnerTestClientSession.GetPage, never calls this method
+        // and gates differently: see docs/page-shape-inventory.md#route-3.
         var tableId = RecordPatches.GetSourceTableIdForPage(pageId);
         if (tableId == 0)
             tableId = RecordPatches.TryGetDependencySourceTableIdForPage(pageId);

--- a/AlRunner/Patches/TestPageFactory.cs
+++ b/AlRunner/Patches/TestPageFactory.cs
@@ -33,6 +33,12 @@ internal static class TestPageFactory
         // precompiled dependency's page (Base App / System App / an ISV .app) falls back to
         // its SymbolReference.json's own SourceTable property — see
         // RecordPatches.TryGetDependencySourceTableIdForPage.
+        //
+        // These are the same two inventories RecordPatches.TryGetAnyPageType reads, which is
+        // why a page driven live always knows its own PageType (#3735). A third source added
+        // here without being added there would make BuiltInPageModeActionRule's
+        // RefuseUnknownPageType reachable — pinned by
+        // AlRunner.Tests/LiveTestPagePageTypeKnownTests.cs.
         var tableId = RecordPatches.GetSourceTableIdForPage(pageId);
         if (tableId == 0)
             tableId = RecordPatches.TryGetDependencySourceTableIdForPage(pageId);

--- a/AlRunner/Patches/TestPageFactory.cs
+++ b/AlRunner/Patches/TestPageFactory.cs
@@ -34,11 +34,17 @@ internal static class TestPageFactory
         // its SymbolReference.json's own SourceTable property — see
         // RecordPatches.TryGetDependencySourceTableIdForPage.
         //
-        // These are the same two inventories RecordPatches.TryGetAnyPageType reads, which is
-        // why a page driven live always knows its own PageType (#3735). A third source added
-        // here without being added there would make BuiltInPageModeActionRule's
-        // RefuseUnknownPageType reachable — pinned by
+        // These are the same two inventories RecordPatches.TryGetAnyPageType reads, which is why
+        // a page driven live THROUGH CodeunitPatches.CreateTestPageClient always knows its own
+        // PageType (#3735). A third source added here without being added there would make
+        // BuiltInPageModeActionRule's RefuseUnknownPageType reachable — pinned by
         // AlRunner.Tests/LiveTestPagePageTypeKnownTests.cs.
+        //
+        // That is TWO of the three routes that construct a LiveNavTestPage. The third,
+        // RunnerTestClientSession.GetPage (the [PageHandler]/[ModalPageHandler] route), never
+        // calls this method and applies no shape gate at all; it rests on a DIFFERENT and
+        // weaker invariant — compile-time handler typing — stated in full at the refusal site,
+        // MockTestPage.LivePage.Actions.cs's RefuseUnknownPageType case.
         var tableId = RecordPatches.GetSourceTableIdForPage(pageId);
         if (tableId == 0)
             tableId = RecordPatches.TryGetDependencySourceTableIdForPage(pageId);

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2667,18 +2667,10 @@ foreach (var bundle in bundles)
     {
         var dirsToRegister = new List<string>();
         foreach (var suite in suites)
-        {
-            var s = Path.Combine(suite, "src");
-            if (SuiteHasAlOutsideConventionalDirs(suite, bucketRoot))
-                // #3611/#3714: AL beside src/ (a root table, a ControlAddin/ folder) — the
-                // compile reads the whole root (CollectSuitePaths), so the table parsers must too.
-                dirsToRegister.Add(suite);
-            else if (Directory.Exists(s))
-                dirsToRegister.Add(s);
-            else if (!Directory.Exists(Path.Combine(suite, "test")))
-                // Flat bundle: register the suite root so table parsers can find .al files.
-                dirsToRegister.Add(suite);
-        }
+            // #3735: exactly what the compile reads. Deriving it a second time here is what let
+            // a page or table under test/ or app2/ compile and never be parsed — see
+            // ProgramSupport.SuiteRegistrationDirs.
+            dirsToRegister.AddRange(SuiteRegistrationDirs(suite, bucketRoot));
         AlRunner.Patches.RecordPatches.AddSourceDirs(dirsToRegister);
     }
 
@@ -5216,14 +5208,11 @@ return strictExitCode ? computedExitCode : 0;
         var dirsToRegister = new List<string>();
         foreach (var suite in suites)
         {
-            var s = Path.Combine(suite, "src");
-            // #3611/#3714: same decision as the CLI loop above — AL beside src/ means the
-            // table parsers read the whole root, as the compile does.
-            if (SuiteHasAlOutsideConventionalDirs(suite, bucketRoot)) dirsToRegister.Add(suite);
-            else if (Directory.Exists(s)) dirsToRegister.Add(s);
-            else if (!Directory.Exists(Path.Combine(suite, "test")))
-                dirsToRegister.Add(suite);
-            allPaths.AddRange(CollectSuitePaths(suite, bucketRoot));
+            // #3735: same one function as the CLI loop above, computed once and used for both
+            // the compile's paths and the registration — they are the same set by construction.
+            var suitePaths = SuiteRegistrationDirs(suite, bucketRoot);
+            dirsToRegister.AddRange(suitePaths);
+            allPaths.AddRange(suitePaths);
         }
         AlRunner.Patches.RecordPatches.AddSourceDirs(dirsToRegister);
         allPaths = allPaths.Distinct().ToList();

--- a/AlRunner/ProgramSupport/Dependencies.cs
+++ b/AlRunner/ProgramSupport/Dependencies.cs
@@ -346,6 +346,24 @@ internal static partial class ProgramSupport
         return groups;
     }
 
+    /// <summary>
+    /// The folders <see cref="AlRunner.Patches.RecordPatches.AddSourceDirs"/> must be given for
+    /// one suite: exactly the folders <see cref="CollectSuitePaths"/> compiles.
+    /// <para>
+    /// It delegates rather than deciding anything, and that is the point (#3735). The two
+    /// register-source-dirs loops in Program.cs used to re-derive the set — <c>src/</c> when it
+    /// exists, else the suite root when no <c>test/</c> exists — so a page or a table declared
+    /// under <c>test/</c> or <c>app2/</c> compiled but was never parsed: a <c>test/</c>-only
+    /// suite registered NOTHING, and <c>Page.RunModal</c> on a page declared there answered
+    /// "An object with that ID does not exist in the current application". #3611/#3714 are the
+    /// record of the same two sets drifting apart once before, which is why this is now one
+    /// function instead of a rule.
+    /// </para>
+    /// <para>Pinned by AlRunner.Tests/SuiteRootAlFilesTests.cs.</para>
+    /// </summary>
+    internal static List<string> SuiteRegistrationDirs(string suite, string? bucketRoot = null)
+        => CollectSuitePaths(suite, bucketRoot);
+
     internal static List<string> CollectSuitePaths(string suite, string? bucketRoot = null)
     {
         var all = ConventionalSourceDirs(suite);

--- a/AlRunner/ProgramSupport/Dependencies.cs
+++ b/AlRunner/ProgramSupport/Dependencies.cs
@@ -405,7 +405,8 @@ internal static partial class ProgramSupport
 
     /// <summary>
     /// The folders the legacy bucket layout put AL in — <c>src/</c>, every <c>app*/</c>, and
-    /// <c>test/</c> — in the order <see cref="CollectSuitePaths"/> has always returned them.
+    /// <c>test/</c> — in the order <see cref="CollectSuitePaths"/> has always returned them,
+    /// with the <c>app*/</c> run ordinal-sorted so the list is the same on every platform.
     /// Empty for a flat suite.
     /// </summary>
     private static List<string> ConventionalSourceDirs(string suite)
@@ -414,7 +415,14 @@ internal static partial class ProgramSupport
         var s = Path.Combine(suite, "src");
         var t = Path.Combine(suite, "test");
         if (Directory.Exists(s)) dirs.Add(s);
-        foreach (var app in Directory.EnumerateDirectories(suite, "app*"))
+        // Ordinal-sorted: Directory.EnumerateDirectories' order is filesystem-dependent — NTFS
+        // hands back app/ then app2/, ext4 hands back whatever order the directory happens to
+        // hold. This list is the compile's path list AND the AddSourceDirs registration list, so
+        // an unsorted one made both order-dependent on the filesystem; sorting is one line and
+        // removes the question. OrdinalIgnoreCase would tie App/ with app/ on a case-sensitive
+        // filesystem and fall back to enumeration order again.
+        foreach (var app in Directory.EnumerateDirectories(suite, "app*")
+                     .OrderBy(p => p, StringComparer.Ordinal))
             dirs.Add(app);
         if (Directory.Exists(t)) dirs.Add(t);
         return dirs;

--- a/docs/page-shape-inventory.md
+++ b/docs/page-shape-inventory.md
@@ -1,0 +1,93 @@
+# What the runner knows about a page's shape, and where that knowledge comes from
+
+Written for issue #3735, which asked why `BuiltInPageModeActionRule.RefuseUnknownPageType`
+exists and whether any AL can reach it. The short answer is in the code, at the refusal site
+(`AlRunner/Patches/MockTestPage.LivePage.Actions.cs`); this is the long form, and the place to
+re-check when either inventory changes.
+
+## The two inventories
+
+A page id resolves its shape — `PageType`, `SourceTable`, `CardPageId` — through exactly two
+sources, both read by `RecordPatches.TryGetAnyPageType` and by `RecordPatches.IsPageShapeKnown`:
+
+1. **Parsed AL source.** `_parsedPages`, written only by `RecordPatches.AlPageParser`'s
+   `ParseSourceFileIntoAllExtractors`, whose callers walk `_sourceDirs` — the directories
+   `RecordPatches.AddSourceDirs` was given.
+2. **A loaded dependency's page symbols.** `BcAppSymbolCache.TryParsePageSymbol`, over the
+   `SymbolReference.json` inside each registered `.app`.
+
+Neither can answer a null `PageType`: both apply AL's absent-property default of `Card`. So
+"`TryGetAnyPageType` is null" and "`IsPageShapeKnown` is false" are the same statement — pinned
+by `AlRunner.Tests/LiveTestPagePageTypeKnownTests.cs`.
+
+## The three routes to a LiveNavTestPage
+
+| route | built by | shape gate |
+|---|---|---|
+| 1. live over a record | `CodeunitPatches.CreateTestPageClient` → `TestPageFactory.TryBuild` | a resolvable source table, looked up through the same two inventories |
+| 2. live, recordless | `CodeunitPatches.CreateTestPageClient` | `IsPageShapeKnown` outright |
+| 3. handler-driven | `RunnerTestClientSession.GetPage`, for `[PageHandler]`/`[ModalPageHandler]` | **none** — its only gate is form construction (`CodeunitPatches.FindFormType`) |
+
+Routes 1 and 2 cannot reach the refusal: a page in neither inventory gets `MockITestPage`, whose
+`View()`/`Edit()` are the base mock's, and `CreateTestPageClient` prints
+`[warn] … navigation mock` when that happens.
+
+## <a id="route-3"></a>Route 3 rests on the compile, not on a shape check
+
+Route 3 applies no shape gate, so what keeps the refusal out of reach is one step earlier: BC
+selects the handler by its `TestPage "X"` parameter type, so the page must resolve in **this
+bundle's compile** — and every source the compile can see is also a registration source.
+
+The CLR-type inventory route 3 does gate on is **not** contained in the symbol inventory by
+construction, which is why the argument has to be made about the compile rather than about the
+types on hand. The two have different lifetimes:
+
+- the symbol side is per-bundle — `RecordPatches.ResetForReload` clears `_sourceDirs` and
+  `_parsedPages`, and `ClearPerBundleBcAppPaths` drops `_bcAppPaths`;
+- loaded assemblies are process-wide, and `BcRuntime.IsStaleBundleAssembly` excludes only
+  superseded generations of a registered name.
+
+So in a multi-bundle run a form type from an earlier bundle can outlive the symbols that
+described it. The containment claim is therefore about what THIS compile could name, not about
+what is loaded.
+
+### <a id="compile-sources"></a>The compile's symbol sources, and their registration
+
+| what the compiler can see | where registration happens |
+|---|---|
+| resolved dependency `.app`s (`_resolvedDeps`, `BcCompiler.cs`) | the same `ordered` list feeds `DependencyLoader.LoadAll` and `RecordPatches.AddBcAppPath` (`Program.cs`) |
+| Microsoft platform apps | `ReadDependencies` synthesises Optional `Application`/`System` roots, so they land in `ordered` too |
+| layered-workspace source dependencies | `RecordPatches.AddSourceDir` in `SiblingCompile.cs` |
+| extra symbol dirs (`SetExtraSymbolDirs`) | resolved as declared dependencies |
+| **the suite's own `.al` folders** | `ProgramSupport.SuiteRegistrationDirs`, which **is** `CollectSuitePaths` |
+
+The last row was a second derivation of the folder set until #3735, and it was wrong: the loops
+registered `src/` when it existed and the suite root when no `test/` existed, while the compile
+read `src/` + every `app*/` + `test/`. A page or table under `test/` or `app2/` therefore
+compiled and was never parsed, and a `test/`-only suite registered nothing at all. Measured on
+`ea27ed9f`: `Page.RunModal` on a page declared under `test/` answered
+
+```
+NavALException: You tried to invoke the Page object with the ID 63342 … An object with that
+ID does not exist in the current application compiled with emit version 28014.
+```
+
+so the refusal was reachable — the run died one step before it. #3611/#3714 are the record of
+the same two sets drifting apart once before. They are now one function, pinned by
+`AlRunner.Tests/SuiteRootAlFilesTests.cs`
+(`RegisteredDirs_AreExactlyTheCompiledDirs` and the two `PageUnder…` end-to-end rows).
+
+### <a id="residual"></a>The one unmeasured source
+
+`BcCompiler._usePackageCacheFallback` (`BcCompiler.cs`) specs every `.app` in the package-cache
+directories with no matching registration, so a page declared only there would be nameable by
+the compiler and absent from both inventories. Its only caller is `SiblingCompile.cs`'s
+precompiled-app decompile compile, which never types a handler in a test bundle — so it is not
+believed to be reachable, but nothing pins that. Tracked as issue #3769.
+
+## What would widen the inventory
+
+A runtime-package metadata reader (#3537). BC's captured emitter metadata
+(`docs/object-metadata-capture.md`) cannot: it exists only for objects this run compiles, which
+is a subset of `_parsedPages`, so a precompiled dependency page never passes through
+`Compilation.Emit`.


### PR DESCRIPTION
Closes #3735

Corpus-NA: suite-folder registration inside the runner; the View/Edit behaviour the fixture asserts is adjudicated on a real service tier by corpus codeunit 60479 "TPMS Tests"

#3735 asked for a second source for a page's `PageType`, so `BuiltInPageModeActionRule.ResolveShape` could answer instead of returning `RefuseUnknownPageType` — and, before that, for the reproducer the issue said was missing.

**The reproducer exists, and the fix is registration, not a second metadata source.** Review at `ea27ed9f` found that the two register-source-dirs loops in `Program.cs` re-derived the suite's folder set instead of asking the compile for it. That was the finding, and this PR fixes it structurally rather than narrowing the claim around it.

## What was wrong

`ProgramSupport.CollectSuitePaths` compiles **`src/` + every `app*/` + `test/`** (plus the bucket's `_shared`). Both registration loops asked a different question — `src/` when it exists, else the suite root when no `test/` exists — so:

* a page or table declared under `test/` or `app2/` **compiled and was never parsed**;
* a suite whose only folder is `test/` fell through both arms and registered **nothing at all**.

`_parsedPages` has one writer, reached only from the registered `_sourceDirs`, so such a page is absent from the runner's object inventory entirely. Measured on `ea27ed9f`, with a `[ModalPageHandler]` typed over a page declared in `test/`:

```
NavALException: You tried to invoke the Page object with the ID 63342 from the object R3H Tests.
An object with that ID does not exist in the current application compiled with emit version 28014.
```

So route 3 — `RunnerTestClientSession.GetPage`, the `[PageHandler]`/`[ModalPageHandler]` route, the one that applies no shape gate — was reachable; the run just died one step earlier.

## The fix

Both loops now call one helper, `ProgramSupport.SuiteRegistrationDirs`, which **is** `CollectSuitePaths`:

```csharp
internal static List<string> SuiteRegistrationDirs(string suite, string? bucketRoot = null)
    => CollectSuitePaths(suite, bucketRoot);
```

The two sets are the same set by construction rather than by maintenance — #3611/#3714 are the record of them drifting apart once already. Its doc comment carries the claim and the trap; the derivation is in `docs/page-shape-inventory.md#compile-sources`. In the server loop the list is computed once per suite and used for both the compile's `allPaths` and the registration, so the sibling walk runs once. `AddSourceDirs` already de-dups, so a bucket's `_shared` handed in per suite is parsed once.

Two deliberate widenings, both stated so a reviewer can weigh them: `_shared` is now registered (it is compiled, so its tables should be parseable), and a suite holding no `.al` at all now registers nothing instead of its root (a no-op either way).

## Route table, corrected

| route | construction site | shape gate | reachable with an unknown PageType? |
|---|---|---|---|
| `LiveOverRecord` | `CodeunitPatches.CreateTestPageClient` → `TestPageClientConstructionRule` | a source table resolved through the same two inventories `TryGetAnyPageType` reads | no |
| `LiveRecordless` | same | `IsPageShapeKnown` outright | no |
| `NavigationMock` | same | neither | no — `MockITestPage.View()/Edit()` never enter `BuiltInPageModeActionFor` |
| **`GetPage`** | `RunnerTestClientSession.cs` | **none.** Only form construction (`CodeunitPatches.FindFormType`) | **was yes; no for the suite's own folders since this PR** |

Route 3 rests on the compile, not on a shape check: BC selects the handler by its `TestPage "X"` parameter type, so the page must resolve in *this bundle's compile*, and every compile symbol source is also a registration source. The full argument — the routes, the two inventories, the per-bundle vs process-wide lifetimes that make the CLR-type inventory *not* contained in the symbol inventory, and the compile-source table — moved to **`docs/page-shape-inventory.md`**, with a one-line pointer at the refusal site (reviewer §3).

**The one unmeasured source, named and filed: #3769.** `BcCompiler._usePackageCacheFallback` (`BcCompiler.cs:1360`) specs every `.app` in the package-cache dirs with no matching registration. Its only caller is `SiblingCompile.cs:146`, a precompiled-app decompile compile that never types a handler in a test bundle — a code read of one call site, not a measurement, so the refusal-site comment now says "no AL is **known** to reach this today" and cites #3769 rather than claiming unreachability.

The reviewer's "`CaptureOutputter` sees a subset of `_parsedPages`" point is true again after this change: a page under `test/` is now parsed as well as compiled, so the capture set is a subset once more.

## RED → GREEN

Six new methods — 13 cases with the theory expanded — in `AlRunner.Tests/SuiteRootAlFilesTests.cs` — the file that already holds the compile-vs-register pins from #3611/#3714 and its spawn harness. No Base Application floor; the AL asserts with raw `Error()`, never `Codeunit Assert`, which would pull the test toolkit.

**RED, by mutation** — `SuiteRegistrationDirs` replaced with the pre-#3735 derivation, everything else untouched: **9 failed, 22 passed**. Nine, not 13: the four theory layouts that still pass (`src`, `flat`, `root-al-beside-src`, `sibling-dir-beside-src`) are exactly the ones where the old and new derivations already agreed, and they are in the theory to hold that agreement. The 22 pre-existing rows all pass under the mutation too, so it is not a blunt break. Before that, the same two AL fixtures were run by hand against the `ea27ed9f` binary and produced the `NavALException` quoted above. Mutation reverted; `git status` clean before the commit.

**GREEN** — `SuiteRootAlFilesTests` alone: 31 passed, 1 skipped (the Unix-permission row). With the five neighbour classes (`LiveTestPagePageTypeKnownTests`, `BuiltInPageModeActionRuleTests`, `LiveNavTestPartRecordlessTests`, `DependencyPageShapeResolutionTests`, `TestPageClientConstructionRuleTests`, `BaseAppFloorFixtureGuardTests`): **107 passed, 0 failed, 1 skipped**. `tools/test_doc_pointers.py`: all checks passed.

| row | what it proves |
|---|---|
| `SuiteRegistrationDirs_CoversEveryConventionalFolder_NotJustSrc` | the concrete list `[src, app, app2, test]`, in order — the old loops answered `[src]` |
| `SuiteRegistrationDirs_TestOnlySuite_RegistersTest` | the branch that used to register nothing |
| `RegisteredDirs_AreExactlyTheCompiledDirs` (8 layouts) | **the drift pin**: registered set == compiled set over src / test / src+test / src+app+app2+test / flat / root-AL-beside-src / sibling-dir-beside-src / `_shared` |
| `PageUnderTestDir_IsDrivenLiveByAModalPageHandler` | end to end: a Card page declared in `test/`, driven by a `[ModalPageHandler]`; the handler runs **once**, the page starts **editable**, and `View().Invoke()` leaves it **read-only** — the shape corpus codeunit 60479 measures on a real service tier. Two concrete booleans and a count, so a defaulted answer fails. |
| `PageUnderAppDir_BesideSrc_IsDrivenLiveByAModalPageHandler` | the same with the page under `app2/` beside a `src/` that does exist |
| `TableUnderTestDir_IsRegisteredForRecords` | the table half of the same branch — Insert-then-Get of `42`, the sibling of `TableAtRoot_UsedFromSrcTest_IsRegisteredForRecords` |

## Wider runs, and what they did not measure

Both wider runs asked for on this change came back **blocked by a local environment fault, not by the change**, and I am reporting them as such rather than as results:

* `tests/runner-extras --strict` — every suite `EXEC-FAIL: Could not load file or assembly 'Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.5'`, 0 tests run.
* corpus (`tools/corpus-checkout.py` → `818ee21b75a01b66a33ea05412fc3b0985a63adf` (master), `--test "TPMS*"`) — the same fault, 0 tests run.

**Control:** re-running `runner-extras --strict` with the pre-#3735 derivation restored gives the identical summary (`exec-fail: 1`, `Tests: 0 total`), and the same DLL-load fault appears in the `ea27ed9f` fixture runs above. So it predates this change on this box. The three PR legs measure both trees properly.

Neither tree has a `test/`, `app/` or `app2/` folder under any suite (`find tests/runner-extras tests/al-language -maxdepth 6 -type d \( -name test -o -name app -o -name app2 \)` returns nothing), so both were controls with no expected delta. What moves and what does not: a `src/`-only or flat suite is unchanged (`SrcOnly_StillReturnsExactlySrc`, `Flat_StillReturnsExactlyTheSuiteRoot`, pre-existing and still green); a `src/`+`test/` suite widens from `[src]` to `[src, test]`, and an `app*/` suite from `[src]` to include it — by design, and the point of the change.

## Fix the shape

1. **Same wrong pattern at another call site?** Measured, not assumed: `rg -n 'AddSourceDirs\(|Combine\(suite, "src"\)|Combine\(suite, "test"\)' AlRunner/` returns the two `AddSourceDirs` call sites (both in this diff, textual near-copies of each other), the two `Path.Combine` lines inside `ConventionalSourceDirs` — the one surviving derivation — and `RecordPatches.AddSourceDir`, the singular wrapper `SiblingCompile` uses for a *dependency's* source dir, which is not a suite-folder decision. There is no third site.
2. **A sibling making the same assumption?** Yes, and it is fixed in the same rows: the branch that dropped a **page** dropped a **table** under `test/` too — hence `TableUnderTestDir_IsRegisteredForRecords`. Outside the suite loops, the remaining compile-vs-registration asymmetry is `_usePackageCacheFallback`, filed as #3769 rather than fixed here: it is a different subsystem, its only caller does not compile test bundles, and fixing it without a reproducer would be an assumption fix.
3. **Two paths writing the same state, with different invariants?** That was the defect: the compile's path and the registration path both decided "which folders is this suite", and only one of them was updated at #3611/#3714. There is now one path.

## Open-issue scan

Open issues in this cluster, none folded — none lands in `Program.cs`'s suite loops or in `ProgramSupport/Dependencies.cs`: #3537 (runtime-package metadata reader — the source that would widen the page inventory itself), #2460 (compiled action metadata for precompiled pages), #3282 (RAD snapshot asymmetry). #3769 is the one this PR filed.

Opened by an agent (`fbk-2`) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kko97BZZL71nF2nK5aftu4
