### PR TITLE
fix(dap): decode a statement's line against its own object, not the file

### DIFF
--- a/AlRunner.Tests/DapMultiObjectFileTests.cs
+++ b/AlRunner.Tests/DapMultiObjectFileTests.cs
@@ -2,23 +2,25 @@
 // line, which is only true for the first object in a .al file.
 //
 // BC records a statement's line relative to the OWNING OBJECT's text. For the first object
-// in a file the two numbering schemes coincide and nothing is visible. For a second object
-// they differ by the line its text starts on, and two things go wrong at once:
+// in a file the two numbering schemes coincide and nothing is visible; for a second object
+// they differ by the line its text starts on. #3713 fixed the coverage consumers by
+// carrying that start line in AlSourceLocationMap and adding it where a line is produced.
+// DapBreakpointResolver and AlDapStackWalker were left.
 //
-//   * a breakpoint on a line inside the second object never matches, so it comes back
-//     verified: false and never fires;
-//   * a breakpoint on a line inside the FIRST object CAN match a statement of the second
-//     whose relative line happens to equal it, so it fires in the wrong place.
+// TWO defects, and measuring is what separated them. #3786 predicted that a line inside the
+// FIRST object would falsely match a second-object statement at the same relative line. It
+// does not: it comes back unverified too, because DapBreakpointResolver's path index held
+// ONE (label,id) per path, so a file's second object evicted its first and there was nothing
+// left to falsely match against. Recorded here because the disproven prediction is the more
+// obvious story and a later reader will otherwise re-derive it.
 //
-// #3713 fixed the coverage consumers by carrying the object's start line in
-// AlSourceLocationMap and adding it where a line is produced. DapBreakpointResolver and
-// AlDapStackWalker were left, and this class is what makes that visible: it drives a real
-// DAP session against Fixtures/DapTwoObjects, whose single .al file holds a helper codeunit
-// (lines 10-16) and the test codeunit (text starting line 18).
+//   * a line inside the second object never matched      -> the missing LineOffset
+//   * a line inside the FIRST object never matched either -> the one-object-per-path index
 //
-// Both directions are here deliberately. The positive fact alone would pass an
-// implementation that verified every requested line; the first-object fact alone would pass
-// the unfixed code.
+// This class drives a real DAP session against Fixtures/DapTwoObjects, whose single .al file
+// holds a helper codeunit (lines 10-16) and the test codeunit (text starting line 18). Each
+// fact below is pinned to one of those two defects by mutation, so neither can be reverted
+// without a red test.
 
 using System.Text.Json;
 using Xunit;
@@ -135,7 +137,9 @@ public class DapMultiObjectFileTests
 
     /// <summary>
     /// The first statement of the same object, so the fact above cannot pass by an
-    /// off-by-something that happens to land on one particular line.
+    /// off-by-something that happens to land on one particular line. Counter is read as well
+    /// as the line: at the FIRST statement nothing has been assigned yet, so 0 is what proves
+    /// the pause is where the name says rather than one statement later.
     /// </summary>
     [SkippableFact]
     public async Task BreakpointOnTheSecondObjectsFirstStatement_StopsThereWithNoEffectApplied()
@@ -153,18 +157,117 @@ public class DapMultiObjectFileTests
 
         var stopped = await dap.ReadUntilEventAsync("stopped");
         Assert.Equal(SecondObjectFirstStatementLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
+
+        var stSeq = dap.SendRequest("stackTrace", new { threadId = 1 });
+        var stResp = await dap.ReadUntilResponseAsync(stSeq);
+        var frameId = stResp.GetProperty("body").GetProperty("stackFrames")[0].GetProperty("id").GetInt32();
+        var scSeq = dap.SendRequest("scopes", new { frameId });
+        var scResp = await dap.ReadUntilResponseAsync(scSeq);
+        var variablesReference = scResp.GetProperty("body").GetProperty("scopes")[0]
+            .GetProperty("variablesReference").GetInt32();
+        var varSeq = dap.SendRequest("variables", new { variablesReference });
+        var varResp = await dap.ReadUntilResponseAsync(varSeq);
+        var vars = varResp.GetProperty("body").GetProperty("variables").EnumerateArray()
+            .ToDictionary(v => v.GetProperty("name").GetString()!, v => v.GetProperty("value").GetString());
+        Assert.True(vars.ContainsKey("Counter"), $"no Counter local reported: {varResp}");
+        Assert.Equal("0", vars["Counter"]);
     }
 
     /// <summary>
-    /// The false-positive direction, and the half a fix that only ADDS an offset could still
-    /// get wrong. File line 14 is <c>exit(X + 1);</c> inside the FIRST object; relative to the
-    /// second object's text, 14 is <c>Counter := 1;</c>. Unfixed, the requested line matches
-    /// the second object's statement and execution stops in the test method instead of in
-    /// <c>Bump</c> — a breakpoint that fires in the wrong function, which is worse than one
-    /// that does not fire.
+    /// DAP's setBreakpoints contract: the request is the COMPLETE set for that source from
+    /// then on. An empty list is how a client says "remove every breakpoint in this file",
+    /// and it has to disarm one that a previous request armed.
     ///
-    /// Asserted through the frame's own function rather than only its line: a stop inside
-    /// <c>Bump</c> has <c>Bump</c> on top of the stack, and the test method below it.
+    /// RED before the #3786 review's fix: the handler cleared only the scope types named by
+    /// the NEW request, so an empty request named none, cleared nothing, and execution still
+    /// stopped at a breakpoint the client had removed. It computed a full source path and
+    /// never read it, which is the shape that defect left behind.
+    /// </summary>
+    [SkippableFact]
+    public async Task SetBreakpointsWithAnEmptyList_DisarmsWhatThePreviousRequestArmed()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dap, bpResp) = await StartAndSetBreakpointAsync(SecondObjectSecondStatementLine);
+        await using var _ = dap;
+        Assert.True(bpResp.GetProperty("body").GetProperty("breakpoints")[0].GetProperty("verified").GetBoolean(),
+            bpResp.ToString());
+
+        // The same source, now with nothing in it.
+        var clearSeq = dap.SendRequest("setBreakpoints", new
+        {
+            source = new { path = Path.Combine(FixtureSrc, SourceFileName) },
+            breakpoints = Array.Empty<object>(),
+        });
+        var clearResp = await dap.ReadUntilResponseAsync(clearSeq);
+        Assert.True(clearResp.GetProperty("success").GetBoolean(), clearResp.ToString());
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        var events = new List<JsonElement>();
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60), events);
+        Assert.DoesNotContain(events, e => e.GetProperty("event").GetString() == "stopped");
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+
+    /// <summary>
+    /// The same contract for a MOVE rather than a removal, which is the case the multi-object
+    /// path index makes reachable: two objects of one file are now separately addressable, so
+    /// replacing a breakpoint in the second object with one in the first must not leave the
+    /// second armed. Both would fire otherwise, and the run would stop twice.
+    /// </summary>
+    [SkippableFact]
+    public async Task MovingABreakpointBetweenTwoObjectsOfOneFile_LeavesOnlyTheNewOneArmed()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dap, bpResp) = await StartAndSetBreakpointAsync(SecondObjectSecondStatementLine);
+        await using var _ = dap;
+        Assert.True(bpResp.GetProperty("body").GetProperty("breakpoints")[0].GetProperty("verified").GetBoolean(),
+            bpResp.ToString());
+
+        var moveSeq = dap.SendRequest("setBreakpoints", new
+        {
+            source = new { path = Path.Combine(FixtureSrc, SourceFileName) },
+            breakpoints = new[] { new { line = FirstObjectStatementLine } },
+        });
+        var moveResp = await dap.ReadUntilResponseAsync(moveSeq);
+        Assert.True(moveResp.GetProperty("body").GetProperty("breakpoints")[0].GetProperty("verified").GetBoolean(),
+            moveResp.ToString());
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        // Exactly one stop, and in the object the LAST request named. Bump is called once, so
+        // a second-object breakpoint left armed would add a stop at line 32 either before or
+        // after this one.
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal(FirstObjectStatementLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
+
+        var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq);
+
+        var events = new List<JsonElement>();
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60), events);
+        Assert.DoesNotContain(events, e => e.GetProperty("event").GetString() == "stopped");
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+
+    /// <summary>
+    /// The first object must stay addressable, which is the half a fix that only ADDS an
+    /// offset does not deliver. File line 14 is <c>exit(X + 1);</c> inside the FIRST object.
+    ///
+    /// RED before the fix: <c>verified: false</c> — not the false match #3786 predicted. The
+    /// path index held one (label,id) per path, so whichever object was written last owned
+    /// the file and the other could not be reached at all. Reverting only the index (leaving
+    /// both offsets in place) turns this fact red again and leaves the other two green, which
+    /// is what separates the two defects.
+    ///
+    /// Asserted through the stack rather than the line alone: paused inside <c>Bump</c>, the
+    /// top frame is <c>Bump</c> and its CALLER is the second object's test method, whose own
+    /// frame must report the file line of the call — the ancestor path in
+    /// AlDapStackWalker.Walk, which an implementation offsetting only frame 0 would fail.
     /// </summary>
     [SkippableFact]
     public async Task BreakpointOnAFirstObjectStatement_StopsInThatObject_NotTheSecondsSameRelativeLine()
@@ -187,11 +290,25 @@ public class DapMultiObjectFileTests
         var stSeq = dap.SendRequest("stackTrace", new { threadId = 1 });
         var stResp = await dap.ReadUntilResponseAsync(stSeq);
         var frames = stResp.GetProperty("body").GetProperty("stackFrames");
+        Assert.True(frames.GetArrayLength() >= 2,
+            $"expected the caller's frame below Bump's: {stResp}");
+
         var top = frames[0];
         Assert.Equal(FirstObjectStatementLine, top.GetProperty("line").GetInt32());
         var topName = top.GetProperty("name").GetString() ?? "";
         Assert.True(topName.Contains("Bump", StringComparison.OrdinalIgnoreCase),
-            $"paused frame is '{topName}', not Bump — the requested first-object line matched a "
-            + $"statement of the SECOND object at the same relative line: {stResp}");
+            $"paused frame is '{topName}', not Bump — the requested first-object line resolved "
+            + $"to a statement of the wrong object: {stResp}");
+
+        // The ANCESTOR frame, and the reason this fact carries the stack walker's second code
+        // path: Walk offsets every frame in its loop, and an implementation that offset only
+        // frame 0 passes every other assertion in this class. The caller is the test method,
+        // paused at its call to Bump — file line 32, in the SECOND object, so its frame is
+        // where an un-offset ancestor would report 15.
+        var caller = frames[1];
+        var callerName = caller.GetProperty("name").GetString() ?? "";
+        Assert.True(callerName.Contains("SecondObjectStatements", StringComparison.OrdinalIgnoreCase),
+            $"frame below Bump is '{callerName}', not the calling test method: {stResp}");
+        Assert.Equal(SecondObjectSecondStatementLine, caller.GetProperty("line").GetInt32());
     }
 }

--- a/AlRunner.Tests/DapMultiObjectFileTests.cs
+++ b/AlRunner.Tests/DapMultiObjectFileTests.cs
@@ -1,0 +1,197 @@
+// DapMultiObjectFileTests — #3786: the DAP surface decodes a [SourceSpans] line as a FILE
+// line, which is only true for the first object in a .al file.
+//
+// BC records a statement's line relative to the OWNING OBJECT's text. For the first object
+// in a file the two numbering schemes coincide and nothing is visible. For a second object
+// they differ by the line its text starts on, and two things go wrong at once:
+//
+//   * a breakpoint on a line inside the second object never matches, so it comes back
+//     verified: false and never fires;
+//   * a breakpoint on a line inside the FIRST object CAN match a statement of the second
+//     whose relative line happens to equal it, so it fires in the wrong place.
+//
+// #3713 fixed the coverage consumers by carrying the object's start line in
+// AlSourceLocationMap and adding it where a line is produced. DapBreakpointResolver and
+// AlDapStackWalker were left, and this class is what makes that visible: it drives a real
+// DAP session against Fixtures/DapTwoObjects, whose single .al file holds a helper codeunit
+// (lines 10-16) and the test codeunit (text starting line 18).
+//
+// Both directions are here deliberately. The positive fact alone would pass an
+// implementation that verified every requested line; the first-object fact alone would pass
+// the unfixed code.
+
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class DapMultiObjectFileTests
+{
+    private static readonly string FixtureSrc = Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "DapTwoObjects"));
+
+    private const string SourceFileName = "TwoObjects.Codeunit.al";
+
+    // Fixtures/DapTwoObjects/TwoObjects.Codeunit.al, asserted against exactly.
+    // The SECOND object's text begins on line 18, so a statement of it decodes 17 too low
+    // while nothing is added.
+    private const int SecondObjectFirstStatementLine = 31;  // Counter := 1;
+    private const int SecondObjectSecondStatementLine = 32; // Counter := Helper.Bump(Counter);
+    private const int FirstObjectStatementLine = 14;        // exit(X + 1);  — inside Bump
+
+    /// <summary>
+    /// Drives initialize / launch / setBreakpoints / configurationDone and returns the
+    /// setBreakpoints response together with the live client, so each fact below asserts on
+    /// the same sequence a real DAP client performs.
+    /// </summary>
+    private static async Task<(DapClient Dap, JsonElement BpResponse)> StartAndSetBreakpointAsync(int line)
+    {
+        var dap = await DapClient.StartAsync(FixtureSrc);
+        try
+        {
+            var initSeq = dap.SendRequest("initialize", new { adapterID = "al-runner-tests" });
+            var initEvents = new List<JsonElement>();
+            var initResp = await dap.ReadUntilResponseAsync(initSeq, initEvents);
+            Assert.True(initResp.GetProperty("success").GetBoolean(), initResp.ToString());
+            var sawInitialized = initEvents.Any(e => e.GetProperty("event").GetString() == "initialized")
+                || (await dap.ReadUntilEventAsync("initialized")).GetProperty("event").GetString() == "initialized";
+            Assert.True(sawInitialized);
+
+            var launchSeq = dap.SendRequest("launch", new { });
+            var launchResp = await dap.ReadUntilResponseAsync(launchSeq, timeout: TimeSpan.FromSeconds(120));
+            Assert.True(launchResp.GetProperty("success").GetBoolean(),
+                $"launch failed: {launchResp}\n--- stderr ---\n{dap.StdErr}");
+
+            var bpSeq = dap.SendRequest("setBreakpoints", new
+            {
+                source = new { path = Path.Combine(FixtureSrc, SourceFileName) },
+                breakpoints = new[] { new { line } },
+            });
+            var bpResp = await dap.ReadUntilResponseAsync(bpSeq);
+            Assert.True(bpResp.GetProperty("success").GetBoolean(), bpResp.ToString());
+            return (dap, bpResp);
+        }
+        catch
+        {
+            await dap.DisposeAsync();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// RED before the fix: <c>verified: false</c>. The requested file line 32 is compared
+    /// against <c>AbsoluteFromLine(span)</c>, which for the second object in the file yields
+    /// 15 — its line within that object's own text — so nothing matches and the breakpoint
+    /// never fires. GREEN: it verifies, execution stops there, and the paused frame reports
+    /// the file line the editor asked for rather than the relative one.
+    /// </summary>
+    [SkippableFact]
+    public async Task BreakpointInsideTheSecondObjectOfAFile_VerifiesAndPausesOnThatFileLine()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dap, bpResp) = await StartAndSetBreakpointAsync(SecondObjectSecondStatementLine);
+        await using var _ = dap;
+
+        var bps = bpResp.GetProperty("body").GetProperty("breakpoints");
+        Assert.Equal(1, bps.GetArrayLength());
+        Assert.True(bps[0].GetProperty("verified").GetBoolean(),
+            $"breakpoint at file line {SecondObjectSecondStatementLine} was not verified — the "
+            + $"line was decoded relative to the object's text, not the file: {bpResp}");
+        Assert.Equal(SecondObjectSecondStatementLine, bps[0].GetProperty("line").GetInt32());
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal("breakpoint", stopped.GetProperty("body").GetProperty("reason").GetString());
+        Assert.Equal(SecondObjectSecondStatementLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
+
+        // The stack walker is the second consumer #3786 names, and it is a separate code
+        // path from the resolver: a frame could stop at the right place and still report the
+        // relative line.
+        var stSeq = dap.SendRequest("stackTrace", new { threadId = 1 });
+        var stResp = await dap.ReadUntilResponseAsync(stSeq);
+        Assert.True(stResp.GetProperty("success").GetBoolean(), stResp.ToString());
+        var frames = stResp.GetProperty("body").GetProperty("stackFrames");
+        Assert.True(frames.GetArrayLength() >= 1, stResp.ToString());
+        Assert.Equal(SecondObjectSecondStatementLine, frames[0].GetProperty("line").GetInt32());
+
+        // The pause is BEFORE the statement's own effect (AlDapSession's boundary), so
+        // Counter is still the first statement's 1 — this is what proves the stop landed on
+        // the statement we asked for rather than somewhere else that happens to be in range.
+        var frameId = frames[0].GetProperty("id").GetInt32();
+        var scSeq = dap.SendRequest("scopes", new { frameId });
+        var scResp = await dap.ReadUntilResponseAsync(scSeq);
+        var variablesReference = scResp.GetProperty("body").GetProperty("scopes")[0]
+            .GetProperty("variablesReference").GetInt32();
+        var varSeq = dap.SendRequest("variables", new { variablesReference });
+        var varResp = await dap.ReadUntilResponseAsync(varSeq);
+        var vars = varResp.GetProperty("body").GetProperty("variables").EnumerateArray()
+            .ToDictionary(v => v.GetProperty("name").GetString()!, v => v.GetProperty("value").GetString());
+        Assert.True(vars.ContainsKey("Counter"), $"no Counter local reported: {varResp}");
+        Assert.Equal("1", vars["Counter"]);
+    }
+
+    /// <summary>
+    /// The first statement of the same object, so the fact above cannot pass by an
+    /// off-by-something that happens to land on one particular line.
+    /// </summary>
+    [SkippableFact]
+    public async Task BreakpointOnTheSecondObjectsFirstStatement_StopsThereWithNoEffectApplied()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dap, bpResp) = await StartAndSetBreakpointAsync(SecondObjectFirstStatementLine);
+        await using var _ = dap;
+
+        Assert.True(bpResp.GetProperty("body").GetProperty("breakpoints")[0].GetProperty("verified").GetBoolean(),
+            bpResp.ToString());
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal(SecondObjectFirstStatementLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
+    }
+
+    /// <summary>
+    /// The false-positive direction, and the half a fix that only ADDS an offset could still
+    /// get wrong. File line 14 is <c>exit(X + 1);</c> inside the FIRST object; relative to the
+    /// second object's text, 14 is <c>Counter := 1;</c>. Unfixed, the requested line matches
+    /// the second object's statement and execution stops in the test method instead of in
+    /// <c>Bump</c> — a breakpoint that fires in the wrong function, which is worse than one
+    /// that does not fire.
+    ///
+    /// Asserted through the frame's own function rather than only its line: a stop inside
+    /// <c>Bump</c> has <c>Bump</c> on top of the stack, and the test method below it.
+    /// </summary>
+    [SkippableFact]
+    public async Task BreakpointOnAFirstObjectStatement_StopsInThatObject_NotTheSecondsSameRelativeLine()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dap, bpResp) = await StartAndSetBreakpointAsync(FirstObjectStatementLine);
+        await using var _ = dap;
+
+        Assert.True(bpResp.GetProperty("body").GetProperty("breakpoints")[0].GetProperty("verified").GetBoolean(),
+            $"breakpoint at file line {FirstObjectStatementLine} (inside the first object) was "
+            + $"not verified: {bpResp}");
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal(FirstObjectStatementLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
+
+        var stSeq = dap.SendRequest("stackTrace", new { threadId = 1 });
+        var stResp = await dap.ReadUntilResponseAsync(stSeq);
+        var frames = stResp.GetProperty("body").GetProperty("stackFrames");
+        var top = frames[0];
+        Assert.Equal(FirstObjectStatementLine, top.GetProperty("line").GetInt32());
+        var topName = top.GetProperty("name").GetString() ?? "";
+        Assert.True(topName.Contains("Bump", StringComparison.OrdinalIgnoreCase),
+            $"paused frame is '{topName}', not Bump — the requested first-object line matched a "
+            + $"statement of the SECOND object at the same relative line: {stResp}");
+    }
+}

--- a/AlRunner.Tests/Fixtures/DapTwoObjects/Assert.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/DapTwoObjects/Assert.Codeunit.al
@@ -1,0 +1,12 @@
+/// <summary>
+/// Minimal assertion helper for this fixture app (own ID range so it
+/// stands alone from the corpus Assert).
+/// </summary>
+codeunit 60260 "Dap Two Assert"
+{
+    procedure AreEqual(Expected: Integer; Actual: Integer; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Assert.AreEqual failed. Expected:<%1>. Actual:<%2>. %3', Expected, Actual, Msg);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/DapTwoObjects/TwoObjects.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/DapTwoObjects/TwoObjects.Codeunit.al
@@ -1,0 +1,35 @@
+/// <summary>
+/// #3786: TWO codeunits in ONE file. The second object's text begins partway down
+/// the file, so BC's [SourceSpans] lines — which are relative to the OWNING OBJECT's
+/// text, not to the file — no longer coincide with file lines for anything it holds.
+///
+/// The line numbers below are asserted against exactly by DapMultiObjectFileTests.
+/// Keep them in sync, and keep the test codeunit SECOND: first-object statements are
+/// the case where the two numbering schemes agree and prove nothing.
+/// </summary>
+codeunit 60261 "Dap Two Helper"
+{
+    procedure Bump(X: Integer): Integer
+    begin
+        exit(X + 1);
+    end;
+}
+
+codeunit 60262 "Dap Two Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Dap Two Assert";
+        Helper: Codeunit "Dap Two Helper";
+
+    [Test]
+    procedure SecondObjectStatements()
+    var
+        Counter: Integer;
+    begin
+        Counter := 1;
+        Counter := Helper.Bump(Counter);
+        Assert.AreEqual(2, Counter, 'Bump ran once on the first statement''s value');
+    end;
+}

--- a/AlRunner.Tests/Fixtures/DapTwoObjects/app.json
+++ b/AlRunner.Tests/Fixtures/DapTwoObjects/app.json
@@ -1,0 +1,23 @@
+{
+  "id": "c3d4e5f6-a7b8-490a-9c3d-4e5f6a7b8093",
+  "name": "Runner Tests Fixture - DAP Two Objects",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Fixture for #3786: two codeunits in ONE .al file, so the test codeunit's [SourceSpans] lines are relative to a text that does not start at line 1.",
+  "description": "Used by AlRunner.Tests' DapMultiObjectFileTests. No application/platform floor - see .claude/rules/no-base-app-in-csharp-tests.md.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "idRanges": [
+    {
+      "from": 60260,
+      "to": 60299
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner/Infrastructure/AlDapStackWalker.cs
+++ b/AlRunner/Infrastructure/AlDapStackWalker.cs
@@ -34,12 +34,15 @@ public static class AlDapStackWalker
     /// (e.g. a dependency app's procedure) still appears, with SourcePath null rather
     /// than the frame being dropped — a debugger UI can show "no source" for it,
     /// matching how ServerProtocol already treats a stack frame with no known file
-    /// (loud-failures.md: never silently omit a frame the caller could act on).
+    /// (loud-failures.md: never silently omit a frame the caller could act on). It also
+    /// carries each object's line offset (#3786), which is what turns the object-relative
+    /// line BC records into the file line a DAP client expects beside that path; an object
+    /// the map does not know offsets by 0, so it keeps its previous line unchanged.
     /// </summary>
     public static List<AlDapFrame> Walk(
         Microsoft.Dynamics.Nav.Runtime.NavMethodScope pausedScope,
         int pausedStatementIndex,
-        IReadOnlyDictionary<(string Label, int Id), string> sourceMap)
+        AlSourceLocationMap sourceMap)
     {
         var frames = new List<AlDapFrame>();
         Microsoft.Dynamics.Nav.Runtime.NavMethodScope? cur = pausedScope;
@@ -48,7 +51,16 @@ public static class AlDapStackWalker
         {
             var (label, objId) = AlCallStackCapture.ParseObjectTypeAndId(cur.GetType());
             sourceMap.TryGetValue((label, objId), out var path);
-            var line = id == 0 ? ResolveLine(cur, pausedStatementIndex) : ResolveCurrentLine(cur);
+            // #3786: ResolveLine answers the line within the OWNING OBJECT's text, which is
+            // a file line only for the first object in a file. The frame's SourcePath and
+            // its Line have to agree about which numbering they use, and a DAP client reads
+            // both together, so the offset is added here where the pair is assembled rather
+            // than inside ResolveLine — whose contract stays "object-relative", the number
+            // BC actually recorded.
+            var raw = id == 0 ? ResolveLine(cur, pausedStatementIndex) : ResolveCurrentLine(cur);
+            // A frame that resolved no line at all stays 0; shifting that by an offset would
+            // invent a line for a frame whose object carries no spans.
+            var line = raw == 0 ? 0 : raw + sourceMap.LineOffset(label, objId);
             frames.Add(new AlDapFrame(id, cur.ScopeName ?? "?", path, line, cur));
             id++;
             cur = cur.ParentScope;
@@ -56,10 +68,14 @@ public static class AlDapStackWalker
         return frames;
     }
 
-    /// <summary>The absolute AL source line <paramref name="scope"/> is currently
-    /// stopped at, per its OWN live StatementNumber — correct for any ANCESTOR frame,
-    /// but NOT for the paused (topmost) frame itself; see <see cref="Walk"/>'s doc
-    /// comment for why.</summary>
+    /// <summary>The AL source line <paramref name="scope"/> is currently stopped at, per its
+    /// OWN live StatementNumber — correct for any ANCESTOR frame, but NOT for the paused
+    /// (topmost) frame itself; see <see cref="Walk"/>'s doc comment for why.
+    /// <para>
+    /// The line is relative to the owning OBJECT's text, which is the file line only for the
+    /// first object in a file (#3786). <see cref="Walk"/> adds the object's offset; a direct
+    /// caller of this method gets the raw number BC recorded and must add its own.
+    /// </para></summary>
     public static int ResolveCurrentLine(Microsoft.Dynamics.Nav.Runtime.NavMethodScope scope)
         => ResolveLine(scope, scope.StatementNumber);
 

--- a/AlRunner/Infrastructure/AlSourceSpanCodec.cs
+++ b/AlRunner/Infrastructure/AlSourceSpanCodec.cs
@@ -1,8 +1,12 @@
 // AlSourceSpanCodec — decodes the `long` values BC's AL compiler packs into the
 // [SourceSpans(...)] / [SignatureSpan(...)] attributes it emits on every generated
 // NavMethodScope subclass (one entry per AL statement, plus one for the method
-// signature). Two call sites need this: AlCallStackCapture (relative "line L" in AL
-// stack traces) and AlCoverageTracker (absolute AL source line for --coverage). Both
+// signature). Four consumers need this: AlCallStackCapture (relative "line L" in AL
+// stack traces), AlCoverageTracker (absolute AL source line for --coverage), and the
+// two DAP consumers, DapBreakpointResolver and AlDapStackWalker (#3786). Everything
+// except AlCallStackCapture wants a FILE line, and AbsoluteFromLine alone does not give
+// one: BC's number is relative to the owning object's text, so each of those three adds
+// AlSourceLocationMap.LineOffset for the object. All
 // used to decode the bit layout independently; this is the single place it happens now
 // — see .claude/rules — "Lift the span-decoding ... into a shared helper ... Do not
 // duplicate the bit layout."

--- a/AlRunner/Infrastructure/DapBreakpointResolver.cs
+++ b/AlRunner/Infrastructure/DapBreakpointResolver.cs
@@ -28,18 +28,35 @@ public static class DapBreakpointResolver
     /// objects present in <paramref name="sourceMap"/> (built from the SAME bundle
     /// roots the run compiled, e.g. via AlCoverageSourceMap.Build) can match — a
     /// breakpoint in a file outside the debugged bundle is unverified, not a crash.
+    /// <para>
+    /// Takes <see cref="AlSourceLocationMap"/> rather than the dictionary interface it
+    /// implements because #3786 needs its <see cref="AlSourceLocationMap.LineOffset"/>: the
+    /// path alone cannot say where an object's text begins, and a caller that supplied only
+    /// paths would silently get the pre-#3786 behaviour for every object after the first in
+    /// a file. The DAP path in Program.cs already builds one.
+    /// </para>
     /// </summary>
     public static List<DapResolvedBreakpoint> Resolve(
         IReadOnlyList<DapBreakpointRequest> requests,
-        IReadOnlyDictionary<(string Label, int Id), string> sourceMap)
+        AlSourceLocationMap sourceMap)
     {
-        // Invert (label,id)->path into full-path -> (label,id). Both sides are real
-        // filesystem paths (not bare filenames — see docs/archive/dap.md's filename-only
-        // caveat, which this improves on), compared case-insensitively for
-        // cross-platform DAP clients.
-        var byPath = new Dictionary<string, (string Label, int Id)>(StringComparer.OrdinalIgnoreCase);
+        // Invert path -> (label,id), MANY per path. One .al file may declare any number of
+        // objects, and this used to be a one-value dictionary, so the last object written
+        // for a file evicted every earlier one and a breakpoint could only ever match
+        // whichever survived (#3786). That is why a request inside the FIRST object of a
+        // two-object file came back unverified as readily as one inside the second — not
+        // the mis-resolution the issue predicted, but a whole object missing from the index.
+        //
+        // Both sides are real filesystem paths (not bare filenames — see
+        // docs/archive/dap.md's filename-only caveat, which this improves on), compared
+        // case-insensitively for cross-platform DAP clients.
+        var byPath = new Dictionary<string, List<(string Label, int Id)>>(StringComparer.OrdinalIgnoreCase);
         foreach (var kv in sourceMap)
-            byPath[Path.GetFullPath(kv.Value)] = kv.Key;
+        {
+            var full = Path.GetFullPath(kv.Value);
+            if (!byPath.TryGetValue(full, out var keys)) byPath[full] = keys = new();
+            keys.Add(kv.Key);
+        }
 
         // (label,id) -> every loaded scope type for that object, each with its own
         // (statement index -> absolute AL line) map.
@@ -58,12 +75,20 @@ public static class DapBreakpointResolver
                 var (label, id) = AlCallStackCapture.ParseObjectTypeAndId(t);
                 if (id == 0) continue;
 
+                // #3786: a [SourceSpans] line is relative to the OWNING OBJECT's text, not
+                // to the file. For the first object in a file the two coincide and nothing
+                // is visible; for any later one every line is short by the number of lines
+                // its text starts down the file. LineOffset is what AlCoverageSourceMap
+                // recorded when it parsed the file, and it is 0 for an object the map does
+                // not know — so an unmapped object keeps exactly its old behaviour rather
+                // than being shifted by a guess.
+                var lineOffset = sourceMap.LineOffset(label, id);
                 var instrumented = AlCoverageInstrumentedStatements.Find(t);
                 var lineByStmt = new Dictionary<int, int>();
                 foreach (var i in instrumented)
                 {
                     if (i < 0 || i >= spans.Length) continue; // defensive: BC shape drift
-                    lineByStmt[i] = AlSourceSpanCodec.AbsoluteFromLine(spans[i]);
+                    lineByStmt[i] = AlSourceSpanCodec.AbsoluteFromLine(spans[i]) + lineOffset;
                 }
                 if (!byObject.TryGetValue((label, id), out var list))
                     byObject[(label, id)] = list = new();
@@ -76,15 +101,23 @@ public static class DapBreakpointResolver
         {
             var full = Path.GetFullPath(req.SourcePath);
             (Type Type, int Stmt, int Line)? match = null;
-            if (byPath.TryGetValue(full, out var objKey) && byObject.TryGetValue(objKey, out var scopes))
+            if (byPath.TryGetValue(full, out var objKeys))
             {
-                foreach (var (type, lineByStmt) in scopes)
+                // Every object the file declares, not just one. The lines are file lines on
+                // both sides now, so the first exact match is the right one whichever object
+                // owns it — two objects cannot claim the same file line.
+                foreach (var objKey in objKeys)
                 {
-                    foreach (var kv in lineByStmt)
+                    if (!byObject.TryGetValue(objKey, out var scopes)) continue;
+                    foreach (var (type, lineByStmt) in scopes)
                     {
-                        if (kv.Value != req.Line) continue;
-                        match = (type, kv.Key, kv.Value);
-                        break;
+                        foreach (var kv in lineByStmt)
+                        {
+                            if (kv.Value != req.Line) continue;
+                            match = (type, kv.Key, kv.Value);
+                            break;
+                        }
+                        if (match != null) break;
                     }
                     if (match != null) break;
                 }

--- a/AlRunner/Infrastructure/DapBreakpointResolver.cs
+++ b/AlRunner/Infrastructure/DapBreakpointResolver.cs
@@ -24,10 +24,29 @@ public readonly record struct DapResolvedBreakpoint(
 public static class DapBreakpointResolver
 {
     /// <summary>
-    /// Resolves each request against every AL object type currently loaded. Only
-    /// objects present in <paramref name="sourceMap"/> (built from the SAME bundle
-    /// roots the run compiled, e.g. via AlCoverageSourceMap.Build) can match — a
+    /// How two source paths are compared. Case-insensitive on Windows and macOS, where the
+    /// filesystem is, and case-SENSITIVE elsewhere (#3786 review): on Linux <c>Foo.al</c> and
+    /// <c>foo.al</c> are two files, and folding them together merges their object lists so a
+    /// line can bind to a statement in the wrong file. That was harmless while the index held
+    /// one object per path and simply evicted; it stops being harmless once the entries merge.
+    /// Exposed so the DAP loop's own per-source breakpoint bookkeeping keys the same way —
+    /// two components disagreeing about path identity is the same bug wearing a different hat.
+    /// </summary>
+    public static StringComparer PathComparer { get; } =
+        OperatingSystem.IsLinux() ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+
+    /// <summary>
+    /// Resolves each request against every AL object type currently loaded that the source
+    /// map knows. Only objects present in <paramref name="sourceMap"/> (built from the SAME
+    /// bundle roots the run compiled, e.g. via AlCoverageSourceMap.Build) can match — a
     /// breakpoint in a file outside the debugged bundle is unverified, not a crash.
+    /// <para>
+    /// "Every object" is bounded by what that map registers, and it registers seven top-level
+    /// kinds: table, page, report, codeunit, query, xmlport, enum. EXTENSION objects
+    /// (tableextension, pageextension, …) are not in it and never resolve a breakpoint, which
+    /// is a pre-existing limit of AlCoverageSourceMap.LabelOf and of the runtime identity
+    /// parsing in AlCallStackCapture, not a decision made here (#3786 review).
+    /// </para>
     /// <para>
     /// Takes <see cref="AlSourceLocationMap"/> rather than the dictionary interface it
     /// implements because #3786 needs its <see cref="AlSourceLocationMap.LineOffset"/>: the
@@ -49,8 +68,8 @@ public static class DapBreakpointResolver
         //
         // Both sides are real filesystem paths (not bare filenames — see
         // docs/archive/dap.md's filename-only caveat, which this improves on), compared
-        // case-insensitively for cross-platform DAP clients.
-        var byPath = new Dictionary<string, List<(string Label, int Id)>>(StringComparer.OrdinalIgnoreCase);
+        // with PathComparer.
+        var byPath = new Dictionary<string, List<(string Label, int Id)>>(PathComparer);
         foreach (var kv in sourceMap)
         {
             var full = Path.GetFullPath(kv.Value);
@@ -103,9 +122,18 @@ public static class DapBreakpointResolver
             (Type Type, int Stmt, int Line)? match = null;
             if (byPath.TryGetValue(full, out var objKeys))
             {
-                // Every object the file declares, not just one. The lines are file lines on
-                // both sides now, so the first exact match is the right one whichever object
-                // owns it — two objects cannot claim the same file line.
+                // Every object the file declares, not just one.
+                //
+                // The first exact match wins, and that is a real limitation rather than a
+                // proof of uniqueness (#3786 review). AL permits two statements on one
+                // physical line — CollectStatementTable's doc comment says so explicitly, and
+                // keeps them apart by id and column precisely because a line cannot — so a
+                // requested line can have more than one executable target, in one scope or
+                // across several. Binding one of them means a breakpoint on such a line stops
+                // only if execution reaches the target that was picked. #3820 tracks
+                // registering every match behind the single DAP breakpoint the protocol
+                // returns; it needs DapResolvedBreakpoint to carry a set, so it is not a
+                // widening of this change.
                 foreach (var objKey in objKeys)
                 {
                     if (!byObject.TryGetValue(objKey, out var scopes)) continue;

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -5663,6 +5663,15 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
     AlRunner.Infrastructure.AlDapSession.Reset();
 
     var sourceMap = AlRunner.Infrastructure.AlSourceLocationMap.Empty;
+    // Which scope types this session has breakpoints registered on, per source file, so a
+    // later setBreakpoints for that file can clear ALL of them (#3786 review). Clearing only
+    // the scopes named by the NEW request leaves the old ones armed: an empty breakpoint
+    // list — the DAP spelling of "remove every breakpoint in this file" — cleared nothing at
+    // all, and once a file's objects became separately addressable, moving a breakpoint from
+    // one object to another in the same file left the first one firing. Keyed by full path
+    // with the same comparer DapBreakpointResolver uses for its own path index.
+    var registeredScopesBySource =
+        new Dictionary<string, HashSet<Type>>(AlRunner.Infrastructure.DapBreakpointResolver.PathComparer);
     var lastFrames = new List<AlRunner.Infrastructure.AlDapFrame>();
 
     var compiledTcs = new System.Threading.Tasks.TaskCompletionSource<Assembly>(
@@ -5856,12 +5865,27 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
 
                         var fullSrcPath = Path.GetFullPath(srcPath);
                         // Replace (not accumulate) — DAP's setBreakpoints contract: this
-                        // request is the COMPLETE set for `source` from now on.
+                        // request is the COMPLETE set for `source` from now on. That means
+                        // clearing what THIS FILE had registered before, not what the new
+                        // request happens to name: an empty list must disarm the file, and a
+                        // breakpoint moved between two objects of one file must not leave the
+                        // first object armed (#3786 review). fullSrcPath was computed and
+                        // never read before, which is the shape that defect left behind.
+                        if (registeredScopesBySource.TryGetValue(fullSrcPath, out var previouslyRegistered))
+                            foreach (var scope in previouslyRegistered)
+                                AlRunner.Infrastructure.AlDapSession.ClearBreakpoints(scope);
+                        var nowRegistered = new HashSet<Type>();
                         foreach (var rb in resolved)
-                            if (rb.ScopeType != null) AlRunner.Infrastructure.AlDapSession.ClearBreakpoints(rb.ScopeType);
-                        foreach (var rb in resolved)
-                            if (rb.Verified && rb.ScopeType != null)
-                                AlRunner.Infrastructure.AlDapSession.SetBreakpoint(rb.ScopeType, rb.StatementIndex);
+                        {
+                            if (!rb.Verified || rb.ScopeType == null) continue;
+                            // A scope reached for the first time in THIS request may still
+                            // carry breakpoints from a request naming a different file that
+                            // declares the same object — clear before the first add, once.
+                            if (nowRegistered.Add(rb.ScopeType))
+                                AlRunner.Infrastructure.AlDapSession.ClearBreakpoints(rb.ScopeType);
+                            AlRunner.Infrastructure.AlDapSession.SetBreakpoint(rb.ScopeType, rb.StatementIndex);
+                        }
+                        registeredScopesBySource[fullSrcPath] = nowRegistered;
 
                         transport.WriteResponse(msg.Seq, command, true, new
                         {


### PR DESCRIPTION
## Summary

BC records a `[SourceSpans]` line relative to the **owning object's text**, not to the `.al` file. For the first object in a file the two coincide; for any later one every line is short by the number of lines its text starts down the file. #3713 fixed the `--coverage` consumers by recording each object's start line in `AlSourceLocationMap.LineOffset` and adding it where a line is produced. The two DAP consumers were left, so a breakpoint inside any object after the first never verified, and a paused frame reported a line inside the previous object's range.

## Measuring it found a second defect, and the more basic one

The issue predicted that a breakpoint on a **first**-object line would falsely match a second-object statement at the same relative line, firing in the wrong function. Building the reproducer showed it does not: it comes back unverified too.

`DapBreakpointResolver` inverted the source map into `Dictionary<string, (string Label, int Id)>` — **one object per path**. A file declaring two objects writes that key twice, the last one wins, and the other object is absent from the index entirely. With only one object reachable per file there is nothing for a first-object line to falsely match against; it simply misses.

So this is two changes, not the one mechanical addition the issue describes:

- the path index is now `Dictionary<string, List<(string Label, int Id)>>` and the match loop iterates every object the file declares;
- each object's `LineOffset` is added where the line is produced, in `DapBreakpointResolver` and in `AlDapStackWalker`.

Both APIs now take `AlSourceLocationMap` rather than the `IReadOnlyDictionary` it implements. The offset is not reachable through the interface, and a caller passing only paths would silently get the pre-fix behaviour for every object after the first. The DAP loop in `Program.cs` already builds one.

The offset is applied with exactly the convention `AlCoverageTracker.Collect` already uses — `AbsoluteFromLine(span) + lineOffset` — so the two consumer families cannot disagree about whether the number is 0- or 1-based.

Two smaller decisions, both deliberate:

- **In the stack walker the offset is added in `Walk`, not inside `ResolveLine`.** `ResolveLine`'s contract stays "the number BC recorded", which is object-relative; `Walk` is where the line is paired with a `SourcePath`, and those two have to agree about which numbering they use because a DAP client reads them together.
- **A frame that resolved no line at all stays 0.** Shifting a 0 by an offset would invent a line for a frame whose object carries no spans.

## Proof

New fixture `AlRunner.Tests/Fixtures/DapTwoObjects`: one `.al` file holding a helper codeunit on lines 10-16 and the test codeunit whose text begins on line 18. Five facts in `DapMultiObjectFileTests` drive a real DAP session through initialize / launch / setBreakpoints / configurationDone, the same sequence `DapServerTests` uses.

RED before the change, with the recorded response:

```
breakpoint at file line 32 was not verified — the line was decoded relative to the
object's text, not the file:
{"command":"setBreakpoints","body":{"breakpoints":[{"id":0,"verified":false,"line":32}]}}
```

Every production change was mutation-checked, and the partition is what shows the defects are independent:

| mutation | facts that fail |
|---|---|
| both `LineOffset` additions removed | the two second-object facts |
| path index back to one object per path | the first-object fact |
| **only** the stack walker's offset removed | the two second-object facts |
| offset applied to frame 0 only | the first-object fact, through its ancestor frame |
| clearing reverted to "only what the new request names" | both replacement facts |

Two rows are worth reading. The walker is not merely following the resolver: the `stopped` event's line comes from it, so fixing the resolver alone would have verified the breakpoint and then reported the wrong line. And offsetting only the paused frame passes every assertion in the class except the ancestor one, which is why that assertion exists.

Each second-object fact also asserts through `scopes`/`variables` that `Counter` is still `1` at the pause, so a stop that landed on some other statement in range fails rather than passing on the line number alone.

**Failures in a wider local sweep are not mine.** Running `~Dap|~Coverage|~SourceSpan` on this branch fails two: `ProvisionExplicitModesTests.TestApps_OnlyUnrelatedAppPresent_DoesNotShortCircuit_DownloadsTheRealSet` and `ServerAffectedSelectionMultiSourcePathsTests.AffectedOnly_CrossBundleCoverage_RunsOnlyTheTestThatCallsTheEditedHelper`. A pristine `origin/main` worktree at `61b7d47f`, built and run with the same filter, fails the same two. 128 pass on both sides.

## Review

An external adversarial review (GPT-5.6-sol, 19 files read) returned two BLOCKING findings, and both were real defects that this change made *reachable* rather than introduced. Fixed in `1489ea4`.

**A source's breakpoints were cleared by request, not by source.** `setBreakpoints` is the complete set for a file, and the handler cleared only the scope types the new request named. An empty list named none and cleared nothing, so a run still stopped at a breakpoint the client had removed; and once a file's objects became separately addressable, moving a breakpoint between two objects of one file left the first armed. The handler now tracks what each source registered. The reviewer spotted that `fullSrcPath` was computed and never read, which is exactly the shape the missing implementation left behind.

**The path index folded case on every platform.** Harmless while it held one object per path and evicted; merging two Linux files differing only in case lets a line bind into the wrong file. `PathComparer` is `Ordinal` on Linux and `OrdinalIgnoreCase` elsewhere, and the DAP loop keys its bookkeeping through the same comparer.

Two facts cover the clearing contract, both RED against the previous handler.

Three findings were corrections to what the code *claims*, and I took all three. "Two objects cannot claim the same file line" was simply wrong — `CollectStatementTable`'s own comment says two statements can share a line — so the first-exact-match behaviour is documented as the limitation it is. "Every AL object type currently loaded" excludes extension objects. `AlSourceSpanCodec`'s header named two consumers when there are four.

Three findings became issues rather than growing this diff:

- **#3820** — a source line can carry several executable targets and only one is bound. Pre-existing, but this change widens the candidate set from one object per file to all of them. Closing it means `DapResolvedBreakpoint` carrying a set and `AlDapSession` registering several, while the protocol still returns one breakpoint per request.
- **#3821** — a `setBreakpoints` arriving between `initialized` and `launch` resolves against an empty map, so every breakpoint reports unverified. That ordering is what the DAP specification describes, so it is a real client shape.
- **#3822** — the reviewer's one SPECULATIVE finding, left speculative deliberately: `LineOffset` is measured from the first *supported* object, so a file opening with an extension may shift every later object. Settling it needs an emitted-span measurement, and it is a property of #3713's parser rather than of this change.

Two test findings are fixed and one is measured. The ancestor stack frame is now asserted, which matters: mutating `Walk` to offset only frame 0 passes every other assertion in the class and fails that one. The first-statement fact reads `Counter == 0` rather than only claiming `NoEffectApplied` in its name. And the reviewer asked whether `AlSourceLocationMap.Empty` is a safe default and whether the signature change breaks callers — the project is `OutputType=Exe` with `PackAsTool`, a dotnet tool rather than a published library, so `AlRunner.Infrastructure` has no external consumers to break.

The reviewer also confirmed, independently, that the offset arithmetic is not off by one and that the `raw == 0` guard is correct, which were the two things I was least sure of.

Closes #3786

Corpus-NA: the DAP surface is a runner-specific protocol contract; no BC behaviour is asserted, so there is nothing for a service tier to adjudicate.

*Opened by an agent (Claude Code) in a session run by @SShadowS.*

https://claude.ai/code/session_01JFQZHC5SEHnLxkc5USksaK
