### PR TITLE
docs: list_contexts' registeredAliases is not evidence a context was loaded

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,16 @@ load_assembly(assemblyPath: "<artifacts>/<ver>/Microsoft.Dynamics.Nav.Ncl.dll",
               additionalSearchDirs: ["<artifacts>/<ver>"], contextAlias: "bc284")
 ```
 
+**`list_contexts` answers two different questions in one response, and the wrong one is the
+easier to read.** `registeredAliases` lists every alias that *can* be activated; `items` lists
+the contexts actually **loaded**. An alias in the first and not the second means nothing has
+been read through it — so a cross-version comparison resting on it is an inference, not a
+measurement. Measured: an agent read `bc270`/`bc273` sharing an MVID from `items`, saw `bc275`
+in `registeredAliases`, and concluded 27.5 was a distinct binary; hashing the files showed all
+three `Ncl.dll` byte-identical. Hash the artifact, or load the context, before claiming two
+versions differ.
+
+
 **3. `grep` here is a shell function, and it fails silently.**
 
 `grep` resolves to a shell **function**, not `/usr/bin/grep`. It rejects `-E`, `--include` and


### PR DESCRIPTION
## What

One paragraph in `CLAUDE.md` §2c, immediately after the `load_assembly` block, on how to read `list_contexts`.

That response carries **two lists answering different questions**: `registeredAliases` is every alias that **can** be activated (20 here); `items` is what is actually **loaded** (4 here). An alias in the first and absent from the second means nothing has been read through it.

## Why — measured, not asserted

Tonight, adjudicating a BC-behaviour claim for #3372, an agent read from `items` that `bc270` and `bc273` share an MVID — correct and measured — then saw `bc275` in `registeredAliases` and concluded 27.5 was a **separate binary**, resting "two independent binaries, identical verdict" on it.

Hashing refutes that:

```
27.0.38460.53934  sha256=affa03c90cc6fc62  10716984
27.3.44313.53909  sha256=affa03c90cc6fc62  10716984
27.5.46862.53931  sha256=affa03c90cc6fc62  10716984
28.4.53241.54346  sha256=6f2cf6821a1e1764  11294560   <- genuinely different
```

`Types.dll` is identical across all three 27.x directories, and each carries 501 DLLs — the whole provisioned 27.x runtime here is one binary set.

The **conclusion** survived on other evidence (two legs failing identically, plus a mechanism found in `Ncl.dll`). The **stated basis** did not, and that is the half a reviewer can check — `loud-failures.md` says so as of #3855, which merged tonight.

## Placement

In `CLAUDE.md` §2c rather than a rule: that section already owns this tool, the trap is about reading its output rather than a direction of work, and a reader meets it at the moment they would make the mistake.

## Scope

Documentation only. No code, no behaviour, no test — the claim is about reading an MCP response, and asserting on the paragraph's wording would pin phrasing rather than behaviour, which `tdd.md` rejects as noise. The hashes above are reproducible with `sha256sum` against `~/.local/share/al-runner/artifacts/`.

Corpus-NA: documentation-only change to a code-navigation note; no AL is compiled, executed or observed, so no corpus test can measure it.

Closes #3860

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
