### PR TITLE
docs(rules): the skipped confirmation is always on the instrument

### DIFF
--- a/.claude/rules/verify-execution-not-the-tick.md
+++ b/.claude/rules/verify-execution-not-the-tick.md
@@ -50,6 +50,25 @@ differently-shaped query whose shape does not depend on the same assumption:
 - the count of *all* PASS names on the leg, which tells you the log parsed at all;
 - for a prefix question, grep for one full test name copied from the `.al` file.
 
+**Where this discipline actually fails: on the instrument, not the subject.** The confirmations
+above get applied to the thing under investigation and skipped on the tool doing the
+investigating — and the tool's answer is the one nothing else cross-checks. Three instances on
+2026-09-11, all by one agent in one task, all caught only because something else ran:
+
+| the instrument | what it returned | why it looked like an answer |
+|---|---|---|
+| a `\| tail` pipeline's `$?` | 0 | it is 0 whatever the tool returned (#3864) |
+| an exit-code claim about `ci-wait.py` | "exits 0 on a non-verdict" | never re-run directly; it exits 2 |
+| a log pattern for `PASS +<name>` | 6 of 9 tests | the `(known-gap)` column widened the gap the `+` had to span |
+
+The third is the sharpest: **six of nine is exactly the shape of a real finding** — "that codeunit
+did not run" — on a leg that was green. A second, differently-shaped query found all nine.
+
+So when a query about a run returns something surprising, re-derive it a second way **before**
+reporting it, and treat the instrument with the suspicion you would give the subject: a tool that
+cannot be wrong in the direction you are reading is not evidence.
+
+
 ## Which legs were ever going to run it
 
 The corpus runs 16 legs, eight cloud and eight OnPrem, and **only the eight cloud legs are the


### PR DESCRIPTION
## What

One section in `verify-execution-not-the-tick.md`, immediately after the existing confirmations. The rule says **what** to do — *"a zero from a pattern you chose is not evidence; confirm it with a second, differently-shaped query"* — and not **where people fail to do it**.

Measured, that is consistent: the discipline is applied to the **subject** under investigation and skipped on the **instrument** doing the investigating — whose answer is the one nothing else cross-checks.

## Measured: three instances, one agent, one task

| the instrument | what it returned | why it looked like an answer |
|---|---|---|
| a `\| tail` pipeline's `$?` | 0 | it is 0 whatever the tool returned (#3864) |
| an exit-code claim about `ci-wait.py` | "exits 0 on a non-verdict" | never re-run directly; it exits **2** |
| a log pattern for `PASS +<name>` | **6 of 9** tests | the `(known-gap)` column widened the gap the `+` had to span |

**The third is the sharpest.** Six of nine is exactly the shape of a real finding — *"that codeunit did not run"* — on a leg that was green. A second, differently-shaped query found all nine. In the agent's words: *"Had I reported six, I would have manufactured a crisis on a green leg."*

In the same task it applied the two-query confirmation correctly to a check-runs query **and skipped it on the exit code sitting beside it**.

## Why not already covered

**#3865** (merged, `7e609ee1`) covers the pipeline instance in `ci-verdicts.md` §0 — one trap, one tool. This is the generalisation, placed in the rule that owns the class. Three independent instances is past the bar of two this repository sets for stating a direction.

## Scope

Documentation only. No code, no behaviour, no test — the claim is about how measurements get taken, and asserting on the section's wording would pin phrasing rather than behaviour, which `tdd.md` rejects as noise.

Corpus-NA: documentation-only change to an agent operating rule; no AL is compiled, executed or observed, so no corpus test can measure it.

Closes #3866

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
