### PR TITLE
fix(diagnostics): the missing-codeunit message names --package-cache, not a v1 bucket stub

### DIFF
--- a/AlRunner.Tests/MissingCodeunitDependencyTableTests.cs
+++ b/AlRunner.Tests/MissingCodeunitDependencyTableTests.cs
@@ -7,11 +7,18 @@
 //
 // HOW THE CORRECT VALUES WERE ESTABLISHED
 //   Every Microsoft .app in ~/.al-runner/test-apps and ~/.al-runner/platform-apps was opened
-//   (a BC .app is a NAVX-prefixed zip, and the runtime packages nest a second .app carrying
-//   src/*.al), and the `codeunit <id> <name>` declarations were read out of the AL sources —
-//   113 app files, 12,540 .al sources, BC 28.1.49838.53910. SymbolReference.json alone is NOT
-//   sufficient: the runtime platform apps ship without one, which is why a symbols-only sweep
-//   returned "not found" for 310/130000/130440/131000 and would have read as a finding.
+//   (a BC .app is a NAVX-prefixed zip) and the `codeunit <id> <name>` declarations were read
+//   out of both SymbolReference.json and the AL sources — 113 app files, BC 28.1.49838.53910.
+//   The two sources agree on all six ids.
+//
+//   THE TRAP, because the first sweep here fell into it and its zero looked like a finding:
+//   the four R2R runtime packages — Application Test Library, Base Application, Business
+//   Foundation, System Application — NEST a second .app inside, and their SymbolReference.json
+//   lives in that inner one. All 113 apps carry a SymbolReference.json; none is missing it. A
+//   sweep that opens only the outer zip therefore sees 109 of 113, silently skips exactly those
+//   four, and answers "not found" for 310/130000/130440/131000 — which is precisely the set
+//   those four packages hold. The zero is a property of the sweep, not of the packages.
+//   Recurse into nested .app entries, and confirm the app count you scanned.
 //
 //   The measured answers, and what the table used to claim:
 //
@@ -27,12 +34,12 @@
 //
 //   130440 and 130500 are the pair #3399 flagged: docs/limitations.md had named them
 //   Library - Random and Any before that entry was removed, and the doc was right on both.
-//   Test Runner's codeunits are 130450-1304xx (Microsoft_Test Runner.app), not 130500.
+//   Test Runner's codeunits are 130450-130471 (Microsoft_Test Runner.app), not 130500.
 //   Library - Variable Storage is 131004 (Microsoft_Library Variable Storage.app), not 130440.
 //
-//   Cross-checked on BC 28.4.53241.54447, whose artifact set carries only test-apps: the two
-//   ids it can see, 130002 and 130500, agree. The other four are unmeasurable there — which
-//   is an absence of measurement, not a disagreement.
+//   Cross-checked on BC 28.4.53241.54447 with the same nested-aware reader: that artifact set
+//   carries only test-apps, so the two ids it can see — 130002 and 130500 — agree, and the
+//   other four are absent from it. That absence is a missing measurement, not a disagreement.
 //
 // WHY PIN IT HERE rather than re-read the packages at test time: the packages are not present
 // on every box that runs the unit suite, and a test that silently skips when they are missing

--- a/AlRunner.Tests/MissingCodeunitDependencyTableTests.cs
+++ b/AlRunner.Tests/MissingCodeunitDependencyTableTests.cs
@@ -9,8 +9,9 @@
 //   Every Microsoft .app in ~/.al-runner/test-apps and ~/.al-runner/platform-apps was opened
 //   (a BC .app is a NAVX-prefixed zip) and the `codeunit <id> <name>` declarations were read
 //   out of both SymbolReference.json and the AL sources — 113 app files, BC 28.1.49838.53910.
-//   Where both answer they agree exactly, on all six ids; the trap below is about making
-//   symbols answer at all.
+//   BOTH instruments answer all six ids, and they agree on every one — same name, no
+//   disagreement anywhere. The trap below is not that symbols come up short; it is that a
+//   symbols reader missing either recursion silently answers a SUBSET.
 //
 //   THE TRAP: reaching these ids needs TWO INDEPENDENT RECURSIONS, and implementing one
 //   without the other answers a strict subset while looking like a complete result. All 113
@@ -37,11 +38,15 @@
 //
 //   So neither shape is the rule, and neither axis alone is a safe default.
 //
-//   Both were implemented separately while establishing this table, and each looked right:
-//   one found three ids, the other found two, and only doing both finds six. Check the app
-//   count you scanned AND that you descended Namespaces; a zero from either is a property of
-//   the reader. Reading the `codeunit <id> <name>` declarations out of the .al sources needs
-//   neither recursion to be got right, which is why it was used as the independent check.
+//   Both single-axis readers were written while establishing this table, and each looked
+//   right: one found three ids, the other two, and only doing both finds six. So check the
+//   app count you scanned AND that you descended Namespaces — a zero from either is a
+//   property of the reader, not of the packages, and it arrives in the shape of a result.
+//
+//   WHY THE .al READ IS THE CHECK: it needs neither recursion got right. A second symbols
+//   reader would have shared both failure modes with the first, and a check that shares a
+//   failure mode with the thing it checks is not a check — it agrees for the same reason it
+//   is wrong.
 //
 //   The measured answers, and what the table used to claim:
 //

--- a/AlRunner.Tests/MissingCodeunitDependencyTableTests.cs
+++ b/AlRunner.Tests/MissingCodeunitDependencyTableTests.cs
@@ -1,0 +1,97 @@
+// MissingCodeunitDependencyTableTests — the second half of #3399.
+//
+// _knownDependencyCodeunits maps a well-known codeunit id to the name and package
+// BuildMissingCodeunitMessage prints. Nothing checked it against the shipped packages, and
+// four of its six rows were wrong — a table whose whole job is to tell a user which .app to
+// go and find.
+//
+// HOW THE CORRECT VALUES WERE ESTABLISHED
+//   Every Microsoft .app in ~/.al-runner/test-apps and ~/.al-runner/platform-apps was opened
+//   (a BC .app is a NAVX-prefixed zip, and the runtime packages nest a second .app carrying
+//   src/*.al), and the `codeunit <id> <name>` declarations were read out of the AL sources —
+//   113 app files, 12,540 .al sources, BC 28.1.49838.53910. SymbolReference.json alone is NOT
+//   sufficient: the runtime platform apps ship without one, which is why a symbols-only sweep
+//   returned "not found" for 310/130000/130440/131000 and would have read as a finding.
+//
+//   The measured answers, and what the table used to claim:
+//
+//     id      measured name             measured package            table said
+//     310     No. Series                Business Foundation         "Base Application"      WRONG package
+//     130000  Assert                    Application Test Library    "Library Assert (…)"    WRONG package
+//     130002  Library Assert            Library Assert              Library Assert          correct
+//     130440  Library - Random          Application Test Library    "Library Variable
+//                                                                    Storage"               WRONG name+package
+//     130500  Any                       Any                         "Test Runner"           WRONG name+package
+//     131000  Library - Utility         Application Test Library    "Library - Test
+//                                                                    Initialize"            WRONG name+package
+//
+//   130440 and 130500 are the pair #3399 flagged: docs/limitations.md had named them
+//   Library - Random and Any before that entry was removed, and the doc was right on both.
+//   Test Runner's codeunits are 130450-1304xx (Microsoft_Test Runner.app), not 130500.
+//   Library - Variable Storage is 131004 (Microsoft_Library Variable Storage.app), not 130440.
+//
+//   Cross-checked on BC 28.4.53241.54447, whose artifact set carries only test-apps: the two
+//   ids it can see, 130002 and 130500, agree. The other four are unmeasurable there — which
+//   is an absence of measurement, not a disagreement.
+//
+// WHY PIN IT HERE rather than re-read the packages at test time: the packages are not present
+// on every box that runs the unit suite, and a test that silently skips when they are missing
+// asserts nothing. This pins the measurement; a BC version that genuinely moves one of these
+// ids should fail here and be re-measured.
+
+using System.Collections.Generic;
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class MissingCodeunitDependencyTableTests
+{
+    /// <summary>
+    /// id → (name, the package the id actually ships in), measured as described above.
+    /// </summary>
+    public static TheoryData<int, string, string> Measured => new()
+    {
+        { 310,    "No. Series",       "Business Foundation" },
+        { 130000, "Assert",           "Application Test Library" },
+        { 130002, "Library Assert",   "Library Assert" },
+        { 130440, "Library - Random", "Application Test Library" },
+        { 130500, "Any",              "Any" },
+        { 131000, "Library - Utility","Application Test Library" },
+    };
+
+    [Theory]
+    [MemberData(nameof(Measured))]
+    public void TableRow_MatchesTheShippedPackage(int id, string name, string package)
+    {
+        var table = BcRuntime.KnownDependencyCodeunitsForTests;
+
+        Assert.True(table.ContainsKey(id), $"codeunit {id} ({name}) is missing from _knownDependencyCodeunits");
+        Assert.Equal(name, table[id].Name);
+        Assert.Equal(package, table[id].Package);
+    }
+
+    [Fact]
+    public void Table_CarriesNoRowThatWasNotMeasured()
+    {
+        // A row nobody measured is the defect #3399 reported, one row later. Adding one means
+        // measuring it and extending Measured above.
+        var measured = new HashSet<int>();
+        foreach (var row in Measured) measured.Add((int)row[0]);
+
+        foreach (var id in BcRuntime.KnownDependencyCodeunitsForTests.Keys)
+            Assert.True(measured.Contains(id),
+                $"codeunit {id} was added to _knownDependencyCodeunits without a measured row here");
+    }
+
+    [Fact]
+    public void NoRow_ClaimsAnIdThatBelongsToADifferentToolkitApp()
+    {
+        var table = BcRuntime.KnownDependencyCodeunitsForTests;
+
+        // The two specific inversions #3399 asked about, pinned by the thing that makes them
+        // wrong rather than only by the corrected value.
+        Assert.DoesNotContain("Test Runner", table[130500].Name);      // 130500 is Any; Test Runner starts at 130450
+        Assert.DoesNotContain("Variable Storage", table[130440].Name); // Library - Variable Storage is 131004
+    }
+}

--- a/AlRunner.Tests/MissingCodeunitDependencyTableTests.cs
+++ b/AlRunner.Tests/MissingCodeunitDependencyTableTests.cs
@@ -9,16 +9,39 @@
 //   Every Microsoft .app in ~/.al-runner/test-apps and ~/.al-runner/platform-apps was opened
 //   (a BC .app is a NAVX-prefixed zip) and the `codeunit <id> <name>` declarations were read
 //   out of both SymbolReference.json and the AL sources — 113 app files, BC 28.1.49838.53910.
-//   The two sources agree on all six ids.
+//   Where both answer they agree exactly, on all six ids; the trap below is about making
+//   symbols answer at all.
 //
-//   THE TRAP, because the first sweep here fell into it and its zero looked like a finding:
-//   the four R2R runtime packages — Application Test Library, Base Application, Business
-//   Foundation, System Application — NEST a second .app inside, and their SymbolReference.json
-//   lives in that inner one. All 113 apps carry a SymbolReference.json; none is missing it. A
-//   sweep that opens only the outer zip therefore sees 109 of 113, silently skips exactly those
-//   four, and answers "not found" for 310/130000/130440/131000 — which is precisely the set
-//   those four packages hold. The zero is a property of the sweep, not of the packages.
-//   Recurse into nested .app entries, and confirm the app count you scanned.
+//   THE TRAP: reaching these ids needs TWO INDEPENDENT RECURSIONS, and implementing one
+//   without the other answers a strict subset while looking like a complete result. All 113
+//   apps carry a SymbolReference.json — none is missing one — so every failure here is the
+//   sweep's, not the packages'. Measured over the 113 apps:
+//
+//     recurse nested .app?  recurse Namespaces?   ids found of the six
+//     no                    no                    none
+//     YES                   no                    130000, 130440, 131000
+//     no                    YES                   130002, 130500
+//     YES                   YES                   all six
+//
+//   The two axes are unrelated, and 310 needs BOTH — which is why it is the only id no
+//   single-axis reader finds. Four apps (Application Test Library, Base Application, Business
+//   Foundation, System Application) NEST a second .app carrying the real SymbolReference.json;
+//   an outer-only sweep sees 109 of 113 and never opens them. Separately, a symbol file may
+//   leave the TOP-LEVEL Codeunits array empty and put objects under Namespaces, so a reader
+//   taking sr["Codeunits"] alone gets nothing from it. Per id:
+//
+//     130002, 130500      outer .app, Namespaces depth 3   -> needs the Namespaces walk
+//     130000, 130440,     nested .app, depth 0 (42 top-    -> needs the .app recursion
+//       131000              level codeunits in that file)
+//     310                 nested .app, Namespaces depth 3  -> needs both
+//
+//   So neither shape is the rule, and neither axis alone is a safe default.
+//
+//   Both were implemented separately while establishing this table, and each looked right:
+//   one found three ids, the other found two, and only doing both finds six. Check the app
+//   count you scanned AND that you descended Namespaces; a zero from either is a property of
+//   the reader. Reading the `codeunit <id> <name>` declarations out of the .al sources needs
+//   neither recursion to be got right, which is why it was used as the independent check.
 //
 //   The measured answers, and what the table used to claim:
 //

--- a/AlRunner.Tests/MissingCodeunitMessageTests.cs
+++ b/AlRunner.Tests/MissingCodeunitMessageTests.cs
@@ -1,0 +1,86 @@
+// MissingCodeunitMessageTests — #3399.
+//
+// BuildMissingCodeunitMessage is the diagnostic a user sees when a codeunit reference
+// resolved at compile time against a Microsoft .app but no runtime DLL for that app is
+// loaded. It told them two things that are false on v2: that "AL Runner does not yet load
+// Microsoft R2R packages at runtime" (loading them IS the architecture — see
+// tests/runner-extras/microsoft-test-library) and to "provide an AL implementation/stub for
+// this codeunit at the bucket level" (there is no bucket layout; that was v1). Both halves
+// direct the reader away from the only fix that works — pointing --package-cache at the
+// directory holding the app — which is why the message is the defect and not just prose.
+//
+// The id table the message reads from was measured against the shipped packages rather than
+// trusted; see MissingCodeunitDependencyTableTests for the ids and the instrument.
+
+using System;
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class MissingCodeunitMessageTests
+{
+    // 130002 is in the table (verified: Microsoft_Library Assert.app); 47111 is not, so the
+    // two arms of BuildMissingCodeunitMessage are both covered.
+    public static TheoryData<int> BothArms => new() { 130002, 47111 };
+
+    [Theory]
+    [MemberData(nameof(BothArms))]
+    public void Message_NamesPackageCacheAsTheRemedy(int id)
+    {
+        var msg = BcRuntime.BuildMissingCodeunitMessageForTests(id);
+
+        // The actionable remedy: the flag a user actually passes, and the fact that it
+        // takes a directory of .app packages. Asserting the flag alone would pass on a
+        // message that merely mentioned it in passing.
+        Assert.Contains("--package-cache", msg);
+        Assert.Contains(".app", msg);
+
+        // The one-command alternative, which ProvisioningCheck already advertises for the
+        // sibling gap. A user with no cache at all cannot act on --package-cache alone.
+        Assert.Contains("al-runner provision", msg);
+    }
+
+    [Theory]
+    [MemberData(nameof(BothArms))]
+    public void Message_DoesNotRepeatTheV1Falsehoods(int id)
+    {
+        var msg = BcRuntime.BuildMissingCodeunitMessageForTests(id);
+
+        // "does not yet load Microsoft R2R packages at runtime" — false; that is the
+        // architecture. Matching on the claim rather than on the word "R2R", so the message
+        // stays free to say truthfully which package failed to load.
+        Assert.DoesNotContain("does not yet load", msg, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("wait until runtime dependency loading lands", msg, StringComparison.OrdinalIgnoreCase);
+
+        // "at the bucket level" — there is no bucket layout on v2.
+        Assert.DoesNotContain("bucket", msg, StringComparison.OrdinalIgnoreCase);
+
+        // Telling the user to hand-write the codeunit is the remedy loud-failures.md and
+        // docs/limitations.md § "Why no real SA implementations" both rule out for a
+        // Microsoft dependency app.
+        Assert.DoesNotContain("implementation/stub", msg, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void KnownId_NamesTheCodeunitAndItsRealPackage()
+    {
+        // 130002 "Library Assert" ships in Microsoft_Library Assert.app — measured, not
+        // assumed. The message must carry both so the reader knows which .app to find.
+        var msg = BcRuntime.BuildMissingCodeunitMessageForTests(130002);
+
+        Assert.Contains("130002", msg);
+        Assert.Contains("Library Assert", msg);
+    }
+
+    [Fact]
+    public void UnknownId_StillNamesTheIdAndTheRemedy()
+    {
+        var msg = BcRuntime.BuildMissingCodeunitMessageForTests(47111);
+
+        Assert.Contains("47111", msg);
+        // No package name is knowable for an unlisted id, so the remedy has to carry the
+        // whole message's weight.
+        Assert.Contains("--package-cache", msg);
+    }
+}

--- a/AlRunner/Patches/CodeunitPatches.cs
+++ b/AlRunner/Patches/CodeunitPatches.cs
@@ -1387,38 +1387,59 @@ public static partial class BcRuntime
     // Well-known codeunit IDs that ship inside Microsoft dependency apps. When the
     // test compile resolves a `Codeunit X` reference against a Microsoft .app at
     // symbol-resolution time but the runtime has no DLL for that .app loaded,
-    // CreateTarget can't find the type. We surface the dependency name instead of
-    // a bare numeric id so the user knows which dependency is missing.
+    // CreateTarget can't find the type. We surface the id's real name and the app it
+    // ships in, so BuildMissingCodeunitMessage can tell the user which .app to put on a
+    // --package-cache directory.
+    //
+    // Package is the app's MANIFEST name, which is what a user matches against a file in
+    // the cache ("Application Test Library" → Microsoft_Application Test Library_<ver>.app).
+    // Every row was measured against the shipped packages for #3399 — four of the six were
+    // wrong, including two that named a different toolkit app entirely. The measurement and
+    // the instrument are in MissingCodeunitDependencyTableTests, which pins each row.
     private static readonly Dictionary<int, (string Name, string Package)> _knownDependencyCodeunits = new()
     {
-        [130000] = ("Assert",                  "Library Assert (test framework)"),
-        [130002] = ("Library Assert",          "Library Assert (test framework)"),
-        [130440] = ("Library Variable Storage","Library Variable Storage (test framework)"),
-        [130500] = ("Test Runner",             "Test Runner (test framework)"),
-        [131000] = ("Library - Test Initialize","Library - Test Initialize (test framework)"),
-        [310]    = ("No. Series",              "Base Application"),
+        [310]    = ("No. Series",        "Business Foundation"),
+        [130000] = ("Assert",            "Application Test Library"),
+        [130002] = ("Library Assert",    "Library Assert"),
+        [130440] = ("Library - Random",  "Application Test Library"),
+        [130500] = ("Any",               "Any"),
+        [131000] = ("Library - Utility", "Application Test Library"),
     };
+
+    /// <summary>Test seam for #3399: the table and the message it produces are the
+    /// user-facing contract, so they are asserted directly rather than through a
+    /// source-text grep. See MissingCodeunitDependencyTableTests.</summary>
+    internal static IReadOnlyDictionary<int, (string Name, string Package)> KnownDependencyCodeunitsForTests
+        => _knownDependencyCodeunits;
+
+    internal static string BuildMissingCodeunitMessageForTests(int id) => BuildMissingCodeunitMessage(id);
 
     private static string BuildMissingCodeunitMessage(int id)
     {
         if (_knownDependencyCodeunits.TryGetValue(id, out var known))
         {
             return
-                $"Codeunit {id} (\"{known.Name}\") is not present in the test " +
-                $"assembly or any loaded dependency. It belongs to {known.Package}, " +
-                $"a Microsoft dependency app. AL Runner does not yet load " +
-                $"Microsoft R2R packages at runtime — either provide an AL " +
-                $"implementation/stub for this codeunit at the bucket level, or " +
-                $"wait until runtime dependency loading lands.";
+                $"Codeunit {id} (\"{known.Name}\") is not present in the test assembly " +
+                $"or any loaded dependency. It ships in Microsoft's '{known.Package}' app, " +
+                $"whose runtime package is not loaded. " +
+                $"Point --package-cache at a directory holding " +
+                $"'Microsoft_{known.Package}*.app' (the test-toolkit apps live in " +
+                $"~/.al-runner/test-apps, the platform apps in ~/.al-runner/platform-apps), " +
+                $"or run 'al-runner provision' — or re-run with --auto-provision — to fetch " +
+                $"them. Note --package-cache may be repeated, and a cache holding only " +
+                $"symbol/dev packages cannot satisfy this: the runtime .app is required.";
         }
         return
-            $"Codeunit {id} is not present in the test assembly or any loaded " +
-            $"dependency. It is most likely defined in a dependency .app " +
-            $"(e.g. System Application, Base Application, a test-framework " +
-            $"library, or a third-party app) whose runtime DLL is not loaded. " +
-            $"AL Runner does not yet load dependency-app DLLs at runtime — " +
-            $"either provide an AL implementation/stub at the bucket level, " +
-            $"or wait until runtime dependency loading lands.";
+            $"Codeunit {id} is not present in the test assembly or any loaded dependency. " +
+            $"It is most likely defined in a dependency .app (System Application, Base " +
+            $"Application, Business Foundation, a test-toolkit library, or a third-party " +
+            $"app) whose runtime package is not loaded. " +
+            $"Check that the app declaring codeunit {id} is listed in your app.json " +
+            $"dependencies, and that --package-cache points at a directory holding its " +
+            $"runtime .app; run 'al-runner provision' — or re-run with --auto-provision — " +
+            $"to fetch Microsoft's. Note --package-cache may be repeated, and a cache " +
+            $"holding only symbol/dev packages cannot satisfy this: the runtime .app is " +
+            $"required.";
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #3399

Corpus-NA: a diagnostic message and an internal id table; no AL-observable behaviour changes, and the corpus cannot express "the message a user sees when a package is absent" because the corpus runs with every package present.

Opened by `stma-auto-11`, an automated implementation agent acting on the account holder's behalf.

## The defect

`BuildMissingCodeunitMessage` told a user two things that are false on v2:

> AL Runner does not yet load Microsoft R2R packages at runtime — either provide an AL implementation/stub for this codeunit at the bucket level, or wait until runtime dependency loading lands.

Loading Microsoft R2R packages **is** the architecture (`tests/runner-extras/microsoft-test-library` invokes the test toolkit), and there is no bucket layout to write a stub in — that was v1. This is the #3799 class: a message that states something false about what the runner does, which then becomes the reader's documented reason not to look further. It is worse than a terse message, because the remedy it names cannot be applied, and the one that works is never mentioned.

## Site count: two, both in this method

The issue named one site; the real count is **two** — both branches of `BuildMissingCodeunitMessage` carried it (the known-id branch and the unknown-id fallback). Both are replaced.

I also checked the one other repo-wide hit for the v1 phrasing, `AlRunner/ProgramSupport/Dependencies.cs:259` ("AL files at the bucket level"). That one **stays**: `bucketRoot` / `SharedDirOf` is live code implementing a real `<bucketRoot>/_shared/` include, and the comment accurately describes what that code does. It is not the v1 stub instruction wearing the same words.

## The new message

Known id:

> Codeunit 130002 ("Library Assert") is not present in the test assembly or any loaded dependency. It ships in Microsoft's 'Library Assert' app, whose runtime package is not loaded. Point --package-cache at a directory holding 'Microsoft_Library Assert*.app' (the test-toolkit apps live in ~/.al-runner/test-apps, the platform apps in ~/.al-runner/platform-apps), or run 'al-runner provision' — or re-run with --auto-provision — to fetch them. Note --package-cache may be repeated, and a cache holding only symbol/dev packages cannot satisfy this: the runtime .app is required.

Every remedy named was verified to exist rather than assumed: `--package-cache` is parsed at `AlRunner/Program.cs:556` and is repeatable (`packageCacheArgs.Add`), `--auto-provision` at `AlRunner/Program.cs:507`, and the two cache directory names are the ones `.github/workflows/bc-tests.yml` passes (lines 686-687). The symbol/dev-package caveat mirrors the sibling gap `ProvisioningCheck.ToDetailedMessage` already reports, which is the failure a user hits next if they point the flag at a symbols directory.

## The id table: measured, and four of six rows were wrong

`_knownDependencyCodeunits` was checked against the shipped packages rather than trusted.

**Instrument.** Every Microsoft `.app` in `~/.al-runner/test-apps` and `~/.al-runner/platform-apps` was opened (a BC `.app` is a NAVX-prefixed zip) and the `codeunit <id> <name>` declarations read out of **both** `SymbolReference.json` and the AL sources — **113 app files, BC 28.1.49838.53910**. The two sources agree on all six ids.

**Two corrections to earlier versions of this body, since this PR exists because a false claim outlived a true one.** Both were settled by re-measuring, not by argument.

*First*, I wrote that "the runtime platform apps ship without a `SymbolReference.json`". **False** — all 113 apps carry one; zero are missing it.

*Second*, I wrote that a nesting-aware symbols read "agrees with the AL sources on all six ids". **That figure is correct and stands** — both instruments answer all six and agree on every one. What it omitted is that "nesting-aware" is only half of what a symbols reader needs: reaching these ids takes **two independent recursions**, and implementing either alone returns a strict subset that looks like a finished answer:

| recurse nested `.app`? | recurse `Namespaces`? | ids found of the six |
|---|---|---|
| no | no | none |
| **yes** | no | 130000, 130440, 131000 |
| no | **yes** | 130002, 130500 |
| **yes** | **yes** | all six |

The two axes are unrelated, and **310 needs both** — it is the only id no single-axis reader finds:

| id | where it sits | axis required |
|---|---|---|
| 130002, 130500 | outer `.app`, `Namespaces` depth 3 | the `Namespaces` walk |
| 130000, 130440, 131000 | nested `.app`, depth 0 (42 top-level codeunits in that file) | the `.app` recursion |
| 310 | nested `.app`, `Namespaces` depth 3 | **both** |

Four apps — Application Test Library, Base Application, Business Foundation, System Application — nest a second `.app` carrying the real symbol file, so an outer-only sweep sees **109 of 113** and never opens them. Separately, a symbol file may leave the top-level `Codeunits` array empty and put objects under `Namespaces`; the inner file in Application Test Library does the opposite, carrying 42 codeunits at depth 0. **Neither shape is the rule, and neither axis alone is a safe default.**

Both single-axis readers were written while establishing this table — one found three ids, the other two — and each looked complete. **Every zero here was a property of the reader, not of the packages**, and each arrived in the shape of a result: `guards-need-a-third-state.md`'s case, where "could not measure" is indistinguishable from "measured, absent" unless the tool says which.

**Both instruments answer all six ids and agree on every one — no disagreement anywhere.** The trap is not that symbols come up short; it is that a symbols reader missing either recursion silently answers a subset.

**Why the `.al` read is the check:** it needs neither recursion got right. A second symbols reader would have shared both failure modes with the first, and a check that shares a failure mode with the thing it checks is not a check — it agrees for the same reason it is wrong.

| id | measured name | measured package | table said | verdict |
|---|---|---|---|---|
| 310 | No. Series | Business Foundation | "Base Application" | wrong package |
| 130000 | Assert | Application Test Library | "Library Assert (test framework)" | wrong package |
| 130002 | Library Assert | Library Assert | "Library Assert (test framework)" | name right, package suffixed |
| 130440 | **Library - Random** | Application Test Library | "Library Variable Storage" | wrong name **and** package |
| 130500 | **Any** | Any | "Test Runner" | wrong name **and** package |
| 131000 | Library - Utility | Application Test Library | "Library - Test Initialize" | wrong name **and** package |

**On the two contested ids #3399 asked about: the removed `docs/limitations.md` entry was right and the code table was wrong.** 130440 is `Library - Random`; `Library - Variable Storage` is **131004** (`Microsoft_Library Variable Storage.app`). 130500 is `Any`; Test Runner's codeunits start at **130450** (`Microsoft_Test Runner.app`, 17 codeunits, 130450-130461+). Neither of the table's claims was off by a near miss — each named a different toolkit app.

Checking the whole table rather than only those two was worth it: four rows were wrong, not two.

**Cross-check.** Re-run on BC 28.4.53241.54447 with the corrected nested-aware reader: that artifact set carries only test-apps, so it sees two of the six ids — 130002 and 130500, both agreeing with 28.1 — and the other four are absent from it. That absence is a missing measurement, not a disagreement.

Two figures the corrected reader also settles: Test Runner's codeunits span **130450-130471** (17 codeunits), so 130500 is well outside it; `Library - Variable Storage` is **131004**.

## RED → GREEN

RED (before the fix): `Failed: 12, Passed: 2, Skipped: 0, Total: 14`. The failures are the defect itself, e.g.

```
Expected: "Library - Random"
Actual:   "Library Variable Storage"
```

GREEN, second run after the build: `Failed: 0, Passed: 14, Skipped: 0, Total: 14`.

### Mutation check

The brief asked that the test prove the message names the **real remedy**, not merely that it changed. Three mutations, each re-run against the same suite:

| mutation | result |
|---|---|
| **A** — replace `--package-cache` with the prose "the package cache" (message still non-empty, still names the codeunit, still free of every v1 falsehood) | **red, 3 failed** |
| **B** — reintroduce the v1 falsehood *while keeping the correct remedy* | **red, 1 failed** |
| **C** — revert only the `130500` row to `("Test Runner", "Test Runner")` | **red, 2 failed** |

A is the one that matters: it is exactly the "changed but useless" outcome a weak assertion would accept, and it fails. Restored to green afterwards and re-verified twice.

## The "Tests updated" gate

The proving tests are runner-side C# (`AlRunner.Tests/`), which is the correct home here and not a concession: the claim is about a message the **runner** emits when a package is absent, not about anything BC does. The corpus runs with every package present, so it cannot reach this code path at all.

## Fix the shape

1. **Same wrong pattern at another call site?** Yes — the issue named one, there were two, and both are fixed. Grepped the whole repo for the shape (`does not yet load`, `at the bucket level`, `runtime dependency loading lands`, `implementation/stub`); the only other hit is the live, accurate `Dependencies.cs:259` comment described above.
2. **Does a sibling function make the same assumption?** `ProvisioningCheck.ToDetailedMessage` is the adjacent "package is missing" diagnostic and is already correct — it names `al-runner provision` and `--auto-provision`. I aligned the new message with its vocabulary rather than inventing a second one, and borrowed its symbol/dev-package caveat, which is the next failure a user hits.
3. **Two code paths writing the same state, one guard?** The two message branches are the instance: both read the same table and both carried the same falsehood, so both now carry the same remedy. The new `Table_CarriesNoRowThatWasNotMeasured` test is the guard that keeps them consistent — a row added to `_knownDependencyCodeunits` without a measured counterpart fails, so the next editor cannot reintroduce an unverified row silently.

**Queue scan.** Searched the open issues for `BuildMissingCodeunitMessage`, `knownDependencyCodeunits`, `package-cache`, `130440`, `130500` and `Library - Random`. Nothing folds in: #3769 and #3812 are both about package-cache *resolution* (which packages register, how the floor is decided), a different file and mechanism, not the diagnostic text.

## Tests run

All figures from a **second** run after the build, with `Skipped:` quoted.

- `--filter FullyQualifiedName~MissingCodeunit` — `Failed: 0, Passed: 14, Skipped: 0, Total: 14`
- `--filter FullyQualifiedName~Codeunit` (the wider surface, 130 tests) — `Failed: 0, Passed: 130, Skipped: 0, Total: 130`

Re-run after each wording correction (comment-only changes, but an unrun figure is worse than none): `Failed: 0, Passed: 14, Skipped: 0, Total: 14`, second run, both times.

One thing worth recording, since it would otherwise read as a regression: the wider sweep first came back `Failed: 23` — every one of them in `< 1 ms` with the #3843 loud refusal, because the in-process BC engine bootstrap had not been run. After `dotnet build -c Release` + `tools/engine-test-bootstrap.sh` + `--settings engine.runsettings`, all 130 pass. None of the 23 were mine; the loud failure did its job, and I am quoting the bootstrapped figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
