### PR TITLE
fix(coverage): extension objects reach the source map, so their executed statements are visible

### DIFF
--- a/AlRunner.Tests/CoverageMultiObjectFileTests.cs
+++ b/AlRunner.Tests/CoverageMultiObjectFileTests.cs
@@ -437,6 +437,93 @@ public sealed class CoverageMultiObjectFileTests : IDisposable
     }
 
     /// <summary>
+    /// #3833: an EXTENSION object's executable statements were invisible. `LabelOf` maps seven
+    /// top-level kinds and no extension, and AlCallStackCapture's prefix map has no extension
+    /// entry either — measured, BC emits `TableExtension63701+Doubled_Scope_...`, which parsed
+    /// to ("?", 0) and was dropped before the map was ever consulted.
+    ///
+    /// The statement runs: the test calls the extension's procedure and asserts its result, so
+    /// a report that omits it is omitting executed code. Both halves are asserted, because
+    /// fixing only the parser leaves the (label, id) unmapped and fixing only LabelOf leaves it
+    /// unparsed.
+    /// </summary>
+    [SkippableFact]
+    public void Coverage_TableExtensionProcedure_IsReportedOnItsOwnFile()
+    {
+        TestArtifacts.SkipIfMissing();
+        var bundle = Path.Combine(_root, "bundle-tableext");
+        Directory.CreateDirectory(bundle);
+        File.WriteAllText(Path.Combine(bundle, "app.json"), """
+        {
+          "id": "5a3f0b11-3833-4a0d-800d-000000003833",
+          "name": "CMOF TableExt Probe",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 63700, "to": 63739 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(bundle, "Base.Table.al"), """
+        table 63700 "P3833 Base"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "Code"; Code[20]) { }
+                field(2; "Value"; Integer) { }
+            }
+            keys { key(PK; "Code") { Clustered = true; } }
+        }
+        """);
+        // The executed statement is `exit(Value * 2);` on line 10 of this file.
+        File.WriteAllText(Path.Combine(bundle, "Ext.TableExt.al"), """
+        tableextension 63701 "P3833 Ext" extends "P3833 Base"
+        {
+            fields
+            {
+                field(50; "Extra"; Integer) { }
+            }
+
+            procedure Doubled(): Integer
+            begin
+                exit(Value * 2);
+            end;
+        }
+        """);
+        File.WriteAllText(Path.Combine(bundle, "T.Codeunit.al"), """
+        codeunit 63710 "P3833 Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure ExtensionProcedureRuns()
+            var
+                R: Record "P3833 Base";
+            begin
+                R.Init();
+                R.Code := 'A';
+                R.Value := 21;
+                if R.Doubled() <> 42 then
+                    Error('Doubled');
+            end;
+        }
+        """);
+
+        var coveragePath = Path.Combine(_root, "cobertura-tableext.xml");
+        var (output, exit) = Spawn(bundle, "--coverage", $"--coverage-out \"{coveragePath}\"");
+
+        Assert.Equal(0, exit);
+        Assert.True(File.Exists(coveragePath), $"cobertura.xml was not written.\n{output}");
+        var doc = XDocument.Load(coveragePath);
+
+        var lines = LinesOf(ClassFor(doc, "Ext.TableExt.al"));
+        Assert.Equal(new[] { 10 }, lines.Keys.OrderBy(k => k).ToArray());
+        Assert.Equal(1, lines[10]);
+    }
+
+    /// <summary>
     /// #3822, the shape that stresses both halves of the origin rule at once: a REAL preamble
     /// (header comment, namespace, using) AND an unmapped object in front of the mapped one.
     ///

--- a/AlRunner.Tests/CoverageMultiObjectFileTests.cs
+++ b/AlRunner.Tests/CoverageMultiObjectFileTests.cs
@@ -437,6 +437,100 @@ public sealed class CoverageMultiObjectFileTests : IDisposable
     }
 
     /// <summary>
+    /// #3841 review: the end-to-end fact proves a JOIN — a statement landed under the right
+    /// file — and a coordinated but wrong implementation returning the same invented label
+    /// from both halves would satisfy it. This pins the map side of the contract exactly:
+    /// the KEY, label and id together, for each extension kind.
+    ///
+    /// The labels are not free. They have to equal what AlCallStackCapture's prefix map
+    /// produces from the emitted type name, and both match the spelling
+    /// RecordPatches.AlSourceParser has always used.
+    /// </summary>
+    [SkippableFact]
+    public void Build_ExtensionObjects_AreKeyedByKindAndTheirOwnId()
+    {
+        RequireEngine();
+        File.WriteAllText(Path.Combine(_root, "Exts.al"), """
+        table 63700 "P3833 Base"
+        {
+            fields { field(1; "Value"; Integer) { } }
+        }
+
+        tableextension 63701 "P3833 TExt" extends "P3833 Base"
+        {
+            procedure Doubled(): Integer
+            begin
+                exit(Value * 2);
+            end;
+        }
+
+        page 63720 "P3833 Base Page"
+        {
+            PageType = Card;
+            SourceTable = "P3833 Base";
+        }
+
+        pageextension 63721 "P3833 PExt" extends "P3833 Base Page"
+        {
+            procedure Tripled(): Integer
+            begin
+                exit(Rec.Value * 3);
+            end;
+        }
+
+        report 63740 "P3833 Base Report"
+        {
+            dataset { dataitem(Loop; Integer) { column(Number; Number) { } } }
+        }
+
+        reportextension 63741 "P3833 RExt" extends "P3833 Base Report"
+        {
+            procedure Quadrupled(X: Integer): Integer
+            begin
+                exit(X * 4);
+            end;
+        }
+        """);
+
+        var map = AlCoverageSourceMap.Build(new[] { _root }, relativeTo: _root);
+
+        // The extension's OWN id, not the base object's, and its own kind label.
+        Assert.True(map.ContainsKey(("TableExtension", 63701)));
+        Assert.True(map.ContainsKey(("PageExtension", 63721)));
+        Assert.True(map.ContainsKey(("ReportExtension", 63741)));
+        // The base objects keep their own entries; an extension does not displace them.
+        Assert.True(map.ContainsKey(("Table", 63700)));
+        Assert.True(map.ContainsKey(("Page", 63720)));
+        Assert.True(map.ContainsKey(("Report", 63740)));
+        // And an extension is NOT filed under the base object's kind or the base's id.
+        Assert.False(map.ContainsKey(("Table", 63701)));
+        Assert.False(map.ContainsKey(("TableExtension", 63700)));
+    }
+
+    /// <summary>
+    /// The parser half, against the emitted type NAMES measured on BC 28.1.49838.54169 —
+    /// `TableExtension63701+Doubled_Scope_750224019` and
+    /// `PageExtension63721+Tripled_Scope_1853489953`. Controls included: the base kinds must
+    /// still parse, `Record&lt;N&gt;` must still mean Table (it is the table-trigger wrapper),
+    /// and a versioned suffix must not defeat the digit run.
+    /// </summary>
+    [Theory]
+    [InlineData("TableExtension63701", "TableExtension", 63701)]
+    [InlineData("PageExtension63721", "PageExtension", 63721)]
+    [InlineData("ReportExtension63731_v2", "ReportExtension", 63731)]
+    [InlineData("Table63700", "Table", 63700)]
+    [InlineData("Record63700", "Table", 63700)]
+    [InlineData("Page63720", "Page", 63720)]
+    [InlineData("Codeunit63710", "CodeUnit", 63710)]
+    public void ParseObjectTypeAndId_ExtensionAndBaseNames_ParseToTheirOwnKindAndId(
+        string typeName, string expectedLabel, int expectedId)
+    {
+        var (label, id) = AlCallStackCapture.ParseObjectTypeAndIdForTests(typeName);
+        Assert.Equal(expectedLabel, label);
+        Assert.Equal(expectedId, id);
+    }
+
+    /// <summary>
     /// #3833: an EXTENSION object's executable statements were invisible. `LabelOf` maps seven
     /// top-level kinds and no extension, and AlCallStackCapture's prefix map has no extension
     /// entry either — measured, BC emits `TableExtension63701+Doubled_Scope_...`, which parsed

--- a/AlRunner/Infrastructure/AlCallStackCapture.cs
+++ b/AlRunner/Infrastructure/AlCallStackCapture.cs
@@ -291,8 +291,16 @@ public static class AlCallStackCapture
         // Walk up to the outermost non-nested type (scope classes are nested).
         var t = type;
         while (t.DeclaringType != null) t = t.DeclaringType;
+        return ParseObjectTypeAndIdForTests(t.Name);
+    }
 
-        var name = t.Name;
+    /// <summary>
+    /// The name half of <see cref="ParseObjectTypeAndId(Type)"/>, split out so the prefix map
+    /// can be asserted against the emitted names measured from BC rather than only through a
+    /// live type (#3841 review). The caller passes an OUTERMOST type name.
+    /// </summary>
+    internal static (string, int) ParseObjectTypeAndIdForTests(string name)
+    {
         // Mapping from IL class-name prefix → BC call-stack label.
         // We try longest prefixes first so "Table" doesn't match "TableExtension".
         (string prefix, string label)[] prefixMap =
@@ -305,9 +313,15 @@ public static class AlCallStackCapture
             // procedures and triggers were invisible to coverage, the statement tables and
             // DAP. Measured on BC 28.1.49838.54169: a tableextension's procedure emits
             // `TableExtension63701+Doubled_Scope_750224019`, a pageextension's
-            // `PageExtension63721+Tripled_Scope_1853489953`. The id is the EXTENSION's own,
-            // not the base object's, so these cannot collide with the base or with each
-            // other. Labels match the spelling RecordPatches.AlSourceParser already uses.
+            // `PageExtension63721+Tripled_Scope_1853489953`, a reportextension's
+            // `ReportExtension63741+Quadrupled_Scope_2053452689`. The id is the EXTENSION's own,
+            // not the base object's. What keeps entries apart is the (label, id) PAIR, not the
+            // id alone: a tableextension and a pageextension may legally share a number, and an
+            // extension id may equal an unrelated base object's, so it is the distinct label
+            // that separates them. Labels match the spelling RecordPatches.AlSourceParser
+            // already uses. Two objects of the SAME kind and id in one map still overwrite —
+            // the AL compiler rejects that within an app, and across apps the map has no
+            // AppId dimension, which is older than this change and not altered by it.
             //
             // Placed before the base kinds to read in the order the note below describes,
             // but the ORDER IS NOT WHAT MAKES IT WORK, and it is worth saying so because the

--- a/AlRunner/Infrastructure/AlCallStackCapture.cs
+++ b/AlRunner/Infrastructure/AlCallStackCapture.cs
@@ -300,14 +300,21 @@ public static class AlCallStackCapture
             ("NavCodeunit",   "CodeUnit"),   // generic codeunit base class
             ("NavTestCodeunit","CodeUnit"),
             ("Codeunit",      "CodeUnit"),
-            // EXTENSION objects, before their base kinds — the "longest prefixes first" note
-            // below was written for this and the entries were never added, so every extension
-            // scope parsed to ("?", 0) and was dropped before any map was consulted (#3833).
-            // Measured on BC 28.1.49838.54169: a tableextension's procedure emits
+            // EXTENSION objects (#3833). Without these every extension scope parsed to
+            // ("?", 0) and was dropped before any map was consulted, so an extension's
+            // procedures and triggers were invisible to coverage, the statement tables and
+            // DAP. Measured on BC 28.1.49838.54169: a tableextension's procedure emits
             // `TableExtension63701+Doubled_Scope_750224019`, a pageextension's
             // `PageExtension63721+Tripled_Scope_1853489953`. The id is the EXTENSION's own,
-            // not the base object's, so these cannot collide with the base or with each other.
-            // Labels match the spelling RecordPatches.AlSourceParser already uses.
+            // not the base object's, so these cannot collide with the base or with each
+            // other. Labels match the spelling RecordPatches.AlSourceParser already uses.
+            //
+            // Placed before the base kinds to read in the order the note below describes,
+            // but the ORDER IS NOT WHAT MAKES IT WORK, and it is worth saying so because the
+            // note invites the opposite conclusion: the loop returns on the first successful
+            // PARSE, not the first prefix match, and "Table" against `TableExtension63701`
+            // leaves `Extension63701`, whose leading digit run is empty. Measured by moving
+            // these three below `Enum` — the fact still passes.
             ("TableExtension",  "TableExtension"),
             ("PageExtension",   "PageExtension"),
             ("ReportExtension", "ReportExtension"),

--- a/AlRunner/Infrastructure/AlCallStackCapture.cs
+++ b/AlRunner/Infrastructure/AlCallStackCapture.cs
@@ -300,6 +300,17 @@ public static class AlCallStackCapture
             ("NavCodeunit",   "CodeUnit"),   // generic codeunit base class
             ("NavTestCodeunit","CodeUnit"),
             ("Codeunit",      "CodeUnit"),
+            // EXTENSION objects, before their base kinds — the "longest prefixes first" note
+            // below was written for this and the entries were never added, so every extension
+            // scope parsed to ("?", 0) and was dropped before any map was consulted (#3833).
+            // Measured on BC 28.1.49838.54169: a tableextension's procedure emits
+            // `TableExtension63701+Doubled_Scope_750224019`, a pageextension's
+            // `PageExtension63721+Tripled_Scope_1853489953`. The id is the EXTENSION's own,
+            // not the base object's, so these cannot collide with the base or with each other.
+            // Labels match the spelling RecordPatches.AlSourceParser already uses.
+            ("TableExtension",  "TableExtension"),
+            ("PageExtension",   "PageExtension"),
+            ("ReportExtension", "ReportExtension"),
             ("Table",         "Table"),
             // Table TRIGGER scopes (OnInsert/OnModify/…) are nested inside the table's
             // generated record wrapper class, named Record<N> — NOT Table<N> (confirmed

--- a/AlRunner/Infrastructure/AlCoverageSourceMap.cs
+++ b/AlRunner/Infrastructure/AlCoverageSourceMap.cs
@@ -188,8 +188,11 @@ public static class AlCoverageSourceMap
     }
 
     // The coverable object kinds, labelled the way AlCallStackCapture.ParseObjectTypeAndId
-    // labels the emitted scope classes. The same seven kinds the header regex accepted before
-    // #3713; extensions and the id-less kinds are not registered, as before.
+    // labels the emitted scope classes: the seven the header regex accepted before #3713,
+    // plus the three code-bearing extension kinds since #3833. What stays unregistered is
+    // the kinds that carry no executable code — an interface, a controladdin, a
+    // permissionset, an enum extension — for which BC emits no scope class at all, so a map
+    // entry would have nothing to join to.
     private static string? LabelOf(NavCA.SyntaxNode obj) => obj switch
     {
         NavSyntax.CodeunitSyntax => "CodeUnit",
@@ -202,11 +205,16 @@ public static class AlCoverageSourceMap
         // #3833: extension objects carry executable procedures and triggers, and BC emits
         // scope classes for them — so without these their statements had a runtime identity
         // and no file, and were dropped. The label must match AlCallStackCapture's prefix map,
-        // and both match the spelling RecordPatches.AlSourceParser already uses. An extension
-        // has its own object id, so it occupies its own map entry rather than sharing the base
-        // object's. Enum extensions are deliberately absent: they declare values, not code,
-        // and BC emits no scope class for one (measured — nothing for `enumextension` appears
-        // among the [SourceSpans]-carrying types of a bundle that declares one).
+        // and both match the spelling RecordPatches.AlSourceParser already uses.
+        //
+        // An extension is keyed by its OWN id, not the base object's — measured, BC emits
+        // TableExtension63701 for an extension of table 63700. What keeps entries apart is
+        // the (label, id) PAIR rather than the id alone: a tableextension and a pageextension
+        // may legally share a number, so it is the distinct label that separates them.
+        //
+        // Enum extensions are deliberately absent: they declare values, not code, and BC
+        // emits no scope class for one (measured — nothing for `enumextension` appears among
+        // the [SourceSpans]-carrying types of a bundle that declares one).
         NavSyntax.TableExtensionSyntax => "TableExtension",
         NavSyntax.PageExtensionSyntax => "PageExtension",
         NavSyntax.ReportExtensionSyntax => "ReportExtension",

--- a/AlRunner/Infrastructure/AlCoverageSourceMap.cs
+++ b/AlRunner/Infrastructure/AlCoverageSourceMap.cs
@@ -29,9 +29,10 @@ namespace AlRunner.Infrastructure;
 /// <para>
 /// "Earliest top-level object" means every entry in <c>root.Objects</c>, including the
 /// kinds <see cref="AlCoverageSourceMap"/> cannot map — an interface, a controladdin, a
-/// permissionset, any extension. Those are objects, not preamble, and measuring the origin
-/// over the mapped subset instead subtracted them as though they were, putting every later
-/// object's lines exactly that far too low (#3822).
+/// permissionset, an enum extension. Those are objects, not preamble, and measuring the
+/// origin over the mapped subset instead subtracted them as though they were, putting every
+/// later object's lines exactly that far too low (#3822). Table, page and report extensions
+/// ARE mapped since #3833; see LabelOf.
 /// </para>
 /// (#3713; CoverageMultiObjectFileTests pins the header shapes that settled both.)
 /// </summary>

--- a/AlRunner/Infrastructure/AlCoverageSourceMap.cs
+++ b/AlRunner/Infrastructure/AlCoverageSourceMap.cs
@@ -198,6 +198,17 @@ public static class AlCoverageSourceMap
         NavSyntax.QuerySyntax => "Query",
         NavSyntax.XmlPortSyntax => "XmlPort",
         NavSyntax.EnumTypeSyntax => "Enum",
+        // #3833: extension objects carry executable procedures and triggers, and BC emits
+        // scope classes for them — so without these their statements had a runtime identity
+        // and no file, and were dropped. The label must match AlCallStackCapture's prefix map,
+        // and both match the spelling RecordPatches.AlSourceParser already uses. An extension
+        // has its own object id, so it occupies its own map entry rather than sharing the base
+        // object's. Enum extensions are deliberately absent: they declare values, not code,
+        // and BC emits no scope class for one (measured — nothing for `enumextension` appears
+        // among the [SourceSpans]-carrying types of a bundle that declares one).
+        NavSyntax.TableExtensionSyntax => "TableExtension",
+        NavSyntax.PageExtensionSyntax => "PageExtension",
+        NavSyntax.ReportExtensionSyntax => "ReportExtension",
         _ => null,
     };
 }

--- a/AlRunner/Infrastructure/DapBreakpointResolver.cs
+++ b/AlRunner/Infrastructure/DapBreakpointResolver.cs
@@ -41,11 +41,13 @@ public static class DapBreakpointResolver
     /// bundle roots the run compiled, e.g. via AlCoverageSourceMap.Build) can match — a
     /// breakpoint in a file outside the debugged bundle is unverified, not a crash.
     /// <para>
-    /// "Every object" is bounded by what that map registers, and it registers seven top-level
-    /// kinds: table, page, report, codeunit, query, xmlport, enum. EXTENSION objects
-    /// (tableextension, pageextension, …) are not in it and never resolve a breakpoint, which
-    /// is a pre-existing limit of AlCoverageSourceMap.LabelOf and of the runtime identity
-    /// parsing in AlCallStackCapture, not a decision made here (#3786 review).
+    /// "Every object" is bounded by what that map registers: seven top-level kinds — table,
+    /// page, report, codeunit, query, xmlport, enum — plus tableextension, pageextension and
+    /// reportextension since #3833, which also taught AlCallStackCapture's prefix map to parse
+    /// their emitted identity. What is still outside it, and so still never resolves a
+    /// breakpoint, is the kinds that carry no executable code: an interface, a controladdin, a
+    /// permissionset, an enum extension. BC emits no scope class for those (measured for
+    /// enumextension in #3833), so there is nothing for a breakpoint to bind to.
     /// </para>
     /// <para>
     /// Takes <see cref="AlSourceLocationMap"/> rather than the dictionary interface it


### PR DESCRIPTION
## Summary

An extension object's procedures and triggers are executable AL, and none of it reached `--coverage`, the statement tables, per-test coverage, or DAP. I filed #3833 unmeasured; measuring it confirmed the hole and found that it has **two** independent causes, both of which had to be closed before anything appeared.

- `AlCallStackCapture`'s prefix map has no extension entry, so an extension scope's runtime identity parsed to `("?", 0)` and was dropped before any map was consulted. Its own comment says *"we try longest prefixes first so Table doesn't match TableExtension"* — the ordering was anticipated and the entries were never added.
- `AlCoverageSourceMap.LabelOf` maps seven top-level kinds and no extension, so even a parsed identity had no file.

## Measured

A bundle with a `tableextension` carrying `procedure Doubled(): Integer` and a test that calls it and asserts the result. The test **passes**, so the statement runs. The Cobertura report contains only `T.Codeunit.al`.

Dumping every `[SourceSpans]`-carrying type during that run says why:

```
TableExtension63701+Doubled_Scope_750224019   parsed=(?,0)             inMap=False
PageExtension63721+Tripled_Scope_1853489953   parsed=(?,0)             inMap=False
Codeunit63710+ExtensionProcedureRuns_Scope    parsed=(CodeUnit,63710)  inMap=True
```

## The trap the issue warned about, and a correction to how I first stated it

I wrote in #3833 that whoever took it must not assume an extension's scopes can reuse the base object's label and id. The measurement settles that half: **the id BC emits is the extension's own**, 63701 rather than the base table's 63700.

My first wording then overstated the conclusion, and the review was right to pull it up. What keeps entries apart is the **(label, id) pair**, not the id on its own: a tableextension and a pageextension may legally share a number, and an extension id may equal an unrelated base object's. Two objects of the same kind *and* id still overwrite, which the AL compiler rejects within an app and which the map cannot see across apps — older than this change and not altered by it. The comment now says that.

## Scope: all three kinds measured

```
TableExtension63701+Doubled_Scope_750224019       parsed=(TableExtension,63701)   inMap=True
PageExtension63721+Tripled_Scope_1853489953       parsed=(PageExtension,63721)    inMap=True
ReportExtension63741+Quadrupled_Scope_2053452689  parsed=(ReportExtension,63741)  inMap=True
```

Report extension was unmeasured in the first revision and is not any more. A scope class is emitted for a compiled extension whether or not it runs, so it needed a compile rather than an execution — which is also why the page extension appeared in the earlier dump without ever being called.

**Enum extensions are deliberately not mapped.** They declare values rather than code, and a bundle declaring one emits no scope class for it, measured in the same dump.

## Proof

`Coverage_TableExtensionProcedure_IsReportedOnItsOwnFile` runs the real runner with `--coverage` over that bundle and asserts the executed statement is reported on `Ext.TableExt.al` line 10 with one hit. RED before: the class is absent entirely.

Two more facts pin the contract rather than the join, because the end-to-end fact alone would be satisfied by a coordinated but wrong implementation returning the same invented label from both halves:

- **the map keys**, label and id together, for all three extension kinds and their three base objects, plus the negatives that an extension is not filed under the base's kind or the base's id;
- **the parser**, against the emitted type NAMES measured from BC, with `Record<N>` and a `_v2` suffix as controls. `ParseObjectTypeAndId` is split so the name half is directly testable.

Mutation-checked, and this is the part that shows neither half is redundant:

| mutation | result |
|---|---|
| the three parser prefixes removed, `LabelOf` kept | red |
| the three `LabelOf` entries removed, parser kept | red |

**One correction to my own code comment.** I claimed the extension prefixes work because they sit before the base kinds. Moving all three below `Enum` and re-running showed the ordering is not load-bearing: the loop returns on the first successful *parse*, and `Table` against `TableExtension63701` leaves a digit run that is empty. They stay first because it reads the way the existing note describes, and the comment now says the order is not what makes it work.

## Merge order: this needs #3836 first

Before this change, extension scopes never reached `AlScopeSyntaxResolver`. After it they do — and on `main` today that resolver compares object-relative span lines against file-relative parser positions, which is #3832, fixed in **#3836** and not yet merged. Merging this one first would open a window in which an extension that is not the first object in its file acquires empty or incorrect iteration and write-set metadata.

Nothing here is wrong in isolation, and coverage is correct either way, because the coverage consumers already apply the offset. It is the ordering that matters, so **#3836 should land first**.

## What this cannot settle locally

The same parser feeds the AL stack-trace string, so an extension frame now renders as `"..."(TableExtension 63701).Doubled`. That `(TableExtension, 63701)` is the right INTERNAL identity is measured; that real BC prints it that way is not, and needs a service tier. Filed as **#3842**, with the protocol that would settle it and the instruction not to weaken the source-map identity to match a display string if they turn out to differ.

The affected-area sweep (`~Coverage|~CallStack|~Dap|~Iteration|~MemberSyntax|~Scope`) fails nine, all of them the known pre-existing set on this box: six `NavReportStaticRunModalHookBindingTests` cases, `SkeletonDatabaseTenantExecutionContextTests.ExecutionContext_IsNormal_AndModuleScopedFormsAgree`, `ProvisionExplicitModesTests.TestApps_OnlyUnrelatedAppPresent_DoesNotShortCircuit_DownloadsTheRealSet` and `ServerAffectedSelectionMultiSourcePathsTests.AffectedOnly_CrossBundleCoverage_RunsOnlyTheTestThatCallsTheEditedHelper`. Identical set on a pristine worktree at this branch's base, measured earlier today.

Closes #3833

Corpus-NA: this is the runner's own source-position bookkeeping; no BC behaviour is asserted, so there is nothing for a service tier to adjudicate.

*Opened by an agent (Claude Code) in a session run by @SShadowS.*

https://claude.ai/code/session_01JFQZHC5SEHnLxkc5USksaK
