### PR TITLE
fix(iterations): convert a span line to the file's coordinates before matching parser positions

### DIFF
--- a/AlRunner.Tests/AlMemberSyntaxIndexTests.cs
+++ b/AlRunner.Tests/AlMemberSyntaxIndexTests.cs
@@ -391,7 +391,7 @@ table 60302 "Loop Trigger Fixture"
     {
         RequireEngine();
         var sites = Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "ForTo").Sites;
-        var t = Assert.Single(AlLoopScopeTable.Build(sites, MeasuredForTo).Sites);
+        var t = Assert.Single(AlLoopScopeTable.Build(sites, MeasuredForTo, instrumented: null, lineOffset: 0).Sites);
         Assert.Equal(new[] { 1 }, t.HeaderIds.Order().ToArray());
         Assert.Equal(new[] { 2 }, t.BodyIds.Order().ToArray());
         Assert.Equal(2, t.MarkerStatementId);
@@ -408,7 +408,7 @@ table 60302 "Loop Trigger Fixture"
     {
         RequireEngine();
         var sites = Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "WhileDo").Sites;
-        var t = Assert.Single(AlLoopScopeTable.Build(sites, MeasuredWhileDo).Sites);
+        var t = Assert.Single(AlLoopScopeTable.Build(sites, MeasuredWhileDo, instrumented: null, lineOffset: 0).Sites);
         Assert.Equal(new[] { 1 }, t.HeaderIds.Order().ToArray());
         Assert.Equal(new[] { 2 }, t.BodyIds.Order().ToArray());
         Assert.Equal(2, t.MarkerStatementId);
@@ -421,7 +421,7 @@ table 60302 "Loop Trigger Fixture"
     {
         RequireEngine();
         var sites = Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "RepeatUntil").Sites;
-        var t = Assert.Single(AlLoopScopeTable.Build(sites, MeasuredRepeatUntil).Sites);
+        var t = Assert.Single(AlLoopScopeTable.Build(sites, MeasuredRepeatUntil, instrumented: null, lineOffset: 0).Sites);
         Assert.Equal(new[] { 2 }, t.HeaderIds.Order().ToArray());
         Assert.Equal(new[] { 1 }, t.BodyIds.Order().ToArray());
         Assert.Equal(1, t.MarkerStatementId);
@@ -432,7 +432,7 @@ table 60302 "Loop Trigger Fixture"
     {
         RequireEngine();
         var sites = Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "Nested").Sites;
-        var table = AlLoopScopeTable.Build(sites, MeasuredNested);
+        var table = AlLoopScopeTable.Build(sites, MeasuredNested, instrumented: null, lineOffset: 0);
         Assert.Equal(2, table.Sites.Count);
         var outer = table.Sites[0];
         var inner = table.Sites[1];
@@ -453,7 +453,7 @@ table 60302 "Loop Trigger Fixture"
     {
         RequireEngine();
         var sites = Member(AlMemberSyntaxIndex.Parse(LoopShapes2Source, "LoopShapes2.al"), "WhileFirst").Sites;
-        var table = AlLoopScopeTable.Build(sites, MeasuredWhileFirst);
+        var table = AlLoopScopeTable.Build(sites, MeasuredWhileFirst, instrumented: null, lineOffset: 0);
         var outer = table.Sites[0];
         Assert.Null(outer.MarkerStatementId);
         Assert.Equal(1, outer.MarkerNestedSiteIndex);
@@ -468,7 +468,7 @@ table 60302 "Loop Trigger Fixture"
     {
         RequireEngine();
         var sites = Member(AlMemberSyntaxIndex.Parse(LoopShapes2Source, "LoopShapes2.al"), "IfFirst").Sites;
-        var t = Assert.Single(AlLoopScopeTable.Build(sites, MeasuredIfFirst).Sites);
+        var t = Assert.Single(AlLoopScopeTable.Build(sites, MeasuredIfFirst, instrumented: null, lineOffset: 0).Sites);
         Assert.Equal(new[] { 0 }, t.HeaderIds.Order().ToArray());
         Assert.Equal(new[] { 1, 2, 3 }, t.BodyIds.Order().ToArray());
         Assert.Equal(1, t.MarkerStatementId); // the `if` condition: fires once per iteration
@@ -480,7 +480,7 @@ table 60302 "Loop Trigger Fixture"
     {
         RequireEngine();
         var sites = Member(AlMemberSyntaxIndex.Parse(LoopShapes2Source, "LoopShapes2.al"), "ForEachList").Sites;
-        var t = Assert.Single(AlLoopScopeTable.Build(sites, MeasuredForEachList).Sites);
+        var t = Assert.Single(AlLoopScopeTable.Build(sites, MeasuredForEachList, instrumented: null, lineOffset: 0).Sites);
         Assert.Equal(new[] { 2 }, t.HeaderIds.Order().ToArray());
         Assert.Equal(new[] { 3 }, t.BodyIds.Order().ToArray());
         Assert.Equal(3, t.MarkerStatementId);
@@ -492,7 +492,7 @@ table 60302 "Loop Trigger Fixture"
     {
         RequireEngine();
         var sites = Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "ZeroIter").Sites;
-        var t = Assert.Single(AlLoopScopeTable.Build(sites, MeasuredZeroIter).Sites);
+        var t = Assert.Single(AlLoopScopeTable.Build(sites, MeasuredZeroIter, instrumented: null, lineOffset: 0).Sites);
         Assert.Equal(new[] { 0 }, t.HeaderIds.Order().ToArray());
         Assert.Equal(new[] { 1 }, t.BodyIds.Order().ToArray());
         Assert.Equal(1, t.MarkerStatementId);
@@ -607,7 +607,7 @@ codeunit 60315 WriteShapes
     {
         RequireEngine();
         var sites = Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "ForTo").Sites;
-        var table = AlLoopScopeTable.Build(sites, MeasuredForTo);
+        var table = AlLoopScopeTable.Build(sites, MeasuredForTo, instrumented: null, lineOffset: 0);
         // ids: 0 t := 0 | 1 for (header) | 2 body | 3 after
         Assert.Empty(table.LoopVariablesAssignedBefore(current: 2, previous: 1)); // first pass: header just ran
         Assert.Equal(new[] { "i" }, table.LoopVariablesAssignedBefore(current: 2, previous: 2).ToArray()); // pass 2+
@@ -620,7 +620,7 @@ codeunit 60315 WriteShapes
     {
         RequireEngine();
         var sites = Member(AlMemberSyntaxIndex.Parse(LoopShapes2Source, "LoopShapes2.al"), "WhileFirst").Sites;
-        var table = AlLoopScopeTable.Build(sites, MeasuredWhileFirst);
+        var table = AlLoopScopeTable.Build(sites, MeasuredWhileFirst, instrumented: null, lineOffset: 0);
         // ids: 0 outer for | 1 while cond (inner header) | 2 inner body | 3 | 4 | 5 end
         // Outer pass 2 opens at the inner while's condition, previous = `s := s + 1` (4).
         Assert.Equal(new[] { "i" }, table.LoopVariablesAssignedBefore(current: 1, previous: 4).ToArray());
@@ -634,7 +634,7 @@ codeunit 60315 WriteShapes
     {
         RequireEngine();
         var m = Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "ForTo");
-        var table = AlWriteSetTable.Build(m.Writes, MeasuredForTo);
+        var table = AlWriteSetTable.Build(m.Writes, MeasuredForTo, instrumented: null, lineOffset: 0);
         Assert.Equal(new[] { "t" }, table.TargetsOf(0).Order().ToArray()); // t := 0
         Assert.Empty(table.TargetsOf(1));                                   // for i := 1 to 3 do (see LoopVariablesAssignedBefore)
         Assert.Equal(new[] { "t" }, table.TargetsOf(2).Order().ToArray()); // t := t + i
@@ -648,7 +648,7 @@ codeunit 60315 WriteShapes
         RequireEngine();
         // WhileDo: id 1 is the condition `n > 0` (starts mid-line); no statement starts there.
         var m = Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "WhileDo");
-        var table = AlWriteSetTable.Build(m.Writes, MeasuredWhileDo);
+        var table = AlWriteSetTable.Build(m.Writes, MeasuredWhileDo, instrumented: null, lineOffset: 0);
         Assert.Equal(new[] { "n" }, table.TargetsOf(0).Order().ToArray()); // n := 3
         Assert.Empty(table.TargetsOf(1));                                   // the condition
         Assert.Equal(new[] { "n" }, table.TargetsOf(2).Order().ToArray()); // n := n - 1
@@ -664,21 +664,32 @@ codeunit 60315 WriteShapes
     // AlSourceLocationMap.LineOffset, which AlCoverageTracker.TryResolveScope already hands
     // back and AlScopeSyntaxResolver dropped on the floor.
     //
-    // These pass the SAME member the facts above use, with the spans shifted down as BC
-    // would emit them for an object that does not start the file, plus the matching offset.
-    // Without it nothing matches: every id resolves to no targets and no loop site, and the
-    // run stays green while its iteration and write tables are empty.
+    // These pass the SAME member the facts above use, with the spans expressed in that
+    // object's own coordinates, plus the matching offset. Without it nothing matches: every
+    // id resolves to no targets and no loop site, and the run stays green while its
+    // iteration and write tables are empty.
+    //
+    // WHAT THEY PROVE, AND WHAT THEY DO NOT. The fixture computes `span - offset` and the
+    // code adds `offset` back, so these are unit tests of the CONVERSION: that the parameter
+    // is applied, that the sign is addition, and that omitting it matches nothing. They are
+    // circular as evidence about BC — they cannot show that BC emits a later object's spans
+    // with exactly this relationship, nor that AlSourceLocationMap.LineOffset is the right
+    // number. That evidence is the real-compiler end-to-end facts in
+    // ServerExecuteIterationsTests, which read file lines off the wire and never state a
+    // span at all. Both layers are needed and neither substitutes for the other.
     //
     // Deliberately NOT written by prepending an object to LoopShapesSource and reusing the
     // measured constants: BC's object text begins at the blank line before the declaration
     // once anything precedes it (#3822), so the real spans shift too and the reused numbers
     // would encode a fiction that passes against a wrong implementation.
 
-    /// <summary>Every measured span moved down by <paramref name="offset"/> lines, which is
-    /// what BC emits for the same member in an object that starts <paramref name="offset"/>
-    /// lines into its file. The parser's own positions do not move, because the source it
-    /// parses is unchanged.</summary>
-    private static long[] ShiftedBy(long[] spans, int offset) =>
+    /// <summary>
+    /// The same spans expressed in OBJECT-relative coordinates for an object whose text
+    /// begins <paramref name="offset"/> lines into its file — so the encoded line numbers go
+    /// DOWN by that much, even though the object itself sits further down the file. The
+    /// parser's own positions do not move, because the source it parses is unchanged.
+    /// </summary>
+    private static long[] ToObjectRelativeBySubtracting(long[] spans, int offset) =>
         spans.Select(x =>
         {
             var (l1, c1, l2, c2) = AlSourceSpanCodec.Decode(x);
@@ -691,7 +702,7 @@ codeunit 60315 WriteShapes
         RequireEngine();
         const int offset = 17;
         var m = Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "ForTo");
-        var spans = ShiftedBy(MeasuredForTo, offset);
+        var spans = ToObjectRelativeBySubtracting(MeasuredForTo, offset);
 
         var table = AlWriteSetTable.Build(m.Writes, spans, instrumented: null, lineOffset: offset);
 
@@ -709,9 +720,9 @@ codeunit 60315 WriteShapes
     {
         RequireEngine();
         var m = Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "ForTo");
-        var spans = ShiftedBy(MeasuredForTo, 17);
+        var spans = ToObjectRelativeBySubtracting(MeasuredForTo, 17);
 
-        var table = AlWriteSetTable.Build(m.Writes, spans);
+        var table = AlWriteSetTable.Build(m.Writes, spans, instrumented: null, lineOffset: 0);
 
         Assert.Empty(table.TargetsOf(0));
         Assert.Empty(table.TargetsOf(2));
@@ -724,11 +735,18 @@ codeunit 60315 WriteShapes
         RequireEngine();
         const int offset = 17;
         var sites = Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "ForTo").Sites;
-        var spans = ShiftedBy(MeasuredForTo, offset);
+        var spans = ToObjectRelativeBySubtracting(MeasuredForTo, offset);
 
         var table = AlLoopScopeTable.Build(sites, spans, instrumented: null, lineOffset: offset);
 
-        // The same ids the unshifted fact above asserts: 1 is the for header, 2 the body.
+        // The EXACT sets, not a derived answer. #3834 was a defect in which ids land where,
+        // and LoopVariablesAssignedBefore alone would have been satisfied by several wrong
+        // classifications. Identical to what the unshifted fixture produces at offset 0.
+        var site = Assert.Single(table.Sites);
+        Assert.Equal(new[] { 1 }, site.HeaderIds.OrderBy(x => x).ToArray());
+        Assert.Equal(new[] { 2 }, site.BodyIds.OrderBy(x => x).ToArray());
+        Assert.Equal(2, site.MarkerStatementId);
+        Assert.Null(site.Unsegmentable);
         Assert.Equal(new[] { "i" }, table.LoopVariablesAssignedBefore(current: 2, previous: 2).ToArray());
         Assert.Empty(table.LoopVariablesAssignedBefore(current: 2, previous: 1));
     }
@@ -740,9 +758,9 @@ codeunit 60315 WriteShapes
     {
         RequireEngine();
         var sites = Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "ForTo").Sites;
-        var spans = ShiftedBy(MeasuredForTo, 17);
+        var spans = ToObjectRelativeBySubtracting(MeasuredForTo, 17);
 
-        var table = AlLoopScopeTable.Build(sites, spans);
+        var table = AlLoopScopeTable.Build(sites, spans, instrumented: null, lineOffset: 0);
 
         Assert.Empty(table.LoopVariablesAssignedBefore(current: 2, previous: 2));
     }
@@ -759,7 +777,7 @@ codeunit 60315 WriteShapes
             Array.Empty<AlLoopBodyStatement>(), null, false);
         var spans = new[] { AlSourceSpanCodec.Encode(8, 8, 8, 27), AlSourceSpanCodec.Encode(9, 8, 9, 14) };
 
-        var t = Assert.Single(AlLoopScopeTable.Build(new[] { site }, spans).Sites);
+        var t = Assert.Single(AlLoopScopeTable.Build(new[] { site }, spans, instrumented: null, lineOffset: 0).Sites);
         Assert.Equal(new[] { 0 }, t.HeaderIds.Order().ToArray());
         Assert.Empty(t.BodyIds);
         Assert.Null(t.MarkerStatementId);
@@ -782,7 +800,7 @@ codeunit 60315 WriteShapes
             AlSourceSpanCodec.Encode(6, 12, 6, 20), // 1: body
             AlSourceSpanCodec.Encode(6, 12, 6, 20), // 2: a sentinel that happens to share the body's span
         };
-        var t = Assert.Single(AlLoopScopeTable.Build(new[] { site }, spans, instrumented: new[] { 0, 1 }).Sites);
+        var t = Assert.Single(AlLoopScopeTable.Build(new[] { site }, spans, instrumented: new[] { 0, 1 }, lineOffset: 0).Sites);
         Assert.Equal(new[] { 1 }, t.BodyIds.Order().ToArray());
         Assert.False(t.Owns(2));
     }
@@ -871,7 +889,7 @@ codeunit 60322 SoleBody
     {
         RequireEngine();
         var sites = Member(AlMemberSyntaxIndex.Parse(SoleBodySource, "SoleBody.al"), "ForRepeat").Sites;
-        var table = AlLoopScopeTable.Build(sites, SoleForRepeat);
+        var table = AlLoopScopeTable.Build(sites, SoleForRepeat, instrumented: null, lineOffset: 0);
         Assert.Equal(AlLoopUnsegmentable.SoleNestedRepeat, table.Sites[0].Unsegmentable);
         Assert.Null(table.Sites[1].Unsegmentable);
         Assert.Equal(1, table.Sites[1].MarkerStatementId);
@@ -882,7 +900,7 @@ codeunit 60322 SoleBody
     {
         RequireEngine();
         var sites = Member(AlMemberSyntaxIndex.Parse(SoleBodySource, "SoleBody.al"), "ForWhileBreak").Sites;
-        var table = AlLoopScopeTable.Build(sites, SoleForWhileBreak);
+        var table = AlLoopScopeTable.Build(sites, SoleForWhileBreak, instrumented: null, lineOffset: 0);
         Assert.Equal(AlLoopUnsegmentable.SoleNestedWhileWithBreak, table.Sites[0].Unsegmentable);
         Assert.Null(table.Sites[1].Unsegmentable);
     }
@@ -892,7 +910,7 @@ codeunit 60322 SoleBody
     {
         RequireEngine();
         var sites = Member(AlMemberSyntaxIndex.Parse(SoleBodySource, "SoleBody.al"), "ForWhile").Sites;
-        var table = AlLoopScopeTable.Build(sites, SoleForWhile);
+        var table = AlLoopScopeTable.Build(sites, SoleForWhile, instrumented: null, lineOffset: 0);
         Assert.Null(table.Sites[0].Unsegmentable);
         Assert.Equal(1, table.Sites[0].MarkerNestedSiteIndex);
     }
@@ -902,7 +920,7 @@ codeunit 60322 SoleBody
     {
         RequireEngine();
         var sites = Member(AlMemberSyntaxIndex.Parse(SoleBodySource, "SoleBody.al"), "ForEmptyWhile").Sites;
-        var table = AlLoopScopeTable.Build(sites, SoleForEmptyWhile);
+        var table = AlLoopScopeTable.Build(sites, SoleForEmptyWhile, instrumented: null, lineOffset: 0);
         Assert.Equal(AlLoopUnsegmentable.EmptyBody, table.Sites[1].Unsegmentable);
         Assert.Equal(AlLoopUnsegmentable.SoleNestedUnsegmentable, table.Sites[0].Unsegmentable);
         // Repeated inner condition hits (previous == current == 1) must not claim `i` was assigned.
@@ -913,13 +931,13 @@ codeunit 60322 SoleBody
     public void LoopVariableOfHeader_ForHeadersOnly_AForEachAssignsAfterItsHeader()
     {
         RequireEngine();
-        var forTo = AlLoopScopeTable.Build(Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "ForTo").Sites, MeasuredForTo);
+        var forTo = AlLoopScopeTable.Build(Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "ForTo").Sites, MeasuredForTo, instrumented: null, lineOffset: 0);
         Assert.Equal("i", forTo.LoopVariableOfHeader(1));
         Assert.Null(forTo.LoopVariableOfHeader(0));
         Assert.Null(forTo.LoopVariableOfHeader(2));
-        var whileDo = AlLoopScopeTable.Build(Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "WhileDo").Sites, MeasuredWhileDo);
+        var whileDo = AlLoopScopeTable.Build(Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "WhileDo").Sites, MeasuredWhileDo, instrumented: null, lineOffset: 0);
         Assert.Null(whileDo.LoopVariableOfHeader(1));
-        var fe = AlLoopScopeTable.Build(Member(AlMemberSyntaxIndex.Parse(LoopShapes2Source, "LoopShapes2.al"), "ForEachList").Sites, MeasuredForEachList);
+        var fe = AlLoopScopeTable.Build(Member(AlMemberSyntaxIndex.Parse(LoopShapes2Source, "LoopShapes2.al"), "ForEachList").Sites, MeasuredForEachList, instrumented: null, lineOffset: 0);
         Assert.Null(fe.LoopVariableOfHeader(2));
         // ...so a foreach's FIRST pass is where its variable is claimed (previous = its header).
         Assert.Equal(new[] { "v" }, fe.LoopVariablesAssignedBefore(current: 3, previous: 2).ToArray());
@@ -930,7 +948,7 @@ codeunit 60322 SoleBody
     public void Build_CarriesColumns_ForTheLoopStatement()
     {
         RequireEngine();
-        var t = Assert.Single(AlLoopScopeTable.Build(Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "ForTo").Sites, MeasuredForTo).Sites);
+        var t = Assert.Single(AlLoopScopeTable.Build(Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "ForTo").Sites, MeasuredForTo, instrumented: null, lineOffset: 0).Sites);
         Assert.Equal(22, t.StartLine);
         Assert.Equal(9, t.StartColumn);   // `for` at column 9 (1-based)
         Assert.Equal(23, t.EndLine);

--- a/AlRunner.Tests/AlMemberSyntaxIndexTests.cs
+++ b/AlRunner.Tests/AlMemberSyntaxIndexTests.cs
@@ -656,6 +656,97 @@ codeunit 60315 WriteShapes
         Assert.Equal(new[] { "n" }, table.TargetsOf(4).Order().ToArray()); // n := 99
     }
 
+    // --- #3832: the two coordinate spaces --------------------------------------------
+    //
+    // A parser position is FILE-relative. A [SourceSpans] line is relative to the OWNING
+    // OBJECT's text. For the first object in a file the two coincide, which is why every
+    // fact above passes without an offset; for any later object they are apart by exactly
+    // AlSourceLocationMap.LineOffset, which AlCoverageTracker.TryResolveScope already hands
+    // back and AlScopeSyntaxResolver dropped on the floor.
+    //
+    // These pass the SAME member the facts above use, with the spans shifted down as BC
+    // would emit them for an object that does not start the file, plus the matching offset.
+    // Without it nothing matches: every id resolves to no targets and no loop site, and the
+    // run stays green while its iteration and write tables are empty.
+    //
+    // Deliberately NOT written by prepending an object to LoopShapesSource and reusing the
+    // measured constants: BC's object text begins at the blank line before the declaration
+    // once anything precedes it (#3822), so the real spans shift too and the reused numbers
+    // would encode a fiction that passes against a wrong implementation.
+
+    /// <summary>Every measured span moved down by <paramref name="offset"/> lines, which is
+    /// what BC emits for the same member in an object that starts <paramref name="offset"/>
+    /// lines into its file. The parser's own positions do not move, because the source it
+    /// parses is unchanged.</summary>
+    private static long[] ShiftedBy(long[] spans, int offset) =>
+        spans.Select(x =>
+        {
+            var (l1, c1, l2, c2) = AlSourceSpanCodec.Decode(x);
+            return AlSourceSpanCodec.Encode(l1 - offset, c1, l2 - offset, c2);
+        }).ToArray();
+
+    [SkippableFact]
+    public void ResolveWrites_ObjectAfterTheFirstInItsFile_MatchesWithTheLineOffset()
+    {
+        RequireEngine();
+        const int offset = 17;
+        var m = Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "ForTo");
+        var spans = ShiftedBy(MeasuredForTo, offset);
+
+        var table = AlWriteSetTable.Build(m.Writes, spans, instrumented: null, lineOffset: offset);
+
+        Assert.Equal(new[] { "t" }, table.TargetsOf(0).Order().ToArray()); // t := 0
+        Assert.Empty(table.TargetsOf(1));                                   // the for header
+        Assert.Equal(new[] { "t" }, table.TargetsOf(2).Order().ToArray()); // t := t + i
+        Assert.Equal(new[] { "t" }, table.TargetsOf(3).Order().ToArray()); // t := t * 10
+    }
+
+    /// <summary>The negative direction, and the failure this defect actually produces: the
+    /// same shifted spans with no offset match nothing at all. Not a throw, not a wrong
+    /// target — an empty table, which reads downstream as "this member writes nothing".</summary>
+    [SkippableFact]
+    public void ResolveWrites_ShiftedSpansWithoutTheOffset_MatchNothing()
+    {
+        RequireEngine();
+        var m = Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "ForTo");
+        var spans = ShiftedBy(MeasuredForTo, 17);
+
+        var table = AlWriteSetTable.Build(m.Writes, spans);
+
+        Assert.Empty(table.TargetsOf(0));
+        Assert.Empty(table.TargetsOf(2));
+        Assert.Empty(table.TargetsOf(3));
+    }
+
+    [SkippableFact]
+    public void ResolveLoops_ObjectAfterTheFirstInItsFile_MatchesWithTheLineOffset()
+    {
+        RequireEngine();
+        const int offset = 17;
+        var sites = Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "ForTo").Sites;
+        var spans = ShiftedBy(MeasuredForTo, offset);
+
+        var table = AlLoopScopeTable.Build(sites, spans, instrumented: null, lineOffset: offset);
+
+        // The same ids the unshifted fact above asserts: 1 is the for header, 2 the body.
+        Assert.Equal(new[] { "i" }, table.LoopVariablesAssignedBefore(current: 2, previous: 2).ToArray());
+        Assert.Empty(table.LoopVariablesAssignedBefore(current: 2, previous: 1));
+    }
+
+    /// <summary>Same shape, no offset: the loop's own ids are not recognised, so the table
+    /// reports no loop-variable assignment at all and iteration segmentation goes quiet.</summary>
+    [SkippableFact]
+    public void ResolveLoops_ShiftedSpansWithoutTheOffset_RecogniseNoLoopIds()
+    {
+        RequireEngine();
+        var sites = Member(AlMemberSyntaxIndex.Parse(LoopShapesSource, "LoopShapes.al"), "ForTo").Sites;
+        var spans = ShiftedBy(MeasuredForTo, 17);
+
+        var table = AlLoopScopeTable.Build(sites, spans);
+
+        Assert.Empty(table.LoopVariablesAssignedBefore(current: 2, previous: 2));
+    }
+
     // --- Build: negative direction, no engine needed ----------------------------------
 
     [Fact]

--- a/AlRunner.Tests/ServerExecuteIterationsTests.cs
+++ b/AlRunner.Tests/ServerExecuteIterationsTests.cs
@@ -207,6 +207,77 @@ public class ServerExecuteIterationsTests : IClassFixture<SharedCliServer>
         Assert.All(steps, x => Assert.Equal(new[] { 18 }, Lines(x)));
     }
 
+    /// <summary>
+    /// #3836 review: the other fact in this class proves the offsets reach the tables, but not
+    /// the member-selection ANCHOR — its file declares `OnRun` once, and FindMember returns a
+    /// sole name candidate whatever anchor it is given. Here BOTH objects declare
+    /// <c>Compute</c>, so the name is ambiguous and only the anchor can choose. The first
+    /// object's copy loops five times and is never called; the second's loops twice and is the
+    /// one that runs.
+    ///
+    /// It also covers the WRITE SET independently. `same := 5` assigns the same value on every
+    /// pass, so an ordinary value diff has nothing to report; only the write-set table can
+    /// attribute it to each iteration.
+    /// </summary>
+    [SkippableFact]
+    public async Task Execute_SameNamedMemberInAnotherObject_ResolvesByAnchorAndAttributesWrites()
+    {
+        TestArtifacts.SkipIfMissing();
+        var code =
+            "codeunit 60397 \"Anchor Lead SX\"\n" +                //  1
+            "{\n" +                                                //  2
+            "    trigger OnRun()\n" +                              //  3  the server runs THIS
+            "    var c: Codeunit \"Anchor Second SX\"; s: Integer;\n" + // 4
+            "    begin\n" +                                        //  5
+            "        s := c.Compute();\n" +                        //  6
+            "    end;\n" +                                         //  7
+            "    procedure Compute(): Integer\n" +                 //  8  same NAME, never called
+            "    var k: Integer; s: Integer;\n" +                  //  9
+            "    begin\n" +                                        // 10
+            "        for k := 1 to 5 do\n" +                       // 11  five passes
+            "            s := s + k;\n" +                          // 12
+            "        exit(s);\n" +                                 // 13
+            "    end;\n" +                                         // 14
+            "}\n" +                                                // 15
+            "\n" +                                                 // 16
+            "codeunit 60398 \"Anchor Second SX\"\n" +              // 17
+            "{\n" +                                                // 18
+            "    procedure Compute(): Integer\n" +                 // 19  the one that RUNS
+            "    var k: Integer; s: Integer; same: Integer;\n" +   // 20
+            "    begin\n" +                                        // 21
+            "        for k := 1 to 2 do begin\n" +                 // 22  two passes
+            "            s := s + k;\n" +                          // 23
+            "            same := 5;\n" +                           // 24  constant write
+            "        end;\n" +                                     // 25
+            "        exit(s);\n" +                                 // 26
+            "    end;\n" +                                         // 27
+            "}\n";                                                 // 28
+
+        var d = await ExecuteAsync(code);
+        var t = SingleTest(d);
+
+        var loop = Assert.Single(Loops(t, "Compute"));
+        // The SECOND object's Compute. An un-offset anchor points into the first object's
+        // range, which is where its five-pass loop on line 6 lives.
+        Assert.Equal(22, loop.GetProperty("line").GetInt32());
+        Assert.Equal(25, loop.GetProperty("endLine").GetInt32());
+        Assert.Equal(2, loop.GetProperty("iterationCount").GetInt32());
+
+        var steps = Steps(d, t, loop);
+        Assert.Equal(new[] { 1, 2 }, steps.Select(x => x.Index).ToArray());
+        Assert.All(steps, x => Assert.Equal(new[] { 23, 24 }, Lines(x)));
+        // The write-set half. `same := 5` assigns the SAME value on every pass, so a value
+        // diff has nothing to report and only AlWriteSetTable can attribute it to a pass.
+        // Removing scope.LineOffset from the AlWriteSetTable.Build call empties these two
+        // while every other assertion in this fact still passes.
+        Assert.Equal(new[] { "5" }, Values(steps[0], "same"));
+        Assert.Equal(new[] { "5" }, Values(steps[1], "same"));
+        // s does change, so it would survive on the value diff alone — asserted to keep the
+        // two halves distinguishable rather than as proof of the write set.
+        Assert.Equal(new[] { "1" }, Values(steps[0], "s"));
+        Assert.Equal(new[] { "3" }, Values(steps[1], "s"));
+    }
+
     // --- every loop kind -------------------------------------------------------------------
 
     [SkippableFact]

--- a/AlRunner.Tests/ServerExecuteIterationsTests.cs
+++ b/AlRunner.Tests/ServerExecuteIterationsTests.cs
@@ -141,6 +141,72 @@ public class ServerExecuteIterationsTests : IClassFixture<SharedCliServer>
         Assert.Equal(new[] { "0", "1", "3", "6" }, flat);
     }
 
+    /// <summary>
+    /// #3832: the whole chain for an object that does NOT start its file. A parser position is
+    /// file-relative and a [SourceSpans] line is relative to the owning object's text, and
+    /// AlScopeSyntaxResolver compared them directly — so for a later object the member anchor
+    /// pointed into the previous object's range, and the loop and write tables matched nothing.
+    ///
+    /// The failure is silent, which is why this asserts the loop is REPORTED rather than that
+    /// its lines are right: unfixed, `loops` is empty and the test still passes with values
+    /// captured, so nothing downstream says iteration tracking gave up.
+    ///
+    /// The unit facts in AlMemberSyntaxIndexTests pin the two Build methods' arithmetic. This
+    /// pins the wiring — that the resolver passes scope.LineOffset at all — which those cannot,
+    /// because they call Build directly.
+    /// </summary>
+    [SkippableFact]
+    public async Task Execute_LoopInTheSecondObjectOfAFile_IsSegmentedOnItsFileLines()
+    {
+        TestArtifacts.SkipIfMissing();
+        // A helper codeunit FIRST, so the test codeunit's text starts partway down the file.
+        var code =
+            "codeunit 60399 \"Iter Lead SX\"\n" +        // 1
+            "{\n" +                                        // 2
+            "    procedure Ping(): Integer\n" +            // 3
+            "    begin\n" +                                // 4
+            "        exit(1);\n" +                         // 5
+            "    end;\n" +                                 // 6
+            "}\n" +                                        // 7
+            "\n" +                                         // 8
+            "codeunit 60304 \"Iter Second SX\"\n" +       // 9
+            "{\n" +                                        // 10
+            "    trigger OnRun()\n" +                      // 11
+            "    var\n" +                                  // 12
+            "        i: Integer;\n" +                      // 13
+            "        total: Integer;\n" +                  // 14
+            "    begin\n" +                                // 15
+            "        total := 0;\n" +                      // 16
+            "        for i := 1 to 3 do begin\n" +         // 17  the loop
+            "            total := total + i;\n" +          // 18  its body
+            "        end;\n" +                             // 19  its end
+            "        total := total * 10;\n" +             // 20  a statement AFTER the loop
+            "    end;\n" +                                 // 21
+            "}\n";                                         // 22
+
+        var d = await ExecuteAsync(code);
+        var t = SingleTest(d);
+
+        // The loop that actually ran. A non-zero offset also produces a SECOND, empty
+        // instance of the same site, which is a separate defect (#3834) and not something
+        // this fact should pretend away: before this change there were no instances at all,
+        // and asserting Single here would tie an unrelated bug to this one's proof.
+        var loop = Assert.Single(Loops(t, "OnRun").Where(l => l.GetProperty("iterationCount").GetInt32() > 0));
+        // FILE lines, not the 8-lines-lower ones the object's own text would give.
+        Assert.Equal(17, loop.GetProperty("line").GetInt32());
+        Assert.Equal(19, loop.GetProperty("endLine").GetInt32());
+        Assert.Equal(3, loop.GetProperty("iterationCount").GetInt32());
+
+        // Segmentation really ran: one step per pass, each with that pass's own values, and
+        // the body's file line. An empty or mis-keyed table gives zero steps.
+        var steps = Steps(d, t, loop);
+        Assert.Equal(new[] { 1, 2, 3 }, steps.Select(x => x.Index).ToArray());
+        Assert.Equal(new[] { "1" }, Values(steps[0], "total"));
+        Assert.Equal(new[] { "3" }, Values(steps[1], "total"));
+        Assert.Equal(new[] { "6" }, Values(steps[2], "total"));
+        Assert.All(steps, x => Assert.Equal(new[] { 18 }, Lines(x)));
+    }
+
     // --- every loop kind -------------------------------------------------------------------
 
     [SkippableFact]

--- a/AlRunner.Tests/ServerExecuteIterationsTests.cs
+++ b/AlRunner.Tests/ServerExecuteIterationsTests.cs
@@ -187,11 +187,11 @@ public class ServerExecuteIterationsTests : IClassFixture<SharedCliServer>
         var d = await ExecuteAsync(code);
         var t = SingleTest(d);
 
-        // The loop that actually ran. A non-zero offset also produces a SECOND, empty
-        // instance of the same site, which is a separate defect (#3834) and not something
-        // this fact should pretend away: before this change there were no instances at all,
-        // and asserting Single here would tie an unrelated bug to this one's proof.
-        var loop = Assert.Single(Loops(t, "OnRun").Where(l => l.GetProperty("iterationCount").GetInt32() > 0));
+        // EXACTLY one instance. A zero-iteration entry is a legitimate value on this wire —
+        // a loop that never ran is reported that way — so a spurious empty duplicate is not
+        // something a consumer can filter out, and asserting on "the one that ran" would
+        // hide it (#3834).
+        var loop = Assert.Single(Loops(t, "OnRun"));
         // FILE lines, not the 8-lines-lower ones the object's own text would give.
         Assert.Equal(17, loop.GetProperty("line").GetInt32());
         Assert.Equal(19, loop.GetProperty("endLine").GetInt32());

--- a/AlRunner/Infrastructure/AlIterationSegmenter.cs
+++ b/AlRunner/Infrastructure/AlIterationSegmenter.cs
@@ -84,6 +84,16 @@ internal sealed class AlIterationSegmenter
         internal Step? Open { get; private set; }
         internal bool Pending { get; private set; }
         internal bool HeaderSeen { get; set; }
+        /// <summary>
+        /// The header statement id that OPENED this instance, or null before its first header
+        /// hit. #3834: BC can emit several statement ids for one `for`, all starting at the
+        /// header's position, so all of them land in HeaderIds — and a hit on a different one
+        /// is this entry continuing, not a new one. Measured: ids 1 and 3 both at line 16
+        /// column 8 for a single `for`, with id 3 arriving after the last body pass.
+        /// </summary>
+        internal int? EntryHeaderId { get; private set; }
+
+        internal void NoteHeaderId(int statementId) => EntryHeaderId ??= statementId;
         private List<Cap>? _carry;
         private List<Cap>? _pendingCaptures;
         private List<Msg>? _pendingMessages;
@@ -261,14 +271,28 @@ internal sealed class AlIterationSegmenter
             var child = table.ChildOwning(cur.Site, statementId);
             if (child == null && cur.Site.HeaderIds.Contains(statementId))
             {
-                if (IsReentry(cur, scopeInstance))
+                if (IsReentry(cur, scopeInstance, statementId))
                 {
                     if (!consumed) { cur.Attach(observed); consumed = true; }
                     Pop(AlLoopEnd.Exit);
                     cur = TopOf(scopeInstance);
                     continue;
                 }
-                RecordHit(scopeInstance, statementId);
+                // #3834: a loop can have SEVERAL header ids — BC emits more than one
+                // statement id for one `for`, all starting at the header's position — and the
+                // ones that are not this instance's ENTRY arrive after the last body
+                // statement. That is the loop closing, not a statement of the pass that just
+                // ran, so recording it put the header's own line into that pass's `lines`.
+                //
+                // Deliberately not narrowed to for/foreach. A while's condition and a repeat's
+                // until are header ids that re-evaluate mid-pass, and their hit DOES belong to
+                // the running pass — but they are the ENTRY id, so this skips nothing for them
+                // and a kind check changes no measured behaviour. Adding one would be a branch
+                // no fact defends; WhileLoop_ConditionHitPerEvaluation_CountsBodyEntriesOnly
+                // and RepeatLoop_UntilConditionAfterBody_ThreeIterations are what hold that.
+                var closingHeader = cur.EntryHeaderId is int entryId && entryId != statementId;
+                if (!closingHeader) RecordHit(scopeInstance, statementId);
+                cur.NoteHeaderId(statementId);
                 if (consumed) cur.OnHeader(NoCaptures);
                 else { cur.OnHeader(observed); consumed = true; }
                 break;
@@ -311,14 +335,21 @@ internal sealed class AlIterationSegmenter
     // A for/foreach header fires once per entry, so a second hit on an active instance is a
     // re-entry. A while condition re-evaluates mid-pass, but then always right after one of
     // its own body statements. A repeat's until-condition is never an entry.
-    private bool IsReentry(LoopInstance cur, object scopeInstance)
+    //
+    // #3834: "the header fired again" means the id that OPENED the instance firing again, not
+    // any member of HeaderIds. BC emits more than one statement id for one `for` — measured,
+    // two ids sharing the header's exact start position — so membership alone made the second
+    // of them look like a re-entry, popping the instance that had counted the passes and
+    // pushing an empty one in its place. An empty instance is a legitimate value on the wire
+    // (a loop that never ran), so nothing downstream could tell the two apart.
+    private bool IsReentry(LoopInstance cur, object scopeInstance, int statementId)
     {
         if (!cur.HeaderSeen) return false;
         switch (cur.Site.Kind)
         {
             case AlLoopKind.For:
             case AlLoopKind.ForEach:
-                return true;
+                return cur.EntryHeaderId is not int entry || entry == statementId;
             case AlLoopKind.While:
                 return !(_lastHit.TryGetValue(scopeInstance, out var last) && cur.Site.BodyIds.Contains(last));
             default:

--- a/AlRunner/Infrastructure/AlLoopModel.cs
+++ b/AlRunner/Infrastructure/AlLoopModel.cs
@@ -125,10 +125,11 @@ public sealed class AlLoopScopeTable
 {
     private readonly Dictionary<int, AlLoopSiteTable> _innermostOwner = new();
 
-    public AlLoopScopeTable(IReadOnlyList<AlLoopSiteTable> sites, long[] spans)
+    public AlLoopScopeTable(IReadOnlyList<AlLoopSiteTable> sites, long[] spans, int lineOffset = 0)
     {
         Sites = sites;
         Spans = spans;
+        LineOffset = lineOffset;
         var roots = new List<AlLoopSiteTable>();
         foreach (var s in sites)
         {
@@ -218,11 +219,22 @@ public sealed class AlLoopScopeTable
         return false;
     }
 
-    /// <summary>1-based line of a statement id; null when the id is outside the span table.</summary>
+    /// <summary>
+    /// Lines to add to a decoded span line to reach the FILE line (#3832) —
+    /// AlSourceLocationMap.LineOffset for the owning object, 0 for the first object in a
+    /// file. Held here because <see cref="LineOf"/> is the one place a line LEAVES this
+    /// table, and AlIterationTracker publishes it straight onto the wire.
+    /// </summary>
+    public int LineOffset { get; }
+
+    /// <summary>1-based FILE line of a statement id; null when the id is outside the span
+    /// table. File, not object-relative: an iteration's lines reach a caller as source
+    /// positions and are compared against nothing else, so a raw span line here is a wrong
+    /// number nobody can detect (#3832).</summary>
     public int? LineOf(int statementId)
     {
         if (statementId < 0 || statementId >= Spans.Length) return null;
-        return AlSourceSpanCodec.Decode(Spans[statementId]).FromLine + 1;
+        return AlSourceSpanCodec.Decode(Spans[statementId]).FromLine + 1 + LineOffset;
     }
 
     /// <summary>
@@ -230,7 +242,15 @@ public sealed class AlLoopScopeTable
     /// starts in a header range, a body id when it starts in a body statement. <paramref
     /// name="instrumented"/> excludes BC's trailing never-instrumented sentinel entry.
     /// </summary>
-    public static AlLoopScopeTable Build(IReadOnlyList<AlLoopSite> sites, long[] spans, IEnumerable<int>? instrumented = null)
+    /// <param name="lineOffset">
+    /// Lines to add to a decoded span line to reach the FILE line <paramref name="sites"/>
+    /// carries (#3832) — see AlWriteSetTable.Build's parameter of the same name for the two
+    /// coordinate spaces. Without it, an object after the first in its file recognises none
+    /// of its own loop ids and iteration segmentation goes quiet.
+    /// </param>
+    public static AlLoopScopeTable Build(
+        IReadOnlyList<AlLoopSite> sites, long[] spans,
+        IEnumerable<int>? instrumented = null, int lineOffset = 0)
     {
         var ids = instrumented?.ToArray() ?? Enumerable.Range(0, spans.Length).ToArray();
         var starts = new Dictionary<int, AlTextPosition>(ids.Length);
@@ -238,7 +258,7 @@ public sealed class AlLoopScopeTable
         {
             if (i < 0 || i >= spans.Length) continue; // defensive: BC shape drift
             var (fromLine, fromColumn, _, _) = AlSourceSpanCodec.Decode(spans[i]);
-            starts[i] = new AlTextPosition(fromLine, fromColumn);
+            starts[i] = new AlTextPosition(fromLine + lineOffset, fromColumn);
         }
 
         var header = new HashSet<int>[sites.Count];
@@ -289,6 +309,6 @@ public sealed class AlLoopScopeTable
                 header[site.Index], body[site.Index], markerId[site.Index], markerNested[site.Index],
                 site.ParentIndex, unsegmentable[site.Index]));
         }
-        return new AlLoopScopeTable(tables, spans);
+        return new AlLoopScopeTable(tables, spans, lineOffset);
     }
 }

--- a/AlRunner/Infrastructure/AlLoopModel.cs
+++ b/AlRunner/Infrastructure/AlLoopModel.cs
@@ -27,7 +27,13 @@ public static class AlLoopUnsegmentable
     public const string SoleNestedUnsegmentable = "soleNestedUnsegmentable";
 }
 
-/// <summary>0-based (line, column): the coordinate space both [SourceSpans] and the syntax tree use.</summary>
+/// <summary>
+/// A 0-based line and column. COORDINATE-AGNOSTIC on purpose: the same type carries both
+/// parser positions, which are file-relative, and decoded [SourceSpans] positions, which are
+/// relative to the owning object's text. Those two are the same numbering only for the first
+/// object in a file, and comparing them directly is #3832. Normalise before you compare —
+/// AlSourceLocationMap.LineOffset is the conversion.
+/// </summary>
 public readonly record struct AlTextPosition(int Line, int Column) : IComparable<AlTextPosition>
 {
     public int CompareTo(AlTextPosition other) =>
@@ -244,13 +250,16 @@ public sealed class AlLoopScopeTable
     /// </summary>
     /// <param name="lineOffset">
     /// Lines to add to a decoded span line to reach the FILE line <paramref name="sites"/>
-    /// carries (#3832) — see AlWriteSetTable.Build's parameter of the same name for the two
+    /// carries (#3832). REQUIRED rather than defaulted: a default of 0 is the exact
+    /// silent-failure this fixed, so a future caller has to choose a coordinate space
+    /// instead of getting the wrong one by omission. Pass 0 explicitly for first-object or
+    /// synthetic data — see AlWriteSetTable.Build's parameter of the same name for the two
     /// coordinate spaces. Without it, an object after the first in its file recognises none
     /// of its own loop ids and iteration segmentation goes quiet.
     /// </param>
     public static AlLoopScopeTable Build(
         IReadOnlyList<AlLoopSite> sites, long[] spans,
-        IEnumerable<int>? instrumented = null, int lineOffset = 0)
+        IEnumerable<int>? instrumented, int lineOffset)
     {
         var ids = instrumented?.ToArray() ?? Enumerable.Range(0, spans.Length).ToArray();
         var starts = new Dictionary<int, AlTextPosition>(ids.Length);

--- a/AlRunner/Infrastructure/AlScopeSyntaxResolver.cs
+++ b/AlRunner/Infrastructure/AlScopeSyntaxResolver.cs
@@ -54,13 +54,18 @@ public static class AlScopeSyntaxResolver
 
         var instrumented = AlCoverageInstrumentedStatements.Find(scopeType);
         if (instrumented.Count == 0) return null;
-        // The first statement's position tells same-named triggers apart.
+        // The first statement's position tells same-named triggers apart — and it has to be
+        // stated in the FILE's coordinates, because that is what the index holds. A decoded
+        // span is relative to the owning object's text, so an object after the first in its
+        // file anchored into the previous object's range and could select a same-named member
+        // there (#3832). scope.LineOffset is the conversion, and TryResolveScope has always
+        // returned it; this is the caller that dropped it.
         int first = instrumented.Min();
         AlTextPosition? anchor = null;
         if (first >= 0 && first < scope.Spans.Length)
         {
             var (fromLine, fromColumn, _, _) = AlSourceSpanCodec.Decode(scope.Spans[first]);
-            anchor = new AlTextPosition(fromLine, fromColumn);
+            anchor = new AlTextPosition(fromLine + scope.LineOffset, fromColumn);
         }
         var member = index.FindMember(scope.FilePath, scope.ScopeName, anchor);
         if (member == null)
@@ -71,8 +76,8 @@ public static class AlScopeSyntaxResolver
         }
 
         return new AlScopeSyntax(
-            AlLoopScopeTable.Build(member.Sites, scope.Spans, instrumented),
-            AlWriteSetTable.Build(member.Writes, scope.Spans, instrumented),
+            AlLoopScopeTable.Build(member.Sites, scope.Spans, instrumented, scope.LineOffset),
+            AlWriteSetTable.Build(member.Writes, scope.Spans, instrumented, scope.LineOffset),
             scope.FilePath,
             scope.ScopeName);
     }

--- a/AlRunner/Infrastructure/AlWriteSetModel.cs
+++ b/AlRunner/Infrastructure/AlWriteSetModel.cs
@@ -25,8 +25,22 @@ public sealed class AlWriteSetTable
     public IReadOnlySet<string> TargetsOf(int statementId) =>
         _byId.TryGetValue(statementId, out var s) ? s : NoTargets;
 
-    /// <summary>Pairs each id with the statement starting exactly where its span starts. A condition's id starts mid-line, a block's `end` id at `end`; neither has a statement there.</summary>
-    public static AlWriteSetTable Build(IReadOnlyList<AlStatementWrites> writes, long[] spans, IEnumerable<int>? instrumented = null)
+    /// <summary>
+    /// Pairs each id with the statement starting exactly where its span starts. A condition's
+    /// id starts mid-line, a block's `end` id at `end`; neither has a statement there.
+    /// </summary>
+    /// <param name="lineOffset">
+    /// Lines to add to a decoded span line to reach the FILE line the parser reported
+    /// (#3832). <paramref name="writes"/> carries parser positions, which are file-relative;
+    /// a [SourceSpans] line is relative to the owning OBJECT's text. They coincide only for
+    /// the first object in a file, so for any later one this comparison matched nothing at
+    /// all — an empty table, indistinguishable downstream from "this member writes nothing".
+    /// The value is AlSourceLocationMap.LineOffset for the owning object;
+    /// AlCoverageTracker.TryResolveScope already returns it.
+    /// </param>
+    public static AlWriteSetTable Build(
+        IReadOnlyList<AlStatementWrites> writes, long[] spans,
+        IEnumerable<int>? instrumented = null, int lineOffset = 0)
     {
         var byStart = new Dictionary<AlTextPosition, IReadOnlySet<string>>();
         foreach (var w in writes)
@@ -39,7 +53,7 @@ public sealed class AlWriteSetTable
         {
             if (i < 0 || i >= spans.Length) continue; // defensive: BC shape drift
             var (fromLine, fromColumn, _, _) = AlSourceSpanCodec.Decode(spans[i]);
-            if (byStart.TryGetValue(new AlTextPosition(fromLine, fromColumn), out var targets))
+            if (byStart.TryGetValue(new AlTextPosition(fromLine + lineOffset, fromColumn), out var targets))
                 byId[i] = targets;
         }
         return new AlWriteSetTable(byId);

--- a/AlRunner/Infrastructure/AlWriteSetModel.cs
+++ b/AlRunner/Infrastructure/AlWriteSetModel.cs
@@ -36,11 +36,13 @@ public sealed class AlWriteSetTable
     /// the first object in a file, so for any later one this comparison matched nothing at
     /// all — an empty table, indistinguishable downstream from "this member writes nothing".
     /// The value is AlSourceLocationMap.LineOffset for the owning object;
-    /// AlCoverageTracker.TryResolveScope already returns it.
+    /// AlCoverageTracker.TryResolveScope already returns it. REQUIRED rather than defaulted:
+    /// a default of 0 is the exact silent-failure this fixed, so a future caller has to
+    /// choose a coordinate space instead of getting the wrong one by omission.
     /// </param>
     public static AlWriteSetTable Build(
         IReadOnlyList<AlStatementWrites> writes, long[] spans,
-        IEnumerable<int>? instrumented = null, int lineOffset = 0)
+        IEnumerable<int>? instrumented, int lineOffset)
     {
         var byStart = new Dictionary<AlTextPosition, IReadOnlySet<string>>();
         foreach (var w in writes)


### PR DESCRIPTION
## Summary

`AlCoverageTracker.TryResolveScope` has always returned each scope's `LineOffset`, and `AlScopeSyntaxResolver` dropped it. So a decoded `[SourceSpans]` line — relative to the **owning object's** text — was compared directly against parser positions, which are **file**-relative. The two coincide only for the first object in a file.

Four places now convert: the member-selection anchor, `AlLoopScopeTable.Build`, `AlWriteSetTable.Build`, and `AlLoopScopeTable.LineOf`, which is where a line leaves the table onto the wire as an iteration's `lines`. The fourth was not in the issue and I found it by measuring.

## The failure was silent in the worst way

Measured through the server's `execute` on a two-codeunit file whose loop sits in the second object:

| | loops reported | body lines | iteration count |
|---|---|---|---|
| before | **0** | — | — |
| after | 1 at file lines 17-19 | 18 | 3, with per-pass totals 1 / 3 / 6 |

Zero loops, and nothing said so. Values were still captured, the test still passed, and the iteration and write tables were simply empty. That is the shape of it: no throw, no warning, a green run whose derived data is missing.

## Proof

**Four unit facts**, both directions, on the two `Build` methods, using the same members the existing facts use with the spans expressed in that object's own coordinates. The negative halves assert the actual failure — an empty table and no recognised loop ids — rather than a wrong number. The loop fact asserts the exact `HeaderIds`, `BodyIds` and `MarkerStatementId`, not a derived answer, because #3834 was a defect in exactly which ids land where.

**Two end-to-end facts** for the wiring, which the unit facts cannot reach because they call `Build` directly. The second one exists because the first does not prove as much as it looks: its file declares `OnRun` once, and `FindMember` returns a sole name candidate whatever anchor it is handed, so the anchor conversion could be deleted and it stayed green. The new fact declares `Compute` in **both** objects — the first's loops five times and is never called, the second's loops twice and runs — so only the anchor can choose. It also carries `same := 5`, assigned identically on every pass, which a value diff cannot report and only the write-set table can attribute per iteration.

Mutation-checked, one row per production decision:

| mutation | what fails |
|---|---|
| the two `Build` offsets | the four unit facts |
| the resolver's three uses | the loop end-to-end fact, back to 0 loops |
| `LineOf` alone | the loop end-to-end fact |
| the **anchor** offset alone | the same-named-member fact, 0 loops |
| the **write-set** offset alone | the `same` assertions only; the rest of that fact stays green |
| `IsReentry` back to `return true` | the exactly-one-instance assertion |
| the closing-header guard | the per-pass `lines` |

**Both `Build` methods now require the offset.** A default of 0 is the silent failure this series fixed, so a future caller has to choose a coordinate space rather than get the wrong one by omission; the 19 zero-offset test call sites say `lineOffset: 0`.

**The unit facts are circular as evidence about BC, and now say so.** The fixture computes `span - offset` and the code adds `offset` back, so they prove the conversion is applied with the right sign and that omitting it matches nothing — not that BC emits a later object's spans with that relationship, and not that `LineOffset` is the right number. The non-circular evidence is the end-to-end facts, which read file lines off the wire and never state a span. Both layers are needed and neither substitutes for the other.

**The obvious test would have been wrong**, and it is worth saying why the fixtures are shaped as they are. My first plan was to prepend an object to `LoopShapesSource` and reuse the measured span constants. That is invalid: BC's object text begins at the blank line before the declaration once anything precedes it (#3822), so the real spans shift too, and the reused constants would encode a fiction that passes against a wrong implementation.

99 facts pass across `AlMemberSyntaxIndexTests`, `ServerExecuteIterationsTests`, `AlValueCaptureWriteSetTests` and `AlIterationSegmenterTests`.

## The duplicate instance is fixed here too, not deferred

An earlier revision of this PR shipped with a second, empty loop instance and a test that asserted on "the instance that ran". An external review blocked that, correctly: a zero-iteration entry is a **legitimate** value on this wire, since a loop that never ran is reported exactly that way, so no consumer can tell the bogus one from a real one. It is corrupt data, not merely incomplete data.

Root cause, found by instrumenting the segmenter and the table to a file because the server subprocess's stderr is not captured:

```
POS id=1 line=16 col=8      POS id=3 line=16 col=8
HDRRANGE Start = { Line = 16, Column = 8 }
SITE header=[1,3] body=[2]
HIT 0, 1, 2, 2, 2, 3, 4
```

Ids 1 and 3 share the header's exact start position — BC emits more than one statement id for a single `for` — and id 3 arrives after the last body pass. `IsReentry` asked only whether the hit was *in* `HeaderIds`, so it popped the instance that had counted the three passes and pushed an empty one. It now asks whether the id that **opened** this instance fired again.

**The coordinate conversion was not at fault.** The printed positions are exactly the file coordinates the parser reported. What the offset changed is that these ids match the ranges at all, so before it there was no instance to duplicate — which is why it looked offset-correlated from outside.

A smaller thing fell out of the same measurement: a header id that is not the entry is the loop *closing*, not a statement of the pass that just ran, so recording it put the header's own line into that pass's `lines`, giving `[18, 17]` instead of `[18]`. It is skipped now.

That guard is deliberately **not** narrowed to for/foreach. A while's condition and a repeat's until are header ids that re-evaluate mid-pass and do belong to the running pass, but they are the entry id, so the guard skips nothing for them. I tried the kind check and mutation-tested it: removing it changed no measured behaviour, which makes it a branch no fact defends, so it is gone.

The end-to-end fact now asserts **exactly one** instance.

## Attribution of the wider sweep

The affected-area sweep fails nine, none in code this touches.

Re-measured against this branch's **exact** base. A pristine worktree at `48634104`, built and run with the same filter, fails the same nine: the six `NavReportStaticRunModalHookBindingTests` cases above, `SkeletonDatabaseTenantExecutionContextTests.ExecutionContext_IsNormal_AndModuleScopedFormsAgree`, `ProvisionExplicitModesTests.TestApps_OnlyUnrelatedAppPresent_DoesNotShortCircuit_DownloadsTheRealSet` and `ServerAffectedSelectionMultiSourcePathsTests.AffectedOnly_CrossBundleCoverage_RunsOnlyTheTestThatCallsTheEditedHelper`. Identical sets, so none is mine.

One documentation correction went in with them: `AlTextPosition` claimed the syntax tree and `[SourceSpans]` share a coordinate space. They do not for any object after the first, which is what this series is about, so the type is now documented as coordinate-agnostic with a pointer to the conversion.

Closes #3832
Closes #3834

Corpus-NA: this is the runner's own source-position bookkeeping for iteration tracking; no BC behaviour is asserted, so there is nothing for a service tier to adjudicate.

*Opened by an agent (Claude Code) in a session run by @SShadowS.*

https://claude.ai/code/session_01JFQZHC5SEHnLxkc5USksaK
