### PR TITLE
test(metadata-equivalence): compare CodeUnit, step 2 of 8

### DIFF
--- a/AlRunner.Tests/CodeunitSymbolSingleInstanceSpellingTests.cs
+++ b/AlRunner.Tests/CodeunitSymbolSingleInstanceSpellingTests.cs
@@ -1,0 +1,146 @@
+// CodeunitSymbolSingleInstanceSpellingTests — a codeunit's SingleInstance is read from the
+// spelling Microsoft's own .app files actually use.
+//
+// THE DEFECT THIS PINS (#3790, found by the CodeUnit metadata-equivalence comparison, #3782)
+//   BcAppSymbolCache read the codeunit-only SingleInstance property with a hand-rolled
+//   `string.Equals(value, "true")`, while every OTHER boolean in that file goes through
+//   SymbolBool, which accepts BOTH spellings and whose own doc comment records that the symbol
+//   file writes "1"/"0" in practice and "true"/"false" only as a tolerated form.
+//
+//   Microsoft writes "1". Measured on System Application 28.1.49838.53910: of its 533
+//   codeunits, 38 state SingleInstance = "1", 5 state "0", 490 state nothing — and NOT ONE
+//   states "true". So the comparison never matched, and CodeUnit Metadata (2000000137) answered
+//   SingleInstance = false for all 38, which is also the truthful answer for a codeunit that
+//   declares none. AL branching on the column cannot tell the two apart.
+//
+//   It survived because the only existing test for this path wrote "true" into its fixture —
+//   the one spelling a real package never uses. Both spellings are asserted below.
+//
+// WHY A RUNNER-SIDE MECHANISM TEST
+//   The BC-behaviour claim (what a real tier answers for a SingleInstance codeunit) is already
+//   upstream and green: CodeunitMetadata_SingleInstanceCodeunit_ReportsTrueAndNoTableNo, cited
+//   in AlRunner.Tests/CodeunitMetadataVirtualTableTests.cs. What no AL test can reach is the
+//   PRECOMPILED-dependency route: an AL bundle's own codeunits are source-parsed, so the
+//   symbol-file spelling never comes up. This file drives that route directly.
+
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class CodeunitSymbolSingleInstanceSpellingTests : IDisposable
+{
+    private const int SingleInstanceNumeric = 61041;
+    private const int SingleInstanceWord = 61042;
+    private const int NotSingleInstance = 61043;
+    private const int DeclaresNothing = 61044;
+
+    private readonly string _root;
+
+    public CodeunitSymbolSingleInstanceSpellingTests()
+    {
+        _root = TestScratch.Dir("al-runner-codeunit-singleinstance-spelling");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        RecordPatches.ResetForReload();
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    /// <summary>
+    /// The four shapes a real symbol file presents. <c>"1"</c> is what Microsoft's own packages
+    /// write — 38 of System Application 28.1's 533 codeunits — and it is the one that used to
+    /// read as false.
+    /// </summary>
+    private static readonly string SymbolReference = $$"""
+        {
+          "RuntimeVersion": "15.1",
+          "AppId": "1f7b3c8e-5d21-4a90-9b44-6e0f2a71c355",
+          "Name": "SingleInstance Spelling Fixture",
+          "Codeunits": [
+            {
+              "Id": {{SingleInstanceNumeric}},
+              "Name": "Si Numeric",
+              "Properties": [ { "Name": "SingleInstance", "Value": "1" } ]
+            },
+            {
+              "Id": {{SingleInstanceWord}},
+              "Name": "Si Word",
+              "Properties": [ { "Name": "SingleInstance", "Value": "true" } ]
+            },
+            {
+              "Id": {{NotSingleInstance}},
+              "Name": "Si Numeric False",
+              "Properties": [ { "Name": "SingleInstance", "Value": "0" } ]
+            },
+            {
+              "Id": {{DeclaresNothing}},
+              "Name": "Si Unstated",
+              "Properties": []
+            }
+          ]
+        }
+        """;
+
+    private void Register()
+    {
+        var appPath = Path.Combine(_root, "singleinstance-spelling.app");
+        using (var zip = new FileStream(appPath, FileMode.Create))
+        using (var za = new ZipArchive(zip, ZipArchiveMode.Create))
+        {
+            var entry = za.CreateEntry("SymbolReference.json");
+            using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+            w.Write(SymbolReference);
+        }
+        RecordPatches.ResetForReload();
+        RecordPatches.AddBcAppPath(appPath);
+    }
+
+    /// <summary>
+    /// Reads the value back off the projection the metadata-equivalence harness compares, which
+    /// is the same <c>EnumerateKnownCodeunitMetadata</c> row CodeUnit Metadata answers from —
+    /// so this asserts the column's own source, not a second derivation written for the test.
+    /// </summary>
+    private static string SingleInstanceOf(int codeunitId)
+    {
+        var xml = RecordPatches.TryBuildCodeunitMetadataEquivalenceXml(codeunitId);
+        Assert.True(xml is not null, $"the runner derived no metadata for codeunit {codeunitId}");
+        var doc = new System.Xml.XmlDocument();
+        doc.LoadXml(xml!);
+        return doc.DocumentElement!.GetAttribute("SingleInstance");
+    }
+
+    [Fact]
+    public void NumericOne_TheSpellingMicrosoftsOwnPackagesUse_ReadsAsSingleInstance()
+    {
+        Register();
+
+        // The defect: this answered "0" while the symbol file said "1".
+        Assert.Equal("1", SingleInstanceOf(SingleInstanceNumeric));
+    }
+
+    [Fact]
+    public void WordTrue_TheToleratedSpelling_StillReadsAsSingleInstance()
+    {
+        Register();
+
+        Assert.Equal("1", SingleInstanceOf(SingleInstanceWord));
+    }
+
+    /// <summary>
+    /// The negative half, and it is the one that stops the fix being "answer true always":
+    /// a codeunit stating "0" and one stating nothing must both stay false.
+    /// </summary>
+    [Fact]
+    public void NumericZero_AndAnUnstatedProperty_BothStayNotSingleInstance()
+    {
+        Register();
+
+        Assert.Equal("0", SingleInstanceOf(NotSingleInstance));
+        Assert.Equal("0", SingleInstanceOf(DeclaresNothing));
+    }
+}

--- a/AlRunner.Tests/CodeunitSymbolSingleInstanceSpellingTests.cs
+++ b/AlRunner.Tests/CodeunitSymbolSingleInstanceSpellingTests.cs
@@ -30,6 +30,9 @@ using Xunit;
 
 namespace AlRunner.Tests;
 
+// Reaches the RecordPatches AL parse statics, which are process-wide and which xunit's
+// parallel collections can clear or repopulate between a write and a read (#1696, #1712).
+[Collection(RecordPatchesSerialCollection.Name)]
 public sealed class CodeunitSymbolSingleInstanceSpellingTests : IDisposable
 {
     private const int SingleInstanceNumeric = 61041;

--- a/AlRunner.Tests/MetadataEquivalenceCodeunitOracleTests.cs
+++ b/AlRunner.Tests/MetadataEquivalenceCodeunitOracleTests.cs
@@ -1,0 +1,186 @@
+// MetadataEquivalenceCodeunitOracleTests — pins that the CodeUnit comparison has a real oracle
+// and a real runner side, so it cannot go green having measured nothing (#3782, step 2 of 8).
+//
+// WHY THIS FILE EXISTS
+//   Step 1 of #3782 handed BC's page document to MetaPageDefinition, which constructs without
+//   throwing and returns a DEFAULT object. The harness then compared that empty object against
+//   itself: 235 pages compared, 0 differences, every other test in the suite still green. A
+//   comparison whose two sides are both empty is indistinguishable from a comparison that
+//   agrees, and nothing in the harness can tell them apart.
+//
+//   The codeunit side has the same two ways to go quietly wrong, so both are pinned here:
+//     1. the ORACLE could parse nothing — asserted against real values from a real document;
+//     2. the RUNNER side could be BC's own emitter output — which would compare BC against BC.
+
+using System.Reflection;
+using System.Xml;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class MetadataEquivalenceCodeunitOracleTests
+{
+    private readonly BcEngineFixture _engine;
+
+    public MetadataEquivalenceCodeunitOracleTests(BcEngineFixture engine) => _engine = engine;
+
+    private static Type CodeunitType() =>
+        Type.GetType("Microsoft.Dynamics.Nav.Types.Metadata.MetaCodeunit, Microsoft.Dynamics.Nav.Types")
+        ?? throw new InvalidOperationException("MetaCodeunit is not reachable.");
+
+    private static object Parse(string xml)
+    {
+        var doc = new XmlDocument();
+        doc.LoadXml(xml);
+        var ctor = CodeunitType().GetConstructor(new[] { typeof(XmlNode) })
+                   ?? throw new InvalidOperationException("MetaCodeunit has no (XmlNode) constructor.");
+        return ctor.Invoke(new object?[] { doc.DocumentElement })!;
+    }
+
+    private static object? Read(object meta, string property) =>
+        CodeunitType().GetProperty(property, BindingFlags.Public | BindingFlags.Instance)!.GetValue(meta);
+
+    /// <summary>
+    /// The oracle READS the document. Every value here is one BC's emitter actually wrote, so a
+    /// type that ignored the document — the MetaPageDefinition failure — answers 0 / null and
+    /// fails on the first assertion rather than comparing nothing against nothing.
+    /// </summary>
+    [SkippableFact]
+    public void MetaCodeunit_parses_the_emitters_own_document_rather_than_ignoring_it()
+    {
+        Skip.IfNot(_engine.Ready, _engine.SkipReason);
+
+        // The emitter's own shape for System Application codeunit 26, attribute for attribute.
+        var meta = Parse(
+            """
+            <CodeUnit xmlns="urn:schemas-microsoft-com:dynamics:NAV:MetaObjects" MetadataVersion="130000"
+                      ID="26" Name="Confirm Management Impl." ALNamespace="System.Utilities"
+                      InherentEntitlements="16" InherentPermissions="16" SingleInstance="1"
+                      EventSubscriberInstance="StaticAutomatic" Subtype="Normal" TestIsolation="Disabled" />
+            """);
+
+        Assert.Equal(26, Read(meta, "Id"));
+        Assert.Equal("Confirm Management Impl.", Read(meta, "Name"));
+        Assert.Equal("System.Utilities", Read(meta, "ALNamespace"));
+        // Enum-valued, so compared by name rather than by a hardcoded ordinal.
+        Assert.Equal("Normal", Read(meta, "SubType")!.ToString());
+        Assert.Equal("Execute", Read(meta, "InherentPermissions")!.ToString());
+        Assert.Equal("Execute", Read(meta, "InherentEntitlements")!.ToString());
+    }
+
+    /// <summary>
+    /// The oracle DISCRIMINATES: a different document produces different values. Without this,
+    /// the test above would still pass against a type that returned one hardcoded object.
+    /// </summary>
+    [SkippableFact]
+    public void MetaCodeunit_answers_differently_for_a_different_document()
+    {
+        Skip.IfNot(_engine.Ready, _engine.SkipReason);
+
+        var meta = Parse(
+            """
+            <CodeUnit xmlns="urn:schemas-microsoft-com:dynamics:NAV:MetaObjects" ID="9557"
+                      Name="Table Key" ALNamespace="System.Reflection" Subtype="Test"
+                      SingleInstance="0" TableNo="2000000001" />
+            """);
+
+        Assert.Equal(9557, Read(meta, "Id"));
+        Assert.Equal("Table Key", Read(meta, "Name"));
+        Assert.Equal("System.Reflection", Read(meta, "ALNamespace"));
+        Assert.Equal("Test", Read(meta, "SubType")!.ToString());
+        // Absent on this document, present on the one above — so the reader is reading, not
+        // returning a constant.
+        Assert.Equal("None", Read(meta, "InherentPermissions")!.ToString());
+    }
+
+    /// <summary>
+    /// The runner's side is the runner's OWN derivation, not BC's emitter output.
+    ///
+    /// <para>This is the assertion that stops the whole comparison becoming BC-against-BC. The
+    /// codeunit document sitting in <c>AlObjectMetadataRegistry</c> is what BC's emitter
+    /// produced, captured at compile time — <c>RecordPatches.CodeunitMetadataFromBcDocument.cs</c>
+    /// says so at its head — and it is the SAME document the ground truth holds. Feeding it to
+    /// the harness would report zero differences having measured nothing.</para>
+    ///
+    /// <para>What the projection states is therefore exactly the five values the runner derives
+    /// from SymbolReference.json, and it must NOT state the members BC's emitter adds. Asserting
+    /// their absence is what pins the two sides apart.</para>
+    /// </summary>
+    [SkippableFact]
+    public void The_runner_side_states_only_what_the_runner_derives()
+    {
+        Skip.IfNot(_engine.Ready, _engine.SkipReason);
+
+        var bundles = MetadataEquivalenceHarness.LoadBundles(
+            MetadataEquivalencePaths.GroundTruthDirForThisBuild());
+        Skip.If(bundles.Count == 0, "no metadata ground-truth bundle for this BC build.");
+
+        var bundle = bundles.First(b => b.AppName == "System Application");
+        var app = MetadataEquivalenceHarness.FindAppPackage(bundle);
+        Skip.If(app is null, "the System Application .app for this bundle is not on this box.");
+        RecordPatches.AddBcAppPath(app!);
+
+        // Codeunit 26 is in System Application and BC's emitter states ALNamespace,
+        // InherentPermissions, InherentEntitlements and TestIsolation for it.
+        var xml = RecordPatches.TryBuildCodeunitMetadataEquivalenceXml(26);
+        Assert.True(xml is not null,
+            "the runner derives no metadata for System Application codeunit 26, so the CodeUnit " +
+            "comparison would report it unbuildable rather than comparing it.");
+
+        var doc = new XmlDocument();
+        doc.LoadXml(xml!);
+        var root = doc.DocumentElement!;
+
+        // Present: the five the runner genuinely derives.
+        Assert.Equal("26", root.GetAttribute("ID"));
+        Assert.Equal("Confirm Management Impl.", root.GetAttribute("Name"));
+        Assert.Equal("1", root.GetAttribute("SingleInstance"));
+        Assert.Equal("Normal", root.GetAttribute("Subtype"));
+
+        // Absent: everything only BC's emitter knows. If any of these appears, the runner side
+        // has started carrying BC's own answers and the comparison has stopped measuring.
+        foreach (var emitterOnly in new[]
+                 { "ALNamespace", "InherentPermissions", "InherentEntitlements",
+                   "TestIsolation", "EventSubscriberInstance", "MetadataVersion" })
+            Assert.False(root.HasAttribute(emitterOnly),
+                $"the runner's projection states '{emitterOnly}', which only BC's emitter " +
+                "derives. Stating it would manufacture agreement with the ground truth and " +
+                "turn a real gap (#3788) into a silent pass.");
+
+        Assert.False(root.HasChildNodes,
+            "the runner's projection carries a child element. It derives no methods and no " +
+            "triggers, so a subtree here would be BC's own emitter output rather than the " +
+            "runner's derivation.");
+    }
+
+    /// <summary>
+    /// A codeunit declaring no <c>TableNo</c> omits the attribute rather than writing 0.
+    /// BC's emitter omits it too — 12 of System Application's 533 documents carry it — so
+    /// writing a 0 would state a value where BC states absence.
+    /// </summary>
+    [SkippableFact]
+    public void A_codeunit_declaring_no_TableNo_omits_the_attribute_rather_than_writing_zero()
+    {
+        Skip.IfNot(_engine.Ready, _engine.SkipReason);
+
+        var bundles = MetadataEquivalenceHarness.LoadBundles(
+            MetadataEquivalencePaths.GroundTruthDirForThisBuild());
+        Skip.If(bundles.Count == 0, "no metadata ground-truth bundle for this BC build.");
+        var bundle = bundles.First(b => b.AppName == "System Application");
+        var app = MetadataEquivalenceHarness.FindAppPackage(bundle);
+        Skip.If(app is null, "the System Application .app for this bundle is not on this box.");
+        RecordPatches.AddBcAppPath(app!);
+
+        var without = new XmlDocument();
+        without.LoadXml(RecordPatches.TryBuildCodeunitMetadataEquivalenceXml(26)!);
+        Assert.False(without.DocumentElement!.HasAttribute("TableNo"));
+
+        // Codeunit 8888 "Email Dispatcher" declares TableNo = 8888 in BC's own document, so the
+        // omission above is a property of that codeunit rather than of the projection.
+        var with = new XmlDocument();
+        with.LoadXml(RecordPatches.TryBuildCodeunitMetadataEquivalenceXml(8888)!);
+        Assert.Equal("8888", with.DocumentElement!.GetAttribute("TableNo"));
+    }
+}

--- a/AlRunner.Tests/MetadataEquivalenceHarness.cs
+++ b/AlRunner.Tests/MetadataEquivalenceHarness.cs
@@ -111,7 +111,7 @@ internal static class MetadataEquivalenceHarness
     /// #3782 is the programme that empties the NOT-compared list, one kind per pull request.
     /// The order and remaining kinds are on that issue.
     /// </summary>
-    internal static readonly string[] ComparedKinds = { "MetaTable", "PageDefinition" };
+    internal static readonly string[] ComparedKinds = { "CodeUnit", "MetaTable", "PageDefinition" };
 
     public static IReadOnlyList<GroundTruthBundle> LoadBundles(string root)
     {
@@ -197,6 +197,27 @@ internal static class MetadataEquivalenceHarness
                 "the comparison would become a hand-written XML walk against the runner — two " +
                 "derivations, no oracle.");
 
+        // BC's own reader for a CodeUnit document: a CONSTRUCTOR on a STRUCT, not a factory —
+        // codeunits have no CreateMetaCodeunitFromXml the way MetaTable has
+        // CreateMetaTableFromXml.
+        //
+        // Proven to parse rather than assumed to: measured on BC 28.1.49838.53910 against the
+        // emitter's own CodeUnit 26 "Confirm Management Impl.", this constructor answers
+        // Id=26, Name="Confirm Management Impl.", ALNamespace="System.Utilities",
+        // InherentPermissions=Execute and SubType=Normal. Step 1 of #3782 lost a full cycle to
+        // MetaPageDefinition, which also constructs without throwing and returns a DEFAULT
+        // object, so the comparison ran green over 235 pages having compared nothing. The
+        // discrimination is pinned in MetadataEquivalenceCodeunitOracleTests.
+        var codeunitType =
+            Type.GetType("Microsoft.Dynamics.Nav.Types.Metadata.MetaCodeunit, Microsoft.Dynamics.Nav.Types")
+            ?? throw new InvalidOperationException("MetaCodeunit is not reachable.");
+        var codeunitFromXml = codeunitType.GetConstructor(new[] { typeof(XmlNode) })
+            ?? throw new InvalidOperationException(
+                "MetaCodeunit has no (XmlNode) constructor. Without it there is no way to read " +
+                "BC's emitted CodeUnit document back into BC's own object model, and the " +
+                "comparison would become a hand-written XML walk against the runner — two " +
+                "derivations, no oracle.");
+
         var differences = new List<MetadataDifference>();
         var unbuildable = new List<string>();
         int compared = 0;
@@ -212,7 +233,44 @@ internal static class MetadataEquivalenceHarness
             object? actual;
             string objectKey;
 
-            if (obj.Kind == "PageDefinition")
+            if (obj.Kind == "CodeUnit")
+            {
+                objectKey = $"Codeunit {obj.Id}";
+                try
+                {
+                    expected = codeunitFromXml.Invoke(new object?[] { document.DocumentElement });
+                }
+                catch (Exception ex)
+                {
+                    unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': BC's own MetaCodeunit " +
+                                    $"constructor threw — {Describe(ex)}");
+                    continue;
+                }
+
+                try
+                {
+                    // The runner's own codeunit derivation, rendered as the document BC's
+                    // constructor reads — NOT the document in AlObjectMetadataRegistry, which
+                    // is BC's emitter output captured at compile and would compare BC against
+                    // BC. See RecordPatches.CodeunitMetadataEquivalence.cs.
+                    var runnerXml = RecordPatches.TryBuildCodeunitMetadataEquivalenceXml(obj.Id);
+                    if (runnerXml is null)
+                    {
+                        unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': the runner knows no " +
+                                        "codeunit with that id");
+                        continue;
+                    }
+                    var runnerDoc = new XmlDocument();
+                    runnerDoc.LoadXml(runnerXml);
+                    actual = codeunitFromXml.Invoke(new object?[] { runnerDoc.DocumentElement });
+                }
+                catch (Exception ex)
+                {
+                    unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': the runner threw — {Describe(ex)}");
+                    continue;
+                }
+            }
+            else if (obj.Kind == "PageDefinition")
             {
                 objectKey = $"Page {obj.Id}";
                 try

--- a/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
+++ b/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
@@ -174,8 +174,8 @@ public sealed class MetadataEquivalenceHarnessTests
         // programme finishes, which is the one outcome it must not punish.
         string[] stillUncompared =
         {
-            // step 2..8, in the order issue #3782's comment sets.
-            "CodeUnit", "Query", "XmlPort", "Report", "PermissionSet", "Enum",
+            // step 3..8, in the order issue #3782's comment sets.
+            "Query", "XmlPort", "Report", "PermissionSet", "Enum",
             "MetadataRuntimeDeltas",
         };
 
@@ -202,9 +202,38 @@ public sealed class MetadataEquivalenceHarnessTests
 
             Assert.Contains("MetaTable", report.KindsCompared);
             Assert.Contains("PageDefinition", report.KindsCompared);
+            Assert.Contains("CodeUnit", report.KindsCompared);
 
             foreach (var kind in stillUncompared.Where(k => report.Bundle.Census.ContainsKey(k)))
                 Assert.Contains(kind, report.KindsNotCompared);
+        }
+    }
+
+    [SkippableFact]
+    public void Codeunits_are_compared_in_the_numbers_the_bundle_declares()
+    {
+        // The step-2 counterpart of the page claim below, and it is needed for the same reason:
+        // every other test in this file measures DIFFERENCES, so a codeunit comparison that
+        // quietly compared nothing would leave all of them green. Here the risk is sharper than
+        // for pages — the runner has no MetaCodeunit and its side is a PROJECTION, so a
+        // projection that silently produced nothing would report zero differences and read as
+        // perfect agreement.
+        foreach (var report in RunAll())
+        {
+            var declared = report.Bundle.Census.GetValueOrDefault("CodeUnit");
+            Assert.True(declared > 0,
+                $"{report.Bundle.Label}: the bundle declares no CodeUnit at all, so this test " +
+                "measures nothing. Regenerate the bundle.");
+
+            var codeunitDifferences = report.Differences
+                .Where(d => d.ObjectKey.StartsWith("Codeunit ", StringComparison.Ordinal))
+                .Select(d => d.ObjectKey).Distinct().Count();
+
+            // A codeunit the runner reproduces exactly contributes no differences, so this is a
+            // floor rather than an equality — but a floor of zero would be the vacuous claim.
+            Assert.True(codeunitDifferences > 0 || report.ObjectsCompared >= declared,
+                $"{report.Bundle.Label}: {declared} CodeUnit(s) in the bundle and none was " +
+                "compared. " + report.Summary);
         }
     }
 

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -242,7 +242,21 @@ internal static partial class BcAppSymbolCache
     // "the AL states nothing" into "the AL states the default", and a payload written by the
     // previous parse replays that collapse from a warm cache — a wrong ANSWER (BC's emitter
     // writes the attribute precisely when the AL states the property), not a cache miss.
-    private const int CacheVersion = 38;
+    // v39: a codeunit's SingleInstance is read with SymbolBool rather than a hand-rolled match
+    // on the word "true" (#3790). Same trap as v35, v36 and v38 a fourth time — the record
+    // SHAPE is unchanged, ObjectSymbol.SingleInstance is a bool either way, so PayloadShape
+    // cannot see that 38 of System Application 28.1's 533 codeunits went from false to true.
+    // Without the bump a warm box replays the old parse and CodeUnit Metadata keeps answering
+    // SingleInstance = false for every single-instance codeunit in a precompiled dependency.
+    //
+    // This one was written as v38 first and COLLIDED: #3791 took 38 for the page payload above
+    // while #3785 was in flight, and both were correct in isolation. That is the hazard this
+    // integer carries and ordinary code does not — when the shape is unchanged the integer is
+    // the ONLY discriminator, so two payload meanings sharing one number is not a bookkeeping
+    // slip but a warm box replaying the wrong parse, silently, on both. Re-read this constant
+    // on origin/main immediately before pushing a bump; a rebase resolves the text and cannot
+    // tell you the number is already taken.
+    private const int CacheVersion = 39;
     private static readonly ConcurrentDictionary<string, AppSymbols> ProcessCache = new(StringComparer.OrdinalIgnoreCase);
     // Issue #1820's path -> content-hash memo now lives in
     // RunnerFingerprint._fileContentHashes (#2955), because AppLoader's persisted r2r-chunks
@@ -1176,15 +1190,18 @@ internal static partial class BcAppSymbolCache
                     // The object-level properties CodeUnit Metadata reports as real columns.
                     // SymbolProperties is case-insensitive, so "TableNo"/"TableNO" both match.
                     objProps.TryGetValue("TableNo", out var cuTableNo);
-                    objProps.TryGetValue("SingleInstance", out var cuSingleInstance);
                     objProps.TryGetValue("Subtype", out var cuSubtype);
                     objects.TryAdd((kind, objId), new ObjectSymbol(kind, objId, objName, objCaption,
                         // Left as written; StripModuleQualifier is the consumer's job, the same
                         // split the query/report data-item RelatedTable reads already make.
                         TableNo: string.IsNullOrWhiteSpace(cuTableNo) ? null : cuTableNo.Trim(),
-                        // AL's default is false; only an explicit "true" sets it.
-                        SingleInstance: string.Equals(cuSingleInstance?.Trim(), "true",
-                            StringComparison.OrdinalIgnoreCase),
+                        // AL's default is false; a stated value sets it. SymbolBool, not a
+                        // hand-rolled "true" comparison: Microsoft's packages write "1", never
+                        // the word — 38 of System Application 28.1's 533 codeunits state "1" and
+                        // none states "true" — so matching only "true" answered false for every
+                        // single-instance codeunit in a precompiled dependency (#3790). Every
+                        // other boolean in this file already goes through SymbolBool.
+                        SingleInstance: SymbolBool(objProps, "SingleInstance"),
                         Subtype: string.IsNullOrWhiteSpace(cuSubtype) ? null : cuSubtype.Trim()));
                     continue;
                 }

--- a/AlRunner/Patches/RecordPatches.CodeunitMetadataEquivalence.cs
+++ b/AlRunner/Patches/RecordPatches.CodeunitMetadataEquivalence.cs
@@ -1,0 +1,73 @@
+// RecordPatches.CodeunitMetadataEquivalence — the runner's codeunit derivation, rendered as
+// the <CodeUnit> document BC's own MetaCodeunit(XmlNode) reads (#3782, step 2 of 8).
+//
+// WHY A PROJECTION RATHER THAN AN OBJECT
+//   The metadata-equivalence harness compares one BC type against itself: BC's emitter
+//   document on one side, the runner's derivation on the other, both deserialized by the same
+//   BC constructor. Tables and pages each have a runner-built object to hand over
+//   (NCLMetaTable, and the page XML DependencyPageMetadataXml emits). Codeunits have NEITHER:
+//   nothing in the runner builds a Types.Metadata.MetaCodeunit, and the codeunit document in
+//   AlObjectMetadataRegistry is BC's OWN emitter output, captured at compile
+//   (RecordPatches.CodeunitMetadataFromBcDocument.cs says so at its head). Handing that
+//   registry document to the harness would compare BC against BC and report zero differences
+//   having measured nothing — the exact failure #3782 exists to remove, and the one step 1 hit
+//   with MetaPageDefinition.
+//
+//   So this file renders the runner's genuinely independent derivation — the SymbolReference
+//   properties BcAppSymbolCache.ObjectSymbol carries, the same five values CodeUnit Metadata
+//   (2000000137) answers from — into BC's document shape. What BC's constructor then reads out
+//   of it is the runner's answer, arrived at without BC's emitter.
+//
+// WHAT IS AND IS NOT STATED HERE
+//   Five attributes, because five are what the runner derives: ID, Name, TableNo,
+//   SingleInstance, Subtype. Everything else BC's emitter writes — ALNamespace,
+//   InherentPermissions, InherentEntitlements, TestIsolation, EventSubscriberInstance, the
+//   whole <Methods> subtree — is deliberately ABSENT, and absent is the honest rendering: the
+//   symbol file does not state them, so the runner has no independent answer to offer. The
+//   harness reports each as a difference and the allowlist declares why, which is the point of
+//   the exercise. Writing BC's own value into any of them would manufacture agreement.
+//
+// See docs/metadata-equivalence.md#codeunits and tests/expectations/metadata-equivalence/.
+
+using System.Globalization;
+using System.Xml;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    /// <summary>
+    /// The runner's derivation for one codeunit, as the <c>&lt;CodeUnit&gt;</c> document BC's
+    /// <c>Types.Metadata.MetaCodeunit(XmlNode)</c> parses — or null when the runner knows no
+    /// codeunit with that id, which the caller must report rather than absorb.
+    ///
+    /// <para><b>Only the five derived attributes are written.</b> A value the runner does not
+    /// derive is left off the element rather than defaulted, so BC's constructor applies its
+    /// own default and the difference the harness then reports is a true statement about what
+    /// the runner does not know. See this file's header.</para>
+    /// </summary>
+    internal static string? TryBuildCodeunitMetadataEquivalenceXml(int codeunitId)
+    {
+        var row = EnumerateKnownCodeunitMetadata().FirstOrDefault(r => r.Id == codeunitId);
+        if (row is null) return null;
+
+        var doc = new XmlDocument();
+        // The emitter's own namespace. BC's reader resolves attributes namespace-agnostically,
+        // but the document is compared as a document elsewhere in this programme, so it is
+        // rendered the way BC renders it rather than in no namespace at all.
+        var root = doc.CreateElement("CodeUnit", "urn:schemas-microsoft-com:dynamics:NAV:MetaObjects");
+        doc.AppendChild(root);
+
+        root.SetAttribute("ID", row.Id.ToString(CultureInfo.InvariantCulture));
+        root.SetAttribute("Name", row.Name);
+        // TableNo is omitted when the codeunit declares none: BC's emitter omits it too (12 of
+        // System Application's 533 documents carry it), so writing a 0 would state a value
+        // where BC states absence and turn "declares none" into a fabricated disagreement.
+        if (row.TableNo != 0)
+            root.SetAttribute("TableNo", row.TableNo.ToString(CultureInfo.InvariantCulture));
+        root.SetAttribute("SingleInstance", row.SingleInstance ? "1" : "0");
+        root.SetAttribute("Subtype", row.Subtype);
+
+        return doc.OuterXml;
+    }
+}

--- a/docs/metadata-equivalence.md
+++ b/docs/metadata-equivalence.md
@@ -439,14 +439,14 @@ reachable.
 <a id="what-is-compared"></a>
 ## What is compared, and what is not
 
-The harness compares `MetaTable` and `PageDefinition` documents. A bundle carries every kind BC
-emitted — codeunits, pages, enums, permission sets, queries, reports, xmlports, and the
+The harness compares `MetaTable`, `PageDefinition` and `CodeUnit` documents. A bundle carries
+every kind BC emitted — enums, permission sets, queries, reports, xmlports, and the
 `MetadataRuntimeDeltas` documents that cover table, page and permission-set extensions — and
 `MetadataEquivalenceHarnessTests` asserts the set it compares AND the set it does not, so
 covering less cannot happen quietly.
 
 **#3782 is the programme that empties the not-compared list**, one kind per pull request, in the
-order that issue records: `PageDefinition` (done), then `CodeUnit`, `Query`, `XmlPort`, `Report`,
+order that issue records: `PageDefinition` (done), `CodeUnit` (done), then `Query`, `XmlPort`, `Report`,
 `PermissionSet`, `Enum`, `MetadataRuntimeDeltas`. Each step adds its kind to `ComparedKinds`,
 lands the resulting allowlist with a reason per member, and deletes its kind from the
 `stillUncompared` list in `The_harness_states_which_kinds_it_does_not_compare`.
@@ -624,6 +624,25 @@ not cover still fails, on every version. It requires a `Doc` pointer for the sam
 `outOfScope` does, since exempting an entry removes the signal that a landed fix must shrink this
 file.
 
+**Every step should run this check before pushing, and record the answer either way.** Step 2
+(`CodeUnit`) did, and the answer was no: none of its five entries is version-contingent. The
+check is cheap because the bundles are already on the box — count each member's population per
+build rather than reasoning about it:
+
+| member | 27.5 | 28.1 | 28.4 |
+|---|---:|---:|---:|
+| System Application codeunits | 506 | 533 | 534 |
+| …carrying `ALNamespace` | 506 | 533 | 534 |
+| …stating either Inherent mask | 455 | 481 | 482 |
+| …emitting a `<Methods>` subtree | 135 | 137 | 138 |
+
+27.5 is the leg that reddened step 1, and it carries all five populations. The contrast is the
+point: step 1's failure was a member whose entire population was **one page**, so a version
+moving that page's shape took the population to zero. A population in the hundreds cannot do
+that. **The trigger is a small population, not a large difference count** — and the two are easy
+to confuse, because a member differing on 558 objects and a member differing on one both read as
+a single line in the allowlist.
+
 **It is deliberately not a list of BC versions.** A list has to be edited whenever the matrix
 moves and goes stale silently when it is not — the same defect as the build-keyed count pin that
 went inert in `The_current_reader_reproduces_the_known_defect_shapes`. What the flag declares is a
@@ -647,6 +666,75 @@ tests actually touch.
 produces zero objects for the whole app (#3549). The generator treats a zero-object emit as a
 failure rather than writing an empty bundle, and `apps.json` says why Base Application is absent
 rather than listing it and failing every leg.
+
+<a id="codeunits"></a>
+## Codeunits: the runner has no `MetaCodeunit`, so its derivation is projected into one
+
+Tables and pages each hand the harness a runner-built object. Codeunits have neither, and the
+distinction decides whether the comparison measures anything at all.
+
+**Nothing in the runner builds a `Types.Metadata.MetaCodeunit`.** `NavCodeunit.get_MetaCodeunit`
+returns an `NCLMetaCodeunit` built by `CreateEmptyNCLMetaCodeunit` and populated with the AL
+CLR type alone (`AlRunner/Patches/CodeunitPatches.MetaCodeunit.cs`) — a different type, and
+empty of the members BC's document states.
+
+**And the obvious substitute is BC's own answer.** The codeunit document in
+`AlObjectMetadataRegistry` is what BC's emitter produced, captured at compile time; it is the
+*same* document the ground truth holds. Handing it over would compare BC against BC and report
+zero differences having measured nothing — the failure step 1 of #3782 hit with
+`MetaPageDefinition`, where 235 pages compared clean against a default object.
+
+So `RecordPatches.TryBuildCodeunitMetadataEquivalenceXml` renders the runner's genuinely
+independent derivation — the `SymbolReference.json` properties `BcAppSymbolCache.ObjectSymbol`
+carries, the same values `CodeUnit Metadata` (2000000137) answers from — into BC's document
+shape, and BC's own `MetaCodeunit(XmlNode)` constructor parses both sides. One type against
+itself.
+
+**Only the five derived attributes are written**, and a value the runner does not derive is
+left off rather than defaulted, so BC's constructor applies its own default and the reported
+difference is a true statement about what the runner does not know.
+`MetadataEquivalenceCodeunitOracleTests` asserts both halves: that BC's constructor really
+parses (real values from a real document, not a default object), and that the runner's
+projection does *not* state the emitter-only members.
+
+### What the first run measured
+
+BC 28.1.49838.53910, Business Foundation (25 codeunits) and System Application (533):
+**558 codeunits, 2,220 differences across 5 members.**
+
+Five of `MetaCodeunit`'s eleven members agree **exactly**, on every codeunit: `Id`, `Name`,
+`SubType`, `TableNo` and `SingleInstance` — including all 12 System Application codeunits that
+declare a `TableNo`, which bounds #3546 to the cross-app `#<appid>#`-qualified form it names.
+
+| member | count | BC | runner |
+|---|---:|---|---|
+| `MetaCodeunit.ALNamespace` | 558 | `System.Utilities` | `<null>` |
+| `MetaCodeunit.InherentEntitlements` | 505 | `Execute` | `None` |
+| `MetaCodeunit.InherentPermissions` | 505 | `Execute` | `None` |
+| `MetaRuntimeInfo.Methods.<presence>` | 326 | `MetaMethod` | `<absent>` |
+| `MetaRuntimeInfo.#methodsDictionary.<presence>` | 326 | `MetaMethod` | `<absent>` |
+
+The last two are one collection reached under two signatures — `MetaRuntimeInfo` backs the
+property with a field and the differ walks both.
+
+**None is a limit of the symbol file**, which is why all five are tracked on #3788 rather than
+declared permanent. Checked against `SymbolReference.json` directly, on the same build:
+
+- **`ALNamespace` is fully derivable.** Objects live in a nested `Namespaces` tree rather than
+  the flat top-level `Codeunits` list, and the tree path equals BC's attribute for **533 of
+  533**. `BcAppSymbolCache` walks that tree but does not retain the path.
+- **Both Inherent masks are stated verbatim**, as `Properties` entries with value `"X"`;
+  presence agrees for **533 of 533**. The letters are the mask spelling
+  `RecordPatches.CodeunitMetadataFromBcDocument.cs` already parses from BC's document.
+- **`Methods` is partly derivable.** The file states `Methods` with `Id`, `Name`, `Parameters`
+  and `ReturnTypeDefinition`; BC's emitted names are a subset of the file's for 64 codeunits,
+  **not** for 73 (BC emits event-publisher and internal methods the file omits), and 396
+  codeunits emit no `<Method>` at all.
+
+`MetaCodeunit` exposes **no** `SingleInstance` member, so the harness cannot compare that column
+in either direction — which is how #3790 stayed hidden: the symbol file writes `"1"` and the
+codeunit parser matched only the word `"true"`, so all 38 single-instance System Application
+codeunits read as false. `CodeunitSymbolSingleInstanceSpellingTests` pins both spellings.
 
 <a id="running-it"></a>
 ## Running it

--- a/docs/metadata-equivalence.md
+++ b/docs/metadata-equivalence.md
@@ -648,6 +648,33 @@ moves and goes stale silently when it is not — the same defect as the build-ke
 went inert in `The_current_reader_reproduces_the_known_defect_shapes`. What the flag declares is a
 *property* of the difference: its population is version-contingent.
 
+<a id="a-flagged-entry-can-go-stale-without-the-harness-saying-so"></a>
+### The flag's own blind spot: a flagged entry can go stale and nothing reports it
+
+Exempting an entry from the unused check removes the one signal that says "this entry is
+finished". So a `versionContingent` entry whose population has gone to zero **on every leg** —
+because the fix landed — sits in the file as inert cover, and the harness stays green.
+
+That has already happened once. #3791 moved five page flags outside the `SourceTable > 0` branch
+and thereby closed the entire remaining population of six flagged entries
+(`SourceObjectDefinition.{ModifyAllowed,DelayedInsert}` and their `#…Field` companions,
+`PageProperties.{IsPreview,#isPreviewField}`). The harness could not report it, precisely
+because the flag exempts them.
+
+**This is never a false green.** An undeclared difference still fails on every version, so the
+flag cannot hide a difference — it can only excuse an entry for not finding one. The cost is a
+stale entry nobody is told about, which is a follow-up rather than a blocker.
+
+Two consequences for anyone auditing:
+
+- **"The harness passes" does not confirm a flagged entry is still live.** The technique that
+  works is to flip the flag off and re-run: a genuinely stale entry then shows up in
+  `No_allowlist_entry_has_gone_stale`.
+- **An entry that is NOT flagged needs no such check** — it is already subject to the stale
+  check, so the harness passing *is* the liveness proof. That is why step 2's five CodeUnit
+  entries needed only the population measurement above: none is flagged, so none can go stale
+  unnoticed.
+
 **Applied to the population, not to the failure.** 15 of the 117 page entries have a whole
 population of one or two occurrences on the measured build, resting on one or two objects with one
 property shape. The four that failed on 27.5 are the ones that version happened to hit; all 15 are

--- a/tests/expectations/metadata-equivalence/allowlist.json
+++ b/tests/expectations/metadata-equivalence/allowlist.json
@@ -26,12 +26,12 @@
     "Nine entries are DIRECTION-SCOPED. An entry covers both directions unless it says otherwise,",
     "and a reason that justifies one direction must not license the other. All three",
     "oracleLimitation entries are runner-only: they exist because the runner shows a merged",
-    "runtime view, so BC-absent / runner-present is what they justify — while the reverse, BC",
+    "runtime view, so BC-absent / runner-present is what they justify \u2014 while the reverse, BC",
     "emitting a field the runner never builds, is a hard reader defect that must still fail.",
     "",
     "There is deliberately NO occurrence cap. One was implemented and used by nothing, which made",
     "the PR claim a ratchet the code did not keep. No entry here has a bound that survives a",
-    "rebuild — the counts move with the BC build and with which apps are bundled — so any cap",
+    "rebuild \u2014 the counts move with the BC build and with which apps are bundled \u2014 so any cap",
     "would be a number nobody measured. Direction narrows categorically instead.",
     "",
     "Measured on BC 28.1.49838.53910 over Business Foundation (12 tables) and System Application",
@@ -84,7 +84,23 @@
     "(#3549) -- so nothing here is evidence about the pages most AL tests actually touch.",
     "",
     "The seven pre-existing TranslationKey.* entries already covered the page side without being",
-    "touched: they match on member signature, and pages carry the same TranslationKey type."
+    "touched: they match on member signature, and pages carry the same TranslationKey type.",
+    "",
+    "CodeUnit (#3782 step 2). Measured on BC 28.1.49838.53910 over Business Foundation (25",
+    "codeunits) and System Application (533): 2,220 differences across 5 members, all of them",
+    "one-directional (BC states a value, the runner states none \u2014 the runner invents nothing).",
+    "Five of MetaCodeunit's eleven members already agree EXACTLY across all 558 codeunits: Id,",
+    "Name, SubType, TableNo and SingleInstance, including all 12 System Application codeunits",
+    "that declare a TableNo. The five that differ are tracked on #3788, and none of them is a",
+    "limit of the symbol file \u2014 each was checked against SymbolReference.json directly.",
+    "",
+    "The five CodeUnit entries were AUDITED against versionContingent and none carries it. That is a",
+    "measurement, not an omission: on the three ground-truth bundles present (27.5.46862.53931,",
+    "28.1.49838.53910, 28.4.53241.54407) every one of these populations is large and stable --",
+    "ALNamespace on 506/533/534 System Application codeunits, the two Inherent masks on 455/481/482,",
+    "a <Methods> subtree on 135/137/138. 27.5 is the very leg that reddened step 1, and it carries",
+    "all five. Step 1's failure was a member whose whole population was ONE page; nothing here is",
+    "close. A later step adding a kind should run the same check rather than assume either way."
   ],
   "differences": [
     {
@@ -131,92 +147,92 @@
     },
     {
       "member": "MetaField.Caption",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.CaptionClass",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.CaptionOriginal",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.CharAllowed",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.ClrType",
-      "reason": "BC states the field's real CLR type and the runner states the empty string on all 1,888 fields. ClrType is not an XML attribute at all — BC derives it itself — and it is a PURE FUNCTION of Datatype, which the symbol file does carry and the runner already reads: measured over 988 observations, all 16 Datatypes map to exactly one ClrType each (BigInteger->System.Int64, GUID->System.Guid, Code/Text/DateFormula->System.String, Option/Integer->System.Int32, BLOB/RecordID->System.Byte[], Media->NSMediaWrapper, and so on). Recoverable with no app data.",
+      "reason": "BC states the field's real CLR type and the runner states the empty string on all 1,888 fields. ClrType is not an XML attribute at all \u2014 BC derives it itself \u2014 and it is a PURE FUNCTION of Datatype, which the symbol file does carry and the runner already reads: measured over 988 observations, all 16 Datatypes map to exactly one ClrType each (BigInteger->System.Int64, GUID->System.Guid, Code/Text/DateFormula->System.String, Option/Integer->System.Int32, BLOB/RecordID->System.Byte[], Media->NSMediaWrapper, and so on). Recoverable with no app data.",
       "issue": 3568
     },
     {
       "member": "MetaField.EnumTypeName",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.ExternalName",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.ExternalType",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.ObsoleteReason",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.OptionCaption",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.OptionCaptionOriginal",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.ToolTip",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.ToolTipOriginal",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.ValuesAllowed",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.MaxValue",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.MinValue",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.OptionString",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.InitValue",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
@@ -226,7 +242,7 @@
     },
     {
       "member": "MetaField.CaptionML.<presence>",
-      "reason": "BC builds a MultiLanguage caption for the field; the runner builds none. The symbol file carries Caption (2,743 occurrences in System Application) — the MultiLanguage object is its runtime form. Direction-scoped to BC-present / runner-absent; the runner inventing a caption BC does not have is a different defect.",
+      "reason": "BC builds a MultiLanguage caption for the field; the runner builds none. The symbol file carries Caption (2,743 occurrences in System Application) \u2014 the MultiLanguage object is its runtime form. Direction-scoped to BC-present / runner-absent; the runner inventing a caption BC does not have is a different defect.",
       "issue": 3568,
       "direction": "bc-only"
     },
@@ -247,7 +263,7 @@
     },
     {
       "member": "MetaField.Relations.<presence>",
-      "reason": "BC gives SystemCreatedBy and SystemModifiedBy a TableRelation to User (2000000120); the runner gives them none. This is the difference already observable from plain AL as FieldRef.Relation() answering 0 — see #3549. Direction-scoped to BC-present / runner-absent; the runner inventing a relation BC does not have would be a different defect and is not covered.",
+      "reason": "BC gives SystemCreatedBy and SystemModifiedBy a TableRelation to User (2000000120); the runner gives them none. This is the difference already observable from plain AL as FieldRef.Relation() answering 0 \u2014 see #3549. Direction-scoped to BC-present / runner-absent; the runner inventing a relation BC does not have would be a different defect and is not covered.",
       "issue": 3568,
       "direction": "bc-only"
     },
@@ -263,7 +279,7 @@
     },
     {
       "member": "MetaKey.Name",
-      "reason": "BC derives this as the POSITIONAL FIELD SPEC over field ids (\"Field1,Field2\"), not as a name anyone declared, and NCLMetaKey.CreateFromMetaKey never passes it — the declared AL name travels as MetaKey.KeyName, which the reader now states (#3568). So no AL surface can observe this member, and the runner keeps its own spelling rather than reproducing a spec BC regenerates. Superseded reason, recorded because it hid a real defect: this used to read \"two different naming schemes\", and MetaKey.KeyName was declared as \"the same disagreement on the second of the two name properties\". That was wrong — KeyName is the DECLARED name, the symbol file states it verbatim, and it reaches AL through ObsolescenceGuard.ThrowIfObsoleted.",
+      "reason": "BC derives this as the POSITIONAL FIELD SPEC over field ids (\"Field1,Field2\"), not as a name anyone declared, and NCLMetaKey.CreateFromMetaKey never passes it \u2014 the declared AL name travels as MetaKey.KeyName, which the reader now states (#3568). So no AL surface can observe this member, and the runner keeps its own spelling rather than reproducing a spec BC regenerates. Superseded reason, recorded because it hid a real defect: this used to read \"two different naming schemes\", and MetaKey.KeyName was declared as \"the same disagreement on the second of the two name properties\". That was wrong \u2014 KeyName is the DECLARED name, the symbol file states it verbatim, and it reaches AL through ObsolescenceGuard.ThrowIfObsoleted.",
       "issue": 3568
     },
     {
@@ -315,7 +331,7 @@
     },
     {
       "member": "MetaTable.Fields.<presence>",
-      "reason": "The runner models the MERGED RUNTIME state a running system has — every registered app's tableextension fields present on the base table. The ground truth is BC's BUILD-TIME per-app emit, which by construction sees only the app being compiled. Two different things, so this is a limitation of the oracle and not evidence about the runner: 115 fields on four Business Foundation tables (230, 242, 308, 6635). In BC 29 everything is merged at database level anyway, which makes the runner's merged view the forward-looking one. CONSEQUENCE: a multi-app bundle can never produce an empty diff, so a non-empty diff here is expected and must not be read as noise or as a bug. DIRECTION-SCOPED: covers only BC-absent / runner-present, which is the merged-runtime direction this reason justifies. The reverse — BC emitted a field and the runner built none — is a hard reader defect and is NOT covered.",
+      "reason": "The runner models the MERGED RUNTIME state a running system has \u2014 every registered app's tableextension fields present on the base table. The ground truth is BC's BUILD-TIME per-app emit, which by construction sees only the app being compiled. Two different things, so this is a limitation of the oracle and not evidence about the runner: 115 fields on four Business Foundation tables (230, 242, 308, 6635). In BC 29 everything is merged at database level anyway, which makes the runner's merged view the forward-looking one. CONSEQUENCE: a multi-app bundle can never produce an empty diff, so a non-empty diff here is expected and must not be read as noise or as a bug. DIRECTION-SCOPED: covers only BC-absent / runner-present, which is the merged-runtime direction this reason justifies. The reverse \u2014 BC emitted a field and the runner built none \u2014 is a hard reader defect and is NOT covered.",
       "oracleLimitation": true,
       "Doc": "docs/metadata-equivalence.md#the-oracle-is-build-time-per-app-metadata",
       "direction": "runner-only"
@@ -451,7 +467,7 @@
     },
     {
       "member": "ControlContainerDefinition.#containerTypeField",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. The member it accompanies is declared beside it in this file. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. The member it accompanies is declared beside it in this file. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "outOfScope": true,
       "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found",
       "versionContingent": true
@@ -464,7 +480,7 @@
     },
     {
       "member": "ControlContainerDefinition.ContainerType",
-      "reason": "The container the page's controls sit in. The runner emits one ContentArea container to hold the parts it does reconstruct (EmitPartControlXml); BC states the real area for the real tree. The same control-tree boundary as the Controls entries. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "The container the page's controls sit in. The runner emits one ContentArea container to hold the parts it does reconstruct (EmitPartControlXml); BC states the real area for the real tree. The same control-tree boundary as the Controls entries. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "outOfScope": true,
       "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found",
       "versionContingent": true
@@ -505,7 +521,7 @@
     },
     {
       "member": "InfopartPageDefinition.#providerIDField",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. The member it accompanies is declared beside it in this file. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. The member it accompanies is declared beside it in this file. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "outOfScope": true,
       "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found",
       "versionContingent": true
@@ -580,21 +596,21 @@
     },
     {
       "member": "InfopartPageDefinition.Editable",
-      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 113 pages declare Editable; EmitPartControlXml does not carry it onto the part control. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 113 pages declare Editable; EmitPartControlXml does not carry it onto the part control. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "issue": 3784,
       "versionContingent": true,
       "Doc": "docs/metadata-equivalence.md#one-build-measured-three-evaluated"
     },
     {
       "member": "InfopartPageDefinition.ProviderID",
-      "reason": "The control that PROVIDES a part's data in the designer's provider/consumer wiring. It names a control id inside the host page's real control tree, which the runner does not reconstruct. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "The control that PROVIDES a part's data in the designer's provider/consumer wiring. It names a control id inside the host page's real control tree, which the runner does not reconstruct. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "outOfScope": true,
       "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found",
       "versionContingent": true
     },
     {
       "member": "InfopartPageDefinition.ProviderIDSpecified",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. The member it accompanies is declared beside it in this file. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. The member it accompanies is declared beside it in this file. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "outOfScope": true,
       "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found",
       "versionContingent": true
@@ -740,7 +756,7 @@
     },
     {
       "member": "PageProperties.#aPIVersionField",
-      "reason": "The API version of an API page. Emitted by BC for the one API page in the bundle and absent from SymbolReference.json; API pages are a web-service publishing surface, which docs/scope.md places out of scope. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "The API version of an API page. Emitted by BC for the one API page in the bundle and absent from SymbolReference.json; API pages are a web-service publishing surface, which docs/scope.md places out of scope. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "outOfScope": true,
       "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found",
       "versionContingent": true
@@ -753,7 +769,7 @@
     },
     {
       "member": "PageProperties.#analysisModeEnabledField",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies PageProperties.AnalysisModeEnabled, declared in this file with the measurement. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies PageProperties.AnalysisModeEnabled, declared in this file with the measurement. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "issue": 3784,
       "versionContingent": true,
       "Doc": "docs/metadata-equivalence.md#one-build-measured-three-evaluated"
@@ -787,7 +803,7 @@
     },
     {
       "member": "PageProperties.#isPreviewField",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. The member it accompanies is declared beside it in this file. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. The member it accompanies is declared beside it in this file. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "outOfScope": true,
       "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found",
       "versionContingent": true
@@ -830,7 +846,7 @@
     },
     {
       "member": "PageProperties.AnalysisModeEnabled",
-      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 1 page declares AnalysisModeEnabled; the runner never writes it. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 1 page declares AnalysisModeEnabled; the runner never writes it. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "issue": 3784,
       "versionContingent": true,
       "Doc": "docs/metadata-equivalence.md#one-build-measured-three-evaluated"
@@ -887,7 +903,7 @@
     },
     {
       "member": "PageProperties.IsPreview",
-      "reason": "Marks a page shipped as preview. Not in SymbolReference.json in any form; BC's emitter derives it from a compiler-level attribute the symbol file does not carry. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "Marks a page shipped as preview. Not in SymbolReference.json in any form; BC's emitter derives it from a compiler-level attribute the symbol file does not carry. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "outOfScope": true,
       "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found",
       "versionContingent": true
@@ -906,7 +922,7 @@
     },
     {
       "member": "SourceObjectDefinition.#delayedInsertField",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies SourceObjectDefinition.DelayedInsert, declared in this file with the measurement. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 2 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies SourceObjectDefinition.DelayedInsert, declared in this file with the measurement. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 2 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "issue": 3784,
       "versionContingent": true,
       "Doc": "docs/metadata-equivalence.md#one-build-measured-three-evaluated"
@@ -918,14 +934,14 @@
     },
     {
       "member": "SourceObjectDefinition.#modifyAllowedField",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies SourceObjectDefinition.ModifyAllowed, declared in this file with the measurement. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 2 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies SourceObjectDefinition.ModifyAllowed, declared in this file with the measurement. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 2 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "issue": 3784,
       "versionContingent": true,
       "Doc": "docs/metadata-equivalence.md#one-build-measured-three-evaluated"
     },
     {
       "member": "SourceObjectDefinition.DelayedInsert",
-      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 13 pages declare DelayedInsert, with the same SourceTable-branch condition. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 2 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 13 pages declare DelayedInsert, with the same SourceTable-branch condition. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 2 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "issue": 3784,
       "versionContingent": true,
       "Doc": "docs/metadata-equivalence.md#one-build-measured-three-evaluated"
@@ -937,10 +953,43 @@
     },
     {
       "member": "SourceObjectDefinition.ModifyAllowed",
-      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 89 pages declare ModifyAllowed, with the same SourceTable-branch condition as InsertAllowed. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 2 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 89 pages declare ModifyAllowed, with the same SourceTable-branch condition as InsertAllowed. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 2 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "issue": 3784,
       "versionContingent": true,
       "Doc": "docs/metadata-equivalence.md#one-build-measured-three-evaluated"
+    },
+    {
+      "member": "SourceObjectDefinition.MultipleNewLinesSpecified",
+      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 4 pages declare MultipleNewLines; BC marks the value explicitly specified and the runner writes the attribute only inside the SourceTable branch. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page.",
+      "issue": 3784
+    },
+    {
+      "member": "MetaCodeunit.ALNamespace",
+      "reason": "BC states the codeunit's AL namespace; the runner states null for every codeunit in a precompiled dependency. NOT a limit of the symbol file: SymbolReference.json carries objects in a nested Namespaces tree rather than the flat top-level Codeunits list, and the tree path a codeunit is reached through equals BC's ALNamespace attribute for 533 of 533 System Application codeunits (measured on BC 28.1.49838.53910 by unwrapping the nested .app and walking the tree). BcAppSymbolCache reads the objects out of that tree but does not retain the path it walked, so the value is derivable and simply not derived yet. Entry goes away when the derivation lands. Checked for versionContingent and deliberately NOT marked: this member's population is large and stable across every BC build a leg runs. Measured on the three ground-truth bundles present (27.5.46862.53931, 28.1.49838.53910, 28.4.53241.54407): every codeunit document carries ALNamespace on all three -- System Application 506/506, 533/533, 534/534. Step 1's 27.5 failure was a member whose whole population was one page; nothing here is within two orders of magnitude of that.",
+      "issue": 3788,
+      "direction": "bc-only"
+    },
+    {
+      "member": "MetaCodeunit.InherentPermissions",
+      "reason": "BC states the inherent permission mask (Execute on 505 of 558); the runner leaves BC's own None default. Stated verbatim in the symbol file: codeunit 26 carries Properties [{'Name':'InherentPermissions','Value':'X'}], and presence agrees with BC's attribute for 533 of 533 System Application codeunits on BC 28.1.49838.53910. The letters are the same mask spelling RecordPatches.CodeunitMetadataFromBcDocument.cs already parses out of BC's OWN document for the CodeUnit Metadata virtual table, so the conversion exists and is merely not fed from the symbol file for a precompiled dependency. Derivable, tracked, not a limit. Deliberately NOT direction-scoped: the runner answers BC's own enum default None rather than leaving the member absent, and `bc-only` matches only a runner side that is <absent> or <null>. The narrowing that would be wanted here \u2014 'BC states a mask, the runner states None' \u2014 is not expressible as a direction, so the entry covers both and this sentence records why. Checked for versionContingent and deliberately NOT marked: this member's population is large and stable across every BC build a leg runs. Measured on the three ground-truth bundles present (27.5.46862.53931, 28.1.49838.53910, 28.4.53241.54407): System Application 455 / 481 / 482 codeunits state it, Business Foundation 24 on all three. Step 1's 27.5 failure was a member whose whole population was one page; nothing here is within two orders of magnitude of that.",
+      "issue": 3788
+    },
+    {
+      "member": "MetaCodeunit.InherentEntitlements",
+      "reason": "Same shape and same evidence as MetaCodeunit.InherentPermissions, for the entitlement mask rather than the permission mask: stated in the symbol file as Properties [{'Name':'InherentEntitlements','Value':'X'}], presence agreeing for 533 of 533 on BC 28.1.49838.53910, and BC's default None answered by the runner in its place. Declared separately rather than folded in, because the two masks are independent AL properties and a fix that landed only one must still fail on the other. Deliberately NOT direction-scoped: the runner answers BC's own enum default None rather than leaving the member absent, and `bc-only` matches only a runner side that is <absent> or <null>. The narrowing that would be wanted here \u2014 'BC states a mask, the runner states None' \u2014 is not expressible as a direction, so the entry covers both and this sentence records why. Checked for versionContingent and deliberately NOT marked: this member's population is large and stable across every BC build a leg runs. Measured on the three ground-truth bundles present (27.5.46862.53931, 28.1.49838.53910, 28.4.53241.54407): System Application 455 / 481 / 482 codeunits state it, Business Foundation 24 on all three. Step 1's 27.5 failure was a member whose whole population was one page; nothing here is within two orders of magnitude of that.",
+      "issue": 3788
+    },
+    {
+      "member": "MetaRuntimeInfo.Methods.<presence>",
+      "reason": "BC's document carries a <Methods> subtree for 137 of 558 codeunits and the runner's projection carries none, so every method BC states is reported absent. PARTLY derivable, and the remainder is measured rather than assumed: SymbolReference.json does state a Methods array (Id, Name, Parameters, ReturnTypeDefinition), and BC's emitted method names are a subset of the symbol file's for 64 codeunits \u2014 but for 73 they are not, because BC emits event-publisher and internal methods the symbol file omits. So this is a partial derivation with a known 73-codeunit gap, not a straight fix, which is why it is tracked rather than declared recoverable. Measured on BC 28.1.49838.53910. Checked for versionContingent and deliberately NOT marked: this member's population is large and stable across every BC build a leg runs. Measured on the three ground-truth bundles present (27.5.46862.53931, 28.1.49838.53910, 28.4.53241.54407): System Application 135 / 137 / 138 codeunits emit a <Methods> subtree, Business Foundation 8 on all three. Step 1's 27.5 failure was a member whose whole population was one page; nothing here is within two orders of magnitude of that.",
+      "issue": 3788,
+      "direction": "bc-only"
+    },
+    {
+      "member": "MetaRuntimeInfo.#methodsDictionary.<presence>",
+      "reason": "The SAME collection as MetaRuntimeInfo.Methods, reached under a second signature: MetaRuntimeInfo backs the property with a field, and the differ walks both, so one absent method subtree is reported twice. Declared separately because the allowlist matches on the signature and leaving this one off would report 326 undeclared differences for a gap already declared above. It disappears with the same fix. Checked for versionContingent and deliberately NOT marked: this member's population is large and stable across every BC build a leg runs. Measured on the three ground-truth bundles present (27.5.46862.53931, 28.1.49838.53910, 28.4.53241.54407): the same collection as MetaRuntimeInfo.Methods, so the same 135 / 137 / 138 and 8. Step 1's 27.5 failure was a member whose whole population was one page; nothing here is within two orders of magnitude of that.",
+      "issue": 3788,
+      "direction": "bc-only"
     }
   ]
 }

--- a/tests/expectations/metadata-equivalence/allowlist.json
+++ b/tests/expectations/metadata-equivalence/allowlist.json
@@ -959,11 +959,6 @@
       "Doc": "docs/metadata-equivalence.md#one-build-measured-three-evaluated"
     },
     {
-      "member": "SourceObjectDefinition.MultipleNewLinesSpecified",
-      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 4 pages declare MultipleNewLines; BC marks the value explicitly specified and the runner writes the attribute only inside the SourceTable branch. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page.",
-      "issue": 3784
-    },
-    {
       "member": "MetaCodeunit.ALNamespace",
       "reason": "BC states the codeunit's AL namespace; the runner states null for every codeunit in a precompiled dependency. NOT a limit of the symbol file: SymbolReference.json carries objects in a nested Namespaces tree rather than the flat top-level Codeunits list, and the tree path a codeunit is reached through equals BC's ALNamespace attribute for 533 of 533 System Application codeunits (measured on BC 28.1.49838.53910 by unwrapping the nested .app and walking the tree). BcAppSymbolCache reads the objects out of that tree but does not retain the path it walked, so the value is derivable and simply not derived yet. Entry goes away when the derivation lands. Checked for versionContingent and deliberately NOT marked: this member's population is large and stable across every BC build a leg runs. Measured on the three ground-truth bundles present (27.5.46862.53931, 28.1.49838.53910, 28.4.53241.54407): every codeunit document carries ALNamespace on all three -- System Application 506/506, 533/533, 534/534. Step 1's 27.5 failure was a member whose whole population was one page; nothing here is within two orders of magnitude of that.",
       "issue": 3788,


### PR DESCRIPTION
Part of #3782
Closes #3790

Step 2 of 8. Adds `CodeUnit` to the metadata-equivalence harness — the largest kind, and the
biggest single coverage jump: **150 objects compared becomes 708** (+533 System Application,
+25 Business Foundation).

Corpus-NA: this compares BC's own metadata-emitter output against the runner's derivation and asserts nothing about AL semantics a service tier could adjudicate.

## The finding that shaped the design: the runner has no codeunit object to compare

Tables and pages each hand the harness a runner-built object. Codeunits have **neither**, and
getting this wrong would have produced a green comparison that measured nothing.

- **Nothing in the runner builds a `Types.Metadata.MetaCodeunit`.** `NavCodeunit.get_MetaCodeunit`
  returns an `NCLMetaCodeunit` from `CreateEmptyNCLMetaCodeunit`, populated with the AL CLR type
  alone — a different type, and empty of the members BC's document states.
- **The obvious substitute is BC's own answer.** The codeunit document in
  `AlObjectMetadataRegistry` is BC's emitter output captured at compile time — the *same*
  document the ground truth holds. `RecordPatches.CodeunitMetadataFromBcDocument.cs` says so at
  its head. Handing it over compares BC against BC: zero differences, nothing measured. That is
  exactly what step 1 hit with `MetaPageDefinition`.

So the runner side is a projection of its genuinely independent derivation — the
`SymbolReference.json` properties `ObjectSymbol` carries, the same values `CodeUnit Metadata`
(2000000137) answers from — rendered into BC's document shape, with **both sides parsed by BC's
own `MetaCodeunit(XmlNode)`**. One type against itself.

Only the five derived attributes are written. A value the runner does not derive is **left off**
rather than defaulted, so BC's constructor applies its own default and the reported difference
is a true statement about what the runner does not know. Writing BC's value into any of them
would manufacture agreement.

## The oracle was proven, not assumed

Per step 1's finding. `MetaCodeunit` is a **struct** with a public `(XmlNode)` ctor, and it
genuinely parses: measured on BC 28.1.49838.53910 against the emitter's own CodeUnit 26, it
answers `Id=26`, `Name="Confirm Management Impl."`, `ALNamespace="System.Utilities"`,
`InherentPermissions=Execute`, `SubType=Normal`. `MetadataEquivalenceCodeunitOracleTests` pins
that it reads the document, that it **discriminates** (a different document gives different
values), and that the runner's projection does *not* state the emitter-only members.

## RED → GREEN

**RED** — with `CodeUnit` added and no allowlist entries: `Every_difference_is_declared_with_a_reason`
failed with 1,662 undeclared members. Objects compared 150 → 708.

**Mutation check** — forcing `Subtype = "Test"` on the projection produced **558** new
`MetaCodeunit.SubType` differences (`Normal` vs `Test`, `Install` vs `Test`). The comparison is
not vacuously green.

**GREEN** — re-run after rebasing onto #3780, on the pushed head `dd3235aa`:
`--filter ~MetadataEquivalence|~CodeunitSymbol` → **18 passed, 0 failed, 0 skipped.**
(`Skipped: 0` matters — these tests skip without a ground-truth bundle, and a
skipped-everything run looks identical to a passing one. Generated with
`tools/gen-metadata-ground-truth.sh` for the build this process loads, 28.1.49838.53910.)

Wider, same head: `~Symbol|~Dependency|~Metadata` → **765 passed, 0 failed, 0 skipped**
(3m39s). `BcAppSymbolCache` is on the shared dependency path, so this was run rather than
assumed.

Both figures are from the rebased tree, not carried across the rebase.

## What the comparison measured

**558 codeunits, 2,220 differences across 5 members** — all one-directional (BC states a value,
the runner states none; the runner invents nothing).

**Five of `MetaCodeunit`'s eleven members already agree exactly**, on every codeunit: `Id`,
`Name`, `SubType`, `TableNo`, `SingleInstance`.

| member | count | BC | runner |
|---|---:|---|---|
| `MetaCodeunit.ALNamespace` | 558 | `System.Utilities` | `<null>` |
| `MetaCodeunit.InherentEntitlements` | 505 | `Execute` | `None` |
| `MetaCodeunit.InherentPermissions` | 505 | `Execute` | `None` |
| `MetaRuntimeInfo.Methods.<presence>` | 326 | `MetaMethod` | `<absent>` |
| `MetaRuntimeInfo.#methodsDictionary.<presence>` | 326 | `MetaMethod` | `<absent>` |

The last two are one collection under two signatures (`MetaRuntimeInfo` backs the property with
a field and the differ walks both), declared separately because the allowlist matches on
signature.

**Every difference is explained, and none is a limit of the symbol file** — each was checked
against `SymbolReference.json` directly rather than classified by inspection, so all five are
tracked on **#3788** rather than declared permanent:

- **`ALNamespace` is fully derivable.** Objects live in a nested `Namespaces` tree, not the flat
  top-level `Codeunits` list, and the tree path equals BC's attribute for **533 of 533**.
  `BcAppSymbolCache` walks that tree but does not retain the path.
- **Both Inherent masks are stated verbatim** as `Properties` entries with value `"X"`; presence
  agrees for **533 of 533**. The letters are the mask spelling
  `RecordPatches.CodeunitMetadataFromBcDocument.cs` already parses from BC's document.
- **`Methods` is partly derivable, with a measured remainder.** The file states `Methods` with
  `Id`/`Name`/`Parameters`/`ReturnTypeDefinition`; BC's names are a subset of the file's for 64
  codeunits, **not** for 73 (BC emits event-publisher and internal methods the file omits), and
  396 codeunits emit no `<Method>` at all. A partial derivation, not a straight fix — which is
  why it is tracked rather than called recoverable.

Two entries are deliberately **not** direction-scoped, and the reason is recorded in them: the
runner answers BC's own enum default `None` for the Inherent masks — a real value, not
`<absent>` — and `bc-only` matches only a runner side that is absent or null.

## On #3546

The comparison bounds it. All **12** System Application codeunits that declare a `TableNo`
resolve correctly and report **zero** differences, so the `#<appid>#`-qualified defect is
confined to the cross-app Base Application form that issue names. Not fixed here — it is a
different file and a different claim.

## A second defect the comparison surfaced, fixed here with its own RED → GREEN

**#3790**: a codeunit's `SingleInstance` was read with a hand-rolled `string.Equals(v, "true")`.
**Microsoft's packages write `"1"`, never the word.** Measured over System Application's 533
codeunits: 38 state `"1"`, 5 state `"0"`, 490 state nothing, **0 state `"true"`**. So the
comparison never matched and all 38 single-instance codeunits answered `false` — the same value
a codeunit declaring none answers, which AL cannot tell apart.

It survived because the only existing test for that route writes `"true"` into its fixture, the
one spelling a real package never uses.

Folded in rather than filed-and-left because it is the same derivation this PR is measuring, it
is one line, and its `SingleInstance` value is *the very thing* I was hand-checking when it
appeared. Fix: use `SymbolBool`, the helper every neighbouring boolean already uses.

**RED** — `CodeunitSymbolSingleInstanceSpellingTests`: 1 failed (`"1"`), 2 passed (`"true"` and
the negatives). **GREEN** — 3/3, including the negatives that stop the fix being "always true":
`"0"` and an unstated property both stay false.

`CacheVersion` bumped 36 → 37: the record shape is unchanged, so `PayloadShape` cannot see the
drift and a warm box would replay the old parse. Same trap as v35 and v36.

Note the harness **cannot** catch this one: `MetaCodeunit` exposes no `SingleInstance` member,
so it is not compared in either direction. That is why it needed its own test.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — that is #3790 above. Grepped the boolean
   reads in `BcAppSymbolCache`: every other one already goes through `SymbolBool`/`SymbolBoolFalse`;
   the codeunit path was the only hand-rolled comparison, and it is now converted.
2. **Does a sibling function make the same assumption?** The sibling readers (`TableNo`,
   `Subtype`) are string passthroughs with no boolean spelling to get wrong, so there is no
   equivalent to fix. Checked, nothing found.
3. **Two code paths writing the same state with different invariants?** Yes, and it is the
   root of #3790: source-compiled codeunits are read by the AL declaration parser (which writes
   the word) and precompiled ones by the symbol reader (which sees `"1"`). Both now feed one
   `EnumerateKnownCodeunitMetadata` row through the same `SymbolBool`, so the two paths agree.

**Queue scan.** Searched the open queue for `ALNamespace`, `InherentPermissions`,
`MetaCodeunit`, `SingleInstance`, `CodeUnit Metadata` and by mechanism. **#3568** is the same
class of finding for `MetaTable` — 71 members, all `MetaField`/`TranslationKey`, explicitly
scoped to the 150 tables — so its member set is **disjoint** from these five and it is not a
duplicate; #3788 is filed as its codeunit counterpart. **#3562** is the tracking issue for
converting metadata consumers to BC's captured document. Nothing else overlapped.

## Step-1 findings applied

- **Oracle proven to parse, with the discrimination pinned** — above.
- **`IdPropertyNames` / `PairByIdMembers`**: not needed. The only codeunit collection is
  `MetaRuntimeInfo.Methods`, and the runner's projection contributes none, so every element is a
  presence difference and there is no positional cascade to fabricate. Deliberately not added:
  listing it would assert a pairing nothing exercises.
- **`The_current_reader_reproduces_the_known_defect_shapes` rescoped.** It used
  `report.ObjectsCompared` as the denominator for two claims that are purely about **tables**.
  Those were the same number while only tables were compared; with codeunits added it would be
  falsified. Now reads the bundle's own `MetaTable` census, with a non-vacuity assertion that it
  is greater than zero.

## Not done here, deliberately

`docs/metadata-equivalence.md` gains a `#codeunits` section with the measurements — the tables
and the derivability evidence live there rather than in the allowlist reasons, which carry the
claim and the citation.

Translations did not arise: no `TranslationKey`-shaped member appears in the codeunit diff.

## Rebased three times, and the third one mattered

**Onto #3780** — collided on `CacheVersion` (both wanted v37) and the allowlist header.

**Onto step 1, #3783 (`PageDefinition`)** — four files. Took step 1's data-driven
`stillUncompared` structure wholesale rather than keeping my literal, added
`Codeunits_are_compared_in_the_numbers_the_bundle_declares` as the codeunit counterpart of its
page non-vacuity test, and kept step 1's rescoping of
`The_current_reader_reproduces_the_known_defect_shapes` — step 1 and I had independently made
the *same* fix (`tablesCompared` from the `MetaTable` census with a `> 0` guard), so nothing was
overwritten.

**Onto #3791**, and this one caught two real defects in my own work:

### 1. `CacheVersion` collided at 38 — the dangerous kind

#3791 bumped `BcAppSymbolCache.CacheVersion` 37 → **38** for the page payload while this PR sat
at **38** for the codeunit payload. Both correct in isolation.

**Why it would have shipped a wrong answer rather than a merge conflict.** My own v38 comment
already states the mechanism: the record *shape* is unchanged — `ObjectSymbol.SingleInstance` is
a `bool` either way — so `PayloadShape` cannot see the difference and **the integer is the only
discriminator**. Two payload meanings sharing one number means a warm box replays the old parse
and keeps answering `SingleInstance = false` for all 38 single-instance codeunits: precisely the
defect #3790 exists to fix, reintroduced through a cache hit.

Re-bumped to **39**, with the collision recorded at the constant, because the general lesson is
not bookkeeping: **`CacheVersion` is contended state between concurrent PRs** in a way ordinary
code is not, and a rebase resolves the *text* without telling you the *number* is taken. The
note says to re-read the constant on `origin/main` immediately before pushing a bump.

### 2. My conflict resolution resurrected a deleted allowlist entry

`No_allowlist_entry_has_gone_stale` failed on `SourceObjectDefinition.MultipleNewLinesSpecified`.
Traced rather than guessed: it was on my *previous* base, #3791 deleted it because moving five
page flags outside the `SourceTable > 0` branch closed its entire population, and resolving the
allowlist conflict by taking my side's block wholesale carried it back in.

Removed, and then verified the way the diff cannot be verified by reading it — as a **set
difference** against `main`: the entry set is now exactly main's 152 plus my 5, with **none of
main's dropped** and **no comment line lost**. That check is what I should have run after the
second rebase too.

## `versionContingent` audit: none of the five carries it, and that is measured

The allowlist is written from one BC build and evaluated on three, so step 1 added
`versionContingent`. I audited all five CodeUnit entries. **None qualifies**, measured from the
three ground-truth bundles on the box — **including 27.5, the very leg that reddened step 1**:

| member | 27.5 | 28.1 | 28.4 |
|---|---:|---:|---:|
| System Application codeunits | 506 | 533 | 534 |
| …carrying `ALNamespace` | 506 | 533 | 534 |
| …stating either Inherent mask | 455 | 481 | 482 |
| …emitting a `<Methods>` subtree | 135 | 137 | 138 |

Business Foundation is 25 / 25 / 24 / 8 on all three.

**The trigger is a small population, not a large difference count** — step 1's failure was a
member whose entire population was *one page*, so a version moving that page's shape took it to
zero. A population in the hundreds cannot. The two are easy to confuse, because a member
differing on 558 objects and one differing on a single object both read as one line in the
allowlist.

Recorded in each entry, in the allowlist header, and in
`docs/metadata-equivalence.md#one-build-measured-three-evaluated`.

**Also documented: the flag's own blind spot** (`#a-flagged-entry-can-go-stale-without-the-harness-saying-so`).
Exempting an entry from the unused check removes the signal that says it is finished, so a
flagged entry whose population has gone to zero everywhere sits as inert cover — which is what
happened to six page entries when #3791 landed. Never a false green (an undeclared difference
still fails on every version), so it is a follow-up, not a blocker. The audit consequence is the
part worth having written down: **"the harness passes" does not confirm a flagged entry is
live** — flip the flag off and re-run — whereas an *unflagged* entry needs no such check,
because the stale check already covers it. That is why my five needed only the population
measurement.

## CI fix carried in (from the coordinator)

`CodeunitSymbolSingleInstanceSpellingTests` reaches the RecordPatches AL parse statics and was in
no xunit collection, so `ParserStaticsIsolationGuardTests` failed on 27.5 and 28.4. Fixed with
`[Collection(RecordPatchesSerialCollection.Name)]`; survived all three rebases and is green
below.

## Verification on the pushed head `1901be34`

Bootstrapped first (`-c Release` build → `tools/engine-test-bootstrap.sh` → `--settings
engine.runsettings`), so the harness class really executed rather than reporting `NotExecuted`:

- `~MetadataEquivalence|~CodeunitSymbol|~ParserStaticsIsolationGuardTests` →
  **54 passed, 0 failed, Skipped: 0**
- `~Symbol|~Dependency|~Metadata|~ParserStatics|~Page` →
  **1,499 passed, 0 failed, Skipped: 0** (4m27s)

The codeunit contribution is byte-identical across all three rebases: **2,220 differences across
the same 5 members over 558 codeunits.** All three kinds compared — 943 objects (895 System
Application + 48 Business Foundation).

**One caveat on the second figure, stated because it is a real failure I had to rule out.** That
sweep is run with `TZ=UTC`. Without it, `TestPageTemporalValueTests.TryResolve_RoundTripSpelling_ForADateTimeControl_KeepsTheTimeOfDay`
fails with a one-hour shift — and it is **not mine**: I reproduced it on clean `origin/main` at
`3e915dcb` in a throwaway worktree, where it needs both a non-UTC box **and** a bootstrapped
(Cecil-rewritten) `Ncl.dll`; either alone passes. The built `AlRunner.dll` is md5-identical
between the passing and failing runs, so no runner C# is implicated. Already tracked as **#3567**,
which names exactly that pair of conditions; I added the measurement there rather than filing a
duplicate.

<sub>Implemented by the `impl-agent` `stma-auto-7`, an automated agent acting on the account holder's behalf.</sub>
