### PR TITLE
fix(testpage): flush the page's PARTS before TestPage.Close() raises OnQueryClosePage

### DIFF
--- a/AlRunner.Tests/HandlerDrivenClosePartFlushOrderTests.cs
+++ b/AlRunner.Tests/HandlerDrivenClosePartFlushOrderTests.cs
@@ -25,15 +25,20 @@ namespace AlRunner.Tests;
 
 public sealed class HandlerDrivenClosePartFlushOrderTests
 {
-    private static MethodDefinition AttemptHandlerDrivenClose()
+    private static MethodDefinition LiveNavTestPageMethod(string name)
     {
         // Any type from the runner assembly locates the image; LiveNavTestPage itself is
         // internal, and this test reads it through Cecil rather than through the type system.
         var path = typeof(AlRunner.TestExecutor).Assembly.Location;
         var module = ModuleDefinition.ReadModule(path);
         var type = module.GetTypes().Single(t => t.FullName == "AlRunner.LiveNavTestPage");
-        return type.Methods.Single(m => m.Name == "AttemptHandlerDrivenClose");
+        return type.Methods.Single(m => m.Name == name);
     }
+
+    private static MethodDefinition AttemptHandlerDrivenClose()
+        => LiveNavTestPageMethod("AttemptHandlerDrivenClose");
+
+    private static MethodDefinition Close() => LiveNavTestPageMethod("Close");
 
     private static int IndexOfCallTo(MethodDefinition method, string calleeName)
     {
@@ -84,5 +89,63 @@ public sealed class HandlerDrivenClosePartFlushOrderTests
             $"FlushParts (IL index {flush}) must come after the guards (WasClosedFromAl at "
             + $"{wasClosedFromAl}) — a page the test opened, or one already closed from AL, must "
             + "not be touched by this route.");
+    }
+
+    // ── The TestPage.Close() twin — issue #3708 ──────────────────────────────────────────────
+    //
+    // Same defect shape on the other close route, and pre-existing rather than a #3672
+    // regression: Close() raised OnQueryClosePage and only afterwards ran FlushParts();
+    // FlushRow();, so a row typed into a part through Card.Lines.New() did not exist yet when
+    // the trigger read the part. The BC-behaviour claim is measured upstream by corpus codeunit
+    // 60438 "Opc Close Part Flush Tests" (StefanMaron/BusinessCentral.AL.Language.Tests#320),
+    // verified in a BC 28.4.53241.0 container before that PR was opened. What is asserted here
+    // is again the ordering, which no return value exposes.
+
+    [Fact]
+    public void Close_FlushesPartsAndTheRow_BeforeItRaisesOnClosePage()
+    {
+        var method = Close();
+
+        var flushParts = IndexOfCallTo(method, "FlushParts");
+        var flushRow = IndexOfCallTo(method, "FlushRow");
+        var raise = IndexOfCallTo(method, "RaiseOnClosePage");
+
+        Assert.True(flushParts >= 0,
+            "Close() must call FlushParts — without it a row typed into a part is still a buffer "
+            + "when OnQueryClosePage runs (#3708), and nothing writes it back at all (#3682).");
+        Assert.True(flushRow >= 0,
+            "Close() must still call FlushRow — FlushParts does not write the host page's own row.");
+        Assert.True(raise >= 0,
+            "Close() must still raise OnQueryClosePage — that is the close the test asked for.");
+        Assert.True(flushParts < raise,
+            $"FlushParts (IL index {flushParts}) must be called BEFORE RaiseOnClosePage ({raise}). "
+            + "Flushing afterwards is the #3708 defect with the call present.");
+        Assert.True(flushRow < raise,
+            $"FlushRow (IL index {flushRow}) must be called BEFORE RaiseOnClosePage ({raise}): BC's "
+            + "client sends the edited row and only then drives the close.");
+        Assert.True(flushParts < flushRow,
+            $"Close() flushes parts THEN the row (found FlushParts at {flushParts}, FlushRow at "
+            + $"{flushRow}) — a part's OnValidate can touch the header, so the header write must "
+            + "come second. The OK route is row-then-parts only because Invoke() has already "
+            + "written the host row (#3701).");
+    }
+
+    // The counterpart to AttemptHandlerDrivenClose_FlushesPartsOnlyAfterItsGuards: a torn-down
+    // page raises "The TestPage is not open." and flushes nothing, so the flush belongs after
+    // that guard rather than at the very top of the method.
+    [Fact]
+    public void Close_FlushesOnlyAfterTheTornDownGuard()
+    {
+        var method = Close();
+
+        var flushParts = IndexOfCallTo(method, "FlushParts");
+        var notOpen = IndexOfCallTo(method, "MakeTestPageNotOpenException");
+
+        Assert.True(notOpen >= 0,
+            "the torn-down guard (MakeTestPageNotOpenException) must still be in Close().");
+        Assert.True(flushParts > notOpen,
+            $"FlushParts (IL index {flushParts}) must come after the torn-down guard "
+            + $"(MakeTestPageNotOpenException at {notOpen}) — a torn-down page throws instead of "
+            + "closing, and must not write anything back on the way out.");
     }
 }

--- a/AlRunner/Patches/MockTestPage.LivePage.WriteBuffer.cs
+++ b/AlRunner/Patches/MockTestPage.LivePage.WriteBuffer.cs
@@ -685,6 +685,30 @@ internal partial class LiveNavTestPage
         // instead of closing -- measured on real BC, Close() does NOT silently no-op here.
         if (_tornDown) throw MakeTestPageNotOpenException();
 
+        // The EXPLICIT close route's flush, BEFORE the trigger. BC's client sends the row being
+        // edited -- INCLUDING a row typed into a part -- and only then drives the close, so
+        // OnQueryClosePage reads a part that already holds it. Measured on a real service tier
+        // for this route: corpus codeunit 60438 "Opc Close Part Flush Tests"
+        // (StefanMaron/BusinessCentral.AL.Language.Tests#320), the TestPage.Close() twin of
+        // codeunit 60663's OK-press arms (#315). Issue #3708.
+        //
+        // Order is parts THEN row here, as at every other close point, because a part's
+        // OnValidate can touch the header; the OK route is row-then-parts only because
+        // Invoke() has already written this page's own row (#3701).
+        //
+        // It runs before the refusal branches below on purpose: BC's send-then-close order does
+        // not depend on what the trigger answers, and the modal route already flushes ahead of
+        // its own raise (AttemptHandlerDrivenClose). No service tier has been asked what a
+        // refused close leaves behind on this route, and no test here asserts it either way.
+        //
+        // The modal route does not come through here at all -- it reaches Dispose() instead --
+        // and the two ROUTES nevertheless agree about an uncommitted subpage-part row, because
+        // both end in a flush: corpus codeunit 60420 "TPMF Tests"
+        // (StefanMaron/BusinessCentral.AL.Language.Tests#311, merged 22e226c4) drives one page
+        // through both routes and both persist the row, green on all eight cloud legs of run
+        // 34345468218. So neither call site may lose its flush; issue #3682.
+        FlushParts(); FlushRow();
+
         // Two ways BC refuses a close, and they are not the same question — see
         // RunnerPageInstance.CloseRefusal.
         if (_page != null && !_page.RaiseOnClosePage(_formResult, out var refusal))
@@ -696,7 +720,7 @@ internal partial class LiveNavTestPage
             // handler exactly once on this route, and the page is left OPEN.
             //
             // Returning here is the whole of that: the tear-down below is skipped, so _opened
-            // stays true, no row is flushed by the close, and BC's own form state is untouched
+            // stays true and BC's own form state is untouched
             // — the test's TestPage variable keeps working, which is what a real tier leaves it
             // holding. It is deliberately NOT a refusal any more; raising one here would be the
             // runner erroring on a path BC completes without an error (issue #3179).
@@ -713,14 +737,7 @@ internal partial class LiveNavTestPage
                 "testpage-close-veto — the page's OnQueryClosePage returned false, which in BC "
                 + "leaves the page open awaiting the user. See docs/scope.md");
         }
-        // The EXPLICIT close route's flush. The modal route does not come through here at all
-        // -- it reaches Dispose() instead (see there) -- and the two ROUTES nevertheless agree
-        // about an uncommitted subpage-part row, because both end in a flush. That agreement is
-        // real BC's, not a runner convention: corpus codeunit 60420 "TPMF Tests"
-        // (StefanMaron/BusinessCentral.AL.Language.Tests#311, merged 22e226c4) drives one page
-        // through both routes and both persist the row, green on all eight cloud legs of run
-        // 34345468218. So neither call site may lose its flush; issue #3682.
-        FlushParts(); FlushRow(); _opened = false;
+        _opened = false;
 
         // The triggers above are this page's close, so BC's own form state has to agree that
         // it happened — otherwise IsOpen stays true and whoever else is holding the form runs


### PR DESCRIPTION
Closes #3708

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/320

## The defect

`LiveNavTestPage.Close()` raised `OnQueryClosePage` and only afterwards ran
`FlushParts(); FlushRow();`. So on the explicit-close route

```al
Card.OpenEdit();
Card.Lines.New();
Card.Lines."Value".SetValue('Alpha');
Card.Close();
```

a host page that reads its ListPart in `OnQueryClosePage` saw the part one row short, and the
ordinary "materialise what the user entered when the page closes" shape saved nothing. This is
the same ordering #3709 fixed on the `[ModalPageHandler]` `OK().Invoke()` route, and unlike that
one it is **pre-existing** rather than a #3672 regression — which is why it was filed separately
and measured on its own before being changed.

The fix moves the existing `FlushParts(); FlushRow();` pair from after the trigger to directly
after the torn-down guard, keeping the parts-then-row order every other close point uses
(`Dispose()`, `SaveCurrentRow()`, the four cursor moves). The OK route is row-then-parts only
because `Invoke()` has already written that page's own row (the #3709 finding); the two orders
are not equivalent in general, because a part's `OnValidate` can touch the header, so the header
write has to come second wherever both are still pending. Nothing is written twice: the repeat
pass is a latched no-op — `FlushPendingNewRow` / `FlushPendingModify` clear their flag on entry.

The flush now runs ahead of the two refusal branches. That is BC's send-then-close order, which
does not depend on what the trigger answers, and it is what the modal route already does
(`AttemptHandlerDrivenClose` flushes before its own raise). Corpus codeunit 60602 "QCM Query
Close Msg Tests" — the suite that pins the refused-close route — asserts message delivery and
that the page stays open, and nothing about row state afterwards; no service tier has been asked
what a refused close leaves behind on this route, and this PR does not claim an answer.

## What real BC does — measured

The corpus arms were compiled and run against a real BC service tier (BC 28.4.53241.0 OnPrem
container, `Run-TestsInBcContainer`) before the corpus PR was opened:

```
  Codeunit 50495 Prb Close Part Flush Tests
    Testfunction CloseFlush_PartRowIsVisibleToQueryClosePage Success (2.603 seconds)
    Testfunction CloseFlush_NothingTypedLeavesThePartEmpty Success (0.083 seconds)
    Testfunction CloseFlush_EveryTypedPartRowIsVisibleInOrder Success (0.05 seconds)
```

A probe-only fourth arm reported what the platform passes the trigger on this route:
`CLOSEACTION >>>OK<<< COUNT >>>0<<<`. The upstream fixture records the close action in a field
but no arm asserts it — that is a separate question, and pinning a guess at it would make an
ordering arm red on an unrelated axis.

## RED → GREEN

Against corpus branch `agent/fbk-3/issue-3708` (corpus PR #320, head `5efc3a97`), resolved with
`tools/corpus-checkout.py --corpus-pr 320`:

| | before | after |
|---|---|---|
| corpus codeunit 60438 "Opc Close Part Flush Tests" | **1P / 2F** | **3P / 0F** |
| `AlRunner.Tests` `HandlerDrivenClosePartFlushOrderTests` (the 2 new `Close()` rows) | **1F** under sabotage (the old ordering restored) | **4P** |

Regression, all on this build and this corpus head:

| | result |
|---|---|
| corpus `--test QueryClosePage` (60276, 60296, 60438, 60602, 60663, 60677) | 18P / 0F |
| corpus `--test ModalPartFlush` (60420 "TPMF Tests", both close routes) | 8P / 0F |
| corpus `--test OkInvoke` (60338, 60663) | 5P / 0F |
| `tests/runner-extras/testpage-close-message-consumed` | 8P / 0F |
| `AlRunner.Tests` `~TestPageModalClosePartFlush\|~HandlerDrivenClosePartFlushOrder\|~TestPageRefusalClaim` | 93P / 0F |

## Where the proving test lives

The BC-behaviour claim is upstream: corpus codeunit 60438 "Opc Close Part Flush Tests"
(corpus PR #320), the `TestPage.Close()` twin of 60663's OK-press arms, with a negative control
that types nothing and a two-row arm so the count cannot be met by a fixed `1`. It reuses
#315's `Opf Line` / `Opf Lines Part` and adds its own head, witness and card objects; the new
card records **unconditionally**, because `Opf Outer Card` exits early unless the close action is
OK/LookupOK and an arm that never wrote its witness row could not tell "the part was empty" from
"the trigger did not run".

The runner-side test is a mechanism test, because the ordering is what the defect was and no
return value exposes it: `HandlerDrivenClosePartFlushOrderTests` gains two rows reading the IL of
`LiveNavTestPage.Close()` — `FlushParts` and `FlushRow` both precede `RaiseOnClosePage`,
`FlushParts` precedes `FlushRow`, and both sit after the torn-down guard. Sabotage-checked: with
the old ordering restored, `Close_FlushesPartsAndTheRow_BeforeItRaisesOnClosePage` fails and the
rest of the file stays green.

There is no pin to bump (#3737); the `Corpus-PR:` line above is what resolves the corpus at PR
#320's head for this PR's legs.

## Fix the shape, not the reported line

1. **Same wrong pattern at another call site?** No. `Close()` was the last close point raising a
   trigger ahead of its flush; `Dispose()` has no trigger, `SaveCurrentRow()` and the four cursor
   moves in `MockTestPage.LivePage.Navigation.cs` flush only, and `AttemptHandlerDrivenClose`
   was fixed by #3709.
2. **A sibling making the same assumption?** `Dispose()` is the sibling and it is already correct
   for a different reason — it raises nothing, so there is no ordering to get wrong. Its two
   calls are redundant for a part row and deliberately both kept (#3682,
   `TestPageModalClosePartFlushTests` holds them in place); this change does not touch them.
3. **Two paths writing the same state — same invariant?** Yes, and that is now true where it was
   not: both close paths raise through `RaiseOnClosePage`, and both now flush first. Corpus 60420
   "TPMF Tests" pins that the two routes agree about an uncommitted part row and stays green.

**Open-issue queue scan** for `MockTestPage` / `OnQueryClosePage` / `FlushParts`: nothing else
open lands in `MockTestPage.LivePage.WriteBuffer.cs`. The nearest neighbours are #3029 (a draft
row's `OnNewRecord` raised twice, in the parts/navigation path) and #3504 / #3518 (subform control
properties and `TableRelation` lookups) — different files, different shapes, nothing folded in.

## Where the prose went

One comment block over ten lines, at the moved call site in `Close()`: it states the claim, cites
corpus 60438 / #320 and the container measurement, gives the parts-then-row constraint a later
editor would otherwise get wrong, and keeps the existing #3682 note that neither call site may
lose its flush. The derivation and the measurement tables are here in the PR body.

---

Written by an agent (Claude, `fbk-3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kko97BZZL71nF2nK5aftu4
