### PR TITLE
fix(dependency-metadata): re-raise METADATA-EMIT-* through the loader, and name ReadSource as the seam

### DIFF
--- a/AlRunner.Tests/DependencyLoaderServiceTierFallbackTests.cs
+++ b/AlRunner.Tests/DependencyLoaderServiceTierFallbackTests.cs
@@ -80,4 +80,59 @@ public sealed class DependencyLoaderServiceTierFallbackTests
 
         Assert.True(result);
     }
+
+    // ---- #3749: the METADATA-* family must never be swallowed --------------------
+    //
+    // DependencyMetadataProducer (#3549) raises METADATA-EMIT-FAIL / METADATA-EMIT-ZERO /
+    // METADATA-SOURCE-UNREADABLE through DependencyLoadException, the same type this catch
+    // guard is written for. Its whole purpose is that a failed emit must never be downgraded
+    // to the hand-derivation, so the service-tier fallback -- which is about an app's CODE --
+    // must not answer for it: a service-tier DLL supplies procedure bodies, never BC's
+    // metadata documents, so deferring to it leaves the metadata question silently unanswered.
+
+    [Theory]
+    [InlineData("METADATA-EMIT-FAIL")]
+    [InlineData("METADATA-EMIT-ZERO")]
+    [InlineData("METADATA-SOURCE-UNREADABLE")]
+    public void MetadataStages_AreNeverSwallowed_EvenWithFullServiceTierCoverage(string stage)
+    {
+        // Every OTHER condition for swallowing is satisfied: Microsoft source-only, and the
+        // index covers this app's codeunit. Only the stage differs, so the stage is what the
+        // assertion is about.
+        Assert.False(DependencyLoader.IsServiceTierFallbackEligible(
+            stage,
+            serviceTierIndexAvailable: true,
+            codeunitTypeNames: new[] { "Codeunit130002" },
+            indexContains: _ => true));
+    }
+
+    [Theory]
+    [InlineData("EMIT-FAIL")]
+    [InlineData("EMIT-ZERO")]
+    [InlineData("COMPILE-FAIL")]
+    [InlineData("LOAD-FAIL")]
+    public void CodeStages_AreStillSwallowedWhenTheIndexCoversTheApp(string stage)
+    {
+        // The #2131 behaviour is unchanged: a CODE failure on an app the index really serves
+        // is a faithful deferral to real MS-compiled bodies. Narrowing the guard for the
+        // metadata family must not narrow it for these.
+        Assert.True(DependencyLoader.IsServiceTierFallbackEligible(
+            stage,
+            serviceTierIndexAvailable: true,
+            codeunitTypeNames: new[] { "Codeunit130002" },
+            indexContains: _ => true));
+    }
+
+    [Fact]
+    public void CodeStage_IsStillNotSwallowedWithoutCoverage()
+    {
+        // The Library Assert shape #2131 fixed, re-pinned through the new predicate so the
+        // stage check cannot accidentally re-open it.
+        Assert.False(DependencyLoader.IsServiceTierFallbackEligible(
+            "EMIT-ZERO",
+            serviceTierIndexAvailable: true,
+            codeunitTypeNames: new[] { "Codeunit130002" },
+            indexContains: _ => false));
+    }
+
 }

--- a/AlRunner.Tests/DependencyMetadataProducerTests.cs
+++ b/AlRunner.Tests/DependencyMetadataProducerTests.cs
@@ -14,7 +14,12 @@
 //   The availability-vs-failure split (`.claude/rules/loud-failures.md`) is the property this
 //   whole class exists to protect: a dependency with no source must be a quiet 0, and a
 //   dependency whose compile failed must throw. Those two answers must never be spelled the
-//   same way, which is what LoudFailure_And_NoSource_AreDifferentAnswers asserts structurally.
+//   same way, which NoSource_ReturnsZero_WhileFailedEmit_Throws asserts by DRIVING both arms.
+//
+//   That test used to assert over reflection metadata -- that Ensure returns int and Loud
+//   returns an exception type -- and #3749 found it would still have passed if Ensure swallowed
+//   its own throw, which is the one defect it was named for. A null compiler is what makes the
+//   emit fail without a BC runtime, so the conversion under test runs for real.
 
 using System;
 using System.IO;
@@ -130,45 +135,90 @@ public sealed class DependencyMetadataProducerTests
     // ---- availability vs failure ---------------------------------------------------
 
     /// <summary>
-    /// A package with no readable source answers "nothing to produce" (false) rather than
-    /// throwing, and it answers that from the PACKAGE — before any compile — which is what
-    /// keeps "unavailable" from ever being inferred from a failure. #3590 is why that ordering
-    /// is load-bearing: a construction failure that reached the consumer would be
-    /// indistinguishable from a document that was never produced.
+    /// A package the reader cannot open at all is a LOUD failure, not an absence.
+    /// <c>ReadSource</c> is the seam that separates the two (#3748): it lets
+    /// <c>ExtractAlWithPaths</c>'s empty list mean "symbol-only, nothing to produce" and turns
+    /// a read that THREW into <c>METADATA-SOURCE-UNREADABLE</c>. Asserted by driving
+    /// <c>Ensure</c> for real, so it fails if the throw is ever softened to a sentinel return.
     /// </summary>
     [Fact]
-    public void HasCompilableSource_IsFalseForAnUnreadablePackage_AndDoesNotThrow()
+    public void UnreadablePackage_ThrowsSourceUnreadable_RatherThanReturningZero()
     {
-        var missing = Path.Combine(Path.GetTempPath(), $"no-such-package-{Guid.NewGuid():N}.app");
-        Assert.False(DependencyMetadataProducer.HasCompilableSource(missing));
-
-        // An owned scratch file: this one IS created, so a killed test host would leak it
-        // (#2743). TestScratch.FilePath creates the owning directory, which is what the
-        // sweep deletes -- so no hand-rolled finally is needed to avoid leaking it.
         var notAnApp = TestScratch.FilePath("dep-metadata-producer", "garbage.app");
         File.WriteAllText(notAnApp, "this is not a NAVX package");
-        Assert.False(DependencyMetadataProducer.HasCompilableSource(notAnApp));
+
+        var ex = Assert.Throws<AlRunner.Infrastructure.DependencyLoadException>(
+            () => DependencyMetadataProducer.Ensure(
+                Manifest("Business Foundation"), notAnApp, compiler: null!));
+
+        Assert.Equal("METADATA-SOURCE-UNREADABLE", ex.Stage);
+        Assert.Equal("Business Foundation", ex.AppName);
     }
 
     /// <summary>
-    /// The two outcomes are structurally different — one returns, one throws — so no caller can
-    /// treat a failed compile as an absent document by reading a return value. Asserted on the
-    /// declared signature rather than by running a compile, so it holds without a BC runtime and
-    /// fails loudly if someone converts the throw into a sentinel return.
+    /// The two answers are observably different when the code actually RUNS, which is the
+    /// property #3749 found the previous version of this test could not make: it asserted that
+    /// <c>Ensure</c> returns <c>int</c> and that <c>Loud</c> returns an exception type, both of
+    /// which stay true if <c>Ensure</c> swallows its own throw.
+    ///
+    /// <para>So both arms are driven here. A package that ships NO AL source returns 0 — the
+    /// ordinary symbol-only case. A package that DOES ship source and whose emit fails throws
+    /// <c>METADATA-EMIT-FAIL</c>. A `null` compiler is what makes the emit fail without a BC
+    /// runtime: <c>Ensure</c> catches whatever the emit raises and restates it as that stage,
+    /// which is exactly the conversion under test.</para>
     /// </summary>
     [Fact]
-    public void LoudFailure_And_NoSource_AreDifferentAnswers()
+    public void NoSource_ReturnsZero_WhileFailedEmit_Throws()
     {
-        var ensure = typeof(DependencyMetadataProducer)
-            .GetMethod("Ensure", BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Public);
-        Assert.NotNull(ensure);
-        // "How many documents are available" — never a status code with a failure value in it.
-        Assert.Equal(typeof(int), ensure!.ReturnType);
+        // Arm 1 — source-less package: a quiet 0, no throw.
+        var symbolOnly = WritePackage("no-source", ("SymbolReference.json", "{}"));
+        Assert.Equal(0, DependencyMetadataProducer.Ensure(
+            Manifest("Business Foundation"), symbolOnly, compiler: null!));
 
-        var loud = typeof(DependencyMetadataProducer)
-            .GetMethod("Loud", BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(loud);
-        Assert.Equal(typeof(AlRunner.Infrastructure.DependencyLoadException), loud!.ReturnType);
+        // Arm 2 — the SAME call shape on a package that ships source: throws instead.
+        var withSource = WritePackage("with-source",
+            ("src/Thing.Table.al", "table 50000 Thing { fields { field(1; A; Integer) { } } }"));
+
+        var ex = Assert.Throws<AlRunner.Infrastructure.DependencyLoadException>(
+            () => DependencyMetadataProducer.Ensure(
+                Manifest("Business Foundation"), withSource, compiler: null!));
+
+        Assert.Equal("METADATA-EMIT-FAIL", ex.Stage);
+
+        // The distinction is the point: absence returned a value, failure did not.
+        Assert.NotEqual("METADATA-SOURCE-UNREADABLE", ex.Stage);
+    }
+
+    // ---- NAVX package fixtures -----------------------------------------------------
+
+    private static byte[] Navx(byte[] zipBytes)
+    {
+        var result = new byte[8 + zipBytes.Length];
+        result[0] = (byte)'N'; result[1] = (byte)'A'; result[2] = (byte)'V'; result[3] = (byte)'X';
+        BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
+        zipBytes.CopyTo(result, 8);
+        return result;
+    }
+
+    private static byte[] ZipWith(params (string Name, string Content)[] entries)
+    {
+        using var ms = new MemoryStream();
+        using (var zip = new System.IO.Compression.ZipArchive(
+            ms, System.IO.Compression.ZipArchiveMode.Create, leaveOpen: true))
+            foreach (var (name, content) in entries)
+            {
+                var e = zip.CreateEntry(name);
+                using var s = e.Open();
+                s.Write(System.Text.Encoding.UTF8.GetBytes(content));
+            }
+        return ms.ToArray();
+    }
+
+    private static string WritePackage(string suffix, params (string Name, string Content)[] entries)
+    {
+        var path = TestScratch.FilePath("dep-metadata-producer", $"pkg-{suffix}.app");
+        File.WriteAllBytes(path, Navx(ZipWith(entries)));
+        return path;
     }
 
     private sealed class EnvVar : IDisposable

--- a/AlRunner.Tests/ScratchDirOwnershipGuardTests.cs
+++ b/AlRunner.Tests/ScratchDirOwnershipGuardTests.cs
@@ -68,10 +68,10 @@ public sealed class ScratchDirOwnershipGuardTests
         ["AppLoaderR2rChunkCacheTests.cs"] =
             (1, "a .app path that must not exist"),
         ["DependencyMetadataProducerTests.cs"] =
-            (2, "two .app paths that must not exist -- one proves an excluded app is never "
-              + "read, one drives HasCompilableSource's miss path; both assert on the absence "
-              + "itself, so creating them would destroy what they measure. This file's one "
-              + "real scratch file IS owned via TestScratch.FilePath"),
+            (1, "one .app path that must not exist, proving an excluded app is never read; it "
+              + "asserts on the absence itself, so creating it would destroy what it measures. "
+              + "Was 2 until #3748 deleted HasCompilableSource, whose miss path was the other. "
+              + "This file's real scratch packages ARE owned via TestScratch.FilePath"),
         ["RunnerFingerprintTests.cs"] =
             (1, "a .dll path that must not exist"),
         ["TestDataProvisioningTests.cs"] =

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -278,7 +278,13 @@ public sealed class DependencyLoader
             // `catch (DependencyLoadException ex)` handler, which aborts the WHOLE run with
             // one loud "FATAL: dependency compile failed — cannot continue. {ex.Message}"
             // line naming the dependency + stage — see .claude/rules/loud-failures.md.
-            catch (AlRunner.Infrastructure.DependencyLoadException) when (microsoftSourceOnly && HasServiceTierDllFallback(path))
+            // #3749: the METADATA-* family is never swallowed — why, on
+            // IsServiceTierFallbackEligible. The trap is that those throws are not visible from
+            // this line: EnsureDependencyMetadata runs at the TOP of LoadOne, inside this try.
+            catch (AlRunner.Infrastructure.DependencyLoadException ex) when (
+                microsoftSourceOnly
+                && !IsMetadataStage(ex.Stage)
+                && HasServiceTierDllFallback(path))
             {
                 Console.Error.WriteLine(
                     $"[deps] Microsoft source-only {m.Publisher}_{m.Name} v{m.Version}: Tier-3 compile " +
@@ -1029,6 +1035,29 @@ public sealed class DependencyLoader
             if (indexContains(name)) return true;
         return false;
     }
+
+    /// <summary>
+    /// Whether LoadAll's catch may swallow this <see cref="Infrastructure.DependencyLoadException"/>
+    /// and defer to service-tier DLL dispatch. The extracted DLLs supply procedure bodies, so
+    /// they can answer for a CODE failure but not for the METADATA-* family
+    /// (<see cref="DependencyMetadataProducer"/>, #3549) — deferring there would silently leave
+    /// the app's tables on the hand-derivation (#3749, loud-failures.md).
+    /// </summary>
+    internal static bool IsServiceTierFallbackEligible(
+        string stage,
+        bool serviceTierIndexAvailable,
+        IReadOnlyCollection<string> codeunitTypeNames,
+        Func<string, bool> indexContains)
+        => !IsMetadataStage(stage)
+           && HasFaithfulServiceTierFallback(serviceTierIndexAvailable, codeunitTypeNames, indexContains);
+
+    /// <summary>
+    /// True for the stages <see cref="DependencyMetadataProducer"/> raises. Matched on the
+    /// prefix rather than a fixed set, so a stage added there is loud by default: a new
+    /// METADATA-* name nobody listed here would otherwise become swallowable the day it lands.
+    /// </summary>
+    internal static bool IsMetadataStage(string stage)
+        => stage != null && stage.StartsWith("METADATA-", StringComparison.Ordinal);
 
     /// <summary>Real-state wrapper around <see cref="HasFaithfulServiceTierFallback"/> —
     /// extracts this app's own codeunit names and asks the actual ServiceTierDllIndex.

--- a/AlRunner/DependencyMetadataProducer.cs
+++ b/AlRunner/DependencyMetadataProducer.cs
@@ -29,9 +29,13 @@
 //                                    is the silent-default shape .claude/rules/loud-failures.md
 //                                    exists to prevent, so it throws.
 //
-//   The seam that separates them is HasCompilableSource: it is answered from the package
-//   BEFORE any compile is attempted, so "unavailable" is never inferred from a failure.
-//   #3590 is why that ordering is load-bearing rather than stylistic — BuildNCLMetaTable
+//   The seam that separates them is ReadSource, and it separates them by ANSWER SHAPE rather
+//   than by ordering: an empty list means the package ships no source, and a package that
+//   could not be read THROWS (METADATA-SOURCE-UNREADABLE) instead of returning empty. So an
+//   unreadable package can never enter through the "absence" door — which is the property
+//   that matters, and the one a boolean precondition answered before the compile could not
+//   give, because a boolean has no way to say "I could not tell" (guards-need-a-third-state.md).
+//   #3590 is why that distinction is load-bearing rather than stylistic — BuildNCLMetaTable
 //   swallows a construction failure into a cached null with its log line filtered out by
 //   default, so a failure that reached the consumer would be indistinguishable from absence.
 //
@@ -77,18 +81,6 @@ internal static class DependencyMetadataProducer
     /// </summary>
     private static readonly HashSet<string> NeverCompile =
         new(StringComparer.OrdinalIgnoreCase) { "Base Application" };
-
-    /// <summary>
-    /// True when this package carries AL source a compile could consume. Answered from the
-    /// package alone, BEFORE any compile — that is what lets a caller tell "nothing to
-    /// produce" apart from "the compile failed", which the header explains is the one
-    /// distinction this class must never blur.
-    /// </summary>
-    internal static bool HasCompilableSource(string appPath)
-    {
-        try { return AppLoader.ExtractAlWithPaths(appPath).Count > 0; }
-        catch { return false; }
-    }
 
     internal static bool IsExcluded(AppManifest m) => NeverCompile.Contains(m.Name);
 
@@ -268,6 +260,12 @@ internal static class DependencyMetadataProducer
         catch { return empty; }
     }
 
+    /// <summary>
+    /// The seam between "nothing to produce" and "the compile failed" (#3748). An empty list
+    /// means the package ships no AL source — the ordinary symbol-only case, which Ensure
+    /// turns into a quiet 0. A package that cannot be READ throws instead, so an unreadable
+    /// package never reaches the caller as an absence.
+    /// </summary>
     private static IReadOnlyList<(string Path, string Source)> ReadSource(AppManifest m, string appPath)
     {
         try { return AppLoader.ExtractAlWithPaths(appPath); }

--- a/docs/dependency-metadata-from-bc.md
+++ b/docs/dependency-metadata-from-bc.md
@@ -84,9 +84,12 @@ failure modes and they must never be spelled the same way:
 | the package ships no source | return 0. The consumer's availability gate finds no document and keeps the derivation — the ordinary state of every symbol-only package (#3533, #3545). |
 | the package ships source and the compile or emit failed | **throw** `DependencyLoadException`. |
 
-`DependencyMetadataProducer.HasCompilableSource` answers the first question **from the package,
-before any compile is attempted**, which is what keeps "unavailable" from ever being inferred
-from a failure. #3590 is why that ordering is load-bearing rather than stylistic:
+`DependencyMetadataProducer.ReadSource` is the seam, and it separates the two by **answer
+shape**: an empty list means the package ships no AL source, while a package that cannot be
+read **throws** `METADATA-SOURCE-UNREADABLE` rather than returning empty. That is what keeps
+"unavailable" from ever being inferred from a failure — an unreadable package cannot enter
+through the absence door at all. #3590 is why that distinction is load-bearing rather than
+stylistic:
 `BuildNCLMetaTable` swallows a construction failure into a cached null with its log line
 filtered out by default, so a failure that reached the consumer would be indistinguishable from
 a document that was never produced.


### PR DESCRIPTION
Closes #3749
Closes #3748

*Filed by an agent (`stma-auto-3`).*

> **Stacked on #3743.** Every file both issues name exists only on that branch — `main` has no
> `DependencyMetadataProducer.cs`, no `DependencyMetadataProducerTests.cs` and no
> `docs/dependency-metadata-from-bc.md`. So this PR is based on `agent/stma-auto-2/issue-3549`,
> not `main`, and shows a **6-file, +187/-52** diff. **Merge #3743 first**, then retarget this to
> `main` — the coordinator does the retarget, not me.
>
> Rebased onto the new base head `fdccf48a` after #3743 was itself rebased to pick up the #3770
> fix (`c76e3f9f`). `git merge-tree` now reports **CLEAN against both the base and `main`**.
> **This PR has never run CI** — the gating workflows are `pull_request: branches: [main]`, so a
> stacked PR silences them while still reading `mergeStateStatus: CLEAN` (#3775). The local runs
> below are the only evidence that exists for this diff.

## 1. `METADATA-*` was swallowable — and the issue understated it (#3749 part 1)

`DependencyLoader.LoadAll`'s catch defers a Microsoft source-only dependency's Tier-3 failure to
service-tier DLL dispatch when the extracted index covers that app's codeunits (#2131). It caught
`DependencyLoadException` **without looking at the stage**, so the `METADATA-EMIT-FAIL` /
`METADATA-EMIT-ZERO` / `METADATA-SOURCE-UNREADABLE` family raised by `DependencyMetadataProducer`
matched it too.

**The issue says this is unreachable today because "only `System.app` qualifies and it `continue`s
at :250". That is not correct, and the correction is the substantive finding here.** The reachability
chain, read off the code:

- `EnsureDependencyMetadata` is called at the **top of `LoadOne`** — which runs **inside the `try`**.
  So a `METADATA-*` throw genuinely arrives at this frame.
- `AL_RUNNER_DEP_METADATA_FROM_BC=1` returns an **empty filter, meaning every app**, not just System
  (`DependencyMetadataAppFilter`). A named list selects any app the operator names.
- The two `continue`s above exclude only System Application / Base Application / Business Foundation
  (`IsKnownPlatformRuntimeApp`) and the platform `System` app (`IsPlatformSymbolOnlySystemApp`).
- `HasServiceTierDllFallback` calls `ExtractAl`, so it is true only for apps that **ship AL source** —
  exactly the apps whose `ReadSource(...).Count > 0` makes a metadata emit failure a real
  `METADATA-EMIT-FAIL`.

What remains is **any Microsoft non-R2R app that is not one of those four and whose codeunits the
index covers** — precisely "case (a), a platform-runtime app not yet in `KnownPlatformRuntimeApps`",
which the loader's own comment at :270 describes as a live case it deliberately handles. So the
swallow is reachable behind the feature flag, not latent.

**Fix:** the guard now asks `IsMetadataStage(ex.Stage)` first. A service-tier DLL supplies procedure
bodies, never metadata documents, so it cannot stand in for the answer that failed — swallowing one
would leave the app's tables on the SymbolReference hand-derivation under a green run, the exact
downgrade `#3549`'s loud path exists to prevent. Matched on the `METADATA-` **prefix**, so a stage
added to the producer later is loud by default rather than silently swallowable the day it lands
(`guards-need-a-third-state.md`).

**RED → GREEN.** `MetadataStages_AreNeverSwallowed_EvenWithFullServiceTierCoverage` failed on all
three stages against the pre-fix guard, reproduced through a stand-in that replicated it:

```
Failed ...MetadataStages_AreNeverSwallowed(stage: "METADATA-SOURCE-UNREADABLE")  Assert.False() Failure
Failed ...MetadataStages_AreNeverSwallowed(stage: "METADATA-EMIT-ZERO")          Assert.False() Failure
Failed ...MetadataStages_AreNeverSwallowed(stage: "METADATA-EMIT-FAIL")          Assert.False() Failure
Failed!  - Failed: 3, Passed: 21
```

Every other condition for swallowing is satisfied in that test (index available, coverage true), so
**the stage is the only variable** — the assertion cannot pass for an unrelated reason.
`CodeStages_AreStillSwallowedWhenTheIndexCoversTheApp` pins the four code stages still swallowing,
and `CodeStage_IsStillNotSwallowedWithoutCoverage` re-pins the #2131 Library Assert shape, so the
narrowing is proven not to have widened or re-opened anything.

## 2. The loudness test proved nothing — verified by mutation (#3749 part 2)

`LoudFailure_And_NoSource_AreDifferentAnswers` asserted that `Ensure` returns `int` and that `Loud`
returns `DependencyLoadException` — both still true if `Ensure` swallowed its own throw.

Replaced with `NoSource_ReturnsZero_WhileFailedEmit_Throws`, which drives both arms for real: a
package shipping **no** AL source returns `0`; the **same call shape** on a package that ships source
throws `METADATA-EMIT-FAIL`. A `null` compiler is what makes the emit fail without a BC runtime, so
the catch-and-restate conversion actually executes.

**I confirmed the new test is not itself noise by mutating in the exact defect it is named for** —
`Ensure` swallowing its own throw and returning `0`:

```
Failed AlRunner.Tests.DependencyMetadataProducerTests.NoSource_ReturnsZero_WhileFailedEmit_Throws
Failed!  - Failed: 1, Passed: 11
```

The old reflection version stayed green through that same mutation. The mutation was reverted;
`git diff` against the pre-mutation copy is empty.

`UnreadablePackage_ThrowsSourceUnreadable_RatherThanReturningZero` additionally pins the third stage
by `ex.Stage`, which no existing test covered.

## 3. `HasCompilableSource` deleted; `ReadSource` named as the seam (#3748)

**I verified the "no production caller" claim independently** before acting on it, enumerating every
`.cs` file on #3743's head: 2 occurrences in its own definition, 3 in its tests, 1 incidental mention
in `ScratchDirOwnershipGuardTests`. Zero production callers — the issue is right.

**And I tested its reasoning rather than accepting it.** Option (2) is correct, and for a sharper
reason than the issue gives: the two methods differ in **answer shape**, not merely in ordering.
`ReadSource` returns an empty list for "ships no source" and **throws** `METADATA-SOURCE-UNREADABLE`
for "could not be read". A `bool` precondition cannot express that third state at all — an unreadable
package and a source-less one both answer `false`, which is exactly the conflation the class header
says it must never make (`guards-need-a-third-state.md`). So the deleted method could not have been
the seam even if it had been wired; option (1) was never viable.

Deleted, with the class header and `docs/dependency-metadata-from-bc.md` corrected to name
`ReadSource` and to state the answer-shape distinction, plus a doc comment at `ReadSource` itself so
the claim sits where the next edit happens.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** I checked every `catch (DependencyLoadException)` in
   the loader. This is the only one that swallows; the `EnsureDependencyMetadata` site is already
   documented as deliberately not catching, and `Program.cs`'s handler aborts the run rather than
   continuing. Nothing else to fix.
2. **Sibling function with the same assumption?** `HasFaithfulServiceTierFallback` is the sibling and
   is left intact — it answers a genuine question about code coverage. The stage check is composed
   *around* it in `IsServiceTierFallbackEligible` rather than folded into it, so the #2131 predicate
   keeps its own meaning and its four existing tests keep testing it.
3. **Two paths writing one invariant?** Yes, and this is the defect: the metadata route and the code
   route both raise `DependencyLoadException`, and only the code route had a fallback that could
   honestly answer for it. The prefix match is what keeps the invariant maintained by both as the
   producer grows new stages.

**Queue scan.** Searched the open queue for `HasCompilableSource`, `METADATA-EMIT`, `DependencyLoader`
and `DependencyMetadataProducer`; found nothing beyond #3749 and #3748 themselves. #3590 is related
but distinct — it is the `BuildNCLMetaTable` swallow one layer up and is not fixed here.

## Corpus linkage

Corpus-NA: runner-internal error propagation only; no AL-observable behavior changes, because every path this touches ends in a run that aborts rather than in a value AL reads

Tested rather than asserted: `check_corpus_linkage.sh` over this diff reports "No file in this diff
can change what AL observes, so no corpus declaration is required." The reason it holds substantively
is that the *only* behavior change is which failures reach `Program.cs`'s abort handler. A swallowed
`METADATA-*` previously left the run continuing with weaker metadata; it now aborts. AL never observes
the difference, because in the aborting case no AL runs at all. Nothing here changes a value AL can
read, so there is no claim for a service tier to adjudicate.

## What I did not do

- **Left the #3590 swallow alone.** It is the pre-existing one layer up, separately tracked, and its
  fix lands in `BuildNCLMetaTable` rather than in this file cluster.
- **Left #3743's branch to its own owner.** The coordinator rebased it onto `main` to pick up
  #3770; I rebased on top of the result rather than touching it myself.

## Review follow-up

Trimmed the comment prose per `loud-failures.md` § "The justification is a claim plus a citation,
not the derivation behind it": the 9-line block at the catch site is now 3 lines (the claim, plus
the trap that the `METADATA-*` throws enter from `EnsureDependencyMetadata` at the top of `LoadOne`,
inside this `try` — not visible from that line), and `IsServiceTierFallbackEligible`'s doc comment
went from 13 lines to 7. `AlRunner/` comment lines dropped **40 → 28** against 15 code lines.

## Testing

- `DependencyLoaderServiceTierFallbackTests`, `DependencyMetadataProducerTests`,
  `ScratchDirOwnershipGuardTests` — **27 passed, 0 failed**.
- Wider filter over `DependencyLoader`, `DependencyMetadata`, `ProvisioningCheck`,
  `ScratchDirOwnershipGuardTests` — **157 passed, 0 failed**, re-run after the rebase onto
  `fdccf48a` (three more than before the rebase, because the new base carries the #3770 fix).
- `ScratchDirOwnershipGuardTests` allowlist count for `DependencyMetadataProducerTests.cs` moved
  **2 → 1** (deleting `HasCompilableSource` removed one must-not-exist path); the guard pins the count
  exactly in both directions, and it passes. The two new packages are owned via `TestScratch.FilePath`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
