### PR TITLE
fix(preflight): reap a merged worktree whose only dirt is the retired corpus gitlink

### DIFF
--- a/docs/incidents/preflight-retired-corpus-gitlink.md
+++ b/docs/incidents/preflight-retired-corpus-gitlink.md
@@ -1,0 +1,76 @@
+# The retired corpus gitlink read as uncommitted work
+
+History for the `worktree_dirt` / `classify_dirt` / `corpus_gitlink_is_workless`
+group in `tools/preflight.py`. Issue #3335; fixed alongside #3759.
+
+## What happened
+
+#3737 removed the `tests/al-language` submodule — but only on `main`. A worktree
+whose branch was cut before that still carries the `160000` gitlink in its own
+`HEAD`, and nothing updates that pin any more. So `git status` prints
+
+```
+ M tests/al-language
+```
+
+for the rest of that worktree's life, `--reap` reads it as uncommitted work, and
+the worktree is kept forever. Before #3737 the remedy was
+`git submodule update --init`; after it, there is no submodule left to update, so
+the state is permanent rather than transient.
+
+Measured on the box 2026-09-11, five days after #3737 merged: **7 worktrees held
+back, every one a MERGED pull request, every one with that single line and
+nothing else.** The issue had measured 5 of 10 on 2026-09-07 under the old
+mechanism, so the fraction grew rather than shrank after the submodule was
+removed.
+
+## The thing that made the obvious fix wrong
+
+The first implementation keyed on the status line plus the index mode, and a test
+caught it: **git prints the same line for three different states.** Measured on
+git 2.55.0, corpus as a submodule:
+
+| state | superproject `status --porcelain` | submodule's own status |
+|---|---|---|
+| pin moved, checkout otherwise empty | ` M tests/al-language` | *(empty)* |
+| untracked file inside the checkout | ` M tests/al-language` | `?? RreLayout.rdl` |
+| both at once | ` M tests/al-language` | `?? RreLayout.rdl` |
+
+`--ignore-submodules=dirty` does not separate them either: it suppresses row 2
+entirely, which turns "there is work in there" into "clean" — the wrong direction
+for a reaper.
+
+So the superproject line establishes only the *shape*. Whether there is work is a
+separate question, answered by descending into the checkout and asking it
+directly (`corpus_gitlink_is_workless`). An unreadable or non-empty answer keeps
+the worktree.
+
+This was not hypothetical: `corpus-stma-auto-32-issue-2943` was on the box at the
+time holding six untracked `.rdl`/`.rdlc` layouts under `tests/al-language`. A
+path-keyed rule would have deleted them.
+
+## Why `gitlink_workless` defaults to False
+
+`classify_dirt(status, modes)` without the third argument treats the gitlink as
+dirt. A caller that forgets to measure gets the conservative answer rather than
+the permissive one — the same reason `agent_self_freshness.py` refuses an
+`unvouched` copy (`guards-need-a-third-state.md`).
+
+## End-to-end result
+
+`tools/preflight.py --agent-id stma-auto-11 --reap`, exit code captured directly
+into `$?` with no pipe: **rc=0**, 13 worktrees removed, of which 3 were
+gitlink-only. Four other gitlink worktrees survived, each for an unrelated
+pre-existing reason the fix does not touch — one unpushed commit, three with no
+resolvable pull request. The shared `.git/config` was unchanged and
+`corpus-stma-auto-32-issue-2943` kept all six of its files.
+
+## `os.getuid` (#3759), fixed in the same file
+
+`check_stale_scratch` called `os.getuid()` unconditionally. It does not exist on
+Windows, so the `AttributeError` propagated out of `main()` and **every** check
+preflight would otherwise have reported was lost — including `branch-ownership`,
+whose job is to stop an agent committing onto another loop's PR branch, and which
+is exactly what an agent on a Windows checkout needs. Where there are no uids
+there is no foreign-owner case to exclude, so the filter is skipped rather than
+faked with a substitute value.

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -882,6 +882,160 @@ def pr_map(slug: Optional[str]) -> tuple[dict, str]:
     return out, "ok"
 
 
+
+# --------------------------------------------------------------------------
+# the retired corpus gitlink
+# --------------------------------------------------------------------------
+# #3737 deleted the tests/al-language submodule, but only on `main`. A branch cut
+# before it still carries the 160000 gitlink in its own HEAD, and nothing updates
+# that pin any more -- so `git status` prints ` M tests/al-language` for the rest
+# of the worktree's life, and the `git submodule update` that used to silence it
+# no longer exists. Measured 2026-09-11: 7 of 7 held-back worktrees on this box,
+# every one a MERGED pull request, every one with that single line and nothing
+# else. See docs/incidents/preflight-retired-corpus-gitlink.md.
+RETIRED_CORPUS_GITLINK_PATH = "tests/al-language"
+GITLINK_MODE = "160000"
+
+# ` M path`, `M  path`, `MM path` -- XY plus one space plus the path. Anything
+# else (a rename's ` -> `, an unmerged code, a line too short to carry a path)
+# is deliberately unmatched, so classify_dirt() calls it dirt.
+_STATUS_LINE = re.compile(r"^(?P<xy>[MADRCU?! ]{2}) (?P<path>[^\x00]+)$")
+
+
+def is_retired_corpus_gitlink(line: str, index_modes: dict) -> bool:
+    """True only for a MODIFIED gitlink at the retired corpus path.
+
+    The discriminator is the index mode, never the path on its own: a worktree
+    cut AFTER #3737 has an ordinary directory at tests/al-language, and files in
+    it are real work. One such worktree is on this box right now
+    (corpus-stma-auto-32-issue-2943, five untracked .rdl/.rdlc layouts), and a
+    path-only rule would have deleted them.
+
+    A deletion (` D`) is not discounted either. Dropping the gitlink is an edit
+    somebody made; drift is the index and the checkout disagreeing about which
+    commit, which only ever renders as a modification.
+
+    This decides only that the LINE has the retired-gitlink shape. It cannot
+    decide that there is no work, because the superproject's ` M <submodule>` is
+    ambiguous -- git prints exactly the same line for a moved pin and for
+    untracked files sitting inside the submodule checkout, and for both at once
+    (measured; see corpus_gitlink_is_workless()). The work question is that
+    function's, and classify_dirt() asks it.
+    """
+    m = _STATUS_LINE.match(line.rstrip("\n"))
+    if not m:
+        return False
+    xy, path = m.group("xy"), m.group("path")
+    if path.strip('"') != RETIRED_CORPUS_GITLINK_PATH:
+        return False
+    if index_modes.get(path.strip('"')) != GITLINK_MODE:
+        return False
+    return set(xy.strip()) == {"M"}
+
+
+def corpus_gitlink_is_workless(worktree: str) -> bool:
+    """True only when the corpus submodule checkout itself holds nothing.
+
+    The whole safety of this feature rests here, because the superproject line is
+    ambiguous. Measured on git 2.55: with the corpus as a submodule,
+    `git status --porcelain` in the superproject prints ` M tests/al-language`
+    for a moved pin, for an untracked file inside the checkout, and for both --
+    three states, one line. Only the submodule's OWN status separates them:
+
+        pin moved, nothing inside     superproject ` M`   submodule ``
+        untracked file inside         superproject ` M`   submodule `?? ...`
+        both                          superproject ` M`   submodule `?? ...`
+
+    So an unreadable submodule status, or a non-empty one, answers False and the
+    worktree stays. Returning False on a failed read is the safe direction: it
+    keeps a tree nobody could measure (guards-need-a-third-state.md).
+    """
+    path = os.path.join(worktree, RETIRED_CORPUS_GITLINK_PATH)
+    if not os.path.isdir(path):
+        return False
+    st = run(["git", "-C", path, "status", "--porcelain"], timeout=60)
+    if not st.ok:
+        return False
+    return not st.out.strip()
+
+
+def classify_dirt(status_porcelain: str, index_modes: dict,
+                  gitlink_workless: bool = False) -> tuple:
+    """(dirty, reason) for a `git status --porcelain` body.
+
+    `gitlink_workless` is corpus_gitlink_is_workless()'s answer. It defaults to
+    False so that a caller which forgets to measure it gets the conservative
+    answer -- the retired gitlink stays dirt until something proves the checkout
+    under it is empty.
+
+    The third state is folded into `dirty`, not out of it: a line this function
+    cannot parse leaves the tree dirty and says so, because "could not tell" must
+    never render as "safe to delete" (guards-need-a-third-state.md).
+    """
+    lines = [l for l in status_porcelain.splitlines() if l.strip()]
+    if not lines:
+        return (False, "")
+    unclassified = []
+    discounted = 0
+    for line in lines:
+        if is_retired_corpus_gitlink(line, index_modes):
+            if not gitlink_workless:
+                return (True, "the tests/al-language checkout holds files of its own")
+            discounted += 1
+            continue
+        if not _STATUS_LINE.match(line.rstrip("\n")):
+            unclassified.append(line.strip()[:60])
+            continue
+        return (True, "")
+    if unclassified:
+        return (True, f"could not classify {len(unclassified)} status line(s): "
+                      f"{', '.join(unclassified[:3])}")
+    if discounted:
+        return (False, "the retired tests/al-language gitlink only")
+    return (True, "")
+
+
+def index_gitlink_modes(worktree: str) -> dict:
+    """Index mode per path, read from `git ls-files -s`.
+
+    Returns {} when the read fails, which keeps every dirty line unexplained and
+    therefore keeps the tree dirty -- the safe direction.
+    """
+    r = run(["git", "-C", worktree, "ls-files", "-s", "--", RETIRED_CORPUS_GITLINK_PATH],
+            timeout=60)
+    if not r.ok:
+        return {}
+    out = {}
+    for line in r.out.splitlines():
+        if "\t" not in line:
+            continue
+        meta, path = line.split("\t", 1)
+        parts = meta.split()
+        if parts:
+            out[path.strip()] = parts[0]
+    return out
+
+def worktree_dirt(worktree: str) -> tuple:
+    """(dirty, note) for one worktree, discounting the retired corpus gitlink.
+
+    The single reader of `git status --porcelain` for worktree disposition. Both
+    the census and the reaper call it, because the reaper re-reads status just
+    before deleting: two readers that classify differently would clear a worktree
+    in the census and then refuse it in the reaper, which is the #3335 symptom
+    with the fix apparently applied.
+
+    A status read that FAILS returns dirty, as it did before -- an unmeasured
+    tree is never safe to delete (guards-need-a-third-state.md).
+    """
+    st = run(["git", "-C", worktree, "status", "--porcelain"], timeout=60)
+    if not st.ok:
+        return (True, "git status could not be read")
+    if not st.out.strip():
+        return (False, "")
+    return classify_dirt(st.out, index_gitlink_modes(worktree),
+                         gitlink_workless=corpus_gitlink_is_workless(worktree))
+
+
 def collect_worktrees(repo: str, prs: dict, measure: bool = True) -> list[tuple]:
     r = run(["git", "-C", repo, "worktree", "list", "--porcelain"])
     if not r.ok:
@@ -896,8 +1050,7 @@ def collect_worktrees(repo: str, prs: dict, measure: bool = True) -> list[tuple]
         dirty = False
         unpushed: Optional[int] = None
         if exists:
-            st = run(["git", "-C", wt.path, "status", "--porcelain"], timeout=60)
-            dirty = bool(st.out.strip()) if st.ok else True
+            dirty, _dirt_note = worktree_dirt(wt.path)
             up = run(["git", "-C", wt.path, "rev-list", "--count", "@{u}..HEAD"], timeout=60)
             if up.ok and up.out.strip().isdigit():
                 unpushed = int(up.out.strip())
@@ -1085,6 +1238,8 @@ def check_worktrees(rows: list[tuple], repo: str, pr_status: str) -> CheckResult
 
 def check_stale_scratch(tmp_dir: str, rows: list[tuple], stale_hours: float) -> CheckResult:
     now = dt.datetime.now().timestamp()
+    _getuid = getattr(os, "getuid", None)
+    _uid = _getuid() if _getuid is not None else None
     entries = []
     try:
         with os.scandir(tmp_dir) as it:
@@ -1093,7 +1248,15 @@ def check_stale_scratch(tmp_dir: str, rows: list[tuple], stale_hours: float) -> 
                     st = entry.stat(follow_symlinks=False)
                 except OSError:
                     continue
-                if st.st_uid != os.getuid() or not entry.is_dir(follow_symlinks=False):
+                if not entry.is_dir(follow_symlinks=False):
+                    continue
+                # os.getuid does not exist on Windows, and reaching it
+                # unconditionally lost EVERY check preflight would otherwise
+                # report on a Windows box -- branch-ownership included, the one
+                # an agent there most needs (#3759). Where there are no uids
+                # there is no foreign-owner case to exclude, so the filter is
+                # skipped rather than faked.
+                if _uid is not None and st.st_uid != _uid:
                     continue
                 size, complete = dir_size(entry.path, budget=200_000)
                 entries.append((size, complete, (now - st.st_mtime) / 3600.0, entry.path))
@@ -2610,9 +2773,10 @@ def reap(repo: str, rows: list[tuple], dry_run: bool) -> list[str]:
     for wt, pr, dirty, unpushed, d, exists in rows:
         if not d.reapable:
             continue
-        st = run(["git", "-C", wt.path, "status", "--porcelain"], timeout=60)
-        if not st.ok or st.out.strip():
-            log.append(f"SKIP  {wt.path} - it became dirty since the census")
+        still_dirty, dirt_note = worktree_dirt(wt.path)
+        if still_dirty:
+            log.append(f"SKIP  {wt.path} - it became dirty since the census"
+                       + (f" ({dirt_note})" if dirt_note else ""))
             continue
         if dry_run:
             log.append(f"WOULD REMOVE  {wt.path}  [{wt.branch}]  {d.reason}")

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -603,6 +603,239 @@ try:
 finally:
     shutil.rmtree(tmp, ignore_errors=True)
 
+
+# --------------------------------- the retired corpus gitlink (#3335)
+print()
+print("preflight.py -- a retired corpus gitlink is not uncommitted work")
+
+# #3737 deleted the tests/al-language submodule. A worktree branched BEFORE that
+# still carries the 160000 gitlink in its own HEAD, so its checkout drifts from
+# a pin nothing updates any more: `git status` prints ` M tests/al-language`
+# forever, and there is no `git submodule update` left to silence it. Measured
+# on this box 2026-09-11: 7 of 7 held-back worktrees, every one a MERGED PR,
+# every one with that single line and nothing else.
+
+check("the retired corpus gitlink is recognised",
+      pf.is_retired_corpus_gitlink(" M tests/al-language", {"tests/al-language": "160000"}),
+      "the exact shape that held back 7 merged worktrees")
+check("...and so is the staged spelling",
+      pf.is_retired_corpus_gitlink("M  tests/al-language", {"tests/al-language": "160000"}))
+
+# The discriminator is the gitlink MODE, not the path. A post-#3737 worktree has
+# an ordinary directory there, and real files in it are real work.
+check("a tracked FILE under the corpus path is real work, not a gitlink",
+      not pf.is_retired_corpus_gitlink(" M tests/al-language/x.al",
+                                       {"tests/al-language/x.al": "100644"}))
+check("an UNTRACKED file under the corpus path is real work",
+      not pf.is_retired_corpus_gitlink("?? tests/al-language/RreLayout.rdl", {}),
+      "corpus-stma-auto-32-issue-2943 on this box holds 5 such files")
+check("a path the index does not call a gitlink is never discounted",
+      not pf.is_retired_corpus_gitlink(" M tests/al-language", {"tests/al-language": "100644"}))
+check("a gitlink at some OTHER path is not discounted",
+      not pf.is_retired_corpus_gitlink(" M vendor/thing", {"vendor/thing": "160000"}))
+check("a DELETED gitlink is not discounted -- that is a real edit",
+      not pf.is_retired_corpus_gitlink(" D tests/al-language", {"tests/al-language": "160000"}))
+
+# classify_dirt(): the three-state answer disposition() consumes.
+GL = {"tests/al-language": "160000"}
+check("a tree dirty ONLY by the retired gitlink is not dirty",
+      pf.classify_dirt(" M tests/al-language\n", GL, gitlink_workless=True)
+      == (False, "the retired tests/al-language gitlink only"))
+check("a tree with the gitlink AND real work stays dirty",
+      pf.classify_dirt(" M tests/al-language\n M AlRunner/X.cs\n", GL,
+                       gitlink_workless=True)[0])
+
+# The superproject line is AMBIGUOUS: git prints ` M tests/al-language` for a
+# moved pin, for untracked files inside the checkout, and for both. Only the
+# submodule's own status separates them, so an unproven checkout stays dirt.
+check("the gitlink stays dirt until the checkout under it is proven empty",
+      pf.classify_dirt(" M tests/al-language\n", GL)[0],
+      "gitlink_workless defaults False -- a forgetful caller gets the safe answer")
+check("...and says the checkout holds files of its own",
+      "holds files of its own" in pf.classify_dirt(" M tests/al-language\n", GL)[1],
+      pf.classify_dirt(" M tests/al-language\n", GL)[1])
+check("a clean tree is clean", pf.classify_dirt("", {}) == (False, ""))
+check("real work alone is dirty", pf.classify_dirt(" M AlRunner/X.cs\n", {})[0])
+
+# guards-need-a-third-state: a line we cannot parse is dirt, never a free pass.
+check("an unparseable status line keeps the tree dirty",
+      pf.classify_dirt("garbage\n", {})[0],
+      "could not classify must not read as safe to delete")
+check("...and says it could not classify it",
+      "could not" in pf.classify_dirt("garbage\n", {})[1].lower(),
+      pf.classify_dirt("garbage\n", {})[1])
+check("a rename line is dirt rather than silently discounted",
+      pf.classify_dirt("R  a -> b\n", {})[0])
+
+
+# ------------------------------- the gitlink reap, end to end (real git, #3335)
+print()
+print("preflight.py -- a merged worktree held back ONLY by the retired gitlink")
+
+# The classifier above is only worth anything if collect_worktrees() and reap()
+# both consult it. reap() re-reads status immediately before deleting, so an
+# unwired reap() refuses every worktree the census just cleared -- the failure
+# that makes the fix look applied while nothing is reaped.
+
+tmp2 = tempfile.mkdtemp(prefix="preflight-gitlink-")
+try:
+    env = dict(os.environ,
+               GIT_AUTHOR_NAME="t", GIT_AUTHOR_EMAIL="t@e",
+               GIT_COMMITTER_NAME="t", GIT_COMMITTER_EMAIL="t@e",
+               GIT_CONFIG_GLOBAL=os.path.join(tmp2, "nogitconfig"),
+               GIT_CONFIG_SYSTEM=os.path.join(tmp2, "nogitconfig"))
+
+    sub2 = os.path.join(tmp2, "corpus")
+    os.makedirs(sub2)
+    git("init", "-q", "-b", "master", cwd=sub2, env=env)
+    open(os.path.join(sub2, "c.txt"), "w").write("one\n")
+    git("add", "c.txt", cwd=sub2, env=env)
+    git("commit", "-qm", "c1", cwd=sub2, env=env)
+
+    repo2 = os.path.join(tmp2, "main")
+    os.makedirs(repo2)
+    git("init", "-q", "-b", "main", cwd=repo2, env=env)
+    open(os.path.join(repo2, "a.txt"), "w").write("one\n")
+    git("add", "a.txt", cwd=repo2, env=env)
+    git("commit", "-qm", "base", cwd=repo2, env=env)
+    git("-c", "protocol.file.allow=always", "submodule", "add", "-q", sub2,
+        "tests/al-language", cwd=repo2, env=env)
+    git("commit", "-qm", "pre-#3737: the corpus is a submodule", cwd=repo2, env=env)
+
+    def gitlink_worktree(name, branch):
+        """A worktree whose ONLY dirt is the retired gitlink -- the #3335 state."""
+        path = os.path.join(tmp2, name)
+        git("branch", branch, cwd=repo2, env=env)
+        git("worktree", "add", "-q", path, branch, cwd=repo2, env=env)
+        git("-c", "protocol.file.allow=always", "submodule", "update", "--init", "-q",
+            cwd=path, env=env)
+        # Move the checkout off the pin, exactly as a corpus resolve does now.
+        open(os.path.join(sub2, "c.txt"), "w").write(f"moved for {name}\n")
+        git("commit", "-qam", f"corpus moves on: {name}", cwd=sub2, env=env)
+        git("fetch", "-q", "origin", cwd=os.path.join(path, "tests/al-language"), env=env)
+        git("checkout", "-q", "FETCH_HEAD",
+            cwd=os.path.join(path, "tests/al-language"), env=env)
+        return path
+
+    wt3 = gitlink_worktree("wt3", "gitlink-only")
+    st3 = subprocess.run(["git", "status", "--porcelain"], cwd=wt3, env=env,
+                         capture_output=True, text=True).stdout
+    check("the fixture reproduces the #3335 state exactly",
+          st3.strip() == "M tests/al-language" or st3.rstrip("\n") == " M tests/al-language",
+          repr(st3))
+
+    modes = pf.index_gitlink_modes(wt3)
+    check("index_gitlink_modes reads the 160000 mode off a real worktree",
+          modes.get("tests/al-language") == "160000", str(modes))
+    check("the submodule checkout under it is proven empty",
+          pf.corpus_gitlink_is_workless(wt3))
+    _cd = pf.classify_dirt(st3, modes, gitlink_workless=True)
+    check("...and classify_dirt then calls the tree clean",
+          _cd == (False, "the retired tests/al-language gitlink only"), str(_cd))
+    check("worktree_dirt agrees", pf.worktree_dirt(wt3)[0] is False, str(pf.worktree_dirt(wt3)))
+
+    head3 = git("rev-parse", "HEAD", cwd=wt3, env=env).stdout.strip()
+    prs = {"gitlink-only": {"number": 3266, "state": "MERGED", "headRefOid": head3}}
+    rows3 = pf.collect_worktrees(repo2, prs, measure=False)
+    mine = [r for r in rows3 if os.path.realpath(r[0].path) == os.path.realpath(wt3)]
+    check("collect_worktrees sees the worktree", len(mine) == 1, str([r[0].path for r in rows3]))
+    check("collect_worktrees no longer calls it dirty", not mine[0][2], "still dirty")
+    check("...so its merged worktree is reapable", mine[0][4].reapable, mine[0][4].reason)
+
+    log3 = pf.reap(repo2, mine, dry_run=False)
+    check("reap() actually removes it -- its own re-read agrees with the census",
+          not os.path.isdir(wt3), str(log3))
+    check("...and says REMOVED", any("REMOVED" in l for l in log3), str(log3))
+
+    # The direction that must NOT change: a real edit still keeps the tree.
+    wt4 = gitlink_worktree("wt4", "gitlink-plus-work")
+    open(os.path.join(wt4, "a.txt"), "w").write("edited by an agent\n")
+    head4 = git("rev-parse", "HEAD", cwd=wt4, env=env).stdout.strip()
+    prs4 = {"gitlink-plus-work": {"number": 3267, "state": "MERGED", "headRefOid": head4}}
+    rows4 = [r for r in pf.collect_worktrees(repo2, prs4, measure=False)
+             if os.path.realpath(r[0].path) == os.path.realpath(wt4)]
+    check("a worktree with the gitlink AND a real edit is still dirty", rows4[0][2])
+    check("...and is NOT reapable", not rows4[0][4].reapable, rows4[0][4].reason)
+    pf.reap(repo2, rows4, dry_run=False)
+    check("...and reap() leaves it on disk", os.path.isdir(wt4))
+    check("...with the agent's edit intact",
+          open(os.path.join(wt4, "a.txt")).read() == "edited by an agent\n")
+
+    # An UNTRACKED file under the corpus path is real work too -- the post-#3737
+    # shape, live on this box as corpus-stma-auto-32-issue-2943.
+    wt5 = gitlink_worktree("wt5", "gitlink-plus-untracked")
+    open(os.path.join(wt5, "tests/al-language", "RreLayout.rdl"), "w").write("layout\n")
+    head5 = git("rev-parse", "HEAD", cwd=wt5, env=env).stdout.strip()
+    prs5 = {"gitlink-plus-untracked": {"number": 3268, "state": "MERGED",
+                                       "headRefOid": head5}}
+    st5 = subprocess.run(["git", "status", "--porcelain"], cwd=wt5, env=env,
+                         capture_output=True, text=True).stdout
+    check("git prints the SAME line for pin drift and for work inside the checkout",
+          st5.rstrip("\n").strip() == "M tests/al-language", repr(st5))
+    check("...so the superproject line alone cannot decide, and the probe does",
+          not pf.corpus_gitlink_is_workless(wt5),
+          "the checkout holds RreLayout.rdl")
+    check("...and worktree_dirt therefore keeps it dirty", pf.worktree_dirt(wt5)[0],
+          str(pf.worktree_dirt(wt5)))
+    rows5 = [r for r in pf.collect_worktrees(repo2, prs5, measure=False)
+             if os.path.realpath(r[0].path) == os.path.realpath(wt5)]
+    check("...and it is not reapable", not rows5[0][4].reapable, rows5[0][4].reason)
+    pf.reap(repo2, rows5, dry_run=False)
+    check("an untracked file inside the corpus directory keeps the worktree",
+          os.path.isdir(wt5) and os.path.exists(
+              os.path.join(wt5, "tests/al-language", "RreLayout.rdl")))
+finally:
+    shutil.rmtree(tmp2, ignore_errors=True)
+
+
+# ------------------------------------ check_stale_scratch on Windows (#3759)
+print()
+print("preflight.py -- the scratch scan must not need os.getuid()")
+
+# os.getuid does not exist on Windows, and check_stale_scratch reached it
+# unconditionally -- so EVERY check preflight would otherwise report was lost on
+# a Windows box, branch-ownership included, which is the one an agent there most
+# needs. Reproduced on all three invocations tried in #3759.
+_real_getuid = getattr(os, "getuid", None)
+try:
+    if hasattr(os, "getuid"):
+        del os.getuid
+    check("os.getuid is absent for this check", not hasattr(os, "getuid"))
+    _scratch = tempfile.mkdtemp(prefix="preflight-nouid-")
+    try:
+        os.makedirs(os.path.join(_scratch, "a-dir"))
+        open(os.path.join(_scratch, "a-file"), "w").write("x")
+        r = pf.check_stale_scratch(_scratch, [], 24.0)
+        check("check_stale_scratch still returns a result without os.getuid",
+              isinstance(r, pf.CheckResult), repr(r))
+        check("...and it is a real verdict, not an error-shaped WARN",
+              r.status in ("PASS", "WARN"), f"{r.status} {r.summary}")
+        check("...and it counted the directory rather than skipping everything",
+              "1 directory" in " ".join([r.summary] + list(r.detail)),
+              " ".join([r.summary] + list(r.detail)))
+    finally:
+        shutil.rmtree(_scratch, ignore_errors=True)
+finally:
+    if _real_getuid is not None:
+        os.getuid = _real_getuid
+
+check("os.getuid is restored for the rest of the run",
+      _real_getuid is None or hasattr(os, "getuid"))
+
+# On a POSIX box the ownership filter must still work: a directory owned by
+# somebody else is not this user's scratch and is not counted.
+if hasattr(os, "getuid"):
+    _scratch2 = tempfile.mkdtemp(prefix="preflight-uid-")
+    try:
+        os.makedirs(os.path.join(_scratch2, "mine"))
+        r2 = pf.check_stale_scratch(_scratch2, [], 24.0)
+        check("a directory this user owns is still counted on POSIX",
+              "1 directory" in " ".join([r2.summary] + list(r2.detail)),
+              " ".join([r2.summary] + list(r2.detail)))
+    finally:
+        shutil.rmtree(_scratch2, ignore_errors=True)
+
+
 # ---------------------------------------------------------------- exit codes
 print()
 print("preflight.py -- exit codes")


### PR DESCRIPTION
Closes #3335
Closes #3759

## The issue was filed against a mechanism that no longer exists — the defect outlived it

#3335 was filed 2026-09-07, when `tests/al-language` was a submodule, and proposed
`git submodule update` as the remedy. **#3737 then removed the submodule.** So the first
question was whether the defect survived, and it did — in a worse form, because the remedy
went away with the submodule while the symptom did not.

#3737 removed the submodule **only on `main`**. A worktree whose branch was cut before it
still carries the `160000` gitlink in its own `HEAD`, and nothing updates that pin any more.
`git status` prints ` M tests/al-language` for the rest of that worktree's life, `--reap`
reads it as uncommitted work, and there is no `git submodule update` left to clear it.

Measured on this box **2026-09-11**, five days after #3737 merged:

| | |
|---|---|
| worktrees held back with `M tests/al-language` as their **only** dirty line | **7** |
| of those, whose PR is **MERGED** | **7 of 7** (#3266, #3401, #2881, #3113, #3110, #3427, #3393) |

The issue measured 5 of 10 under the old mechanism. The fraction grew after the submodule
was removed, because the state became permanent rather than transient.

## The obvious fix is wrong, and a test caught it

The first implementation keyed on the status line plus the index mode. That is not sound:
**git prints the same line for three different states.** Measured on git 2.55.0:

| state | superproject `status --porcelain` | submodule's own status |
|---|---|---|
| pin moved, checkout otherwise empty | ` M tests/al-language` | *(empty)* |
| untracked file inside the checkout | ` M tests/al-language` | `?? RreLayout.rdl` |
| both at once | ` M tests/al-language` | `?? RreLayout.rdl` |

`--ignore-submodules=dirty` does not separate them either — it suppresses row 2 entirely,
turning "there is work in there" into "clean", which is the wrong direction for a reaper.

This was not hypothetical. `corpus-stma-auto-32-issue-2943` was on the box holding **six
untracked `.rdl`/`.rdlc` layouts** under `tests/al-language`. A path-keyed rule would have
deleted them.

So the superproject line establishes only the **shape**; whether there is work is a separate
question, answered by descending into the checkout and asking it
(`corpus_gitlink_is_workless`). A non-empty answer, an unreadable one, or a missing directory
all keep the worktree.

## The refusal stays the default

- `classify_dirt(status, modes)` without the new `gitlink_workless` argument treats the
  gitlink as **dirt**. A caller that forgets to measure gets the conservative answer.
- A `git status` that fails to run returns dirty, as before.
- A status line that does not parse — a rename, an unmerged code — returns dirty **and says
  it could not classify it**, rather than being skipped (`guards-need-a-third-state.md`).
- A **deleted** gitlink (` D`) is not discounted; dropping it is an edit somebody made.
- A gitlink at any other path is not discounted.

## RED → GREEN

**RED (#3335), before the fix:** `AttributeError: module 'preflight' has no attribute
'is_retired_corpus_gitlink'`, then with the classifier present but unwired —

```
FAIL collect_worktrees no longer calls it dirty  still dirty
FAIL ...so its merged worktree is reapable  PR #3266 is merged, but the tree has uncommitted changes
FAIL reap() actually removes it  ['nothing to reap']
```

That middle failure is the one worth naming: `reap()` re-reads status immediately before
deleting, so a classifier wired into the census alone clears a worktree and then refuses it —
the fix looks applied while nothing is reaped. Both call sites now route through one
`worktree_dirt()`, and the test asserts the reap actually happens.

**RED (#3759), before the fix** — the traceback from the issue, reproduced by deleting
`os.getuid` from the module under test:

```
File "tools/preflight.py", line 1249, in check_stale_scratch
  if st.st_uid != os.getuid() or not entry.is_dir(follow_symlinks=False):
AttributeError: module 'os' has no attribute 'getuid'
```

**GREEN:** `python3 tools/test_preflight.py` → **rc=0, "all checks passed"**. Every
`tools/test_*.py` passes. No `Skipped:` — this is a plain Python suite, not `dotnet test`.

Both directions are proven on real git, not mocks: a fixture builds a genuine pre-#3737
worktree, moves the corpus checkout off its pin, and asserts the worktree is removed; two
more add a tracked edit and an untracked file inside the checkout and assert the worktree
**and its contents** survive.

## End to end on this box

`tools/preflight.py --agent-id stma-auto-11 --reap`, **exit code captured directly into `$?`
with no pipe** (per #3871): **rc=0**, 13 worktrees removed, 3 of them gitlink-only —
the ones logged `(after clearing submodule directories; submodule deinit deliberately NOT
used)`.

The conservative directions all held on the real box:

- the **4** other gitlink worktrees survived, each kept for an unrelated pre-existing reason
  the fix does not touch — one unpushed commit, three with no resolvable PR;
- `corpus-stma-auto-32-issue-2943` kept **all six** of its untracked layout files;
- the shared `.git/config` was unchanged.

Confirmed a second, differently-shaped way (`verify-execution-not-the-tick.md`): counting the
worktrees git itself still registers, and re-listing every worktree whose status is exactly
` M tests/al-language`. Both agree — exactly the 4 kept-for-other-reasons remain.

## #3759, folded in

Same file, one line, trivially provable. `check_stale_scratch` reached `os.getuid()`
unconditionally; it does not exist on Windows, so the `AttributeError` propagated out of
`main()` and **every** check preflight would otherwise report was lost — `branch-ownership`
included, which is the one an agent on a Windows checkout most needs. Where there are no uids
there is no foreign-owner case to exclude, so the filter is skipped rather than faked with a
substitute value; a POSIX test asserts the ownership filter still works.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** **Yes, one, and it was load-bearing.**
   `reap()` had its own copy of `status --porcelain` → boolean, and it re-reads immediately
   before deleting. Fixing only the census would have produced a fix that reaps nothing. Both
   now call `worktree_dirt()`; `command grep -n "bool(st.out.strip())" tools/preflight.py`
   returns nothing.
2. **Sibling function making the same assumption?** **No others found.** `worktree_dirt` is
   now the only reader of `git status --porcelain` for worktree disposition in the whole
   repository — no other `tools/*.py`, `.claude/hooks/` or `.github/scripts/` file reads
   worktree dirtiness.
3. **Two paths writing the same state with different invariants?** This is exactly what 1 was
   — census and reaper classifying independently. One function now, so they cannot drift.

**Queue scan** (`batch-sibling-issues-by-file.md`, `search-for-the-same-defect-first.md`),
searched on `preflight`, `reap worktree`, and the mechanism (`submodule pointer drift`,
`uncommitted work`):

| issue | in `preflight.py`? | decision |
|---|---|---|
| **#3759** `os.getuid` on Windows | yes | **folded in**, own RED → GREEN |
| **#3478** corpus-pin unmerged index | **no longer** | **obsolete** — `tools/corpus-pin.py` and `corpus_pin_readings` were both deleted by #3737. Commented on the issue. |
| #3264 `bc260` context never registrable | yes, different function | **not folded** — a policy question about `.github/bc-versions.txt`, not this code path, and it needs different reasoning to review |
| #3275 one-GitHub-account assumption | no | documentation rule, unrelated |

No duplicate of #3335 itself exists; searched the open queue by symbol, by observable
(`M tests/al-language`), and by mechanism.

## Docs

Long-form measurement, including the three-state table and why `gitlink_workless` defaults to
False, is in `docs/incidents/preflight-retired-corpus-gitlink.md`, cited from the code. No
`README`/`--guide`/`limitations`/`scope` change: no user-facing behaviour changed, only which
worktrees the reaper is willing to remove.

Filed by an agent (`stma-auto-11`) acting on the account holder's behalf, during an
autonomous-cycle session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
