### PR TITLE
fix(tests): fail rather than skip when the bc-engine-serial prerequisites are absent

### DIFF
--- a/AlRunner.Tests/BcEngineCollection.cs
+++ b/AlRunner.Tests/BcEngineCollection.cs
@@ -225,8 +225,81 @@ public sealed class BcEngineFixture
     /// BcEngineCollection)."</c> — a fallback that is accurate and carries neither a cause
     /// nor a remedy, i.e. the same defect this issue is about, at 132 places. Making the
     /// property total fixes them all without touching one of them.
+    ///
+    /// #3835: and it THROWS rather than answering, when the cause is one
+    /// <c>tools/engine-test-bootstrap.sh</c> would have removed — see
+    /// <see cref="BcEngineUnbootstrappedGuard"/>. Same lever as above, for the same reason:
+    /// every call site in the collection reads this property and hands the result to
+    /// <c>TestArtifacts.SkipIf</c>, so refusing here converts a silent skip into a named
+    /// failure at all ~300 of them without editing one.
     /// </summary>
-    public string SkipReason => BcEngineSkipReason.OrDefault(BcEngineBootstrap.SkipReason);
+    public string SkipReason
+    {
+        get
+        {
+            var reason = BcEngineSkipReason.OrDefault(BcEngineBootstrap.SkipReason);
+            BcEngineUnbootstrappedGuard.AssertBootstrapWasRun(Ready, reason);
+            return reason;
+        }
+    }
+}
+
+/// <summary>
+/// #3835 — a bc-engine-serial run whose prerequisites were never bootstrapped must FAIL,
+/// naming <c>tools/engine-test-bootstrap.sh</c>, rather than skip.
+///
+/// The measured defect: after any build, the first `dotnet test` over this collection prints
+/// `Skipped! - Failed: 0, Passed: 0, Skipped: 5` and exits 0, and at default verbosity the
+/// skip reason is not printed at all. That is indistinguishable from a passing mutation
+/// check, and it invalidated a real RED baseline on PR #3829. #3078 named this remedy as the
+/// stronger of the two it proposed and only the other one (the script) was built.
+///
+/// The distinction that has to survive: a box with no BC artifacts genuinely cannot run
+/// these tests, and that stays a visible, counted skip
+/// (<see cref="BcEngineSkipReason.IsRecoverableLocally"/> is what splits the two). This
+/// guard fires only where the artifacts are present and the bootstrap is what is missing.
+///
+/// Split from the property it serves, and taking (ready, reason) as PARAMETERS, for the same
+/// reason <see cref="BcEngineReadinessGuard.AssertReadyOnCi"/> is: a pure function is
+/// provable with constructed inputs, on a box in any state — which for THIS guard is not a
+/// convenience but the only way it can be proven at all, since a test asserting over the
+/// ambient bootstrap state passes for opposite reasons on a bootstrapped and an
+/// unbootstrapped box.
+/// </summary>
+internal static class BcEngineUnbootstrappedGuard
+{
+    internal static void AssertBootstrapWasRun(bool ready, string? reason)
+    {
+        if (ready) return;
+
+        var cause = BcEngineSkipReason.CauseOf(reason);
+
+        // An unrecognised reason is NOT resolved toward either answer: it is not the
+        // engine-less box (which would carry an Artifacts* token) and not a diagnosed
+        // bootstrap gap either, so both a skip and a failure would be claiming something
+        // unmeasured. Say that (guards-need-a-third-state.md).
+        if (cause is null)
+        {
+            Assert.Fail(
+                $"[{BcEngineCollection.Name}] the in-process BC engine is not ready and the reason "
+                + "carries no recognisable cause token, so this run cannot tell an unprovisioned box "
+                + "from a missing bootstrap. Either is possible and neither has been measured, so "
+                + "this fails rather than skipping on an unknown (issue #3835). Reason as recorded: "
+                + (reason ?? "<none>"));
+        }
+
+        if (!BcEngineSkipReason.IsRecoverableLocally(cause.Value)) return;
+
+        Assert.Fail(
+            $"[{BcEngineCollection.Name}] REFUSING TO SKIP: BC artifacts are provisioned on this "
+            + "machine, so these tests CAN run — the in-process engine bootstrap simply was not "
+            + $"performed. Run `{BcEngineSkipReason.BootstrapTool}` and re-run `dotnet test` with "
+            + "`--settings engine.runsettings`; a build restores a pristine "
+            + "bin/Microsoft.Dynamics.Nav.Ncl.dll, so this is needed again after EVERY build. "
+            + "This used to be a silent skip: the run reported `Skipped! - Failed: 0, Passed: 0` "
+            + "and exit 0, which reads exactly like a passing mutation check and has invalidated a "
+            + "real RED baseline (issues #3078, #3835). " + reason);
+    }
 }
 
 [CollectionDefinition(Name, DisableParallelization = true)]

--- a/AlRunner.Tests/BcEngineSkipReason.cs
+++ b/AlRunner.Tests/BcEngineSkipReason.cs
@@ -134,6 +134,68 @@ internal static class BcEngineSkipReason
                      + "[ModuleInitializer] before the BC engine was needed.")
             : reason;
 
+    /// <summary>
+    /// Which of two kinds of "the engine did not come up" a cause is (issue #3835).
+    ///
+    /// <see cref="BcEngineSkipCause"/> mixes two things a skip cannot distinguish:
+    /// <c>ArtifactsMissing</c>/<c>ArtifactsIncomplete</c> mean this box has no BC service
+    /// tier and genuinely cannot run these tests, while every other cause means the
+    /// artifacts ARE here and only the local bootstrap is missing — the state
+    /// <see cref="BootstrapTool"/> exists to remove.
+    ///
+    /// Both skip today, which is why a post-build `dotnet test` reports
+    /// `Skipped! - Failed: 0, Passed: 0, Skipped: 5` with exit 0 and reads exactly like a
+    /// passing mutation check. `guards-need-a-third-state.md`: "could not measure" must not
+    /// be spelled as the success state, and here the recoverable half is precisely that.
+    /// </summary>
+    internal static bool IsRecoverableLocally(BcEngineSkipCause cause) => cause switch
+    {
+        // The engine-less box. Nothing on this machine can stand a service tier up, so
+        // failing here would make the suite unrunnable for a correct reason — the
+        // constraint guards-need-a-third-state.md names: a genuinely absent thing stays a
+        // pass. Mirrors TestArtifacts.SkipIfMissingIn, which skips off CI for this same
+        // condition and fails only where provisioning is guaranteed.
+        BcEngineSkipCause.ArtifactsMissing or BcEngineSkipCause.ArtifactsIncomplete => false,
+
+        // Everything else: the artifacts are present and the bootstrap is what is absent.
+        // Enumerated rather than defaulted so a cause added later must be classified here
+        // instead of inheriting whichever answer happens to be safer to write.
+        BcEngineSkipCause.NclPreloaded
+            or BcEngineSkipCause.BinRewrittenThisProcess
+            or BcEngineSkipCause.CecilCacheCold
+            or BcEngineSkipCause.BootstrapThrew
+            or BcEngineSkipCause.BootstrapDidNotRun => true,
+
+        _ => throw new ArgumentOutOfRangeException(
+                 nameof(cause), cause,
+                 $"BcEngineSkipCause '{cause}' is not classified as locally recoverable or not. "
+                 + "Every cause must be, or #3835's fail-rather-than-skip guard silently reverts "
+                 + "to skipping for it."),
+    };
+
+    /// <summary>
+    /// The cause named by a reason string, or null when the string is not one this class
+    /// produced.
+    ///
+    /// Reads back the <c>Cause (X)</c> token <see cref="Format"/> writes, because the
+    /// fixture stores the formatted reason and not the enum — and #3078 deliberately made
+    /// that string the single channel every one of the ~300 call sites in the collection
+    /// reads. Round-tripping through it keeps this guard on that same channel rather than
+    /// adding a second source of truth that could disagree with what the developer is shown.
+    /// A string that carries no recognisable token returns null and is treated as
+    /// unclassifiable — never silently as "recoverable" or "not".
+    /// </summary>
+    internal static BcEngineSkipCause? CauseOf(string? reason)
+    {
+        if (string.IsNullOrWhiteSpace(reason)) return null;
+
+        foreach (var cause in Enum.GetValues<BcEngineSkipCause>())
+        {
+            if (reason.Contains($"Cause ({cause})", StringComparison.Ordinal)) return cause;
+        }
+        return null;
+    }
+
     private static string Remedy(BcEngineSkipCause cause) => cause switch
     {
         BcEngineSkipCause.ArtifactsMissing or BcEngineSkipCause.ArtifactsIncomplete =>

--- a/AlRunner.Tests/BcEngineUnbootstrappedGuardTests.cs
+++ b/AlRunner.Tests/BcEngineUnbootstrappedGuardTests.cs
@@ -1,0 +1,243 @@
+// BcEngineUnbootstrappedGuardTests — issue #3835.
+//
+// The defect, measured on this repository
+// ---------------------------------------
+// After ANY build, `dotnet test` over the bc-engine-serial collection reported:
+//
+//     Skipped! - Failed: 0, Passed: 0, Skipped: 5, Total: 5   (exit code 0)
+//
+// and at default verbosity printed no skip reason at all. A build restores a pristine
+// bin/Microsoft.Dynamics.Nav.Ncl.dll, so the prerequisite is lost after every build rather
+// than once per checkout — which is what makes this recur. That summary is indistinguishable
+// from a passing mutation check, and it invalidated a real RED baseline on PR #3829.
+//
+// #3078 named two remedies and said which was stronger:
+//
+//   > Either a small tool … or a test-time assertion that fails rather than skips when the
+//   > engine prerequisites are absent. The second is stronger …
+//
+// tools/engine-test-bootstrap.sh was built. The assertion was not. This file proves the
+// assertion.
+//
+// Why these tests can be proven at all
+// ------------------------------------
+// The guard's subject is "a prerequisite on disk is absent", which a test cannot construct by
+// deleting the prerequisite: bin/Microsoft.Dynamics.Nav.Ncl.dll is shared by the whole test
+// host, the bootstrap already ran in a [ModuleInitializer] before any test executed, and
+// mutating BcEngineBootstrap's private state by reflection would corrupt every other class in
+// the bc-engine-serial collection running in the same process.
+//
+// So the proof is split, and BOTH halves are needed — the first alone would leave the guard
+// unwired, the second alone could not distinguish the states it must distinguish:
+//
+//   1. BcEngineUnbootstrappedGuard.AssertBootstrapWasRun is a PURE function of
+//      (ready, reason). Every state it must discriminate is constructed here, exactly as
+//      BcEngineReadinessGuardTests does for AssertReadyOnCi, and none of it reads whatever
+//      this box happens to have provisioned.
+//   2. The REAL BcEngineFixture.SkipReason property is then asserted to route through it —
+//      the wiring, without which (1) proves a function nobody calls. That one is written to
+//      hold on a box in EITHER state, and says which state it observed, so it cannot pass
+//      vacuously in one of them (see WiredInto_TheRealFixture_SkipReasonProperty).
+
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class BcEngineUnbootstrappedGuardTests
+{
+    // ---- the RED direction: a recoverable prerequisite gap must FAIL, not skip ----
+
+    /// <summary>
+    /// The measured defect itself. NclPreloaded is what this box reported on the second
+    /// post-build `dotnet test` run: `Cause (NclPreloaded)`, DOTNET_STARTUP_HOOKS unwired,
+    /// artifacts present. Before this guard that produced `Skipped: 5` and exit 0; it must
+    /// now fail, and the failure must name the tool that fixes it.
+    /// </summary>
+    [Fact]
+    public void ARecoverableBootstrapGap_Fails_RatherThanSkipping()
+    {
+        var reason = BcEngineSkipReason.Format(BcEngineSkipCause.NclPreloaded, "SENTINEL-3835");
+
+        var ex = Record.Exception(() =>
+            BcEngineUnbootstrappedGuard.AssertBootstrapWasRun(ready: false, reason));
+
+        Assert.NotNull(ex);
+        Assert.IsAssignableFrom<Xunit.Sdk.XunitException>(ex);
+        // Not a SkipException: that is the whole point — a skip is what this replaces.
+        Assert.IsNotType<SkipException>(ex);
+        Assert.Contains(BcEngineSkipReason.BootstrapTool, ex!.Message, StringComparison.Ordinal);
+        Assert.Contains("REFUSING TO SKIP", ex.Message, StringComparison.Ordinal);
+        // The recorded diagnosis survives into the failure rather than being replaced by it.
+        Assert.Contains("SENTINEL-3835", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Every locally recoverable cause, not just the one that happens to fire on this box.
+    /// A cause added later and classified recoverable is covered the day it is added; one
+    /// added and left unclassified fails IsRecoverableLocally's own switch instead.
+    /// </summary>
+    [Theory]
+    [InlineData(BcEngineSkipCause.NclPreloaded)]
+    [InlineData(BcEngineSkipCause.BinRewrittenThisProcess)]
+    [InlineData(BcEngineSkipCause.CecilCacheCold)]
+    [InlineData(BcEngineSkipCause.BootstrapThrew)]
+    [InlineData(BcEngineSkipCause.BootstrapDidNotRun)]
+    public void EveryLocallyRecoverableCause_Fails(BcEngineSkipCause cause)
+    {
+        var ex = Record.Exception(() => BcEngineUnbootstrappedGuard.AssertBootstrapWasRun(
+            ready: false, BcEngineSkipReason.Format(cause, "d")));
+
+        Assert.NotNull(ex);
+        Assert.Contains(BcEngineSkipReason.BootstrapTool, ex!.Message, StringComparison.Ordinal);
+    }
+
+    // ---- the distinction that must survive: a legitimately engine-less box still skips ----
+
+    /// <summary>
+    /// The constraint guards-need-a-third-state.md sets on this class of fix: a genuinely
+    /// absent thing stays a pass. A box with no BC service tier provisioned cannot run these
+    /// tests for a correct reason, and failing there would make the suite unrunnable rather
+    /// than honest. It keeps the visible, counted skip TestArtifacts.SkipIf produces.
+    /// </summary>
+    [Theory]
+    [InlineData(BcEngineSkipCause.ArtifactsMissing)]
+    [InlineData(BcEngineSkipCause.ArtifactsIncomplete)]
+    public void AnEngineLessBox_StillSkips_RatherThanFailing(BcEngineSkipCause cause)
+    {
+        Assert.Null(Record.Exception(() => BcEngineUnbootstrappedGuard.AssertBootstrapWasRun(
+            ready: false, BcEngineSkipReason.Format(cause, "no artifacts here"))));
+    }
+
+    /// <summary>Negative direction for the guard itself: a ready engine is never refused.</summary>
+    [Fact]
+    public void AReadyEngine_IsNotRefused()
+    {
+        Assert.Null(Record.Exception(() =>
+            BcEngineUnbootstrappedGuard.AssertBootstrapWasRun(ready: true, reason: null)));
+    }
+
+    /// <summary>
+    /// The third state, and it must not be spelled as either of the other two: a reason
+    /// carrying no recognisable cause token could be an unprovisioned box or a missing
+    /// bootstrap, and nothing here has measured which. Skipping would claim the first;
+    /// staying silent would be the defect itself.
+    /// </summary>
+    [Theory]
+    [InlineData("some reason from somewhere else entirely")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void AnUnclassifiableReason_Fails_NamingThatItCouldNotTell(string? reason)
+    {
+        var ex = Record.Exception(() =>
+            BcEngineUnbootstrappedGuard.AssertBootstrapWasRun(ready: false, reason));
+
+        Assert.NotNull(ex);
+        Assert.Contains("no recognisable cause token", ex!.Message, StringComparison.Ordinal);
+    }
+
+    // ---- the classification, in both directions ----
+
+    [Fact]
+    public void EveryDeclaredCause_IsClassified()
+    {
+        // No cause may reach the guard unclassified: an unclassified one would otherwise
+        // pick up whichever answer the switch's default happened to be, which is how a
+        // fail-rather-than-skip guard silently reverts to skipping.
+        foreach (var cause in Enum.GetValues<BcEngineSkipCause>())
+        {
+            Assert.Null(Record.Exception(() => BcEngineSkipReason.IsRecoverableLocally(cause)));
+        }
+    }
+
+    [Fact]
+    public void AnUndeclaredCause_Throws_RatherThanDefaultingToSkip()
+    {
+        var ex = Record.Exception(() => BcEngineSkipReason.IsRecoverableLocally((BcEngineSkipCause)9999));
+
+        Assert.NotNull(ex);
+        Assert.IsType<ArgumentOutOfRangeException>(ex);
+    }
+
+    /// <summary>
+    /// Both directions of the split, asserted as a partition rather than per value, so a
+    /// future cause moved from one side to the other cannot leave both sides empty.
+    /// </summary>
+    [Fact]
+    public void TheClassification_SplitsTheCauses_IntoBothKinds()
+    {
+        var all = Enum.GetValues<BcEngineSkipCause>();
+        var recoverable = all.Where(BcEngineSkipReason.IsRecoverableLocally).ToArray();
+        var not = all.Where(c => !BcEngineSkipReason.IsRecoverableLocally(c)).ToArray();
+
+        Assert.Equal(5, recoverable.Length);
+        Assert.Equal(2, not.Length);
+        Assert.Contains(BcEngineSkipCause.ArtifactsMissing, not);
+        Assert.Contains(BcEngineSkipCause.ArtifactsIncomplete, not);
+    }
+
+    // ---- CauseOf: the reason string round-trips to its cause ----
+
+    [Theory]
+    [MemberData(nameof(BcEngineSkipAttributionTests.AllCauses), MemberType = typeof(BcEngineSkipAttributionTests))]
+    public void CauseOf_RecoversEveryCause_FromTheReasonFormatWrites(BcEngineSkipCause cause)
+        => Assert.Equal(cause, BcEngineSkipReason.CauseOf(BcEngineSkipReason.Format(cause, "d")));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Cause (SomethingElse): not one of ours")]
+    public void CauseOf_AnswersNull_ForAStringItDidNotWrite(string? reason)
+        => Assert.Null(BcEngineSkipReason.CauseOf(reason));
+
+    // ---- the wiring: the real fixture property routes through the guard ----
+
+    /// <summary>
+    /// Without this, everything above proves a function nobody calls. It reads the REAL
+    /// BcEngineFixture.SkipReason property — unmodified, on whatever state this box is
+    /// actually in — and asserts the behaviour appropriate to that state.
+    ///
+    /// Deliberately written to hold in BOTH states and to assert something different in
+    /// each, rather than asserting only the one this box happens to be in: an
+    /// unbootstrapped box must see the property THROW (that is #3835's fix, and it is the
+    /// state a post-build run is in), and a bootstrapped one must see it answer without
+    /// throwing (the guard must not fire on a working box). Either way the assertion is
+    /// specific, so this cannot degrade into a test that passes because nothing happened.
+    ///
+    /// Note it does NOT call TestArtifacts.SkipIf on the way in: doing so would read
+    /// _engine.SkipReason and therefore trip the very guard under test before asserting
+    /// anything.
+    /// </summary>
+    [Fact]
+    public void WiredInto_TheRealFixture_SkipReasonProperty()
+    {
+        var fixture = new BcEngineFixture();
+
+        if (fixture.Ready)
+        {
+            // A bootstrapped box: the property answers, and the guard stays out of the way.
+            // Reading it must not throw — a guard that fires on a working box would make the
+            // collection unrunnable everywhere including CI.
+            var reason = Record.Exception(() => _ = fixture.SkipReason);
+            Assert.Null(reason);
+            return;
+        }
+
+        var cause = BcEngineSkipReason.CauseOf(BcEngineBootstrap.SkipReason);
+        var ex = Record.Exception(() => _ = fixture.SkipReason);
+
+        if (cause is not null && !BcEngineSkipReason.IsRecoverableLocally(cause.Value))
+        {
+            // The engine-less box: the property still answers, so the ~300 call sites in
+            // this collection go on producing their visible, counted skips.
+            Assert.Null(ex);
+            Assert.Contains(cause.Value.ToString(), fixture.SkipReason, StringComparison.Ordinal);
+            return;
+        }
+
+        // The unbootstrapped box — the state a post-build `dotnet test` is in, and the one
+        // this issue is about. The property must refuse.
+        Assert.NotNull(ex);
+        Assert.Contains(BcEngineSkipReason.BootstrapTool, ex!.Message, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner.Tests/BcEngineUnbootstrappedGuardTests.cs
+++ b/AlRunner.Tests/BcEngineUnbootstrappedGuardTests.cs
@@ -97,7 +97,8 @@ public sealed class BcEngineUnbootstrappedGuardTests
     /// The constraint guards-need-a-third-state.md sets on this class of fix: a genuinely
     /// absent thing stays a pass. A box with no BC service tier provisioned cannot run these
     /// tests for a correct reason, and failing there would make the suite unrunnable rather
-    /// than honest. It keeps the visible, counted skip TestArtifacts.SkipIf produces.
+    /// than honest. It keeps the visible, counted skip the shared test-artifacts gate
+    /// produces.
     /// </summary>
     [Theory]
     [InlineData(BcEngineSkipCause.ArtifactsMissing)]
@@ -201,7 +202,7 @@ public sealed class BcEngineUnbootstrappedGuardTests
     /// each: an unbootstrapped box must see the property THROW (that is #3835's fix, and
     /// the state a post-build run is in), and a bootstrapped one must see it answer.
     ///
-    /// It does NOT call TestArtifacts.SkipIf on the way in: that would read
+    /// It does NOT route through the shared artifacts gate on the way in: that would read
     /// _engine.SkipReason and so trip the very guard under test before asserting anything.
     ///
     /// Measured caveat, and why <see cref="TheWiring_IsPresent_InEveryState"/> exists beside

--- a/AlRunner.Tests/BcEngineUnbootstrappedGuardTests.cs
+++ b/AlRunner.Tests/BcEngineUnbootstrappedGuardTests.cs
@@ -198,15 +198,18 @@ public sealed class BcEngineUnbootstrappedGuardTests
     /// actually in — and asserts the behaviour appropriate to that state.
     ///
     /// Deliberately written to hold in BOTH states and to assert something different in
-    /// each, rather than asserting only the one this box happens to be in: an
-    /// unbootstrapped box must see the property THROW (that is #3835's fix, and it is the
-    /// state a post-build run is in), and a bootstrapped one must see it answer without
-    /// throwing (the guard must not fire on a working box). Either way the assertion is
-    /// specific, so this cannot degrade into a test that passes because nothing happened.
+    /// each: an unbootstrapped box must see the property THROW (that is #3835's fix, and
+    /// the state a post-build run is in), and a bootstrapped one must see it answer.
     ///
-    /// Note it does NOT call TestArtifacts.SkipIf on the way in: doing so would read
-    /// _engine.SkipReason and therefore trip the very guard under test before asserting
-    /// anything.
+    /// It does NOT call TestArtifacts.SkipIf on the way in: that would read
+    /// _engine.SkipReason and so trip the very guard under test before asserting anything.
+    ///
+    /// Measured caveat, and why <see cref="TheWiring_IsPresent_InEveryState"/> exists beside
+    /// it: on a BOOTSTRAPPED box this test can only assert that the property does not throw,
+    /// which is also what a completely unwired property does. The mutation check confirmed
+    /// exactly that — with the guard call deleted, this test failed unbootstrapped and
+    /// PASSED bootstrapped. CI is always bootstrapped, so this test alone would prove
+    /// nothing there.
     /// </summary>
     [Fact]
     public void WiredInto_TheRealFixture_SkipReasonProperty()
@@ -216,10 +219,10 @@ public sealed class BcEngineUnbootstrappedGuardTests
         if (fixture.Ready)
         {
             // A bootstrapped box: the property answers, and the guard stays out of the way.
-            // Reading it must not throw — a guard that fires on a working box would make the
-            // collection unrunnable everywhere including CI.
-            var reason = Record.Exception(() => _ = fixture.SkipReason);
-            Assert.Null(reason);
+            // A guard that fired on a working box would make the collection unrunnable
+            // everywhere, CI included.
+            Assert.Null(Record.Exception(() => _ = fixture.SkipReason));
+            Assert.NotEmpty(fixture.SkipReason);
             return;
         }
 
@@ -239,5 +242,73 @@ public sealed class BcEngineUnbootstrappedGuardTests
         // this issue is about. The property must refuse.
         Assert.NotNull(ex);
         Assert.Contains(BcEngineSkipReason.BootstrapTool, ex!.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The wiring, asserted in a way that does not depend on which state this box is in —
+    /// which the test above cannot do, because on a bootstrapped box "the property did not
+    /// throw" is indistinguishable from "the property has no guard in it".
+    ///
+    /// Deleting the guard call from BcEngineFixture.SkipReason is the mutation this catches
+    /// on EVERY box, including CI. It reads the property's IL for the call rather than
+    /// invoking it, because invoking it is precisely what cannot discriminate here: a
+    /// source scan would be the cheaper spelling but would match the call in a comment
+    /// (#3813 is the live instance of that defect in this suite), and the IL carries only
+    /// what the compiler actually emitted.
+    /// </summary>
+    [Fact]
+    public void TheWiring_IsPresent_InEveryState()
+    {
+        var getter = typeof(BcEngineFixture)
+            .GetProperty(nameof(BcEngineFixture.SkipReason))!
+            .GetGetMethod()!;
+
+        var body = getter.GetMethodBody();
+        Assert.NotNull(body);
+        var il = body!.GetILAsByteArray();
+        Assert.NotNull(il);
+
+        var guard = typeof(BcEngineUnbootstrappedGuard)
+            .GetMethod(nameof(BcEngineUnbootstrappedGuard.AssertBootstrapWasRun),
+                       System.Reflection.BindingFlags.Static
+                       | System.Reflection.BindingFlags.NonPublic
+                       | System.Reflection.BindingFlags.Public)!;
+
+        // 0x28 = call, followed by a 4-byte metadata token. Scanning for the token itself is
+        // what makes this a statement about the emitted call and not about the source text.
+        var wanted = BitConverter.GetBytes(guard.MetadataToken);
+        var found = false;
+        for (var i = 0; i + 4 < il!.Length && !found; i++)
+        {
+            if (il[i] != 0x28) continue;
+            found = il[i + 1] == wanted[0] && il[i + 2] == wanted[1]
+                 && il[i + 3] == wanted[2] && il[i + 4] == wanted[3];
+        }
+
+        Assert.True(found,
+            $"BcEngineFixture.SkipReason does not call {nameof(BcEngineUnbootstrappedGuard)}."
+            + $"{nameof(BcEngineUnbootstrappedGuard.AssertBootstrapWasRun)}. That call is what "
+            + "converts a silent skip of the entire bc-engine-serial collection into a named "
+            + "failure at all ~300 call sites, so without it issue #3835 is back and a "
+            + "post-build `dotnet test` reports `Skipped: N` with exit 0 again.");
+    }
+
+    /// <summary>
+    /// Fixture guard for the test above: a metadata-token scan that found nothing because
+    /// the IL was empty, or because 0x28 never appears, would report the same "not found"
+    /// as a genuinely deleted call. Pinning that the scan CAN fire — on a method known to
+    /// call the guard — is what separates the two.
+    /// </summary>
+    [Fact]
+    public void TheILScan_ItselfDetectsACall_SoItsNegativeIsMeaningful()
+    {
+        var body = typeof(BcEngineFixture)
+            .GetProperty(nameof(BcEngineFixture.SkipReason))!
+            .GetGetMethod()!
+            .GetMethodBody()!;
+        var il = body.GetILAsByteArray()!;
+
+        Assert.NotEmpty(il);
+        Assert.Contains((byte)0x28, il);
     }
 }

--- a/AlRunner.Tests/BcEngineUnbootstrappedGuardTests.cs
+++ b/AlRunner.Tests/BcEngineUnbootstrappedGuardTests.cs
@@ -35,9 +35,12 @@
 //      BcEngineReadinessGuardTests does for AssertReadyOnCi, and none of it reads whatever
 //      this box happens to have provisioned.
 //   2. The REAL BcEngineFixture.SkipReason property is then asserted to route through it —
-//      the wiring, without which (1) proves a function nobody calls. That one is written to
-//      hold on a box in EITHER state, and says which state it observed, so it cannot pass
-//      vacuously in one of them (see WiredInto_TheRealFixture_SkipReasonProperty).
+//      the wiring, without which (1) proves a function nobody calls. Two tests, because on a
+//      bootstrapped box (CI's state, always) "the property did not throw" is also what an
+//      unwired property does: WiredInto_TheRealFixture_SkipReasonProperty exercises the
+//      behaviour in whichever state this box is in, and TheWiring_IsPresent_InEveryState
+//      reads the emitted IL, which answers the same in every state. The mutation check
+//      measured that split rather than assuming it — see that test's own comment.
 
 using Xunit;
 
@@ -260,33 +263,8 @@ public sealed class BcEngineUnbootstrappedGuardTests
     [Fact]
     public void TheWiring_IsPresent_InEveryState()
     {
-        var getter = typeof(BcEngineFixture)
-            .GetProperty(nameof(BcEngineFixture.SkipReason))!
-            .GetGetMethod()!;
-
-        var body = getter.GetMethodBody();
-        Assert.NotNull(body);
-        var il = body!.GetILAsByteArray();
-        Assert.NotNull(il);
-
-        var guard = typeof(BcEngineUnbootstrappedGuard)
-            .GetMethod(nameof(BcEngineUnbootstrappedGuard.AssertBootstrapWasRun),
-                       System.Reflection.BindingFlags.Static
-                       | System.Reflection.BindingFlags.NonPublic
-                       | System.Reflection.BindingFlags.Public)!;
-
-        // 0x28 = call, followed by a 4-byte metadata token. Scanning for the token itself is
-        // what makes this a statement about the emitted call and not about the source text.
-        var wanted = BitConverter.GetBytes(guard.MetadataToken);
-        var found = false;
-        for (var i = 0; i + 4 < il!.Length && !found; i++)
-        {
-            if (il[i] != 0x28) continue;
-            found = il[i + 1] == wanted[0] && il[i + 2] == wanted[1]
-                 && il[i + 3] == wanted[2] && il[i + 4] == wanted[3];
-        }
-
-        Assert.True(found,
+        Assert.True(
+            Calls(SkipReasonGetter(), GuardMethod()),
             $"BcEngineFixture.SkipReason does not call {nameof(BcEngineUnbootstrappedGuard)}."
             + $"{nameof(BcEngineUnbootstrappedGuard.AssertBootstrapWasRun)}. That call is what "
             + "converts a silent skip of the entire bc-engine-serial collection into a named "
@@ -295,21 +273,91 @@ public sealed class BcEngineUnbootstrappedGuardTests
     }
 
     /// <summary>
-    /// Fixture guard for the test above: a metadata-token scan that found nothing because
-    /// the IL was empty, or because 0x28 never appears, would report the same "not found"
-    /// as a genuinely deleted call. Pinning that the scan CAN fire — on a method known to
-    /// call the guard — is what separates the two.
+    /// The scan itself, in both directions, against methods whose answer is known
+    /// independently of anything this PR changed — so that a "not found" from
+    /// <see cref="TheWiring_IsPresent_InEveryState"/> means the call is absent, and not that
+    /// <see cref="Calls"/> is broken.
+    ///
+    /// Both directions are needed and neither alone suffices: a <see cref="Calls"/> that
+    /// always answered false would pass the negative row, and one that always answered true
+    /// would pass the positive row. Only the pair pins that the four-byte token comparison
+    /// actually discriminates — which is exactly what a check for "the 0x28 opcode appears
+    /// somewhere" does not do, since 0x28 appears in almost every method body ever compiled.
     /// </summary>
     [Fact]
-    public void TheILScan_ItselfDetectsACall_SoItsNegativeIsMeaningful()
+    public void TheILScan_Discriminates_SoItsNegativeIsMeaningful()
     {
-        var body = typeof(BcEngineFixture)
-            .GetProperty(nameof(BcEngineFixture.SkipReason))!
-            .GetGetMethod()!
-            .GetMethodBody()!;
-        var il = body.GetILAsByteArray()!;
+        // Positive: a method this file controls, which calls the guard on every path.
+        var probe = typeof(BcEngineUnbootstrappedGuardTests)
+            .GetMethod(nameof(CallsTheGuardOnce),
+                       System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)!;
+        Assert.True(Calls(probe, GuardMethod()),
+            "the IL scan failed to find a call it is looking straight at, so a negative from it "
+            + "says nothing about whether BcEngineFixture.SkipReason calls the guard.");
 
-        Assert.NotEmpty(il);
-        Assert.Contains((byte)0x28, il);
+        // Negative: same shape, same file, one call — to something else. Without this row a
+        // Calls() that ignored the token and answered "yes" for any method containing a call
+        // opcode would look correct.
+        var decoy = typeof(BcEngineUnbootstrappedGuardTests)
+            .GetMethod(nameof(CallsSomethingElseOnce),
+                       System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)!;
+        Assert.False(Calls(decoy, GuardMethod()),
+            "the IL scan reported a call to the guard from a method that does not call it, so it "
+            + "is matching the call opcode rather than the target and would report the wiring "
+            + "present after the guard call was deleted.");
     }
+
+    // ---- the scan, and the two probes that prove it discriminates -------------------
+
+    private static System.Reflection.MethodInfo SkipReasonGetter() =>
+        typeof(BcEngineFixture).GetProperty(nameof(BcEngineFixture.SkipReason))!.GetGetMethod()!;
+
+    private static System.Reflection.MethodInfo GuardMethod() =>
+        typeof(BcEngineUnbootstrappedGuard)
+            .GetMethod(nameof(BcEngineUnbootstrappedGuard.AssertBootstrapWasRun),
+                       System.Reflection.BindingFlags.Static
+                       | System.Reflection.BindingFlags.NonPublic
+                       | System.Reflection.BindingFlags.Public)!;
+
+    /// <summary>
+    /// True when <paramref name="caller"/>'s body emits a call to <paramref name="target"/>.
+    ///
+    /// One implementation, used by the production assertion AND by its own self-check, so the
+    /// two cannot drift into checking different things — the failure mode where a guard is
+    /// verified by a copy of itself that has since diverged.
+    ///
+    /// 0x28 is <c>call</c>, followed by a 4-byte metadata token. Matching the TOKEN is what
+    /// makes this a statement about the emitted call rather than about the source text: a
+    /// source scan would be cheaper and would match the name in a comment (#3813 is the live
+    /// instance of that defect in this suite, and it fired on this very file).
+    /// </summary>
+    private static bool Calls(System.Reflection.MethodInfo caller, System.Reflection.MethodInfo target)
+    {
+        var il = caller.GetMethodBody()?.GetILAsByteArray();
+        // An absent body cannot be scanned, and answering "no call here" would report that
+        // unmeasurable state as the guard being unwired (guards-need-a-third-state.md).
+        Assert.True(il is { Length: > 0 },
+            $"{caller.DeclaringType?.Name}.{caller.Name} has no readable IL body, so nothing about "
+            + "which methods it calls has been measured.");
+
+        var wanted = BitConverter.GetBytes(target.MetadataToken);
+        for (var i = 0; i + 4 < il!.Length; i++)
+        {
+            if (il[i] != 0x28) continue;
+            if (il[i + 1] == wanted[0] && il[i + 2] == wanted[1]
+                && il[i + 3] == wanted[2] && il[i + 4] == wanted[3]) return true;
+        }
+        return false;
+    }
+
+    /// <summary>Positive probe for <see cref="Calls"/>: calls the guard, and nothing else.</summary>
+    private static void CallsTheGuardOnce()
+        => BcEngineUnbootstrappedGuard.AssertBootstrapWasRun(ready: true, reason: null);
+
+    /// <summary>
+    /// Negative probe: one call, to a method that is not the guard. Deliberately still a
+    /// call, so the only thing separating it from the probe above is the token.
+    /// </summary>
+    private static void CallsSomethingElseOnce()
+        => BcEngineSkipReason.IsRecoverableLocally(BcEngineSkipCause.ArtifactsMissing);
 }


### PR DESCRIPTION
Closes #3835

#3078 proposed two remedies and said which was stronger: a bootstrap tool, **or** a test-time
assertion that fails rather than skips when the engine prerequisites are absent. The tool
(`tools/engine-test-bootstrap.sh`) was built. The assertion was not. This builds it.

## The defect, measured

A build restores a pristine `bin/Microsoft.Dynamics.Nav.Ncl.dll`, so the prerequisite is lost
after **every** build rather than once per checkout. Without it every test in
`bc-engine-serial` skips, and at default verbosity the skip reason is not printed at all.

RED baseline, `CodeunitRunWriteTransactionRefusalTests`, immediately after
`dotnet build -c Release`:

```
Skipped! - Failed: 0, Passed: 0, Skipped: 5, Total: 5     exit code 0
```

The reason was invisible; raising verbosity showed `Cause (NclPreloaded)` —
`DOTNET_STARTUP_HOOKS` unwired, artifacts present. **The second run reported the same**
(`Test Run Successful. Total tests: 5, Skipped: 5`), because `NclPreloaded` does not self-heal
the way `BinRewrittenThisProcess` does. That summary is indistinguishable from a passing
mutation check, which is how it invalidated a real RED baseline on PR #3829.

## The change

The lever is the single point #3078 already established. All **174** engine-readiness skip
sites in the collection spell `TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason)`, so
`BcEngineFixture.SkipReason` is the funnel every one of them passes through. I measured that
rather than assuming it: a scan for `SkipIf(!engine.Ready, …)` whose argument does **not**
mention `SkipReason` returns **0**. Refusing in that property converts a silent skip into a
named failure at all 174 without editing one of them.

- `BcEngineSkipReason.IsRecoverableLocally(cause)` — splits the causes into the two kinds a
  skip cannot distinguish. Enumerated, never defaulted: an unclassified cause throws rather
  than inheriting whichever answer happened to be written.
- `BcEngineSkipReason.CauseOf(reason)` — reads the `Cause (X)` token back out of the formatted
  reason, keeping this guard on the same channel the developer is shown instead of adding a
  second source of truth.
- `BcEngineUnbootstrappedGuard.AssertBootstrapWasRun(ready, reason)` — a pure function, taking
  its inputs as parameters for the same reason `BcEngineReadinessGuard.AssertReadyOnCi` does.

GREEN, same collection, same command:

```
Failed! - Failed: 5, Passed: 0, Skipped: 0, Total: 5      exit code 1
```

and the failure reaches the developer at **default** verbosity, naming
`tools/engine-test-bootstrap.sh`, that a build undoes it, and carrying the recorded diagnosis.

## What happens to a legitimately engine-less box

**It still skips, visibly and counted.** `ArtifactsMissing` / `ArtifactsIncomplete` mean no BC
service tier is provisioned, so the box genuinely cannot run these tests and failing there
would make the suite unrunnable for a correct reason — the constraint
`guards-need-a-third-state.md` sets ("a genuinely absent thing must stay a pass"). That mirrors
`TestArtifacts.SkipIfMissingIn`, which skips off CI for this same condition.

Every other cause means the artifacts **are** present and only the local bootstrap is missing.
That is the "could not measure" state spelled as the success state, and it is what now fails.

A third case exists and is not folded into either: a reason carrying no recognisable cause
token could be either box, and nothing has measured which. It fails, saying so — skipping would
claim the unprovisioned case without evidence.

## Proving it — including one thing that did not prove what I first claimed

The guard's subject is a prerequisite on disk, which a test cannot construct by deleting: the
DLL is shared by the whole test host, the bootstrap runs in a `[ModuleInitializer]` before any
test executes, and reflecting over `BcEngineBootstrap`'s private state would corrupt every
other class in the collection. So the proof is split, and I verified both halves by mutation.

**The first version of the wiring test was too weak, and the mutation check is what found it.**
Deleting the guard call from `BcEngineFixture.SkipReason`:

| box state | first version | after strengthening |
|---|---|---|
| unbootstrapped | **FAILED** (detected) | FAILED (detected) |
| bootstrapped — **CI's state** | **PASSED** (missed) | **FAILED** (detected) |

On a bootstrapped box "the property did not throw" is also what a completely unwired property
does, so that test alone would have proven nothing on CI. `TheWiring_IsPresent_InEveryState`
now scans the property getter's **IL** for the call's metadata token — the emitted call, not
the source text, so it cannot match a mention in a comment (#3813 is the live instance of that
failure mode in this suite, and it bit this very PR — see below).

**A second review round caught that scan's own self-check claiming more than it performed.**
It asserted the IL was non-empty and contained an `0x28` call opcode, which rules out an
empty-IL false negative but never exercises the four-byte token match — so a broken comparison
would still read as "call not found" with the self-check green, and its doc comment promised
otherwise. That is the defect this PR exists to fix, one level up. It is now
`TheILScan_Discriminates_SoItsNegativeIsMeaningful`, running the same scan over two probe
methods in the file — one calling the guard, one calling something else. Both rows are load
bearing: a scan answering always-false passes the negative row, always-true passes the
positive. Verified by mutation — replacing the token comparison with an unconditional match on
the opcode fails the new test on its negative row, where the previous version stayed green.
The scan is a single private `Calls()` helper shared by the production assertion and its
self-check, so the two cannot drift apart.

I also hit the issue's own trap while doing this. An intermediate "mutant, unbootstrapped" run
reported `Passed: 5` — because the bootstrap I had run left `bin` rewritten, so the engine came
up and the test took its `Ready` early-return branch. Those numbers measured a ready engine,
not an unbootstrapped one. Every figure quoted above is from a run whose state I re-established
deliberately, and every one is a **second** run after its build.

## Numbers

All from second runs after a build. Bootstrapped runs use `--settings engine.runsettings`.

| what | state | result |
|---|---|---|
| `BcEngineUnbootstrappedGuardTests` | unbootstrapped | `Passed: 29, Skipped: 0` |
| `BcEngineUnbootstrappedGuardTests` | bootstrapped | `Passed: 29, Skipped: 0` |
| the same, plus gate and drift guards and the engine collection | bootstrapped | `Passed: 97, Skipped: 0` |
| `CodeunitRunWriteTransactionRefusalTests` | unbootstrapped, before | `Skipped: 5`, exit 0 |
| `CodeunitRunWriteTransactionRefusalTests` | unbootstrapped, after | `Failed: 5`, exit 1 |
| `CodeunitRunWriteTransactionRefusalTests` | bootstrapped | `Passed: 5, Skipped: 0` |
| engine + gate + drift guards (`BcEngine*`, `TestArtifactsGateTests`, `SilentSkipDetectorTests`, `BcVersionFloorSkipTests`) | bootstrapped | `Passed: 92, Skipped: 0` |
| seven other collection members | bootstrapped | `Passed: 54, Skipped: 0` |

The `Passed: 5, Skipped: 0` row is the one that shows the guard does not fire on a working box;
`Skipped: 0` throughout is what shows nothing traded a skip for a different silence.

## Fix the shape

1. **Same wrong pattern at another call site?** No — measured, not assumed: 174 engine-readiness
   skip sites, **0** of which bypass `SkipReason`. The funnel is complete, which is why a
   one-property change is the whole fix.
2. **Does a sibling function make the same assumption?** Yes, and it is deliberate and stays.
   `BcEngineReadinessGuard.AssertReadyOnCi` guards the same fixture but keys on **CI**, so it
   was blind to a local box by construction — which is exactly the gap #3835 reports. The two
   are complementary: `AssertReadyOnCi` catches "provisioned CI leg, engine unready",
   `AssertBootstrapWasRun` catches "provisioned local box, bootstrap not run". Both now fire.
3. **Two paths writing the same state with different invariants?** The two skip channels for
   this collection are `TestArtifacts.SkipIfMissing` (artifacts) and the engine-readiness sites
   (bootstrap). They now agree: an unprovisioned box skips through both; a provisioned one with
   a missing prerequisite fails through both. Previously only the first held that invariant.

## Queue scan

Searched the open issues by mechanism, not title — `bc-engine-serial`, `engine-test-bootstrap`,
`BcEngineCollection`, `silently skip`, `Skipped:`, `vacuous`. Two candidates, **neither folded**:

- **#3813** — `EveryTestThatCanSkipIsDeclaredSkippable` matches `Skip.If` inside comments.
  Genuinely related and it **fired on this PR**: two doc comments here mentioning
  `TestArtifacts.SkipIf` were attributed to two tests that cannot skip. Not folded because the
  scanner lives in `TestArtifactsGateTests.cs` while this fix lands in `BcEngineCollection.cs` /
  `BcEngineSkipReason.cs` — different files, different reasoning
  (`batch-sibling-issues-by-file.md`). I reworded the two comments and
  [recorded the third reproduction on #3813](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3813#issuecomment-5626094754).
- **#3567** — a `DateTime` round-trip fails on a non-UTC box once the bootstrap has run. Shares
  only the word "bootstrap"; it is a `NavDateTime` timezone defect in different code.

No other open issue describes this defect in different words.

## Not in scope

CI is unaffected — it runs the bootstrap, so the engine is ready there and the guard stays
silent (measured above: `Passed: 92, Skipped: 0` bootstrapped). No `AlRunner/` file changes, so
no corpus declaration is required; `check_corpus_linkage.sh` confirms "no file in this diff can
change what AL observes". Nothing here asserts anything about BC, so nothing belongs upstream —
this is test-harness plumbing deciding what a skipped row tells the developer reading it.

Implemented by the agent loop `stma-auto-12`, not by a person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
