### PR TITLE
fix(cli): write stdout as UTF-8, so a redirected consumer reads the bytes the runner wrote

### DIFF
--- a/AlRunner.Tests/ConsoleOutputEncodingTests.cs
+++ b/AlRunner.Tests/ConsoleOutputEncodingTests.cs
@@ -75,13 +75,15 @@ public sealed class ConsoleOutputEncodingTests : IDisposable
 
     /// <summary>Runs the runner with stdout redirected and returns the RAW bytes — never a
     /// decoded string, because the decode is the thing under test.</summary>
-    private byte[] RunAndCaptureRawStdout(params string[] extraArgs)
+    private byte[] RunAndCaptureRawStdout(params string[] extraArgs) =>
+        RunAndCaptureRawStdout(withBundle: true, extraArgs);
+
+    private byte[] RunAndCaptureRawStdout(bool withBundle, params string[] extraArgs)
     {
         var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
-        args.Append(TestBuildConfig.BcVersionArg);
-        args.Append(" --no-auto-provision");
+        if (withBundle) args.Append(TestBuildConfig.BcVersionArg).Append(" --no-auto-provision");
         foreach (var a in extraArgs) args.Append(' ').Append(a);
-        args.Append(" \"").Append(Path.Combine(_root, "bundle")).Append('"');
+        if (withBundle) args.Append(" \"").Append(Path.Combine(_root, "bundle")).Append('"');
         var psi = new ProcessStartInfo
         {
             FileName = "dotnet", Arguments = args.ToString(),
@@ -113,12 +115,43 @@ public sealed class ConsoleOutputEncodingTests : IDisposable
 
         var raw = RunAndCaptureRawStdout();
 
-        var text = Encoding.UTF8.GetString(raw);
-        Assert.Contains("suites", text, StringComparison.Ordinal);
+        AssertStrictUtf8NoBom(raw);
         // The exact bytes, not a decoded comparison: 0xE2 0x80 0x94 is U+2014 in UTF-8.
-        Assert.Contains("— 1 suites", text, StringComparison.Ordinal);
         Assert.True(Contains(raw, new byte[] { 0xE2, 0x80, 0x94 }),
             "no UTF-8 em dash in the runner's redirected stdout:\n" + Preview(raw));
+        Assert.Contains("— 1 suites", Encoding.UTF8.GetString(raw), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// `--help` and `--guide` return before almost everything else, and CliText opens both
+    /// with an em dash. A fix placed after those fast paths would leave exactly the output a
+    /// new user sees first still transliterated — which is where this one was until the PR
+    /// #3795 review pointed at it. Needs no BC artifacts, so it is not a SkippableFact.
+    /// </summary>
+    [Fact]
+    public void HelpAndGuide_AreAlsoUtf8_BeforeAnyFastPathReturns()
+    {
+        foreach (var flag in new[] { "--help", "--guide" })
+        {
+            var raw = RunAndCaptureRawStdout(withBundle: false, flag);
+            AssertStrictUtf8NoBom(raw);
+            Assert.True(Contains(raw, new byte[] { 0xE2, 0x80, 0x94 }),
+                $"no UTF-8 em dash in `{flag}` output:\n" + Preview(raw));
+        }
+    }
+
+    /// <summary>
+    /// Strict decode, so a malformed sequence ANYWHERE in the stream fails rather than only
+    /// at the one line an assertion happens to name; plus no BOM, which a byte-exact consumer
+    /// of `--output-json` or the NDJSON protocol would otherwise have to strip.
+    /// </summary>
+    private static void AssertStrictUtf8NoBom(byte[] raw)
+    {
+        Assert.False(raw.Length >= 3 && raw[0] == 0xEF && raw[1] == 0xBB && raw[2] == 0xBF,
+            "stdout begins with a UTF-8 BOM:\n" + Preview(raw));
+        var strict = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+        var ex = Record.Exception(() => strict.GetString(raw));
+        Assert.True(ex == null, $"stdout is not valid UTF-8 ({ex?.Message}):\n" + Preview(raw));
     }
 
     /// <summary>
@@ -136,8 +169,8 @@ public sealed class ConsoleOutputEncodingTests : IDisposable
 
         var raw = RunAndCaptureRawStdout($"--out \"{outPath}\"");
 
-        var text = Encoding.UTF8.GetString(raw);
-        Assert.Contains("Classification → ", text, StringComparison.Ordinal);
+        AssertStrictUtf8NoBom(raw);
+        Assert.Contains("Classification → ", Encoding.UTF8.GetString(raw), StringComparison.Ordinal);
         Assert.False(Array.IndexOf(raw, (byte)0x1A) >= 0,
             "0x1A (SUB) in stdout — a character was dropped by the console codec:\n" + Preview(raw));
     }
@@ -154,6 +187,14 @@ public sealed class ConsoleOutputEncodingTests : IDisposable
         return false;
     }
 
-    private static string Preview(byte[] raw) =>
-        Encoding.UTF8.GetString(raw, 0, Math.Min(raw.Length, 3000));
+    private static string Preview(byte[] raw)
+    {
+        var head = Encoding.UTF8.GetString(raw, 0, Math.Min(raw.Length, 3000));
+        // A host that could not reconfigure its own console is the other explanation for a red
+        // run here, and it is not the runner's fault — say so rather than leaving the reader to
+        // infer it from an output that looks fine.
+        return SpawnedRunnerEncoding.Problem is { } p
+            ? $"(the TEST HOST could not set its console encoding: {p})\n{head}"
+            : head;
+    }
 }

--- a/AlRunner.Tests/ConsoleOutputEncodingTests.cs
+++ b/AlRunner.Tests/ConsoleOutputEncodingTests.cs
@@ -1,0 +1,159 @@
+// ConsoleOutputEncodingTests — #3738: the runner's non-ASCII console output is transliterated
+// away when stdout is redirected on Windows, so every consumer that parses it — a CI log, a
+// test, LethAL — reads different bytes from the ones the runner wrote.
+//
+// Measured on this box (Windows 11, ANSI cp1252, OEM cp850). A redirected child's stdout
+// defaults to the OEM code page, and .NET's encoder silently best-fits what that page lacks:
+//
+//   U+2014 —  em dash    -> 0x2D '-'
+//   U+2192 →  arrow      -> 0x1A     (SUB, a control character — not a rendering of anything)
+//   U+2026 …  ellipsis   -> 0x2E '.'
+//   U+2500 ─  box line   -> 0xC4     (survives; cp850 has it)
+//
+// The runner writes all four (13 Console.Write* statements). The arrow is the one that matters
+// beyond cosmetics: 0x1A is data loss, and it lands in `Classification → <path>` and
+// `JUnit XML → <path>`, two lines a consumer reads to find an output file.
+//
+// It surfaced as SuiteEnumerationTests failing on Windows only: its regex matched the em dash
+// the runner writes, and the test host read back a hyphen. That test's own fix is not to depend
+// on typography (see SuiteEnumerationTests' suite-count reader); this class pins the runner
+// side, which is what makes the bytes a consumer sees the bytes the runner wrote.
+
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ConsoleOutputEncodingTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private readonly string _root;
+
+    public ConsoleOutputEncodingTests()
+    {
+        _root = TestScratch.Dir("al-runner-console-encoding");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private void WriteBundle(string dir)
+    {
+        Directory.CreateDirectory(dir);
+        // No "application" property — see .claude/rules/no-base-app-in-csharp-tests.md.
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "5a3f0b11-3738-4a02-8002-000000003738",
+          "name": "COE Probe",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 63950, "to": 63959 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "T.Codeunit.al"), """
+        codeunit 63950 "COE Probe Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure Trivial()
+            begin
+            end;
+        }
+        """);
+    }
+
+    /// <summary>Runs the runner with stdout redirected and returns the RAW bytes — never a
+    /// decoded string, because the decode is the thing under test.</summary>
+    private byte[] RunAndCaptureRawStdout(params string[] extraArgs)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" --no-auto-provision");
+        foreach (var a in extraArgs) args.Append(' ').Append(a);
+        args.Append(" \"").Append(Path.Combine(_root, "bundle")).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        using var p = Process.Start(psi)!;
+        using var stdout = new MemoryStream();
+        var copy = p.StandardOutput.BaseStream.CopyToAsync(stdout);
+        var errTask = p.StandardError.BaseStream.CopyToAsync(Stream.Null);
+        if (!p.WaitForExit(600_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        copy.GetAwaiter().GetResult();
+        errTask.GetAwaiter().GetResult();
+        return stdout.ToArray();
+    }
+
+    /// <summary>
+    /// RED on Windows before the fix: the per-bundle "— N suites" line arrived as
+    /// <c>- N suites</c>, the em dash best-fitted to 0x2D by cp850. GREEN: the bytes are the
+    /// UTF-8 encoding of the character the runner wrote. Green on Linux either way, where the
+    /// default is already UTF-8 — the point is that a consumer no longer has to know which.
+    /// </summary>
+    [SkippableFact]
+    public void RedirectedStdout_IsUtf8_SoAnEmDashSurvives()
+    {
+        TestArtifacts.SkipIfMissing();
+        WriteBundle(Path.Combine(_root, "bundle"));
+
+        var raw = RunAndCaptureRawStdout();
+
+        var text = Encoding.UTF8.GetString(raw);
+        Assert.Contains("suites", text, StringComparison.Ordinal);
+        // The exact bytes, not a decoded comparison: 0xE2 0x80 0x94 is U+2014 in UTF-8.
+        Assert.Contains("— 1 suites", text, StringComparison.Ordinal);
+        Assert.True(Contains(raw, new byte[] { 0xE2, 0x80, 0x94 }),
+            "no UTF-8 em dash in the runner's redirected stdout:\n" + Preview(raw));
+    }
+
+    /// <summary>
+    /// The half that is not cosmetic. U+2192 has no cp850 representation at all, so the encoder
+    /// emits 0x1A (SUB) — a control character, in `Classification → &lt;path&gt;` and
+    /// `JUnit XML → &lt;path&gt;`, both of which name a file a consumer goes on to read. No
+    /// control byte may appear in the runner's stdout.
+    /// </summary>
+    [SkippableFact]
+    public void RedirectedStdout_CarriesNoSubstituteControlBytes()
+    {
+        TestArtifacts.SkipIfMissing();
+        WriteBundle(Path.Combine(_root, "bundle"));
+        var outPath = Path.Combine(_root, "classification.json");
+
+        var raw = RunAndCaptureRawStdout($"--out \"{outPath}\"");
+
+        var text = Encoding.UTF8.GetString(raw);
+        Assert.Contains("Classification → ", text, StringComparison.Ordinal);
+        Assert.False(Array.IndexOf(raw, (byte)0x1A) >= 0,
+            "0x1A (SUB) in stdout — a character was dropped by the console codec:\n" + Preview(raw));
+    }
+
+    private static bool Contains(byte[] haystack, byte[] needle)
+    {
+        for (int i = 0; i + needle.Length <= haystack.Length; i++)
+        {
+            var hit = true;
+            for (int j = 0; j < needle.Length; j++)
+                if (haystack[i + j] != needle[j]) { hit = false; break; }
+            if (hit) return true;
+        }
+        return false;
+    }
+
+    private static string Preview(byte[] raw) =>
+        Encoding.UTF8.GetString(raw, 0, Math.Min(raw.Length, 3000));
+}

--- a/AlRunner.Tests/SpawnedRunnerEncoding.cs
+++ b/AlRunner.Tests/SpawnedRunnerEncoding.cs
@@ -1,0 +1,47 @@
+// SpawnedRunnerEncoding — the test host decodes a spawned runner's stdout as UTF-8, which is
+// what the runner writes (#3738, Program.cs's console-encoding block).
+//
+// 158 classes in this assembly spawn the runner with RedirectStandardOutput and read it as
+// text. None sets ProcessStartInfo.StandardOutputEncoding, and it does not need to: .NET falls
+// back to the PARENT's Console.OutputEncoding when that property is null. Measured on this box
+// (Windows 11, OEM cp850), with a child that writes "— em dash, → arrow" as UTF-8:
+//
+//   host default, no StandardOutputEncoding        dash-ok=False arrow-ok=False
+//   host=UTF8,    no StandardOutputEncoding        dash-ok=True  arrow-ok=True
+//   host=UTF8,    StandardOutputEncoding=UTF8      dash-ok=True  arrow-ok=True
+//
+// So one setting here covers every spawn site, and no per-call plumbing is needed. Without it,
+// on Windows only, every assertion comparing captured output against a non-ASCII character the
+// runner writes reads mojibake and fails — the reported symptom in SuiteEnumerationTests, and
+// the same latent failure in BackupReaderFailureReportingTests, BundleFailureStageTests,
+// CleanRunStartupVerbosityTests, CollateralFailureReportingTests and ExecFailureTests. CI is
+// Linux, where both ends already default to UTF-8, which is why none of them was ever red there.
+//
+// A [ModuleInitializer], like BcEngineBootstrap's, because it must run before any test spawns
+// anything. Failure is tolerated and reported rather than fatal: a test host whose stdout
+// handle refuses reconfiguration should still run the suite, and only the non-ASCII assertions
+// would then behave as they did before.
+
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace AlRunner.Tests;
+
+internal static class SpawnedRunnerEncoding
+{
+    /// <summary>Null when the encoding was set; the failure's message otherwise.</summary>
+    internal static string? Problem { get; private set; }
+
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        try
+        {
+            Console.OutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        }
+        catch (Exception ex) when (ex is IOException or PlatformNotSupportedException or ArgumentException)
+        {
+            Problem = $"{ex.GetType().Name}: {ex.Message}";
+        }
+    }
+}

--- a/AlRunner.Tests/SpawnedRunnerEncoding.cs
+++ b/AlRunner.Tests/SpawnedRunnerEncoding.cs
@@ -18,9 +18,16 @@
 // Linux, where both ends already default to UTF-8, which is why none of them was ever red there.
 //
 // A [ModuleInitializer], like BcEngineBootstrap's, because it must run before any test spawns
-// anything. Failure is tolerated and reported rather than fatal: a test host whose stdout
-// handle refuses reconfiguration should still run the suite, and only the non-ASCII assertions
-// would then behave as they did before.
+// anything; neither initializer depends on the other, so their order does not matter. Failure
+// is tolerated rather than fatal — a test host whose stdout handle refuses reconfiguration
+// should still run the suite — and recorded in Problem, which the encoding facts print when
+// they fail, so a red run on such a host says why rather than looking like the runner's fault.
+//
+// This does change the test host's own console output code page on Windows, which is process-
+// global. It does NOT make the encoding facts circular: with the production block removed and
+// this initializer left installed, both facts in ConsoleOutputEncodingTests still FAIL
+// (measured for the PR #3795 review), because the child sets its own encoding rather than
+// inheriting the parent's code page.
 
 using System.Runtime.CompilerServices;
 using System.Text;

--- a/AlRunner.Tests/SuiteEnumerationTests.cs
+++ b/AlRunner.Tests/SuiteEnumerationTests.cs
@@ -121,13 +121,20 @@ public sealed class SuiteEnumerationTests : IDisposable
     }
 
     /// <summary>
-    /// Reads the per-bundle "— N suites" line. This is the number under test: a
-    /// directory of suites is still ONE bundle (one "bucket"), but must enumerate
+    /// Reads the per-bundle "[i/N] &lt;path&gt; — N suites" line. This is the number under
+    /// test: a directory of suites is still ONE bundle (one "bucket"), but must enumerate
     /// every suite inside it. Asserting on the bucket count would prove nothing.
+    /// <para>
+    /// Anchored on the "N suites" tail, NOT on the em dash before it. #3738: the runner's
+    /// stdout used to be transliterated by the console's code page when redirected, so on
+    /// Windows this line arrived with a hyphen and both facts below failed while enumeration
+    /// was correct. ConsoleOutputEncodingTests pins the runner side; this reader no longer
+    /// depends on the typography either way.
+    /// </para>
     /// </summary>
     private static int SuiteCount(string output)
     {
-        var m = System.Text.RegularExpressions.Regex.Match(output, @"—\s*(\d+)\s*suites");
+        var m = System.Text.RegularExpressions.Regex.Match(output, @"\]\s+\S.*?\s(\d+)\s+suites\b");
         Assert.True(m.Success, $"run output had no suite count line. Output:\n{output}");
         return int.Parse(m.Groups[1].Value);
     }

--- a/AlRunner/Infrastructure/ParallelFanOut.cs
+++ b/AlRunner/Infrastructure/ParallelFanOut.cs
@@ -305,6 +305,13 @@ internal static class ParallelFanOut
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
+                // #3738: a worker writes UTF-8, so decode UTF-8 — do not inherit whatever this
+                // parent's console happens to be. Leaving these null works only while the
+                // parent's own OutputEncoding assignment succeeded; if it took the documented
+                // degradation path while a worker's succeeded, the parent would decode a
+                // worker's UTF-8 as its old code page and reprint mojibake (PR #3795 review).
+                StandardOutputEncoding = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                StandardErrorEncoding = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
             };
             foreach (var kv in WorkerEnvironment(
                          Environment.ProcessorCount, shards.Count,

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -33,6 +33,38 @@ if (Environment.GetEnvironmentVariable("AL_RUNNER_DIAG_FIRSTCHANCE") is string f
     };
 }
 
+// ── stdout and stderr speak UTF-8, on every platform and whether or not they are
+// redirected. #3738: a redirected child's console defaults to the OEM code page on Windows,
+// and .NET's encoder silently best-fits whatever that page lacks — on a cp1252 box (cp850)
+// the four non-ASCII characters this program writes become 0x2D, 0x1A, 0x2E and 0xC4. The
+// 0x1A is the one that is not cosmetic: it stands for nothing, and it lands in
+// `Classification → <path>` and `JUnit XML → <path>`, two lines a consumer reads to find an
+// output file. So the bytes a caller read were not the bytes this program wrote, and which
+// substitution it got depended on the box's code page. The measurements are in the PR for
+// #3738; ConsoleOutputEncodingTests pins the contract.
+//
+// FIRST, before PhaseLog.Install and before the --help / --guide / --version fast paths:
+// each of those writes non-ASCII (CliText's headers) and returns, so a block placed after
+// them would leave exactly the outputs a new user sees first still transliterated.
+//
+// Only OutputEncoding. Setting Console.InputEncoding would change what `--server` decodes
+// its inbound NDJSON as — an unannounced protocol change with no bearing on this defect, so
+// it stays out (PR #3795 review). `--dap stdio` is unaffected either way: it opens the raw
+// streams and DapTransport encodes its own bytes.
+//
+// A handle that refuses reconfiguration is not a reason to refuse to run: the failure is
+// named on stderr and output falls back to the platform default, transliterated as before.
+try
+{
+    Console.OutputEncoding = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine(
+        $"[warn] could not set the console output encoding to UTF-8 ({ex.GetType().Name}: {ex.Message}); "
+        + "non-ASCII output may be transliterated by this console's code page (#3738).");
+}
+
 // Opt-in per-bundle / per-process cost instrumentation (issue #1825). Installed
 // before the --help / --guide / --version fast paths on purpose: those return
 // before any BC type loads, so their rows measure the bare process floor (host
@@ -96,33 +128,6 @@ if (args.Contains("--bc-version") && args.Contains("--artifact-path"))
 // it: 2076/2076 corpus fail-set unchanged, one cached test 9.50s -> 8.61s warm. See
 // AlRunner.Tests/StartupJitModeTests. Anyone needing the old behaviour can still preset
 // DOTNET_ReadyToRun=0 in the environment — the CLR honours it without our help.
-
-// ── stdout/stderr speak UTF-8, on every platform and whether or not they are redirected.
-// #3738: a redirected child's console defaults to the OEM code page on Windows (cp850 on a
-// cp1252 box), and .NET's encoder silently best-fits whatever that page lacks. Measured on
-// the four non-ASCII characters this program writes: `—` becomes 0x2D, `…` becomes 0x2E,
-// `─` survives, and `→` — which appears in `Classification → <path>` and `JUnit XML →
-// <path>`, two lines a consumer reads to find an output file — becomes 0x1A, a control
-// character standing for nothing. So the bytes a caller reads were not the bytes this
-// program wrote, and which substitution it got depended on the box's code page.
-//
-// Set before Log.Install and before any Console.Write, so every writer downstream (Log's
-// FilteredWriter, --server's captured stdout, the DAP stdio streams) inherits it. The
-// setter throws on a handle it cannot reconfigure (a closed or unusual stdout); that is not
-// a reason to refuse to run, so it degrades to the platform default and says so on stderr —
-// the output is then still readable, just transliterated as before.
-try
-{
-    var utf8NoBom = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-    Console.OutputEncoding = utf8NoBom;
-    Console.InputEncoding = utf8NoBom;
-}
-catch (Exception ex) when (ex is IOException or PlatformNotSupportedException or ArgumentException)
-{
-    Console.Error.WriteLine(
-        $"[warn] could not set the console encoding to UTF-8 ({ex.GetType().Name}: {ex.Message}); "
-        + "non-ASCII output may be transliterated by this console's code page (#3738).");
-}
 
 // ── --server mode: long-running JSON-RPC daemon over stdin/stdout (the VS Code
 // extension depends on this flag). The protocol requires stdout to carry ONLY the

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -97,6 +97,33 @@ if (args.Contains("--bc-version") && args.Contains("--artifact-path"))
 // AlRunner.Tests/StartupJitModeTests. Anyone needing the old behaviour can still preset
 // DOTNET_ReadyToRun=0 in the environment — the CLR honours it without our help.
 
+// ── stdout/stderr speak UTF-8, on every platform and whether or not they are redirected.
+// #3738: a redirected child's console defaults to the OEM code page on Windows (cp850 on a
+// cp1252 box), and .NET's encoder silently best-fits whatever that page lacks. Measured on
+// the four non-ASCII characters this program writes: `—` becomes 0x2D, `…` becomes 0x2E,
+// `─` survives, and `→` — which appears in `Classification → <path>` and `JUnit XML →
+// <path>`, two lines a consumer reads to find an output file — becomes 0x1A, a control
+// character standing for nothing. So the bytes a caller reads were not the bytes this
+// program wrote, and which substitution it got depended on the box's code page.
+//
+// Set before Log.Install and before any Console.Write, so every writer downstream (Log's
+// FilteredWriter, --server's captured stdout, the DAP stdio streams) inherits it. The
+// setter throws on a handle it cannot reconfigure (a closed or unusual stdout); that is not
+// a reason to refuse to run, so it degrades to the platform default and says so on stderr —
+// the output is then still readable, just transliterated as before.
+try
+{
+    var utf8NoBom = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+    Console.OutputEncoding = utf8NoBom;
+    Console.InputEncoding = utf8NoBom;
+}
+catch (Exception ex) when (ex is IOException or PlatformNotSupportedException or ArgumentException)
+{
+    Console.Error.WriteLine(
+        $"[warn] could not set the console encoding to UTF-8 ({ex.GetType().Name}: {ex.Message}); "
+        + "non-ASCII output may be transliterated by this console's code page (#3738).");
+}
+
 // ── --server mode: long-running JSON-RPC daemon over stdin/stdout (the VS Code
 // extension depends on this flag). The protocol requires stdout to carry ONLY the
 // newline-delimited JSON — so capture the real stdin/stdout now and redirect ALL


### PR DESCRIPTION
## Summary

`SuiteEnumerationTests` fails on Windows while enumeration is correct: its regex matches the em dash the runner writes in `[i/N] <path> — N suites`, and the test host reads back a hyphen.

Measuring it found a wider defect than the issue described. A redirected child's console defaults to the **OEM** code page on Windows — cp850 on this cp1252 box — and .NET's encoder silently best-fits whatever that page lacks. The four non-ASCII characters this program writes, across 13 `Console.Write*` statements:

| character | cp850 result |
|---|---|
| `—` U+2014 em dash | `0x2D` `-` |
| `→` U+2192 arrow | `0x1A` (SUB, a control character standing for nothing) |
| `…` U+2026 ellipsis | `0x2E` `.` |
| `─` U+2500 box line | `0xC4` (survives) |

The arrow is the half that is not cosmetic. It appears in `Classification → <path>` and `JUnit XML → <path>`, two lines a consumer reads to find an output file. So the bytes a caller read were not the bytes the runner wrote, and which substitution it got depended on the box's code page. Confirmed against the raw redirected bytes: no `0x97`, no UTF-8 em dash, the transliteration had already happened before anything read it.

## Fix

Both ends of the same contract.

- **The runner writes UTF-8** (`AlRunner/Program.cs`): `Console.OutputEncoding` is set first, above `PhaseLog.Install` and above the `--help` / `--guide` / no-argument fast paths — each of those writes CliText's em-dash header and returns, so a block placed after them would leave exactly the output a new user sees first still transliterated. A handle that refuses reconfiguration degrades to the platform default with a named warning rather than refusing to run.
- **The test host decodes UTF-8** (`AlRunner.Tests/SpawnedRunnerEncoding.cs`): one `Console.OutputEncoding` setting in a `[ModuleInitializer]`, not 158 per-`ProcessStartInfo` changes. .NET falls back to the **parent's** `Console.OutputEncoding` when `StandardOutputEncoding` is null, which I measured rather than assumed, with a child writing `— em dash, → arrow` as UTF-8:

```
host default, no StandardOutputEncoding     dash-ok=False arrow-ok=False
host=UTF8,    no StandardOutputEncoding     dash-ok=True  arrow-ok=True
host=UTF8,    StandardOutputEncoding=UTF8   dash-ok=True  arrow-ok=True
```

That one setting also clears the same latent Windows-only failure in `BackupReaderFailureReportingTests`, `BundleFailureStageTests`, `CleanRunStartupVerbosityTests`, `CollateralFailureReportingTests` and `ExecFailureTests` — 109 test lines compare captured output against one of these characters. None was ever red on CI, because CI is Linux, where both ends already default to UTF-8.

- **`ParallelFanOut` decodes its workers explicitly**, rather than inheriting the parent's console. Leaving those properties null worked only while the parent's own assignment had succeeded; had the parent taken the degradation path while a worker's succeeded, the parent would decode a worker's UTF-8 as its old code page and reprint mojibake.

`SuiteEnumerationTests`' own suite-count reader is anchored on the `N suites` tail instead of the dash, so it no longer depends on the typography either way.

**`Console.InputEncoding` is deliberately not set.** It has no bearing on a stdout defect, and setting it changed what `--server` decodes its inbound NDJSON as — an unannounced protocol change. `--dap stdio` never depended on it: it opens the raw streams and `DapTransport` encodes its own bytes.

## Proof

`AlRunner.Tests/ConsoleOutputEncodingTests.cs` captures the runner's **raw** redirected stdout bytes — never a decoded string, because the decode is the thing under test. Every fact additionally decodes with `throwOnInvalidBytes`, so a malformed sequence anywhere in the stream fails rather than only at the line an assertion names, and rejects a leading BOM.

- `RedirectedStdout_IsUtf8_SoAnEmDashSurvives` asserts the bytes `E2 80 94` are present. RED before: absent.
- `RedirectedStdout_CarriesNoSubstituteControlBytes` runs with `--out` so `Classification → <path>` is emitted, and asserts no `0x1A` anywhere. RED before: present.
- `HelpAndGuide_AreAlsoUtf8_BeforeAnyFastPathReturns` covers the two fast paths and needs no BC artifacts. RED measured under the earlier block placement, GREEN once it moved above them.

**Not circular.** With the production block removed and `SpawnedRunnerEncoding` left installed, both original facts still FAIL — measured, because the child sets its own encoding rather than inheriting the parent's code page.

**Also measured, all clean:** no BOM on stdout; `--output-json` still starts with `{` and parses as UTF-8; a `--server` round trip returns three NDJSON lines that all parse; a run with stdin closed emits no warning.

153 facts across the affected classes pass, with one unrelated skip (`BackupReaderFailureReportingTests` needs a fixture this box lacks).

**Five pre-existing Windows failures were measured against pristine `origin/main`** — changed files reverted, new files moved aside, rebuilt — and all five fail there too, so they are untouched: `ProvisionExplicitModesTests.TestApps_OnlyUnrelatedAppPresent_DoesNotShortCircuit_DownloadsTheRealSet`, both of `ServerAffectedSelectionTests`' `AffectedOnly_` facts, `ServerAffectedSelectionMultiSourcePathsTests.AffectedOnly_CrossBundleCoverage_RunsOnlyTheTestThatCallsTheEditedHelper`, and `ServerAppVersionBumpTests.TwoDifferentDirectoriesSharingOneAppId_StillCollide`. Two further server tests failed once under a 247-test filter and passed in isolation and on a second run of the same tree, which is the load-dependent signal, not the code.

## What this changes for consumers

On Linux, nothing: both ends already defaulted to UTF-8. On Windows, **stdout and stderr** bytes change — from OEM-transliterated to UTF-8 — for every consumer that reads runner output as text. A consumer decoding UTF-8 now gets the characters the runner wrote; one that assumed the OEM page and relied on the transliteration would need to decode UTF-8 instead. That is the point of the change rather than a side effect, but it is a byte-level change and worth stating plainly.

No in-repo consumer requires OEM bytes: `tools/corpus-pass-count.py`, `.github/scripts/compare_corpus_count.py`, `scripts/ms-bucket-summary.py` and `tools/test_text_encoding.py` all decode UTF-8 explicitly, and the workflows capture bytes through `tee` on Ubuntu. Compatibility of LethAL and the separate VS Code extension is **not** established by this repository and is not claimed here.

## Review history

An external adversarial review (GPT-5.6) found no blocking protocol corruption and four should-fix items: the fast-path placement, the unnecessary `InputEncoding`, the fan-out's implicit decoding, and a circularity question about the test-host initializer. The first three are fixed in the second commit; the fourth is answered by the mutation measurement above.

Closes #3738

Corpus-NA: console encoding is a runner output contract; no BC behaviour is asserted, so there is nothing for a service tier to adjudicate.

*Opened by an agent (Claude Code) in a session run by @SShadowS.*

https://claude.ai/code/session_01JFQZHC5SEHnLxkc5USksaK
