### PR TITLE
docs(rules): a pipeline replaces ci-wait.py's exit code with 0

### DIFF
--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -22,6 +22,16 @@ per cycle (`orchestrating-a-session`, one listing per sweep) and reads the verdi
 considers arming then, and nothing is lost by reading late:
 `gh pr merge --auto` lands a reviewed PR the moment its checks go green with nobody present.
 
+**Read the tool's exit code, not a pipeline's.** Every row of the table below is worthless if
+`$?` came from the last command in a pipe: `tools/ci-wait.py <N> --timeout 0 | tail -25` leaves
+`$?` as **`tail`'s** status, which is 0 whatever the verdict was — so a FAILED or a
+still-running PR reads as green, and the printed text saying otherwise is the only thing left
+that is true. Redirect to a file and check `$?`, or use `${PIPESTATUS[0]}`. Measured twice on
+2026-09-11: an agent reported this tool "exits 0 on a non-verdict" from a piped read (it exits
+2, and did), and the coordinator made the same mistake reading a `| tail` earlier the same
+night. It is the same class as the trap below — an answer that could not have come out any
+other way.
+
 **Trap: an answer that could not have come out any other way is not evidence.** Under the
 pre-#3351 zero-timeout path a green PR, a red PR and a PR with no checks all printed `STILL
 RUNNING`, and its only tell was the empty parentheses of `STILL RUNNING after 0s ()`, where the


### PR DESCRIPTION
## What

One paragraph in `ci-verdicts.md` §0, immediately **above** the exit-code table, on the shell construct that silently discards the code the table describes.

```bash
tools/ci-wait.py <N> --timeout 0 | tail -25
echo $?      # tail's status: 0, whatever the verdict was
```

## Why

§0 keys every merge decision in this repository on that exit code. A piped read leaves `$?` as the pipeline's last command, so **a FAILED or still-running PR reads as green** and the printed text is the only thing left that is true.

The defect is **self-concealing in the direction that matters**: a piped read of a red PR prints the failure *and* returns 0. A caller trusting the code over the text — which is the whole point of having the table — arms a merge on a PR whose log it just printed.

It is also the exact class §0 already names one paragraph later — *"an answer that could not have come out any other way is not evidence"* — so the rule stated the principle and omitted its most load-bearing instance.

## Measured twice, both 2026-09-11

1. An implementation agent reported `ci-wait.py` **"exits 0 while its own text says this is NOT a verdict"** and flagged it as worth care when scripting. It exits **2** and always did; its command was `… | tail -25; echo "exit: $?"`. Asked to check, it reproduced the mechanism: `PIPELINE $? = 0`, `PIPESTATUS[0] = 2`.
2. The coordinator made the same mistake reading a `| tail` earlier the same night.

Two independent instances is this repository's bar for stating a direction.

## Scope

Documentation only. **`ci-wait.py` is correct and unchanged** — it exits 2 on a non-verdict exactly as documented, verified twice against a live PR. No workflow or documented recipe pipes it (checked `.claude/`, `docs/`, `tools/`); this is a hazard in ad-hoc invocation, which is how the tool is mostly used.

No test: the claim is about shell semantics, not repository behaviour, and asserting on the paragraph's wording would pin phrasing rather than behaviour — which `tdd.md` rejects as noise.

Corpus-NA: documentation-only change to an agent operating rule; no AL is compiled, executed or observed, so no corpus test can measure it.

Closes #3864

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
