### PR TITLE
fix(exit-codes): a count-baseline mismatch outranks a concurrent test failure

### DIFF
--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -830,13 +830,28 @@ jobs:
           # 28.0 on) — tests/expectations/count-baseline/test-count-baseline.json
           # carries a per-BC-version expected count for exactly that reason, not a
           # single global value.
+          #
+          # The exit code is EXPLAINED here, not left bare (#3350). This is the only
+          # step in the matrix that still passes --count-baseline, so it is the only
+          # one that can exit 4 -- and a 4 arrives with every suite reporting zero
+          # failures, which reads as a mystery until someone searches the log for the
+          # [count-baseline] line. A leg must be diagnosable from its own log.
+          rc=0
           dotnet run --no-build --project AlRunner -c Release --framework net8.0 -- \
               tests/runner-extras \
               --package-cache "$HOME/.al-runner/platform-apps" \
               --package-cache "$HOME/.al-runner/test-apps" \
               --strict \
               --count-baseline tests/expectations/count-baseline/test-count-baseline.json \
-              --out runner-extras-results.json
+              --out runner-extras-results.json || rc=$?
+          if [ "$rc" -ne 0 ]; then
+            if [ "$rc" -eq 4 ]; then
+              echo "::error::runner-extras count-baseline mismatch (exit 4) -- a suite ran a different NUMBER of tests than tests/expectations/count-baseline/test-count-baseline.json declares. Search this log for '[count-baseline]': the DROP/GROWTH line names the suite, the expected count and the actual one. A GROWTH means the baseline needs bumping in this PR; a DROP means an app group stopped being discovered."
+            else
+              echo "::error::runner-extras run failed (exit $rc: 1=test failure, 2=exec fail, 3=compile fail, 4=count-baseline mismatch, 5=expectations entry matched no test, 134/139=crash)"
+            fi
+            exit "$rc"
+          fi
 
       - name: Run runner-extras suites that need --isolation disabled
         # A SECOND invocation because isolation is a process-global flag with no per-bundle

--- a/AlRunner.Tests/CountBaselineIntegrationTests.cs
+++ b/AlRunner.Tests/CountBaselineIntegrationTests.cs
@@ -42,6 +42,8 @@ public sealed class CountBaselineIntegrationTests : IDisposable
     private readonly string _root;
     private readonly string _suiteKey;
     private readonly string _baselinePath;
+    private readonly string _failRoot;
+    private readonly string _failSuiteKey;
 
     public CountBaselineIntegrationTests()
     {
@@ -50,11 +52,21 @@ public sealed class CountBaselineIntegrationTests : IDisposable
         _suiteKey = Path.GetFileName(_root);
         _baselinePath = TestScratch.FilePath("al-runner-count-baseline", "baseline.json");
         WriteFixture(_root);
+
+        // #3350: a SECOND fixture whose second test deliberately fails, so a run can
+        // have a real test failure and a count mismatch at the same time. Separate root
+        // (not a flag on the first) because the suite key is the directory basename and
+        // the two fixtures must be independently addressable by a baseline.
+        _failRoot = TestScratch.Dir("al-runner-count-baseline-fail");
+        Directory.CreateDirectory(_failRoot);
+        _failSuiteKey = Path.GetFileName(_failRoot);
+        WriteFailingFixture(_failRoot);
     }
 
     public void Dispose()
     {
         try { Directory.Delete(_root, recursive: true); } catch { }
+        try { Directory.Delete(_failRoot, recursive: true); } catch { }
         try { File.Delete(_baselinePath); } catch { }
     }
 
@@ -100,6 +112,47 @@ public sealed class CountBaselineIntegrationTests : IDisposable
         """);
     }
 
+    /// <summary>
+    /// #3350: the same two-test shape as <see cref="WriteFixture"/>, except the second
+    /// test ERRORs. Lets one run hold BOTH a real test failure and a count-baseline
+    /// mismatch, which is the only way to observe which of the two the exit code reports.
+    /// </summary>
+    private static void WriteFailingFixture(string dir)
+    {
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "c3d4e5f6-a7b8-4901-cdef-234567890123",
+          "name": "Count Baseline Failing Fixture",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62210, "to": 62219 } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(dir, "CountBaselineFailingFixtureTests.Codeunit.al"), """
+        codeunit 62210 "Count Baseline Fail Fixture"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure FailFixtureFirstPasses()
+            begin
+                if 1 <> 1 then
+                    Error('unreachable');
+            end;
+
+            [Test]
+            procedure FailFixtureSecondFailsDeliberately()
+            begin
+                Error('deliberate failure: #3350 exit-code precedence fixture');
+            end;
+        }
+        """);
+    }
+
     private void WriteBaseline(string json) => File.WriteAllText(_baselinePath, json);
 
     private string TestsBaseline(int testsDefault) =>
@@ -112,13 +165,16 @@ public sealed class CountBaselineIntegrationTests : IDisposable
         { "suites": { "{{_suiteKey}}": { "appGroups": { "default": {{appGroupsDefault}} } } } }
         """;
 
-    private (string output, int exit) RunRunner(params string[] extraArgs)
+    private (string output, int exit) RunRunner(params string[] extraArgs) =>
+        RunRunnerOn(_root, extraArgs);
+
+    private (string output, int exit) RunRunnerOn(string bundleRoot, params string[] extraArgs)
     {
         var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
         args.Append(TestBuildConfig.BcVersionArg);
         args.Append(" --strict");
         args.Append($" --count-baseline \"{_baselinePath}\"");
-        args.Append($" \"{_root}\"");
+        args.Append($" \"{bundleRoot}\"");
         foreach (var a in extraArgs) args.Append($" {a}");
         var psi = new ProcessStartInfo
         {
@@ -264,5 +320,77 @@ public sealed class CountBaselineIntegrationTests : IDisposable
         Assert.Contains("[count-baseline] appGroups check skipped", output);
         Assert.DoesNotContain("[count-baseline] DROP", output);
         Assert.DoesNotContain("[count-baseline] GROWTH", output);
+    }
+
+    // ── #3350: the count guard must not be masked by a concurrent test failure ──────
+    //
+    // Both of the tests below run the FAILING fixture, so `failed + errored > 0` holds.
+    // They differ only in whether the baseline also mismatches, which is what isolates
+    // the precedence question from the plain fail-count gate.
+
+    /// <summary>
+    /// #3350 RED: a run that BOTH fails a test and measured the wrong number of tests
+    /// must report the count mismatch (4), not the test failure (1).
+    ///
+    /// The two statements are different in kind. "A test failed" is a statement about the
+    /// AL under test; "this suite measured 2 tests where 5 were declared" is a statement
+    /// that the RUN DID NOT MEASURE WHAT IT CLAIMS TO — the same kind as the carried-attempt
+    /// loss the ladder already ranks ABOVE a plain test failure, for the reason its own
+    /// comment gives: a consumer must not read it as "some tests failed". A consumer told
+    /// only "1" investigates two failing tests, fixes them, sees green, and never learns
+    /// that three tests' worth of coverage stopped being discovered — the exact silent
+    /// shrinkage #1880 built this guard for.
+    ///
+    /// Before the fix this exited 1 and the DROP line was printed but unrepresented in the
+    /// exit code (measured on BC 28.1: baseline 5, actual 2, one deliberate failure → 1).
+    /// </summary>
+    [SkippableFact]
+    public void CountMismatchConcurrentWithATestFailure_ReportsTheCountMismatchNotTheFailure()
+    {
+        TestArtifacts.SkipIfMissing();
+        WriteBaseline($$"""
+        { "suites": { "{{_failSuiteKey}}": { "tests": { "default": 5 } } } }
+        """);
+
+        var (output, exit) = RunRunnerOn(_failRoot);
+
+        // Both conditions genuinely hold in this run — otherwise the assertion below is
+        // about nothing. A test really failed:
+        Assert.Contains("FailFixtureSecondFailsDeliberately", output);
+        Assert.Contains("FAIL  Codeunit", output);
+        // ...and the count really mismatched:
+        Assert.Contains("[count-baseline] DROP", output);
+        Assert.Contains($"suite '{_failSuiteKey}'", output);
+        Assert.Contains("expected 5", output);
+        Assert.Contains("actual 2", output);
+
+        // The whole point: 4, not 1.
+        Assert.Equal(4, exit);
+    }
+
+    /// <summary>
+    /// #3350, the other direction — the fix must not create the inverse defect. A run with
+    /// a real test failure and a baseline that MATCHES still reports 1: raising the count
+    /// guard above the fail-count gate must not make a plain test failure disappear behind
+    /// a guard that found nothing wrong.
+    ///
+    /// Same fixture, same failing test, only the baseline differs, so this is a true
+    /// controlled pair with the test above: whatever separates their exit codes is the
+    /// count mismatch and nothing else.
+    /// </summary>
+    [SkippableFact]
+    public void TestFailureWithAMatchingBaseline_StillReports1()
+    {
+        TestArtifacts.SkipIfMissing();
+        WriteBaseline($$"""
+        { "suites": { "{{_failSuiteKey}}": { "tests": { "default": 2 } } } }
+        """);
+
+        var (output, exit) = RunRunnerOn(_failRoot);
+
+        Assert.Contains("FAIL  Codeunit", output);
+        Assert.DoesNotContain("[count-baseline] DROP", output);
+        Assert.DoesNotContain("[count-baseline] GROWTH", output);
+        Assert.Equal(1, exit);
     }
 }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -4402,14 +4402,33 @@ int computedExitCode = 0;
             else if (t.Outcome == TestOutcome.Error) errored++;
         }
     }
+    // The ladder is ordered by WHAT THE CODE ASSERTS, not by how alarming it sounds. Two
+    // tiers, and the boundary between them is the whole design:
+    //
+    //   3, 2, 4  — "this report cannot be trusted": the run did not measure what it claims
+    //              to, so a consumer must not read the results at face value.
+    //   1, 5, 0  — "the report is sound": these are statements ABOUT the AL it measured.
+    //
+    // A run can hold several of these at once and reports the most fundamental, so a code
+    // only ever UNDER-states how much is wrong — never over-states it.
     computedExitCode = compileFail > 0 ? 3       // compile errors
         // #2747: a carried attempt was promised and is not here, so whatever this run reports
         // omits it. Ranked above a plain test failure because it is not a statement about the
         // AL at all — it says the REPORT cannot be trusted, which a consumer must not read as
         // "some tests failed". Below a compile failure, which is the more fundamental problem.
         : (execFail > 0 || carryIncomplete) ? 2  // bucket-level execution error, or a lost attempt
-        : (failed + errored > 0 ? 1               // at least one test failed
-        : (countBaselineMismatch ? 4                    // #1880: suite's count didn't exactly match its baseline
+        // #3350: ABOVE a plain test failure, on #2747's reasoning applied consistently. "This
+        // suite ran 2 tests where 5 were declared" is not a statement about the AL either — it
+        // says a bundle or app group stopped being discovered, which is the silent shrinkage
+        // #1880 built this guard for. Ranked below 2 because a lost attempt loses results
+        // wholesale while a count mismatch still delivers the ones it ran.
+        //
+        // It was BELOW 1 until #3350: measured on BC 28.1, a fixture with one deliberate
+        // failure and a baseline of 5 against an actual 2 printed the DROP line and exited 1,
+        // so the mismatch was invisible in the exit code. A consumer told only "1" fixes the
+        // failing test, sees green, and never learns three tests' worth of coverage vanished.
+        : (countBaselineMismatch ? 4             // #1880: suite's count didn't exactly match its baseline
+        : (failed + errored > 0 ? 1              // at least one test failed
         : (expectationsMatchFailure ? 5 : 0)));  // #3123: an expectations entry matched no test
 }
 
@@ -6644,7 +6663,12 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
 
             var allTests = runs.SelectMany(r => r.Tests).ToList();
             var allCompileErrors = runs.SelectMany(r => r.CompileErrors ?? Array.Empty<CompilationErrorGroup>()).ToList();
-            // Same priority as the CLI's computedExitCode: 3 (compile) > 2 (exec) > 1 (test fail) > 0.
+            // Max() is the right aggregator ONLY because the codes a per-bundle run can carry
+            // happen to rank in numeric order: 3 (compile) > 2 (exec) > 1 (test fail) > 0. The
+            // whole-run codes do not — the CLI ranks 4 (count baseline) above 1 (#3350) — but
+            // 4 and 5 are audits over the FULL run, computed once in the CLI path, so no
+            // BundleRun ever carries one and Max() cannot meet them here. Give a bundle a code
+            // that is not in that ordered set and this silently picks the wrong one.
             var exitCode = runs.Count > 0 ? runs.Max(r => r.ExitCode) : 0;
             var cached = runs.Count > 0 && runs.All(r => r.Cached);
 

--- a/README.md
+++ b/README.md
@@ -266,6 +266,13 @@ table is a copy and the CLI is the authority.
 | `4` | `--count-baseline`: a suite's test or app-group count did not exactly match its declared baseline |
 | `5` | `--expectations-require-match`: an expectations entry matched no test in this run |
 
+When a run holds several of these at once it reports the most fundamental, in the order
+**`3` > `2` > `4` > `1` > `5`**. The boundary that matters is between `3`/`2`/`4` — *this
+report cannot be trusted, because the run did not measure what it claims to* — and `1`/`5`,
+which are statements about the AL the run did measure. So a run that both fails a test and
+measured the wrong number of tests reports `4`: fixing the failing test would otherwise turn
+the leg green while the missing coverage stayed missing.
+
 ## Tooling for AI-assisted development (optional)
 
 This repo is largely developed with coding agents, and its instruction files

--- a/docs/manual/cli-reference.md
+++ b/docs/manual/cli-reference.md
@@ -65,6 +65,13 @@ al-runner [OPTIONS] <bundle-dir>...
 | `4` | A suite's test or app-group count did not match its declared baseline (`--count-baseline`). |
 | `5` | An expectations entry matched no test in this run (`--expectations-require-match`). |
 
+A run can hold several of these at once, and reports the most fundamental: **`3` > `2` > `4` >
+`1` > `5`**. `3`, `2` and `4` all say *the run did not measure what it claims to*, so the
+report cannot be read at face value; `1` and `5` are statements about the AL it did measure.
+That is why a count-baseline mismatch outranks a test failure (#3350) — a consumer who sees
+only `1` fixes the failing test, sees green, and never learns that a bundle stopped being
+discovered.
+
 ## Environment variables
 
 `AL_RUNNER_VERBOSE=1` and `AL_RUNNER_SHOW_PASS=1` mirror the flags of the same


### PR DESCRIPTION
Closes #3350

Corpus-NA: the runner's own exit-code contract; nothing in this diff asserts anything about Business Central, so no corpus test is owed.

## The defect, reproduced

`computedExitCode` ranked `failed + errored > 0 -> 1` **above** `countBaselineMismatch -> 4`. So a run that both failed a test and measured the wrong number of tests reported only the test failure: the `[count-baseline] DROP` line was printed and then discarded by the exit code.

Measured on BC 28.1 with `--package-cache --strict --count-baseline`, on a two-test fixture, before the fix:

| arm | count mismatch | test failure | exit |
|---|---|---|---|
| A (control) | baseline 5, actual 2 | none | **4** |
| B | baseline 5, actual 2 | one deliberate `Error()` | **1** — mismatch masked |
| C (control) | baseline 2, actual 2 | one deliberate `Error()` | **1** |

Arm B is the defect. Arms A and C are the controls that make it attributable: A shows the guard works when nothing else is wrong, C shows a plain test failure is unaffected by the baseline. After the fix, A stays 4, **B becomes 4**, C stays 1.

## The title's mechanism: verified, not adopted

The issue was retitled by its reporter before I picked it up, and the retitled claim is what I measured. Both halves check out:

- **Masking is real and requires a concurrent test failure.** Arm A proves a mismatch alone was always exit 4 — the mismatch by itself was never swallowed.
- **The *original* headline is refuted**, as the reporter and two previous commenters already concluded: "a mismatch warns and exits 0 under `--strict`" never held, because `--strict` is a no-op (strict exit has been the default since the v2 cut) and growth already set `countBaselineMismatch`. Arm A is the direct measurement of that. No correction to #3350 is needed — its body already carries the reporter's own retraction.

## The precedence rule, and why this one

**`3` > `2` > `4` > `1` > `5`.**

The ladder is ordered by *what the code asserts*, not by how alarming it sounds, and the boundary is between two tiers:

- **`3`, `2`, `4` — "this report cannot be trusted."** The run did not measure what it claims to, so a consumer must not read the results at face value.
- **`1`, `5`, `0` — "the report is sound."** These are statements about the AL the run did measure.

That is not a new principle; it is the one the `#2747` comment already states in this same expression, for `carryIncomplete`: it is ranked above a plain test failure *"because it is not a statement about the AL at all — it says the REPORT cannot be trusted, which a consumer must not read as 'some tests failed'."* A count-baseline mismatch says exactly that, so it belongs in that tier. It sits **below** `2` because a lost attempt loses results wholesale, while a count mismatch still delivers the ones it ran.

**What breaks without it:** a consumer told only `1` fixes the failing test, sees green, and never learns that three tests' worth of coverage stopped being discovered — the silent shrinkage #1880 built the guard for.

**What I deliberately did not do**, because losing the test failure behind the count would be a new defect: `TestFailureWithAMatchingBaseline_StillReports1` pins arm C. A test failure with a matching baseline still reports `1`.

**`5` stays below `1`.** It is the nearest sibling and it is tempting to move it too, but it makes a different claim: an unmatched expectations entry says the *manifest* is wrong, not that the run's coverage shrank, and it does not invalidate the results the run reports. Left where it is, deliberately, rather than widened without a case.

## `--strict` is honoured

`--strict` is the default, so this path is what every CI invocation already takes; `--no-strict-exit` still forces 0, unchanged. No flag now swallows a mismatch.

## Third state: already distinct, verified not assumed

`guards-need-a-third-state.md` requires "could not measure the count" to differ from "the count matched". It already does, and **before** any test runs: `CountBaselineManifest.Load` is called at `Program.cs:975`, and a missing, unreadable, malformed or suite-less baseline throws `InvalidOperationException` and returns **2** there — so it can never be confused with a `0`, and the run does not pay for a full corpus first. I read the load path to confirm this rather than assuming the neighbour covers it.

## Fix the shape, not just the reported line

**1. Same wrong pattern at another call site?** Yes — three `Max(r => r.ExitCode)` aggregations on the server path (`Program.cs:5912`, `:6672`, `:6972`), whose comment claimed "same priority as the CLI's computedExitCode". After this change that is no longer literally true, since the CLI ladder is not numerically ordered any more. **Measured rather than assumed**: I enumerated every construction of `ServerRunResult` — 4x `Failure(2)`, 7x `Failure(3)`, and 6 direct constructions carrying 1, 3 or a computed `0`/`1`. Nothing can carry 4 or 5, because both are whole-run audits computed once in the CLI path. So `Max()` is still correct; I corrected the comment to say *why* it is correct and what would break it, instead of leaving a claim that has quietly stopped being true.

**2. Sibling functions making the same assumption?** The three post-hoc writers at `:4637`, `:4668` and `:4682` all set `2` under an `== 0` guard ("never RAISED above what the tests earned"). They are unaffected: any run that reached them with `0` before still reaches them with `0`. Checked, no change needed.

**3. Two code paths writing the same state with different invariants?** No. `computedExitCode` is written in exactly the one ladder plus those three `== 0`-guarded escalations, and the JSON `exitCode` field is serialized after all of them so the document and the process cannot disagree.

## Also fixed: a bare exit 4 was undiagnosable from the leg log

The coordinator hit the downstream half of this while I was working: a missing baseline bump exited a leg **4** with every suite reporting zero failures, which read as a mystery until someone searched the log. `runner-extras` is the only step in the matrix that still passes `--count-baseline` (the corpus step dropped it at #3675), and it had **no exit-code legend at all** — while the corpus step, which cannot produce a 4, has one that omits 4. That step now names the cause, points at the `[count-baseline]` line, and says which direction each of DROP and GROWTH implies.

## Queue scan

Searched the open queue on the symbol (`countBaselineMismatch`, `computedExitCode`), the observable (`exit code precedence`, `masked`) and the subsystem (`count-baseline`).

- **#3130** — `--count-baseline` skips a declared suite that produced no bucket. Same guard, but **not folded**: it lands in `CountBaseline.cs` (`Evaluate`'s `continue`), not the exit ladder, and the issue itself states it needs a new per-invocation coverage-declaration mechanism rather than a one-line change. Different reasoning to review, so folding it would fail `batch-sibling-issues-by-file.md` point 4. Linked here instead.
- **#2803** — the baseline file's numeric fields auto-merge wrongly. Same *file*, but that is the JSON data file, not the code; unrelated fix.
- Nothing else in the queue describes this defect in different words.

## Tests

Both new tests are in `AlRunner.Tests/CountBaselineIntegrationTests.cs`, using that file's existing subprocess harness against a new two-test fixture whose second test deliberately errors — so one run can hold both conditions, which is the only way to observe which one the exit code reports.

- `CountMismatchConcurrentWithATestFailure_ReportsTheCountMismatchNotTheFailure` — asserts **both conditions genuinely hold** in the run (a real `FAIL  Codeunit` line *and* a real DROP naming expected 5 / actual 2) before asserting the exit code is 4. Without those first assertions the test could pass for the wrong reason.
- `TestFailureWithAMatchingBaseline_StillReports1` — the inverse-defect guard, a true controlled pair with the above: same fixture, same failing test, only the baseline differs.

**Mutation check.** Reverting only the ladder swap (leaving both tests in place) and rebuilding:

```
Failed  CountMismatchConcurrentWithATestFailure_ReportsTheCountMismatchNotTheFailure
  Assert.Equal() Failure: Values differ   Expected: 4   Actual: 1
Failed!  - Failed: 1, Passed: 7, Skipped: 0, Total: 8
```

Exactly one test goes red, on exactly the assertion the fix is about, and the inverse-defect guard stays green in both states. `Program.cs` was restored from a copy held outside the repository, per `no-git-stash-with-worktrees.md`, and re-verified to carry zero mutation markers.

## Numbers, all from second runs after a build

| suite | result |
|---|---|
| `~CountBaseline` (all count-baseline tests) | `Failed: 0, Passed: 39, Skipped: 0, Total: 39` |
| `~CountBaseline\|~CountOut\|~Expectations\|~BundleSuiteError\|~BundleFailureStage\|~LostOutput\|~CompileFailedBucket` | `Failed: 0, Passed: 90, Skipped: 0, Total: 90` |
| `~CliDocumentation\|~Documentation\|~Readme\|~ExitCode\|~Workflow` | `Failed: 0, Passed: 113, Skipped: 0, Total: 113` |
| `tools/test_doc_pointers.py`, `tools/test_matrix_docs_drift.py`, `tools/test_preflight.py` | rc=0 each |

**The real CI invocation, run end to end on this box:** `tests/runner-extras` with the checked-in baseline exits **0**, 424/424 passing, no `[count-baseline]` line — so this change does not red the one leg that can produce a 4.

The edited workflow parses as YAML and its `run:` block passes `bash -n`.

## Docs

`README.md` and `docs/manual/cli-reference.md` both documented what each code *means* but never their **precedence**, which is what made "exit 1 while the count was also wrong" defensible-looking. Both now state the ordering and the two-tier reasoning behind it. No behaviour outside the ladder changed, so nothing else needed updating; `CHANGELOG.md` untouched.

---

Implemented by `stma-auto-12`, an automated agent acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
