### PR TITLE
fix(coverage): measure the file preamble over every object, not just the mapped ones

### DIFF
--- a/AlRunner.Tests/CoverageMultiObjectFileTests.cs
+++ b/AlRunner.Tests/CoverageMultiObjectFileTests.cs
@@ -332,6 +332,77 @@ public sealed class CoverageMultiObjectFileTests : IDisposable
     }
 
     /// <summary>
+    /// #3822: the origin is measured from the first SUPPORTED object, and LabelOf maps only
+    /// seven top-level kinds. An `interface` is not one of them, so a file that opens with one
+    /// leaves the following codeunit as the first entry in the parsed list and gives it offset
+    /// 0 — while BC, which excludes other OBJECTS from an object's text but keeps the file
+    /// preamble, would have measured it from after the interface.
+    ///
+    /// The executed statement sits on file line 10. If the offset is wrong the report says 5.
+    /// </summary>
+    [SkippableFact]
+    public void Coverage_FileOpeningWithAnUnmappedObject_ReportsFileLines()
+    {
+        TestArtifacts.SkipIfMissing();
+        var bundle = Path.Combine(_root, "bundle-unmapped-first");
+        Directory.CreateDirectory(bundle);
+        File.WriteAllText(Path.Combine(bundle, "app.json"), """
+        {
+          "id": "5a3f0b11-3822-4a0a-800a-000000003822",
+          "name": "CMOF Unmapped First Probe",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 63670, "to": 63689 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(bundle, "Two.Codeunit.al"), string.Join("\n", new[]
+        {
+            "interface \"Edge Iface\"",        // 1  NOT mapped by LabelOf
+            "{",                               // 2
+            "    procedure Ping(): Integer;",  // 3
+            "}",                               // 4
+            "",                                // 5
+            "codeunit 63670 \"Edge D\"",       // 6
+            "{",                               // 7
+            "    procedure D(): Integer",      // 8
+            "    begin",                       // 9
+            "        exit(4);",                // 10  called once
+            "    end;",                        // 11
+            "}",                               // 12
+            "",
+        }));
+        File.WriteAllText(Path.Combine(bundle, "T.Codeunit.al"), """
+        codeunit 63680 "Edge Unmapped Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure CallsD()
+            var
+                D: Codeunit "Edge D";
+            begin
+                if D.D() <> 4 then
+                    Error('D');
+            end;
+        }
+        """);
+
+        var coveragePath = Path.Combine(_root, "cobertura-unmapped.xml");
+        var (output, exit) = Spawn(bundle, "--coverage", $"--coverage-out \"{coveragePath}\"");
+
+        Assert.Equal(0, exit);
+        Assert.True(File.Exists(coveragePath), $"cobertura.xml was not written.\n{output}");
+        var doc = XDocument.Load(coveragePath);
+        var lines = LinesOf(ClassFor(doc, "Two.Codeunit.al"));
+
+        Assert.Equal(new[] { 10 }, lines.Keys.OrderBy(k => k).ToArray());
+        Assert.Equal(1, lines[10]);
+    }
+
+    /// <summary>
     /// Every shape that could move the origin, in one file: a UTF-8 BOM, CRLF line endings, two
     /// header comment lines, a file-scoped `namespace`, a `using`, a comment between objects, an
     /// indented declaration keyword, and a third object with no blank line before it. The

--- a/AlRunner.Tests/CoverageMultiObjectFileTests.cs
+++ b/AlRunner.Tests/CoverageMultiObjectFileTests.cs
@@ -403,6 +403,40 @@ public sealed class CoverageMultiObjectFileTests : IDisposable
     }
 
     /// <summary>
+    /// #3822 review: the two end-to-end probes both use an `interface`, so an implementation
+    /// that special-cased interfaces — or grew an "origin-capable kinds" allowlist — would
+    /// pass them and still be wrong for every other unmapped kind. The invariant is that
+    /// EVERY entry in <c>root.Objects</c> participates in the origin regardless of whether it
+    /// can become a map entry, and this pins it across kinds rather than for one.
+    ///
+    /// Map-level rather than end-to-end on purpose: it costs a parse instead of a runner
+    /// spawn, so covering several kinds is cheap. The end-to-end facts above are what prove
+    /// the offset is the one BC's spans actually need.
+    ///
+    /// Each case is the same file with a different leading unmapped object, sized so the
+    /// mapped codeunit's FullSpan begins on 0-based line 6 — the blank line before its
+    /// declaration, which is its own leading trivia.
+    /// </summary>
+    [SkippableTheory]
+    [InlineData("interface \"Probe Iface\"\n{\n    procedure Ping(): Integer;\n}")]
+    [InlineData("controladdin \"Probe Addin\"\n{\n    StartupScript = 'a.js';\n}")]
+    [InlineData("permissionset 63699 \"Probe Perms\"\n{\n    Assignable = true;\n}")]
+    public void Build_AnyUnmappedLeadingObject_CountsTowardTheOrigin(string leading)
+    {
+        RequireEngine();
+        var text = leading + "\n\ncodeunit 63690 \"Probe After\"\n{\n    procedure P(): Integer\n"
+                 + "    begin\n        exit(1);\n    end;\n}\n";
+        File.WriteAllText(Path.Combine(_root, "Lead.Codeunit.al"), text);
+
+        var map = AlCoverageSourceMap.Build(new[] { _root }, relativeTo: _root);
+
+        // The leading object occupies four lines, so the codeunit's FullSpan starts on the
+        // blank 0-based line 4 and the preamble is empty: offset 4. Under the pre-fix rule
+        // the codeunit was its own origin and this was 0, whatever the leading kind.
+        Assert.Equal(4, map.LineOffset("CodeUnit", 63690));
+    }
+
+    /// <summary>
     /// #3822, the shape that stresses both halves of the origin rule at once: a REAL preamble
     /// (header comment, namespace, using) AND an unmapped object in front of the mapped one.
     ///

--- a/AlRunner.Tests/CoverageMultiObjectFileTests.cs
+++ b/AlRunner.Tests/CoverageMultiObjectFileTests.cs
@@ -403,6 +403,83 @@ public sealed class CoverageMultiObjectFileTests : IDisposable
     }
 
     /// <summary>
+    /// #3822, the shape that stresses both halves of the origin rule at once: a REAL preamble
+    /// (header comment, namespace, using) AND an unmapped object in front of the mapped one.
+    ///
+    /// The two are measured differently and must not be confused. The preamble is what BC
+    /// keeps in front of every object's text, so it is subtracted; the interface is an object,
+    /// so it is not. Getting either wrong moves the report — subtracting the interface as well
+    /// (the pre-fix behaviour) reports 6, and subtracting neither reports 20.
+    ///
+    /// The executed statement is on file line 15.
+    /// </summary>
+    [SkippableFact]
+    public void Coverage_PreambleThenAnUnmappedObject_ReportsFileLines()
+    {
+        TestArtifacts.SkipIfMissing();
+        var bundle = Path.Combine(_root, "bundle-preamble-unmapped");
+        Directory.CreateDirectory(bundle);
+        File.WriteAllText(Path.Combine(bundle, "app.json"), """
+        {
+          "id": "5a3f0b11-3822-4a0c-800c-00000000382b",
+          "name": "CMOF Preamble Unmapped Probe",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 63670, "to": 63689 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(bundle, "Two.Codeunit.al"), string.Join("\n", new[]
+        {
+            "// header comment",               // 1  \
+            "namespace Probe.Cov3822;",        // 2   |  preamble: subtracted
+            "",                                // 3   |
+            "using System.Utilities;",         // 4   |
+            "",                                // 5  /
+            "interface \"Edge Iface\"",        // 6  \
+            "{",                               // 7   |  an OBJECT, not preamble: NOT subtracted
+            "    procedure Ping(): Integer;",  // 8   |
+            "}",                               // 9  /
+            "",                                // 10
+            "codeunit 63670 \"Edge D\"",       // 11
+            "{",                               // 12
+            "    procedure D(): Integer",      // 13
+            "    begin",                       // 14
+            "        exit(4);",                // 15  called once
+            "    end;",                        // 16
+            "}",                               // 17
+            "",
+        }));
+        File.WriteAllText(Path.Combine(bundle, "T.Codeunit.al"), """
+        codeunit 63680 "Edge Preamble Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure CallsD()
+            var
+                D: Codeunit "Edge D";
+            begin
+                if D.D() <> 4 then
+                    Error('D');
+            end;
+        }
+        """);
+
+        var coveragePath = Path.Combine(_root, "cobertura-preamble-unmapped.xml");
+        var (output, exit) = Spawn(bundle, "--coverage", $"--coverage-out \"{coveragePath}\"");
+
+        Assert.Equal(0, exit);
+        Assert.True(File.Exists(coveragePath), $"cobertura.xml was not written.\n{output}");
+        var lines = LinesOf(ClassFor(XDocument.Load(coveragePath), "Two.Codeunit.al"));
+
+        Assert.Equal(new[] { 15 }, lines.Keys.OrderBy(k => k).ToArray());
+        Assert.Equal(1, lines[15]);
+    }
+
+    /// <summary>
     /// Every shape that could move the origin, in one file: a UTF-8 BOM, CRLF line endings, two
     /// header comment lines, a file-scoped `namespace`, a `using`, a comment between objects, an
     /// indented declaration keyword, and a third object with no blank line before it. The

--- a/AlRunner/Infrastructure/AlCoverageSourceMap.cs
+++ b/AlRunner/Infrastructure/AlCoverageSourceMap.cs
@@ -15,9 +15,25 @@ namespace AlRunner.Infrastructure;
 /// <c>IReadOnlyDictionary&lt;(Label, Id), string&gt;</c> the older consumers take, plus
 /// <see cref="LineOffset"/>, the number of lines to add to a decoded [SourceSpans] line to
 /// get the file line. BC's [SourceSpans] lines are relative to the object's own text with
-/// the file's preamble (anything before the first object) counted in, so the offset is the
-/// object's FullSpan start minus the first object's — 0 for the first object in a file
-/// (#3713; CoverageMultiObjectFileTests pins the four header shapes that settled it).
+/// the file's PREAMBLE counted in, so the offset is the object's FullSpan start minus the
+/// preamble's length — 0 for the first object in a file.
+/// <para>
+/// The preamble is <b>the number of complete source lines before the earliest top-level
+/// object's FullSpan</b>, which is not the same as "everything before the first
+/// declaration keyword" (#3822). A FullSpan owns its own leading trivia, so a comment or a
+/// blank line immediately in front of a declaration belongs to that object and is NOT
+/// preamble; a <c>namespace</c> or <c>using</c> is a sibling syntax node, so it is. That is
+/// why the first object of a file with a header measures 1 and 5 in the fixtures rather
+/// than 0.
+/// </para>
+/// <para>
+/// "Earliest top-level object" means every entry in <c>root.Objects</c>, including the
+/// kinds <see cref="AlCoverageSourceMap"/> cannot map — an interface, a controladdin, a
+/// permissionset, any extension. Those are objects, not preamble, and measuring the origin
+/// over the mapped subset instead subtracted them as though they were, putting every later
+/// object's lines exactly that far too low (#3822).
+/// </para>
+/// (#3713; CoverageMultiObjectFileTests pins the header shapes that settled both.)
 /// </summary>
 public sealed class AlSourceLocationMap : IReadOnlyDictionary<(string Label, int Id), string>
 {

--- a/AlRunner/Infrastructure/AlCoverageSourceMap.cs
+++ b/AlRunner/Infrastructure/AlCoverageSourceMap.cs
@@ -139,8 +139,10 @@ public static class AlCoverageSourceMap
             var root = tree.GetCompilationUnitRoot();
 
             var objects = new List<(string Label, int Id, int Start)>();
+            var allStarts = new List<int>();
             foreach (var obj in root.Objects)
             {
+                allStarts.Add(tree.GetLineSpan(obj.FullSpan).StartLinePosition.Line);
                 var label = LabelOf(obj);
                 if (label == null) continue;
                 if (obj is not NavSyntax.ApplicationObjectSyntax ao || ao.ObjectId?.Value.Value is not int id) continue;
@@ -150,7 +152,12 @@ public static class AlCoverageSourceMap
             // object from its own text but keeps the file's preamble in front of each of them,
             // so a namespace/using header shifts the later objects by its length and the first
             // object by nothing (#3713, CoverageMultiObjectFileTests.Build_ObjectsAfterAFileHeader_*).
-            var firstStart = objects.Count > 0 ? objects.Min(o => o.Start) : 0;
+            // firstStart is the FILE PREAMBLE's length: BC's text for every object is
+            // [preamble][that object], while the parser's FullSpan starts after the preamble.
+            // Measured over EVERY object, not just the mapped ones (#3822) — an unmapped
+            // object in front is not preamble, and taking the first MAPPED object's start
+            // subtracts it as though it were.
+            var firstStart = allStarts.Count > 0 ? allStarts.Min() : 0;
             result = objects.Select(o => new ParsedObject(o.Label, o.Id, o.Start - firstStart)).ToList();
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary

`AlCoverageSourceMap` subtracts a file's preamble length from each object's span start, because BC's text for an object is `[preamble][that object]` while the parser's `FullSpan` begins after the preamble. It took that length from the first object it **maps**, and `LabelOf` maps seven top-level kinds. An `interface`, a `controladdin`, a `permissionset` or any extension is not one of them.

So a file opening with an unmapped object made the first *mapped* object its own origin, and the subtraction removed the preamble **and** the unmapped object.

## Measured

Three variants of one file on BC 28.1.49838.54169, differing only in how many lines the leading `interface` occupies:

| interface spans | codeunit declared on | `exit(4)` true file line | line the report gives |
|---|---|---|---|
| 1-4 | 6 | 10 | **6** |
| 1-7 | 9 | 13 | **6** |
| 1-11 | 13 | 17 | **6** |

The reported line does not move as the leading object grows. Every statement of the following object is pinned where it would sit if that object were not there, and silently: the lines are present in the Cobertura output, attributed to lines that hold other code.

## The fix, and the one I tried first that was wrong

`firstStart` is now the minimum `FullSpan` start over **every** object the parser returns, rather than over the mapped subset.

I first tried dropping the subtraction entirely, on the belief that a `FullSpan` swallows the file preamble so `firstStart` is always 0 when the first mapped object is the first thing in the file. It is not, and the tests said so immediately:

| candidate | the unmapped-first probe | the two all-mapped fixtures |
|---|---|---|
| `offset = o.Start`, no subtraction | passes | **both fail** — the header fixture's first object wants 0 and gets 1; the CRLF end-to-end report shifts from `[11, 21, 28]` to `[16, 26, 33]` |
| `firstStart` over all `root.Objects` | passes | pass |

Those two failures are the useful part: the header fixture's first object starts at 0-based line 1 and the CRLF one at 5, and those numbers *are* the preamble lengths. The subtraction exists to remove them, and `firstStart` is only ever wrong about what the preamble is.

I recorded the wrong version of this analysis on the issue before running the check, and corrected it there rather than editing it away.

## Proof

`Coverage_FileOpeningWithAnUnmappedObject_ReportsFileLines` runs the real runner with `--coverage` over a file whose first object is an `interface` — the cheapest unmapped kind, since it needs no base object — and asserts the executed statement is reported on its true file line 10. RED before: `Expected: [10] / Actual: [6]`.

Reverting only `firstStart` to the filtered list turns that fact red again and leaves the other seven in the class green, so it is pinned to this change and nothing else.

All 8 facts in `CoverageMultiObjectFileTests` pass, including the two that the rejected candidate broke.

**Failures in a wider sweep are not mine.** Running `~Coverage|~Dap|~SourceSpan|~PerTest|~Scope` fails 9 on this branch. A pristine `origin/main` worktree at `7aa03dea`, built and run with the same filter, fails the same 9: six `NavReportStaticRunModalHookBindingTests` cases, `SkeletonDatabaseTenantExecutionContextTests.ExecutionContext_IsNormal_AndModuleScopedFormsAgree`, `ProvisionExplicitModesTests.TestApps_OnlyUnrelatedAppPresent_DoesNotShortCircuit_DownloadsTheRealSet`, and `ServerAffectedSelectionMultiSourcePathsTests.AffectedOnly_CrossBundleCoverage_RunsOnlyTheTestThatCallsTheEditedHelper`.

## Blast radius

Every consumer of `LineOffset` was reporting the wrong line for such a file: the coverage report, the statement tables, the per-test coverage, the scope resolver, and — since #3823, which is open — DAP breakpoints and stack frames. A file that opens with an `interface` or an extension is ordinary AL, so this is not an exotic layout.

This does not conflict with #3823: that PR changes the two DAP consumers, this one changes the map they read.

Closes #3822

Corpus-NA: this is the runner's own source-position bookkeeping; no BC behaviour is asserted, so there is nothing for a service tier to adjudicate.

*Opened by an agent (Claude Code) in a session run by @SShadowS.*

https://claude.ai/code/session_01JFQZHC5SEHnLxkc5USksaK
