### PR TITLE
fix(tests): decide the skippable-attribute guard from code, not from comments

### DIFF
--- a/AlRunner.Tests/MetadataEquivalenceBundleGateTests.cs
+++ b/AlRunner.Tests/MetadataEquivalenceBundleGateTests.cs
@@ -85,10 +85,7 @@ public sealed class MetadataEquivalenceBundleGateTests
             "not scanning what it claims to. The detection strings are probably stale.");
     }
 
-    // SkippableFact, not Fact, though this test cannot skip: BundleReaders() only does
-    // EnumerateFiles/ReadAllText. The attribute answers a textual scanner, not a skip path --
-    // see #3813, which is where the mechanism is stated and pinned.
-    [SkippableFact]
+    [Fact]
     public void No_bundle_reader_writes_its_own_empty_bundle_skip()
     {
         // The second half, because a class could hold a bundles list from RequireBundles and

--- a/AlRunner.Tests/SkippableAttributeDetectorTests.cs
+++ b/AlRunner.Tests/SkippableAttributeDetectorTests.cs
@@ -433,7 +433,8 @@ public sealed class SkippableAttributeDetectorTests
     [Fact]
     public void TheSuiteWideScanExaminesTestDeclarations()
     {
-        Assert.True(TestArtifactsGateTests.CountTestDeclarations() > 100,
+        Assert.True(
+            TestArtifactsGateTests.CountTestDeclarations() > TestArtifactsGateTests.MinimumTestDeclarations,
             "the suite-wide skippable-attribute scan found almost no [Fact]/[Theory] declarations, "
             + "so its 'no offenders' verdict is about nothing.");
     }

--- a/AlRunner.Tests/SkippableAttributeDetectorTests.cs
+++ b/AlRunner.Tests/SkippableAttributeDetectorTests.cs
@@ -1,0 +1,440 @@
+// SkippableAttributeDetectorTests -- the detector behind
+// TestArtifactsGateTests.EveryTestThatCanSkipIsDeclaredSkippable, exercised against synthetic
+// sources instead of the suite's own contents (issue #3813).
+//
+// That guard was a textual scanner that matched the skip-call spelling ANYWHERE in a line,
+// comments included, and attributed the match to whichever test declaration preceded it. So a
+// test's required attribute was decided by prose and line position rather than by whether the
+// test can skip: an edit changing no behaviour changed whether CI passed, and the failure named
+// a test that had nothing to do with the match.
+//
+// It fired four times, twice inside comments that were explaining the defect. This file holds
+// the two directions apart -- a real call in a plain [Fact] is still reported, and the same
+// spelling in a comment is not -- against inputs this file controls, so a future narrowing of
+// the detector fails here rather than going unnoticed until nobody writes the shape it misses.
+//
+// This file is exempt from the guard for the same reason SilentSkipDetectorTests.cs is exempt
+// from the silent-skip guard: its synthetic offenders are literals in it.
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class SkippableAttributeDetectorTests
+{
+    private static IReadOnlyList<string> Offenders(string source) =>
+        TestArtifactsGateTests.FindTestsThatCanSkipButAreNotSkippable("Probe.cs", source).ToList();
+
+    // ---- the defect: a comment must not decide anything -------------------------
+
+    /// <summary>
+    /// #3813's exact shape, and the reason this file exists. The method body's prose mentions
+    /// the skip helper while the method cannot reach one -- reproduced verbatim from
+    /// MetadataEquivalenceBundleGateTests, where an unnecessary [SkippableFact] was held in
+    /// place by a comment until this fix removed the need for it.
+    /// </summary>
+    [Fact]
+    public void AProseCommentNamingTheHelperIsNotACall()
+    {
+        var source = """
+            [Fact]
+            public void CannotSkip()
+            {
+                // a class could hold a bundles list and still add a defensive
+                // TestArtifacts.SkipIf on its count -- which would be dead code.
+                Assert.Equal(0, offenders.Length);
+            }
+            """;
+
+        Assert.Empty(Offenders(source));
+    }
+
+    /// <summary>
+    /// The other spelling the guard matches, in the doc-comment form that tripped it on
+    /// BcEngineUnbootstrappedGuardTests (PR #3843): two <c>///</c> lines describing what the
+    /// guard deliberately does NOT do, attributed to two tests that are pure functions.
+    /// </summary>
+    [Fact]
+    public void ADocCommentNamingTheHelperIsNotACall()
+    {
+        var source = """
+            /// <summary>
+            /// Deliberately does not call TestArtifacts.SkipIf: an unbootstrapped box is a
+            /// defect here, not an absent prerequisite, so Skip.If would hide it.
+            /// </summary>
+            [Theory]
+            [InlineData(1)]
+            public void CannotSkip(int n)
+            {
+                Assert.Equal(n, n);
+            }
+            """;
+
+        Assert.Empty(Offenders(source));
+    }
+
+    /// <summary>A trailing comment on a line of real code: only the comment names the helper.</summary>
+    [Fact]
+    public void ATrailingCommentNamingTheHelperIsNotACall()
+    {
+        var source = """
+            [Fact]
+            public void CannotSkip()
+            {
+                Assert.True(ready); // not Skip.If(!ready, ...): absence here is a defect
+            }
+            """;
+
+        Assert.Empty(Offenders(source));
+    }
+
+    /// <summary>Block comments, including one that opens and closes mid-line.</summary>
+    [Theory]
+    [InlineData("    /* TestArtifacts.SkipIf would be wrong here */")]
+    [InlineData("    Assert.True(ready); /* not Skip.Always */")]
+    public void ABlockCommentNamingTheHelperIsNotACall(string commentLine)
+    {
+        var source = "[Fact]\npublic void CannotSkip()\n{\n" + commentLine + "\n    Assert.True(ready);\n}";
+
+        Assert.Empty(Offenders(source));
+    }
+
+    /// <summary>
+    /// A block comment spanning several lines, which is the form a line-at-a-time stripper
+    /// gets wrong: only the opening line carries <c>/*</c>, so the lines after it look like
+    /// ordinary code to anything that does not carry state across the newline.
+    /// </summary>
+    [Fact]
+    public void AMultiLineBlockCommentNamingTheHelperIsNotACall()
+    {
+        var source = """
+            [Fact]
+            public void CannotSkip()
+            {
+                /*
+                   TestArtifacts.SkipIf is deliberately absent here.
+                   Skip.Always would be worse.
+                */
+                Assert.True(ready);
+            }
+            """;
+
+        Assert.Empty(Offenders(source));
+    }
+
+    // ---- the guard's real job, which the fix must not weaken --------------------
+
+    /// <summary>
+    /// The true positive, and the half easiest to lose while making a scanner ignore comments:
+    /// a real call in a plain <c>[Fact]</c> body still has to be reported, and named correctly.
+    /// A SkipException out of a plain [Fact] is recorded Failed, not Skipped.
+    /// </summary>
+    [Fact]
+    public void ARealCallInAPlainFactIsReported()
+    {
+        var source = """
+            [Fact]
+            public void CanSkip()
+            {
+                TestArtifacts.SkipIf(!ready, "no engine");
+                Assert.True(ready);
+            }
+            """;
+
+        var offenders = Offenders(source);
+
+        Assert.Single(offenders);
+        Assert.Contains("Probe.cs.CanSkip", offenders[0], StringComparison.Ordinal);
+        Assert.Contains("[Fact]", offenders[0], StringComparison.Ordinal);
+    }
+
+    /// <summary>Every spelling the detector claims to know, each one alone in a plain [Fact].</summary>
+    [Theory]
+    [InlineData("TestArtifacts.SkipIf(cond, \"r\");")]
+    [InlineData("TestArtifacts.SkipIfMissing();")]
+    [InlineData("TestArtifacts.SkipIfDirectoryMissing(dir, \"what\");")]
+    [InlineData("Skip.If(cond, \"r\");")]
+    [InlineData("Skip.IfNot(cond, \"r\");")]
+    [InlineData("Skip.Always(\"r\");")]
+    public void EverySkipSpellingIsStillDetected(string call)
+    {
+        var source = "[Fact]\npublic void CanSkip()\n{\n    " + call + "\n}";
+
+        Assert.Single(Offenders(source));
+    }
+
+    /// <summary>
+    /// A real call on a line that ALSO carries a comment. The comment-aware pass must strip the
+    /// comment and keep the code, not discard the whole line -- discarding it is the cheap
+    /// mistake that would turn this guard silent while looking like a fix.
+    /// </summary>
+    [Fact]
+    public void ARealCallIsStillDetectedWhenTheLineAlsoHasAComment()
+    {
+        var source = """
+            [Fact]
+            public void CanSkip()
+            {
+                Skip.If(!ready, "no engine"); // absent artifacts are not this test's business
+            }
+            """;
+
+        Assert.Single(Offenders(source));
+    }
+
+    /// <summary>A [Theory] is reported exactly as a [Fact] is, and named as one.</summary>
+    [Fact]
+    public void ARealCallInAPlainTheoryIsReported()
+    {
+        var source = """
+            [Theory]
+            [InlineData(1)]
+            public void CanSkip(int n)
+            {
+                Skip.If(n == 0, "zero");
+            }
+            """;
+
+        var offenders = Offenders(source);
+
+        Assert.Single(offenders);
+        Assert.Contains("[Theory]", offenders[0], StringComparison.Ordinal);
+    }
+
+    /// <summary>The correctly-declared spellings are what the guard exists to push people to.</summary>
+    [Theory]
+    [InlineData("SkippableFact")]
+    [InlineData("SkippableTheory")]
+    public void ADeclaredSkippableTestIsNotReported(string attribute)
+    {
+        var source = "[" + attribute + "]\npublic void CanSkip()\n{\n    Skip.If(!ready, \"no engine\");\n}";
+
+        Assert.Empty(Offenders(source));
+    }
+
+    // ---- strings are code, not comments -----------------------------------------
+
+    /// <summary>
+    /// A <c>//</c> inside a string literal opens no comment, so the code after it on the same
+    /// line is still code. 116 lines in this suite carry that shape -- URLs in XML manifests,
+    /// and AlSourceParserCommentTests' own AL fixtures -- and a stripper that cut at the first
+    /// <c>//</c> would silently truncate every one of them.
+    /// </summary>
+    [Fact]
+    public void ASlashSlashInsideAStringDoesNotHideARealCallAfterIt()
+    {
+        var source = """
+            [Fact]
+            public void CanSkip()
+            {
+                Assert.Equal("http://example/x", url); Skip.If(!ready, "no engine");
+            }
+            """;
+
+        Assert.Single(Offenders(source));
+    }
+
+    /// <summary>The same, for a verbatim string, where a backslash is not an escape.</summary>
+    [Fact]
+    public void ASlashSlashInsideAVerbatimStringDoesNotHideARealCallAfterIt()
+    {
+        var source = "[Fact]\npublic void CanSkip()\n{\n"
+            + "    var p = @\"C:\\a//b\"; Skip.If(!ready, \"no engine\");\n}";
+
+        Assert.Single(Offenders(source));
+    }
+
+    /// <summary>
+    /// And a raw string literal, where neither backslash escapes nor doubled quotes apply and
+    /// the terminator is the fence itself.
+    /// </summary>
+    [Fact]
+    public void ASlashSlashInsideARawStringDoesNotHideARealCallAfterIt()
+    {
+        var source = "[Fact]\npublic void CanSkip()\n{\n"
+            + "    var s = \"\"\"a // b\"\"\"; Skip.If(!ready, \"no engine\");\n}";
+
+        Assert.Single(Offenders(source));
+    }
+
+    /// <summary>
+    /// The converse, and the one that decides whether the string handling earns its keep: a
+    /// skip spelling that only ever appears INSIDE a string literal is not a call either. This
+    /// is the shape MetadataEquivalenceBundleGateTests' own regex has -- and the one the
+    /// issue's first account misattributed the failure to.
+    /// </summary>
+    [Fact]
+    public void ASkipSpellingInsideAStringIsNotACall()
+    {
+        var source = """
+            [Fact]
+            public void CannotSkip()
+            {
+                var pattern = new Regex("Skip.If" + suffix);
+                Assert.NotNull(pattern);
+            }
+            """;
+
+        Assert.Empty(Offenders(source));
+    }
+
+    /// <summary>A char literal holding a quote must not be read as opening a string.</summary>
+    [Fact]
+    public void ACharLiteralQuoteDoesNotSwallowTheRestOfTheFile()
+    {
+        var source = """
+            [Fact]
+            public void CanSkip()
+            {
+                var q = '"';
+                Skip.If(!ready, "no engine");
+            }
+            """;
+
+        Assert.Single(Offenders(source));
+    }
+
+    // ---- attribution, the second half of the reported defect ---------------------
+
+    /// <summary>
+    /// The guard reported the wrong test name, because a match was attributed to whichever
+    /// declaration preceded the line. With comments excluded there is no stray match to
+    /// attribute -- so the test named here is the one that actually calls.
+    /// </summary>
+    [Fact]
+    public void TheReportedNameIsTheTestThatActuallyCalls()
+    {
+        var source = """
+            [Fact]
+            public void FirstCannotSkip()
+            {
+                Assert.True(true);
+            }
+
+            // TestArtifacts.SkipIf belongs to neither of these.
+
+            [Fact]
+            public void SecondCanSkip()
+            {
+                Skip.Always("always");
+            }
+            """;
+
+        var offenders = Offenders(source);
+
+        Assert.Single(offenders);
+        Assert.Contains("SecondCanSkip", offenders[0], StringComparison.Ordinal);
+        Assert.DoesNotContain("FirstCannotSkip", offenders[0], StringComparison.Ordinal);
+    }
+
+    /// <summary>Several offending tests in one file are all reported, not just the first.</summary>
+    [Fact]
+    public void EveryOffenderInAFileIsReported()
+    {
+        var source = """
+            [Fact]
+            public void OneCanSkip()
+            {
+                Skip.Always("a");
+            }
+
+            [Fact]
+            public void TwoCanSkip()
+            {
+                Skip.Always("b");
+            }
+            """;
+
+        Assert.Equal(2, Offenders(source).Count);
+    }
+
+    // ---- the comment stripper, on its own ----------------------------------------
+
+    /// <summary>
+    /// The stripper replaces comment text rather than deleting the line, so a line number in
+    /// the stripped text still means the same line of the original. Without that, attribution
+    /// -- the half of #3813 that produced wrong test names -- would break in a new way.
+    /// </summary>
+    [Fact]
+    public void StrippingPreservesTheLineCount()
+    {
+        var source = """
+            var a = 1; // one
+            /* two
+               three */
+            var b = 2;
+            """;
+
+        Assert.Equal(source.Split('\n').Length,
+                     TestArtifactsGateTests.StripCommentsPreservingLines(source).Split('\n').Length);
+    }
+
+    /// <summary>Code on the same line as a comment survives; the comment does not.</summary>
+    [Fact]
+    public void StrippingKeepsTheCodeAndDropsTheComment()
+    {
+        var stripped = TestArtifactsGateTests.StripCommentsPreservingLines("var a = 1; // set a to one");
+
+        Assert.Contains("var a = 1;", stripped, StringComparison.Ordinal);
+        Assert.DoesNotContain("set a to one", stripped, StringComparison.Ordinal);
+    }
+
+    /// <summary>An unterminated block comment swallows the rest of the file, as the compiler
+    /// would have it -- and must not throw, because a guard that throws on a file it cannot
+    /// parse reports nothing about every other file in the suite.</summary>
+    [Fact]
+    public void AnUnterminatedBlockCommentSwallowsTheRestWithoutThrowing()
+    {
+        var stripped = TestArtifactsGateTests.StripCommentsPreservingLines("var a = 1;\n/* open\nSkip.Always(\"x\");\n");
+
+        Assert.Contains("var a = 1;", stripped, StringComparison.Ordinal);
+        Assert.DoesNotContain("Skip.Always", stripped, StringComparison.Ordinal);
+    }
+
+    // ---- the sibling guard in the same file, which had the same blind spot -------
+
+    /// <summary>
+    /// <c>OnlyTheSharedHelperNamesTheArtifactCachePathsInCode</c> documents that "comments may
+    /// still discuss the paths", and skipped a line whose FIRST characters were <c>//</c> to
+    /// achieve it. That caught a comment on its own line and missed a trailing one and a block
+    /// one, so the same prose-decides-the-verdict defect lived in the function next door. It
+    /// now shares this file's stripper, which is what makes the two agree.
+    /// </summary>
+    [Theory]
+    [InlineData("    // the .bcartifacts.cache layout is legacy")]
+    [InlineData("    var x = 1; // the .bcartifacts.cache layout is legacy")]
+    [InlineData("    /* .bcartifacts.cache is the legacy layout */")]
+    [InlineData("    /// <summary>.bcartifacts.cache is legacy</summary>")]
+    public void ACommentNamingAnArtifactPathIsNotCode(string line)
+        => Assert.Empty(TestArtifactsGateTests.FindHardCodedArtifactPaths("Probe.cs", line));
+
+    /// <summary>The true positive it exists for: a path spelled in real code is still reported.</summary>
+    [Theory]
+    [InlineData("    var dir = Path.Combine(home, \".bcartifacts.cache\", \"sandbox\");")]
+    [InlineData("    var dir = Path.Combine(home, \"al-runner\", \"artifacts\");")]
+    public void APathSpelledInCodeIsStillReported(string line)
+        => Assert.Single(TestArtifactsGateTests.FindHardCodedArtifactPaths("Probe.cs", line));
+
+    // ---- the guard must not report clean when it measured nothing ----------------
+
+    /// <summary>
+    /// guards-need-a-third-state.md: a source carrying no test declaration at all yields no
+    /// offenders, which is a legitimate pass for a helper file -- the non-vacuity claim lives
+    /// on the suite-wide scan, which asserts it found test declarations to look at.
+    /// </summary>
+    [Fact]
+    public void AFileWithNoTestDeclarationsYieldsNoOffenders()
+        => Assert.Empty(Offenders("internal static class Helper { internal static void X() { } }"));
+
+    /// <summary>
+    /// The non-vacuity backstop itself: the suite-wide scan must have seen test declarations.
+    /// Zero offenders out of zero declarations examined is how this guard passes having
+    /// measured nothing, which is the same shape as the defect it guards against.
+    /// </summary>
+    [Fact]
+    public void TheSuiteWideScanExaminesTestDeclarations()
+    {
+        Assert.True(TestArtifactsGateTests.CountTestDeclarations() > 100,
+            "the suite-wide skippable-attribute scan found almost no [Fact]/[Theory] declarations, "
+            + "so its 'no offenders' verdict is about nothing.");
+    }
+}

--- a/AlRunner.Tests/TestArtifactsGateTests.cs
+++ b/AlRunner.Tests/TestArtifactsGateTests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 
 namespace AlRunner.Tests;
@@ -460,153 +461,88 @@ public class TestArtifactsGateTests
     }
 
     /// <summary>
-    /// <paramref name="sourceText"/> with every comment AND every string/char literal's contents
-    /// blanked to spaces, and every newline kept, so line N of the result is line N of the
-    /// input. Characters become spaces rather than being deleted, which keeps the code that
-    /// shares a line with a comment.
+    /// <paramref name="sourceText"/> with every comment blanked to spaces and every newline
+    /// kept, so line N of the result is line N of the input — attribution in the scans below
+    /// depends on that alignment. Optionally the contents of string and char literals go the
+    /// same way.
     ///
-    /// <para>Literals go for the same reason comments do: neither calls anything, so a skip
-    /// spelling in either is not a skip. Tracking them is also what makes the comment half
-    /// correct, because a <c>//</c> inside a literal opens no comment — 116 lines in this suite
-    /// carry that shape (URLs in XML manifests, AlSourceParserCommentTests' AL fixtures), and
-    /// cutting at the first <c>//</c> would truncate real code on every one of them. The three
-    /// string forms differ only in how they END — <c>\</c> escapes in a regular literal,
-    /// <c>""</c> in a verbatim one, the fence itself in a raw one.</para>
+    /// <para>Roslyn draws the line rather than a hand-rolled scanner. <c>DescendantTokens()</c>
+    /// does not descend into trivia, so comments — <c>//</c>, <c>/* */</c>, XML doc comments and
+    /// disabled <c>#if</c> regions alike — contribute no tokens at all, and a <c>//</c> inside a
+    /// literal is not one either. That last case is not hypothetical: 116 lines in this suite
+    /// carry a <c>//</c> inside a string (URLs in XML manifests, AlSourceParserCommentTests' AL
+    /// fixtures), and a scanner cutting at the first <c>//</c> would truncate real code on every
+    /// one of them.</para>
     ///
-    /// <para>Deliberately not a Roslyn parse: the input is one file's text at a time with no
-    /// compilation behind it, and a parser would answer the same question at the cost of a
-    /// syntax tree per file. An unterminated construct swallows the rest of the text, which is
-    /// what the compiler does with it too.</para>
+    /// <para>This is the third guard in the project to need the distinction —
+    /// <c>BaseAppFloorFixtureGuardTests.CSharpWritesFloor</c> is the model, and its doc comment
+    /// names by hand exactly the trailing-comment and block-comment holes this replaces (#3153,
+    /// #3527: do not add a fourth handwritten C# lexer).</para>
     /// </summary>
     internal static string StripCommentsPreservingLines(string sourceText) =>
         StripCommentsPreservingLines(sourceText, blankStringContents: true);
 
     /// <summary>
-    /// The same pass, with a choice about string literals, because the two guards in this file
+    /// The same pass, with a choice about string literals, because the two scans in this file
     /// need opposite answers about them and both are right.
     ///
     /// <para><paramref name="blankStringContents"/> true — the skippable-attribute scan: a
     /// literal calls nothing, so a skip spelling inside one is not a skip. False — the
-    /// artifact-path scan, whose entire subject is a path spelled as a literal, and for which
-    /// blanking them would remove the thing being looked for.</para>
-    ///
-    /// <para>Literals are tracked either way: that is what makes the COMMENT half correct, since
-    /// a <c>//</c> inside a literal opens no comment.</para>
+    /// artifact-path scan, whose whole subject is a path spelled as a literal, and for which
+    /// blanking literals would remove the thing being looked for.</para>
     /// </summary>
     internal static string StripCommentsPreservingLines(string sourceText, bool blankStringContents)
     {
-        var outp = new System.Text.StringBuilder(sourceText.Length);
-        var i = 0;
-        while (i < sourceText.Length)
+        var kept = new System.Text.StringBuilder(sourceText);
+        // Blank by SPAN rather than rebuilding the text, so anything not explicitly blanked --
+        // code, and the literals the artifact-path scan needs -- is preserved byte for byte.
+        void Blank(Microsoft.CodeAnalysis.Text.TextSpan span)
         {
-            var c = sourceText[i];
-
-            if (c == '/' && i + 1 < sourceText.Length && sourceText[i + 1] == '/')
-            {
-                while (i < sourceText.Length && sourceText[i] != '\n') { outp.Append(' '); i++; }
-                continue;
-            }
-
-            if (c == '/' && i + 1 < sourceText.Length && sourceText[i + 1] == '*')
-            {
-                outp.Append("  ");
-                i += 2;
-                while (i < sourceText.Length
-                       && !(sourceText[i] == '*' && i + 1 < sourceText.Length && sourceText[i + 1] == '/'))
-                {
-                    // Newlines are copied through so the line count survives an unterminated or
-                    // multi-line comment; everything else becomes a space.
-                    outp.Append(sourceText[i] == '\n' ? '\n' : ' ');
-                    i++;
-                }
-                if (i < sourceText.Length) { outp.Append("  "); i += 2; }
-                continue;
-            }
-
-            if (c == '"' || c == '\'')
-            {
-                i = CopyLiteral(sourceText, i, outp, blankStringContents);
-                continue;
-            }
-
-            outp.Append(c);
-            i++;
+            for (var i = span.Start; i < span.End && i < kept.Length; i++)
+                if (kept[i] != '\n' && kept[i] != '\r') kept[i] = ' ';
         }
 
-        return outp.ToString();
+        var root = CSharpSyntaxTree.ParseText(sourceText).GetRoot();
+
+        foreach (var trivia in root.DescendantTrivia(descendIntoTrivia: true))
+            if (IsCommentOrDisabledCode(trivia.Kind()))
+                Blank(trivia.Span);
+
+        if (blankStringContents)
+            foreach (var token in root.DescendantTokens(descendIntoTrivia: true))
+                if (IsLiteralContent(token.Kind()))
+                    Blank(token.Span);
+
+        return kept.ToString();
     }
 
     /// <summary>
-    /// Blanks the string or char literal starting at <paramref name="start"/> — quotes kept,
-    /// contents replaced by spaces, newlines kept — and answers the index just past it.
-    ///
-    /// <para>Contents go for the same reason comments do: a literal calls nothing, so a skip
-    /// spelling inside one is not a skip. The quotes stay so the result still reads as C#
-    /// rather than as a line whose structure has changed.</para>
+    /// Trivia that is not code. Disabled <c>#if</c> regions are included because the compiler
+    /// does not build them either, so a call spelled there is not a call this suite can make.
     /// </summary>
-    private static int CopyLiteral(string text, int start, System.Text.StringBuilder outp, bool blank)
-    {
-        // `blank` false keeps the literal verbatim; the newline-preserving replacement only
-        // applies when the caller asked for contents to go.
-        void Blank(int from, int count)
-        {
-            for (var n = 0; n < count; n++)
-                outp.Append(!blank ? text[from + n] : text[from + n] == '\n' ? '\n' : ' ');
-        }
+    private static bool IsCommentOrDisabledCode(SyntaxKind kind) => kind
+        is SyntaxKind.SingleLineCommentTrivia
+        or SyntaxKind.MultiLineCommentTrivia
+        or SyntaxKind.SingleLineDocumentationCommentTrivia
+        or SyntaxKind.MultiLineDocumentationCommentTrivia
+        or SyntaxKind.DocumentationCommentExteriorTrivia
+        or SyntaxKind.DisabledTextTrivia;
 
-        // A raw string literal: three or more quotes, closed by a run of at least that many.
-        if (text[start] == '"' && start + 2 < text.Length && text[start + 1] == '"' && text[start + 2] == '"')
-        {
-            var fence = 0;
-            while (start + fence < text.Length && text[start + fence] == '"') fence++;
-            outp.Append(text, start, fence);
-            var j = start + fence;
-            while (j < text.Length)
-            {
-                if (text[j] != '"') { Blank(j, 1); j++; continue; }
-                var run = 0;
-                while (j + run < text.Length && text[j + run] == '"') run++;
-                if (run >= fence) { outp.Append(text, j, run); return j + run; }
-                Blank(j, run);
-                j += run;
-            }
-            return j;
-        }
-
-        var quote = text[start];
-        // `@"…"` — no backslash escapes, and `""` is one embedded quote.
-        var verbatim = quote == '"' && start > 0 && text[start - 1] == '@';
-        outp.Append(quote);
-        var k = start + 1;
-        while (k < text.Length)
-        {
-            var ch = text[k];
-            if (!verbatim && ch == '\\' && k + 1 < text.Length)
-            {
-                Blank(k, 2);
-                k += 2;
-                continue;
-            }
-            if (ch == quote)
-            {
-                if (verbatim && k + 1 < text.Length && text[k + 1] == '"')
-                {
-                    Blank(k, 2);
-                    k += 2;
-                    continue;
-                }
-                outp.Append(ch);
-                return k + 1;
-            }
-            // An unterminated literal ends at the newline rather than swallowing the file: a
-            // stray quote in ordinary code would otherwise hide every line below it, which is
-            // the direction that turns the guard silent (guards-need-a-third-state.md).
-            if (ch == '\n' && !verbatim) return k;
-            Blank(k, 1);
-            k++;
-        }
-        return k;
-    }
+    /// <summary>
+    /// Every token kind whose text is literal CONTENT rather than code. The interpolated-string
+    /// TEXT token is content; the expressions inside <c>{…}</c> holes are separate tokens and are
+    /// deliberately left alone, because an interpolation hole really can call something —
+    /// the blind spot #3527 names.
+    /// </summary>
+    private static bool IsLiteralContent(SyntaxKind kind) => kind
+        is SyntaxKind.StringLiteralToken
+        or SyntaxKind.Utf8StringLiteralToken
+        or SyntaxKind.SingleLineRawStringLiteralToken
+        or SyntaxKind.MultiLineRawStringLiteralToken
+        or SyntaxKind.Utf8SingleLineRawStringLiteralToken
+        or SyntaxKind.Utf8MultiLineRawStringLiteralToken
+        or SyntaxKind.InterpolatedStringTextToken
+        or SyntaxKind.CharacterLiteralToken;
 
     internal static int CountTestDeclarations() =>
         TestSourcePaths().Sum(f => CountTestDeclarationsIn(File.ReadAllText(f)));

--- a/AlRunner.Tests/TestArtifactsGateTests.cs
+++ b/AlRunner.Tests/TestArtifactsGateTests.cs
@@ -291,20 +291,39 @@ public class TestArtifactsGateTests
         var offenders = new List<string>();
         foreach (var (rel, text) in TestSources())
         {
-            if (rel is "TestArtifacts.cs" or "TestArtifactsGateTests.cs") continue;
-            foreach (var line in text.Split('\n'))
-            {
-                var trimmed = line.TrimStart();
-                if (trimmed.StartsWith("//", StringComparison.Ordinal)) continue;
-                if (trimmed.Contains(".bcartifacts.cache", StringComparison.Ordinal)
-                    || trimmed.Contains("\"al-runner\", \"artifacts\"", StringComparison.Ordinal))
-                    offenders.Add($"{rel}: {trimmed.Trim()}");
-            }
+            if (rel is "TestArtifacts.cs" or "TestArtifactsGateTests.cs"
+                    or "SkippableAttributeDetectorTests.cs") continue;
+            offenders.AddRange(FindHardCodedArtifactPaths(rel, text));
         }
 
         Assert.True(offenders.Count == 0,
             "these lines spell an artifact cache path instead of asking TestArtifacts:\n"
             + string.Join("\n", offenders));
+    }
+
+    /// <summary>
+    /// The lines of one source that spell an artifact cache path in code.
+    ///
+    /// <para>The parenthesis in the summary above — "comments may still discuss the paths" —
+    /// used to be implemented as "skip a line whose first characters are <c>//</c>", which
+    /// caught a comment on its own line and missed a trailing one and a block one. So the same
+    /// prose-decides-the-verdict defect #3813 reports lived in the function next door, and both
+    /// now share one stripper rather than two disagreeing approximations of one.</para>
+    ///
+    /// <para>String contents are KEPT here, unlike the skippable-attribute scan: a hard-coded
+    /// path IS a string literal, so blanking literals would remove the subject.</para>
+    /// </summary>
+    internal static IEnumerable<string> FindHardCodedArtifactPaths(string rel, string sourceText)
+    {
+        var offenders = new List<string>();
+        foreach (var line in StripCommentsPreservingLines(sourceText, blankStringContents: false).Split('\n'))
+        {
+            if (line.Contains(".bcartifacts.cache", StringComparison.Ordinal)
+                || line.Contains("\"al-runner\", \"artifacts\"", StringComparison.Ordinal))
+                offenders.Add($"{rel}: {line.Trim()}");
+        }
+
+        return offenders;
     }
 
     /// <summary>
@@ -378,34 +397,220 @@ public class TestArtifactsGateTests
     [Fact]
     public void EveryTestThatCanSkipIsDeclaredSkippable()
     {
-        var factLine = new Regex(@"^\s*\[(?<attr>SkippableFact|SkippableTheory|Fact|Theory)[\](]");
-        var methodLine = new Regex(@"^\s*(?:public|private|internal|protected)[^=]*\s(?<name>\w+)\s*\(");
-        var skipCall = new Regex(@"\bTestArtifacts\.(SkipIfMissing|SkipIf|SkipIfDirectoryMissing)\b|\bSkip\.(If|IfNot|Always)\b");
-
         var offenders = new List<string>();
+        var declarations = 0;
         foreach (var file in TestSourcePaths())
         {
             var rel = Rel(file);
-            if (rel is "TestArtifacts.cs" or "TestArtifactsGateTests.cs") continue;
-            string? attr = null, method = null;
-            foreach (var line in File.ReadAllLines(file))
-            {
-                var f = factLine.Match(line);
-                if (f.Success) { attr = f.Groups["attr"].Value; method = null; continue; }
-                if (attr != null && method == null)
-                {
-                    var m = methodLine.Match(line);
-                    if (m.Success) { method = m.Groups["name"].Value; continue; }
-                }
-                if (attr is "Fact" or "Theory" && method != null && skipCall.IsMatch(line))
-                {
-                    offenders.Add($"{rel}.{method} is [{attr}] but can skip");
-                    attr = null;
-                }
-            }
+            if (rel is "TestArtifacts.cs" or "TestArtifactsGateTests.cs"
+                    or "SkippableAttributeDetectorTests.cs") continue;
+            var text = File.ReadAllText(file);
+            offenders.AddRange(FindTestsThatCanSkipButAreNotSkippable(rel, text));
+            declarations += CountTestDeclarationsIn(text);
         }
+
+        Assert.True(declarations > 100,
+            $"only {declarations} [Fact]/[Theory] declaration(s) were examined across the suite, so "
+            + "'no offenders' would be a verdict about nothing rather than a clean suite.");
 
         Assert.True(offenders.Count == 0,
             "a SkipException out of a plain [Fact] is reported Failed, not Skipped:\n" + string.Join("\n", offenders));
     }
+
+    private static readonly Regex FactLine =
+        new(@"^\s*\[(?<attr>SkippableFact|SkippableTheory|Fact|Theory)[\](]");
+
+    private static readonly Regex MethodLine =
+        new(@"^\s*(?:public|private|internal|protected)[^=]*\s(?<name>\w+)\s*\(");
+
+    private static readonly Regex SkipCall =
+        new(@"\bTestArtifacts\.(SkipIfMissing|SkipIf|SkipIfDirectoryMissing)\b|\bSkip\.(If|IfNot|Always)\b");
+
+    /// <summary>
+    /// The offenders in one source text: tests declared <c>[Fact]</c>/<c>[Theory]</c> whose body
+    /// can reach a skip. A function over TEXT so the detector is testable against synthetic
+    /// inputs — see <see cref="SkippableAttributeDetectorTests"/>. #3813: as inline logic over
+    /// raw lines it matched the skip spelling inside COMMENTS and attributed the match to
+    /// whichever declaration preceded that line, so prose and line position decided whether a
+    /// test needed the attribute, and the failure named a test unrelated to the match.
+    /// </summary>
+    internal static IEnumerable<string> FindTestsThatCanSkipButAreNotSkippable(string rel, string sourceText)
+    {
+        var offenders = new List<string>();
+        string? attr = null, method = null;
+        // Comments cannot call anything, so they are removed before the scan — line-for-line, so
+        // that a declaration and a match still line up the way they do in the file.
+        foreach (var line in StripCommentsPreservingLines(sourceText).Split('\n'))
+        {
+            var f = FactLine.Match(line);
+            if (f.Success) { attr = f.Groups["attr"].Value; method = null; continue; }
+            if (attr != null && method == null)
+            {
+                var m = MethodLine.Match(line);
+                if (m.Success) { method = m.Groups["name"].Value; continue; }
+            }
+            if (attr is "Fact" or "Theory" && method != null && SkipCall.IsMatch(line))
+            {
+                offenders.Add($"{rel}.{method} is [{attr}] but can skip");
+                attr = null;
+            }
+        }
+
+        return offenders;
+    }
+
+    /// <summary>
+    /// <paramref name="sourceText"/> with every comment AND every string/char literal's contents
+    /// blanked to spaces, and every newline kept, so line N of the result is line N of the
+    /// input. Characters become spaces rather than being deleted, which keeps the code that
+    /// shares a line with a comment.
+    ///
+    /// <para>Literals go for the same reason comments do: neither calls anything, so a skip
+    /// spelling in either is not a skip. Tracking them is also what makes the comment half
+    /// correct, because a <c>//</c> inside a literal opens no comment — 116 lines in this suite
+    /// carry that shape (URLs in XML manifests, AlSourceParserCommentTests' AL fixtures), and
+    /// cutting at the first <c>//</c> would truncate real code on every one of them. The three
+    /// string forms differ only in how they END — <c>\</c> escapes in a regular literal,
+    /// <c>""</c> in a verbatim one, the fence itself in a raw one.</para>
+    ///
+    /// <para>Deliberately not a Roslyn parse: the input is one file's text at a time with no
+    /// compilation behind it, and a parser would answer the same question at the cost of a
+    /// syntax tree per file. An unterminated construct swallows the rest of the text, which is
+    /// what the compiler does with it too.</para>
+    /// </summary>
+    internal static string StripCommentsPreservingLines(string sourceText) =>
+        StripCommentsPreservingLines(sourceText, blankStringContents: true);
+
+    /// <summary>
+    /// The same pass, with a choice about string literals, because the two guards in this file
+    /// need opposite answers about them and both are right.
+    ///
+    /// <para><paramref name="blankStringContents"/> true — the skippable-attribute scan: a
+    /// literal calls nothing, so a skip spelling inside one is not a skip. False — the
+    /// artifact-path scan, whose entire subject is a path spelled as a literal, and for which
+    /// blanking them would remove the thing being looked for.</para>
+    ///
+    /// <para>Literals are tracked either way: that is what makes the COMMENT half correct, since
+    /// a <c>//</c> inside a literal opens no comment.</para>
+    /// </summary>
+    internal static string StripCommentsPreservingLines(string sourceText, bool blankStringContents)
+    {
+        var outp = new System.Text.StringBuilder(sourceText.Length);
+        var i = 0;
+        while (i < sourceText.Length)
+        {
+            var c = sourceText[i];
+
+            if (c == '/' && i + 1 < sourceText.Length && sourceText[i + 1] == '/')
+            {
+                while (i < sourceText.Length && sourceText[i] != '\n') { outp.Append(' '); i++; }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < sourceText.Length && sourceText[i + 1] == '*')
+            {
+                outp.Append("  ");
+                i += 2;
+                while (i < sourceText.Length
+                       && !(sourceText[i] == '*' && i + 1 < sourceText.Length && sourceText[i + 1] == '/'))
+                {
+                    // Newlines are copied through so the line count survives an unterminated or
+                    // multi-line comment; everything else becomes a space.
+                    outp.Append(sourceText[i] == '\n' ? '\n' : ' ');
+                    i++;
+                }
+                if (i < sourceText.Length) { outp.Append("  "); i += 2; }
+                continue;
+            }
+
+            if (c == '"' || c == '\'')
+            {
+                i = CopyLiteral(sourceText, i, outp, blankStringContents);
+                continue;
+            }
+
+            outp.Append(c);
+            i++;
+        }
+
+        return outp.ToString();
+    }
+
+    /// <summary>
+    /// Blanks the string or char literal starting at <paramref name="start"/> — quotes kept,
+    /// contents replaced by spaces, newlines kept — and answers the index just past it.
+    ///
+    /// <para>Contents go for the same reason comments do: a literal calls nothing, so a skip
+    /// spelling inside one is not a skip. The quotes stay so the result still reads as C#
+    /// rather than as a line whose structure has changed.</para>
+    /// </summary>
+    private static int CopyLiteral(string text, int start, System.Text.StringBuilder outp, bool blank)
+    {
+        // `blank` false keeps the literal verbatim; the newline-preserving replacement only
+        // applies when the caller asked for contents to go.
+        void Blank(int from, int count)
+        {
+            for (var n = 0; n < count; n++)
+                outp.Append(!blank ? text[from + n] : text[from + n] == '\n' ? '\n' : ' ');
+        }
+
+        // A raw string literal: three or more quotes, closed by a run of at least that many.
+        if (text[start] == '"' && start + 2 < text.Length && text[start + 1] == '"' && text[start + 2] == '"')
+        {
+            var fence = 0;
+            while (start + fence < text.Length && text[start + fence] == '"') fence++;
+            outp.Append(text, start, fence);
+            var j = start + fence;
+            while (j < text.Length)
+            {
+                if (text[j] != '"') { Blank(j, 1); j++; continue; }
+                var run = 0;
+                while (j + run < text.Length && text[j + run] == '"') run++;
+                if (run >= fence) { outp.Append(text, j, run); return j + run; }
+                Blank(j, run);
+                j += run;
+            }
+            return j;
+        }
+
+        var quote = text[start];
+        // `@"…"` — no backslash escapes, and `""` is one embedded quote.
+        var verbatim = quote == '"' && start > 0 && text[start - 1] == '@';
+        outp.Append(quote);
+        var k = start + 1;
+        while (k < text.Length)
+        {
+            var ch = text[k];
+            if (!verbatim && ch == '\\' && k + 1 < text.Length)
+            {
+                Blank(k, 2);
+                k += 2;
+                continue;
+            }
+            if (ch == quote)
+            {
+                if (verbatim && k + 1 < text.Length && text[k + 1] == '"')
+                {
+                    Blank(k, 2);
+                    k += 2;
+                    continue;
+                }
+                outp.Append(ch);
+                return k + 1;
+            }
+            // An unterminated literal ends at the newline rather than swallowing the file: a
+            // stray quote in ordinary code would otherwise hide every line below it, which is
+            // the direction that turns the guard silent (guards-need-a-third-state.md).
+            if (ch == '\n' && !verbatim) return k;
+            Blank(k, 1);
+            k++;
+        }
+        return k;
+    }
+
+    internal static int CountTestDeclarations() =>
+        TestSourcePaths().Sum(f => CountTestDeclarationsIn(File.ReadAllText(f)));
+
+    private static int CountTestDeclarationsIn(string sourceText) =>
+        sourceText.Split('\n').Count(line => FactLine.IsMatch(line));
 }

--- a/AlRunner.Tests/TestArtifactsGateTests.cs
+++ b/AlRunner.Tests/TestArtifactsGateTests.cs
@@ -410,13 +410,21 @@ public class TestArtifactsGateTests
             declarations += CountTestDeclarationsIn(text);
         }
 
-        Assert.True(declarations > 100,
+        Assert.True(declarations > MinimumTestDeclarations,
             $"only {declarations} [Fact]/[Theory] declaration(s) were examined across the suite, so "
-            + "'no offenders' would be a verdict about nothing rather than a clean suite.");
+            + "'no offenders' would be a verdict about nothing rather than a clean suite. "
+            + $"The floor of {MinimumTestDeclarations} is a tripwire against a scan that stopped "
+            + "matching, not a target: it was set when this landed, against 4,119 declarations in "
+            + "676 files — 41x headroom. So a count near the floor means the scan broke, and only "
+            + "a suite that genuinely lost most of its tests should reach it. If that shrink is "
+            + "real, lower this deliberately and say why.");
 
         Assert.True(offenders.Count == 0,
             "a SkipException out of a plain [Fact] is reported Failed, not Skipped:\n" + string.Join("\n", offenders));
     }
+
+    /// <summary>Tripwire floor; the reasoning and the calibration are in the failure message.</summary>
+    internal const int MinimumTestDeclarations = 100;
 
     private static readonly Regex FactLine =
         new(@"^\s*\[(?<attr>SkippableFact|SkippableTheory|Fact|Theory)[\](]");


### PR DESCRIPTION
Closes #3813

`TestArtifactsGateTests.EveryTestThatCanSkipIsDeclaredSkippable` matched the skip-call spelling anywhere in a line, comments included, and attributed the match to whichever test declaration preceded that line. A test's required attribute was therefore decided by prose and line position rather than by whether the test can actually skip: an edit changing no behaviour changed whether CI passed, and the failure named a test with nothing to do with the match.

Both drift guards in that file now decide from **code**, via one Roslyn-tokenizing pass.

## Which instrument, and why not the other one

The brief offered two, and named source-stripping as the one to reach for first. I reached for a third position, and the evidence moved me twice.

**Not IL token-matching** (the #3843 shape), despite it being right there and right for #3843. That guard asks about one caller/target pair it can name with `typeof(...)`. This one asks about every test method in the assembly, transitively through arbitrary helpers — so IL would need `Module.ResolveMethod` on each `0x28`/`0x6F` operand, a transitive walk with cycle detection, and a depth bound, all to answer "did someone forget an attribute?". Worse, it would change what the guard measures: a `[Fact]` whose body textually contains the call must fire even when the call sits in a lambda hoisted into a closure class or a `#if`-disabled branch, and a transitive IL walk would newly fire on any test reaching a framework helper. It is a heavier instrument that solves the same single problem. Both of #3843's `#3813` citations remain accurate for that guard and are untouched.

**Not a handwritten stripper either**, which is what I built first and then deleted. Two open issues say not to:

- **#3527** — "Replace handwritten C# lexers in structural guards with the existing Roslyn parser", naming two existing scanners and asking that no more be added.
- **#3153** — proposes exactly this shared Roslyn helper, and its Suggested Direction is the design I ended up at.

And `BaseAppFloorFixtureGuardTests.CSharpWritesFloor` already tokenizes with Roslyn for the same question. Its doc comment names by hand the trailing-comment and block-comment holes a handwritten stripper has to rediscover — I had rediscovered both by then. Roslyn is a dependency of the test project already.

So: `DescendantTrivia` carries the comments and `DescendantTokens` does not descend into trivia, which answers the question directly. Disabled `#if` regions come along for free; the handwritten version did not handle them. Interpolation holes are deliberately left as code, because a hole really can call something — the blind spot #3527 names. **Net 64 lines smaller than the handwritten version, and one fewer C# lexer to keep correct.**

## RED → GREEN

RED is behavioural, not just a compile error. The first commit extracts the existing comment-blind logic into the new function shape with an identity stripper, so the new tests run against the defect itself:

```
RED    Failed: 9, Passed: 20, Skipped: 0, Total: 29
GREEN  Failed: 0, Passed: 35, Skipped: 0, Total: 35   (35 after the sibling tests were added)
```

The nine RED failures are the comment and literal cases; the true-positive cases passed in RED already, which is the point — the fix had to move only one direction.

One test passed in RED for a bad reason and is kept as a regression pin: `ADocCommentNamingTheHelperIsNotACall`. Its `///` lines sit *before* the attribute, so `attr` was null when they were scanned. Positional luck, which is the defect restated.

## Mutation results

Every behaviour has a test that dies with it. Seven mutations, each reverted afterwards:

| # | mutation | result |
|---|---|---|
| 1 | scan raw text again (fix reverted at the call site) | **Failed: 7**, Passed: 22 |
| 2 | stripper returns its input unchanged | **Failed: 9**, Passed: 20 — identical to the RED baseline |
| 3 | inject a **real** skip call into a plain `[Fact]` | guard **fires**, naming `The_gate_fails_rather_than_skips_when_CI_has_no_bundle` — the test that actually calls |
| 4 | make the declaration regex match nothing | **third state fires**: `only 0 [Fact]/[Theory] declaration(s) were examined` |
| 5 | sibling guard back to leading-`//` only | **Failed: 2** (trailing + block rows), Passed: 4 |
| 6 | Roslyn version stops blanking comment trivia | **Failed: 12**, Passed: 23 |
| 7 | Roslyn version stops blanking literal contents | **Failed: 1** — exactly `ASkipSpellingInsideAStringIsNotACall`, the only test claiming it |

Mutations 6 and 7 were run against the **final** Roslyn implementation, not the handwritten draft, so the discrimination is measured in the state that ships. Mutation 3 was run against both.

**Mutation 3 is the one that matters most**, because it is the direction easiest to lose while making a scanner ignore comments — the both-directions requirement stated in the issue's "Done when" and again in its second comment. The guard still catches a genuine unattributed skip, and now names the right test.

## guards-need-a-third-state

The suite-wide scan previously could not tell "no offenders" from "measured nothing". It now counts the declarations it examined and refuses below a floor. Mutation 4 is the proof that path fires; without it that mutation was a silent green — a guard reporting success on something it no longer measures, which is the family this issue belongs to.

`StripCommentsPreservingLines` preserves line numbers by blanking spans in place rather than rebuilding text, so attribution still lines up with the file, and anything not explicitly blanked survives byte for byte.

## Fix the shape, not just the reported line

**1. Same wrong pattern at another call site — found one, fixed it.** `OnlyTheSharedHelperNamesTheArtifactCachePathsInCode`, the adjacent function in the same file, documents that "comments may still discuss the paths" and implemented it as "skip a line starting with `//`". Replay confirms it fires on a trailing comment and on a `/* */` block:

```
leading //   -> fires: False      (handled)
trailing //  -> fires: True       (defect)
block /* */  -> fires: True       (defect)
doc ///      -> fires: False      (handled by accident of position)
```

No checked-in file carried that shape, so nothing had gone red — it was one comment away from a false positive, not correct. Six new tests, and mutation 5 pins them.

**2. Sibling functions sharing the assumption.** Both scans in the file now share one pass. They need **opposite** answers about string literals and both are right, so the pass takes a flag: a skip spelling inside a literal is not a call, while a hard-coded artifact path *is* a literal and is precisely what its guard looks for. Collapsing them into one behaviour would have broken the second guard silently — I nearly did exactly that, and its true-positive test caught it.

**3. Two paths, same invariant.** That is what the flag makes explicit rather than leaving as two approximations that disagree.

**4. The workaround this issue exists to remove.** `MetadataEquivalenceBundleGateTests.No_bundle_reader_writes_its_own_empty_bundle_skip` carried `[SkippableFact]` though it cannot skip, held in place by a comment three lines into its body, plus a pointer comment explaining the arrangement. Both are gone; it is a plain `[Fact]`, and the real suite-wide guard is green with it that way. Isolated by replay before removing: deleting that one prose line made the offender vanish, and the regex literal below it could never match (`Skip\.If` in the source defeats the `\bSkip\.` in the pattern).

**5. #3843's two reworded doc comments** in `BcEngineUnbootstrappedGuardTests.cs` — the third reproduction — needed no change: the rewording removed every mention of the spelling from that file, so there is nothing left to restore, and both of its `#3813` citations remain true statements about why IL suits *that* guard.

## Queue scan — what I did not fold, and why

Searched by symbol (`TestArtifactsGateTests`, `SkippableFact`), by observable (a comment deciding a verdict), and by mechanism ("textual scanner", "raw-text scan", "source scan"). Two related, **neither folded, both left open**:

- **#3153** — `DocumentServiceProviderScopeGuardTests` excludes its own source because prose trips its raw-text scan. Same defect class, different file, and a different token filter ("every token except trivia" rather than comments-and-literals). Its fix deletes a `SelfSourcePath` constant this PR does not touch.
- **#3527** — replace handwritten C# lexers with Roslyn across structural guards. A 2–4 day architecture task covering two further scanners (`BcInternalsNullForgivingGuardTests`, `BracelessIfSecondStatementGuardTests`). This PR moves one guard in that direction and adds no new lexer, but does not attempt the rest.

Folding either would make the diff stop being one coherent change. **I did correct a factual claim in #3153**: its audit records `TestArtifactsGateTests` as "not currently wrong on any checked-in file", which I measured to be false in two places — comment posted there with the replay.

## Notes for the reviewer

- The new test file is exempt from the guard it tests, exactly as `SilentSkipDetectorTests.cs` is exempt from the silent-skip guard: its synthetic offenders are literals in it. Both exemptions are by filename and visible.
- Writing about this defect reproduces it, so the code comments here name the mechanism without spelling the token where the guard would read it as a call. The suite being green is the proof that held.
- Local verification: `Failed: 0, Passed: 85` over `SkippableAttributeDetectorTests`, `TestArtifactsGateTests`, `SilentSkipDetectorTests` and `BaseAppFloorFixtureGuardTests`, run twice (second run `--no-build`). A wider filtered run of 396 guard-adjacent tests gave `Failed: 3, Passed: 393`; all three are `bc-engine-serial` tests refusing to run because `engine.runsettings` was never generated in this worktree — the #3843 loud-refusal working as intended, in no file this PR touches, and satisfied by CI's own bootstrap step.

Corpus-NA: this changes only a drift guard over the C# test suite's own source; nothing here is AL-observable and no BC behaviour is asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
