### PR TITLE
test(guard): the scratch-dir ownership guard must see Directory.CreateTempSubdirectory

### DIFF
--- a/AlRunner.Tests/JUnitCollateralFailureTests.cs
+++ b/AlRunner.Tests/JUnitCollateralFailureTests.cs
@@ -44,7 +44,8 @@ namespace AlRunner.Tests;
 
 public sealed class JUnitCollateralFailureTests : IDisposable
 {
-    private readonly string _dir = Directory.CreateTempSubdirectory("al-runner-junit-collateral-").FullName;
+    private readonly string _dir =
+        Directory.CreateDirectory(TestScratch.FlatDir("al-runner-junit-collateral-")).FullName;
 
     public void Dispose()
     {

--- a/AlRunner.Tests/PrecompileNclShadowHopTests.cs
+++ b/AlRunner.Tests/PrecompileNclShadowHopTests.cs
@@ -73,7 +73,7 @@ public sealed class PrecompileNclShadowHopTests
             "something wrote it (the defect issue #2065 is about), and mirroring would copy " +
             "that contamination forward and make these tests assert nothing.");
 
-        var privateDir = Directory.CreateTempSubdirectory("al-runner-precompile-mirror-").FullName;
+        var privateDir = Directory.CreateDirectory(TestScratch.FlatDir("al-runner-precompile-mirror-")).FullName;
         NclShadowRuntime.MirrorInstallDirectory(originalBinDir, privateDir);
         return privateDir;
     }

--- a/AlRunner.Tests/ScratchDirOwnershipGuardTests.cs
+++ b/AlRunner.Tests/ScratchDirOwnershipGuardTests.cs
@@ -16,10 +16,18 @@ namespace AlRunner.Tests;
 /// (it skips any depth-0 name without a scanned prefix). Nothing noticed for three weeks,
 /// because a textual conversion leaves no record of what it missed.
 ///
-/// So the remainder is enforced here rather than described in a PR body. A new
-/// <c>Path.GetTempPath()</c> in AlRunner.Tests fails this test unless its file is on the
-/// allowlist below WITH the reason the site cannot be owned — and the COUNT is part of the
-/// allowlist, so adding a second, ownable site to an allowlisted file still fails.
+/// So the remainder is enforced here rather than described in a PR body. A new scanned
+/// expression in AlRunner.Tests fails this test unless its file is on the allowlist below WITH
+/// the reason the site cannot be owned — and the COUNT is part of the allowlist, so adding a
+/// second, ownable site to an allowlisted file still fails.
+///
+/// #3831 widened WHAT is scanned, which is the axis that had never been questioned. The scan
+/// matched <c>Path.GetTempPath()</c> only, so <c>Directory.CreateTempSubdirectory</c> — which
+/// creates a directory under the same <c>TMPDIR</c> and leaks identically — was invisible, and
+/// the guard reported green on 13 such sites across 6 files for as long as it had existed. Two
+/// of them were instance fields, leaking once per test-class instantiation rather than once per
+/// run. A guard silent on the API a developer is most likely to reach for is reporting its
+/// success state about something it never measured (<c>guards-need-a-third-state.md</c>).
 ///
 /// The failure mode this shape exists to avoid is the one
 /// <c>.claude/rules/no-base-app-in-csharp-tests.md</c> already recorded: an allowlist written
@@ -46,7 +54,26 @@ public sealed class ScratchDirOwnershipGuardTests
 
     private static string TestsDir => Path.Combine(RepoRoot, "AlRunner.Tests");
 
-    private const string Expression = "Path.GetTempPath()";
+    /// <summary>
+    /// Every way this project has of naming a location under <c>TMPDIR</c>. All of them leak the
+    /// same way, so all of them are scanned and all of them count against the same per-file
+    /// budget — a file may not trade an allowlisted <c>Path.GetTempPath()</c> for an unowned
+    /// <c>CreateTempSubdirectory</c> without the count moving.
+    ///
+    /// <c>Path.GetTempFileName</c> is deliberately here with ZERO call sites today (#3831
+    /// measured it). It is the third member of the family and creates a real file in the temp
+    /// root, so scanning for it costs one string and closes the gap before a first caller opens
+    /// it, rather than after — which is the whole complaint this test was widened to answer.
+    /// It is scanned, not special-cased: if it ever appears it is an ordinary offender.
+    /// </summary>
+    private static readonly string[] Expressions =
+    [
+        "Path.GetTempPath()",
+        "Directory.CreateTempSubdirectory",
+        "Path.GetTempFileName",
+    ];
+
+    private static string ExpressionList => string.Join(", ", Expressions);
 
     /// <summary>
     /// Source path, relative to <c>AlRunner.Tests</c> → (how many non-comment
@@ -60,7 +87,10 @@ public sealed class ScratchDirOwnershipGuardTests
         ["TestScratch.cs"] =
             (3, "the helper itself — Dir, FlatDir and FilePath are what everything else calls"),
         ["ScratchDirOwnershipGuardTests.cs"] =
-            (1, "the literal this guard scans for, in the const it scans with"),
+            (5, "the literals this guard scans FOR, never paths it creates: 3 in the Expressions "
+              + "array and 2 more in EveryScannedExpression_IsMatchedByTheScanner_OnSyntheticSource, "
+              + "which builds synthetic source lines to prove each entry fires. Was 1 until #3831 "
+              + "widened the scan from one expression to three"),
 
         // ── paths that must NOT exist ───────────────────────────────────────────────────
         ["AppLoaderManifestCacheTests.cs"] =
@@ -147,42 +177,53 @@ public sealed class ScratchDirOwnershipGuardTests
         return paths;
     }
 
-    /// <summary>Non-comment occurrences of the expression, per source path.</summary>
-    private static Dictionary<string, int> Occurrences()
+    /// <summary>
+    /// Non-comment occurrences of any scanned expression, per source path, each carrying the
+    /// 1-based line it sits on. The line numbers are what makes a failure actionable: the
+    /// pre-#3831 message named 6 files and left the reader to find 13 sites inside them.
+    /// </summary>
+    private static Dictionary<string, List<(int Line, string Expression)>> Occurrences()
     {
-        var found = new Dictionary<string, int>(StringComparer.Ordinal);
+        var found = new Dictionary<string, List<(int, string)>>(StringComparer.Ordinal);
         foreach (var path in TestSources())
         {
-            var n = 0;
+            var hits = new List<(int, string)>();
+            var lineNo = 0;
             foreach (var raw in File.ReadAllLines(path))
             {
-                var line = raw.TrimStart();
-                if (line.StartsWith("//", StringComparison.Ordinal)
-                    || line.StartsWith("*", StringComparison.Ordinal)) continue;
-
-                var i = 0;
-                while ((i = raw.IndexOf(Expression, i, StringComparison.Ordinal)) >= 0)
+                lineNo++;
+                foreach (var expression in Expressions)
                 {
-                    n++;
-                    i += Expression.Length;
+                    if (!MatchesInLine(raw, expression)) continue;
+
+                    var i = 0;
+                    while ((i = raw.IndexOf(expression, i, StringComparison.Ordinal)) >= 0)
+                    {
+                        hits.Add((lineNo, expression));
+                        i += expression.Length;
+                    }
                 }
             }
-            if (n > 0) found[Key(path)] = n;
+            if (hits.Count > 0) found[Key(path)] = hits;
         }
         return found;
     }
 
     /// <summary>
-    /// The forward direction: a file using <c>Path.GetTempPath()</c> without being on the
-    /// allowlist is a scratch path nothing owns.
+    /// The forward direction: a file naming a temp location through any scanned expression,
+    /// without being on the allowlist, is a scratch path nothing owns.
     /// </summary>
     [Fact]
     public void NoTestSource_BuildsAnUnownedTempPath_ExceptTheAllowlisted()
     {
-        var offenders = Occurrences().Keys.Where(f => !Allowed.ContainsKey(f)).OrderBy(f => f).ToList();
+        var offenders = Occurrences()
+            .Where(kv => !Allowed.ContainsKey(kv.Key))
+            .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+            .SelectMany(kv => kv.Value.Select(h => $"{kv.Key}:{h.Line}  {h.Expression}"))
+            .ToList();
 
         Assert.True(offenders.Count == 0,
-            $"These test sources build a path under {Expression} directly, so nothing "
+            $"These test sources name a temp location directly ({ExpressionList}), so nothing "
             + "records an owner for it and a killed test host leaks it permanently:\n  "
             + string.Join("\n  ", offenders)
             + "\n\nUse TestScratch.Dir / TestScratch.FlatDir for a directory, or "
@@ -205,9 +246,12 @@ public sealed class ScratchDirOwnershipGuardTests
 
         foreach (var (name, (count, why)) in Allowed)
         {
-            var actual = found.TryGetValue(name, out var n) ? n : 0;
+            var actual = found.TryGetValue(name, out var hits) ? hits.Count : 0;
             if (actual != count)
-                wrong.Add($"{name}: allowlist says {count}, source has {actual} ({why})");
+                wrong.Add($"{name}: allowlist says {count}, source has {actual} ({why})"
+                    + (actual > 0
+                        ? " — at " + string.Join(", ", hits!.Select(h => $"line {h.Line} {h.Expression}"))
+                        : string.Empty));
         }
 
         Assert.True(wrong.Count == 0,
@@ -216,6 +260,85 @@ public sealed class ScratchDirOwnershipGuardTests
             + "already-allowlisted file — route it through TestScratch. Lower means the entry is "
             + "stale: correct the count, or delete the entry, so it stops pre-approving the next "
             + "site that lands in that file.");
+    }
+
+    /// <summary>
+    /// The scan itself, measured rather than assumed. <c>TestScratch.cs</c> is the one file
+    /// guaranteed to name a temp location — it is the helper every other site delegates to —
+    /// so finding it there proves the matcher runs, reads real source, and does not skip the
+    /// file as a comment.
+    ///
+    /// Without this, a typo in <see cref="Expressions"/>, a matcher that never fires, or an
+    /// enumeration that reached no source would leave
+    /// <see cref="NoTestSource_BuildsAnUnownedTempPath_ExceptTheAllowlisted"/> green with an
+    /// empty offender list — the guard reporting its success state about something it never
+    /// measured, which is the exact defect #3831 fixed one level up
+    /// (<c>guards-need-a-third-state.md</c>). <see cref="TestSources"/> asserts the enumeration
+    /// is non-empty; this asserts the MATCHING is.
+    ///
+    /// Only <c>Path.GetTempPath()</c> can be demanded of the live project: after #3831's sweep
+    /// no source uses <c>CreateTempSubdirectory</c> or <c>GetTempFileName</c> at all, which is
+    /// the desired end state, so demanding either would force a site to exist purely to keep
+    /// this green. Those two are proved to match by
+    /// <see cref="EveryScannedExpression_IsMatchedByTheScanner_OnSyntheticSource"/>, which
+    /// feeds the matcher source it writes itself.
+    /// </summary>
+    [Fact]
+    public void TheScanItself_ActuallyMatches_SoAnEmptyOffenderListMeansSomething()
+    {
+        var found = Occurrences();
+
+        Assert.True(found.TryGetValue("TestScratch.cs", out var helper),
+            "the scan found no temp expression in TestScratch.cs, the one file that must "
+            + $"contain them ({ExpressionList}) — so the matcher is not working and an empty "
+            + "offender list from this class proves nothing.");
+
+        Assert.Equal(3, helper!.Count);
+        Assert.All(helper, h => Assert.Equal("Path.GetTempPath()", h.Expression));
+    }
+
+    /// <summary>
+    /// Every entry in <see cref="Expressions"/> is matched by the same code path the project
+    /// scan uses, and a comment carrying it is not.
+    ///
+    /// This is what makes an entry with no live call site — <c>CreateTempSubdirectory</c> and
+    /// <c>GetTempFileName</c> after the #3831 sweep — a measured guard rather than a string
+    /// nobody has ever seen fire. A never-fire branch and a correctly-silent one are
+    /// indistinguishable from the outside, and the never-fire one is the whole defect.
+    /// </summary>
+    [Fact]
+    public void EveryScannedExpression_IsMatchedByTheScanner_OnSyntheticSource()
+    {
+        foreach (var expression in Expressions)
+        {
+            Assert.True(MatchesInLine($"        var x = {expression};", expression),
+                $"'{expression}' is listed as scanned but the matcher does not find it in a "
+                + "line that contains it — the entry would never fire, so the guard would be "
+                + "silent on it exactly as it was on CreateTempSubdirectory before #3831.");
+
+            Assert.False(MatchesInLine($"        // var x = {expression};", expression),
+                $"'{expression}' matched inside a comment. Files quote these while explaining "
+                + "that they deliberately do not use them, and flagging those would train "
+                + "readers to ignore this test.");
+        }
+
+        // Negative: a name that merely resembles a scanned one must not match, or the guard
+        // would report offenders nobody can act on.
+        Assert.False(MatchesInLine("var p = MyPath.GetTempPathish();", "Path.GetTempFileName"));
+    }
+
+    /// <summary>
+    /// The single-line form of the loop in <see cref="Occurrences"/>: comment lines skipped,
+    /// ordinal substring match. Kept separate so
+    /// <see cref="EveryScannedExpression_IsMatchedByTheScanner_OnSyntheticSource"/> exercises
+    /// the real predicate rather than a re-statement of it.
+    /// </summary>
+    private static bool MatchesInLine(string raw, string expression)
+    {
+        var line = raw.TrimStart();
+        if (line.StartsWith("//", StringComparison.Ordinal)
+            || line.StartsWith("*", StringComparison.Ordinal)) return false;
+        return raw.IndexOf(expression, StringComparison.Ordinal) >= 0;
     }
 
     /// <summary>

--- a/AlRunner.Tests/StartupOutputReexecDedupTests.cs
+++ b/AlRunner.Tests/StartupOutputReexecDedupTests.cs
@@ -428,7 +428,7 @@ public sealed class StartupOutputReexecDedupTests
     [Fact]
     public void DeleteDirectoryOrFail_UndeletableDirectory_FailsLoudlyNamingDirectoryAndException()
     {
-        var dir = Directory.CreateTempSubdirectory("al-runner-deletedirorfail-").FullName;
+        var dir = Directory.CreateDirectory(TestScratch.FlatDir("al-runner-deletedirorfail-")).FullName;
         File.WriteAllText(Path.Combine(dir, "Microsoft.Dynamics.Nav.Ncl.dll"), "not a real dll — just needs to exist");
         try
         {
@@ -465,7 +465,7 @@ public sealed class StartupOutputReexecDedupTests
     [Fact]
     public void DeleteDirectoryOrFail_DeletableDirectory_DeletesAndReturns()
     {
-        var dir = Directory.CreateTempSubdirectory("al-runner-deletedirorfail-ok-").FullName;
+        var dir = Directory.CreateDirectory(TestScratch.FlatDir("al-runner-deletedirorfail-ok-")).FullName;
         File.WriteAllText(Path.Combine(dir, "Microsoft.Dynamics.Nav.Ncl.dll"), "not a real dll — just needs to exist");
 
         DeleteDirectoryOrFail(dir);
@@ -558,7 +558,7 @@ public sealed class StartupOutputReexecDedupTests
             "hand) has contaminated the shared source, and the private mirror below would " +
             "otherwise silently copy that contamination forward.");
 
-        var privateDir = Directory.CreateTempSubdirectory("al-runner-startup-mirror-").FullName;
+        var privateDir = Directory.CreateDirectory(TestScratch.FlatDir("al-runner-startup-mirror-")).FullName;
         NclShadowRuntime.MirrorInstallDirectory(originalBinDir, privateDir);
         return privateDir;
     }

--- a/AlRunner.Tests/TestDataLazyHydrationTests.cs
+++ b/AlRunner.Tests/TestDataLazyHydrationTests.cs
@@ -44,7 +44,7 @@ public sealed class TestDataLazyLoadPolicyTests : IDisposable
 
     public TestDataLazyLoadPolicyTests()
     {
-        _dir = Directory.CreateTempSubdirectory("al-runner-lazy-testdata");
+        _dir = Directory.CreateDirectory(TestScratch.Dir("al-runner-lazy-testdata"));
         _log = Path.Combine(_dir.FullName, "reader-invocations.log");
         _backup = Path.Combine(_dir.FullName, "BusinessCentral-W1.bak");
         File.WriteAllBytes(_backup, new byte[256]);

--- a/AlRunner.Tests/TestDataProvisioningTests.cs
+++ b/AlRunner.Tests/TestDataProvisioningTests.cs
@@ -75,7 +75,7 @@ public sealed class TestDataProvisioningTests : IDisposable
         // function whose result keys both tiers — rather than re-composing the key here. A
         // test that re-composed it would still pass if the call site stopped folding the
         // identity in, which is precisely the regression that ships a silent empty database.
-        var dir = Directory.CreateTempSubdirectory("al-runner-testdata-cachekey");
+        var dir = Directory.CreateDirectory(TestScratch.Dir("al-runner-testdata-cachekey"));
         var previousEnv = Environment.GetEnvironmentVariable(BackupReaderTool.ExecutableEnvVar);
         try
         {
@@ -128,7 +128,7 @@ public sealed class TestDataProvisioningTests : IDisposable
     [Fact]
     public void NormalizedRun_AndUnnormalizedRun_DoNotShareAnInstallBaselineCacheKey()
     {
-        var dir = Directory.CreateTempSubdirectory("al-runner-normalize-cachekey");
+        var dir = Directory.CreateDirectory(TestScratch.Dir("al-runner-normalize-cachekey"));
         var previousEnv = Environment.GetEnvironmentVariable(BackupReaderTool.ExecutableEnvVar);
         try
         {
@@ -202,7 +202,7 @@ public sealed class TestDataProvisioningTests : IDisposable
     [Fact]
     public void CacheIdentity_TracksTheBackupFilesContent_NotJustItsName()
     {
-        var dir = Directory.CreateTempSubdirectory("al-runner-testdata-key");
+        var dir = Directory.CreateDirectory(TestScratch.Dir("al-runner-testdata-key"));
         try
         {
             var bak = Path.Combine(dir.FullName, "BusinessCentral-W1.bak");
@@ -364,7 +364,7 @@ public sealed class TestDataProvisioningTests : IDisposable
         // identical between builds and only the managed .dlls change, so hashing the
         // executable alone would let a reader fix that changes decoded VALUES be masked by
         // a cached baseline keyed on an unchanged identity.
-        var dir = Directory.CreateTempSubdirectory("al-runner-bcbak-identity");
+        var dir = Directory.CreateDirectory(TestScratch.Dir("al-runner-bcbak-identity"));
         try
         {
             var exe = Path.Combine(dir.FullName, "bcbak");

--- a/AlRunner.Tests/TestDataSymbolPackagesTests.cs
+++ b/AlRunner.Tests/TestDataSymbolPackagesTests.cs
@@ -82,7 +82,7 @@ public sealed class TestDataSymbolPackagesTests
     [Fact]
     public void SourceOnlyNavx_IsNotReaderConsumable()
     {
-        var dir = Directory.CreateTempSubdirectory("al-runner-2794-").FullName;
+        var dir = Directory.CreateDirectory(TestScratch.FlatDir("al-runner-2794-")).FullName;
         try
         {
             var p = WritePackage(dir, "Repro_ReproDepApp_1_0_0_0.app", withSymbolReference: false);
@@ -94,7 +94,7 @@ public sealed class TestDataSymbolPackagesTests
     [Fact]
     public void SymbolBearingNavx_IsReaderConsumable()
     {
-        var dir = Directory.CreateTempSubdirectory("al-runner-2794-").FullName;
+        var dir = Directory.CreateDirectory(TestScratch.FlatDir("al-runner-2794-")).FullName;
         try
         {
             var p = WritePackage(dir, "Microsoft_Something.app", withSymbolReference: true);
@@ -108,7 +108,7 @@ public sealed class TestDataSymbolPackagesTests
     [Fact]
     public void UnreadableFile_IsLeftForTheReader()
     {
-        var dir = Directory.CreateTempSubdirectory("al-runner-2794-").FullName;
+        var dir = Directory.CreateDirectory(TestScratch.FlatDir("al-runner-2794-")).FullName;
         try
         {
             var p = Path.Combine(dir, "Fake_App_1_0_0_0.app");


### PR DESCRIPTION
Closes #3831

The scratch-dir ownership guard scanned for `Path.GetTempPath()` and nothing else, so `Directory.CreateTempSubdirectory` — which creates a directory under the same `TMPDIR` and leaks identically, since nothing records an owner — was invisible to it. The guard reported green on 13 such call sites across 6 files for as long as it had existed.

Two of those were instance fields (`JUnitCollateralFailureTests.cs:47`, `TestDataLazyHydrationTests.cs:47`), so they leaked once per test-class instantiation rather than once per run.

## The guard first, then the sweep

Landing the sweep first would have left nothing stopping the 14th site, which is how these accumulated. So the widened guard went in first and its RED is the proof the widening works.

### What changed in the guard

- `Expression` (one string) became `Expressions` (three): `Path.GetTempPath()`, `Directory.CreateTempSubdirectory`, `Path.GetTempFileName`. **Added, not replaced** — the existing `GetTempPath` scan is unchanged and all 15 pre-existing allowlist entries kept their counts.
- Occurrences now carry their **line number and which expression matched**, so a failure names `File.cs:47  Directory.CreateTempSubdirectory` instead of just the file. The pre-existing message named 6 files and left the reader to find 13 sites inside them.
- All three expressions share one per-file budget, so a file cannot trade an allowlisted `GetTempPath()` for an unowned `CreateTempSubdirectory` without the count moving.

### RED — the widened guard on unmodified sources

Second run, after a full build (figures from the first run after a build are not quoted; see the note at the end):

```
Failed!  - Failed: 2, Passed: 3, Skipped: 0, Total: 5
```

The 13 split across the two facts exactly as the allowlist design dictates:

**9 sites in 5 unallowlisted files** → `NoTestSource_BuildsAnUnownedTempPath_ExceptTheAllowlisted`:

```
JUnitCollateralFailureTests.cs:47      Directory.CreateTempSubdirectory
PrecompileNclShadowHopTests.cs:76      Directory.CreateTempSubdirectory
StartupOutputReexecDedupTests.cs:431   Directory.CreateTempSubdirectory
StartupOutputReexecDedupTests.cs:468   Directory.CreateTempSubdirectory
StartupOutputReexecDedupTests.cs:561   Directory.CreateTempSubdirectory
TestDataLazyHydrationTests.cs:47       Directory.CreateTempSubdirectory
TestDataSymbolPackagesTests.cs:85      Directory.CreateTempSubdirectory
TestDataSymbolPackagesTests.cs:97      Directory.CreateTempSubdirectory
TestDataSymbolPackagesTests.cs:111     Directory.CreateTempSubdirectory
```

**4 sites in `TestDataProvisioningTests.cs`** → `EveryAllowlistEntry_MatchesItsRecordedCount`, reported as `allowlist says 1, source has 5`. That file was already allowlisted for its one `GetTempPath()` (the `.bak` path that must not exist), and the count direction is what stopped four new sites hiding behind that entry. This is the allowlist working as designed, not a second defect.

All 13 accounted for, none of them a false positive.

### GREEN — the sweep

All 13 converted to `TestScratch`, none allowlisted. Every one calls `CreateTempSubdirectory` and therefore genuinely wants a real directory, so none met the allowlist bar (a path that must **not** exist, where reserving would create the parent and drop a sidecar beside the thing being measured).

`TestScratch.Dir` and `FlatDir` reserve **without creating the leaf** (`TestScratch.cs` line 11), so each converted site wraps the reservation in an explicit create:

```csharp
var dir = Directory.CreateDirectory(TestScratch.FlatDir("al-runner-2794-")).FullName;
```

`FlatDir` for the sites whose prefix ends in `-` (matching their original `<temp>/<prefix><guid>` shape), `Dir` for the rest. `TestDataLazyHydrationTests` holds a `DirectoryInfo`, which `Directory.CreateDirectory` returns directly, so that field needed no other change.

```
Passed!  - Failed: 0, Passed: 5, Skipped: 0, Total: 5     (guard class)
Passed!  - Failed: 0, Passed: 102, Skipped: 0, Total: 102 (guard + 4 converted classes)
Passed!  - Failed: 0, Passed: 9, Skipped: 0, Total: 9     (the 2 runner-spawning converted classes, 27 s)
```

After the sweep, `CreateTempSubdirectory` and `GetTempFileName` appear nowhere in `AlRunner.Tests/` except inside the guard that scans for them.

## `Path.GetTempFileName` has zero call sites, and is scanned anyway

Measured, not assumed: zero occurrences in `AlRunner.Tests/` before this change and after it. It is the third member of the family and creates a real file in the temp root, so scanning for it costs one string and closes the gap before a first caller opens it.

That creates the risk the brief warned about — an unexercised branch, where a never-fire entry and a correctly-silent one look identical. Two new facts close it:

- **`TheScanItself_ActuallyMatches_SoAnEmptyOffenderListMeansSomething`** — asserts the project scan finds exactly 3 hits in `TestScratch.cs`, all `Path.GetTempPath()`. Without it, a typo in `Expressions` or a matcher that never fires would leave the offender list empty and the guard green, which is #3831 one level up. `TestSources()` already asserted the file enumeration is non-empty; this asserts the **matching** is.
- **`EveryScannedExpression_IsMatchedByTheScanner_OnSyntheticSource`** — feeds each of the three expressions to the real predicate on source it writes itself: matched in a code line, **not** matched in a comment line, plus a negative that a lookalike name (`MyPath.GetTempPathish()`) does not match `Path.GetTempFileName`. `Occurrences()` was refactored to call that same `MatchesInLine` predicate, so this exercises the real path rather than a restatement of it.

Only `GetTempPath()` can be demanded of the live project, since the desired end state is that the other two have no call sites — demanding them would force a site to exist purely to keep the test green.

## The allowlist count is a measured fact, not pre-approval

The guard's own file went from 1 to 5 (3 in the `Expressions` array, 2 in the synthetic-source test — literals it scans **for**, never paths it creates). Per the discipline from #3826, I mutated that `5` to `6` and confirmed the staleness check fails:

```
ScratchDirOwnershipGuardTests.cs: allowlist says 6, source has 5 (...)
  — at line 71 Path.GetTempPath(), line 72 Directory.CreateTempSubdirectory,
    line 73 Path.GetTempFileName, line 297 Path.GetTempPath(), line 327 Path.GetTempFileName
Failed!  - Failed: 1, Passed: 4, Skipped: 0, Total: 5
```

Then restored it and confirmed the file is byte-identical to its pre-mutation state.

## Fix the shape, not just the reported line

**Does the same wrong pattern appear at another call site?** Yes — one, in production code, and it is **not** in this PR. `AlRunner/DependencyMetadataProducer.cs:140` creates its per-app compile scratch with `Directory.CreateTempSubdirectory`. It has a `finally` that deletes, so it is not the every-run leak the test sites were; the residual is that a killed process leaves it permanently, holding a full copy of a dependency app's source tree. Filed as **#3838** rather than folded: this guard scans `AlRunner.Tests/` by construction, `TestScratch` is not available to production code, and choosing the right `ScratchDirs` entry point for a directory normally deleted in a `finally` is a different judgement than the test sweep. That is the only such site under `AlRunner/`.

**Does a sibling function make the same assumption?** I checked for other ways to name a temp location that the widened scan still would not see: `Path.GetRandomFileName` (0 sites), and the `TMPDIR` / `TEMP` / `SpecialFolder` hits, which are an env value fed to the runner under test, paths built under an already-scanned variable inside the sweep test, and `SpecialFolder.UserProfile` (the home directory, not the temp root). No fourth API to add.

**If two code paths write the same state, do they maintain the same invariant?** The two guard facts read one `Occurrences()`, so the forward and count directions cannot disagree about what was found. The refactor to a shared `MatchesInLine` closed the one place they could have drifted: the comment-skipping predicate was previously inline in `Occurrences()` and would have been restated, not shared, by the new synthetic-source test.

## Queue scan

I searched the open issues for `scratch`, `temp dir`, `leak`, `TestScratch` and `ownership`, and for the symbol and file this lands in. Nothing folds: #3759 is `preflight.py`'s `os.getuid()` on Windows, #3619 is `agent_scratchpad.py`'s per-agent namespacing, #2181 is a runtime `SingleInstance` leak. None lands in `ScratchDirOwnershipGuardTests.cs` or the converted files.

## Corpus linkage and CI gates

No corpus declaration, and not by omission — I ran the gate script against this diff:

```
No file in this diff can change what AL observes, so no corpus declaration is required.
```

Nothing here asserts BC behavior; it is test-infrastructure ownership. Every changed path is under `AlRunner.Tests/`, so `require-tests` does not fire, and no label is needed.

## Note on the figures

Every number above is from a **second** run after the relevant build. The first `dotnet test` after any build skips the whole `bc-engine-serial` collection and reports `Skipped: N`, which reads exactly like a pass (filed separately as #3835, not fixed here). One run in this task did report a stale failure for that family of reason — a run against the mutation-test binary I had not rebuilt after restoring the source; I rebuilt and re-measured rather than reading it as a real failure.

Implemented by the agent loop `stma-auto-12`, not by a person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
