### PR TITLE
docs(rules): name the instrument for "is my tree clean?" in the no-stash table

### DIFF
--- a/.claude/rules/no-git-stash-with-worktrees.md
+++ b/.claude/rules/no-git-stash-with-worktrees.md
@@ -24,6 +24,7 @@ no per-worktree stash.
 | Set aside changes you will bring back | `git diff HEAD > /tmp/mine.patch`, then `git apply /tmp/mine.patch`. `git diff HEAD`, not `git diff` — plain `git diff` captures **nothing** once the change is staged. Neither captures untracked files; copy those by hand. |
 | Keep work safe across a crash or reboot | Commit it on your own branch; nobody else can pop it. |
 | Move to another branch with changes in hand | You should not need to — one agent, one worktree, one branch. |
+| Check whether your tree is clean, before a rebase or a push | `git status --porcelain` — empty output means clean. **Not the stash-listing command**, which is the pre-rebase reflex the hook refuses: it reports on the SHARED stack rather than on your worktree, so it is both blocked and the wrong instrument for the question. |
 
 Committing early is the preferred answer to all of these.
 


### PR DESCRIPTION
## What

Adds one row to `no-git-stash-with-worktrees.md`'s **"What to use instead"** table, for the question agents actually reach for the stash listing to answer: *is my worktree clean before I rebase or push?*

```
| Check whether your tree is clean, before a rebase or a push | `git status --porcelain` — empty
  output means clean. **Not the stash-listing command**, which is the pre-rebase reflex the hook
  refuses: it reports on the SHARED stack rather than on your worktree, so it is both blocked and
  the wrong instrument for the question. |
```

## Why

Every existing row addresses **setting work aside** — revert a file, keep a patch, move branches. None addressed **inspecting state**. So an agent forms the right intent, picks the wrong instrument, and hits a refusal whose listed remedies are all about a different goal.

Two independent instances today, which is this repository's bar for stating a direction:

- the implementation agent on #3829 reported it unprompted after tripping the hook before a rebase;
- the coordinator did the same **while editing this very file** to document the gap.

The row makes the point that matters beyond the ban: worktree cleanliness has nothing to do with the shared stack, so it would be the wrong command even if the hook did not exist.

## The trap this fix had to avoid

The hook matches command text, and my first attempt was **refused for containing the literal command inside documentation prose** — the same class of defect as #3813, where a comment's wording decided which test a scanner flagged. The row is therefore worded to describe the command without spelling it. A later editor who "helpfully" inserts the literal will re-break the hook against this file.

## Scope

Documentation only. The hook is right and unchanged; the ban is right and unchanged. This adds the missing signpost so the refusal lands on someone who already knows where to go.

No test: this is a prose row in a rules file, and asserting on its wording would pin the exact phrasing rather than the behaviour. The claim it makes — `git status --porcelain` answers the question — is a git property, not a repo one.

Corpus-NA: documentation-only change to an agent operating rule; no AL is compiled, executed or observed, so no corpus test can measure it.

Closes #3839

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
