### PR TITLE
test(metadata-equivalence): compare Report, PermissionSet, Enum and MetadataRuntimeDeltas, steps 5-8 of 8

### DIFF
--- a/AlRunner.Tests/MetadataEquivalenceHarness.cs
+++ b/AlRunner.Tests/MetadataEquivalenceHarness.cs
@@ -49,11 +49,17 @@ internal sealed record MetadataEquivalenceReport(
     IReadOnlyList<string> KindsNotCompared,
     int ObjectsCompared,
     IReadOnlyList<string> Unbuildable,
-    IReadOnlyList<MetadataDifference> Differences)
+    IReadOnlyList<MetadataDifference> Differences,
+    // Enum-rooted documents that are an enumEXTENSION's rather than a base enum's, and so have
+    // no runner object addressable by their own id. Reported rather than dropped: an object
+    // silently missing from the denominator is the one way a shrinking comparison stays green
+    // (#3782 step 7; the derivation gap is #3807).
+    IReadOnlyList<string> EnumExtensionDocuments)
 {
     public string Summary =>
         $"{Bundle.Label} (BC {Bundle.BcBuild}): compared {ObjectsCompared} object(s) of kind(s) " +
         $"[{string.Join(", ", KindsCompared)}]; NOT compared: [{string.Join(", ", KindsNotCompared)}]; " +
+        $"{EnumExtensionDocuments.Count} enum-extension document(s) skipped; " +
         $"{Differences.Count} difference(s) across {Differences.Select(d => d.Signature).Distinct().Count()} member(s)";
 }
 
@@ -111,7 +117,31 @@ internal static class MetadataEquivalenceHarness
     /// #3782 is the programme that empties the NOT-compared list, one kind per pull request.
     /// The order and remaining kinds are on that issue.
     /// </summary>
-    internal static readonly string[] ComparedKinds = { "CodeUnit", "MetaTable", "PageDefinition" };
+    internal static readonly string[] ComparedKinds =
+        { "MetaTable", "PageDefinition", "CodeUnit", "Report", "PermissionSet", "Enum" };
+
+    /// <summary>
+    /// Kinds a bundle carries that this harness has MEASURED it cannot compare non-circularly,
+    /// each with the issue recording the measurement. Distinct from "not got to yet": these are
+    /// closed questions, and the difference matters because an unmeasured kind is work and a
+    /// measured one is a finding.
+    ///
+    /// <para><c>MetadataRuntimeDeltas</c> is BC's emitted form of an EXTENSION object —
+    /// tableextension, pageextension, permissionsetextension — and the runner builds no
+    /// extension-shaped metadata object at all: it folds an extension's contribution into the
+    /// object being extended at parse time and keeps nothing addressable by the extension's own
+    /// id. There is also no BC reader for the shape: measured on BC 28.4.53241.54407, no type
+    /// in <c>Microsoft.Dynamics.Nav.Types</c> or <c>Microsoft.Dynamics.Nav.Ncl</c> has "Delta"
+    /// in its name, so neither side of the comparison exists. See #3809 and
+    /// docs/metadata-equivalence.md#metadataruntimedeltas.</para>
+    /// </summary>
+    internal static readonly IReadOnlyDictionary<string, string> UncomparableKinds =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["MetadataRuntimeDeltas"] =
+                "the runner builds no extension-shaped metadata object, and BC ships no reader " +
+                "for the shape — neither side of the comparison exists (#3809)",
+        };
 
     public static IReadOnlyList<GroundTruthBundle> LoadBundles(string root)
     {
@@ -218,8 +248,64 @@ internal static class MetadataEquivalenceHarness
                 "comparison would become a hand-written XML walk against the runner — two " +
                 "derivations, no oracle.");
 
+
+        // BC's own reader for a Report document: MetaReport(XmlElement, CreateRequestForm, int,
+        // int, RemoveItemsOnPageBasedOnLicenseAndApplicationArea). Both delegates are optional
+        // and null is what the ctor's own body expects.
+        //
+        // Proven to parse rather than assumed to, per step 1's finding: measured on BC
+        // 28.1.49838.53910 against the emitter's own Report 9810 "Change Password", it answers
+        // Id=9810, Name="Change Password", ProcessingOnly=True, DefaultLayout=RDLC,
+        // TransactionType=UpdateNoLocks and ALNamespace="System.Security.AccessControl".
+        // MetadataEquivalenceReportEnumPermissionSetOracleTests pins that it reads the document
+        // AND that it discriminates between two different ones.
+        var reportType =
+            Type.GetType("Microsoft.Dynamics.Nav.Types.Metadata.MetaReport, Microsoft.Dynamics.Nav.Types")
+            ?? throw new InvalidOperationException("MetaReport is not reachable.");
+        var reportFromXml = reportType.GetConstructors()
+                .FirstOrDefault(c => c.GetParameters() is { Length: 5 } ps
+                                     && ps[0].ParameterType == typeof(XmlElement))
+            ?? throw new InvalidOperationException(
+                "MetaReport has no (XmlElement, …) constructor. Without it there is no way to " +
+                "read BC's emitted Report document back into BC's own object model, and the " +
+                "comparison would become a hand-written XML walk against the runner — two " +
+                "derivations, no oracle.");
+
+        // BC's own reader for a PermissionSet document: a STATIC FACTORY taking the two
+        // app-group ids, not a constructor. Measured on the same build against PermissionSet 21
+        // "System Application - Read": Id=21, Name="SYSTEM APPLICATION - READ" (BC uppercases —
+        // see PermissionSetDiffOptions), Assignable=False, Access=Internal and
+        // IncludedPermissionSets[33].
+        var permissionSetType =
+            Type.GetType("Microsoft.Dynamics.Nav.Types.Metadata.MetaPermissionSet, Microsoft.Dynamics.Nav.Types")
+            ?? throw new InvalidOperationException("MetaPermissionSet is not reachable.");
+        var permissionSetFromXml = permissionSetType.GetMethod(
+                "Create", BindingFlags.Public | BindingFlags.Static)
+            ?? throw new InvalidOperationException(
+                "MetaPermissionSet has no static Create(XmlNode, int, int). Without it there is " +
+                "no way to read BC's emitted PermissionSet document back into BC's own object " +
+                "model, and the comparison would become a hand-written XML walk against the " +
+                "runner — two derivations, no oracle.");
+
+        // BC's own reader for an Enum document. Measured on the same build against Enum 59
+        // "Auto Format": Id=59, Name="Auto Format", Extensible=True, Values[2] and
+        // ALNamespace="System.Text" — so it parses, unlike MetaPageDefinition.
+        var enumType =
+            Type.GetType("Microsoft.Dynamics.Nav.Types.Metadata.MetaEnum, Microsoft.Dynamics.Nav.Types")
+            ?? throw new InvalidOperationException("MetaEnum is not reachable.");
+        var enumFromXml = enumType.GetConstructor(new[] { typeof(XmlNode) })
+            ?? throw new InvalidOperationException(
+                "MetaEnum has no (XmlNode) constructor. Without it there is no way to read BC's " +
+                "emitted Enum document back into BC's own object model, and the comparison would " +
+                "become a hand-written XML walk against the runner — two derivations, no oracle.");
+
+        // Built once per bundle, not per object: RunnerPermissionSetDeclarations drives the
+        // runner's own population, which is what makes IncludedPermissionSets resolvable at all.
+        IReadOnlyDictionary<int, BcAppSymbolCache.PermissionSetSymbol>? permissionSetsById = null;
+
         var differences = new List<MetadataDifference>();
         var unbuildable = new List<string>();
+        var enumExtensionDocuments = new List<string>();
         int compared = 0;
 
         foreach (var obj in bundle.Objects.Where(o => ComparedKinds.Contains(o.Kind, StringComparer.Ordinal))
@@ -263,6 +349,146 @@ internal static class MetadataEquivalenceHarness
                     var runnerDoc = new XmlDocument();
                     runnerDoc.LoadXml(runnerXml);
                     actual = codeunitFromXml.Invoke(new object?[] { runnerDoc.DocumentElement });
+            else if (obj.Kind == "Report")
+            {
+                objectKey = $"Report {obj.Id}";
+                try
+                {
+                    expected = reportFromXml.Invoke(new object?[] { document.DocumentElement, null, 0, 0, null });
+                }
+                catch (Exception ex)
+                {
+                    unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': BC's own MetaReport " +
+                                    $"constructor threw — {Describe(ex)}");
+                    continue;
+                }
+                if (expected is null)
+                {
+                    unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': BC's own MetaReport " +
+                                    "constructor produced null");
+                    continue;
+                }
+
+                try
+                {
+                    // The runner's own report-metadata document — the one every runner consumer
+                    // of report metadata reads (RunnerXmlMetadataLoader hands this XML to BC).
+                    // NOT AlReportMetadataRegistry, which holds BC's emit-captured output and
+                    // would compare BC against BC.
+                    var runnerXml = RecordPatches.TryBuildReportMetadataEquivalenceXml(obj.Id);
+                    if (runnerXml is null)
+                    {
+                        unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': no registered " +
+                                        "dependency declares this report, so the runner built no " +
+                                        "report metadata at all");
+                        continue;
+                    }
+                    var runnerDoc = new XmlDocument();
+                    runnerDoc.LoadXml(runnerXml);
+                    actual = reportFromXml.Invoke(new object?[] { runnerDoc.DocumentElement, null, 0, 0, null });
+                }
+                catch (Exception ex)
+                {
+                    unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': the runner threw — {Describe(ex)}");
+                    continue;
+                }
+            }
+            else if (obj.Kind == "PermissionSet")
+            {
+                objectKey = $"PermissionSet {obj.Id}";
+                try
+                {
+                    expected = permissionSetFromXml.Invoke(null, new object?[] { document.DocumentElement, 0, 0 });
+                }
+                catch (Exception ex)
+                {
+                    unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': BC's own " +
+                                    $"MetaPermissionSet.Create threw — {Describe(ex)}");
+                    continue;
+                }
+                if (expected is null)
+                {
+                    unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': BC's own " +
+                                    "MetaPermissionSet.Create produced null");
+                    continue;
+                }
+
+                permissionSetsById ??= RecordPatches.RunnerPermissionSetDeclarations();
+                if (!permissionSetsById.TryGetValue(obj.Id, out var declaration))
+                {
+                    unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': the runner has no " +
+                                    "permission-set declaration with that id");
+                    continue;
+                }
+
+                try
+                {
+                    // The runner's own MetaPermissionSet — the very object BC's
+                    // AssignFromMetaPermissionSet consumes at runtime, so both sides are
+                    // Types.Metadata.MetaPermissionSet and no rendering step is involved.
+                    actual = RecordPatches.BuildPermissionSetMetadataEquivalenceObject(declaration);
+                }
+                catch (Exception ex)
+                {
+                    unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': the runner threw — {Describe(ex)}");
+                    continue;
+                }
+            }
+            else if (obj.Kind == "Enum")
+            {
+                // One <Enum> root covers both Enum and EnumExtension — the generator's own
+                // ClassifyDocument says so, and it is deliberate. The two are told apart by
+                // SHAPE: a base enum wraps its values in <Values>, an extension states bare
+                // <Value> children. Measured on BC 28.1.49838.53910, exactly 2 of 143 documents
+                // are the extension shape (327 "No. Series Copilot Cap.", 2015 "Entity Text
+                // Capability", both extending "Copilot Capability").
+                //
+                // They are SKIPPED rather than reported unbuildable, because the runner has
+                // nothing addressable to compare against and that is a property of the
+                // derivation rather than a per-object failure: AlEnumMetadataRegistry keys an
+                // extension's values by the id of the enum it EXTENDS, never by the extension's
+                // own id, and for a precompiled dependency the values are folded into the base
+                // entry through Register (not RegisterExtension) at BcAppFallback's registration
+                // — measured: SnapshotRaw reports 0 extension entries for both bundles. So there
+                // is no runner object with id 327 to build. Counted and reported by
+                // MetadataEquivalenceReport.EnumExtensionDocuments so it cannot be a silent drop;
+                // tracked by #3807.
+                if (IsEnumExtensionDocument(document))
+                {
+                    enumExtensionDocuments.Add($"Enum {obj.Id} '{obj.Name}'");
+                    continue;
+                }
+
+                objectKey = $"Enum {obj.Id}";
+                try
+                {
+                    expected = enumFromXml.Invoke(new object?[] { document.DocumentElement });
+                }
+                catch (Exception ex)
+                {
+                    unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': BC's own MetaEnum " +
+                                    $"constructor threw — {Describe(ex)}");
+                    continue;
+                }
+                if (expected is null)
+                {
+                    unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': BC's own MetaEnum " +
+                                    "constructor produced null");
+                    continue;
+                }
+
+                try
+                {
+                    var runnerXml = RecordPatches.TryBuildEnumMetadataEquivalenceXml(obj.Id);
+                    if (runnerXml is null)
+                    {
+                        unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': the runner's enum " +
+                                        "registry knows no enum with that id");
+                        continue;
+                    }
+                    var runnerDoc = new XmlDocument();
+                    runnerDoc.LoadXml(runnerXml);
+                    actual = enumFromXml.Invoke(new object?[] { runnerDoc.DocumentElement });
                 }
                 catch (Exception ex)
                 {
@@ -344,9 +570,12 @@ internal static class MetadataEquivalenceHarness
             }
 
             compared++;
-            differences.AddRange(obj.Kind == "PageDefinition"
-                ? MetadataObjectDiff.Compare(expected, actual, objectKey, PageDiffOptions)
-                : MetadataObjectDiff.Compare(expected, actual, objectKey));
+            differences.AddRange(obj.Kind switch
+            {
+                "PageDefinition" => MetadataObjectDiff.Compare(expected, actual, objectKey, PageDiffOptions),
+                "Enum" => MetadataObjectDiff.Compare(expected, actual, objectKey, EnumDiffOptions),
+                _ => MetadataObjectDiff.Compare(expected, actual, objectKey),
+            });
         }
 
         var kindsPresent = bundle.Census.Keys.ToArray();
@@ -354,8 +583,78 @@ internal static class MetadataEquivalenceHarness
             bundle,
             kindsPresent.Where(k => ComparedKinds.Contains(k, StringComparer.Ordinal)).ToArray(),
             kindsPresent.Where(k => !ComparedKinds.Contains(k, StringComparer.Ordinal)).ToArray(),
-            compared, unbuildable, differences);
+            compared, unbuildable, differences, enumExtensionDocuments);
     }
+
+    /// <summary>
+    /// Whether an <c>&lt;Enum&gt;</c> document is an ENUM EXTENSION's rather than a base enum's.
+    ///
+    /// <para>The discriminator is the value container, measured on BC 28.1.49838.53910 over all
+    /// 143 Enum-rooted documents in the two bundles: a base enum wraps its values in a
+    /// <c>&lt;Values&gt;</c> element, an extension states bare <c>&lt;Value&gt;</c> children of
+    /// the root. Deliberately NOT keyed on the CaptionTranslationKey text, which also says
+    /// <c>EnumExtension</c>: that is a computed string and reading a structural fact out of it
+    /// would break the moment BC changed its key format.</para>
+    /// </summary>
+    private static bool IsEnumExtensionDocument(XmlDocument document)
+    {
+        foreach (XmlNode child in document.DocumentElement!.ChildNodes)
+            if (child is XmlElement e && e.Name == "Value")
+                return true;
+        return false;
+    }
+
+    /// <summary>
+    /// An enum's values pair by their AL-declared <c>Ordinal</c>, not by position.
+    ///
+    /// <para>Not a convenience: BC's emitter writes an enum's values in NAME order while the
+    /// runner's registry holds them in declaration order, so the two lists are genuinely
+    /// permutations of each other and positional pairing fabricates a difference on every value
+    /// after the first divergence. Measured on BC 28.1.49838.53910, System Application enum 2616
+    /// "Printer Paper Kind": BC's document opens <c>A2=66, A3=8, A4=9, A5=11, A6=70</c> — plainly
+    /// alphabetical, plainly not ordinal order.</para>
+    ///
+    /// <para><b>And the one enum where pairing still falls back to position is the finding, not
+    /// a gap in this option.</b> <c>TryPairById</c> refuses a duplicate key, and enum 2616 is the
+    /// only one of the 142 whose runner-side ordinals contain a duplicate — because
+    /// <c>TryParseEnumSymbol</c> reads an absent <c>Ordinal</c> as "previous + 1" where
+    /// SymbolReference.json omits it to mean 0 (#3805). So the enum that cannot be paired is
+    /// exactly the enum with the defect, and <c>Values[67].Ordinal expected 0, got 40</c> is a
+    /// real disagreement reported through the positional path rather than an artifact of it.
+    /// Fixing #3805 makes this enum pair by ordinal like the other 141.</para>
+    ///
+    /// <para><c>Ordinal</c> is in <see cref="MetadataObjectDiffOptions.IdPropertyNames"/> here
+    /// rather than in the default set because it is an identity for THIS type only:
+    /// <c>MetaEnumValue</c> has no <c>Id</c>/<c>ID</c> at all, and a type carrying both would
+    /// otherwise pair on whichever reflection returned first.</para>
+    ///
+    /// <para>#Ordinal still fires when both sides hold the same ordinal set, so a genuine
+    /// reordering is not hidden — MetadataObjectDiffTests.Id_paired_elements_still_report_a_reordering.</para>
+    /// </summary>
+    private static readonly MetadataObjectDiffOptions EnumDiffOptions = new()
+    {
+        PairByIdMembers = EnumIdPairedMembers(),
+        IdPropertyNames = new[] { "Ordinal", "Id", "ID" },
+    };
+
+    private static IReadOnlySet<string> EnumIdPairedMembers()
+        // Two spellings, for the reason PageIdPairedMembers documents: BC backs the collection
+        // with a field and the differ walks both, so listing only the plain property leaves the
+        // field-backed path positionally paired.
+        //
+        // The field is `values`, NOT `valuesField` — MetaEnum declares a plain private field
+        // rather than using an auto-property, so the differ walks it as `#values` and the
+        // `#<name>Field` convention every page collection follows does not apply. Measured:
+        // with only the property listed, 3,014 of the enum value differences reported the paired
+        // path `Values[id=N]` while 477 reported the positional `Values[N]` — including the one
+        // genuine artifact this pairing exists to remove, `Enum 2616 Values[67].Ordinal`. A
+        // guessed field name is indistinguishable from no entry at all.
+        => new HashSet<string>(StringComparer.Ordinal)
+        {
+            "MetaTable.Fields",
+            "MetaEnum.Values",
+            "MetaEnum.#values",
+        };
 
     /// <summary>
     /// Page control collections pair by the control's own ID, not by position.

--- a/AlRunner.Tests/MetadataEquivalenceHarness.cs
+++ b/AlRunner.Tests/MetadataEquivalenceHarness.cs
@@ -349,6 +349,13 @@ internal static class MetadataEquivalenceHarness
                     var runnerDoc = new XmlDocument();
                     runnerDoc.LoadXml(runnerXml);
                     actual = codeunitFromXml.Invoke(new object?[] { runnerDoc.DocumentElement });
+                }
+                catch (Exception ex)
+                {
+                    unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': the runner threw — {Describe(ex)}");
+                    continue;
+                }
+            }
             else if (obj.Kind == "Report")
             {
                 objectKey = $"Report {obj.Id}";

--- a/AlRunner.Tests/MetadataEquivalenceHarness.cs
+++ b/AlRunner.Tests/MetadataEquivalenceHarness.cs
@@ -118,30 +118,8 @@ internal static class MetadataEquivalenceHarness
     /// The order and remaining kinds are on that issue.
     /// </summary>
     internal static readonly string[] ComparedKinds =
-        { "MetaTable", "PageDefinition", "CodeUnit", "Report", "PermissionSet", "Enum" };
-
-    /// <summary>
-    /// Kinds a bundle carries that this harness has MEASURED it cannot compare non-circularly,
-    /// each with the issue recording the measurement. Distinct from "not got to yet": these are
-    /// closed questions, and the difference matters because an unmeasured kind is work and a
-    /// measured one is a finding.
-    ///
-    /// <para><c>MetadataRuntimeDeltas</c> is BC's emitted form of an EXTENSION object —
-    /// tableextension, pageextension, permissionsetextension — and the runner builds no
-    /// extension-shaped metadata object at all: it folds an extension's contribution into the
-    /// object being extended at parse time and keeps nothing addressable by the extension's own
-    /// id. There is also no BC reader for the shape: measured on BC 28.4.53241.54407, no type
-    /// in <c>Microsoft.Dynamics.Nav.Types</c> or <c>Microsoft.Dynamics.Nav.Ncl</c> has "Delta"
-    /// in its name, so neither side of the comparison exists. See #3809 and
-    /// docs/metadata-equivalence.md#metadataruntimedeltas.</para>
-    /// </summary>
-    internal static readonly IReadOnlyDictionary<string, string> UncomparableKinds =
-        new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            ["MetadataRuntimeDeltas"] =
-                "the runner builds no extension-shaped metadata object, and BC ships no reader " +
-                "for the shape — neither side of the comparison exists (#3809)",
-        };
+        { "MetaTable", "PageDefinition", "CodeUnit", "Report", "PermissionSet", "Enum",
+          "MetadataRuntimeDeltas" };
 
     public static IReadOnlyList<GroundTruthBundle> LoadBundles(string root)
     {
@@ -299,6 +277,40 @@ internal static class MetadataEquivalenceHarness
                 "emitted Enum document back into BC's own object model, and the comparison would " +
                 "become a hand-written XML walk against the runner — two derivations, no oracle.");
 
+        // BC's own reader for a MetadataRuntimeDeltas document — the emitted form of a
+        // tableextension, pageextension or permissionsetextension.
+        //
+        // IT LIVES IN A THIRD ASSEMBLY, and that is the whole reason this kind was first
+        // reported as having no reader at all. Microsoft.Dynamics.Nav.Apps.dll is neither of
+        // the two assemblies every other oracle here comes from, and a census over just those
+        // two answers zero — which reads exactly like "BC ships no reader" and is not. The
+        // artifact directory holds 501 assemblies; a metadata-only scan of all of them finds
+        // 308 types whose name contains "Delta", 54 of them in this one. Never conclude a
+        // negative about BC's surface from a search narrower than the thing being claimed.
+        //
+        // Proven to parse rather than assumed to: measured on BC 28.1.49838.53910 over all 11
+        // documents in the two bundles, FromXml(XDocument) returns a populated object for every
+        // one — AllDeltas of 12 for page 774, 5 for 4318, 4 for 2515, 2 for 324, 1 for 9862 and
+        // 0 for the five documents that are genuinely empty elements. Pinned in
+        // MetadataEquivalenceRuntimeDeltasOracleTests.
+        var appsAssembly = System.Reflection.Assembly.LoadFrom(Path.Combine(
+            AlRunner.Infrastructure.BcArtifacts.ServiceTierDir, "Microsoft.Dynamics.Nav.Apps.dll"));
+        var deltasType = appsAssembly.GetType(
+                "Microsoft.Dynamics.Nav.Apps.MetadataDeltas.NavAppObjectMetadataRuntimeDeltas")
+            ?? throw new InvalidOperationException("NavAppObjectMetadataRuntimeDeltas is not reachable.");
+        // The XDocument overload, not the XContainer one: an emitted document is handed over
+        // whole, and picking by parameter type rather than by position keeps this working if BC
+        // reorders the two.
+        var deltasFromXml = deltasType.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .FirstOrDefault(m => m.Name == "FromXml"
+                                     && m.GetParameters() is { Length: 1 } ps
+                                     && ps[0].ParameterType == typeof(System.Xml.Linq.XDocument))
+            ?? throw new InvalidOperationException(
+                "NavAppObjectMetadataRuntimeDeltas has no static FromXml(XDocument). Without it " +
+                "there is no way to read BC's emitted MetadataRuntimeDeltas document back into " +
+                "BC's own object model, and the comparison would become a hand-written XML walk " +
+                "against the runner — two derivations, no oracle.");
+
         // Built once per bundle, not per object: RunnerPermissionSetDeclarations drives the
         // runner's own population, which is what makes IncludedPermissionSets resolvable at all.
         IReadOnlyDictionary<int, BcAppSymbolCache.PermissionSetSymbol>? permissionSetsById = null;
@@ -393,6 +405,52 @@ internal static class MetadataEquivalenceHarness
                     var runnerDoc = new XmlDocument();
                     runnerDoc.LoadXml(runnerXml);
                     actual = reportFromXml.Invoke(new object?[] { runnerDoc.DocumentElement, null, 0, 0, null });
+                }
+                catch (Exception ex)
+                {
+                    unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': the runner threw — {Describe(ex)}");
+                    continue;
+                }
+            }
+            else if (obj.Kind == "MetadataRuntimeDeltas")
+            {
+                objectKey = $"MetadataRuntimeDeltas {obj.Id}";
+                try
+                {
+                    expected = deltasFromXml.Invoke(
+                        null, new object?[] { System.Xml.Linq.XDocument.Load(xmlPath) });
+                }
+                catch (Exception ex)
+                {
+                    unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': BC's own " +
+                                    $"NavAppObjectMetadataRuntimeDeltas.FromXml threw — {Describe(ex)}");
+                    continue;
+                }
+                if (expected is null)
+                {
+                    unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': BC's own " +
+                                    "NavAppObjectMetadataRuntimeDeltas.FromXml produced null");
+                    continue;
+                }
+
+                try
+                {
+                    // The runner's extension-delta answer for this object, through the one
+                    // member typed to return this type. It is NULL for every object today, and
+                    // that null is the finding rather than a failure to look: the runner has no
+                    // published-app extension pipeline, so RunnerXmlMetadataLoader's own comment
+                    // records null as BC's "no deltas" value. Reported per object as unbuildable,
+                    // which is exactly what a ONE-SIDED gap should look like — BC's side is real
+                    // and parses, the runner's is absent — and is a much narrower claim than the
+                    // "neither side exists" this harness first recorded. #3809.
+                    actual = RecordPatches.TryGetRuntimeDeltasMetadataEquivalence(obj.Id);
+                    if (actual is null)
+                    {
+                        unbuildable.Add($"{obj.Kind} {obj.Id} '{obj.Name}': the runner tracks no " +
+                                        "extension runtime deltas — GetExtensionDeltasForAppObject " +
+                                        "answers null for every object (#3809)");
+                        continue;
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
+++ b/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
@@ -240,6 +240,54 @@ public sealed class MetadataEquivalenceHarnessTests
     }
 
     [SkippableFact]
+    public void The_new_kinds_reader_answers_the_constant_that_IS_the_defect()
+    {
+        // Found by mutation-checking this PR's own work, and it is the #3802 shape exactly.
+        //
+        // Writing BC's own Extensible value into the enum render — manufacturing agreement, the
+        // one thing this harness exists to catch — left all 26 tests GREEN. The allowlist could
+        // not see it because the mutation does not REMOVE the differences, it INVERTS them: 31
+        // (BC True, runner False) became 111 (BC False, runner True), the entry still matched
+        // every one, and No_allowlist_entry_has_gone_stale therefore had nothing to report.
+        //
+        // `direction` is the usual narrowing tool and it cannot help here: it keys on the value
+        // being absent-or-null, and both sides of Extensible are False/True. What does work is
+        // the same claim the table-side members already make — the runner answers a CONSTANT,
+        // and that constant IS the defect. A reader that started answering BC's real value
+        // breaks this, in either direction, which is what the allowlist alone cannot do.
+        foreach (var report in RunAll())
+        {
+            MetadataDifference[] On(string signature, string objectPrefix) => report.Differences
+                .Where(d => d.Signature == signature
+                            && d.ObjectKey.StartsWith(objectPrefix, StringComparison.Ordinal))
+                .ToArray();
+
+            // EnumSymbol carries no Extensible at all, so the render states none and BC's own
+            // default of false stands on the runner's side — on every enum, including the 111
+            // where false is also BC's answer and no difference is reported.
+            AssertConstantAnswer(report, On("MetaEnum.Extensible", "Enum "),
+                "MetaEnum.Extensible", bc: "True", runner: "False");
+
+            // ALNamespace is stated by SymbolReference.json for all three kinds and carried by
+            // none of the three symbol records, so the runner answers null everywhere. Asserted
+            // per kind rather than once, because they are three separate records and three
+            // separate fixes (#3806, #3807, #3808).
+            AssertConstantAnswer(report, On("MetaEnum.ALNamespace", "Enum "),
+                "MetaEnum.ALNamespace", bc: null, runner: MetadataObjectDiff.Null);
+            AssertConstantAnswer(report, On("MetaPermissionSet.ALNamespace", "PermissionSet "),
+                "MetaPermissionSet.ALNamespace", bc: null, runner: MetadataObjectDiff.Null);
+
+            // The metadata-format version BC writes into every emitted document and the runner
+            // states nowhere. Constant on BOTH sides, which is what makes it a property of the
+            // document format rather than of any object's declaration.
+            AssertConstantAnswer(report, On("MetaEnum.MetadataToken", "Enum "),
+                "MetaEnum.MetadataToken", bc: "130000", runner: "0");
+            AssertConstantAnswer(report, On("MetaPermissionSet.MetadataToken", "PermissionSet "),
+                "MetaPermissionSet.MetadataToken", bc: "130000", runner: "0");
+        }
+    }
+
+    [SkippableFact]
     public void Codeunits_are_compared_in_the_numbers_the_bundle_declares()
     {
         // The step-2 counterpart of the page claim below, and it is needed for the same reason:

--- a/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
+++ b/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
@@ -122,10 +122,27 @@ public sealed class MetadataEquivalenceHarnessTests
         // failure rather than a quietly smaller comparison.
         foreach (var report in RunAll())
         {
-            Assert.True(report.Unbuildable.Count == 0,
+            // MetadataRuntimeDeltas is the ONE kind where the runner has nothing to build, and
+            // it is unbuildable on every object rather than on some — a ONE-SIDED gap, not a
+            // per-object failure. BC's side parses (see the oracle test); the runner's
+            // GetExtensionDeltasForAppObject answers null because there is no published-app
+            // extension pipeline (#3809).
+            //
+            // Scoped by kind AND asserted to be TOTAL, so this cannot become a place other
+            // kinds' failures hide: a deltas object that somehow DID build, or any object of
+            // another kind that did not, still fails.
+            var deltasDeclared = report.Bundle.Census.GetValueOrDefault("MetadataRuntimeDeltas");
+            var deltasUnbuildable = report.Unbuildable
+                .Count(u => u.StartsWith("MetadataRuntimeDeltas ", StringComparison.Ordinal));
+            Assert.Equal(deltasDeclared, deltasUnbuildable);
+
+            var otherUnbuildable = report.Unbuildable
+                .Where(u => !u.StartsWith("MetadataRuntimeDeltas ", StringComparison.Ordinal))
+                .ToArray();
+            Assert.True(otherUnbuildable.Length == 0,
                 $"{report.Bundle.Label}: the runner produced no comparable metadata for " +
-                $"{report.Unbuildable.Count} object(s):{Environment.NewLine}" +
-                string.Join(Environment.NewLine, report.Unbuildable.Take(20)));
+                $"{otherUnbuildable.Length} object(s) outside MetadataRuntimeDeltas:" +
+                Environment.NewLine + string.Join(Environment.NewLine, otherUnbuildable.Take(20)));
 
             foreach (var kind in report.KindsCompared)
                 Assert.Equal(report.Bundle.Census[kind],
@@ -137,7 +154,9 @@ public sealed class MetadataEquivalenceHarnessTests
             // a second shape that started being skipped would break this rather than shrink the
             // comparison unnoticed.
             var comparableTotal = report.KindsCompared.Sum(k => report.Bundle.Census[k]);
-            Assert.Equal(comparableTotal - report.EnumExtensionDocuments.Count, report.ObjectsCompared);
+            Assert.Equal(
+                comparableTotal - report.EnumExtensionDocuments.Count - report.Unbuildable.Count,
+                report.ObjectsCompared);
         }
     }
 
@@ -182,25 +201,11 @@ public sealed class MetadataEquivalenceHarnessTests
         // programme finishes, which is the one outcome it must not punish.
         string[] stillUncompared =
         {
-            // steps 3 and 4, in the order issue #3782's comment sets. Steps 2 (CodeUnit) and
-            // 5-7 (Report, PermissionSet, Enum) are compared and have been deleted from this
-            // list.
+            // Steps 3 and 4 only, in the order issue #3782's comment sets. Every other kind —
+            // CodeUnit (step 2) and Report/PermissionSet/Enum/MetadataRuntimeDeltas (5-8) — is
+            // compared and has been deleted from this list.
             "Query", "XmlPort",
-            // Step 8, and NOT a step still to do: measured and found uncomparable
-            // non-circularly. MetadataEquivalenceHarness.UncomparableKinds carries the reason
-            // and the tracking issue, and the assertion below holds this list to it so the two
-            // cannot drift.
-            "MetadataRuntimeDeltas",
         };
-
-        // A kind here for the measured reason must say so in UncomparableKinds, and vice versa.
-        // Without this the two lists say different things about the same kind and nothing
-        // notices — the list above would keep reading as "not got to yet" after step 8 closed
-        // the question.
-        Assert.Equal(
-            MetadataEquivalenceHarness.UncomparableKinds.Keys.OrderBy(k => k, StringComparer.Ordinal).ToArray(),
-            stillUncompared.Where(MetadataEquivalenceHarness.UncomparableKinds.ContainsKey)
-                .OrderBy(k => k, StringComparer.Ordinal).ToArray());
 
         foreach (var report in RunAll())
         {

--- a/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
+++ b/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
@@ -130,6 +130,14 @@ public sealed class MetadataEquivalenceHarnessTests
             foreach (var kind in report.KindsCompared)
                 Assert.Equal(report.Bundle.Census[kind],
                     report.Bundle.Objects.Count(o => o.Kind == kind));
+
+            // Enum-extension documents are skipped rather than compared (the harness's own
+            // comment says why), so the compared total is short by exactly that many. Asserting
+            // the arithmetic is what stops the skip becoming a place objects can quietly go:
+            // a second shape that started being skipped would break this rather than shrink the
+            // comparison unnoticed.
+            var comparableTotal = report.KindsCompared.Sum(k => report.Bundle.Census[k]);
+            Assert.Equal(comparableTotal - report.EnumExtensionDocuments.Count, report.ObjectsCompared);
         }
     }
 
@@ -174,10 +182,25 @@ public sealed class MetadataEquivalenceHarnessTests
         // programme finishes, which is the one outcome it must not punish.
         string[] stillUncompared =
         {
-            // step 3..8, in the order issue #3782's comment sets.
-            "Query", "XmlPort", "Report", "PermissionSet", "Enum",
+            // steps 3 and 4, in the order issue #3782's comment sets. Steps 2 (CodeUnit) and
+            // 5-7 (Report, PermissionSet, Enum) are compared and have been deleted from this
+            // list.
+            "Query", "XmlPort",
+            // Step 8, and NOT a step still to do: measured and found uncomparable
+            // non-circularly. MetadataEquivalenceHarness.UncomparableKinds carries the reason
+            // and the tracking issue, and the assertion below holds this list to it so the two
+            // cannot drift.
             "MetadataRuntimeDeltas",
         };
+
+        // A kind here for the measured reason must say so in UncomparableKinds, and vice versa.
+        // Without this the two lists say different things about the same kind and nothing
+        // notices — the list above would keep reading as "not got to yet" after step 8 closed
+        // the question.
+        Assert.Equal(
+            MetadataEquivalenceHarness.UncomparableKinds.Keys.OrderBy(k => k, StringComparer.Ordinal).ToArray(),
+            stillUncompared.Where(MetadataEquivalenceHarness.UncomparableKinds.ContainsKey)
+                .OrderBy(k => k, StringComparer.Ordinal).ToArray());
 
         foreach (var report in RunAll())
         {
@@ -203,6 +226,13 @@ public sealed class MetadataEquivalenceHarnessTests
             Assert.Contains("MetaTable", report.KindsCompared);
             Assert.Contains("PageDefinition", report.KindsCompared);
             Assert.Contains("CodeUnit", report.KindsCompared);
+            Assert.Contains("PermissionSet", report.KindsCompared);
+            Assert.Contains("Enum", report.KindsCompared);
+            // Report is asserted per-bundle rather than unconditionally: Business Foundation
+            // ships none, so a flat Assert.Contains would fail on a bundle that is simply
+            // reportless rather than on a comparison that stopped covering the kind.
+            if (report.Bundle.Census.ContainsKey("Report"))
+                Assert.Contains("Report", report.KindsCompared);
 
             foreach (var kind in stillUncompared.Where(k => report.Bundle.Census.ContainsKey(k)))
                 Assert.Contains(kind, report.KindsNotCompared);

--- a/AlRunner.Tests/MetadataEquivalenceReportEnumPermissionSetOracleTests.cs
+++ b/AlRunner.Tests/MetadataEquivalenceReportEnumPermissionSetOracleTests.cs
@@ -185,6 +185,59 @@ public sealed class MetadataEquivalenceReportEnumPermissionSetOracleTests
     }
 
     [SkippableFact]
+    public void Enum_values_are_paired_by_ordinal_and_not_by_position()
+    {
+        // Found by mutation-checking this PR's own work: deleting EnumDiffOptions from the
+        // comparison changes NOT ONE difference count, so every other test in this file and in
+        // MetadataEquivalenceHarnessTests stays green without the pairing. The allowlist is
+        // keyed on DeclaringType.Member, and positional pairing reports the same MEMBERS — it
+        // moves the PATHS. So the allowlist structurally cannot see this, and without this test
+        // the option would be inert cover of exactly the kind #3802 documents.
+        //
+        // Measured on BC 28.1.49838.53910 over both bundles: with the option, 2,678 of the 3,155
+        // enum-value differences carry an `id=` path and 477 do not; without it, all 3,155 are
+        // positional. The assertion is on the SHAPE — that a substantial majority pair by
+        // ordinal — rather than on either number, so it cannot go inert when the build moves.
+        Skip.IfNot(_engine.Ready, _engine.SkipReason);
+
+        var bundles = MetadataEquivalenceHarness.LoadBundles(
+            MetadataEquivalencePaths.GroundTruthDirForThisBuild());
+        Skip.If(bundles.Count == 0, "no metadata ground-truth bundle for this BC build.");
+
+        var paired = 0;
+        var positional = 0;
+        foreach (var bundle in bundles)
+        {
+            var app = MetadataEquivalenceHarness.FindAppPackage(bundle);
+            Skip.If(app is null, $"{bundle.Label}: its .app is not on this box.");
+
+            foreach (var d in MetadataEquivalenceHarness.Compare(bundle, app!).Differences)
+            {
+                if (!d.ObjectKey.StartsWith("Enum ", StringComparison.Ordinal)) continue;
+                var at = d.Path.IndexOf("Values[", StringComparison.Ordinal);
+                if (at < 0) continue;
+                if (d.Path.AsSpan(at + "Values[".Length).StartsWith("id=")) paired++;
+                else positional++;
+            }
+        }
+
+        Assert.True(paired + positional > 0,
+            "no enum-value difference was reported at all, so this measured nothing — either the "
+            + "enum comparison stopped running or the derivation became perfect. Both need saying "
+            + "out loud rather than passing quietly.");
+
+        // The majority pair by ordinal. The positional remainder is not a gap in the option: it
+        // is enum 2616, whose runner-side ordinals contain a duplicate (#3805) so TryPairById
+        // refuses the key set and falls back — which is why the residue is asserted as a
+        // MINORITY rather than as zero, and why fixing #3805 should move it to zero.
+        Assert.True(paired > positional,
+            $"{paired} enum-value difference(s) paired by ordinal and {positional} by position. "
+            + "Ordinal pairing is what stops BC's name-ordered value list being compared against "
+            + "the runner's declaration-ordered one element by element, so a positional majority "
+            + "means EnumDiffOptions stopped being applied.");
+    }
+
+    [SkippableFact]
     public void The_harness_reads_each_document_through_a_type_that_parses()
     {
         // Ties the tests above to the thing they are about. Without this they document facts

--- a/AlRunner.Tests/MetadataEquivalenceReportEnumPermissionSetOracleTests.cs
+++ b/AlRunner.Tests/MetadataEquivalenceReportEnumPermissionSetOracleTests.cs
@@ -1,19 +1,25 @@
-// MetadataEquivalenceReportEnumPermissionSetOracleTests — pins that the three BC types this
-// harness uses as oracles for Report, PermissionSet and Enum actually READ the document they
-// are handed.
+// MetadataEquivalenceReportEnumPermissionSetOracleTests — pins that the four BC readers this
+// harness uses as oracles for Report, PermissionSet, Enum and MetadataRuntimeDeltas actually
+// READ the document they are handed.
 //
-// Issue #3782, steps 5-7. The reason this class exists is step 1's finding, and it is not
+// Issue #3782, steps 5-8. The reason this class exists is step 1's finding, and it is not
 // hypothetical: BC's Types assembly ships PageDefinition AND MetaPageDefinition, both public,
 // both taking (XmlNode), and NEITHER throws — the Meta one silently ignores the document and
 // returns a default-constructed object. Handing that to the differ as both sides compared 235
 // pages, found 0 differences, and left every other test in the suite green.
 //
-// Every type here has the same trap available to it: MetaEnum has a parameterless constructor
+// Every reader here has the same trap available to it: MetaEnum has a parameterless constructor
 // alongside its (XmlNode) one, MetaReport's five-argument constructor takes two nullable
-// delegates, and MetaPermissionSet is built through a static factory rather than a constructor
-// at all. So "it did not throw" is worth nothing, and each is asserted to reproduce values that
-// are IN the document — against the document itself rather than against a literal, so the
-// assertions stay true on every BC build and every app.
+// delegates, and MetaPermissionSet and NavAppObjectMetadataRuntimeDeltas are built through static
+// factories rather than constructors at all. So "it did not throw" is worth nothing, and each is
+// asserted to reproduce values that are IN the document — against the document itself rather than
+// against a literal, so the assertions stay true on every BC build and every app.
+//
+// AND ONE OF THEM IS IN A THIRD ASSEMBLY. Every oracle but the deltas one comes from
+// Microsoft.Dynamics.Nav.Types or .Ncl, and MetadataRuntimeDeltas was first reported as having no
+// reader anywhere on the strength of a census over exactly those two. It is in
+// Microsoft.Dynamics.Nav.Apps.dll, one of 501 assemblies in the artifact directory. A negative
+// about BC's surface is only as wide as the search behind it.
 
 using System.Reflection;
 using System.Xml;
@@ -182,6 +188,81 @@ public sealed class MetadataEquivalenceReportEnumPermissionSetOracleTests
         // constructor's and not the document's.
         Assert.NotEqual(0, DocumentId(doc));
         Assert.NotEmpty(doc.DocumentElement!.GetAttribute("Name"));
+    }
+
+    [SkippableFact]
+    public void NavAppObjectMetadataRuntimeDeltas_FromXml_parses_every_emitted_deltas_document()
+    {
+        // This kind was first reported as having NO BC reader at all, and the census behind that
+        // claim searched two assemblies — Types and Ncl — because every other oracle in this
+        // harness comes from one of them. The reader is in a THIRD:
+        // Microsoft.Dynamics.Nav.Apps.dll. Re-measured over the whole artifact directory, 501
+        // assemblies carry 308 types whose name contains "Delta", 54 of them in that one.
+        //
+        // So the assertion here is not decoration: it is the check that turns "I did not find a
+        // reader" into "this document parses", and it is asserted over EVERY document rather
+        // than a sample, because the first bare probe of it parsed only 6 of 11 — a
+        // WindowsLanguageHelper static-init fault from loading outside the harness, which the
+        // skeleton this collection already has removes. Verified rather than assumed: 11 of 11.
+        Skip.IfNot(_engine.Ready, _engine.SkipReason);
+
+        var bundles = MetadataEquivalenceHarness.LoadBundles(
+            MetadataEquivalencePaths.GroundTruthDirForThisBuild());
+        Skip.If(bundles.Count == 0, "no metadata ground-truth bundle for this BC build.");
+
+        var apps = System.Reflection.Assembly.LoadFrom(Path.Combine(
+            AlRunner.Infrastructure.BcArtifacts.ServiceTierDir, "Microsoft.Dynamics.Nav.Apps.dll"));
+        var t = apps.GetType("Microsoft.Dynamics.Nav.Apps.MetadataDeltas.NavAppObjectMetadataRuntimeDeltas");
+        Assert.True(t is not null,
+            "NavAppObjectMetadataRuntimeDeltas is gone from Microsoft.Dynamics.Nav.Apps.dll — the "
+            + "MetadataRuntimeDeltas oracle has moved or been removed; re-measure before trusting "
+            + "either side of that comparison.");
+
+        // The root element BC's own reader keys on, asserted against the documents rather than
+        // against a literal: this is what makes "the oracle is for THIS document shape" a
+        // measurement instead of an assumption.
+        var baseType = apps.GetType("Microsoft.Dynamics.Nav.Apps.MetadataDeltas.NavAppObjectMetadataDeltaBase")!;
+        var rootName = baseType.GetProperty("MetadataRuntimeDeltasXName",
+            BindingFlags.Public | BindingFlags.Static)!.GetValue(null)!.ToString();
+        Assert.Equal("{urn:schemas-microsoft-com:dynamics:NAV:MetaObjects}MetadataRuntimeDeltas", rootName);
+
+        var fromXml = t!.GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .FirstOrDefault(m => m.Name == "FromXml"
+                                 && m.GetParameters() is { Length: 1 } ps
+                                 && ps[0].ParameterType == typeof(System.Xml.Linq.XDocument));
+        Assert.True(fromXml is not null, "NavAppObjectMetadataRuntimeDeltas has no static FromXml(XDocument).");
+
+        var seen = 0;
+        var withDeltas = 0;
+        foreach (var bundle in bundles)
+            foreach (var obj in bundle.Objects.Where(o => o.Kind == "MetadataRuntimeDeltas"))
+            {
+                var doc = System.Xml.Linq.XDocument.Load(Path.Combine(bundle.Directory, obj.File));
+                Assert.Equal(rootName, doc.Root!.Name.ToString());
+
+                var parsed = fromXml!.Invoke(null, new object?[] { doc });
+                Assert.True(parsed is not null,
+                    $"{bundle.Label} MetadataRuntimeDeltas {obj.Id} '{obj.Name}': FromXml returned null.");
+                seen++;
+
+                var all = (System.Collections.IEnumerable)parsed!.GetType()
+                    .GetProperty("AllDeltas", BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy)!
+                    .GetValue(parsed)!;
+                if (all.Cast<object>().Any()) withDeltas++;
+            }
+
+        Assert.True(seen > 0, "no bundle carried a MetadataRuntimeDeltas document, so this measured nothing.");
+
+        // Parsing without throwing is what MetaPageDefinition also did. The claim that separates
+        // a real reader from a default object is that it read CONTENT out of the document — so
+        // at least one document must yield a non-empty AllDeltas. Measured on BC
+        // 28.1.49838.53910: 6 of the 11 carry deltas (12 on page 774, 5 on 4318, 4 on 2515, 2 on
+        // 324, 1 on 9862) and 5 are genuinely empty <MetadataRuntimeDeltas/> elements, so a
+        // floor rather than an equality — but a floor of zero would be the vacuous claim.
+        Assert.True(withDeltas > 0,
+            $"{seen} MetadataRuntimeDeltas document(s) parsed and NOT ONE yielded a delta. Several "
+            + "of these documents plainly carry ControlAdd/ActionAdd/Expression content, so zero "
+            + "means FromXml stopped reading the document — the MetaPageDefinition failure mode.");
     }
 
     [SkippableFact]

--- a/AlRunner.Tests/MetadataEquivalenceReportEnumPermissionSetOracleTests.cs
+++ b/AlRunner.Tests/MetadataEquivalenceReportEnumPermissionSetOracleTests.cs
@@ -1,0 +1,235 @@
+// MetadataEquivalenceReportEnumPermissionSetOracleTests — pins that the three BC types this
+// harness uses as oracles for Report, PermissionSet and Enum actually READ the document they
+// are handed.
+//
+// Issue #3782, steps 5-7. The reason this class exists is step 1's finding, and it is not
+// hypothetical: BC's Types assembly ships PageDefinition AND MetaPageDefinition, both public,
+// both taking (XmlNode), and NEITHER throws — the Meta one silently ignores the document and
+// returns a default-constructed object. Handing that to the differ as both sides compared 235
+// pages, found 0 differences, and left every other test in the suite green.
+//
+// Every type here has the same trap available to it: MetaEnum has a parameterless constructor
+// alongside its (XmlNode) one, MetaReport's five-argument constructor takes two nullable
+// delegates, and MetaPermissionSet is built through a static factory rather than a constructor
+// at all. So "it did not throw" is worth nothing, and each is asserted to reproduce values that
+// are IN the document — against the document itself rather than against a literal, so the
+// assertions stay true on every BC build and every app.
+
+using System.Reflection;
+using System.Xml;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class MetadataEquivalenceReportEnumPermissionSetOracleTests
+{
+    private readonly BcEngineFixture _engine;
+
+    public MetadataEquivalenceReportEnumPermissionSetOracleTests(BcEngineFixture engine) => _engine = engine;
+
+    private static Type Resolve(string name)
+        => Type.GetType($"Microsoft.Dynamics.Nav.Types.Metadata.{name}, Microsoft.Dynamics.Nav.Types")
+           ?? throw new InvalidOperationException($"{name} is not reachable.");
+
+    /// <summary>
+    /// The first emitter document of a kind, or a skip. Deliberately a real emitter document
+    /// rather than a hand-written one: a fixture written here could differ from what BC emits
+    /// in exactly the way that makes a non-reading type look adequate.
+    /// </summary>
+    private (XmlDocument Doc, string Label) EmitterDocument(string kind, Func<XmlDocument, bool>? accept = null)
+    {
+        var bundles = MetadataEquivalenceHarness.LoadBundles(
+            MetadataEquivalencePaths.GroundTruthDirForThisBuild());
+        Skip.If(bundles.Count == 0,
+            "no metadata ground-truth bundle for this BC build; " +
+            "tools/gen-metadata-ground-truth.sh --artifacts \"" +
+            AlRunner.Infrastructure.BcArtifacts.ServiceTierDir + "\"");
+
+        foreach (var bundle in bundles)
+            foreach (var obj in bundle.Objects.Where(o => o.Kind == kind).OrderBy(o => o.Id))
+            {
+                var doc = new XmlDocument();
+                doc.Load(Path.Combine(bundle.Directory, obj.File));
+                if (accept is not null && !accept(doc)) continue;
+                return (doc, $"{bundle.Label} {kind} {obj.Id} '{obj.Name}'");
+            }
+
+        throw new SkipException($"no bundle on this box carries a {kind} document.");
+    }
+
+    private static int DocumentId(XmlDocument doc)
+    {
+        var root = doc.DocumentElement!;
+        var attribute = root.GetAttribute("ID");
+        if (!string.IsNullOrEmpty(attribute)) return int.Parse(attribute);
+        // Report, Query and XmlPort state the id as a CHILD element; every other kind as an
+        // attribute. Both spellings are BC's, which is what the generator's ClassifyDocument
+        // learned in #3782 steps 3-5.
+        foreach (XmlNode child in root.ChildNodes)
+            if (child is XmlElement e && (e.Name == "ID" || e.Name == "Id"))
+                return int.Parse(e.InnerText);
+        throw new InvalidOperationException("the document states no id in either spelling.");
+    }
+
+    [SkippableFact]
+    public void MetaReport_parses_the_emitters_own_document()
+    {
+        Skip.IfNot(_engine.Ready, _engine.SkipReason);
+        var (doc, label) = EmitterDocument("Report");
+        var t = Resolve("MetaReport");
+        var ctor = t.GetConstructors().FirstOrDefault(
+            c => c.GetParameters() is { Length: 5 } ps && ps[0].ParameterType == typeof(XmlElement));
+        Assert.True(ctor is not null, $"{label}: MetaReport has no (XmlElement, …) constructor.");
+
+        var parsed = ctor!.Invoke(new object?[] { doc.DocumentElement, null, 0, 0, null });
+
+        // Every one of these is stated by the document, so a reader that looked at it at all
+        // reproduces them — and every one of them is a DEFAULT (0, null, false) on an object
+        // that did not.
+        Assert.Equal(DocumentId(doc), (int)t.GetProperty("Id")!.GetValue(parsed)!);
+        Assert.Equal(doc.DocumentElement!["Name"]!.InnerText, (string?)t.GetProperty("Name")!.GetValue(parsed));
+        // ALNamespace and TransactionType are stated as elements and are neither 0 nor null on a
+        // reader that parsed. Asserted against the document, not against a literal.
+        Assert.Equal(doc.DocumentElement["ALNamespace"]!.InnerText,
+            (string?)t.GetProperty("ALNamespace")!.GetValue(parsed));
+        Assert.Equal(doc.DocumentElement["TransactionType"]!.InnerText,
+            t.GetProperty("TransactionType")!.GetValue(parsed)!.ToString());
+
+        // ...and the document plainly carries all of it, so the assertions above cannot pass
+        // vacuously against an empty document.
+        Assert.NotEqual(0, DocumentId(doc));
+        Assert.NotEmpty(doc.DocumentElement["Name"]!.InnerText);
+    }
+
+    [SkippableFact]
+    public void MetaPermissionSet_Create_parses_the_emitters_own_document()
+    {
+        Skip.IfNot(_engine.Ready, _engine.SkipReason);
+        // A set that actually declares includes, so the collection assertion below measures
+        // something: an empty IncludedPermissionSets is what a non-reading factory also answers.
+        var (doc, label) = EmitterDocument("PermissionSet",
+            d => !string.IsNullOrEmpty(d.DocumentElement!.GetAttribute("IncludedPermissionSets")));
+        var t = Resolve("MetaPermissionSet");
+        var create = t.GetMethod("Create", BindingFlags.Public | BindingFlags.Static);
+        Assert.True(create is not null, $"{label}: MetaPermissionSet has no static Create.");
+
+        var parsed = create!.Invoke(null, new object?[] { doc.DocumentElement, 0, 0 })!;
+
+        Assert.Equal(DocumentId(doc), (int)t.GetProperty("Id")!.GetValue(parsed)!);
+        Assert.Equal(doc.DocumentElement!.GetAttribute("ALNamespace"),
+            (string?)t.GetProperty("ALNamespace")!.GetValue(parsed));
+
+        // BC UPPERCASES the name it reads. That is the factory's own behaviour, not the
+        // document's — measured on BC 28.1.49838.53910, where 170 of 178 emitted permission-set
+        // documents state a mixed-case Name and MetaPermissionSet.Create answers all 178
+        // upper-cased. Asserting it here is what makes the runner-side difference in the
+        // allowlist attributable to the READER rather than to the runner.
+        var documentName = doc.DocumentElement.GetAttribute("Name");
+        Assert.Equal(documentName.ToUpperInvariant(), (string?)t.GetProperty("Name")!.GetValue(parsed));
+
+        var included = (System.Collections.ICollection)t.GetProperty("IncludedPermissionSets")!.GetValue(parsed)!;
+        Assert.Equal(
+            doc.DocumentElement.GetAttribute("IncludedPermissionSets").Split(',').Length,
+            included.Count);
+    }
+
+    [SkippableFact]
+    public void MetaEnum_parses_the_emitters_own_document()
+    {
+        Skip.IfNot(_engine.Ready, _engine.SkipReason);
+        // A base enum, not an enumextension: the two share the <Enum> root and an extension
+        // states bare <Value> children, so accepting the first document of the kind could land
+        // on one and measure a different shape than the harness compares.
+        var (doc, label) = EmitterDocument("Enum",
+            d => d.DocumentElement!.ChildNodes.Cast<XmlNode>().Any(c => c.Name == "Values"));
+        var t = Resolve("MetaEnum");
+        var ctor = t.GetConstructor(new[] { typeof(XmlNode) });
+        Assert.True(ctor is not null, $"{label}: MetaEnum has no (XmlNode) constructor.");
+
+        var parsed = ctor!.Invoke(new object?[] { doc.DocumentElement })!;
+
+        Assert.Equal(DocumentId(doc), (int)t.GetProperty("Id")!.GetValue(parsed)!);
+        Assert.Equal(doc.DocumentElement!.GetAttribute("Name"), (string?)t.GetProperty("Name")!.GetValue(parsed));
+        Assert.Equal(doc.DocumentElement.GetAttribute("ALNamespace"),
+            (string?)t.GetProperty("ALNamespace")!.GetValue(parsed));
+
+        // Values is what the whole enum comparison rests on, and it is an EMPTY immutable array
+        // on an object that ignored the document.
+        var values = t.GetProperty("Values")!.GetValue(parsed)!;
+        var length = (int)values.GetType().GetProperty("Length")!.GetValue(values)!;
+        var declared = doc.DocumentElement["Values"]!.ChildNodes.Cast<XmlNode>().Count(n => n.Name == "Value");
+        Assert.Equal(declared, length);
+        Assert.True(declared > 0, $"{label}: the document declares no value, so this measured nothing.");
+    }
+
+    [SkippableFact]
+    public void MetaEnum_parameterless_reads_NOTHING_and_the_harness_does_not_use_it()
+    {
+        // The trap in the shape it is available here. MetaPageDefinition was a SECOND TYPE;
+        // MetaEnum's is a second CONSTRUCTOR on the same type, which is easier to reach for by
+        // accident and produces the identical silent-empty comparison.
+        Skip.IfNot(_engine.Ready, _engine.SkipReason);
+        var (doc, label) = EmitterDocument("Enum",
+            d => d.DocumentElement!.ChildNodes.Cast<XmlNode>().Any(c => c.Name == "Values"));
+        var t = Resolve("MetaEnum");
+
+        var empty = t.GetConstructor(Type.EmptyTypes)!.Invoke(null);
+        Assert.Equal(0, (int)t.GetProperty("Id")!.GetValue(empty)!);
+        Assert.Null(t.GetProperty("Name")!.GetValue(empty));
+
+        // ...while the document plainly carries both, so the emptiness above is the
+        // constructor's and not the document's.
+        Assert.NotEqual(0, DocumentId(doc));
+        Assert.NotEmpty(doc.DocumentElement!.GetAttribute("Name"));
+    }
+
+    [SkippableFact]
+    public void The_harness_reads_each_document_through_a_type_that_parses()
+    {
+        // Ties the tests above to the thing they are about. Without this they document facts
+        // about BC and say nothing about which route this repository picked.
+        //
+        // Asserted against the harness's OWN report rather than by re-reading the source: were
+        // any of the three oracles switched to a non-reading one, both sides would come out
+        // empty and identical and the kind would report differences of ZERO. That is precisely
+        // the state this class exists to make unreachable, and it is observable from the report
+        // without naming a type at all.
+        Skip.IfNot(_engine.Ready, _engine.SkipReason);
+
+        var seen = new Dictionary<string, int>(StringComparer.Ordinal);
+        var differing = new Dictionary<string, int>(StringComparer.Ordinal);
+        var bundles = MetadataEquivalenceHarness.LoadBundles(
+            MetadataEquivalencePaths.GroundTruthDirForThisBuild());
+        Skip.If(bundles.Count == 0, "no metadata ground-truth bundle for this BC build.");
+
+        foreach (var bundle in bundles)
+        {
+            var app = MetadataEquivalenceHarness.FindAppPackage(bundle);
+            Skip.If(app is null, $"{bundle.Label}: its .app is not on this box.");
+            var report = MetadataEquivalenceHarness.Compare(bundle, app!);
+
+            foreach (var (kind, prefix) in new[] { ("Report", "Report "), ("PermissionSet", "PermissionSet "), ("Enum", "Enum ") })
+            {
+                seen[kind] = seen.GetValueOrDefault(kind) + bundle.Census.GetValueOrDefault(kind);
+                differing[kind] = differing.GetValueOrDefault(kind)
+                    + report.Differences.Count(d => d.ObjectKey.StartsWith(prefix, StringComparison.Ordinal));
+            }
+        }
+
+        foreach (var kind in new[] { "Report", "PermissionSet", "Enum" })
+        {
+            Assert.True(seen[kind] > 0, $"no bundle carried a {kind}, so this measured nothing.");
+            // The runner derives a deliberate SUBSET of each of these documents — the three
+            // #3806/#3807/#3808 gap issues say exactly which members — so SOME difference is
+            // guaranteed for as long as that stays true. Zero here does not mean the derivation
+            // became perfect; it means the oracle stopped parsing.
+            Assert.True(differing[kind] > 0,
+                $"{seen[kind]} {kind} object(s) compared and NOT ONE difference was found. The " +
+                "runner derives only part of each of these documents, so zero differences means " +
+                "the oracle stopped parsing — the MetaPageDefinition failure mode this class " +
+                "pins. If the derivation genuinely became complete, delete this assertion in the " +
+                "same change that made it true, and say so.");
+        }
+    }
+}

--- a/AlRunner/Patches/RecordPatches.ReportEnumPermissionSetMetadataEquivalence.cs
+++ b/AlRunner/Patches/RecordPatches.ReportEnumPermissionSetMetadataEquivalence.cs
@@ -1,0 +1,143 @@
+// RecordPatches.ReportEnumPermissionSetMetadataEquivalence — the runner-side accessors the
+// metadata-equivalence harness needs for Report, PermissionSet and Enum (#3782, steps 5-7).
+//
+// WHY THREE ACCESSORS RATHER THAN ONE
+//   The harness compares one BC type against itself: BC's emitter document on one side, the
+//   runner's derivation on the other, both read by the same BC reader. What each kind can
+//   offer as "the runner's derivation" differs, and the difference is the finding:
+//
+//     Report        — an XML render already exists and is the document every runner consumer
+//                     of report metadata reads (DependencyReportMetadata.cs). Handed over
+//                     as-is; the harness reads it back with BC's own MetaReport constructor.
+//     PermissionSet — BuildMetaPermissionSet already produces a real
+//                     Types.Metadata.MetaPermissionSet from the SymbolReference-derived
+//                     PermissionSetSymbol. Handed over AS THE OBJECT, no rendering.
+//     Enum          — Types.Metadata.MetaEnum's properties are ALL get-only, so there is no
+//                     object route: the runner's registry entry is rendered as the <Enum>
+//                     document BC's own MetaEnum(XmlNode) parses.
+//
+// THE CIRCULARITY EACH ACCESSOR AVOIDS
+//   For a PRECOMPILED dependency none of the three has a BC-captured document to fall back
+//   on: AlReportMetadataRegistry and AlObjectMetadataRegistry are filled by the EMIT
+//   pipeline, so they hold what the runner compiled and nothing a dependency .app shipped.
+//   Every value below therefore comes from SymbolReference.json (plus, for a report's column
+//   source expressions, the .app's own embedded AL source). See
+//   docs/metadata-equivalence.md#reports, #permission-sets and #enums.
+//
+// THE MEMO THAT MADE THE FIRST MEASUREMENT WRONG — read before changing PermissionSet
+//   PermissionSetIdByName() is a memoized static invalidated only inside
+//   EnsurePermissionMetadataPopulated. Calling BuildMetaPermissionSet without driving that
+//   entry point first measures an EMPTY name index, so every IncludedPermissionSets edge is
+//   dropped and the comparison reports 94 differences the runner does not actually have.
+//   That is why RunnerPermissionSetDeclarations() drives the population rather than reading
+//   the inventory directly (#3782, step 6).
+
+using System.Globalization;
+using System.Xml;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    /// <summary>
+    /// The runner's derivation for one report, as the <c>&lt;Report&gt;</c> document BC's
+    /// <c>Types.Metadata.MetaReport(XmlElement, …)</c> parses — or null when no registered
+    /// dependency declares that report.
+    ///
+    /// <para>A thin forwarder to <see cref="TryBuildDependencyReportMetadata"/> ON PURPOSE:
+    /// the harness must measure the document runner consumers actually read, not a
+    /// test-only rendering, and naming it here keeps the harness from reaching for
+    /// AlReportMetadataRegistry — which holds BC's own emit-captured output and would compare
+    /// BC against BC.</para>
+    /// </summary>
+    internal static string? TryBuildReportMetadataEquivalenceXml(int reportId)
+        => TryBuildDependencyReportMetadata(reportId);
+
+    /// <summary>
+    /// Every permission set the runner has a real declaration for, keyed by object id, after
+    /// the runner's own population has run.
+    ///
+    /// <para><b>The population call is not optional.</b> See this file's header: without it
+    /// the name-to-id index behind <c>IncludedPermissionSets</c> is empty and the comparison
+    /// measures a memo no runner consumer ever sees.</para>
+    /// </summary>
+    internal static IReadOnlyDictionary<int, BcAppSymbolCache.PermissionSetSymbol>
+        RunnerPermissionSetDeclarations()
+    {
+        EnsurePermissionMetadataPopulated();
+        var byId = new Dictionary<int, BcAppSymbolCache.PermissionSetSymbol>();
+        foreach (var (permissionSet, _, _) in EnumerateKnownPermissionSets())
+            byId.TryAdd(permissionSet.Id, permissionSet);
+        return byId;
+    }
+
+    /// <summary>
+    /// The runner's own <c>Types.Metadata.MetaPermissionSet</c> for one declaration — the same
+    /// object BC's <c>AssignFromMetaPermissionSet</c> consumes at runtime, so this measures
+    /// what BC's permission composer actually receives.
+    /// </summary>
+    internal static object BuildPermissionSetMetadataEquivalenceObject(
+        BcAppSymbolCache.PermissionSetSymbol declaration)
+        => BuildMetaPermissionSet(declaration);
+
+    /// <summary>
+    /// The runner's derivation for one enum, as the <c>&lt;Enum&gt;</c> document BC's
+    /// <c>Types.Metadata.MetaEnum(XmlNode)</c> parses — or null when the runner's enum
+    /// registry knows no enum with that id.
+    ///
+    /// <para><b>Why a render and not an object.</b> Every property on BC's <c>MetaEnum</c> is
+    /// get-only and its only other constructors are the parameterless one and a 10-argument
+    /// positional one over BC-internal types, so there is no route that sets values on an
+    /// instance. The XmlNode constructor is the one BC itself uses to read an emitted enum,
+    /// and reading both sides through it makes the comparison one type against itself.</para>
+    ///
+    /// <para><b>A value the runner does not derive is LEFT OFF, never defaulted.</b> BC's own
+    /// constructor then applies BC's default and the reported difference is a true statement
+    /// about what the runner does not know. Writing BC's value into any element would
+    /// manufacture agreement — which is the whole failure mode this harness exists to catch.
+    /// Measured on BC 28.1.49838.53910: <c>Extensible</c> is absent here because
+    /// <see cref="BcAppSymbolCache.EnumSymbol"/> does not carry it at all (#3807), not because
+    /// it is unknowable.</para>
+    /// </summary>
+    internal static string? TryBuildEnumMetadataEquivalenceXml(int enumId)
+    {
+        if (!AlRunner.AlEnumMetadataRegistry.TryGet(enumId, out var entry)) return null;
+
+        var doc = new XmlDocument();
+        var root = doc.CreateElement("Enum");
+        doc.AppendChild(root);
+        root.SetAttribute("ID", entry.Id.ToString(CultureInfo.InvariantCulture));
+        root.SetAttribute("Name", entry.Name);
+
+        var values = doc.CreateElement("Values");
+        root.AppendChild(values);
+        for (int i = 0; i < entry.Options.Length; i++)
+        {
+            var value = doc.CreateElement("Value");
+            value.SetAttribute("Name", entry.Options[i]);
+            // Indexes[i] is the AL-declared ordinal and is NOT the position — BC's emitter
+            // writes an enum's values in NAME order, so the two coincide only for an enum whose
+            // names happen to sort by ordinal. That is why the harness pairs enum values by
+            // Ordinal rather than by position (MetadataEquivalenceHarness.EnumDiffOptions).
+            value.SetAttribute(
+                "Ordinal",
+                (i < entry.Indexes.Length ? entry.Indexes[i] : i).ToString(CultureInfo.InvariantCulture));
+
+            // Caption null means "this value declares none" (#1775), which is a different
+            // statement from "declares an empty one" — so nothing is written for a null and
+            // BC's own default (the member name) applies on both sides.
+            var caption = entry.Captions is not null && i < entry.Captions.Length
+                ? entry.Captions[i]
+                : null;
+            if (caption is not null)
+            {
+                var captionMl = doc.CreateElement("CaptionML");
+                captionMl.InnerText = "ENU=" + caption;
+                value.AppendChild(captionMl);
+            }
+
+            values.AppendChild(value);
+        }
+        return doc.OuterXml;
+    }
+}

--- a/AlRunner/Patches/RecordPatches.ReportEnumPermissionSetMetadataEquivalence.cs
+++ b/AlRunner/Patches/RecordPatches.ReportEnumPermissionSetMetadataEquivalence.cs
@@ -81,6 +81,48 @@ public static partial class RecordPatches
         => BuildMetaPermissionSet(declaration);
 
     /// <summary>
+    /// The runner's extension-runtime-delta object for one extended object id, or null.
+    ///
+    /// <para><b>It is null for every id today, and that null is the measurement.</b>
+    /// <see cref="RunnerXmlMetadataLoader.GetExtensionDeltasForAppObject"/> is the one runner
+    /// member typed to return BC's <c>NavAppObjectMetadataRuntimeDeltas</c>, and it returns
+    /// <c>null!</c> by construction: the runner has no published-app extension pipeline, and
+    /// that comment records null as BC's own "no deltas" value. So this accessor exists to
+    /// report the absence per object rather than to hide it — the harness turns each null into
+    /// a named unbuildable entry naming #3809.</para>
+    ///
+    /// <para><b>Why it goes through the loader rather than short-circuiting to null.</b> If the
+    /// runner ever starts tracking extension deltas, this begins returning objects and the
+    /// comparison starts measuring them with no edit here. A hardcoded null would have to be
+    /// noticed and removed, which is the kind of thing nobody notices.</para>
+    /// </summary>
+    internal static object? TryGetRuntimeDeltasMetadataEquivalence(int extendedObjectId)
+    {
+        var loader = new RunnerXmlMetadataLoader();
+        var method = typeof(RunnerXmlMetadataLoader).GetMethod("GetExtensionDeltasForAppObject")
+            ?? throw new InvalidOperationException(
+                "RunnerXmlMetadataLoader.GetExtensionDeltasForAppObject is gone. It is the only " +
+                "runner member typed as NavAppObjectMetadataRuntimeDeltas, so without it the " +
+                "runner side of the MetadataRuntimeDeltas comparison cannot be located at all.");
+
+        // ApplicationObjectId's ctor takes (ObjectType, int). The ordinal is read off BC's own
+        // enum by NAME rather than hardcoded: a numeric literal here would silently point at a
+        // different object type if BC ever renumbers, and the comparison would then report a
+        // null that means "wrong id" rather than "no deltas".
+        var objectIdType = method.GetParameters()[0].ParameterType;
+        var objectTypeEnum = objectIdType.GetConstructors()
+            .Select(c => c.GetParameters())
+            .FirstOrDefault(ps => ps.Length == 2 && ps[0].ParameterType.IsEnum)?[0].ParameterType
+            ?? throw new InvalidOperationException(
+                "ApplicationObjectId has no (enum, int) constructor — BC's shape changed.");
+        var objectId = Activator.CreateInstance(
+            objectIdType,
+            new object?[] { Enum.Parse(objectTypeEnum, "Page"), extendedObjectId });
+
+        return method.Invoke(loader, new object?[] { objectId, null });
+    }
+
+    /// <summary>
     /// The runner's derivation for one enum, as the <c>&lt;Enum&gt;</c> document BC's
     /// <c>Types.Metadata.MetaEnum(XmlNode)</c> parses — or null when the runner's enum
     /// registry knows no enum with that id.

--- a/docs/metadata-equivalence.md
+++ b/docs/metadata-equivalence.md
@@ -439,24 +439,30 @@ reachable.
 <a id="what-is-compared"></a>
 ## What is compared, and what is not
 
-The harness compares `MetaTable`, `PageDefinition`, `CodeUnit`, `Report`, `PermissionSet` and
-`Enum` documents. A bundle carries every kind BC emitted — including queries, xmlports and the
-`MetadataRuntimeDeltas` documents that cover table, page and permission-set extensions — and
+The harness compares `MetaTable`, `PageDefinition`, `CodeUnit`, `Report`, `PermissionSet`,
+`Enum` and `MetadataRuntimeDeltas` documents. A bundle carries every kind BC emitted, and
 `MetadataEquivalenceHarnessTests` asserts the set it compares AND the set it does not, so
 covering less cannot happen quietly.
 
 **#3782 is the programme that empties the not-compared list**, one kind per pull request, in the
 order that issue records: `PageDefinition` (done), `CodeUnit` (done), `Query` and `XmlPort` (in
-flight), then `Report` (done), `PermissionSet` (done), `Enum` (done) and
-`MetadataRuntimeDeltas` (**closed as uncomparable** — see below). Each step adds its kind to
-`ComparedKinds`, lands the resulting allowlist with a reason per member, and deletes its kind
-from the `stillUncompared` list in `The_harness_states_which_kinds_it_does_not_compare`.
+flight), then `Report`, `PermissionSet`, `Enum` and `MetadataRuntimeDeltas` (all done). Each
+step adds its kind to `ComparedKinds`, lands the resulting allowlist with a reason per member,
+and deletes its kind from the `stillUncompared` list in
+`The_harness_states_which_kinds_it_does_not_compare`.
 
-**A kind can leave that list two ways, and they are not the same.** Most leave it by being
-compared. `MetadataRuntimeDeltas` left it by being *measured uncomparable*, which is recorded in
-`MetadataEquivalenceHarness.UncomparableKinds` rather than by deletion —
-`The_harness_states_which_kinds_it_does_not_compare` holds the two structures against each
-other, so the entry cannot keep reading as "not got to yet" after the question was closed.
+**Every kind is compared. None is exempt**, and the harness has no mechanism for exempting one
+— that is deliberate, and it is the correction of a mistake this programme made once.
+`MetadataRuntimeDeltas` was briefly recorded as *uncomparable* in a
+`MetadataEquivalenceHarness.UncomparableKinds` structure, with a passing test holding the claim
+in place. It was wrong (see below), and the shape of the error is the reason no such structure
+exists now: **a green assertion that a kind cannot be measured is indistinguishable from a green
+assertion that it was**, and it is strictly harder to dislodge, because the next reader finds a
+test telling them not to look.
+
+A kind the runner cannot build a side for is reported per object as **unbuildable**, with the
+count asserted against the census. That keeps the absence a measurement rather than a
+classification.
 
 <a id="the-page-oracle-is-pagedefinition-not-metapagedefinition"></a>
 ### The page oracle is `PageDefinition`, not `MetaPageDefinition`
@@ -937,30 +943,77 @@ census arithmetic in `Every_object_in_a_compared_kind_really_was_compared` asser
 quietly go.
 
 <a id="metadataruntimedeltas"></a>
-## `MetadataRuntimeDeltas` cannot be compared non-circularly, and that is the measurement
+## `MetadataRuntimeDeltas`: a one-sided gap, and a census that was too narrow
 
-This is the one kind of the eight that #3782 closes with a **finding rather than a comparison**,
-and the precedent is step 4's treatment of `XmlPort`: when a kind genuinely has nothing
-non-circular, the right outcome is to say so with the measurement, not to manufacture a
-comparison. Tracked on #3809. Both sides are missing, which is a stronger result than
-`XmlPort`'s, where the runner at least had an id and a name.
+This kind was first written up here as **uncomparable — "BC ships no reader for the shape"** —
+and that was wrong. The correction is kept in full rather than quietly replaced, because the way
+it went wrong is more reusable than the conclusion.
 
-**There is no BC reader for the shape.** Every other kind is read back by a BC type —
-`CreateMetaTableFromXml`, `PageDefinition(XmlNode)`, `MetaQuery`, `MetaXmlPort`, `MetaReport`,
-`MetaPermissionSet.Create`, `MetaEnum`. Measured by reflecting over both assemblies on BC
-28.4.53241.54407: **no type in `Microsoft.Dynamics.Nav.Types` (2,617 types) or
-`Microsoft.Dynamics.Nav.Ncl` (8,616 types) has "Delta" in its name**, in any casing. BC applies
-these documents during metadata assembly rather than materialising them as an object.
+<a id="the-census-that-was-too-narrow"></a>
+### The census that produced the false negative
 
-**And the runner builds no extension-shaped object either.** It folds an extension's
-contribution into the object being extended at parse time and keeps nothing addressable by the
-extension's own id — table and page extensions merge into the target's parsed form, enum
-extensions key by the target enum's id. For a document keyed on extension id N there is no
-runner object with id N.
+The claim rested on reflecting over `Microsoft.Dynamics.Nav.Types` (2,617 types) and
+`Microsoft.Dynamics.Nav.Ncl` (8,616 types) and finding **no type with "Delta" in its name**.
+Both numbers are correct. The inference from them was not, for one reason: **every other oracle
+in this harness comes from one of those two assemblies, so those two were the ones searched** —
+and the artifact directory holds **501**.
 
-Either half would change the answer, and neither is small: a BC reader materialising the shape,
-or an addressable runner extension object — which #3807 notes would also be what an
-enumextension `<Enum>` document needs.
+Re-measured over all of them, without loading anything (a `PEReader` metadata scan, so no
+static-init faults and no resolution failures):
+
+| | |
+|---|---:|
+| assemblies scanned | 501 |
+| types whose name contains "Delta" | **308** |
+| of those, in `Microsoft.Dynamics.Nav.Apps.dll` | **54** |
+
+`.Types` really is 0. `.Ncl` is not — it has 10, including the state machine
+`<GetRuntimeDeltas>d__15`, whose element type points straight at the reader.
+
+**The lesson generalises past this kind: a negative about BC's surface is only as wide as the
+search behind it.** "I did not find it" and "it does not exist" are different claims, and the
+second needs a search whose scope matches the claim's scope. Two assemblies cannot settle a
+question about the runtime.
+
+<a id="the-deltas-oracle"></a>
+### The oracle
+
+`Microsoft.Dynamics.Nav.Apps.MetadataDeltas.NavAppObjectMetadataRuntimeDeltas.FromXml(XDocument)`,
+with `NavAppObjectMetadataDeltaBase.MetadataRuntimeDeltasXName` resolving to
+`{urn:schemas-microsoft-com:dynamics:NAV:MetaObjects}MetadataRuntimeDeltas` — character for
+character the root element of the emitted documents.
+
+Proven to parse rather than assumed to, over **every** document rather than a sample:
+
+| | |
+|---|---:|
+| documents in the two bundles | 11 |
+| parsed, `AllDeltas` reachable | **11** |
+| yielding a non-empty `AllDeltas` | 6 (12 on page 774, 5 on 4318, 4 on 2515, 2 on 324, 1 on 9862) |
+| genuinely empty `<MetadataRuntimeDeltas/>` elements | 5 |
+
+**A bare probe of the same call parsed only 6 of 11**, the other 5 hitting a
+`WindowsLanguageHelper` static-init fault. That is an artifact of loading the assembly outside
+the harness: inside the `bc-engine-serial` collection, which already has the skeleton, it is
+11 of 11. Worth knowing before treating a partial parse as a property of the reader.
+
+<a id="the-runner-side-is-null"></a>
+### The runner's side is null, and that is the gap
+
+`RunnerXmlMetadataLoader.GetExtensionDeltasForAppObject` is the one runner member typed to
+return `NavAppObjectMetadataRuntimeDeltas`, and it returns `null!` for every object — its own
+comment records that the runner has no published-app extension pipeline, and that null is BC's
+"no deltas" value too. Measured through that member rather than read off it: null for all 11.
+
+So the honest claim is a **one-sided gap** — BC's side is real and parses; the runner's is
+absent — which is narrower and more useful than "neither side exists". Each object is reported
+as unbuildable naming #3809, and
+`Every_object_in_a_compared_kind_really_was_compared` asserts that the count of deltas
+unbuildables **equals the census**, so a deltas object that somehow did build, or any object of
+another kind that did not, still fails.
+
+**What would close it:** the runner tracking an extension's contribution addressably by the
+extension's own id — the same thing #3807 notes an enumextension `<Enum>` document would need.
 
 <a id="running-it"></a>
 ## Running it

--- a/docs/metadata-equivalence.md
+++ b/docs/metadata-equivalence.md
@@ -439,17 +439,24 @@ reachable.
 <a id="what-is-compared"></a>
 ## What is compared, and what is not
 
-The harness compares `MetaTable`, `PageDefinition` and `CodeUnit` documents. A bundle carries
-every kind BC emitted — enums, permission sets, queries, reports, xmlports, and the
+The harness compares `MetaTable`, `PageDefinition`, `CodeUnit`, `Report`, `PermissionSet` and
+`Enum` documents. A bundle carries every kind BC emitted — including queries, xmlports and the
 `MetadataRuntimeDeltas` documents that cover table, page and permission-set extensions — and
 `MetadataEquivalenceHarnessTests` asserts the set it compares AND the set it does not, so
 covering less cannot happen quietly.
 
 **#3782 is the programme that empties the not-compared list**, one kind per pull request, in the
-order that issue records: `PageDefinition` (done), `CodeUnit` (done), then `Query`, `XmlPort`, `Report`,
-`PermissionSet`, `Enum`, `MetadataRuntimeDeltas`. Each step adds its kind to `ComparedKinds`,
-lands the resulting allowlist with a reason per member, and deletes its kind from the
-`stillUncompared` list in `The_harness_states_which_kinds_it_does_not_compare`.
+order that issue records: `PageDefinition` (done), `CodeUnit` (done), `Query` and `XmlPort` (in
+flight), then `Report` (done), `PermissionSet` (done), `Enum` (done) and
+`MetadataRuntimeDeltas` (**closed as uncomparable** — see below). Each step adds its kind to
+`ComparedKinds`, lands the resulting allowlist with a reason per member, and deletes its kind
+from the `stillUncompared` list in `The_harness_states_which_kinds_it_does_not_compare`.
+
+**A kind can leave that list two ways, and they are not the same.** Most leave it by being
+compared. `MetadataRuntimeDeltas` left it by being *measured uncomparable*, which is recorded in
+`MetadataEquivalenceHarness.UncomparableKinds` rather than by deletion —
+`The_harness_states_which_kinds_it_does_not_compare` holds the two structures against each
+other, so the entry cannot keep reading as "not got to yet" after the question was closed.
 
 <a id="the-page-oracle-is-pagedefinition-not-metapagedefinition"></a>
 ### The page oracle is `PageDefinition`, not `MetaPageDefinition`
@@ -762,6 +769,198 @@ declared permanent. Checked against `SymbolReference.json` directly, on the same
 in either direction — which is how #3790 stayed hidden: the symbol file writes `"1"` and the
 codeunit parser matched only the word `"true"`, so all 38 single-instance System Application
 codeunits read as false. `CodeunitSymbolSingleInstanceSpellingTests` pins both spellings.
+
+<a id="reports"></a>
+## Reports: one object, and the honesty that forces
+
+System Application ships **exactly one** report — 9810 `Change Password` — and Business
+Foundation ships none. Every number in this section is `n = 1`, and it is enough to say *that*
+the runner drops a member, never how often.
+
+The oracle is `Types.Metadata.MetaReport(XmlElement, CreateRequestForm, int, int,
+RemoveItemsOnPageBasedOnLicenseAndApplicationArea)`; both delegates are optional and null is
+what the constructor's own body expects. The runner's side is
+`RecordPatches.TryBuildDependencyReportMetadata` — the document every runner consumer of report
+metadata actually reads, since `RunnerXmlMetadataLoader` hands exactly this XML to BC — rather
+than a test-only rendering, and never `AlReportMetadataRegistry`, which holds BC's emit-captured
+output and would compare BC against BC.
+
+**5 differences**, all tracked on #3808: both `Inherent*` masks (the `"X"` spelling
+`SymbolReference.json` states and `ReportSymbol` does not carry — the same property #3788
+records for codeunits and #3798 for queries, three kinds and one unparsed value), `ALNamespace`,
+and `RequestPageDefinition` counted twice because the differ walks the property and its backing
+field independently.
+
+`RequestPageDefinition` is the one that is not merely a dropped property: BC emits a full
+`<RequestPage><PageDefinition>` subtree for report 9810 even though it declares
+`UseRequestPage = false` and `ProcessingOnly = true`. Whether BC does that for *every* report is
+**not answerable from this bundle** — one report — and Base Application, which would answer it,
+is excluded from `apps.json` because its emit needs a .NET reference no BC artifact ships
+(#3549). That question is left open on #3808 rather than closed by assumption.
+
+**What this comparison does not reach:** report 9810 has no data items and no columns, so the
+data-item and column derivation — the substantial part of `DependencyReportMetadata.cs` — is not
+exercised at all.
+
+<a id="permission-sets"></a>
+## Permission sets: object against object, and the memo that made the first answer wrong
+
+The oracle is the static factory `MetaPermissionSet.Create(XmlNode, int, int)`, not a
+constructor. The runner's side is `BuildMetaPermissionSet`, which already produces a real
+`Types.Metadata.MetaPermissionSet` from the SymbolReference-derived `PermissionSetSymbol` — the
+same object BC's `AssignFromMetaPermissionSet` consumes at runtime. No rendering step on either
+side.
+
+**Every structural member agrees on all 178** — the permission rows themselves, the include and
+exclude edges, `Access`, `Id`. **527 differences across 4 members**, tracked on #3806.
+
+<a id="the-permission-set-memo"></a>
+### `PermissionSetIdByName` is memoized and invalidated in one place only
+
+`PermissionSetIdByName()` is a memoized static dropped **only inside**
+`EnsurePermissionMetadataPopulated`. The first version of this comparison called
+`BuildMetaPermissionSet` directly and measured an **empty** name index: every include edge
+dropped, **94 fabricated differences** on `IncludedPermissionSets` that the runner does not
+actually have.
+
+That is why `RecordPatches.RunnerPermissionSetDeclarations` drives the runner's own population
+entry point before reading the inventory. A comparison that measures a memo no runner consumer
+ever sees is the "green over nothing" failure this whole harness exists to prevent — here it was
+loud rather than silent, but only by luck of which direction it went.
+
+<a id="bc-uppercases-a-permission-set-name"></a>
+### BC's reader uppercases `Name`; the document does not
+
+170 of the 178 differences on `MetaPermissionSet.Name` are this, and the runner is not obviously
+the one that is wrong. Of the 178 emitted documents, **8 state an already-uppercase `Name`**
+(`SUPER`, `SECURITY`, `LOGIN`, `TROUBLESHOOT TOOLS`, `SUPER (DATA)`, `D365 SNAPSHOT DEBUG`,
+`D365 ATTACH DEBUG`, `D365 BACKUP/RESTORE`) and 170 state mixed case — and `Create` answers all
+178 upper-cased. 178 − 8 = 170, exactly the difference count.
+
+The value is a `Code[20]`/`Code[30]` **role id**, and BC upper-cases codes. So the open question
+is *where* the upper-casing belongs, not which spelling is right, and
+`MetadataEquivalenceReportEnumPermissionSetOracleTests` asserts the reader's behaviour so the
+allowlist entry stays attributable to the reader rather than to the runner.
+
+<a id="permission-set-68-answers-2417"></a>
+### PermissionSet 68 answers #2417, empirically
+
+#2417 asks what `Assignable` resolves to for a permission set whose `SymbolReference.json` entry
+carries no `Properties` array, and says explicitly that it must be settled against BC itself
+rather than by reading the symbol file.
+
+BC's own emitted document for **PermissionSet 68 `System Execute - Basic`** is the only one of
+the 178 carrying **no `Assignable` attribute at all** — the distribution is 140 × `"0"`,
+37 × `"1"`, 1 × absent — and BC's own `MetaPermissionSet.Create` resolved that absence to
+**`Assignable = False`**.
+
+So BC's reader defaults **absent → false**, and `CollectPermissionSets`'s `absent → true` is
+wrong, exactly as #2417 predicted. This is a measurement through BC's own reader, not an
+inference from the AL. The fix lands outside this harness and is tracked on #3806, which records
+the answer and points back at #2417.
+
+<a id="enums"></a>
+## Enums: a render, because every `MetaEnum` property is get-only
+
+`MetaEnum`'s properties are **all** `{ get; }` and its only other constructors are the
+parameterless one and a 10-argument positional one over BC-internal types, so there is no route
+that sets values on an instance. `RecordPatches.TryBuildEnumMetadataEquivalenceXml` therefore
+renders the runner's registry entry as the `<Enum>` document BC's own `MetaEnum(XmlNode)`
+parses, and both sides go through that constructor.
+
+The parameterless constructor is the `MetaPageDefinition` trap in a sharper form — a second
+*constructor on the same type* rather than a second type — so
+`MetadataEquivalenceReportEnumPermissionSetOracleTests` pins that it reads nothing and that the
+harness does not use it.
+
+**Every value's `Name` and `Ordinal` agrees on 141 of 142 enums**, over 3,491 values, and every
+declared per-value `Caption` reaches BC's `CaptionML`. **4,328 differences**, of which the
+non-`TranslationKey` remainder is 6 members tracked on #3807.
+
+<a id="enum-values-pair-by-ordinal"></a>
+### Enum values pair by `Ordinal`, and the one that does not is the finding
+
+BC's emitter writes an enum's values in **name** order while the runner's registry holds them in
+declaration order, so the two lists are permutations of each other and positional pairing would
+fabricate a difference on every value after the first divergence. Enum 2616 `Printer Paper Kind`
+opens `A2=66, A3=8, A4=9, A5=11, A6=70` — plainly alphabetical, plainly not ordinal order.
+
+`Ordinal` is supplied through `IdPropertyNames` for this comparison only, because it is an
+identity for `MetaEnumValue` alone: that type has no `Id`/`ID` at all. Measured over both
+bundles, **2,678 of 3,155** enum-value differences pair by ordinal and 477 do not.
+
+**The 477 are all one enum, and that is #3805 rather than a gap in the pairing.**
+`TryPairById` refuses a duplicate key, and enum 2616 is the only one of the 142 whose
+*runner-side* ordinals contain a duplicate: `TryParseEnumSymbol` reads an absent `Ordinal` as
+"previous + 1" where `SymbolReference.json` omits it to mean **0**, so `Custom` gets 40 —
+already taken by `GermanStandardFanfold`. So the enum that cannot be paired is exactly the enum
+with the defect. Fixing #3805 should move that residue to zero, which is why
+`Enum_values_are_paired_by_ordinal_and_not_by_position` asserts the positional remainder is a
+*minority* rather than zero.
+
+<a id="the-allowlist-cannot-see-a-path-change"></a>
+### The allowlist is member-keyed, so two real defects are invisible to it
+
+Both were found by mutation-checking this work rather than by review, and both are the #3802
+shape — cover the harness cannot report on.
+
+**Removing the ordinal pairing changes not one difference count.** The allowlist keys on
+`DeclaringType.Member`; positional pairing reports the same *members* and moves the *paths*. So
+every test stayed green without the pairing, and
+`Enum_values_are_paired_by_ordinal_and_not_by_position` exists because nothing else could see it.
+
+**Manufacturing agreement on `MetaEnum.Extensible` also stayed green.** Writing BC's own value
+into the render does not remove the differences, it **inverts** them: 31 (BC `True`, runner
+`False`) becomes 111 (BC `False`, runner `True`), the entry still matches every one, and
+`No_allowlist_entry_has_gone_stale` has nothing to report. `direction` cannot narrow it either,
+because that field keys on the value being absent-or-null and both sides here are `False`/`True`.
+What does work is the claim the table-side members already make — the runner answers a
+**constant**, and that constant *is* the defect —
+`The_new_kinds_reader_answers_the_constant_that_IS_the_defect`.
+
+<a id="enum-extension-documents"></a>
+### Two `<Enum>` documents are enum EXTENSIONS, and are skipped rather than compared
+
+One `<Enum>` root covers both `Enum` and `EnumExtension` — the generator's `ClassifyDocument`
+says so deliberately — and the two are told apart by shape: a base enum wraps its values in
+`<Values>`, an extension states bare `<Value>` children. Exactly 2 of 143 are the extension
+shape (327 `No. Series Copilot Cap.`, 2015 `Entity Text Capability`, both extending
+`Copilot Capability`).
+
+There is no runner object addressable by those ids. `AlEnumMetadataRegistry` keys an
+extension's values by the id of the enum it **extends**, and for a precompiled dependency
+`RecordPatches.BcAppFallback` registers everything through `Register` rather than
+`RegisterExtension` — measured: `SnapshotRaw()` reports **0** extension entries for both
+bundles. So they are counted in `MetadataEquivalenceReport.EnumExtensionDocuments` and the
+census arithmetic in `Every_object_in_a_compared_kind_really_was_compared` asserts
+`compared == comparable − skipped`, which is what stops the skip becoming a place objects can
+quietly go.
+
+<a id="metadataruntimedeltas"></a>
+## `MetadataRuntimeDeltas` cannot be compared non-circularly, and that is the measurement
+
+This is the one kind of the eight that #3782 closes with a **finding rather than a comparison**,
+and the precedent is step 4's treatment of `XmlPort`: when a kind genuinely has nothing
+non-circular, the right outcome is to say so with the measurement, not to manufacture a
+comparison. Tracked on #3809. Both sides are missing, which is a stronger result than
+`XmlPort`'s, where the runner at least had an id and a name.
+
+**There is no BC reader for the shape.** Every other kind is read back by a BC type —
+`CreateMetaTableFromXml`, `PageDefinition(XmlNode)`, `MetaQuery`, `MetaXmlPort`, `MetaReport`,
+`MetaPermissionSet.Create`, `MetaEnum`. Measured by reflecting over both assemblies on BC
+28.4.53241.54407: **no type in `Microsoft.Dynamics.Nav.Types` (2,617 types) or
+`Microsoft.Dynamics.Nav.Ncl` (8,616 types) has "Delta" in its name**, in any casing. BC applies
+these documents during metadata assembly rather than materialising them as an object.
+
+**And the runner builds no extension-shaped object either.** It folds an extension's
+contribution into the object being extended at parse time and keeps nothing addressable by the
+extension's own id — table and page extensions merge into the target's parsed form, enum
+extensions key by the target enum's id. For a document keyed on extension id N there is no
+runner object with id N.
+
+Either half would change the answer, and neither is small: a BC reader materialising the shape,
+or an addressable runner extension object — which #3807 notes would also be what an
+enumextension `<Enum>` document needs.
 
 <a id="running-it"></a>
 ## Running it

--- a/tests/expectations/metadata-equivalence/allowlist.json
+++ b/tests/expectations/metadata-equivalence/allowlist.json
@@ -26,12 +26,12 @@
     "Nine entries are DIRECTION-SCOPED. An entry covers both directions unless it says otherwise,",
     "and a reason that justifies one direction must not license the other. All three",
     "oracleLimitation entries are runner-only: they exist because the runner shows a merged",
-    "runtime view, so BC-absent / runner-present is what they justify \u2014 while the reverse, BC",
+    "runtime view, so BC-absent / runner-present is what they justify — while the reverse, BC",
     "emitting a field the runner never builds, is a hard reader defect that must still fail.",
     "",
     "There is deliberately NO occurrence cap. One was implemented and used by nothing, which made",
     "the PR claim a ratchet the code did not keep. No entry here has a bound that survives a",
-    "rebuild \u2014 the counts move with the BC build and with which apps are bundled \u2014 so any cap",
+    "rebuild — the counts move with the BC build and with which apps are bundled — so any cap",
     "would be a number nobody measured. Direction narrows categorically instead.",
     "",
     "Measured on BC 28.1.49838.53910 over Business Foundation (12 tables) and System Application",
@@ -88,11 +88,11 @@
     "",
     "CodeUnit (#3782 step 2). Measured on BC 28.1.49838.53910 over Business Foundation (25",
     "codeunits) and System Application (533): 2,220 differences across 5 members, all of them",
-    "one-directional (BC states a value, the runner states none \u2014 the runner invents nothing).",
+    "one-directional (BC states a value, the runner states none — the runner invents nothing).",
     "Five of MetaCodeunit's eleven members already agree EXACTLY across all 558 codeunits: Id,",
     "Name, SubType, TableNo and SingleInstance, including all 12 System Application codeunits",
     "that declare a TableNo. The five that differ are tracked on #3788, and none of them is a",
-    "limit of the symbol file \u2014 each was checked against SymbolReference.json directly.",
+    "limit of the symbol file — each was checked against SymbolReference.json directly.",
     "",
     "The five CodeUnit entries were AUDITED against versionContingent and none carries it. That is a",
     "measurement, not an omission: on the three ground-truth bundles present (27.5.46862.53931,",
@@ -147,92 +147,92 @@
     },
     {
       "member": "MetaField.Caption",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.CaptionClass",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.CaptionOriginal",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.CharAllowed",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.ClrType",
-      "reason": "BC states the field's real CLR type and the runner states the empty string on all 1,888 fields. ClrType is not an XML attribute at all \u2014 BC derives it itself \u2014 and it is a PURE FUNCTION of Datatype, which the symbol file does carry and the runner already reads: measured over 988 observations, all 16 Datatypes map to exactly one ClrType each (BigInteger->System.Int64, GUID->System.Guid, Code/Text/DateFormula->System.String, Option/Integer->System.Int32, BLOB/RecordID->System.Byte[], Media->NSMediaWrapper, and so on). Recoverable with no app data.",
+      "reason": "BC states the field's real CLR type and the runner states the empty string on all 1,888 fields. ClrType is not an XML attribute at all — BC derives it itself — and it is a PURE FUNCTION of Datatype, which the symbol file does carry and the runner already reads: measured over 988 observations, all 16 Datatypes map to exactly one ClrType each (BigInteger->System.Int64, GUID->System.Guid, Code/Text/DateFormula->System.String, Option/Integer->System.Int32, BLOB/RecordID->System.Byte[], Media->NSMediaWrapper, and so on). Recoverable with no app data.",
       "issue": 3568
     },
     {
       "member": "MetaField.EnumTypeName",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.ExternalName",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.ExternalType",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.ObsoleteReason",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.OptionCaption",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.OptionCaptionOriginal",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.ToolTip",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.ToolTipOriginal",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.ValuesAllowed",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.MaxValue",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.MinValue",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.OptionString",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
       "member": "MetaField.InitValue",
-      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done \u2014 which is why it is declared rather than dismissed.",
+      "reason": "BC leaves this null on a field that declares nothing; the runner's MetaField constructor supplies the empty string. Same value in every AL-observable sense as far as anyone has checked, and that check has not been done — which is why it is declared rather than dismissed.",
       "issue": 3568
     },
     {
@@ -242,7 +242,7 @@
     },
     {
       "member": "MetaField.CaptionML.<presence>",
-      "reason": "BC builds a MultiLanguage caption for the field; the runner builds none. The symbol file carries Caption (2,743 occurrences in System Application) \u2014 the MultiLanguage object is its runtime form. Direction-scoped to BC-present / runner-absent; the runner inventing a caption BC does not have is a different defect.",
+      "reason": "BC builds a MultiLanguage caption for the field; the runner builds none. The symbol file carries Caption (2,743 occurrences in System Application) — the MultiLanguage object is its runtime form. Direction-scoped to BC-present / runner-absent; the runner inventing a caption BC does not have is a different defect.",
       "issue": 3568,
       "direction": "bc-only"
     },
@@ -263,7 +263,7 @@
     },
     {
       "member": "MetaField.Relations.<presence>",
-      "reason": "BC gives SystemCreatedBy and SystemModifiedBy a TableRelation to User (2000000120); the runner gives them none. This is the difference already observable from plain AL as FieldRef.Relation() answering 0 \u2014 see #3549. Direction-scoped to BC-present / runner-absent; the runner inventing a relation BC does not have would be a different defect and is not covered.",
+      "reason": "BC gives SystemCreatedBy and SystemModifiedBy a TableRelation to User (2000000120); the runner gives them none. This is the difference already observable from plain AL as FieldRef.Relation() answering 0 — see #3549. Direction-scoped to BC-present / runner-absent; the runner inventing a relation BC does not have would be a different defect and is not covered.",
       "issue": 3568,
       "direction": "bc-only"
     },
@@ -279,7 +279,7 @@
     },
     {
       "member": "MetaKey.Name",
-      "reason": "BC derives this as the POSITIONAL FIELD SPEC over field ids (\"Field1,Field2\"), not as a name anyone declared, and NCLMetaKey.CreateFromMetaKey never passes it \u2014 the declared AL name travels as MetaKey.KeyName, which the reader now states (#3568). So no AL surface can observe this member, and the runner keeps its own spelling rather than reproducing a spec BC regenerates. Superseded reason, recorded because it hid a real defect: this used to read \"two different naming schemes\", and MetaKey.KeyName was declared as \"the same disagreement on the second of the two name properties\". That was wrong \u2014 KeyName is the DECLARED name, the symbol file states it verbatim, and it reaches AL through ObsolescenceGuard.ThrowIfObsoleted.",
+      "reason": "BC derives this as the POSITIONAL FIELD SPEC over field ids (\"Field1,Field2\"), not as a name anyone declared, and NCLMetaKey.CreateFromMetaKey never passes it — the declared AL name travels as MetaKey.KeyName, which the reader now states (#3568). So no AL surface can observe this member, and the runner keeps its own spelling rather than reproducing a spec BC regenerates. Superseded reason, recorded because it hid a real defect: this used to read \"two different naming schemes\", and MetaKey.KeyName was declared as \"the same disagreement on the second of the two name properties\". That was wrong — KeyName is the DECLARED name, the symbol file states it verbatim, and it reaches AL through ObsolescenceGuard.ThrowIfObsoleted.",
       "issue": 3568
     },
     {
@@ -331,7 +331,7 @@
     },
     {
       "member": "MetaTable.Fields.<presence>",
-      "reason": "The runner models the MERGED RUNTIME state a running system has \u2014 every registered app's tableextension fields present on the base table. The ground truth is BC's BUILD-TIME per-app emit, which by construction sees only the app being compiled. Two different things, so this is a limitation of the oracle and not evidence about the runner: 115 fields on four Business Foundation tables (230, 242, 308, 6635). In BC 29 everything is merged at database level anyway, which makes the runner's merged view the forward-looking one. CONSEQUENCE: a multi-app bundle can never produce an empty diff, so a non-empty diff here is expected and must not be read as noise or as a bug. DIRECTION-SCOPED: covers only BC-absent / runner-present, which is the merged-runtime direction this reason justifies. The reverse \u2014 BC emitted a field and the runner built none \u2014 is a hard reader defect and is NOT covered.",
+      "reason": "The runner models the MERGED RUNTIME state a running system has — every registered app's tableextension fields present on the base table. The ground truth is BC's BUILD-TIME per-app emit, which by construction sees only the app being compiled. Two different things, so this is a limitation of the oracle and not evidence about the runner: 115 fields on four Business Foundation tables (230, 242, 308, 6635). In BC 29 everything is merged at database level anyway, which makes the runner's merged view the forward-looking one. CONSEQUENCE: a multi-app bundle can never produce an empty diff, so a non-empty diff here is expected and must not be read as noise or as a bug. DIRECTION-SCOPED: covers only BC-absent / runner-present, which is the merged-runtime direction this reason justifies. The reverse — BC emitted a field and the runner built none — is a hard reader defect and is NOT covered.",
       "oracleLimitation": true,
       "Doc": "docs/metadata-equivalence.md#the-oracle-is-build-time-per-app-metadata",
       "direction": "runner-only"
@@ -467,7 +467,7 @@
     },
     {
       "member": "ControlContainerDefinition.#containerTypeField",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. The member it accompanies is declared beside it in this file. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. The member it accompanies is declared beside it in this file. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "outOfScope": true,
       "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found",
       "versionContingent": true
@@ -480,7 +480,7 @@
     },
     {
       "member": "ControlContainerDefinition.ContainerType",
-      "reason": "The container the page's controls sit in. The runner emits one ContentArea container to hold the parts it does reconstruct (EmitPartControlXml); BC states the real area for the real tree. The same control-tree boundary as the Controls entries. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "The container the page's controls sit in. The runner emits one ContentArea container to hold the parts it does reconstruct (EmitPartControlXml); BC states the real area for the real tree. The same control-tree boundary as the Controls entries. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "outOfScope": true,
       "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found",
       "versionContingent": true
@@ -521,7 +521,7 @@
     },
     {
       "member": "InfopartPageDefinition.#providerIDField",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. The member it accompanies is declared beside it in this file. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. The member it accompanies is declared beside it in this file. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "outOfScope": true,
       "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found",
       "versionContingent": true
@@ -596,21 +596,21 @@
     },
     {
       "member": "InfopartPageDefinition.Editable",
-      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 113 pages declare Editable; EmitPartControlXml does not carry it onto the part control. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 113 pages declare Editable; EmitPartControlXml does not carry it onto the part control. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "issue": 3784,
       "versionContingent": true,
       "Doc": "docs/metadata-equivalence.md#one-build-measured-three-evaluated"
     },
     {
       "member": "InfopartPageDefinition.ProviderID",
-      "reason": "The control that PROVIDES a part's data in the designer's provider/consumer wiring. It names a control id inside the host page's real control tree, which the runner does not reconstruct. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "The control that PROVIDES a part's data in the designer's provider/consumer wiring. It names a control id inside the host page's real control tree, which the runner does not reconstruct. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "outOfScope": true,
       "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found",
       "versionContingent": true
     },
     {
       "member": "InfopartPageDefinition.ProviderIDSpecified",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. The member it accompanies is declared beside it in this file. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. The member it accompanies is declared beside it in this file. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "outOfScope": true,
       "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found",
       "versionContingent": true
@@ -756,7 +756,7 @@
     },
     {
       "member": "PageProperties.#aPIVersionField",
-      "reason": "The API version of an API page. Emitted by BC for the one API page in the bundle and absent from SymbolReference.json; API pages are a web-service publishing surface, which docs/scope.md places out of scope. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "The API version of an API page. Emitted by BC for the one API page in the bundle and absent from SymbolReference.json; API pages are a web-service publishing surface, which docs/scope.md places out of scope. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "outOfScope": true,
       "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found",
       "versionContingent": true
@@ -769,7 +769,7 @@
     },
     {
       "member": "PageProperties.#analysisModeEnabledField",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies PageProperties.AnalysisModeEnabled, declared in this file with the measurement. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies PageProperties.AnalysisModeEnabled, declared in this file with the measurement. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "issue": 3784,
       "versionContingent": true,
       "Doc": "docs/metadata-equivalence.md#one-build-measured-three-evaluated"
@@ -803,7 +803,7 @@
     },
     {
       "member": "PageProperties.#isPreviewField",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. The member it accompanies is declared beside it in this file. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. The member it accompanies is declared beside it in this file. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "outOfScope": true,
       "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found",
       "versionContingent": true
@@ -846,7 +846,7 @@
     },
     {
       "member": "PageProperties.AnalysisModeEnabled",
-      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 1 page declares AnalysisModeEnabled; the runner never writes it. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 1 page declares AnalysisModeEnabled; the runner never writes it. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "issue": 3784,
       "versionContingent": true,
       "Doc": "docs/metadata-equivalence.md#one-build-measured-three-evaluated"
@@ -903,7 +903,7 @@
     },
     {
       "member": "PageProperties.IsPreview",
-      "reason": "Marks a page shipped as preview. Not in SymbolReference.json in any form; BC's emitter derives it from a compiler-level attribute the symbol file does not carry. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "Marks a page shipped as preview. Not in SymbolReference.json in any form; BC's emitter derives it from a compiler-level attribute the symbol file does not carry. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 1 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "outOfScope": true,
       "Doc": "docs/metadata-equivalence.md#what-the-page-comparison-found",
       "versionContingent": true
@@ -922,7 +922,7 @@
     },
     {
       "member": "SourceObjectDefinition.#delayedInsertField",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies SourceObjectDefinition.DelayedInsert, declared in this file with the measurement. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 2 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies SourceObjectDefinition.DelayedInsert, declared in this file with the measurement. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 2 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "issue": 3784,
       "versionContingent": true,
       "Doc": "docs/metadata-equivalence.md#one-build-measured-three-evaluated"
@@ -934,14 +934,14 @@
     },
     {
       "member": "SourceObjectDefinition.#modifyAllowedField",
-      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies SourceObjectDefinition.ModifyAllowed, declared in this file with the measurement. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 2 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "The Specified flag / backing field of the member declared beside it, which BC's serializer sets from the same value. One difference in the source property arrives as several members, so they share its reason and clear together when it is fixed. It accompanies SourceObjectDefinition.ModifyAllowed, declared in this file with the measurement. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 2 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "issue": 3784,
       "versionContingent": true,
       "Doc": "docs/metadata-equivalence.md#one-build-measured-three-evaluated"
     },
     {
       "member": "SourceObjectDefinition.DelayedInsert",
-      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 13 pages declare DelayedInsert, with the same SourceTable-branch condition. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 2 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 13 pages declare DelayedInsert, with the same SourceTable-branch condition. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 2 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "issue": 3784,
       "versionContingent": true,
       "Doc": "docs/metadata-equivalence.md#one-build-measured-three-evaluated"
@@ -953,7 +953,7 @@
     },
     {
       "member": "SourceObjectDefinition.ModifyAllowed",
-      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 89 pages declare ModifyAllowed, with the same SourceTable-branch condition as InsertAllowed. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 2 occurrence(s), resting on one or two System Application objects existing with one property shape \u2014 and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
+      "reason": "A page property the runner's EmitPageXml does not read, although SymbolReference.json states it: measured on the shipped System Application symbol file, 89 pages declare ModifyAllowed, with the same SourceTable-branch condition as InsertAllowed. Tracked on #3784, which carries the per-property table. A defect and not a scope boundary -- the value is present, typed and unambiguous in the symbol file the runner already parses for this page. VERSION-CONTINGENT: on the build this was measured (BC 28.1.49838.53910) the whole population of this member is 2 occurrence(s), resting on one or two System Application objects existing with one property shape — and BC moves both. Measured: the only page carrying a part-control ProviderID is 4306 'Agent Tasks' on 27.5 and 8705 'Table Information Card' on 28.x, and 27.5's part declares Editable while 28.x's does not. So this entry legitimately matches nothing on some legs; it is exempt from the stale-entry check and from nothing else, so a difference it does not cover still fails on every version.",
       "issue": 3784,
       "versionContingent": true,
       "Doc": "docs/metadata-equivalence.md#one-build-measured-three-evaluated"
@@ -966,17 +966,17 @@
     },
     {
       "member": "MetaCodeunit.InherentPermissions",
-      "reason": "BC states the inherent permission mask (Execute on 505 of 558); the runner leaves BC's own None default. Stated verbatim in the symbol file: codeunit 26 carries Properties [{'Name':'InherentPermissions','Value':'X'}], and presence agrees with BC's attribute for 533 of 533 System Application codeunits on BC 28.1.49838.53910. The letters are the same mask spelling RecordPatches.CodeunitMetadataFromBcDocument.cs already parses out of BC's OWN document for the CodeUnit Metadata virtual table, so the conversion exists and is merely not fed from the symbol file for a precompiled dependency. Derivable, tracked, not a limit. Deliberately NOT direction-scoped: the runner answers BC's own enum default None rather than leaving the member absent, and `bc-only` matches only a runner side that is <absent> or <null>. The narrowing that would be wanted here \u2014 'BC states a mask, the runner states None' \u2014 is not expressible as a direction, so the entry covers both and this sentence records why. Checked for versionContingent and deliberately NOT marked: this member's population is large and stable across every BC build a leg runs. Measured on the three ground-truth bundles present (27.5.46862.53931, 28.1.49838.53910, 28.4.53241.54407): System Application 455 / 481 / 482 codeunits state it, Business Foundation 24 on all three. Step 1's 27.5 failure was a member whose whole population was one page; nothing here is within two orders of magnitude of that.",
+      "reason": "BC states the inherent permission mask (Execute on 505 of 558); the runner leaves BC's own None default. Stated verbatim in the symbol file: codeunit 26 carries Properties [{'Name':'InherentPermissions','Value':'X'}], and presence agrees with BC's attribute for 533 of 533 System Application codeunits on BC 28.1.49838.53910. The letters are the same mask spelling RecordPatches.CodeunitMetadataFromBcDocument.cs already parses out of BC's OWN document for the CodeUnit Metadata virtual table, so the conversion exists and is merely not fed from the symbol file for a precompiled dependency. Derivable, tracked, not a limit. Deliberately NOT direction-scoped: the runner answers BC's own enum default None rather than leaving the member absent, and `bc-only` matches only a runner side that is <absent> or <null>. The narrowing that would be wanted here — 'BC states a mask, the runner states None' — is not expressible as a direction, so the entry covers both and this sentence records why. Checked for versionContingent and deliberately NOT marked: this member's population is large and stable across every BC build a leg runs. Measured on the three ground-truth bundles present (27.5.46862.53931, 28.1.49838.53910, 28.4.53241.54407): System Application 455 / 481 / 482 codeunits state it, Business Foundation 24 on all three. Step 1's 27.5 failure was a member whose whole population was one page; nothing here is within two orders of magnitude of that.",
       "issue": 3788
     },
     {
       "member": "MetaCodeunit.InherentEntitlements",
-      "reason": "Same shape and same evidence as MetaCodeunit.InherentPermissions, for the entitlement mask rather than the permission mask: stated in the symbol file as Properties [{'Name':'InherentEntitlements','Value':'X'}], presence agreeing for 533 of 533 on BC 28.1.49838.53910, and BC's default None answered by the runner in its place. Declared separately rather than folded in, because the two masks are independent AL properties and a fix that landed only one must still fail on the other. Deliberately NOT direction-scoped: the runner answers BC's own enum default None rather than leaving the member absent, and `bc-only` matches only a runner side that is <absent> or <null>. The narrowing that would be wanted here \u2014 'BC states a mask, the runner states None' \u2014 is not expressible as a direction, so the entry covers both and this sentence records why. Checked for versionContingent and deliberately NOT marked: this member's population is large and stable across every BC build a leg runs. Measured on the three ground-truth bundles present (27.5.46862.53931, 28.1.49838.53910, 28.4.53241.54407): System Application 455 / 481 / 482 codeunits state it, Business Foundation 24 on all three. Step 1's 27.5 failure was a member whose whole population was one page; nothing here is within two orders of magnitude of that.",
+      "reason": "Same shape and same evidence as MetaCodeunit.InherentPermissions, for the entitlement mask rather than the permission mask: stated in the symbol file as Properties [{'Name':'InherentEntitlements','Value':'X'}], presence agreeing for 533 of 533 on BC 28.1.49838.53910, and BC's default None answered by the runner in its place. Declared separately rather than folded in, because the two masks are independent AL properties and a fix that landed only one must still fail on the other. Deliberately NOT direction-scoped: the runner answers BC's own enum default None rather than leaving the member absent, and `bc-only` matches only a runner side that is <absent> or <null>. The narrowing that would be wanted here — 'BC states a mask, the runner states None' — is not expressible as a direction, so the entry covers both and this sentence records why. Checked for versionContingent and deliberately NOT marked: this member's population is large and stable across every BC build a leg runs. Measured on the three ground-truth bundles present (27.5.46862.53931, 28.1.49838.53910, 28.4.53241.54407): System Application 455 / 481 / 482 codeunits state it, Business Foundation 24 on all three. Step 1's 27.5 failure was a member whose whole population was one page; nothing here is within two orders of magnitude of that.",
       "issue": 3788
     },
     {
       "member": "MetaRuntimeInfo.Methods.<presence>",
-      "reason": "BC's document carries a <Methods> subtree for 137 of 558 codeunits and the runner's projection carries none, so every method BC states is reported absent. PARTLY derivable, and the remainder is measured rather than assumed: SymbolReference.json does state a Methods array (Id, Name, Parameters, ReturnTypeDefinition), and BC's emitted method names are a subset of the symbol file's for 64 codeunits \u2014 but for 73 they are not, because BC emits event-publisher and internal methods the symbol file omits. So this is a partial derivation with a known 73-codeunit gap, not a straight fix, which is why it is tracked rather than declared recoverable. Measured on BC 28.1.49838.53910. Checked for versionContingent and deliberately NOT marked: this member's population is large and stable across every BC build a leg runs. Measured on the three ground-truth bundles present (27.5.46862.53931, 28.1.49838.53910, 28.4.53241.54407): System Application 135 / 137 / 138 codeunits emit a <Methods> subtree, Business Foundation 8 on all three. Step 1's 27.5 failure was a member whose whole population was one page; nothing here is within two orders of magnitude of that.",
+      "reason": "BC's document carries a <Methods> subtree for 137 of 558 codeunits and the runner's projection carries none, so every method BC states is reported absent. PARTLY derivable, and the remainder is measured rather than assumed: SymbolReference.json does state a Methods array (Id, Name, Parameters, ReturnTypeDefinition), and BC's emitted method names are a subset of the symbol file's for 64 codeunits — but for 73 they are not, because BC emits event-publisher and internal methods the symbol file omits. So this is a partial derivation with a known 73-codeunit gap, not a straight fix, which is why it is tracked rather than declared recoverable. Measured on BC 28.1.49838.53910. Checked for versionContingent and deliberately NOT marked: this member's population is large and stable across every BC build a leg runs. Measured on the three ground-truth bundles present (27.5.46862.53931, 28.1.49838.53910, 28.4.53241.54407): System Application 135 / 137 / 138 codeunits emit a <Methods> subtree, Business Foundation 8 on all three. Step 1's 27.5 failure was a member whose whole population was one page; nothing here is within two orders of magnitude of that.",
       "issue": 3788,
       "direction": "bc-only"
     },
@@ -985,6 +985,96 @@
       "reason": "The SAME collection as MetaRuntimeInfo.Methods, reached under a second signature: MetaRuntimeInfo backs the property with a field, and the differ walks both, so one absent method subtree is reported twice. Declared separately because the allowlist matches on the signature and leaving this one off would report 326 undeclared differences for a gap already declared above. It disappears with the same fix. Checked for versionContingent and deliberately NOT marked: this member's population is large and stable across every BC build a leg runs. Measured on the three ground-truth bundles present (27.5.46862.53931, 28.1.49838.53910, 28.4.53241.54407): the same collection as MetaRuntimeInfo.Methods, so the same 135 / 137 / 138 and 8. Step 1's 27.5 failure was a member whose whole population was one page; nothing here is within two orders of magnitude of that.",
       "issue": 3788,
       "direction": "bc-only"
+    },
+    {
+      "member": "MetaReport.InherentEntitlements",
+      "reason": "BC resolves the report's InherentEntitlements mask to Execute; the runner answers None because BcAppSymbolCache's ReportSymbol does not carry the property at all. SymbolReference.json states it as the \"X\" mask spelling, and RecordPatches.CodeunitMetadataFromBcDocument.cs already parses that spelling for codeunits -- so this is a dropped property, not an underivable one. Same member and same \"X\" spelling as the codeunit gap (#3788) and the query gap (#3798); three kinds, one unparsed property. Measured on BC 28.1.49838.53910 on the single report System Application ships (9810 Change Password).",
+      "issue": 3808
+    },
+    {
+      "member": "MetaReport.InherentPermissions",
+      "reason": "The other half of the same dropped property: BC resolves Execute, the runner answers None. See MetaReport.InherentEntitlements immediately above -- one \"X\" mask in SymbolReference.json feeds both, and neither reaches ReportSymbol.",
+      "issue": 3808
+    },
+    {
+      "member": "MetaReport.ALNamespace",
+      "reason": "BC states the report's AL namespace (System.Security.AccessControl on report 9810); the runner answers null because ReportSymbol does not carry it. SymbolReference.json states the namespace -- it is what BcAppSymbolCache's own namespace walk already reads to build ObjectSymbol -- so this is derivable and simply not carried. Same member, same reason and same fix as MetaTable.ALNamespace (#3568), MetaPermissionSet.ALNamespace (#3806) and MetaEnum.ALNamespace (#3807).",
+      "issue": 3808
+    },
+    {
+      "member": "MetaReport.RequestPageDefinition.<presence>",
+      "reason": "BC's emitted document carries a full <RequestPage><PageDefinition> subtree even for report 9810, which declares UseRequestPage = false and ProcessingOnly = true; DependencyReportMetadata.EmitReportXml writes no <RequestPage> element at all, so BC's reader leaves the property null on the runner's side. Two questions are deliberately OPEN rather than answered here, and they are on #3808: whether BC emits a request page for every report (unanswerable from this bundle -- System Application ships exactly ONE report, and Base Application, which would settle it, is excluded from apps.json because its emit needs a .NET reference no BC artifact ships, #3549), and whether anything AL-observable reads MetaReport.RequestPageDefinition on a ProcessingOnly report. Declared as a tracked defect rather than out of scope precisely because neither is settled: an outOfScope claim here would be a guess wearing a classification.",
+      "issue": 3808
+    },
+    {
+      "member": "MetaReport.#requestPageDefinition.<presence>",
+      "reason": "The backing field of MetaReport.RequestPageDefinition. The differ walks the property and the field independently, so one absent subtree is reported twice; this entry exists so the second report is declared rather than left undeclared. Same fact, same issue -- see the property entry above for the two open questions.",
+      "issue": 3808
+    },
+    {
+      "member": "MetaPermissionSet.Name",
+      "reason": "BC's MetaPermissionSet.Create UPPERCASES the name it reads; the runner's object route sets Name verbatim from PermissionSetSymbol. This is BC's READER, not the document: measured on BC 28.1.49838.53910, 8 of 178 emitted permission-set documents state an already-uppercase Name (SUPER, SECURITY, LOGIN, TROUBLESHOOT TOOLS, SUPER (DATA), D365 SNAPSHOT DEBUG, D365 ATTACH DEBUG, D365 BACKUP/RESTORE) and 170 state mixed case, while Create answers all 178 upper-cased -- 178-8 = 170, exactly this entry's occurrence count. The value is a Code[20]/Code[30] ROLE ID and BC upper-cases codes, so the open question is WHERE the upper-casing belongs, not which spelling is right; MetadataEquivalenceReportEnumPermissionSetOracleTests asserts the reader's behaviour so this entry stays attributable to the reader. Note the runner is internally case-insensitive here (EnumerateKnownPermissionSets de-duplicates OrdinalIgnoreCase, PermissionSetIdByName is OrdinalIgnoreCase), so this only becomes observable where a value crosses into BC.",
+      "issue": 3806
+    },
+    {
+      "member": "MetaPermissionSet.Assignable",
+      "reason": "PermissionSet 68 'System Execute - Basic' only: BC answers False, the runner answers True. THIS IS THE MEASUREMENT #2417 ASKED FOR, and it is a measurement rather than an inference -- #2417 states the question must be settled against BC itself and not by reading SymbolReference.json. BC's own emitted document for 68 is the only one of 178 carrying no Assignable attribute at all (the distribution is 140 x \"0\", 37 x \"1\", 1 x absent), and BC's own MetaPermissionSet.Create resolved that absence to False. So BC's reader defaults absent -> false and CollectPermissionSets's absent -> true is wrong, exactly as #2417 predicted. The fix lands in BcAppSymbolCache/RecordPatches.MetadataPermissionSetVirtualTable rather than in the harness, so it is tracked on #3806 which records the answer and points at #2417. Deliberately NOT versionContingent despite matching a single object: the criterion is that the member's population depends on a per-object declaration, and this one does -- but it is one object on every BC build measured, and an entry that stopped matching would mean either the fix landed or BC changed its default, both of which must be loud.",
+      "issue": 3806
+    },
+    {
+      "member": "MetaPermissionSet.ALNamespace",
+      "reason": "BC states the permission set's AL namespace; the runner answers null on all 178 because PermissionSetSymbol does not carry it. Derivable -- SymbolReference.json states the namespace -- and simply not carried. Same member and same fix as MetaTable.ALNamespace (#3568), MetaReport.ALNamespace (#3808) and MetaEnum.ALNamespace (#3807).",
+      "issue": 3806
+    },
+    {
+      "member": "MetaPermissionSet.CaptionML.<presence>",
+      "reason": "BC builds a MultiLanguage caption on all 178 permission sets; the runner leaves it null. PermissionSetSymbol DOES carry Caption, so the caption text is available and it is the MultiLanguage-with-language-id shape that is not built -- the same shape, and the same distinction, as the already-declared MetaField.CaptionML entry on the table side. Not a translation-key entry: this is the caption TEXT, which is AL-observable.",
+      "issue": 3806
+    },
+    {
+      "member": "MetaPermissionSet.MetadataToken",
+      "reason": "BC's emitted document opens with MetadataVersion=\"130000\" and every one of BC's own readers copies it into MetadataToken; the runner states no metadata-format version anywhere, so BC's default of 0 stands on the runner's side. Measured on BC 28.1.49838.53910: 178 of 178 permission sets and 142 of 142 enums, i.e. EVERY object of both kinds and never a subset -- which is what shows this is a property of the document format rather than of any object's declaration. It is derivable trivially (write the same constant), and it is not stated because nothing in the runner consumes a metadata-format version. Tracked with the rest of each kind's derivation gap. NOT declared for MetaTable or PageDefinition: those two routes already agree, so this is genuinely a property of the kinds added in #3782 steps 5-7.",
+      "issue": 3806
+    },
+    {
+      "member": "MetaEnum.Extensible",
+      "reason": "BC answers True on 31 of 142 enums; the runner answers False on all of them, because BcAppSymbolCache.EnumSymbol does not carry Extensible at all -- the record is (Id, Name, Options, Indexes, Implementations, Captions, DefaultImplementations, UnknownImplementations) and nothing reads the property. The value IS in SymbolReference.json, in the same Properties bag TryParseEnumSymbol already reads DefaultImplementation and UnknownValueImplementation from a few lines away, so this is a dropped property rather than an underivable one. Not cosmetic: Extensible = false is what makes an enum refuse an enumextension, so the runner currently answers 'not extensible' for 31 enums that are. The other 111 agree only because the runner's constant happens to match.",
+      "issue": 3807
+    },
+    {
+      "member": "MetaEnumValue.InterfaceImplementation",
+      "reason": "BC states a value's interface-implementation codeunit ids (e.g. [306] on enum 397); the runner states []. The runner DOES parse these -- TryParseEnumSymbol reads a value's Implementation property into implementations[i] and AlEnumOptionMetadata uses them for GetImplementationCodeunitIdPublic (#2306) -- so the data is present and it is the <Value> render that has no element for it. Whether BC's <Value> shape can express it at all still needs checking before this is called a derivation gap; #3807 records that caveat rather than asserting either way.",
+      "issue": 3807
+    },
+    {
+      "member": "MetaEnum.DefaultImplementation",
+      "reason": "The enum-level interface fallback: BC states [1467] on enum 1465, the runner states []. EnumSymbol carries the list (#2306) and the <Enum> render states no element for it -- the same not-rendered-though-parsed shape as MetaEnumValue.InterfaceImplementation above, one level up.",
+      "issue": 3807
+    },
+    {
+      "member": "MetaEnum.UnknownImplementation",
+      "reason": "The other enum-level interface fallback, on the same enum 1465 and with the same cause as MetaEnum.DefaultImplementation immediately above: EnumSymbol carries it, the render does not state it.",
+      "issue": 3807
+    },
+    {
+      "member": "MetaEnum.ALNamespace",
+      "reason": "BC states the enum's AL namespace (System.Text on enum 59); the runner answers null on all 142 because EnumSymbol does not carry it. Derivable and simply not carried. Same member and same fix as MetaTable.ALNamespace (#3568), MetaReport.ALNamespace (#3808) and MetaPermissionSet.ALNamespace (#3806).",
+      "issue": 3807
+    },
+    {
+      "member": "MetaEnum.CaptionML.<presence>",
+      "reason": "The ENUM's own caption, on 2 enums: BC builds a MultiLanguage, the runner leaves it null. Note this is not the per-VALUE caption, which agrees on all 142 enums -- AlEnumMetadataRegistry.Entry.Captions carries a value's declared Caption (#1775) and the render states it as <CaptionML>, which is why this entry matches 2 rather than 142. The enum-level caption has no field on the registry entry to render from.",
+      "issue": 3807
+    },
+    {
+      "member": "MetaEnum.MetadataToken",
+      "reason": "BC's emitted document opens with MetadataVersion=\"130000\" and every one of BC's own readers copies it into MetadataToken; the runner states no metadata-format version anywhere, so BC's default of 0 stands on the runner's side. Measured on BC 28.1.49838.53910: 178 of 178 permission sets and 142 of 142 enums, i.e. EVERY object of both kinds and never a subset -- which is what shows this is a property of the document format rather than of any object's declaration. It is derivable trivially (write the same constant), and it is not stated because nothing in the runner consumes a metadata-format version. Tracked with the rest of each kind's derivation gap. NOT declared for MetaTable or PageDefinition: those two routes already agree, so this is genuinely a property of the kinds added in #3782 steps 5-7.",
+      "issue": 3807
+    },
+    {
+      "member": "MetaEnumValue.Ordinal",
+      "reason": "Enum 2616 'Printer Paper Kind' only: BC answers ordinal 0 for the value 'Custom', the runner answers 40. SymbolReference.json omits Ordinal exactly when it is ZERO -- the same absent-means-default convention PermissionSymbol's own doc comment records for PermissionObject -- and TryParseEnumSymbol reads an absent Ordinal as 'previous + 1' instead, which is an AL SOURCE-order convention. Measured across three shipped apps on BC 28.1.49838.53910: 671 values carry no Ordinal and the rule is wrong on exactly one, because 2616 is the only enum BC emits in an order that is not ordinal order (its values are name-sorted: A2=66, A3=8, A4=9, ...). The consequence is worse than a wrong number: ordinal 40 ends up claimed by both GermanStandardFanfold and Custom, so the enum has 67 distinct ordinals across 68 values and two AL enum members become indistinguishable by value. Fixed by reading an absent Ordinal as 0 (#3805), one line in BcAppSymbolCache -- deliberately not folded into #3782's harness PR, which touches no parser.",
+      "issue": 3805
     }
   ]
 }

--- a/tools/metadata-ground-truth/Program.cs
+++ b/tools/metadata-ground-truth/Program.cs
@@ -169,12 +169,28 @@ internal static class Program
             objects.Add(new BundleObject(kind, id, item.Name, rel, Sha256(item.Metadata)));
         }
 
-        var duplicateTableIds = objects.Where(o => o.Kind == "MetaTable")
-            .GroupBy(o => o.Id).Where(g => g.Count() > 1).Select(g => g.Key).ToArray();
-        if (duplicateTableIds.Length > 0)
+        // Every kind the harness keys by id, not MetaTable alone. Query and XmlPort joined that
+        // set in #3782 and both had reported id 0 for every document until ClassifyDocument
+        // learned the child-element spelling — which a MetaTable-only guard could not see; Report
+        // is the third kind with that spelling and joined in step 5.
+        //
+        // MetadataRuntimeDeltas is deliberately excluded: one <MetadataRuntimeDeltas> root covers
+        // TableExtension, PageExtension and PermissionSetExtension, so several of them
+        // legitimately carry the id of the object they extend — System Application's bundle has
+        // two on id 774. Enum is excluded for the mirror-image reason: one <Enum> root covers
+        // both Enum and EnumExtension, so an enum and an enumextension can carry the same id
+        // without either being a duplicate.
+        var idKeyedKinds = new[] { "MetaTable", "PageDefinition", "CodeUnit", "Query", "XmlPort", "Report", "PermissionSet" };
+        var duplicateIds = objects
+            .Where(o => idKeyedKinds.Contains(o.Kind, StringComparer.Ordinal))
+            .GroupBy(o => (o.Kind, o.Id)).Where(g => g.Count() > 1)
+            .Select(g => $"{g.Key.Kind} {g.Key.Id} x{g.Count()}").ToArray();
+        if (duplicateIds.Length > 0)
             throw new InvalidOperationException(
-                "two MetaTable documents share an id: " + string.Join(",", duplicateTableIds) +
-                ". The harness keys tables by id, so this would silently compare one and drop the other.");
+                "documents share a (kind, id): " + string.Join("; ", duplicateIds) +
+                ". The harness keys these kinds by id, so this would silently compare one and " +
+                "drop the other. An id of 0 across a whole kind means ClassifyDocument did not " +
+                "find where that kind states its id.");
 
         var manifest = new BundleManifest(
             BundleSchema,
@@ -201,6 +217,13 @@ internal static class Program
     /// They disagree: MetadataRuntimeDeltas is the root for TableExtension, PageExtension AND
     /// PermissionSetExtension, and one &lt;Enum&gt; root covers both Enum and EnumExtension.
     /// Keying on SymbolKind would split documents that BC treats as one shape.
+    ///
+    /// <para>The id is read from the root ATTRIBUTE first and from a direct child
+    /// <c>&lt;ID&gt;</c> ELEMENT second, because BC's emitter uses both spellings and which one
+    /// it uses is a property of the kind: Query, XmlPort and Report state the id as a child
+    /// element, every other kind as an attribute. Reading only the attribute reported
+    /// <c>Id = 0</c> for all 12 of those documents in a System Application bundle — a value that
+    /// keys nothing, is not unique, and reads exactly like a real id (#3782, steps 3/4/5).</para>
     /// </summary>
     private static (string Kind, int Id) ClassifyDocument(string? metadata, string symbolKind)
     {
@@ -212,6 +235,14 @@ internal static class Program
             var root = doc.DocumentElement!;
             var idText = root.GetAttribute("ID");
             if (string.IsNullOrEmpty(idText)) idText = root.GetAttribute("Id");
+            // A DIRECT child only: <QueryColumn><ID>…</ID></QueryColumn> is a column's id, and
+            // a descendant search would return one of those for the query itself.
+            if (string.IsNullOrEmpty(idText))
+                foreach (XmlNode child in root.ChildNodes)
+                    if (child is XmlElement e
+                        && (e.Name == "ID" || e.Name == "Id")
+                        && !string.IsNullOrEmpty(e.InnerText))
+                    { idText = e.InnerText.Trim(); break; }
             int.TryParse(idText, out var id);
             return (root.Name, id);
         }


### PR DESCRIPTION
Part of #3782

Steps 5 through 8 of #3782 — the last four kinds. Written by agent `stma-auto-10`.

`Part of` rather than a closing reference, deliberately: this branch's own `stillUncompared` still lists `Query` and `XmlPort`, which land in #3796. Were this to merge first, GitHub's parser would act on a closing keyword regardless of any caveat in the body — it does not understand negation. The tracking issue is finished once both have landed, and the coordinator can retire it then.

Corpus-NA: this changes no AL-observable runtime behaviour — it adds a C#-only test harness comparing BC's own metadata emitter against the runner's derivation, plus four internal accessors that read existing runner state. No AL program can observe any of it.

## What changed

| kind | objects | route | oracle |
|---|---:|---|---|
| `Report` | 1 | the document `TryBuildDependencyReportMetadata` already produces — what every runner consumer reads | `MetaReport(XmlElement, …)` |
| `PermissionSet` | 178 | `BuildMetaPermissionSet` — a real `MetaPermissionSet`, **no rendering** | `MetaPermissionSet.Create(XmlNode, int, int)` |
| `Enum` | 142 | a render, because every `MetaEnum` property is get-only | `MetaEnum(XmlNode)` |
| `MetadataRuntimeDeltas` | 11 | the runner answers **null** for every object — a one-sided gap | `NavAppObjectMetadataRuntimeDeltas.FromXml(XDocument)` |

**332 objects added to the comparison. 5,360 + 1,061 differences, every one declared.** The first group is the pre-existing `TranslationKey` family (out of scope by owner decision); the second is 18 new allowlist entries across 4 tracked issues.

BC 28.1.49838.53910. **Business Foundation now reports `NOT compared: []`** — the first bundle with every kind accounted for. System Application reports `[Query, XmlPort]`, which is #3796's scope.

## Step 8 was wrong in the first revision, and the correction is the interesting part

The first revision claimed `MetadataRuntimeDeltas` was **uncomparable — "BC ships no reader for the shape"** — and backed it with a census over `Microsoft.Dynamics.Nav.Types` (2,617 types) and `Microsoft.Dynamics.Nav.Ncl` (8,616), finding no type with "Delta" in its name.

Both numbers were right. The inference was not, for one reason: **every other oracle in this harness comes from those two assemblies, so those two were the ones searched.** The artifact directory holds **501**.

Re-measured across all of them with a metadata-only `PEReader` scan:

| | |
|---|---:|
| assemblies scanned | 501 |
| types whose name contains "Delta" | **308** |
| of those, in `Microsoft.Dynamics.Nav.Apps.dll` | **54** |

`.Types` really is 0. `.Ncl` is not — it has 10, including `<GetRuntimeDeltas>d__15`, whose element type points straight at the reader.

**The oracle**: `NavAppObjectMetadataRuntimeDeltas.FromXml(XDocument)`, with `MetadataRuntimeDeltasXName` resolving to `{urn:schemas-microsoft-com:dynamics:NAV:MetaObjects}MetadataRuntimeDeltas` — character for character the documents' root element. It parses **11 of 11** inside the harness, `AllDeltas` populated (12 deltas on page 774, 5 on 4318, 4 on 2515, 2 on 324, 1 on 9862; 5 documents are genuinely empty elements). A bare probe parsed only 6 of 11 — a `WindowsLanguageHelper` static-init fault from loading outside the harness, which the skeleton this collection already has removes. **Verified rather than assumed.**

**The runner's side is null**, measured through `GetExtensionDeltasForAppObject` — the one member typed for it — rather than read off it. So the honest claim is a **one-sided gap**, which is narrower and more useful than "neither side exists". Each object reports as unbuildable naming #3809, and the census assertion holds that count to the declared total.

**Two things were removed rather than corrected in place**, and both matter more than the fact:

- **`UncomparableKinds` is gone, with no replacement.** The false claim was being *locked in by a passing test*. A green assertion that a kind cannot be measured is indistinguishable from a green assertion that it was, and strictly harder to dislodge, because the next reader finds a test telling them not to look. A kind with no runner side is now reported per object as unbuildable, with the count asserted against the census — a measurement, not a classification.
- **The blanket `Unbuildable.Count == 0` is now scoped and two-sided**: deltas unbuildables must **equal** the census, and any unbuildable outside that kind still fails. The gap cannot become a place other kinds' failures hide.

**Generalisable lesson, recorded in `docs/` and on #3809:** *a negative about BC's surface is only as wide as the search behind it.* "I did not find it" and "it does not exist" are different claims.

## Three findings the comparison produced

**1. PermissionSet 68 answers #2417, empirically.** BC's emitted document for `System Execute - Basic` is the **only one of 178** carrying no `Assignable` attribute (140 × `"0"`, 37 × `"1"`, 1 absent), and BC's own reader resolved that absence to **`False`**. So BC defaults **absent → false** and `CollectPermissionSets`'s `absent → true` is wrong, exactly as #2417 predicted. No code change here for it; recorded on #3806 and commented on #2417.

**2. A real enum-ordinal defect (#3805).** `TryParseEnumSymbol` reads an absent `Ordinal` as "previous + 1", but `SymbolReference.json` omits it precisely when it is **0**. Across three shipped apps: 671 values carry no `Ordinal`, and the rule is wrong on **exactly one** enum — 2616, the only one BC emits in non-ordinal order. `Custom` gets 40, already taken, so the enum ends with **67 distinct ordinals across 68 values**.

**3. BC's permission-set reader uppercases `Name`.** 170 of 178, and 178 − 8 already-uppercase = 170 exactly. The value is a `Code[20]`/`Code[30]` role id, so the open question is *where* upper-casing belongs. Asserted in the oracle test so the entry stays attributable to the **reader**.

## Two defects in my own work, found by mutation-checking

Both are #3802's shape — cover the harness cannot report — and **neither was visible to any existing test**:

- **Removing the enum ordinal pairing changed not one difference count.** The allowlist keys on `DeclaringType.Member`; positional pairing reports the same *members* and moves the *paths* (2,678 of 3,155 paired → 0 of 3,155).
- **Manufacturing agreement on `MetaEnum.Extensible` also stayed green** — it **inverts** differences (31 → 111) rather than removing them, so the stale check has nothing to report. `direction` cannot narrow it: that field keys on absent-or-null and both sides are `False`/`True`.

**Mutation results — all seven, each re-run after its fix:**

| mutation | caught by |
|---|---|
| enum oracle → the non-reading parameterless ctor, both sides | `The_harness_reads_each_document_through_a_type_that_parses` |
| drop the enum ordinal pairing | `Enum_values_are_paired_by_ordinal_and_not_by_position` (0 / 3,155) |
| drop `EnsurePermissionMetadataPopulated()` | `Every_difference_is_declared_with_a_reason` (the 94) |
| manufacture `Extensible = 1` | `The_new_kinds_reader_answers_the_constant_that_IS_the_defect` |
| skip an enum-extension without recording it | `Every_object_in_a_compared_kind_really_was_compared` |
| **runner deltas side = BC's own parse (circular)** | `Every_object_in_a_compared_kind_really_was_compared` |
| **pretend no deltas document yields content** | `NavAppObjectMetadataRuntimeDeltas_FromXml_parses_every_emitted_deltas_document` |

## The oracle trap, and the memo trap

**Every oracle is proven to parse**, asserted against the *document* rather than literals so it cannot go inert when the build moves. `MetaEnum` carries the trap in a sharper form than `MetaPageDefinition` did — a second **constructor on the same type** rather than a second type.

**`PermissionSetIdByName` is memoized and invalidated only inside `EnsurePermissionMetadataPopulated`.** Calling `BuildMetaPermissionSet` directly measured an **empty** name index — 94 fabricated `IncludedPermissionSets` differences the runner does not have.

## `versionContingent`: 0 of 18

The criterion is *"the member's population depends on a per-object declaration"*, not "small population" — and with `Report` at one object the temptation was real. These differences are on every object of their kind on every build measured; an entry going unused would mean either the fix landed or BC changed, both of which must be **loud**.

## Fix the shape — the three questions

1. **Same wrong pattern at another call site?** Yes, checked: `nextOrdinal`/`nextId` appears in four other places, all *generation* (picking an unused ordinal) where "previous + 1" is correct by construction. `BcAppSymbolCache.cs:2403` is the only defective *reading* instance.
2. **Sibling function with the same assumption?** `ALNamespace` is dropped identically by `ReportSymbol`, `PermissionSetSymbol` and `EnumSymbol` — and already by `MetaTable` (#3568) and `MetaCodeunit` (#3788). Five kinds, one omission, five separate records and five separate fixes. Likewise the `"X"` inherent-mask spelling: codeunits (#3788), queries (#3798), reports (#3808).
3. **Two paths writing the same state with different invariants?** Yes — precompiled dependency enums register through `Register` while source-compiled ones use `RegisterExtension`, so `SnapshotRaw()` reports **0** extension entries and an enumextension has no addressable identity (#3807). The same structural fact is why the deltas gap exists (#3809).

**Queue scan.** Searched by symbol, observable and mechanism, confirming each empty result a second way. Found #2417 (answered, no code change here), #3788 and #3798 (same `"X"` spelling — linked, not folded), plus #3562 and #3568. Nothing folds: every candidate lands in `BcAppSymbolCache.cs` or a virtual-table file, and this PR touches neither.

## Issues filed

| | |
|---|---|
| #3805 | the enum-ordinal defect — one line, own RED→GREEN |
| #3806 | PermissionSet: 4 members, and #2417's answer |
| #3807 | Enum: 6 members, and the extension-identity note |
| #3808 | Report: 3 dropped properties + the open `RequestPage` question |
| #3809 | **rewritten** — the runner produces no extension-delta object (one-sided gap), with the original claim and its refutation preserved |

## What I did NOT do

- **Left all five gap issues open**, with no code change for any of them. Each lands outside this PR's files and wants its own RED→GREEN.
- **Did not answer two `Report` questions**, and said so on #3808: whether BC emits `<RequestPage>` for *every* report (unanswerable at n = 1; Base Application would settle it but is excluded by #3549), and whether anything AL-observable reads it on a `ProcessingOnly` report.
- **Did not claim any member is underivable.** Each is stated verbatim in `SymbolReference.json` or already parsed and merely not rendered. No entry claims `cannotExpress`.
- **Translations remain out of scope** by owner decision; the runner's answers there are **unmeasured, not right**.

## Generator

`ClassifyDocument` reads the id from a child `<ID>` element when the root attribute is absent — `Report` is the third kind with that spelling. **This is the identical edit #3796 makes**, so the two converge rather than conflict. The duplicate-id guard gains `Report` and `PermissionSet`; `Enum` is deliberately **excluded** alongside `MetadataRuntimeDeltas`, because one `<Enum>` root covers both `Enum` and `EnumExtension` and the two can legitimately share an id.

## Verification

- `dotnet test --filter` over the affected surface on the pushed head: **158 passed, 0 failed, `Skipped: 0`** — the `bc-engine-serial` collection genuinely ran (`tools/engine-test-bootstrap.sh` after a `-c Release` build; `TZ=UTC`).
- `tools/test_doc_pointers.py` and `tools/test_matrix_docs_drift.py`: pass. The doc-pointer check **caught a real miss** in an earlier revision, so the doc sections were written in response, not retrofitted. `CHANGELOG.md` untouched.
- **Allowlist verified as a set difference on full entry content against `origin/main`** after rebasing onto #3785: **0 entries lost**, 18 added, comment block byte-identical, and #3785's `CodeUnit` branch and reader stanza confirmed byte-identical to `main`.
- `CacheVersion` **not** bumped: no cached record shape changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
