### PR TITLE
fix(deps): follow a Microsoft platform app's own Platform floor so System Application and Business Foundation compile against System.app

### DIFF
--- a/AlRunner.Tests/DependencyResolverTests.cs
+++ b/AlRunner.Tests/DependencyResolverTests.cs
@@ -623,6 +623,49 @@ public sealed class DependencyResolverTests : IDisposable
         bool r2r, bool alSource, string? platform)
         => MakeMinimalApp(appId, name, publisher, version, r2r, alSource, platform, application: null);
 
+    /// <summary>
+    /// A package declaring explicit <c>&lt;Dependency&gt;</c> entries alongside its
+    /// <c>Platform</c> floor — the shape Business Foundation and Base Application actually ship
+    /// (#3875). Always carries AL source, because the closure only matters for a package this
+    /// run would source-compile.
+    /// </summary>
+    private static byte[] MakeMinimalAppWithDeps(
+        string appId, string name, string publisher, string version, string? platform,
+        (string Id, string Name, string Publisher, string MinVersion)[] deps)
+    {
+        var platformAttr = platform == null ? "" : $" Platform=\"{platform}\"";
+        var depXml = deps.Length == 0
+            ? "<Dependencies />"
+            : "<Dependencies>"
+              + string.Concat(deps.Select(d =>
+                  $"<Dependency Id=\"{d.Id}\" Name=\"{d.Name}\" Publisher=\"{d.Publisher}\" MinVersion=\"{d.MinVersion}\" />"))
+              + "</Dependencies>";
+        var xml = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+              <App Id="{appId}" Name="{name}" Publisher="{publisher}" Version="{version}"{platformAttr}/>
+              {depXml}
+            </Package>
+            """;
+
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = zip.CreateEntry("NavxManifest.xml");
+            using (var es = entry.Open())
+                es.Write(Encoding.UTF8.GetBytes(xml));
+            var al = zip.CreateEntry("src/" + name + ".al");
+            using var als = al.Open();
+            als.Write(Encoding.UTF8.GetBytes("codeunit 130002 \"" + name + "\" { }"));
+        }
+        var zipBytes = ms.ToArray();
+        var result = new byte[8 + zipBytes.Length];
+        result[0] = (byte)'N'; result[1] = (byte)'A'; result[2] = (byte)'V'; result[3] = (byte)'X';
+        BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
+        Buffer.BlockCopy(zipBytes, 0, result, 8, zipBytes.Length);
+        return result;
+    }
+
     private static byte[] MakeMinimalApp(string appId, string name, string publisher, string version,
         bool r2r, bool alSource, string? platform, string? application)
     {
@@ -791,30 +834,161 @@ public sealed class DependencyResolverTests : IDisposable
             AppLoader.ImplicitRoots(manifest).Select(r => r.Name).OrderBy(n => n, StringComparer.Ordinal).ToArray());
     }
 
+    // -- #3875: a Microsoft platform app's Platform floor IS followed; its Application floor is not --
+    //
+    // #3719 made Visit follow a resolved package's implicit floors and exempted the Microsoft
+    // platform apps, on the premise that their floors cycle (Application -> Base Application ->
+    // Application ...). Measured across six artifact builds, 27.3 through 28.4, that premise is
+    // false for the floor that matters: NO Microsoft platform app declares Application= at all,
+    // every one declares Platform=, and System.app itself declares neither a floor nor a
+    // dependency. The cycle lives in the <Dependencies> array, which Visit already guards with
+    // its own cycle detector, not in the floors. Blanket-exempting both floors therefore bought
+    // nothing and cost System Application every symbol it compiles against -- see
+    // docs/dependency-metadata-from-bc.md#platform-floor.
+    //
+    // The Application floor stays unfollowed, because that is the one that could cycle if a
+    // future build did declare it; PlatformApp_ApplicationFloor_IsStillNotFollowed pins that.
+
     /// <summary>
-    /// The trap AppLoader.ImplicitRoots' own doc comment names: every Microsoft platform app's
-    /// manifest carries these attributes and they reference each other (Application → Base
-    /// Application → Application …), so following a PLATFORM app's floors would cycle. They
-    /// are not followed; only a non-platform package's are. Base Application declaring a
-    /// Platform floor resolves to exactly itself, no System, no cycle exception.
+    /// System Application's real shape: <c>Platform="28.0.0.0"</c> and an EMPTY
+    /// <c>&lt;Dependencies /&gt;</c>. Before #3875 it resolved to a closure of exactly itself,
+    /// so its Tier-3 source compile ran with <c>specsLen=0</c>, produced 2,587 AL0185
+    /// declaration diagnostics and zero metadata documents, and aborted the run.
     /// </summary>
     [Fact]
-    public void MicrosoftPlatformAppDeclaringPlatform_FloorIsNotFollowed()
+    public void PlatformAppDeclaringOnlyAPlatformFloor_ResolvesSystemApp()
     {
-        var dir = MakeDir("PlatformFloorGuard");
+        var dir = MakeDir("PlatformFloorSysApp");
         var systemId = "00000000-0000-0000-0000-00000000c0de";
+        var sysAppId = "63ca2fa4-4f03-4f2b-a480-172fef340d3f";
+        File.WriteAllBytes(Path.Combine(dir, "System.app"),
+            MakeMinimalApp(systemId, "System", "Microsoft", "28.0.54265.0", r2r: false, alSource: false, platform: null));
+        File.WriteAllBytes(Path.Combine(dir, "Microsoft_System Application.app"),
+            MakeMinimalApp(sysAppId, "System Application", "Microsoft", "28.1.49838.54308",
+                r2r: false, alSource: true, platform: "28.0.0.0"));
+
+        var result = new DependencyResolver(new[] { dir }).Resolve(new[]
+        {
+            new DependencyRef(Guid.Parse(sysAppId), "System Application", "Microsoft", new Version(28, 0, 0, 0)),
+        });
+
+        var names = result.Select(r => r.Manifest.Name).ToArray();
+        Assert.Contains("System", names);
+        Assert.Contains("System Application", names);
+        // System must precede the app that needs it: Resolve emits post-order, and
+        // BcCompiler turns this list into SymbolReferenceSpecifications in order.
+        Assert.True(Array.IndexOf(names, "System") < Array.IndexOf(names, "System Application"),
+            $"System must be resolved before System Application; got [{string.Join(", ", names)}]");
+    }
+
+    /// <summary>
+    /// Business Foundation's real shape, and the reason this bug hid: BF declares ONE dependency
+    /// (System Application) plus <c>Platform="28.0.0.0"</c>, so before #3875 it compiled with
+    /// <c>specsLen=1</c> and SUCCEEDED -- emitting 55 of the 70 documents BC emits, the 15 that
+    /// need platform tables (<c>Field</c>, <c>Table Metadata</c>) silently falling back to the
+    /// hand-derivation under a green run. The closure must contain System, not merely be
+    /// non-empty.
+    /// </summary>
+    [Fact]
+    public void PlatformAppWithOneDependencyAndAPlatformFloor_StillResolvesSystemApp()
+    {
+        var dir = MakeDir("PlatformFloorBusinessFoundation");
+        var systemId = "00000000-0000-0000-0000-00000000c0de";
+        var sysAppId = "63ca2fa4-4f03-4f2b-a480-172fef340d3f";
+        var bfId = "f3552374-a1f2-4356-848e-196002525837";
+        File.WriteAllBytes(Path.Combine(dir, "System.app"),
+            MakeMinimalApp(systemId, "System", "Microsoft", "28.0.54265.0", r2r: false, alSource: false, platform: null));
+        File.WriteAllBytes(Path.Combine(dir, "Microsoft_System Application.app"),
+            MakeMinimalApp(sysAppId, "System Application", "Microsoft", "28.1.49838.54308",
+                r2r: false, alSource: true, platform: "28.0.0.0"));
+        File.WriteAllBytes(Path.Combine(dir, "Microsoft_Business Foundation.app"),
+            MakeMinimalAppWithDeps(bfId, "Business Foundation", "Microsoft", "28.1.49838.54308",
+                platform: "28.0.0.0",
+                deps: new[] { (sysAppId, "System Application", "Microsoft", "28.0.0.0") }));
+
+        var result = new DependencyResolver(new[] { dir }).Resolve(new[]
+        {
+            new DependencyRef(Guid.Parse(bfId), "Business Foundation", "Microsoft", new Version(28, 0, 0, 0)),
+        });
+
+        var names = result.Select(r => r.Manifest.Name).ToArray();
+        Assert.Contains("System", names);
+        Assert.Equal(
+            new[] { "Business Foundation", "System", "System Application" },
+            names.OrderBy(n => n, StringComparer.Ordinal).ToArray());
+    }
+
+    /// <summary>
+    /// The half of the #3719 exemption that stays: an <c>Application</c> floor on a platform app
+    /// is NOT followed. No shipped build declares one (measured 27.3-28.4), but Microsoft/Application
+    /// transitively pulls Base Application, whose own manifest names Business Foundation and
+    /// System Application, so following it would re-enter the closure through a second route for
+    /// no symbol the Platform floor does not already supply.
+    /// </summary>
+    [Fact]
+    public void PlatformApp_ApplicationFloor_IsStillNotFollowed()
+    {
+        var dir = MakeDir("PlatformFloorApplicationGuard");
+        var systemId = "00000000-0000-0000-0000-00000000c0de";
+        var umbrellaId = "00000000-0000-0000-0000-0000000a9911";
         var baseId = "437dbf0e-84ff-417a-965d-ed2bb9650972";
         File.WriteAllBytes(Path.Combine(dir, "System.app"),
-            MakeMinimalApp(systemId, "System", "Microsoft", "28.0.54265.0", r2r: false, alSource: false, platform: "28.0.54265.0"));
+            MakeMinimalApp(systemId, "System", "Microsoft", "28.0.54265.0", r2r: false, alSource: false, platform: null));
+        File.WriteAllBytes(Path.Combine(dir, "Microsoft_Application.app"),
+            MakeMinimalApp(umbrellaId, "Application", "Microsoft", "28.1.49838.54308",
+                r2r: true, alSource: false, platform: "28.0.0.0"));
+        // A synthetic Application floor -- no shipped build has one; this pins that we do not
+        // start following it if one appears.
         File.WriteAllBytes(Path.Combine(dir, "Microsoft_Base Application.app"),
-            MakeMinimalApp(baseId, "Base Application", "Microsoft", "28.1.49838.54169", r2r: true, alSource: false, platform: "28.0.0.0"));
+            MakeMinimalApp(baseId, "Base Application", "Microsoft", "28.1.49838.54169",
+                r2r: true, alSource: false, platform: "28.0.0.0", application: "28.1.0.0"));
 
         var result = new DependencyResolver(new[] { dir }).Resolve(new[]
         {
             new DependencyRef(Guid.Parse(baseId), "Base Application", "Microsoft", new Version(28, 0, 0, 0)),
         });
 
-        Assert.Equal(new[] { "Base Application" }, result.Select(r => r.Manifest.Name).ToArray());
+        var names = result.Select(r => r.Manifest.Name).ToArray();
+        Assert.DoesNotContain("Application", names);
+        Assert.Equal(new[] { "Base Application", "System" },
+            names.OrderBy(n => n, StringComparer.Ordinal).ToArray());
+    }
+
+    /// <summary>
+    /// The cycle #3719 actually guarded against is in the &lt;Dependencies&gt; array, not in the
+    /// floors, and Visit's own cycle detector handles it. Base Application naming Business
+    /// Foundation naming Base Application resolves rather than throwing, with System pulled in
+    /// through both floors exactly once.
+    /// </summary>
+    [Fact]
+    public void PlatformAppsNamingEachOtherInDependencies_DoNotCycleWhenFloorsAreFollowed()
+    {
+        var dir = MakeDir("PlatformFloorMutualDeps");
+        var systemId = "00000000-0000-0000-0000-00000000c0de";
+        var baseId = "437dbf0e-84ff-417a-965d-ed2bb9650972";
+        var bfId = "f3552374-a1f2-4356-848e-196002525837";
+        File.WriteAllBytes(Path.Combine(dir, "System.app"),
+            MakeMinimalApp(systemId, "System", "Microsoft", "28.0.54265.0", r2r: false, alSource: false, platform: null));
+        File.WriteAllBytes(Path.Combine(dir, "Microsoft_Base Application.app"),
+            MakeMinimalAppWithDeps(baseId, "Base Application", "Microsoft", "28.1.49838.54169",
+                platform: "28.0.0.0",
+                deps: new[] { (bfId, "Business Foundation", "Microsoft", "28.0.0.0") }));
+        File.WriteAllBytes(Path.Combine(dir, "Microsoft_Business Foundation.app"),
+            MakeMinimalAppWithDeps(bfId, "Business Foundation", "Microsoft", "28.1.49838.54308",
+                platform: "28.0.0.0",
+                deps: Array.Empty<(string, string, string, string)>()));
+
+        var result = new DependencyResolver(new[] { dir }).Resolve(new[]
+        {
+            new DependencyRef(Guid.Parse(baseId), "Base Application", "Microsoft", new Version(28, 0, 0, 0)),
+        });
+
+        var names = result.Select(r => r.Manifest.Name).ToArray();
+        Assert.Equal(
+            new[] { "Base Application", "Business Foundation", "System" },
+            names.OrderBy(n => n, StringComparer.Ordinal).ToArray());
+        // Exactly once, not once per floor that named it.
+        Assert.Single(names.Where(n => n == "System"));
     }
 
     // -- #3794: a floor that cannot be supplied is named, not skipped in silence --

--- a/AlRunner.Tests/ManifestDependencyEdgeScanTests.cs
+++ b/AlRunner.Tests/ManifestDependencyEdgeScanTests.cs
@@ -120,15 +120,17 @@ public sealed class ManifestDependencyEdgeScanTests : IDisposable
     }
 
     /// <summary>
-    /// A Microsoft PLATFORM app's own floor is not recorded, matching
-    /// DependencyResolver.Visit's guard: their manifests reference each other
-    /// (Application → Base Application → Application …), and an edge the resolver refuses to
-    /// walk would make provisioning fetch a set resolution never asks for. Both directions
-    /// here — a self-pointing floor (System declaring Platform) and a cross-pointing one
-    /// (Base Application declaring Platform, i.e. → System).
+    /// #3875: a Microsoft platform app's PLATFORM floor IS recorded, because
+    /// DependencyResolver.Visit now walks it — a scan that withheld the edge would tell
+    /// provisioning a bundle needs no System.app for a closure resolution does pull it into,
+    /// which is the direction that under-fetches rather than over-fetches. The two guards
+    /// stay matched; what changed is what they guard.
+    ///
+    /// <para>Both directions here: a self-pointing floor (System declaring Platform, which
+    /// must not become a self-edge) and a cross-pointing one (Base Application → System).</para>
     /// </summary>
     [Fact]
-    public void ScanDependencyEdges_PlatformAppsOwnFloor_IsNotRecorded()
+    public void ScanDependencyEdges_PlatformAppsPlatformFloor_IsRecorded()
     {
         var dir = NewDir("floor-edge-platform");
         WriteAppWithPlatform(dir, "System", "Microsoft", "28.0.54265.0", platform: "28.0.54265.0");
@@ -136,8 +138,30 @@ public sealed class ManifestDependencyEdgeScanTests : IDisposable
 
         var edges = ProvisioningCheck.ScanDependencyEdges(new[] { dir }).Edges;
 
-        Assert.Empty(edges["System"]);
-        Assert.Empty(edges["Base Application"]);
+        Assert.Equal(new[] { "System" }, edges["Base Application"]);
+        // System's own Platform floor points at System: recorded, and harmless — the resolver
+        // marks System done before the floor is visited, so the self-edge terminates there.
+        Assert.Equal(new[] { "System" }, edges["System"]);
+    }
+
+    /// <summary>
+    /// The other half of #3875's narrowing, and the one that keeps the cycle closed: a
+    /// platform app's APPLICATION floor is still not recorded. No shipped build declares one
+    /// (measured across six artifact builds, 27.3-28.4), and Microsoft/Application
+    /// transitively names Base Application, so recording it would make provisioning demand a
+    /// set resolution never walks.
+    /// </summary>
+    [Fact]
+    public void ScanDependencyEdges_PlatformAppsApplicationFloor_IsNotRecorded()
+    {
+        var dir = NewDir("floor-edge-platform-application");
+        WriteAppWithFloors(dir, "Base Application", "Microsoft", "28.1.49838.54169",
+            platform: "28.0.0.0", application: "28.1.0.0");
+
+        var edges = ProvisioningCheck.ScanDependencyEdges(new[] { dir }).Edges;
+
+        Assert.DoesNotContain("Application", edges["Base Application"]);
+        Assert.Equal(new[] { "System" }, edges["Base Application"]);
     }
 
     /// <summary>

--- a/AlRunner/AppLoader.cs
+++ b/AlRunner/AppLoader.cs
@@ -671,11 +671,17 @@ public static class AppLoader
     /// and resolved by (Name, Publisher) — version is informational.
     ///
     /// Applied to the root app being compiled and, since #3719, to every resolved package
-    /// that is NOT itself a Microsoft platform app (DependencyResolver.Visit): Microsoft's
-    /// test-toolkit packages declare only a Platform floor, and their source compile needs
-    /// System.app for it. The platform apps' own floors are still never followed — their
-    /// manifests reference each other (Application → Base Application → Application …) and
-    /// the resolver throws on cycles.
+    /// (DependencyResolver.Visit): Microsoft's test-toolkit packages declare only a Platform
+    /// floor, and their source compile needs System.app for it.
+    ///
+    /// <para>Since #3875 a Microsoft platform app's <c>Platform</c> floor is followed as well —
+    /// it is the reference System Application and Business Foundation compile against, and
+    /// withholding it cost System Application every symbol (specsLen=0, EMIT-ZERO) and Business
+    /// Foundation 15 of BC's 70 documents under a green run. Only their <c>Application</c> floor
+    /// stays unfollowed; no shipped build declares one (measured 27.3-28.4), and following it
+    /// would re-enter the closure through Microsoft/Application for no symbol the Platform floor
+    /// does not already supply. The cycle #3719's comment named is in the <c>&lt;Dependencies&gt;</c>
+    /// array, which DependencyResolver.Visit detects itself.</para>
     /// </summary>
     public static IEnumerable<DependencyRef> ImplicitRoots(AppManifest manifest)
     {

--- a/AlRunner/DependencyResolver.cs
+++ b/AlRunner/DependencyResolver.cs
@@ -201,13 +201,28 @@ public sealed class DependencyResolver
         // Microsoft's test-toolkit packages declare NOTHING else (Library Assert: Platform=
         // "28.0.0.0", empty <Dependencies />). Without this, a consumer whose app.json has no
         // `platform` of its own resolved a closure with no System.app, and Library Assert was
-        // source-compiled without the platform symbols: EMIT-ZERO. Not followed for the Microsoft
-        // platform apps themselves, whose manifests reference each other (Application → Base
-        // Application → Application …) and would cycle — AppLoader.ImplicitRoots' trap.
+        // source-compiled without the platform symbols: EMIT-ZERO.
+        //
+        // #3875: a Microsoft PLATFORM app's Platform floor is followed too; only its Application
+        // floor is not. #3719 exempted platform apps from both, on the premise that their floors
+        // cycle (Application → Base Application → Application …). Measured across six artifact
+        // builds, 27.3 through 28.4, that premise is false for the floor that matters: no
+        // Microsoft platform app declares Application= at all, every one declares Platform=, and
+        // System.app declares neither a floor nor a dependency, so following it terminates in one
+        // step. The cycle lives in the <Dependencies> array — which Visit's own `state` detector
+        // already handles — not in the floors. Cost of the blanket exemption: System Application
+        // declares ZERO <Dependency> entries, so its Tier-3 source compile ran with specsLen=0,
+        // and Business Foundation's with specsLen=1, silently emitting 55 of BC's 70 documents.
+        // docs/dependency-metadata-from-bc.md#platform-floor has the per-app measurement.
+        //
         // Optional, like the consumer-side roots: a missing System.app skips, as above.
-        if (!IsMicrosoftPlatformApp(found.Manifest.Name, found.Manifest.Publisher))
-            foreach (var floor in AppLoader.ImplicitRoots(found.Manifest))
-                Visit(floor, state, output, stack, floorOwner: found);
+        foreach (var floor in AppLoader.ImplicitRoots(found.Manifest))
+        {
+            if (IsMicrosoftPlatformApp(found.Manifest.Name, found.Manifest.Publisher)
+                && !string.Equals(floor.Name, "System", StringComparison.OrdinalIgnoreCase))
+                continue;
+            Visit(floor, state, output, stack, floorOwner: found);
+        }
         stack.Pop();
         state[id] = 2;
         output.Add((found.Manifest, found.Path));

--- a/AlRunner/DependencyResolver.cs
+++ b/AlRunner/DependencyResolver.cs
@@ -213,7 +213,7 @@ public sealed class DependencyResolver
         // already handles — not in the floors. Cost of the blanket exemption: System Application
         // declares ZERO <Dependency> entries, so its Tier-3 source compile ran with specsLen=0,
         // and Business Foundation's with specsLen=1, silently emitting 55 of BC's 70 documents.
-        // docs/dependency-metadata-from-bc.md#platform-floor has the per-app measurement.
+        // docs/dependency-metadata-from-bc.md#the-platform-floor has the per-app measurement.
         //
         // Optional, like the consumer-side roots: a missing System.app skips, as above.
         foreach (var floor in AppLoader.ImplicitRoots(found.Manifest))

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -1135,22 +1135,35 @@ public static class ProvisioningCheck
                 // edge a bundle naming only it never learns it needs the platform set, downloads
                 // the test set alone, and the toolkit's source compile dies (EMIT-ZERO).
                 //
-                // Two guards, both matching DependencyResolver's. Skipped for the Microsoft
-                // platform apps themselves, whose manifests reference each other (Application ->
-                // Base Application -> Application ...), so a graph the resolver refuses to walk
-                // cannot make provisioning fetch a set resolution never asks for. And skipped
-                // for an R2R package (#3794): a floor exists to be compiled against, Tier-2
-                // serves an R2R payload without compiling, and demanding a 116 MB platform
-                // download — or refusing the run offline — for a package nothing will compile is
-                // a cost with no failure behind it. Its declared <Dependencies> are recorded
-                // either way, because those are runtime dependencies rather than symbols.
-                if (!AlRunner.DependencyResolver.IsMicrosoftPlatformApp(manifest.Name, manifest.Publisher))
-                {
-                    var floors = AlRunner.AppLoader.ImplicitRoots(manifest).ToList();
-                    if (floors.Count > 0 && !IsR2RQuietly(file))
-                        foreach (var floor in floors)
-                            Record(floor);
-                }
+                // Two guards, both matching DependencyResolver.Visit's — and they must stay
+                // matched in BOTH directions: an edge the resolver walks but this scan withholds
+                // tells provisioning a bundle needs no System.app for a closure that does pull
+                // one in, which under-fetches and reproduces #3719's unattributable EMIT-ZERO.
+                //
+                // #3875 narrowed the platform-app guard on both sides. A Microsoft platform app's
+                // PLATFORM floor is now walked and recorded: System Application declares zero
+                // <Dependency> entries and compiles against System.app alone, so withholding it
+                // cost that app every symbol. Only the APPLICATION floor stays unrecorded — no
+                // shipped build declares one (measured 27.3-28.4), and Microsoft/Application
+                // transitively names Base Application, so it would demand a set resolution never
+                // walks. That is where the cycle #3719's comment named actually lives.
+                //
+                // The R2R guard (#3794) is unchanged and independent: a floor exists to be
+                // compiled against, Tier-2 serves an R2R payload without compiling, and demanding
+                // a 116 MB platform download — or refusing the run offline — for a package nothing
+                // will compile is a cost with no failure behind it. In practice it is what
+                // exempts the shipped System Application / Business Foundation / Base Application
+                // packages here, all three of which are R2R. Their declared <Dependencies> are
+                // recorded either way, because those are runtime dependencies rather than symbols.
+                var isPlatformApp =
+                    AlRunner.DependencyResolver.IsMicrosoftPlatformApp(manifest.Name, manifest.Publisher);
+                var floors = AlRunner.AppLoader.ImplicitRoots(manifest)
+                    .Where(f => !isPlatformApp
+                                || string.Equals(f.Name, "System", StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+                if (floors.Count > 0 && !IsR2RQuietly(file))
+                    foreach (var floor in floors)
+                        Record(floor);
                 edges[key] = deps;
                 edgeRequirements[key] = reqs;
                 recordedVersion[key] = manifest.Version;

--- a/docs/dependency-metadata-from-bc.md
+++ b/docs/dependency-metadata-from-bc.md
@@ -42,7 +42,7 @@ the entire app, not a partial result. Measured per app:
 
 | app | `.al` files | outcome | documents |
 |---|---|---|---|
-| Business Foundation | 96 | clean, 6.0–6.2 s | **55** (11 tables, 16 codeunits, 13 permission sets, 9 pages, 5 tableextensions, 1 enum) |
+| Business Foundation | 96 | clean, 5.8–6.2 s | **70** (was 55 before #3875 — see “The platform floor”) |
 | System Application | 1,319 | clean since #3745, 10.9–13.1 s | **1,218** (138 tables, 533 codeunits, 224 pages, 164 permission sets, 142 enums, 7 queries, 5 runtime deltas, 4 xmlports, 1 report) |
 | Base Application | 8,025 | not attempted — see below | — |
 
@@ -99,6 +99,59 @@ needs a `PublicKeyToken=null` copy of `Microsoft.AspNetCore.StaticFiles` that no
 ships, and without it the emitter produces **zero objects**.
 `tests/expectations/metadata-equivalence/apps.json` records the same exclusion for the same
 reason, and attributes it to this issue.
+
+## The platform floor
+
+Both apps here compile against `System.app` — BC's platform symbols — and neither says so in a
+way the resolver used to read. That made the reference silently absent, and #3875 is the fix.
+
+**What the manifests actually declare.** Parsed from every platform package's
+`NavxManifest.xml`, across six artifact builds from 27.3 to 28.4 (identical in all six):
+
+| package | `Platform=` | `Application=` | `<Dependency>` entries |
+|---|---|---|---|
+| System (`System.app`) | — | — | **0** |
+| System Application | `<major>.0.0.0` | — | **0** |
+| Business Foundation | `<major>.0.0.0` | — | 1 (System Application) |
+| Base Application | `<major>.0.0.0` | — | 2 |
+| Application | `<major>.0.0.0` | — | 3 |
+
+So **System Application names no dependency at all**, and its only statement of what it needs is
+the `Platform` attribute. `DependencyResolver.Visit` turns that attribute into a synthetic
+`Microsoft/System` root (`AppLoader.ImplicitRoots`) — but until #3875 it skipped that step for
+the Microsoft platform apps themselves, on the premise that their floors cycle
+(`Application → Base Application → Application …`).
+
+**That premise does not hold for the floor that matters.** No platform app declares
+`Application=` at all; `System.app` declares neither a floor nor a dependency, so following a
+`Platform` floor terminates in one step. The cycle the premise describes lives in the
+`<Dependencies>` array, which `Visit`'s own colour-marker detector already handles. The
+exemption therefore prevented no cycle and cost both apps their platform symbols:
+
+| app | before #3875 | after | BC's own emitter |
+|---|---|---|---|
+| System Application | `specsLen=0` → 2,587 declaration diagnostics → `METADATA-EMIT-ZERO`, run aborts | **1,218** documents | 1,218 |
+| Business Foundation | `specsLen=1` → **55** documents, **reported as success** | **70** documents | 70 |
+
+Business Foundation is the one worth remembering. It survived because 55 of its 70 objects need
+nothing from the platform; the other 15 — the ones referencing `Field`, `Table Metadata` and the
+other platform tables — silently fell back to the SymbolReference hand-derivation, under a green
+run with a cache entry written. At default verbosity that run printed **zero** `AL0185` lines.
+
+So #3875 follows a platform app's `Platform` floor and still refuses its `Application` floor,
+which is the half that could cycle if a future build ever declared one.
+`ProvisioningCheck.ScanDependencyEdges` carries the matching guard and is narrowed identically —
+an edge resolution walks but provisioning does not would under-fetch `System.app`, which is how
+#3719's unattributable `EMIT-ZERO` arrives.
+
+**Measuring this needs a bundle that declares no floor of its own.** A bundle whose `app.json`
+carries `application` or `platform` already injects `Microsoft/System` into the closure, so the
+shortfall does not reproduce and Business Foundation yields 70 either way. The 55 appears only
+when the app's own floor is the sole route to the platform.
+
+**What is still silent.** #3875 removed one *cause* of a partial compile; it did not make a
+partial compile loud. `DependencyMetadataProducer` sees how many documents appeared and never
+how many BC should have produced, so it has no local comparison to make — tracked by #2247.
 
 ## Availability decides the route; a failed compile is loud
 


### PR DESCRIPTION
Closes #3875

`DependencyResolver` resolved a closure with **no `System.app`** for Microsoft's own
platform apps, so the reference package they compile against was never added. System
Application declares **zero** `<Dependency>` entries, so its Tier-3 source compile ran
with `specsLen=0` and aborted the run; Business Foundation declares one, ran with
`specsLen=1`, and emitted **55 of BC's 70** documents while reporting success.

## The cause is one line, and the premise behind it was measurably false

`DependencyResolver.Visit` follows a resolved package's implicit `Platform` / `Application`
floors (#3719) — the roots the real `al` compiler injects as `Microsoft/System` and
`Microsoft/Application`. #3719 exempted the Microsoft platform apps from **both**, with this
justification:

> Not followed for the Microsoft platform apps themselves, whose manifests reference each
> other (Application → Base Application → Application …) and would cycle

**That cycle is in the `<Dependencies>` array, not in the floors**, and `Visit`'s own
colour-marker detector already handles it. Measured by parsing every platform app's
`NavxManifest.xml` across six artifact builds, 27.3 through 28.4:

| app | `Platform=` | `Application=` | `<Dependency>` entries |
|---|---|---|---|
| System | *(none)* | *(none)* | **0** |
| System Application | `28.0.0.0` | *(none)* | **0** |
| Business Foundation | `28.0.0.0` | *(none)* | 1 |
| Base Application | `28.0.0.0` | *(none)* | 2 |
| Application | `28.0.0.0` | *(none)* | 3 |

**No Microsoft platform app declares `Application=` at all**, every one declares `Platform=`,
and `System.app` declares neither a floor nor a dependency — so following the Platform floor
terminates in one step and cannot cycle. The blanket exemption bought nothing and cost these
two apps their platform symbols.

So: follow the `Platform` floor for platform apps; keep the `Application` floor unfollowed,
which is the half that could cycle if a future build ever declared one.

## Measured, same bundle and same BC build, the fix the only variable

BC 28.1.49838 (engine `…53910`, packages `…54308`), on a probe bundle that declares **no
`platform` of its own** — the condition under which the app's own floor is load-bearing:

| app | before | after | BC's own emitter (`tools/gen-metadata-ground-truth.sh`) |
|---|---|---|---|
| Business Foundation | **55** documents | **70** | `objects=70 errors=0` |
| System Application | `METADATA-EMIT-ZERO`, `FATAL`, exit 1 | **1218** documents | `objects=1218 errors=0` |

Both after-counts match BC's own emitter exactly. **Each count was confirmed a second,
differently-shaped way** — by reading `objects` out of the persisted
`*.object-metadata.json` sidecar rather than off the trace line: 55 and 70 respectively,
and 1218 for System Application. That mattered here: my *first* attempt to measure the
before-state used `tests/runner-extras/microsoft-dependencies`, which declares
`application: 27.0.0.0`, so the **bundle's own** floor already put `System` in the closure
and the pre-fix build also produced 70. Reporting 55→70 off that run would have been wrong.
The 55 only reproduces when nothing else supplies the floor.

## The proving tests target the PARTIAL case, not just the total failure

A test asserting "System Application now produces documents" would pass against a build that
still dropped 15 of Business Foundation's 70 — the shape that hid this. So the tests assert
closure **membership**, in both directions, and the load-bearing one is the BF case:

- `PlatformAppWithOneDependencyAndAPlatformFloor_StillResolvesSystemApp` — BF's real shape
  (one `<Dependency>` **plus** a Platform floor). Asserts the closure is exactly
  `{Business Foundation, System, System Application}`; a closure that is merely *non-empty*,
  which is what the 55-document state had, fails it.
- `PlatformAppDeclaringOnlyAPlatformFloor_ResolvesSystemApp` — System Application's real shape
  (zero dependencies). Also asserts `System` **precedes** it, since `Resolve` emits post-order
  and `BcCompiler` turns that list into specs in order.
- `PlatformApp_ApplicationFloor_IsStillNotFollowed` — the negative: `Application` stays out
  while `System` comes in. It fails pre-fix on the missing `System` and post-fix would fail if
  the narrowing were widened to both floors, so it pins the boundary rather than one side.
- `PlatformAppsNamingEachOtherInDependencies_DoNotCycleWhenFloorsAreFollowed` — the premise
  #3719 feared: mutually-naming `<Dependencies>` resolve without throwing, `System` appearing
  exactly once rather than once per floor that named it.

**Mutation result.** Reverting the one-line guard while keeping the tests turns all four red
(`Failed: 4, Passed: 46`); restoring it returns `Failed: 0, Passed: 50`. So they measure the
fix rather than incidental resolver state.

## Fix the shape — the three questions

**1. Same wrong pattern at another call site?** Yes, one, and it is fixed here.
`ProvisioningCheck.ScanDependencyEdges` carries the same guard, and its own comment says the
two "must stay matched". Left alone it would under-fetch: the resolver would pull
`Microsoft/System` into a closure that provisioning never learned to download — the quiet
direction, which reproduces #3719's unattributable `EMIT-ZERO`. Narrowed identically, with its
own RED → GREEN (`ScanDependencyEdges_PlatformAppsPlatformFloor_IsRecorded` and
`…ApplicationFloor_IsNotRecorded`, red before the change: `Failed: 2, Passed: 37`).

Worth recording because it is *why* the desync is narrow in practice: the shipped System
Application, Business Foundation and Base Application packages are all `IsR2R=true` (verified
by listing `publishedartifacts/*.dll` in each), so `IsR2RQuietly` already exempted them there
for the separate #3794 reason. `Microsoft_Application.app` is **not** R2R and does declare
`Platform=`, which is the case that would actually have desynced.

**2. Sibling function making the same assumption?** The other four `ImplicitRoots` call sites
were checked — `SiblingCompile` (a root app's own floors, never a platform app),
`InProcessAppPackager` (a comment reference only), and the two test call sites. None applies a
platform-app exemption. `AppLoader.ImplicitRoots`' doc comment *stated* the false cycle premise
and is corrected, since it is the sentence a later editor would read before re-widening the
guard.

**3. Two code paths writing one invariant with different guards?** That is exactly question 1's
finding — resolver and provisioning graph — now guarded identically and pinned from both sides.

## What I deliberately did NOT do, and why

**The partial compile is still silent, and that is #2247's work, not this PR's.** The
55-document run printed **zero** `AL0185` lines at default verbosity — I grepped the run log
and got 0. This fix removes one *cause* of a partial compile; it does not make a partial
compile loud, and a different cause would land in the same silence.
`DependencyMetadataProducer` cannot detect it locally: it sees how many registry keys appeared,
never how many BC *should* have produced, so there is no comparison available without plumbing
a signal out of `BcCompiler.Emit` — the shared compile path, broad blast radius.

**#2247 already tracks this exact shape** ("a partially-recovered dependency compile silently
drops objects"), is open and `status: ready`, so I recorded the measurement there rather than
filing a duplicate: <https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2247#issuecomment-5631742830>.
It stays open after this merges.

## Queue scan — what did not fold

Searched the open queue on the symbol (`DependencyResolver`, `ImplicitRoots`), the observable
(`System.app`, `EMIT-ZERO`, `specsLen`), the mechanism ("platform floor") and the measurement
("Business Foundation"). Two issues name the resolver and neither folds:

- **#3811** — the provisioning graph keys by app *name* while the resolver keys by *AppId*.
  Same file as my sibling fix, different defect: identity/selection, not floor-following. Needs
  its own reasoning to review.
- **#3812** — `ReportUnsuppliableFloor` is gated on package shape rather than on whether the run
  compiles the package. Adjacent to the floors, but about *reporting* an unmet floor, not about
  which floors are walked.

Neither carries `status: ready`, and folding either would make one diff a reviewer cannot hold.

## Docs

`docs/dependency-metadata-from-bc.md` gains **"The platform floor"**, the section the resolver's
code comment points at. It carries the per-app manifest table above, because that table is what
shows #3719's cycle premise does not hold for the `Platform` floor, and it is what a later editor
needs before re-widening the guard. The first push named a `#platform-floor` anchor that did not
exist; `tools/test_doc_pointers.py` caught it, and the anchor is `#the-platform-floor` — verified
by running that guard (exit 0, 359 pointers).

The same file's matrix table recorded Business Foundation at **55** documents. That number
measured the defect, not the app, so it is corrected to 70; left standing it would read as the
expected figure for anyone checking the new behaviour.

**Deliberately not corrected here: line 95, "Base Application: a hard blocker, not a cost
question".** #3876 disproved it (7,842 documents once the ASP.NET Core reference pack is on the
probing path) and names this line as one of three places to fix. The other two are
`DependencyMetadataProducer`'s `NOT BASE APPLICATION` header, which justifies the `NeverCompile`
allowlist that actually excludes the app, and an entry in
`tests/expectations/metadata-equivalence/apps.json`. Correcting the prose alone would leave the
doc saying "not a blocker" while the code still refuses to compile it — a worse state than the
current consistent-but-wrong one, and it would strand #3876's PR with a partly-edited file.
It belongs to that PR, which moves all three together.

## Verification

- **Targeted, second run after the build:** `dotnet test AlRunner.Tests --filter
  "…ManifestDependencyEdgeScanTests|…DependencyResolverTests|…ProvisioningCheckTests|…DependencyMetadataProducer|…DependencyLoader"`
  → `Passed! - Failed: 0, Passed: 247, Skipped: 0`.
- **Full `AlRunner.Tests`** (run wider deliberately: this is the shared dependency-resolution
  path) → `Failed: 305, Passed: 5004, Skipped: 8`. **302 of the 305 carry the
  `[bc-engine-serial] REFUSING TO SKIP` message** — this box did not run
  `tools/engine-test-bootstrap.sh`, which CI does. Counted two ways that do not share a
  shape: 305 `^  Failed ` lines and 305 distinct `[FAIL]` names, against 302 occurrences of the
  refusal string. **The remaining 3 reproduce identically on `origin/main` at 3772c6a5**, a
  commit predating this branch — `TestPageEvaluatorFaultTests.TryResolve_AnUnreadableSpelling…`,
  `SkeletonFormatSettingsWarmTests.Warm_WithTheRealSkeletonSession…` and
  `BuildNclMetaTableFailureAttributionTests.TheTwoAbsentReturns…`, all the same unbootstrapped
  engine surfacing through a different assertion. None is attributable to this change.
- **`tools/` unit tests:** all 20 suites pass, including `test_doc_pointers.py` (359
  pointers), `test_comment_density.py` and `test_doc_summary_uniqueness.py` — the gates a
  long comment block and a new doc section could trip.
- **Corpus linkage:** `check_corpus_linkage.sh` over this diff answers *"No file in this diff
  can change what AL observes, so no corpus declaration is required"* (exit 0) — measured, not
  assumed. `DependencyMetadataProducer.cs` is not in the diff; the fix is in the resolver.

Corpus-NA: which reference packages the runner hands its own compiler is runner mechanism, invisible to AL; a corpus test cannot observe a closure's membership.

Opened by the agent loop `stma-auto-11`, not by a person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
