### PR TITLE
fix(bccompiler): align .NET probing paths so System Application emits

### DIFF
--- a/AlRunner.Tests/DotNetShimProbingTests.cs
+++ b/AlRunner.Tests/DotNetShimProbingTests.cs
@@ -48,6 +48,23 @@ public sealed class DotNetShimProbingTests : IDisposable
     public void Dispose() =>
         Environment.SetEnvironmentVariable("AL_RUNNER_DOTNET_SHIMS", _savedOverride);
 
+    /// <summary>
+    /// An owned scratch directory that EXISTS.
+    ///
+    /// <para><c>TestScratch.Dir</c> reserves the path and writes the <c>.owner</c> sidecar that
+    /// lets a later runner start reclaim a killed host's leftovers, but it deliberately does NOT
+    /// create the leaf — see <c>TestScratch.cs</c>, where some callers rely on observing whether
+    /// the runner created it. These tests hand the path to <c>BuildDotNetProbingPaths</c>, which
+    /// filters on <c>Directory.Exists</c>, so the directory has to be real: hence the explicit
+    /// create here rather than an assumption that the helper did it.</para>
+    /// </summary>
+    private static string OwnedDir(string prefix)
+    {
+        var dir = TestScratch.Dir(prefix);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
     private static IReadOnlyList<string> ShimDirs()
     {
         var m = typeof(BcCompiler).GetMethod(
@@ -132,15 +149,15 @@ public sealed class DotNetShimProbingTests : IDisposable
     [Fact]
     public void OrderPutsShimsAheadOfTheServiceTier()
     {
-        var probeDir = Directory.CreateTempSubdirectory("al-runner-shim-order-");
+        var probeDir = OwnedDir("al-runner-shim-order");
         try
         {
-            Environment.SetEnvironmentVariable("AL_RUNNER_DOTNET_SHIMS", probeDir.FullName);
+            Environment.SetEnvironmentVariable("AL_RUNNER_DOTNET_SHIMS", probeDir);
 
             var paths = InvokeProbingPaths();
             var shimIdx = paths.FindIndex(
                 p => string.Equals(Path.GetFullPath(p).TrimEnd(Path.DirectorySeparatorChar),
-                                   probeDir.FullName.TrimEnd(Path.DirectorySeparatorChar),
+                                   probeDir.TrimEnd(Path.DirectorySeparatorChar),
                                    StringComparison.Ordinal));
             Assert.True(shimIdx >= 0,
                 "the AL_RUNNER_DOTNET_SHIMS directory did not reach the probing paths: " +
@@ -160,7 +177,7 @@ public sealed class DotNetShimProbingTests : IDisposable
         finally
         {
             Environment.SetEnvironmentVariable("AL_RUNNER_DOTNET_SHIMS", null);
-            try { probeDir.Delete(recursive: true); } catch { /* best effort */ }
+            try { Directory.Delete(probeDir, recursive: true); } catch { /* best effort */ }
         }
     }
 
@@ -172,38 +189,42 @@ public sealed class DotNetShimProbingTests : IDisposable
     [Fact]
     public void OverrideAcceptsSeveralPathsAndUnsetContributesNone()
     {
-        var a = Directory.CreateTempSubdirectory("al-runner-shim-a-");
-        var b = Directory.CreateTempSubdirectory("al-runner-shim-b-");
+        var a = OwnedDir("al-runner-shim-a");
+        var b = OwnedDir("al-runner-shim-b");
+        // Deliberately NOT a TestScratch path, and allowlisted in ScratchDirOwnershipGuardTests
+        // for that reason: this path's whole point is that nothing is there. Reserving it would
+        // create the parent and drop a .owner sidecar beside a path the assertion below measures
+        // the ABSENCE of, which is the guard's own "a path that must NOT exist" category.
         var missing = Path.Combine(Path.GetTempPath(), "al-runner-shim-absent-" + Guid.NewGuid());
         try
         {
             Environment.SetEnvironmentVariable(
                 "AL_RUNNER_DOTNET_SHIMS",
-                string.Join(Path.PathSeparator, a.FullName, missing, b.FullName));
+                string.Join(Path.PathSeparator, a, missing, b));
 
             var yielded = ShimDirs().Select(p => p.TrimEnd(Path.DirectorySeparatorChar)).ToList();
-            Assert.Equal(a.FullName.TrimEnd(Path.DirectorySeparatorChar), yielded[0]);
+            Assert.Equal(a.TrimEnd(Path.DirectorySeparatorChar), yielded[0]);
             Assert.Equal(missing.TrimEnd(Path.DirectorySeparatorChar), yielded[1]);
-            Assert.Equal(b.FullName.TrimEnd(Path.DirectorySeparatorChar), yielded[2]);
+            Assert.Equal(b.TrimEnd(Path.DirectorySeparatorChar), yielded[2]);
 
             // The enumeration yields candidates; the caller filters. A directory that does not
             // exist must not reach the assembled probing paths.
             var paths = InvokeProbingPaths().Select(Path.GetFullPath).ToList();
-            Assert.Contains(Path.GetFullPath(a.FullName), paths);
-            Assert.Contains(Path.GetFullPath(b.FullName), paths);
+            Assert.Contains(Path.GetFullPath(a), paths);
+            Assert.Contains(Path.GetFullPath(b), paths);
             Assert.DoesNotContain(Path.GetFullPath(missing), paths);
 
             Environment.SetEnvironmentVariable("AL_RUNNER_DOTNET_SHIMS", "");
             var defaults = ShimDirs();
-            Assert.DoesNotContain(a.FullName.TrimEnd(Path.DirectorySeparatorChar),
+            Assert.DoesNotContain(a.TrimEnd(Path.DirectorySeparatorChar),
                 defaults.Select(p => p.TrimEnd(Path.DirectorySeparatorChar)));
             Assert.All(defaults, p => Assert.Equal("dotnet-shims", Path.GetFileName(p)));
         }
         finally
         {
             Environment.SetEnvironmentVariable("AL_RUNNER_DOTNET_SHIMS", null);
-            try { a.Delete(recursive: true); } catch { /* best effort */ }
-            try { b.Delete(recursive: true); } catch { /* best effort */ }
+            try { Directory.Delete(a, recursive: true); } catch { /* best effort */ }
+            try { Directory.Delete(b, recursive: true); } catch { /* best effort */ }
         }
     }
 
@@ -217,7 +238,7 @@ public sealed class DotNetShimProbingTests : IDisposable
     [Fact]
     public void DuplicateShimDirectoriesAreCollapsedInTheProbingPaths()
     {
-        var probeDir = Directory.CreateTempSubdirectory("al-runner-shim-dup-");
+        var probeDir = OwnedDir("al-runner-shim-dup");
         try
         {
             // The same directory twice, plus a trailing-separator spelling of it, which is the
@@ -225,21 +246,21 @@ public sealed class DotNetShimProbingTests : IDisposable
             Environment.SetEnvironmentVariable(
                 "AL_RUNNER_DOTNET_SHIMS",
                 string.Join(Path.PathSeparator,
-                    probeDir.FullName,
-                    probeDir.FullName,
-                    probeDir.FullName + Path.DirectorySeparatorChar));
+                    probeDir,
+                    probeDir,
+                    probeDir + Path.DirectorySeparatorChar));
 
             var paths = InvokeProbingPaths();
             var matches = paths.Count(p => string.Equals(
                 Path.GetFullPath(p).TrimEnd(Path.DirectorySeparatorChar),
-                probeDir.FullName.TrimEnd(Path.DirectorySeparatorChar),
+                probeDir.TrimEnd(Path.DirectorySeparatorChar),
                 StringComparison.Ordinal));
             Assert.Equal(1, matches);
         }
         finally
         {
             Environment.SetEnvironmentVariable("AL_RUNNER_DOTNET_SHIMS", null);
-            try { probeDir.Delete(recursive: true); } catch { /* best effort */ }
+            try { Directory.Delete(probeDir, recursive: true); } catch { /* best effort */ }
         }
     }
 

--- a/AlRunner.Tests/DotNetShimProbingTests.cs
+++ b/AlRunner.Tests/DotNetShimProbingTests.cs
@@ -208,25 +208,47 @@ public sealed class DotNetShimProbingTests : IDisposable
     }
 
     /// <summary>
-    /// Rebuilds the probing list the same way <c>GetOrCreateDotNetFactory</c> does. That method
-    /// memoises its factory in a static, so calling it twice in one process cannot show a change
-    /// of environment — this mirrors its path instead of caching an answer the test then cannot
-    /// re-measure.
+    /// One entry per directory. The runner shadow-copies its own directory before re-exec, so
+    /// <c>AppContext.BaseDirectory</c> and the assembly's directory are then the SAME path and
+    /// the enumeration yields it twice — measured in a real run, where the probing-path dump
+    /// printed the shadow directory on two consecutive lines. Harmless to BC's locator, but a
+    /// probing list that double-counts is a list nobody can read a verdict off.
     /// </summary>
-    private static List<string> InvokeProbingPaths()
+    [Fact]
+    public void DuplicateShimDirectoriesAreCollapsedInTheProbingPaths()
     {
-        var paths = new List<string>();
-        foreach (var d in ShimDirs())
-            if (Directory.Exists(d)) paths.Add(d);
+        var probeDir = Directory.CreateTempSubdirectory("al-runner-shim-dup-");
+        try
+        {
+            // The same directory twice, plus a trailing-separator spelling of it, which is the
+            // shape the shadow-copy case actually produces.
+            Environment.SetEnvironmentVariable(
+                "AL_RUNNER_DOTNET_SHIMS",
+                string.Join(Path.PathSeparator,
+                    probeDir.FullName,
+                    probeDir.FullName,
+                    probeDir.FullName + Path.DirectorySeparatorChar));
 
-        var refDirs = (IEnumerable<string>)typeof(BcCompiler)
-            .GetMethod("EnumerateDotNetRefAssemblyDirs", BindingFlags.NonPublic | BindingFlags.Static)!
-            .Invoke(null, null)!;
-        foreach (var d in refDirs)
-            if (Directory.Exists(d)) paths.Add(d);
-
-        if (Directory.Exists(BcCompiler.DefaultServiceTierDir))
-            paths.Add(BcCompiler.DefaultServiceTierDir);
-        return paths;
+            var paths = InvokeProbingPaths();
+            var matches = paths.Count(p => string.Equals(
+                Path.GetFullPath(p).TrimEnd(Path.DirectorySeparatorChar),
+                probeDir.FullName.TrimEnd(Path.DirectorySeparatorChar),
+                StringComparison.Ordinal));
+            Assert.Equal(1, matches);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AL_RUNNER_DOTNET_SHIMS", null);
+            try { probeDir.Delete(recursive: true); } catch { /* best effort */ }
+        }
     }
+
+    /// <summary>
+    /// The probing list PRODUCTION builds, not a reconstruction of it. This is the whole point:
+    /// an earlier version of this file rebuilt the list from the same two enumerations, and when
+    /// the production order was inverted so that shims came after the service tier, every
+    /// assertion here still passed — the test was measuring its own copy. Calling
+    /// <c>BuildDotNetProbingPaths</c> is what makes the ordering assertions mean anything.
+    /// </summary>
+    private static List<string> InvokeProbingPaths() => BcCompiler.BuildDotNetProbingPaths();
 }

--- a/AlRunner.Tests/DotNetShimProbingTests.cs
+++ b/AlRunner.Tests/DotNetShimProbingTests.cs
@@ -1,0 +1,232 @@
+// DotNetShimProbingTests — issue #3745.
+//
+// RUNNER-MECHANISM test. The claim is about the runner's own compile configuration, not about
+// what Business Central does, so a service tier cannot adjudicate it and there is nothing for
+// the corpus to express: the corpus compiles its apps and runs them, and this is about which
+// assembly BC's AL binder resolves a DotNet parameter type from while compiling somebody else's
+// app. See the PR body for the measured end-to-end result the shim produces.
+//
+// WHAT WENT WRONG, AND WHY IT COST THE WHOLE APP
+//   System Application's SamplingPerfProfilerImpl calls JsonSerializer.Deserialize(TextReader,
+//   Type). The BC service tier ships only the net6.0 build of Newtonsoft.Json, whose TextReader
+//   parameter is typed against System.Runtime 6.0.0.0. No .NET 6 reference assemblies exist on a
+//   net8 box, so that parameter type never resolves and the call raises AL0133. Compilation.Emit
+//   is atomic per module, so that ONE unresolvable reference yielded zero metadata documents for
+//   all 1,319 of System Application's source files rather than a partial result.
+//
+//   The netstandard2.0 build of the SAME Newtonsoft version binds against netstandard, which
+//   does resolve. AlRunner.csproj's CopyDotNetShims target stages it into a `dotnet-shims`
+//   directory and GetOrCreateDotNetFactory probes that directory FIRST.
+//
+// WHY "FIRST" IS THE LOAD-BEARING PART, AND WHAT THIS FILE PINS
+//   A shim exists precisely because the service tier's own copy of that assembly does not bind.
+//   Probing the tier ahead of the shim would find the net6.0 copy again and defeat the whole
+//   mechanism, silently — the compile would go back to producing zero documents with nothing
+//   naming the cause. So ordering is not a detail here, it is the fix, and OrderPutsShimsFirst
+//   is the assertion that fails if a later edit appends the shim directory instead of
+//   prepending it.
+//
+//   These are unit tests over the probing-path construction, deliberately not a full System
+//   Application compile: that compile is ~14s and needs provisioned BC artifacts, so it belongs
+//   to the measurement recorded in docs/dependency-metadata-from-bc.md rather than to every
+//   `dotnet test` run.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class DotNetShimProbingTests : IDisposable
+{
+    private readonly string? _savedOverride =
+        Environment.GetEnvironmentVariable("AL_RUNNER_DOTNET_SHIMS");
+
+    public void Dispose() =>
+        Environment.SetEnvironmentVariable("AL_RUNNER_DOTNET_SHIMS", _savedOverride);
+
+    private static IReadOnlyList<string> ShimDirs()
+    {
+        var m = typeof(BcCompiler).GetMethod(
+                    "EnumerateDotNetShimDirs", BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "BcCompiler.EnumerateDotNetShimDirs not found. If it was renamed, this test " +
+                    "and the probing-order guarantee it protects need to move with it.");
+        return ((IEnumerable<string>)m.Invoke(null, null)!).ToList();
+    }
+
+    /// <summary>
+    /// The shim the fix exists for is actually staged next to the RUNNER binary. Asserted on the
+    /// real build output rather than a fixture: a test that stages its own copy would pass with
+    /// the csproj target deleted, which is the failure mode this pins against.
+    ///
+    /// <para>The runner's output directory, not <c>AppContext.BaseDirectory</c> — the test host
+    /// runs out of AlRunner.Tests' own output, which is a different directory, so asserting on
+    /// the ambient one would measure the test project's build rather than the shipped runner's
+    /// (measured while writing this: the shim was correctly staged and the assertion still
+    /// failed).</para>
+    /// </summary>
+    [Fact]
+    public void BuildStagesTheNewtonsoftNetstandardShimBesideTheRunnerBinary()
+    {
+        var dir = Path.Combine(RunnerOutputDir(), "dotnet-shims");
+        Assert.True(Directory.Exists(dir),
+            $"no dotnet-shims directory at {dir}. AlRunner.csproj's CopyDotNetShims target " +
+            "stages it; without it System Application's emit yields zero documents (#3745).");
+
+        var shim = Path.Combine(dir, "Newtonsoft.Json.dll");
+        Assert.True(File.Exists(shim), $"Newtonsoft.Json.dll missing from {dir}");
+
+        // The netstandard2.0 build specifically. The net6.0 build is the one that does NOT bind,
+        // and the service tier already ships that — staging it here would be a no-op wearing the
+        // shape of a fix.
+        var name = AssemblyName.GetAssemblyName(shim);
+        Assert.Equal("Newtonsoft.Json", name.Name);
+
+        var text = File.ReadAllText(shim, System.Text.Encoding.Latin1);
+        Assert.Contains(".NETStandard,Version=v2.0", text);
+        Assert.DoesNotContain(".NETCoreApp,Version=v6.0", text);
+    }
+
+    /// <summary>
+    /// The staged directory is one the probing enumeration actually yields. Without this the
+    /// file could ship to a path nothing reads — green csproj, green probing list, no fix.
+    /// </summary>
+    [Fact]
+    public void StagedShimDirectoryIsOneOfTheProbedDirectories()
+    {
+        Environment.SetEnvironmentVariable("AL_RUNNER_DOTNET_SHIMS", null);
+        var probed = ShimDirs().Select(Path.GetFullPath).ToList();
+
+        // In a shipped run these two are the same directory; under the test host they are not,
+        // which is exactly why the enumeration yields both.
+        Assert.Contains(Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "dotnet-shims")),
+            probed);
+        Assert.Contains(
+            Path.GetFullPath(Path.Combine(
+                Path.GetDirectoryName(typeof(BcCompiler).Assembly.Location)!, "dotnet-shims")),
+            probed);
+    }
+
+    /// <summary>
+    /// The runner project's build output. Derived from the location of the assembly under test
+    /// rather than from a path relative to the source tree, so it stays correct under any
+    /// configuration or target-framework layout.
+    /// </summary>
+    private static string RunnerOutputDir()
+    {
+        var dir = Path.GetDirectoryName(typeof(BcCompiler).Assembly.Location);
+        Assert.False(string.IsNullOrEmpty(dir),
+            "could not locate the runner assembly on disk; the staging assertion has nothing to measure.");
+        return dir!;
+    }
+
+    /// <summary>
+    /// The ordering guarantee, and the reason the whole mechanism works: every shim directory
+    /// precedes the service-tier directory in the assembled probing path. A later edit that
+    /// appends instead of prepends leaves a compile that silently resolves the net6.0 copy again.
+    /// </summary>
+    [Fact]
+    public void OrderPutsShimsAheadOfTheServiceTier()
+    {
+        var probeDir = Directory.CreateTempSubdirectory("al-runner-shim-order-");
+        try
+        {
+            Environment.SetEnvironmentVariable("AL_RUNNER_DOTNET_SHIMS", probeDir.FullName);
+
+            var paths = InvokeProbingPaths();
+            var shimIdx = paths.FindIndex(
+                p => string.Equals(Path.GetFullPath(p).TrimEnd(Path.DirectorySeparatorChar),
+                                   probeDir.FullName.TrimEnd(Path.DirectorySeparatorChar),
+                                   StringComparison.Ordinal));
+            Assert.True(shimIdx >= 0,
+                "the AL_RUNNER_DOTNET_SHIMS directory did not reach the probing paths: " +
+                string.Join(", ", paths));
+            Assert.Equal(0, shimIdx);
+
+            var tierIdx = paths.FindIndex(
+                p => string.Equals(Path.GetFullPath(p).TrimEnd(Path.DirectorySeparatorChar),
+                                   Path.GetFullPath(BcCompiler.DefaultServiceTierDir)
+                                       .TrimEnd(Path.DirectorySeparatorChar),
+                                   StringComparison.Ordinal));
+            if (tierIdx >= 0)
+                Assert.True(shimIdx < tierIdx,
+                    $"shim dir at {shimIdx} must precede the service tier at {tierIdx}; " +
+                    "the tier ships the copy that does not bind.");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AL_RUNNER_DOTNET_SHIMS", null);
+            try { probeDir.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    /// <summary>
+    /// The override takes several paths, and a non-existent one is dropped rather than handed to
+    /// BC's AssemblyLocator. Negative direction: an empty or unset override contributes nothing,
+    /// so the default staged directory is the only shim source.
+    /// </summary>
+    [Fact]
+    public void OverrideAcceptsSeveralPathsAndUnsetContributesNone()
+    {
+        var a = Directory.CreateTempSubdirectory("al-runner-shim-a-");
+        var b = Directory.CreateTempSubdirectory("al-runner-shim-b-");
+        var missing = Path.Combine(Path.GetTempPath(), "al-runner-shim-absent-" + Guid.NewGuid());
+        try
+        {
+            Environment.SetEnvironmentVariable(
+                "AL_RUNNER_DOTNET_SHIMS",
+                string.Join(Path.PathSeparator, a.FullName, missing, b.FullName));
+
+            var yielded = ShimDirs().Select(p => p.TrimEnd(Path.DirectorySeparatorChar)).ToList();
+            Assert.Equal(a.FullName.TrimEnd(Path.DirectorySeparatorChar), yielded[0]);
+            Assert.Equal(missing.TrimEnd(Path.DirectorySeparatorChar), yielded[1]);
+            Assert.Equal(b.FullName.TrimEnd(Path.DirectorySeparatorChar), yielded[2]);
+
+            // The enumeration yields candidates; the caller filters. A directory that does not
+            // exist must not reach the assembled probing paths.
+            var paths = InvokeProbingPaths().Select(Path.GetFullPath).ToList();
+            Assert.Contains(Path.GetFullPath(a.FullName), paths);
+            Assert.Contains(Path.GetFullPath(b.FullName), paths);
+            Assert.DoesNotContain(Path.GetFullPath(missing), paths);
+
+            Environment.SetEnvironmentVariable("AL_RUNNER_DOTNET_SHIMS", "");
+            var defaults = ShimDirs();
+            Assert.DoesNotContain(a.FullName.TrimEnd(Path.DirectorySeparatorChar),
+                defaults.Select(p => p.TrimEnd(Path.DirectorySeparatorChar)));
+            Assert.All(defaults, p => Assert.Equal("dotnet-shims", Path.GetFileName(p)));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AL_RUNNER_DOTNET_SHIMS", null);
+            try { a.Delete(recursive: true); } catch { /* best effort */ }
+            try { b.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    /// <summary>
+    /// Rebuilds the probing list the same way <c>GetOrCreateDotNetFactory</c> does. That method
+    /// memoises its factory in a static, so calling it twice in one process cannot show a change
+    /// of environment — this mirrors its path instead of caching an answer the test then cannot
+    /// re-measure.
+    /// </summary>
+    private static List<string> InvokeProbingPaths()
+    {
+        var paths = new List<string>();
+        foreach (var d in ShimDirs())
+            if (Directory.Exists(d)) paths.Add(d);
+
+        var refDirs = (IEnumerable<string>)typeof(BcCompiler)
+            .GetMethod("EnumerateDotNetRefAssemblyDirs", BindingFlags.NonPublic | BindingFlags.Static)!
+            .Invoke(null, null)!;
+        foreach (var d in refDirs)
+            if (Directory.Exists(d)) paths.Add(d);
+
+        if (Directory.Exists(BcCompiler.DefaultServiceTierDir))
+            paths.Add(BcCompiler.DefaultServiceTierDir);
+        return paths;
+    }
+}

--- a/AlRunner.Tests/ScratchDirOwnershipGuardTests.cs
+++ b/AlRunner.Tests/ScratchDirOwnershipGuardTests.cs
@@ -72,6 +72,11 @@ public sealed class ScratchDirOwnershipGuardTests
               + "asserts on the absence itself, so creating it would destroy what it measures. "
               + "Was 2 until #3748 deleted HasCompilableSource, whose miss path was the other. "
               + "This file's real scratch packages ARE owned via TestScratch.FilePath"),
+        ["DotNetShimProbingTests.cs"] =
+            (1, "one shim directory that must not exist, proving an absent override path never "
+              + "reaches the probing paths; the assertion measures that absence, so reserving "
+              + "it would create the parent and place a sidecar beside it. This file's four "
+              + "real directories ARE owned, via TestScratch.Dir plus an explicit create"),
         ["RunnerFingerprintTests.cs"] =
             (1, "a .dll path that must not exist"),
         ["TestDataProvisioningTests.cs"] =

--- a/AlRunner/AlRunner.csproj
+++ b/AlRunner/AlRunner.csproj
@@ -196,8 +196,6 @@
              Pack="true" PackagePath="tools/$(TargetFramework)/any/dotnet-shims/" />
   </ItemGroup>
 
-
-
   <!-- Per-BC-minor engine variants (#2024 item 3 / #2027). This binary is only ONE
        engine build (whichever _BCVersion it was compiled with); EngineVariants.cs +
        NclShadowRuntime pick and swap to the matching one at startup among whatever

--- a/AlRunner/AlRunner.csproj
+++ b/AlRunner/AlRunner.csproj
@@ -160,6 +160,44 @@
     <None Include="../CHANGELOG.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 
+  <!-- .NET assemblies BC's AL BINDER must see before the service tier's own copies, staged
+       into a dotnet-shims directory that BcCompiler puts at the head of its DotNet probing
+       paths (GetOrCreateDotNetFactory). Compile-time reference resolution only: the file is
+       never loaded into the runner's own load chain, so nothing here can perturb the BC
+       engine bind.
+
+       Today that is one file, and it earns its place. System Application's
+       SamplingPerfProfilerImpl calls JsonSerializer.Deserialize(TextReader, Type). The service
+       tier ships only the net6.0 build of Newtonsoft.Json, whose TextReader parameter is typed
+       against System.Runtime 6.0.0.0; no .NET 6 reference assemblies exist on a net8 box, so
+       that parameter type never resolves and the call raises AL0133. Emit is atomic per module,
+       so that one unresolvable reference cost all 1,319 of System Application's objects (#3745).
+       The netstandard2.0 build of the SAME Newtonsoft version binds against netstandard, which
+       does resolve.
+
+       ExcludeAssets="all": referenced for its FILE, never linked. A package reference rather
+       than a path into ~/.nuget so a CI leg's success does not depend on what happened to be
+       cached on the machine — the same choice tools/metadata-ground-truth makes, and this
+       shim is the one its CopyDotNetShims target proved out. -->
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3"
+                      GeneratePathProperty="true" ExcludeAssets="all" PrivateAssets="all" />
+  </ItemGroup>
+
+  <!-- Staged as CONTENT rather than by a bare <Copy>, so the shim travels with al-runner.dll
+       into every output that references this project — AlRunner.Tests' output above all, where
+       the assembly is copied and its probing paths are therefore resolved. A plain copy into
+       $(OutDir) puts the file beside the runner's OWN build only, and a referencing project
+       then loads a BcCompiler whose shim directory does not exist. -->
+  <ItemGroup Condition="'$(PkgNewtonsoft_Json)' != ''">
+    <Content Include="$(PkgNewtonsoft_Json)/lib/netstandard2.0/Newtonsoft.Json.dll"
+             Link="dotnet-shims/Newtonsoft.Json.dll"
+             CopyToOutputDirectory="PreserveNewest"
+             Pack="true" PackagePath="tools/$(TargetFramework)/any/dotnet-shims/" />
+  </ItemGroup>
+
+
+
   <!-- Per-BC-minor engine variants (#2024 item 3 / #2027). This binary is only ONE
        engine build (whichever _BCVersion it was compiled with); EngineVariants.cs +
        NclShadowRuntime pick and swap to the matching one at startup among whatever

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -522,29 +522,7 @@ public sealed partial class BcCompiler
             // ref pack) carry the same types as real TypeDefinitions, so probe those FIRST.
             // This is what lets the source-dependency compile of Microsoft's Tests-TestLibraries
             // (XmlDocument/XmlNode/etc. interop) emit instead of zeroing the whole module.
-            var probingPaths = new List<string>();
-            // Shims staged beside the binary by AlRunner.csproj's CopyDotNetShims target, ahead
-            // of everything: a shim exists precisely because the service tier's own copy of that
-            // assembly does not bind, so probing the tier first would defeat it. See the csproj
-            // for what is in the directory and why each file is there (#3745).
-            foreach (var shimDir in EnumerateDotNetShimDirs())
-                if (Directory.Exists(shimDir))
-                    probingPaths.Add(shimDir);
-            foreach (var refDir in EnumerateDotNetRefAssemblyDirs())
-                if (Directory.Exists(refDir))
-                    probingPaths.Add(refDir);
-            // BC service-tier artifacts dir (BC's own .NET deps such as Aspose, Azure SDK,
-            // BouncyCastle etc. shipped alongside Ncl.dll, plus PermissionTestHelper add-in).
-            if (Directory.Exists(DefaultServiceTierDir))
-                probingPaths.Add(DefaultServiceTierDir);
-            foreach (var addinDir in EnumerateServiceTierAddinDirs())
-                if (Directory.Exists(addinDir))
-                    probingPaths.Add(addinDir);
-            // BCL: where mscorlib / System.* lives (shared framework) — last-resort
-            // fallback for assemblies with no reference-assembly counterpart.
-            var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
-            if (Directory.Exists(runtimeDir))
-                probingPaths.Add(runtimeDir);
+            var probingPaths = BuildDotNetProbingPaths();
 
             if (Environment.GetEnvironmentVariable("BCCOMPILER_DIAG") == "1")
                 Console.Error.WriteLine(
@@ -568,6 +546,75 @@ public sealed partial class BcCompiler
     /// single-file or shadow-copied host makes those differ, and the shim ships beside the
     /// assembly.</para>
     /// </summary>
+    /// <summary>
+    /// The DotNet probing paths BC's <c>AssemblyLocator</c> is given, in priority order. BC's
+    /// DotNet metadata reader resolves a <c>DotNet "Type"</c> alias by loading the named
+    /// assembly and looking the type up as a <b>TypeDefinition</b>; it does NOT follow
+    /// type-forwarders. So the order below is the whole behaviour, and each step earns its
+    /// position:
+    ///
+    /// <list type="number">
+    /// <item>staged <b>shims</b> — an assembly whose service-tier copy is known not to bind.
+    ///   These must come first, because probing the tier ahead of them finds that copy again
+    ///   and the shim does nothing (#3745).</item>
+    /// <item>.NET <b>reference packs</b> — real TypeDefinitions rather than the forwarder
+    ///   facades the shared framework ships, so <c>DotNet "System.Xml.XmlException"</c> binds
+    ///   instead of yielding NavTypeKind.None and crashing the emit.</item>
+    /// <item>the <b>service tier</b> and its add-ins — BC's own .NET dependencies.</item>
+    /// <item>the <b>shared framework</b>, last — a fallback for assemblies with no
+    ///   reference-assembly counterpart.</item>
+    /// </list>
+    ///
+    /// <para>Extracted from <see cref="GetOrCreateDotNetFactory"/> so a test can assert the
+    /// real ordering. It previously read a list the test rebuilt itself, which passed
+    /// unchanged when the production order was inverted — a test of its own copy.</para>
+    /// </summary>
+    internal static List<string> BuildDotNetProbingPaths()
+    {
+        var probingPaths = new List<string>();
+        // Shims staged beside the binary by AlRunner.csproj's CopyDotNetShims target, ahead
+        // of everything: a shim exists precisely because the service tier's own copy of that
+        // assembly does not bind, so probing the tier first would defeat it. See the csproj
+        // for what is in the directory and why each file is there (#3745).
+        // Deduplicated: the runner shadow-copies its own directory before re-exec, so
+        // AppContext.BaseDirectory and the assembly's directory are usually the SAME path
+        // and a plain append listed it twice.
+        var seenShims = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var shimDir in EnumerateDotNetShimDirs())
+            if (Directory.Exists(shimDir) && seenShims.Add(NormalizeDir(shimDir)))
+                probingPaths.Add(shimDir);
+        foreach (var refDir in EnumerateDotNetRefAssemblyDirs())
+            if (Directory.Exists(refDir))
+                probingPaths.Add(refDir);
+        // BC service-tier artifacts dir (BC's own .NET deps such as Aspose, Azure SDK,
+        // BouncyCastle etc. shipped alongside Ncl.dll, plus PermissionTestHelper add-in).
+        if (Directory.Exists(DefaultServiceTierDir))
+            probingPaths.Add(DefaultServiceTierDir);
+        foreach (var addinDir in EnumerateServiceTierAddinDirs())
+            if (Directory.Exists(addinDir))
+                probingPaths.Add(addinDir);
+        // BCL: where mscorlib / System.* lives (shared framework) — last-resort
+        // fallback for assemblies with no reference-assembly counterpart.
+        var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        if (Directory.Exists(runtimeDir))
+            probingPaths.Add(runtimeDir);
+
+        if (Environment.GetEnvironmentVariable("BCCOMPILER_DIAG") == "1")
+            Console.Error.WriteLine(
+                "[BcCompiler-diag] DotNet probing paths:\n  " + string.Join("\n  ", probingPaths));
+
+        return probingPaths;
+    }
+
+    /// <summary>
+    /// A comparison key for a directory path: absolute, with any trailing separator removed.
+    /// The trailing separator is the part that matters — the shadow-copy path and the
+    /// assembly-location path for the same directory differ by exactly that, and
+    /// <see cref="Path.GetFullPath(string)"/> preserves it, so it alone does not collapse them.
+    /// </summary>
+    private static string NormalizeDir(string path)
+        => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
     private static IEnumerable<string> EnumerateDotNetShimDirs()
     {
         var overridePaths = Environment.GetEnvironmentVariable("AL_RUNNER_DOTNET_SHIMS");

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -535,18 +535,6 @@ public sealed partial class BcCompiler
     }
 
     /// <summary>
-    /// Directories holding .NET assemblies BC's AL binder must prefer over the service tier's
-    /// own copies. Staged next to the binary by <c>AlRunner.csproj</c>'s <c>CopyDotNetShims</c>
-    /// target, and overridable with <c>AL_RUNNER_DOTNET_SHIMS</c> (one path, or several
-    /// separated by the platform path separator) so a run can point at a different set without
-    /// a rebuild.
-    ///
-    /// <para>Yields candidates whether or not they exist; the caller filters. Both the
-    /// AppContext base directory and the assembly's own directory are probed because a
-    /// single-file or shadow-copied host makes those differ, and the shim ships beside the
-    /// assembly.</para>
-    /// </summary>
-    /// <summary>
     /// The DotNet probing paths BC's <c>AssemblyLocator</c> is given, in priority order. BC's
     /// DotNet metadata reader resolves a <c>DotNet "Type"</c> alias by loading the named
     /// assembly and looking the type up as a <b>TypeDefinition</b>; it does NOT follow
@@ -615,6 +603,18 @@ public sealed partial class BcCompiler
     private static string NormalizeDir(string path)
         => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
+    /// <summary>
+    /// Directories holding .NET assemblies BC's AL binder must prefer over the service tier's
+    /// own copies. Staged next to the binary by <c>AlRunner.csproj</c>'s <c>CopyDotNetShims</c>
+    /// target, and overridable with <c>AL_RUNNER_DOTNET_SHIMS</c> (one path, or several
+    /// separated by the platform path separator) so a run can point at a different set without
+    /// a rebuild.
+    ///
+    /// <para>Yields candidates whether or not they exist; the caller filters. Both the
+    /// AppContext base directory and the assembly's own directory are probed because a
+    /// single-file or shadow-copied host makes those differ, and the shim ships beside the
+    /// assembly.</para>
+    /// </summary>
     private static IEnumerable<string> EnumerateDotNetShimDirs()
     {
         var overridePaths = Environment.GetEnvironmentVariable("AL_RUNNER_DOTNET_SHIMS");

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -523,6 +523,13 @@ public sealed partial class BcCompiler
             // This is what lets the source-dependency compile of Microsoft's Tests-TestLibraries
             // (XmlDocument/XmlNode/etc. interop) emit instead of zeroing the whole module.
             var probingPaths = new List<string>();
+            // Shims staged beside the binary by AlRunner.csproj's CopyDotNetShims target, ahead
+            // of everything: a shim exists precisely because the service tier's own copy of that
+            // assembly does not bind, so probing the tier first would defeat it. See the csproj
+            // for what is in the directory and why each file is there (#3745).
+            foreach (var shimDir in EnumerateDotNetShimDirs())
+                if (Directory.Exists(shimDir))
+                    probingPaths.Add(shimDir);
             foreach (var refDir in EnumerateDotNetRefAssemblyDirs())
                 if (Directory.Exists(refDir))
                     probingPaths.Add(refDir);
@@ -547,6 +554,32 @@ public sealed partial class BcCompiler
             _dotNetResolverFactory = new NavDotNet.DotNetResolverFactory(locator);
             return _dotNetResolverFactory;
         }
+    }
+
+    /// <summary>
+    /// Directories holding .NET assemblies BC's AL binder must prefer over the service tier's
+    /// own copies. Staged next to the binary by <c>AlRunner.csproj</c>'s <c>CopyDotNetShims</c>
+    /// target, and overridable with <c>AL_RUNNER_DOTNET_SHIMS</c> (one path, or several
+    /// separated by the platform path separator) so a run can point at a different set without
+    /// a rebuild.
+    ///
+    /// <para>Yields candidates whether or not they exist; the caller filters. Both the
+    /// AppContext base directory and the assembly's own directory are probed because a
+    /// single-file or shadow-copied host makes those differ, and the shim ships beside the
+    /// assembly.</para>
+    /// </summary>
+    private static IEnumerable<string> EnumerateDotNetShimDirs()
+    {
+        var overridePaths = Environment.GetEnvironmentVariable("AL_RUNNER_DOTNET_SHIMS");
+        if (!string.IsNullOrEmpty(overridePaths))
+            foreach (var p in overridePaths.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+                yield return p;
+
+        yield return Path.Combine(AppContext.BaseDirectory, "dotnet-shims");
+
+        var asmDir = Path.GetDirectoryName(typeof(BcCompiler).Assembly.Location);
+        if (!string.IsNullOrEmpty(asmDir))
+            yield return Path.Combine(asmDir, "dotnet-shims");
     }
 
     /// <summary>

--- a/AlRunner/DependencyMetadataProducer.cs
+++ b/AlRunner/DependencyMetadataProducer.cs
@@ -45,16 +45,18 @@
 //   replayed on every later run. Business Foundation (96 AL files): ~6.2 s cold, 55 documents.
 //
 //   Emit is atomic per module, so one object BC cannot emit yields ZERO documents for the whole
-//   app rather than a partial result. System Application hits exactly that — BadExpression on
-//   `Business Chart.Initialize()` under the runner's .NET probing paths — which is why
-//   AL_RUNNER_DEP_METADATA_FROM_BC takes app NAMES and not just "on". #3745 is that blocker;
-//   the same app compiles clean in tools/metadata-ground-truth/, which ships .NET reference
-//   shims the runner's probing paths do not.
+//   app rather than a partial result. System Application hit exactly that until #3745: the
+//   service tier ships only the net6.0 Newtonsoft.Json, one System Application call against it
+//   raised AL0133, and all 1,319 files produced nothing. AlRunner.csproj now stages the
+//   netstandard2.0 build into dotnet-shims and BcCompiler probes it ahead of the tier; the app
+//   produces 1,218 documents in ~11-13 s (docs/dependency-metadata-from-bc.md).
 //
 // NOT BASE APPLICATION
 //   Base Application ships 8,025 AL files and is deliberately excluded. Its emit needs a
 //   PublicKeyToken=null copy of Microsoft.AspNetCore.StaticFiles that no BC artifact ships,
 //   and without it the emitter produces ZERO objects — a hard blocker, not a cost question.
+//   #3745's shim does NOT reach it: that is a different assembly, absent from the artifacts
+//   entirely rather than present in a build that does not bind.
 //   tests/expectations/metadata-equivalence/apps.json records the same exclusion for the same
 //   reason. EmitProducedNothing below is what turns that into a loud failure rather than an
 //   empty cache entry that would read as "this app has no metadata".

--- a/docs/dependency-metadata-from-bc.md
+++ b/docs/dependency-metadata-from-bc.md
@@ -43,28 +43,54 @@ the entire app, not a partial result. Measured per app:
 | app | `.al` files | outcome | documents |
 |---|---|---|---|
 | Business Foundation | 96 | clean, 6.0–6.2 s | **55** (11 tables, 16 codeunits, 13 permission sets, 9 pages, 5 tableextensions, 1 enum) |
-| System Application | 1,319 | **`BadExpression` while emitting `Codeunit System.Visualization."Business Chart"::Initialize()`** | **0** |
+| System Application | 1,319 | clean since #3745, 10.9–13.1 s | **1,218** (138 tables, 533 codeunits, 224 pages, 164 permission sets, 142 enums, 7 queries, 5 runtime deltas, 4 xmlports, 1 report) |
 | Base Application | 8,025 | not attempted — see below | — |
 
-So the feature is **opt-in and per-app**, `AL_RUNNER_DEP_METADATA_FROM_BC`:
+The feature stays **opt-in**, `AL_RUNNER_DEP_METADATA_FROM_BC` — the cost of the first compile
+per (app, BC version) is real even though it is paid once:
 
 - unset / `0` — off. Byte-identical to the behaviour before #3549; verified as a regression arm.
 - `1` — every source-shipping dependency.
 - `Business Foundation` (comma-separated names) — exactly those apps.
 
-Naming the app is the difference between a dependency whose metadata is BC's own and a run that
-refuses to start. #3745 tracks removing the need for it.
+Since #3745 both source-shipping Microsoft apps the runner compiles — Business Foundation and
+System Application — succeed, so `1` no longer means "a run that refuses to start"; naming apps
+individually is now a cost choice rather than a way around a blocker.
 
-### System Application: a .NET reference the runner does not resolve
+### System Application: fixed in #3745 by staging the shim the ground truth already used
 
-The failure is not in the AL. `tools/metadata-ground-truth/` compiles the same app cleanly
-(1,218 documents in 14.5 s) because it ships **dedicated .NET reference-pack shims** and puts
-them at the head of BC's probing paths — its `CopyDotNetShims` target explains the one it needs
-today, and names this exact shape as "the same shape as the Base Application blocker in #3549".
-`BcCompiler`'s probing paths differ, the DotNet declaration does not bind, and the unbound
-expression reaches the emitter as `BadExpression`.
+The failure was never in the AL. `tools/metadata-ground-truth/` compiled the same app cleanly
+because it ships a **.NET reference shim** at the head of BC's probing paths; `BcCompiler` did
+not, so one DotNet declaration failed to bind and `Emit`'s per-module atomicity turned that into
+zero documents for all 1,319 files.
 
-That is a compile-configuration difference, not a metadata problem, and it is #3745.
+**The specific assembly, measured rather than inferred.** System Application's
+`SamplingPerfProfilerImpl` calls `JsonSerializer.Deserialize(TextReader, Type)`. The service tier
+ships only the **net6.0** build of `Newtonsoft.Json`, whose `TextReader` parameter is typed
+against `System.Runtime 6.0.0.0`; no .NET 6 reference assemblies exist on a net8 box, so that
+parameter type never resolves and the call raises **AL0133**. The **netstandard2.0** build of the
+same Newtonsoft version binds against netstandard, which does resolve.
+
+How it was isolated, on BC 28.1.49838: removing the shim directory from the ground-truth tool —
+the only change — took it from `success=True objects=1218 errors=0` to
+`success=False objects=0 errors=1` with that AL0133 named. Three other candidate differences
+were tested and **ruled out**: the `System.app` version (28.0.53872.0 vs the 28.0.54265.0 the
+runner resolves — 1,218 objects either way), the package's resources (stripping `addin/` gives
+62 × AL0327, a different signature), and the DotNet probing *order*, which already matched.
+
+`AlRunner.csproj` now stages that shim into a `dotnet-shims` directory as build **content**, so
+it travels with `al-runner.dll` into every output that references the project, and
+`BcCompiler.BuildDotNetProbingPaths` probes it **first** — ahead of the service tier, which is
+load-bearing, because the tier is where the copy that does not bind lives.
+
+**The 23 AL0185 "is missing" declaration errors this used to report were a consequence, not a
+cause.** With the shim in place they become 62 × AL0327 for control-add-in resources the
+producer's work directory does not carry, which are non-fatal: the emit produces all 1,218
+documents anyway.
+
+Note what this does **not** fix: Base Application's blocker is a different assembly
+(`Microsoft.AspNetCore.StaticFiles` with `PublicKeyToken=null`, which no BC artifact ships at
+all — verified absent from the 28.1 artifacts) and it remains excluded.
 
 ### Base Application: a hard blocker, not a cost question
 


### PR DESCRIPTION
Closes #3745

Corpus-NA: the change decides which .NET assembly BC's compiler binds a DotNet parameter type from while compiling a Microsoft dependency's shipped source for metadata; a corpus test compiles and runs its own app and cannot observe which assembly a dependency's metadata compile resolved against

Filed and implemented by an agent (`agent: stma-auto-12`).

## What was wrong

`BcCompiler.Emit` over **System Application**'s own AL source produced **0 metadata documents for all 1,319 source files**. `Compilation.Emit` is atomic per module, so one unbindable reference costs the whole app rather than one object.

**The specific assembly, measured.** System Application's `SamplingPerfProfilerImpl` calls `JsonSerializer.Deserialize(TextReader, Type)`. The service tier ships only the **net6.0** build of `Newtonsoft.Json`, whose `TextReader` parameter is typed against `System.Runtime 6.0.0.0`. No .NET 6 reference assemblies exist on a net8 box, so that parameter type never resolves and the call raises **AL0133**. The **netstandard2.0** build of the same Newtonsoft version binds against netstandard, which does resolve.

## The issue's own diagnosis was close but not right, and that matters

The issue attributes the failure to the **probing-path order** and reports `BadExpression` on `Codeunit System.Visualization."Business Chart"::Initialize()`. Neither survived measurement:

- **The order already matched.** `BcCompiler` and `tools/metadata-ground-truth/` both do ref-packs → service tier → add-ins → shared framework last. The ground truth's advantage was one thing the runner lacked entirely: a `dotnet-shims` directory holding an assembly the tier's own copy cannot supply.
- **`Business Chart` was not the failing object** on the build I measured. The runner reported 12 emit crashes (`NavTypeKind.None`, `IndexOutOfRange`, one `BadExpression` on `Retention Policy Setup`) plus 23 `AL0185` declaration errors. `Business Chart` appeared in none of them.

## How it was isolated — one variable at a time

`tools/metadata-ground-truth/` compiles the same app, from the same package, on the same box: `[emit] success=True objects=1218 errors=0`. Removing **only** its `dotnet-shims` directory:

```
[emit] 4287ms success=False objects=0 errors=1
   [AL0133] x1 :: Argument 1: cannot convert from 'DotNet "System.IO.StreamReader"'
                  to 'DotNet "Newtonsoft.Json.JsonReader"'
                  @ .../Performance Profiler/src/SamplingPerfProfilerImpl.Codeunit.al@117:50
```

Three other candidate differences were tested and **ruled out** — each is a negative result that would otherwise have looked like a plausible cause:

| candidate | test | verdict |
|---|---|---|
| `System.app` version (runner resolves 28.0.**54265**.0, ground truth 28.0.**53872**.0) | ran the ground truth with the runner's newer copy | **not it** — 1,218 objects either way |
| package resources absent from the producer's work dir | stripped `addin/` + `resources/` from the package | **not it** — 62 × AL0327, a different signature |
| DotNet probing order | compared both lists | **not it** — already identical |

**The 23 AL0185 "is missing" errors were a consequence, not a cause.** All the "missing" objects are declared in files that are present and correctly written to the work directory (verified: `sources=1319 writtenAl=1319`, each named file found). With the shim in place they become 62 × AL0327 for control-add-in resources — non-fatal, and the emit produces all 1,218 documents anyway. Chasing them as the cause is the wrong turn this PR body exists to save the next reader.

## The fix

- **`AlRunner.csproj`** stages the netstandard2.0 `Newtonsoft.Json` into `dotnet-shims` as build **content**, so it travels with `al-runner.dll` into every referencing output and into the tool package. A `PackageReference` with `ExcludeAssets="all"` — referenced for its file, never linked — so a CI leg does not depend on what happened to be cached on the box. This is the pattern `tools/metadata-ground-truth/`'s `CopyDotNetShims` already proved.
- **`BcCompiler`** probes shim directories **first**, ahead of the service tier. That ordering is the fix, not a detail: the tier is exactly where the copy that does not bind lives.
- `AL_RUNNER_DOTNET_SHIMS` overrides the directory set without a rebuild.

The shim is compile-time **reference resolution** only — it never enters the runner's own load chain, and it is not an implementation of anything BC ships.

## RED → GREEN

`AlRunner.Tests/DotNetShimProbingTests.cs`, 5 tests. Per `bc-behavior-tests-go-upstream.md` this is a runner-mechanism claim, and per the `require-tests` gate it is a runner-side test.

- **RED** (fix reverted): `Failed: 4, Passed: 0, Skipped: 0, Total: 4`
- **GREEN**: `Failed: 0, Passed: 5, Skipped: 0, Total: 5`
- **End to end, no env override, shipped configuration**: `EXIT=0`, `captured=1218`, `[dep-metadata] WROTE System Application v28.1.49838.54308 — 1218 document(s), 13140ms` — matching the ground truth's 1,218 exactly. Before: `FATAL ... METADATA-EMIT-ZERO`.

### A test that passed while measuring nothing, caught by mutation

The first version of the ordering test **rebuilt** the probing list from the same two enumerations instead of reading production's. Mutating `BcCompiler` to append shims *after* the service tier — the exact defect the test exists to catch — left all 5 tests green. Fixed by extracting `BuildDotNetProbingPaths()` and having the test call it.

Every assertion mutation-checked afterwards; each is caught by exactly one test, with the other four still passing:

| mutation | result |
|---|---|
| shims probed after the service tier | `OrderPutsShimsAheadOfTheServiceTier` fails |
| csproj staging removed | `BuildStagesTheNewtonsoftNetstandardShimBesideTheRunnerBinary` fails |
| **net6.0** build staged instead of netstandard2.0 | same test fails — a no-op wearing the shape of a fix |

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** No. `BuildDotNetProbingPaths` is now the single place the list is built; the three other `AddReferences` sites in `BcCompiler` share it through `GetOrCreateDotNetFactory`.
2. **Sibling making the same assumption?** Yes, and fixed: the runner **shadow-copies its own directory** before re-exec, so `AppContext.BaseDirectory` and the assembly's directory can differ (under the test host) or coincide (in a real run). The enumeration yields both and now **deduplicates** — the first real run printed the shadow directory on two consecutive lines. Normalizing on `Path.GetFullPath` alone was not enough; the trailing separator is what differs, which a test caught.
3. **Two paths writing the same state with different invariants?** The staging was originally a bare `<Copy>` into `$(OutDir)`, which reached the runner's own build but **not** `AlRunner.Tests`' output, where `al-runner.dll` is copied and its probing paths are therefore resolved. Build content fixes both from one declaration.

## What this does NOT fix

**Base Application is unchanged and still excluded.** Its blocker is a different assembly — `Microsoft.AspNetCore.StaticFiles` with `PublicKeyToken=null`, which no BC artifact ships **at all** (verified absent from the 28.1 artifacts, unlike Newtonsoft, which is present in a build that does not bind). `tests/expectations/metadata-equivalence/apps.json` keeps recording that, correctly.

## Queue scan

Searched open issues on the symbol (`BcCompiler`, probing, Newtonsoft), the observable (zero objects, 1,319 files, AL0133) and the mechanism (atomic emit, unbound DotNet declaration). **No duplicate.** The nearby `#3568`/`#3788`/`#3798`/`#3806`/`#3808` family is about the *`SymbolReference` derivation* — a different file and mechanism. This PR shrinks that family's territory for System Application by giving BC's own document instead of a derivation, but fixes none of them and closes none of them.

## Measurement notes

- BC **28.1.49838** (engine `28.1.49838.53910`, packages `28.1.49838.54308`), `TZ=UTC`.
- Targeted suite, engine bootstrapped via `tools/engine-test-bootstrap.sh` so nothing skipped silently: `dotnet test AlRunner.Tests -c Release --settings engine.runsettings --filter "FullyQualifiedName~BcCompiler|FullyQualifiedName~DotNet|FullyQualifiedName~DependencyMetadataProducer|FullyQualifiedName~NavDotNetPatches"` → **`Failed: 0, Passed: 120, Skipped: 0, Total: 120`**. Unbootstrapped, the same filter reports `Passed: 80, Skipped: 40` — the skip count is quoted because a skipped-everything run looks like a passing one.
- Built against **27.0** (`-p:_BCVersion=27.0.38460.53934`) as well as the local 28.1 default: clean, and the shim stages there too. The change references no BC type — MSBuild plus `System.IO` — so it carries no version-specific surface.
- `tools/test_doc_pointers.py` and `tools/test_matrix_docs_drift.py`: both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
