### PR TITLE
fix(metadata): make a BuildNCLMetaTable construction failure attributable

### DIFF
--- a/AlRunner.Tests/BuildNclMetaTableFailureAttributionTests.cs
+++ b/AlRunner.Tests/BuildNclMetaTableFailureAttributionTests.cs
@@ -1,0 +1,264 @@
+// BuildNclMetaTableFailureAttributionTests — issue #3590.
+//
+// WHAT IS BEING PROVED
+//   RecordPatches.BuildNCLMetaTable wrapped its whole body in `catch (Exception) { ...; return
+//   null; }`, and its caller is `_metaTableCache.GetOrAdd(tableId, BuildNCLMetaTable)`. So a
+//   failure to CONSTRUCT a table's metadata became the same answer as "this table does not
+//   exist", the null was CACHED, and every later consumer took its own not-found branch:
+//   NavRecordHandle_CreateTarget's not-found path, TryBuildBlankRecord's `why` string,
+//   GetMetaFieldEditable answering `true`. None of them names the table or the reason.
+//
+// THE DECISION THIS FILE PINS, AND WHY IT IS NOT "RETHROW EVERYTHING"
+//   `.claude/rules/guards-need-a-third-state.md` states the constraint that decides this: a
+//   genuinely ABSENT thing must stay a pass; only an UNMEASURABLE one becomes the third state.
+//   A blanket rethrow would trade a false green for a false red, because every caller listed
+//   above legitimately asks about tables that cannot exist.
+//
+//   The method's own structure already draws that line, and it draws it OUTSIDE the try:
+//
+//     _parsedTables miss + TryPopulateParsedTableFromBcApps miss   -> return null   (absent)
+//     _tMetaTable / _mCreateFromMetaTable not resolved             -> return null   (absent)
+//     ------------------------------- try starts here -------------------------------
+//     anything that throws while BUILDING a table we know exists   -> was ALSO null (the bug)
+//
+//   So the catch never sees the absent case at all. Everything reaching it is a failure to
+//   measure something the runner had already established was there — row 3, spelled as row 1.
+//
+// WHY A FILTER AND NOT A BARE RETHROW OF EVERYTHING
+//   Two refusal types are raised deliberately from inside that try and are the ones whose whole
+//   purpose is to name what could not be read: BcShapeGapException (a BC member moved) and
+//   BcAppSymbolReadException (a dependency's symbols could not be read to completion). Both
+//   tear through AL's two trapping seams BY CONTRACT — see BcShapeGapException.cs's table —
+//   and this catch was a THIRD seam nobody enumerated, which turned them back into a null.
+//
+//   The same file already settled this exact shape one method over: WireFieldTriggerHandlers'
+//   catch carries a `when (BcShapeGapException.Find(ex) is null && ...)` filter for #3026 and
+//   #3048, with the reasoning that without it "this catch converts every refusal raised above
+//   into a stderr line plus the same not-installed outcome the refusals exist to stop". This is
+//   that precedent applied to its neighbour, not a new mechanism.
+//
+// THE NEGATIVE CONTROLS ARE THE POINT, NOT DECORATION
+//   "A construction failure is attributable" is satisfiable by a change that rethrows
+//   everything, which is the false-red trap above. Section 2 pins what must STILL be swallowed
+//   into a null, and section 3 pins that the two absent paths never reach the catch at all.
+//
+// WHY RUNNER-LOCAL AND NOT THE CORPUS
+//   No AL statement can make a BC member move or corrupt a .app's symbols, so a service tier
+//   has nothing to adjudicate: the subject is which exceptions the runner's own catch may
+//   absorb. Same reasoning as PageControlFieldEditableShapeGapTests and BcShapeGapConventionTests.
+using System;
+using System.Linq;
+using System.Reflection;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class BuildNclMetaTableFailureAttributionTests
+{
+    // The classification the catch applies, driven directly. Returning false means "this catch
+    // may not absorb it" — the exception carries on to the caller.
+    private static bool MayAbsorb(Exception ex)
+    {
+        var m = typeof(RecordPatches).GetMethod(
+            "BuildNclMetaTableCatchMayAbsorb",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(m);
+        return (bool)m!.Invoke(null, new object?[] { ex })!;
+    }
+
+    // ══ 1. WHAT MUST TEAR THROUGH ════════════════════════════════════════════════════════
+    //
+    // Each arm names one refusal type whose entire purpose is to say what could not be read.
+    // Absorbing one here re-creates the silent default it was raised to replace.
+
+    [Fact]
+    public void AShapeGap_IsNotAbsorbed_SoTheMemberThatMovedReachesTheDeveloper()
+    {
+        var gap = new BcShapeGapException(
+            "Table metadata (table 50100)", "MetaTable.Fields", "field not found — BC moved it");
+
+        Assert.False(MayAbsorb(gap));
+    }
+
+    [Fact]
+    public void AShapeGapArrivingWrapped_IsNotAbsorbed_BecauseTheBuilderCallsBcThroughReflection()
+    {
+        // Every construction step in the builder goes through MethodBase.Invoke or a reflective
+        // ctor, so a refusal raised underneath arrives inside a TargetInvocationException. An
+        // `is` test would miss it — the same reason BcShapeGapException.Find is a chain walk.
+        var wrapped = new TargetInvocationException(
+            new BcShapeGapException("Table metadata (table 50100)", "MetaTable.Fields", "moved"));
+
+        Assert.False(MayAbsorb(wrapped));
+    }
+
+    [Fact]
+    public void ASymbolReadRefusal_IsNotAbsorbed_BecauseACorruptDependencyIsNotAMissingTable()
+    {
+        var read = new BcAppSymbolReadException(
+            "/tmp/Some.app", "table symbols", new OutOfMemoryException("truncated"));
+
+        Assert.False(MayAbsorb(read));
+    }
+
+    [Fact]
+    public void ASymbolReadRefusalArrivingWrapped_IsNotAbsorbed_ForTheSameReason()
+    {
+        var wrapped = new TargetInvocationException(
+            new BcAppSymbolReadException("/tmp/Some.app", "table extensions",
+                new OutOfMemoryException("truncated")));
+
+        Assert.False(MayAbsorb(wrapped));
+    }
+
+    [Fact]
+    public void ATypedOutOfScopeRefusal_IsNotAbsorbed_MatchingTheNeighbouringCatchsContract()
+    {
+        // WireFieldTriggerHandlers' catch in this same file was widened to the TYPED
+        // RunnerOutOfScopeException by #3048, on the argument that swallowing one "would restore
+        // precisely the silent skip they replace". The same argument applies here.
+        var oos = new RunnerOutOfScopeException(
+            "NCLMetaTable construction", "not-yet-implemented — see docs/scope.md");
+
+        Assert.False(MayAbsorb(oos));
+    }
+
+    // ══ 2. WHAT MUST STILL BE ABSORBED ═══════════════════════════════════════════════════
+    //
+    // Without these, the change is a blanket rethrow: every caller that legitimately asks about
+    // a table that cannot exist would start failing the run instead of taking its not-found
+    // branch. That is the false-red half of guards-need-a-third-state.md's constraint.
+
+    [Fact]
+    public void AnOrdinaryConstructionFailure_IsStillAbsorbed_SoNoCallerLosesItsNotFoundBranch()
+    {
+        Assert.True(MayAbsorb(new InvalidOperationException("ctor arity changed")));
+        Assert.True(MayAbsorb(new NullReferenceException()));
+        Assert.True(MayAbsorb(new TargetInvocationException(new ArgumentException("bad arg"))));
+    }
+
+    [Fact]
+    public void AnUntypedOutOfScopeLookalike_IsStillAbsorbed_BecauseItIsNotOneOfOurs()
+    {
+        // A BC exception whose MESSAGE merely happens to carry the out-of-scope convention is
+        // not a runner refusal. #3048 drew this line explicitly for the neighbouring catch:
+        // "Typed only".
+        var lookalike = new InvalidOperationException(
+            OutOfScopeMessage.Prefix + "something that only looks like ours");
+
+        Assert.True(MayAbsorb(lookalike));
+    }
+
+    // ══ 3. THE ABSENT CASES NEVER REACH THE CATCH ════════════════════════════════════════
+    //
+    // The claim that makes section 1 safe. If either early return sat inside the try, section
+    // 1 would be converting "no such table" into a hard failure.
+
+    [Fact]
+    public void TheTwoAbsentReturns_SitOutsideTheTry_SoNoMissingTableCanReachTheFilter()
+    {
+        var body = typeof(RecordPatches)
+            .GetMethod("BuildNCLMetaTable", BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetMethodBody()!;
+
+        // An exception handler's try block is a byte range in the method body. Both early
+        // returns must lie before every handler's try offset.
+        var firstTryOffset = body.ExceptionHandlingClauses
+            .Select(c => c.TryOffset)
+            .DefaultIfEmpty(int.MaxValue)
+            .Min();
+
+        Assert.NotEqual(int.MaxValue, firstTryOffset);
+
+        // The IL before the first try must contain the two early-return paths, i.e. at least
+        // one `ret` — a method whose try starts at offset 0 has folded them in.
+        var il = body.GetILAsByteArray()!;
+        Assert.True(firstTryOffset > 0,
+            "BuildNCLMetaTable's try must start after the absent-table early returns; a try at "
+            + "offset 0 means a missing table now reaches the catch filter.");
+        Assert.Contains((byte)0x2A /* ret */, il.Take(firstTryOffset).ToArray());
+    }
+
+    // ══ 4. THE FAILURE IS VISIBLE AT DEFAULT VERBOSITY ═══════════════════════════════════
+    //
+    // The second half of #3590. The old write was `[RecordPatches] ...`, and Log.FilteredWriter
+    // drops a line starting with a bracketed component tag unless --verbose. An invisible
+    // diagnostic is the same defect in a new place, so the message the developer is meant to
+    // read must not start with one. BcAppSymbolReadException.BuildMessage carries the same
+    // constraint as a comment for the same reason.
+
+    [Fact]
+    public void TheRethrownRefusalsMessage_DoesNotStartWithAComponentTag_SoTheFilterCannotDropIt()
+    {
+        var gap = new BcShapeGapException(
+            "Table metadata (table 50100)", "MetaTable.Fields", "field not found");
+
+        Assert.False(gap.Message.StartsWith("[", StringComparison.Ordinal));
+        Assert.StartsWith(BcShapeGapException.Prefix, gap.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheAbsorbedFailuresLogLine_NamesTheTableAndTheCause_AndSurvivesTheDefaultFilter()
+    {
+        var m = typeof(RecordPatches).GetMethod(
+            "BuildNclMetaTableFailureLine", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(m);
+
+        var line = (string)m!.Invoke(null, new object?[]
+        {
+            50100, new InvalidOperationException("ctor arity changed"),
+        })!;
+
+        // Names the table, the exception type and the message — the three things the old
+        // several-layers-later NRE could not name.
+        Assert.Contains("50100", line, StringComparison.Ordinal);
+        Assert.Contains(nameof(InvalidOperationException), line, StringComparison.Ordinal);
+        Assert.Contains("ctor arity changed", line, StringComparison.Ordinal);
+
+        // And it is not dropped at default verbosity.
+        Assert.False(line.StartsWith("[", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void TheFailureLine_UnwrapsAReflectionWrapper_SoTheCauseIsNamedRatherThanTheWrapper()
+    {
+        var m = typeof(RecordPatches).GetMethod(
+            "BuildNclMetaTableFailureLine", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        var line = (string)m.Invoke(null, new object?[]
+        {
+            50100, new TargetInvocationException(new ArgumentException("bad field id")),
+        })!;
+
+        Assert.Contains(nameof(ArgumentException), line, StringComparison.Ordinal);
+        Assert.Contains("bad field id", line, StringComparison.Ordinal);
+        Assert.DoesNotContain(nameof(TargetInvocationException), line, StringComparison.Ordinal);
+    }
+
+    // ══ 5. THE REFLECTION PIN: name, arity, uniqueness ═══════════════════════════════════
+    //
+    // ReflectionDrivenHelperLivenessTests measures liveness from IL for every RecordPatches
+    // member a test names as a literal. Pinned here is the half that guard cannot see.
+
+    [Fact]
+    public void BothHelpersAreUniqueByName_AndTakeWhatTheseArmsDriveThemWith()
+    {
+        var declared = typeof(RecordPatches)
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .ToList();
+
+        var filter = declared.Where(x => x.Name == "BuildNclMetaTableCatchMayAbsorb").ToList();
+        Assert.Single(filter);
+        Assert.Equal(new[] { typeof(Exception) },
+            filter[0].GetParameters().Select(p => p.ParameterType).ToArray());
+        Assert.Equal(typeof(bool), filter[0].ReturnType);
+
+        var line = declared.Where(x => x.Name == "BuildNclMetaTableFailureLine").ToList();
+        Assert.Single(line);
+        Assert.Equal(new[] { typeof(int), typeof(Exception) },
+            line[0].GetParameters().Select(p => p.ParameterType).ToArray());
+        Assert.Equal(typeof(string), line[0].ReturnType);
+    }
+}

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -165,10 +165,10 @@ public static partial class RecordPatches
             // table (#3548), let BC construct the NCLMetaTable from it rather than deriving one
             // below. AVAILABILITY decides the route, and a failure is never re-routed to the
             // derivation: a weaker answer substituted on error is what
-            // .claude/rules/loud-failures.md exists to prevent. It is not LOUD here, though —
-            // this site is inside the catch below, which swallows any throw into `return null`
-            // for both routes alike (pre-existing, #3590). What each step supplies, and which
-            // tables are deliberately left on the derivation:
+            // .claude/rules/loud-failures.md exists to prevent. Since #3590 it is LOUD here too:
+            // the catch below still absorbs an ordinary construction failure into `return null`
+            // for both routes alike, but a refusal naming what could not be read tears through.
+            // What each step supplies, and which tables are deliberately left on the derivation:
             // docs/object-metadata-from-bc.md#the-seam.
             if (ShouldBuildTableFromBcDocument(tableId, parsed))
             {
@@ -309,18 +309,72 @@ public static partial class RecordPatches
             TraceTableMetadataSource(tableId, "derived", built);
             return built;
         }
-        catch (Exception ex)
+        // #3590 — the filter is what keeps a REFUSAL out of the cached null. Everything reaching
+        // this catch is a failure while building a table the runner already established exists:
+        // both absent-table returns are above the `try`, so "no such table" never arrives here.
+        // That makes this row 3 of guards-need-a-third-state.md, and it was spelled as row 1 —
+        // the caller is `_metaTableCache.GetOrAdd(tableId, BuildNCLMetaTable)`, so the null was
+        // CACHED and every later consumer took its own not-found branch several layers away.
+        //
+        // Narrow, not a bare rethrow: NavRecordHandle_CreateTarget, TryBuildBlankRecord and
+        // GetMetaFieldEditable all legitimately ask about tables that cannot exist, so rethrowing
+        // everything would trade a false green for a false red. Only the two types whose whole
+        // purpose is to name what could not be READ tear through, plus the typed out-of-scope
+        // refusal — exactly the filter WireFieldTriggerHandlers carries in this same file for
+        // #3026 and #3048, for the identical reason: without it this frame converts a refusal
+        // into the same silent outcome the refusal exists to stop. BcShapeGapException is
+        // contractually uncatchable at AL's two seams (BcShapeGapException.cs); this catch was a
+        // third seam nobody enumerated.
+        catch (Exception ex) when (BuildNclMetaTableCatchMayAbsorb(ex))
         {
-            var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
-            // Header + top frame in ONE tagged write — a separate write for the frame has no
-            // `[Component]` tag for Log.FilteredWriter to match, so it would print at default
-            // verbosity under a header the filter had just dropped.
-            Console.Error.WriteLine(
-                $"[RecordPatches] BuildNCLMetaTable({tableId}) failed: {inner.GetType().Name}: "
-                + $"{inner.Message}"
-                + (inner.StackTrace != null ? "\n" + inner.StackTrace.Split('\n')[0] : ""));
+            Console.Error.WriteLine(BuildNclMetaTableFailureLine(tableId, ex));
             return null;
         }
+    }
+
+    /// <summary>
+    /// Whether <see cref="BuildNCLMetaTable"/>'s catch may absorb <paramref name="ex"/> into the
+    /// cached null, or must let it reach the caller so the cause is attributable (#3590).
+    ///
+    /// <para>False for the three refusals the runner raises deliberately: a
+    /// <see cref="BcShapeGapException"/> (a BC member moved — it names the member and is
+    /// contractually uncatchable at AL's seams), a <see cref="BcAppSymbolReadException"/> (a
+    /// dependency's symbols could not be read to completion), and a TYPED
+    /// <see cref="RunnerOutOfScopeException"/>. Both <c>Find</c> calls walk the inner chain
+    /// rather than testing with <c>is</c>, because every construction step here goes through
+    /// reflection and a refusal raised underneath arrives wrapped in a
+    /// <see cref="TargetInvocationException"/>.</para>
+    ///
+    /// <para>True for everything else, which is what keeps a table that cannot be built from
+    /// failing the run: the callers listed at the catch have real not-found branches, and
+    /// guards-need-a-third-state.md's constraint is that a genuinely absent thing stays a pass.
+    /// Typed only for the out-of-scope case — a BC exception whose message merely happens to
+    /// carry the convention is not one of ours (#3048).</para>
+    /// </summary>
+    private static bool BuildNclMetaTableCatchMayAbsorb(Exception ex)
+        => AlRunner.Infrastructure.BcShapeGapException.Find(ex) is null
+           && AlRunner.Infrastructure.BcAppSymbolReadException.Find(ex) is null
+           && AlRunner.Infrastructure.OutOfScopeMessage.FromException(ex) is not { Typed: true };
+
+    /// <summary>
+    /// The stderr line for a construction failure this catch DID absorb (#3590).
+    ///
+    /// <para>No leading <c>[RecordPatches]</c> tag: <c>Log.FilteredWriter</c> drops a line
+    /// starting with a bracketed component tag unless <c>--verbose</c>, so the old tagged write
+    /// made the failure invisible at default verbosity and the developer saw only whatever the
+    /// missing metatable caused several layers later. Same constraint, same reason, as
+    /// <c>BcAppSymbolReadException.BuildMessage</c>.</para>
+    ///
+    /// <para>Unwraps a <see cref="TargetInvocationException"/> so the line names the cause
+    /// rather than the reflection wrapper. Header and top frame are ONE write: a second write
+    /// would be filtered independently of the first.</para>
+    /// </summary>
+    private static string BuildNclMetaTableFailureLine(int tableId, Exception ex)
+    {
+        var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
+        return $"al-runner: table {tableId} metadata could not be built: "
+               + $"{inner.GetType().Name}: {inner.Message}"
+               + (inner.StackTrace != null ? "\n" + inner.StackTrace.Split('\n')[0] : "");
     }
 
     private static object? CallMetaTableCtor(int id, string name, object[] fields, object[] allKeys,

--- a/AlRunner/Patches/RecordPatches.NclMetaTableFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableFromBcDocument.cs
@@ -21,13 +21,15 @@
 //   would be wrong metadata under a green build, which is what
 //   .claude/rules/loud-failures.md exists to prevent.
 //
-//   How far a failure then travels differs by call site, and only one of the two is loud:
-//   the post-emit sweep (RebuildTablesFromBcMetadataAll ← BcRuntime.SetTestAssembly) has no
-//   handler over it, so a throw there aborts bundle load naming the member; the cold build
-//   sits inside BuildNCLMetaTable's pre-existing `catch → Console.Error → return null`, which
-//   swallows it into "no metatable" exactly as it does for a derivation failure. That swallow
-//   predates this change and is #3590 — do not read the paragraph above as a claim that the
-//   cold path tears through, because it does not.
+//   How far a failure then travels differs by call site. The post-emit sweep
+//   (RebuildTablesFromBcMetadataAll ← BcRuntime.SetTestAssembly) has no handler over it, so a
+//   throw there aborts bundle load naming the member. The cold build sits inside
+//   BuildNCLMetaTable's catch, which since #3590 discriminates: a refusal naming what could not
+//   be READ — BcShapeGapException, BcAppSymbolReadException, a typed RunnerOutOfScopeException —
+//   tears through on both routes, and an ordinary construction failure is still absorbed into
+//   "no metatable" exactly as for a derivation failure. So the cold path is attributable for the
+//   refusals and still silent for the rest; do not read the paragraph above as a claim that
+//   EVERY cold-path failure tears through.
 using System.Linq;
 using System.Reflection;
 using Microsoft.Dynamics.Nav.Runtime;

--- a/AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs
@@ -134,12 +134,16 @@ public static partial class RecordPatches
     /// <c>.claude/rules/loud-failures.md</c> exists to prevent.</para>
     ///
     /// <para><b>The limit this inherits, stated rather than implied away.</b> A failure here is
-    /// not loud. <see cref="TryGetBcPageControlDocument"/> memoises a null on a parse failure
-    /// and the table-side builder swallows a cold-build throw into a cached null the same way
-    /// (pre-existing, <b>#3590</b>). So a page whose document genuinely failed to load and a
-    /// page that never had one are <b>indistinguishable from this trace</b>: both show as the
-    /// derivation route. A trace implying a guarantee #3590 makes impossible would be worse
-    /// than no trace — see docs/where-metadata-comes-from.md.</para>
+    /// not loud: <see cref="TryGetBcPageControlDocument"/> memoises a null on a parse failure. So
+    /// a page whose document genuinely failed to load and a page that never had one are
+    /// <b>indistinguishable from this trace</b> — both show as the derivation route. A trace
+    /// implying a guarantee that does not exist would be worse than no trace; see
+    /// docs/where-metadata-comes-from.md.</para>
+    ///
+    /// <para>The table-side builder used to swallow a cold-build throw the same way. #3590 has
+    /// since narrowed that catch, so a REFUSAL naming what could not be read now tears through
+    /// there — but this page-side memo is a separate mechanism and is untouched, which is why
+    /// the limit above still stands.</para>
     /// </summary>
     private static void TracePageMetadataSource(int pageId, string source)
     {

--- a/AlRunner/Patches/RecordPatches.PageControlFieldVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.PageControlFieldVirtualTable.cs
@@ -185,8 +185,10 @@ public static partial class RecordPatches
                 }
 
                 // #3750 — the fall-through arm: no document was available for this page, OR
-                // one was and did not parse. Those two are indistinguishable from here and
-                // from the trace (#3590); TracePageMetadataSource says so at length.
+                // one was and did not parse. Those two are indistinguishable from here and from
+                // the trace, because TryGetBcPageControlDocument memoises a null on a parse
+                // failure; TracePageMetadataSource says so at length. (The table-side swallow
+                // #3590 named is a different mechanism, narrowed by that issue's fix.)
                 TracePageMetadataSource(page.Id, "derived");
 
                 var tableId = GetSourceTableIdForPage(page.Id);

--- a/docs/object-metadata-from-bc.md
+++ b/docs/object-metadata-from-bc.md
@@ -230,12 +230,18 @@ and `BlankZero` were themselves found this way — by re-measuring, not by readi
 
 Availability decides the route, and a failure is never re-routed to the derivation: a weaker
 answer substituted on error is what `.claude/rules/loud-failures.md` exists to prevent. **How
-far that failure travels differs by call site, and only one of the two is loud.** The post-emit
-sweep has no handler over it and aborts bundle load naming the member. The cold build sits
-inside `BuildNCLMetaTable`'s pre-existing `catch → Console.Error → return null`, which swallows
-it into "no metatable" exactly as it does a derivation failure — and that write is
-`[RecordPatches]`-tagged, so the default log filter drops it. That swallow predates this work
-and is tracked as **#3590**; it is not a claim this page makes about the cold path.
+far that failure travels differs by call site.** The post-emit sweep has no handler over it and
+aborts bundle load naming the member. The cold build sits inside `BuildNCLMetaTable`'s catch,
+which **#3590** narrowed: a refusal naming what could not be READ — `BcShapeGapException`,
+`BcAppSymbolReadException`, or a typed `RunnerOutOfScopeException` — now reaches the caller
+rather than becoming a cached null, and the line for a failure that IS still absorbed no longer
+carries a `[RecordPatches]` tag, so the default log filter no longer drops it.
+
+**An ordinary construction failure is still absorbed into "no metatable"**, and deliberately so:
+`NavRecordHandle_CreateTarget`, `TryBuildBlankRecord` and `GetMetaFieldEditable` all legitimately
+ask about tables that cannot exist, so rethrowing everything would trade a false green for a
+false red (`.claude/rules/guards-need-a-third-state.md`). The two absent-table returns sit
+outside the `try`, which is what makes the narrower filter safe.
 
 <a id="reading-the-values-back"></a>
 

--- a/docs/where-metadata-comes-from.md
+++ b/docs/where-metadata-comes-from.md
@@ -23,12 +23,17 @@ Neither flag has a **failure route**, and neither may grow one: **availability**
 an object takes, and a failure is never *re-routed* to a derivation — substituting a weaker answer on
 error is what `loud-failures.md` exists to prevent.
 
-**A failure there is not loud, though, and this page must not imply it is.** The site sits inside a
-catch that swallows any throw into `return null` for both routes alike — pre-existing, tracked as
-**#3590**. So a genuine load failure and "no document was available" are **indistinguishable from the
-trace**, and a table that failed to load shows as `derived` exactly like one that never had a
-document. `RecordPatches.NclMetaTableBuilder.cs` says so at the site itself; #3590 is open precisely
-because the guarantee a reader would want here does not yet exist.
+**A failure there is only PARTLY loud, and this page must not imply otherwise.** The site sits
+inside `BuildNCLMetaTable`'s catch, which **#3590** narrowed: a refusal naming what could not be
+read — `BcShapeGapException`, `BcAppSymbolReadException`, a typed `RunnerOutOfScopeException` —
+reaches the caller and names the table. An **ordinary** construction failure is still absorbed
+into `return null` for both routes alike, because every caller has a legitimate not-found branch
+for a table that cannot exist.
+
+So for that remaining class, a genuine load failure and "no document was available" are still
+**indistinguishable from the trace**: a table that failed to build shows as `derived` exactly like
+one that never had a document. `RecordPatches.NclMetaTableBuilder.cs` states the split at the site
+itself.
 
 **The page trace inherits exactly the same limit, and states it rather than implying it away.**
 `TryGetBcPageControlDocument` memoises a null when the document does not parse, so a page whose


### PR DESCRIPTION
Closes #3590

Corpus-NA: a BC member moving or a dependency's SymbolReference.json being corrupt is not something any AL statement can cause, so a service tier has nothing to adjudicate; on every BC version the corpus runs, the filter never fires and AL observes no change

Implemented by an agent (Claude, stma-auto-4).

## The decision the issue left open, and the evidence for it

The issue asked whether "the runner could not build this table's metadata" is ever a condition a
run should survive. **Yes for one class of failure, no for another** — and the method's own
structure already draws that line, which is what makes the narrow answer safe rather than a
guess.

Both absent-table returns sit **outside** the `try`:

```
_parsedTables miss + TryPopulateParsedTableFromBcApps miss   -> return null   (absent)
_tMetaTable / _mCreateFromMetaTable not resolved             -> return null   (absent)
---------------------------------- try ----------------------------------
anything that throws while BUILDING a table we know exists   -> was ALSO null (the bug)
```

So nothing reaching the catch is a missing table. Everything there is a failure to measure
something the runner had **already established was there** — `guards-need-a-third-state.md` row
3, spelled as row 1. `TheTwoAbsentReturns_SitOutsideTheTry_SoNoMissingTableCanReachTheFilter`
pins that from the method's IL rather than by reading, because it is the claim the whole change
rests on.

**A blanket rethrow would have been the false-red trap the brief warned about.** I checked every
caller, and each has a real not-found branch for a table that cannot exist:

| caller | what it does with the null |
|---|---|
| `NavRecordHandle_CreateTarget` (`RecordPatches.cs:966`) | its own not-found path, including a `tableId == 0` special case |
| `TryBuildBlankRecord` (`TestPageFactory.cs:114`) | sets `why = "source table N has no runtime record type here"` |
| `GetMetaFieldEditable` (`PageControlFieldFromBcDocument.cs:548`) | answers `true`, with a comment already drawing this exact line |
| `PopulateOneObjectType` (`NclMetadataCachePopulator.cs:79`) | skips the id |

So the fix is a filter, not a rethrow: `BcShapeGapException`, `BcAppSymbolReadException` and a
**typed** `RunnerOutOfScopeException` tear through; everything else is still absorbed.

**This is not a new mechanism — the same file already settled it one method over.**
`WireFieldTriggerHandlers` carries `catch (Exception ex) when (BcShapeGapException.Find(ex) is
null && ...)` for #3026 and #3048, with the reasoning that without it "this catch converts every
refusal raised above into a stderr line plus the same not-installed outcome the refusals exist to
stop". `BcShapeGapException.cs` documents that its type tears through **both** of AL's trapping
seams by contract; this catch was a **third seam nobody enumerated**, and it turned those
refusals back into a cached null.

## The caching hazard

`_metaTableCache.GetOrAdd(tableId, BuildNCLMetaTable)` caches the null, so the second call never
retried — and `RebuildTablesFromBcMetadataAll`'s post-emit sweep skips cached nulls outright
(`if (kvp.Value is not NCLMetaTable built) continue;`), so a table whose cold build was swallowed
was never revisited either. A refusal now propagates instead of being cached, so it cannot be
made un-diagnosable by a warm run. Nothing is cached on the refusal path at all: `GetOrAdd` does
not record a value for a factory that throws.

## The log-visibility half

The old write was `[RecordPatches] BuildNCLMetaTable(N) failed: ...`, and `Log.FilteredWriter`
drops any line starting with a bracketed component tag unless `--verbose` — so the failure was
invisible by default and the developer saw only the NRE several layers later. The line for a
failure that **is** still absorbed now reads `al-runner: table N metadata could not be built:
<Type>: <message>`, with no tag, and unwraps a `TargetInvocationException` so it names the cause
rather than the reflection wrapper. `BcAppSymbolReadException.BuildMessage` carries the same
constraint as a comment for the same reason. Two arms pin it, including that the wrapper's name
does **not** appear.

## RED -> GREEN

`AlRunner.Tests/BuildNclMetaTableFailureAttributionTests.cs`, 12 arms.

- **RED:** 10 failed, 2 passed. The 2 that passed are the controls that were already true — the
  IL-structure claim and the exception message's shape — not the change.
- **GREEN:** 12/12.

The negative controls are the point, not decoration: section 2 pins that an ordinary
`InvalidOperationException`/`NullReferenceException`, and an **untyped** out-of-scope lookalike,
are still absorbed. Without them, "a construction failure is attributable" would be satisfied by
a change that rethrows everything, which is exactly the defect this must not trade for.

## Fix the shape, not just the reported line

**1. Same wrong pattern at another call site?** Yes — three, and they are filed as **#3776**
rather than folded, because they land in different files
(`batch-sibling-issues-by-file.md`). `BuildNCLMetaForm` and `BuildNCLMetaReport`
(`RecordPatches.NclMetaFormReportBuilder.cs:151,192`) and `BuildRealNCLMetaQuery`
(`RecordPatches.NclMetaQueryBuilder.cs:116`) match this shape point for point: existence check
outside the `try`, unfiltered `catch (Exception)`, and the two form/report writes are
`[RecordPatches]`-tagged too. I scanned every `catch (Exception) { ... return null/false }` in
`RecordPatches.*` to find them; the others (`InstallBaselineDisk`, `SkeletonSession`,
`UserSystemTable`) are not builders and do not share the structure.

**2. Sibling function making the same assumption?** The three above are exactly that — the same
builder shape one object kind over. Worth recording: **#3499** looks like the symptom end of this
class for queries (356 failures rooted in a null `NCLMetaQuery` dereferenced inside BC's own
`ALSetFilter`, several layers from the cause). #3776 states that connection without claiming
causation, since that has not been measured and #3499 is tracked as blocked on the metadata
emitter.

**3. Two paths writing the same state, same invariant?** This was the actual asymmetry the issue
named, and it is now closed. Both writers of `_metaTableCache` are the post-emit sweep
(`RebuildTablesFromBcMetadataAll`, no handler — aborts bundle load naming the member) and the
cold build. They **disagreed**: the same failure aborted the run on one path and became a cached
null on the other. After this change both let a refusal through.

## Corpus linkage

`Corpus-NA:`, decided rather than defaulted. The filter is reachable only when a BC internal has
moved or a `.app`'s symbols are corrupt — states no AL statement can produce, so there is nothing
for a service tier to adjudicate. On every BC version the corpus runs, all these members resolve,
the filter never fires, and what AL observes is unchanged. This is the same reasoning
`PageControlFieldEditableShapeGapTests` and `BcShapeGapConventionTests` record for runner-local
refusal-contract tests. The `require-tests` gate is satisfied by a real runner-side mechanism
test, not by a bypass label.

## Docs and stale comments

Four places asserted the un-fixed state as a live limit. Each is corrected to what is now true
rather than deleted, and the parts that **remain** true are kept:

- `RecordPatches.NclMetaTableBuilder.cs` (the `#3552` route comment) and
  `RecordPatches.NclMetaTableFromBcDocument.cs`'s header — both said the cold path swallows any
  throw; now they state the split.
- `RecordPatches.PageControlFieldFromBcDocument.cs` and
  `RecordPatches.PageControlFieldVirtualTable.cs` — these cite #3590 but rest on a **different**
  mechanism, `TryGetBcPageControlDocument` memoising a null on a parse failure, which this PR
  does not touch. Their limit **still stands**; only the attribution changed.
- `docs/where-metadata-comes-from.md` and `docs/object-metadata-from-bc.md` — same split, and
  both keep the honest statement that an ordinary failure is still indistinguishable from "no
  document available".

New prose stayed in code only where it changes what the next person would type (why the filter is
narrow, why the tag is absent); the argument for the decision is here in the body.

## What I ran

- `dotnet test AlRunner.Tests --filter FullyQualifiedName~BuildNclMetaTableFailureAttributionTests`
  — RED 10/12 failing, GREEN 12/12.
- `dotnet test AlRunner.Tests --filter "FullyQualifiedName~MetaTable|FullyQualifiedName~ShapeGap|FullyQualifiedName~Metadata|FullyQualifiedName~ReflectionDrivenHelperLiveness"`
  — **553 passed, 0 failed, 57 skipped** (the skips are pre-existing; they need BC artifacts).
- `tools/test_doc_pointers.py` and `tools/test_matrix_docs_drift.py` — both pass.

I did not run the full unfiltered suite or the AL corpus locally; that is CI's job
(`local-test-scope.md`).

## Deliberately left out

- The three sibling builders — filed as #3776 with the diagnosis, not folded, because they are in
  different files and each needs its own RED -> GREEN.
- The page-side memoised null (`TryGetBcPageControlDocument`). It is a genuinely separate
  mechanism, not this catch, and folding it would have made the diff two changes.
- Sharing one helper between the four builders. That is a decision for whoever takes #3776, once
  more than one call site actually needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
