### PR TITLE
fix(coverage): report every object of a multi-object .al file, on its file lines

### DIFF
--- a/AlRunner.Tests/AlPerTestCoverageTests.cs
+++ b/AlRunner.Tests/AlPerTestCoverageTests.cs
@@ -233,6 +233,81 @@ public class AlPerTestCoverageTests : IClassFixture<SharedCliServer>
             $"perTestCoverage must be absent when perTestCoverage:true wasn't requested: {string.Join(" | ", lines)}");
     }
 
+    // #3713: a file declaring TWO objects. AlCoverageSourceMap registered only the first, so the
+    // second object's scopes resolved to no file and perTestCoverage lost Two.Codeunit.al
+    // altogether (the reporter's server-mode measurement: "Two.Codeunit.al absent ENTIRELY,
+    // though SecondOnly() demonstrably ran"). And BC's [SourceSpans] lines are relative to the
+    // object's own text, so once mapped the statement must land on FILE line 13, not on line 6.
+    // Not observed red locally on this fact — the shared map fix was already in place when it
+    // was written; the RED is the reporter's log and CoverageMultiObjectFileTests' Cobertura fact.
+    [SkippableFact]
+    public async Task SecondObjectInAFile_IsAttributedUnderItsFileWithFileLines()
+    {
+        TestArtifacts.SkipIfMissing();
+        var dir = TestScratch.Dir("al-runner-per-test-coverage-multi-object");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "9f1e2d3c-4b5a-6978-8a9b-0c1d2e3f4a5c",
+          "name": "Per-Test Coverage Multi-Object Probe",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 60210, "to": 60219 } ],
+          "runtime": "14.0"
+        }
+        """);
+        // `exit(22)` is file line 13 of this file; its object's text starts on line 8.
+        File.WriteAllText(Path.Combine(dir, "Two.Codeunit.al"), """
+        codeunit 60210 "PTC MO First"
+        {
+            procedure FirstOnly(): Integer
+            begin
+                exit(11);
+            end;
+        }
+
+        codeunit 60211 "PTC MO Second"
+        {
+            procedure SecondOnly(): Integer
+            begin
+                exit(22);
+            end;
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "T.Codeunit.al"), """
+        codeunit 60212 "PTC MO Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure CallsOnlySecond()
+            var
+                S: Codeunit "PTC MO Second";
+            begin
+                if S.SecondOnly() <> 22 then
+                    Error('expected 22');
+            end;
+        }
+        """);
+
+        var server = await _fixture.GetAsync();
+        var lines = await server.SendRequestStreamingAsync(RunTestsRequest(dir, perTestCoverage: true, testIsolation: "test"));
+        var (_, summary) = ProtocolV2Streaming.Split(lines);
+        var entries = summary.GetProperty("perTestCoverage").EnumerateArray().ToList();
+        var key = FindTestKey(entries, "CallsOnlySecond");
+        var files = entries.Single(e => e.GetProperty("test").GetString() == key)
+            .GetProperty("coverage").EnumerateArray().ToList();
+
+        var two = Assert.Single(files, f =>
+            f.GetProperty("file").GetString()!.Replace('\\', '/').EndsWith("/Two.Codeunit.al", StringComparison.Ordinal));
+        var stmt = Assert.Single(two.GetProperty("statements").EnumerateArray());
+        Assert.Equal("SecondOnly", stmt.GetProperty("scope").GetString());
+        Assert.Equal(13, stmt.GetProperty("line").GetInt32());
+        Assert.Equal(1, stmt.GetProperty("hits").GetInt32());
+    }
+
     private static string FindTestKey(List<JsonElement> entries, string methodNameSuffix)
     {
         var match = entries.Single(e => e.GetProperty("test").GetString()!.EndsWith("." + methodNameSuffix, StringComparison.Ordinal));

--- a/AlRunner.Tests/CoverageMultiObjectFileTests.cs
+++ b/AlRunner.Tests/CoverageMultiObjectFileTests.cs
@@ -114,6 +114,54 @@ public sealed class CoverageMultiObjectFileTests : IDisposable
         Assert.Equal(0, map.LineOffset("CodeUnit", 99999)); // unknown object: no offset, never a throw
     }
 
+    /// <summary>
+    /// The trap the plain FullSpan model fell into. With a `namespace` line before the first
+    /// object, that object's FullSpan starts on line 1 (0-based), yet BC still reports its lines
+    /// from the file's line 1 — the preamble stays in front of every object's text. So the
+    /// offset is each object's FullSpan start MINUS the first object's: 0, 8 and 18 here, not
+    /// 1, 9 and 19. Measured through the runner on four header variants (none, comments,
+    /// namespace, using); the Cobertura fact below is the emitted-span proof for this shape.
+    /// </summary>
+    [SkippableFact]
+    public void Build_ObjectsAfterAFileHeader_OffsetRelativeToTheFirstObject()
+    {
+        RequireEngine();
+        File.WriteAllText(Path.Combine(_root, "Three.Codeunit.al"), """
+        namespace Probe.CovEdge;
+
+        codeunit 63650 "Edge A"
+        {
+            procedure A(): Integer
+            begin
+                exit(1);
+            end;
+        }
+
+        // a comment between objects
+
+          codeunit 63651 "Edge B"
+        {
+            procedure B(): Integer
+            begin
+                exit(2);
+            end;
+        }
+        codeunit 63652 "Edge C"
+        {
+            procedure C(): Integer
+            begin
+                exit(3);
+            end;
+        }
+        """);
+
+        var map = AlCoverageSourceMap.Build(new[] { _root }, relativeTo: _root);
+
+        Assert.Equal(0, map.LineOffset("CodeUnit", 63650));
+        Assert.Equal(8, map.LineOffset("CodeUnit", 63651));
+        Assert.Equal(18, map.LineOffset("CodeUnit", 63652));
+    }
+
     [SkippableFact]
     public void Build_FileWithATableAndACodeunit_MapsBothKinds()
     {
@@ -281,5 +329,94 @@ public sealed class CoverageMultiObjectFileTests : IDisposable
         var cov = doc.Root!;
         Assert.Equal("4", cov.Attribute("lines-valid")!.Value);
         Assert.Equal("2", cov.Attribute("lines-covered")!.Value);
+    }
+
+    /// <summary>
+    /// Every shape that could move the origin, in one file: a UTF-8 BOM, CRLF line endings, two
+    /// header comment lines, a file-scoped `namespace`, a `using`, a comment between objects, an
+    /// indented declaration keyword, and a third object with no blank line before it. The
+    /// executed statements sit on file lines 21 and 28, the unexecuted one on 11. RED under the
+    /// plain FullSpan model: 16, 26 and 33 (every object shifted by the five preamble lines).
+    /// </summary>
+    [SkippableFact]
+    public void Coverage_FileWithNamespaceHeaderAndThreeObjects_ReportsFileLines()
+    {
+        TestArtifacts.SkipIfMissing();
+        var bundle = Path.Combine(_root, "bundle-header");
+        Directory.CreateDirectory(bundle);
+        File.WriteAllText(Path.Combine(bundle, "app.json"), """
+        {
+          "id": "5a3f0b11-3713-4a09-8009-000000003713",
+          "name": "CMOF Header Probe",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 63650, "to": 63669 } ],
+          "runtime": "14.0"
+        }
+        """);
+        var three = string.Join("\r\n", new[]
+        {
+            "// header comment line 1",        // 1
+            "// header comment line 2",        // 2
+            "namespace Probe.CovEdge;",        // 3
+            "",                                // 4
+            "using System.Utilities;",         // 5
+            "",                                // 6
+            "codeunit 63650 \"Edge A\"",       // 7
+            "{",                               // 8
+            "    procedure A(): Integer",      // 9
+            "    begin",                       // 10
+            "        exit(1);",                // 11  never called
+            "    end;",                        // 12
+            "}",                               // 13
+            "",                                // 14
+            "// a comment between objects",    // 15
+            "",                                // 16
+            "  codeunit 63651 \"Edge B\"",     // 17  indented keyword
+            "{",                               // 18
+            "    procedure B(): Integer",      // 19
+            "    begin",                       // 20
+            "        exit(2);",                // 21  called
+            "    end;",                        // 22
+            "}",                               // 23
+            "codeunit 63652 \"Edge C\"",       // 24  no blank line before it
+            "{",                               // 25
+            "    procedure C(): Integer",      // 26
+            "    begin",                       // 27
+            "        exit(3);",                // 28  called
+            "    end;",                        // 29
+            "}",                               // 30
+            "",
+        });
+        File.WriteAllText(Path.Combine(bundle, "Three.Codeunit.al"), three, new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+        File.WriteAllText(Path.Combine(bundle, "T.Codeunit.al"), """
+        codeunit 63660 "Edge Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure CallsBAndC()
+            var
+                B: Codeunit "Edge B";
+                C: Codeunit "Edge C";
+            begin
+                if B.B() + C.C() <> 5 then
+                    Error('expected 5');
+            end;
+        }
+        """);
+        var coveragePath = Path.Combine(_root, "cobertura-header.xml");
+
+        var (output, exit) = Spawn(bundle, "--coverage", $"--coverage-out \"{coveragePath}\"");
+
+        Assert.Equal(0, exit);
+        Assert.True(File.Exists(coveragePath), $"cobertura.xml was not written.\n{output}");
+        var lines = LinesOf(ClassFor(XDocument.Load(coveragePath), "Three.Codeunit.al"));
+        Assert.Equal(new[] { 11, 21, 28 }, lines.Keys.OrderBy(k => k).ToArray());
+        Assert.Equal(0, lines[11]);
+        Assert.Equal(1, lines[21]);
+        Assert.Equal(1, lines[28]);
     }
 }

--- a/AlRunner.Tests/CoverageMultiObjectFileTests.cs
+++ b/AlRunner.Tests/CoverageMultiObjectFileTests.cs
@@ -1,0 +1,285 @@
+// CoverageMultiObjectFileTests — #3713: --coverage reported only the FIRST object of a
+// multi-object .al file; lines executed in a later object were absent from the report,
+// indistinguishable from never executed. Exit 0, no warning.
+//
+// The loss is in AlCoverageSourceMap.Build, the (object label, object id) -> file map that
+// both writers consume: it registered one header per file (`Regex.Match`, not `Matches`), on
+// the belief that "AL files declare exactly one top-level object". They do not — alc compiles
+// a file holding several objects at 0 errors, and real apps do it (1 of 553 files in Continia
+// Document Output). Every object after the first had no file, so AlCoverageTracker.Collect
+// skipped its scopes, and the Cobertura class for the file carried the first object's lines
+// only. Server mode (perTestCoverage) shares the map and lost the file altogether.
+//
+// Two layers: the map itself, in-process and fast; and the Cobertura output of a real run,
+// asserting the SPECIFIC line of the second object with a SPECIFIC hit count, so a fix that
+// merely stopped crashing, or reported every line as 0, cannot pass.
+
+using System.Diagnostics;
+using System.Text;
+using System.Xml.Linq;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// The map facts parse AL with BC's own parser in-process, so they join BcEngineCollection
+// (see that file); the end-to-end fact spawns the runner and needs only the artifact cache.
+[Collection(BcEngineCollection.Name)]
+public sealed class CoverageMultiObjectFileTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private readonly BcEngineFixture _engine;
+    private readonly string _root;
+
+    public CoverageMultiObjectFileTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = TestScratch.Dir("al-runner-coverage-multi-object");
+        Directory.CreateDirectory(_root);
+    }
+
+    private void RequireEngine() =>
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    // ── the map ──────────────────────────────────────────────────────────────────────────
+
+    [SkippableFact]
+    public void Build_FileWithTwoCodeunits_MapsBothIdsToTheFile()
+    {
+        RequireEngine();
+        File.WriteAllText(Path.Combine(_root, "Two.Codeunit.al"), """
+        codeunit 63600 "Cov First"
+        {
+            procedure FirstOnly(): Integer
+            begin
+                exit(11);
+            end;
+        }
+
+        codeunit 63601 "Cov Second"
+        {
+            procedure SecondOnly(): Integer
+            begin
+                exit(22);
+            end;
+        }
+        """);
+
+        var map = AlCoverageSourceMap.Build(new[] { _root }, relativeTo: _root);
+
+        Assert.Equal("Two.Codeunit.al", map[("CodeUnit", 63600)]);
+        Assert.Equal("Two.Codeunit.al", map[("CodeUnit", 63601)]);
+        Assert.Equal(2, map.Count);
+    }
+
+    /// <summary>
+    /// The second object's text begins on file line 8 (0-based 7): the blank line after the
+    /// first object's closing brace is its leading trivia, and BC's [SourceSpans] count from
+    /// there. That is the offset every consumer adds to a decoded statement line.
+    /// </summary>
+    [SkippableFact]
+    public void Build_SecondObjectInAFile_CarriesItsStartLineAsOffset()
+    {
+        RequireEngine();
+        File.WriteAllText(Path.Combine(_root, "Two.Codeunit.al"), """
+        codeunit 63600 "Cov First"
+        {
+            procedure FirstOnly(): Integer
+            begin
+                exit(11);
+            end;
+        }
+
+        codeunit 63601 "Cov Second"
+        {
+            procedure SecondOnly(): Integer
+            begin
+                exit(22);
+            end;
+        }
+        """);
+
+        var map = AlCoverageSourceMap.Build(new[] { _root }, relativeTo: _root);
+
+        Assert.Equal(0, map.LineOffset("CodeUnit", 63600));
+        Assert.Equal(7, map.LineOffset("CodeUnit", 63601));
+        Assert.Equal(0, map.LineOffset("CodeUnit", 99999)); // unknown object: no offset, never a throw
+    }
+
+    [SkippableFact]
+    public void Build_FileWithATableAndACodeunit_MapsBothKinds()
+    {
+        RequireEngine();
+        File.WriteAllText(Path.Combine(_root, "Mixed.al"), """
+        table 63602 "Cov Mixed Table"
+        {
+            fields { field(1; "Code"; Code[20]) { } }
+            keys { key(PK; "Code") { Clustered = true; } }
+        }
+
+        codeunit 63603 "Cov Mixed Codeunit"
+        {
+            procedure P(): Integer
+            begin
+                exit(1);
+            end;
+        }
+        """);
+
+        var map = AlCoverageSourceMap.Build(new[] { _root }, relativeTo: _root);
+
+        Assert.Equal("Mixed.al", map[("Table", 63602)]);
+        Assert.Equal("Mixed.al", map[("CodeUnit", 63603)]);
+    }
+
+    /// <summary>Pin for the one-object file, green before and after: exactly one entry.</summary>
+    [SkippableFact]
+    public void Build_FileWithOneCodeunit_MapsExactlyOneId()
+    {
+        RequireEngine();
+        File.WriteAllText(Path.Combine(_root, "One.Codeunit.al"), """
+        codeunit 63604 "Cov One"
+        {
+            procedure P(): Integer
+            begin
+                // codeunit 63605 mentioned in a comment is not a declaration
+                exit(1);
+            end;
+        }
+        """);
+
+        var map = AlCoverageSourceMap.Build(new[] { _root }, relativeTo: _root);
+
+        Assert.Equal(new[] { ("CodeUnit", 63604) }, map.Keys.ToArray());
+    }
+
+    // ── the report, end to end ───────────────────────────────────────────────────────────
+
+    private void WriteBundle(string dir)
+    {
+        Directory.CreateDirectory(dir);
+        // No "application" property — see .claude/rules/no-base-app-in-csharp-tests.md.
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "5a3f0b11-3713-4a01-8001-000000003713",
+          "name": "CMOF Coverage Probe",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 63600, "to": 63619 } ],
+          "runtime": "14.0"
+        }
+        """);
+        // Line numbers below are load-bearing: `exit(11)` is file line 5 (first object, never
+        // called) and `exit(22)` is file line 13 (second object, called by the test).
+        File.WriteAllText(Path.Combine(dir, "Two.Codeunit.al"), """
+        codeunit 63600 "CMOF First"
+        {
+            procedure FirstOnly(): Integer
+            begin
+                exit(11);
+            end;
+        }
+
+        codeunit 63601 "CMOF Second"
+        {
+            procedure SecondOnly(): Integer
+            begin
+                exit(22);
+            end;
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "T.Codeunit.al"), """
+        codeunit 63610 "CMOF Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure CallsOnlySecond()
+            var
+                S: Codeunit "CMOF Second";
+            begin
+                if S.SecondOnly() <> 22 then
+                    Error('expected 22');
+            end;
+        }
+        """);
+    }
+
+    private (string Output, int Exit) Spawn(string bundle, params string[] extraArgs)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" --no-cache"); // must re-emit and re-instrument, not replay an al-out cache HIT
+        foreach (var a in extraArgs) args.Append(' ').Append(a);
+        args.Append(" \"").Append(bundle).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(600_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>The Cobertura class whose filename ends with <paramref name="fileName"/>.</summary>
+    private static XElement ClassFor(XDocument doc, string fileName)
+    {
+        var cls = doc.Descendants("class").FirstOrDefault(c =>
+            (c.Attribute("filename")?.Value ?? "").Replace('\\', '/').EndsWith("/" + fileName, StringComparison.Ordinal));
+        Assert.True(cls != null, $"no <class> for {fileName} in:\n{doc}");
+        return cls!;
+    }
+
+    private static Dictionary<int, int> LinesOf(XElement cls) =>
+        cls.Descendants("line").ToDictionary(
+            l => int.Parse(l.Attribute("number")!.Value),
+            l => int.Parse(l.Attribute("hits")!.Value));
+
+    /// <summary>
+    /// RED before the fix: the class for Two.Codeunit.al held line 5 only (hits 0); line 13,
+    /// which the passing test demonstrably executed, was absent, and lines-valid was 3.
+    /// </summary>
+    [SkippableFact]
+    public void Coverage_SecondObjectInAFile_IsReportedWithItsHits()
+    {
+        TestArtifacts.SkipIfMissing();
+        var bundle = Path.Combine(_root, "bundle");
+        WriteBundle(bundle);
+        var coveragePath = Path.Combine(_root, "cobertura.xml");
+
+        var (output, exit) = Spawn(bundle, "--coverage", $"--coverage-out \"{coveragePath}\"");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("CallsOnlySecond", output);
+        Assert.True(File.Exists(coveragePath), $"cobertura.xml was not written.\n{output}");
+        var doc = XDocument.Load(coveragePath);
+
+        var lines = LinesOf(ClassFor(doc, "Two.Codeunit.al"));
+        Assert.Equal(new[] { 5, 13 }, lines.Keys.OrderBy(k => k).ToArray());
+        Assert.Equal(0, lines[5]);   // FirstOnly, never called: still reported, as 0
+        Assert.Equal(1, lines[13]);  // SecondOnly, called once by the test
+
+        // The whole-report totals count the second object too: 2 lines here + 2 in T.Codeunit.al.
+        var cov = doc.Root!;
+        Assert.Equal("4", cov.Attribute("lines-valid")!.Value);
+        Assert.Equal("2", cov.Attribute("lines-covered")!.Value);
+    }
+}

--- a/AlRunner/Infrastructure/AlCoverageSourceMap.cs
+++ b/AlRunner/Infrastructure/AlCoverageSourceMap.cs
@@ -1,10 +1,10 @@
 // AlCoverageSourceMap — maps (AL object type label, AL object id) back to the .al file
-// that declares it AND to where in that file the object's text begins, for --coverage's
-// cobertura output, the server's statement tables and the DAP session. Coverage-only
-// utility: it does not touch AL compilation, just parses the same .al files the bundle was
-// already compiled from with BC's own parser.
+// that declares it AND to the line offset BC's [SourceSpans] need to become file lines,
+// for --coverage's cobertura output, the server's statement tables and the DAP session.
+// Coverage-only utility: it does not touch AL compilation, just parses the same .al files
+// the bundle was already compiled from with BC's own parser.
 using System.Collections;
-using System.Text.RegularExpressions;
+using System.Collections.Concurrent;
 using NavCA = Microsoft.Dynamics.Nav.CodeAnalysis;
 using NavSyntax = Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 
@@ -12,16 +12,12 @@ namespace AlRunner.Infrastructure;
 
 /// <summary>
 /// (object label, object id) → the declaring file, readable as the plain
-/// <c>IReadOnlyDictionary&lt;(Label, Id), string&gt;</c> every consumer already takes, plus
-/// <see cref="LineOffset"/>: the 0-based file line on which the object's text begins.
-/// <para>
-/// BC's [SourceSpans] lines are relative to the object's own text, not to the file. For the
-/// first object in a file the two coincide, which is why one-object files never showed the
-/// difference. For a later object in the same file (#3713) every statement line must have
-/// the object's start line added, or the report places the second object's statements
-/// inside the first's range — measured: <c>exit(22)</c> on file line 13 reported as line 6,
-/// because its object's text starts on line 8 (0-based 7) and BC counted from there.
-/// </para>
+/// <c>IReadOnlyDictionary&lt;(Label, Id), string&gt;</c> the older consumers take, plus
+/// <see cref="LineOffset"/>, the number of lines to add to a decoded [SourceSpans] line to
+/// get the file line. BC's [SourceSpans] lines are relative to the object's own text with
+/// the file's preamble (anything before the first object) counted in, so the offset is the
+/// object's FullSpan start minus the first object's — 0 for the first object in a file
+/// (#3713; CoverageMultiObjectFileTests pins the four header shapes that settled it).
 /// </summary>
 public sealed class AlSourceLocationMap : IReadOnlyDictionary<(string Label, int Id), string>
 {
@@ -33,11 +29,8 @@ public sealed class AlSourceLocationMap : IReadOnlyDictionary<(string Label, int
     internal void Add(string label, int id, string path, int lineOffset) =>
         _entries[(label, id)] = (path, lineOffset);
 
-    /// <summary>
-    /// The 0-based file line the object's text (leading trivia included, as BC's syntax
-    /// tree counts it) starts on; 0 for the first object in a file and for an unknown
-    /// object. Add it to a decoded [SourceSpans] line to get the file line.
-    /// </summary>
+    /// <summary>Lines to add to a decoded [SourceSpans] line of this object to get its file
+    /// line; 0 for the first object in a file and for an object not in the map.</summary>
     public int LineOffset(string label, int id) =>
         _entries.TryGetValue((label, id), out var e) ? e.LineOffset : 0;
 
@@ -62,70 +55,80 @@ public sealed class AlSourceLocationMap : IReadOnlyDictionary<(string Label, int
 
 public static class AlCoverageSourceMap
 {
-    // Text fallback for a file BC's parser refuses: an AL object declaration header,
-    // `<keyword> <id> <name>`, anchored to the start of a (trimmed) line so it does not fire
-    // inside comments/strings later in the file. Labels must match
-    // AlCallStackCapture.ParseObjectTypeAndId's exactly — that is the other half of the
-    // (label, id) key this map is looked up by.
-    private static readonly Regex ObjectHeaderPattern = new(
-        @"^\s*(codeunit|table|page|report|xmlport|query|enum)\s+(\d+)\b",
-        RegexOptions.IgnoreCase | RegexOptions.Multiline);
+    /// <summary>One object as parsed from a file: label, id, and its line offset.</summary>
+    private readonly record struct ParsedObject(string Label, int Id, int LineOffset);
 
-    private static readonly Dictionary<string, string> KeywordToLabel = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["codeunit"] = "CodeUnit",
-        ["table"] = "Table",
-        ["page"] = "Page",
-        ["report"] = "Report",
-        ["query"] = "Query",
-        ["xmlport"] = "XmlPort",
-        ["enum"] = "Enum",
-    };
+    // Parse results per file, keyed by (path, length, last write, symbols). A --server process
+    // builds this map on every coverage request over the same tree; re-parsing thousands of
+    // unchanged files per request was the review's cost finding on the #3713 PR.
+    private static readonly ConcurrentDictionary<string, IReadOnlyList<ParsedObject>> _parsed = new(StringComparer.Ordinal);
 
     /// <summary>
     /// Scans every *.al file under <paramref name="roots"/> (recursively) and returns a map
     /// from (object label, object id) to the file's path — relative to
-    /// <paramref name="relativeTo"/> when given, else absolute — and the object's start line.
-    /// EVERY object declared in a file is registered: AL lets one file declare several
-    /// objects and alc compiles such a file at 0 errors. Registering only the first (#3713)
-    /// made <see cref="AlCoverageTracker.Collect"/> skip every later object's scopes, so
-    /// their executed lines were absent from the report, indistinguishable from never run.
+    /// <paramref name="relativeTo"/> when given, else absolute — and the object's line
+    /// offset. EVERY coverable object declared in a file is registered: AL lets one file
+    /// declare several objects and alc compiles such a file at 0 errors; registering only the
+    /// first (#3713) dropped every later object's executed lines from the report.
     /// <para>
-    /// Objects and their start lines come from BC's own parser (the same
-    /// <c>SyntaxTree.ParseObjectText</c> <see cref="AlMemberSyntaxIndex"/> uses, with the
-    /// root's app.json preprocessor symbols). A file the parser throws on falls back to the
-    /// text headers with start line 0 and says so on stdout: for such a file the lines of
-    /// any object after the first are wrong, and silence here is the defect this map exists
-    /// to remove.
+    /// Objects come from BC's own parser (<c>SyntaxTree.ParseObjectText</c>, as
+    /// <see cref="AlMemberSyntaxIndex"/> uses it), with the preprocessor symbols of the nearest
+    /// app.json above each file. A file the parser throws on is an error, not a fallback: a
+    /// map with a guessed offset reports wrong lines with exit 0, the shape this method exists
+    /// to remove (loud-failures.md).
     /// </para>
     /// </summary>
     public static AlSourceLocationMap Build(IEnumerable<string> roots, string? relativeTo = null)
     {
         var map = new AlSourceLocationMap();
+        var symbolsByAppJson = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+        var appJsonByDir = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
         foreach (var root in roots)
         {
             if (!Directory.Exists(root)) continue;
-            var appJson = Path.Combine(root, "app.json");
-            var symbols = AlMemberSyntaxIndex.PreprocessorSymbols(File.Exists(appJson) ? appJson : null);
             foreach (var file in SafeDirectoryScan.Files(root, "*.al"))
             {
-                string content;
-                try { content = File.ReadAllText(file); }
-                catch (IOException) { continue; }
+                var appJson = NearestAppJson(Path.GetDirectoryName(file)!, appJsonByDir);
+                if (!symbolsByAppJson.TryGetValue(appJson ?? "", out var symbols))
+                    symbolsByAppJson[appJson ?? ""] = symbols = AlMemberSyntaxIndex.PreprocessorSymbols(appJson);
 
                 var path = relativeTo != null
                     ? Path.GetRelativePath(relativeTo, file).Replace('\\', '/')
                     : file.Replace('\\', '/');
-                if (!TryAddFromSyntax(map, content, file, path, symbols))
-                    AddFromHeaders(map, content, path);
+                foreach (var o in ParseObjects(file, symbols))
+                    map.Add(o.Label, o.Id, path, o.LineOffset);
             }
         }
         return map;
     }
 
-    private static bool TryAddFromSyntax(
-        AlSourceLocationMap map, string content, string file, string path, IReadOnlyList<string> symbols)
+    /// <summary>The nearest app.json in <paramref name="dir"/> or an ancestor, or null. The
+    /// bundle root is not always the app root: a server request may name <c>app/src</c>, and a
+    /// bundle can be a parent of several apps with their own manifests and symbols.</summary>
+    private static string? NearestAppJson(string dir, Dictionary<string, string?> cache)
     {
+        if (cache.TryGetValue(dir, out var known)) return known;
+        string? found = null;
+        for (var d = dir; d != null; d = Path.GetDirectoryName(d))
+        {
+            var candidate = Path.Combine(d, "app.json");
+            if (File.Exists(candidate)) { found = candidate; break; }
+        }
+        cache[dir] = found;
+        return found;
+    }
+
+    private static IReadOnlyList<ParsedObject> ParseObjects(string file, IReadOnlyList<string> symbols)
+    {
+        var info = new FileInfo(file);
+        var key = $"{file}|{info.Length}|{info.LastWriteTimeUtc.Ticks}|{string.Join(",", symbols)}";
+        if (_parsed.TryGetValue(key, out var cached)) return cached;
+
+        string content;
+        try { content = File.ReadAllText(file); }
+        catch (IOException) { return Array.Empty<ParsedObject>(); }
+
+        List<ParsedObject> result;
         try
         {
             var parseOpts = new NavCA.ParseOptions(
@@ -134,42 +137,35 @@ public static class AlCoverageSourceMap
                 documentationMode: NavCA.DocumentationMode.None);
             var tree = NavSyntax.SyntaxTree.ParseObjectText(content, path: file, encoding: null!, parseOpts, default);
             var root = tree.GetCompilationUnitRoot();
+
+            var objects = new List<(string Label, int Id, int Start)>();
             foreach (var obj in root.Objects)
             {
                 var label = LabelOf(obj);
                 if (label == null) continue;
                 if (obj is not NavSyntax.ApplicationObjectSyntax ao || ao.ObjectId?.Value.Value is not int id) continue;
-                // FullSpan, not Span: BC counts an object's lines from the start of its leading
-                // trivia — the blank line and comments between it and the previous object —
-                // which is where the emitted [SourceSpans] lines are measured from.
-                var startLine = tree.GetLineSpan(obj.FullSpan).StartLinePosition.Line;
-                map.Add(label, id, path, startLine);
+                objects.Add((label, id, tree.GetLineSpan(obj.FullSpan).StartLinePosition.Line));
             }
-            return true;
+            // Offset = this object's FullSpan start minus the FIRST object's: BC measures every
+            // object from its own text but keeps the file's preamble in front of each of them,
+            // so a namespace/using header shifts the later objects by its length and the first
+            // object by nothing (#3713, CoverageMultiObjectFileTests.Build_ObjectsAfterAFileHeader_*).
+            var firstStart = objects.Count > 0 ? objects.Min(o => o.Start) : 0;
+            result = objects.Select(o => new ParsedObject(o.Label, o.Id, o.Start - firstStart)).ToList();
         }
         catch (Exception ex)
         {
-            Console.WriteLine(
-                $"[coverage] warn: {path}: BC's parser failed ({ex.GetType().Name}: {ex.Message}). Registering its "
-                + "object headers by text with start line 0, so the reported lines of any object after the first in "
-                + "this file are wrong.");
-            return false;
+            throw new InvalidOperationException(
+                $"[coverage] {file}: BC's parser failed ({ex.GetType().Name}: {ex.Message}), so the objects it declares "
+                + "cannot be placed on their lines. Refusing to write a coverage report that would put them elsewhere.", ex);
         }
-    }
-
-    private static void AddFromHeaders(AlSourceLocationMap map, string content, string path)
-    {
-        foreach (Match m in ObjectHeaderPattern.Matches(content))
-        {
-            if (!KeywordToLabel.TryGetValue(m.Groups[1].Value, out var label)) continue;
-            if (!int.TryParse(m.Groups[2].Value, out var id)) continue;
-            map.Add(label, id, path, 0);
-        }
+        _parsed[key] = result;
+        return result;
     }
 
     // The coverable object kinds, labelled the way AlCallStackCapture.ParseObjectTypeAndId
-    // labels the emitted scope classes. Extensions, interfaces, controladdins, profiles and
-    // permission sets carry no [SourceSpans] scopes of their own and stay out, as before.
+    // labels the emitted scope classes. The same seven kinds the header regex accepted before
+    // #3713; extensions and the id-less kinds are not registered, as before.
     private static string? LabelOf(NavCA.SyntaxNode obj) => obj switch
     {
         NavSyntax.CodeunitSyntax => "CodeUnit",

--- a/AlRunner/Infrastructure/AlCoverageSourceMap.cs
+++ b/AlRunner/Infrastructure/AlCoverageSourceMap.cs
@@ -1,18 +1,72 @@
 // AlCoverageSourceMap — maps (AL object type label, AL object id) back to the .al file
-// that declares it, for --coverage's cobertura output. Coverage-only utility: it does
-// not touch AL parsing/compilation, just scans header lines of the same .al files the
-// bundle was already compiled from, the same way v1's SourceFileMapper did.
+// that declares it AND to where in that file the object's text begins, for --coverage's
+// cobertura output, the server's statement tables and the DAP session. Coverage-only
+// utility: it does not touch AL compilation, just parses the same .al files the bundle was
+// already compiled from with BC's own parser.
+using System.Collections;
 using System.Text.RegularExpressions;
+using NavCA = Microsoft.Dynamics.Nav.CodeAnalysis;
+using NavSyntax = Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 
 namespace AlRunner.Infrastructure;
 
+/// <summary>
+/// (object label, object id) → the declaring file, readable as the plain
+/// <c>IReadOnlyDictionary&lt;(Label, Id), string&gt;</c> every consumer already takes, plus
+/// <see cref="LineOffset"/>: the 0-based file line on which the object's text begins.
+/// <para>
+/// BC's [SourceSpans] lines are relative to the object's own text, not to the file. For the
+/// first object in a file the two coincide, which is why one-object files never showed the
+/// difference. For a later object in the same file (#3713) every statement line must have
+/// the object's start line added, or the report places the second object's statements
+/// inside the first's range — measured: <c>exit(22)</c> on file line 13 reported as line 6,
+/// because its object's text starts on line 8 (0-based 7) and BC counted from there.
+/// </para>
+/// </summary>
+public sealed class AlSourceLocationMap : IReadOnlyDictionary<(string Label, int Id), string>
+{
+    private readonly Dictionary<(string Label, int Id), (string Path, int LineOffset)> _entries = new();
+
+    /// <summary>A map with no objects; never mutated.</summary>
+    public static AlSourceLocationMap Empty { get; } = new();
+
+    internal void Add(string label, int id, string path, int lineOffset) =>
+        _entries[(label, id)] = (path, lineOffset);
+
+    /// <summary>
+    /// The 0-based file line the object's text (leading trivia included, as BC's syntax
+    /// tree counts it) starts on; 0 for the first object in a file and for an unknown
+    /// object. Add it to a decoded [SourceSpans] line to get the file line.
+    /// </summary>
+    public int LineOffset(string label, int id) =>
+        _entries.TryGetValue((label, id), out var e) ? e.LineOffset : 0;
+
+    public string this[(string Label, int Id) key] => _entries[key].Path;
+    public IEnumerable<(string Label, int Id)> Keys => _entries.Keys;
+    public IEnumerable<string> Values => _entries.Values.Select(e => e.Path);
+    public int Count => _entries.Count;
+    public bool ContainsKey((string Label, int Id) key) => _entries.ContainsKey(key);
+
+    public bool TryGetValue((string Label, int Id) key, out string value)
+    {
+        if (_entries.TryGetValue(key, out var e)) { value = e.Path; return true; }
+        value = null!;
+        return false;
+    }
+
+    public IEnumerator<KeyValuePair<(string Label, int Id), string>> GetEnumerator() =>
+        _entries.Select(kv => new KeyValuePair<(string Label, int Id), string>(kv.Key, kv.Value.Path)).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
 public static class AlCoverageSourceMap
 {
-    // Matches an AL object declaration header: `<keyword> <id> <name>`. Anchored to the
-    // start of a (trimmed) line so it does not fire inside comments/strings later in the
-    // file. Only the keyword + numeric id are needed; the label mapping below must match
-    // AlCallStackCapture.ParseObjectTypeAndId's labels exactly, since that is the other
-    // half of the (label, id) key this map is looked up by.
+    // Text fallback for a file BC's parser refuses: an AL object declaration header,
+    // `<keyword> <id> <name>`, anchored to the start of a (trimmed) line so it does not fire
+    // inside comments/strings later in the file. Labels must match
+    // AlCallStackCapture.ParseObjectTypeAndId's exactly — that is the other half of the
+    // (label, id) key this map is looked up by.
     private static readonly Regex ObjectHeaderPattern = new(
         @"^\s*(codeunit|table|page|report|xmlport|query|enum)\s+(\d+)\b",
         RegexOptions.IgnoreCase | RegexOptions.Multiline);
@@ -29,36 +83,102 @@ public static class AlCoverageSourceMap
     };
 
     /// <summary>
-    /// Scans every *.al file under <paramref name="roots"/> (recursively) and returns a
-    /// map from (object label, object id) to the file's path, relative to
-    /// <paramref name="relativeTo"/> when given (else absolute). Only the FIRST object
-    /// header found per file is registered — AL files declare exactly one top-level
-    /// object, matching the compiler's own constraint.
+    /// Scans every *.al file under <paramref name="roots"/> (recursively) and returns a map
+    /// from (object label, object id) to the file's path — relative to
+    /// <paramref name="relativeTo"/> when given, else absolute — and the object's start line.
+    /// EVERY object declared in a file is registered: AL lets one file declare several
+    /// objects and alc compiles such a file at 0 errors. Registering only the first (#3713)
+    /// made <see cref="AlCoverageTracker.Collect"/> skip every later object's scopes, so
+    /// their executed lines were absent from the report, indistinguishable from never run.
+    /// <para>
+    /// Objects and their start lines come from BC's own parser (the same
+    /// <c>SyntaxTree.ParseObjectText</c> <see cref="AlMemberSyntaxIndex"/> uses, with the
+    /// root's app.json preprocessor symbols). A file the parser throws on falls back to the
+    /// text headers with start line 0 and says so on stdout: for such a file the lines of
+    /// any object after the first are wrong, and silence here is the defect this map exists
+    /// to remove.
+    /// </para>
     /// </summary>
-    public static Dictionary<(string Label, int Id), string> Build(
-        IEnumerable<string> roots, string? relativeTo = null)
+    public static AlSourceLocationMap Build(IEnumerable<string> roots, string? relativeTo = null)
     {
-        var map = new Dictionary<(string, int), string>();
+        var map = new AlSourceLocationMap();
         foreach (var root in roots)
         {
             if (!Directory.Exists(root)) continue;
-            foreach (var file in AlRunner.Infrastructure.SafeDirectoryScan.Files(root, "*.al"))
+            var appJson = Path.Combine(root, "app.json");
+            var symbols = AlMemberSyntaxIndex.PreprocessorSymbols(File.Exists(appJson) ? appJson : null);
+            foreach (var file in SafeDirectoryScan.Files(root, "*.al"))
             {
                 string content;
                 try { content = File.ReadAllText(file); }
                 catch (IOException) { continue; }
 
-                var m = ObjectHeaderPattern.Match(content);
-                if (!m.Success) continue;
-                if (!KeywordToLabel.TryGetValue(m.Groups[1].Value, out var label)) continue;
-                if (!int.TryParse(m.Groups[2].Value, out var id)) continue;
-
                 var path = relativeTo != null
                     ? Path.GetRelativePath(relativeTo, file).Replace('\\', '/')
                     : file.Replace('\\', '/');
-                map[(label, id)] = path;
+                if (!TryAddFromSyntax(map, content, file, path, symbols))
+                    AddFromHeaders(map, content, path);
             }
         }
         return map;
     }
+
+    private static bool TryAddFromSyntax(
+        AlSourceLocationMap map, string content, string file, string path, IReadOnlyList<string> symbols)
+    {
+        try
+        {
+            var parseOpts = new NavCA.ParseOptions(
+                runtimeVersion: null!,
+                preprocessorSymbols: symbols,
+                documentationMode: NavCA.DocumentationMode.None);
+            var tree = NavSyntax.SyntaxTree.ParseObjectText(content, path: file, encoding: null!, parseOpts, default);
+            var root = tree.GetCompilationUnitRoot();
+            foreach (var obj in root.Objects)
+            {
+                var label = LabelOf(obj);
+                if (label == null) continue;
+                if (obj is not NavSyntax.ApplicationObjectSyntax ao || ao.ObjectId?.Value.Value is not int id) continue;
+                // FullSpan, not Span: BC counts an object's lines from the start of its leading
+                // trivia — the blank line and comments between it and the previous object —
+                // which is where the emitted [SourceSpans] lines are measured from.
+                var startLine = tree.GetLineSpan(obj.FullSpan).StartLinePosition.Line;
+                map.Add(label, id, path, startLine);
+            }
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(
+                $"[coverage] warn: {path}: BC's parser failed ({ex.GetType().Name}: {ex.Message}). Registering its "
+                + "object headers by text with start line 0, so the reported lines of any object after the first in "
+                + "this file are wrong.");
+            return false;
+        }
+    }
+
+    private static void AddFromHeaders(AlSourceLocationMap map, string content, string path)
+    {
+        foreach (Match m in ObjectHeaderPattern.Matches(content))
+        {
+            if (!KeywordToLabel.TryGetValue(m.Groups[1].Value, out var label)) continue;
+            if (!int.TryParse(m.Groups[2].Value, out var id)) continue;
+            map.Add(label, id, path, 0);
+        }
+    }
+
+    // The coverable object kinds, labelled the way AlCallStackCapture.ParseObjectTypeAndId
+    // labels the emitted scope classes. Extensions, interfaces, controladdins, profiles and
+    // permission sets carry no [SourceSpans] scopes of their own and stay out, as before.
+    private static string? LabelOf(NavCA.SyntaxNode obj) => obj switch
+    {
+        NavSyntax.CodeunitSyntax => "CodeUnit",
+        NavSyntax.TableSyntax => "Table",
+        NavSyntax.PageSyntax => "Page",
+        NavSyntax.ReportSyntax => "Report",
+        NavSyntax.QuerySyntax => "Query",
+        NavSyntax.XmlPortSyntax => "XmlPort",
+        NavSyntax.EnumTypeSyntax => "Enum",
+        _ => null,
+    };
 }

--- a/AlRunner/Infrastructure/AlCoverageTracker.cs
+++ b/AlRunner/Infrastructure/AlCoverageTracker.cs
@@ -302,10 +302,10 @@ public static class AlCoverageTracker
     // Null means "not a coverable, mapped AL scope" — a framework type, or an owning object
     // outside sourceMap. CollectPerTestStatementTable memoizes per scope Type, nulls included,
     // because the (Type, statementId) identity does not vary per test and only the hit count does.
-    // LineOffset: the owning object's 0-based start line in FilePath (#3713); 0 for the first
-    // object in a file, or when the map is not an AlSourceLocationMap.
+    // LineOffset: what to add to this scope's decoded [SourceSpans] lines to get file lines
+    // (#3713, AlSourceLocationMap.LineOffset); 0 for the first object in a file.
     private static (string FilePath, string ScopeName, long[] Spans, int LineOffset)? ResolveScopeInfo(
-        Type type, IReadOnlyDictionary<(string Label, int Id), string> sourceMap)
+        Type type, AlSourceLocationMap sourceMap)
     {
         if (Attribute.GetCustomAttribute(type, _tSourceSpansAttr!) is not object srcAttr) return null;
         if (_piEncodedSpans!.GetValue(srcAttr) is not long[] spans || spans.Length == 0) return null;
@@ -313,13 +313,12 @@ public static class AlCoverageTracker
         if (id == 0) return null;
         if (!sourceMap.TryGetValue((label, id), out var filePath)) return null;
         var scopeName = AlNavNameReflection.GetAlName(type) ?? "?";
-        var lineOffset = sourceMap is AlSourceLocationMap located ? located.LineOffset(label, id) : 0;
-        return (filePath, scopeName, spans, lineOffset);
+        return (filePath, scopeName, spans, sourceMap.LineOffset(label, id));
     }
 
     /// <summary>ResolveScopeInfo with the reflection init done; null for a scope outside the bundle.</summary>
     internal static (string FilePath, string ScopeName, long[] Spans, int LineOffset)? TryResolveScope(
-        Type type, IReadOnlyDictionary<(string Label, int Id), string> sourceMap)
+        Type type, AlSourceLocationMap sourceMap)
     {
         EnsureReflInit();
         AlNavNameReflection.EnsureInit();

--- a/AlRunner/Infrastructure/AlCoverageTracker.cs
+++ b/AlRunner/Infrastructure/AlCoverageTracker.cs
@@ -179,11 +179,13 @@ public static class AlCoverageTracker
     /// count 0 because this is a reflection scan over the compiled shape, not a replay of
     /// what ran — the "did not execute" half of coverage is not vacuous.
     ///
-    /// <paramref name="sourceMap"/> resolves (object label, object id) to a file path
-    /// (see AlCoverageSourceMap.Build); scopes whose owning object is not in the map are
-    /// skipped, e.g. framework/library assemblies outside the bundle under test.
+    /// <paramref name="sourceMap"/> resolves (object label, object id) to a file path and the
+    /// object's start line in that file (see AlCoverageSourceMap.Build); scopes whose owning
+    /// object is not in the map are skipped, e.g. framework/library assemblies outside the
+    /// bundle under test. The decoded span line is relative to the object's text, so the
+    /// start line is added to make it a file line (#3713).
     /// </summary>
-    public static List<AlCoverageStatement> Collect(IReadOnlyDictionary<(string Label, int Id), string> sourceMap)
+    public static List<AlCoverageStatement> Collect(AlSourceLocationMap sourceMap)
     {
         EnsureReflInit();
         var result = new List<AlCoverageStatement>();
@@ -207,11 +209,12 @@ public static class AlCoverageTracker
                 // are real, coverable statements — see AlCoverageInstrumentedStatements
                 // for why the raw SourceSpans array is not that set on its own (it
                 // carries a trailing, never-instrumented sentinel entry).
+                var lineOffset = sourceMap.LineOffset(label, id);
                 var instrumented = AlCoverageInstrumentedStatements.Find(t);
                 foreach (var i in instrumented)
                 {
                     if (i < 0 || i >= spans.Length) continue; // defensive: BC shape drift
-                    int line = AlSourceSpanCodec.AbsoluteFromLine(spans[i]);
+                    int line = AlSourceSpanCodec.AbsoluteFromLine(spans[i]) + lineOffset;
                     result.Add(new AlCoverageStatement(label, id, filePath, line, GetHitCount(t, i)));
                 }
             }
@@ -262,7 +265,7 @@ public static class AlCoverageTracker
     /// entries here with the SAME line but different id/column, which is exactly the
     /// distinction <see cref="AlCoverageReport"/>'s line-rollup necessarily discards.
     /// </summary>
-    public static List<AlStatementRecord> CollectStatementTable(IReadOnlyDictionary<(string Label, int Id), string> sourceMap)
+    public static List<AlStatementRecord> CollectStatementTable(AlSourceLocationMap sourceMap)
     {
         EnsureReflInit();
         AlNavNameReflection.EnsureInit();
@@ -282,7 +285,7 @@ public static class AlCoverageTracker
                 var (fromLine, fromColumn, toLine, toColumn) = AlSourceSpanCodec.Decode(resolved.Spans[i]);
                 result.Add(new AlStatementRecord(
                     resolved.FilePath, resolved.ScopeName, i,
-                    fromLine + 1, fromColumn + 1, toLine + 1, toColumn + 1,
+                    fromLine + 1 + resolved.LineOffset, fromColumn + 1, toLine + 1 + resolved.LineOffset, toColumn + 1,
                     GetHitCount(t, i)));
             }
         }
@@ -299,7 +302,9 @@ public static class AlCoverageTracker
     // Null means "not a coverable, mapped AL scope" — a framework type, or an owning object
     // outside sourceMap. CollectPerTestStatementTable memoizes per scope Type, nulls included,
     // because the (Type, statementId) identity does not vary per test and only the hit count does.
-    private static (string FilePath, string ScopeName, long[] Spans)? ResolveScopeInfo(
+    // LineOffset: the owning object's 0-based start line in FilePath (#3713); 0 for the first
+    // object in a file, or when the map is not an AlSourceLocationMap.
+    private static (string FilePath, string ScopeName, long[] Spans, int LineOffset)? ResolveScopeInfo(
         Type type, IReadOnlyDictionary<(string Label, int Id), string> sourceMap)
     {
         if (Attribute.GetCustomAttribute(type, _tSourceSpansAttr!) is not object srcAttr) return null;
@@ -308,11 +313,12 @@ public static class AlCoverageTracker
         if (id == 0) return null;
         if (!sourceMap.TryGetValue((label, id), out var filePath)) return null;
         var scopeName = AlNavNameReflection.GetAlName(type) ?? "?";
-        return (filePath, scopeName, spans);
+        var lineOffset = sourceMap is AlSourceLocationMap located ? located.LineOffset(label, id) : 0;
+        return (filePath, scopeName, spans, lineOffset);
     }
 
     /// <summary>ResolveScopeInfo with the reflection init done; null for a scope outside the bundle.</summary>
-    internal static (string FilePath, string ScopeName, long[] Spans)? TryResolveScope(
+    internal static (string FilePath, string ScopeName, long[] Spans, int LineOffset)? TryResolveScope(
         Type type, IReadOnlyDictionary<(string Label, int Id), string> sourceMap)
     {
         EnsureReflInit();
@@ -338,12 +344,12 @@ public static class AlCoverageTracker
     /// alongside `perTestCoverage:true`.</para>
     /// </summary>
     public static Dictionary<string, List<AlStatementRecord>> CollectPerTestStatementTable(
-        IReadOnlyDictionary<(string Label, int Id), string> sourceMap)
+        AlSourceLocationMap sourceMap)
     {
         EnsureReflInit();
         AlNavNameReflection.EnsureInit();
         var result = new Dictionary<string, List<AlStatementRecord>>();
-        var typeInfo = new Dictionary<Type, (string FilePath, string ScopeName, long[] Spans)?>();
+        var typeInfo = new Dictionary<Type, (string FilePath, string ScopeName, long[] Spans, int LineOffset)?>();
 
         foreach (var testEntry in _perTestHits)
         {
@@ -363,7 +369,7 @@ public static class AlCoverageTracker
                 var (fromLine, fromColumn, toLine, toColumn) = AlSourceSpanCodec.Decode(resolved.Spans[stmtId]);
                 (list ??= new List<AlStatementRecord>()).Add(new AlStatementRecord(
                     resolved.FilePath, resolved.ScopeName, stmtId,
-                    fromLine + 1, fromColumn + 1, toLine + 1, toColumn + 1,
+                    fromLine + 1 + resolved.LineOffset, fromColumn + 1, toLine + 1 + resolved.LineOffset, toColumn + 1,
                     stmtEntry.Value));
             }
             if (list is { Count: > 0 }) result[testEntry.Key] = list;

--- a/AlRunner/Infrastructure/AlMemberSyntaxIndex.cs
+++ b/AlRunner/Infrastructure/AlMemberSyntaxIndex.cs
@@ -124,7 +124,7 @@ public sealed class AlMemberSyntaxIndex
     }
 
     // Same union BcCompiler.Emit uses.
-    private static IReadOnlyList<string> PreprocessorSymbols(string? appJsonPath)
+    internal static IReadOnlyList<string> PreprocessorSymbols(string? appJsonPath)
     {
         var manifest = BcCompiler.ReadManifestCompilerInputs(appJsonPath);
         return Enumerable.Range(1, 25).Select(n => $"CLEANSCHEMA{n}")

--- a/AlRunner/Infrastructure/AlScopeSyntaxResolver.cs
+++ b/AlRunner/Infrastructure/AlScopeSyntaxResolver.cs
@@ -11,7 +11,7 @@ public sealed record AlScopeSyntax(AlLoopScopeTable Loops, AlWriteSetTable Write
 public static class AlScopeSyntaxResolver
 {
     private static AlMemberSyntaxIndex? _index;
-    private static IReadOnlyDictionary<(string Label, int Id), string>? _sourceMap;
+    private static AlSourceLocationMap? _sourceMap;
     private static readonly ConcurrentDictionary<Type, AlScopeSyntax?> _scopes = new();
     private static readonly ConcurrentDictionary<Type, string> _unresolved = new();
 
@@ -20,7 +20,7 @@ public static class AlScopeSyntaxResolver
     public static IReadOnlyCollection<string> UnresolvedScopes => _unresolved.Values.Distinct().OrderBy(s => s, StringComparer.Ordinal).ToList();
 
     /// <summary>Installs the request's index and file map and forgets earlier resolutions.</summary>
-    public static void Configure(AlMemberSyntaxIndex index, IReadOnlyDictionary<(string Label, int Id), string> sourceMap)
+    public static void Configure(AlMemberSyntaxIndex index, AlSourceLocationMap sourceMap)
     {
         _index = index;
         _sourceMap = sourceMap;
@@ -54,16 +54,13 @@ public static class AlScopeSyntaxResolver
 
         var instrumented = AlCoverageInstrumentedStatements.Find(scopeType);
         if (instrumented.Count == 0) return null;
-        // The first statement's position tells same-named triggers apart. The index's
-        // positions are file positions; the span's line is relative to the owning object's
-        // text, so the object's start line is added (#3713) — for the first object in a
-        // file that is 0 and nothing changes.
+        // The first statement's position tells same-named triggers apart.
         int first = instrumented.Min();
         AlTextPosition? anchor = null;
         if (first >= 0 && first < scope.Spans.Length)
         {
             var (fromLine, fromColumn, _, _) = AlSourceSpanCodec.Decode(scope.Spans[first]);
-            anchor = new AlTextPosition(fromLine + scope.LineOffset, fromColumn);
+            anchor = new AlTextPosition(fromLine, fromColumn);
         }
         var member = index.FindMember(scope.FilePath, scope.ScopeName, anchor);
         if (member == null)

--- a/AlRunner/Infrastructure/AlScopeSyntaxResolver.cs
+++ b/AlRunner/Infrastructure/AlScopeSyntaxResolver.cs
@@ -54,13 +54,16 @@ public static class AlScopeSyntaxResolver
 
         var instrumented = AlCoverageInstrumentedStatements.Find(scopeType);
         if (instrumented.Count == 0) return null;
-        // The first statement's position tells same-named triggers apart.
+        // The first statement's position tells same-named triggers apart. The index's
+        // positions are file positions; the span's line is relative to the owning object's
+        // text, so the object's start line is added (#3713) — for the first object in a
+        // file that is 0 and nothing changes.
         int first = instrumented.Min();
         AlTextPosition? anchor = null;
         if (first >= 0 && first < scope.Spans.Length)
         {
             var (fromLine, fromColumn, _, _) = AlSourceSpanCodec.Decode(scope.Spans[first]);
-            anchor = new AlTextPosition(fromLine, fromColumn);
+            anchor = new AlTextPosition(fromLine + scope.LineOffset, fromColumn);
         }
         var member = index.FindMember(scope.FilePath, scope.ScopeName, anchor);
         if (member == null)

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -5620,7 +5620,7 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
     using var tcpClientDisposable = tcpClient;
     AlRunner.Infrastructure.AlDapSession.Reset();
 
-    Dictionary<(string Label, int Id), string> sourceMap = new();
+    var sourceMap = AlRunner.Infrastructure.AlSourceLocationMap.Empty;
     var lastFrames = new List<AlRunner.Infrastructure.AlDapFrame>();
 
     var compiledTcs = new System.Threading.Tasks.TaskCompletionSource<Assembly>(


### PR DESCRIPTION
## Summary

`--coverage` wrote one Cobertura `<class>` per file and, for a file declaring more than one object, reported only the first. Lines executed in the second object were absent, indistinguishable from never executed. Exit 0, no warning. Server-mode `perTestCoverage` lost the file altogether.

Two defects, one on top of the other:

1. `AlCoverageSourceMap.Build` registered one object header per file (`Regex.Match`, not `Matches`), on the belief that "AL files declare exactly one top-level object". They do not: `alc` compiles a multi-object file at 0 errors and real apps ship them (1 of 553 files in Continia Document Output). Every object after the first had no file, so `AlCoverageTracker.Collect` skipped its scopes.
2. Once mapped, the second object's statement landed on the wrong line. BC's `[SourceSpans]` lines are relative to the **owning object's text**, not to the file, and the file's preamble (`namespace`/`using` lines before the first object) stays in front of every object. So the offset to add is the object's `FullSpan` start line minus the **first object's** `FullSpan` start line: 0 for the first object in any file, and for a later object the lines between the first object's start and its own. For one-object files the two origins coincide, which is why nothing showed it before.

Measured through the runner on five shapes of a three-object file (no header; two comment lines; `namespace`; `using`; and all of those plus a UTF-8 BOM, CRLF, a comment between objects, an indented keyword and a third object with no blank line before it). The first version of this PR used the object's own `FullSpan` start; that matched the first two shapes and was off by one line per preamble line on the others.

## Fix

- `AlCoverageSourceMap.Build` parses each file with BC's own parser (`SyntaxTree.ParseObjectText`, the one `AlMemberSyntaxIndex` already uses), registers every coverable object (the same seven kinds the header regex accepted: codeunit, table, page, report, query, xmlport, enum), and records its offset as above. Preprocessor symbols come from the **nearest app.json above each file**, not the scan root's, so a root that is a parent of several apps, or a passed `src/` folder, parses each file with its own app's symbols. Parse results are cached per (path, size, mtime, symbols); a `--server` process builds this map on every coverage request over the same tree.
- A file BC's parser throws on is an **error** naming the file, not a fallback. The first version fell back to the text headers with offset 0 and warned on stdout; that reported wrong lines with exit 0, and stdout is the protocol stream in `--server` mode.
- The result is `AlSourceLocationMap`: still an `IReadOnlyDictionary<(Label, Id), string>` for the DAP consumers, plus `LineOffset(label, id)`. `Collect`, `CollectStatementTable`, `CollectPerTestStatementTable` add the offset to the decoded line (start and end). `ResolveScopeInfo`, `TryResolveScope` and `AlScopeSyntaxResolver.Configure` take the class, so no caller can hand in a plain dictionary and get a silent offset 0.
- `AlMemberSyntaxIndex.PreprocessorSymbols` becomes `internal` for reuse. One declaration in `Program.cs` (the DAP session's `sourceMap`) changes type.

The Cobertura writer is unchanged: it groups by file and line, and the lines are now file lines, so one `<class>` per file with both objects' lines is correct Cobertura.

`AlScopeSyntaxResolver` is **unchanged**. The first version offset its member-matching anchor; review showed the loop and write-set tables it builds afterwards would still compare object-relative spans against file positions, so a second object's loops would go silently wrong where today its member lookup fails with a message. That consumer, with the two DAP ones, is #3786.

## Proof

`AlRunner.Tests/CoverageMultiObjectFileTests.cs`:

- Map facts (in-process, `BcEngineCollection`): a two-codeunit file maps both ids to the file; a table + codeunit file maps both kinds; a one-codeunit file maps exactly one id (pin); the second object's `LineOffset` is 7 and the first's is 0; with a `namespace` header, three objects' offsets are 0, 8 and 18 (plain `FullSpan` would say 1, 9, 19). RED before the fix: `KeyNotFoundException` for the second id.
- Cobertura run, two codeunits in one file, a test calling only the second: the class for `Two.Codeunit.al` has exactly lines 5 and 13, hits 0 and 1, `lines-valid` 4, `lines-covered` 2. RED in two stages: `[5]` only; after the map fix alone, `[5, 6]`. GREEN: `[5, 13]`.
- Cobertura run, the five-shape header file: lines exactly 11, 21, 28 with hits 0, 1, 1. RED under the first version's model: 16, 26, 33.

`AlRunner.Tests/AlPerTestCoverageTests.cs`, `SecondObjectInAFile_IsAttributedUnderItsFileWithFileLines`: server mode, `perTestCoverage:true`. The test's entry lists `Two.Codeunit.al` with exactly one statement, `scope` `SecondOnly`, `line` 13, `hits` 1. Written after the shared fix was in place, so not observed red locally; the RED is the reporter's server-mode log in the issue (file absent entirely) and the Cobertura facts above.

Locally on Windows, BC 28.1.49838.54169: all 13 facts in the two classes green; `CoverageTests`, `AlStatementTableTests`, `AlMemberSyntaxIndexTests`, `AlIterationSegmenterTests` and the DAP classes stay green. Two unrelated Windows-only failures were seen in a wider run and not touched: `PartialCompanyInitializationTests.PartialCompanyInit_OnAnInMemoryCacheHit_IsReportedByTheSecondAppGroup` (`[reexec] Symlink for 'al-runner.exe' refused`) and `ProvisionExplicitModesTests.TestApps_OnlyUnrelatedAppPresent_DoesNotShortCircuit_DownloadsTheRealSet` (`already present at C:`).

## Review history

An external adversarial review (GPT-5.6) of the first commit found: the resolver's anchor-only offset would make second-object loop tables silently wrong (reverted; #3786); the regex fallback produced a known-wrong report and wrote to stdout in server mode (now an error); symbols were read from the scan root, not the file's app (now nearest app.json per file); the `is AlSourceLocationMap` check let a plain dictionary through with offset 0 (types tightened); the `FullSpan` origin was proven for one layout only (four more measured, model corrected); repeated full-tree parses per server request (cached). Its remaining points are recorded here: the per-test fact was not observed red, and the offset claim is a claim about BC's compiler output validated on BC 28.1, not something a service-tier corpus run adjudicates.

## Not folded

- #3786: `DapBreakpointResolver`, `AlDapStackWalker`, and `AlScopeSyntaxResolver` with `AlLoopModel`/`AlWriteSetModel` still use object-relative `[SourceSpans]` lines as file positions. Same root cause, same map; each needs its own harness (a DAP session, an iteration-tracking run with a loop in a second object).
- `AlCallStackCapture`'s stack-trace lines are signature-relative and unaffected.

Closes #3713

Corpus-NA: `--coverage` and `perTestCoverage` are runner features. The one claim about BC here is about its compiler's `[SourceSpans]` output, measured on BC 28.1.49838.54169 through the runner; a service-tier corpus run cannot observe it, so there is nothing for the corpus to adjudicate.

*Opened by an agent (Claude Code) in a session run by @SShadowS.*

https://claude.ai/code/session_01JFQZHC5SEHnLxkc5USksaK
