### PR TITLE
fix(deps): follow a resolved package's own Platform/Application floor, so Library Assert compiles

### DIFF
--- a/AlRunner.Tests/BaseAppFloorFixtureGuardTests.cs
+++ b/AlRunner.Tests/BaseAppFloorFixtureGuardTests.cs
@@ -217,8 +217,8 @@ public sealed class BaseAppFloorFixtureGuardTests
     };
 
     /// <summary>
-    /// C# test sources permitted to write the floor into a manifest they generate. Both
-    /// remaining entries are legitimate: the floor itself is what they assert about. Keep the
+    /// C# test sources permitted to write the floor into a manifest they generate. Every
+    /// entry is legitimate: the floor itself is what they assert about. Keep the
     /// reasons — the rule was ignored once already because it read as advice. Paths are
     /// relative to AlRunner.Tests/ with '/' separators, exactly like
     /// <see cref="AllowedFixtures"/>; for a top-level file that is just the file name, which
@@ -239,6 +239,13 @@ public sealed class BaseAppFloorFixtureGuardTests
             "legitimate — the placeholder 1.0.0.0 floor IS the subject",
         ["ProvisionExplicitModesTests.cs"] =
             "legitimate — asserts provisioning against a bundle declaring an older major",
+        ["DependencyResolverTests.cs"] =
+            "legitimate (#3719) — the floor is the SUBJECT, not a dependency the test leans on: "
+            + "SynthesizedPackage_CarriesTheAppJsonFloors asserts that InProcessAppPackager reads "
+            + "app.json's \"application\" onto BundleIdentity and writes it back out as the "
+            + "synthesized package's App/@Application, so DependencyResolver can follow it. The "
+            + "cost this rule guards is zero here: the manifest is packaged and read back "
+            + "in-process, and no runner subprocess is ever spawned against it",
     };
 
     [Fact]
@@ -261,7 +268,7 @@ public sealed class BaseAppFloorFixtureGuardTests
     }
 
     [Fact]
-    public void NoTestSource_WritesTheBaseApplicationFloor_ExceptTheAllowlistedTwo()
+    public void NoTestSource_WritesTheBaseApplicationFloor_ExceptTheAllowlistedThree()
     {
         var offenders = new List<string>();
         foreach (var path in TestSourcePaths())

--- a/AlRunner.Tests/DependencyResolverTests.cs
+++ b/AlRunner.Tests/DependencyResolverTests.cs
@@ -621,12 +621,17 @@ public sealed class DependencyResolverTests : IDisposable
     /// </summary>
     private static byte[] MakeMinimalApp(string appId, string name, string publisher, string version,
         bool r2r, bool alSource, string? platform)
+        => MakeMinimalApp(appId, name, publisher, version, r2r, alSource, platform, application: null);
+
+    private static byte[] MakeMinimalApp(string appId, string name, string publisher, string version,
+        bool r2r, bool alSource, string? platform, string? application)
     {
         var platformAttr = platform == null ? "" : $" Platform=\"{platform}\"";
+        var applicationAttr = application == null ? "" : $" Application=\"{application}\"";
         var xml = $"""
             <?xml version="1.0" encoding="utf-8"?>
             <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
-              <App Id="{appId}" Name="{name}" Publisher="{publisher}" Version="{version}"{platformAttr}/>
+              <App Id="{appId}" Name="{name}" Publisher="{publisher}" Version="{version}"{applicationAttr}{platformAttr}/>
             </Package>
             """;
 
@@ -714,6 +719,76 @@ public sealed class DependencyResolverTests : IDisposable
         });
 
         Assert.Equal(new[] { "Library Assert" }, result.Select(r => r.Manifest.Name).ToArray());
+    }
+
+    /// <summary>
+    /// The Application floor is followed too, not only Platform — an implementation handling
+    /// `Platform` alone passes every other fact here. Microsoft's test packages really declare
+    /// it: Tests-ERM's manifest is <c>Platform="28.0.0.0" Application="28.1.0.0"</c>.
+    /// </summary>
+    [Fact]
+    public void ResolvedPackageDeclaringApplication_PullsApplicationIntoTheClosure()
+    {
+        var dir = MakeDir("ApplicationFloor");
+        var applicationId = "00000000-0000-0000-0000-0000000a9911";
+        var ermId = "00000000-0000-0000-0000-0000000e2222";
+        File.WriteAllBytes(Path.Combine(dir, "Microsoft_Application.app"),
+            MakeMinimalApp(applicationId, "Application", "Microsoft", "28.1.49838.54368", r2r: false, alSource: false, platform: null));
+        File.WriteAllBytes(Path.Combine(dir, "Microsoft_Tests-ERM.app"),
+            MakeMinimalApp(ermId, "Tests-ERM", "Microsoft", "28.1.49838.54169", r2r: false, alSource: true,
+                platform: null, application: "28.1.0.0"));
+
+        var result = new DependencyResolver(new[] { dir }).Resolve(new[]
+        {
+            new DependencyRef(Guid.Parse(ermId), "Tests-ERM", "Microsoft", new Version(28, 0, 0, 0)),
+        });
+
+        Assert.Equal(new[] { "Application", "Tests-ERM" }, result.Select(r => r.Manifest.Name).ToArray());
+    }
+
+    /// <summary>
+    /// #3719: a package this run SYNTHESIZED from source must carry its own app.json floors, or
+    /// the resolver has nothing to follow and the sibling is source-compiled without the platform
+    /// symbols it asked for — the reported bug, on a path the runner manufactures itself.
+    /// BuildNavxManifestXml filters <c>&lt;Dependencies&gt;</c> to non-Optional entries, which is
+    /// exactly where the implicit floors live, so they have to travel as App attributes.
+    /// </summary>
+    [Fact]
+    public void SynthesizedPackage_CarriesTheAppJsonFloors_SoTheResolverCanFollowThem()
+    {
+        var src = MakeDir("SynthSource");
+        File.WriteAllText(Path.Combine(src, "app.json"), """
+        {
+          "id": "00000000-0000-0000-0000-0000000b1111",
+          "name": "Synth Sibling",
+          "publisher": "Contoso",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "28.0.0.0",
+          "application": "28.1.0.0",
+          "runtime": "13.0"
+        }
+        """);
+
+        var identity = AlRunner.Infrastructure.InProcessAppPackager.ReadIdentity(Path.Combine(src, "app.json"));
+        Assert.NotNull(identity);
+        Assert.Equal(new Version(28, 0, 0, 0), identity!.Platform);
+        Assert.Equal(new Version(28, 1, 0, 0), identity.Application);
+
+        // Round-trip: package it the way SiblingCompile does, read it back the way
+        // DependencyResolver does.
+        File.WriteAllText(Path.Combine(src, "Helper.Codeunit.al"), "codeunit 63900 \"Synth Helper\" { }");
+        var outDir = MakeDir("SynthOut");
+        var appPath = Path.Combine(outDir, "Contoso_Synth_Sibling.app");
+        AlRunner.Infrastructure.InProcessAppPackager.EmitAppPackageToFile(src, identity, appPath);
+
+        var manifest = AppLoader.ReadManifest(appPath);
+        Assert.NotNull(manifest);
+        Assert.Equal(new Version(28, 0, 0, 0), manifest!.Platform);
+        Assert.Equal(new Version(28, 1, 0, 0), manifest.Application);
+        Assert.Equal(
+            new[] { "Application", "System" },
+            AppLoader.ImplicitRoots(manifest).Select(r => r.Name).OrderBy(n => n, StringComparer.Ordinal).ToArray());
     }
 
     /// <summary>

--- a/AlRunner.Tests/DependencyResolverTests.cs
+++ b/AlRunner.Tests/DependencyResolverTests.cs
@@ -611,11 +611,22 @@ public sealed class DependencyResolverTests : IDisposable
 
     private static byte[] MakeMinimalApp(string appId, string name, string publisher, string version,
         bool r2r, bool alSource)
+        => MakeMinimalApp(appId, name, publisher, version, r2r, alSource, platform: null);
+
+    /// <summary>
+    /// <paramref name="platform"/> becomes the App element's <c>Platform</c> attribute — the
+    /// floor the real `al` compiler turns into an implicit Microsoft/System dependency, and
+    /// the only dependency Microsoft's test-toolkit packages declare (Library Assert's manifest:
+    /// <c>Platform="28.0.0.0"</c>, an empty <c>&lt;Dependencies /&gt;</c>).
+    /// </summary>
+    private static byte[] MakeMinimalApp(string appId, string name, string publisher, string version,
+        bool r2r, bool alSource, string? platform)
     {
+        var platformAttr = platform == null ? "" : $" Platform=\"{platform}\"";
         var xml = $"""
             <?xml version="1.0" encoding="utf-8"?>
             <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
-              <App Id="{appId}" Name="{name}" Publisher="{publisher}" Version="{version}"/>
+              <App Id="{appId}" Name="{name}" Publisher="{publisher}" Version="{version}"{platformAttr}/>
             </Package>
             """;
 
@@ -650,6 +661,85 @@ public sealed class DependencyResolverTests : IDisposable
         BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
         zipBytes.CopyTo(result, 8);
         return result;
+    }
+
+    // ── #3719: a resolved package's OWN platform floor joins the closure ──────
+    //
+    // Library Assert's manifest declares Platform="28.0.0.0" and no <Dependencies>. A consumer
+    // whose app.json declares neither `platform` nor `application` (LethAL's sandbox-data
+    // fixture; nothing in AL requires the keys) therefore resolved a closure with no System.app
+    // in it, Library Assert was source-compiled against that closure, and BC's emitter died on
+    // `Table 'Field' is missing` / `namespace 'Reflection' is unknown` — reported as EMIT-ZERO.
+    // Adding `"platform"` to the CONSUMER made the same fixture pass, 66 tests. The resolver must
+    // follow a resolved package's own Platform/Application floors the way it follows its
+    // <Dependencies>, so the dependency compiles against what ITS manifest asks for.
+
+    [Fact]
+    public void ResolvedPackageDeclaringPlatform_PullsSystemIntoTheClosure_BeforeIt()
+    {
+        var dir = MakeDir("PlatformFloor");
+        var systemId = "00000000-0000-0000-0000-00000000c0de";
+        var assertId = "dd0be2ea-f733-4d65-bb34-a28f4624fb14";
+        File.WriteAllBytes(Path.Combine(dir, "System.app"),
+            MakeMinimalApp(systemId, "System", "Microsoft", "28.0.54265.0", r2r: false, alSource: false, platform: null));
+        File.WriteAllBytes(Path.Combine(dir, "Microsoft_Library Assert.app"),
+            MakeMinimalApp(assertId, "Library Assert", "Microsoft", "28.1.49838.54169", r2r: false, alSource: true, platform: "28.0.0.0"));
+
+        var resolver = new DependencyResolver(new[] { dir });
+        var result = resolver.Resolve(new[]
+        {
+            new DependencyRef(Guid.Parse(assertId), "Library Assert", "Microsoft", new Version(28, 0, 0, 0)),
+        });
+
+        var names = result.Select(r => r.Manifest.Name).ToList();
+        Assert.Equal(new[] { "System", "Library Assert" }, names); // topological: the floor first
+    }
+
+    /// <summary>
+    /// The floor is Optional, exactly like the implicit roots a consumer's app.json yields: a
+    /// cache without System.app resolves the package alone rather than throwing. (Whether the
+    /// compile then fails is the loader's business, and it does fail loudly.)
+    /// </summary>
+    [Fact]
+    public void ResolvedPackageDeclaringPlatform_SystemAbsent_ResolvesThePackageAlone()
+    {
+        var dir = MakeDir("PlatformFloorAbsent");
+        var assertId = "dd0be2ea-f733-4d65-bb34-a28f4624fb14";
+        File.WriteAllBytes(Path.Combine(dir, "Microsoft_Library Assert.app"),
+            MakeMinimalApp(assertId, "Library Assert", "Microsoft", "28.1.49838.54169", r2r: false, alSource: true, platform: "28.0.0.0"));
+
+        var result = new DependencyResolver(new[] { dir }).Resolve(new[]
+        {
+            new DependencyRef(Guid.Parse(assertId), "Library Assert", "Microsoft", new Version(28, 0, 0, 0)),
+        });
+
+        Assert.Equal(new[] { "Library Assert" }, result.Select(r => r.Manifest.Name).ToArray());
+    }
+
+    /// <summary>
+    /// The trap AppLoader.ImplicitRoots' own doc comment names: every Microsoft platform app's
+    /// manifest carries these attributes and they reference each other (Application → Base
+    /// Application → Application …), so following a PLATFORM app's floors would cycle. They
+    /// are not followed; only a non-platform package's are. Base Application declaring a
+    /// Platform floor resolves to exactly itself, no System, no cycle exception.
+    /// </summary>
+    [Fact]
+    public void MicrosoftPlatformAppDeclaringPlatform_FloorIsNotFollowed()
+    {
+        var dir = MakeDir("PlatformFloorGuard");
+        var systemId = "00000000-0000-0000-0000-00000000c0de";
+        var baseId = "437dbf0e-84ff-417a-965d-ed2bb9650972";
+        File.WriteAllBytes(Path.Combine(dir, "System.app"),
+            MakeMinimalApp(systemId, "System", "Microsoft", "28.0.54265.0", r2r: false, alSource: false, platform: "28.0.54265.0"));
+        File.WriteAllBytes(Path.Combine(dir, "Microsoft_Base Application.app"),
+            MakeMinimalApp(baseId, "Base Application", "Microsoft", "28.1.49838.54169", r2r: true, alSource: false, platform: "28.0.0.0"));
+
+        var result = new DependencyResolver(new[] { dir }).Resolve(new[]
+        {
+            new DependencyRef(Guid.Parse(baseId), "Base Application", "Microsoft", new Version(28, 0, 0, 0)),
+        });
+
+        Assert.Equal(new[] { "Base Application" }, result.Select(r => r.Manifest.Name).ToArray());
     }
 
     // ── #1689: a resolved package that NO loader tier can implement ───────────

--- a/AlRunner.Tests/LibraryAssertPlatformlessConsumerTests.cs
+++ b/AlRunner.Tests/LibraryAssertPlatformlessConsumerTests.cs
@@ -1,0 +1,175 @@
+// LibraryAssertPlatformlessConsumerTests — #3719: a bundle depending on Microsoft's Library
+// Assert failed before any test ran: `[dep-load-fail] Microsoft_Library Assert v28.x: EMIT-ZERO`.
+//
+// The trigger is the CONSUMER's app.json declaring neither `platform` nor `application` (AL
+// requires neither; LethAL's sandbox-data fixture has neither). Library Assert's own manifest
+// declares Platform="28.0.0.0" and no <Dependencies>, and DependencyResolver followed only a
+// resolved package's <Dependencies>, never its floors — so with no consumer-side `platform`
+// root either, System.app was not in the closure Library Assert was source-compiled against:
+// BC's emitter saw `Table 'Field' is missing` and `namespace 'Reflection' is unknown` and died
+// with `Unexpected value 'None' of type NavTypeKind` at TypeOf(Variant), which the loader
+// reports as EMIT-ZERO. Adding `"platform"` to the consumer alone made the fixture pass.
+//
+// This spawns the runner on that exact shape with the platform and test-toolkit packages
+// already on disk and provisioning off, so it proves the RESOLUTION half: the closure must
+// carry System.app because the dependency asks for it. The provisioning half (a fresh box must
+// download the platform set when the toolkit is needed) is ProvisioningCheckTests.
+// Skips (not passes) when no Library Assert package is provisioned on the box.
+
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class LibraryAssertPlatformlessConsumerTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private readonly string _root;
+
+    public LibraryAssertPlatformlessConsumerTests()
+    {
+        _root = TestScratch.Dir("al-runner-libassert-platformless");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    /// <summary>
+    /// A provisioned test-apps directory holding Microsoft_Library Assert.app, and a platform-apps
+    /// directory holding System.app — the runner-owned layout under the artifacts root, or the
+    /// legacy ~/.al-runner layout CI populates. Null when either is absent.
+    /// </summary>
+    private static (string TestApps, string PlatformApps)? FindProvisionedDirs()
+    {
+        var home = TestArtifacts.HomeDir();
+        var candidates = new List<(string TestApps, string PlatformApps)>();
+        if (home != null)
+            candidates.Add((Path.Combine(home, ".al-runner", "test-apps"), Path.Combine(home, ".al-runner", "platform-apps")));
+        var root = AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir;
+        if (Directory.Exists(root))
+            foreach (var ver in Directory.EnumerateDirectories(root).OrderByDescending(d => d, StringComparer.Ordinal))
+                candidates.Add((Path.Combine(ver, "test-apps"), Path.Combine(ver, "platform-apps")));
+
+        string? testApps = null, platformApps = null;
+        foreach (var c in candidates)
+        {
+            if (testApps == null && File.Exists(Path.Combine(c.TestApps, "Microsoft_Library Assert.app"))) testApps = c.TestApps;
+            if (platformApps == null && File.Exists(Path.Combine(c.PlatformApps, "System.app"))) platformApps = c.PlatformApps;
+        }
+        return testApps != null && platformApps != null ? (testApps, platformApps) : null;
+    }
+
+    private void WriteBundles(out string app, out string tests)
+    {
+        app = Path.Combine(_root, "app");
+        tests = Path.Combine(_root, "tests");
+        Directory.CreateDirectory(app);
+        Directory.CreateDirectory(tests);
+        // Deliberately NO "platform" and NO "application" in either manifest — that is the shape.
+        File.WriteAllText(Path.Combine(app, "app.json"), """
+        {
+          "id": "5a3f0b11-3719-4a10-8010-000000003719",
+          "name": "LAPC App",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "idRanges": [ { "from": 63700, "to": 63709 } ],
+          "runtime": "13.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(app, "Helper.Codeunit.al"), """
+        codeunit 63700 "LAPC Helper"
+        {
+            procedure Answer(): Integer
+            begin
+                exit(42);
+            end;
+        }
+        """);
+        File.WriteAllText(Path.Combine(tests, "app.json"), """
+        {
+          "id": "5a3f0b11-3719-4a11-8011-000000003719",
+          "name": "LAPC Tests",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14", "name": "Library Assert", "publisher": "Microsoft", "version": "28.0.0.0" },
+            { "id": "5a3f0b11-3719-4a10-8010-000000003719", "name": "LAPC App", "publisher": "AL Runner", "version": "1.0.0.0" }
+          ],
+          "idRanges": [ { "from": 63710, "to": 63719 } ],
+          "runtime": "13.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(tests, "T.Codeunit.al"), """
+        codeunit 63710 "LAPC Tests"
+        {
+            Subtype = Test;
+
+            var
+                Assert: Codeunit "Library Assert";
+
+            [Test]
+            procedure HelperAnswersThroughLibraryAssert()
+            var
+                H: Codeunit "LAPC Helper";
+            begin
+                Assert.AreEqual(42, H.Answer(), 'helper');
+            end;
+        }
+        """);
+    }
+
+    private (string Output, int Exit) RunRunner(string app, string tests, string testApps, string platformApps)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" --no-cache --no-auto-provision --isolation test");
+        args.Append($" --package-cache \"{testApps}\" --package-cache \"{platformApps}\"");
+        args.Append($" \"{app}\" \"{tests}\"");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(600_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>
+    /// RED before the fix: `[dep-load-fail] Microsoft_Library Assert v…: EMIT-ZERO`, `FATAL:
+    /// dependency compile failed`, exit 1, no test ran. After: Library Assert compiles against
+    /// System.app, the one test runs through Assert.AreEqual and passes, exit 0.
+    /// </summary>
+    [SkippableFact]
+    public void ConsumerWithoutPlatformKey_LibraryAssertDependency_CompilesAndRuns()
+    {
+        TestArtifacts.SkipIfMissing();
+        var dirs = FindProvisionedDirs();
+        Skip.If(dirs == null, "no provisioned Microsoft_Library Assert.app + System.app pair on this box");
+        WriteBundles(out var app, out var tests);
+
+        var (output, exit) = RunRunner(app, tests, dirs!.Value.TestApps, dirs.Value.PlatformApps);
+
+        Assert.DoesNotContain("EMIT-ZERO", output);
+        Assert.DoesNotContain("dep-load-fail", output);
+        Assert.True(Regex.IsMatch(output, @"PASS\s+\S*\bHelperAnswersThroughLibraryAssert\b"),
+            $"no PASS line for HelperAnswersThroughLibraryAssert. Output:\n{output}");
+        Assert.Equal(0, exit);
+    }
+}

--- a/AlRunner.Tests/LibraryAssertPlatformlessConsumerTests.cs
+++ b/AlRunner.Tests/LibraryAssertPlatformlessConsumerTests.cs
@@ -20,6 +20,7 @@ using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
 using Xunit;
+using AlRunner;
 
 namespace AlRunner.Tests;
 
@@ -42,14 +43,25 @@ public sealed class LibraryAssertPlatformlessConsumerTests : IDisposable
         try { Directory.Delete(_root, recursive: true); } catch { }
     }
 
+    /// <summary>What one provisioned location supplies: both directories, and the Library
+    /// Assert package's OWN manifest, which is what the consumer must ask for.</summary>
+    private sealed record Provisioned(string TestApps, string PlatformApps, AppManifest LibraryAssert);
+
     /// <summary>
     /// A test-apps directory holding Microsoft_Library Assert.app together with a platform-apps
     /// directory holding System.app. Both come from ONE candidate location — the legacy
     /// <c>~/.al-runner</c> layout CI populates, or one version directory under the artifacts
     /// root — never mixed across versions, which would measure a pairing no real run produces.
-    /// Null when no single location has both.
+    /// Null when no single location has both, or when the package's manifest will not parse.
+    ///
+    /// The manifest comes back with it because the toolkit's version tracks the BC leg: the
+    /// 27.5 leg provisions Library Assert v27.x, the 28.4 leg v28.x. A consumer asking for a
+    /// hardcoded minimum resolves nothing on the lower leg (DependencyResolver skips a
+    /// candidate whose version is below the request), so the bundle fails to compile for a
+    /// reason that has nothing to do with #3719 — measured as a red 27.5 leg on PR #3793,
+    /// reported as the bundle's own EMIT-ZERO rather than the dependency's.
     /// </summary>
-    private static (string TestApps, string PlatformApps)? FindProvisionedDirs()
+    private static Provisioned? FindProvisionedDirs()
     {
         var home = TestArtifacts.HomeDir();
         var candidates = new List<(string TestApps, string PlatformApps)>();
@@ -61,13 +73,16 @@ public sealed class LibraryAssertPlatformlessConsumerTests : IDisposable
                 candidates.Add((Path.Combine(ver, "test-apps"), Path.Combine(ver, "platform-apps")));
 
         foreach (var c in candidates)
-            if (File.Exists(Path.Combine(c.TestApps, "Microsoft_Library Assert.app"))
-                && File.Exists(Path.Combine(c.PlatformApps, "System.app")))
-                return c;
+        {
+            var assertPath = Path.Combine(c.TestApps, "Microsoft_Library Assert.app");
+            if (!File.Exists(assertPath) || !File.Exists(Path.Combine(c.PlatformApps, "System.app"))) continue;
+            var manifest = AppLoader.ReadManifest(assertPath);
+            if (manifest != null) return new Provisioned(c.TestApps, c.PlatformApps, manifest);
+        }
         return null;
     }
 
-    private void WriteBundles(out string app, out string tests)
+    private void WriteBundles(AppManifest libraryAssert, out string app, out string tests)
     {
         app = Path.Combine(_root, "app");
         tests = Path.Combine(_root, "tests");
@@ -94,14 +109,17 @@ public sealed class LibraryAssertPlatformlessConsumerTests : IDisposable
             end;
         }
         """);
-        File.WriteAllText(Path.Combine(tests, "app.json"), """
+        // The Library Assert dependency is written at the version this box actually has, read
+        // from the package's own manifest — see FindProvisionedDirs. `al` generates the entry
+        // the same way, from the package it compiled against.
+        File.WriteAllText(Path.Combine(tests, "app.json"), $$"""
         {
           "id": "5a3f0b11-3719-4a11-8011-000000003719",
           "name": "LAPC Tests",
           "publisher": "AL Runner",
           "version": "1.0.0.0",
           "dependencies": [
-            { "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14", "name": "Library Assert", "publisher": "Microsoft", "version": "28.0.0.0" },
+            { "id": "{{libraryAssert.AppId}}", "name": "{{libraryAssert.Name}}", "publisher": "{{libraryAssert.Publisher}}", "version": "{{libraryAssert.Version}}" },
             { "id": "5a3f0b11-3719-4a10-8010-000000003719", "name": "LAPC App", "publisher": "AL Runner", "version": "1.0.0.0" }
           ],
           "idRanges": [ { "from": 63710, "to": 63719 } ],
@@ -169,12 +187,17 @@ public sealed class LibraryAssertPlatformlessConsumerTests : IDisposable
                 + "CI provisions both (al-runner provision --test-apps --platform-apps).");
         TestArtifacts.SkipIf(dirs == null,
             "no Microsoft_Library Assert.app + System.app pair in one provisioned location on this box.");
-        WriteBundles(out var app, out var tests);
+        WriteBundles(dirs!.LibraryAssert, out var app, out var tests);
 
-        var (output, exit) = RunRunner(app, tests, dirs!.Value.TestApps, dirs.Value.PlatformApps);
+        var (output, exit) = RunRunner(app, tests, dirs.TestApps, dirs.PlatformApps);
 
-        Assert.DoesNotContain("EMIT-ZERO", output);
-        Assert.DoesNotContain("dep-load-fail", output);
+        // Each of these prints the whole run. A bare Assert.DoesNotContain reports only the
+        // ~40 characters around the hit, which on the red 27.5 leg of PR #3793 named the
+        // symptom and hid the AL errors underneath it.
+        Assert.False(output.Contains("EMIT-ZERO", StringComparison.Ordinal),
+            $"EMIT-ZERO in the run against Library Assert v{dirs.LibraryAssert.Version}. Output:\n{output}");
+        Assert.False(output.Contains("dep-load-fail", StringComparison.Ordinal),
+            $"a dependency failed to load. Output:\n{output}");
         Assert.True(Regex.IsMatch(output, @"PASS\s+\S*\bHelperAnswersThroughLibraryAssert\b"),
             $"no PASS line for HelperAnswersThroughLibraryAssert. Output:\n{output}");
         Assert.Equal(0, exit);

--- a/AlRunner.Tests/LibraryAssertPlatformlessConsumerTests.cs
+++ b/AlRunner.Tests/LibraryAssertPlatformlessConsumerTests.cs
@@ -43,9 +43,11 @@ public sealed class LibraryAssertPlatformlessConsumerTests : IDisposable
     }
 
     /// <summary>
-    /// A provisioned test-apps directory holding Microsoft_Library Assert.app, and a platform-apps
-    /// directory holding System.app — the runner-owned layout under the artifacts root, or the
-    /// legacy ~/.al-runner layout CI populates. Null when either is absent.
+    /// A test-apps directory holding Microsoft_Library Assert.app together with a platform-apps
+    /// directory holding System.app. Both come from ONE candidate location — the legacy
+    /// <c>~/.al-runner</c> layout CI populates, or one version directory under the artifacts
+    /// root — never mixed across versions, which would measure a pairing no real run produces.
+    /// Null when no single location has both.
     /// </summary>
     private static (string TestApps, string PlatformApps)? FindProvisionedDirs()
     {
@@ -58,13 +60,11 @@ public sealed class LibraryAssertPlatformlessConsumerTests : IDisposable
             foreach (var ver in Directory.EnumerateDirectories(root).OrderByDescending(d => d, StringComparer.Ordinal))
                 candidates.Add((Path.Combine(ver, "test-apps"), Path.Combine(ver, "platform-apps")));
 
-        string? testApps = null, platformApps = null;
         foreach (var c in candidates)
-        {
-            if (testApps == null && File.Exists(Path.Combine(c.TestApps, "Microsoft_Library Assert.app"))) testApps = c.TestApps;
-            if (platformApps == null && File.Exists(Path.Combine(c.PlatformApps, "System.app"))) platformApps = c.PlatformApps;
-        }
-        return testApps != null && platformApps != null ? (testApps, platformApps) : null;
+            if (File.Exists(Path.Combine(c.TestApps, "Microsoft_Library Assert.app"))
+                && File.Exists(Path.Combine(c.PlatformApps, "System.app")))
+                return c;
+        return null;
     }
 
     private void WriteBundles(out string app, out string tests)
@@ -161,7 +161,14 @@ public sealed class LibraryAssertPlatformlessConsumerTests : IDisposable
     {
         TestArtifacts.SkipIfMissing();
         var dirs = FindProvisionedDirs();
-        Skip.If(dirs == null, "no provisioned Microsoft_Library Assert.app + System.app pair on this box");
+        // On CI the toolkit and platform sets are provisioned, so their absence is a broken leg
+        // rather than an unavailable environment — fail, do not skip, matching
+        // TestArtifacts.SkipIfMissingIn's own rule.
+        if (dirs == null && TestArtifacts.RunningOnCi)
+            Assert.Fail("no Microsoft_Library Assert.app + System.app pair in one provisioned location; "
+                + "CI provisions both (al-runner provision --test-apps --platform-apps).");
+        TestArtifacts.SkipIf(dirs == null,
+            "no Microsoft_Library Assert.app + System.app pair in one provisioned location on this box.");
         WriteBundles(out var app, out var tests);
 
         var (output, exit) = RunRunner(app, tests, dirs!.Value.TestApps, dirs.Value.PlatformApps);

--- a/AlRunner.Tests/ManifestDependencyEdgeScanTests.cs
+++ b/AlRunner.Tests/ManifestDependencyEdgeScanTests.cs
@@ -77,6 +77,73 @@ public sealed class ManifestDependencyEdgeScanTests : IDisposable
         File.WriteAllBytes(Path.Combine(dir, $"{publisher}_{name}.app"), WrapNavx(xml));
     }
 
+    /// <summary>As <see cref="WriteApp"/>, with the App element's <c>Platform</c> attribute set —
+    /// the only dependency Microsoft's test-toolkit packages declare (Library Assert's manifest:
+    /// <c>Platform="28.0.0.0"</c>, empty <c>&lt;Dependencies /&gt;</c>).</summary>
+    private static void WriteAppWithPlatform(
+        string dir, string name, string publisher, string version, string platform,
+        params (string Name, string Publisher)[] dependencies)
+    {
+        var deps = string.Concat(dependencies.Select(d =>
+            $"""    <Dependency Id="{Guid.NewGuid()}" Name="{d.Name}" Publisher="{d.Publisher}" MinVersion="{version}" />{"\n"}"""));
+        var xml = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+              <App Id="{Guid.NewGuid()}" Name="{name}" Publisher="{publisher}" Version="{version}" Platform="{platform}"/>
+              <Dependencies>
+            {deps}  </Dependencies>
+            </Package>
+            """;
+        File.WriteAllBytes(Path.Combine(dir, $"{publisher}_{name}.app"), WrapNavx(xml));
+    }
+
+    // ── #3719: a package's own Platform floor is an edge ──────────────────────
+
+    [Fact]
+    public void ScanDependencyEdges_PackageDeclaringPlatform_RecordsAnEdgeToSystem()
+    {
+        var dir = NewDir("floor-edge");
+        WriteAppWithPlatform(dir, "Library Assert", "Microsoft", "28.1.49838.54169", platform: "28.0.0.0");
+
+        var edges = ProvisioningCheck.ScanDependencyEdges(new[] { dir }).Edges;
+
+        Assert.Equal(new[] { "System" }, edges["Library Assert"]);
+    }
+
+    /// <summary>The floor edge does not point a package at itself: a System.app that declares a
+    /// Platform records an empty edge list, exactly as an app declaring nothing does.</summary>
+    [Fact]
+    public void ScanDependencyEdges_SystemDeclaringPlatform_RecordsNoSelfEdge()
+    {
+        var dir = NewDir("floor-edge-self");
+        WriteAppWithPlatform(dir, "System", "Microsoft", "28.0.54265.0", platform: "28.0.54265.0");
+
+        var edges = ProvisioningCheck.ScanDependencyEdges(new[] { dir }).Edges;
+
+        Assert.Empty(edges["System"]);
+    }
+
+    /// <summary>
+    /// The end-to-end need: a bundle naming only Library Assert, with the real-shaped toolkit
+    /// package on disk, requires System — derived from that package's Platform floor, in the
+    /// same second round that learns Application Test Library from Tests-TestLibraries. Without
+    /// the edge the bundle downloaded test-apps alone and Library Assert's source compile died
+    /// with EMIT-ZERO on the first run.
+    /// </summary>
+    [Fact]
+    public void DetermineManifestNeeds_LibraryAssertOnDisk_RequiresSystemThroughItsPlatformFloor()
+    {
+        var dir = NewDir("floor-need");
+        WriteAppWithPlatform(dir, "Library Assert", "Microsoft", "28.1.49838.54169", platform: "28.0.0.0");
+        var edges = ProvisioningCheck.ScanDependencyEdges(new[] { dir }).Edges;
+
+        var needs = ProvisioningCheck.DetermineManifestNeeds(
+            new[] { Root("Library Assert", version: "28.0.0.0") }, edges);
+
+        Assert.True(needs.NeedsTestApps);
+        Assert.Equal(new[] { "System" }, needs.RequiredPlatformApps);
+    }
+
     /// <summary>As <see cref="WriteApp"/>, but the package carries a
     /// <c>publishedartifacts/</c> entry — i.e. an R2R runtime package rather than a
     /// symbol-only one, which is what a real provisioned platform-apps dir holds.</summary>

--- a/AlRunner.Tests/ManifestDependencyEdgeScanTests.cs
+++ b/AlRunner.Tests/ManifestDependencyEdgeScanTests.cs
@@ -83,13 +83,22 @@ public sealed class ManifestDependencyEdgeScanTests : IDisposable
     private static void WriteAppWithPlatform(
         string dir, string name, string publisher, string version, string platform,
         params (string Name, string Publisher)[] dependencies)
+        => WriteAppWithFloors(dir, name, publisher, version, platform, application: null, dependencies);
+
+    /// <summary>As <see cref="WriteApp"/>, with either or both floor attributes set.</summary>
+    private static void WriteAppWithFloors(
+        string dir, string name, string publisher, string version,
+        string? platform, string? application,
+        params (string Name, string Publisher)[] dependencies)
     {
         var deps = string.Concat(dependencies.Select(d =>
             $"""    <Dependency Id="{Guid.NewGuid()}" Name="{d.Name}" Publisher="{d.Publisher}" MinVersion="{version}" />{"\n"}"""));
+        var platformAttr = platform == null ? "" : $" Platform=\"{platform}\"";
+        var applicationAttr = application == null ? "" : $" Application=\"{application}\"";
         var xml = $"""
             <?xml version="1.0" encoding="utf-8"?>
             <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
-              <App Id="{Guid.NewGuid()}" Name="{name}" Publisher="{publisher}" Version="{version}" Platform="{platform}"/>
+              <App Id="{Guid.NewGuid()}" Name="{name}" Publisher="{publisher}" Version="{version}"{applicationAttr}{platformAttr}/>
               <Dependencies>
             {deps}  </Dependencies>
             </Package>
@@ -110,17 +119,42 @@ public sealed class ManifestDependencyEdgeScanTests : IDisposable
         Assert.Equal(new[] { "System" }, edges["Library Assert"]);
     }
 
-    /// <summary>The floor edge does not point a package at itself: a System.app that declares a
-    /// Platform records an empty edge list, exactly as an app declaring nothing does.</summary>
+    /// <summary>
+    /// A Microsoft PLATFORM app's own floor is not recorded, matching
+    /// DependencyResolver.Visit's guard: their manifests reference each other
+    /// (Application → Base Application → Application …), and an edge the resolver refuses to
+    /// walk would make provisioning fetch a set resolution never asks for. Both directions
+    /// here — a self-pointing floor (System declaring Platform) and a cross-pointing one
+    /// (Base Application declaring Platform, i.e. → System).
+    /// </summary>
     [Fact]
-    public void ScanDependencyEdges_SystemDeclaringPlatform_RecordsNoSelfEdge()
+    public void ScanDependencyEdges_PlatformAppsOwnFloor_IsNotRecorded()
     {
-        var dir = NewDir("floor-edge-self");
+        var dir = NewDir("floor-edge-platform");
         WriteAppWithPlatform(dir, "System", "Microsoft", "28.0.54265.0", platform: "28.0.54265.0");
+        WriteAppWithPlatform(dir, "Base Application", "Microsoft", "28.1.49838.54169", platform: "28.0.0.0");
 
         var edges = ProvisioningCheck.ScanDependencyEdges(new[] { dir }).Edges;
 
         Assert.Empty(edges["System"]);
+        Assert.Empty(edges["Base Application"]);
+    }
+
+    /// <summary>
+    /// The Application floor is recorded too, not only Platform — an implementation that
+    /// handled `Platform` alone would pass every other fact here. Microsoft's test packages
+    /// really do declare it: Tests-ERM's manifest is Platform="28.0.0.0" Application="28.1.0.0".
+    /// </summary>
+    [Fact]
+    public void ScanDependencyEdges_PackageDeclaringApplication_RecordsAnEdgeToApplication()
+    {
+        var dir = NewDir("floor-edge-application");
+        WriteAppWithFloors(dir, "Tests-ERM", "Microsoft", "28.1.49838.54169",
+            platform: "28.0.0.0", application: "28.1.0.0", ("Library Assert", "Microsoft"));
+
+        var edges = ProvisioningCheck.ScanDependencyEdges(new[] { dir }).Edges;
+
+        Assert.Equal(new[] { "Library Assert", "Application", "System" }, edges["Tests-ERM"]);
     }
 
     /// <summary>

--- a/AlRunner.Tests/ProvisioningCheckTests.cs
+++ b/AlRunner.Tests/ProvisioningCheckTests.cs
@@ -694,6 +694,33 @@ public sealed class ProvisioningCheckTests : IDisposable
         Assert.True(needs.NeedsTestApps);
     }
 
+    /// <summary>
+    /// #3719: a bundle declaring only a test-toolkit dependency and no `platform`/`application`
+    /// of its own still needs System.app — Library Assert's own manifest declares
+    /// Platform="28.0.0.0" (and no Dependencies), and its source compile dies without the
+    /// platform symbols. ScanDependencyEdges records that floor as an edge to "System", so
+    /// once the toolkit package is on disk the ordinary walk derives the need — the same
+    /// second round that already learns Application Test Library from Tests-TestLibraries'
+    /// manifest. With no edges known (nothing downloaded yet) the answer stays "no platform
+    /// need", as every other edge-derived need does; the sibling below pins that.
+    /// </summary>
+    [Fact]
+    public void DetermineManifestNeeds_LibraryAssertDependency_WithItsPlatformFloorEdge_RequiresSystem()
+    {
+        var roots = new[]
+        {
+            new DependencyRef(Guid.Parse("dd0be2ea-f733-4d65-bb34-a28f4624fb14"), "Library Assert", "Microsoft", new Version(28, 0, 0, 0)),
+        };
+        var edges = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Library Assert"] = new[] { "System" }, // what ScanDependencyEdges records from Platform="28.0.0.0"
+        };
+        var needs = ProvisioningCheck.DetermineManifestNeeds(roots, edges);
+        Assert.True(needs.NeedsTestApps);
+        Assert.True(needs.NeedsPlatformApps);
+        Assert.Equal(new[] { "System" }, needs.RequiredPlatformApps); // and nothing beyond it
+    }
+
     [Fact]
     public void DetermineManifestNeeds_ImplicitApplicationAndSystemRootsAlone_NeedNoTestApps()
     {
@@ -723,6 +750,9 @@ public sealed class ProvisioningCheckTests : IDisposable
     [Fact]
     public void DetermineManifestNeeds_LibraryAssertDependency_NeedsTestNotPlatform()
     {
+        // No edges known — nothing downloaded yet. The platform need Library Assert really has
+        // (#3719, its Platform="28.0.0.0" floor) is learned from its manifest once the test set
+        // is on disk, never invented here; see the _WithItsPlatformFloorEdge_ sibling.
         var roots = new[]
         {
             new DependencyRef(Guid.NewGuid(), "Library Assert", "Microsoft", new Version(28, 1, 0, 0)),

--- a/AlRunner/AppLoader.cs
+++ b/AlRunner/AppLoader.cs
@@ -670,9 +670,12 @@ public static class AppLoader
     /// same way app.json inputs do. Roots are Optional (warn-not-throw if absent)
     /// and resolved by (Name, Publisher) — version is informational.
     ///
-    /// Apply ONLY to the root app being compiled, never transitively: the
-    /// dependency resolver throws on cycles, and every Microsoft app's manifest
-    /// carries these same attributes (Application → Base Application → Application …).
+    /// Applied to the root app being compiled and, since #3719, to every resolved package
+    /// that is NOT itself a Microsoft platform app (DependencyResolver.Visit): Microsoft's
+    /// test-toolkit packages declare only a Platform floor, and their source compile needs
+    /// System.app for it. The platform apps' own floors are still never followed — their
+    /// manifests reference each other (Application → Base Application → Application …) and
+    /// the resolver throws on cycles.
     /// </summary>
     public static IEnumerable<DependencyRef> ImplicitRoots(AppManifest manifest)
     {

--- a/AlRunner/DependencyResolver.cs
+++ b/AlRunner/DependencyResolver.cs
@@ -172,6 +172,18 @@ public sealed class DependencyResolver
         stack.Push(found.Manifest.Name);
         foreach (var child in found.Manifest.Dependencies)
             Visit(child, state, output, stack);
+        // #3719: a package's own Platform/Application floors are dependencies too — the real
+        // `al` compiler injects Microsoft/System and Microsoft/Application from them, and
+        // Microsoft's test-toolkit packages declare NOTHING else (Library Assert: Platform=
+        // "28.0.0.0", empty <Dependencies />). Without this, a consumer whose app.json has no
+        // `platform` of its own resolved a closure with no System.app, and Library Assert was
+        // source-compiled without the platform symbols: EMIT-ZERO. Not followed for the Microsoft
+        // platform apps themselves, whose manifests reference each other (Application → Base
+        // Application → Application …) and would cycle — AppLoader.ImplicitRoots' trap.
+        // Optional, like the consumer-side roots: a missing System.app skips, as above.
+        if (!IsMicrosoftPlatformApp(found.Manifest.Name, found.Manifest.Publisher))
+            foreach (var floor in AppLoader.ImplicitRoots(found.Manifest))
+                Visit(floor, state, output, stack);
         stack.Pop();
         state[id] = 2;
         output.Add((found.Manifest, found.Path));

--- a/AlRunner/Infrastructure/InProcessAppPackager.cs
+++ b/AlRunner/Infrastructure/InProcessAppPackager.cs
@@ -25,13 +25,22 @@ namespace AlRunner.Infrastructure;
 /// <summary>
 /// Identity read from a bundle's app.json, used to synthesize a NAVX .app.
 /// </summary>
+/// <param name="Application">app.json's <c>application</c> floor, or null when it declares none.</param>
+/// <param name="Platform">
+/// app.json's <c>platform</c> floor, or null. #3719: both are written onto the synthesized
+/// package's App element, because a resolved package's floors are dependencies —
+/// <see cref="AlRunner.AppLoader.ImplicitRoots"/>, followed by DependencyResolver. Dropping
+/// them here made a synthesized sibling lose the platform symbols its own app.json asked for.
+/// </param>
 public sealed record BundleIdentity(
     Guid AppId,
     string Name,
     string Publisher,
     Version Version,
     Version RuntimeVersion,
-    IReadOnlyList<DependencyRef> Dependencies);
+    IReadOnlyList<DependencyRef> Dependencies,
+    Version? Application = null,
+    Version? Platform = null);
 
 public static class InProcessAppPackager
 {
@@ -108,7 +117,11 @@ public static class InProcessAppPackager
                 }
             }
             // Inject implicit MS deps from application/platform fields (same logic as
-            // Program.cs ReadDependencies) so the reference loader resolves them.
+            // Program.cs ReadDependencies) so the reference loader resolves them. #3719: the
+            // floors are ALSO carried on the identity, because BuildNavxManifestXml drops every
+            // Optional dep — so without them a synthesized package's manifest would declare
+            // neither the dependency nor the floor, and the resolver could not follow either.
+            Version? applicationFloor = null, platformFloor = null;
             foreach (var (field, implName) in new[] { ("application", "Application"), ("platform", "System") })
             {
                 if (root.TryGetProperty(field, out var fv)
@@ -117,10 +130,11 @@ public static class InProcessAppPackager
                 {
                     if (!Version.TryParse(fv.GetString(), out var iv)) iv = new Version(0, 0, 0, 0);
                     deps.Add(new DependencyRef(Guid.Empty, implName, "Microsoft", iv, Optional: true));
+                    if (implName == "Application") applicationFloor = iv; else platformFloor = iv;
                 }
             }
 
-            return new BundleIdentity(appId, name, pub, ver, rtVer, deps);
+            return new BundleIdentity(appId, name, pub, ver, rtVer, deps, applicationFloor, platformFloor);
         }
         catch (Exception ex)
         {
@@ -347,6 +361,11 @@ public static class InProcessAppPackager
                     new XAttribute("Name", identity.Name),
                     new XAttribute("Publisher", identity.Publisher),
                     new XAttribute("Version", identity.Version.ToString()),
+                    // #3719: the floors go on the App element, the way a real package declares
+                    // them, NOT into <Dependencies> above — that list is filtered to non-Optional
+                    // entries, and AppLoader reads the floors from these attributes.
+                    identity.Application == null ? null : new XAttribute("Application", identity.Application.ToString()),
+                    identity.Platform == null ? null : new XAttribute("Platform", identity.Platform.ToString()),
                     new XAttribute("ShowMyCode", "true")),
                 depsEl));
 

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -1049,19 +1049,18 @@ public static class ProvisioningCheck
                         deps.Add(d.Name);
                 }
                 // #3719: a package's Platform / Application floors are dependencies the real `al`
-                // compiler injects (Microsoft/System, Microsoft/Application), and Microsoft's
-                // test-toolkit packages declare NOTHING else — Library Assert's manifest is
-                // Platform="28.0.0.0" with an empty <Dependencies />. Recording them as edges is
-                // what lets a bundle that names only a toolkit app learn, from the package's own
-                // manifest once the test set is on disk, that it needs the platform set too;
-                // without System.app the toolkit's source compile dies (EMIT-ZERO). Same walk,
-                // same round order as every other edge here; no hand rule.
-                foreach (var floor in AlRunner.AppLoader.ImplicitRoots(manifest))
-                {
-                    if (string.Equals(floor.Name, manifest.Name, StringComparison.OrdinalIgnoreCase)) continue;
-                    if (!deps.Any(x => string.Equals(x, floor.Name, StringComparison.OrdinalIgnoreCase)))
-                        deps.Add(floor.Name);
-                }
+                // compiler injects (Microsoft/System, Microsoft/Application). Library Assert
+                // declares Platform="28.0.0.0" and an empty <Dependencies />, so without this
+                // edge a bundle naming only it never learns it needs the platform set, downloads
+                // the test set alone, and the toolkit's source compile dies (EMIT-ZERO).
+                // Trap: skipped for the Microsoft platform apps themselves, matching
+                // DependencyResolver.Visit's guard — their manifests reference each other
+                // (Application -> Base Application -> Application ...), and a graph the resolver
+                // does not walk would make provisioning fetch a set resolution never asks for.
+                if (!AlRunner.DependencyResolver.IsMicrosoftPlatformApp(manifest.Name, manifest.Publisher))
+                    foreach (var floor in AlRunner.AppLoader.ImplicitRoots(manifest))
+                        if (!deps.Any(x => string.Equals(x, floor.Name, StringComparison.OrdinalIgnoreCase)))
+                            deps.Add(floor.Name);
                 edges[manifest.Name] = deps;
             }
         }

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -1048,6 +1048,20 @@ public static class ProvisioningCheck
                     if (!deps.Any(x => string.Equals(x, d.Name, StringComparison.OrdinalIgnoreCase)))
                         deps.Add(d.Name);
                 }
+                // #3719: a package's Platform / Application floors are dependencies the real `al`
+                // compiler injects (Microsoft/System, Microsoft/Application), and Microsoft's
+                // test-toolkit packages declare NOTHING else — Library Assert's manifest is
+                // Platform="28.0.0.0" with an empty <Dependencies />. Recording them as edges is
+                // what lets a bundle that names only a toolkit app learn, from the package's own
+                // manifest once the test set is on disk, that it needs the platform set too;
+                // without System.app the toolkit's source compile dies (EMIT-ZERO). Same walk,
+                // same round order as every other edge here; no hand rule.
+                foreach (var floor in AlRunner.AppLoader.ImplicitRoots(manifest))
+                {
+                    if (string.Equals(floor.Name, manifest.Name, StringComparison.OrdinalIgnoreCase)) continue;
+                    if (!deps.Any(x => string.Equals(x, floor.Name, StringComparison.OrdinalIgnoreCase)))
+                        deps.Add(floor.Name);
+                }
                 edges[manifest.Name] = deps;
             }
         }


### PR DESCRIPTION
## Summary

A bundle depending on Microsoft's `Library Assert` failed before any test ran:

```
[dep-load-fail] Microsoft_Library Assert v28.1.49838.54169: EMIT-ZERO - BC Compilation.Emit() returned 0 sources
FATAL: dependency compile failed - cannot continue.
```

Reproduced with the reporter's actual fixture, LethAL's `fixtures/sandbox-data` (31 files) + `sandbox-data-tests`. Six earlier probes with my own manifests did not reproduce it; the difference was one thing: the fixture's manifests declare **neither `platform` nor `application`** (AL requires neither). `BCCOMPILER_DIAG=1` names what BC saw while compiling Library Assert:

```
AL0791 … LibraryAssert.Codeunit.al@8:14: The namespace 'Reflection' is unknown.
AL0185 … LibraryAssert.Codeunit.al@345:18: Table 'Field' is missing
emit-crash: Codeunit System.TestLibraries.Utilities."Library Assert" :: TypeOf(Variant) (Unexpected value 'None' of type NavTypeKind)
```

`System.app` was not in the closure. Library Assert's own manifest declares `Platform="28.0.0.0"` and an empty `<Dependencies />`; `DependencyResolver.Visit` followed only `<Dependencies>`, and with no consumer-side `platform` root either, nothing ever asked for `System`. Adding `"platform": "28.0.0.0"` to the consumer manifests alone made the fixture pass, 66 tests; `runtime` and the `.alpackages` contents were irrelevant (three variants measured). Same shape as #2131's first problem.

## Fix

Three places, one root cause: a package's `Platform`/`Application` floors are dependencies, and only the consumer's were ever treated as such.

- **Resolution** (`AlRunner/DependencyResolver.cs`): after a resolved package's `<Dependencies>`, `Visit` follows its own floors through `AppLoader.ImplicitRoots`, for packages that are not themselves Microsoft platform apps. That guard is the trap `ImplicitRoots`' doc comment named: the platform apps' manifests reference each other (Application → Base Application → Application …) and would cycle. The roots stay `Optional`, so a missing `System.app` still skips rather than failing — see "Not fixed here".
- **Provisioning** (`AlRunner/Infrastructure/ProvisioningCheck.ScanDependencyEdges`): the same floors are recorded as edges to `System`/`Application`, behind the same platform-app guard, so both halves walk one graph. A bundle naming only a toolkit app then learns the platform need from the package's real manifest in the ordinary second round (test-apps, re-decide, platform-apps; the order `Program.cs` already runs for #2103) instead of downloading the test set alone and failing on the first run. With nothing on disk the answer stays "no platform need", exactly as for every other edge-derived need, so the existing tests pinning that stand unchanged. A first version added `needsTest ⇒ System` to `DetermineManifestNeeds` instead; it broke six tests that pin the derive-from-disk design and was replaced by the edge.
- **Synthesized packages** (`AlRunner/Infrastructure/InProcessAppPackager.cs`): `BuildNavxManifestXml` wrote no floor attributes and filters `<Dependencies>` to non-`Optional` entries, which is exactly where the implicit floors live — so a sibling app the runner packages from source lost the floors its own app.json declared, and the resolver had nothing to follow. #3719's shape on a path the runner manufactures itself. `BundleIdentity` now carries them and the manifest writes them as `App` attributes, where `AppLoader` reads them.

## Proof

- `DependencyResolverTests`: a package declaring `Platform` pulls `System` into the closure, ordered before it (RED: `["Library Assert"]`, GREEN: `["System", "Library Assert"]`); one declaring `Application` pulls `Application` in, so an implementation handling `Platform` alone fails; a Microsoft platform app's own floor is not followed and raises no cycle; `System` absent resolves the package alone; a package synthesized from an app.json with both floors round-trips them through `EmitAppPackageToFile` and `AppLoader.ReadManifest`.
- `ManifestDependencyEdgeScanTests`: a package with `Platform="28.0.0.0"` records the edge `["System"]`; one with both floors records `["Library Assert", "Application", "System"]`; a platform app's own floor is recorded in neither direction (`System`'s self-pointing one, `Base Application`'s cross-pointing one); a Library-Assert-shaped package on disk makes a bundle naming only it require exactly `["System"]`.
- `ProvisioningCheckTests`: the need through a synthetic `Library Assert → System` edge (RED: `NeedsPlatformApps` false).
- `LibraryAssertPlatformlessConsumerTests` spawns the runner on the exact shape: two bundles with no `platform`/`application`, the tests app depending on Library Assert, provisioning off, the provisioned `test-apps` and `platform-apps` directories passed as package caches. RED: `EMIT-ZERO`, exit 1, no test ran. GREEN: the `Assert.AreEqual` test passes, exit 0. Both directories come from ONE provisioned location, never mixed across versions; absent, it fails on CI (where both sets are provisioned) and skips locally.

Measured locally on Windows, BC 28.1.49838.54169: 212 facts across the touched classes, all green, no skips. LethAL's real fixture pair through the rebuilt runner: `[dep] Microsoft/System 28.0.54265.0` now precedes Library Assert in the closure, 66 of 66 tests pass, exit 0.

**Blast radius, measured.** Nearly every Microsoft test-apps package declares a floor — surveyed on a real 28.1 `test-apps` directory, 110 packages, every one `Platform="28.0.0.0"` and most also `Application="28.1.0.0"` — so closures can now gain `System` and `Application`. A probe bundle depending on `Tests-TestLibraries` resolves 13 packages including both; `System` is recognised as the symbol-only platform app and skipped by the loader rather than source-compiled, and `Application` resolves through the same platform-app path a consumer-declared `application` root has always used. The provisioning consequence: such a bundle may now fetch the curated platform set (~135 MB) on a cold box where it previously fetched only the test set and then failed to compile.

## Not fixed here

Filed as **#3794**, from the same review, each verified in the code and none a regression from this PR:

- Provisioning ignores floors on **non-Microsoft** packages while resolution follows them, so an ISV package declaring `Platform` can reach the same generic failure. Letting the need walk start at non-Microsoft roots changes which bundles report `NeedsPlatformApps` far beyond this bug, and needs its own measurement.
- The floor **version** is discarded: the scan records only the target name, and `Visit`'s `Optional || IsMicrosoftPlatformApp` check returns before the version-mismatch branch, so a below-floor `System.app` is skipped in silence. That ordering predates this PR and applies to every platform app.
- When a floor genuinely cannot be supplied the loader still prints a generic `EMIT-ZERO`, naming neither the floor nor the missing package nor the searched directories. `ResolvedPackageDeclaringPlatform_SystemAbsent_ResolvesThePackageAlone` pins today's behaviour and is the test to invert.
- Nearby: `EnsurePlatformAppsProvisioned` returns `void` and never re-checks `RequiredPlatformApps` after downloading, so explicit `al-runner provision` can exit 0 with `System.app` still absent.

Also: #2131 closed on 2026-08-30 as no longer reproducing; its reproducer had `platform` in the manifest, which is why. This is its remaining half.

## Review history

An external adversarial review (GPT-5.6) found the synthesized-package gap, the two-graph asymmetry between resolution and the edge scan, the missing `Application`-floor coverage, and a CI-skip in the new integration test that would have hidden a broken leg; all fixed in the second commit. Its three remaining findings are #3794 above, with the reasons they are not folded. Its blast-radius question is answered by the measurement above rather than by argument.

Closes #3719

Corpus-NA: the claims here are about `al`'s manifest-floor injection and Microsoft's shipped package manifests, both measured directly off the packages on disk; a service-tier corpus run executes AL and can observe neither, so there is nothing for it to adjudicate.

*Opened by an agent (Claude Code) in a session run by @SShadowS.*

https://claude.ai/code/session_01JFQZHC5SEHnLxkc5USksaK
