### PR TITLE
docs(bundle-gate): correct two comments that justified correct code wrongly

### DIFF
--- a/AlRunner.Tests/MetadataEquivalenceBundleGateTests.cs
+++ b/AlRunner.Tests/MetadataEquivalenceBundleGateTests.cs
@@ -85,13 +85,9 @@ public sealed class MetadataEquivalenceBundleGateTests
             "not scanning what it claims to. The detection strings are probably stale.");
     }
 
-    // SkippableFact, not Fact, and NOT because this test can skip: BundleReaders() only does
-    // EnumerateFiles/ReadAllText and cannot raise SkipException. EveryTestThatCanSkipIsDeclared-
-    // Skippable is a TEXTUAL scanner over the source, and the regex literal a few lines below
-    // matches its pattern. So this attribute answers a string in a comment, not a real skip
-    // path -- and the match is attributed to whichever test precedes the line it sits on.
-    // Trap: rewording or moving that comment changes which test needs the attribute. Writing
-    // this note is itself how that was discovered. Tracked as its own issue.
+    // SkippableFact, not Fact, though this test cannot skip: BundleReaders() only does
+    // EnumerateFiles/ReadAllText. The attribute answers a textual scanner, not a skip path --
+    // see #3813, which is where the mechanism is stated and pinned.
     [SkippableFact]
     public void No_bundle_reader_writes_its_own_empty_bundle_skip()
     {
@@ -124,8 +120,7 @@ public sealed class MetadataEquivalenceBundleGateTests
         // creating it" (ScratchDirsTests.Reserve_WritesSidecarButDoesNotCreateTheDirectory).
         // That is fine here and is the point: RequireBundles reads
         // Path.Combine(<override>, <serviceTierDirName>), which is absent either way, so the
-        // gate sees no bundle. An earlier version of this comment claimed the directory is
-        // created; it is not, and nothing depends on it being so.
+        // gate sees no bundle.
         var empty = TestScratch.FlatDir("al-runner-bundle-gate");
 
         var previousRoot = Environment.GetEnvironmentVariable("AL_RUNNER_METADATA_GROUND_TRUTH");

--- a/AlRunner.Tests/MetadataEquivalenceBundleGateTests.cs
+++ b/AlRunner.Tests/MetadataEquivalenceBundleGateTests.cs
@@ -85,8 +85,13 @@ public sealed class MetadataEquivalenceBundleGateTests
             "not scanning what it claims to. The detection strings are probably stale.");
     }
 
-    // SkippableFact, not Fact: BundleReaders() can raise SkipException, and a SkipException out
-    // of a plain [Fact] is reported Failed rather than Skipped (TestArtifactsGateTests).
+    // SkippableFact, not Fact, and NOT because this test can skip: BundleReaders() only does
+    // EnumerateFiles/ReadAllText and cannot raise SkipException. EveryTestThatCanSkipIsDeclared-
+    // Skippable is a TEXTUAL scanner over the source, and the regex literal a few lines below
+    // matches its pattern. So this attribute answers a string in a comment, not a real skip
+    // path -- and the match is attributed to whichever test precedes the line it sits on.
+    // Trap: rewording or moving that comment changes which test needs the attribute. Writing
+    // this note is itself how that was discovered. Tracked as its own issue.
     [SkippableFact]
     public void No_bundle_reader_writes_its_own_empty_bundle_skip()
     {
@@ -113,8 +118,14 @@ public sealed class MetadataEquivalenceBundleGateTests
         // empty directory through AL_RUNNER_METADATA_GROUND_TRUTH, which is the same override
         // the skip message tells a developer about — so this exercises the real code path
         // rather than a reimplementation of it.
-        // Owned: this directory IS created, so a killed test host would leak it (#2743).
-        // TestScratch.FlatDir creates it and records an owner, which the sweep deletes.
+        // Owned rather than a raw Path.GetTempPath() combine (#2743): FlatDir reserves the
+        // path and writes ScratchDirs' sidecar, so the sweep deletes it if this host is killed.
+        // It does NOT create the directory -- ScratchDirs.Reserve is explicitly "WITHOUT
+        // creating it" (ScratchDirsTests.Reserve_WritesSidecarButDoesNotCreateTheDirectory).
+        // That is fine here and is the point: RequireBundles reads
+        // Path.Combine(<override>, <serviceTierDirName>), which is absent either way, so the
+        // gate sees no bundle. An earlier version of this comment claimed the directory is
+        // created; it is not, and nothing depends on it being so.
         var empty = TestScratch.FlatDir("al-runner-bundle-gate");
 
         var previousRoot = Environment.GetEnvironmentVariable("AL_RUNNER_METADATA_GROUND_TRUTH");


### PR DESCRIPTION
Part of #3813

Corpus-NA: comment-only change in a test file; it asserts nothing about AL semantics a service tier could adjudicate and alters no runner code path.

## What this fixes

Two comments **I wrote** during the guard fixes on #3796, both caught by that PR's review. In each case the code is correct and the stated justification is false — which is worse than no comment, because it hands the next reader a wrong mental model with the authority of a citation.

**1. `FlatDir` does not create the directory.** My comment said *"this directory IS created, so a killed test host would leak it"*. `TestScratch.FlatDir` → `ScratchDirs.Reserve`, which is documented **"WITHOUT creating it"** and pinned by `ScratchDirsTests.Reserve_WritesSidecarButDoesNotCreateTheDirectory`.

The behaviour is right either way — `RequireBundles` reads `Path.Combine(<override>, <serviceTierDirName>)`, absent whether or not the parent exists, so the gate sees no bundle. Using `FlatDir` over a raw `Path.GetTempPath()` combine is still correct for #2743: it reserves the path and writes the sidecar. Only my reason was wrong.

**2. `BundleReaders()` cannot raise `SkipException`.** My comment blamed it. It only does `EnumerateFiles`/`ReadAllText`.

The real trigger: `EveryTestThatCanSkipIsDeclaredSkippable` is a **textual** scanner that matches the `Skip.If` literal **in a comment**, attributed to whichever test precedes that line.

## Writing the second comment reproduced the defect

My first rewrite explained the coupling — and contained the literal. The guard failed again immediately, this time naming a **different** test, because the new comment sat above `Only_the_shared_gate_loads_bundles_directly`. Rewording without the literal made all 30 pass.

The note describing the trap sprang the trap. That is now filed as **#3813**, with both directions specified for a fix: a real `Skip.If` in a `[Fact]` body must still fail, and the same literal in a comment must not fire.

## Verification

`30 passed, 0 failed, Skipped: 0` across `MetadataEquivalenceBundleGateTests`, `TestArtifactsGateTests` and `ScratchDirOwnershipGuardTests`.

No behaviour change. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
