### PR TITLE
fix(metadata): the form, report and query builders must not swallow a construction refusal

### DIFF
--- a/AlRunner.Tests/BuildNclMetaObjectFailureAttributionTests.cs
+++ b/AlRunner.Tests/BuildNclMetaObjectFailureAttributionTests.cs
@@ -1,0 +1,350 @@
+// BuildNclMetaObjectFailureAttributionTests — issue #3776.
+//
+// WHAT IS BEING PROVED
+//   #3590 fixed BuildNCLMetaTable: its `catch (Exception)` turned every construction failure
+//   into the same answer as "this table does not exist". The four object-kind siblings carried
+//   the identical shape, so a deliberate refusal naming what could not be read — a moved BC
+//   member, a dependency whose symbols would not read to completion — came back as a null and
+//   surfaced several layers later as somebody else's NRE or NavMetadataNotFoundException.
+//
+//   Each builder now classifies through its own `*CatchMayAbsorb` predicate. Sections 1 and 2
+//   drive those predicates directly; section 3 pins the structural claim they rest on.
+//
+// THE DECISION THIS FILE PINS, AND WHY IT IS NOT "RETHROW EVERYTHING"
+//   guards-need-a-third-state.md: a genuinely ABSENT thing must stay a pass; only an
+//   UNMEASURABLE one becomes the third state. Every caller of these five builders reaches them
+//   through a `GetOrAdd` and takes a real not-found branch on null (the callers are enumerated
+//   in the PR body), so a blanket rethrow would trade a false green for a false red.
+//
+//   Each builder already draws that line OUTSIDE its try, which is what section 3 measures from
+//   IL rather than from reading the source.
+//
+// WHY RUNNER-LOCAL AND NOT THE CORPUS
+//   No AL statement can make a BC member move or corrupt a .app's symbols, so a service tier has
+//   nothing to adjudicate: the subject is which exceptions the runner's own catch may absorb.
+//   Same reasoning as BuildNclMetaTableFailureAttributionTests (#3590).
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class BuildNclMetaObjectFailureAttributionTests
+{
+    // The five builders this file covers, each with the predicate its catch filters on and the
+    // failure-line helper it writes through. #3776 named the first three; Form/Report/Query/
+    // XmlPort share one file and were identical in shape, so the same edit covers all four
+    // (batch-sibling-issues-by-file.md).
+    public static TheoryData<string, string, string> Builders => new()
+    {
+        { "BuildNCLMetaForm",         "BuildNclMetaFormCatchMayAbsorb",    "BuildNclMetaFormFailureLine" },
+        { "BuildNCLMetaReport",       "BuildNclMetaReportCatchMayAbsorb",  "BuildNclMetaReportFailureLine" },
+        { "BuildNCLMetaQuery",        "BuildNclMetaQueryCatchMayAbsorb",   "BuildNclMetaQueryFailureLine" },
+        { "BuildNCLMetaXmlPort",      "BuildNclMetaXmlPortCatchMayAbsorb", "BuildNclMetaXmlPortFailureLine" },
+        { "BuildRealNCLMetaQueryCore", "BuildRealNclMetaQueryCatchMayAbsorb", "BuildRealNclMetaQueryFailureLine" },
+    };
+
+    private static MethodInfo Method(string name)
+    {
+        var m = typeof(RecordPatches).GetMethod(name, BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.True(m != null, $"RecordPatches.{name} not found");
+        return m!;
+    }
+
+    private static bool MayAbsorb(string predicate, Exception ex)
+        => (bool)Method(predicate).Invoke(null, new object?[] { ex })!;
+
+    private static string FailureLine(string helper, int objectId, Exception ex)
+        => (string)Method(helper).Invoke(null, new object?[] { objectId, ex })!;
+
+    // ══ 1. WHAT MUST TEAR THROUGH ════════════════════════════════════════════════════════
+    //
+    // Each type here exists to name what could not be read. Absorbing one re-creates the silent
+    // default it was raised to replace.
+
+    [Theory]
+    [MemberData(nameof(Builders))]
+    public void AShapeGap_IsNotAbsorbed_SoTheMemberThatMovedReachesTheDeveloper(
+        string builder, string predicate, string _)
+    {
+        var gap = new BcShapeGapException(
+            $"{builder} metadata", "NCLMetaApplicationObject.CreateEmpty", "member not found — BC moved it");
+
+        Assert.False(MayAbsorb(predicate, gap),
+            $"{builder}'s catch must not absorb a BcShapeGapException.");
+    }
+
+    [Theory]
+    [MemberData(nameof(Builders))]
+    public void AShapeGapArrivingWrapped_IsNotAbsorbed_BecauseEveryBuilderCallsBcThroughReflection(
+        string builder, string predicate, string _)
+    {
+        // Every construction step in all five builders is a MethodBase.Invoke or a reflective
+        // ctor, so a refusal raised underneath arrives inside a TargetInvocationException. An
+        // `is` test would miss exactly the cases the filter exists for — this is the subtlest
+        // half of #3590 and it carries over unchanged.
+        var wrapped = new TargetInvocationException(
+            new BcShapeGapException($"{builder} metadata", "NCLMetaApplicationObject.CreateEmpty", "moved"));
+
+        Assert.False(MayAbsorb(predicate, wrapped),
+            $"{builder}'s filter must walk the inner chain, not test with `is`.");
+    }
+
+    [Theory]
+    [MemberData(nameof(Builders))]
+    public void ASymbolReadRefusal_IsNotAbsorbed_BecauseACorruptDependencyIsNotAMissingObject(
+        string builder, string predicate, string _)
+    {
+        var read = new BcAppSymbolReadException(
+            "/tmp/Some.app", "object symbols", new OutOfMemoryException("truncated"));
+
+        Assert.False(MayAbsorb(predicate, read), $"{builder}: a symbol-read refusal must tear through.");
+    }
+
+    [Theory]
+    [MemberData(nameof(Builders))]
+    public void ASymbolReadRefusalArrivingWrapped_IsNotAbsorbed_ForTheSameReason(
+        string builder, string predicate, string _)
+    {
+        var wrapped = new TargetInvocationException(
+            new BcAppSymbolReadException("/tmp/Some.app", "object symbols",
+                new OutOfMemoryException("truncated")));
+
+        Assert.False(MayAbsorb(predicate, wrapped), $"{builder}: wrapped symbol-read refusal must tear through.");
+    }
+
+    [Theory]
+    [MemberData(nameof(Builders))]
+    public void ATypedOutOfScopeRefusal_IsNotAbsorbed_MatchingTheNeighbouringCatchsContract(
+        string builder, string predicate, string _)
+    {
+        var oos = new RunnerOutOfScopeException(
+            $"{builder} construction", "not-yet-implemented — see docs/scope.md");
+
+        Assert.False(MayAbsorb(predicate, oos), $"{builder}: a typed out-of-scope refusal must tear through.");
+    }
+
+    // ══ 2. WHAT MUST STILL BE ABSORBED ═══════════════════════════════════════════════════
+    //
+    // Without these, the change is a blanket rethrow and every caller that legitimately asks
+    // about an object that cannot exist starts failing the run instead of taking its not-found
+    // branch. That is the false-red half of guards-need-a-third-state.md's constraint.
+
+    [Theory]
+    [MemberData(nameof(Builders))]
+    public void AnOrdinaryConstructionFailure_IsStillAbsorbed_SoNoCallerLosesItsNotFoundBranch(
+        string builder, string predicate, string _)
+    {
+        Assert.True(MayAbsorb(predicate, new InvalidOperationException("ctor arity changed")), builder);
+        Assert.True(MayAbsorb(predicate, new NullReferenceException()), builder);
+        Assert.True(MayAbsorb(predicate, new TargetInvocationException(new ArgumentException("bad arg"))), builder);
+    }
+
+    [Theory]
+    [MemberData(nameof(Builders))]
+    public void AnUntypedOutOfScopeLookalike_IsStillAbsorbed_BecauseItIsNotOneOfOurs(
+        string builder, string predicate, string _)
+    {
+        // A BC exception whose MESSAGE merely happens to carry the out-of-scope convention is
+        // not a runner refusal. #3048 drew this line explicitly: "Typed only".
+        var lookalike = new InvalidOperationException(
+            OutOfScopeMessage.Prefix + "something that only looks like ours");
+
+        Assert.True(MayAbsorb(predicate, lookalike), builder);
+    }
+
+    // ══ 3. THE ABSENT CASES NEVER REACH THE CATCH ════════════════════════════════════════
+    //
+    // The claim that makes section 1 safe, measured per builder from IL rather than assumed from
+    // the source. A refactor that moves an existence check inside the try must fail here.
+    //
+    // NOT the `ret`-before-the-try byte scan #3590 used. That reads a CODEGEN accident, not the
+    // structure: Roslyn gives four of these five builders a single shared epilogue and branches
+    // every early return to it, so their pre-try region holds no `ret` at all while the checks
+    // are still entirely outside the try. Measured — the scan holds only for BuildNCLMetaTable
+    // and BuildNCLMetaXmlPort, and would be a false failure for the other four (PR body).
+    //
+    // What is structural, and what is asserted instead: no branch in the pre-try region targets
+    // anything INSIDE the try, and at least one leaves past the handler. That is exactly "an
+    // absent object exits without the catch seeing it", and it survives a codegen change.
+
+    [Theory]
+    [MemberData(nameof(Builders))]
+    public void TheAbsentReturns_SitOutsideTheTry_SoNoMissingObjectCanReachTheFilter(
+        string builder, string _, string __)
+    {
+        var body = Method(builder).GetMethodBody()!;
+        var clauses = body.ExceptionHandlingClauses;
+        Assert.True(clauses.Count > 0, $"{builder} has no exception handler at all.");
+
+        var tryOffset = clauses.Select(c => c.TryOffset).Min();
+        var clause = clauses.First(c => c.TryOffset == tryOffset);
+        var tryEnd = clause.TryOffset + clause.TryLength;
+
+        Assert.True(tryOffset > 0,
+            $"{builder}'s try must start after its absent-object early returns; a try at offset 0 "
+            + "means a missing object now reaches the catch filter.");
+
+        var il = body.GetILAsByteArray()!;
+        var preTryBranches = ShortAndLongBranches(il, tryOffset).ToList();
+
+        Assert.True(preTryBranches.Count > 0,
+            $"{builder}: no branch before the try — the existence checks are not where this "
+            + "test thinks they are, so it is measuring nothing.");
+
+        var intoTry = preTryBranches.Where(t => t >= clause.TryOffset && t < tryEnd).ToList();
+        Assert.True(intoTry.Count == 0,
+            $"{builder}: a branch before the try targets IL offset(s) "
+            + $"{string.Join(", ", intoTry)} inside the try [{clause.TryOffset},{tryEnd}). An "
+            + "existence check has moved inside the try, so a genuinely absent object can now "
+            + "reach the catch filter and be rethrown — the false-red half of "
+            + "guards-need-a-third-state.md's constraint.");
+
+        Assert.True(preTryBranches.Any(t => t >= tryEnd),
+            $"{builder}: no pre-try branch leaves past the handler, so no early-exit path "
+            + "bypasses the try at all.");
+    }
+
+    /// <summary>
+    /// Branch targets of the one-byte-opcode short (0x2B-0x37) and long (0x38-0x44) branch forms
+    /// occurring before <paramref name="limit"/>. Deliberately a coarse forward scan: it can
+    /// mis-frame an operand as an opcode, which can only ADD spurious targets, never hide a real
+    /// one — so the "targets nothing inside the try" assertion cannot be weakened by it.
+    /// </summary>
+    private static IEnumerable<int> ShortAndLongBranches(byte[] il, int limit)
+    {
+        var i = 0;
+        while (i < limit)
+        {
+            var op = il[i];
+            if (op >= 0x2B && op <= 0x37 && i + 1 < il.Length)
+            {
+                yield return i + 2 + (sbyte)il[i + 1];
+                i += 2;
+            }
+            else if (op >= 0x38 && op <= 0x44 && i + 4 < il.Length)
+            {
+                yield return i + 5 + BitConverter.ToInt32(il, i + 1);
+                i += 5;
+            }
+            else
+            {
+                i++;
+            }
+        }
+    }
+
+    // ══ 4. THE FAILURE IS VISIBLE AT DEFAULT VERBOSITY ═══════════════════════════════════
+    //
+    // The second half of #3590, and the half that differs between the object kinds. The
+    // form/report/query/xmlport writes were `[RecordPatches] ...`, which Log.FilteredWriter
+    // (AlRunner/Log.cs) drops unless --verbose. BuildRealNCLMetaQuery's was worse: it went to
+    // QLog, which writes nothing at all unless AL_RUNNER_QDIAG=1. Both are the same defect —
+    // an absorbed failure the developer cannot see — so every builder's line must survive the
+    // default filter.
+
+    [Theory]
+    [MemberData(nameof(Builders))]
+    public void TheAbsorbedFailuresLogLine_NamesTheObjectAndTheCause_AndSurvivesTheDefaultFilter(
+        string builder, string _, string helper)
+    {
+        var line = FailureLine(helper, 50100, new InvalidOperationException("ctor arity changed"));
+
+        Assert.Contains("50100", line, StringComparison.Ordinal);
+        Assert.Contains(nameof(InvalidOperationException), line, StringComparison.Ordinal);
+        Assert.Contains("ctor arity changed", line, StringComparison.Ordinal);
+
+        // Not dropped at default verbosity: Log.cs's ComponentTag matches a LEADING bracketed
+        // tag, so the line must not start with one.
+        Assert.False(line.StartsWith("[", StringComparison.Ordinal),
+            $"{builder}'s failure line starts with a component tag and is filtered out by default.");
+    }
+
+    [Theory]
+    [MemberData(nameof(Builders))]
+    public void TheFailureLine_UnwrapsAReflectionWrapper_SoTheCauseIsNamedRatherThanTheWrapper(
+        string builder, string _, string helper)
+    {
+        var line = FailureLine(helper, 50100, new TargetInvocationException(new ArgumentException("bad id")));
+
+        Assert.Contains(nameof(ArgumentException), line, StringComparison.Ordinal);
+        Assert.Contains("bad id", line, StringComparison.Ordinal);
+        Assert.DoesNotContain(nameof(TargetInvocationException), line, StringComparison.Ordinal);
+        Assert.False(line.StartsWith("[", StringComparison.Ordinal), builder);
+    }
+
+    [Theory]
+    [MemberData(nameof(Builders))]
+    public void TheFailureLine_NamesItsOwnObjectKind_SoFiveNearIdenticalLinesStayDistinguishable(
+        string builder, string _, string helper)
+    {
+        // The five builders differ only in object kind, and the whole point of the line is to
+        // say WHICH lookup failed. A line naming the wrong kind is as unattributable as none.
+        var kind = builder switch
+        {
+            "BuildNCLMetaForm" => "page",
+            "BuildNCLMetaReport" => "report",
+            "BuildNCLMetaXmlPort" => "xmlport",
+            _ => "query",
+        };
+
+        var line = FailureLine(helper, 50100, new InvalidOperationException("boom"));
+        Assert.Contains(kind, line, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ══ 5. THE REFLECTION PIN: name, arity, uniqueness ═══════════════════════════════════
+
+    [Theory]
+    [MemberData(nameof(Builders))]
+    public void BothHelpersAreUniqueByName_AndTakeWhatTheseArmsDriveThemWith(
+        string _, string predicate, string helper)
+    {
+        var declared = typeof(RecordPatches)
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .ToList();
+
+        var filter = declared.Where(x => x.Name == predicate).ToList();
+        Assert.Single(filter);
+        Assert.Equal(new[] { typeof(Exception) },
+            filter[0].GetParameters().Select(p => p.ParameterType).ToArray());
+        Assert.Equal(typeof(bool), filter[0].ReturnType);
+
+        var line = declared.Where(x => x.Name == helper).ToList();
+        Assert.Single(line);
+        Assert.Equal(new[] { typeof(int), typeof(Exception) },
+            line[0].GetParameters().Select(p => p.ParameterType).ToArray());
+        Assert.Equal(typeof(string), line[0].ReturnType);
+    }
+
+    // ══ 6. THE CACHE CANNOT HIDE A REFUSAL ═══════════════════════════════════════════════
+    //
+    // BuildRealNCLMetaQuery is `_realMetaQueryCache.GetOrAdd(id, _ => Core(...))`, and every
+    // other builder is reached through a GetOrAdd at its call site. This pins the property that
+    // makes section 1 reach the caller on a warm run too: ConcurrentDictionary.GetOrAdd writes
+    // NO entry when the factory throws, so a torn-through refusal is raised again on the next
+    // call rather than being answered from a cached null. Measured, not assumed — the same
+    // question local-test-scope.md's cache-sensitivity note asks.
+
+    [Fact]
+    public void GetOrAdd_CachesNothingWhenTheFactoryThrows_SoARefusalIsNotHiddenByAWarmRun()
+    {
+        var cache = new System.Collections.Concurrent.ConcurrentDictionary<int, object?>();
+        var calls = 0;
+
+        for (var i = 0; i < 2; i++)
+        {
+            Assert.Throws<BcShapeGapException>(() => cache.GetOrAdd(42, _ =>
+            {
+                calls++;
+                throw new BcShapeGapException("q", "m", "moved");
+            }));
+        }
+
+        Assert.Equal(2, calls);            // the factory ran BOTH times
+        Assert.False(cache.ContainsKey(42)); // and nothing was written
+    }
+}

--- a/AlRunner.Tests/BuildNclMetaObjectFailureAttributionTests.cs
+++ b/AlRunner.Tests/BuildNclMetaObjectFailureAttributionTests.cs
@@ -206,6 +206,15 @@ public sealed class BuildNclMetaObjectFailureAttributionTests
         var clause = clauses.First(c => c.TryOffset == tryOffset);
         var il = body.GetILAsByteArray()!;
 
+        // THE ASSERTION THAT MAKES THIS A PROVING TEST FOR THIS PR.
+        //
+        // Every offset below is byte-identical before and after this change — measured on a
+        // pre-fix build, all five try offsets are the same (79, 55, 86, 57, 436) and every other
+        // assertion in this method passes on BOTH. The one thing the fix actually alters is the
+        // clause KIND: a bare `catch (Exception)` is Clause, a `catch ... when (...)` is Filter.
+        // Without this line the method is sound but proves nothing about this PR (tdd.md).
+        Assert.Equal(ExceptionHandlingClauseOptions.Filter, clause.Flags);
+
         // The property: the try starts after the existence checks, so nothing absent reaches the
         // catch filter. A try at offset 0 means a check has moved inside it.
         Assert.True(tryOffset > 0,
@@ -310,6 +319,75 @@ public sealed class BuildNclMetaObjectFailureAttributionTests
         Assert.Equal(new[] { typeof(int), typeof(Exception) },
             line[0].GetParameters().Select(p => p.ParameterType).ToArray());
         Assert.Equal(typeof(string), line[0].ReturnType);
+    }
+
+    // ══ 5b. THE CALLER FRAME MUST NOT RE-SWALLOW IT (#3781) ══════════════════════════════
+    //
+    // A builder that correctly lets a refusal tear through buys nothing if its CALLER catches
+    // it. PopulateOneObjectType is the caller of five of the six builders (Table at line 79,
+    // Page 87, Report 109, Query 113, XmlPort 117) and it is the STARTUP path — it runs once per
+    // bundle before any AL test code, so it carries most of the traffic. Its bare catch
+    // converted every refusal straight back to `meta = null`, and its `[NclMetadataCachePopulator]`
+    // tag meant Log.cs's ^\[-anchored regex dropped the line at default verbosity too: the
+    // observable was exactly what it was before #3590 and #3776.
+    //
+    // This is the third instance of one shape in this family (#3749, #3590, #3776), each fixed
+    // correctly and each defeated by a catch one frame up that nobody had enumerated. So the
+    // structural arm here asserts the clause KIND, which is the thing that actually changed.
+
+    [Fact]
+    public void PopulateOneObjectTypesCatch_IsFiltered_SoARefusalIsNotReSwallowedOneFrameUp()
+    {
+        var m = typeof(RecordPatches).GetMethod(
+            "PopulateOneObjectType", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.True(m != null, "RecordPatches.PopulateOneObjectType not found");
+
+        var clauses = m!.GetMethodBody()!.ExceptionHandlingClauses;
+        Assert.True(clauses.Count > 0, "PopulateOneObjectType has no exception handler at all.");
+
+        // The buildMeta call is wrapped in the FIRST handler in the method. A bare
+        // `catch (Exception)` reports Clause; the `when (...)` filter reports Filter.
+        var first = clauses.OrderBy(c => c.TryOffset).First();
+        Assert.Equal(ExceptionHandlingClauseOptions.Filter, first.Flags);
+    }
+
+    [Fact]
+    public void ThePopulatorsFailureLine_NamesTheObjectKindAndId_AndSurvivesTheDefaultFilter()
+    {
+        var m = typeof(RecordPatches).GetMethod(
+            "PopulateOneObjectTypeFailureLine", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.True(m != null, "RecordPatches.PopulateOneObjectTypeFailureLine not found");
+
+        var line = (string)m!.Invoke(null, new object?[]
+        {
+            "XmlPort", 1230, new InvalidOperationException("ctor arity changed"),
+        })!;
+
+        Assert.Contains("1230", line, StringComparison.Ordinal);
+        Assert.Contains("xmlport", line, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(nameof(InvalidOperationException), line, StringComparison.Ordinal);
+        Assert.Contains("ctor arity changed", line, StringComparison.Ordinal);
+
+        // The half of #3781 that is not the catch: the old line was `[NclMetadataCachePopulator]
+        // ...`, which Log.cs drops at default verbosity, so even the absorbed case was invisible.
+        Assert.False(line.StartsWith("[", StringComparison.Ordinal),
+            "the populator's failure line starts with a component tag and is filtered out by default.");
+    }
+
+    [Fact]
+    public void ThePopulatorsFailureLine_UnwrapsAReflectionWrapper_SoTheCauseIsNamed()
+    {
+        var m = typeof(RecordPatches).GetMethod(
+            "PopulateOneObjectTypeFailureLine", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        var line = (string)m.Invoke(null, new object?[]
+        {
+            "Report", 1306, new TargetInvocationException(new ArgumentException("bad id")),
+        })!;
+
+        Assert.Contains(nameof(ArgumentException), line, StringComparison.Ordinal);
+        Assert.Contains("bad id", line, StringComparison.Ordinal);
+        Assert.DoesNotContain(nameof(TargetInvocationException), line, StringComparison.Ordinal);
     }
 
     // ══ 6. THE CACHE CANNOT HIDE A REFUSAL ═══════════════════════════════════════════════

--- a/AlRunner.Tests/BuildNclMetaObjectFailureAttributionTests.cs
+++ b/AlRunner.Tests/BuildNclMetaObjectFailureAttributionTests.cs
@@ -162,15 +162,32 @@ public sealed class BuildNclMetaObjectFailureAttributionTests
     // The claim that makes section 1 safe, measured per builder from IL rather than assumed from
     // the source. A refactor that moves an existence check inside the try must fail here.
     //
-    // NOT the `ret`-before-the-try byte scan #3590 used. That reads a CODEGEN accident, not the
-    // structure: Roslyn gives four of these five builders a single shared epilogue and branches
-    // every early return to it, so their pre-try region holds no `ret` at all while the checks
-    // are still entirely outside the try. Measured — the scan holds only for BuildNCLMetaTable
-    // and BuildNCLMetaXmlPort, and would be a false failure for the other four (PR body).
+    // WHAT THIS ASSERTS, AND WHAT IT DELIBERATELY DOES NOT
     //
-    // What is structural, and what is asserted instead: no branch in the pre-try region targets
-    // anything INSIDE the try, and at least one leaves past the handler. That is exactly "an
-    // absent object exits without the catch seeing it", and it survives a codegen change.
+    //   Asserted: the protected region begins at a nonzero offset and does not reach the method's
+    //   entry point, and the unprotected prologue is big enough to hold the existence checks. So
+    //   the checks run OUTSIDE the handler's reach, and an absent object returns without the
+    //   filter ever seeing it.
+    //
+    //   NOT asserted: which IL offset any particular early return branches to. Two attempts at
+    //   that both measured codegen rather than structure, and the second was unsound:
+    //
+    //   1. #3590's version asserts a `ret` byte appears before the first try offset. Roslyn gives
+    //      four of these five builders one shared epilogue and branches every early return to it,
+    //      so no `ret` is emitted before the try at all. Measured: the scan holds only for
+    //      BuildNCLMetaTable and BuildNCLMetaXmlPort.
+    //   2. This test's first version scanned the pre-try bytes for branch opcodes and required one
+    //      to target past the handler. Without a real opcode-length table a forward byte scan
+    //      cannot tell an opcode from an operand, and mis-framing yields garbage targets — on one
+    //      box BuildNCLMetaForm produced targets of 755630105 and 755630118, which satisfied
+    //      "past the handler" and made the check PASS on nonsense, while the same assertion failed
+    //      honestly on another box. It was wrong in both directions, so it is gone.
+    //
+    //   A sound version needs the full opcode table (or Cecil), and a behavioural arm driving a
+    //   real absent object through needs the BC engine, which would make this skip on boxes that
+    //   lack it — a non-vacuity guard that silently does not run is the defect it exists to catch.
+    //   The offsets below are source-determined, always run, and are what actually carries the
+    //   safety property.
 
     [Theory]
     [MemberData(nameof(Builders))]
@@ -179,63 +196,38 @@ public sealed class BuildNclMetaObjectFailureAttributionTests
     {
         var body = Method(builder).GetMethodBody()!;
         var clauses = body.ExceptionHandlingClauses;
-        Assert.True(clauses.Count > 0, $"{builder} has no exception handler at all.");
+
+        // Non-vacuity, part 1: there is a handler at all. Without this the two offset assertions
+        // below would be trivially satisfiable by a method that lost its try entirely.
+        Assert.True(clauses.Count > 0,
+            $"{builder} has no exception handler at all — this test would otherwise measure nothing.");
 
         var tryOffset = clauses.Select(c => c.TryOffset).Min();
         var clause = clauses.First(c => c.TryOffset == tryOffset);
-        var tryEnd = clause.TryOffset + clause.TryLength;
+        var il = body.GetILAsByteArray()!;
 
+        // The property: the try starts after the existence checks, so nothing absent reaches the
+        // catch filter. A try at offset 0 means a check has moved inside it.
         Assert.True(tryOffset > 0,
             $"{builder}'s try must start after its absent-object early returns; a try at offset 0 "
-            + "means a missing object now reaches the catch filter.");
+            + "means a genuinely missing object now reaches the catch filter and can be rethrown "
+            + "— the false-red half of guards-need-a-third-state.md's constraint.");
 
-        var il = body.GetILAsByteArray()!;
-        var preTryBranches = ShortAndLongBranches(il, tryOffset).ToList();
+        // Non-vacuity, part 2: the unprotected prologue is substantial, not a stray byte or two.
+        // Every existence check in these builders is at least a dictionary/set lookup plus a
+        // branch, so a prologue this small would mean the checks are no longer there. 16 bytes is
+        // well under the smallest real value (55) and well over a degenerate one.
+        Assert.True(tryOffset >= 16,
+            $"{builder}: only {tryOffset} IL bytes precede the try. The existence checks are not "
+            + "where this test thinks they are, so the assertion above is not measuring them.");
 
-        Assert.True(preTryBranches.Count > 0,
-            $"{builder}: no branch before the try — the existence checks are not where this "
-            + "test thinks they are, so it is measuring nothing.");
+        // And the handler does not reach back over the prologue.
+        Assert.True(clause.HandlerOffset > tryOffset,
+            $"{builder}: the handler starts at {clause.HandlerOffset}, at or before the try at "
+            + $"{tryOffset} — the protected region covers the existence checks.");
 
-        var intoTry = preTryBranches.Where(t => t >= clause.TryOffset && t < tryEnd).ToList();
-        Assert.True(intoTry.Count == 0,
-            $"{builder}: a branch before the try targets IL offset(s) "
-            + $"{string.Join(", ", intoTry)} inside the try [{clause.TryOffset},{tryEnd}). An "
-            + "existence check has moved inside the try, so a genuinely absent object can now "
-            + "reach the catch filter and be rethrown — the false-red half of "
-            + "guards-need-a-third-state.md's constraint.");
-
-        Assert.True(preTryBranches.Any(t => t >= tryEnd),
-            $"{builder}: no pre-try branch leaves past the handler, so no early-exit path "
-            + "bypasses the try at all.");
-    }
-
-    /// <summary>
-    /// Branch targets of the one-byte-opcode short (0x2B-0x37) and long (0x38-0x44) branch forms
-    /// occurring before <paramref name="limit"/>. Deliberately a coarse forward scan: it can
-    /// mis-frame an operand as an opcode, which can only ADD spurious targets, never hide a real
-    /// one — so the "targets nothing inside the try" assertion cannot be weakened by it.
-    /// </summary>
-    private static IEnumerable<int> ShortAndLongBranches(byte[] il, int limit)
-    {
-        var i = 0;
-        while (i < limit)
-        {
-            var op = il[i];
-            if (op >= 0x2B && op <= 0x37 && i + 1 < il.Length)
-            {
-                yield return i + 2 + (sbyte)il[i + 1];
-                i += 2;
-            }
-            else if (op >= 0x38 && op <= 0x44 && i + 4 < il.Length)
-            {
-                yield return i + 5 + BitConverter.ToInt32(il, i + 1);
-                i += 5;
-            }
-            else
-            {
-                i++;
-            }
-        }
+        Assert.True(il.Length > tryOffset,
+            $"{builder}: IL is shorter than its own try offset; the body could not be read.");
     }
 
     // ══ 4. THE FAILURE IS VISIBLE AT DEFAULT VERBOSITY ═══════════════════════════════════

--- a/AlRunner/Patches/RecordPatches.NclMetaFormReportBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaFormReportBuilder.cs
@@ -148,13 +148,35 @@ public static partial class RecordPatches
 
             return meta;
         }
-        catch (Exception ex)
+        // #3776 — the existence checks above sit OUTSIDE this try, so nothing reaching here is a
+        // "no such page" case: everything is a failure to build a page the runner had already
+        // established exists. Absorbing a deliberate refusal into the same null turns it into
+        // NavForm.GetMasterPage's not-found several layers later, naming neither page nor cause.
+        // Same filter and same reason as BuildNCLMetaTable's (#3590).
+        catch (Exception ex) when (BuildNclMetaFormCatchMayAbsorb(ex))
         {
-            var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
-            Console.Error.WriteLine($"[RecordPatches] BuildNCLMetaForm({pageId}) failed: {inner.GetType().Name}: {inner.Message}");
+            Console.Error.WriteLine(BuildNclMetaFormFailureLine(pageId, ex));
             return null;
         }
     }
+
+    /// <summary>
+    /// Whether <see cref="BuildNCLMetaForm"/>'s catch may absorb <paramref name="ex"/> into the
+    /// cached null, or must let it reach the caller so the cause is attributable (#3776).
+    /// False for the three deliberate refusals; true for everything else, which is what keeps
+    /// each caller's real not-found branch (guards-need-a-third-state.md). Both <c>Find</c> calls
+    /// walk the inner chain rather than testing with <c>is</c>: every construction step here is a
+    /// reflective invoke, so a refusal arrives wrapped in a <see cref="TargetInvocationException"/>.
+    /// </summary>
+    private static bool BuildNclMetaFormCatchMayAbsorb(Exception ex) => MetaObjectCatchMayAbsorb(ex);
+
+    /// <summary>
+    /// The stderr line for a page-metadata construction failure this catch DID absorb (#3776).
+    /// No leading <c>[RecordPatches]</c> tag — <c>Log.FilteredWriter</c> (AlRunner/Log.cs) drops a
+    /// line starting with one unless <c>--verbose</c>, which is what made the old write invisible.
+    /// </summary>
+    private static string BuildNclMetaFormFailureLine(int pageId, Exception ex)
+        => MetaObjectFailureLine("page", pageId, ex);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static object? BuildNCLMetaReport(int reportId)
@@ -189,13 +211,20 @@ public static partial class RecordPatches
 
             return meta;
         }
-        catch (Exception ex)
+        // #3776 — see BuildNclMetaFormCatchMayAbsorb. KnownReportIdSet() above is the existence
+        // check and it is outside this try, so everything here is a build failure for a report
+        // that exists, not a missing report.
+        catch (Exception ex) when (BuildNclMetaReportCatchMayAbsorb(ex))
         {
-            var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
-            Console.Error.WriteLine($"[RecordPatches] BuildNCLMetaReport({reportId}) failed: {inner.GetType().Name}: {inner.Message}");
+            Console.Error.WriteLine(BuildNclMetaReportFailureLine(reportId, ex));
             return null;
         }
     }
+
+    private static bool BuildNclMetaReportCatchMayAbsorb(Exception ex) => MetaObjectCatchMayAbsorb(ex);
+
+    private static string BuildNclMetaReportFailureLine(int reportId, Exception ex)
+        => MetaObjectFailureLine("report", reportId, ex);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static object? BuildNCLMetaQuery(int queryId)
@@ -221,13 +250,20 @@ public static partial class RecordPatches
 
             return meta;
         }
-        catch (Exception ex)
+        // #3776 — see BuildNclMetaFormCatchMayAbsorb. This is the SKELETON query builder; the
+        // real one is BuildRealNCLMetaQueryCore in RecordPatches.NclMetaQueryBuilder.cs, which
+        // carries the same filter.
+        catch (Exception ex) when (BuildNclMetaQueryCatchMayAbsorb(ex))
         {
-            var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
-            Console.Error.WriteLine($"[RecordPatches] BuildNCLMetaQuery({queryId}) failed: {inner.GetType().Name}: {inner.Message}");
+            Console.Error.WriteLine(BuildNclMetaQueryFailureLine(queryId, ex));
             return null;
         }
     }
+
+    private static bool BuildNclMetaQueryCatchMayAbsorb(Exception ex) => MetaObjectCatchMayAbsorb(ex);
+
+    private static string BuildNclMetaQueryFailureLine(int queryId, Exception ex)
+        => MetaObjectFailureLine("query", queryId, ex);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static object? BuildNCLMetaXmlPort(int xmlPortId)
@@ -256,11 +292,55 @@ public static partial class RecordPatches
 
             return meta;
         }
-        catch (Exception ex)
+        // #3776 — see BuildNclMetaFormCatchMayAbsorb. #3510 is this null's symptom end for
+        // xmlports: it surfaces as NavMetadataNotFoundException from inside the xmlport's own
+        // ctor, naming neither the failing construction step nor the cause.
+        catch (Exception ex) when (BuildNclMetaXmlPortCatchMayAbsorb(ex))
         {
-            var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
-            Console.Error.WriteLine($"[RecordPatches] BuildNCLMetaXmlPort({xmlPortId}) failed: {inner.GetType().Name}: {inner.Message}");
+            Console.Error.WriteLine(BuildNclMetaXmlPortFailureLine(xmlPortId, ex));
             return null;
         }
+    }
+
+    private static bool BuildNclMetaXmlPortCatchMayAbsorb(Exception ex) => MetaObjectCatchMayAbsorb(ex);
+
+    private static string BuildNclMetaXmlPortFailureLine(int xmlPortId, Exception ex)
+        => MetaObjectFailureLine("xmlport", xmlPortId, ex);
+
+    /// <summary>
+    /// The classification every metadata-object builder's catch filters on (#3776, #3590).
+    ///
+    /// <para>False — must NOT be absorbed — for the three refusals the runner raises
+    /// deliberately: <see cref="BcShapeGapException"/> (a BC member moved; contractually
+    /// uncatchable at AL's seams), <see cref="BcAppSymbolReadException"/> (a dependency's symbols
+    /// would not read to completion), and a TYPED <see cref="RunnerOutOfScopeException"/>. Typed
+    /// only: a BC exception whose message merely carries the convention is not one of ours
+    /// (#3048).</para>
+    ///
+    /// <para>Both <c>Find</c> calls walk the inner chain rather than testing with <c>is</c>,
+    /// because a refusal raised under a reflective invoke arrives wrapped in a
+    /// <see cref="TargetInvocationException"/>.</para>
+    ///
+    /// <para>Trap: this is shared by five catches whose builders each have their own named
+    /// wrapper, so the wrappers are what the proving test drives and what a future divergence
+    /// would specialise. Widening this predicate widens all five at once.</para>
+    /// </summary>
+    private static bool MetaObjectCatchMayAbsorb(Exception ex)
+        => AlRunner.Infrastructure.BcShapeGapException.Find(ex) is null
+           && AlRunner.Infrastructure.BcAppSymbolReadException.Find(ex) is null
+           && AlRunner.Infrastructure.OutOfScopeMessage.FromException(ex) is not { Typed: true };
+
+    /// <summary>
+    /// The stderr line for a construction failure a metadata-object builder's catch DID absorb
+    /// (#3776). Names the object kind, the id and the unwrapped cause, and carries no leading
+    /// bracketed component tag so <c>Log.FilteredWriter</c> cannot drop it at default verbosity.
+    /// Header and top frame are ONE write: a second write would be filtered independently.
+    /// </summary>
+    private static string MetaObjectFailureLine(string objectKind, int objectId, Exception ex)
+    {
+        var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
+        return $"al-runner: {objectKind} {objectId} metadata could not be built: "
+               + $"{inner.GetType().Name}: {inner.Message}"
+               + (inner.StackTrace != null ? "\n" + inner.StackTrace.Split('\n')[0] : "");
     }
 }

--- a/AlRunner/Patches/RecordPatches.NclMetaQueryBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaQueryBuilder.cs
@@ -113,13 +113,30 @@ public static partial class RecordPatches
             QLog($"BuildRealNCLMetaQuery({queryId}): built {(meta == null ? "NULL" : meta.GetType().Name)} clrType={clrType.FullName}");
             return meta;
         }
-        catch (Exception ex)
+        // #3776 — the reflection-availability check above sits OUTSIDE this try, so everything
+        // reaching here is a failure to build a query the runner had already established it
+        // could build. The absorbed null flows to CodeunitPatches.cs's NavQuery ctor and to
+        // EnsureQueryInMetadataCache, where it is dereferenced inside BC's own ALSetFilter /
+        // ValidateExpectedType — #3499's shape.
+        //
+        // The visibility half differs from the form/report builders and is WORSE: their write
+        // was merely tag-filtered at default verbosity, while QLog writes nothing at all unless
+        // AL_RUNNER_QDIAG=1, so an absorbed failure here produced no output anywhere. The
+        // absorbed case now writes the same unfiltered stderr line the others do; QLog keeps
+        // the stack-trace detail for a diagnostic run.
+        catch (Exception ex) when (BuildRealNclMetaQueryCatchMayAbsorb(ex))
         {
             var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
             QLog($"BuildRealNCLMetaQuery({queryId}) FAILED: {inner.GetType().Name}: {inner.Message}\n{inner.StackTrace}");
+            Console.Error.WriteLine(BuildRealNclMetaQueryFailureLine(queryId, ex));
             return null;
         }
     }
+
+    private static bool BuildRealNclMetaQueryCatchMayAbsorb(Exception ex) => MetaObjectCatchMayAbsorb(ex);
+
+    private static string BuildRealNclMetaQueryFailureLine(int queryId, Exception ex)
+        => MetaObjectFailureLine("query", queryId, ex);
 
     // Generic MetaQuery design builder, driven by the query's SymbolReference.json
     // definition (parsed by BcAppSymbolCache, indexed by BcAppFallback). Works for both

--- a/AlRunner/Patches/RecordPatches.NclMetadataCachePopulator.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetadataCachePopulator.cs
@@ -304,9 +304,24 @@ public static partial class RecordPatches
     }
 
     /// <summary>
+    /// The stderr line for a builder failure this populator's catch DID absorb (#3781). Names
+    /// the object kind, the id and the unwrapped cause, and carries no leading bracketed
+    /// component tag: <c>Log.FilteredWriter</c> (AlRunner/Log.cs) drops a line starting with one
+    /// unless <c>--verbose</c>, which is what made the old `[NclMetadataCachePopulator]` write
+    /// invisible at default verbosity. Same constraint as <see cref="MetaObjectFailureLine"/>.
+    /// </summary>
+    private static string PopulateOneObjectTypeFailureLine(string label, int id, Exception ex)
+    {
+        var inner = ex is System.Reflection.TargetInvocationException tie ? tie.InnerException ?? ex : ex;
+        return $"al-runner: {label.ToLowerInvariant()} {id} metadata could not be built: "
+               + $"{inner.GetType().Name}: {inner.Message}";
+    }
+
+    /// <summary>
     /// Insert one cache-entry per parsed object-id into
     /// metadataCacheEntries[objectTypeIndex]. Idempotent (TryAdd via dict[]= but skipped
-    /// if the key already exists). Errors are logged + counted, never thrown.
+    /// if the key already exists). Errors are logged + counted, never thrown — except the three
+    /// deliberate refusals, which tear through so the cause is attributable (#3781).
     /// </summary>
     private static void PopulateOneObjectType(Array arr, int objectTypeIndex,
         int[] ids, Func<int, object?> buildMeta, string label)
@@ -322,11 +337,15 @@ public static partial class RecordPatches
         {
             if (dict.Contains(id)) { skipped++; continue; }
             object? meta;
+            // #3781 — the same filter every metadata-object builder's own catch carries. This
+            // frame is the caller of five of the six builders and is the startup path, so a
+            // bare catch here converts a refusal that has just correctly torn through a
+            // builder's filter straight back into `meta = null`, one frame up, and #3590/#3776
+            // buy nothing on the path that carries most of the traffic.
             try { meta = buildMeta(id); }
-            catch (Exception ex)
+            catch (Exception ex) when (MetaObjectCatchMayAbsorb(ex))
             {
-                var inner = ex is System.Reflection.TargetInvocationException tie ? tie.InnerException ?? ex : ex;
-                Console.Error.WriteLine($"[NclMetadataCachePopulator] buildMeta({id}) threw {inner.GetType().Name}: {inner.Message}");
+                Console.Error.WriteLine(PopulateOneObjectTypeFailureLine(label, id, ex));
                 meta = null;
             }
             if (meta == null) { failed++; continue; }


### PR DESCRIPTION
Closes #3776
Closes #3781

Corpus-NA: the three tear-through types require a moved BC member, unreadable .app symbols, or a runner out-of-scope refusal — states no AL statement can produce, so a service tier has nothing to adjudicate. The subject is which exceptions the runner's own catch may absorb.

Filed and implemented by an agent (Claude, stma-auto-5).

## What changed

#3590 fixed `BuildNCLMetaTable`: its bare `catch (Exception)` turned every construction failure into the same answer as "this table does not exist". The sibling metadata-object builders carried the identical shape, so a `BcShapeGapException` naming the BC member that moved, a `BcAppSymbolReadException` naming a dependency whose symbols would not read to completion, and a typed `RunnerOutOfScopeException` all came back as `null` and surfaced several layers later as somebody else's NRE or `NavMetadataNotFoundException`.

Each catch now carries `when (Build<Kind>CatchMayAbsorb(ex))`, and the absorbed case writes a line the default log filter cannot drop.

## The caller frame defeated all of it — #3781, folded in

Found in review of this PR, and it is the blocker: `PopulateOneObjectType`
(`RecordPatches.NclMetadataCachePopulator.cs:325`) wrapped every builder call in a bare catch and
converted each refusal straight back to `meta = null`, **one frame up**. It is the caller of five
of the six builders (Table 79, Page 87, Report 109, Query 113, XmlPort 117) and it is the
**startup path** — it runs once per bundle before any AL test code, so it carries most of the
traffic. Its `[NclMetadataCachePopulator]` log tag meant `Log.cs`'s `^\[`-anchored regex dropped
even the absorbed case at default verbosity. On that path the observable was exactly what it was
before #3590 and #3776.

Folded in rather than left tracked: shipping a fix that is defeated on the busiest path invites
the next reader to treat the family as done. Same filter, same shared helper, and a failure line
with no leading component tag.

**This is the third instance of one shape in this family** — #3749, #3590, #3776 — each fixed
correctly and each defeated by a catch one frame up that nobody had enumerated. That is why the
new structural arm asserts the clause **kind** rather than offsets: it is the property that
actually distinguishes a filtered catch from a bare one.

## Five sites, not the three the issue named

`BuildNCLMetaQuery` (the **skeleton** query builder, distinct from `BuildRealNCLMetaQuery`) and `BuildNCLMetaXmlPort` sit in the same file as `BuildNCLMetaForm` and `BuildNCLMetaReport` and were identical in shape. Same file, same edit, so they fold in under `batch-sibling-issues-by-file.md` rather than becoming two more issues.

| builder | file | log path before |
|---|---|---|
| `BuildNCLMetaForm` | `RecordPatches.NclMetaFormReportBuilder.cs` | `[RecordPatches]`-tagged stderr |
| `BuildNCLMetaReport` | same | `[RecordPatches]`-tagged stderr |
| `BuildNCLMetaQuery` | same (**not named in the issue**) | `[RecordPatches]`-tagged stderr |
| `BuildNCLMetaXmlPort` | same (**not named in the issue**) | `[RecordPatches]`-tagged stderr |
| `BuildRealNCLMetaQueryCore` | `RecordPatches.NclMetaQueryBuilder.cs` | `QLog` |

## One shared predicate, five named wrappers — decided on the diff

The brief asked me to decide on the diff rather than on principle. Five copies of the three-line predicate would be five copies of the chain-walking `Find` calls, which is precisely the subtle part (see below) and the part that can silently drift in one copy. So: one `MetaObjectCatchMayAbsorb` core plus a thin named wrapper per builder. The wrappers are what the proving test drives and what a future divergence would specialise; the core is one place to get the walk right.

## The log-path finding: `QLog` is worse than tag-filtered, not merely different

The brief flagged that the query builder's log path is worth checking separately, and it is. The form/report/xmlport writes were `[RecordPatches] ...`, which `Log.FilteredWriter` (`AlRunner/Log.cs:114`) drops unless `--verbose`. `QLog` (`RecordPatches.NclMetaQueryBuilder.cs:38-42`) writes to `/tmp/qdiag.txt` **only when `AL_RUNNER_QDIAG=1`** — so an absorbed query-construction failure produced no output anywhere at default settings, not even a filtered one. The absorbed case now writes the same unfiltered stderr line the others do, and `QLog` keeps its stack-trace detail for a diagnostic run.

## The structural claim: verified per builder, and the #3590 test's version of it is codegen luck

The brief said to verify the "existence checks sit outside the try" property per builder rather than assume it, and pin each. Verifying it turned up a real defect in the pin itself.

#3590's `TheTwoAbsentReturns_SitOutsideTheTry_...` asserts a `ret` (IL `0x2A`) byte appears before the first try offset. Measured across all six builders:

| builder | first try offset | `ret` before try? |
|---|---:|---|
| `BuildNCLMetaForm` | 79 | **no** |
| `BuildNCLMetaReport` | 55 | **no** |
| `BuildNCLMetaQuery` | 86 | **no** |
| `BuildNCLMetaXmlPort` | 57 | yes |
| `BuildRealNCLMetaQueryCore` | 436 | **no** |
| `BuildNCLMetaTable` (#3590) | 648 | yes |

The four "no" rows are **not** existence checks inside the try — every try offset is far past the checks. Roslyn gives those methods a single shared 2-byte epilogue and branches every early return to it, so no `ret` is emitted before the try at all. The byte scan reads a codegen accident; it happens to hold for the two builders #3590 and I looked at first, and would be a false failure on the other four.

My first replacement was **also** codegen-dependent, and worse — it was unsound. It scanned the pre-try bytes for branch opcodes and required one to target past the handler. Without an opcode-length table a forward byte scan cannot tell an opcode from an operand, and mis-framing yields garbage: on my box `BuildNCLMetaForm` produced branch targets of **755630105** and **755630118**, which trivially satisfy "past the handler" and made the check **pass on nonsense**. On the coordinator's box the mis-framing landed differently and four arms failed honestly. Wrong in both directions, so it is gone. I am grateful this was caught before review rather than after.

What the test pins now is **source-determined rather than codegen-determined**: the try begins at a nonzero offset, at least 16 IL bytes precede it, and the handler begins after the try. Measured:

| builder | try offset | IL bytes before try | handler after try |
|---|---:|---:|---|
| `BuildNCLMetaForm` | 79 | 79 | yes |
| `BuildNCLMetaReport` | 55 | 55 | yes |
| `BuildNCLMetaQuery` | 86 | 86 | yes |
| `BuildNCLMetaXmlPort` | 57 | 57 | yes |
| `BuildRealNCLMetaQueryCore` | 436 | 436 | yes |

**The property holds for all five builders** — no negative result to report on that axis.

**And it did not prove this PR until review said so.** Every offset above is byte-identical on a
pre-fix build — all five try offsets are the same (79, 55, 86, 57, 436) and all four assertions
passed on **both** sides of the change. The one thing the fix actually alters is the clause
**kind**: a bare `catch (Exception)` reports `ExceptionHandlingClauseOptions.Clause`, a
`catch ... when (...)` reports `Filter`. That is now asserted, and it is what makes the method a
proving test rather than a sound one (`tdd.md`). Verified by reverting only the five `when (...)`
filters, keeping the helpers: all five arms fail, every other assertion still passing.

Non-vacuity is carried by the clause count and the 16-byte floor, and it is verified **by mutation rather than by assertion**: moving `BuildNCLMetaReport`'s existence check inside its try fails exactly that builder's arm with `only 1 IL bytes precede the try`, and no other arm. The production file was restored byte-identical afterwards (`git diff` empty).

## `guards-need-a-third-state.md`: the callers do have real not-found branches

Enumerated with `tools/lsp-query.py callers` per builder — and the first version of this table was **one short in two places**, which review caught. This is the LSP's answer, not a hand-built list:

| caller | branch |
|---|---|
| `NclMetadataCachePopulator.cs:87` | `GetOrAdd(id, BuildNCLMetaForm)` via `PopulateOneObjectType` |
| `NclMetadataCachePopulator.cs:109` | same shape, `"Report"` |
| `NclMetadataCachePopulator.cs:113` | same shape, `"Query"` |
| `NclMetadataCachePopulator.cs:117` | same shape, `"XmlPort"` |
| `NclMetadataCachePopulator.cs:161` | `if (meta != null) return meta;` |
| `NclMetadataCachePopulator.cs:172` | `EnsureRealPageMetadata(objectId) ?? GetOrAdd(...)`, then `if (meta != null)` |
| `NclMetadataCachePopulator.cs:217` | **missed first time** — `EnsureRealXmlPortMetadata(objectId) ?? GetOrAdd(...)`, then `if (meta != null) return meta;` |
| `NclMetadataCachePopulator.cs:279` | `EnsureQueryInMetadataCache` → `if (meta == null) return null;` |
| `RealPageMetadata.cs:211`, `:216` | `if (meta == null) { _pageRealMetadataNegativeEpoch[pageId] = epoch; return null; }` |
| `RealXmlPortMetadata.cs:111` | **missed first time** — `if (meta == null) return null;` |
| `CodeunitPatches.cs:1197` | passes the result into BC's `NavQuery` ctor — this is #3499's null |

Both missed sites take genuine null branches, so the conclusion survives; the table was just incomplete. Lesson taken: enumerate with the LSP and let that be the list.

So a blanket rethrow would be the false-red trap, and the negative controls in section 2 of the test are what stop this becoming one.

## Caching

`BuildRealNCLMetaQuery` is `_realMetaQueryCache.GetOrAdd(id, _ => Core(...))`, and every other builder is reached through a `GetOrAdd` at its call site. `ConcurrentDictionary.GetOrAdd` writes **no entry when the factory throws**, so a torn-through refusal is raised again on the next call rather than being answered from a cached null — a warm run cannot hide it. The test measures this directly (`GetOrAdd_CachesNothingWhenTheFactoryThrows_...`) rather than asserting it in prose, which is why I did not need the second warm run `local-test-scope.md` asks for on cache-touching changes: the refusal path provably creates no entry to hit.

There is no post-emit sweep asymmetry to mirror here — the `_metaFormCache` eviction path (`RealPageMetadata.cs:209`, `EvictPageMetaForm`) already exists for pages and is unchanged by this PR.

## Fix the shape

1. **Same wrong pattern at another call site?** Yes — two more than the issue named (`BuildNCLMetaQuery`, `BuildNCLMetaXmlPort`), both folded in. I read every `catch (Exception` in both files; those five are all of them in the builder family.
2. **Sibling function making the same assumption?** The two extra builders were exactly that. `WireFieldTriggerHandlers` in `RecordPatches.NclMetaTableBuilder.cs` already carries this filter (#3026/#3048) and needs nothing.
3. **Two code paths writing the same state with different invariants?** Yes, and it is the `QLog` finding above: the four form/report-file builders and the query builder wrote the same "construction failed" state through log paths with different visibility guarantees. Both now write an unfiltered line.

## Issues searched, and what I did NOT fold

Searched the open queue on the mechanism ("swallow", "construction failure"), the symbol ("NCLMeta"), the observable ("xmlport metadata"), and the `area: metadata-conversion` label.

- **#3510** — "Precompiled BaseApp XmlPort metadata cannot be built and the skeleton fallback also returns null: 42 failures". This is the **symptom end** of the xmlport site I fixed: its stack shows `NavMetadataNotFoundException` raised from inside `XmlPort1230`'s own ctor, naming neither the failing construction step nor the cause. **Not folded and not closed** — it needs the metadata to actually build, which this PR does not do. What this PR changes is that a *refusal* on that path is now attributable instead of arriving as that same anonymous not-found. Left open with a comment.
- **#3499** — "356 Microsoft-surface failures are one null NCLMetaQuery". Same relationship for `BuildRealNCLMetaQueryCore` and `CodeunitPatches.cs:1197`. The issue itself is explicit that it does not claim the swallow *causes* it. Not folded; it is `blocked-by: metadata-emitter`.
- **#3590** — the parent. Its PR (#3772) is not merged yet; I branched off `main` and wrote these independently, so there is no dependency between the two PRs. They touch different files and do not conflict.
- **#3749**, **#3479** — other swallowed-catch issues, different files and different mechanisms (`METADATA-EMIT-*` throws, `TryGetControlFormat`). Not foldable under the same-file test.

## RED → GREEN

RED (helpers absent, filters bare): **59 failed, 2 passed** of 61. The 2 passing were the `GetOrAdd` cache measurement (a real `ConcurrentDictionary` property, correctly independent of this change) and the xmlport structural check.

RED for #3781, measured by reverting the populator to its pre-fix state: **3 failed, 0 passed** of the 3 new arms.
RED for the clause-kind assertion, measured by reverting only the five `when (...)` filters: **5 failed, 0 passed** of 5.

GREEN, on the pushed head `7ffc891c` with a clean tree and a from-scratch rebuild (`obj/` and `bin/` removed):

```
Passed!  - Failed: 0, Passed: 156, Skipped: 10, Total: 166
```

covering `BuildNclMetaObjectFailureAttributionTests` (64), `ReflectionDrivenHelperLiveness`, `ScratchDirOwnershipGuard`, `BcShapeGapConvention`, `MetaQueryCacheBundleBoundary`, `NclMeta`, `MetaQuery`, `XmlPort`, `PageMetadata`, `ReportMetadata` and `CachePopulator`.

**A correction on process.** The first version of this PR reported 61/61 having edited the test after that run and never re-run the full filter — the adjacent-suite greens afterwards were read as covering it. They did not. The coordinator measured 4 failures on the same SHA. Every number above was re-measured on the pushed head after a clean rebuild.

`ScratchDirOwnershipGuardTests` is unaffected: the new tests build no temp paths at all, so its allowlist and recorded counts are untouched.

## Where the prose went

The derivation behind the codegen finding is in this body, not in the source. What stayed at the lines is the claim, the citation and the trap: why the filter walks the chain instead of using `is`, why `QLog` needed a second write, and that widening the shared predicate widens all five catches at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
