### PR TITLE
fix(tests): scope the --no-cache leak assertion to this test's own throwaway root

### DIFF
--- a/AlRunner.Tests/NoCacheLastWinsIntegrationTests.cs
+++ b/AlRunner.Tests/NoCacheLastWinsIntegrationTests.cs
@@ -37,6 +37,29 @@ public class NoCacheLastWinsIntegrationTests
     private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
 
     private static (string output, int exit) RunRunner(string bundleDir, string absentPackageCache, params string[] extraArgs)
+        => RunRunnerCore(bundleDir, absentPackageCache, noCacheRoot: null, extraArgs);
+
+    /// <param name="noCacheRoot">
+    /// When non-null, handed to the child as <see cref="CacheRoots.NoCacheRootEnvVar"/> so a
+    /// <c>--no-cache</c> run ADOPTS this exact directory instead of minting a GUID-named one
+    /// (CacheRoots.DisableForRun's adopt branch). Set on the child's own ProcessStartInfo, never
+    /// through Environment.SetEnvironmentVariable: the environment is process-global and
+    /// Path.GetTempPath() re-reads it per call, so a test host mutating it redirects the temp
+    /// root for every OTHER test class running in parallel (#3838).
+    /// </param>
+    /// <remarks>
+    /// Named differently from <c>RunRunner</c>, and takes <c>string[]</c> rather than
+    /// <c>params</c>, deliberately. An overload pair
+    /// <c>(string, string, params string[])</c> / <c>(string, string, string?, params string[])</c>
+    /// is not ambiguous to the compiler and picks the SECOND for a three-argument call, binding
+    /// the caller's first flag to <c>noCacheRoot</c> and leaving <c>extraArgs</c> empty — so
+    /// <c>RunRunner(bundle, pkg, "--cache DIR")</c> silently drops <c>--cache</c> and the child
+    /// runs against the default cache root. Measured: that turned this file's sibling test red
+    /// deterministically (A/B/A, three builds), and it fails as a MISSING cache entry, which
+    /// reads like a caching defect rather than a dropped argument (#3849).
+    /// </remarks>
+    private static (string output, int exit) RunRunnerCore(
+        string bundleDir, string absentPackageCache, string? noCacheRoot, string[] extraArgs)
     {
         var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
         args.Append(TestBuildConfig.BcVersionArg);
@@ -50,6 +73,8 @@ public class NoCacheLastWinsIntegrationTests
             RedirectStandardOutput = true, RedirectStandardError = true,
             UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
         };
+        if (noCacheRoot != null)
+            psi.Environment[AlRunner.Infrastructure.CacheRoots.NoCacheRootEnvVar] = noCacheRoot;
         var sb = new StringBuilder();
         using var p = Process.Start(psi)!;
         p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
@@ -175,17 +200,37 @@ public class NoCacheLastWinsIntegrationTests
         }
         """);
 
-        // Set difference, not a count (#2706): the spawned runner sweeps stale al-runner-*
-        // directories of DEAD processes at startup, so the count can legitimately go DOWN
-        // across the run on a machine with leftovers. The claim here is only that this run
-        // left no NEW directory behind.
-        var tempRoot = Path.GetTempPath();
-        var before = Directory.GetDirectories(tempRoot, "al-runner-no-cache-*").ToHashSet(StringComparer.Ordinal);
+        // Name this run's throwaway root, rather than looking for whichever al-runner-no-cache-*
+        // directories appear in the shared temp root while the run is in flight (#3849). Ten
+        // other classes in this assembly spawn --no-cache runners — CacheGateProbeScopeTests,
+        // CoverageTests, PlainRunInstrumentationGateTests, AlObjectEmitOrderDeterminismTests,
+        // the four ServerAffectedSelection* files, both WatchPageMetadataReload* files — and
+        // xunit.runner.json runs 4 collections at once, so a neighbour's live root is in the
+        // temp root, is absent from `before`, and reads as this run's leak. Measured: with just
+        // four of those classes selected the set difference named TWO directories at once, from
+        // a test that spawns exactly ONE runner, and both were gone by the time the assertion
+        // was read — they were neighbours mid-run, never leaks. CacheRootStartupFailureTests'
+        // "al-runner-no-cache-root-expectations" matches that glob too.
+        //
+        // DisableForRun ADOPTS AL_RUNNER_NO_CACHE_ROOT when set, so this is the same code path
+        // a re-exec'd child takes, and the run still gets exactly one throwaway root. The claim
+        // is unchanged and the assertion is strictly stronger: not "no unexplained directory
+        // appeared" but "the directory THIS run was told to use is gone, and so is its .owner
+        // sidecar". A neighbour cannot satisfy or break it, because it names one path.
+        var throwawayRoot = Path.Combine(
+            Path.GetTempPath(), "al-runner-no-cache-scoped-" + Guid.NewGuid().ToString("N"));
 
-        var (output, exit) = RunRunner(bundleDir, absentPackageCache, "--no-cache");
+        var (output, exit) = RunRunnerCore(
+            bundleDir, absentPackageCache, throwawayRoot, new[] { "--no-cache" });
         Assert.True(exit == 0 && output.Contains("1P/0F/0E"), $"run must pass:\n{output}");
 
-        var leaked = Directory.GetDirectories(tempRoot, "al-runner-no-cache-*").Where(d => !before.Contains(d)).ToList();
-        Assert.True(leaked.Count == 0, "the --no-cache run left its throwaway root behind: " + string.Join(", ", leaked));
+        // Positive: the run really USED the root it was handed — without this the negative below
+        // would pass against a runner that ignored the variable and leaked a minted root instead.
+        Assert.Contains(throwawayRoot, output, StringComparison.Ordinal);
+
+        Assert.False(Directory.Exists(throwawayRoot),
+            $"the --no-cache run left its throwaway root behind: {throwawayRoot}");
+        Assert.False(File.Exists(AlRunner.Infrastructure.ScratchDirs.MarkerPathFor(throwawayRoot)),
+            $"the --no-cache run left its throwaway root's .owner sidecar behind: {throwawayRoot}");
     }
 }


### PR DESCRIPTION
Closes #3849

`NoCacheAlone_DoesNotLeakItsThrowawayTempDirectory` failed intermittently under a wide
parallel filter and passed every time in isolation. Filed by, and fixed by, the agent loop
`stma-auto-11`.

## Reproduction on current `main`

Reproduced at **iteration 1** of the issue's own wide filter, on `main` @ `81af2ea5`:

```
the --no-cache run left its throwaway root behind:
/home/stefan/.cache/claude-tmp/al-runner-no-cache-a8097c32dc3a48eab16a792ecba6c813
```

That directory **no longer existed** when I looked for it after the run.

## The mechanism

Not a leak, and not an unsound claim — an **imprecise observation**. The test took a set
difference over `al-runner-no-cache-*` in the *shared* temp root, which cannot tell whose
directory it found.

Ten other classes in this assembly spawn `--no-cache` runner subprocesses —
`CacheGateProbeScopeTests`, `CoverageTests`, `PlainRunInstrumentationGateTests`,
`AlObjectEmitOrderDeterminismTests`, the four `ServerAffectedSelection*` files, both
`WatchPageMetadataReload*` files — and `xunit.runner.json` sets
`parallelizeTestCollections: true`, `maxParallelThreads: 4`. Each such run mints
`al-runner-no-cache-<guid>` under `Path.GetTempPath()` via `CacheRoots.cs:165`. A
neighbour's **live** root is absent from the `before` snapshot, so it reads as this run's
leak. `CacheRootStartupFailureTests`'s `al-runner-no-cache-root-expectations` matches the
same glob.

**The evidence that settles it against the "real leak" reading:** selecting just four of
those classes made the failure deterministic, and the set difference then named **two**
directories at once — from a test that spawns exactly **one** runner. Two leaks from one
run is arithmetically impossible under the test's own claim. Both were gone by the time I
read the message, cleaned up by their owning runners.

## The fix

The run now names its own throwaway root through `AL_RUNNER_NO_CACHE_ROOT` on the *child's*
`ProcessStartInfo`, which `CacheRoots.DisableForRun` adopts — the same path a re-exec'd child
takes, so the run still gets exactly one root. The assertion then names one path.

This is **stronger**, not weaker. The old assertion said "no unexplained directory appeared";
the new one says "the directory this run was *told* to use is gone, and so is its `.owner`
sidecar", plus a positive `Assert.Contains(throwawayRoot, output)` so the negative cannot pass
against a runner that ignored the variable. A neighbour can neither satisfy nor break it.

The env var is set on the child's `ProcessStartInfo`, never via
`Environment.SetEnvironmentVariable` — that is process-global and `Path.GetTempPath()` re-reads
it per call, which is how #3838 redirected the temp root for every parallel test.

## Proof

- **Mutation test.** With `CacheRoots.CleanupThrowawayRoot` neutered to leak, the test fails
  and names **its own** root. Re-verified after the signature fix below. The assertion is not
  vacuous.
- **Before:** wide filter reproduced at iteration 1.
- **After:** **0 failures in 20 iterations** of the deterministic-repro filter (~28 s each),
  **0 in 10 more** after the rebase, and **0 in 2** runs of the issue's full wide filter
  (~4 min each). Passed count went 742 -> 743.
- Targeted `--filter "FullyQualifiedName~CacheRoots|~NoCacheLastWins|~ScratchDirs"`: **51/51**,
  twice, after the rebase.

The 11 remaining failures in the wide run are all the `bc-engine-serial` "REFUSING TO SKIP"
bootstrap refusal (#3843) — I did not run `tools/engine-test-bootstrap.sh` locally; CI does.
The same 11 were failing in the pre-fix baseline.

## A second defect, found and fixed here

My first cut added an overload
`(string, string, string?, params string[])` beside the existing
`(string, string, params string[])`. That pair is **not ambiguous to the compiler** — it binds
a three-argument call to the *second*, putting the caller's first flag in `noCacheRoot` and
leaving `extraArgs` empty. So `RunRunner(bundle, pkg, "--cache DIR")` silently dropped
`--cache`, and this file's sibling test
`CacheThenNoCache_RedirectsAwayFromTheExplicitDir_...` went red **deterministically** — failing
as a *missing cache entry*, which reads like a caching defect rather than a dropped argument.

I caught it by alternating `main` and my branch in the same warm-cache state (`main` passed
twice, mine failed twice), then A/B/A over three builds. The env-var entry point is now
`RunRunnerCore` and takes `string[]`, not `params`, with the trap recorded at the line.

Worth stating plainly: I first assumed that sibling failure was pre-existing warm-cache noise.
The alternating control disproved that. It was mine.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** I grepped every use of `Path.GetTempPath()`
   plus a glob in `AlRunner.Tests`. `CacheRootsDisableForRunTests` reserves a *named* directory
   and asserts on that exact path, so it is already precise. No other test counts or
   set-differences a shared-temp-root glob. Nothing further to fix.
2. **Sibling function making the same assumption?** Yes — the other test in this file shares
   `RunRunner`, which is exactly how the overload trap bit it. Covered above; both tests pass.
3. **Two code paths writing the same state?** `CacheRoots.DisableForRun` has two branches,
   adopt and mint. The mint branch reserves through `ScratchDirs`; the adopt branch previously
   had no test exercising it end-to-end through a spawned runner. This test now takes the adopt
   branch, so both branches are covered.

**Same-defect queue scan** (`search-for-the-same-defect-first.md`): searched open issues for
`al-runner-no-cache`, `GetTempPath`, `throwaway`, `DisableForRun`, `leak` and the flake's test
name. Nothing else reports this. Nothing folded in — no other open issue's fix lands in this
file.

## Not a BC-behaviour claim

Nothing here asserts what Business Central does. The claim is entirely about the runner's own
temp-directory ownership and this repository's test isolation, so it stays in `AlRunner.Tests/`
and owes no corpus test.

Corpus-NA: runner-local test-isolation fix; no AL-observable behaviour changes and no BC semantics are asserted

Filed and implemented by the agent loop `stma-auto-11`, not by a person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
