### PR TITLE
fix(metadata): read the page properties the symbol file states, and stop hardcoding Extensible=1

### DIFF
--- a/AlRunner.Tests/DependencyPagePropertiesFromSymbolTests.cs
+++ b/AlRunner.Tests/DependencyPagePropertiesFromSymbolTests.cs
@@ -1,0 +1,413 @@
+// DependencyPagePropertiesFromSymbolTests — issue #3784: the page properties
+// SymbolReference.json states and RecordPatches.EmitPageXml did not read.
+//
+// WHY A RUNNER-SIDE MECHANISM TEST AND NOT A CORPUS TEST
+//   The defect is reachable only through a PRECOMPILED dependency: EmitPageXml runs for a page
+//   the runner never source-compiles, and a corpus test compiles its pages from source, which
+//   takes the real compiler's own metadata path and never reaches this synthesizer at all
+//   (bc-behavior-tests-go-upstream.md's structural case). So the proving test pins the runner's
+//   own reader against a fixture symbol file, and the VALUES it asserts are the ones BC's own
+//   emitter writes for the same input — measured, not chosen.
+//
+// WHAT THE EXPECTED VALUES REST ON
+//   BC 28.4.53241.54407, Business Foundation (11 pages) + System Application (225 pages), by
+//   parsing each app's shipped SymbolReference.json and the PageDefinition documents
+//   tools/gen-metadata-ground-truth.sh produces from BC's own emitter, and cross-tabulating
+//   every (symbol value -> emitted attribute) pair over all 236 pages:
+//
+//     Extensible          sym absent -> BC "1" (110 pages); sym "0" -> "0" (105); "1" -> "1" (21)
+//     RefreshOnActivate   sym absent -> BC "0" (207);       sym "1" -> "1" (29)
+//     UsageCategory       written iff stated, verbatim (68 pages, 6 distinct enum names)
+//     HelpLink            written iff stated, verbatim (6 pages state it)
+//     InsertAllowed       sym "0" -> "0" (121), "1" -> "1" (1), absent -> absent (114)
+//     ModifyAllowed       sym "0" -> "0" (80),  "1" -> "1" (11), absent -> absent (145)
+//     DeleteAllowed       sym "0" -> "0" (101), "1" -> "1" (6),  absent -> absent (129)
+//     DelayedInsert       sym "1" -> "1" (14),  "0" -> "0" (1),  absent -> absent (221)
+//     MultipleNewLines    sym "0" -> "0" (3),   "1" -> "1" (1),  absent -> absent (232)
+//     AboutTitle/AboutText/AdditionalSearchTerms/InstructionalText -> "ENU=" + the value
+//     InherentEntitlements / InherentPermissions   sym "X" -> BC "16"
+//
+//   PermissionMask.Execute is 16 in Microsoft.Dynamics.Nav.Types, which is what makes the last
+//   row a DECODE of the AL permission letters rather than a guess — see EmitInherentMask.
+//
+// WHAT IS DELIBERATELY NOT HERE
+//   AnalysisModeEnabled and OnAfterGetCurrentRecordEnabled are NOT symbol reads and are left
+//   alone: cross-tabulated over the same 236 pages, AnalysisModeEnabled tracks PageType
+//   (List/Worksheet -> "1", every other type -> absent) on 94 pages whose symbol file states
+//   nothing at all, and OnAfterGetCurrentRecordEnabled tracks trigger presence. Deriving either
+//   is a different change from reading one. IndirectPermissions, CardFormID and DataCaptionExpr
+//   are likewise excluded: they need table/page NAME resolution or BC's own
+//   "DataCaptionExprCode" marker, none of which the symbol file states.
+
+using System.IO.Compression;
+using System.Text;
+using System.Xml;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Same reason as DependencyPageMetadataXmlTests: BcAppSymbolCache.Get() resolves through the
+// process-global CacheRoots override, and the per-id metadata-xml memo is process-global too.
+[Collection(CacheRootsSerialCollection.Name)]
+public class DependencyPagePropertiesFromSymbolTests
+{
+    private static string WriteApp(string dir, string symbolReferenceJson)
+    {
+        var appPath = Path.Combine(dir, Guid.NewGuid().ToString("N") + ".app");
+        using var zip = new FileStream(appPath, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(symbolReferenceJson);
+        return appPath;
+    }
+
+    // Distinctive ids in their own block, for the reason DependencyPageMetadataXmlTests states:
+    // the dependency-page state is process-global, so an id another test also declares would
+    // read back that test's cached document instead of this one's.
+    private const int NotExtensiblePageId = 88784001;
+    private const int ExtensiblePageId = 88784002;
+    private const int SilentPageId = 88784003;
+    private const int RichPageId = 88784004;
+    private const int NoSourceTableFlagsPageId = 88784005;
+    private const int UnreadableMaskPageId = 88784006;
+
+    private const string SymbolReference = """
+        {
+          "RuntimeVersion": "15.1",
+          "Pages": [
+            {
+              "Id": 88784001,
+              "Name": "P3784 Not Extensible",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "SourceTable", "Value": "700" },
+                { "Name": "Extensible", "Value": "0" },
+                { "Name": "InsertAllowed", "Value": "0" },
+                { "Name": "ModifyAllowed", "Value": "0" },
+                { "Name": "DeleteAllowed", "Value": "0" }
+              ]
+            },
+            {
+              "Id": 88784002,
+              "Name": "P3784 Extensible",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "SourceTable", "Value": "700" },
+                { "Name": "Extensible", "Value": "1" },
+                { "Name": "InsertAllowed", "Value": "1" },
+                { "Name": "ModifyAllowed", "Value": "1" },
+                { "Name": "DeleteAllowed", "Value": "1" }
+              ]
+            },
+            {
+              "Id": 88784003,
+              "Name": "P3784 Silent",
+              "Properties": [
+                { "Name": "PageType", "Value": "Card" },
+                { "Name": "SourceTable", "Value": "700" }
+              ]
+            },
+            {
+              "Id": 88784004,
+              "Name": "P3784 Rich",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "SourceTable", "Value": "700" },
+                { "Name": "UsageCategory", "Value": "Administration" },
+                { "Name": "RefreshOnActivate", "Value": "1" },
+                { "Name": "HelpLink", "Value": "https://go.microsoft.com/fwlink/?linkid=2149387" },
+                { "Name": "AboutTitle", "Value": "About performance profiling" },
+                { "Name": "AboutText", "Value": "Record a slow scenario." },
+                { "Name": "AdditionalSearchTerms", "Value": "Database,Size,Storage" },
+                { "Name": "InstructionalText", "Value": "Assign email scenarios" },
+                { "Name": "IsPreview", "Value": "1" },
+                { "Name": "InherentEntitlements", "Value": "X" },
+                { "Name": "InherentPermissions", "Value": "X" },
+                { "Name": "DelayedInsert", "Value": "1" },
+                { "Name": "MultipleNewLines", "Value": "0" }
+              ]
+            },
+            {
+              "Id": 88784005,
+              "Name": "P3784 No Source Table Flags",
+              "Properties": [
+                { "Name": "PageType", "Value": "NavigatePage" },
+                { "Name": "InsertAllowed", "Value": "0" },
+                { "Name": "ModifyAllowed", "Value": "0" },
+                { "Name": "DeleteAllowed", "Value": "0" },
+                { "Name": "DelayedInsert", "Value": "1" }
+              ]
+            },
+            {
+              "Id": 88784006,
+              "Name": "P3784 Unreadable Mask",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "SourceTable", "Value": "700" },
+                { "Name": "InherentEntitlements", "Value": "Q" },
+                { "Name": "InherentPermissions", "Value": "X" }
+              ]
+            }
+          ]
+        }
+        """;
+
+    /// <summary>
+    /// THE HEADLINE. <c>Extensible</c> was written as a literal <c>"1"</c> for every page, so it
+    /// was a WRONG answer rather than a missing one on the 105 of 236 System Application +
+    /// Business Foundation pages BC's own emitter writes <c>"0"</c> for — all 105 of which state
+    /// <c>Extensible = "0"</c> in the symbol file, with zero omissions.
+    ///
+    /// <para>Asserted in BOTH directions on purpose: a hardcode in either direction fails one of
+    /// the two, so this cannot be satisfied by swapping one constant for another.</para>
+    /// </summary>
+    [Fact]
+    public void Extensible_IsReadFromTheSymbolFile_NotHardcoded()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-page-props-3784");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, SymbolReference));
+
+            Assert.Equal("0", ReadProperties(NotExtensiblePageId).GetAttribute("Extensible"));
+            Assert.Equal("1", ReadProperties(ExtensiblePageId).GetAttribute("Extensible"));
+            // The AL default, which BC's emitter writes for the 110 pages stating nothing.
+            Assert.Equal("1", ReadProperties(SilentPageId).GetAttribute("Extensible"));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The Insert/Modify/Delete trio and the two line flags, on a page that HAS a source table.
+    /// Both values of each, because the runner's previous rule ("write only a false one") could
+    /// not express an explicitly-stated <c>true</c>, which BC's emitter writes on 18 of the 236
+    /// pages measured.
+    /// </summary>
+    [Fact]
+    public void SourceObjectFlags_CarryTheStatedValue_InBothDirections()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-page-props-3784");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, SymbolReference));
+
+            var off = ReadSourceObject(NotExtensiblePageId);
+            Assert.Equal("0", off.GetAttribute("InsertAllowed"));
+            Assert.Equal("0", off.GetAttribute("ModifyAllowed"));
+            Assert.Equal("0", off.GetAttribute("DeleteAllowed"));
+
+            var on = ReadSourceObject(ExtensiblePageId);
+            Assert.Equal("1", on.GetAttribute("InsertAllowed"));
+            Assert.Equal("1", on.GetAttribute("ModifyAllowed"));
+            Assert.Equal("1", on.GetAttribute("DeleteAllowed"));
+
+            // A page stating none of them gets none of the attributes — BC's reader defaults
+            // all three to true, so writing "1" here would be indistinguishable from the AL
+            // stating it, which BC's Equals()/Freeze() can tell apart.
+            var silent = ReadSourceObject(SilentPageId);
+            Assert.False(silent.HasAttribute("InsertAllowed"));
+            Assert.False(silent.HasAttribute("ModifyAllowed"));
+            Assert.False(silent.HasAttribute("DeleteAllowed"));
+            Assert.False(silent.HasAttribute("DelayedInsert"));
+            Assert.False(silent.HasAttribute("MultipleNewLines"));
+
+            // DelayedInsert/MultipleNewLines likewise carry a stated "0", which the old
+            // write-only-a-true rule dropped. BC writes DelayedInsert="0" on 1 page and
+            // MultipleNewLines="0" on 3 of the 236.
+            var rich = ReadSourceObject(RichPageId);
+            Assert.Equal("1", rich.GetAttribute("DelayedInsert"));
+            Assert.Equal("0", rich.GetAttribute("MultipleNewLines"));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The same five flags on a page with NO source table, which the old code could not write at
+    /// all because they sat inside its <c>SourceTable &gt; 0</c> branch. Five System Application
+    /// pages are in exactly this shape — 502 OAuth2ControlAddIn, 2718 Page Summary Settings,
+    /// 4326 Agent Creation Control, 7775 Copilot AI Capabilities, 9260 Customer Experience
+    /// Survey — and BC's emitter writes the attributes for all five.
+    ///
+    /// <para>The empty-<c>SourceObject</c> rule from #2451 is unaffected and re-asserted here:
+    /// no <c>SourceTable</c> attribute is invented alongside them.</para>
+    /// </summary>
+    [Fact]
+    public void SourceObjectFlags_AreWrittenForAPageWithNoSourceTable()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-page-props-3784");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, SymbolReference));
+
+            var so = ReadSourceObject(NoSourceTableFlagsPageId);
+            Assert.Equal("0", so.GetAttribute("InsertAllowed"));
+            Assert.Equal("0", so.GetAttribute("ModifyAllowed"));
+            Assert.Equal("0", so.GetAttribute("DeleteAllowed"));
+            Assert.Equal("1", so.GetAttribute("DelayedInsert"));
+
+            // #2451 stands: no SourceTable is invented for a page that declares none.
+            Assert.False(so.HasAttribute("SourceTable"));
+            Assert.False(so.HasAttribute("SourceTableTemporary"));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The <c>PageProperties</c> scalars: written if and only if the symbol file states one,
+    /// carrying the value it states. <c>UsageCategory</c> and <c>HelpLink</c> go through
+    /// verbatim; the four ML strings take BC's own <c>ENU=</c> prefix, which is the form its
+    /// emitter writes on all 21/21/28/6 pages stating them.
+    /// </summary>
+    [Fact]
+    public void PageProperties_ScalarsAreWrittenOnlyWhenStated()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-page-props-3784");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, SymbolReference));
+
+            var rich = ReadProperties(RichPageId);
+            Assert.Equal("Administration", rich.GetAttribute("UsageCategory"));
+            Assert.Equal("1", rich.GetAttribute("RefreshOnActivate"));
+            Assert.Equal("https://go.microsoft.com/fwlink/?linkid=2149387", rich.GetAttribute("HelpLink"));
+            Assert.Equal("ENU=About performance profiling", rich.GetAttribute("AboutTitleML"));
+            Assert.Equal("ENU=Record a slow scenario.", rich.GetAttribute("AboutTextML"));
+            Assert.Equal("ENU=Database,Size,Storage", rich.GetAttribute("AdditionalSearchTermsML"));
+            Assert.Equal("ENU=Assign email scenarios", rich.GetAttribute("InstructionalTextML"));
+            Assert.Equal("1", rich.GetAttribute("IsPreview"));
+
+            // The negative half: a page stating none of them gets none of the attributes. BC's
+            // UsageCategorySpecified bit is raised by the SETTER, so writing UsageCategory="None"
+            // for a silent page would be a different document from the one BC emits.
+            var silent = ReadProperties(SilentPageId);
+            Assert.False(silent.HasAttribute("UsageCategory"));
+            Assert.False(silent.HasAttribute("HelpLink"));
+            Assert.False(silent.HasAttribute("AboutTitleML"));
+            Assert.False(silent.HasAttribute("AboutTextML"));
+            Assert.False(silent.HasAttribute("AdditionalSearchTermsML"));
+            Assert.False(silent.HasAttribute("InstructionalTextML"));
+            Assert.False(silent.HasAttribute("IsPreview"));
+            // RefreshOnActivate's AL default is false and BC's emitter writes "0" for a page
+            // stating nothing, so this one IS written unconditionally — the same shape as
+            // Extensible, and the opposite of the seven above.
+            Assert.Equal("0", silent.GetAttribute("RefreshOnActivate"));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// <c>InherentEntitlements</c> / <c>InherentPermissions</c> are <c>Int32</c> permission masks
+    /// on BC's <c>PageProperties</c>, and the symbol file states them as AL permission LETTERS.
+    /// Across Base Application + System Application + Business Foundation (2,852 pages) the only
+    /// value either property ever takes is <c>"X"</c>, which BC's emitter writes as <c>16</c> —
+    /// <c>PermissionMask.Execute</c> in Microsoft.Dynamics.Nav.Types.
+    /// </summary>
+    [Fact]
+    public void InherentMasks_AreDecodedFromThePermissionLetters()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-page-props-3784");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, SymbolReference));
+
+            var rich = ReadProperties(RichPageId);
+            Assert.Equal("16", rich.GetAttribute("InherentEntitlements"));
+            Assert.Equal("16", rich.GetAttribute("InherentPermissions"));
+
+            // Absent when unstated, so BC's InherentEntitlementsSpecified bit stays down.
+            var silent = ReadProperties(SilentPageId);
+            Assert.False(silent.HasAttribute("InherentEntitlements"));
+            Assert.False(silent.HasAttribute("InherentPermissions"));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// A permission letter the decoder does not know is REFUSED and SAID, never folded into 0 —
+    /// the same rule <c>EmitSourceObjectPropertiesXml</c> already applies to an unreadable
+    /// boolean and to a <c>DataCaptionFields</c> value of the wrong shape. A mask of 0 and an
+    /// absent attribute are different documents to BC (the <c>Specified</c> bit), and inventing
+    /// either from a value nobody could read is the defect shape this whole change fixes.
+    ///
+    /// <para>The page states a second, READABLE mask, so this cannot pass by the synthesizer
+    /// giving up on the page.</para>
+    /// </summary>
+    [Fact]
+    public void InherentMask_StatedInAFormItCannotRead_IsRefusedLoudly()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-page-props-3784");
+        Directory.CreateDirectory(dir);
+        var previousError = Console.Error;
+        var captured = new StringWriter();
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, SymbolReference));
+
+            // The document is memoized per id and only this test asks for this page, so the one
+            // and only build happens inside the capture.
+            Console.SetError(captured);
+            var props = ReadProperties(UnreadableMaskPageId);
+            Console.SetError(previousError);
+
+            Assert.False(props.HasAttribute("InherentEntitlements"),
+                "an unreadable permission letter must not be invented into a mask");
+            // …and the readable sibling on the same page is unaffected.
+            Assert.Equal("16", props.GetAttribute("InherentPermissions"));
+
+            var diagnostic = captured.ToString();
+            Assert.Contains("InherentEntitlements", diagnostic);
+            Assert.Contains(UnreadableMaskPageId.ToString(), diagnostic);
+            // The value itself, so a reader can see WHAT the file said.
+            Assert.Contains("Q", diagnostic);
+            // The readable one must not be reported as a problem.
+            Assert.DoesNotContain("InherentPermissions", diagnostic);
+        }
+        finally
+        {
+            Console.SetError(previousError);
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    private static XmlElement ReadProperties(int pageId)
+    {
+        var xml = RecordPatches.TryBuildDependencyPageMetadata(pageId);
+        Assert.NotNull(xml);
+
+        var doc = new XmlDocument();
+        doc.LoadXml(xml!);
+        var ns = new XmlNamespaceManager(doc.NameTable);
+        ns.AddNamespace("m", "urn:schemas-microsoft-com:dynamics:NAV:MetaObjects");
+        return (XmlElement)doc.DocumentElement!.SelectSingleNode("m:Properties", ns)!;
+    }
+
+    private static XmlElement ReadSourceObject(int pageId)
+    {
+        var props = ReadProperties(pageId);
+        var ns = new XmlNamespaceManager(props.OwnerDocument.NameTable);
+        ns.AddNamespace("m", "urn:schemas-microsoft-com:dynamics:NAV:MetaObjects");
+        return (XmlElement)props.SelectSingleNode("m:SourceObject", ns)!;
+    }
+}

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -233,7 +233,16 @@ internal static partial class BcAppSymbolCache
     // It used to reach the builder as a bare id list under a hardcoded "PK", and now carries
     // its declared name, so a warm payload written by the previous parse replays keys that
     // are shaped identically and named wrongly — the v35 trap exactly.
-    private const int CacheVersion = 37;
+    // v38: PageSymbol gained the PageProperties the symbol file states and EmitPageXml never
+    // read (#3784) — Extensible, RefreshOnActivate, UsageCategory, HelpLink, IsPreview, the
+    // four ML strings, the two inherent masks — plus three-state forms of InsertAllowed /
+    // ModifyAllowed / DeleteAllowed. Both halves of the v32 rule are true at once. The record
+    // SHAPE changed, which PayloadShape keys on by itself; the integer is here for the PARSE
+    // change it cannot see, which is the trio: they used to arrive as `bool` collapsing
+    // "the AL states nothing" into "the AL states the default", and a payload written by the
+    // previous parse replays that collapse from a warm cache — a wrong ANSWER (BC's emitter
+    // writes the attribute precisely when the AL states the property), not a cache miss.
+    private const int CacheVersion = 38;
     private static readonly ConcurrentDictionary<string, AppSymbols> ProcessCache = new(StringComparer.OrdinalIgnoreCase);
     // Issue #1820's path -> content-hash memo now lives in
     // RunnerFingerprint._fileContentHashes (#2955), because AppLoader's persisted r2r-chunks
@@ -437,6 +446,36 @@ internal static partial class BcAppSymbolCache
         // check. See RecordPatches.EmitSourceObjectPropertiesXml.
         bool? LinksAllowed = null, bool? ShowFilter = null, bool? SaveValues = null,
         bool? PopulateAllFields = null, string? DataCaptionFields = null,
+        // #3784's PageProperties, all read straight off the same Properties array and none of
+        // them derived. The three-state ones follow the #2860 rule above for the same reason:
+        // BC's emitter writes the attribute precisely when the AL states the property, and its
+        // reader's default differs from the value, so collapsing the two states is observable.
+        //
+        // Extensible and RefreshOnActivate are the exceptions and are BOOL, not bool?, because
+        // BC's emitter writes them on ALL 236 pages measured whether the AL states them or not:
+        // Extensible absent -> "1" (110 pages), RefreshOnActivate absent -> "0" (207). Their AL
+        // defaults are therefore the whole answer for a silent page, so a third state would
+        // encode a distinction the emitted document cannot carry.
+        //
+        // InsertAllowedStated / ModifyAllowedStated / DeleteAllowedStated sit ALONGSIDE the
+        // bool trio further up rather than replacing it: the Page Metadata (2000000138) virtual
+        // table wants the AL-defaulted answer (a page stating nothing IS insertable), while the
+        // emitter wants to know whether the AL said so. Two questions, two fields, neither one
+        // derivable from the other.
+        //
+        // InherentEntitlements / InherentPermissions are the AL permission LETTERS verbatim
+        // ("X" on all 200 pages of Base + System + Business Foundation that state either);
+        // decoding them to BC's Int32 mask is RecordPatches.EmitInherentMask's job, so nothing
+        // is interpreted at parse time.
+        bool Extensible = true, bool RefreshOnActivate = false,
+        string? UsageCategory = null, string? HelpLink = null,
+        string? AboutTitle = null, string? AboutText = null,
+        string? AdditionalSearchTerms = null, string? InstructionalText = null,
+        string? InherentEntitlements = null, string? InherentPermissions = null,
+        bool IsPreview = false,
+        bool? InsertAllowedStated = null, bool? ModifyAllowedStated = null,
+        bool? DeleteAllowedStated = null, bool? DelayedInsertStated = null,
+        bool? MultipleNewLinesStated = null,
         // Names of the booleans above the symbol file STATED but this could not read as a
         // boolean, with the value it stated ("PopulateAllFields=yes"). Null when there were
         // none, which is the case for every Microsoft-produced symbol file measured.
@@ -1331,6 +1370,37 @@ internal static partial class BcAppSymbolCache
         var populateAllFields = SymbolBoolOrNull(props, "PopulateAllFields", ref unreadableBooleans);
         props.TryGetValue("DataCaptionFields", out var dataCaptionFields);
 
+        // #3784's PageProperties. Two AL defaults BC's emitter writes unconditionally, so
+        // SymbolBool/SymbolBoolFalse (which fold absence into the default) are the right
+        // readers here — unlike the three-state group below.
+        bool extensible = !SymbolBoolFalse(props, "Extensible");
+        bool refreshOnActivate = SymbolBool(props, "RefreshOnActivate");
+        bool isPreview = SymbolBool(props, "IsPreview");
+
+        // The three-state group, for the #2860 reason: BC's emitter writes each attribute
+        // precisely when the AL states the property, whatever the value, and its reader's
+        // default (InsertAllowed/ModifyAllowed/DeleteAllowed true, the other two false)
+        // differs from at least one legal stated value in every case.
+        var insertAllowedStated = SymbolBoolOrNull(props, "InsertAllowed", ref unreadableBooleans);
+        var modifyAllowedStated = SymbolBoolOrNull(props, "ModifyAllowed", ref unreadableBooleans);
+        var deleteAllowedStated = SymbolBoolOrNull(props, "DeleteAllowed", ref unreadableBooleans);
+        var delayedInsertStated = SymbolBoolOrNull(props, "DelayedInsert", ref unreadableBooleans);
+        var multipleNewLinesStated = SymbolBoolOrNull(props, "MultipleNewLines", ref unreadableBooleans);
+
+        // Scalars, verbatim. Nothing is resolved, normalised or defaulted here: whether an
+        // absent value means "write nothing" or "write the AL default" is the emitter's
+        // question, and it differs per property (see EmitPageXml).
+        props.TryGetValue("UsageCategory", out var usageCategory);
+        props.TryGetValue("HelpLink", out var helpLink);
+        props.TryGetValue("AboutTitle", out var aboutTitle);
+        props.TryGetValue("AboutText", out var aboutText);
+        props.TryGetValue("AdditionalSearchTerms", out var additionalSearchTerms);
+        props.TryGetValue("InstructionalText", out var instructionalText);
+        props.TryGetValue("InherentEntitlements", out var inherentEntitlements);
+        props.TryGetValue("InherentPermissions", out var inherentPermissions);
+
+        static string? OrNullIfBlank(string? v) => string.IsNullOrWhiteSpace(v) ? null : v;
+
         return new PageSymbol(pageId, name!, sourceTableId, sourceTableTemporary,
             string.IsNullOrWhiteSpace(pageType) ? "Card" : pageType!, caption,
             editable, insertAllowed, modifyAllowed, deleteAllowed, controls,
@@ -1340,6 +1410,14 @@ internal static partial class BcAppSymbolCache
             ParseSourceTableView(pageId, sourceTableView), runObjects,
             linksAllowed, showFilter, saveValues, populateAllFields,
             string.IsNullOrWhiteSpace(dataCaptionFields) ? null : dataCaptionFields,
+            extensible, refreshOnActivate,
+            OrNullIfBlank(usageCategory), OrNullIfBlank(helpLink),
+            OrNullIfBlank(aboutTitle), OrNullIfBlank(aboutText),
+            OrNullIfBlank(additionalSearchTerms), OrNullIfBlank(instructionalText),
+            OrNullIfBlank(inherentEntitlements), OrNullIfBlank(inherentPermissions),
+            isPreview,
+            insertAllowedStated, modifyAllowedStated, deleteAllowedStated,
+            delayedInsertStated, multipleNewLinesStated,
             unreadableBooleans);
     }
 

--- a/AlRunner/Patches/DependencyPageMetadataXml.cs
+++ b/AlRunner/Patches/DependencyPageMetadataXml.cs
@@ -27,6 +27,11 @@
 //   Insert/Modify/DeleteAllowed, AutoSplitKey, MultipleNewLines, DelayedInsert,
 //   SourceTableView (#2820), and LinksAllowed / ShowFilter / SaveValues /
 //   PopulateAllFields / DataCaptionFields (#2860, see EmitSourceObjectPropertiesXml).
+//   #3784 added the <Properties> scalars on the same rule — Extensible (which this used to
+//   HARDCODE to "1", a wrong answer on 105 of 236 measured pages), RefreshOnActivate,
+//   UsageCategory, HelpLink, IsPreview, the four ML strings and the two inherent permission
+//   masks; see EmitPagePropertiesXml, which also records which nearby members are
+//   DERIVATIONS rather than reads and therefore deliberately still absent.
 //
 // WHAT IS DELIBERATELY OMITTED, AND WHY THAT IS SAFE HERE
 //   Ordinary field Content/Controls, ActionContainers, ViewContainers,
@@ -125,7 +130,13 @@ public static partial class RecordPatches
             w.WriteAttributeString("SourceExtensionType", "ModernDev");
             w.WriteAttributeString("PageType", page.PageType);
             w.WriteAttributeString("Editable", page.Editable ? "1" : "0");
-            w.WriteAttributeString("Extensible", "1");
+            // #3784. Written unconditionally, carrying what the symbol file states — NOT the
+            // literal "1" this used to write for every page, which was a WRONG answer rather
+            // than a missing one on the 105 of 236 System Application + Business Foundation
+            // pages BC's own emitter writes "0" for, all 105 of which state Extensible = "0"
+            // in the symbol file with zero omissions. Same shape as Editable above it.
+            w.WriteAttributeString("Extensible", page.Extensible ? "1" : "0");
+            EmitPagePropertiesXml(w, page);
             if (!string.IsNullOrEmpty(page.Caption))
             {
                 w.WriteStartElement("CaptionML");
@@ -157,15 +168,13 @@ public static partial class RecordPatches
                     page.SourceTableId.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 if (page.SourceTableTemporary)
                     w.WriteAttributeString("SourceTableTemporary", "1");
-                if (!page.InsertAllowed) w.WriteAttributeString("InsertAllowed", "0");
-                if (!page.ModifyAllowed) w.WriteAttributeString("ModifyAllowed", "0");
-                if (!page.DeleteAllowed) w.WriteAttributeString("DeleteAllowed", "0");
-                // The three flags the AL compiler writes here alongside SourceTable, all
-                // three defaulting to false, so only a true one is written — the same
-                // "state what the symbol file states, default the rest" rule as above.
+                // AutoSplitKey defaults to false in AL, so only a true one is written, and it
+                // stays INSIDE this branch: all 3 pages of the 236 measured that state it also
+                // declare a source table, and NeedsAutoSplitKey's reader only runs for a bound
+                // page anyway.
                 //
-                // Measured by compiling a page declaring all three and reading back the
-                // metadata the compiler captured for it, on BC 28.1:
+                // Measured by compiling a page declaring it and reading back the metadata the
+                // compiler captured for it, on BC 28.1:
                 //     <SourceObject AutoSplitKey="1" DelayedInsert="1"
                 //                   MultipleNewLines="1" SourceTable="65940" />
                 //
@@ -176,15 +185,13 @@ public static partial class RecordPatches
                 // and per the note in MockTestPage the first new row then lands at line
                 // no. 0 and the second fails on a duplicate primary key.
                 if (page.AutoSplitKey) w.WriteAttributeString("AutoSplitKey", "1");
-                if (page.MultipleNewLines) w.WriteAttributeString("MultipleNewLines", "1");
-                if (page.DelayedInsert) w.WriteAttributeString("DelayedInsert", "1");
             }
-            // The attributes above only mean anything alongside a SourceTable, so a page
-            // without one gets the bare element the compiler itself emits — not
+            // SourceTable and AutoSplitKey above only mean anything alongside a source table,
+            // so a page without one gets the bare element the compiler itself emits — not
             // SourceTable="0", which would answer "table 0" to a question about a table the
             // page does not have.
             //
-            // The five below are OUTSIDE that branch on purpose — measured, not assumed; see
+            // Everything below is OUTSIDE that branch on purpose — measured, not assumed; see
             // EmitSourceObjectPropertiesXml.
             //
             // ORDER IS LOAD-BEARING, and this is the whole reason the SourceTableView child
@@ -253,6 +260,128 @@ public static partial class RecordPatches
     private const string XsiNs = "http://www.w3.org/2001/XMLSchema-instance";
 
     /// <summary>
+    /// The <c>&lt;Properties&gt;</c> attributes SymbolReference.json states and this
+    /// synthesizer used to drop (issue #3784), all of them a READ: the symbol file states the
+    /// value and this writes it, with no resolution, derivation or default-guessing anywhere.
+    ///
+    /// <para>THE RULE, in two halves, because BC's emitter applies a different one per
+    /// property and the difference is measurable. <c>RefreshOnActivate</c> is written
+    /// UNCONDITIONALLY, carrying the AL default when the file states nothing, exactly like
+    /// <c>Extensible</c> and <c>Editable</c> at the call site. Everything else is written IF
+    /// AND ONLY IF the file states it, because BC's <c>PageProperties</c> raises a
+    /// <c>…Specified</c> bit from the SETTER — <c>UsageCategorySpecified</c>,
+    /// <c>InherentEntitlementsSpecified</c>, <c>InherentPermissionsSpecified</c> — which its
+    /// <c>Equals()</c> compares, so writing a "default" for a silent page is a DIFFERENT
+    /// document, not a harmless one.</para>
+    ///
+    /// <para>Measured on BC 28.4.53241.54407 over Business Foundation (11 pages) + System
+    /// Application (225), by cross-tabulating each app's shipped SymbolReference.json against
+    /// the PageDefinition documents <c>tools/gen-metadata-ground-truth.sh</c> produces from
+    /// BC's own emitter. Every pair below agreed on all 236 pages:</para>
+    /// <code>
+    /// RefreshOnActivate    absent -> "0" (207 pages);  "1" -> "1" (29)
+    /// UsageCategory        written iff stated, verbatim (68 pages, 6 distinct enum names)
+    /// HelpLink             written iff stated, verbatim (6)
+    /// IsPreview            written iff stated (1)
+    /// AboutTitle/AboutText/AdditionalSearchTerms/InstructionalText
+    ///                      -> the SAME attribute prefixed "ENU=" (21/21/28/6)
+    /// InherentEntitlements/InherentPermissions   "X" -> "16"   (94/92)
+    /// </code>
+    ///
+    /// <para>WHAT IS DELIBERATELY NOT READ HERE, having been checked rather than assumed.
+    /// <c>AnalysisModeEnabled</c> and <c>OnAfterGetCurrentRecordEnabled</c> are NOT symbol
+    /// reads: cross-tabulated over the same 236 pages, the first tracks <c>PageType</c>
+    /// (List/Worksheet -> "1", every other type -> absent) on 94 pages whose symbol file
+    /// states nothing at all, and the second tracks trigger presence.
+    /// <c>IndirectPermissions</c> needs table NAME -> id resolution plus a permission-mask
+    /// encode; <c>CardFormID</c> needs page NAME -> id; <c>DataCaptionExpr</c> is BC's own
+    /// literal marker <c>"DataCaptionExprCode"</c> and carries none of the AL expression the
+    /// symbol file states. Each is a derivation, which is a different change from a read —
+    /// see the file header and issues #2460 / #3504.</para>
+    /// </summary>
+    private static void EmitPagePropertiesXml(XmlWriter w, BcAppSymbolCache.PageSymbol page)
+    {
+        // Unconditional, carrying the AL default for a page that states nothing — the same
+        // shape as Extensible and Editable at the call site.
+        w.WriteAttributeString("RefreshOnActivate", page.RefreshOnActivate ? "1" : "0");
+
+        void Scalar(string name, string? stated)
+        {
+            if (!string.IsNullOrEmpty(stated)) w.WriteAttributeString(name, stated);
+        }
+
+        Scalar("UsageCategory", page.UsageCategory);
+        Scalar("HelpLink", page.HelpLink);
+        if (page.IsPreview) w.WriteAttributeString("IsPreview", "1");
+
+        // BC's emitter writes these four as a MultiLanguage attribute, and its own
+        // MultiLanguage parser reads "ENU=<text>" — the identical form EmitPartControlXml
+        // already writes for a part's CaptionML. The symbol file states the bare text.
+        void MultiLanguage(string name, string? stated)
+        {
+            if (!string.IsNullOrEmpty(stated)) w.WriteAttributeString(name, "ENU=" + stated);
+        }
+
+        MultiLanguage("AboutTitleML", page.AboutTitle);
+        MultiLanguage("AboutTextML", page.AboutText);
+        MultiLanguage("AdditionalSearchTermsML", page.AdditionalSearchTerms);
+        MultiLanguage("InstructionalTextML", page.InstructionalText);
+
+        EmitInherentMask(w, page, "InherentEntitlements", page.InherentEntitlements);
+        EmitInherentMask(w, page, "InherentPermissions", page.InherentPermissions);
+    }
+
+    /// <summary>
+    /// One inherent-permission mask: the symbol file states AL permission LETTERS
+    /// (<c>InherentEntitlements = X</c>) and BC's <c>PageProperties</c> holds an
+    /// <c>Int32</c>, so the letters are decoded against
+    /// <c>Microsoft.Dynamics.Nav.Types.PermissionMask</c> — <c>Read 1, Insert 2, Modify 4,
+    /// Delete 8, Execute 16</c>. That enum is what makes this a DECODE of a stated value
+    /// rather than a guess at an absent one.
+    ///
+    /// <para>Measured on Base Application + System Application + Business Foundation at BC
+    /// 28.4.53241.54407 (2,852 pages): the only value either property ever takes is
+    /// <c>"X"</c> — 101 + 99 occurrences — which BC's emitter writes as <c>16</c>. The other
+    /// four letters are implemented because the decode is total and cheap, not because a page
+    /// stating them was observed; that is why an unknown letter refuses rather than
+    /// contributing nothing.</para>
+    ///
+    /// <para>A letter this cannot read is REFUSED and SAID, never folded into 0 — the same
+    /// choice, and the same reason, as the unreadable-boolean and wrong-shape-DataCaptionFields
+    /// arms of <see cref="EmitSourceObjectPropertiesXml"/>. Both a mask of 0 and an absent
+    /// attribute are answers BC can tell apart (the <c>Specified</c> bit its setter raises),
+    /// so inventing either from a value nobody could read would be a silent wrong answer on a
+    /// surface with no way to fail.</para>
+    /// </summary>
+    private static void EmitInherentMask(
+        XmlWriter w, BcAppSymbolCache.PageSymbol page, string attribute, string? stated)
+    {
+        if (string.IsNullOrWhiteSpace(stated)) return;
+
+        int mask = 0;
+        foreach (var c in stated)
+        {
+            if (c == ' ' || c == ',') continue;
+            int bit = char.ToUpperInvariant(c) switch
+            {
+                'R' => 1, 'I' => 2, 'M' => 4, 'D' => 8, 'X' => 16,
+                _ => 0,
+            };
+            if (bit == 0)
+            {
+                Console.Error.WriteLine(
+                    $"[RecordPatches] page {page.Id} \"{page.Name}\": {attribute} \"{stated}\" "
+                    + "is not the R/I/M/D/X permission-letter list BC reads — omitted, so the "
+                    + "page reads as declaring none");
+                return;
+            }
+            mask |= bit;
+        }
+
+        w.WriteAttributeString(attribute, mask.ToString(System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>
     /// The five further <c>&lt;SourceObject&gt;</c> properties the symbol file states and this
     /// synthesizer used to drop (issue #2860): <c>LinksAllowed</c>, <c>ShowFilter</c>,
     /// <c>SaveValues</c>, <c>PopulateAllFields</c> and <c>DataCaptionFields</c>.
@@ -319,6 +448,29 @@ public static partial class RecordPatches
         Flag("ShowFilter", page.ShowFilter);
         Flag("SaveValues", page.SaveValues);
         Flag("PopulateAllFields", page.PopulateAllFields);
+
+        // #3784's five, on exactly the same rule and for exactly the same reason — the only
+        // difference is that these were already being written, just wrongly: the trio could
+        // only ever emit a "0" (so an explicitly-stated `InsertAllowed = true`, which BC's
+        // emitter writes on 18 of the 236 pages measured, was dropped), and all five sat
+        // inside the `SourceTable > 0` branch, which silenced them entirely for the 5 System
+        // Application pages that state one with no source table — 502 OAuth2ControlAddIn,
+        // 2718 Page Summary Settings, 4326 Agent Creation Control, 7775 Copilot AI
+        // Capabilities, 9260 Customer Experience Survey. BC's emitter writes the attributes
+        // for all five, and BC's SourceObjectDefinition reader has no SourceTable guard.
+        //
+        // Cross-tabulated over those 236 pages (BC 28.4.53241.54407), symbol value -> emitted
+        // attribute, with no disagreement in either direction:
+        //     InsertAllowed    "0"->"0" 121, "1"->"1" 1,  absent->absent 114
+        //     ModifyAllowed    "0"->"0" 80,  "1"->"1" 11, absent->absent 145
+        //     DeleteAllowed    "0"->"0" 101, "1"->"1" 6,  absent->absent 129
+        //     DelayedInsert    "1"->"1" 14,  "0"->"0" 1,  absent->absent 221
+        //     MultipleNewLines "0"->"0" 3,   "1"->"1" 1,  absent->absent 232
+        Flag("InsertAllowed", page.InsertAllowedStated);
+        Flag("ModifyAllowed", page.ModifyAllowedStated);
+        Flag("DeleteAllowed", page.DeleteAllowedStated);
+        Flag("MultipleNewLines", page.MultipleNewLinesStated);
+        Flag("DelayedInsert", page.DelayedInsertStated);
 
         // A boolean the symbol file STATED in a form the parser could not read comes through
         // as the same null as "not stated at all", and therefore as the same absent attribute

--- a/docs/metadata-equivalence.md
+++ b/docs/metadata-equivalence.md
@@ -514,8 +514,48 @@ overstates the page gap.
   `Extensible` is the sharpest: the runner hardcodes `"1"`, BC answers `0` on 104 of 235 pages, and
   the symbol file states `Extensible=0` for **all 104 with zero omissions** — a pure
   read-don't-guess fix rather than merely a wrong default.
+
+  **Of those 55, thirty entries were closed by the reader fix and deleted** (#3784, step 1 of the
+  four the owner approved): `Extensible`, `RefreshOnActivate`, `UsageCategory`, the two inherent
+  permission masks, the four `…ML` strings with their `<presence>` companions, and
+  `InsertAllowed` / `DeleteAllowed` / `MultipleNewLinesSpecified`. What stayed, and why, is
+  [the read/derive split](#a-read-and-a-derivation-are-different-fixes) below.
 - **62 entries / 38 distinct members — the ordinary field-control tree the runner does not build
   today**, plus the translation keys.
+
+<a id="a-read-and-a-derivation-are-different-fixes"></a>
+### A read and a derivation are different fixes, and the difference is measurable
+
+#3784 looked like one bucket — "properties the symbol file states and the emitter drops" — and is
+two. Sorting them needs a cross-tabulation of *(symbol value → emitted attribute)* over every page,
+not a reading of the property's name, because the two look identical from the allowlist entry.
+
+Measured on **BC 28.4.53241.54407**, Business Foundation (11 pages) + System Application (225),
+symbol file against the ground truth this harness generates:
+
+| the runner must | example | what the cross-tab shows |
+|---|---|---|
+| **read** the stated value | `Extensible` | absent → BC `"1"` (110), `"0"` → `"0"` (105), `"1"` → `"1"` (21) — BC's answer is a function of the symbol value alone |
+| **derive** a value the file never states | `AnalysisModeEnabled` | 94 pages where the symbol file states **nothing** and BC writes `"1"`; it tracks `PageType` (List/Worksheet), not the file |
+
+Three traps this sorting sprang, each of which would have produced a wrong entry deletion:
+
+- **A property can be BOTH.** `HelpLink` is a read on the 6 pages that state it and a **derived
+  default on the other 230** (`https://learn.microsoft.com/dynamics365/business-central/` and
+  friends). Reading it closes a sixth of the difference and the entry stays — so "the fix reads
+  this property" does not imply "the entry goes".
+- **Two write rules, not one.** BC writes `Extensible` and `RefreshOnActivate` on all 236 pages
+  whether the AL states them or not; everything else it writes *iff* stated, because
+  `PageProperties` raises its `…Specified` bit **from the setter** and `Equals()` compares it.
+  Emitting an AL default for a silent page is a different document, not a harmless one.
+- **A fix closes entries that never cited it.** Writing the `…ML` strings materialises BC's
+  `MultiLanguage` object, so eight `…ML.<presence>` / `#…MLField.<presence>` entries filed under
+  the control-tree group went stale too.
+
+**So take the stale list from the harness, never from the fix's own account of itself.**
+`No_allowlist_entry_has_gone_stale` prints exactly which entries stopped matching; predicting them
+from the diff got `HelpLink` wrong in one direction and those eight `<presence>` entries wrong in
+the other.
 
 <a id="the-control-tree-is-a-cost-decision-not-an-unprovable-one"></a>
 ### The control tree is a cost decision, and it has a proof path

--- a/tests/expectations/metadata-equivalence/allowlist.json
+++ b/tests/expectations/metadata-equivalence/allowlist.json
@@ -746,26 +746,8 @@
       "versionContingent": true
     },
     {
-      "member": "PageProperties.#aboutTextMLField.<presence>",
-      "reason": "A multi-language caption element the runner emits only when the symbol file states that property. BC's emitter writes the element whenever the AL declares the property, including where its resolved value is empty, so BC-present / runner-null is the same scope boundary as the *MLString member declared beside it: the runner reads no translation resources at all (docs/limitations.md), so the only language it could ever state is the one already in the symbol file.",
-      "outOfScope": true,
-      "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found"
-    },
-    {
-      "member": "PageProperties.#aboutTitleMLField.<presence>",
-      "reason": "A multi-language caption element the runner emits only when the symbol file states that property. BC's emitter writes the element whenever the AL declares the property, including where its resolved value is empty, so BC-present / runner-null is the same scope boundary as the *MLString member declared beside it: the runner reads no translation resources at all (docs/limitations.md), so the only language it could ever state is the one already in the symbol file.",
-      "outOfScope": true,
-      "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found"
-    },
-    {
       "member": "PageProperties.#actionsV2Field",
       "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. The member it accompanies is declared beside it in this file.",
-      "outOfScope": true,
-      "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found"
-    },
-    {
-      "member": "PageProperties.#additionalSearchTermsMLField.<presence>",
-      "reason": "A multi-language caption element the runner emits only when the symbol file states that property. BC's emitter writes the element whenever the AL declares the property, including where its resolved value is empty, so BC-present / runner-null is the same scope boundary as the *MLString member declared beside it: the runner reads no translation resources at all (docs/limitations.md), so the only language it could ever state is the one already in the symbol file.",
       "outOfScope": true,
       "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found"
     },
@@ -793,11 +775,6 @@
       "issue": 3784
     },
     {
-      "member": "PageProperties.#extensibleField",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies PageProperties.Extensible, declared in this file with the measurement.",
-      "issue": 3784
-    },
-    {
       "member": "PageProperties.#extensionsWithPromotedActionSyntaxField",
       "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. The member it accompanies is declared beside it in this file.",
       "outOfScope": true,
@@ -807,22 +784,6 @@
       "member": "PageProperties.#helpLinkField",
       "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies PageProperties.HelpLink, declared in this file with the measurement.",
       "issue": 3784
-    },
-    {
-      "member": "PageProperties.#inherentEntitlementsField",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies PageProperties.InherentEntitlements, declared in this file with the measurement.",
-      "issue": 3784
-    },
-    {
-      "member": "PageProperties.#inherentPermissionsField",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies PageProperties.InherentPermissions, declared in this file with the measurement.",
-      "issue": 3784
-    },
-    {
-      "member": "PageProperties.#instructionalTextMLField.<presence>",
-      "reason": "A multi-language caption element the runner emits only when the symbol file states that property. BC's emitter writes the element whenever the AL declares the property, including where its resolved value is empty, so BC-present / runner-null is the same scope boundary as the *MLString member declared beside it: the runner reads no translation resources at all (docs/limitations.md), so the only language it could ever state is the one already in the symbol file.",
-      "outOfScope": true,
-      "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found"
     },
     {
       "member": "PageProperties.#isPreviewField",
@@ -844,42 +805,10 @@
       "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found"
     },
     {
-      "member": "PageProperties.#refreshOnActivateField",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies PageProperties.RefreshOnActivate, declared in this file with the measurement.",
-      "issue": 3784
-    },
-    {
-      "member": "PageProperties.#usageCategoryField",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies PageProperties.UsageCategory, declared in this file with the measurement.",
-      "issue": 3784
-    },
-    {
-      "member": "PageProperties.AboutTextML.<presence>",
-      "reason": "A multi-language caption element the runner emits only when the symbol file states that property. BC's emitter writes the element whenever the AL declares the property, including where its resolved value is empty, so BC-present / runner-null is the same scope boundary as the *MLString member declared beside it: the runner reads no translation resources at all (docs/limitations.md), so the only language it could ever state is the one already in the symbol file.",
-      "outOfScope": true,
-      "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found"
-    },
-    {
-      "member": "PageProperties.AboutTextMLString",
-      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 21 pages declare AboutText; the runner never writes it. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page.",
-      "issue": 3784
-    },
-    {
       "member": "PageProperties.AboutTextTranslationKey",
       "reason": "A translation-file lookup id for a page-level property. Same boundary as the seven TranslationKey.* entries already in this file and for the same measured reason: the runner reads no .xlf or Translations/ resources anywhere, so a key it could state would address a file it never opens. Separately derivable rather than impossible -- the FNV-1a-32 construction in TranslationKeysAreDerivable_NotAPermanentLimit reproduces BC's own keys -- so this is a scope boundary that the runner gaining translation support invalidates.",
       "outOfScope": true,
       "Doc": "docs/metadata-equivalence.md#translation-keys-are-out-of-scope"
-    },
-    {
-      "member": "PageProperties.AboutTitleML.<presence>",
-      "reason": "A multi-language caption element the runner emits only when the symbol file states that property. BC's emitter writes the element whenever the AL declares the property, including where its resolved value is empty, so BC-present / runner-null is the same scope boundary as the *MLString member declared beside it: the runner reads no translation resources at all (docs/limitations.md), so the only language it could ever state is the one already in the symbol file.",
-      "outOfScope": true,
-      "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found"
-    },
-    {
-      "member": "PageProperties.AboutTitleMLString",
-      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 21 pages declare AboutTitle; the runner never writes it. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page.",
-      "issue": 3784
     },
     {
       "member": "PageProperties.AboutTitleTranslationKey",
@@ -892,17 +821,6 @@
       "reason": "Set by BC's emitter on every page it compiles, marking the modern action syntax. It describes the emitter's own output shape rather than anything the AL declares, and SymbolReference.json states nothing about it.",
       "outOfScope": true,
       "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found"
-    },
-    {
-      "member": "PageProperties.AdditionalSearchTermsML.<presence>",
-      "reason": "A multi-language caption element the runner emits only when the symbol file states that property. BC's emitter writes the element whenever the AL declares the property, including where its resolved value is empty, so BC-present / runner-null is the same scope boundary as the *MLString member declared beside it: the runner reads no translation resources at all (docs/limitations.md), so the only language it could ever state is the one already in the symbol file.",
-      "outOfScope": true,
-      "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found"
-    },
-    {
-      "member": "PageProperties.AdditionalSearchTermsMLString",
-      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 27 pages declare AdditionalSearchTerms; the runner never writes it. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page.",
-      "issue": 3784
     },
     {
       "member": "PageProperties.AdditionalSearchTermsTranslationKey",
@@ -951,11 +869,6 @@
       "Doc": "docs/metadata-equivalence.md#translation-keys-are-out-of-scope"
     },
     {
-      "member": "PageProperties.Extensible",
-      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 124 pages declare Extensible and the runner hardcodes the attribute to \"1\", so BC answers False on 104 of 235 pages. A wrong answer rather than a missing one. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page.",
-      "issue": 3784
-    },
-    {
       "member": "PageProperties.ExtensionsWithPromotedActionSyntax",
       "reason": "The set of extension app ids whose pageextensions use promoted-action syntax against this page. A property of the MERGED runtime view across installed extensions, which the build-time per-app oracle documents from the compiler's side while the runner emits a per-app document -- the same class as the merged-runtime entries the table side already declares.",
       "outOfScope": true,
@@ -964,37 +877,6 @@
     {
       "member": "PageProperties.HelpLink",
       "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 6 pages declare HelpLink and BC states a default for the rest; the runner never writes the attribute at all. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page.",
-      "issue": 3784
-    },
-    {
-      "member": "PageProperties.InherentEntitlements",
-      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 91 pages declare InherentEntitlements; the runner never writes it. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page.",
-      "issue": 3784
-    },
-    {
-      "member": "PageProperties.InherentEntitlementsSpecified",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies PageProperties.InherentEntitlements, declared in this file with the measurement.",
-      "issue": 3784
-    },
-    {
-      "member": "PageProperties.InherentPermissions",
-      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 89 pages declare InherentPermissions; the runner never writes it. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page.",
-      "issue": 3784
-    },
-    {
-      "member": "PageProperties.InherentPermissionsSpecified",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies PageProperties.InherentPermissions, declared in this file with the measurement.",
-      "issue": 3784
-    },
-    {
-      "member": "PageProperties.InstructionalTextML.<presence>",
-      "reason": "A multi-language caption element the runner emits only when the symbol file states that property. BC's emitter writes the element whenever the AL declares the property, including where its resolved value is empty, so BC-present / runner-null is the same scope boundary as the *MLString member declared beside it: the runner reads no translation resources at all (docs/limitations.md), so the only language it could ever state is the one already in the symbol file.",
-      "outOfScope": true,
-      "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found"
-    },
-    {
-      "member": "PageProperties.InstructionalTextMLString",
-      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 6 pages declare InstructionalText; the runner never writes it. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page.",
       "issue": 3784
     },
     {
@@ -1023,21 +905,6 @@
       "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found"
     },
     {
-      "member": "PageProperties.RefreshOnActivate",
-      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 28 pages declare RefreshOnActivate; the runner never writes it. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page.",
-      "issue": 3784
-    },
-    {
-      "member": "PageProperties.UsageCategory",
-      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 62 pages declare UsageCategory; the runner never writes it, so every one answers the None default. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page.",
-      "issue": 3784
-    },
-    {
-      "member": "PageProperties.UsageCategorySpecified",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies PageProperties.UsageCategory, declared in this file with the measurement.",
-      "issue": 3784
-    },
-    {
       "member": "SourceObjectDefinition.#delayedInsertField",
       "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies SourceObjectDefinition.DelayedInsert, declared in this file with the measurement. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 2 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "issue": 3784,
@@ -1045,18 +912,8 @@
       "Doc": "docs/metadata-equivalence.md#one-build-measured-three-evaluated"
     },
     {
-      "member": "SourceObjectDefinition.#deleteAllowedField",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies SourceObjectDefinition.DeleteAllowed, declared in this file with the measurement.",
-      "issue": 3784
-    },
-    {
       "member": "SourceObjectDefinition.#indirectPermissionsField",
       "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies SourceObjectDefinition.IndirectPermissions, declared in this file with the measurement.",
-      "issue": 3784
-    },
-    {
-      "member": "SourceObjectDefinition.#insertAllowedField",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies SourceObjectDefinition.InsertAllowed, declared in this file with the measurement.",
       "issue": 3784
     },
     {
@@ -1074,18 +931,8 @@
       "Doc": "docs/metadata-equivalence.md#one-build-measured-three-evaluated"
     },
     {
-      "member": "SourceObjectDefinition.DeleteAllowed",
-      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 104 pages declare DeleteAllowed, with the same SourceTable-branch condition as InsertAllowed. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page.",
-      "issue": 3784
-    },
-    {
       "member": "SourceObjectDefinition.IndirectPermissions",
       "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 86 pages declare a Permissions property, which BC resolves into the SourceObject's IndirectPermissions vector; the runner never writes it. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page.",
-      "issue": 3784
-    },
-    {
-      "member": "SourceObjectDefinition.InsertAllowed",
-      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 119 pages declare InsertAllowed. EmitPageXml writes it only inside the SourceTable branch, so a page whose symbol states InsertAllowed=0 without a source table keeps the true default. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page.",
       "issue": 3784
     },
     {
@@ -1094,11 +941,6 @@
       "issue": 3784,
       "versionContingent": true,
       "Doc": "docs/metadata-equivalence.md#one-build-measured-three-evaluated"
-    },
-    {
-      "member": "SourceObjectDefinition.MultipleNewLinesSpecified",
-      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 4 pages declare MultipleNewLines; BC marks the value explicitly specified and the runner writes the attribute only inside the SourceTable branch. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page.",
-      "issue": 3784
     }
   ]
 }


### PR DESCRIPTION
Closes #3784

Corpus-NA: the defect is reachable only through a PRECOMPILED dependency page, which a corpus test structurally cannot produce — see "Why no corpus PR" below

Step 1 of the 4-step sequence the repository owner approved for reconstructing precompiled page metadata from `SymbolReference.json` (#3784 → #2460 → #3504 → #3745). This step is a pure symbol **read**: no reconstruction, no derived values, no guessing at BC's conventions.

**Rebased onto `main` after #3783 (`28013bb0`) merged**, so the page comparison now measures this fix and the entries it closes are deleted here rather than in a follow-up — `main` stays green at every commit.

*Implemented by an agent (`stma-auto-8`) acting on the account holder's behalf.*

## What was wrong

`AlRunner/Patches/DependencyPageMetadataXml.cs` builds the runtime `PageDefinition` document for a page that ships compiled inside a dependency `.app`. Three defects, all the same shape — the symbol file states a value and the emitter did not read it:

1. **`Extensible` was hardcoded to `"1"`** (`DependencyPageMetadataXml.cs:128`). A *wrong* answer, not a missing one: BC's own emitter writes `"0"` on **105 of 236** pages, and all 105 state `Extensible = "0"` in `SymbolReference.json` with **zero omissions**.
2. **The `InsertAllowed`/`ModifyAllowed`/`DeleteAllowed` trio could only ever emit a `"0"`** (`if (!page.InsertAllowed) …`), so an explicitly-stated `true` — which BC writes on 18 of the 236 pages — was dropped. The `bool` they came from had already folded "the AL states nothing" into "the AL states the default", so the information was gone before the emitter saw it.
3. **All five `SourceObject` flags sat inside the `SourceTable > 0` branch**, silencing them for the 5 System Application pages that state one with no source table — 502 `OAuth2ControlAddIn`, 2718 `Page Summary Settings`, 4326 `Agent Creation Control`, 7775 `Copilot AI Capabilities`, 9260 `Customer Experience Survey`. BC's `SourceObjectDefinition` reader has no `SourceTable` guard.

Plus twelve `PageProperties` never read at all.

## How the expected values were established

Measured, not chosen. **BC 28.4.53241.54407**, Business Foundation (11 pages) + System Application (225), by parsing each app's shipped `SymbolReference.json` and the `PageDefinition` documents `tools/gen-metadata-ground-truth.sh` produces from BC's own emitter, then cross-tabulating every *(symbol value → emitted attribute)* pair over all **236** pages. Every pair agreed on all 236, both directions:

| property | symbol → BC |
|---|---|
| `Extensible` | absent → `"1"` (110); `"0"` → `"0"` (105); `"1"` → `"1"` (21) |
| `RefreshOnActivate` | absent → `"0"` (207); `"1"` → `"1"` (29) |
| `UsageCategory` | written iff stated, verbatim (68 pages, 6 distinct enum names) |
| `IsPreview` | written iff stated (1) |
| `AboutTitle`/`AboutText`/`AdditionalSearchTerms`/`InstructionalText` | → the `…ML` attribute, prefixed `ENU=` (21/21/28/6) |
| `InherentEntitlements`/`InherentPermissions` | `"X"` → `"16"` (94/92) |
| `InsertAllowed` | `"0"`→`"0"` 121, `"1"`→`"1"` 1, absent→absent 114 |
| `ModifyAllowed` | `"0"`→`"0"` 80, `"1"`→`"1"` 11, absent→absent 145 |
| `DeleteAllowed` | `"0"`→`"0"` 101, `"1"`→`"1"` 6, absent→absent 129 |
| `DelayedInsert` | `"1"`→`"1"` 14, `"0"`→`"0"` 1, absent→absent 221 |
| `MultipleNewLines` | `"0"`→`"0"` 3, `"1"`→`"1"` 1, absent→absent 232 |
| `HelpLink` | stated → verbatim on **6**; **derived default on the other 230** — see below |

**Two write rules, not one, because BC applies two.** `Extensible` and `RefreshOnActivate` are written *unconditionally* (BC writes them on all 236 pages whether the AL states them or not, so their AL default is the whole answer for a silent page). Everything else is written *iff stated*, because BC's `PageProperties` raises a `…Specified` bit **from the setter** — `UsageCategorySpecified`, `InherentEntitlementsSpecified`, `InherentPermissionsSpecified` — which `Equals()` compares. Emitting an AL default for a silent page is a different document, not a harmless one. Confirmed by reflecting over `Microsoft.Dynamics.Nav.Types.dll` and feeding a minimal document to BC's own `PageDefinition(XmlNode)` constructor (the oracle type #3783 pins).

`InherentEntitlements = "X"` → `16` is a **decode**, not a guess: `PermissionMask.Execute` is `16` (`Read 1, Insert 2, Modify 4, Delete 8`). `"X"` is the only value either property takes across Base + System + Business Foundation (2,852 pages; 101 + 99 occurrences); the other four letters are implemented because the decode is total and cheap, which is why an **unknown letter refuses and says so** rather than contributing 0 — a mask of 0 and an absent attribute are answers BC tells apart.

## The allowlist: 30 entries deleted, measured rather than predicted

`main` carried **55** entries citing `issue: 3784`. The harness's `No_allowlist_entry_has_gone_stale` names exactly which stopped matching; I took the list from it rather than from my own account of the fix, **and that mattered in both directions**:

- **`HelpLink` STAYS**, contrary to my pre-rebase prediction. It is a read on the 6 pages that state it and a **derived default on the other 230** (`https://learn.microsoft.com/dynamics365/business-central/` and friends). Reading it closes a sixth of the difference; the entry still matches. "The fix reads this property" does not imply "the entry goes".
- **Eight `…ML.<presence>` / `#…MLField.<presence>` entries go that never cited 3784.** Writing the four ML strings materialises BC's `MultiLanguage` object, so entries filed under the control-tree group went stale too.

**30 deleted** (182 → 152 entries; a deletion-only diff, no reformatting): `Extensible`, `RefreshOnActivate`, `UsageCategory`(+`Specified`), `InherentEntitlements`(+`Specified`), `InherentPermissions`(+`Specified`), the four `…MLString`s with their `…ML.<presence>` and `#…Field` companions, `InsertAllowed`, `DeleteAllowed`, `MultipleNewLinesSpecified`, and the `#extensibleField` / `#refreshOnActivateField` / `#usageCategoryField` / `#inherentEntitlementsField` / `#inherentPermissionsField` / `#insertAllowedField` / `#deleteAllowedField` companions.

**25 stay**, and each is genuinely still differing: `HelpLink`(+`#helpLinkField`) per above; `AnalysisModeEnabled`, `CardFormID`(+`Specified`), `DataCaptionExpr`, `IndirectPermissions` — all derivations, below; every `InfopartPageDefinition.*` (control-level, #3504); and the `PageDefinition.*` array-presence entries (control/action tree, #2460).

**On `versionContingent`:** I deleted no `versionContingent` entry. The four in the 3784 group — `ModifyAllowed`, `DelayedInsert` and their `#…Field` companions, plus `AnalysisModeEnabled` — all still match at 28.4 and stay. That flag exempts an entry from the unused check only, so none of them could have been hidden from the measurement. My fix reads from the symbol file rather than deriving, so it should be version-robust; I verified the 28.4 ground truth directly (`Extensible="1"` on 131, `"0"` on 105).

## What I deliberately did NOT do

Checked, not assumed — each is a **derivation**, a different change, owned by #2460/#3504:

- **`AnalysisModeEnabled`** tracks `PageType`, not the symbol file: `List`/`Worksheet` → `"1"`, every other type → absent, on **94 pages whose symbol file states nothing at all**. (BC's reader also defaults it to `true` when absent, so it cannot be passed through.)
- **`OnAfterGetCurrentRecordEnabled`** tracks trigger presence (54 pages).
- **`IndirectPermissions`** needs table NAME → id plus a mask encode: `tabledata "Guided Experience Item" = r` → `1990, 32, 0, 0`.
- **`CardFormID`** needs page NAME → id.
- **`DataCaptionExpr`** is BC's literal marker `"DataCaptionExprCode"` on all 32 pages, carrying none of the AL expression.
- **`ApplicationArea`** — BC's `PageProperties` writes nothing for it (`#All` on 116 pages → absent); the allowlist entry is `InfopartPageDefinition.ApplicationArea`, control-level, so #3504.
- **`Editable`** was already read correctly and is untouched.

`docs/metadata-equivalence.md` records this read-vs-derivation split and the three traps it sprang, because steps 2–4 of the same programme sort the same way.

## RED → GREEN

New file `AlRunner.Tests/DependencyPagePropertiesFromSymbolTests.cs`, 6 tests.

- **RED**: `Failed: 6, Passed: 0, Skipped: 0`. `Extensible` failed `Expected "0", Actual "1"` — the hardcode, exactly as reported.
- **GREEN**: `Failed: 0, Passed: 6, Skipped: 0`.

`Extensible` is asserted in **both** directions plus the silent default, so no hardcode either way satisfies it.

**Mutation-checked, every new assertion** — each failed exactly the covering tests and no others:

| mutation | result |
|---|---|
| `Extensible` back to hardcoded `"1"` | 1 failed (`Extensible_IsReadFromTheSymbolFile_NotHardcoded`) |
| drop the five `SourceObject` flags | 2 failed (both `SourceObjectFlags_*`) |
| `EmitPagePropertiesXml` scalars → no-ops | 1 failed (`PageProperties_ScalarsAreWrittenOnlyWhenStated`) |
| `EmitInherentMask` writes nothing | 2 failed (both `InherentMask*`) |
| unknown permission letter contributes 0 instead of refusing | 1 failed (`InherentMask_StatedInAFormItCannotRead_IsRefusedLoudly`) |

## Suites run, on the pushed head `fb5b158f`

`tools/engine-test-bootstrap.sh` after a `-c Release` build, then `--settings engine.runsettings` (this box skips the harness otherwise, #1813). **`Skipped: 0` throughout** — the engine was genuinely up, so these ran rather than reporting a skipped-everything summary.

| filter | result |
|---|---|
| `DependencyPagePropertiesFromSymbolTests` | **Failed: 0, Passed: 6, Skipped: 0** |
| `MetadataEquivalence` (the harness that now measures this fix) | **Failed: 0, Passed: 15, Skipped: 0** |
| changed-surface (`DependencyPage`\|`BcAppSymbolCache`\|`PageMetadata`\|`MetadataEquivalence`\|`MetadataDifferenceAllowlist`\|`MetadataObjectDiff`\|`DependencyMetadata`\|`SkeletonProfilePage`\|`DependencyControls`) | **Failed: 0, Passed: 199, Skipped: 0** |
| broad (`Symbol`\|`Page`\|`Metadata`\|`Dependency`\|`Cache`\|`Allowlist`) | **Failed: 1, Passed: 1645, Skipped: 0** |

The one broad-run failure is **not mine**, measured rather than asserted: `TestPageTemporalValueTests.TryResolve_RoundTripSpelling_ForADateTimeControl_KeepsTheTimeOfDay` **fails identically on a clean `origin/main` worktree** (`Expected 14:30:00, Actual 13:30:00`) — a box-local timezone failure (CEST, one-hour offset). Baseline on `origin/main`, same filter, pre-rebase: `Failed: 1, Passed: 1621, Skipped: 0`.

Also run: `tools/test_doc_pointers.py` (66 links, 13 anchors, 75 `Doc` values — all resolve, including the new anchor) and `tools/test_matrix_docs_drift.py`. `check_corpus_linkage.sh` against this body and the real diff: exit 0.

## Cache version

`BcAppSymbolCache.CacheVersion` 37 → 38, reason stated in the file. Both halves of the v32 rule at once: the record shape changed (which `PayloadShape` keys on by itself), **and** the parse changed in a way no structural hash can see — the trio used to arrive as `bool`, collapsing "states nothing" into "states the default". Without the bump a warm payload replays that collapse: a wrong *answer*, not a cache miss.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes, fixed here: the "write only a false one" rule applied to the Insert/Modify/Delete trio *and* the `SourceTable > 0` scoping applied to all five flags. Neither was in the issue's headline. `EmitSourceObjectPropertiesXml`'s existing `#2860` five already used the correct three-state rule, so the fix was to make the other five match the sibling that was already right.
2. **Does a sibling function make the same assumption?** Checked `RecordPatches.PageMetadataVirtualTable.cs` and `RecordPatches.AlPageParser.cs`, the other consumers of `PageSymbol.InsertAllowed`/`ModifyAllowed`/`DeleteAllowed`. They are **correct as they are** and want the *AL-defaulted* answer (a page stating nothing IS insertable), which is why the three-state values were added as `…Stated` siblings rather than by changing the `bool` fields' type. Two questions, two fields, neither derivable from the other.
3. **Two code paths writing the same state with different invariants?** Yes — `EmitSourceObjectPropertiesXml` (three-state, write-iff-stated) and the inline block in `EmitPageXml` (two-state, write-only-a-false, `SourceTable`-scoped) both wrote `<SourceObject>` attributes under opposite rules. The five moved to the first, so there is now one rule for that element. `AutoSplitKey` stays inside the `SourceTable` branch deliberately: all 3 pages stating it declare a source table, and `NeedsAutoSplitKey`'s reader only runs for a bound page.

**Open-issue queue scanned** for `DependencyPageMetadataXml`, `EmitPageXml`, `Extensible`, `PageProperties`, `SymbolReference page`, and by mechanism (hardcoded value, unread symbol property). **Nothing folds.** Adjacent, and why not: **#2460** (action tree) and **#3504** (field controls) are the next two steps of this approved sequence, deliberately sequenced apart — both are reconstructions, not reads, and land in the control-tree half of this file. **#3562** tracks retiring the hand-derivation wholesale. **#3247** is `SubPageLink` resolution, a different function. **#2200** is `ParseMemberNames`, a different parser.

## Why no corpus PR

`Corpus-NA` above, and this is the **structural** argument, not convenience. `EmitPageXml` runs only for a page the runner never source-compiles — one shipping compiled inside a dependency `.app`, which ships no compiled metadata form of its objects. A corpus test compiles its pages from source, takes the real AL compiler's own metadata path, and **never reaches this synthesizer**. There is no AL a service tier could run that would exercise the changed code; a corpus test of `Editable`/`InsertAllowed` would pass identically before and after — exactly the "green means the runner agrees with itself" failure the upstream rule exists to prevent.

That is why the proving test is a runner-side mechanism test under `AlRunner.Tests/` (the `Tests updated` gate's only remaining path since #3737), pinning the runner's own reader against a fixture symbol file — with the asserted values taken from BC's own emitted documents rather than invented. The metadata-equivalence harness is the second, independent measurement, and it now runs against a real ground-truth bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
