### PR TITLE
fix(dap): resolve setBreakpoints against a built source map whatever order the client asks in

### DIFF
--- a/AlRunner.Tests/DapPreLaunchBreakpointTests.cs
+++ b/AlRunner.Tests/DapPreLaunchBreakpointTests.cs
@@ -178,7 +178,9 @@ public class DapPreLaunchBreakpointTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-dap-3821-" + Guid.NewGuid().ToString("N"));
+        // TestScratch, not Path.GetTempPath(): an unowned temp path is leaked permanently by a
+        // killed test host, and ScratchDirOwnershipGuardTests fails the build over one.
+        var dir = TestScratch.Dir("al-runner-dap-uncompilable");
         Directory.CreateDirectory(dir);
         try
         {

--- a/AlRunner.Tests/DapPreLaunchBreakpointTests.cs
+++ b/AlRunner.Tests/DapPreLaunchBreakpointTests.cs
@@ -34,12 +34,22 @@ public class DapPreLaunchBreakpointTests
     private const int SecondObjectSecondStatementLine = 32; // Counter := Helper.Bump(Counter);
     private const int NoStatementLine = 16;                 // the first codeunit's closing brace
 
+    /// <summary>
+    /// Holds the adapter's source-map preparation open for a known interval
+    /// (`AL_RUNNER_DAP_TEST_DELAY_MAP_MS`, honoured only by `RunDapLoop`). The two liveness
+    /// facts at the bottom of this file need "the map is not ready yet" to be a state that
+    /// lasts long enough to assert against; an organically slow bundle would make them flaky.
+    /// </summary>
+    private static IReadOnlyDictionary<string, string> HoldMapPreparation(int ms) =>
+        new Dictionary<string, string> { ["AL_RUNNER_DAP_TEST_DELAY_MAP_MS"] = ms.ToString() };
+
     /// <summary>Drives `initialize` and waits for the `initialized` event, leaving the
     /// session at exactly the point the specification says configuration requests may be
     /// sent — and BEFORE `launch`.</summary>
-    private static async Task<DapClient> StartAndInitializeAsync()
+    private static async Task<DapClient> StartAndInitializeAsync(
+        IReadOnlyDictionary<string, string>? extraEnv = null)
     {
-        var dap = await DapClient.StartAsync(FixtureSrc);
+        var dap = await DapClient.StartAsync(FixtureSrc, extraEnv: extraEnv);
         try
         {
             var initSeq = dap.SendRequest("initialize", new { adapterID = "al-runner-tests" });
@@ -250,5 +260,81 @@ public class DapPreLaunchBreakpointTests
         {
             try { Directory.Delete(dir, recursive: true); } catch (IOException) { }
         }
+    }
+
+    /// <summary>
+    /// #3846: the request loop must stay able to read while a breakpoint request is waiting
+    /// for the source map. The fix for #3821 first made `setBreakpoints` BLOCK the loop for
+    /// the whole compile, which is worse than it sounds: nothing else is read meanwhile, so a
+    /// client that gives up and disconnects is not heard until the compile ends, and a
+    /// compile that never ends is an adapter that never exits.
+    ///
+    /// Map preparation is held open for 25 seconds and the client disconnects immediately.
+    /// The response must come back in a small fraction of that.
+    ///
+    /// Mutation that turns this red: make the `setBreakpoints` case call
+    /// AnswerSetBreakpoints unconditionally instead of deferring — the disconnect is then
+    /// answered ~25s later and the 10s read below times out.
+    /// </summary>
+    [SkippableFact]
+    public async Task DisconnectWhileABreakpointRequestWaitsForTheMap_IsAnsweredAtOnce()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        await using var dap = await StartAndInitializeAsync(HoldMapPreparation(25_000));
+
+        // Deferred by construction: the map cannot be ready for another 25 seconds.
+        dap.SendRequest("setBreakpoints", new
+        {
+            source = new { path = Path.Combine(FixtureSrc, SourceFileName) },
+            breakpoints = new[] { new { line = SecondObjectSecondStatementLine } },
+        });
+
+        var started = System.Diagnostics.Stopwatch.StartNew();
+        var discSeq = dap.SendRequest("disconnect", new { });
+        var discResp = await dap.ReadUntilResponseAsync(discSeq, timeout: TimeSpan.FromSeconds(10));
+        started.Stop();
+
+        Assert.True(discResp.GetProperty("success").GetBoolean(), discResp.ToString());
+        // Well inside the 25s hold, so this cannot pass by the hold having elapsed. The bound
+        // is deliberately loose against a loaded CI box; the failing behaviour is 25s.
+        Assert.True(started.Elapsed < TimeSpan.FromSeconds(15),
+            $"disconnect took {started.Elapsed.TotalSeconds:F1}s while a breakpoint request was "
+            + $"waiting for the map — the loop was blocked rather than reading");
+
+        // The session really is being torn down, not merely answered.
+        await dap.ReadUntilEventAsync("terminated", TimeSpan.FromSeconds(15));
+    }
+
+    /// <summary>
+    /// The other half: a deferred request is not merely postponed, it is ANSWERED, and
+    /// without the client sending anything further. Between the request and the response the
+    /// client is silent, so the only thing that can produce it is the loop's race between the
+    /// outstanding transport read and the map becoming available.
+    ///
+    /// The answer is the real one — verified, on the file line asked for — so a version that
+    /// drained the queue by writing a placeholder would not pass.
+    /// </summary>
+    [SkippableFact]
+    public async Task ABreakpointRequestDeferredForTheMap_IsAnsweredWhenTheMapArrives()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        await using var dap = await StartAndInitializeAsync(HoldMapPreparation(4_000));
+
+        var bpSeq = dap.SendRequest("setBreakpoints", new
+        {
+            source = new { path = Path.Combine(FixtureSrc, SourceFileName) },
+            breakpoints = new[] { new { line = SecondObjectSecondStatementLine } },
+        });
+
+        // Nothing else is sent. No launch, no configurationDone.
+        var bpResp = await dap.ReadUntilResponseAsync(bpSeq, timeout: TimeSpan.FromSeconds(120));
+        Assert.True(bpResp.GetProperty("success").GetBoolean(), bpResp.ToString());
+        var bp = bpResp.GetProperty("body").GetProperty("breakpoints")[0];
+        Assert.True(bp.GetProperty("verified").GetBoolean(),
+            $"the deferred request was answered, but not resolved: {bpResp}\n"
+            + $"--- stderr ---\n{dap.StdErr}");
+        Assert.Equal(SecondObjectSecondStatementLine, bp.GetProperty("line").GetInt32());
     }
 }

--- a/AlRunner.Tests/DapPreLaunchBreakpointTests.cs
+++ b/AlRunner.Tests/DapPreLaunchBreakpointTests.cs
@@ -151,4 +151,94 @@ public class DapPreLaunchBreakpointTests
         Assert.True(message.Contains("no executable AL statement", StringComparison.OrdinalIgnoreCase),
             $"an unverified breakpoint must say which of the two reasons applies; got '{message}': {bpResp}");
     }
+
+    /// <summary>
+    /// The OTHER reason, and the one the fact above cannot reach: a bundle that does not
+    /// compile. Before the fix a pre-launch request answered `verified: false` here too, so
+    /// the two states were the same response — and the wrong one to act on, since "wait, it
+    /// is still loading" and "this will never bind" call for opposite client behaviour.
+    ///
+    /// The bundle is written to a temp directory rather than checked in, so the repository
+    /// does not carry a fixture that is deliberately broken.
+    /// </summary>
+    [SkippableFact]
+    public async Task SetBreakpointsBeforeLaunch_OnABundleThatDoesNotCompile_SaysSoRatherThanBlamingTheLine()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-dap-3821-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            // No application/platform floor — .claude/rules/no-base-app-in-csharp-tests.md.
+            File.WriteAllText(Path.Combine(dir, "app.json"), """
+            {
+              "id": "b1f2c3d4-e5a6-4b7c-8d9e-0f1a2b3c4d5e",
+              "name": "Runner Tests Fixture - DAP Uncompilable",
+              "publisher": "AL Runner",
+              "version": "1.0.0.0",
+              "dependencies": [],
+              "idRanges": [ { "from": 60300, "to": 60309 } ],
+              "runtime": "14.0"
+            }
+            """);
+            // NoSuchType is not a type, so this bundle cannot compile.
+            File.WriteAllText(Path.Combine(dir, "Broken.Codeunit.al"), """
+            codeunit 60300 "Dap Broken"
+            {
+                procedure Nope()
+                var
+                    X: NoSuchType;
+                begin
+                    X := 1;
+                end;
+            }
+            """);
+
+            await using var dap = await DapClient.StartAsync(dir);
+
+            var initSeq = dap.SendRequest("initialize", new { adapterID = "al-runner-tests" });
+            var initEvents = new List<JsonElement>();
+            var initResp = await dap.ReadUntilResponseAsync(initSeq, initEvents);
+            Assert.True(initResp.GetProperty("success").GetBoolean(), initResp.ToString());
+
+            var bpSeq = dap.SendRequest("setBreakpoints", new
+            {
+                source = new { path = Path.Combine(dir, "Broken.Codeunit.al") },
+                breakpoints = new[] { new { line = 7 } },
+            });
+            var bpResp = await dap.ReadUntilResponseAsync(bpSeq, timeout: TimeSpan.FromSeconds(120));
+            Assert.True(bpResp.GetProperty("success").GetBoolean(), bpResp.ToString());
+
+            var bp = bpResp.GetProperty("body").GetProperty("breakpoints")[0];
+            Assert.False(bp.GetProperty("verified").GetBoolean(), bpResp.ToString());
+            var message = bp.TryGetProperty("message", out var msgEl) ? msgEl.GetString() ?? "" : "";
+            Assert.True(message.Contains("did not compile", StringComparison.OrdinalIgnoreCase),
+                $"a breakpoint in a bundle that does not compile must say so, not blame the "
+                + $"line; got '{message}': {bpResp}\n--- stderr ---\n{dap.StdErr}");
+            // And it must not be the other reason, which is what makes this fact more than
+            // an assertion that SOME message is present.
+            Assert.DoesNotContain("no executable AL statement", message, StringComparison.OrdinalIgnoreCase);
+
+            // The diagnostic is CACHED, and a later launch must report it rather than
+            // succeeding against an empty map it now believes is resolved (#3845 review).
+            // This is the assertion that pins the latch: EnsureSourceMap marks itself
+            // resolved on the way out, so a version that recorded no reason would leave a
+            // green launch behind a bundle that cannot run.
+            var launchSeq = dap.SendRequest("launch", new { });
+            var launchResp = await dap.ReadUntilResponseAsync(launchSeq, timeout: TimeSpan.FromSeconds(120));
+            Assert.False(launchResp.GetProperty("success").GetBoolean(),
+                $"launch must fail on a bundle that does not compile: {launchResp}");
+            var launchMsg = launchResp.TryGetProperty("message", out var lm) ? lm.GetString() ?? "" : "";
+            Assert.NotEqual("", launchMsg);
+            // launch reports the diagnostic bare; the breakpoint message wraps the same
+            // string. Asserting containment ties the two answers to one cached value rather
+            // than to two independently-produced ones.
+            Assert.Contains(launchMsg, message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch (IOException) { }
+        }
+    }
 }

--- a/AlRunner.Tests/DapPreLaunchBreakpointTests.cs
+++ b/AlRunner.Tests/DapPreLaunchBreakpointTests.cs
@@ -1,0 +1,154 @@
+// DapPreLaunchBreakpointTests — #3821: a `setBreakpoints` that arrives after `initialized`
+// but before `launch` was answered against a source map that did not exist yet.
+//
+// The DAP specification's own sequence has the client react to the `initialized` event by
+// sending its configuration requests, and `launch` is a separate exchange that finishes
+// after `configurationDone`. So a client sending breakpoints before launch is following the
+// protocol, not misusing it. This adapter built the source map inside `launch`, so in that
+// window `sourceMap` was still AlSourceLocationMap.Empty and EVERY breakpoint came back
+// `verified: false` — a successful response carrying a wrong answer, with nothing to tell it
+// apart from "that line has no statement".
+//
+// The fix defers RESOLUTION rather than the `initialized` event: whichever request needs the
+// map first waits for the compile that is already running and builds it. That keeps both
+// client orderings working, which emitting `initialized` late would not.
+//
+// These facts drive a real DAP session against Fixtures/DapTwoObjects — the same fixture and
+// line numbers DapMultiObjectFileTests pins — with launch and setBreakpoints swapped.
+
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class DapPreLaunchBreakpointTests
+{
+    private static readonly string FixtureSrc = Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "DapTwoObjects"));
+
+    private const string SourceFileName = "TwoObjects.Codeunit.al";
+
+    // Fixtures/DapTwoObjects/TwoObjects.Codeunit.al, asserted against exactly.
+    private const int SecondObjectSecondStatementLine = 32; // Counter := Helper.Bump(Counter);
+    private const int NoStatementLine = 16;                 // the first codeunit's closing brace
+
+    /// <summary>Drives `initialize` and waits for the `initialized` event, leaving the
+    /// session at exactly the point the specification says configuration requests may be
+    /// sent — and BEFORE `launch`.</summary>
+    private static async Task<DapClient> StartAndInitializeAsync()
+    {
+        var dap = await DapClient.StartAsync(FixtureSrc);
+        try
+        {
+            var initSeq = dap.SendRequest("initialize", new { adapterID = "al-runner-tests" });
+            var initEvents = new List<JsonElement>();
+            var initResp = await dap.ReadUntilResponseAsync(initSeq, initEvents);
+            Assert.True(initResp.GetProperty("success").GetBoolean(), initResp.ToString());
+            var sawInitialized = initEvents.Any(e => e.GetProperty("event").GetString() == "initialized")
+                || (await dap.ReadUntilEventAsync("initialized")).GetProperty("event").GetString() == "initialized";
+            Assert.True(sawInitialized);
+            return dap;
+        }
+        catch
+        {
+            await dap.DisposeAsync();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// RED before the fix: <c>verified: false</c> on a line that verifies perfectly well when
+    /// the same request is sent after `launch` (DapMultiObjectFileTests asserts exactly that
+    /// line, in that order). GREEN: it verifies here too, reports the file line asked for,
+    /// and execution actually stops there — the last part is what makes this more than a
+    /// response-shape assertion, since an adapter could answer <c>verified: true</c> and arm
+    /// nothing.
+    /// </summary>
+    [SkippableFact]
+    public async Task SetBreakpointsBeforeLaunch_VerifiesAndArms()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        await using var dap = await StartAndInitializeAsync();
+
+        var bpSeq = dap.SendRequest("setBreakpoints", new
+        {
+            source = new { path = Path.Combine(FixtureSrc, SourceFileName) },
+            breakpoints = new[] { new { line = SecondObjectSecondStatementLine } },
+        });
+        // The same 120s the launch request gets in DapMultiObjectFileTests: this request is
+        // now the one that waits for the compile, so it inherits that cost.
+        var bpResp = await dap.ReadUntilResponseAsync(bpSeq, timeout: TimeSpan.FromSeconds(120));
+        Assert.True(bpResp.GetProperty("success").GetBoolean(), bpResp.ToString());
+
+        var bps = bpResp.GetProperty("body").GetProperty("breakpoints");
+        Assert.Equal(1, bps.GetArrayLength());
+        Assert.True(bps[0].GetProperty("verified").GetBoolean(),
+            $"a pre-launch breakpoint at file line {SecondObjectSecondStatementLine} was not "
+            + $"verified — it resolved against an empty source map: {bpResp}\n"
+            + $"--- stderr ---\n{dap.StdErr}");
+        Assert.Equal(SecondObjectSecondStatementLine, bps[0].GetProperty("line").GetInt32());
+
+        var launchSeq = dap.SendRequest("launch", new { });
+        var launchResp = await dap.ReadUntilResponseAsync(launchSeq, timeout: TimeSpan.FromSeconds(120));
+        Assert.True(launchResp.GetProperty("success").GetBoolean(),
+            $"launch failed: {launchResp}\n--- stderr ---\n{dap.StdErr}");
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal("breakpoint", stopped.GetProperty("body").GetProperty("reason").GetString());
+        Assert.Equal(SecondObjectSecondStatementLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
+
+        // Paused BEFORE the statement runs, so Counter still holds the previous statement's
+        // 1. Reading it proves the arm landed on the requested statement rather than on some
+        // other statement of the same object.
+        var stSeq = dap.SendRequest("stackTrace", new { threadId = 1 });
+        var stResp = await dap.ReadUntilResponseAsync(stSeq);
+        var frameId = stResp.GetProperty("body").GetProperty("stackFrames")[0].GetProperty("id").GetInt32();
+        var scSeq = dap.SendRequest("scopes", new { frameId });
+        var scResp = await dap.ReadUntilResponseAsync(scSeq);
+        var variablesReference = scResp.GetProperty("body").GetProperty("scopes")[0]
+            .GetProperty("variablesReference").GetInt32();
+        var varSeq = dap.SendRequest("variables", new { variablesReference });
+        var varResp = await dap.ReadUntilResponseAsync(varSeq);
+        var vars = varResp.GetProperty("body").GetProperty("variables").EnumerateArray()
+            .ToDictionary(v => v.GetProperty("name").GetString()!, v => v.GetProperty("value").GetString());
+        Assert.Equal("1", vars["Counter"]);
+    }
+
+    /// <summary>
+    /// The negative direction, and the half #3821 says must stay distinguishable: a line that
+    /// genuinely carries no executable statement is still unverified after the fix — the wait
+    /// must not turn every request into a yes — and it now says WHY.
+    ///
+    /// Before the fix both cases answered <c>verified: false</c> with no message at all, so a
+    /// client could not tell "nothing is loaded yet" from "that line has no statement". The
+    /// assertion is on the message's substance, not its exact wording.
+    /// </summary>
+    [SkippableFact]
+    public async Task SetBreakpointsBeforeLaunch_OnALineWithNoStatement_IsUnverifiedAndSaysWhy()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        await using var dap = await StartAndInitializeAsync();
+
+        var bpSeq = dap.SendRequest("setBreakpoints", new
+        {
+            source = new { path = Path.Combine(FixtureSrc, SourceFileName) },
+            breakpoints = new[] { new { line = NoStatementLine } },
+        });
+        var bpResp = await dap.ReadUntilResponseAsync(bpSeq, timeout: TimeSpan.FromSeconds(120));
+        Assert.True(bpResp.GetProperty("success").GetBoolean(), bpResp.ToString());
+
+        var bp = bpResp.GetProperty("body").GetProperty("breakpoints")[0];
+        Assert.False(bp.GetProperty("verified").GetBoolean(),
+            $"file line {NoStatementLine} is a closing brace and carries no statement, so it "
+            + $"must not verify: {bpResp}");
+        Assert.Equal(NoStatementLine, bp.GetProperty("line").GetInt32());
+        var message = bp.TryGetProperty("message", out var msgEl) ? msgEl.GetString() ?? "" : "";
+        Assert.True(message.Contains("no executable AL statement", StringComparison.OrdinalIgnoreCase),
+            $"an unverified breakpoint must say which of the two reasons applies; got '{message}': {bpResp}");
+    }
+}

--- a/AlRunner.Tests/DapPreLaunchBreakpointTests.cs
+++ b/AlRunner.Tests/DapPreLaunchBreakpointTests.cs
@@ -10,8 +10,10 @@
 // apart from "that line has no statement".
 //
 // The fix defers RESOLUTION rather than the `initialized` event: whichever request needs the
-// map first waits for the compile that is already running and builds it. That keeps both
-// client orderings working, which emitting `initialized` late would not.
+// map first waits for the compile that is already running and builds it. Deferring the event
+// would also work — compilation needs nothing from the client — but it holds the client's
+// WHOLE configuration sequence behind the compile rather than only the requests that need a
+// map. RunDapLoop's EnsureSourceMap carries the same note; keep the two in step.
 //
 // These facts drive a real DAP session against Fixtures/DapTwoObjects — the same fixture and
 // line numbers DapMultiObjectFileTests pins — with launch and setBreakpoints swapped.
@@ -220,20 +222,28 @@ public class DapPreLaunchBreakpointTests
             // an assertion that SOME message is present.
             Assert.DoesNotContain("no executable AL statement", message, StringComparison.OrdinalIgnoreCase);
 
-            // The diagnostic is CACHED, and a later launch must report it rather than
-            // succeeding against an empty map it now believes is resolved (#3845 review).
-            // This is the assertion that pins the latch: EnsureSourceMap marks itself
-            // resolved on the way out, so a version that recorded no reason would leave a
-            // green launch behind a bundle that cannot run.
+            // A later launch must report the same failure rather than succeeding against an
+            // empty map it now believes is resolved.
+            //
+            // What this does NOT cover, stated because an earlier version of this comment
+            // claimed it did (#3845 round-two review): a compile DIAGNOSTIC takes the
+            // ordinary branch of EnsureSourceMap and never enters its catch, so this fact
+            // would pass against the earlier implementation that latched before the work.
+            // The catch is for a bundleRunTask that FAULTS or an AlCoverageSourceMap.Build
+            // that throws, and proving that needs a seam to force one — #3846.
             var launchSeq = dap.SendRequest("launch", new { });
             var launchResp = await dap.ReadUntilResponseAsync(launchSeq, timeout: TimeSpan.FromSeconds(120));
             Assert.False(launchResp.GetProperty("success").GetBoolean(),
                 $"launch must fail on a bundle that does not compile: {launchResp}");
             var launchMsg = launchResp.TryGetProperty("message", out var lm) ? lm.GetString() ?? "" : "";
-            Assert.NotEqual("", launchMsg);
+            // The REAL compiler diagnostic, in both answers — not a generic "compile failed",
+            // which every other assertion here would accept (#3845 round-two review).
+            Assert.Contains("AL0134", launchMsg, StringComparison.Ordinal);
+            Assert.Contains("NoSuchType", launchMsg, StringComparison.Ordinal);
             // launch reports the diagnostic bare; the breakpoint message wraps the same
-            // string. Asserting containment ties the two answers to one cached value rather
-            // than to two independently-produced ones.
+            // string. Containment ties the two answers together — it does not by itself prove
+            // one cached value, since recomputing the same deterministic diagnostic would
+            // satisfy it too.
             Assert.Contains(launchMsg, message, StringComparison.Ordinal);
         }
         finally

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -5717,29 +5717,52 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
     // waiting here cannot deadlock: nothing this loop has yet to receive is upstream of
     // the compile.
     //
-    // Deferring the `initialized` event until the map exists was the other candidate and is
-    // worse: a client that sends launch only after `initialized` would then never send it.
-    // Deferring resolution keeps both client orderings working.
+    // Deferring the `initialized` event until the map exists is the other candidate, and it
+    // would work — for the same reason this does, that compilation needs nothing from the
+    // client. (An earlier version of this comment claimed it would strand a client that waits
+    // for `initialized` before sending launch. That was wrong: such a client would still get
+    // the event.) It is rejected for what it costs, not because it breaks: it holds the
+    // client's WHOLE configuration sequence — breakpoints, exception filters, everything —
+    // behind the compile, where deferring resolution charges that wait only to the requests
+    // that actually need the map.
     string? EnsureSourceMap()
     {
         if (sourceMapResolved) return compileFailure;
-        sourceMapResolved = true;
-        var winner = System.Threading.Tasks.Task.WhenAny(compiledTcs.Task, bundleRunTask)
-            .GetAwaiter().GetResult();
-        if (!ReferenceEquals(winner, compiledTcs.Task))
+        try
         {
-            // The run finished (or failed) before ever reaching dapRunStep — a compile
-            // failure. Kept rather than thrown so both requests report the same thing.
-            var runs = bundleRunTask.Result;
-            compileFailure = runs
-                .SelectMany(r => r.CompileErrors ?? Array.Empty<CompilationErrorGroup>())
-                .SelectMany(g => g.Errors)
-                .FirstOrDefault() ?? "compile failed (no diagnostic captured)";
-            return compileFailure;
+            var winner = System.Threading.Tasks.Task.WhenAny(compiledTcs.Task, bundleRunTask)
+                .GetAwaiter().GetResult();
+            if (!ReferenceEquals(winner, compiledTcs.Task))
+            {
+                // The run finished before ever reaching dapRunStep — a compile failure.
+                // Kept rather than thrown so every later request reports the same thing.
+                var runs = bundleRunTask.Result;
+                compileFailure = runs
+                    .SelectMany(r => r.CompileErrors ?? Array.Empty<CompilationErrorGroup>())
+                    .SelectMany(g => g.Errors)
+                    .FirstOrDefault() ?? "compile failed (no diagnostic captured)";
+            }
+            else
+            {
+                sourceMap = AlRunner.Infrastructure.AlCoverageSourceMap.Build(
+                    new[] { bundleDir }, relativeTo: null);
+            }
         }
-        sourceMap = AlRunner.Infrastructure.AlCoverageSourceMap.Build(
-            new[] { bundleDir }, relativeTo: null);
-        return null;
+        catch (Exception ex)
+        {
+            // The run FAULTED rather than reporting compile errors (bundleRunTask.Result
+            // rethrows), or building the map threw. Recorded as the reason, because the
+            // latch below is about to make this the permanent answer: without this the
+            // exception would escape, leave compileFailure null with sourceMapResolved
+            // already true, and every later setBreakpoints would resolve against the
+            // still-empty map and report "no executable AL statement on this line" — a
+            // confident wrong verdict where the honest one is that nothing was measured
+            // (.claude/rules/guards-need-a-third-state.md).
+            compileFailure = "the run failed before a source map could be built: "
+                + ex.GetBaseException().Message;
+        }
+        sourceMapResolved = true;
+        return compileFailure;
     }
 
     int exitCode = 0;
@@ -5901,7 +5924,13 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
                         // `initialized` and `launch` is the specification's own sequence,
                         // and answering it against an empty map made every breakpoint
                         // unverified.
-                        var bpCompileErr = EnsureSourceMap();
+                        //
+                        // An EMPTY list is the exception, and it is the one that matters for
+                        // responsiveness: "remove every breakpoint in this source" resolves
+                        // nothing, so it needs no map, and waiting for the compile to answer
+                        // it would block this single-threaded loop for no reason (#3845
+                        // review). The clear below runs either way.
+                        var bpCompileErr = lines.Count > 0 ? EnsureSourceMap() : null;
 
                         var requests = lines.Select(l => new AlRunner.Infrastructure.DapBreakpointRequest(srcPath, l)).ToList();
                         var resolved = AlRunner.Infrastructure.DapBreakpointResolver.Resolve(requests, sourceMap);

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -5673,6 +5673,23 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
     // from the first wait.
     var sourceMapResolved = false;
     string? compileFailure = null;
+
+    // setBreakpoints requests that arrived before the map could be built, waiting to be
+    // answered. Answering one needs the compile, and BLOCKING this single-threaded loop for
+    // the compile makes the session deaf to `disconnect` and turns a compile that never
+    // finishes into an adapter that never exits (#3846). DAP matches a response to its
+    // request by `request_seq`, so answering later is within the protocol.
+    var deferredBreakpointRequests = new List<(int Seq, string Command, string SrcPath, List<int> Lines)>();
+
+    // A test seam, and the only way to prove the paragraph above: an organically slow bundle
+    // makes a flaky test, so this holds map preparation open for a known interval while the
+    // loop stays live. Off unless the variable is set, and read nowhere else.
+    var testMapDelayMs = int.TryParse(
+        Environment.GetEnvironmentVariable("AL_RUNNER_DAP_TEST_DELAY_MAP_MS"), out var dapTestDelay)
+        && dapTestDelay > 0 ? dapTestDelay : 0;
+    System.Threading.Tasks.Task mapGate = testMapDelayMs > 0
+        ? System.Threading.Tasks.Task.Delay(testMapDelayMs)
+        : System.Threading.Tasks.Task.CompletedTask;
     // Which scope types this session has breakpoints registered on, per source file, so a
     // later setBreakpoints for that file can clear ALL of them (#3786 review). Clearing only
     // the scopes named by the NEW request leaves the old ones armed: an empty breakpoint
@@ -5725,11 +5742,24 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
     // client's WHOLE configuration sequence — breakpoints, exception filters, everything —
     // behind the compile, where deferring resolution charges that wait only to the requests
     // that actually need the map.
+    // When EnsureSourceMap could answer without blocking, as a task to race against the
+    // transport read, and as a predicate for the deferral decision. Both spell the same two
+    // conditions, so the race and the decision cannot disagree.
+    System.Threading.Tasks.Task MapAnswerReady() =>
+        System.Threading.Tasks.Task.WhenAll(
+            mapGate,
+            System.Threading.Tasks.Task.WhenAny(compiledTcs.Task, bundleRunTask));
+
+    bool MapAnswerAvailable() =>
+        sourceMapResolved
+        || (mapGate.IsCompleted && (compiledTcs.Task.IsCompleted || bundleRunTask.IsCompleted));
+
     string? EnsureSourceMap()
     {
         if (sourceMapResolved) return compileFailure;
         try
         {
+            mapGate.GetAwaiter().GetResult();
             var winner = System.Threading.Tasks.Task.WhenAny(compiledTcs.Task, bundleRunTask)
                 .GetAwaiter().GetResult();
             if (!ReferenceEquals(winner, compiledTcs.Task))
@@ -5763,6 +5793,80 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
         }
         sourceMapResolved = true;
         return compileFailure;
+    }
+
+    // The whole of what `setBreakpoints` does once the map question is settled, lifted out of
+    // the switch so a DEFERRED request is answered by exactly the same code as an immediate
+    // one — two copies of this would drift, and the deferred path is the one nobody watches.
+    void AnswerSetBreakpoints(int seq, string command, string srcPath, List<int> lines)
+    {
+        // #3821: a request arriving between `initialized` and `launch` is the specification's
+        // own sequence, and answering it against an empty map made every breakpoint
+        // unverified. An empty list needs no map (see the call site).
+        var bpCompileErr = lines.Count > 0 ? EnsureSourceMap() : null;
+
+        var requests = lines.Select(l => new AlRunner.Infrastructure.DapBreakpointRequest(srcPath, l)).ToList();
+        var resolved = AlRunner.Infrastructure.DapBreakpointResolver.Resolve(requests, sourceMap);
+
+        // Why an unverified breakpoint is unverified. DAP's Breakpoint has a
+        // `message` field for exactly this, and without it "nothing is
+        // loaded" and "that line carries no statement" are the same answer —
+        // the first is a state the client can wait out, the second is not.
+        var unverifiedReason = bpCompileErr != null
+            ? $"the bundle did not compile, so nothing could be bound: {bpCompileErr}"
+            : "no executable AL statement on this line in this file";
+
+        var fullSrcPath = Path.GetFullPath(srcPath);
+        // Replace (not accumulate) — DAP's setBreakpoints contract: this
+        // request is the COMPLETE set for `source` from now on. That means
+        // clearing what THIS FILE had registered before, not what the new
+        // request happens to name: an empty list must disarm the file, and a
+        // breakpoint moved between two objects of one file must not leave the
+        // first object armed (#3786 review). fullSrcPath was computed and
+        // never read before, which is the shape that defect left behind.
+        if (registeredScopesBySource.TryGetValue(fullSrcPath, out var previouslyRegistered))
+            foreach (var scope in previouslyRegistered)
+                AlRunner.Infrastructure.AlDapSession.ClearBreakpoints(scope);
+        var nowRegistered = new HashSet<Type>();
+        foreach (var rb in resolved)
+        {
+            if (!rb.Verified || rb.ScopeType == null) continue;
+            // A scope reached for the first time in THIS request may still
+            // carry breakpoints from a request naming a different file that
+            // declares the same object — clear before the first add, once.
+            if (nowRegistered.Add(rb.ScopeType))
+                AlRunner.Infrastructure.AlDapSession.ClearBreakpoints(rb.ScopeType);
+            AlRunner.Infrastructure.AlDapSession.SetBreakpoint(rb.ScopeType, rb.StatementIndex);
+        }
+        registeredScopesBySource[fullSrcPath] = nowRegistered;
+
+        transport.WriteResponse(seq, command, true, new
+        {
+            breakpoints = resolved.Select((rb, idx) => new
+            {
+                id = idx,
+                verified = rb.Verified,
+                line = rb.Verified ? rb.ActualLine : rb.RequestedLine,
+                message = rb.Verified ? null : unverifiedReason,
+            }),
+        });
+    }
+
+    // Answers everything deferred, in arrival order. Called only where the map question is
+    // already settled — the read race, launch, configurationDone — so it never blocks for
+    // longer than the caller was going to anyway.
+    void DrainDeferredBreakpoints()
+    {
+        if (deferredBreakpointRequests.Count == 0) return;
+        var batch = deferredBreakpointRequests.ToList();
+        deferredBreakpointRequests.Clear();
+        foreach (var (seq, cmd, path, lines) in batch)
+        {
+            // Per request, because one bad path must not swallow the answers to the others:
+            // the switch's own catch is not in scope here.
+            try { AnswerSetBreakpoints(seq, cmd, path, lines); }
+            catch (Exception ex) { transport.WriteResponse(seq, cmd, false, message: ex.Message); }
+        }
     }
 
     int exitCode = 0;
@@ -5863,12 +5967,33 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
         }
     };
 
+    System.Threading.Tasks.Task<AlRunner.Infrastructure.DapIncomingMessage?>? outstandingRead = null;
     try
     {
         while (true)
         {
             AlRunner.Infrastructure.DapIncomingMessage? msg;
-            try { msg = transport.ReadMessageAsync().GetAwaiter().GetResult(); }
+            try
+            {
+                // ONE outstanding read, held across iterations. While a breakpoint request is
+                // deferred this loop must be woken by EITHER the next message or the map
+                // becoming available, and a read started for the race must not be dropped
+                // when the map wins — the client's next message would be consumed by a read
+                // nobody is awaiting (#3846).
+                outstandingRead ??= transport.ReadMessageAsync();
+                if (deferredBreakpointRequests.Count > 0)
+                {
+                    var winner = System.Threading.Tasks.Task
+                        .WhenAny(outstandingRead, MapAnswerReady()).GetAwaiter().GetResult();
+                    if (!ReferenceEquals(winner, outstandingRead))
+                    {
+                        DrainDeferredBreakpoints();
+                        continue; // outstandingRead is still pending, and stays held
+                    }
+                }
+                msg = outstandingRead.GetAwaiter().GetResult();
+                outstandingRead = null;
+            }
             catch (Exception ex)
             {
                 Console.Error.WriteLine($"[dap] transport error: {ex.Message}");
@@ -5896,6 +6021,9 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
                         // Report a compile failure on this response rather than silently
                         // proceeding into a session that will never run anything.
                         var launchErr = EnsureSourceMap();
+                        // Before this response, so a breakpoint request the client sent
+                        // FIRST is answered first.
+                        DrainDeferredBreakpoints();
                         if (launchErr != null)
                         {
                             transport.WriteResponse(msg.Seq, command, false, message: launchErr);
@@ -5920,67 +6048,29 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
                         else if (args.Value.TryGetProperty("lines", out var legacyLinesEl) && legacyLinesEl.ValueKind == System.Text.Json.JsonValueKind.Array)
                             foreach (var l in legacyLinesEl.EnumerateArray()) lines.Add(l.GetInt32());
 
-                        // #3821: before resolving anything. A request arriving between
-                        // `initialized` and `launch` is the specification's own sequence,
-                        // and answering it against an empty map made every breakpoint
-                        // unverified.
-                        //
-                        // An EMPTY list is the exception, and it is the one that matters for
-                        // responsiveness: "remove every breakpoint in this source" resolves
-                        // nothing, so it needs no map, and waiting for the compile to answer
-                        // it would block this single-threaded loop for no reason (#3845
-                        // review). The clear below runs either way.
-                        var bpCompileErr = lines.Count > 0 ? EnsureSourceMap() : null;
-
-                        var requests = lines.Select(l => new AlRunner.Infrastructure.DapBreakpointRequest(srcPath, l)).ToList();
-                        var resolved = AlRunner.Infrastructure.DapBreakpointResolver.Resolve(requests, sourceMap);
-
-                        // Why an unverified breakpoint is unverified. DAP's Breakpoint has a
-                        // `message` field for exactly this, and without it "nothing is
-                        // loaded" and "that line carries no statement" are the same answer —
-                        // the first is a state the client can wait out, the second is not.
-                        var unverifiedReason = bpCompileErr != null
-                            ? $"the bundle did not compile, so nothing could be bound: {bpCompileErr}"
-                            : "no executable AL statement on this line in this file";
-
-                        var fullSrcPath = Path.GetFullPath(srcPath);
-                        // Replace (not accumulate) — DAP's setBreakpoints contract: this
-                        // request is the COMPLETE set for `source` from now on. That means
-                        // clearing what THIS FILE had registered before, not what the new
-                        // request happens to name: an empty list must disarm the file, and a
-                        // breakpoint moved between two objects of one file must not leave the
-                        // first object armed (#3786 review). fullSrcPath was computed and
-                        // never read before, which is the shape that defect left behind.
-                        if (registeredScopesBySource.TryGetValue(fullSrcPath, out var previouslyRegistered))
-                            foreach (var scope in previouslyRegistered)
-                                AlRunner.Infrastructure.AlDapSession.ClearBreakpoints(scope);
-                        var nowRegistered = new HashSet<Type>();
-                        foreach (var rb in resolved)
+                        // An EMPTY list resolves nothing — "remove every breakpoint in this
+                        // source" needs no map — so it is answered now, whatever the compile
+                        // is doing. A non-empty one needs the map, and when the map is not
+                        // ready yet it is DEFERRED rather than waited for, so this loop stays
+                        // able to read `disconnect` (#3846). The deferred request is answered
+                        // by DrainDeferredBreakpoints, from the read race below or from
+                        // launch / configurationDone.
+                        if (lines.Count > 0 && !MapAnswerAvailable())
                         {
-                            if (!rb.Verified || rb.ScopeType == null) continue;
-                            // A scope reached for the first time in THIS request may still
-                            // carry breakpoints from a request naming a different file that
-                            // declares the same object — clear before the first add, once.
-                            if (nowRegistered.Add(rb.ScopeType))
-                                AlRunner.Infrastructure.AlDapSession.ClearBreakpoints(rb.ScopeType);
-                            AlRunner.Infrastructure.AlDapSession.SetBreakpoint(rb.ScopeType, rb.StatementIndex);
+                            deferredBreakpointRequests.Add((msg.Seq, command, srcPath, lines));
+                            break;
                         }
-                        registeredScopesBySource[fullSrcPath] = nowRegistered;
-
-                        transport.WriteResponse(msg.Seq, command, true, new
-                        {
-                            breakpoints = resolved.Select((rb, idx) => new
-                            {
-                                id = idx,
-                                verified = rb.Verified,
-                                line = rb.Verified ? rb.ActualLine : rb.RequestedLine,
-                                message = rb.Verified ? null : unverifiedReason,
-                            }),
-                        });
+                        AnswerSetBreakpoints(msg.Seq, command, srcPath, lines);
                         break;
                     }
 
                     case "configurationDone":
+                        // This releases the run-start gate, so AL execution begins right
+                        // after it. A deferred breakpoint request must be REGISTERED before
+                        // that, or the run starts with breakpoints the client believes it
+                        // set and this adapter has not armed. This is the one place the wait
+                        // is unavoidable — execution cannot begin without the map either.
+                        DrainDeferredBreakpoints();
                         transport.WriteResponse(msg.Seq, command, true);
                         AlRunner.Infrastructure.AlDapSession.Enabled = true;
                         configurationDoneGate.Release();

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -5615,12 +5615,16 @@ return strictExitCode ? computedExitCode : 0;
 // AlDapSession's file header for why pausing at StmtHit(N) — unlike
 // --capture-values, #1640 — needs no Exit()-style redesign):
 //   initialize     -> capabilities, then an `initialized` event
-//   launch/attach  -> compiles the bundle SYNCHRONOUSLY (blocks the response until
-//                     compiledTcs resolves or the whole run finishes without ever
-//                     reaching runStep, i.e. a compile failure) so setBreakpoints
-//                     right after has real statement indices to resolve against
-//   setBreakpoints -> DapBreakpointResolver against the now-loaded scope types;
-//                     REPLACES this source's previous set (DAP contract)
+//   launch/attach  -> EnsureSourceMap() (below): blocks the response until compiledTcs
+//                     resolves or the whole run finishes without ever reaching runStep,
+//                     i.e. a compile failure, which is reported on this response
+//   setBreakpoints -> EnsureSourceMap() FIRST, then DapBreakpointResolver against the
+//                     now-loaded scope types; REPLACES this source's previous set (DAP
+//                     contract). #3821: the wait is here and not only in launch because
+//                     the specification's own sequence has a client answer `initialized`
+//                     with its configuration requests, so setBreakpoints legitimately
+//                     arrives BEFORE launch — and used to resolve against an empty map
+//                     and report every breakpoint unverified.
 //   configurationDone -> releases the run-start gate; AL execution begins
 //   (AlDapSession.Stopped fires on the AL thread when a breakpoint hits; this loop
 //    pushes the "stopped" event the moment it fires — see the subscription below)
@@ -5663,6 +5667,12 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
     AlRunner.Infrastructure.AlDapSession.Reset();
 
     var sourceMap = AlRunner.Infrastructure.AlSourceLocationMap.Empty;
+    // Whether EnsureSourceMap has run, and what it found. Two flags rather than testing
+    // `sourceMap` for emptiness: a bundle can legitimately produce an empty map (nothing
+    // mappable in it), and re-waiting on every request would then be indistinguishable
+    // from the first wait.
+    var sourceMapResolved = false;
+    string? compileFailure = null;
     // Which scope types this session has breakpoints registered on, per source file, so a
     // later setBreakpoints for that file can clear ALL of them (#3786 review). Clearing only
     // the scopes named by the NEW request leaves the old ones armed: an empty breakpoint
@@ -5695,6 +5705,42 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
 
     var bundleRunTask = System.Threading.Tasks.Task.Run(
         () => RunAllBundlesForServer(new[] { bundleDir }, null, dapRunStep, cts.Token, false, null));
+
+    // Builds the source map on first need, once, and reports a compile failure instead.
+    // Returns null when the map is usable and the compile diagnostic otherwise.
+    //
+    // #3821: this used to live inside `launch`, which made the ANSWER TO A CORRECT CLIENT
+    // depend on the order two of its requests happened to arrive in. Compilation does not
+    // wait for launch — bundleRunTask starts the moment this loop does, and dapRunStep
+    // publishes the assembly through compiledTcs before it blocks on configurationDoneGate
+    // — so whichever request needs the map first can simply wait for it. That is why
+    // waiting here cannot deadlock: nothing this loop has yet to receive is upstream of
+    // the compile.
+    //
+    // Deferring the `initialized` event until the map exists was the other candidate and is
+    // worse: a client that sends launch only after `initialized` would then never send it.
+    // Deferring resolution keeps both client orderings working.
+    string? EnsureSourceMap()
+    {
+        if (sourceMapResolved) return compileFailure;
+        sourceMapResolved = true;
+        var winner = System.Threading.Tasks.Task.WhenAny(compiledTcs.Task, bundleRunTask)
+            .GetAwaiter().GetResult();
+        if (!ReferenceEquals(winner, compiledTcs.Task))
+        {
+            // The run finished (or failed) before ever reaching dapRunStep — a compile
+            // failure. Kept rather than thrown so both requests report the same thing.
+            var runs = bundleRunTask.Result;
+            compileFailure = runs
+                .SelectMany(r => r.CompileErrors ?? Array.Empty<CompilationErrorGroup>())
+                .SelectMany(g => g.Errors)
+                .FirstOrDefault() ?? "compile failed (no diagnostic captured)";
+            return compileFailure;
+        }
+        sourceMap = AlRunner.Infrastructure.AlCoverageSourceMap.Build(
+            new[] { bundleDir }, relativeTo: null);
+        return null;
+    }
 
     int exitCode = 0;
     bool terminatedSent = false;
@@ -5824,23 +5870,14 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
                     case "launch":
                     case "attach":
                     {
-                        var winner = System.Threading.Tasks.Task.WhenAny(compiledTcs.Task, bundleRunTask)
-                            .GetAwaiter().GetResult();
-                        if (!ReferenceEquals(winner, compiledTcs.Task))
+                        // Report a compile failure on this response rather than silently
+                        // proceeding into a session that will never run anything.
+                        var launchErr = EnsureSourceMap();
+                        if (launchErr != null)
                         {
-                            // The run finished (or failed) before ever reaching dapRunStep —
-                            // a compile failure. Report it on the launch response rather than
-                            // silently proceeding into a session that will never run anything.
-                            var runs = bundleRunTask.Result;
-                            var errMsg = runs
-                                .SelectMany(r => r.CompileErrors ?? Array.Empty<CompilationErrorGroup>())
-                                .SelectMany(g => g.Errors)
-                                .FirstOrDefault() ?? "compile failed (no diagnostic captured)";
-                            transport.WriteResponse(msg.Seq, command, false, message: errMsg);
+                            transport.WriteResponse(msg.Seq, command, false, message: launchErr);
                             break;
                         }
-                        sourceMap = AlRunner.Infrastructure.AlCoverageSourceMap.Build(
-                            new[] { bundleDir }, relativeTo: null);
                         transport.WriteResponse(msg.Seq, command, true);
                         break;
                     }
@@ -5860,8 +5897,22 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
                         else if (args.Value.TryGetProperty("lines", out var legacyLinesEl) && legacyLinesEl.ValueKind == System.Text.Json.JsonValueKind.Array)
                             foreach (var l in legacyLinesEl.EnumerateArray()) lines.Add(l.GetInt32());
 
+                        // #3821: before resolving anything. A request arriving between
+                        // `initialized` and `launch` is the specification's own sequence,
+                        // and answering it against an empty map made every breakpoint
+                        // unverified.
+                        var bpCompileErr = EnsureSourceMap();
+
                         var requests = lines.Select(l => new AlRunner.Infrastructure.DapBreakpointRequest(srcPath, l)).ToList();
                         var resolved = AlRunner.Infrastructure.DapBreakpointResolver.Resolve(requests, sourceMap);
+
+                        // Why an unverified breakpoint is unverified. DAP's Breakpoint has a
+                        // `message` field for exactly this, and without it "nothing is
+                        // loaded" and "that line carries no statement" are the same answer —
+                        // the first is a state the client can wait out, the second is not.
+                        var unverifiedReason = bpCompileErr != null
+                            ? $"the bundle did not compile, so nothing could be bound: {bpCompileErr}"
+                            : "no executable AL statement on this line in this file";
 
                         var fullSrcPath = Path.GetFullPath(srcPath);
                         // Replace (not accumulate) — DAP's setBreakpoints contract: this
@@ -5894,6 +5945,7 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
                                 id = idx,
                                 verified = rb.Verified,
                                 line = rb.Verified ? rb.ActualLine : rb.RequestedLine,
+                                message = rb.Verified ? null : unverifiedReason,
                             }),
                         });
                         break;


### PR DESCRIPTION
Closes #3821
Closes #3846

## What was wrong

`RunDapLoop` built the source map inside `launch`. Between the `initialized` event and
`launch`, `sourceMap` was still `AlSourceLocationMap.Empty`, so a `setBreakpoints` arriving
in that window resolved against an empty map and every breakpoint came back
`verified: false` — a successful response carrying a wrong answer.

That ordering is the DAP specification's own sequence, not client misuse: a client reacts to
`initialized` by sending its configuration requests, and the `launch` exchange finishes after
`configurationDone`. Every existing DAP test launches first, which is why none of them saw it.

## The fix

`EnsureSourceMap()` builds the map once, on first need, and is called by whichever of
`launch` or `setBreakpoints` gets there first. It returns the compile diagnostic instead when
the run finished without ever reaching `dapRunStep`, so both requests report the same failure.

**Why waiting there cannot deadlock.** Compilation is driven by `bundleRunTask`, which starts
when the loop does and does not wait for `launch`; `dapRunStep` publishes the assembly through
`compiledTcs` *before* it blocks on `configurationDoneGate`. So nothing this loop has yet to
receive is upstream of the compile.

The issue listed three candidate fixes. This is its first and preferred one. Its second —
emit `initialized` only once the map is built — is the one the specification's sequence
diagram suggests, and it is worse here: a client that sends `launch` only after `initialized`
would then never send it. Deferring resolution keeps both client orderings working.

## The second half: the two unverified reasons were the same answer

The issue requires that "unverified because nothing is loaded" and "unverified because that
line has no statement" stay distinguishable. They were both a bare `verified: false`. An
unverified breakpoint now carries DAP's `Breakpoint.message`:

- `the bundle did not compile, so nothing could be bound: <diagnostic>`
- `no executable AL statement on this line in this file`

`DapTransport`'s writer already sets `JsonIgnoreCondition.WhenWritingNull`, so a verified
breakpoint's response shape is unchanged.

## Proving tests

`AlRunner.Tests/DapPreLaunchBreakpointTests.cs`, driving a real DAP session against the
existing `Fixtures/DapTwoObjects` with `launch` and `setBreakpoints` swapped:

| fact | RED before | proves |
|---|---|---|
| `SetBreakpointsBeforeLaunch_VerifiesAndArms` | `verified: false` | it verifies, reports the file line asked for, execution actually stops there, and `Counter` still reads `1` at the pause — so the arm landed on the requested statement, not merely on a `true` in the response |
| `SetBreakpointsBeforeLaunch_OnALineWithNoStatement_IsUnverifiedAndSaysWhy` | no `message` field at all | the wait does not turn every request into a yes, and the remaining no says which reason applies |

### Mutation-checked, one slice at a time

| mutation | result |
|---|---|
| remove only the `message` projection | `…SaysWhy` red, `…VerifiesAndArms` **green** |
| remove only the `EnsureSourceMap()` call in `setBreakpoints` | `…VerifiesAndArms` red on the `verified` assertion, `…SaysWhy` **green** |

So each fact catches its own defect rather than both riding on one change.

## Local runs

- `~Dap` filter: **79 passed, 1 failed**. The failure is
  `ProvisionExplicitModesTests.TestApps_OnlyUnrelatedAppPresent_DoesNotShortCircuit_DownloadsTheRealSet`,
  which matched only because `dAp` occurs inside `OnlyUnrelatedAppPresent`. It is a known
  pre-existing local failure on this box, measured identically on a pristine baseline earlier,
  and touches nothing this PR changes.
- The four DAP suites alone (`DapPreLaunchBreakpointTests`, `DapMultiObjectFileTests`,
  `DapServerTests`, `DapStdioServerTests`): **16 passed, 0 failed**.

## Related, not folded

- #3820 — a source line can carry several executable targets and only one is bound. Same
  handler, but it is a signature change to `DapResolvedBreakpoint` and `Resolve`, and needs
  different reasoning to review.
- #3847 — `AlCoverageSourceMap.Build` reports a vanished root or an unreadable file as a
  bundle with no objects, so a missing map entry can mean "I could not read the sources"
  while this handler reports `no executable AL statement on this line in this file`. Filed
  from the round-two review; the fix belongs in the builder, not here, and `Count == 0`
  cannot be the check because a legitimately empty map is a real state.
- #3526 — breakpoint replacement semantics. Its core defect ("clears only the scopes the new
  request names") was already fixed by the #3786 review follow-up: `registeredScopesBySource`
  clears what the file had registered before, and `DapMultiObjectFileTests` covers the empty-list
  and moved-breakpoint criteria. Two of its acceptance criteria still have no test. Left open
  and commented rather than closed here.

Corpus-NA: a DAP request-ordering fix in the adapter loop; no AL-observable behaviour changes, and the corpus cannot express a debug-adapter request sequence.

*Opened by an agent (Claude Code) in a session run by @SShadowS.*

https://claude.ai/code/session_01JFQZHC5SEHnLxkc5USksaK



---

## Second half: the loop stays readable while a request waits (#3846)

An adversarial review caught that the fix above, as first written, made `setBreakpoints`
**block the single-threaded request loop for the whole compile**. Nothing else is read
meanwhile, so a client that gives up and disconnects is not heard until the compile ends, and
a compile that never ends is an adapter that never exits. The `launch` handler has always had
that shape, but a session abandoned during pre-launch configuration is exactly where the two
differ: before this PR, a pre-launch `setBreakpoints` returned immediately — wrongly, which is
the defect — so the loop went back to reading and serviced the `disconnect`.

I first split this to #3846 on the ground that it was pre-existing. That was half wrong, and
the record on #3846 says so. It is fixed here instead.

**What it does now.** A non-empty `setBreakpoints` whose map is not ready is **queued**, and
the loop keeps reading. It is answered by `DrainDeferredBreakpoints` from whichever comes
first:

- the loop's race between the one outstanding `ReadMessageAsync` and map availability;
- `launch`, which drains before writing its own response so a request the client sent first is
  answered first;
- `configurationDone`, which **must** drain before releasing the run-start gate — otherwise
  execution begins with breakpoints the client believes it set and this adapter has not armed.
  That hazard is created by deferral and is the reason this was not a two-line change.

An empty list still needs no map and is answered immediately, whatever the compile is doing.

The whole `setBreakpoints` body moved into `AnswerSetBreakpoints` so the deferred path and the
immediate path are the same code. DAP matches a response to its request by `request_seq`, so
answering later is within the protocol.

**The read is now held across iterations.** A read started for the race must not be dropped
when the map wins — the client's next message would be consumed by a read nobody is awaiting.

### The test seam, and why there is one

`AL_RUNNER_DAP_TEST_DELAY_MAP_MS` holds map preparation open for a known interval, read only
by `RunDapLoop`. Both liveness facts need "the map is not ready yet" to last long enough to
assert against, and an organically slow bundle makes a flaky test — the review said so, and it
is right.

| fact | proves |
|---|---|
| `DisconnectWhileABreakpointRequestWaitsForTheMap_IsAnsweredAtOnce` | preparation held 25s, client disconnects at once: the response comes back well inside that, and `terminated` follows |
| `ABreakpointRequestDeferredForTheMap_IsAnsweredWhenTheMapArrives` | the client is silent between request and response, so only the read race can produce it — and the answer is the real one, verified on the file line asked for |

### Mutation-checked

| mutation | result |
|---|---|
| remove the deferral (call `AnswerSetBreakpoints` unconditionally) | the disconnect fact reds **alone** — the other four stay green |
| remove the read race (`if (false)`) | **four of five** red, including both pre-launch facts, which send nothing further |

Local after this: **19 passed, 0 failed** across `DapPreLaunchBreakpointTests`,
`DapMultiObjectFileTests`, `DapServerTests` and `DapStdioServerTests`.
