### PR TITLE
test(phase-log): bound app stages against the span they decompose, not an absolute 50ms

### DIFF
--- a/AlRunner.Tests/PhaseLogIntegrationTests.cs
+++ b/AlRunner.Tests/PhaseLogIntegrationTests.cs
@@ -443,7 +443,80 @@ public sealed class PhaseLogIntegrationTests : IDisposable
     /// app row this fixture produces carries the full named breakdown, and — like the
     /// bundle-level check — the sum leaves almost nothing unattributed.
     /// </summary>
-    private static void AssertAppStagesAccountForTheRunTurn(List<JsonElement> appRows)
+    /// <summary>
+    /// #3474: app stages whose PhaseLog.AppStage call site sits OUTSIDE every AddAppRun span,
+    /// so their time is not part of run_ms and must not be summed against it. Both are entered
+    /// from the AL-output cache gate in Program.cs (the `needCompile &amp;&amp; alCacheDir != null`
+    /// block), which runs in the emit/compile pass. They are AppStages rather than bundle
+    /// Stages because BeginApp is already open there — see the comment on `orderedDepIds`.
+    /// </summary>
+    private static readonly HashSet<string> CompileGateStages =
+        new(StringComparer.Ordinal) { "ordered-dep-ids", "query-decl-probe" };
+
+    /// <summary>
+    /// Run-turn app stages that must be PRESENT on every app row. Every app group walks these
+    /// whatever it declares, and they are named individually rather than counted, so deleting a
+    /// mark fails loudly instead of quietly moving its time into the unattributed remainder.
+    /// </summary>
+    private static readonly string[] RequiredAppStages =
+    {
+        "set-test-assembly", "type-discovery",
+        // The #1861 follow-up review split the single opaque "install-seed"
+        // mark (85.1% of run_ms in the original PR's own measurement) into
+        // one mark per call, so a follow-up fix knows which of the six to
+        // chase instead of re-running this whole attribution exercise.
+        // #1867 replaced "install-seed-run-install-triggers" +
+        // "install-seed-ensure-company-initialized" (together ~82.5% of
+        // run_ms, the #1861 breakdown's own finding) with a single
+        // "install-seed-dep-company-baseline" mark that is either a cache
+        // restore or a fresh compute-and-cache — see TestExecutor.Run and
+        // AlRunner.Tests.InstallSeedDepCompanyCacheTests — plus a distinct
+        // "install-seed-run-own-install-triggers" mark for the bundle's own
+        // (always fresh, never cached) Install triggers.
+        "install-seed-reset-per-test", "install-seed-reset-for-new-bundle",
+        "install-seed-set-test-assembly", "install-seed-dep-company-baseline",
+        "install-seed-run-own-install-triggers",
+        // #3176 — the Access Control SUPER row that backs the session user's
+        // IsSuper answer. Named here so deleting the mark fails, and because
+        // its position between the User row and the baseline capture is the
+        // load-bearing part: seeded after the capture it would survive only
+        // until the first codeunit boundary restored the store.
+        "install-seed-access-control-row",
+        "install-seed-capture-baseline",
+        "codeunit-scan",
+        "event-subscriber-inject", "codeunit-reset", "codeunit-instantiate",
+        "resolve-display-name", "run-test-methods", "codeunit-dispose",
+    };
+
+    /// <summary>
+    /// #3474: run-turn stages that are emitted but are NOT required to be present. They still
+    /// need classifying — an unclassified stage fails the closed-partition check in
+    /// <see cref="AssertAppStagesAccountForTheRunTurn"/> — but requiring one is a separate
+    /// claim from classifying it, and this change does not quietly turn the second into the
+    /// first. Promote an entry to <see cref="RequiredAppStages"/> only with a reason it must
+    /// appear on EVERY app row.
+    /// </summary>
+    private static readonly string[] RunTurnStagesNotRequired =
+    {
+        "install-seed-arm-event-subscribers", "install-seed-user-row", "install-seed-company-row",
+        "install-seed-published-application-row",
+    };
+
+    /// <summary>
+    /// #3474: every app stage entered inside an AddAppRun span, so run_ms is exactly what this
+    /// set decomposes. Together with <see cref="CompileGateStages"/> it partitions every
+    /// AppStage the runner emits; a name in neither is what the closed-partition check refuses.
+    /// </summary>
+    private static readonly HashSet<string> RunTurnStages =
+        new(RequiredAppStages.Concat(RunTurnStagesNotRequired), StringComparer.Ordinal);
+
+    /// <summary>
+    /// #3474: internal rather than private so PhaseLogStageAccountingTests can drive THIS
+    /// function — the one the real run uses — with synthetic app rows. A reimplementation in the
+    /// test would prove only that the copy behaves; the mutation check (a stage deliberately
+    /// counted twice must still fail) is only worth anything against the live code path.
+    /// </summary>
+    internal static void AssertAppStagesAccountForTheRunTurn(List<JsonElement> appRows)
     {
         foreach (var app in appRows)
         {
@@ -454,35 +527,7 @@ public sealed class PhaseLogIntegrationTests : IDisposable
             // Every app group walks these, whatever it declares. Named individually
             // rather than counted, so deleting a mark fails here instead of quietly
             // moving its time back into the unattributed remainder.
-            foreach (var required in new[]
-                     {
-                         "set-test-assembly", "type-discovery",
-                         // The #1861 follow-up review split the single opaque "install-seed"
-                         // mark (85.1% of run_ms in the original PR's own measurement) into
-                         // one mark per call, so a follow-up fix knows which of the six to
-                         // chase instead of re-running this whole attribution exercise.
-                         // #1867 replaced "install-seed-run-install-triggers" +
-                         // "install-seed-ensure-company-initialized" (together ~82.5% of
-                         // run_ms, the #1861 breakdown's own finding) with a single
-                         // "install-seed-dep-company-baseline" mark that is either a cache
-                         // restore or a fresh compute-and-cache — see TestExecutor.Run and
-                         // AlRunner.Tests.InstallSeedDepCompanyCacheTests — plus a distinct
-                         // "install-seed-run-own-install-triggers" mark for the bundle's own
-                         // (always fresh, never cached) Install triggers.
-                         "install-seed-reset-per-test", "install-seed-reset-for-new-bundle",
-                         "install-seed-set-test-assembly", "install-seed-dep-company-baseline",
-                         "install-seed-run-own-install-triggers",
-                         // #3176 — the Access Control SUPER row that backs the session user's
-                         // IsSuper answer. Named here so deleting the mark fails, and because
-                         // its position between the User row and the baseline capture is the
-                         // load-bearing part: seeded after the capture it would survive only
-                         // until the first codeunit boundary restored the store.
-                         "install-seed-access-control-row",
-                         "install-seed-capture-baseline",
-                         "codeunit-scan",
-                         "event-subscriber-inject", "codeunit-reset", "codeunit-instantiate",
-                         "resolve-display-name", "run-test-methods", "codeunit-dispose",
-                     })
+            foreach (var required in RequiredAppStages)
                 Assert.True(stages.ContainsKey(required),
                     $"app stage '{required}' missing: {string.Join(", ", stages.Keys)}");
 
@@ -503,20 +548,75 @@ public sealed class PhaseLogIntegrationTests : IDisposable
             AssertStageOrder(order, "install-seed-access-control-row", "install-seed-capture-baseline");
 
             var runMs = app.GetProperty("run_ms").GetInt64();
-            var staged = stages.Values.Sum();
 
-            // No stage may exceed the run turn it decomposes — that would mean a stage
-            // is double-counting time (e.g. nesting inside another mark).
-            Assert.True(staged <= runMs + 50,
-                $"app stages ({staged}ms) exceed run_ms ({runMs}ms) — a stage is double-counting: {app}");
+            // #3474: only the stages that lie INSIDE an AddAppRun span may be summed against
+            // run_ms. Two AppStage marks do not: `ordered-dep-ids` and `query-decl-probe` are
+            // entered from the AL-output cache gate (Program.cs, the `needCompile &&
+            // alCacheDir != null` block), which runs in the emit/compile pass — before, and
+            // outside, the `rt` stopwatch whose elapsed time AddAppRun banks as run_ms. They
+            // are AppStages rather than bundle Stages only because BeginApp is already open
+            // there, so a bundle stage would overlap the app group and #1828's bundle-level
+            // sum would report it as manufactured overhead.
+            //
+            // So `Σ ALL stages <= run_ms` was never true by construction, and the absolute
+            // +50ms was absorbing that structural error rather than timing jitter. It held on
+            // an idle box because the two marks cost 1-2ms there, and failed on CI twice
+            // (72/19ms on 60f7e953, 82/13ms on 3b939eb5) when a loaded runner took tens of ms
+            // over one of them while the run turn itself stayed genuinely tiny.
+            var outOfTurn = stages.Where(kv => CompileGateStages.Contains(kv.Key)).Sum(kv => kv.Value);
+            var inTurn = stages.Values.Sum() - outOfTurn;
 
-            // And the attribution is near-complete: whatever the marks miss shows up
-            // here. These fixtures run one [Test] each on a near-empty install baseline,
-            // so both run_ms and any residual are small; the allowance is absolute.
-            var unattributed = runMs - staged;
-            Assert.True(unattributed <= 250,
+            // The partition must stay closed, or this check silently stops measuring what it
+            // claims to. A new AppStage added to the cache gate would otherwise land in
+            // `inTurn`, inflate the sum against a run turn it was never part of, and reproduce
+            // exactly the #3474 false failure under a new name — passing on an idle box, so
+            // nothing would say so until CI went red. Every stage is therefore named in one of
+            // the two sets, and an unrecognised one fails here naming itself.
+            var unclassified = stages.Keys
+                .Where(k => !CompileGateStages.Contains(k) && !RunTurnStages.Contains(k))
+                .ToList();
+            Assert.True(unclassified.Count == 0,
+                $"app stage(s) {string.Join(", ", unclassified)} are in neither "
+                + $"CompileGateStages nor RunTurnStages. Classify each by whether its "
+                + $"PhaseLog.AppStage call site sits inside an AddAppRun span (run-turn) or in "
+                + $"the AL-output cache gate (compile-gate) — an unclassified stage is counted "
+                + $"against run_ms without anything having checked that it belongs there: {app}");
+
+            // The invariant #1861 actually asserts: the run turn's OWN stages decompose it, so
+            // their sum cannot exceed it. A stage nested inside another, or one mark banked
+            // twice, makes the parts sum past the whole and fails here.
+            //
+            // Bounded PROPORTIONALLY (10%) rather than by a constant, plus a 2ms floor for the
+            // integer truncation below. Each stage is truncated to whole ms by
+            // PhaseLog.AddStageTo, and run_ms by AddAppRun, so on a sub-millisecond run turn
+            // the rounding alone can put the sum one or two ms over. A proportional bound
+            // cannot get stricter as the machine slows down, which is what the absolute one
+            // did: the parts and the whole scale together under load, so the RATIO is the
+            // quantity that stays put while both grow.
+            //
+            // Why this still catches a real double-count: duplicating a stage of any
+            // significance adds ~100% of that stage's own time, not 10% of the total, so
+            // anything but a rounding-sized mark breaks it. Proven in
+            // PhaseLogStageAccountingTests, which feeds this function a row with one stage
+            // counted twice and asserts it fails.
+            Assert.True(inTurn <= runMs + Math.Max(2, runMs / 10),
+                $"run-turn app stages ({inTurn}ms) exceed run_ms ({runMs}ms) — a stage is "
+                + $"double-counting (nesting inside another mark, or banked twice). "
+                + $"Compile-gate stages excluded: {outOfTurn}ms. Row: {app}");
+
+            // And the attribution is near-complete: whatever the run-turn marks miss shows up
+            // here. Proportional for the same reason, and this direction was measured failing
+            // too — under 16x CPU oversubscription the residual reached 515ms against a 5,781ms
+            // run turn (14.6x the old absolute 250ms), because the UNMARKED work inside the run
+            // turn slows down exactly as the marked work does. 25% rather than 10%: the
+            // residual is unmarked time, so it has no upper bound from the marks themselves,
+            // and the floor is 250ms so the near-empty fixtures this suite runs — where run_ms
+            // is a few ms and one unmarked allocation dominates — keep the allowance the
+            // absolute form gave them.
+            var unattributed = runMs - inTurn;
+            Assert.True(unattributed <= Math.Max(250, runMs / 4),
                 $"{unattributed}ms of app run_ms is attributed to nothing "
-                + $"(run_ms {runMs}ms, stages {staged}ms) — add a stage mark: {app}");
+                + $"(run_ms {runMs}ms, run-turn stages {inTurn}ms) — add a stage mark: {app}");
         }
     }
 

--- a/AlRunner.Tests/PhaseLogStageAccountingTests.cs
+++ b/AlRunner.Tests/PhaseLogStageAccountingTests.cs
@@ -1,0 +1,351 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #3474 — the mutation check for <see cref="PhaseLogIntegrationTests.AssertAppStagesAccountForTheRunTurn"/>.
+///
+/// That function's stage-accounting bound was an absolute `Σ stages &lt;= run_ms + 50`, which
+/// fired on CI twice as a false "a stage is double-counting" report (72ms against 19ms on
+/// 60f7e953; 82ms against 13ms on 3b939eb5, where `ordered-dep-ids` alone was 75ms). The
+/// replacement is proportional AND excludes the two compile-gate stages that are not inside the
+/// run turn at all.
+///
+/// A weakened bound is the obvious failure mode of that change, and a real double-count is rare
+/// enough that no real run would catch it. So this suite drives the live function with synthetic
+/// rows and asserts BOTH directions: the recorded CI records now pass, and a stage deliberately
+/// counted twice still fails. Without the second half the fix would be indistinguishable from
+/// deleting the assertion.
+/// </summary>
+public sealed class PhaseLogStageAccountingTests
+{
+    /// <summary>
+    /// Every stage the runner emits inside the run turn, at 0ms unless overridden — so a row
+    /// built here satisfies the "required stage present" and "install-seed order" checks and
+    /// reaches the arithmetic this suite is actually about.
+    /// </summary>
+    private static readonly string[] RunTurnOrder =
+    {
+        "set-test-assembly", "type-discovery",
+        "install-seed-reset-per-test", "install-seed-reset-for-new-bundle",
+        "install-seed-set-test-assembly", "install-seed-arm-event-subscribers",
+        "install-seed-dep-company-baseline",
+        "install-seed-user-row", "install-seed-company-row",
+        "install-seed-published-application-row",
+        // Order is load-bearing and separately asserted: after the per-bundle reset, before the
+        // baseline capture (#3176).
+        "install-seed-access-control-row",
+        "install-seed-run-own-install-triggers", "install-seed-capture-baseline",
+        "codeunit-scan", "event-subscriber-inject", "codeunit-reset", "codeunit-instantiate",
+        "resolve-display-name", "run-test-methods", "codeunit-dispose",
+    };
+
+    /// <summary>
+    /// Builds one app row. <paramref name="stages"/> overrides individual stage values;
+    /// <paramref name="extra"/> appends stages not in the standard set (used for the
+    /// compile-gate marks and for the unclassified-stage check).
+    /// </summary>
+    private static JsonElement AppRow(
+        long runMs,
+        IDictionary<string, long>? stages = null,
+        IEnumerable<KeyValuePair<string, long>>? extra = null)
+    {
+        var ordered = new List<KeyValuePair<string, long>>();
+        // Compile-gate marks are entered first on a real run (the cache gate precedes the run
+        // turn), so emitting them first keeps the synthetic row faithful to the real ordering.
+        foreach (var kv in extra ?? Enumerable.Empty<KeyValuePair<string, long>>())
+            ordered.Add(kv);
+        foreach (var name in RunTurnOrder)
+            ordered.Add(new KeyValuePair<string, long>(
+                name, stages != null && stages.TryGetValue(name, out var v) ? v : 0));
+
+        var stageJson = string.Join(",", ordered.Select(kv => $"\"{kv.Key}\":{kv.Value}"));
+        return ParseRow(runMs, stageJson);
+    }
+
+    /// <summary>
+    /// Assembles the app-row JSON. Written with concatenation rather than a raw string literal
+    /// because the stage object needs a brace immediately against an interpolation hole, which
+    /// raw-string brace counting cannot express readably.
+    /// </summary>
+    private static JsonElement ParseRow(long runMs, string stageJson)
+    {
+        var json =
+            "{\"kind\":\"app\",\"pid\":1,\"bundle\":\"b\",\"bundle_index\":1,"
+            + "\"bundles_in_process\":1,\"app\":\"synthetic\",\"app_index\":1,"
+            + "\"apps_in_bundle\":1,\"run_ms\":" + runMs
+            + ",\"stages\":{" + stageJson + "}}";
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+
+    private static void Run(JsonElement row) =>
+        PhaseLogIntegrationTests.AssertAppStagesAccountForTheRunTurn(new List<JsonElement> { row });
+
+    // ── The two recorded CI false positives now pass ───────────────────────────────────────
+
+    /// <summary>
+    /// Tonight's floor record (3b939eb5, BC 28.4, run 34552096539): `ordered-dep-ids` 75ms
+    /// against a 13ms run turn, every other stage 0-4ms. Under the old absolute bound this
+    /// summed to 82ms and failed. The stage is entered from the AL-output cache gate, outside
+    /// every AddAppRun span, so it is not part of run_ms and must not be summed against it.
+    /// </summary>
+    [Fact]
+    public void RecordedFloorFailure_OrderedDepIdsDominating_NoLongerReadsAsDoubleCounting()
+    {
+        var row = AppRow(
+            runMs: 13,
+            stages: new Dictionary<string, long>
+            {
+                ["install-seed-dep-company-baseline"] = 4,
+                ["run-test-methods"] = 2,
+                ["install-seed-user-row"] = 1,
+            },
+            extra: new[] { new KeyValuePair<string, long>("ordered-dep-ids", 75) });
+
+        Run(row);   // the claim: this no longer throws
+    }
+
+    /// <summary>
+    /// The original report (60f7e953): 72ms of stages against a 19ms run turn, of which
+    /// `ordered-dep-ids` was 59ms — more than the entire old 50ms allowance on its own.
+    /// </summary>
+    [Fact]
+    public void RecordedOriginalFailure_NoLongerReadsAsDoubleCounting()
+    {
+        var row = AppRow(
+            runMs: 19,
+            stages: new Dictionary<string, long>
+            {
+                ["install-seed-dep-company-baseline"] = 7,
+                ["install-seed-published-application-row"] = 3,
+                ["run-test-methods"] = 2,
+            },
+            extra: new[] { new KeyValuePair<string, long>("ordered-dep-ids", 59) });
+
+        Run(row);
+    }
+
+    // ── ...and a genuine double-count still fails ──────────────────────────────────────────
+
+    /// <summary>
+    /// THE mutation check. A stage nested inside another — or one mark banked twice — makes the
+    /// parts sum past the whole, which is exactly what #1861's invariant exists to catch. Here
+    /// `install-seed-dep-company-baseline` is counted twice inside a run turn that only ever
+    /// contained it once: run_ms 100ms, one 90ms stage, and a second 90ms stage standing in for
+    /// the duplicate. 180 &gt; 100 + 10%.
+    ///
+    /// This is the assertion that makes the rest of the change safe: a bound that survives load
+    /// but no longer fires here would be a deleted test wearing an assertion.
+    /// </summary>
+    [Fact]
+    public void AStageCountedTwice_StillFailsAsDoubleCounting()
+    {
+        var row = AppRow(
+            runMs: 100,
+            stages: new Dictionary<string, long>
+            {
+                ["install-seed-dep-company-baseline"] = 90,
+                // The duplicate: the same 90ms of work banked under a second mark.
+                ["install-seed-user-row"] = 90,
+            });
+
+        var ex = Assert.ThrowsAny<Xunit.Sdk.XunitException>(() => Run(row));
+        Assert.Contains("double-counting", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("180ms", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The proportional bound must not be a blank cheque: a double-count is ~100% of the
+    /// duplicated stage, so even a modest one on a large run turn breaks it. run_ms 1,000ms with
+    /// 1,150ms of stages — 15% over, comfortably inside what CI load produced in the recorded
+    /// records as a FRACTION (82/13 is 530% over) but still a real accounting error.
+    /// </summary>
+    [Fact]
+    public void AModestOvershootOnALargeRunTurn_StillFails()
+    {
+        var row = AppRow(
+            runMs: 1000,
+            stages: new Dictionary<string, long>
+            {
+                ["install-seed-dep-company-baseline"] = 600,
+                ["run-test-methods"] = 550,
+            });
+
+        var ex = Assert.ThrowsAny<Xunit.Sdk.XunitException>(() => Run(row));
+        Assert.Contains("double-counting", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The 10% band is not so wide that it swallows a duplicate of a mark this suite's own
+    /// fixtures produce: on an idle box `install-seed-user-row` was 38ms of a 130ms run turn
+    /// (measured, this branch). Counting it twice is 168 against 130 + 13 — still caught.
+    /// </summary>
+    [Fact]
+    public void DuplicatingAMeasuredIdleBoxStage_StillFails()
+    {
+        var row = AppRow(
+            runMs: 130,
+            stages: new Dictionary<string, long>
+            {
+                ["install-seed-reset-per-test"] = 6,
+                ["install-seed-dep-company-baseline"] = 17,
+                ["install-seed-user-row"] = 38,
+                ["install-seed-company-row"] = 2,
+                ["install-seed-published-application-row"] = 8,
+                ["install-seed-access-control-row"] = 21,
+                ["install-seed-capture-baseline"] = 2,
+                ["run-test-methods"] = 16,
+                // The duplicate of the 38ms user-row seed.
+                ["install-seed-arm-event-subscribers"] = 38,
+            });
+
+        Assert.ThrowsAny<Xunit.Sdk.XunitException>(() => Run(row));
+    }
+
+    // ── The bound survives load in both directions ─────────────────────────────────────────
+
+    /// <summary>
+    /// Measured on this branch under 4x CPU oversubscription: run_ms 27ms with
+    /// `ordered-dep-ids` at 24ms, so `Σ ALL stages` (39ms) genuinely exceeded run_ms — the exact
+    /// condition the old message called double-counting. The run-turn stages sum to 15ms, well
+    /// inside 27ms, because nothing was double-counted.
+    /// </summary>
+    [Fact]
+    public void MeasuredUnderLoad_OutOfTurnStageExceedingTheRunTurn_Passes()
+    {
+        var row = AppRow(
+            runMs: 27,
+            stages: new Dictionary<string, long>
+            {
+                ["install-seed-dep-company-baseline"] = 5,
+                ["install-seed-published-application-row"] = 4,
+                ["install-seed-access-control-row"] = 1,
+                ["run-test-methods"] = 5,
+            },
+            extra: new[] { new KeyValuePair<string, long>("ordered-dep-ids", 24) });
+
+        Run(row);
+    }
+
+    /// <summary>
+    /// The mirror direction, and the one measured failing outright on this branch: under 16x CPU
+    /// oversubscription the unattributed residual reached 515ms against a 5,781ms run turn —
+    /// 14.6x the old absolute 250ms allowance — because the UNMARKED work inside the run turn
+    /// slows down exactly as the marked work does. `unattributed &lt;= max(250, run_ms/4)`
+    /// accommodates it; a constant cannot.
+    /// </summary>
+    [Fact]
+    public void MeasuredUnderLoad_ResidualScalingWithTheRunTurn_Passes()
+    {
+        var row = AppRow(
+            runMs: 5781,
+            stages: new Dictionary<string, long>
+            {
+                ["install-seed-reset-per-test"] = 427,
+                ["install-seed-reset-for-new-bundle"] = 1,
+                ["install-seed-arm-event-subscribers"] = 51,
+                ["install-seed-dep-company-baseline"] = 925,
+                ["install-seed-user-row"] = 2045,
+                ["install-seed-company-row"] = 91,
+                ["install-seed-published-application-row"] = 328,
+                ["install-seed-access-control-row"] = 689,
+                ["install-seed-run-own-install-triggers"] = 16,
+                ["install-seed-capture-baseline"] = 47,
+                ["codeunit-scan"] = 15,
+                ["codeunit-reset"] = 9,
+                ["codeunit-instantiate"] = 1,
+                ["run-test-methods"] = 536,
+                ["codeunit-dispose"] = 35,
+            },
+            extra: new[]
+            {
+                new KeyValuePair<string, long>("ordered-dep-ids", 49),
+                new KeyValuePair<string, long>("query-decl-probe", 1),
+            });
+
+        Run(row);
+    }
+
+    /// <summary>
+    /// The residual bound is still real: half a run turn attributed to nothing means a stage
+    /// mark is missing, whatever the machine speed. 3,000ms unmarked of a 6,000ms run turn is
+    /// over the 25% band.
+    /// </summary>
+    [Fact]
+    public void HalfTheRunTurnUnmarked_StillFailsAsUnattributed()
+    {
+        var row = AppRow(
+            runMs: 6000,
+            stages: new Dictionary<string, long> { ["run-test-methods"] = 3000 });
+
+        var ex = Assert.ThrowsAny<Xunit.Sdk.XunitException>(() => Run(row));
+        Assert.Contains("attributed to nothing", ex.Message, StringComparison.Ordinal);
+    }
+
+    // ── The partition stays closed ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// #3474, and the reason this is not merely a wider tolerance: a NEW AppStage added to the
+    /// AL-output cache gate would otherwise be summed against a run turn it was never part of
+    /// and reproduce this very defect under a new name — passing on an idle box, so nothing
+    /// would say so until CI went red. An unclassified stage fails here instead, naming itself
+    /// and both sets.
+    ///
+    /// This is the third state `guards-need-a-third-state.md` asks for: "I cannot tell whether
+    /// this stage belongs in the sum" is reported as a refusal, never resolved toward a pass.
+    /// </summary>
+    [Fact]
+    public void AnUnclassifiedStage_IsRefusedRatherThanCountedAgainstTheRunTurn()
+    {
+        var row = AppRow(
+            runMs: 50,
+            stages: new Dictionary<string, long> { ["run-test-methods"] = 40 },
+            extra: new[] { new KeyValuePair<string, long>("some-new-cache-gate-mark", 5) });
+
+        var ex = Assert.ThrowsAny<Xunit.Sdk.XunitException>(() => Run(row));
+        Assert.Contains("some-new-cache-gate-mark", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("CompileGateStages", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("RunTurnStages", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A stage vanishing from the run-turn set is still caught by the required-stage check, so
+    /// making the partition closed did not weaken the "deleting a mark fails" property that
+    /// #1861 and #3176 rely on.
+    /// </summary>
+    [Fact]
+    public void ADeletedRequiredStage_StillFails()
+    {
+        var ordered = RunTurnOrder
+            .Where(n => n != "install-seed-access-control-row")
+            .Select(n => $"\"{n}\":0");
+        var row = ParseRow(10, string.Join(",", ordered));
+
+        var ex = Assert.ThrowsAny<Xunit.Sdk.XunitException>(() => Run(row));
+        Assert.Contains("install-seed-access-control-row", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The rounding floor: every stage and run_ms are truncated to whole milliseconds
+    /// (PhaseLog.AddStageTo, PhaseLog.AddAppRun), so on a sub-millisecond run turn the
+    /// truncation alone can put the sum a millisecond or two over. A 0ms run turn with 2ms of
+    /// stages is that case and must not fail; 20ms of stages against it is not, and must.
+    /// </summary>
+    [Fact]
+    public void SubMillisecondRunTurn_ToleratesTruncationButNotARealOvershoot()
+    {
+        Run(AppRow(runMs: 0, stages: new Dictionary<string, long>
+        {
+            ["run-test-methods"] = 1,
+            ["codeunit-instantiate"] = 1,
+        }));
+
+        Assert.ThrowsAny<Xunit.Sdk.XunitException>(() => Run(AppRow(
+            runMs: 0,
+            stages: new Dictionary<string, long> { ["run-test-methods"] = 20 })));
+    }
+}


### PR DESCRIPTION
Closes #3474

## The constant was hiding a structural error, not absorbing jitter

`AssertAppStagesAccountForTheRunTurn` asserted `sum(ALL stages) <= run_ms + 50`. **That was never true by construction.**

Two of the 22 `AppStage` marks are not inside the run turn at all:

| mark | call site | inside an `AddAppRun` span? |
|---|---|---|
| `ordered-dep-ids` | `Program.cs:2838` | **no** |
| `query-decl-probe` | `Program.cs:2983`, `5368` | **no** |
| the other 20 | `Program.cs:3763/3895`, `TestExecutor.cs` | yes |

Both are entered from the AL-output cache gate — the `needCompile && alCacheDir != null` block — which runs in the **emit/compile** pass. `run_ms` is accumulated only by `AddAppRun(rt.Elapsed)` around `executor.Run(asm)`, in the later test-execution pass. They are `AppStage` rather than bundle `Stage` only because `BeginApp` is already open there, so a bundle stage would overlap the app group and #1828's sum would report it as manufactured overhead.

So the `+50ms` was papering over a sum that includes time `run_ms` never contained. It held on an idle box because those two marks cost 1-2ms there, and failed on CI when a loaded runner spent tens of ms in one of them while the run turn stayed genuinely tiny. **The check got stricter exactly as the machine got slower** — which is why raising 50 to 200 would only move the next false failure.

## Reproduced, twice, before changing anything

**End-to-end, on this box.** Under 16x CPU oversubscription the real test failed (4m 1s, exit 1). After the fix, same load, same fixture: passes (4m 2s, exit 0).

Under 4x load I caught the mechanism mid-flight — `PL WithDeps` recorded `run_ms=27` with `staged=39`, so the sum genuinely exceeded the run turn, the exact condition the message calls double-counting. It passed only because `39 <= 27+50`. Of that overshoot, `ordered-dep-ids` was 24ms; the run-turn stages summed to 15ms, comfortably inside 27ms, because nothing was double-counted.

**Exactly, as a RED baseline.** Feeding the recorded CI rows to `origin/main`'s assertion reproduces its message character for character:

```
app stages (82ms) exceed run_ms (13ms) — a stage is double-counting: {...}
```

6 of the 11 new tests fail against the old assertion, 11/11 pass against the new one.

## What replaced it, and why it still catches a real double-count

1. **Partition the stages** — `CompileGateStages` vs `RunTurnStages` — and bound only the run-turn sum against `run_ms`. On both recorded records the in-turn sum is well inside the run turn with no tolerance needed at all (7ms of 13ms; 13ms of 19ms).
2. **Proportional bounds**, not constants: `inTurn <= run_ms + max(2, run_ms/10)` and `unattributed <= max(250, run_ms/4)`. Parts and whole scale together under load, so the **ratio** is what stays put while both grow. The floors cover integer truncation (every stage and `run_ms` are truncated to whole ms) and the near-empty fixtures this suite runs.
3. **The partition is closed.** A new `AppStage` added to the cache gate would otherwise land in the run-turn sum and reproduce this defect under a new name — passing on an idle box, so nothing would say so until CI went red. An unclassified stage now fails naming itself and both sets. That is `guards-need-a-third-state.md`'s third state: *"I cannot tell whether this belongs in the sum"* is a refusal, never resolved toward a pass.

**Why a proportional bound still fires on a genuine double-count:** duplicating a stage adds ~100% of that stage's own time, not 10% of the total. `AStageCountedTwice_StillFailsAsDoubleCounting` proves it against the live function; `DuplicatingAMeasuredIdleBoxStage_StillFails` duplicates a mark measured on this branch (`install-seed-user-row`, 38ms of a 130ms run turn) and still fails. The five mutation checks pass in **both** states — that is the point: the change did not weaken double-count detection, it removed a term that was never part of the quantity.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site?** **Yes, and folded in.** The residual bound two lines down, `unattributed <= 250`, has the identical defect in the mirror direction — unmarked work inside the run turn slows exactly as marked work does. Measured failing on this branch: **515ms against a 5,781ms run turn, 14.6x the old allowance.** Under 16x load this was the assertion that actually fired, not the reported one. Now `max(250, run_ms/4)`.
2. **Does a sibling function make the same assumption?** **Yes — `AssertBundleStagesAccountForTheBundleTurn` (line 407) uses `staged + appWall <= bundleWall + 50` and `unattributed <= 750`.** Deliberately **not** changed here: its sum is bounded by a bundle wall clock that *does* contain every term, so it has no structural error — only the same absolute-tolerance fragility, and it has never been observed failing. Changing it would be an unproven edit to a passing assertion in the same PR. Worth a follow-up if it ever fires; I did not file one for a defect nobody has measured.
3. **Two code paths writing the same state with different invariants?** The three `AddAppRun` call sites (`Program.cs:3784/3804`, `3914/3923`, `5605`) all bank the same `rt` stopwatch, and the run-turn marks sit inside all of them. No divergence found.

**Queue scan** (`batch-sibling-issues-by-file.md`, `search-for-the-same-defect-first.md`): searched open issues for `PhaseLog`, `unattributed`, `double-counting`, `phase-log stage`, `attributed to nothing`. Only #3474 matches. #3774 and #2366 touch phase-log *stages* but are performance investigations in `AlRunner/`, not this assertion — nothing to fold. The residual direction had no issue of its own; it is the same defect in the same function, so it is fixed here rather than filed as a duplicate.

## Measurements

All figures from **second** runs after a build, on this box (12 cores):

| suite | result |
|---|---|
| `PhaseLogStageAccountingTests` (new) | `Failed: 0, Passed: 11, Skipped: 0` |
| `~PhaseLog` | `Failed: 0, Passed: 39, Skipped: 0` |
| `~PhaseLog\|~InstallSeed\|~AccessControl` | `Failed: 0, Passed: 48, Skipped: 0` |
| real test under 16x load, after fix | `Failed: 0, Passed: 1, Skipped: 0` (4m 2s) |

RED baseline against `origin/main`'s assertion: `Failed: 6, Passed: 5, Total: 11`.

No corpus declaration: the diff touches only `AlRunner.Tests/`, and `check_corpus_linkage.sh` agrees (`No file in this diff can change what AL observes`). Nothing here asserts BC behaviour — the claim is about the runner's own phase-log instrument.

## Where the prose went

The classification of each stage and the reason the partition must stay closed are **at the line**, because that is what the next editor adding an `AppStage` gets wrong. The derivation — which call sites sit in which pass, and the load measurements — is in this body and in the new suite's doc comments, which are the executable record of it.

---
*Implemented by the automated agent loop `stma-auto-11`, not by a person.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
