### PR TITLE
docs(testpage): correct two false "TestPageClient is not present" comments

### DIFF
--- a/AlRunner.Tests/TestPageClientPresenceTests.cs
+++ b/AlRunner.Tests/TestPageClientPresenceTests.cs
@@ -1,0 +1,131 @@
+// TestPageClientPresenceTests — pins the fact two code comments got wrong for a long time
+// (#3799): Microsoft.Dynamics.Nav.Client.TestPageClient.dll SHIPS in the BC artifact
+// directory and LOADS here. It is not absent, and the runner's parallel TestPage
+// implementation does not rest on it being absent.
+//
+// Why this test exists at all, rather than just a corrected comment: the comments claiming
+// the DLL "does not exist in the runner" / was "not present in the runner" were false, and
+// because they were written down every later reader had a documented reason not to look
+// again. A comment cannot fail; this can. If Microsoft ever genuinely stops shipping the
+// assembly, this test fails and the docs get revisited on evidence instead of on memory.
+//
+// What it deliberately does NOT assert: that reusing TestPageClient is viable. It is not,
+// for a measured reason that has nothing to do with presence — BC's TestPageProxy resolves
+// fields only by name through a control tree, and the runner synthesizes none for a
+// precompiled page. docs/testpageclient-reuse.md has that measurement.
+using System;
+using System.IO;
+using System.Reflection;
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestPageClientPresenceTests
+{
+    private const string TestPageClientAssembly =
+        "Microsoft.Dynamics.Nav.Client.TestPageClient";
+
+    private static string ServiceTierDirOrSkip()
+    {
+        string dir = string.Empty;
+        string? selectionError = null;
+        try { dir = AlRunner.Infrastructure.BcArtifacts.ServiceTierDir; }
+        catch (Exception ex) { selectionError = ex.Message; }
+        TestArtifacts.SkipIf(selectionError != null,
+            $"no BC service-tier artifact directory could be selected: {selectionError}");
+        return dir;
+    }
+
+    [SkippableFact]
+    public void TestPageClientDll_ShipsInTheArtifactDirectory()
+    {
+        var dir = ServiceTierDirOrSkip();
+        var probe = Path.Combine(dir, TestPageClientAssembly + ".dll");
+
+        Assert.True(File.Exists(probe),
+            $"'{probe}' does not exist. Two code comments once claimed this assembly was "
+            + "'not present in the runner' and that claim was false on every version measured "
+            + "in #3799 (27.0, 27.3, 27.5, 28.0-28.4). If it is genuinely absent now, that is "
+            + "a real change: re-measure and update docs/testpageclient-reuse.md rather than "
+            + "restoring the old wording.");
+    }
+
+    // The load BC itself performs, reproduced exactly: NavTestExecution.CreateTestClientSession
+    // builds the name as "Microsoft.Dynamics.Nav.Client.TestPageClient" + Ncl's own
+    // version/culture/PublicKeyToken suffix. That is a STRONG-NAME load, and "the strong name
+    // did not match" was one candidate explanation for the original swallowed failure. It is
+    // not the explanation: the identities match exactly and the load succeeds.
+    [SkippableFact]
+    public void TheStrongNameLoadBcPerforms_Succeeds_AndYieldsTestPageClientSession()
+    {
+        var dir = ServiceTierDirOrSkip();
+        TestArtifacts.SkipIf(
+            !File.Exists(Path.Combine(dir, TestPageClientAssembly + ".dll")),
+            "BC artifacts are incomplete: TestPageClient.dll is not in the artifact dir.");
+        // BC reaches TestPageClientSession through Framework.UI. One provisioned directory
+        // (27.5.46862.48827) lacks it, which is exactly the missing-transitive-dependency
+        // case BC's `catch (FileNotFoundException)` converts into "test client not installed".
+        TestArtifacts.SkipIf(
+            !File.Exists(Path.Combine(dir, "Microsoft.Dynamics.Framework.UI.dll")),
+            "BC artifacts are incomplete: Microsoft.Dynamics.Framework.UI.dll is not in the "
+            + "artifact dir, so TestPageClientSession cannot resolve (see #3799).");
+
+        DependencyLoader.EnsureResolverInstalled_Public();
+
+        var ncl = Assembly.Load(new AssemblyName("Microsoft.Dynamics.Nav.Ncl"));
+        var nclFullName = ncl.FullName!;
+        var requested = TestPageClientAssembly
+                        + nclFullName.Substring(nclFullName.IndexOf(','));
+
+        var asm = Assembly.Load(requested);
+
+        Assert.NotNull(asm);
+        // Identity, not just "something loaded": the whole point is that the strong name matches.
+        Assert.Equal(ncl.GetName().Version, asm.GetName().Version);
+        Assert.Equal(
+            BitConverter.ToString(ncl.GetName().GetPublicKeyToken()!),
+            BitConverter.ToString(asm.GetName().GetPublicKeyToken()!));
+
+        // The exact type and factory BC invokes by reflection.
+        var sessionType = asm.GetType(
+            "Microsoft.Dynamics.Nav.Client.TestPageClient.TestPageClientSession",
+            throwOnError: false);
+        Assert.NotNull(sessionType);
+
+        var create = sessionType!.GetMethod(
+            "Create", BindingFlags.Static | BindingFlags.Public);
+        Assert.NotNull(create);
+        Assert.Equal(6, create!.GetParameters().Length);
+    }
+
+    // The OTHER half of what the Forms.cs comment got wrong. It said TestClientProxy<T>.Proxy
+    // "tries to load Microsoft.Dynamics.Nav.Client.TestPageClient". It does not: Proxy is a
+    // System.Reflection.DispatchProxy living in Nav.Types.dll, and the reason the Cecil
+    // rewrite strips it is that its dispatcher needs an initialized UISessionManager — which
+    // is what the two neighbouring comments in that same file always said.
+    [SkippableFact]
+    public void TestClientProxy_IsADispatchProxy_NotAnAssemblyLoader()
+    {
+        var dir = ServiceTierDirOrSkip();
+        TestArtifacts.SkipIf(
+            !File.Exists(Path.Combine(dir, "Microsoft.Dynamics.Nav.Types.dll")),
+            "BC artifacts are incomplete: Nav.Types.dll is not in the artifact dir.");
+
+        DependencyLoader.EnsureResolverInstalled_Public();
+
+        var types = Assembly.Load(new AssemblyName("Microsoft.Dynamics.Nav.Types"));
+        var proxyType = types.GetType(
+            "Microsoft.Dynamics.Nav.Types.TestClientProxy`1", throwOnError: false);
+
+        Assert.NotNull(proxyType);
+        Assert.Equal(
+            "System.Reflection.DispatchProxy",
+            proxyType!.BaseType?.FullName);
+
+        // It declares Proxy(T) itself — the call site the Cecil rewrite removes.
+        var proxy = proxyType.GetMethod(
+            "Proxy", BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+        Assert.NotNull(proxy);
+    }
+}

--- a/AlRunner/Infrastructure/NclCecilRewrite.Forms.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Forms.cs
@@ -614,8 +614,12 @@ public static partial class NclCecilRewrite
         //     Rewrite CheckPageOpened to be a no-op: the mock is always usable.
         //
         //  4. GetField / GetAction / GetDataItem / GetPart / GetBuiltInAction / FindBuiltInAction
-        //     pass the raw ITest* result through TestClientProxy<T>.Proxy() which tries to
-        //     load Microsoft.Dynamics.Nav.Client.TestPageClient — not present in the runner.
+        //     pass the raw ITest* result through TestClientProxy<T>.Proxy(), which wraps it in
+        //     the TestPageClient's dispatcher — and that needs a UI session ("The
+        //     UISessionManager was expected to be initialized"), which the runner has not set
+        //     up. It is NOT that the assembly is missing: TestPageClient.dll ships in every
+        //     artifact directory and Assembly.Load-s fine here (#3799; steps 3 and 4 below
+        //     state the same dispatcher reason, and #3185 is the call site this missed).
         //     Remove the Proxy call from each method; the raw mock interface value works fine.
 
         var navTestPageType = asm.MainModule.GetType("Microsoft.Dynamics.Nav.Runtime.NavTestPage")

--- a/AlRunner/Patches/RunnerTestClientSession.cs
+++ b/AlRunner/Patches/RunnerTestClientSession.cs
@@ -6,9 +6,16 @@
 //   AL [ModalPageHandler] receives:
 //       new NavTestPage(..., TestClientProxy<ITestPage>.Proxy(
 //           testClientSession.GetPage(runRequest.Data.FormHandle)))
-//   Real BC gets that session by Assembly.Load-ing the TestPageClient, which does not exist
-//   in the runner — so testClientSession stayed null and the delegate NRE'd the moment the
-//   dispatch reached it.
+//   Real BC gets that session from NavTestExecution.CreateTestClientSession, which
+//   Assembly.Load-s Microsoft.Dynamics.Nav.Client.TestPageClient. That assembly SHIPS in every
+//   artifact directory and the load SUCCEEDS here — measured on 27.0, 27.3, 27.5, 28.0-28.4,
+//   with TestPageClientSession.Create resolving at the 6-arg signature BC invokes (#3799).
+//   The reason we supply our own ITestClientSession is NOT absence: BC's proxies resolve a
+//   field only by NAME through the control tree (TestPageProxy.GetField searches
+//   form.ContainedControls and returns null when no control matches; TestFieldProxy holds a
+//   LogicalControl, never a record), and for a PRECOMPILED page the runner synthesizes no
+//   control tree — DependencyPageMetadataXml omits it deliberately. So MS's proxy builds page
+//   chrome and answers null for every field there. See docs/testpageclient-reuse.md.
 //
 // WHAT GetPage RETURNS
 //   The page BC already opened. The form is live and registered under the handle, so the

--- a/docs/testpageclient-reuse.md
+++ b/docs/testpageclient-reuse.md
@@ -1,0 +1,133 @@
+# Why the runner does not reuse `TestPageClient.dll` (and what was false about the old reason)
+
+Microsoft ships `Microsoft.Dynamics.Nav.Client.TestPageClient.dll`, its own server-side
+`TestPage` harness, in every BC artifact directory. `precompiled-dll-respect.md` §
+"Reuse before you re-implement" says a shim needs Microsoft not to ship the component
+first — so this page records what was measured when that question was finally asked of
+`RunnerPageInstance` / `MockTestPage`, and what the answer turned out to be.
+
+**Short version: the DLL is present, it loads, and it runs — but it resolves fields only
+through a control tree, and for a precompiled page the runner synthesizes none. That, not
+absence, is why the shim exists.** (#3799)
+
+## What was written down before, and why it was wrong
+
+Two comments recorded the DLL as absent:
+
+| file | claim |
+|---|---|
+| `AlRunner/Patches/RunnerTestClientSession.cs` | "the TestPageClient, which does not exist in the runner" |
+| `AlRunner/Infrastructure/NclCecilRewrite.Forms.cs` | "tries to load … TestPageClient — not present in the runner" |
+
+Both are false, and the second was wrong twice over: `TestClientProxy<T>.Proxy` does not
+load that assembly at all. It is a `System.Reflection.DispatchProxy` defined in
+`Microsoft.Dynamics.Nav.Types.dll`, which contains **no** `"Microsoft.Dynamics.Nav.Client.TestPageClient"`
+string literal — it wraps its argument in a dispatcher that needs an initialized
+`UISessionManager`. The two neighbouring comments in that same file (steps 3 and 4) had
+the reason right the whole time: *"The UISessionManager was expected to be initialized."*
+
+## The swallowed load failure
+
+`NavTestExecution.CreateTestClientSession` is the load site, and BC's own body explains how
+a real failure became a false absence:
+
+```csharp
+try {
+    string fullName = Assembly.GetExecutingAssembly().FullName;
+    Assembly assembly = Assembly.Load("Microsoft.Dynamics.Nav.Client.TestPageClient"
+                                      + fullName.Substring(fullName.IndexOf(',')));
+    ...
+}
+catch (FileNotFoundException) { }
+throw new NavTestTestClientNotInstalledException();
+```
+
+It catches `FileNotFoundException` **only**, and then throws an exception whose *name*
+asserts the client is not installed. So any failure to reach the type — including a missing
+transitive dependency — surfaces as "test client not installed". The exception name was read
+as a diagnosis, and the diagnosis was written into the comments.
+
+**A strong-name mismatch, a missing transitive dependency, and a genuine absence are three
+different answers with three different remedies.** Here it was the second, never the third.
+
+## What was measured
+
+Driving BC's exact `Assembly.Load` string under the runner's own resolver shape
+(`DependencyLoader.EnsureResolverInstalled`, which serves any `Microsoft.Dynamics.*` request
+from the artifact directory by filename probe):
+
+| BC version | `TestPageClient.dll` | `Assembly.Load` | `TestPageClientSession.Create` |
+|---|---|---|---|
+| 27.0.38460.53934 | present | **OK**, `Version=27.0.0.0, PublicKeyToken=31bf3856ad364e35` | resolves, 6 args |
+| 27.5.46862.53931 | present | OK | resolves |
+| 28.1.49838.53910 | present | **OK**, `Version=28.0.0.0` | resolves, 6 args |
+| 28.4.53241.54346 | present | **OK**, `Version=28.0.0.0` | resolves, 6 args |
+
+Strong-name binding was never the problem — the requested and actual identities match
+exactly. `TestPageClient.dll` is present in all nine provisioned artifact directories
+(27.0, 27.3, 27.5 ×2, 28.0, 28.1, 28.2, 28.3, 28.4).
+
+### The one failure, and it is a provisioning artifact
+
+`27.5.46862.48827` loads the assembly but `GetType(..., throwOnError: true)` fails:
+
+```
+FileNotFoundException: Could not load file or assembly
+  'Microsoft.Dynamics.Framework.UI, Version=27.0.0.0, PublicKeyToken=31bf3856ad364e35'
+```
+
+That directory is missing `Microsoft.Dynamics.Framework.UI.dll`; its sibling
+`27.5.46862.53931` has it, as do the other eight. So this is an incomplete artifact
+directory, not a version-shape difference — and it is precisely the **missing transitive
+dependency** case BC's `catch (FileNotFoundException)` converts into "not installed".
+
+## Why reuse still does not follow
+
+The blocker is in BC's proxy design, and it is measured (issue #3799, spike comments):
+
+`TestPageProxy.GetField(id)` searches the control tree **by name** —
+`form.ContainedControls.FindAll(c => c.Name != null && string.Compare(c.Name, s, ...) == 0)`
+— and returns `null` when nothing matches. `TestFieldProxy` holds only a `LogicalControl` /
+`RepeaterControl`; `Value` is `Control.StringValue`. **There is no record-side fallback
+anywhere in the assembly.**
+
+So the whole field / part / action surface depends on a control tree, and:
+
+| page | kind | control nodes | data controls | `GetField` |
+|---|---|---|---|---|
+| 70601 (fixture) | source-compiled | 50 | 9 | real `TestFieldProxy` |
+| 46 Sales Order Subform | precompiled | 16 | **0** | **null** |
+| 21 (Aged Acc. Receivable) | precompiled | 8 | **0** | **null** |
+
+For a precompiled page the runner deliberately synthesizes no control tree —
+`AlRunner/Patches/DependencyPageMetadataXml.cs` says so in its own header, and gives the
+reason: `SourceExpression` in `SymbolReference.json` is AL text (`Rec."No."`), not the
+compiled field-number `DataColumnName` the real metadata XML carries, so reconstructing one
+would add guessed data with no way to prove it faithful. BC's `PageBuilder` builds exactly
+what the metadata declares: no controls declared, no controls built, no `Editable` to
+resolve.
+
+**The open work is entirely on precompiled surfaces** (#3504, #2460, #3825), so adopting MS's
+proxy would cover only source-compiled pages while `MockTestPage` + `RunnerPageInstance` stay
+in full for the precompiled path — strictly more code, two behaviours to keep consistent, and
+divergent AL-observable messages. That is the measured basis on which the shim stands.
+
+## What is still unproven
+
+- Whether the `Editable`/`Enabled` dominating-value resolution could be reused for
+  **source-compiled** pages alone. It works there (BC evaluated a page-variable-backed AL
+  expression and changed its answer), but see the paragraph above on why partial adoption
+  is a net loss.
+- Every field answered `Editable=False` on the source-compiled page including one declared
+  editable, consistent with `RuntimeEditable=False` in View mode but not confirmed in Edit
+  mode.
+- A write succeeded on a field declared `Editable = false`. Unresolved.
+
+## Reproducing the load measurement
+
+The load half of this page is a dozen lines: install a `Resolving` handler that probes the
+artifact directory by filename, `Assembly.LoadFrom` Ncl to get its identity, then run BC's
+own concatenation — `"Microsoft.Dynamics.Nav.Client.TestPageClient" + fullName.Substring(fullName.IndexOf(','))`
+— through `Assembly.Load`, and call `GetType("…TestPageClientSession", throwOnError: true)`.
+Pointing it at a directory missing `Framework.UI.dll` reproduces the
+`FileNotFoundException` that BC swallows.

--- a/docs/testpageclient-reuse.md
+++ b/docs/testpageclient-reuse.md
@@ -50,6 +50,29 @@ as a diagnosis, and the diagnosis was written into the comments.
 **A strong-name mismatch, a missing transitive dependency, and a genuine absence are three
 different answers with three different remedies.** Here it was the second, never the third.
 
+### The transferable lesson: an exception's NAME is not a measurement
+
+This is the part worth carrying to other surfaces, more than anything specific to this DLL.
+Those four lines are the entire causal chain of #3799:
+
+1. a measurement **failed to happen** (the type could not be reached),
+2. the failure was **swallowed** (`catch (FileNotFoundException) { }`),
+3. what surfaced instead was a **name asserting a negative result** —
+   `NavTestTestClientNotInstalledException`,
+4. a reader took the name for a finding and **wrote it down as fact**, after which every
+   later reader had a documented reason not to look again.
+
+That is exactly the shape `.claude/rules/guards-need-a-third-state.md` governs: *I could not
+measure* was reported as *I measured, and the answer is no*. The third state was spelled as
+the negative one, and a negative is the answer that ends an investigation.
+
+The rule is written for guards this repository writes. The trap here is that the collapsing
+guard was **BC's**, in a precompiled DLL we may not rewrite
+(`.claude/rules/precompiled-dll-respect.md`) — so the third state cannot be restored at the
+source. It has to be restored by the reader: when a BC exception name asserts a negative,
+treat it as *the measurement did not complete* and go find out which of the causes it was.
+Reproducing the load in isolation (below) takes minutes and distinguishes all three.
+
 ## What was measured
 
 Driving BC's exact `Assembly.Load` string under the runner's own resolver shape

--- a/docs/testpageclient-reuse.md
+++ b/docs/testpageclient-reuse.md
@@ -87,10 +87,30 @@ from the artifact directory by filename probe):
 | 28.4.53241.54346 | present | **OK**, `Version=28.0.0.0` | resolves, 6 args |
 
 Strong-name binding was never the problem — the requested and actual identities match
-exactly. `TestPageClient.dll` is present in all nine provisioned artifact directories
-(27.0, 27.3, 27.5 ×2, 28.0, 28.1, 28.2, 28.3, 28.4).
+exactly.
 
-### The one failure, and it is a provisioning artifact
+**Stated as a dated measurement, because an artifact cache changes under you.** On
+2026-09-11, this machine held **twelve service-tier artifact directories** — a directory
+counts as one when it carries `Microsoft.Dynamics.Nav.Ncl.dll`, which is what makes it the
+kind of directory this claim is about — and **every one of the twelve carried
+`TestPageClient.dll`**: 27.0, 27.3, 27.5 ×2, 28.0, 28.1 ×2, 28.2, 28.3, 28.4 ×3.
+
+A count is a snapshot; the next `al-runner provision` changes it. **The durable claim is not
+the number but the absence of a counter-example**: no service-tier directory has yet been
+found without the DLL. Re-run the recipe at the end of this page rather than trusting the
+figure — and if you find one that lacks it, that is a real finding and this page is wrong.
+
+The duplicates are load-bearing twice over. `27.5` appears twice because one of those two
+directories is the incomplete one below, which is the whole finding. And the `28.0` pair is
+the trap: only one of them is a service-tier directory at all.
+
+> **A directory under `artifacts/` is not necessarily a service tier.** On the same day,
+> `28.0.46665.54452` held **zero DLLs** — one entry, `platform-apps/`. It has no `Ncl.dll`,
+> so it is a different artifact kind, and it neither has nor should have `TestPageClient.dll`.
+> Counting it would manufacture a counter-example out of a directory the claim was never
+> about. Filter on `Ncl.dll` before counting, which is exactly what the twelve above does.
+
+### The one real failure, and it is a provisioning artifact
 
 `27.5.46862.48827` loads the assembly but `GetType(..., throwOnError: true)` fails:
 
@@ -100,9 +120,15 @@ FileNotFoundException: Could not load file or assembly
 ```
 
 That directory is missing `Microsoft.Dynamics.Framework.UI.dll`; its sibling
-`27.5.46862.53931` has it, as do the other eight. So this is an incomplete artifact
-directory, not a version-shape difference — and it is precisely the **missing transitive
-dependency** case BC's `catch (FileNotFoundException)` converts into "not installed".
+`27.5.46862.53931` has it, as did every other service-tier directory measured on 2026-09-11.
+It is also visibly truncated — **82 DLLs against the 501 a complete extraction carries** — so
+this is an incomplete artifact directory, not a version-shape difference, and it is precisely
+the **missing transitive dependency** case BC's `catch (FileNotFoundException)` converts into
+"not installed".
+
+The DLL-count asymmetry is the cheap way to recognise the state: a directory with `Ncl.dll`
+but far fewer than ~500 DLLs is partially extracted, and BC will report whatever is missing
+from it under a name that sounds like a verdict about the product.
 
 ## Why reuse still does not follow
 
@@ -154,3 +180,24 @@ own concatenation — `"Microsoft.Dynamics.Nav.Client.TestPageClient" + fullName
 — through `Assembly.Load`, and call `GetType("…TestPageClientSession", throwOnError: true)`.
 Pointing it at a directory missing `Framework.UI.dll` reproduces the
 `FileNotFoundException` that BC swallows.
+
+**Re-measuring the presence figure takes one command**, and it filters on `Ncl.dll` so a
+`platform-apps` directory cannot become a false counter-example:
+
+```bash
+cd ~/.local/share/al-runner/artifacts
+for v in */; do v=${v%/}
+  [ -f "$v/Microsoft.Dynamics.Nav.Ncl.dll" ] || continue      # service-tier dirs only
+  printf '%-22s TestPageClient=%s FrameworkUI=%s dlls=%s\n' "$v" \
+    "$([ -f "$v/Microsoft.Dynamics.Nav.Client.TestPageClient.dll" ] && echo yes || echo NO)" \
+    "$([ -f "$v/Microsoft.Dynamics.Framework.UI.dll" ] && echo yes || echo NO)" \
+    "$(ls "$v"/*.dll 2>/dev/null | wc -l)"
+done
+```
+
+A `TestPageClient=NO` row on a directory that has `Ncl.dll` contradicts this page. A
+`FrameworkUI=NO` row with a low `dlls=` count is the incomplete-extraction state above, not a
+finding about BC.
+
+`AlRunner.Tests/TestPageClientPresenceTests.cs` asserts the same thing against whichever
+artifact directory the runner selects, so the claim fails a test rather than merely aging.

--- a/tools/test_matrix_docs_drift.py
+++ b/tools/test_matrix_docs_drift.py
@@ -144,6 +144,21 @@ NOT_A_MATRIX_CLAIM = [
     ("docs/incidents/precompiled-dll-respect.md", "27.0 27.5 28.1 28.4",
      "the same historical observation as the rule it documents -- which artifact "
      "directories were checked for TestPageClient.dll and Framework.UI.dll (#3799)"),
+    # The two halves of one sentence enumerating the ARTIFACT DIRECTORIES provisioned on
+    # the machine that measured whether TestPageClient.dll ships (#3799). Not a leg set and
+    # not expressible as one: the same sentence counts 27.5 TWICE, because two directories
+    # of that minor were provisioned and one of them (27.5.46862.48827) is missing
+    # Framework.UI.dll -- which is the whole finding, since that is the
+    # missing-transitive-dependency case BC's `catch (FileNotFoundException)` converts into
+    # "test client not installed". Rewriting either half into a matrix set would delete the
+    # evidence the sentence exists to carry.
+    ("docs/testpageclient-reuse.md", "27.0 27.3 27.5",
+     "the 27.x artifact directories provisioned on the machine that checked whether "
+     "TestPageClient.dll ships -- a historical observation of where the DLL was found, "
+     "not a claim about which legs any workflow runs (#3799)"),
+    ("docs/testpageclient-reuse.md", "28.0 28.1 28.2 28.3 28.4",
+     "the 28.x half of the same historical observation -- which artifact directories were "
+     "present at measurement time, not the matrix (#3799)"),
     ("docs/upstream-corpus-workflow.md", "27.1 27.2 27.4",
      "the 27 minors the corpus does NOT run; naming the gap is the point of the sentence"),
     ("docs/virtual-tables-allobj.md", "27.0 27.3 27.5 28.2 28.3",

--- a/tools/test_matrix_docs_drift.py
+++ b/tools/test_matrix_docs_drift.py
@@ -156,9 +156,11 @@ NOT_A_MATRIX_CLAIM = [
      "the 27.x artifact directories provisioned on the machine that checked whether "
      "TestPageClient.dll ships -- a historical observation of where the DLL was found, "
      "not a claim about which legs any workflow runs (#3799)"),
-    ("docs/testpageclient-reuse.md", "28.0 28.1 28.2 28.3 28.4",
-     "the 28.x half of the same historical observation -- which artifact directories were "
-     "present at measurement time, not the matrix (#3799)"),
+    ("docs/testpageclient-reuse.md", "28.2 28.3 28.4",
+     "the tail of the same dated enumeration. The sentence reads '28.0, 28.1 x2, 28.2, "
+     "28.3, 28.4 x3', so the multiplicity markers break it into runs and only this one "
+     "scans as a version list -- which is itself the tell that it is a directory census "
+     "and not a leg set (#3799)"),
     ("docs/upstream-corpus-workflow.md", "27.1 27.2 27.4",
      "the 27 minors the corpus does NOT run; naming the gap is the point of the sentence"),
     ("docs/virtual-tables-allobj.md", "27.0 27.3 27.5 28.2 28.3",


### PR DESCRIPTION
Closes #3799

Corpus-NA: comment and docs correction plus a C# artifact-presence test; zero non-comment lines change in the gated files, so nothing the AL compiler or runtime observes differs and no corpus test could distinguish before from after.

Item 1 of the issue (the `Reuse before you re-implement` rule section) landed earlier and is not touched here. This is items **2 and 3**.

## Item 2 — the false comments, corrected

Two comments recorded `Microsoft.Dynamics.Nav.Client.TestPageClient.dll` as absent. I confirmed the count is exactly two in production code by searching the phrasings independently (`not present in the runner`, `does not exist in the runner`, and six more spellings); the other hits are unrelated surfaces (Ncl.dll shipping, out-of-scope APIs) or this issue's own history in `docs/incidents/`.

| file | claim | status |
|---|---|---|
| `AlRunner/Patches/RunnerTestClientSession.cs:9` | "the TestPageClient, which does not exist in the runner" | **false** |
| `AlRunner/Infrastructure/NclCecilRewrite.Forms.cs:618` | "tries to load … TestPageClient — not present in the runner" | **false, twice over** |

The second is wrong about the *mechanism* as well as about presence: `TestClientProxy<T>.Proxy` does not load that assembly at all. It is a `System.Reflection.DispatchProxy` defined in `Microsoft.Dynamics.Nav.Types.dll`, and that assembly contains **no** `"Microsoft.Dynamics.Nav.Client.TestPageClient"` string literal. The real reason the Cecil rewrite strips the call is that the dispatcher needs an initialized `UISessionManager` — which is exactly what the two *neighbouring* comments in the same file (steps 3 and 4, lines ~829 and ~864) have said all along. One comment in that file disagreed with its own neighbours, and it was the wrong one.

Both now state the measured reason the parallel implementation exists.

## Item 3 — the spike

The spike itself was completed on the issue by `stma-auto-2` across three comments; I did not re-derive it. What I added is the part that was still open — **the swallowed load failure's actual exception** — and independent confirmation of the disk facts.

**Does `TestPageClient` initialize headless? Yes**, and the earlier spike drove it to real discriminating booleans. **But reuse still does not follow**, for a reason that has nothing to do with presence — see below.

### The swallowed failure, from BC's own body

`NavTestExecution.CreateTestClientSession` (decompiled, 28.1):

```csharp
try {
    string fullName = Assembly.GetExecutingAssembly().FullName;
    Assembly assembly = Assembly.Load("Microsoft.Dynamics.Nav.Client.TestPageClient"
                                      + fullName.Substring(fullName.IndexOf(',')));
    ...
}
catch (FileNotFoundException) { }
throw new NavTestTestClientNotInstalledException();
```

It catches `FileNotFoundException` **only**, then throws an exception whose *name* asserts the client is not installed. **That is the mechanism by which the false comment got written**: the exception name was read as a diagnosis. A strong-name mismatch, a missing transitive dependency and a genuine absence are three different answers with three different remedies, and BC collapses all of them into the third.

Here it is the **second**, never the third.

### Measured, by executing BC's exact load

| BC version | DLL present | `Assembly.Load` | `TestPageClientSession.Create` |
|---|---|---|---|
| 27.0.38460.53934 | yes | **OK** `Version=27.0.0.0, PKT=31bf3856ad364e35` | resolves, 6 args |
| 27.5.46862.53931 | yes | OK | resolves |
| 28.1.49838.53910 | yes | **OK** `Version=28.0.0.0` | resolves, 6 args |
| 28.4.53241.54346 | yes | **OK** `Version=28.0.0.0` | resolves, 6 args |

Strong-name binding was never the problem — requested and actual identities match exactly. The DLL is present in **all nine** provisioned artifact directories.

**The one failure is a provisioning artifact, and it is the smoking gun.** `27.5.46862.48827` loads the assembly but `GetType(…, throwOnError: true)` throws:

```
FileNotFoundException: Could not load file or assembly
  'Microsoft.Dynamics.Framework.UI, Version=27.0.0.0, PublicKeyToken=31bf3856ad364e35'
```

That directory is missing `Framework.UI.dll`; its sibling `27.5.46862.53931` has it, as do the other eight. So it is an incomplete artifact directory — and it is precisely the missing-transitive-dependency case BC's `catch (FileNotFoundException)` converts into "not installed". I reproduced the original swallowed failure and it is not an absence.

### Why the shim stands anyway

`TestPageProxy.GetField(id)` searches the control tree **by name** and returns `null` when nothing matches; `TestFieldProxy` holds a `LogicalControl`, never a record; there is no record-side fallback in the assembly. For a precompiled page the runner deliberately synthesizes no control tree — `DependencyPageMetadataXml.cs`'s own header says so and gives the reason. So MS's proxy builds chrome and answers `null` for every field there, and the open work (#3504, #2460, #3825) is entirely on precompiled surfaces. That is a far stronger justification than the false one.

**I did not touch `RunnerPageInstance`, did not attempt the replacement, and weakened nothing** — per the issue's scope discipline.

## RED → GREEN

`AlRunner.Tests/TestPageClientPresenceTests.cs`, 3 tests. The `require-tests` gate needs a runner-side mechanism test, and a comment cannot fail — this can.

- **GREEN**: 3 passed, 0 skipped, against real artifacts. Run twice (33 ms, then 64 ms); stable.
- **RED, proving they are not vacuous**: pointed at an artifact directory with `TestPageClient.dll` removed, the presence test **fails** with its diagnostic and the load test **skips** — `Failed: 1, Passed: 1, Skipped: 1`.
- **Third-state check**: with `TestPageClient.dll` present but `Framework.UI.dll` missing, presence **passes** and the load test **skips** rather than reporting a false failure — the exact discrimination BC's `catch` collapses, kept separate here (`guards-need-a-third-state.md`).

### Wider targeted run

`--filter "FullyQualifiedName~TestPageClient|FullyQualifiedName~TestPageViewEditActionBinding|FullyQualifiedName~LiveTestPagePageTypeKnown"`, Release, with `engine.runsettings`, re-run after the waiver commit:

```
Passed!  - Failed:     0, Passed:    35, Skipped:     0, Total:    35, Duration: 220 ms
Passed!  - Failed:     0, Passed:    35, Skipped:     0, Total:    35, Duration: 224 ms
```

`Skipped: 0` on both, quoted from the second run — nothing passed by not running. `tools/test_matrix_docs_drift.py`, `tools/test_doc_pointers.py`, every `tools/test_*.py` and every `.github/scripts/test_*.sh` also pass locally (0 failing).

One thing worth recording for the next person, since it cost me a detour. Without the in-process engine bootstrap those same 11 `TestPageViewEditActionBindingTests` **fail** rather than skip — deliberately, per #3078/#3835, because a silent skip once invalidated a real RED baseline. I verified against a pristine `origin/main` worktree that all 11 fail there identically with my changes absent, so they were never mine; `tools/engine-test-bootstrap.sh` plus `--settings engine.runsettings` turns all 35 green. Re-run that script after every build.

## Follow-up: the `tools/ unit tests` RED, and why the fix is a waiver

The first push went red on `test_matrix_docs_drift.py`. Line 68 of the new doc —
*"present in all nine provisioned artifact directories (27.0, 27.3, 27.5 ×2, 28.0, …)"* —
was read as two BC version claims, `{27.0 27.3 27.5}` and `{28.0 28.1 28.2 28.3 28.4}`,
neither of which is a set the version files define.

**I took the waiver, not the reword**, and the reason is stronger than "keep the evidence":
the sentence is *not expressible* as a leg set. It counts **27.5 twice**, because two
directories of that minor were provisioned and one of them — `27.5.46862.48827` — is the one
missing `Framework.UI.dll`. That duplicate is the finding, so any rewording into a matrix set
would delete the evidence the sentence exists to carry. Two entries added to
`NOT_A_MATRIX_CLAIM`, each with its reason, following the shape of the three #3799 entries
already there.

Both waivers match live text, so `the NotAMatrixClaim allowlist has no dead entries` passes at
10 entries — a waiver that matched nothing would itself fail that check.

Re-read after pushing, as asked, rather than assuming that was the only failure: **9/9 required
checks complete, 0 failing**; only `BC test matrix passed` had yet to enter the rollup. `main`
floor GREEN.

## Follow-up 2: the doc stated a count that had already drifted

The coordinator caught that the doc said *"all nine provisioned artifact directories"* in the
present tense while the box now holds 13 entries — a stale presence claim, in a PR about a
stale presence claim. Fixed by **dating the measurement**, which is what the document's own
argument calls for: a snapshot written in the present tense is exactly how *"not present in the
runner"* became durable in the first place.

Re-measuring turned up two things the old sentence would have gotten wrong, and both are now
in the doc:

- **`28.0.46665.54452` holds zero DLLs** — a single `platform-apps/` entry, no `Ncl.dll`. It is
  not a service-tier directory at all, so it neither has nor should have `TestPageClient.dll`.
  Counting it would have manufactured a counter-example out of a directory the claim was never
  about. The census now filters on `Ncl.dll`: **twelve service-tier directories on 2026-09-11,
  all twelve carrying the DLL.**
- **`27.5.46862.48827` carries 82 DLLs against the 501** a complete extraction has. That
  asymmetry is the cheap way to recognise the partial-extraction state that produces the
  swallowed `FileNotFoundException`, so it is now stated as the recognition signal rather than
  left as a bare fact about one directory.

**The durable claim is now the absence of a counter-example, not the number** — no service-tier
directory has yet been found without the DLL — plus a one-command recipe to re-measure, and a
note that `TestPageClientPresenceTests` asserts it so the claim **fails a test rather than
merely aging**. The 27.5 duplicate stays visible; it is load-bearing.

**The waiver trap fired, as predicted.** Adding the `×2` / `×3` multiplicity markers broke the
28.x version run into pieces, so the waiver string `28.0 28.1 28.2 28.3 28.4` matched nothing
and `the NotAMatrixClaim allowlist has no dead entries` failed — the exact failure mode I
flagged when adding it. Updated to `28.2 28.3 28.4`, the run that now scans, with a reason
noting that the markers breaking it up *is itself* the tell that this is a directory census
rather than a leg set. Both waivers live again: 10 entries, none dead.

## The transferable lesson is now in the doc

At the coordinator's request, `docs/testpageclient-reuse.md` now states the mechanism
explicitly rather than leaving it implicit in the quoted BC source — it is the part that
generalizes beyond this DLL:

1. a measurement **failed to happen** (the type could not be reached),
2. the failure was **swallowed** (`catch (FileNotFoundException) { }`),
3. what surfaced was a **name asserting a negative result** — `NavTestTestClientNotInstalledException`,
4. a reader took the name for a finding and **wrote it down as fact**, after which every later
   reader had a documented reason not to look again.

That is `guards-need-a-third-state.md`'s shape — *could not measure* reported as *measured, and
the answer is no*. With one twist worth writing down: the collapsing guard is **BC's**, inside a
precompiled DLL `precompiled-dll-respect.md` forbids rewriting, so the third state cannot be
restored at the source. It has to be restored by the reader.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** Searched eight phrasings across the repo. Exactly two in production code, both fixed. Two further mentions are in `docs/incidents/precompiled-dll-respect.md`, where they are quoted *as* the historical error and are correct as history — deliberately left.
2. **Sibling making the same assumption?** Yes, and this is the useful find: `NclCecilRewrite.Forms.cs` already contained two *correct* statements of the reason at lines ~829 and ~864. The defect was one comment disagreeing with its neighbours, not a uniformly held belief. `DependencyPageMetadataXml.cs`'s header is also correct and needed no change.
3. **Two paths writing the same state with different invariants?** Not applicable — no state is written. The analogous asymmetry is BC's own: `CreateTestClientSession` catches only `FileNotFoundException`, so three distinct causes surface under one name. That is in a precompiled DLL and not ours to rewrite; it is now documented so the next reader is not misled by it.

## Queue scan

Searched open issues for `TestPageClient`, `NclCecilRewrite.Forms`, `RunnerPageInstance` and `not present in the runner`. **Nothing folds** — no open issue reports these comments. Adjacent but distinct, left alone: #3803 (`Framework.UI` P/Invoke resolver, filed by the earlier spike), #3825 (expression-bound properties on precompiled pages), #3504/#2460 (the precompiled surfaces that a successful reuse would have helped), #3491/#3801 (same "Microsoft already ships this" shape, different components).

## Where the prose went

The derivation — the measurement tables, BC's decompiled body, the reproduction recipe — is in **`docs/testpageclient-reuse.md`**, with a one-line pointer from the code, per `loud-failures.md`. The code comments keep claim + citation + trap. `tools/test_doc_pointers.py` passes, so the pointer resolves.

*Implemented by an agent (`stma-auto-12`) acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
