### PR TITLE
fix(deps): a floor is a real dependency, with a real version, on both sides

### DIFF
--- a/AlRunner.Tests/DependencyResolverTests.cs
+++ b/AlRunner.Tests/DependencyResolverTests.cs
@@ -817,6 +817,132 @@ public sealed class DependencyResolverTests : IDisposable
         Assert.Equal(new[] { "Base Application" }, result.Select(r => r.Manifest.Name).ToArray());
     }
 
+    // -- #3794: a floor that cannot be supplied is named, not skipped in silence --
+    //
+    // #3793 made Visit follow a resolved package's floors. When the floor cannot be met,
+    // Visit reaches `if (dep.Optional || IsMicrosoftPlatformApp(...))` and returns BEFORE
+    // the nearMissVersions branch, so both "System.app absent" and "System.app present but
+    // below the declared floor" print one line -- `[deps] dependency not found in cache,
+    // skipping: Microsoft/System` -- and the run then dies in the dependent's source
+    // compile with the generic `EMIT-ZERO - BC Compilation.Emit() returned 0 sources`,
+    // naming neither the floor, nor the versions that were found, nor the repair.
+    //
+    // The skip itself stays: it is what lets the al-language corpus declare System
+    // Application >= 27.5 and still run green on the 27.0 and 27.3 legs, where no download
+    // can clear the floor (DropUnsatisfiableFloors documents the same tolerance on the
+    // provisioning side). What changes is that a floor belonging to a package this run will
+    // SOURCE-COMPILE is reported, because for that package the skip is not a tolerance --
+    // it is the EMIT-ZERO, one step earlier and still explicable.
+
+    /// <summary>
+    /// The dependent ships AL source and no R2R payload, so Tier-3 will compile it against
+    /// whatever closure resolution produced. Its Platform floor is unmet -- System.app is
+    /// present at 27.0, below the declared 28.0 -- and that must be stated, naming the
+    /// dependent, the floor, and the version that was actually found.
+    /// </summary>
+    [Fact]
+    public void SourceCompilablePackageFloor_SystemBelowFloor_IsReportedAsUnservable()
+    {
+        var dir = MakeDir("FloorBelowMinimum");
+        var systemId = "00000000-0000-0000-0000-00000000c0de";
+        var assertId = "dd0be2ea-f733-4d65-bb34-a28f4624fb14";
+        File.WriteAllBytes(Path.Combine(dir, "System.app"),
+            MakeMinimalApp(systemId, "System", "Microsoft", "27.0.38460.0", r2r: false, alSource: false, platform: null));
+        File.WriteAllBytes(Path.Combine(dir, "Microsoft_Library Assert.app"),
+            MakeMinimalApp(assertId, "Library Assert", "Microsoft", "28.1.49838.54169", r2r: false, alSource: true, platform: "28.0.0.0"));
+
+        var resolver = new DependencyResolver(new[] { dir });
+        var result = resolver.Resolve(new[]
+        {
+            new DependencyRef(Guid.Parse(assertId), "Library Assert", "Microsoft", new Version(28, 0, 0, 0)),
+        });
+
+        // Still resolves -- a below-floor platform app is not a hard failure, per the corpus
+        // 27.0/27.3 tolerance above.
+        Assert.Contains("Library Assert", result.Select(r => r.Manifest.Name));
+
+        var report = Assert.Single(resolver.UnservableDependencies, d => d.Contains("Library Assert", StringComparison.Ordinal));
+        Assert.Contains("Microsoft/System", report, StringComparison.Ordinal);
+        Assert.Contains("28.0.0.0", report, StringComparison.Ordinal);   // the declared floor
+        Assert.Contains("27.0.38460.0", report, StringComparison.Ordinal); // what was found instead
+        Assert.Contains(dir, report, StringComparison.Ordinal);          // where it looked
+        Assert.Contains("provision", report, StringComparison.OrdinalIgnoreCase); // how to repair it
+    }
+
+    /// <summary>
+    /// The absent case, which is #3719's own reproduction: no System.app at all. The package
+    /// still resolves alone (that behaviour is pinned by
+    /// <see cref="ResolvedPackageDeclaringPlatform_SystemAbsent_ResolvesThePackageAlone"/>),
+    /// and the run now says why the compile that follows will fail.
+    /// </summary>
+    [Fact]
+    public void SourceCompilablePackageFloor_SystemAbsent_IsReportedAsUnservable()
+    {
+        var dir = MakeDir("FloorAbsentReported");
+        var assertId = "dd0be2ea-f733-4d65-bb34-a28f4624fb14";
+        File.WriteAllBytes(Path.Combine(dir, "Microsoft_Library Assert.app"),
+            MakeMinimalApp(assertId, "Library Assert", "Microsoft", "28.1.49838.54169", r2r: false, alSource: true, platform: "28.0.0.0"));
+
+        var resolver = new DependencyResolver(new[] { dir });
+        resolver.Resolve(new[]
+        {
+            new DependencyRef(Guid.Parse(assertId), "Library Assert", "Microsoft", new Version(28, 0, 0, 0)),
+        });
+
+        var report = Assert.Single(resolver.UnservableDependencies, d => d.Contains("Library Assert", StringComparison.Ordinal));
+        Assert.Contains("Microsoft/System", report, StringComparison.Ordinal);
+        Assert.Contains("28.0.0.0", report, StringComparison.Ordinal);
+        Assert.Contains("provision", report, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The negative direction, and the one that keeps this quiet on the legs that need it:
+    /// an R2R dependent is served by Tier-2 and never source-compiled, so its unmet floor is
+    /// the ordinary tolerated skip and must produce NO report. Without this the 27.0 and
+    /// 27.3 corpus legs would gain an unconditional message on every run.
+    /// </summary>
+    [Fact]
+    public void PrecompiledPackageFloor_SystemAbsent_IsNotReported()
+    {
+        var dir = MakeDir("FloorAbsentPrecompiled");
+        var depId = "00000000-0000-0000-0000-0000000c1111";
+        File.WriteAllBytes(Path.Combine(dir, "Contoso_Precompiled.app"),
+            MakeMinimalApp(depId, "Precompiled", "Contoso", "1.0.0.0", r2r: true, alSource: false, platform: "28.0.0.0"));
+
+        var resolver = new DependencyResolver(new[] { dir });
+        resolver.Resolve(new[]
+        {
+            new DependencyRef(Guid.Parse(depId), "Precompiled", "Contoso", new Version(1, 0, 0, 0)),
+        });
+
+        Assert.DoesNotContain(resolver.UnservableDependencies, d => d.Contains("Microsoft/System", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// And the floor that IS supplied produces no report either -- so the two facts above
+    /// are the floor talking, not every source-bearing package generating a message.
+    /// </summary>
+    [Fact]
+    public void SourceCompilablePackageFloor_SystemAtTheFloor_IsNotReported()
+    {
+        var dir = MakeDir("FloorMet");
+        var systemId = "00000000-0000-0000-0000-00000000c0de";
+        var assertId = "dd0be2ea-f733-4d65-bb34-a28f4624fb14";
+        File.WriteAllBytes(Path.Combine(dir, "System.app"),
+            MakeMinimalApp(systemId, "System", "Microsoft", "28.0.54265.0", r2r: false, alSource: false, platform: null));
+        File.WriteAllBytes(Path.Combine(dir, "Microsoft_Library Assert.app"),
+            MakeMinimalApp(assertId, "Library Assert", "Microsoft", "28.1.49838.54169", r2r: false, alSource: true, platform: "28.0.0.0"));
+
+        var resolver = new DependencyResolver(new[] { dir });
+        var result = resolver.Resolve(new[]
+        {
+            new DependencyRef(Guid.Parse(assertId), "Library Assert", "Microsoft", new Version(28, 0, 0, 0)),
+        });
+
+        Assert.Equal(new[] { "System", "Library Assert" }, result.Select(r => r.Manifest.Name).ToArray());
+        Assert.DoesNotContain(resolver.UnservableDependencies, d => d.Contains("Microsoft/System", StringComparison.Ordinal));
+    }
+
     // ── #1689: a resolved package that NO loader tier can implement ───────────
     //
     // Reported shape: a symbols-only `Library Assert` in .alpackages satisfies resolution,

--- a/AlRunner.Tests/DependencyResolverTests.cs
+++ b/AlRunner.Tests/DependencyResolverTests.cs
@@ -830,18 +830,21 @@ public sealed class DependencyResolverTests : IDisposable
     // The skip itself stays: it is what lets the al-language corpus declare System
     // Application >= 27.5 and still run green on the 27.0 and 27.3 legs, where no download
     // can clear the floor (DropUnsatisfiableFloors documents the same tolerance on the
-    // provisioning side). What changes is that a floor belonging to a package this run will
-    // SOURCE-COMPILE is reported, because for that package the skip is not a tolerance --
-    // it is the EMIT-ZERO, one step earlier and still explicable.
+    // provisioning side). What changes is that a floor belonging to a package this run MAY
+    // source-compile is reported, on ProvisioningGaps rather than UnservableDependencies:
+    // "no loader tier can implement this" is a certain failure and an unmet floor is not,
+    // since the dependent may still be served from the compiled-dependency cache, the
+    // service-tier DLL index, or an already-loaded assembly. Deciding it where the compile
+    // actually happens is #3812.
 
     /// <summary>
-    /// The dependent ships AL source and no R2R payload, so Tier-3 will compile it against
-    /// whatever closure resolution produced. Its Platform floor is unmet -- System.app is
-    /// present at 27.0, below the declared 28.0 -- and that must be stated, naming the
-    /// dependent, the floor, and the version that was actually found.
+    /// The dependent ships AL source and no R2R payload, so Tier-3 is the only route that can
+    /// implement it. Its Platform floor is unmet -- System.app is present at 27.0, below the
+    /// declared 28.0 -- and that must be stated, naming the dependent, the floor, and the
+    /// version that was actually found.
     /// </summary>
     [Fact]
-    public void SourceCompilablePackageFloor_SystemBelowFloor_IsReportedAsUnservable()
+    public void SourceCompilablePackageFloor_SystemBelowFloor_IsReportedAsAProvisioningGap()
     {
         var dir = MakeDir("FloorBelowMinimum");
         var systemId = "00000000-0000-0000-0000-00000000c0de";
@@ -876,7 +879,7 @@ public sealed class DependencyResolverTests : IDisposable
     /// and the run now says why the compile that follows will fail.
     /// </summary>
     [Fact]
-    public void SourceCompilablePackageFloor_SystemAbsent_IsReportedAsUnservable()
+    public void SourceCompilablePackageFloor_SystemAbsent_IsReportedAsAProvisioningGap()
     {
         var dir = MakeDir("FloorAbsentReported");
         var assertId = "dd0be2ea-f733-4d65-bb34-a28f4624fb14";

--- a/AlRunner.Tests/DependencyResolverTests.cs
+++ b/AlRunner.Tests/DependencyResolverTests.cs
@@ -861,7 +861,7 @@ public sealed class DependencyResolverTests : IDisposable
         // 27.0/27.3 tolerance above.
         Assert.Contains("Library Assert", result.Select(r => r.Manifest.Name));
 
-        var report = Assert.Single(resolver.UnservableDependencies, d => d.Contains("Library Assert", StringComparison.Ordinal));
+        var report = Assert.Single(resolver.ProvisioningGaps, d => d.Contains("Library Assert", StringComparison.Ordinal));
         Assert.Contains("Microsoft/System", report, StringComparison.Ordinal);
         Assert.Contains("28.0.0.0", report, StringComparison.Ordinal);   // the declared floor
         Assert.Contains("27.0.38460.0", report, StringComparison.Ordinal); // what was found instead
@@ -889,7 +889,7 @@ public sealed class DependencyResolverTests : IDisposable
             new DependencyRef(Guid.Parse(assertId), "Library Assert", "Microsoft", new Version(28, 0, 0, 0)),
         });
 
-        var report = Assert.Single(resolver.UnservableDependencies, d => d.Contains("Library Assert", StringComparison.Ordinal));
+        var report = Assert.Single(resolver.ProvisioningGaps, d => d.Contains("Library Assert", StringComparison.Ordinal));
         Assert.Contains("Microsoft/System", report, StringComparison.Ordinal);
         Assert.Contains("28.0.0.0", report, StringComparison.Ordinal);
         Assert.Contains("provision", report, StringComparison.OrdinalIgnoreCase);
@@ -915,7 +915,7 @@ public sealed class DependencyResolverTests : IDisposable
             new DependencyRef(Guid.Parse(depId), "Precompiled", "Contoso", new Version(1, 0, 0, 0)),
         });
 
-        Assert.DoesNotContain(resolver.UnservableDependencies, d => d.Contains("Microsoft/System", StringComparison.Ordinal));
+        Assert.DoesNotContain(resolver.ProvisioningGaps, d => d.Contains("Microsoft/System", StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -940,7 +940,88 @@ public sealed class DependencyResolverTests : IDisposable
         });
 
         Assert.Equal(new[] { "System", "Library Assert" }, result.Select(r => r.Manifest.Name).ToArray());
-        Assert.DoesNotContain(resolver.UnservableDependencies, d => d.Contains("Microsoft/System", StringComparison.Ordinal));
+        Assert.DoesNotContain(resolver.ProvisioningGaps, d => d.Contains("Microsoft/System", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The gate is three predicates, and only the AL-source one had a fact of its own: the
+    /// R2R negative used a fixture with no AL source either, so a wrong gate consisting only
+    /// of `if (!HasAlSource) return` passed everything (#3810 review). This package has BOTH
+    /// an R2R payload AND AL source, so it separates them — Tier-2 serves it, and it must
+    /// stay silent.
+    /// </summary>
+    [Fact]
+    public void PackageWithBothR2RAndAlSource_FloorAbsent_IsNotReported()
+    {
+        var dir = MakeDir("FloorR2RPlusSource");
+        var depId = "00000000-0000-0000-0000-0000000c2222";
+        File.WriteAllBytes(Path.Combine(dir, "Contoso_Both.app"),
+            MakeMinimalApp(depId, "Both", "Contoso", "1.0.0.0", r2r: true, alSource: true, platform: "28.0.0.0"));
+
+        var resolver = new DependencyResolver(new[] { dir });
+        resolver.Resolve(new[]
+        {
+            new DependencyRef(Guid.Parse(depId), "Both", "Contoso", new Version(1, 0, 0, 0)),
+        });
+
+        Assert.Empty(resolver.ProvisioningGaps);
+    }
+
+    /// <summary>
+    /// One floor unmet for two source-bearing packages is two reports, one per owner — they
+    /// name different packages and a reader needs both. The same (owner, floor) pair twice is
+    /// not, and a second Resolve on one resolver must not duplicate what the first said
+    /// (#3810 review).
+    /// </summary>
+    [Fact]
+    public void UnsuppliableFloor_IsReportedOncePerOwner_AndNotRepeatedAcrossResolves()
+    {
+        var dir = MakeDir("FloorDedup");
+        var oneId = "00000000-0000-0000-0000-0000000d1111";
+        var twoId = "00000000-0000-0000-0000-0000000d2222";
+        File.WriteAllBytes(Path.Combine(dir, "Contoso_One.app"),
+            MakeMinimalApp(oneId, "One", "Contoso", "1.0.0.0", r2r: false, alSource: true, platform: "28.0.0.0"));
+        File.WriteAllBytes(Path.Combine(dir, "Contoso_Two.app"),
+            MakeMinimalApp(twoId, "Two", "Contoso", "1.0.0.0", r2r: false, alSource: true, platform: "28.0.0.0"));
+
+        var resolver = new DependencyResolver(new[] { dir });
+        var roots = new[]
+        {
+            new DependencyRef(Guid.Parse(oneId), "One", "Contoso", new Version(1, 0, 0, 0)),
+            new DependencyRef(Guid.Parse(twoId), "Two", "Contoso", new Version(1, 0, 0, 0)),
+        };
+        resolver.Resolve(roots);
+
+        Assert.Equal(2, resolver.ProvisioningGaps.Count);
+        Assert.Single(resolver.ProvisioningGaps, g => g.Contains("Contoso/One", StringComparison.Ordinal));
+        Assert.Single(resolver.ProvisioningGaps, g => g.Contains("Contoso/Two", StringComparison.Ordinal));
+
+        resolver.Resolve(roots);
+
+        Assert.Equal(2, resolver.ProvisioningGaps.Count);
+    }
+
+    /// <summary>
+    /// An unmet floor is not an unservable package, and must not be filed as one: #1689's list
+    /// means "no loader tier can implement this", which is certain, while this package has AL
+    /// source and may well be served from a cache without compiling at all.
+    /// </summary>
+    [Fact]
+    public void UnsuppliableFloor_DoesNotEnterTheUnservableList()
+    {
+        var dir = MakeDir("FloorNotUnservable");
+        var assertId = "dd0be2ea-f733-4d65-bb34-a28f4624fb14";
+        File.WriteAllBytes(Path.Combine(dir, "Microsoft_Library Assert.app"),
+            MakeMinimalApp(assertId, "Library Assert", "Microsoft", "28.1.49838.54169", r2r: false, alSource: true, platform: "28.0.0.0"));
+
+        var resolver = new DependencyResolver(new[] { dir });
+        resolver.Resolve(new[]
+        {
+            new DependencyRef(Guid.Parse(assertId), "Library Assert", "Microsoft", new Version(28, 0, 0, 0)),
+        });
+
+        Assert.Single(resolver.ProvisioningGaps);
+        Assert.Empty(resolver.UnservableDependencies);
     }
 
     // ── #1689: a resolved package that NO loader tier can implement ───────────

--- a/AlRunner.Tests/ManifestDependencyEdgeScanTests.cs
+++ b/AlRunner.Tests/ManifestDependencyEdgeScanTests.cs
@@ -178,6 +178,247 @@ public sealed class ManifestDependencyEdgeScanTests : IDisposable
         Assert.Equal(new[] { "System" }, needs.RequiredPlatformApps);
     }
 
+    // -- #3794: a floor is a real dependency, with a real version, on BOTH sides --
+    //
+    // #3793 taught DependencyResolver.Visit to follow a resolved package's own
+    // Platform/Application floors. Provisioning did not learn the same thing, in two
+    // separate ways, and the floor's VERSION was discarded on both sides:
+    //
+    //   1. ScanDependencyEdges dropped every non-Microsoft package before reading it, and
+    //      DetermineManifestNeeds only started its walk at Microsoft-published roots -- so a
+    //      platform-less consumer depending on a source-bearing Contoso/Library whose
+    //      manifest declares Platform="28.0.0.0" reported no platform need, downloaded
+    //      nothing, and the Tier-3 compile of that library died on the same generic
+    //      EMIT-ZERO as #3719.
+    //   2. Only the edge's NAME was recorded, never its MinVersion, and DetermineVersionFloors
+    //      read only the bundle's own roots -- so an existing but too-old app satisfied
+    //      FindMissingPlatformApps through a transitive edge. That is #2193, filed against
+    //      exactly this line and closed by the same change.
+
+    /// <summary>
+    /// A NON-Microsoft package's floor is an edge. The publisher filter belongs on the edge
+    /// TARGET (a third-party name can never collide usefully with a platform-app name), not
+    /// on the SOURCE: the resolver follows every non-platform package's floors whatever its
+    /// publisher, so a provisioning scan that reads only Microsoft sources answers a
+    /// different question from the one resolution asks.
+    /// </summary>
+    [Fact]
+    public void ScanDependencyEdges_NonMicrosoftPackageDeclaringPlatform_IsRecordedAsAnEdgeSource()
+    {
+        var dir = NewDir("floor-edge-thirdparty");
+        WriteAppWithPlatform(dir, "Library", "Contoso", "1.0.0.0", platform: "28.0.0.0");
+
+        var edges = ProvisioningCheck.ScanDependencyEdges(new[] { dir }).Edges;
+
+        Assert.Equal(new[] { "System" }, edges["Library"]);
+    }
+
+    /// <summary>
+    /// The same for an ordinary declared &lt;Dependency&gt;: a third-party package naming a
+    /// Microsoft app is an edge into the platform set. Only the TARGET stays
+    /// Microsoft-filtered -- a Contoso dependency of a Contoso package is not recorded.
+    /// </summary>
+    [Fact]
+    public void ScanDependencyEdges_NonMicrosoftSource_KeepsMicrosoftTargetsAndDropsTheRest()
+    {
+        var dir = NewDir("floor-edge-thirdparty-deps");
+        WriteApp(dir, "Library", "Contoso", "1.0.0.0",
+            ("Application", "Microsoft"), ("Other Contoso Thing", "Contoso"));
+
+        var edges = ProvisioningCheck.ScanDependencyEdges(new[] { dir }).Edges;
+
+        Assert.Equal(new[] { "Application" }, edges["Library"]);
+    }
+
+    /// <summary>
+    /// The walk must start at a non-Microsoft root too. Without this the edge recorded above
+    /// is never consulted: DetermineManifestNeeds skipped every root whose publisher was not
+    /// Microsoft before asking ReachesAnyOf anything.
+    /// </summary>
+    [Fact]
+    public void DetermineManifestNeeds_NonMicrosoftRootReachingSystem_RequiresThePlatformSet()
+    {
+        var dir = NewDir("floor-need-thirdparty");
+        WriteAppWithPlatform(dir, "Library", "Contoso", "1.0.0.0", platform: "28.0.0.0");
+        var edges = ProvisioningCheck.ScanDependencyEdges(new[] { dir }).Edges;
+
+        var needs = ProvisioningCheck.DetermineManifestNeeds(
+            new[] { Root("Library", publisher: "Contoso", version: "1.0.0.0") }, edges);
+
+        Assert.True(needs.NeedsPlatformApps);
+        Assert.Equal(new[] { "System" }, needs.RequiredPlatformApps);
+        // The platform set is not the test toolkit, and needing one must not drag the other
+        // along: that is a separate 20 MB download this root says nothing about.
+        Assert.False(needs.NeedsTestApps);
+    }
+
+    /// <summary>
+    /// A third-party root that reaches nothing Microsoft stays out of the platform set --
+    /// the negative direction, so the fix above cannot be "every root needs everything".
+    /// </summary>
+    [Fact]
+    public void DetermineManifestNeeds_NonMicrosoftRootReachingNothing_RequiresNoPlatformSet()
+    {
+        var dir = NewDir("floor-need-thirdparty-none");
+        WriteApp(dir, "Library", "Contoso", "1.0.0.0");
+        var edges = ProvisioningCheck.ScanDependencyEdges(new[] { dir }).Edges;
+
+        var needs = ProvisioningCheck.DetermineManifestNeeds(
+            new[] { Root("Library", publisher: "Contoso", version: "1.0.0.0") }, edges);
+
+        Assert.False(needs.NeedsPlatformApps);
+        Assert.Empty(needs.RequiredPlatformApps);
+    }
+
+    // -- #2193: the edge's declared MinVersion, closed over the graph --
+
+    /// <summary>
+    /// The scan records each edge's declared <c>MinVersion</c>, not just the target name.
+    /// #2193: Tests-TestLibraries' manifest declares
+    /// <c>&lt;Dependency Name="Application Test Library" MinVersion="28.1.0.0" /&gt;</c>, and
+    /// discarding that number is why a warm cache holding 28.0 satisfied a bundle that
+    /// transitively requires 28.1.
+    /// </summary>
+    [Fact]
+    public void ScanDependencyEdges_RecordsTheDeclaredMinVersionOfEachEdge()
+    {
+        var dir = NewDir("edge-minversion");
+        WriteAppWithDependencyVersions(dir, "Tests-TestLibraries", "Microsoft", "28.1.49838.54169",
+            ("Application Test Library", "Microsoft", "28.1.0.0"));
+
+        var scan = ProvisioningCheck.ScanDependencyEdges(new[] { dir });
+
+        var atl = Assert.Single(
+            scan.EdgeRequirements["Tests-TestLibraries"],
+            r => string.Equals(r.Name, "Application Test Library", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(new Version(28, 1, 0, 0), atl.Version);
+    }
+
+    /// <summary>
+    /// A floor declared on a package the bundle only reaches TRANSITIVELY is a floor. The
+    /// bundle names Tests-TestLibraries &gt;= 28.1.0.0 and nothing else; the floor for
+    /// Application Test Library has to come off that package's own manifest.
+    /// </summary>
+    [Fact]
+    public void DetermineVersionFloors_TransitiveEdge_ClosesTheFloorOverTheGraph()
+    {
+        var dir = NewDir("floor-transitive");
+        WriteAppWithDependencyVersions(dir, "Tests-TestLibraries", "Microsoft", "28.1.49838.54169",
+            ("Application Test Library", "Microsoft", "28.1.0.0"));
+        var scan = ProvisioningCheck.ScanDependencyEdges(new[] { dir });
+
+        var floors = ProvisioningCheck.DetermineVersionFloors(
+            new[] { Root("Tests-TestLibraries", version: "28.1.0.0") }, scan.EdgeRequirements);
+
+        Assert.Equal(new Version(28, 1, 0, 0), floors["Application Test Library"]);
+        Assert.Equal(new Version(28, 1, 0, 0), floors["Tests-TestLibraries"]);
+    }
+
+    /// <summary>
+    /// Where a root and a traversed edge disagree, the HIGHER floor wins -- the same rule the
+    /// root-only map already applied across bundles. Both directions, so an implementation
+    /// that simply overwrites cannot pass: the root is stricter here, the edge stricter in
+    /// the fact above.
+    /// </summary>
+    [Fact]
+    public void DetermineVersionFloors_RootStricterThanTheEdge_KeepsTheRootFloor()
+    {
+        var dir = NewDir("floor-transitive-max");
+        WriteAppWithDependencyVersions(dir, "Tests-TestLibraries", "Microsoft", "28.1.49838.54169",
+            ("Application Test Library", "Microsoft", "28.0.0.0"));
+        var scan = ProvisioningCheck.ScanDependencyEdges(new[] { dir });
+
+        var floors = ProvisioningCheck.DetermineVersionFloors(
+            new[]
+            {
+                Root("Tests-TestLibraries", version: "28.1.0.0"),
+                Root("Application Test Library", version: "28.2.0.0"),
+            },
+            scan.EdgeRequirements);
+
+        Assert.Equal(new Version(28, 2, 0, 0), floors["Application Test Library"]);
+    }
+
+    /// <summary>
+    /// A cycle in the manifest graph terminates rather than hanging, matching
+    /// <see cref="ProvisioningCheck.ReachesAnyOf"/>'s own guarantee. Real Microsoft platform
+    /// manifests reference each other, so this is the ordinary case, not an exotic one.
+    /// </summary>
+    [Fact]
+    public void DetermineVersionFloors_CyclicEdges_Terminate()
+    {
+        var dir = NewDir("floor-transitive-cycle");
+        WriteAppWithDependencyVersions(dir, "A", "Microsoft", "28.0.0.0", ("B", "Microsoft", "28.1.0.0"));
+        WriteAppWithDependencyVersions(dir, "B", "Microsoft", "28.0.0.0", ("A", "Microsoft", "28.3.0.0"));
+        var scan = ProvisioningCheck.ScanDependencyEdges(new[] { dir });
+
+        var floors = ProvisioningCheck.DetermineVersionFloors(
+            new[] { Root("A", version: "28.0.0.0") }, scan.EdgeRequirements);
+
+        Assert.Equal(new Version(28, 1, 0, 0), floors["B"]);
+        Assert.Equal(new Version(28, 3, 0, 0), floors["A"]);
+    }
+
+    /// <summary>
+    /// End to end, the shape #2193 reported: a warm cache whose Application Test Library is
+    /// 28.0 while Tests-TestLibraries transitively requires 28.1. The app is present, so a
+    /// presence-only check calls the set complete and downloads nothing; the floor makes it
+    /// missing, which is what a download can then fix.
+    /// </summary>
+    [Fact]
+    public void DecideManifestProvisioning_TransitivelyBelowFloorApp_CountsAsMissing()
+    {
+        var dir = NewDir("floor-transitive-decision");
+        WriteAppWithDependencyVersions(dir, "Tests-TestLibraries", "Microsoft", "28.1.49838.54169",
+            ("Application Test Library", "Microsoft", "28.1.0.0"));
+        WriteR2RApp(dir, "Application Test Library", "Microsoft", "28.0.46665.53459");
+        var legacy = ProvisioningCheck.CheckPlatformApps("28.1.49838.53910", new[] { dir });
+
+        var decision = ProvisioningCheck.DecideManifestProvisioning(
+            new[] { Root("Tests-TestLibraries", version: "28.1.0.0") }, legacy, new[] { dir });
+
+        Assert.Contains("Application Test Library", decision.MissingPlatformApps);
+        Assert.False(decision.PlatformComplete);
+    }
+
+    /// <summary>The same cache one build newer than the transitive floor is complete -- the
+    /// negative direction, so "missing" above is the floor talking and not the scan failing
+    /// to see the app at all.</summary>
+    [Fact]
+    public void DecideManifestProvisioning_TransitiveFloorSatisfied_CountsAsPresent()
+    {
+        var dir = NewDir("floor-transitive-decision-ok");
+        WriteAppWithDependencyVersions(dir, "Tests-TestLibraries", "Microsoft", "28.1.49838.54169",
+            ("Application Test Library", "Microsoft", "28.1.0.0"));
+        WriteR2RApp(dir, "Application Test Library", "Microsoft", "28.1.49838.54169");
+        var legacy = ProvisioningCheck.CheckPlatformApps("28.1.49838.53910", new[] { dir });
+
+        var decision = ProvisioningCheck.DecideManifestProvisioning(
+            new[] { Root("Tests-TestLibraries", version: "28.1.0.0") }, legacy, new[] { dir });
+
+        Assert.DoesNotContain("Application Test Library", decision.MissingPlatformApps);
+    }
+
+    /// <summary>As <see cref="WriteApp"/>, with a per-dependency MinVersion rather than the
+    /// package's own version -- which is what a real manifest declares, and what #2193 is
+    /// about.</summary>
+    private static void WriteAppWithDependencyVersions(
+        string dir, string name, string publisher, string version,
+        params (string Name, string Publisher, string MinVersion)[] dependencies)
+    {
+        var deps = string.Concat(dependencies.Select(d =>
+            $"""    <Dependency Id="{Guid.NewGuid()}" Name="{d.Name}" Publisher="{d.Publisher}" MinVersion="{d.MinVersion}" />{"\n"}"""));
+        var xml = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+              <App Id="{Guid.NewGuid()}" Name="{name}" Publisher="{publisher}" Version="{version}"/>
+              <Dependencies>
+            {deps}  </Dependencies>
+            </Package>
+            """;
+        File.WriteAllBytes(Path.Combine(dir, $"{publisher}_{name}.app"), WrapNavx(xml));
+    }
+
     /// <summary>As <see cref="WriteApp"/>, but the package carries a
     /// <c>publishedartifacts/</c> entry — i.e. an R2R runtime package rather than a
     /// symbol-only one, which is what a real provisioned platform-apps dir holds.</summary>
@@ -373,16 +614,42 @@ public sealed class ManifestDependencyEdgeScanTests : IDisposable
         Assert.True(ProvisioningCheck.TestToolkitPresent(new[] { dir }));
     }
 
+    /// <summary>
+    /// #3794 inverted the SOURCE half of this: a third-party package is now an edge source,
+    /// because DependencyResolver.Visit follows its floors and &lt;Dependencies&gt; whatever
+    /// its publisher, and a scan blind to it made provisioning answer a different question
+    /// from resolution. The TARGET half is unchanged and is what the name-keyed graph rests
+    /// on, so both directions are asserted here rather than only the one that moved.
+    /// </summary>
     [Fact]
-    public void ScanDependencyEdges_NonMicrosoftPackage_IsNotRecordedAsAnEdgeSource()
+    public void ScanDependencyEdges_NonMicrosoftPackage_IsAnEdgeSourceWithMicrosoftTargetsOnly()
     {
         var dir = NewDir("isv");
         WriteApp(dir, "Contoso Extension", "Contoso ISV", "1.0.0.0",
-            ("Application Test Library", "Microsoft"));
+            ("Application Test Library", "Microsoft"), ("Contoso Helper", "Contoso ISV"));
 
         var scan = ProvisioningCheck.ScanDependencyEdges(new[] { dir });
 
-        Assert.False(scan.Edges.ContainsKey("Contoso Extension"));
+        Assert.Equal(new[] { "Application Test Library" }, scan.Edges["Contoso Extension"].ToArray());
+    }
+
+    /// <summary>
+    /// The displacement rule the name key needs once third-party sources are admitted: a
+    /// third-party app sharing a Microsoft app's NAME must not shadow the real one's edges.
+    /// Ordinary first-wins precedence would let it, because the scan reads directories in
+    /// order and both are called "Application".
+    /// </summary>
+    [Fact]
+    public void ScanDependencyEdges_ThirdPartyAppNamedLikeAMicrosoftOne_DoesNotShadowIt()
+    {
+        var first = NewDir("shadow-first");
+        var second = NewDir("shadow-second");
+        WriteApp(first, "Application", "Contoso ISV", "1.0.0.0");
+        WriteApp(second, "Application", "Microsoft", "28.1.49838.54169", ("Base Application", "Microsoft"));
+
+        var scan = ProvisioningCheck.ScanDependencyEdges(new[] { first, second });
+
+        Assert.Equal(new[] { "Base Application" }, scan.Edges["Application"].ToArray());
     }
 
     [Fact]

--- a/AlRunner.Tests/ManifestDependencyEdgeScanTests.cs
+++ b/AlRunner.Tests/ManifestDependencyEdgeScanTests.cs
@@ -210,16 +210,118 @@ public sealed class ManifestDependencyEdgeScanTests : IDisposable
 
         var edges = ProvisioningCheck.ScanDependencyEdges(new[] { dir }).Edges;
 
-        Assert.Equal(new[] { "System" }, edges["Library"]);
+        // Keyed Publisher/Name, so it can never occupy or satisfy a Microsoft goal node.
+        Assert.Equal(new[] { "System" }, edges["Contoso/Library"]);
+        Assert.False(edges.ContainsKey("Library"));
+    }
+
+    /// <summary>
+    /// The floor's declared VERSION reaches EdgeRequirements too, not only an ordinary
+    /// &lt;Dependency&gt;'s MinVersion — a separate code path, since a floor is synthesized by
+    /// AppLoader.ImplicitRoots rather than parsed from the Dependencies block.
+    /// </summary>
+    [Fact]
+    public void ScanDependencyEdges_ImplicitFloor_CarriesItsDeclaredVersion()
+    {
+        var dir = NewDir("floor-edge-version");
+        WriteAppWithFloors(dir, "Library Assert", "Microsoft", "28.1.49838.54169",
+            platform: "28.0.0.0", application: "28.1.0.0");
+
+        var reqs = ProvisioningCheck.ScanDependencyEdges(new[] { dir }).EdgeRequirements["Library Assert"];
+
+        Assert.Equal(new Version(28, 0, 0, 0),
+            Assert.Single(reqs, r => r.Name == "System").Version);
+        Assert.Equal(new Version(28, 1, 0, 0),
+            Assert.Single(reqs, r => r.Name == "Application").Version);
+    }
+
+    /// <summary>
+    /// The defect the #3810 review found: a non-Microsoft INTERMEDIATE vertex was dropped, so
+    /// `Consumer -> Contoso/A -> Fabrikam/B (Platform=28.0)` recorded B's floor and then had no
+    /// path from A to reach it with. Only the walk's GOALS are Microsoft-only; intermediate
+    /// vertices cannot be filtered by publisher, because the resolver does not filter them.
+    /// </summary>
+    [Fact]
+    public void ScanDependencyEdges_ThirdPartyIntermediate_IsTraversableToAMicrosoftGoal()
+    {
+        var dir = NewDir("floor-edge-intermediate");
+        WriteApp(dir, "A", "Contoso", "1.0.0.0", ("B", "Fabrikam"));
+        WriteAppWithPlatform(dir, "B", "Fabrikam", "1.0.0.0", platform: "28.0.0.0");
+        var edges = ProvisioningCheck.ScanDependencyEdges(new[] { dir }).Edges;
+
+        Assert.Equal(new[] { "Fabrikam/B" }, edges["Contoso/A"]);
+
+        var needs = ProvisioningCheck.DetermineManifestNeeds(
+            new[] { Root("A", publisher: "Contoso", version: "1.0.0.0") }, edges);
+
+        Assert.Equal(new[] { "System" }, needs.RequiredPlatformApps);
+    }
+
+    /// <summary>
+    /// The same two hops for a FLOOR, which is what #2193's closure walks: the version has to
+    /// survive the third-party intermediate as well as the name.
+    /// </summary>
+    [Fact]
+    public void DetermineVersionFloors_ThroughAThirdPartyIntermediate_KeepsTheFloor()
+    {
+        var dir = NewDir("floor-intermediate-version");
+        WriteApp(dir, "A", "Contoso", "1.0.0.0", ("B", "Fabrikam"));
+        WriteAppWithDependencyVersions(dir, "B", "Fabrikam", "1.0.0.0",
+            ("Application Test Library", "Microsoft", "28.2.0.0"));
+        var scan = ProvisioningCheck.ScanDependencyEdges(new[] { dir });
+
+        var floors = ProvisioningCheck.DetermineVersionFloors(
+            new[] { Root("A", publisher: "Contoso", version: "1.0.0.0") }, scan.EdgeRequirements);
+
+        Assert.Equal(new Version(28, 2, 0, 0), floors["Application Test Library"]);
+        // A third-party name never becomes a floor: floors are looked up by plain name against
+        // the curated Microsoft sets, and FindMissingPlatformApps would never ask for these.
+        Assert.False(floors.ContainsKey("B"));
+        Assert.False(floors.ContainsKey("Fabrikam/B"));
+    }
+
+    /// <summary>
+    /// An R2R package's IMPLICIT floors are not edges (#3810 review): a floor exists to be
+    /// compiled against, Tier-2 serves an R2R payload without compiling, and demanding the
+    /// 116 MB platform download for a package nothing will compile is a cost with no failure
+    /// behind it. Its declared &lt;Dependencies&gt; are recorded either way — those are runtime
+    /// dependencies, not symbols — which is the half that keeps this from being a blanket
+    /// exemption.
+    /// </summary>
+    [Fact]
+    public void ScanDependencyEdges_R2RPackage_ContributesItsDependenciesButNotItsFloors()
+    {
+        var dir = NewDir("floor-edge-r2r");
+        WriteR2RAppWithPlatform(dir, "Precompiled", "Contoso", "1.0.0.0", platform: "28.0.0.0",
+            ("Application Test Library", "Microsoft"));
+
+        var edges = ProvisioningCheck.ScanDependencyEdges(new[] { dir }).Edges;
+
+        Assert.Equal(new[] { "Application Test Library" }, edges["Contoso/Precompiled"]);
+    }
+
+    /// <summary>The source-bearing twin of the fact above, same fixture but no payload — so
+    /// the exemption is the R2R payload talking and not the floor being ignored outright.
+    /// </summary>
+    [Fact]
+    public void ScanDependencyEdges_SourceBearingPackage_ContributesItsFloors()
+    {
+        var dir = NewDir("floor-edge-nor2r");
+        WriteAppWithPlatform(dir, "Precompiled", "Contoso", "1.0.0.0", platform: "28.0.0.0",
+            ("Application Test Library", "Microsoft"));
+
+        var edges = ProvisioningCheck.ScanDependencyEdges(new[] { dir }).Edges;
+
+        Assert.Equal(new[] { "Application Test Library", "System" }, edges["Contoso/Precompiled"]);
     }
 
     /// <summary>
     /// The same for an ordinary declared &lt;Dependency&gt;: a third-party package naming a
-    /// Microsoft app is an edge into the platform set. Only the TARGET stays
-    /// Microsoft-filtered -- a Contoso dependency of a Contoso package is not recorded.
+    /// Microsoft app is an edge into the platform set, and a third-party target is kept as an
+    /// intermediate vertex under its qualified key.
     /// </summary>
     [Fact]
-    public void ScanDependencyEdges_NonMicrosoftSource_KeepsMicrosoftTargetsAndDropsTheRest()
+    public void ScanDependencyEdges_NonMicrosoftSource_KeepsEveryTargetUnderItsOwnKey()
     {
         var dir = NewDir("floor-edge-thirdparty-deps");
         WriteApp(dir, "Library", "Contoso", "1.0.0.0",
@@ -227,7 +329,10 @@ public sealed class ManifestDependencyEdgeScanTests : IDisposable
 
         var edges = ProvisioningCheck.ScanDependencyEdges(new[] { dir }).Edges;
 
-        Assert.Equal(new[] { "Application" }, edges["Library"]);
+        // Both targets are kept, each under its own key. Only the walk's GOALS are
+        // Microsoft-only; a third-party target is an intermediate vertex and dropping it
+        // severed real paths (#3810 review).
+        Assert.Equal(new[] { "Application", "Contoso/Other Contoso Thing" }, edges["Contoso/Library"]);
     }
 
     /// <summary>
@@ -440,6 +545,26 @@ public sealed class ManifestDependencyEdgeScanTests : IDisposable
             WrapNavx(xml, includePublishedArtifact: true));
     }
 
+    /// <summary>As <see cref="WriteR2RApp"/>, with the App element's <c>Platform</c>
+    /// attribute set.</summary>
+    private static void WriteR2RAppWithPlatform(
+        string dir, string name, string publisher, string version, string platform,
+        params (string Name, string Publisher)[] dependencies)
+    {
+        var deps = string.Concat(dependencies.Select(d =>
+            $"""    <Dependency Id="{Guid.NewGuid()}" Name="{d.Name}" Publisher="{d.Publisher}" MinVersion="{version}" />{"\n"}"""));
+        var xml = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+              <App Id="{Guid.NewGuid()}" Name="{name}" Publisher="{publisher}" Version="{version}" Platform="{platform}"/>
+              <Dependencies>
+            {deps}  </Dependencies>
+            </Package>
+            """;
+        File.WriteAllBytes(Path.Combine(dir, $"{publisher}_{name}.app"),
+            WrapNavx(xml, includePublishedArtifact: true));
+    }
+
     private static byte[] WrapNavx(string manifestXml, bool includePublishedArtifact = false)
     {
         using var ms = new MemoryStream();
@@ -618,11 +743,11 @@ public sealed class ManifestDependencyEdgeScanTests : IDisposable
     /// #3794 inverted the SOURCE half of this: a third-party package is now an edge source,
     /// because DependencyResolver.Visit follows its floors and &lt;Dependencies&gt; whatever
     /// its publisher, and a scan blind to it made provisioning answer a different question
-    /// from resolution. The TARGET half is unchanged and is what the name-keyed graph rests
-    /// on, so both directions are asserted here rather than only the one that moved.
+    /// from resolution. The node key is what keeps that unambiguous: this package occupies
+    /// `Contoso ISV/Contoso Extension`, never the bare name a Microsoft app could hold.
     /// </summary>
     [Fact]
-    public void ScanDependencyEdges_NonMicrosoftPackage_IsAnEdgeSourceWithMicrosoftTargetsOnly()
+    public void ScanDependencyEdges_NonMicrosoftPackage_IsAnEdgeSourceUnderItsQualifiedKey()
     {
         var dir = NewDir("isv");
         WriteApp(dir, "Contoso Extension", "Contoso ISV", "1.0.0.0",
@@ -630,26 +755,61 @@ public sealed class ManifestDependencyEdgeScanTests : IDisposable
 
         var scan = ProvisioningCheck.ScanDependencyEdges(new[] { dir });
 
-        Assert.Equal(new[] { "Application Test Library" }, scan.Edges["Contoso Extension"].ToArray());
+        Assert.False(scan.Edges.ContainsKey("Contoso Extension"));
+        Assert.Equal(
+            new[] { "Application Test Library", "Contoso ISV/Contoso Helper" },
+            scan.Edges["Contoso ISV/Contoso Extension"].ToArray());
     }
 
     /// <summary>
-    /// The displacement rule the name key needs once third-party sources are admitted: a
-    /// third-party app sharing a Microsoft app's NAME must not shadow the real one's edges.
-    /// Ordinary first-wins precedence would let it, because the scan reads directories in
-    /// order and both are called "Application".
+    /// A third-party app sharing a Microsoft app's NAME occupies a different node, in BOTH
+    /// directory orders — the #3810 review's point that a one-order test passes a "last one
+    /// wins" implementation as readily as the right one.
     /// </summary>
-    [Fact]
-    public void ScanDependencyEdges_ThirdPartyAppNamedLikeAMicrosoftOne_DoesNotShadowIt()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ScanDependencyEdges_ThirdPartyAppNamedLikeAMicrosoftOne_DoesNotShadowIt(bool microsoftFirst)
     {
-        var first = NewDir("shadow-first");
-        var second = NewDir("shadow-second");
-        WriteApp(first, "Application", "Contoso ISV", "1.0.0.0");
-        WriteApp(second, "Application", "Microsoft", "28.1.49838.54169", ("Base Application", "Microsoft"));
+        var msDir = NewDir($"shadow-ms-{microsoftFirst}");
+        var isvDir = NewDir($"shadow-isv-{microsoftFirst}");
+        WriteApp(isvDir, "Application", "Contoso ISV", "1.0.0.0", ("Contoso Helper", "Contoso ISV"));
+        WriteApp(msDir, "Application", "Microsoft", "28.1.49838.54169", ("Base Application", "Microsoft"));
 
-        var scan = ProvisioningCheck.ScanDependencyEdges(new[] { first, second });
+        var dirs = microsoftFirst ? new[] { msDir, isvDir } : new[] { isvDir, msDir };
+        var scan = ProvisioningCheck.ScanDependencyEdges(dirs);
 
         Assert.Equal(new[] { "Base Application" }, scan.Edges["Application"].ToArray());
+        Assert.Equal(new[] { "Contoso ISV/Contoso Helper" }, scan.Edges["Contoso ISV/Application"].ToArray());
+    }
+
+    /// <summary>
+    /// Two builds of ONE app: the higher version's edges are the operative ones, in both
+    /// directory orders. #3810's review found this: first-directory-wins was harmless while
+    /// the graph only answered "does this reach a platform app", and stopped being harmless
+    /// when the edges started carrying floors — a cache with B v28.1 (needing Application Test
+    /// Library 28.0) ahead of B v28.2 (needing 28.2) recorded the 28.0 floor while the
+    /// resolver selects v28.2 and enforces 28.2, which is #2193's stale cache all over again.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ScanDependencyEdges_TwoBuildsOfOneApp_TheHigherVersionsEdgesWin(bool newerFirst)
+    {
+        var older = NewDir($"ver-old-{newerFirst}");
+        var newer = NewDir($"ver-new-{newerFirst}");
+        WriteAppWithDependencyVersions(older, "B", "Microsoft", "28.1.0.0",
+            ("Application Test Library", "Microsoft", "28.0.0.0"));
+        WriteAppWithDependencyVersions(newer, "B", "Microsoft", "28.2.0.0",
+            ("Application Test Library", "Microsoft", "28.2.0.0"));
+
+        var dirs = newerFirst ? new[] { newer, older } : new[] { older, newer };
+        var scan = ProvisioningCheck.ScanDependencyEdges(dirs);
+
+        var floors = ProvisioningCheck.DetermineVersionFloors(
+            new[] { Root("B", version: "28.2.0.0") }, scan.EdgeRequirements);
+
+        Assert.Equal(new Version(28, 2, 0, 0), floors["Application Test Library"]);
     }
 
     [Fact]

--- a/AlRunner.Tests/ProvisioningCheckTests.cs
+++ b/AlRunner.Tests/ProvisioningCheckTests.cs
@@ -765,8 +765,8 @@ public sealed class ProvisioningCheckTests : IDisposable
     /// <summary>
     /// #3794 let the reachability walk start at a non-Microsoft root, and this is the guard
     /// on it: a third-party app that merely SHARES a Microsoft app's name is not that app.
-    /// A third-party root is followed through its recorded edges only, so one with no edges
-    /// on disk — this — requires nothing, exactly as before.
+    /// Its node key is qualified, so it can neither satisfy a Microsoft goal by
+    /// self-membership nor read a Microsoft app's edges. Empty graph.
     /// </summary>
     [Fact]
     public void DetermineManifestNeeds_NonMicrosoftPublisher_RootNameIsNotAnIdentity()
@@ -778,6 +778,55 @@ public sealed class ProvisioningCheckTests : IDisposable
         var needs = ProvisioningCheck.DetermineManifestNeeds(roots);
         Assert.False(needs.NeedsPlatformApps);
         Assert.False(needs.NeedsTestApps);
+    }
+
+    /// <summary>
+    /// The half the fact above cannot reach, and the one the #3810 review called out as the
+    /// dangerous case: the colliding name is PRESENT in the graph. An implementation that is
+    /// correct only when the key is absent — and reads the Microsoft app's edges when it is —
+    /// passes the empty-graph fact and fails this one. Both directions here: the third-party
+    /// root must not borrow the Microsoft edges, and the Microsoft root must still use them.
+    /// </summary>
+    [Fact]
+    public void DetermineManifestNeeds_NonMicrosoftRoot_DoesNotBorrowASameNamedMicrosoftAppsEdges()
+    {
+        var edges = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            // What a scan of a real cache would hold for Microsoft's own app...
+            ["Tests-TestLibraries"] = new[] { "Application Test Library" },
+            // ...beside an unrelated third-party app of the same NAME, which declares nothing.
+            ["Contoso ISV/Tests-TestLibraries"] = Array.Empty<string>(),
+        };
+
+        var isv = ProvisioningCheck.DetermineManifestNeeds(
+            new[] { new DependencyRef(Guid.NewGuid(), "Tests-TestLibraries", "Contoso ISV", new Version(1, 0, 0, 0)) },
+            edges);
+        Assert.False(isv.NeedsPlatformApps);
+        Assert.Empty(isv.RequiredPlatformApps);
+
+        var ms = ProvisioningCheck.DetermineManifestNeeds(
+            new[] { new DependencyRef(Guid.NewGuid(), "Tests-TestLibraries", "Microsoft", new Version(28, 1, 0, 0)) },
+            edges);
+        Assert.Equal(new[] { "Application Test Library" }, ms.RequiredPlatformApps);
+    }
+
+    /// <summary>
+    /// The mirror: a Microsoft root must not pick up a third-party package's edges. Only the
+    /// third-party node is in the graph, so the Microsoft root reaches nothing beyond itself.
+    /// </summary>
+    [Fact]
+    public void DetermineManifestNeeds_MicrosoftRoot_DoesNotBorrowASameNamedThirdPartyAppsEdges()
+    {
+        var edges = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Contoso ISV/Tests-TestLibraries"] = new[] { "Application Test Library" },
+        };
+
+        var needs = ProvisioningCheck.DetermineManifestNeeds(
+            new[] { new DependencyRef(Guid.NewGuid(), "Tests-TestLibraries", "Microsoft", new Version(28, 1, 0, 0)) },
+            edges);
+
+        Assert.DoesNotContain("Application Test Library", needs.RequiredPlatformApps);
     }
 
     [Fact]

--- a/AlRunner.Tests/ProvisioningCheckTests.cs
+++ b/AlRunner.Tests/ProvisioningCheckTests.cs
@@ -762,8 +762,14 @@ public sealed class ProvisioningCheckTests : IDisposable
         Assert.False(needs.NeedsPlatformApps);
     }
 
+    /// <summary>
+    /// #3794 let the reachability walk start at a non-Microsoft root, and this is the guard
+    /// on it: a third-party app that merely SHARES a Microsoft app's name is not that app.
+    /// A third-party root is followed through its recorded edges only, so one with no edges
+    /// on disk — this — requires nothing, exactly as before.
+    /// </summary>
     [Fact]
-    public void DetermineManifestNeeds_NonMicrosoftPublisher_Ignored()
+    public void DetermineManifestNeeds_NonMicrosoftPublisher_RootNameIsNotAnIdentity()
     {
         var roots = new[]
         {

--- a/AlRunner/DependencyResolver.cs
+++ b/AlRunner/DependencyResolver.cs
@@ -31,6 +31,17 @@ public sealed class DependencyResolver
     // under --verbose: a dependency that no loader tier can implement is a certain runtime
     // failure, and the whole point of #1689 is that the developer never saw it coming.
     private readonly List<string> _unservable = new();
+    // #3794. Kept out of _unservable, which makes a stronger claim than this one can:
+    // "no loader tier can implement this package" is certain, and an unmet floor is not —
+    // the dependent may still be served from the compiled-dependency cache, from the
+    // service-tier DLL index, or from an already-loaded assembly, in which case nothing
+    // compiles and nothing fails. Always printed, like _unservable, because when it does
+    // bite it produces #3719's unattributable EMIT-ZERO.
+    private readonly List<string> _provisioningGaps = new();
+    // (owner identity, floor identity) already reported. One floor unmet for six packages
+    // in a toolkit closure is six worthwhile lines; the same one twice is noise, and
+    // Resolve can legitimately be called more than once on one resolver.
+    private readonly HashSet<string> _reportedFloorGaps = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Problems detected while resolving that are NOT fatal but almost certainly wrong —
@@ -49,6 +60,16 @@ public sealed class DependencyResolver
     /// call that will end in "The object with ID 0 does not have a member with that ID".
     /// </summary>
     public IReadOnlyList<string> UnservableDependencies => _unservable;
+
+    /// <summary>
+    /// Provisioning problems that are not certain failures but will produce an unattributable
+    /// one if they bite: currently a package that this run may source-compile, declaring a
+    /// Platform/Application floor the package caches cannot supply (#3794). Printed
+    /// unconditionally alongside <see cref="UnservableDependencies"/> and collected into the
+    /// bundle's provisioning gaps, because the failure it precedes — #3719's
+    /// <c>EMIT-ZERO — BC Compilation.Emit() returned 0 sources</c> — names nothing at all.
+    /// </summary>
+    public IReadOnlyList<string> ProvisioningGaps => _provisioningGaps;
 
     // Dirs holding packages this run built FROM SOURCE (SiblingCompile's synthesized
     // workspace dirs). A candidate under one of these outranks any packaged copy of the
@@ -194,20 +215,28 @@ public sealed class DependencyResolver
 
     /// <summary>
     /// #3794: name a floor that cannot be supplied, when the package that declared it is one
-    /// this run will SOURCE-COMPILE.
+    /// this run MAY source-compile.
     ///
     /// The skip above stays, and must: it is what lets the al-language corpus declare System
     /// Application &gt;= 27.5 and still run green on the 27.0 and 27.3 legs, where no download
     /// can clear the floor (ProvisioningCheck.DropUnsatisfiableFloors documents the same
-    /// tolerance on the other side). For a Tier-3 dependent the skip is not a tolerance
-    /// though — it is #3719's `EMIT-ZERO — BC Compilation.Emit() returned 0 sources`, arriving
-    /// one step later with nothing in it naming the floor, the versions found, the directories
-    /// searched, or the repair. So the report is gated on the OWNER being source-compilable
-    /// rather than on the floor being unmet, which is why an R2R dependent stays silent.
+    /// tolerance on the other side). For a package with no precompiled payload the skip is not
+    /// a tolerance though — it is #3719's `EMIT-ZERO — BC Compilation.Emit() returned 0
+    /// sources`, arriving one step later with nothing in it naming the floor, the versions
+    /// found, the directories searched, or the repair.
     ///
-    /// Goes to <see cref="UnservableDependencies"/>, not <see cref="Diagnostics"/>: like
-    /// #1689's unservable packages this is a failure the developer never saw coming, and it
-    /// is printed unconditionally rather than under --verbose.
+    /// MAY, not WILL, and the message says so. What is decided here is a property of the
+    /// PACKAGE — no R2R payload, no sidecar DLL, AL source present — which is a necessary
+    /// condition for the Tier-3 compile and not a sufficient one. DependencyLoader can still
+    /// serve the same package from the compiled-dependency cache, from the service-tier DLL
+    /// index when every codeunit is covered, or from an assembly already loaded in this
+    /// process, and then nothing compiles and nothing fails. Deciding it where the compile
+    /// actually happens would be exact; it would also mean re-deriving the closure inside
+    /// DependencyLoader, so the honest phrasing is here instead — #3812.
+    ///
+    /// Not <see cref="UnservableDependencies"/>: that list means "no loader tier can implement
+    /// this", which is certain, and this is not. <see cref="ProvisioningGaps"/> is printed just
+    /// as unconditionally.
     /// </summary>
     private void ReportUnsuppliableFloor(
         DependencyRef floor,
@@ -216,24 +245,38 @@ public sealed class DependencyResolver
     {
         if (owner is not { } o) return;
         // Tier-2 serves an R2R payload and Tier-1 a committed sidecar DLL; neither compiles
-        // the package's AL, so neither needs the floor's symbols. Only a package whose ONLY
-        // implementation route is the Tier-3 source compile is affected. The same three
+        // the package's AL, so neither can need the floor's symbols. The same three
         // predicates, in the same order, that SelectBestVersion's unservable check uses.
+        //
+        // Trap: HasPrecompiledSidecar asks only whether the file EXISTS. A corrupt sidecar
+        // silences this report and DependencyLoader then falls through to Tier-3 anyway, so a
+        // package in that state can still hit the unattributed EMIT-ZERO. Reading the sidecar
+        // to find out is DependencyLoader's job and it already reports the load failure
+        // loudly, which is the signal a reader gets instead.
         if (AppLoader.IsR2R(o.Path)) return;
         if (HasPrecompiledSidecar(o.Manifest)) return;
         if (!AppLoader.HasAlSource(o.Path)) return;
 
+        if (!_reportedFloorGaps.Add(
+                $"{o.Manifest.Publisher}/{o.Manifest.Name}/{o.Manifest.Version}"
+                + $"->{floor.Publisher}/{floor.Name}/{floor.Version}"))
+            return;
+
         var found = nearMissVersions == null
             ? "no copy was found in any searched directory"
             : $"found, but below the minimum: {nearMissVersions}";
-        _unservable.Add(
+        var searched = _cacheDirs.Count > 0
+            ? string.Join(", ", _cacheDirs)
+            : "nothing — this run was given no package cache directories";
+        _provisioningGaps.Add(
             $"[dep] {o.Manifest.Publisher}/{o.Manifest.Name} v{o.Manifest.Version} declares a floor of "
             + $"{floor.Publisher}/{floor.Name} >= {floor.Version}, and it cannot be supplied:"
             + $"\n      {found}"
-            + $"\n      searched: {string.Join(", ", _cacheDirs)}"
-            + $"\n      That package carries AL source and no precompiled payload, so it is compiled"
-            + $"\n      here against whatever the closure holds — without {floor.Name} its compile ends"
-            + $"\n      in \"EMIT-ZERO — 0 sources emitted\" naming nothing (#3719)."
+            + $"\n      searched: {searched}"
+            + $"\n      That package carries AL source and no precompiled payload. If this run compiles"
+            + $"\n      it — rather than serving it from the compiled-dependency cache, the service-tier"
+            + $"\n      DLLs or an already-loaded assembly — the compile has no {floor.Name} symbols and"
+            + $"\n      ends in \"EMIT-ZERO — 0 sources emitted\" naming nothing (#3719)."
             + $"\n      Repair: al-runner provision --platform-apps --bc-version <a build >= {floor.Version}>");
     }
 

--- a/AlRunner/DependencyResolver.cs
+++ b/AlRunner/DependencyResolver.cs
@@ -118,7 +118,8 @@ public sealed class DependencyResolver
         DependencyRef dep,
         Dictionary<Guid, byte> state,
         List<(AppManifest, string)> output,
-        Stack<string> stack)
+        Stack<string> stack,
+        (AppManifest Manifest, string Path)? floorOwner = null)
     {
         if (!TryFind(dep, out var found, out var nearMissVersions))
         {
@@ -132,7 +133,9 @@ public sealed class DependencyResolver
                 // dependent's manifest (this branch also fires for non-Optional manifest deps).
                 Console.Error.WriteLine(
                     $"  [deps] dependency not found in cache, skipping: " +
-                    $"{dep.Publisher}/{dep.Name}");
+                    $"{dep.Publisher}/{dep.Name}"
+                    + (nearMissVersions != null ? $" (found, below the minimum: {nearMissVersions})" : ""));
+                ReportUnsuppliableFloor(dep, floorOwner, nearMissVersions);
                 return;
             }
             if (nearMissVersions != null)
@@ -183,10 +186,55 @@ public sealed class DependencyResolver
         // Optional, like the consumer-side roots: a missing System.app skips, as above.
         if (!IsMicrosoftPlatformApp(found.Manifest.Name, found.Manifest.Publisher))
             foreach (var floor in AppLoader.ImplicitRoots(found.Manifest))
-                Visit(floor, state, output, stack);
+                Visit(floor, state, output, stack, floorOwner: found);
         stack.Pop();
         state[id] = 2;
         output.Add((found.Manifest, found.Path));
+    }
+
+    /// <summary>
+    /// #3794: name a floor that cannot be supplied, when the package that declared it is one
+    /// this run will SOURCE-COMPILE.
+    ///
+    /// The skip above stays, and must: it is what lets the al-language corpus declare System
+    /// Application &gt;= 27.5 and still run green on the 27.0 and 27.3 legs, where no download
+    /// can clear the floor (ProvisioningCheck.DropUnsatisfiableFloors documents the same
+    /// tolerance on the other side). For a Tier-3 dependent the skip is not a tolerance
+    /// though — it is #3719's `EMIT-ZERO — BC Compilation.Emit() returned 0 sources`, arriving
+    /// one step later with nothing in it naming the floor, the versions found, the directories
+    /// searched, or the repair. So the report is gated on the OWNER being source-compilable
+    /// rather than on the floor being unmet, which is why an R2R dependent stays silent.
+    ///
+    /// Goes to <see cref="UnservableDependencies"/>, not <see cref="Diagnostics"/>: like
+    /// #1689's unservable packages this is a failure the developer never saw coming, and it
+    /// is printed unconditionally rather than under --verbose.
+    /// </summary>
+    private void ReportUnsuppliableFloor(
+        DependencyRef floor,
+        (AppManifest Manifest, string Path)? owner,
+        string? nearMissVersions)
+    {
+        if (owner is not { } o) return;
+        // Tier-2 serves an R2R payload and Tier-1 a committed sidecar DLL; neither compiles
+        // the package's AL, so neither needs the floor's symbols. Only a package whose ONLY
+        // implementation route is the Tier-3 source compile is affected. The same three
+        // predicates, in the same order, that SelectBestVersion's unservable check uses.
+        if (AppLoader.IsR2R(o.Path)) return;
+        if (HasPrecompiledSidecar(o.Manifest)) return;
+        if (!AppLoader.HasAlSource(o.Path)) return;
+
+        var found = nearMissVersions == null
+            ? "no copy was found in any searched directory"
+            : $"found, but below the minimum: {nearMissVersions}";
+        _unservable.Add(
+            $"[dep] {o.Manifest.Publisher}/{o.Manifest.Name} v{o.Manifest.Version} declares a floor of "
+            + $"{floor.Publisher}/{floor.Name} >= {floor.Version}, and it cannot be supplied:"
+            + $"\n      {found}"
+            + $"\n      searched: {string.Join(", ", _cacheDirs)}"
+            + $"\n      That package carries AL source and no precompiled payload, so it is compiled"
+            + $"\n      here against whatever the closure holds — without {floor.Name} its compile ends"
+            + $"\n      in \"EMIT-ZERO — 0 sources emitted\" naming nothing (#3719)."
+            + $"\n      Repair: al-runner provision --platform-apps --bc-version <a build >= {floor.Version}>");
     }
 
     /// <summary>

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -947,9 +947,21 @@ public static class ProvisioningCheck
     /// is precisely the quiet wrong answer .claude/rules/loud-failures.md exists to stop —
     /// it reads downstream as "this app needs no provisioning".
     /// </summary>
+    /// <param name="EdgeRequirements">
+    /// The same graph as <paramref name="Edges"/>, carrying each edge's declared
+    /// <c>MinVersion</c> alongside its name. #2193: a manifest's
+    /// <c>&lt;Dependency Name="Application Test Library" MinVersion="28.1.0.0" /&gt;</c> is a
+    /// floor on a package the bundle reaches only transitively, and recording the name alone
+    /// is why a warm cache holding 28.0 satisfied a bundle that requires 28.1.
+    /// <see cref="DetermineVersionFloors(IEnumerable{AlRunner.DependencyRef}, IReadOnlyDictionary{string, IReadOnlyList{AlRunner.DependencyRef}}?)"/>
+    /// closes the floors over it. Kept beside <paramref name="Edges"/> rather than replacing
+    /// it: <see cref="ReachesAnyOf"/> asks a reachability question that has nothing to do
+    /// with versions, and every caller and test of it is written in names.
+    /// </param>
     public sealed record DependencyEdgeScan(
         IReadOnlyDictionary<string, IReadOnlyList<string>> Edges,
-        IReadOnlyList<string> UnreadablePackages);
+        IReadOnlyList<string> UnreadablePackages,
+        IReadOnlyDictionary<string, IReadOnlyList<AlRunner.DependencyRef>> EdgeRequirements);
 
     /// <summary>
     /// Reads the REAL direct dependency edges among Microsoft apps out of the `.app`
@@ -993,6 +1005,10 @@ public static class ProvisioningCheck
     public static DependencyEdgeScan ScanDependencyEdges(IEnumerable<string> searchDirs)
     {
         var edges = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+        var edgeRequirements =
+            new Dictionary<string, IReadOnlyList<AlRunner.DependencyRef>>(StringComparer.OrdinalIgnoreCase);
+        // Which recorded source was Microsoft-published — see the displacement rule below.
+        var sourceIsMicrosoftByName = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
         var unreadable = new List<string>();
         var seenDirs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -1036,18 +1052,49 @@ public static class ProvisioningCheck
                     unreadable.Add(file);
                     continue;
                 }
-                if (!string.Equals(manifest.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase))
-                    continue;
-                if (edges.ContainsKey(manifest.Name)) continue;
+                var sourceIsMicrosoft =
+                    string.Equals(manifest.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase);
+                // #3794: a THIRD-PARTY package is an edge source too. The resolver follows
+                // every non-platform package's floors and <Dependencies> whatever its
+                // publisher (DependencyResolver.Visit), so a scan that read only Microsoft
+                // sources answered a different question from the one resolution asks: a
+                // platform-less consumer depending on a source-bearing Contoso/Library that
+                // declares Platform="28.0.0.0" reported no platform need, downloaded nothing,
+                // and that library's Tier-3 compile died on #3719's generic EMIT-ZERO.
+                //
+                // Only the edge TARGET stays Microsoft-filtered, which is what the graph's
+                // name key rests on: the walk's targets are Microsoft app names, so a
+                // third-party target could only collide with one, never reach it.
+                if (edges.TryGetValue(manifest.Name, out _))
+                {
+                    // First-wins across directories, per the package-cache precedence — with
+                    // one exception. A third-party app sharing a Microsoft app's NAME would
+                    // otherwise shadow the real one in a graph keyed by name alone, so a
+                    // Microsoft source displaces a non-Microsoft one already recorded.
+                    if (!sourceIsMicrosoft) continue;
+                    if (sourceIsMicrosoftByName.TryGetValue(manifest.Name, out var incumbentIsMicrosoft)
+                        && incumbentIsMicrosoft)
+                        continue;
+                }
 
                 var deps = new List<string>();
-                foreach (var d in manifest.Dependencies)
+                var reqs = new List<AlRunner.DependencyRef>();
+                void Record(AlRunner.DependencyRef d)
                 {
-                    if (!string.Equals(d.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase)) continue;
-                    if (string.IsNullOrWhiteSpace(d.Name)) continue;
+                    if (!string.Equals(d.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase)) return;
+                    if (string.IsNullOrWhiteSpace(d.Name)) return;
                     if (!deps.Any(x => string.Equals(x, d.Name, StringComparison.OrdinalIgnoreCase)))
                         deps.Add(d.Name);
+                    // #2193: keep the declared MinVersion beside the name. A repeated name is
+                    // recorded once, at the HIGHER floor, matching DetermineVersionFloors'
+                    // own rule — a looser declaration can never relax a stricter one.
+                    var i = reqs.FindIndex(x => string.Equals(x.Name, d.Name, StringComparison.OrdinalIgnoreCase));
+                    if (i < 0) reqs.Add(d);
+                    else if (d.Version > reqs[i].Version) reqs[i] = d;
                 }
+
+                foreach (var d in manifest.Dependencies)
+                    Record(d);
                 // #3719: a package's Platform / Application floors are dependencies the real `al`
                 // compiler injects (Microsoft/System, Microsoft/Application). Library Assert
                 // declares Platform="28.0.0.0" and an empty <Dependencies />, so without this
@@ -1059,13 +1106,14 @@ public static class ProvisioningCheck
                 // does not walk would make provisioning fetch a set resolution never asks for.
                 if (!AlRunner.DependencyResolver.IsMicrosoftPlatformApp(manifest.Name, manifest.Publisher))
                     foreach (var floor in AlRunner.AppLoader.ImplicitRoots(manifest))
-                        if (!deps.Any(x => string.Equals(x, floor.Name, StringComparison.OrdinalIgnoreCase)))
-                            deps.Add(floor.Name);
+                        Record(floor);
                 edges[manifest.Name] = deps;
+                edgeRequirements[manifest.Name] = reqs;
+                sourceIsMicrosoftByName[manifest.Name] = sourceIsMicrosoft;
             }
         }
 
-        return new DependencyEdgeScan(edges, unreadable);
+        return new DependencyEdgeScan(edges, unreadable, edgeRequirements);
     }
 
     /// <summary>
@@ -1162,6 +1210,27 @@ public static class ProvisioningCheck
         var rootList = roots as IReadOnlyCollection<AlRunner.DependencyRef> ?? roots.ToList();
         bool needsTest = false;
 
+        // #3794: the walk starts at EVERY root, not only Microsoft-published ones. A
+        // third-party package is an edge source in the graph (ScanDependencyEdges), so a
+        // bundle whose only dependency is a Contoso library that itself declares
+        // Platform="28.0.0.0" reaches System in one hop — and used to be dropped before
+        // ReachesAnyOf was asked anything.
+        //
+        // A third-party root is walked through its EDGES only: its own name is not a
+        // platform-app identity however it is spelled. Asking ReachesAnyOf about the name
+        // directly would let `Contoso ISV/Application Test Library` — an unrelated app that
+        // merely shares a Microsoft name — demand the Microsoft download by self-membership,
+        // which is what DetermineManifestNeeds_NonMicrosoftPublisher_RootNameIsNotAnIdentity
+        // pins. For a Microsoft root the name IS the identity, so nothing changes there.
+        bool RootReaches(AlRunner.DependencyRef d, IReadOnlyList<string> targets)
+        {
+            if (string.IsNullOrWhiteSpace(d.Name)) return false;
+            if (string.Equals(d.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase))
+                return ReachesAnyOf(d.Name, edges, targets);
+            return edges.TryGetValue(d.Name, out var deps)
+                && deps.Any(t => ReachesAnyOf(t, edges, targets));
+        }
+
         // Which apps out of the curated platform-apps set (plus, for a non-w1 country, any
         // extra candidate the caller supplied) do these manifests require? Asked per-app,
         // over whatever the manifests NAME (directly, or reach through recorded edges) —
@@ -1179,8 +1248,7 @@ public static class ProvisioningCheck
             var single = new[] { candidate };
             foreach (var d in rootList)
             {
-                if (!string.Equals(d.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase)) continue;
-                if (!ReachesAnyOf(d.Name, edges, single)) continue;
+                if (!RootReaches(d, single)) continue;
                 requiredPlatformApps.Add(candidate);
                 break;
             }
@@ -1189,14 +1257,13 @@ public static class ProvisioningCheck
 
         foreach (var d in rootList)
         {
-            if (!string.Equals(d.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase)) continue;
             // Issue #2087: ONE closure walk replaces what used to be two separate checks —
             // a direct KnownNoFallbackPlatformApps membership test, and a second hardcoded
             // list of names known (by hand) to transitively reach one. ReachesAnyOf treats
             // "d.Name IS a no-fallback app" and "d.Name REACHES one through recorded edges"
             // as the same question, so a future multi-hop chain is caught the moment its own
             // edge is recorded — no new list, no per-shape entry.
-            if (ReachesAnyOf(d.Name, edges, KnownNoFallbackPlatformApps))
+            if (RootReaches(d, KnownNoFallbackPlatformApps))
             {
                 // Confirmed via a live BC 28.1 platform-apps download (issue #1996): App
                 // Test Library's OWN manifest transitively depends on the MS test toolkit
@@ -1206,7 +1273,11 @@ public static class ProvisioningCheck
                 // app therefore always implies needing the test toolkit too.
                 needsTest = true;
             }
-            if (KnownTestFrameworkAppNames.Any(n => string.Equals(n, d.Name, StringComparison.OrdinalIgnoreCase)))
+            // Still Microsoft-only, deliberately, unlike the walk above: this is a match on
+            // NAME with no edge behind it, so a third-party app that happens to be called
+            // "Any" would otherwise pull in the separate 20 MB test-apps download.
+            if (string.Equals(d.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase)
+                && KnownTestFrameworkAppNames.Any(n => string.Equals(n, d.Name, StringComparison.OrdinalIgnoreCase)))
                 needsTest = true;
         }
         return new ManifestNeeds(needsPlatform, needsTest, requiredPlatformApps);
@@ -1239,14 +1310,67 @@ public static class ProvisioningCheck
     /// presence-only check.
     /// </summary>
     public static IReadOnlyDictionary<string, Version> DetermineVersionFloors(IEnumerable<AlRunner.DependencyRef> roots)
+        => DetermineVersionFloors(roots, edgeRequirements: null);
+
+    /// <summary>
+    /// As above, and additionally closes the floors over
+    /// <paramref name="edgeRequirements"/> — the per-edge <c>MinVersion</c>s
+    /// <see cref="ScanDependencyEdges"/> read out of the packages on disk.
+    ///
+    /// Issue #2193: a bundle declaring only <c>Microsoft/Tests-TestLibraries &gt;= 28.1.0.0</c>
+    /// produced exactly one floor, so <see cref="FindMissingPlatformApps"/> applied none to
+    /// <c>Application Test Library</c> even though that package's own manifest declares
+    /// <c>MinVersion="28.1.0.0"</c> for it — and a warm cache holding 28.0 read as complete.
+    /// The failure was the quiet kind: the app resolved, compilation proceeded, and the run
+    /// died later on a missing symbol pointing at the test code rather than at the stale
+    /// provisioning.
+    ///
+    /// The walk is a BFS from the roots over the same graph <see cref="ReachesAnyOf"/> uses,
+    /// visiting each app name once, so a manifest cycle terminates rather than hanging —
+    /// real Microsoft platform manifests reference each other, so that is the ordinary case.
+    /// A revisit still RAISES an already-recorded floor when the new edge declares a higher
+    /// one; only the enqueue is suppressed. Null <paramref name="edgeRequirements"/> means
+    /// "no edges known" and reduces this to the roots-only map, which is the honest answer
+    /// when nothing has been downloaded yet.
+    /// </summary>
+    public static IReadOnlyDictionary<string, Version> DetermineVersionFloors(
+        IEnumerable<AlRunner.DependencyRef> roots,
+        IReadOnlyDictionary<string, IReadOnlyList<AlRunner.DependencyRef>>? edgeRequirements)
     {
         var floors = new Dictionary<string, Version>(StringComparer.OrdinalIgnoreCase);
-        foreach (var d in roots)
+        var queue = new Queue<string>();
+        var enqueued = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        void Declare(AlRunner.DependencyRef d)
         {
-            if (!string.Equals(d.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase)) continue;
+            if (!string.Equals(d.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase)) return;
+            if (string.IsNullOrWhiteSpace(d.Name)) return;
             if (!floors.TryGetValue(d.Name, out var existing) || d.Version > existing)
                 floors[d.Name] = d.Version;
         }
+
+        foreach (var d in roots)
+        {
+            Declare(d);
+            // Every root is walked, whatever its publisher (#3794): a third-party package on
+            // disk carries Microsoft floors of its own, and only its NAME is needed to find
+            // them in the graph. Declare above still records Microsoft floors only.
+            if (!string.IsNullOrWhiteSpace(d.Name) && enqueued.Add(d.Name)) queue.Enqueue(d.Name);
+        }
+
+        if (edgeRequirements == null) return floors;
+
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            if (!edgeRequirements.TryGetValue(current, out var reqs)) continue;
+            foreach (var d in reqs)
+            {
+                Declare(d);
+                if (!string.IsNullOrWhiteSpace(d.Name) && enqueued.Add(d.Name)) queue.Enqueue(d.Name);
+            }
+        }
+
         return floors;
     }
 
@@ -1438,6 +1562,9 @@ public static class ProvisioningCheck
         var countryNormalized = NormalizeCountry(country);
         IReadOnlyList<string>? extraPlatformNeedCandidates = countryNormalized == "w1"
             ? null
+            // Microsoft-only, unlike the reachability walk in DetermineManifestNeeds (#3794):
+            // these names become DOWNLOAD candidates, and a country-selected platform-apps
+            // download can only supply Microsoft apps under Extensions/.
             : rootsList
                 .Where(d => string.Equals(d.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase))
                 .Select(d => d.Name)
@@ -1448,7 +1575,7 @@ public static class ProvisioningCheck
         // demand no download can clear — see DropUnsatisfiableFloors. The report carries
         // the selected version, which is exactly the version a download would target.
         var versionFloors = DropUnsatisfiableFloors(
-            DetermineVersionFloors(rootsList), legacySymbolOnlyReport.Version);
+            DetermineVersionFloors(rootsList, scan.EdgeRequirements), legacySymbolOnlyReport.Version);
         // Presence is asked of exactly the apps the manifests required — so an app the
         // bundle never names cannot make the set look incomplete, and an app it DOES name
         // cannot be silently exempted from the check.

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -910,6 +910,32 @@ public static class ProvisioningCheck
     private static readonly IReadOnlyList<string> PlatformNeedTargets = PlatformAppSetContents;
 
     /// <summary>
+    /// The graph's node key for one app identity. A Microsoft app is keyed by NAME, because
+    /// that is what the walk's targets and the curated download sets are written in; anything
+    /// else is keyed <c>Publisher/Name</c>.
+    ///
+    /// #3794 is why this exists. The graph used to hold Microsoft sources only, so a bare name
+    /// was unambiguous. Admitting third-party sources — which the resolver has always followed
+    /// — makes a bare name ambiguous in the one direction that matters: an unrelated
+    /// <c>Contoso ISV/Application Test Library</c> would occupy the node the real Microsoft app
+    /// needs, satisfy a target by self-membership, and lend its edges to a Microsoft root of the
+    /// same name. Qualifying the third-party key removes all three at once, and removes the need
+    /// for a publisher special case in the walk, because a qualified key can never equal one of
+    /// the Microsoft target names.
+    ///
+    /// A Microsoft app whose own name contains "/" would be keyed plainly and could in principle
+    /// be shadowed by a third-party <c>Publisher/Name</c> spelling it. No BC app name contains a
+    /// slash, and the alternative — a separator no name may contain — is not available for a
+    /// key that must also equal a plain Microsoft name.
+    /// </summary>
+    public static string EdgeKey(string publisher, string name) =>
+        string.Equals(publisher, "Microsoft", StringComparison.OrdinalIgnoreCase)
+            ? name
+            : $"{publisher}/{name}";
+
+    private static string EdgeKey(AlRunner.DependencyRef d) => EdgeKey(d.Publisher, d.Name);
+
+    /// <summary>
     /// True iff <paramref name="appName"/> itself is in <paramref name="targets"/>, or
     /// reaches a member of it by following <paramref name="edges"/> through any number of
     /// hops. Pure graph BFS — the general closure-walk mechanism issue #2087 asked for,
@@ -979,11 +1005,24 @@ public static class ProvisioningCheck
     /// instead). A table recording one of those shapes is silently wrong for the other, and
     /// the resulting failure looks like a runner capability gap rather than a stale table.
     ///
-    /// Only Microsoft-published packages become edge SOURCES, and only Microsoft-published
-    /// dependencies become edge TARGETS: the graph is keyed by app NAME (matching every
-    /// other Microsoft-app comparison in this file) and the walk's targets
-    /// (<see cref="KnownNoFallbackPlatformApps"/>) are Microsoft apps, so admitting
-    /// third-party names could only introduce name collisions, never a real path.
+    /// EVERY package is an edge source and EVERY declared dependency is an edge target,
+    /// whatever the publisher, keyed by <see cref="EdgeKey(string, string)"/> (#3794).
+    /// DependencyResolver.Visit traverses a package's dependencies and floors without
+    /// consulting the publisher, so a graph that dropped third-party nodes answered a
+    /// different question from the one resolution asks — and dropping them as INTERMEDIATE
+    /// vertices was the worse half: `Consumer -> Contoso/A -> Fabrikam/B (Platform=28.0)`
+    /// recorded B's floor and then had no path from A to B to reach it with.
+    ///
+    /// Only the WALK'S GOALS stay Microsoft-only, which is the property that actually
+    /// matters: they are the contents of the curated download sets, and a qualified
+    /// third-party key can never equal one.
+    ///
+    /// A package that ships an R2R payload contributes its declared &lt;Dependencies&gt; but
+    /// NOT its implicit Platform/Application floors. Those floors exist to be compiled
+    /// against, and Tier-2 serves an R2R package from its payload without compiling anything
+    /// — the same predicate DependencyResolver.ReportUnsuppliableFloor gates on, so the two
+    /// sides agree about which packages a floor can actually matter for. Reading it costs one
+    /// zip entry-name scan, and only for a package that declares a floor at all.
     ///
     /// Each directory is walked RECURSIVELY, matching
     /// <see cref="NoFallbackPlatformAppsPresent"/> and <see cref="TestToolkitPresent"/> —
@@ -992,9 +1031,19 @@ public static class ProvisioningCheck
     ///
     /// An app that declares NO dependencies is recorded with an EMPTY list rather than
     /// omitted — "scanned, declares nothing" is a fact, and must not be indistinguishable
-    /// from "never looked at". When the same app name appears in more than one directory,
-    /// the FIRST directory in <paramref name="searchDirs"/> wins, matching the search-order
-    /// precedence the rest of the package-cache lookups use.
+    /// from "never looked at".
+    ///
+    /// When the same key appears more than once, the HIGHEST VERSION wins, not the first
+    /// directory (#3794). Directory precedence was harmless while the graph answered only
+    /// "does this reach a platform app", because two builds of one app declare much the same
+    /// dependencies. It stopped being harmless when the edges started carrying floors: a
+    /// cache holding B v28.1 (needing Application Test Library 28.0) in the first directory
+    /// and B v28.2 (needing 28.2) in the second would record the 28.0 floor while the
+    /// RESOLVER selects v28.2 and enforces 28.2 — the stale-cache-reads-as-complete failure
+    /// #2193 is about, reintroduced one level up. Highest-version-wins is not the resolver's
+    /// full selection rule (it weighs source-built and executable candidates too); it is the
+    /// part of it that decides which manifest's floors are the operative ones. Closing the
+    /// remainder needs AppId-keyed identity and shared candidate selection — #3811.
     /// </summary>
     /// <summary>&quot;No edges known&quot; — the honest default when nothing has been
     /// downloaded yet, in place of the version-blind hand-written table issue #2103
@@ -1007,8 +1056,9 @@ public static class ProvisioningCheck
         var edges = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
         var edgeRequirements =
             new Dictionary<string, IReadOnlyList<AlRunner.DependencyRef>>(StringComparer.OrdinalIgnoreCase);
-        // Which recorded source was Microsoft-published — see the displacement rule below.
-        var sourceIsMicrosoftByName = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+        // The version of the package whose edges are currently recorded under each key —
+        // see the highest-version-wins rule below.
+        var recordedVersion = new Dictionary<string, Version>(StringComparer.OrdinalIgnoreCase);
         var unreadable = new List<string>();
         var seenDirs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -1052,43 +1102,27 @@ public static class ProvisioningCheck
                     unreadable.Add(file);
                     continue;
                 }
-                var sourceIsMicrosoft =
-                    string.Equals(manifest.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase);
-                // #3794: a THIRD-PARTY package is an edge source too. The resolver follows
-                // every non-platform package's floors and <Dependencies> whatever its
-                // publisher (DependencyResolver.Visit), so a scan that read only Microsoft
-                // sources answered a different question from the one resolution asks: a
-                // platform-less consumer depending on a source-bearing Contoso/Library that
-                // declares Platform="28.0.0.0" reported no platform need, downloaded nothing,
-                // and that library's Tier-3 compile died on #3719's generic EMIT-ZERO.
-                //
-                // Only the edge TARGET stays Microsoft-filtered, which is what the graph's
-                // name key rests on: the walk's targets are Microsoft app names, so a
-                // third-party target could only collide with one, never reach it.
-                if (edges.TryGetValue(manifest.Name, out _))
-                {
-                    // First-wins across directories, per the package-cache precedence — with
-                    // one exception. A third-party app sharing a Microsoft app's NAME would
-                    // otherwise shadow the real one in a graph keyed by name alone, so a
-                    // Microsoft source displaces a non-Microsoft one already recorded.
-                    if (!sourceIsMicrosoft) continue;
-                    if (sourceIsMicrosoftByName.TryGetValue(manifest.Name, out var incumbentIsMicrosoft)
-                        && incumbentIsMicrosoft)
-                        continue;
-                }
+                // #3794: EVERY package is an edge source, keyed by EdgeKey — see this
+                // method's doc comment for why, and for why the goals stay Microsoft-only.
+                var key = EdgeKey(manifest.Publisher, manifest.Name);
+                // Highest version wins, not first directory: the edges now carry floors, and
+                // the operative floors are the ones on the manifest the RESOLVER will select.
+                if (recordedVersion.TryGetValue(key, out var incumbent) && incumbent >= manifest.Version)
+                    continue;
 
                 var deps = new List<string>();
                 var reqs = new List<AlRunner.DependencyRef>();
                 void Record(AlRunner.DependencyRef d)
                 {
-                    if (!string.Equals(d.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase)) return;
                     if (string.IsNullOrWhiteSpace(d.Name)) return;
-                    if (!deps.Any(x => string.Equals(x, d.Name, StringComparison.OrdinalIgnoreCase)))
-                        deps.Add(d.Name);
-                    // #2193: keep the declared MinVersion beside the name. A repeated name is
+                    var target = EdgeKey(d);
+                    if (!deps.Any(x => string.Equals(x, target, StringComparison.OrdinalIgnoreCase)))
+                        deps.Add(target);
+                    // #2193: keep the declared MinVersion beside the name. A repeated target is
                     // recorded once, at the HIGHER floor, matching DetermineVersionFloors'
                     // own rule — a looser declaration can never relax a stricter one.
-                    var i = reqs.FindIndex(x => string.Equals(x.Name, d.Name, StringComparison.OrdinalIgnoreCase));
+                    var i = reqs.FindIndex(x =>
+                        string.Equals(EdgeKey(x), target, StringComparison.OrdinalIgnoreCase));
                     if (i < 0) reqs.Add(d);
                     else if (d.Version > reqs[i].Version) reqs[i] = d;
                 }
@@ -1100,20 +1134,43 @@ public static class ProvisioningCheck
                 // declares Platform="28.0.0.0" and an empty <Dependencies />, so without this
                 // edge a bundle naming only it never learns it needs the platform set, downloads
                 // the test set alone, and the toolkit's source compile dies (EMIT-ZERO).
-                // Trap: skipped for the Microsoft platform apps themselves, matching
-                // DependencyResolver.Visit's guard — their manifests reference each other
-                // (Application -> Base Application -> Application ...), and a graph the resolver
-                // does not walk would make provisioning fetch a set resolution never asks for.
+                //
+                // Two guards, both matching DependencyResolver's. Skipped for the Microsoft
+                // platform apps themselves, whose manifests reference each other (Application ->
+                // Base Application -> Application ...), so a graph the resolver refuses to walk
+                // cannot make provisioning fetch a set resolution never asks for. And skipped
+                // for an R2R package (#3794): a floor exists to be compiled against, Tier-2
+                // serves an R2R payload without compiling, and demanding a 116 MB platform
+                // download — or refusing the run offline — for a package nothing will compile is
+                // a cost with no failure behind it. Its declared <Dependencies> are recorded
+                // either way, because those are runtime dependencies rather than symbols.
                 if (!AlRunner.DependencyResolver.IsMicrosoftPlatformApp(manifest.Name, manifest.Publisher))
-                    foreach (var floor in AlRunner.AppLoader.ImplicitRoots(manifest))
-                        Record(floor);
-                edges[manifest.Name] = deps;
-                edgeRequirements[manifest.Name] = reqs;
-                sourceIsMicrosoftByName[manifest.Name] = sourceIsMicrosoft;
+                {
+                    var floors = AlRunner.AppLoader.ImplicitRoots(manifest).ToList();
+                    if (floors.Count > 0 && !IsR2RQuietly(file))
+                        foreach (var floor in floors)
+                            Record(floor);
+                }
+                edges[key] = deps;
+                edgeRequirements[key] = reqs;
+                recordedVersion[key] = manifest.Version;
             }
         }
 
         return new DependencyEdgeScan(edges, unreadable, edgeRequirements);
+    }
+
+    /// <summary>
+    /// <see cref="AlRunner.AppLoader.IsR2R"/>, with an unreadable package answering FALSE —
+    /// "we could not tell whether this package carries a payload" must not silently exempt it
+    /// from its own floors, because the exemption is the quiet direction: it removes a
+    /// provisioning demand rather than adding one. A package this scan could not open is
+    /// already reported through <see cref="DependencyEdgeScan.UnreadablePackages"/>.
+    /// </summary>
+    private static bool IsR2RQuietly(string appPath)
+    {
+        try { return AlRunner.AppLoader.IsR2R(appPath); }
+        catch (Exception) { return false; }
     }
 
     /// <summary>
@@ -1216,20 +1273,14 @@ public static class ProvisioningCheck
         // Platform="28.0.0.0" reaches System in one hop — and used to be dropped before
         // ReachesAnyOf was asked anything.
         //
-        // A third-party root is walked through its EDGES only: its own name is not a
-        // platform-app identity however it is spelled. Asking ReachesAnyOf about the name
-        // directly would let `Contoso ISV/Application Test Library` — an unrelated app that
-        // merely shares a Microsoft name — demand the Microsoft download by self-membership,
-        // which is what DetermineManifestNeeds_NonMicrosoftPublisher_RootNameIsNotAnIdentity
-        // pins. For a Microsoft root the name IS the identity, so nothing changes there.
-        bool RootReaches(AlRunner.DependencyRef d, IReadOnlyList<string> targets)
-        {
-            if (string.IsNullOrWhiteSpace(d.Name)) return false;
-            if (string.Equals(d.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase))
-                return ReachesAnyOf(d.Name, edges, targets);
-            return edges.TryGetValue(d.Name, out var deps)
-                && deps.Any(t => ReachesAnyOf(t, edges, targets));
-        }
+        // EdgeKey is what makes that safe with no publisher special case here: a third-party
+        // root's key is qualified, so it can never equal one of the Microsoft goal names and
+        // can never satisfy a target by self-membership, and it can never pick up the edges
+        // of a Microsoft app that shares its bare name. Both hazards are pinned —
+        // DetermineManifestNeeds_NonMicrosoftPublisher_RootNameIsNotAnIdentity and its
+        // _EvenWhenThatNameIsInTheGraph sibling.
+        bool RootReaches(AlRunner.DependencyRef d, IReadOnlyList<string> targets) =>
+            !string.IsNullOrWhiteSpace(d.Name) && ReachesAnyOf(EdgeKey(d), edges, targets);
 
         // Which apps out of the curated platform-apps set (plus, for a non-w1 country, any
         // extra candidate the caller supplied) do these manifests require? Asked per-app,
@@ -1352,10 +1403,14 @@ public static class ProvisioningCheck
         foreach (var d in roots)
         {
             Declare(d);
-            // Every root is walked, whatever its publisher (#3794): a third-party package on
-            // disk carries Microsoft floors of its own, and only its NAME is needed to find
-            // them in the graph. Declare above still records Microsoft floors only.
-            if (!string.IsNullOrWhiteSpace(d.Name) && enqueued.Add(d.Name)) queue.Enqueue(d.Name);
+            // Every root is walked, whatever its publisher (#3794), by its EdgeKey — the same
+            // key ScanDependencyEdges recorded it under, so a third-party root reads its OWN
+            // edges rather than those of a Microsoft app with the same bare name. Declare
+            // above still records Microsoft floors only, keyed by plain name, because that is
+            // what FindMissingPlatformApps looks them up by.
+            if (string.IsNullOrWhiteSpace(d.Name)) continue;
+            var key = EdgeKey(d);
+            if (enqueued.Add(key)) queue.Enqueue(key);
         }
 
         if (edgeRequirements == null) return floors;
@@ -1367,7 +1422,9 @@ public static class ProvisioningCheck
             foreach (var d in reqs)
             {
                 Declare(d);
-                if (!string.IsNullOrWhiteSpace(d.Name) && enqueued.Add(d.Name)) queue.Enqueue(d.Name);
+                if (string.IsNullOrWhiteSpace(d.Name)) continue;
+                var next = EdgeKey(d);
+                if (enqueued.Add(next)) queue.Enqueue(next);
             }
         }
 

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2557,6 +2557,16 @@ foreach (var bundle in bundles)
                     Console.Error.WriteLine(u);
                     bundleProvisionGaps.Add(u);
                 }
+                // Also always-on, and for the same reason, but a weaker claim than the list
+                // above: a floor this package cache cannot supply for a package that may be
+                // source-compiled (#3794). Kept a separate list on the resolver so
+                // "unservable" keeps meaning "certain failure"; printed and collected the
+                // same way, because the failure it precedes names nothing (#3719).
+                foreach (var g in resolver.ProvisioningGaps)
+                {
+                    Console.Error.WriteLine(g);
+                    bundleProvisionGaps.Add(g);
+                }
                 // Compiler sees only non-workspace dirs in its .app scanner; the
                 // synthetic workspace dirs are registered as symbols.json-only
                 // sources via SetExtraSymbolDirs (called AFTER SetResolvedDeps,


### PR DESCRIPTION
## Summary

#3793 taught `DependencyResolver.Visit` to follow a resolved package's own `Platform`/`Application` floors, the change #3719 asked for. Provisioning never learned the same thing, and neither side kept the floor's version. Three defects, one root: a floor was a soft hint on the resolution side and invisible on the provisioning side.

Closing #2193 alongside it, because it is the same edit. That issue was filed against `ScanDependencyEdges` discarding `MinVersion` and asked for exactly the closure this PR adds.

## 1. The provisioning graph gets the resolver's shape

`ScanDependencyEdges` dropped every non-Microsoft package before reading anything, and `DetermineManifestNeeds` skipped every non-Microsoft root before asking `ReachesAnyOf` anything. The resolver has no such filter, so provisioning was answering a different question from the one resolution asks.

Failing shape: a platform-less consumer depends on a source-bearing `Contoso/Library` whose manifest declares `Platform="28.0.0.0"`. Provisioning reports no platform need and downloads nothing; resolution asks for `Microsoft/System`, does not find it, and skips it; the Tier-3 source compile of the library then runs without the platform symbols and ends in #3719's generic `EMIT-ZERO`.

Every package is now an edge source and every declared dependency an edge target, whatever the publisher. **Only the walk's goals stay Microsoft-only**, which is the property that actually matters: they are the contents of the curated download sets. An earlier version of this PR filtered edge *targets* by publisher too, and that was wrong in the worse direction — it severed `Consumer → Contoso/A → Fabrikam/B (Platform=28.0)` at the intermediate hop, recording B's floor with no path left to reach it.

Admitting third-party nodes makes a bare app name ambiguous, so nodes are keyed by `EdgeKey`: a Microsoft app by its name, because that is what the goals and the download sets are written in, anything else by `Publisher/Name`. That one key removes three hazards together. A third-party node cannot satisfy a Microsoft goal by self-membership, cannot read a same-named Microsoft app's edges, and cannot lend its own to a Microsoft root of that name.

Where the same key appears twice, the **highest version wins** rather than the first directory. Directory precedence was harmless while the graph only answered "does this reach a platform app"; it stopped being harmless once the edges carried floors, because the operative floors are the ones on the manifest the resolver will select.

**An R2R package contributes its declared `<Dependencies>` but not its implicit floors.** A floor exists to be compiled against and Tier-2 serves an R2R payload without compiling, so demanding a 116 MB download — or refusing the run offline — for a package nothing will compile is a cost with no failure behind it. This is the same predicate `ReportUnsuppliableFloor` gates on, so both sides agree about which packages a floor can matter for.

## 2. The floor's declared version, closed over the graph (#2193)

The scan recorded only each edge's name. `DetermineVersionFloors` read only the bundle's own roots. So a bundle declaring `Microsoft/Tests-TestLibraries >= 28.1.0.0` produced exactly one floor, and `FindMissingPlatformApps` applied none to `Application Test Library` even though that package's own manifest declares `MinVersion="28.1.0.0"` for it. A warm cache holding 28.0 read as complete.

`DependencyEdgeScan` gains `EdgeRequirements`, the same graph carrying each edge's `MinVersion`, and `DetermineVersionFloors` gains an overload that closes the floors over it from the roots. `Edges` stays as it is, because `ReachesAnyOf` asks a reachability question that has nothing to do with versions and every caller of it is written in names.

The walk visits each node once, so a manifest cycle terminates rather than hanging, which is the ordinary case and not an exotic one: real Microsoft platform manifests reference each other. A revisit still raises an already-recorded floor when the new edge declares a higher one; only the enqueue is suppressed. Floors are recorded for Microsoft names only, keyed plainly, because that is what `FindMissingPlatformApps` looks them up by.

## 3. A floor that cannot be supplied is named

`Visit` reached `if (dep.Optional || IsMicrosoftPlatformApp(...))` and returned before the `nearMissVersions` branch, so both "System.app absent" and "System.app present but below the floor" printed one line naming neither the floor nor what was found.

**The skip itself stays, and has to.** It is what lets the al-language corpus declare System Application >= 27.5 and still run green on the 27.0 and 27.3 legs, where no download can clear the floor. `DropUnsatisfiableFloors` documents the same tolerance on the provisioning side.

What changes is that a floor belonging to a package with no precompiled payload is reported to a new **`ProvisioningGaps`** channel, printed unconditionally and collected into the bundle's provisioning gaps:

```
[dep] Microsoft/Library Assert v28.1.49838.54169 declares a floor of Microsoft/System >= 28.0.0.0,
      and it cannot be supplied:
      found, but below the minimum: 27.0.38460.0
      searched: <the cache dirs>
      That package carries AL source and no precompiled payload. If this run compiles
      it — rather than serving it from the compiled-dependency cache, the service-tier
      DLLs or an already-loaded assembly — the compile has no System symbols and
      ends in "EMIT-ZERO — 0 sources emitted" naming nothing (#3719).
      Repair: al-runner provision --platform-apps --bc-version <a build >= 28.0.0.0>
```

Not `UnservableDependencies`: that list means "no loader tier can implement this", which is certain, and this is not. The message says **may** rather than **will** for the same reason and names the three routes that can serve the package without compiling it. Deciding it where the compile actually happens is exact and needs the closure threaded into `DependencyLoader`; that is #3812.

Reports are deduplicated by owner and floor, so one missing floor across a toolkit closure is one line per owner rather than a flood, and a second `Resolve` on one resolver does not repeat itself. The `[deps] … skipping` line also now says when the app was found below the minimum rather than absent, which were previously indistinguishable.

## Proof

29 new facts across the two commits. Every production change was mutation-checked: removed, then the facts re-run.

| mutation | facts that failed |
|---|---|
| source publisher filter restored, third-party roots not walked | 4 |
| Microsoft-source displacement removed, floor closure never traverses | 4 |
| `ReportUnsuppliableFloor` call removed | 2 |

The negative-direction facts carry as much weight as the positive ones. `PrecompiledPackageFloor_SystemAbsent_IsNotReported`, `PackageWithBothR2RAndAlSource_FloorAbsent_IsNotReported` and `SourceCompilablePackageFloor_SystemAtTheFloor_IsNotReported` together separate the report gate's three predicates, which a single `!HasAlSource` check would otherwise pass. `DetermineManifestNeeds_NonMicrosoftRoot_DoesNotBorrowASameNamedMicrosoftAppsEdges` tests the colliding name **present** in the graph, which is the case an empty-graph test cannot reach.

215 facts pass across `DependencyResolverTests`, `ManifestDependencyEdgeScanTests` and `ProvisioningCheckTests` on BC 28.1.49838.54169.

**Blast radius, measured rather than reasoned.** Of every checked-in fixture `.app` under `tests/runner-extras/` and `AlRunner.Tests/Fixtures/`, zero declare a Platform or Application floor. Across all 123 fixture `app.json` files, zero consumers without a floor of their own depend on a sibling that has one. Nothing in the repo newly demands a platform download.

**One pre-existing test changed behavior deliberately.** `ScanDependencyEdges_NonMicrosoftPackage_IsNotRecordedAsAnEdgeSource` pinned the source-side filter this PR removes. It now asserts the qualified key instead.

**13 failures in a wider local sweep are pre-existing on this box.** Measured against a pristine `origin/main` worktree, built and run with the same filter: that baseline fails 15, a strict superset of this branch's 13. They are network-dependent provisioning tests plus a symlink test, none of them touched here.

## Review

An external adversarial review (GPT-5.6-sol) returned five blocking findings; four were real defects in the first commit and are fixed in `8f874d4`. The comment thread has the item-by-item response. Two findings were split into follow-ups rather than grown into this diff:

- **#3811** — the graph's identity and package selection still do not match the resolver's: same-name different-AppId apps collapse, and source-built precedence, executability and below-minimum exclusion are not expressible. Closing it needs AppId keying and selection logic shared with `DependencyResolver.SelectBestVersion`.
- **#3812** — the floor report is decided from package shape rather than from whether the run actually compiles the package. Exact only at the `Emit` call site.

## What I did not fold, and why

- **#2232** — a real (non-placeholder) floor forces a platform-apps download even when the bundle uses nothing Microsoft. Same area, but the issue's own analysis concludes that separating "declared" from "actually used" needs a compile attempt rather than a manifest read.
- **#2661** — `provision --platform-apps` / `--service-tier` use a glob-based rather than content-verified entry guard. Adjacent to the "also worth fixing nearby" note in #3794 (`EnsurePlatformAppsProvisioned` returns void and never re-checks `RequiredPlatformApps` after downloading), but it lands in `ArtifactDownloader` and `ProgramSupport/Provisioning`, not in the files here.

Closes #3794
Closes #2193

Corpus-NA: dependency resolution and provisioning are runner-side concerns; no BC behaviour is asserted, so there is nothing for a service tier to adjudicate.

*Opened by an agent (Claude Code) in a session run by @SShadowS.*

https://claude.ai/code/session_01JFQZHC5SEHnLxkc5USksaK
