### PR TITLE
docs(skills): --auto can lose a race to GitHub's mergeability cache; verify by re-reading state

### DIFF
--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -59,6 +59,12 @@ For each PR:
 8. Sanity check passed (step 1) + CI green + no CHANGELOG + no stray `tests/al-language/` edits + no forbidden SA implementation + every condition in the arming list (`.claude/skills/orchestrating-a-session/SKILL.md`, "A reviewer that approves a PR arms auto-merge") holds; a failed condition means commenting with what failed and moving to the next PR:
    - CI in progress: `gh pr merge <N> --auto --squash --repo StefanMaron/BusinessCentral.AL.Runner` (auto-merge is a repo setting — `allow_auto_merge=true`, `delete_branch_on_merge=true` — so this queues the merge rather than failing; it won't show in a checkout diff). **`--auto` only queues while the required checks are still pending. If they are already green it MERGES IMMEDIATELY** — `gh` branches on that itself — so do not reach for it as a safe "arm it and decide later": running it on a green PR is the merge (#3127).
    - CI complete: `gh pr merge <N> --squash --repo StefanMaron/BusinessCentral.AL.Runner`
+   - **After either, re-read the PR — the exit code is not the check.** `gh` branches on a
+     cached `mergeStateStatus`, so a PR whose checks have just settled can read `UNKNOWN`, take
+     the arming path, and be refused with `Pull request is in clean status` — left neither
+     merged nor armed (#3341). `gh pr view <N> --json state,mergedAt,autoMergeRequest`:
+     `MERGED` is done, `OPEN` with auto set is armed, and `OPEN` with no auto on a green PR
+     means re-run **without** `--auto`.
    - Skip `gh pr review --approve` (fails when you are the repo owner).
 9. CI failing: read job log, post a specific actionable comment.
 

--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -37,7 +37,10 @@ something, spawning an agent to re-measure it wastes a full context. Write the P
   the proving test is there, and whether CI is green on the **current head** — then merge.
 - **Arming auto-merge** instead of waiting. Review the PR when it arrives; if it passes, arm
   it (`gh pr merge <N> --squash --delete-branch --auto`) and move on. Do not sit watching a
-  run you cannot influence.
+  run you cannot influence. **If the required checks are already green that command merges it
+  now, not later** — so running it is the merge, and every condition in the arming list below
+  has to hold at that moment. Re-read the PR afterwards rather than trusting the exit code;
+  both are in "A reviewer that approves a PR arms auto-merge" (#3150, #3341).
 - **Claiming an issue assigned to another contributor when it overlaps work already in
   flight**, once the repo owner has released that contributor's backlog. `branch-and-pr.md`'s
   assignee boundary still holds as the default. When a released issue is the same defect an
@@ -184,18 +187,53 @@ checkpoint after it, and nobody looks again. Every condition in the list above h
 the moment you run the command, because running it is the merge — not a request for one. Weigh
 the verdict accordingly rather than assuming a later sweep will catch a mistake.
 
-An earlier version of this section claimed the opposite: that GitHub *refuses* to arm an
-already-mergeable PR, answering `Pull request is in clean status`, and that the coordinator
-would merge it by hand. That was wrong, and a reviewer following it would report "it refused,
-please merge it yourself" about a PR that had already merged. It was falsified on PR #3095 —
-the documented command returned rc=0 and merged it immediately at the reviewed SHA. `gh` never
-produces that message at all; the phrase does not occur anywhere in the binary. It appears to be
-a GitHub API error from the `enablePullRequestAutoMerge` mutation, which is the call `gh` skips
-when the PR is already mergeable — so it is not something this command can produce. See #3127.
+**But `gh` decides that from a cached status, so it can lose the race — verify by re-reading the
+PR, never by the exit code.** `gh` picks the path once, at command start, from the
+`mergeStateStatus` it fetched: `autoMerge: opts.AutoMergeEnable &&
+!isImmediatelyMergeable(pr.MergeStateStatus)` (`pkg/cmd/pr/merge/merge.go`).
+`isImmediatelyMergeable` is true for `CLEAN`, `HAS_HOOKS` and `UNSTABLE` only. GitHub's enum
+also has **`UNKNOWN`** — "the state cannot currently be determined", which is what a PR reads
+while GitHub recomputes mergeability, and `gh` has no constant for it at all. So a PR whose
+checks have *just* settled reads `UNKNOWN`, `gh` takes the **arming** path, and by the time the
+mutation lands GitHub has settled to `CLEAN` and refuses to arm what can already merge:
 
-**Check the exit code either way.** It is not decoration: `gh pr merge` exits non-zero for real
-reasons (`Pull request #N is not mergeable: ...`), and a loop that printed "armed" regardless of
-it once left four green PRs sitting unarmed.
+```
+GraphQL: Pull request Pull request is in clean status (enablePullRequestAutoMerge)
+```
+
+The PR is then **neither merged nor armed** — measured twice, on #3336 and #3772, each landed
+afterwards by re-running the same command **without** `--auto`. Re-running without `--auto` is
+the fix; the state is genuinely clean, which is why it works.
+
+The message is a GitHub API error, not a `gh` one: the phrase does not occur in the binary
+(`gh` 2.98.0). That much of #3127 was right. Its conclusion — that `gh` therefore *cannot*
+produce it, because it skips the mutation on a mergeable PR — does not follow, because "already
+mergeable" there means *as cached at fetch time*, and the gap between the two reads is the race.
+`--auto` on a settled-green PR still merges on the spot (#3095); that is not in question.
+
+**So the exit code is not the check — the PR's state is.** After any `gh pr merge`, re-read it:
+
+```bash
+gh pr view <N> --repo StefanMaron/BusinessCentral.AL.Runner \
+  --json state,mergedAt,autoMergeRequest \
+  --jq '"state=\(.state) mergedAt=\(.mergedAt // "-") auto=\(.autoMergeRequest != null)"'
+```
+
+| what it reads | meaning |
+|---|---|
+| `state=MERGED`, `mergedAt` set | done — record the SHA |
+| `state=OPEN`, `auto=true` | armed; it lands when the checks pass |
+| `state=OPEN`, `auto=false`, and the PR is green | **the race above** — re-run without `--auto` |
+
+**Read that exit code directly, and never through a pipe.** `gh pr merge` does exit 1 on this
+refusal — verified on `gh` 2.98.0, and its error propagates unaltered from the mutation through
+`merge()` to the exit. The `rc=0` reported alongside this failure on #3772 came from the
+*measurement*: `cmd | tail` yields `tail`'s status, and `out=$(cmd); echo "$out"` yields
+`echo`'s, so both print the GraphQL error and then report 0 (`ci-verdicts.md` §0). That is why
+the re-read above is the check and the exit code is only corroboration: one of them was
+misreported for three days, and it was not the one GitHub sends. See #3341.
+
+Still read it: `gh pr merge` exits non-zero for real reasons too (`Pull request #N is not mergeable: ...`), and a loop that printed "armed" regardless of it once left four green PRs sitting unarmed. It is the second check, not the first.
 
 When it arms rather than merges, arming is still not merging, and it does not replace the merge
 bar — it is the bar expressed as a standing instruction to GitHub, so a PR lands the moment its


### PR DESCRIPTION
Closes #3341
Closes #3150

`#3341` was dispatched to me as *probably already refuted* — `orchestrating-a-session` carries a
paragraph naming it and asserting the failure cannot happen. I was asked to establish that
myself rather than take it on anyone's say-so. **It does not hold. The failure is real, and the
paragraph that denies it is the defect.**

## The measurement

Five checks, on `gh` 2.98.0 and against GitHub's live schema.

**1. The phrase is not in the `gh` binary** — the one fact the old paragraph got right.

```
$ strings /usr/bin/gh | command grep -i "clean status"   # no output
rc=1
$ strings /usr/bin/gh | command grep -c "isImmediatelyMergeable"
1
```

**2. `gh` decides once, from a cached status.** From `pkg/cmd/pr/merge/merge.go` at the v2.98.0
tag — the version on this box, not a guess at it:

```go
autoMerge: opts.AutoMergeEnable && !isImmediatelyMergeable(pr.MergeStateStatus),
```

`isImmediatelyMergeable` returns true for `CLEAN`, `HAS_HOOKS`, `UNSTABLE`; everything else
falls to `default: return false`.

**3. GitHub has a status `gh` has no constant for.** `pkg/cmd/pr/merge/http.go` defines seven
`MergeStateStatus*` constants. The live enum has eight:

```
$ gh api graphql -f query='{ __type(name: "MergeStateStatus") { enumValues { name } } }'
DIRTY  UNKNOWN  BLOCKED  BEHIND  UNSTABLE  HAS_HOOKS  CLEAN
```

`UNKNOWN` — GitHub's own description: *"The state cannot currently be determined."* That is what
a PR reads while GitHub recomputes mergeability. `gh` has no case for it, so it takes the
**arming** path on a PR that is about to be clean, and GitHub refuses to arm what can already
merge. **That is the race, and it is visible in the source, not merely inferred from the
symptom.**

**4. Both reported failures are corroborated by ground truth**, independently of the reports:

| PR | outcome | landed |
|---|---|---|
| #3336 | `--auto` left it open, `auto=none` | `a36b9699`, by re-running without `--auto` |
| #3772 | same | `3ea3c780`, same remedy |

Both currently read `mergeState=UNKNOWN` — the very status that triggers it.

**5. The `rc=0` in the issue's newest comment is the instrument, not `gh`.** This one I set out
to confirm because it contradicted the source: `mergeRun` propagates every error, so `gh` should
exit 1. It does:

```
$ gh pr merge 999999 ... --auto ; echo "rc=$?"
GraphQL: Could not resolve to a PullRequest with the number of 999999.
rc=1                                    <- read directly

$ gh pr merge 999999 ... --auto | tail -2 ; echo "rc=$?"
GraphQL: Could not resolve to a PullRequest ...
rc=0                                    <- through a pipe

$ out=$(gh pr merge 999999 ... --auto 2>&1); echo "$out"; echo "rc=$?"
GraphQL: Could not resolve to a PullRequest ...
rc=0                                    <- via echo
```

Both shapes reproduce the comment's signature exactly: **the GraphQL error printed, then `rc=0`.**
So the exit code is trustworthy when read directly — but the reported one was not, and nobody
could tell from the transcript. This is `ci-verdicts.md` §0 landing on the issue that is *about*
an exit code.

## Verdict: real but partly misattributed

Of the three outcomes I was given — refuted / real but different / real as stated — this is the
middle one. The issue's mechanism is right and its remedy is right. What is wrong is the
sub-claim that the return code is unreliable *in both directions*: it is reliable, and the
counter-example was a measurement artifact. Both roads lead to the same rule, which is why the
fix keeps the re-read as the primary check.

## What changed

Documentation only, in the two places an agent actually reads before merging.

- **`.claude/skills/orchestrating-a-session/SKILL.md`** — replaces the paragraph asserting the
  message "is not something this command can produce" with the mechanism, the two measurements,
  the remedy (re-run without `--auto`), and a state-reading table. `--auto` merging a
  settled-green PR on the spot is unchanged and restated; that half was never in doubt (#3095).
- **`.claude/agents/orchestrator.md`** — adds the post-merge re-read to the merge recipe, where
  the command is actually run.

Kept deliberately: the "four green PRs left unarmed" measurement, which still justifies reading
the exit code as the *second* check.

**No code changed, so there is no proving test, and I have not invented one.** The subject is
`gh`'s behavior and a claim in a skill file; `tdd.md` decides where a proving test lives, not
whether a measurement needs one. The evidence is the five checks above, each reproducible from
this body. **I did not touch the arming command** — a speculative change there is worse than the
bug, and the fix needed is the one the two reproductions already demonstrate.

## Fix the shape, not just the reported line

1. **Same wrong pattern elsewhere?** Yes — `orchestrating-a-session` lines 38-40 still framed
   `--auto` as "arm it and decide later", filed separately as **#3150**. Same file, same section,
   so it folds in here per `batch-sibling-issues-by-file.md` and is fixed with its own edit.
   #3150 also names `.claude/agents/orchestrator.md`, corrected above.
2. **Sibling making the same assumption?** `autonomous-cycle/SKILL.md` carried the identical
   paragraph when #3341 was filed; it no longer contains it, so there is nothing to correct
   there — checked, not assumed.
3. **Two paths writing the same state?** The skill and `orchestrator.md` both instruct the merge
   and disagreed about what to check afterwards. They now both say: re-read `state`/`mergedAt`.

**Same-defect scan** (`search-for-the-same-defect-first.md`): searched the open queue on the
message, `enablePullRequestAutoMerge`, "auto-merge", "arming" and "pr merge". #3150 folds in.
#3775 ("a stacked PR reads `mergeStateStatus=CLEAN` while running no CI") is adjacent —
mergeability status being misleading — but a different mechanism and a different fix, so it
stays open and is not claimed. Nothing else overlaps.

## CI

Every changed path ends in `.md` and none is under `AlRunner/`, so no BC legs run and
`require-tests.yml` does not trigger (#2890). Ran locally, each exit code read directly rather
than through a pipe: `test_doc_pointers.py`, `test_matrix_docs_drift.py`,
`test_agent_workflow_hooks.py`, `test_line_endings.py`, `test_text_encoding.py`,
`test_doc_summary_uniqueness.py`, `test_comment_density.py` — all rc=0.

Corpus-NA: documentation-only change to agent coordination skills; asserts nothing about AL or BC behaviour and touches no runner code.

---
*Opened by an agent (`stma-auto-12`) acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
