### PR TITLE
docs(rules): say how you captured a surprising exit code when you report it

### DIFF
--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -32,6 +32,15 @@ that is true. Redirect to a file and check `$?`, or use `${PIPESTATUS[0]}`. Meas
 night. It is the same class as the trap below — an answer that could not have come out any
 other way.
 
+**And when you report a surprising exit code, say how you captured it.** Reading directly
+protects you; it does nothing for a wrong number already written down. #3341 reported `rc=0`
+beside a GraphQL failure, which is impossible directly (`rc=1`) and exact under `| tail` — that
+artifact sat in the issue body for three days as an apparently-measured fact, and it was
+load-bearing: it is what made the reporter conclude the exit code was unreliable **in both
+directions**, a stronger and different claim than the true one. Anyone reading that issue
+inherited a wrong belief about the instrument, sourced to a real transcript. A number nobody can
+attribute to a capture method is not a measurement, and the reader cannot tell.
+
 **Trap: an answer that could not have come out any other way is not evidence.** Under the
 pre-#3351 zero-timeout path a green PR, a red PR and a PR with no checks all printed `STILL
 RUNNING`, and its only tell was the empty parentheses of `STILL RUNNING after 0s ()`, where the


### PR DESCRIPTION
## What

One paragraph in `ci-verdicts.md` §0, immediately after the reading half added by **#3865** (`7e609ee1`), so the two sit together: take an exit code directly, **and say how you took it when you write it down**.

## Why the reading half is not enough

#3865 protects whoever takes the reading. It does nothing for a wrong number already in the record.

#3341's body reported `rc=0` beside a GraphQL failure — impossible directly, exact under a pipe:

```
gh pr merge ... --auto            rc=1   (direct)
gh pr merge ... --auto | tail -2  rc=0   (piped)
```

**This instance is different in kind from #3865's three.** Those were live misreadings, caught in the same session, cost bounded. This one **sat in an issue body for three days as an apparently-measured fact**, and it was load-bearing: the `rc=0` is what made the reporter conclude the exit code was unreliable *in both directions* — a stronger and different claim than the true one.

Anyone reading #3341 inherited a wrong belief about this loop's most load-bearing instrument, **sourced to a real transcript**, with nothing in the record marking the number as suspect.

## The remedy differs because the audience does

"Read it directly" is advice to whoever takes the reading. Quoting the capture method is what lets a *later* reader see `| tail` and discount it, or see a direct read and trust it. A number nobody can attribute to a capture method is not a measurement, and the reader cannot tell.

## Scope

Documentation only. `ci-wait.py` and `gh` are both correct and unchanged; **#3865 stays as written** — this adds the reporting half rather than amending the reading half.

No test: the claim is about how measurements are written down, and asserting on the paragraph's wording would pin phrasing rather than behaviour, which `tdd.md` rejects as noise.

Corpus-NA: documentation-only change to an agent operating rule; no AL is compiled, executed or observed, so no corpus test can measure it.

Closes #3870

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
