### PR TITLE
docs(rules): say why a citation must be right, not only that it must be followable

### DIFF
--- a/.claude/rules/loud-failures.md
+++ b/.claude/rules/loud-failures.md
@@ -91,6 +91,17 @@ be shortened, never for one to be removed, and may never accept a patch that has
 the shortened claim and the `docs/` section disagree, the `docs/` section is the one under
 test, because it is the copy a drift test can check.
 
+**Why the citation must be right even when the claim is: a reviewer can only check the
+account, never the result.** A correct finding reached by a method you have misdescribed is not
+merely at risk of being disbelieved — it is *indistinguishable* from a wrong one, because the
+account is all a checker has to work with. Measured twice on 2026-09-11 (#3399): an agent
+produced the correct answer in round one and could not defend it for three rounds, having
+described the wrong mechanism; and the coordinator's own correction to it was wrong for the
+same reason. Both were settled by re-running the scan, never by argument. So state the method
+you actually used, and when a disagreement persists, re-measure rather than restate — a
+disagreement kept attached to something measurable converges, and one that is not becomes two
+positions.
+
 **Leave the pointer, and pin a load-bearing claim with a drift test.** Prose moved out of the
 code can stop matching it with nothing failing; the pointer is what lets a reader who finds
 the claim find the document, and this repository already has about ten such drift tests

--- a/docs/incidents/loud-failures.md
+++ b/docs/incidents/loud-failures.md
@@ -21,3 +21,38 @@ attributing each comment block by its vocabulary:
 accounts for well under a tenth of what is in these files, and the prose it is embedded in
 accounts for several times more — which is the evidence that the *form*, not the requirement,
 is what needs bounding.
+
+## The account is what gets checked (2026-09-11, #3399)
+
+Four rounds of correction on one claim, none of which moved the finding.
+
+An implementation agent measured six codeunit ids against Microsoft's shipped `.app` files and
+found four of six rows in `_knownDependencyCodeunits` wrong. That result was correct in round
+one and never changed. What changed four times was the stated method.
+
+| round | claim about how the ids were reached | status |
+|---|---|---|
+| 1 | "the runtime platform apps ship without a `SymbolReference.json`" | false — all 113 carry one |
+| 2 | coordinator: "the file is present but its array is empty" | false — true of 5 apps, none holding the missing ids |
+| 3 | agent: "recurse into nested `.app`; symbols then answer all six" | right mechanism, and the figure was right |
+| 4 | coordinator: "symbols answer only three of six" | false — the coordinator's reader lacked the `Namespaces` walk |
+
+The resolution is two **independent** recursion axes — nested `.app` files, and the `Namespaces`
+tree inside a symbol file. Id 310 needs both, so it is invisible to either single-axis reader,
+and a reader who fixes one axis finds five of six and looks complete.
+
+Each party named the axis they had missed and had in fact implemented the other. Neither could
+have found the pair alone: the observation was available only because two parties disagreed with
+different instruments in hand.
+
+Two things this measured, both now in the rule:
+
+- **A right answer with a wrong account is indistinguishable from a wrong answer.** The agent
+  held the correct result for three rounds and could not defend it, because a reviewer can only
+  check the account. The reviewer was behaving correctly at every step.
+- **Re-measuring is what made it converge.** Every round re-ran a scan rather than restating a
+  position. A disagreement kept attached to something measurable converges; one that is not
+  becomes two positions and hardens.
+
+The four wrong rows, the two false-message sites, and the mutation results never moved across
+any round.


### PR DESCRIPTION
## What

One paragraph in `loud-failures.md` § *"The justification is a claim plus a citation"*, saying **why** a citation must be a followable pointer rather than only that it must be. The section already owns citation form, so this is a rationale added where the requirement lives — not a new rule.

> **Why the citation must be right even when the claim is: a reviewer can only check the account, never the result.** A correct finding reached by a method you have misdescribed is not merely at risk of being disbelieved — it is *indistinguishable* from a wrong one, because the account is all a checker has to work with.

Plus the derivation in `docs/incidents/loud-failures.md`, per the repository's split of claim + citation + trap in the rule from the investigation in `docs/incidents/`.

## Why — measured, not asserted

Four rounds of correction on one claim while working #3399, in which **the finding never moved**:

| round | stated method | status |
|---|---|---|
| 1 | agent: "the runtime platform apps ship without a `SymbolReference.json`" | **false** — all 113 carry one |
| 2 | coordinator: "present but the array is empty" | **false** — true of 5 apps, none holding the missing ids |
| 3 | agent: "recurse into nested `.app`; symbols answer all six" | **right** |
| 4 | coordinator: "symbols answer only three of six" | **false** — the coordinator's reader lacked the `Namespaces` walk |

The resolution is **two independent recursion axes**: nested `.app` files, and the `Namespaces` tree inside a symbol file. Id 310 needs both, so it is invisible to either single-axis reader — fix one axis and you find five of six and look complete.

Each party named the axis they had missed and had in fact implemented the other. The pair was findable only because two parties disagreed **with different instruments in hand**.

Two independent instances in one session, which is this repository's own bar for stating a direction: the agent held the *correct* result for three rounds and could not defend it, and the coordinator's correction was wrong the same way. Both were settled by re-running the scan; neither by argument.

## Scope

Documentation only. No code, no behaviour, no test — the claim it makes is about how review works, not about the runner. Asserting on the paragraph's wording would pin phrasing rather than behaviour, which `tdd.md`'s "would this still pass against a default return" test correctly rejects as noise.

Corpus-NA: documentation-only change to an agent operating rule; no AL is compiled, executed or observed, so no corpus test can measure it.

Closes #3854

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
