### PR TITLE
fix(record): AreFieldsLoaded refuses a null field list instead of answering true

### DIFF
--- a/AlRunner.Tests/PartialLoadDeadRewriteTests.cs
+++ b/AlRunner.Tests/PartialLoadDeadRewriteTests.cs
@@ -1,0 +1,160 @@
+// PartialLoadDeadRewriteTests — why three partial-load Cecil rewrites produced zero red tests,
+// and what pins them now (#3372 item 3).
+//
+// ── THE OBSERVATION THE ISSUE RECORDED ───────────────────────────────────────────────────
+// The reviewer of #3365 no-opped three rewrites — NavRecord.ALSetBaseLoadFields/0 and /1, and
+// RecordImplementation.SetLoadFields(FieldLoadInfo) — and got ZERO red tests, while a fourth
+// break on the same type did turn a test red. The issue's stated hypothesis was R2R inlining
+// of the thin AL* forwarders, the documented trap where a hook on a tiny method is bypassed.
+//
+// ── WHAT IT ACTUALLY IS, MEASURED ────────────────────────────────────────────────────────
+// Not inlining. Nothing on any AL-reachable path CALLS those three. Measured with
+// find_callers over Microsoft.Dynamics.Nav.Ncl.dll, on 27.0 and 28.4, identical on both:
+//
+//   ALSetBaseLoadFields()            ZERO callers anywhere in Ncl.dll
+//   ALSetBaseLoadFields(DataError)   one caller: ALSetBaseLoadFields/0, itself uncalled
+//   RecordImplementation
+//     .SetLoadFields(FieldLoadInfo)  one caller: DataItemIterator.SetLoadFieldsBasedOnMetadata
+//
+// The third one is the interesting case, and it is self-inflicted rather than dead upstream:
+// the runner ALREADY Cecil-no-ops DataItemIterator.SetLoadFieldsBasedOnMetadata — see
+// NclCecilRewrite.Runtime.cs, "partial records disabled; full field load" — so its body is a
+// bare `ret` before it can reach the only call site of the FieldLoadInfo overload.
+//
+// AL's own SetLoadFields does not go near any of the three. It routes
+// NavRecord.SetLoadFields(DataError, int[]) -> recordImplementation.SetLoadFields(HashSet),
+// which is the ISet OVERLOAD — a different method from the FieldLoadInfo one that was no-opped.
+//
+// So "no test isolates these three" is not a coverage gap to be filled with a contrived test,
+// and it is not the "verified only in aggregate" the issue offered as the fallback. Two of the
+// three are unreachable in BC itself, and the third is unreachable because of a deliberate
+// runner rewrite. A test that turned red when they were no-opped would mean something had
+// started calling them — which is exactly what these tests watch for.
+//
+// ── WHY THIS IS THE PROPORTIONATE FIX ────────────────────────────────────────────────────
+// The issue asked for one of two things: find an outer caller to rewrite instead, or write
+// down that the surface is verified only in aggregate. Neither applies once the call graph is
+// measured. What is worth pinning is the REASON, so that a later BC version wiring a caller up
+// — or a later runner change dropping the DataItemIterator no-op — does not silently leave
+// three rewrites acting on a live path with nothing measuring them.
+//
+// ── WHY THESE LIVE IN AlRunner.Tests AND NOT THE UPSTREAM CORPUS ─────────────────────────
+// The subject is which Cecil rewrites the runner registers and why, plus the runner's own
+// no-op of DataItemIterator.SetLoadFieldsBasedOnMetadata. No AL statement can observe any of
+// it and a service tier has nothing to adjudicate, so bc-behavior-tests-go-upstream.md places
+// it here. The partial-record BEHAVIOUR these rewrites sit next to is pinned upstream, by
+// corpus codeunit 60775.
+using System;
+using System.IO;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PartialLoadDeadRewriteTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    // A source read that silently returned "" would make every Contains assertion below pass
+    // vacuously — the absent thing reading as the success answer. So it refuses instead
+    // (guards-need-a-third-state.md).
+    private static string Read(params string[] parts)
+    {
+        var path = Path.Combine(RepoRoot, Path.Combine(parts));
+        Assert.True(File.Exists(path), $"source not found, so nothing was measured: {path}");
+        var src = File.ReadAllText(path);
+        Assert.False(string.IsNullOrWhiteSpace(src), $"source is empty, so nothing was measured: {path}");
+        return src;
+    }
+
+    private static string Rewrites() =>
+        Read("AlRunner", "Infrastructure", "NclCecilRewrite.Runtime.cs");
+
+    // ══ 1. The no-op that makes the third rewrite unreachable is still there ══════════════
+    //
+    // This is the one of the three that is NOT dead in BC. Its only caller,
+    // DataItemIterator.SetLoadFieldsBasedOnMetadata, is reachable on a real tier and is
+    // unreachable here only because the runner empties it. Drop that no-op and the
+    // FieldLoadInfo overload goes live on the report data-item path with nothing measuring it,
+    // which is precisely the state this test exists to make loud.
+
+    // Assert the QUOTED method name as the Cecil lookup spells it, not a bare substring: a
+    // bare Contains("SetLoadFieldsBasedOnMetadata") also matches "...MetadataXX", so renaming
+    // the lookup target away left this test green. Measured — that mutation passed 6/6 before
+    // this line was tightened, which is the "test green in both states" defect one level up.
+    [Fact]
+    public void DataItemIteratorNoOp_IsStillRegistered()
+    {
+        var src = Rewrites();
+
+        Assert.Contains("\"DataItemIterator\", \"SetLoadFieldsBasedOnMetadata\", 1",
+            src, StringComparison.Ordinal);
+        Assert.Contains("partial records disabled", src, StringComparison.Ordinal);
+    }
+
+    // The reason the no-op is safe is BC's own JIT-load contract, and it is stated at the
+    // registration rather than left to be rediscovered. If the justification goes, the claim
+    // that skipping the optimization is faithful has nothing behind it (loud-failures.md's
+    // audit obligation).
+    [Fact]
+    public void DataItemIteratorNoOp_StatesWhySkippingItIsFaithful()
+    {
+        var src = Rewrites();
+
+        Assert.Contains("superset", src, StringComparison.Ordinal);
+    }
+
+    // ══ 2. The AreFieldsLoaded rewrite — the one that IS on a live AL path ════════════════
+    //
+    // The contrast that makes item 3's finding meaningful: of the four rewrites the #3365
+    // review probed, this is the one a corpus test can turn red, because AL reaches it.
+
+    [Fact]
+    public void AreFieldsLoadedRewrite_IsStillRegistered_AndNamesItsHelper()
+    {
+        var src = Rewrites();
+
+        Assert.Contains("\"AreFieldsLoaded\"", src, StringComparison.Ordinal);
+        Assert.Contains("RecordImplementation_AreFieldsLoaded", src, StringComparison.Ordinal);
+    }
+
+    // ══ 3. The finding itself is written down where the next reader will be ══════════════
+    //
+    // Without this, the next person to no-op those three and see zero red tests repeats the
+    // whole investigation, and the R2R-inlining hypothesis is the one they will reach for —
+    // it is plausible, it is documented elsewhere in this repo, and it is wrong here.
+
+    [Fact]
+    public void TheDeadCallGraphFinding_IsRecordedForTheNextReader()
+    {
+        var src = Read("AlRunner", "Patches", "RecordPatches.PartialLoad.cs");
+
+        Assert.Contains("ALSetBaseLoadFields", src, StringComparison.Ordinal);
+        Assert.Contains("#3372", src, StringComparison.Ordinal);
+    }
+
+    // The claim must name what settled it, not merely assert it: a reader who cannot re-run the
+    // measurement cannot check the account, and loud-failures.md's citation clause (#3399) is
+    // about exactly that — a correct finding reached by a misdescribed method is
+    // indistinguishable from a wrong one.
+    [Fact]
+    public void TheFinding_CitesHowItWasMeasured_NotJustItsConclusion()
+    {
+        var src = Read("AlRunner", "Patches", "RecordPatches.PartialLoad.cs");
+
+        Assert.Contains("find_callers", src, StringComparison.Ordinal);
+        // Both BC versions the measurement was taken on, so "identical on both" is checkable.
+        Assert.Contains("27.0", src, StringComparison.Ordinal);
+        Assert.Contains("28.4", src, StringComparison.Ordinal);
+    }
+
+    // The hypothesis that turned out to be wrong is named as wrong. An investigation that
+    // records only its conclusion invites the next reader to re-derive the discarded branch.
+    [Fact]
+    public void TheFinding_SaysItIsNotR2rInlining()
+    {
+        var src = Read("AlRunner", "Patches", "RecordPatches.PartialLoad.cs");
+
+        Assert.Contains("inlin", src, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/AlRunner.Tests/PartialLoadFieldListRefusalTests.cs
+++ b/AlRunner.Tests/PartialLoadFieldListRefusalTests.cs
@@ -1,0 +1,231 @@
+// PartialLoadFieldListRefusalTests — the `fields is null` arm of the AreFieldsLoaded patch
+// refuses instead of answering the success value (#3372 item 1).
+//
+// ── WHAT WAS THERE, AND WHY IT WAS THE ONE WRITTEN THE OTHER WAY ─────────────────────────
+// RecordPatches.PartialLoad.cs replaces RecordImplementation.AreFieldsLoaded(IEnumerable<
+// NCLMetaField>). Its `fields is null` arm returned TRUE — the success answer — for an input
+// it had not interpreted. loud-failures.md forbids exactly that: a surface the runner cannot
+// answer faithfully throws, naming the API and the reason, never returns a default.
+//
+// The reviewer of #3365 judged the arm unreachable from AL, and that reading is correct TODAY:
+// NavRecord.AreFieldsLoaded(DataError, params int[]) calls ArgumentNullException.ThrowIfNull
+// (fields) and then passes a GetMetaFields result that is either null — returning false
+// without reaching the patch — or a real NCLMetaField[]. Body-identical on 27.0 and 28.4
+// (compare_symbols, bodyChanged: false, on both NavRecord.AreFieldsLoaded and
+// RecordImplementation.AreFieldsLoaded).
+//
+// That is a property of today's CALLERS, not of the code, and nothing enforced it. PR #3856
+// measured the cost of trusting exactly that kind of reading: guards-need-a-third-state.md
+// had recorded #3361 part 2 as unreachable with a named backstop, three independent readers
+// credited the backstop, and it turned out not to cover the shape that occurs. Its operative
+// line — a neighbour is evidence only when you have executed the guard on the input you are
+// claiming it covers — is what these tests do: they CALL the guard with null and assert the
+// refusal, rather than arguing the call cannot happen.
+//
+// ── WHY BcShapeGapException AND NOT RunnerOutOfScopeException ────────────────────────────
+// BcShapeGapException.cs's header draws the line on whether the runner OBTAINED the
+// information. A null field list is a value the runner was handed and cannot interpret —
+// the same case as the non-enumerable value the very next line already refuses through
+// BcShape.RequiredEnumerable. It is not a scope claim: partial records are in scope and
+// implemented. And a shape gap cannot be absorbed by an `expect-oos` manifest entry, which
+// matters because whether BC hands a null here is a property of the BC build on disk.
+//
+// ── THE SHAPE, NOT THE REPORTED LINE ─────────────────────────────────────────────────────
+// RequiredEnumerable had seven call sites. Six handle null BEFORE calling it — three with an
+// explicit BcShapeGapException, three with a deliberate return/continue carrying a stated
+// reason. PartialLoad.cs was the seventh and the only one answering the success value. The
+// fix puts the refusal in RequiredEnumerable itself, so the helper can no longer be reached
+// with a null that produces a NullReferenceException from `value.GetType()` naming nothing.
+// Class 2 below pins that root fix; the six existing sites keep their own earlier handling
+// and are unaffected, which class 2's last test asserts directly.
+//
+// ── WHY THESE LIVE IN AlRunner.Tests AND NOT THE UPSTREAM CORPUS ─────────────────────────
+// Nothing here is a claim about Business Central. No AL statement can hand BC's own
+// AreFieldsLoaded a null field list — that is the whole point of the unreachability finding
+// above — so a service tier has nothing to adjudicate. The subject is the runner's own
+// refusal contract, which bc-behavior-tests-go-upstream.md classifies as runner-specific.
+// Same reasoning as BcShapeGapConventionTests and VirtualTableRefusalClaimTests.
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using System.Reflection;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PartialLoadFieldListRefusalTests
+{
+    private const string Surface = "Record.AreFieldsLoaded (partial records)";
+    private const string Member = "RecordImplementation.AreFieldsLoaded(fields)";
+
+    // ══ 1. The patch's own null arm refuses ═══════════════════════════════════════════════
+    //
+    // The patch reads BC internals off `self.GetType()` before it looks at `fields`, so these
+    // drive the interpretation step through the same helper the patch calls, with the same
+    // surface and member strings the patch passes. That keeps the assertion about the runner's
+    // refusal contract rather than about a BC type being loadable in a unit-test process.
+
+    [Fact]
+    public void NullFieldList_Refuses_RatherThanAnsweringTrue()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => BcShape.RequiredEnumerable(
+                null!, Member, Surface, "the runner cannot tell which fields were asked about"));
+
+        Assert.Equal(Surface, ex.Surface);
+        Assert.Equal(Member, ex.Member);
+        Assert.Contains("read as null", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("the runner cannot tell which fields were asked about",
+            ex.Message, StringComparison.Ordinal);
+    }
+
+    // The refusal must name the surface and member in the MESSAGE, not only in the properties:
+    // the reporter and the expectations manifest see the rendered text, and a message that
+    // names neither sends a reader to no particular line.
+    [Fact]
+    public void NullRefusal_MessageNamesTheSurfaceAndTheMember()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => BcShape.RequiredEnumerable(null!, Member, Surface, "detail text"));
+
+        Assert.StartsWith(BcShapeGapException.Prefix, ex.Message, StringComparison.Ordinal);
+        Assert.Contains(Surface, ex.Message, StringComparison.Ordinal);
+        Assert.Contains(Member, ex.Message, StringComparison.Ordinal);
+    }
+
+    // guards-need-a-third-state.md's constraint, asserted rather than assumed: the fix must not
+    // trade a false green for a false red. A field list that IS enumerable — including a
+    // legitimately EMPTY one, which BC's own body treats as "all loaded" — keeps answering.
+    [Fact]
+    public void EmptyFieldList_StillEnumerates_AndIsNotRefused()
+    {
+        var empty = new object[0];
+
+        var result = BcShape.RequiredEnumerable(empty, Member, Surface, "detail text");
+
+        Assert.Same(empty, result);
+        Assert.Empty(result.Cast<object>());
+    }
+
+    [Fact]
+    public void NonEmptyFieldList_StillEnumerates_AndIsNotRefused()
+    {
+        var fields = new object[] { "FieldA", "FieldB" };
+
+        var result = BcShape.RequiredEnumerable(fields, Member, Surface, "detail text");
+
+        Assert.Equal(new object[] { "FieldA", "FieldB" }, result.Cast<object>().ToArray());
+    }
+
+    // The three-state discrimination, all three arms in one place so a later edit that collapses
+    // two of them fails here. Absent (null) and uninterpretable are BOTH refusals and must stay
+    // DISTINGUISHABLE by message; present-and-enumerable stays the pass.
+    [Fact]
+    public void NullAndNonEnumerable_BothRefuse_ButSayDifferentThings()
+    {
+        var onNull = Assert.Throws<BcShapeGapException>(
+            () => BcShape.RequiredEnumerable(null!, Member, Surface, "detail text"));
+        var onOpaque = Assert.Throws<BcShapeGapException>(
+            () => BcShape.RequiredEnumerable(42, Member, Surface, "detail text"));
+
+        Assert.Contains("read as null", onNull.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("read as null", onOpaque.Message, StringComparison.Ordinal);
+        Assert.Contains("Int32", onOpaque.Message, StringComparison.Ordinal);
+        Assert.Contains("cannot be enumerated", onOpaque.Message, StringComparison.Ordinal);
+
+        // And the pass arm, so "everything refuses" cannot satisfy this test.
+        Assert.Empty(BcShape.RequiredEnumerable(
+            new object[0], Member, Surface, "detail text").Cast<object>());
+    }
+
+    // A null must NOT come back as the NullReferenceException that `value.GetType()` produced
+    // before the fix. That exception names no surface, no member and no remedy, and on an
+    // AL-entered path MethodScopePatches.NavMethodScope_AssertError's unfiltered catch would
+    // swallow it — the inversion BcShapeGapException.cs's header documents at #3046.
+    [Fact]
+    public void NullRefusal_IsNotABareNullReferenceException()
+    {
+        var ex = Record.Exception(
+            () => BcShape.RequiredEnumerable(null!, Member, Surface, "detail text"));
+
+        Assert.NotNull(ex);
+        Assert.IsNotType<NullReferenceException>(ex);
+        Assert.IsType<BcShapeGapException>(ex);
+    }
+
+    // ══ 2. The patch source no longer carries the silent default ══════════════════════════
+    //
+    // Classes 1's assertions are about the helper. This one is about the CALL SITE: the arm
+    // the issue names must be gone from RecordPatches.PartialLoad.cs, and it must be gone by
+    // being routed through the refusing helper rather than by being deleted outright (which
+    // would leave the null reaching `foreach` as a NullReferenceException instead).
+
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    // A source-reading assertion whose file is missing or empty would pass VACUOUSLY — the
+    // absent thing reading as the success answer, which is the defect class these tests are
+    // about. So the read refuses rather than returning "" (guards-need-a-third-state.md).
+    private static string ReadPatch(string fileName)
+    {
+        var path = Path.Combine(RepoRoot, "AlRunner", "Patches", fileName);
+        Assert.True(File.Exists(path), $"patch source not found, so nothing was measured: {path}");
+        var src = File.ReadAllText(path);
+        Assert.False(string.IsNullOrWhiteSpace(src), $"patch source is empty, so nothing was measured: {path}");
+        return src;
+    }
+
+    private static string PartialLoadSource() => ReadPatch("RecordPatches.PartialLoad.cs");
+
+    [Fact]
+    public void PatchSource_NoLongerReturnsTrueForANullFieldList()
+    {
+        var src = PartialLoadSource();
+
+        Assert.DoesNotContain("if (fields is null) return true;", src, StringComparison.Ordinal);
+        Assert.DoesNotContain("if (fields == null) return true;", src, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PatchSource_StillRoutesTheFieldListThroughTheRefusingHelper()
+    {
+        var src = PartialLoadSource();
+
+        Assert.Contains("BcShape.RequiredEnumerable(", src, StringComparison.Ordinal);
+        Assert.Contains(Member, src, StringComparison.Ordinal);
+    }
+
+    // The unfetched-record short-circuit is BC's own and is NOT what this change is about.
+    // It must survive: corpus test PartialLoad_AreFieldsLoaded_BeforeFetch_ReturnsFalse rests
+    // on it, and turning it into a refusal would red that test.
+    [Fact]
+    public void PatchSource_KeepsBcsOwnUnfetchedBufferShortCircuit()
+    {
+        var src = PartialLoadSource();
+
+        Assert.Contains("return false;", src, StringComparison.Ordinal);
+        Assert.Contains("mutableRecordBuffer", src, StringComparison.Ordinal);
+    }
+
+    // The six pre-existing RequiredEnumerable call sites each handle null themselves, before
+    // the helper is reached. The root fix must not have removed that: their own handling is
+    // what distinguishes "BC legitimately has no rows" (a pass, per
+    // guards-need-a-third-state.md's constraint) from "the member moved".
+    [Theory]
+    [InlineData("RecordPatches.ObjectMetadataSystemTable.cs")]
+    [InlineData("RecordPatches.PageControlFieldFromBcDocument.cs")]
+    [InlineData("RecordPatches.QueryProjection.cs")]
+    [InlineData("RowVersionPatches.SystemIdIntegrity.cs")]
+    [InlineData("RecordPatches.InstallBaseline.cs")]
+    public void SiblingCallSites_StillHandleNullBeforeReachingTheHelper(string fileName)
+    {
+        var src = ReadPatch(fileName);
+
+        Assert.Contains("RequiredEnumerable", src, StringComparison.Ordinal);
+        Assert.Contains("== null", src, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner/Infrastructure/BcShapeGapException.cs
+++ b/AlRunner/Infrastructure/BcShapeGapException.cs
@@ -272,11 +272,22 @@ internal static class BcShape
     /// <see cref="BcShapeGapException"/> naming what it actually held. A member that exists
     /// but holds an uninterpretable shape is the same "BC's layout moved" case as an absent
     /// one, and folding it into the absent/null branch is how #2786's silent skip happened.
+    /// A null refuses too, and says so distinguishably: before #3372 it reached
+    /// <c>value.GetType()</c> and raised a <see cref="NullReferenceException"/> naming no
+    /// surface, member or remedy — which an AL-entered path's unfiltered catch would swallow.
+    /// Callers that can legitimately be handed a null still decide that themselves, ahead of
+    /// this call; six of the seven call sites do, and their handling is unaffected.
     /// </summary>
-    public static IEnumerable RequiredEnumerable(object value, string member, string surface, string detail)
-        => value as IEnumerable
-           ?? throw new BcShapeGapException(
-               surface, member, $"holds a {value.GetType().Name}, which cannot be enumerated — {detail}");
+    public static IEnumerable RequiredEnumerable(object? value, string member, string surface, string detail)
+    {
+        if (value is null)
+            throw new BcShapeGapException(
+                surface, member, $"read as null, so it cannot be enumerated — {detail}");
+
+        return value as IEnumerable
+               ?? throw new BcShapeGapException(
+                   surface, member, $"holds a {value.GetType().Name}, which cannot be enumerated — {detail}");
+    }
 
     // ── THE NULL-FORGIVING HALF (#3051) ─────────────────────────────────────────────────
     //

--- a/AlRunner/Patches/RecordPatches.PartialLoad.cs
+++ b/AlRunner/Patches/RecordPatches.PartialLoad.cs
@@ -17,7 +17,9 @@
 // the data path is untouched: the read of an unloaded field still lands on BC's
 // GetFieldValue `else if` arm, which calls AddLoadField and flips the field to loaded.
 //
-// Alternatives weighed and the one divergence this leaves: PR for #3358.
+// The one divergence this leaves — narrowing the load set AFTER a fetch and asking before
+// re-fetching — is written up, with the BC side still awaiting a service-tier verdict, at
+// docs/limitations.md#are-fields-loaded-narrow-after-fetch. Alternatives weighed: PR for #3358.
 // Reference: upstream corpus codeunit 60775 "Test Record Partial Load".
 
 using System.Collections;
@@ -48,10 +50,12 @@ public static partial class RecordPatches
         // Get/Find nothing is loaded, not even the primary key.
         if (_riMutableRecordBuffer!.GetValue(self) is null) return false;
 
-        // BC's own body treats an empty field list as "all loaded" and does not null-check
-        // here — NavRecord.AreFieldsLoaded has already thrown on a null array upstream.
-        if (fields is null) return true;
-
+        // An EMPTY field list is "all loaded", which the loop below answers by not iterating —
+        // BC's own body does the same. A NULL one is refused by RequiredEnumerable rather than
+        // answered: today NavRecord.AreFieldsLoaded's ArgumentNullException.ThrowIfNull upstream
+        // makes it unreachable, but that is a property of BC's callers, not of this code,
+        // so answering the success value would be the silent default loud-failures.md forbids
+        // (#3372; the refusal is executed on a null in PartialLoadFieldListRefusalTests).
         var enumerable = BcShape.RequiredEnumerable(
             fields, "RecordImplementation.AreFieldsLoaded(fields)", PartialLoadSurface,
             "the runner cannot tell which fields were asked about");

--- a/AlRunner/Patches/RecordPatches.PartialLoad.cs
+++ b/AlRunner/Patches/RecordPatches.PartialLoad.cs
@@ -21,6 +21,16 @@
 // re-fetching — is written up, with the BC side still awaiting a service-tier verdict, at
 // docs/limitations.md#are-fields-loaded-narrow-after-fetch. Alternatives weighed: PR for #3358.
 // Reference: upstream corpus codeunit 60775 "Test Record Partial Load".
+//
+// TRAP: three NEIGHBOURING partial-load rewrites cannot be turned red by any test, and the
+// reason is a dead call graph, NOT the R2R inlining the obvious hypothesis reaches for
+// (#3372). Measured with find_callers over Ncl.dll, identical on 27.0 and 28.4:
+// ALSetBaseLoadFields/0 has ZERO callers; ALSetBaseLoadFields/1's only caller is /0; and
+// RecordImplementation.SetLoadFields(FieldLoadInfo)'s only caller is
+// DataItemIterator.SetLoadFieldsBasedOnMetadata, which this runner already Cecil-no-ops.
+// AL's SetLoadFields reaches the ISet overload instead, never the FieldLoadInfo one. So a
+// test going red on those three would mean a caller appeared — which is what
+// PartialLoadDeadRewriteTests watches for.
 
 using System.Collections;
 using System.Reflection;

--- a/AlRunner/Patches/RecordPatches.PartialLoad.cs
+++ b/AlRunner/Patches/RecordPatches.PartialLoad.cs
@@ -17,8 +17,9 @@
 // the data path is untouched: the read of an unloaded field still lands on BC's
 // GetFieldValue `else if` arm, which calls AddLoadField and flips the field to loaded.
 //
-// The one divergence this leaves — narrowing the load set AFTER a fetch and asking before
-// re-fetching — is written up, with the BC side still awaiting a service-tier verdict, at
+// The one divergence this leaves — narrowing the load set after a field is already in the
+// fetched buffer — is service-tier measured (corpus PR 323, cloud legs 27.3 and 27.5: BC keeps
+// the field loaded, and a re-fetch does not change that) and tracked by #3859. Write-up:
 // docs/limitations.md#are-fields-loaded-narrow-after-fetch. Alternatives weighed: PR for #3358.
 // Reference: upstream corpus codeunit 60775 "Test Record Partial Load".
 //

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -684,7 +684,7 @@ the exact value will see different results.
 | `Commit()` | Commits current transaction | Establishes a rollback commit-point — see "Transaction semantics" above; not a no-op |
 | `FilterGroup(n)` | Scoped filter groups | Tracked — BC's own `NavRecord` filter state runs here. Pinned upstream by `record/TestFilterContracts.al` (`FilterGroup2_CombinesWithFilterGroup0_AsAND`, `Reset_AfterFilterGroup2_ClearsBothGroups`) and measured 2026-09-07: a group-2 `SetRange` intersected with a group-0 `SetFilter` answered the intersection, and `GetFilters` reported only group 0, as on BC. This row said "no-op" until the 2026-09 audit |
 
-### `Record.AreFieldsLoaded` after a load set narrows — answered from the requested set, not the buffer in hand
+### `Record.AreFieldsLoaded` after a load set narrows — answered from the requested set, not the buffer in hand (service-tier measured)
 
 <a id="are-fields-loaded-narrow-after-fetch"></a>
 
@@ -694,30 +694,34 @@ runner's `TempTableDataProvider` returns whole rows and the fetched buffer there
 table's *default* load info whatever the request asked for — so reading the buffer answered
 "loaded" for every field on every table.
 
-That leaves **one ordering** where the runner and real BC can differ:
+That leaves a divergence whenever a load set **narrows after a field is already in the buffer**:
 
 ```
-fetch  ->  SetLoadFields(narrower)  ->  AreFieldsLoaded, WITHOUT re-fetching
+full fetch  ->  SetLoadFields(narrower)  ->  AreFieldsLoaded
 ```
 
 | | answers |
 |---|---|
-| real BC | from the buffer already in hand, which was fetched under the wider set — so a field the narrowing call just dropped still reports **loaded** |
+| real BC | from the buffer in hand — the field was fetched under the wider set, so it still reports **loaded**, and **a re-fetch does not change that** |
 | al-runner | from the narrowed request — so it reports **unloaded** |
 
-Re-fetch between the two calls and the answers agree. Every test in corpus codeunit 60775
-`"Test Record Partial Load"` does re-fetch, which is the shape BC's documentation describes,
-so nothing in the corpus measures this ordering today and no `expect-divergence` entry exists
-for it — that mode declares a corpus test that fails here, and none does.
+**Measured on a service tier**, corpus PR
+[#323](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/323), cloud legs
+27.3 and 27.5, identical on both (27.0 and 27.3 ship the same `Ncl.dll`; 27.5 is a separate
+binary). The re-fetch case is the part worth stating, because it is the one that surprises: this
+row originally claimed a re-fetch made the narrowed set observable and **the tier said
+otherwise**, which is why the corpus codeunit 60766 now asserts BC's answer instead.
 
-**The BC column is not yet adjudicated.** It is the reading of BC's own
-`RecordImplementation.AreFieldsLoaded`, whose body reads `mutableRecordBuffer.ReadOnlyBuffer`
-(body-identical on 27.0 and 28.4), not a service-tier measurement — and
-`ask-the-corpus-before-claiming-bc-behavior.md` ranks reading the code below a corpus verdict.
-Corpus PR
-[#323](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/323) puts the
-ordering in front of a real tier, with a re-fetching control arm. **If it comes back the other
-way, this row is what gets corrected.**
+**What distinguishes this from corpus codeunit 60775**, whose
+`PartialLoad_SetLoadFieldsNoArgs_ResetsToFullLoad` asserts *unloaded* and is green in the same
+run: the preceding **full** fetch, not the re-fetch. 60775 fetches under an already-narrow set,
+so the field was never in the buffer. Narrowing is a hint about what to fetch next; it does not
+evict a row already materialised.
+
+**Tracked by [#3859](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3859).**
+No `expect-divergence` entry exists yet, because that mode declares a corpus test that **fails**
+here and corpus codeunit 60766 has not merged. Once it does, its first and third arms are
+expected to fail on the runner, and will need either the fix or an entry naming that issue.
 
 Why the runner does not simply stamp the request's `FieldLoadInfo` onto the fetched buffer:
 `GetFieldValue` branches on the **buffer**, so a buffer claiming a field is absent routes the

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -707,16 +707,22 @@ full fetch  ->  SetLoadFields(narrower)  ->  AreFieldsLoaded
 
 **Measured on a service tier**, corpus PR
 [#323](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/323), cloud legs
-27.3 and 27.5, identical on both (27.0 and 27.3 ship the same `Ncl.dll`; 27.5 is a separate
-binary). The re-fetch case is the part worth stating, because it is the one that surprises: this
-row originally claimed a re-fetch made the narrowed set observable and **the tier said
-otherwise**, which is why the corpus codeunit 60766 now asserts BC's answer instead.
+27.3 and 27.5. The re-fetch case is the part worth stating, because it is the one that
+surprises: this row originally claimed a re-fetch made the narrowed set observable and **the
+tier said otherwise**, which is why corpus codeunit 60766 now asserts BC's answer instead.
+
+Those two legs are **not independent confirmations of each other**: on the box where this was
+investigated, 27.0, 27.3 and 27.5 all ship a byte-identical `Ncl.dll` (sha256 `affa03c9…`,
+10716984 bytes), so the whole provisioned 27.x runtime is one binary set. What carries the claim
+is the mechanism below, which does not depend on how many legs reported.
 
 **What distinguishes this from corpus codeunit 60775**, whose
 `PartialLoad_SetLoadFieldsNoArgs_ResetsToFullLoad` asserts *unloaded* and is green in the same
 run: the preceding **full** fetch, not the re-fetch. 60775 fetches under an already-narrow set,
 so the field was never in the buffer. Narrowing is a hint about what to fetch next; it does not
-evict a row already materialised.
+evict a row already materialised — `RecordImplementation.TrySetNewFieldLoadInfoAndInvalidate`
+assigns `TableState.FieldLoadInfo` and invalidates the result-set enumerator, and discards no
+materialised row.
 
 **Tracked by [#3859](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3859).**
 No `expect-divergence` entry exists yet, because that mode declares a corpus test that **fails**

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -684,6 +684,47 @@ the exact value will see different results.
 | `Commit()` | Commits current transaction | Establishes a rollback commit-point — see "Transaction semantics" above; not a no-op |
 | `FilterGroup(n)` | Scoped filter groups | Tracked — BC's own `NavRecord` filter state runs here. Pinned upstream by `record/TestFilterContracts.al` (`FilterGroup2_CombinesWithFilterGroup0_AsAND`, `Reset_AfterFilterGroup2_ClearsBothGroups`) and measured 2026-09-07: a group-2 `SetRange` intersected with a group-0 `SetFilter` answered the intersection, and `GetFilters` reported only group 0, as on BC. This row said "no-op" until the 2026-09 audit |
 
+### `Record.AreFieldsLoaded` after a load set narrows — answered from the requested set, not the buffer in hand
+
+<a id="are-fields-loaded-narrow-after-fetch"></a>
+
+`AreFieldsLoaded` reports from the load set BC maintains in `TableState.FieldLoadInfo`
+([#3358](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3358)), because the
+runner's `TempTableDataProvider` returns whole rows and the fetched buffer therefore carries the
+table's *default* load info whatever the request asked for — so reading the buffer answered
+"loaded" for every field on every table.
+
+That leaves **one ordering** where the runner and real BC can differ:
+
+```
+fetch  ->  SetLoadFields(narrower)  ->  AreFieldsLoaded, WITHOUT re-fetching
+```
+
+| | answers |
+|---|---|
+| real BC | from the buffer already in hand, which was fetched under the wider set — so a field the narrowing call just dropped still reports **loaded** |
+| al-runner | from the narrowed request — so it reports **unloaded** |
+
+Re-fetch between the two calls and the answers agree. Every test in corpus codeunit 60775
+`"Test Record Partial Load"` does re-fetch, which is the shape BC's documentation describes,
+so nothing in the corpus measures this ordering today and no `expect-divergence` entry exists
+for it — that mode declares a corpus test that fails here, and none does.
+
+**The BC column is not yet adjudicated.** It is the reading of BC's own
+`RecordImplementation.AreFieldsLoaded`, whose body reads `mutableRecordBuffer.ReadOnlyBuffer`
+(body-identical on 27.0 and 28.4), not a service-tier measurement — and
+`ask-the-corpus-before-claiming-bc-behavior.md` ranks reading the code below a corpus verdict.
+Corpus PR
+[#323](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/323) puts the
+ordering in front of a real tier, with a re-fetching control arm. **If it comes back the other
+way, this row is what gets corrected.**
+
+Why the runner does not simply stamp the request's `FieldLoadInfo` onto the fetched buffer:
+`GetFieldValue` branches on the **buffer**, so a buffer claiming a field is absent routes the
+read down `NavRecord.LoadFieldsAsync` — a genuine partial re-fetch the runner's provider has
+never served, on the path every fetch takes. Leaving it alone keeps BC's `else if` arm, which
+calls `AddLoadField` and flips the field to loaded, which is what the JIT-load claim requires.
+
 ### `TestPage.Edit()` on a page declaring `Editable = false` — refused by name, not by NRE
 
 <a id="testpage-page-mode-no-edit-action"></a>

--- a/tests/expectations/known-gaps-record-partial-load-narrow.json
+++ b/tests/expectations/known-gaps-record-partial-load-narrow.json
@@ -1,0 +1,26 @@
+[
+  {
+    "codeunitId": 60766,
+    "CodeunitName": "Test Rec Partial Load Narrow",
+    "Method": "PartialLoadNarrow_AfterFetch_NoRefetch_ReportsBufferInHand",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3859",
+    "Note": "Real BC answers AreFieldsLoaded from the MATERIALISED BUFFER; the runner answers from the REQUESTED load set (TableState.FieldLoadInfo). Here a full fetch loads Text Field, SetLoadFields(Integer Field) then narrows the request without a re-fetch, and BC still reports the field loaded because it is physically in the buffer. The runner reports unloaded.\n\nMeasured on a real service tier, not inferred: corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#323 is green on all eight cloud legs (27.0, 27.3, 27.5, 28.0, 28.1, 28.2, 28.3, 28.4), and this runner's 27.0 and 27.5 legs fail all three of the codeunit's methods.\n\nWhy the runner reports from the request at all: the runner routes every table through BC's in-memory TempTableDataProvider, which returns WHOLE ROWS, so the fetched buffer carries the table's DEFAULT FieldLoadInfo whatever was asked for. Reading the buffer therefore answered 'loaded' for every field on every table, which is the defect #3358 fixed by reporting from the load set instead -- pinned by corpus codeunit 60775, also green on all eight legs. So the two codeunits require the two different sources, and neither can simply be switched to the other: a real fix has to make the runner's buffer itself carry a truthful FieldLoadInfo. That is the LoadFieldsAsync blast radius #3358 weighed and rejected, on the path every fetch takes. #3859 tracks it."
+  },
+  {
+    "codeunitId": 60766,
+    "CodeunitName": "Test Rec Partial Load Narrow",
+    "Method": "PartialLoadNarrow_AfterNarrowFetch_WidenNoRefetch_StaysUnloaded",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3859",
+    "Note": "The mirror direction, and the one showing the divergence is not one-sided. A field genuinely ABSENT from the buffer must stay unloaded when the requested set widens without a re-fetch -- BC answers from the buffer, which no fetch has refilled. The runner answers from the request, which SetLoadFields() has just widened to the full default, so it reports loaded.\n\nSo the runner is wrong in both directions on this axis: it reports unloaded where BC reports loaded (the entry above) and loaded where BC reports unloaded (here). Both are the same root cause -- the source the answer is read from -- rather than two defects. Same measurement as the entry above: corpus PR #323 green on eight cloud legs, this runner red on 27.0 and 27.5. #3859."
+  },
+  {
+    "codeunitId": 60766,
+    "CodeunitName": "Test Rec Partial Load Narrow",
+    "Method": "PartialLoadNarrow_AfterFetch_WithRefetch_KeepsTheFieldLoaded",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3859",
+    "Note": "Narrowing after a full fetch does not unload a field already in the buffer EVEN ACROSS A RE-FETCH. This arm is the one that refuted the original prediction: it first asserted the narrowed set becomes observable after re-fetching, and the 27.3 and 27.5 legs of corpus PR #323 said otherwise, so the assertion was corrected to BC's answer rather than the tier being argued with.\n\nThe distinguishing factor is the preceding FULL fetch, not the re-fetch, which is what reconciles this with corpus codeunit 60775's PartialLoad_SetLoadFieldsNoArgs_ResetsToFullLoad asserting UNLOADED and staying green in the same run: 60775 fetches under an already-narrow set, so the field was never in the buffer. Narrowing is a hint about what to fetch next; it does not evict a materialised row -- RecordImplementation.TrySetNewFieldLoadInfoAndInvalidate assigns TableState.FieldLoadInfo and invalidates the result-set enumerator, and discards no row.\n\nThe method's second half is a NEGATIVE arm on a different row fetched for the first time under the narrow set, which the runner answers correctly; the method fails on the first assertion. #3859."
+  }
+]

--- a/tools/test_matrix_docs_drift.py
+++ b/tools/test_matrix_docs_drift.py
@@ -182,6 +182,16 @@ NOT_A_MATRIX_CLAIM = [
     ("docs/runtime-packages.md", "27.5 28.1 28.4",
      "the three BC compilers that built the three genuine third-party runtime packages measured "
      "for #3537 -- a historical measurement of which builds were compared, not the matrix"),
+    # The artifact directories whose Ncl.dll was HASHED, recording that they are one binary
+    # (#3372). The sentence exists to retract a claim that two of those legs independently
+    # confirmed a corpus verdict -- they do not, because all three ship sha256 affa03c9....
+    # Not expressible as a leg set: rewriting it into one would delete the retraction, which
+    # is the only reason the sentence is there.
+    ("docs/limitations.md", "27.0 27.3 27.5",
+     "the 27.x artifact directories whose Ncl.dll was hashed while checking whether the "
+     "AreFieldsLoaded corpus verdict rested on independent binaries -- it does not, all "
+     "three are byte-identical. A historical measurement of what was compared, not the "
+     "matrix (#3372)"),
 ]
 
 


### PR DESCRIPTION
Closes #3372

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/323

Implemented by the `stma-auto-11` agent. Three follow-ups from the review of #3365, all in code that merged. All three are addressed; item 3's answer is different from either branch the issue anticipated, and the difference is the finding.

---

## Item 1 — the silent default, and why it throws rather than being asserted unreachable

The `fields is null` arm of the `AreFieldsLoaded` patch returned **`true`** — the success answer — for an input it had not interpreted. `loud-failures.md` forbids exactly that.

**The unreachability claim is correct, and I measured it rather than taking it on trust.** `NavRecord.AreFieldsLoaded(DataError, params int[])` calls `ArgumentNullException.ThrowIfNull(fields)` and then passes a `GetMetaFields` result that is either `null` — returning `false` before the patch is reached — or a real `NCLMetaField[]`. `compare_symbols` reports `bodyChanged: false` between 27.0 and 28.4 for both `NavRecord.AreFieldsLoaded` and `RecordImplementation.AreFieldsLoaded`, so it is stable across the supported range.

**I still made it throw.** The issue's fork allows either, and the brief asked for a deliberate pick with a reason:

- Unreachability is a property of BC's *callers*, not of this code, and nothing enforced it. PR #3856 measured what trusting that kind of reading costs — a "neighbour" three independent readers had credited turned out not to cover the shape that occurs.
- Asserting unreachability instead would mean pinning the absence of a caller inside a precompiled DLL. That is a weaker guarantee than a refusal *and* something to maintain forever; the refusal needs neither.
- The refusal arm is **executed on a null** by the new tests, which is the standard #3856 set: a guard is covered when you have run it on the input you claim it covers, not when you have argued the input cannot arrive.

**`BcShapeGapException`, not `RunnerOutOfScopeException`** — `BcShapeGapException.cs`'s header draws the line on whether the runner *obtained* the information. A null field list is a value handed to the runner that it cannot interpret: the same case as the non-enumerable value the very next line already refuses. It is not a scope claim (partial records are in scope and implemented), and a shape gap cannot be absorbed by an `expect-oos` entry — which matters, because whether BC hands a null here is a property of the BC build on disk.

### Fix the shape, not the reported line

`BcShape.RequiredEnumerable` had **seven** call sites. Six handle null *before* calling it — three with an explicit `BcShapeGapException`, three with a deliberate `return`/`continue` carrying a stated reason. `RecordPatches.PartialLoad.cs` was the seventh and **the only one answering the success value**. Six against one is the two-independent-instances bar, so the fix went into `RequiredEnumerable` itself rather than only at the reported line: a null previously reached `value.GetType()` and raised a `NullReferenceException` naming no surface, member or remedy.

The six existing sites keep their own earlier handling and are unaffected — a test asserts that directly, because that handling is what distinguishes "BC legitimately has no rows" (a pass) from "the member moved".

### RED → GREEN, with the mutation

| | result |
|---|---|
| RED (fix absent) | **Failed: 5, Passed: 9**, Total 14 — the null arrived at `value.GetType()` as `NullReferenceException` |
| GREEN (fix present) | **Failed: 0, Passed: 14, Skipped: 0** |

`guards-need-a-third-state.md`'s constraint is asserted, not assumed: an **empty** field list — which BC's own body treats as "all loaded" — still enumerates and is not refused, so the fix cannot have traded a false green for a false red. And null vs. non-enumerable stay distinguishable by message, both refusing, with the pass arm in the same test so "everything refuses" cannot satisfy it.

---

## Item 2 — the divergence now has a durable home, and a service tier is being asked

The narrow-after-fetch divergence lived only in a merged PR body. It is now `docs/limitations.md#are-fields-loaded-narrow-after-fetch`, in the "Behavioural differences" section, with a pointer left at the patch (`loud-failures.md`'s claim-plus-citation split).

**The part that needed care: the BC side of that table is a BC-behaviour claim, and it had never been measured.** "Real BC answers from the buffer already in hand" came from reading `RecordImplementation.AreFieldsLoaded`, which `ask-the-corpus-before-claiming-bc-behavior.md` ranks *below* a corpus verdict. Writing it into `docs/` as established would have laundered a reading into a fact — so the entry said plainly that it was awaiting adjudication, and **corpus PR #323** put the ordering in front of a real service tier.

### The tier answered, and it contradicted one arm

Cloud legs **27.3 and 27.5**, identical on both. Codeunit 60766 confirmed executed, `[294/426]`, via `tools/corpus-pass-count.py`; the six other cloud legs were still pending, and the OnPrem legs correctly report "codeunit not in this leg's suite".

**Correction to my own stated basis, on review.** I justified acting on two legs by calling them independent binaries. They are not. On this box 27.0, 27.3 **and 27.5** all ship a byte-identical `Ncl.dll` — `sha256 affa03c9…`, 10716984 bytes — so the provisioned 27.x runtime is one binary set and those two legs confirm one binary, not two. What I actually measured was 27.0 ≡ 27.3 by MVID; I then *inferred* 27.5 differed because it is a different minor and wrote that inference as a measurement. 27.5 was never loaded or hashed.

The conclusion stands, but on the **mechanism**, which does not depend on binary independence at all — and the mechanism is the stronger evidence anyway. Corrected in `docs/`, in the corpus test's claim comment, and here. Per `loud-failures.md` (#3855): a reviewer can only check the account, never the result, so a correct finding with a misdescribed method is indistinguishable from a wrong one.

| arm | BC |
|---|---|
| narrow after full fetch, no re-fetch | **loaded** — as predicted |
| widen after narrow fetch, no re-fetch | **unloaded** — as predicted |
| narrow after full fetch, **with** re-fetch | **loaded** — the opposite of what I asserted |

So the re-fetch does **not** make the narrowed set observable. I corrected the corpus assertion to BC's answer and did **not** touch the tier — inverting a service-tier result is the move `ask-the-corpus-before-claiming-bc-behavior.md` exists to prevent.

**The mechanism, which also reconciles it with 60775 — and which is what the claim actually rests on.** `PartialLoad_SetLoadFieldsNoArgs_ResetsToFullLoad` asserts *unloaded* on an apparently similar shape and is green in the same run. Two corpus tests appearing to contradict each other means the distinction has not been found yet — and it is the **preceding full fetch**, not the re-fetch: 60775 fetches under an already-narrow set, so the field was never in the buffer. Narrowing is a hint about what to fetch next; it does not evict a row already materialised. Corroborated in `Ncl.dll`: `RecordImplementation.TrySetNewFieldLoadInfoAndInvalidate` assigns `TableState.FieldLoadInfo` and invalidates the result-set enumerator, and discards no materialised row. The corrected arm also gains a **negative half** on a second row fetched for the first time under the narrow set, so the file cannot be satisfied by an implementation answering "loaded" to everything.

**This is why the row was written as unadjudicated.** The gate held it, the tier disagreed, and nothing false shipped. The `docs/` row now carries the measurement, and the divergence — wider than first described, since it survives a re-fetch — is tracked on its own as **#3859** rather than living only in a limitations row.

### Corpus #323 merged, and the runner fails all three arms — declared, not fixed

Upstream green on all **eight** cloud legs (corpus `00356d14`), execution verified per `verify-execution-not-the-tick.md`: 3 distinct PASS on each of the eight, 8 OnPrem `not-run` as expected. This runner fails all three on 27.0 and 27.5.

`al-language-submodule.md` gives two options: land the fix, or add an `expect-fail-known-gap` entry. **I added the entry** (`tests/expectations/known-gaps-record-partial-load-narrow.json`, `Issue: #3859` on each), and the reason is not blast radius alone — it is that **no fix can pick a source**:

| corpus codeunit | requires `AreFieldsLoaded` to answer from | status |
|---|---|---|
| **60775** (4 tests, the defect #3358 fixed) | the **requested load set** — the buffer always claims "loaded", because `TempTableDataProvider` returns whole rows | green on 8 tiers |
| **60766** (3 tests, new) | the **materialised buffer** | green on 8 tiers |

Both are green upstream, so switching the runner from one source to the other just moves the failure. A real fix has to make the runner's *buffer* carry a truthful `FieldLoadInfo` — which routes reads down `NavRecord.LoadFieldsAsync`, a partial re-fetch the provider has never served, on the path every fetch takes. That is the blast radius #3358 weighed; **the measurement confirms that judgement rather than weakening it**, because both directions are now pinned upstream.

**The runner is wrong in both directions**, which the second arm shows: it reports *unloaded* where BC reports loaded, and *loaded* where BC reports unloaded. One root cause, not three defects — #3859's body was written before that arm's measurement existed and has been updated to say so.

Methods are named individually, not `Method: "*"`. All three fail today, so a wildcard would be correct *now* and would silently claim any method later added to that codeunit. Verified both ways against the merged corpus file: no manifest name missing from the codeunit, none of its methods unlisted. `.github/scripts/check_expectation_gap_issues.py` passes with **no overlap** between `#3859` and this PR's closing reference — so the gap stays tracked after this merges.

**Proving test, with its mutation:** the pointer is gated by `tools/test_doc_pointers.py`, which runs on every PR.

| | result |
|---|---|
| anchor present | `ok AlRunner/**/*.cs doc pointers resolve (357 pointers)` — all checks passed |
| anchor renamed away | `FAIL ... (1 of 357): RecordPatches.PartialLoad.cs -> docs/limitations.md#are-fields-loaded-narrow-after-fetch: anchor ... is not in that file` |

So the entry cannot be deleted or renamed without CI saying which file and which anchor.

---

## Item 3 — it is a dead call graph, not R2R inlining

The issue offered two outcomes: find an outer caller to rewrite, or write down that the surface is verified only in aggregate. **Neither is right**, and the measurement is cheap enough that "not fixable at proportionate cost" would have been the wrong answer.

`find_callers` over `Ncl.dll`, **identical on 27.0 and 28.4**:

| rewrite | callers | reachable from AL? |
|---|---|---|
| `NavRecord.ALSetBaseLoadFields()` | **zero, anywhere** | no |
| `NavRecord.ALSetBaseLoadFields(DataError)` | one — `ALSetBaseLoadFields/0`, itself uncalled | no |
| `RecordImplementation.SetLoadFields(FieldLoadInfo)` | one — `DataItemIterator.SetLoadFieldsBasedOnMetadata` | **no — the runner already Cecil-no-ops that caller** |

The third is the one that is *not* dead upstream: its only call site sits inside a method this runner empties to a bare `ret` ("partial records disabled; full field load"). And AL's own `SetLoadFields` never goes near any of the three — `NavRecord.SetLoadFields(DataError, int[])` routes to `recordImplementation.SetLoadFields(HashSet)`, the **`ISet` overload**, a different method from the `FieldLoadInfo` one that was no-opped.

So zero red tests was the correct result, for a reason nobody had established. The R2R-inlining hypothesis is plausible, is documented elsewhere in this repo, and is wrong here — which is why the note names it as wrong rather than only stating the conclusion.

**What is pinned** is the reason, so a later BC version wiring a caller up, or a runner change dropping the `DataItemIterator` no-op, does not leave three rewrites acting on a live path with nothing measuring them.

| mutation | result |
|---|---|
| the finding removed from the patch header | **Failed: 3, Passed: 3** |
| `DataItemIterator` lookup target renamed | **Failed: 1, Passed: 5** |
| the whole `DataItemIterator` no-op block deleted | **Failed: 2, Passed: 4** |
| unmutated | **Failed: 0, Passed: 6, Skipped: 0** |

### One test was green in both states, and I caught it with the mutation

The first version of `DataItemIteratorNoOp_IsStillRegistered` asserted `Contains("SetLoadFieldsBasedOnMetadata")`. Renaming the lookup target to `...MetadataXX` **still contains that substring**, so the mutation passed 6/6 — a test green in both states, the defect one level up. It now asserts the quoted form the Cecil lookup actually uses, `"DataItemIterator", "SetLoadFieldsBasedOnMetadata", 1`, and the same mutation goes red. Reported here because the mutation run is the only reason it was found.

---

## Test runs

Bootstrapped per #3843 (`tools/engine-test-bootstrap.sh` + `--settings engine.runsettings`), second run quoted:

```
dotnet test AlRunner.Tests -c Release --no-build --settings engine.runsettings \
  --filter "FullyQualifiedName~BcShape|FullyQualifiedName~PartialLoad|\
FullyQualifiedName~CecilReplaceBodyArity|FullyQualifiedName~VirtualTableRefusal"

Passed!  - Failed: 0, Passed: 189, Skipped: 0, Total: 189
```

Both runs identical. Before the bootstrap the four `CecilReplaceBodyArityTests` `bc-engine-serial` rows **failed loudly** rather than skipping — #3843 working as intended; they pass once bootstrapped and are unrelated to this diff.

`tools/test_doc_pointers.py` and `tools/test_matrix_docs_drift.py`: both green.

## Issue-queue scan

Searched the open queue on the symbols (`AreFieldsLoaded`, `RequiredEnumerable`, `BcShapeGapException`, `ALSetBaseLoadFields`), the mechanism ("silent default", "returns true", "shape gap") and the files this diff touches. **Nothing folds.** #3358 is the issue whose fix produced these follow-ups and is already merged. See #2398 (limitations entries rotting in both directions), which is adjacent to item 2: it is a process issue across the whole document, not a change in these files — and the doc-pointer gate this PR leans on is part of the answer to it.

## Where the prose went

The patch header gained a **trap** note — the thing the next editor gets wrong, with its citation — which `loud-failures.md` keeps at the line. The mechanism tables, the rejected alternatives and the mutation figures are in this body. The divergence write-up is in `docs/`, with the pointer left behind and gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
