### PR TITLE
fix(preflight): make the corpus-baseline guards able to fail

### DIFF
--- a/.claude/rules/guards-need-a-third-state.md
+++ b/.claude/rules/guards-need-a-third-state.md
@@ -91,10 +91,20 @@ and conflating the two refused every CI run in the first version of that fix (#3
    never-fire path, which is the defect itself. `pr-gate.yml` discovers `test_*.sh` and
    `tools/test_*.py` siblings by glob, so a correctly-named test gates the day it lands (#3683).
 
-**A guard that is safe only by accident of a neighbour is still on this list** — #3361 part 2
-is one, where a leg summary that lost its `fail` key reads as zero failures. It is not reachable
-as a false pass today, because a `summary.get("pass") != want` comparison a few lines down fails
-loudly on a `None`; it is still written the opposite way from every neighbour in that function.
+**A guard that is safe only by accident of a neighbour is not safe** — and this rule said
+otherwise about its own outstanding instance until #3856 measured it. #3361 part 2, where
+`check_corpus`'s summary lost its `fail` key and read as zero failures, was recorded here as
+unreachable "because a `summary.get("pass") != want` comparison a few lines down fails loudly on
+a `None`". Both halves were wrong: the comparison is against `counted`, the per-bundle PASS
+lines, and on the shape that actually occurs — a summary truncated after `pass:` — `pass` is
+present **and agrees**, so both guards pass and `preflight.py` reports a reproduced baseline for
+a run that never said whether anything failed. Executed on `main`, the truncated summary returned
+PASS (#3856; derivation in the incidents file).
+
+Three independent readers checked that neighbour and all three credited it. **So a neighbour is
+evidence only when you have executed the guard on the input you are claiming it covers** — the
+backstop was real, and simply did not cover the case, which is indistinguishable from covering it
+until something runs it.
 
 ## The same shape one level down
 

--- a/docs/incidents/guards-need-a-third-state.md
+++ b/docs/incidents/guards-need-a-third-state.md
@@ -28,7 +28,7 @@ separately as its own defect.
 | #3351 | `ci-wait.py --timeout 0` — no poll could occur | exit 2, a verdict-shaped non-verdict | **closed**, fixed |
 | #3299 | `SUBMODULE_PATH` matches nothing | exit 0, identical output to a real forward-bump | **open**, fixed in PR #3683 |
 | #3681 | `check_count_baseline_history.sh`'s `PIN_PATH` matches nothing | exit 0, "does not move the pin", on every PR forever | fixed in PR #3683; the script itself went with the corpus pin at #3737 |
-| #3361 (part 2) | a leg summary lost its `fail` key | zero failures | **open** |
+| #3361 (part 2) | a leg summary lost its `fail` key | zero failures — a **live** false green, not the unreachable one three sources recorded | fixed in PR #3856 |
 
 **#3681 is the argument for writing this down.** `check_count_baseline_history.sh` landed on
 `main` the morning of 2026-09-09 (#3666) as a guard against a corpus pin bump that silently
@@ -37,20 +37,45 @@ day at 11:03Z. A guard authored to catch a silent omission reproduced the shape 
 catch, two days after two instances of it had been fixed. Naming the class is what makes the
 fifth instance a lookup instead of a rediscovery.
 
-**#3361 part 2 is the outstanding one**, and its own body records the honest qualifier: that
-spot is currently backstopped by a `summary.get("pass") != want` comparison a few lines down
-where a `None` fails loudly, so it is not reachable as a false pass **today**. It is still
-written the opposite way from every neighbour in that function, where an uncomputable value is
-an explicit refusal rather than a silent zero. A guard that is safe only by accident of a
-neighbour is on this list.
+**#3361 part 2 was the outstanding one, and the qualifier attached to it was false** — fixed and
+corrected by #3856.
+
+Three sources recorded it as unreachable: the issue body, the reviewer's comment on it, and this
+rule. All three credited the same neighbour, a `summary.get("pass")` comparison a few lines below
+the defect, said to fail loudly on a `None`. Two errors compounded:
+
+- the comparison is against **`counted`**, the sum of the per-bundle PASS lines — not a `want`
+  from a baseline, which is what the phrasing implied and what would have made a `None` fail;
+- it never sees a `None` in the shape that occurs. `parse_corpus_run` seeds the summary from
+  `Tests: N total` and adds a key only when its line appears, so a block truncated after
+  `pass:` yields `{"total", "pass"}`: `fail` absent, `pass` **present and agreeing**.
+
+Both guards therefore pass cleanly. Executed on `main`, in order, with the guards as written:
+
+```
+healthy run              -> PASS -- baseline reproduced
+real failures            -> FAIL: tests failed
+TRUNCATED after 'pass:'  -> PASS -- baseline reproduced      <-- the false green
+```
+
+`check_corpus` reporting `the corpus ran clean on this box: 15 tests passed across 3 app(s)` for
+a run that never said whether anything failed — in the check gating every unattended cycle. The
+issue had ranked it the lowest blast radius of six; it was a live false green.
+
+**The lesson is the one the rule already taught, sharpened.** "Safe only by accident of a
+neighbour" was recorded as a real-but-acceptable state; it is not. A neighbour that does not
+cover the case is indistinguishable from one that does, until something executes the guard on
+that input — which is the same false-zero class the rule is about, applied to a reader instead of
+a check. Three readers is the measurement: the count is what makes it a property of the reasoning
+rather than one person's slip.
 
 ## The instances (status moved from the rule, #3728 review round 2)
 
-#3361 part 2 was open when this rule was written, and its own body records the honest qualifier:
-that spot is currently backstopped by a `summary.get("pass") != want` comparison a few lines down
-where a `None` fails loudly, so it is not reachable as a false pass **today**. It is still written
-the opposite way from every neighbour in that function, where an uncomputable value is an explicit
-refusal rather than a silent zero.
+#3361 part 2 was open when this rule was written, and this section carried the same "not
+reachable as a false pass **today**" qualifier the rule did. #3856 measured it and it was false —
+the correction, the mechanism and the executed evidence are above, under the fifth instance.
+Stated once rather than twice: a claim repeated in two places is a claim that can be corrected in
+one of them.
 
 ## Counting `die_undetermined` (moved from the rule, #3728 review round 3)
 

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -2531,6 +2531,22 @@ def check_corpus(repo: str, enabled: bool) -> CheckResult:
                     obs.broken_buckets + obs.lost_suites + lines,
                     "Fix the compile/suite error above - the tests those suites "
                     "declare are MISSING from this run, not passing.", data)
+    # A key that is ABSENT is a third state, not a zero (#3361). parse_corpus_run
+    # seeds the summary from `Tests: N total` and adds a key only when its line
+    # appears, so a block truncated or reshaped by a BC-version change yields
+    # {"total", "pass"} -- and `.get("fail")` answers None, which is falsy, which
+    # is this check's PASS direction for a question it never measured. The
+    # `pass != counted` comparison below does not backstop it: `pass` is still
+    # there and still agrees, so the run goes green (`guards-need-a-third-state.md`).
+    missing = [k for k in ("fail", "error") if k not in obs.summary]
+    if missing:
+        return fail("the run's summary did not report " + " or ".join(missing) +
+                    " at all, so whether anything failed was never measured",
+                    [f"summary as parsed: {obs.summary}", tail] + lines,
+                    "Re-run the invocation by hand and read its summary block. This is "
+                    "NOT a report of zero failures - the line the count comes from was "
+                    "absent, which usually means the run was truncated or the summary "
+                    "changed shape.", data)
     if obs.summary.get("fail") or obs.summary.get("error"):
         return fail(f"{obs.summary.get('fail', 0)} test(s) failed and "
                     f"{obs.summary.get('error', 0)} errored on this box",

--- a/tools/test_corpus_pass_count.py
+++ b/tools/test_corpus_pass_count.py
@@ -286,12 +286,25 @@ check("...and a FAIL next to them is still a FAIL",
 
 # The additive half: the corpus fixtures must parse to exactly what they did
 # before the pattern learned the local spelling.
-check("the 27.x corpus fixture is unaffected by the widened pattern",
-      cpc.parse_leg(LOG_27X, "TestPart_")["passed"] == r27["passed"],
-      str(cpc.parse_leg(LOG_27X, "TestPart_")["passed"]))
-check("the 28.x corpus fixture is unaffected too",
-      cpc.parse_leg(LOG_28X, "TestPart_")["passed"] == r28["passed"],
-      str(cpc.parse_leg(LOG_28X, "TestPart_")["passed"]))
+#
+# The expectation is a LITERAL, transcribed from the fixtures above, and that is
+# the whole point of it (#3361). Both of these used to read
+# `cpc.parse_leg(LOG_27X, ...)["passed"] == r27["passed"]`, comparing one call
+# against another call of the same parser in the same process -- `x == x`, green
+# under a parser returning an empty list. They were cited as #3359's evidence that
+# widening `_RESULT` is additive for corpus logs, and they were the only two checks
+# in this file that survived a deliberate revert of that widening.
+CORPUS_FIXTURE_NAMES = [
+    "TestPart_Editable_IsNotDrivenByTheHostControlsEditableProperty",
+    "TestPart_Enabled_AnswersTrueForAReachablePart",
+    "TestPart_InvisiblePart_IsNotInTheControlTreeAtAll",
+    "TestPart_Visible_AnswersTrueForAReachablePart",
+]
+check("the 27.x corpus fixture parses to the four recorded names, unchanged by "
+      "the widened pattern",
+      r27["passed"] == CORPUS_FIXTURE_NAMES, str(r27["passed"]))
+check("the 28.x corpus fixture parses to those same four names too",
+      r28["passed"] == CORPUS_FIXTURE_NAMES, str(r28["passed"]))
 check("a bare corpus name is still captured without a dot",
       all("." not in n for n in r27["passed"]), str(r27["passed"]))
 

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -1578,7 +1578,8 @@ def corpus_repo():
 # every summary line below are that output, not an idea of it -- a fixture shaped
 # to satisfy the parser would test the author rather than the runner (#3311).
 def corpus_output(counts, *, fail=0, error=0, skipped=0, oos=0, known_gap=0,
-                  reported_pass=None, summary=True, suite_errors=(), compile_fail=()):
+                  reported_pass=None, summary=True, suite_errors=(), compile_fail=(),
+                  drop_fields=()):
     """Synthesise runner output for `counts` = {bundle dir name: passing tests}."""
     lines = ["al-runner — running %d bundle(s)" % (len(counts) + len(compile_fail))]
     for name in compile_fail:
@@ -1616,7 +1617,14 @@ def corpus_output(counts, *, fail=0, error=0, skipped=0, oos=0, known_gap=0,
         lines.append(f"    pass-oos:        {oos}")
     if known_gap:
         lines.append(f"    pass-known-gap:  {known_gap}")
-    lines += [f"  fail:        {fail}", f"  error:       {error}"]
+    # `drop_fields` omits a summary LINE, which is how a key goes missing for
+    # real: parse_corpus_run seeds the dict from `Tests: N total` and adds a key
+    # only when its line appears, so a summary block truncated or reshaped by a
+    # BC-version change yields {"total", "pass"} with no `fail` at all (#3361).
+    if "fail" not in drop_fields:
+        lines.append(f"  fail:        {fail}")
+    if "error" not in drop_fields:
+        lines.append(f"  error:       {error}")
     if skipped:
         lines.append(f"  skipped:     {skipped}")
     lines += ["Time:", "  AL emit:     2.1s", "  C# compile:  1.7s",
@@ -1735,6 +1743,46 @@ check("a summary that disagrees with the per-bundle PASS lines FAILs",
 _res, _ = corpus_result(_full, apps=[])
 check("an enumerator that produced no apps FAILs -- a run of nothing is not a baseline",
       _res.status == "FAIL", f"{_res.status}: {_res.summary}")
+
+# ---- a summary that parsed but LOST a key is unreadable, not "zero failures"
+#
+# #3361 part 2. The guard used to read `if summary.get("fail") or
+# summary.get("error")`, so a summary block without those lines answered False --
+# the success direction -- for a question it had not measured.
+#
+# The issue and its reviewer both judged this unreachable, backstopped by the
+# `summary.get("pass") != counted` comparison below it, where a None FAILs
+# loudly. That backstop does not cover this shape: `pass` is still present and
+# still agrees with the per-bundle PASS lines, so the run goes green on a summary
+# that never said whether anything failed.
+_no_fail_key = corpus_output({"al-language": 12,
+                              "al-language-internals-fixture": 0,
+                              "al-language-onprem": 3}, drop_fields=("fail",))
+check("the fixture really does lose the key -- otherwise the check below proves nothing",
+      "fail" not in (pf.parse_corpus_run(_no_fail_key).summary or {"fail": 0}),
+      str(pf.parse_corpus_run(_no_fail_key).summary))
+_res, _ = corpus_result(_no_fail_key)
+check("a summary missing `fail` FAILs rather than reading as zero failures",
+      _res.status == "FAIL", f"{_res.status}: {_res.summary}")
+check("...and says the count is MISSING, not that it counted zero",
+      "did not report" in (_res.summary + " ".join(_res.detail)).lower(),
+      f"{_res.summary} {_res.detail}")
+check("...and names which key was absent, so the remedy is not a guess",
+      "fail" in _res.summary.lower(), _res.summary)
+
+_no_error_key = corpus_output({"al-language": 12,
+                               "al-language-internals-fixture": 0,
+                               "al-language-onprem": 3}, drop_fields=("error",))
+check("a summary missing `error` FAILs the same way -- the sibling key, same shape",
+      corpus_result(_no_error_key)[0].status == "FAIL",
+      corpus_result(_no_error_key)[0].summary)
+
+# The constraint from guards-need-a-third-state.md: only an UNMEASURABLE thing
+# becomes the third state. A summary that reports zero failures explicitly is a
+# legitimate pass and must stay one, or the fix has traded a false green for a
+# false red.
+check("a summary reporting `fail: 0` explicitly still PASSes -- zero measured is not zero missing",
+      corpus_result(_full)[0].status == "PASS", corpus_result(_full)[0].summary)
 
 # ---- SKIP stays honest, and still points at the file it is about
 _res = pf.check_corpus(corpus_repo(), False)


### PR DESCRIPTION
Closes #3361

Three guards in the corpus-baseline cluster that could not fail, or could fail for the wrong reason. Two were real and are fixed; the third no longer exists and is reported as a negative rather than forced into a change.

Every claim below is a measurement taken in this branch. Each fix was reverted in an isolated copy and the suite re-run, because a test that cannot tell the fixed state from the broken one is precisely the defect being fixed.

## 1. Two assertions compared a call against itself

`tools/test_corpus_pass_count.py` asserted `cpc.parse_leg(LOG_27X, ...)["passed"] == r27["passed"]`, where `r27` came from the same call to the same parser in the same process. `x == x`, green under any parser. Both now compare against `CORPUS_FIXTURE_NAMES`, a literal transcribed from the recorded fixtures.

This mattered beyond a dead assertion: #3359's body cites these two lines as the evidence that widening `_RESULT` is additive for corpus logs. The claim is true — the concrete count and name assertions carry it — but the two lines pointed at were the only two that could not testify.

**Mutation results**, running the suite against a mutated copy of `tools/corpus-pass-count.py`:

| mutation | failing checks before | after | the two "unaffected" checks |
|---|---|---|---|
| `parse_leg` returns `[]` | 19 | **21** | `ok, ok` -> **`FAIL, FAIL`** |
| `_RESULT` reverted to the pre-#3359 two-space pattern | 13 | **14** | `ok, ok` -> **`ok, FAIL`** |

The second row is the reviewer's own revert, and it is the one that proves the fix. The 27.x check staying green there is correct, not a residual defect: that revert restores the two-space 27.x spelling, so the 27.x fixture genuinely still parses to those four names. To show that assertion is nonetheless falsifiable, I mutated one name in the expected literal instead — both checks go red, which the old `x == x` form could not have noticed.

## 2. A missing `fail` key read as "no failures" — and it is a LIVE false green

`tools/preflight.py`'s `check_corpus` read `if obs.summary.get("fail") or obs.summary.get("error")`, so an absent key answered `None`, falsy, the PASS direction, for a question never measured.

**The issue, the reviewer, and `guards-need-a-third-state.md` all record this as unreachable**, backstopped by `obs.summary.get("pass") != counted` a few lines down where a `None` fails loudly. That backstop does not cover the shape that actually occurs.

`parse_corpus_run` seeds the summary from `Tests: N total` and adds a key only when its line appears. A summary block truncated after `pass:` yields `{"total": 1, "pass": 1}` — `fail` absent, but `pass` present **and still agreeing with the per-bundle PASS lines**. The comparison passes cleanly. Measured through `check_corpus` before the fix:

```
FAIL a summary missing `fail` FAILs rather than reading as zero failures
     PASS: the corpus ran clean on this box: 15 tests passed across 3 app(s)
```

That is the guard gating every unattended cycle reporting a reproduced baseline for a run that never said whether anything failed. Worth re-ranking from the issue's "lowest blast radius of the six".

The fix makes the absence its own state, names which key was missing, and says the count is absent rather than zero. **The constraint from `guards-need-a-third-state.md` is held**: a genuinely-measured `fail: 0` must stay a pass, or the fix has traded a false green for a false red. That is asserted explicitly and passes in both the fixed and reverted states.

**Mutation result**: removing the new block from an isolated copy turns exactly the four new checks red and nothing else. The fixture-integrity check (`the fixture really does lose the key`) passes in both states, so the four are measuring the guard rather than a broken fixture.

## 3. The `byBcVersion` refusal — already gone, reported as a negative

No change made, because there is no code left to change.

#3747 (`a4e41968`) deleted the entire baseline-reading function that held the refusal, along with `CORPUS_BASELINE_REL`. `check_corpus` no longer opens `test-count-baseline.json` at all.

```
$ git log --oneline -S "byBcVersion" -- tools/preflight.py
a4e41968 ci(corpus): resolve tests/al-language per run instead of pinning it (#3747)
c629695e fix(preflight): verify the corpus baseline against its own numbers... (#3359)
```

Confirmed absent with both `rg --hidden` and `command grep -rn`, since one tool alone is not evidence here.

The remedy the issue asked for — teach the check to read the override instead of refusing — is what the surviving code does one level down: `ExpectedCount.Resolve(bcVersionKey)` in `AlRunner/Infrastructure/CountBaseline.cs:55` selects the override for the running version and falls back to `default`, invoked from `bc-tests.yml` where the BC version is known. So the reviewer's observation that preflight's ignorance of the BC version was fixable rather than structural is right; the fix landed by moving the comparison to where the version is known. No suite currently carries an override, so the future-dated failure cannot fire from any direction.

Writing a test here would assert the absence of deleted code — it would pass against any implementation, which is the defect this PR exists to remove.

## 4. The rule about this defect class stated the defect

`.claude/rules/guards-need-a-third-state.md` recorded #3361 part 2 as unreachable, "because a `summary.get("pass") != want` comparison a few lines down fails loudly on a `None`". That is the rule warning about false greens, containing one — about the very code this PR changes.

Both halves are wrong. The comparison is against **`counted`**, the sum of the per-bundle PASS lines, not a `want` from a baseline; and it never sees a `None` in the shape that occurs, because a summary truncated after `pass:` has `pass` present and agreeing. The coordinator executed the two guards in order on `main` and reproduced it independently:

```
healthy run              -> PASS -- baseline reproduced
real failures            -> FAIL: tests failed
TRUNCATED after 'pass:'  -> PASS -- baseline reproduced      <-- the false green
```

Corrected in the rule, keeping the section's lesson and sharpening it: **"safe only by accident of a neighbour" is not safe**. Three independent readers — the issue body, the reviewer's comment, and the rule — checked that neighbour and all three credited it, which makes this the strongest available evidence for the section it sits in. A neighbour that does not cover the case is indistinguishable from one that does until something executes the guard on that input, which is the same false-zero class the rule is about, applied to a reader rather than to a check.

The derivation and the executed evidence go to `docs/incidents/guards-need-a-third-state.md`, per the repository's rule/incident split. The stale claim was stated **twice** there — once as the fifth instance, once in "The instances" section — so a search for the wrong text found one copy while the other survived. It is now stated once, with a pointer, and the status-table row moved from **open** to fixed.

Not scope creep: the rule text is a claim about the code in this diff, and leaving it saying "not reachable" after this PR makes it unreachable for a different reason would mislead the next reader more than before.

## Fix the shape, not just the reported line

**Does the same wrong pattern appear at another call site?** Yes, once, and it is fixed in the same commit: `error` has the identical `.get()` shape as `fail` and the identical absence mode. It gets its own check. I scanned the rest of `check_corpus` for `.get()` on a summary key in a boolean position — the only other reads are `obs.summary.get("pass")`, already compared with `!=` against a concrete count (so a `None` fails loudly), and `obs.summary.get("fail", 0)` inside the message string, which is reached only after the new presence check.

**Does a sibling function make the same assumption?** `parse_corpus_run` is the producer, and it is already written the right way — a missing summary is `None`, never `{"pass": 0}`, with a comment saying why. The defect was that its one honest `None` was consumed by a caller that flattened absence into falsity.

**If two code paths write the same state, do they maintain the same invariant?** Only `parse_corpus_run` writes `obs.summary`, so there is no second writer to diverge. The invariant it maintains — a key exists only if its line was read — is now the one `check_corpus` reads it under, rather than the one it assumed.

## Searching for the same defect filed twice

Searched the open queue on `preflight.py`, `corpus_pass_count`, `byBcVersion`, `check_corpus` and `count-baseline`. Nothing duplicates this. Two land nearby and are deliberately **not** folded, because their fixes are in different code:

- **#3350** — a count-baseline mismatch masked by a concurrent test failure. Exit-code precedence in the runner's own reporting, not `check_corpus`'s summary read.
- **#3130** — `--count-baseline` skips a declared suite that produced no bucket. `CountBaseline.cs`, the C# side.

Neither touches the two files here, so folding them would widen the diff without sharing a line.

## What ran

- `tools/test_corpus_pass_count.py` — all checks passed
- `tools/test_preflight.py` — all checks passed
- All 20 `tools/test_*.py` suites (the set `pr-gate.yml` discovers by glob) — **20/20**, re-run after the rule correction; the six that read `.md` (`test_doc_pointers`, `test_doc_summary_uniqueness`, `test_comment_density`, `test_matrix_docs_drift`, `test_line_endings`, `test_text_encoding`) pass against the edited files
- `tools/preflight.py --agent-id stma-auto-11` end to end — **exit 0**, 11 passed, 5 warned, 0 failed, 1 skipped

The end-to-end preflight run is not optional diligence here: this PR edits the file that gates every unattended cycle, so a defect introduced in it would stop the loop for every agent.

No `dotnet test` figures are quoted because the diff is Python-only and touches no C#.

## Gates

`check_corpus_linkage.sh` against this diff: "No file in this diff can change what AL observes, so no corpus declaration is required." The `require-tests` gate does not trigger — the diff touches no `AlRunner/` path. Both new test files are `tools/test_*.py`, which `pr-gate.yml` discovers by glob, so they gate the day they land and their absence from any workflow file is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
