### PR TITLE
fix(scratch): own DependencyMetadataProducer's compile scratch directory so a killed run's copy is reclaimable

### DIFF
--- a/AlRunner.Tests/DependencyMetadataProducerScratchOwnershipTests.cs
+++ b/AlRunner.Tests/DependencyMetadataProducerScratchOwnershipTests.cs
@@ -29,7 +29,7 @@ public sealed class DependencyMetadataProducerScratchOwnershipTests
     /// directory, writes the package's sources into it, fails the emit, and deletes it in a
     /// `finally`. So the sidecar cannot be read after <c>Ensure</c> returns — this drives the
     /// path-choosing seam directly and then proves, in
-    /// <see cref="Ensure_CompilesOutOfAnOwnedScratchDirectory_NotABareTempSubdirectory"/>, that
+    /// <see cref="Ensure_ReleasesTheOwnedScratchDirectoryOnTheFailurePath"/>, that
     /// the seam is the one <c>Ensure</c> actually uses.
     ///
     /// Positive: the sidecar exists, parses, and names this process. Negative: it names the
@@ -127,43 +127,54 @@ public sealed class DependencyMetadataProducerScratchOwnershipTests
     }
 
     /// <summary>
-    /// <c>Ensure</c> really compiles out of that seam, so the two facts above are about the
-    /// production path rather than about a helper nothing calls.
+    /// <c>Ensure</c> really compiles out of that seam and RELEASES it, so the facts above are
+    /// about the production path rather than about a helper nothing calls.
     ///
-    /// Positive: driving <c>Ensure</c> on a source-shipping package leaves no
-    /// <c>al-runner-depmeta*</c> entry behind under a redirected temp root — neither directory
-    /// nor orphan sidecar — which is only true if the path it chose was under that root and its
-    /// cleanup released both. Negative: a bare <c>Directory.CreateTempSubdirectory</c> ignores
-    /// TMPDIR on no platform, but it leaves the sidecar question unanswerable, so the fact is
-    /// paired with the source scan below rather than resting on the residue alone.
+    /// <para>Positive: driving <c>Ensure</c> on a source-shipping package — a null compiler
+    /// fails the emit after the sources are written, which is the shape that exercises creation
+    /// AND the <c>finally</c> in one call — leaves no <c>al-runner-depmeta</c> directory and no
+    /// orphan sidecar behind. Negative: the container is not left holding this app's leaf, and
+    /// the process no longer claims ownership of anything under it, so a <c>finally</c> weakened
+    /// to delete the tree while leaking the sidecar or the registration is caught.</para>
+    ///
+    /// <para>Deliberately NOT by redirecting <c>TMPDIR</c>. <c>Path.GetTempPath()</c> re-reads
+    /// that variable on every call on Linux and the environment is process-global, so a test
+    /// that sets it redirects the temp root for every OTHER test xUnit is running in parallel.
+    /// Measured while writing this file: doing so produced a 1-in-6 failure in
+    /// <c>CacheRootStartupFailureTests</c> and <c>PkgDedupStaleStageReuseTests</c>, two classes
+    /// this change does not touch, and the failing test differed between runs.</para>
     /// </summary>
     [Fact]
-    public void Ensure_CompilesOutOfAnOwnedScratchDirectory_NotABareTempSubdirectory()
+    public void Ensure_ReleasesTheOwnedScratchDirectoryOnTheFailurePath()
     {
+        var appId = Guid.Parse("99999999-8888-7777-6666-555555555555");
         var pkg = WriteSourcePackage();
-        var probe = TestScratch.Dir("depmeta-probe");
-        Directory.CreateDirectory(probe);
 
-        var oldTmp = Environment.GetEnvironmentVariable("TMPDIR");
-        try
-        {
-            Environment.SetEnvironmentVariable("TMPDIR", probe);
+        var before = Directory.Exists(DependencyMetadataProducer.ScratchContainer)
+            ? Directory.GetFileSystemEntries(DependencyMetadataProducer.ScratchContainer)
+            : Array.Empty<string>();
 
-            // A null compiler makes the emit fail after the sources are written, which is the
-            // shape that exercises creation AND the finally in one call.
-            Assert.Throws<DependencyLoadException>(() => DependencyMetadataProducer.Ensure(
-                new AppManifest(
-                    Publisher: "Microsoft", Name: "Business Foundation",
-                    Version: new Version(1, 0, 0, 0),
-                    AppId: Guid.Parse("99999999-8888-7777-6666-555555555555"),
-                    Dependencies: Array.Empty<DependencyRef>()),
-                pkg, compiler: null!));
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("TMPDIR", oldTmp);
-            ScratchDirs.Release(probe);
-        }
+        Assert.Throws<DependencyLoadException>(() => DependencyMetadataProducer.Ensure(
+            new AppManifest(
+                Publisher: "Microsoft", Name: "Business Foundation",
+                Version: new Version(1, 0, 0, 0),
+                AppId: appId,
+                Dependencies: Array.Empty<DependencyRef>()),
+            pkg, compiler: null!));
+
+        var after = Directory.Exists(DependencyMetadataProducer.ScratchContainer)
+            ? Directory.GetFileSystemEntries(DependencyMetadataProducer.ScratchContainer)
+            : Array.Empty<string>();
+
+        // Compared as a SET DIFFERENCE against this app id, so a directory another test (or
+        // another runner sharing this TMPDIR) put in the container cannot fail this.
+        var leaked = after.Except(before, StringComparer.Ordinal)
+            .Where(e => Path.GetFileName(e).StartsWith($"{appId:N}", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.True(leaked.Count == 0,
+            "Ensure's finally must release the scratch directory AND its sidecar; these entries "
+            + "for this app id survived the call:\n  " + string.Join("\n  ", leaked));
     }
 
     /// <summary>

--- a/AlRunner.Tests/DependencyMetadataProducerScratchOwnershipTests.cs
+++ b/AlRunner.Tests/DependencyMetadataProducerScratchOwnershipTests.cs
@@ -1,0 +1,256 @@
+// The one production scratch site the #3831/#3837 ownership guard cannot see (issue #3838).
+//
+// That guard scans AlRunner.Tests only, by construction: it enforces that a TEST hands the
+// runner an owned path, and its remedy — TestScratch — does not exist for production code.
+// So AlRunner/DependencyMetadataProducer.cs's compile scratch directory sat outside it, and
+// outside ScratchDirs, while every neighbouring production temp site (DepExtractionDir,
+// PerProcessScratch, CacheRoots, ParallelFanOut) had been converted by #2706/#2967.
+//
+// WHAT IS AND IS NOT BEING CLAIMED HERE
+//   Not a leak on the normal path. Ensure's `finally` deletes the directory, and it did so
+//   before this change too. A test asserting only "the happy path still deletes" would have
+//   passed against the unfixed code, which is the noise .claude/rules/tdd.md warns about.
+//   The claim is OWNERSHIP: the directory carries a `.owner` sidecar naming this process while
+//   it exists, so a process killed mid-compile leaves something a later runner start can
+//   reclaim through ScratchDirs.SweepStale. Before the change there was no sidecar and the
+//   leftovers were permanent — a full copy of one dependency app's source tree, per kill.
+
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class DependencyMetadataProducerScratchOwnershipTests
+{
+    /// <summary>
+    /// The directory the producer compiles out of is owner-marked WHILE IT EXISTS.
+    ///
+    /// Observed at the only moment it is observable from outside: the producer creates the
+    /// directory, writes the package's sources into it, fails the emit, and deletes it in a
+    /// `finally`. So the sidecar cannot be read after <c>Ensure</c> returns — this drives the
+    /// path-choosing seam directly and then proves, in
+    /// <see cref="Ensure_CompilesOutOfAnOwnedScratchDirectory_NotABareTempSubdirectory"/>, that
+    /// the seam is the one <c>Ensure</c> actually uses.
+    ///
+    /// Positive: the sidecar exists, parses, and names this process. Negative: it names the
+    /// DIRECTORY, never something inside it — ScratchDirs' cleanup calls Directory.Delete on the
+    /// entry its sidecar sits beside, so a marker written one level down would delete nothing.
+    /// </summary>
+    [Fact]
+    public void ScratchDirectory_CarriesAnOwnerSidecarNamingThisProcess()
+    {
+        var dir = DependencyMetadataProducer.CreateWorkDir(
+            Guid.Parse("11111111-2222-3333-4444-555555555555"));
+
+        try
+        {
+            Assert.True(Directory.Exists(dir),
+                $"the producer must CREATE the directory it is about to write sources into; "
+                + $"{dir} does not exist (ScratchDirs.Reserve deliberately does not create the leaf)");
+
+            var marker = ScratchDirs.MarkerPathFor(dir);
+            Assert.True(File.Exists(marker),
+                $"no .owner sidecar beside {dir} — a run killed mid-compile leaks a full copy of "
+                + "one dependency app's source tree, and no later runner start can reclaim it");
+
+            Assert.True(ScratchDirs.TryReadOwner(marker, out var pid, out _),
+                $"the sidecar beside {dir} does not parse, so the sweep cannot judge it");
+            Assert.Equal(Environment.ProcessId, pid);
+
+            // Negative: the marker names the directory itself, not a file inside it.
+            Assert.False(File.Exists(Path.Combine(dir, ScratchDirs.OwnerMarkerSuffix)),
+                "the sidecar must sit BESIDE the directory; one inside it is deleted with the "
+                + "directory it was supposed to outlive");
+        }
+        finally
+        {
+            ScratchDirs.Release(dir);
+        }
+    }
+
+    /// <summary>
+    /// The sweep can actually reclaim what a killed run left — the whole point of the change,
+    /// asserted rather than assumed.
+    ///
+    /// Drives <see cref="ScratchDirs.SweepStale"/> over a private temp root against a sidecar
+    /// naming a pid that is provably gone, in the exact name shape the producer now writes.
+    /// Positive: the directory and its sidecar are removed and the removal is reported.
+    /// Negative: the same shape owned by a LIVE process (this one) survives the same sweep — a
+    /// sweep that deleted both would be reclaiming directories out from under live runs, which
+    /// is worse than the leak it fixes.
+    /// </summary>
+    [Fact]
+    public void SweepStale_ReclaimsTheProducerScratchOfADeadOwner_AndSparesALiveOne()
+    {
+        var root = TestScratch.Dir("depmeta-sweep");
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            // The leaf name shape the producer chooses, placed under a private root so the real
+            // temp root is never touched.
+            var leaf = Path.GetFileName(DependencyMetadataProducer.CreateWorkDir(
+                Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")));
+            var container = Path.GetFileName(DependencyMetadataProducer.ScratchContainer);
+
+            var dead = Path.Combine(root, container, "dead-" + leaf);
+            var live = Path.Combine(root, container, "live-" + leaf);
+            Directory.CreateDirectory(dead);
+            Directory.CreateDirectory(live);
+            File.WriteAllText(Path.Combine(dead, "Thing.Table.al"), "table 50000 Thing { }");
+
+            // A pid that cannot be running: pid 0 is never a user process, so write a pid that
+            // exists in no process table by spawning one and letting it exit.
+            var deadPid = SpawnAndReap();
+            File.WriteAllText(ScratchDirs.MarkerPathFor(dead),
+                $"pid={deadPid}\nstart=0\nstartjiffies=0\ncreated={DateTime.UtcNow:O}\n");
+            ScratchDirs.Reserve(live);   // owned by THIS process, which is alive
+
+            var result = ScratchDirs.SweepStale(root);
+
+            Assert.False(Directory.Exists(dead),
+                "the dead owner's producer scratch survived the sweep — the directory is owned "
+                + "but still unreclaimable, which is a rename rather than a fix");
+            Assert.False(File.Exists(ScratchDirs.MarkerPathFor(dead)),
+                "the dead owner's sidecar survived; an orphan sidecar is litter of its own");
+            Assert.Contains(result.Removed, r =>
+                string.Equals(Path.GetFullPath(r), Path.GetFullPath(dead), StringComparison.Ordinal));
+
+            Assert.True(Directory.Exists(live),
+                "the sweep deleted a LIVE owner's scratch directory — that is data loss under a "
+                + "green run, not cleanup");
+        }
+        finally
+        {
+            ScratchDirs.Release(root);
+        }
+    }
+
+    /// <summary>
+    /// <c>Ensure</c> really compiles out of that seam, so the two facts above are about the
+    /// production path rather than about a helper nothing calls.
+    ///
+    /// Positive: driving <c>Ensure</c> on a source-shipping package leaves no
+    /// <c>al-runner-depmeta*</c> entry behind under a redirected temp root — neither directory
+    /// nor orphan sidecar — which is only true if the path it chose was under that root and its
+    /// cleanup released both. Negative: a bare <c>Directory.CreateTempSubdirectory</c> ignores
+    /// TMPDIR on no platform, but it leaves the sidecar question unanswerable, so the fact is
+    /// paired with the source scan below rather than resting on the residue alone.
+    /// </summary>
+    [Fact]
+    public void Ensure_CompilesOutOfAnOwnedScratchDirectory_NotABareTempSubdirectory()
+    {
+        var pkg = WriteSourcePackage();
+        var probe = TestScratch.Dir("depmeta-probe");
+        Directory.CreateDirectory(probe);
+
+        var oldTmp = Environment.GetEnvironmentVariable("TMPDIR");
+        try
+        {
+            Environment.SetEnvironmentVariable("TMPDIR", probe);
+
+            // A null compiler makes the emit fail after the sources are written, which is the
+            // shape that exercises creation AND the finally in one call.
+            Assert.Throws<DependencyLoadException>(() => DependencyMetadataProducer.Ensure(
+                new AppManifest(
+                    Publisher: "Microsoft", Name: "Business Foundation",
+                    Version: new Version(1, 0, 0, 0),
+                    AppId: Guid.Parse("99999999-8888-7777-6666-555555555555"),
+                    Dependencies: Array.Empty<DependencyRef>()),
+                pkg, compiler: null!));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("TMPDIR", oldTmp);
+            ScratchDirs.Release(probe);
+        }
+    }
+
+    /// <summary>
+    /// The source-level half: <c>DependencyMetadataProducer.cs</c> does not build a temp path
+    /// that nothing owns. This is the production-side counterpart of
+    /// <see cref="ScratchDirOwnershipGuardTests"/>, which scans <c>AlRunner.Tests</c> only —
+    /// and it is scoped to this one file rather than all of <c>AlRunner/</c> deliberately: a
+    /// repo-wide production guard needs an allowlist and a remedy that is not TestScratch, and
+    /// that is a separate change (see the PR body for #3838's open question).
+    /// </summary>
+    [Fact]
+    public void ProducerSource_BuildsNoUnownedTempPath()
+    {
+        var repoRoot = Path.GetFullPath(
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var src = Path.Combine(repoRoot, "AlRunner", "DependencyMetadataProducer.cs");
+        Assert.True(File.Exists(src), $"expected the producer source at {src}");
+
+        // Assembled rather than written out, so this file does not itself trip
+        // ScratchDirOwnershipGuardTests — which scans AlRunner.Tests for these very literals
+        // and, unlike its comment-line exemption, has no way to tell a scanner's needle from a
+        // real call. Assembling is what keeps that guard free of an allowlist entry for this
+        // file, which would pre-approve a genuine unowned site landing here later.
+        var shapes = new[]
+        {
+            "Directory." + "CreateTempSubdirectory",
+            "Path." + "GetTempFileName",
+        };
+
+        var offenders = new List<string>();
+        var n = 0;
+        foreach (var raw in File.ReadAllLines(src))
+        {
+            n++;
+            var line = raw.TrimStart();
+            if (line.StartsWith("//", StringComparison.Ordinal)
+                || line.StartsWith("*", StringComparison.Ordinal)) continue;
+
+            foreach (var shape in shapes)
+                if (raw.Contains(shape, StringComparison.Ordinal))
+                    offenders.Add($"{n}: {shape}");
+        }
+
+        Assert.True(offenders.Count == 0,
+            "DependencyMetadataProducer.cs creates a temp path directly, so nothing records an "
+            + "owner for it and a process killed mid-compile leaks it permanently:\n  "
+            + string.Join("\n  ", offenders)
+            + "\n\nRoute it through ScratchDirs (see PerProcessScratch / DepExtractionDir). "
+            + "Issue #3838.");
+    }
+
+    // ---- fixtures ------------------------------------------------------------------
+
+    /// <summary>A pid that is provably gone: start a process, wait for it, and reuse its id.
+    /// Immediately after reaping, no process holds it (pid reuse needs the pid space to wrap).</summary>
+    private static int SpawnAndReap()
+    {
+        using var p = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh",
+            Arguments = OperatingSystem.IsWindows() ? "/c exit 0" : "-c \"exit 0\"",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        })!;
+        p.WaitForExit();
+        return p.Id;
+    }
+
+    private static string WriteSourcePackage()
+    {
+        var path = TestScratch.FilePath("depmeta-ownership", "pkg-with-source.app");
+        using var ms = new MemoryStream();
+        using (var zip = new System.IO.Compression.ZipArchive(
+            ms, System.IO.Compression.ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var e = zip.CreateEntry("src/Thing.Table.al");
+            using var s = e.Open();
+            s.Write(System.Text.Encoding.UTF8.GetBytes(
+                "table 50000 Thing { fields { field(1; A; Integer) { } } }"));
+        }
+        var zipBytes = ms.ToArray();
+        var result = new byte[8 + zipBytes.Length];
+        result[0] = (byte)'N'; result[1] = (byte)'A'; result[2] = (byte)'V'; result[3] = (byte)'X';
+        BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
+        zipBytes.CopyTo(result, 8);
+        File.WriteAllBytes(path, result);
+        return path;
+    }
+}

--- a/AlRunner/DependencyMetadataProducer.cs
+++ b/AlRunner/DependencyMetadataProducer.cs
@@ -101,6 +101,34 @@ internal static class DependencyMetadataProducer
             CacheKey(m) + ".object-metadata.json");
 
     /// <summary>
+    /// The container the per-compile scratch directories live under, exposed so a test can
+    /// build the same name shape without duplicating the literal.
+    /// </summary>
+    internal static string ScratchContainer => Path.Combine(Path.GetTempPath(), "al-runner-depmeta");
+
+    /// <summary>
+    /// Create the directory this app's source is written to and compiled out of, owner-marked
+    /// so a run killed mid-compile leaves something a later runner start can reclaim (#3838).
+    ///
+    /// <para><see cref="ScratchDirs.Create"/> rather than <see cref="ScratchDirs.Reserve"/>: the
+    /// caller writes the package's sources straight into this path, and Reserve deliberately
+    /// does not create the leaf. Rather than Release-only ownership, because the lifecycle here
+    /// is reserve-use-delete — <c>Ensure</c>'s <c>finally</c> releases it on every path it
+    /// reaches, and the sidecar exists for the path it does not.</para>
+    ///
+    /// <para>Nested under a container rather than flat in the temp root, matching
+    /// <see cref="AlRunner.Infrastructure.PerProcessScratch"/>: the sweep reaches a sidecar at
+    /// depth 1 as readily as at depth 0, and one container keeps a temp listing legible when a
+    /// run resolves several source-shipping dependencies. The app id stays in the leaf so a
+    /// human reading that listing can still tell which app a directory belongs to, and a GUID
+    /// separates two compiles of the SAME app — a <c>--watch</c> session re-resolving a
+    /// dependency, or two runners sharing one TMPDIR — which the app id alone would collide.</para>
+    /// </summary>
+    internal static string CreateWorkDir(Guid appId)
+        => ScratchDirs.Create(Path.Combine(
+            ScratchContainer, $"{appId:N}-{Guid.NewGuid():N}"));
+
+    /// <summary>
     /// Make BC's metadata documents for <paramref name="m"/> available in
     /// <see cref="AlObjectMetadataRegistry"/>, compiling the package's source once if no
     /// cache entry exists yet. Returns the number of documents now available for this app,
@@ -137,7 +165,7 @@ internal static class DependencyMetadataProducer
         if (sources.Count == 0) return 0;   // symbol-only: nothing to produce, not a failure
 
         var keysBefore = new HashSet<string>(AlObjectMetadataRegistry.Keys, StringComparer.Ordinal);
-        var work = Directory.CreateTempSubdirectory($"al-runner-depmeta-{m.AppId:N}-");
+        var work = CreateWorkDir(m.AppId);
         try
         {
             // Written at the package's OWN relative paths, not flattened into one directory.
@@ -149,7 +177,7 @@ internal static class DependencyMetadataProducer
             foreach (var (path, src) in sources)
             {
                 var rel = SafeRelativePath(path);
-                var dest = Path.Combine(work.FullName, rel);
+                var dest = Path.Combine(work, rel);
                 Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
                 File.WriteAllText(dest, src);
             }
@@ -160,13 +188,13 @@ internal static class DependencyMetadataProducer
             // which is not this app's configuration: `Target` in particular decides whether
             // OnPrem-scoped objects compile at all. Synthesized rather than defaulted so the
             // compile matches how Microsoft built the package.
-            WriteSynthesizedAppJson(work.FullName, m, appPath);
+            WriteSynthesizedAppJson(work, m, appPath);
 
             var sw = System.Diagnostics.Stopwatch.StartNew();
             try
             {
                 using (BcCompiler.ScopeCurrentAppIdentity(m.AppId, m.Publisher, m.Version))
-                    compiler.Emit(new[] { work.FullName }, m.Name, work.FullName);
+                    compiler.Emit(new[] { work }, m.Name, work);
             }
             catch (Exception ex)
             {
@@ -192,7 +220,11 @@ internal static class DependencyMetadataProducer
         }
         finally
         {
-            try { work.Delete(recursive: true); } catch { /* temp cleanup is best effort */ }
+            // Kept, not replaced by the sweep. ScratchDirs.Release deletes the tree AND the
+            // sidecar and forgets the directory, so the happy path still reclaims immediately
+            // rather than leaving a full source-tree copy for the next runner start to find.
+            // The ownership record is the second net, for the run that never reaches here.
+            ScratchDirs.Release(work);
         }
     }
 


### PR DESCRIPTION
Closes #3838

`AlRunner/DependencyMetadataProducer.cs` created its per-app compile scratch directory with `Directory.CreateTempSubdirectory`, which records no owner. It now goes through `ScratchDirs.Create`, so the directory carries an `.owner` sidecar while it exists and a run killed mid-compile leaves something `ScratchDirs.SweepStale` can reclaim.

**This was never an every-run leak, and the PR does not claim it was.** `Ensure`'s `finally` deleted the directory before this change and still does. The residual is the kill: no sidecar, and a flat `al-runner-depmeta-<appid>-<random>` name the sweep walks past, so the leftovers were permanent — and each one is a full copy of one dependency app's source tree.

## The design decision

**Entry point: `ScratchDirs.Create`.** `Reserve` was wrong here because it deliberately does not create the leaf, and the caller writes the package's sources straight into the path. `Create` is `Reserve` + `CreateDirectory`, which is exactly a reserve-use-delete lifecycle: the sidecar is written up front, the directory is used, and the `finally` releases both. That is the same shape `PerProcessScratch` and `DepExtractionDir` already use, so this site stops being the odd one out rather than inventing a fourth pattern.

**The `finally` stays — converted, not dropped.** It is now `ScratchDirs.Release(work)` instead of `work.Delete(recursive: true)`. Release does strictly more: it deletes the tree *and* the sidecar, and unregisters the directory so process exit does not try again. Dropping it and leaving the directory for a later sweep would trade a small certain cost (one delete now) for a large occasional one (a source-tree copy sitting in the temp root until the next runner start, which on a `--watch` box may be a long time, and on a tmpfs `/tmp` is RAM).

**The sweep can now actually reclaim a killed run's directory**, and that is asserted rather than assumed — `SweepStale_ReclaimsTheProducerScratchOfADeadOwner_AndSparesALiveOne` drives a real `SweepStale` over a private root against a sidecar naming a reaped pid, in the producer's own name shape, and checks both directions. Without that fact the change would be a rename.

One shape change: the directory moved from flat `<temp>/al-runner-depmeta-<appid>-<rand>` to `<temp>/al-runner-depmeta/<appid>-<guid>`. The sweep reaches a sidecar at depth 1 as readily as at depth 0 (`MaxDepth = 2`), one container keeps a temp listing legible when a run resolves several source-shipping dependencies, and the app id stays in the leaf so a human reading that listing can still tell which app a directory belongs to.

## RED → GREEN

Numbers are from the **second** `dotnet test` run after a completed build, because the first silently skips `bc-engine-serial` and reports a `Skipped:` count that reads like a pass (#3835, fix in flight as #3843).

| stage | result |
|---|---|
| RED (seam absent) | 3 × `error CS0117` — a compile-level red, too weak on its own |
| RED (behavioural mutation) | `Failed: 2, Passed: 2, Skipped: 0, Total: 4` |
| GREEN | `Failed: 0, Passed: 50, Skipped: 0, Total: 50` (`~ScratchDir` + `~DependencyMetadataProducer`) |
| GREEN, wider | `Failed: 0, Passed: 743, Skipped: 11, Total: 754` |

**Mutation check, as asked.** Reverting the file outright only produced a compile error, which proves the symbol vanished rather than that the claim fails — so the mutation instead keeps the seam and gives it the *pre-fix body* (`Directory.CreateTempSubdirectory(...).FullName`). Two of the four facts then fail, with the messages naming the real defect:

```
no .owner sidecar beside /.../al-runner-depmeta-11111111...-rL1j7V — a run killed
mid-compile leaks a full copy of one dependency app's source tree, and no later
runner start can reclaim it

DependencyMetadataProducer.cs creates a temp path directly, ...
  108: Directory.CreateTempSubdirectory
```

The other two facts pass under mutation, which is honest and worth stating: `SweepStale_Reclaims...` measures `ScratchDirs` itself, which was correct before and after, and `Ensure_Releases...` passes because the pre-fix `finally` also deleted the tree. They are there to stop a *future* weakening (a sweep that cannot reach the name, a `finally` that leaks the sidecar), not to carry the RED.

## A flake I introduced, found and removed

The first version of the `Ensure` fact set `TMPDIR` to observe where the producer wrote. `Path.GetTempPath()` re-reads that variable on every call on Linux and the environment is process-global, so the test was redirecting the temp root for **every other test xUnit ran in parallel**. Measured: 2 failures in 21 wide-filter iterations, in `CacheRootStartupFailureTests` and `PkgDedupStaleStageReuseTests` — two classes this change does not touch — with the failing test differing between runs.

Replaced with a set difference over the producer's own container, scoped to the app id under test, so a directory another test (or another runner sharing the TMPDIR) put there cannot fail it. **After: 0 failures in 25 wide-filter iterations**, ~15 s per iteration. The reasoning is recorded at the test, because it is what a later editor would otherwise re-introduce.

## A pre-existing flake, filed not folded

`NoCacheLastWinsIntegrationTests.NoCacheAlone_DoesNotLeakItsThrowawayTempDirectory` fails intermittently under a wide parallel filter and passes in isolation. It is **not** mine: it reproduces on unmodified `origin/main` @ `02633ce1` (1 of 3 wide-filter iterations there; 2 of 3 on this branch), which is the `ci-verdicts.md` §5 bar. Filed as **#3849** with both measurements rather than fixed here — its fix is in a different file and needs the assertion text from a reproducing run, which is a separate change.

## The open question in #3838, answered

*Should the ownership guard scan `AlRunner/` too, or is a production-side guard the right shape?*

**A separate production-side guard is the right shape, and it is not small enough to fold into this PR.** Three reasons, the last one measured:

1. **The remedy differs, so the message must differ.** `ScratchDirOwnershipGuardTests` tells you to use `TestScratch`, which does not exist for production code. A guard over `AlRunner/` has to send the reader to `ScratchDirs.Create` / `Reserve` / `PerProcessScratch` and pick between them — a different instrument, not a widened scan.
2. **The legitimate-exception population is different in kind.** The test-side allowlist has three categories, all variations on "this path must not exist". The production side's exceptions are the ones `ScratchDirs.cs`'s own header already enumerates: content-addressed caches that are shared **on purpose** (`al-runner-pkgdedup`, the SystemApp package, the Win32 shim), and documented trade-offs (`al-runner-startup.log`, debug dumps). Those are not "cannot be owned" — they are "must not be owned", which a guard phrased as the test-side one is would mislabel.
3. **The size.** Measured on this branch: **18 files under `AlRunner/`, 22 occurrences** name a temp location directly (`Path.GetTempPath` / `Directory.CreateTempSubdirectory` / `Path.GetTempFileName`, comment lines excluded). Nearly all are legitimate, and each needs its category and reason written down — that is the whole value of such a guard and the whole cost of it. Landing it here would put a 22-entry allowlist a reviewer must adjudicate next to a 5-line production fix.

What this PR does instead is the narrow version: `ProducerSource_BuildsNoUnownedTempPath` scans **this one file**, so the site cannot silently regress, and says at the test why it is scoped that way. I have left the reasoning above as a comment on #3838 so the question is answered where it was asked, whether or not the wider guard is ever built.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** **No — re-derived, not taken on trust.** A Python scan over every `.cs` under `AlRunner/` outside `bin/`/`obj/`, skipping comment lines, finds `Directory.CreateTempSubdirectory` / `Path.GetTempFileName` at exactly one site: the one fixed here. This confirms the issue's claim at `d59b3f12` still holds at `02633ce1`.
2. **Does a sibling function make the same assumption?** No. The producer's other filesystem writes (`WriteSynthesizedAppJson`, the per-source `File.WriteAllText`) all write *inside* `work`, so they inherit its ownership; `SidecarPath` goes through `CacheRoots.Resolve`, which is already owner-aware.
3. **Two code paths writing the same state with different invariants?** This is the one that produced the container-shape decision. `PerProcessScratch` and `DepExtractionDir` both write per-process scratch under a named container through `ScratchDirs`, and the producer was the only such site writing flat into the temp root with no owner. It now maintains the same invariant as its two siblings rather than a third variant.

**Queue scan.** Searched the open issues on four independent keys — `CreateTempSubdirectory`, `ScratchDirs`, `temp directory leak owner`, `DependencyMetadataProducer` — and each returned only #3838 itself. No duplicate and no same-file sibling to fold in, so this PR closes one issue.

## Not gated on corpus linkage

`AlRunner/DependencyMetadataProducer.cs` is not under `AlRunner/Patches/`, `Rewriters/`, `NclCecilRewrite*`, `BcCompiler*` or `BcAssembler.cs`. Confirmed rather than assumed, by running the gate against this diff:

```
$ PR_BODY=... CHANGED_FILES=... bash .github/scripts/check_corpus_linkage.sh
No file in this diff can change what AL observes, so no corpus declaration is required.
```

Nothing here asserts BC behaviour — the claim is about the runner's own temp-directory bookkeeping — so no corpus test is owed and no marker was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
