### PR TITLE
test(corpus): get a verdict on TableRelation = T.SystemRowVersion

### DIFF
--- a/AlRunner.Tests/TableRelationOntoSystemRowVersionTests.cs
+++ b/AlRunner.Tests/TableRelationOntoSystemRowVersionTests.cs
@@ -6,9 +6,9 @@
 // the built `NCLMetaFieldRelation` for a `TableRelation = <Table>.SystemRowVersion`, and that
 // it is the SAME id a relation naming no field at all produces.
 //
-// It does NOT assert what real BC does with such a relation. That is plain BC behaviour, it is
-// the actual open question in #3325, and it is asked upstream where a service tier answers it:
-// corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#324 adds
+// It does NOT assert what real BC does with such a relation. That is plain BC behaviour and it
+// is asserted upstream, where a service tier adjudicates it: corpus PR
+// StefanMaron/BusinessCentral.AL.Language.Tests#324 adds
 // `Record_Validate_TableRelationOntoSystemRowVersion` to codeunit 60818. Duplicating that
 // claim here would give it a green tick from the runner agreeing with itself, which is exactly
 // what `.claude/rules/bc-behavior-tests-go-upstream.md` exists to prevent.
@@ -25,18 +25,28 @@
 //     TableRelation = "TRSRV Row"                      -> no field,   fieldId = 0
 //
 // and from `NCLMetaFieldRelation` onward nothing can tell them apart. BC reads
-// `SourceFieldId = 0` as "relate to the related table's primary key", which is why the runner
-// today refuses a rowversion that genuinely exists on a row — the observation #3325 was filed
-// on. That collision is the runner's own structure, visible without asking a service tier
-// anything, and it is what the assertions below hold.
+// `SourceFieldId = 0` as "relate to the related table's primary key", which is why a rowversion
+// that genuinely exists on a row is refused — the observation #3325 was filed on. That
+// collision is visible in the runner's own structure without asking a service tier anything,
+// and it is what the assertions below hold; whether it MATCHES BC is the next section.
 //
-// WHY IT IS WORTH A TEST WHATEVER THE CORPUS ANSWERS
-// --------------------------------------------------
-// Both possible verdicts land here. If BC relates to the rowversion column, the runner has to
-// stop encoding this target as 0 and this test is the RED that the fix turns; if BC relates to
-// the primary key, the runner is already right and this test is what stops a later change to
-// `SystemRowVersionParsedField`'s id — a plausible edit, since 0 looks like a placeholder —
-// from silently moving the relation off the shape BC adjudicated.
+// THE VERDICT: BC DOES THE SAME, SO THE ENCODING IS CORRECT
+// ---------------------------------------------------------
+// Corpus run 34573236729 answered it on BC 27.0, 27.3 and 27.5. Real BC refuses an existing
+// line's own rowversion, with the same message the runner produces:
+//
+//     The field Line Row Version Ref of table CFSF Header contains a value (397405) that
+//     cannot be found in the related table (CFSF Line).
+//
+// So field id 0 is not a runner artefact to be fixed — it is what BC itself resolves a
+// SystemRowVersion relation target to, and the primary-key reading is BC's own. A
+// TableRelation onto SystemRowVersion compiles and then rejects every value; it is not a
+// usable foreign key, unlike the SystemId relation on the same corpus fixture.
+//
+// That makes this file a REGRESSION guard rather than a RED baseline. Changing
+// `SystemRowVersionParsedField`'s id away from 0 is a plausible edit — 0 reads like a
+// placeholder — and it would silently move the relation off the shape a service tier
+// adjudicated. These three tests are what refuse that edit.
 using AlRunner.Patches;
 using Microsoft.Dynamics.Nav.Runtime;
 using Xunit;

--- a/AlRunner.Tests/TableRelationOntoSystemRowVersionTests.cs
+++ b/AlRunner.Tests/TableRelationOntoSystemRowVersionTests.cs
@@ -1,0 +1,232 @@
+// TableRelationOntoSystemRowVersionTests — issue #3325.
+//
+// WHAT IS PINNED, AND WHAT DELIBERATELY IS NOT
+// --------------------------------------------
+// This file pins ONE runner-side mechanical fact: the `SourceFieldId` the runner writes into
+// the built `NCLMetaFieldRelation` for a `TableRelation = <Table>.SystemRowVersion`, and that
+// it is the SAME id a relation naming no field at all produces.
+//
+// It does NOT assert what real BC does with such a relation. That is plain BC behaviour, it is
+// the actual open question in #3325, and it is asked upstream where a service tier answers it:
+// corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#324 adds
+// `Record_Validate_TableRelationOntoSystemRowVersion` to codeunit 60818. Duplicating that
+// claim here would give it a green tick from the runner agreeing with itself, which is exactly
+// what `.claude/rules/bc-behavior-tests-go-upstream.md` exists to prevent.
+//
+// THE MECHANISM
+// -------------
+// `SystemRowVersionParsedField` is `new ParsedField(0, "SystemRowVersion", "BigInteger", 0, …)`
+// — field id 0, because BC gives the rowversion column id 0 under its metadata name
+// `timestamp`. `BuildMetaFieldRelations` initialises its local `fieldId` to 0 and overwrites it
+// only when `TryResolveTableFieldByName` succeeds. So two different AL spellings converge on
+// one value:
+//
+//     TableRelation = "TRSRV Row".SystemRowVersion     -> resolved,   fieldId = 0
+//     TableRelation = "TRSRV Row"                      -> no field,   fieldId = 0
+//
+// and from `NCLMetaFieldRelation` onward nothing can tell them apart. BC reads
+// `SourceFieldId = 0` as "relate to the related table's primary key", which is why the runner
+// today refuses a rowversion that genuinely exists on a row — the observation #3325 was filed
+// on. That collision is the runner's own structure, visible without asking a service tier
+// anything, and it is what the assertions below hold.
+//
+// WHY IT IS WORTH A TEST WHATEVER THE CORPUS ANSWERS
+// --------------------------------------------------
+// Both possible verdicts land here. If BC relates to the rowversion column, the runner has to
+// stop encoding this target as 0 and this test is the RED that the fix turns; if BC relates to
+// the primary key, the runner is already right and this test is what stops a later change to
+// `SystemRowVersionParsedField`'s id — a plausible edit, since 0 looks like a placeholder —
+// from silently moving the relation off the shape BC adjudicated.
+using AlRunner.Patches;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class TableRelationOntoSystemRowVersionTests : IDisposable
+{
+    private readonly BcEngineFixture _engine;
+    private readonly string _root;
+
+    // Process-wide unique among AlRunner.Tests statics: these land in the same static
+    // _parsedTables / _metaTableCache the whole assembly shares, so a duplicate id does not
+    // fail loudly — it hands back the OTHER file's table. Same hazard
+    // TableRelationUnresolvedRefusalTests documents at its own id constants.
+    private const int RowTableId = 94240;
+    private const int RelTableId = 94241;
+
+    private const int RowVersionRelationFieldId = 2;
+    private const int SystemIdRelationFieldId = 3;
+    private const int WholeTableRelationFieldId = 4;
+    private const int NamedFieldRelationFieldId = 5;
+
+    public TableRelationOntoSystemRowVersionTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = TestScratch.Dir("al-runner-3325-rowversion-relation");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    [SkippableFact]
+    public void RelationOntoSystemRowVersion_IsCarried_AndTargetsTheRelatedTable()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var rel = BuildRelTable();
+
+        Assert.True(rel.TryGetFieldByNo(RowVersionRelationFieldId, out var rowVersionRef));
+
+        // The relation survives the builder at all. Before #3307's resolver change
+        // `SystemRowVersion` did not resolve, `BuildMetaFieldRelations` refused the whole
+        // property, and this collection was empty — which every consumer reads as "this field
+        // declares no TableRelation". Asserting non-empty is what stops a regression to that.
+        Assert.NotNull(rowVersionRef.FieldRelations);
+        var arm = Assert.Single(rowVersionRef.FieldRelations!);
+
+        // It names the right table concretely. A relation carried with the target lost would
+        // still leave FieldRef.Relation answering 0.
+        Assert.Equal(RowTableId, arm.SourceTableId);
+        Assert.Equal(RelTableId, arm.ReferencingTableId);
+        Assert.Equal(RowVersionRelationFieldId, arm.ReferencingFieldId);
+    }
+
+    [SkippableFact]
+    public void SystemRowVersionTarget_EncodesAsFieldZero_IndistinguishableFromAWholeTableRelation()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var rel = BuildRelTable();
+
+        Assert.True(rel.TryGetFieldByNo(RowVersionRelationFieldId, out var rowVersionRef));
+        Assert.True(rel.TryGetFieldByNo(WholeTableRelationFieldId, out var wholeTableRef));
+
+        var rowVersionArm = Assert.Single(rowVersionRef.FieldRelations!);
+        var wholeTableArm = Assert.Single(wholeTableRef.FieldRelations!);
+
+        // The claim, stated as a concrete id rather than as "they are equal": naming
+        // SystemRowVersion as the relation target produces SourceFieldId 0.
+        Assert.Equal(0, rowVersionArm.SourceFieldId);
+
+        // And 0 is what a relation naming NO field produces, so BC cannot tell the two apart.
+        // This is the collision #3325 is about, and it is the reason the runner refuses a
+        // rowversion that exists: BC reads 0 as "the related table's primary key".
+        Assert.Equal(0, wholeTableArm.SourceFieldId);
+        Assert.Equal(rowVersionArm.SourceFieldId, wholeTableArm.SourceFieldId);
+    }
+
+    [SkippableFact]
+    public void OrdinaryAndSystemIdTargets_EncodeAsTheirOwnNonZeroIds()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var rel = BuildRelTable();
+
+        // The discriminating control, and the half that makes the assertions above mean
+        // something. If the builder encoded EVERY target as 0 — a resolver that silently
+        // failed, say — the two "SourceFieldId is 0" assertions above would pass for a reason
+        // that has nothing to do with SystemRowVersion. These two must be non-zero and must be
+        // their own distinct ids.
+        Assert.True(rel.TryGetFieldByNo(NamedFieldRelationFieldId, out var namedRef));
+        var namedArm = Assert.Single(namedRef.FieldRelations!);
+        Assert.Equal(1, namedArm.SourceFieldId);
+
+        // SystemId is the sibling shape the corpus already pins on a service tier
+        // (Record_Validate_TableRelationOntoSystemId, corpus codeunit 60818). It lives in the
+        // 2000000000-2000000004 block rather than at 0, which is precisely why it does NOT
+        // collide with a whole-table relation and SystemRowVersion does.
+        Assert.True(rel.TryGetFieldByNo(SystemIdRelationFieldId, out var sysIdRef));
+        var sysIdArm = Assert.Single(sysIdRef.FieldRelations!);
+        Assert.Equal(2000000000, sysIdArm.SourceFieldId);
+        Assert.NotEqual(0, sysIdArm.SourceFieldId);
+    }
+
+    // ── plumbing ───────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Build the referencing table's real NCLMetaTable from AL source, through the same entry
+    /// point Validate and FieldRef.Relation reach. Four relation fields: onto SystemRowVersion
+    /// (the subject), onto SystemId (the sibling that resolves to a non-zero id), onto the
+    /// whole table with no field named (the shape SystemRowVersion collides with), and onto an
+    /// ordinary declared field (the control that proves the builder encodes real ids at all).
+    /// </summary>
+    private NCLMetaTable BuildRelTable()
+    {
+        var srcDir = Path.Combine(_root, "src");
+        Directory.CreateDirectory(srcDir);
+        File.WriteAllText(Path.Combine(srcDir, "Row.al"), $$"""
+            table {{RowTableId}} "TRSRV Row"
+            {
+                DataClassification = CustomerContent;
+                fields
+                {
+                    field(1; "Entry No."; Integer) { }
+                    field(2; "Name"; Text[30]) { }
+                }
+                keys { key(PK; "Entry No.") { Clustered = true; } }
+            }
+            """);
+        File.WriteAllText(Path.Combine(srcDir, "Rel.al"), $$"""
+            table {{RelTableId}} "TRSRV Rel"
+            {
+                DataClassification = CustomerContent;
+                fields
+                {
+                    field(1; "Entry No."; Integer) { }
+                    field({{RowVersionRelationFieldId}}; "Row Ver Ref"; BigInteger)
+                    {
+                        TableRelation = "TRSRV Row".SystemRowVersion;
+                    }
+                    field({{SystemIdRelationFieldId}}; "Row Sys Id Ref"; Guid)
+                    {
+                        TableRelation = "TRSRV Row".SystemId;
+                    }
+                    field({{WholeTableRelationFieldId}}; "Row Ref"; Integer)
+                    {
+                        TableRelation = "TRSRV Row";
+                    }
+                    field({{NamedFieldRelationFieldId}}; "Row Entry Ref"; Integer)
+                    {
+                        TableRelation = "TRSRV Row"."Entry No.";
+                    }
+                }
+                keys { key(PK; "Entry No.") { Clustered = true; } }
+            }
+            """);
+        var skeleton = AlRunner.BcRuntime.SkeletonNCLMetadata;
+        Assert.NotNull(skeleton);
+
+        // Registered and built up to three times, because `_parsedTables` and the metatable
+        // cache are process-wide and another collection may call ResetForReload between the
+        // parse and the build. Same recovery TableRelationUnresolvedRefusalTests documents.
+        NCLMetaTable? rel = null;
+        for (var attempt = 1; attempt <= 3; attempt++)
+        {
+            RecordPatches.AddSourceDir(srcDir);
+            rel = RecordPatches.EnsureTableInMetadataCache(RelTableId)
+                  ?? RecordPatches.NCLMetadata_GetMetaTableById(skeleton!, RelTableId, false, 0);
+            if (rel != null
+                && rel.TryGetFieldByNo(RowVersionRelationFieldId, out _)
+                && rel.TryGetFieldByNo(SystemIdRelationFieldId, out _)
+                && rel.TryGetFieldByNo(WholeTableRelationFieldId, out _)
+                && rel.TryGetFieldByNo(NamedFieldRelationFieldId, out _))
+                return rel;
+        }
+
+        Assert.Fail(
+            $"table {RelTableId} did not come back carrying all four fields after three "
+            + "register-and-rebuild attempts; it has field(s): "
+            + (rel == null
+                ? "<no metatable at all>"
+                : string.Join(", ", rel.Fields.Select(f => $"{f.FieldNo} {f.FieldName}"))));
+        return rel!;
+    }
+}


### PR DESCRIPTION
Closes #3325

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/324

## The verdict: the runner is correct, and now there is a measurement saying so

#3325 was a knowledge gap, not a break. PR #3324 made `TableRelation = <Table>.SystemRowVersion` **resolve and be enforced**, where it previously did not resolve and the relation was silently dropped. Enforcing beats dropping, but nobody had established what real BC does, so the runner could have been newly wrong in a different direction.

**A real service tier has now answered it.** Corpus run [34573236729](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/actions/runs/34573236729), BC 27.0 / 27.3 / 27.5:

```
FAIL  Record_Validate_TableRelationOntoSystemRowVersion — The field Line Row Version Ref
      of table CFSF Header contains a value (397405) that cannot be found in the related
      table (CFSF Line).
```

That is BC refusing **an existing line's own rowversion**, with the same message and on the same arm as the runner. Three previously-unknown things, all settled:

1. **Microsoft's AL compiler accepts the relation.** All 16 corpus legs built and published the app, so the refusal is a runtime one, not `AL0xxx`. (The issue named this as "the first thing to check".)
2. **`Validate` enforces it**, rather than dropping an unrepresentable relation.
3. **The value it enforces against is not the rowversion column.** It is the related table's primary key.

**So no runner behaviour change is needed, and none is made here.** The answer to #3325 is "verified against a service tier; the runner already matches".

## Why the tier refuting my test is the good outcome

The corpus test's first arm was written asserting that an existing rowversion is **accepted**, because that is the only assertion separating the two candidate mechanisms:

| BC resolves the target to | existing rowversion | absent rowversion |
|---|---|---|
| the related table's **rowversion column** | accepted | refused |
| the related table's **primary key** | **refused** | refused |

The absent-rowversion arm alone proves only that the relation is enforced — both rows produce it. Writing the discriminating arm as a hypothesis and letting the tier knock it down is what produced a fact. The corpus assertion was then corrected to what BC does; it was **not** adjusted to match the runner, and the corrected version's commit message records the refuting run.

## The mechanism, and what this PR actually lands

`SystemRowVersionParsedField` is `new ParsedField(0, "SystemRowVersion", "BigInteger", 0, …)` — field id **0**, because BC gives the rowversion column id 0 under its metadata name `timestamp`. `BuildMetaFieldRelations` initialises its local `fieldId` to `0` and overwrites it only when `TryResolveTableFieldByName` succeeds. So two AL spellings converge on one encoded value:

```
TableRelation = "TRSRV Row".SystemRowVersion   ->  SourceFieldId 0
TableRelation = "TRSRV Row"                    ->  SourceFieldId 0
```

and `SourceFieldId = 0` is BC's own encoding for *relate to the primary key*. That collision is why everything is refused — and, per the tier, it is BC's collision, not the runner's.

`AlRunner.Tests/TableRelationOntoSystemRowVersionTests.cs` pins exactly that encoding and nothing about BC — three tests driven through `BcEngineFixture`, building the real `NCLMetaTable` from AL source:

1. the relation is carried at all and names the right table (guards regression to the pre-#3307 silent drop);
2. the `SystemRowVersion` target and a whole-table target both encode as `SourceFieldId` **0**;
3. the control — an ordinary named field encodes as **1**, `SystemId` as **2000000000** — so "every target encodes as 0" cannot pass as a fix.

It is a **regression guard**, not a RED baseline: changing `SystemRowVersionParsedField`'s id away from 0 is a plausible edit, since `0` reads like a placeholder, and it would silently move the relation off the shape a service tier adjudicated.

The `2000000000` in test 3 was **measured, not assumed** — written, run, and confirmed by the runner rather than read off anywhere.

### Proving checks, run rather than reasoned about

Runner side — two mutations of `RecordPatches.NclMetaTableBuilder.cs`, each rebuilt and re-bootstrapped (`tools/engine-test-bootstrap.sh` after every build, since a build restores a pristine `Ncl.dll`):

| mutation | result |
|---|---|
| `SystemRowVersionParsedField` id `0` → `1` | **1 of 3 fails** |
| `SystemRowVersion` dropped from `ResolvableFields` (pre-#3307) | **2 of 3 fail** |
| restored | 3 of 3 pass |

Test 3 stayed green through both, correctly — it is scoped to non-`SystemRowVersion` targets, which is what makes it a control rather than a duplicate.

Corpus side — removing the `TableRelation` from field 35 makes `Record_Validate_TableRelationOntoSystemRowVersion` fail, so it is not passing for free.

## How the corpus legs were read

`tools/corpus-pass-count.py 34573236729 Record_Validate_TableRelationOntoSystemRowVersion`, not a bare green tick:

- **3 cloud legs reported at the time of reading** — 27.0, 27.3, 27.5 — each `3294/3295` with the **one** failure being this test. The rest were still pending; I did not wait on them (Step 5).
- **8 OnPrem legs: `codeunit not in this leg's suite`.** That is the expected answer there, not a finding — the OnPrem legs run a different, smaller suite.

The whole-corpus-green-except-this-one shape is what makes the failure attributable to the new test rather than to anything ambient.

## Fix the shape, not just the reported line

**Does the same wrong pattern appear at another call site?** The `fieldId = 0` local in `BuildMetaFieldRelations` is one site reached by both spellings; there is no second copy, since `TryResolveTableFieldByName` is the single resolver and `ResolvableFields` the single set. And per the tier it is not wrong — it matches BC. The CalcFormula half of the same resolver change was settled separately (corpus PR #232) and is unaffected: a formula names the field as a *source*, where id 0 is simply the field's id, while a relation names it as a *target*, where BC overloads 0. The overload is the whole difference.

**Does a sibling function make the same assumption?** The five system fields in `SystemParsedFields` (2000000000-2000000004) cannot collide, because none is 0 — asserted in test 3 rather than argued. `SystemRowVersion` is the only one of the six at id 0.

**If two code paths write the same state, do they maintain the same invariant?** They write the same value and mean different things by it — the "resolved a named field" path and the "no field named" path both produce 0. That is the defect shape, and the tier says BC has it too, which converts it from a bug into a documented BC behaviour.

**Queue scan, both axes** (`batch-sibling-issues-by-file.md` by file, `search-for-the-same-defect-first.md` by defect), searching the symbol (`SystemRowVersion`, `BuildMetaFieldRelations`, `TryResolveTableFieldByName`), the observable (a relation refusing a value that exists), and the mechanism (a target encoding as field 0). **Nothing folds.** Nearest neighbours and why each is distinct:

- **#3204** — no corpus test that a *tableextension-contributed* TableRelation is enforced. Different resolution path (`GetAllFieldsIncludingExtensions`), no overlap with the id-0 overload.
- **#3367** — CalcFormula's parser-level refusals drop the whole formula silently. This target resolves fine, so a different failure mode.
- **#2789** — follow-ups to precompiled TableRelation support: conditional arms and rename cascade, not target encoding.
- **#3518, #2383, #3491** — TableRelation by keyword only (lookup pages, RapidStart, and the headless-derivation research issue).

## Gates

- `require-tests`: the diff adds `AlRunner.Tests/TableRelationOntoSystemRowVersionTests.cs`, so it is satisfied directly.
- `check_corpus_linkage.sh` reports *no declaration required* for this diff (nothing under `AlRunner/`) — I ran it. The `Corpus-PR:` line is carried anyway because it is the truthful linkage and because `resolve-corpus-ref` uses it to point the matrix at corpus PR #324's branch head, so these legs measure the new corpus test rather than `master`. An empty commit was pushed after the line was added, so the matrix actually read it.

## What I ran

- `dotnet test AlRunner.Tests --settings engine.runsettings --filter FullyQualifiedName~TableRelationOntoSystemRowVersionTests` — 3/3 pass, plus the two mutation runs.
- The corpus suite filtered to `Record_Validate_TableRelationOnto` against corpus PR #324's tree — both tests pass after the correction, and the relation-removal mutation fails as it must.
- A standalone probe bundle establishing the runner baseline before any of it.

Not run: the full `AlRunner.Tests` suite and the full corpus. `local-test-scope.md` — one new test file, no production code touched.

## Merge order

Corpus PR #324 merges first; it carries the evidence this PR's conclusion rests on. I have not merged either.

---

*Implemented by agent `stma-auto-12`, an automated implementation agent.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
