### PR TITLE
fix(dap): arm every statement a breakpoint line resolves to, not the first one found

### DIFF
--- a/AlRunner.Tests/DapMultiTargetLineTests.cs
+++ b/AlRunner.Tests/DapMultiTargetLineTests.cs
@@ -1,0 +1,170 @@
+// DapMultiTargetLineTests — #3820: a DAP breakpoint bound ONE statement per source line.
+//
+// `DapBreakpointResolver.Resolve` returned one (ScopeType, StatementIndex) per request and
+// stopped at the first exact line match. AL permits more than one executable statement on one
+// physical line — AlCoverageTracker.CollectStatementTable's own doc comment says so, and keeps
+// such statements apart by id and column precisely because a line cannot — so binding one of
+// them means the breakpoint fires only if execution reaches the one that was picked.
+//
+// Which one that was is arbitrary rather than "the first in the file": the instrumented
+// statement indexes come out of a HashSet, and assembly and type enumeration order is not a
+// semantic ordering. So the defect is not that a particular target wins; it is that the others
+// are not armed at all.
+//
+// These facts drive a real DAP session against Fixtures/DapMultiTarget, whose line 29 carries
+// two assignments that both execute, with line 28 as the single-statement control.
+
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class DapMultiTargetLineTests
+{
+    private static readonly string FixtureSrc = Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "DapMultiTarget"));
+
+    private const string SourceFileName = "MultiTarget.Codeunit.al";
+
+    // Fixtures/DapMultiTarget/MultiTarget.Codeunit.al, asserted against exactly.
+    private const int SharedLine = 29;       // Second := 2; First := First + Second;
+    private const int SingleStatementLine = 28; // First := 1;
+
+    /// <summary>Drives initialize / launch / setBreakpoints / configurationDone and returns the
+    /// live client together with the setBreakpoints response.</summary>
+    private static async Task<(DapClient Dap, JsonElement BpResponse)> StartAndSetBreakpointAsync(int line)
+    {
+        var dap = await DapClient.StartAsync(FixtureSrc);
+        try
+        {
+            var initSeq = dap.SendRequest("initialize", new { adapterID = "al-runner-tests" });
+            var initEvents = new List<JsonElement>();
+            var initResp = await dap.ReadUntilResponseAsync(initSeq, initEvents);
+            Assert.True(initResp.GetProperty("success").GetBoolean(), initResp.ToString());
+            var sawInitialized = initEvents.Any(e => e.GetProperty("event").GetString() == "initialized")
+                || (await dap.ReadUntilEventAsync("initialized")).GetProperty("event").GetString() == "initialized";
+            Assert.True(sawInitialized);
+
+            var launchSeq = dap.SendRequest("launch", new { });
+            var launchResp = await dap.ReadUntilResponseAsync(launchSeq, timeout: TimeSpan.FromSeconds(120));
+            Assert.True(launchResp.GetProperty("success").GetBoolean(),
+                $"launch failed: {launchResp}\n--- stderr ---\n{dap.StdErr}");
+
+            var bpSeq = dap.SendRequest("setBreakpoints", new
+            {
+                source = new { path = Path.Combine(FixtureSrc, SourceFileName) },
+                breakpoints = new[] { new { line } },
+            });
+            var bpResp = await dap.ReadUntilResponseAsync(bpSeq);
+            Assert.True(bpResp.GetProperty("success").GetBoolean(), bpResp.ToString());
+            return (dap, bpResp);
+        }
+        catch
+        {
+            await dap.DisposeAsync();
+            throw;
+        }
+    }
+
+    /// <summary>Reads the integer locals of the top frame of the current pause.</summary>
+    private static async Task<Dictionary<string, string?>> ReadTopFrameLocalsAsync(DapClient dap)
+    {
+        var stSeq = dap.SendRequest("stackTrace", new { threadId = 1 });
+        var stResp = await dap.ReadUntilResponseAsync(stSeq);
+        var frameId = stResp.GetProperty("body").GetProperty("stackFrames")[0].GetProperty("id").GetInt32();
+        var scSeq = dap.SendRequest("scopes", new { frameId });
+        var scResp = await dap.ReadUntilResponseAsync(scSeq);
+        var variablesReference = scResp.GetProperty("body").GetProperty("scopes")[0]
+            .GetProperty("variablesReference").GetInt32();
+        var varSeq = dap.SendRequest("variables", new { variablesReference });
+        var varResp = await dap.ReadUntilResponseAsync(varSeq);
+        return varResp.GetProperty("body").GetProperty("variables").EnumerateArray()
+            .ToDictionary(v => v.GetProperty("name").GetString()!, v => v.GetProperty("value").GetString());
+    }
+
+    /// <summary>
+    /// RED before the fix: exactly ONE stop. Line 29 carries two assignments and both execute,
+    /// so a breakpoint there has two targets; binding one of them means the client stops once
+    /// and the other statement runs past a breakpoint it was told is set.
+    ///
+    /// GREEN: two stops, in execution order, and the locals prove WHICH statement each one is
+    /// in front of — the pause is before the statement's own effect, so at the first stop
+    /// Second is still 0, and at the second it is 2 while First is still 1. That is what makes
+    /// this more than a count: an implementation that armed one target twice would give two
+    /// stops with identical locals.
+    /// </summary>
+    [SkippableFact]
+    public async Task BreakpointOnALineWithTwoStatements_StopsAtEachOfThem()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dap, bpResp) = await StartAndSetBreakpointAsync(SharedLine);
+        await using var _ = dap;
+
+        // One breakpoint per request on the wire, whatever the line binds to — the protocol
+        // requires the response to match the request one for one.
+        var bps = bpResp.GetProperty("body").GetProperty("breakpoints");
+        Assert.Equal(1, bps.GetArrayLength());
+        Assert.True(bps[0].GetProperty("verified").GetBoolean(), bpResp.ToString());
+        Assert.Equal(SharedLine, bps[0].GetProperty("line").GetInt32());
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        var first = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal("breakpoint", first.GetProperty("body").GetProperty("reason").GetString());
+        Assert.Equal(SharedLine, first.GetProperty("body").GetProperty("line").GetInt32());
+        var atFirst = await ReadTopFrameLocalsAsync(dap);
+        Assert.Equal("1", atFirst["First"]);
+        Assert.Equal("0", atFirst["Second"]);
+
+        var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq);
+
+        var second = await dap.ReadUntilEventAsync("stopped", TimeSpan.FromSeconds(30));
+        Assert.Equal("breakpoint", second.GetProperty("body").GetProperty("reason").GetString());
+        Assert.Equal(SharedLine, second.GetProperty("body").GetProperty("line").GetInt32());
+        var atSecond = await ReadTopFrameLocalsAsync(dap);
+        Assert.Equal("1", atSecond["First"]);
+        Assert.Equal("2", atSecond["Second"]);
+
+        var contSeq2 = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq2);
+
+        var events = new List<JsonElement>();
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60), events);
+        Assert.DoesNotContain(events, e => e.GetProperty("event").GetString() == "stopped");
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+
+    /// <summary>
+    /// The control, and the reason the fact above is about multiple TARGETS rather than about
+    /// stopping twice: a line carrying one statement must still stop exactly once. An
+    /// implementation that registered a line's statements more than once, or that re-armed on
+    /// continue, would pass the fact above and fail here.
+    /// </summary>
+    [SkippableFact]
+    public async Task BreakpointOnALineWithOneStatement_StopsExactlyOnce()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dap, bpResp) = await StartAndSetBreakpointAsync(SingleStatementLine);
+        await using var _ = dap;
+        Assert.True(bpResp.GetProperty("body").GetProperty("breakpoints")[0]
+            .GetProperty("verified").GetBoolean(), bpResp.ToString());
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal(SingleStatementLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
+
+        var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq);
+
+        var events = new List<JsonElement>();
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60), events);
+        Assert.DoesNotContain(events, e => e.GetProperty("event").GetString() == "stopped");
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+}

--- a/AlRunner.Tests/DapMultiTargetLineTests.cs
+++ b/AlRunner.Tests/DapMultiTargetLineTests.cs
@@ -37,20 +37,26 @@ public class DapMultiTargetLineTests
     private const int ThreeStatementLine = 37;  // Third := 1; Third := Third + 1; Third := Third + 1;
     private const int TwoProceduresLine = 26;   // procedure Seven() ... end;  procedure Nine() ... end;
 
-    /// <summary>The 1-based column <c>First := First + Second;</c> starts at on
+    /// <summary>The 1-based column at which <c>First := First + Second;</c> starts on
     /// <see cref="SharedLine"/> — DAP's inline-breakpoint coordinate for the SECOND of that
     /// line's two statements.</summary>
     private const int SecondStatementColumn = 22;
 
+    /// <summary>A column INSIDE the second statement rather than at its start — what a client
+    /// produces when the user clicks mid-token. Column 22 is the <c>F</c> of <c>First</c>, so
+    /// 25 is within the same identifier.</summary>
+    private const int InsideSecondStatementColumn = 25;
+
     /// <summary>Drives initialize / launch / setBreakpoints / configurationDone and returns the
     /// live client together with the setBreakpoints response.</summary>
     private static async Task<(DapClient Dap, JsonElement BpResponse)> StartAndSetBreakpointAsync(
-        int line, int? column = null)
+        int line, int? column = null, bool columnsStartAt1 = true)
     {
         var dap = await DapClient.StartAsync(FixtureSrc);
         try
         {
-            var initSeq = dap.SendRequest("initialize", new { adapterID = "al-runner-tests" });
+            var initSeq = dap.SendRequest("initialize",
+                new { adapterID = "al-runner-tests", columnsStartAt1 });
             var initEvents = new List<JsonElement>();
             var initResp = await dap.ReadUntilResponseAsync(initSeq, initEvents);
             Assert.True(initResp.GetProperty("success").GetBoolean(), initResp.ToString());
@@ -96,7 +102,7 @@ public class DapMultiTargetLineTests
     }
 
     /// <summary>
-    /// RED before the fix: exactly ONE stop. Line 29 carries two assignments and both execute,
+    /// RED before the fix: exactly ONE stop. Line 36 carries two assignments and both execute,
     /// so a breakpoint there has two targets; binding one of them means the client stops once
     /// and the other statement runs past a breakpoint it was told is set.
     ///
@@ -309,10 +315,12 @@ public class DapMultiTargetLineTests
     }
 
     /// <summary>
-    /// The other direction of the column rule: a column that names no statement start must
-    /// not resolve to nothing. A client pointing mid-statement, or at whitespace, gets the
-    /// line it clicked on rather than a breakpoint that silently never fires — so both of
-    /// line 36's statements stay armed.
+    /// The widest arm of the column rule, and the last one: a column that starts no statement
+    /// AND is inside none — column 2 is in the indentation — gets the whole line rather than a
+    /// breakpoint that silently never fires. Both of line 36's statements stay armed.
+    ///
+    /// That is a relocation, so the response reports the column actually bound; the fact above
+    /// covers the middle arm, where a column inside a statement binds that statement alone.
     /// </summary>
     [SkippableFact]
     public async Task InlineBreakpointOnAColumnNoStatementStartsAt_FallsBackToTheWholeLine()
@@ -337,5 +345,91 @@ public class DapMultiTargetLineTests
         var second = await dap.ReadUntilEventAsync("stopped", TimeSpan.FromSeconds(30));
         Assert.Equal(SharedLine, second.GetProperty("body").GetProperty("line").GetInt32());
         Assert.Equal("2", (await ReadTopFrameLocalsAsync(dap))["Second"]);
+
+        // Run to completion like every other fact here: stopping at the second pause and
+        // disposing would hide an extra stop after it, or a run that cannot finish
+        // (#3879 Copilot review).
+        var contSeq2 = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq2);
+        var events = new List<JsonElement>();
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60), events);
+        Assert.DoesNotContain(events, e => e.GetProperty("event").GetString() == "stopped");
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+
+    /// <summary>
+    /// #3879 Copilot review: a column that names no statement START used to fall straight
+    /// through to the whole line, which turns an inline breakpoint into a gutter one. A column
+    /// INSIDE a statement is the common case — a user clicking mid-token — and it now resolves
+    /// to the statement that contains it.
+    ///
+    /// Column 25 is within <c>First</c> on line 36, so exactly one stop, at the second
+    /// statement: Second already reads 2.
+    /// </summary>
+    [SkippableFact]
+    public async Task InlineBreakpointInsideAStatement_ArmsThatStatementAlone()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dap, bpResp) = await StartAndSetBreakpointAsync(SharedLine, InsideSecondStatementColumn);
+        await using var _ = dap;
+        var bp = bpResp.GetProperty("body").GetProperty("breakpoints")[0];
+        Assert.True(bp.GetProperty("verified").GetBoolean(), bpResp.ToString());
+        // The column actually bound is reported, and it is the statement's START, not the
+        // column asked for — so the client can see where the breakpoint went.
+        Assert.Equal(SecondStatementColumn, bp.GetProperty("column").GetInt32());
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal(SharedLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
+        Assert.Equal("2", (await ReadTopFrameLocalsAsync(dap))["Second"]);
+
+        var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq);
+        var events = new List<JsonElement>();
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60), events);
+        Assert.DoesNotContain(events, e => e.GetProperty("event").GetString() == "stopped");
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+
+    /// <summary>
+    /// #3879 Copilot review: DAP's `initialize` carries `columnsStartAt1`, and a client that
+    /// sets it FALSE counts columns from 0. Its numbers were compared against 1-based spans,
+    /// so its inline breakpoint landed one column left of the statement it meant — off the
+    /// start, into the containing-statement arm at best and the whole line at worst.
+    ///
+    /// The same statement, named 0-based as column 21, must bind exactly as column 22 does
+    /// 1-based — and the reported column must come back in the client's own base.
+    /// </summary>
+    [SkippableFact]
+    public async Task InlineBreakpointFromAZeroBasedClient_BindsTheSameStatement()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dap, bpResp) = await StartAndSetBreakpointAsync(
+            SharedLine, SecondStatementColumn - 1, columnsStartAt1: false);
+        await using var _ = dap;
+        var bp = bpResp.GetProperty("body").GetProperty("breakpoints")[0];
+        Assert.True(bp.GetProperty("verified").GetBoolean(), bpResp.ToString());
+        Assert.Equal(SecondStatementColumn - 1, bp.GetProperty("column").GetInt32());
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        // One stop, at the SECOND statement — the same binding the 1-based fact gets.
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal(SharedLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
+        var locals = await ReadTopFrameLocalsAsync(dap);
+        Assert.Equal("2", locals["Second"]);
+        Assert.Equal("1", locals["First"]);
+
+        var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq);
+        var events = new List<JsonElement>();
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60), events);
+        Assert.DoesNotContain(events, e => e.GetProperty("event").GetString() == "stopped");
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
     }
 }

--- a/AlRunner.Tests/DapMultiTargetLineTests.cs
+++ b/AlRunner.Tests/DapMultiTargetLineTests.cs
@@ -11,8 +11,13 @@
 // semantic ordering. So the defect is not that a particular target wins; it is that the others
 // are not armed at all.
 //
-// These facts drive a real DAP session against Fixtures/DapMultiTarget, whose line 29 carries
-// two assignments that both execute, with line 28 as the single-statement control.
+// These facts drive a real DAP session against Fixtures/DapMultiTarget, which carries four
+// shapes: two statements on one line (36), three on one line (37), two one-line procedures on
+// one line (26, so the targets are in two different scopes), and a single-statement control
+// (35). The column facts use line 36, whose second statement starts at column 22.
+//
+// The column half is #3879 review: arming every target is right for a gutter breakpoint and
+// wrong for an INLINE one, which is what DAP SourceBreakpoint.column means.
 
 using System.Text.Json;
 using Xunit;
@@ -27,12 +32,20 @@ public class DapMultiTargetLineTests
     private const string SourceFileName = "MultiTarget.Codeunit.al";
 
     // Fixtures/DapMultiTarget/MultiTarget.Codeunit.al, asserted against exactly.
-    private const int SharedLine = 29;       // Second := 2; First := First + Second;
-    private const int SingleStatementLine = 28; // First := 1;
+    private const int SharedLine = 36;          // Second := 2; First := First + Second;
+    private const int SingleStatementLine = 35; // First := 1;
+    private const int ThreeStatementLine = 37;  // Third := 1; Third := Third + 1; Third := Third + 1;
+    private const int TwoProceduresLine = 26;   // procedure Seven() ... end;  procedure Nine() ... end;
+
+    /// <summary>The 1-based column <c>First := First + Second;</c> starts at on
+    /// <see cref="SharedLine"/> — DAP's inline-breakpoint coordinate for the SECOND of that
+    /// line's two statements.</summary>
+    private const int SecondStatementColumn = 22;
 
     /// <summary>Drives initialize / launch / setBreakpoints / configurationDone and returns the
     /// live client together with the setBreakpoints response.</summary>
-    private static async Task<(DapClient Dap, JsonElement BpResponse)> StartAndSetBreakpointAsync(int line)
+    private static async Task<(DapClient Dap, JsonElement BpResponse)> StartAndSetBreakpointAsync(
+        int line, int? column = null)
     {
         var dap = await DapClient.StartAsync(FixtureSrc);
         try
@@ -53,7 +66,7 @@ public class DapMultiTargetLineTests
             var bpSeq = dap.SendRequest("setBreakpoints", new
             {
                 source = new { path = Path.Combine(FixtureSrc, SourceFileName) },
-                breakpoints = new[] { new { line } },
+                breakpoints = new[] { new { line, column } },
             });
             var bpResp = await dap.ReadUntilResponseAsync(bpSeq);
             Assert.True(bpResp.GetProperty("success").GetBoolean(), bpResp.ToString());
@@ -166,5 +179,163 @@ public class DapMultiTargetLineTests
         var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60), events);
         Assert.DoesNotContain(events, e => e.GetProperty("event").GetString() == "stopped");
         Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+
+    /// <summary>
+    /// #3879 review: the base fact proves TWO targets in ONE scope, and an implementation
+    /// that armed at most two, or that handled only same-scope fan-out, would pass it. Line 37
+    /// carries three statements, all of which run, so this pins "every match" rather than "at
+    /// least two".
+    ///
+    /// Third counts 1, 2, 3 across the three, and the locals at each stop say which statement
+    /// is next — so three stops with the same value would not pass.
+    /// </summary>
+    [SkippableFact]
+    public async Task BreakpointOnALineWithThreeStatements_StopsAtEachOfThem()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dap, bpResp) = await StartAndSetBreakpointAsync(ThreeStatementLine);
+        await using var _ = dap;
+        Assert.True(bpResp.GetProperty("body").GetProperty("breakpoints")[0]
+            .GetProperty("verified").GetBoolean(), bpResp.ToString());
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        // Before each of the three statements: Third is 0, then 1, then 2.
+        foreach (var expected in new[] { "0", "1", "2" })
+        {
+            var stopped = await dap.ReadUntilEventAsync("stopped", TimeSpan.FromSeconds(60));
+            Assert.Equal(ThreeStatementLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
+            var locals = await ReadTopFrameLocalsAsync(dap);
+            Assert.Equal(expected, locals["Third"]);
+            var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+            await dap.ReadUntilResponseAsync(contSeq);
+        }
+
+        var events = new List<JsonElement>();
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60), events);
+        Assert.DoesNotContain(events, e => e.GetProperty("event").GetString() == "stopped");
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+
+    /// <summary>
+    /// #3879 review: fan-out ACROSS scope types, which the same-scope facts cannot show. Line
+    /// 26 declares two one-line procedures, so its two targets live in two different emitted
+    /// scope classes; both are called, so both must stop.
+    ///
+    /// This is the shape the old code could not serve at all — it picked one scope and left
+    /// the other unarmed — and it is the case the issue named as reachable across objects
+    /// since a file's objects became separately addressable.
+    /// </summary>
+    [SkippableFact]
+    public async Task BreakpointOnALineWithTwoOneLineProcedures_StopsInsideEachOfThem()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dap, bpResp) = await StartAndSetBreakpointAsync(TwoProceduresLine);
+        await using var _ = dap;
+        Assert.True(bpResp.GetProperty("body").GetProperty("breakpoints")[0]
+            .GetProperty("verified").GetBoolean(),
+            $"a line declaring two one-line procedures did not verify: {bpResp}\n"
+            + $"--- stderr ---\n{dap.StdErr}");
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        // Seven() then Nine(), in call order. The frame NAME is what proves these are two
+        // different scopes rather than one scope hit twice.
+        foreach (var expectedFrame in new[] { "Seven", "Nine" })
+        {
+            var stopped = await dap.ReadUntilEventAsync("stopped", TimeSpan.FromSeconds(60));
+            Assert.Equal(TwoProceduresLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
+
+            var stSeq = dap.SendRequest("stackTrace", new { threadId = 1 });
+            var stResp = await dap.ReadUntilResponseAsync(stSeq);
+            var frameName = stResp.GetProperty("body").GetProperty("stackFrames")[0]
+                .GetProperty("name").GetString() ?? "";
+            Assert.True(frameName.Contains(expectedFrame, StringComparison.OrdinalIgnoreCase),
+                $"paused frame is '{frameName}', not {expectedFrame} — the two targets on this "
+                + $"line are not in two different scopes: {stResp}");
+
+            var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+            await dap.ReadUntilResponseAsync(contSeq);
+        }
+
+        var events = new List<JsonElement>();
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60), events);
+        Assert.DoesNotContain(events, e => e.GetProperty("event").GetString() == "stopped");
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+
+    /// <summary>
+    /// #3879 review: arming every target on the line is right for a gutter breakpoint and
+    /// WRONG for an inline one. DAP's <c>SourceBreakpoint.column</c> is how a client says
+    /// "this statement, not the others on the line" — VS Code's inline breakpoints exist for
+    /// exactly the multiple-statements-per-line case — and the handler used to discard it.
+    ///
+    /// Column 22 on line 36 is the second statement. So: one stop, not two, and at the
+    /// SECOND statement — Second is already 2 when it pauses, which the first statement's
+    /// pause would report as 0.
+    /// </summary>
+    [SkippableFact]
+    public async Task InlineBreakpointNamingAColumn_ArmsOnlyThatStatement()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dap, bpResp) = await StartAndSetBreakpointAsync(SharedLine, SecondStatementColumn);
+        await using var _ = dap;
+        Assert.True(bpResp.GetProperty("body").GetProperty("breakpoints")[0]
+            .GetProperty("verified").GetBoolean(), bpResp.ToString());
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal(SharedLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
+        var locals = await ReadTopFrameLocalsAsync(dap);
+        Assert.Equal("2", locals["Second"]);
+        Assert.Equal("1", locals["First"]);
+
+        var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq);
+
+        // No second stop on that line: the other statement was not armed.
+        var events = new List<JsonElement>();
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60), events);
+        Assert.DoesNotContain(events, e => e.GetProperty("event").GetString() == "stopped");
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+
+    /// <summary>
+    /// The other direction of the column rule: a column that names no statement start must
+    /// not resolve to nothing. A client pointing mid-statement, or at whitespace, gets the
+    /// line it clicked on rather than a breakpoint that silently never fires — so both of
+    /// line 36's statements stay armed.
+    /// </summary>
+    [SkippableFact]
+    public async Task InlineBreakpointOnAColumnNoStatementStartsAt_FallsBackToTheWholeLine()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        // Column 2 is inside the indentation: no statement begins there.
+        var (dap, bpResp) = await StartAndSetBreakpointAsync(SharedLine, 2);
+        await using var _ = dap;
+        Assert.True(bpResp.GetProperty("body").GetProperty("breakpoints")[0]
+            .GetProperty("verified").GetBoolean(), bpResp.ToString());
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        var first = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal(SharedLine, first.GetProperty("body").GetProperty("line").GetInt32());
+        Assert.Equal("0", (await ReadTopFrameLocalsAsync(dap))["Second"]);
+        var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq);
+
+        var second = await dap.ReadUntilEventAsync("stopped", TimeSpan.FromSeconds(30));
+        Assert.Equal(SharedLine, second.GetProperty("body").GetProperty("line").GetInt32());
+        Assert.Equal("2", (await ReadTopFrameLocalsAsync(dap))["Second"]);
     }
 }

--- a/AlRunner.Tests/Fixtures/DapMultiTarget/Assert.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/DapMultiTarget/Assert.Codeunit.al
@@ -1,0 +1,12 @@
+/// <summary>
+/// Minimal assertion helper for this fixture app (own ID range so it
+/// stands alone from the corpus Assert).
+/// </summary>
+codeunit 60310 "Dap Multi Assert"
+{
+    procedure AreEqual(Expected: Integer; Actual: Integer; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Assert.AreEqual failed. Expected:<%1>. Actual:<%2>. %3', Expected, Actual, Msg);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/DapMultiTarget/MultiTarget.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/DapMultiTarget/MultiTarget.Codeunit.al
@@ -1,16 +1,20 @@
 /// <summary>
 /// #3820: ONE source line carrying more than one executable statement.
 ///
-/// Line 29 holds two assignments, and BOTH run. A DAP breakpoint on that line used to bind
-/// one of them — DapBreakpointResolver.Resolve stopped at the first exact line match — so it
-/// fired once instead of at each target. Which one it bound was arbitrary: the instrumented
-/// statement indexes come out of a HashSet.
+/// A DAP breakpoint on such a line used to bind one of them — DapBreakpointResolver.Resolve
+/// stopped at the first exact line match — so it fired once instead of at each target. Which
+/// one it bound was arbitrary: the instrumented statement indexes come out of a HashSet.
 ///
-/// Line 28 is the single-statement control, so a fact about line 29 cannot pass by an
-/// implementation that stops twice on every line.
+/// Four shapes, so a fact cannot pass by handling only the easy one:
 ///
-/// The line numbers below are asserted against exactly by DapMultiTargetLineTests.
-/// Keep them in sync.
+///   line 36  two statements, one scope   — the base case
+///   line 35  one statement               — the control: a normal line still stops once
+///   line 37  THREE statements, one scope — pins "every", not "at least two"
+///   line 26  two one-line procedures     — fan-out ACROSS scope types, not within one
+///
+/// Line 36's second statement starts at column 22, which is what the column-breakpoint fact
+/// uses. The line numbers and that column are asserted against exactly by
+/// DapMultiTargetLineTests. Keep them in sync.
 /// </summary>
 codeunit 60311 "Dap Multi Tests"
 {
@@ -19,15 +23,29 @@ codeunit 60311 "Dap Multi Tests"
     var
         Assert: Codeunit "Dap Multi Assert";
 
+    procedure Seven(): Integer begin exit(7); end;  procedure Nine(): Integer begin exit(9); end;
+
     [Test]
     procedure TwoStatementsOnOneLine()
     var
         First: Integer;
         Second: Integer;
+        Third: Integer;
     begin
         First := 1;
         Second := 2; First := First + Second;
+        Third := 1; Third := Third + 1; Third := Third + 1;
         Assert.AreEqual(3, First, 'both statements on the shared line ran');
         Assert.AreEqual(2, Second, 'the first of the two ran');
+        Assert.AreEqual(3, Third, 'all three statements on the shared line ran');
+    end;
+
+    [Test]
+    procedure TwoProceduresOnOneLine()
+    var
+        Total: Integer;
+    begin
+        Total := Seven() + Nine();
+        Assert.AreEqual(16, Total, 'both one-line procedures ran');
     end;
 }

--- a/AlRunner.Tests/Fixtures/DapMultiTarget/MultiTarget.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/DapMultiTarget/MultiTarget.Codeunit.al
@@ -1,0 +1,33 @@
+/// <summary>
+/// #3820: ONE source line carrying more than one executable statement.
+///
+/// Line 29 holds two assignments, and BOTH run. A DAP breakpoint on that line used to bind
+/// one of them — DapBreakpointResolver.Resolve stopped at the first exact line match — so it
+/// fired once instead of at each target. Which one it bound was arbitrary: the instrumented
+/// statement indexes come out of a HashSet.
+///
+/// Line 28 is the single-statement control, so a fact about line 29 cannot pass by an
+/// implementation that stops twice on every line.
+///
+/// The line numbers below are asserted against exactly by DapMultiTargetLineTests.
+/// Keep them in sync.
+/// </summary>
+codeunit 60311 "Dap Multi Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Dap Multi Assert";
+
+    [Test]
+    procedure TwoStatementsOnOneLine()
+    var
+        First: Integer;
+        Second: Integer;
+    begin
+        First := 1;
+        Second := 2; First := First + Second;
+        Assert.AreEqual(3, First, 'both statements on the shared line ran');
+        Assert.AreEqual(2, Second, 'the first of the two ran');
+    end;
+}

--- a/AlRunner.Tests/Fixtures/DapMultiTarget/app.json
+++ b/AlRunner.Tests/Fixtures/DapMultiTarget/app.json
@@ -1,0 +1,23 @@
+{
+  "id": "d4e5f6a7-b8c9-4a0b-9d4e-5f6a7b8c9d04",
+  "name": "Runner Tests Fixture - DAP Multi Target",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Fixture for #3820: one source line carrying more than one executable statement.",
+  "description": "Used by AlRunner.Tests' DapMultiTargetLineTests. No application/platform floor - see .claude/rules/no-base-app-in-csharp-tests.md.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "idRanges": [
+    {
+      "from": 60310,
+      "to": 60339
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner/Infrastructure/AlSourceSpanCodec.cs
+++ b/AlRunner/Infrastructure/AlSourceSpanCodec.cs
@@ -78,4 +78,14 @@ public static class AlSourceSpanCodec
     /// value is 0-based like its line.
     /// </summary>
     public static int AbsoluteFromColumn(long statementSpan) => Decode(statementSpan).FromColumn + 1;
+
+    /// <summary>The 1-based line a statement span ENDS on — equal to the from-line for a
+    /// statement written on one line, greater for one that wraps.</summary>
+    public static int AbsoluteToLine(long statementSpan) => Decode(statementSpan).ToLine + 1;
+
+    /// <summary>The 1-based column a statement span ends at. With the three above, this is
+    /// what decides whether a requested column falls INSIDE a statement rather than at its
+    /// start — the difference between an inline breakpoint a client placed precisely and one
+    /// it placed somewhere in the middle of the statement it meant.</summary>
+    public static int AbsoluteToColumn(long statementSpan) => Decode(statementSpan).ToColumn + 1;
 }

--- a/AlRunner/Infrastructure/AlSourceSpanCodec.cs
+++ b/AlRunner/Infrastructure/AlSourceSpanCodec.cs
@@ -70,4 +70,12 @@ public static class AlSourceSpanCodec
     /// report or an editor gutter needs, as opposed to RelativeLine's stack-trace format.
     /// </summary>
     public static int AbsoluteFromLine(long statementSpan) => Decode(statementSpan).FromLine + 1;
+
+    /// <summary>
+    /// The 1-based column a statement span starts at — the other half of
+    /// <see cref="AbsoluteFromLine"/>, and what tells two statements on ONE line apart. DAP
+    /// counts columns from 1 by default, which is the convention this matches; BC's packed
+    /// value is 0-based like its line.
+    /// </summary>
+    public static int AbsoluteFromColumn(long statementSpan) => Decode(statementSpan).FromColumn + 1;
 }

--- a/AlRunner/Infrastructure/DapBreakpointResolver.cs
+++ b/AlRunner/Infrastructure/DapBreakpointResolver.cs
@@ -29,6 +29,11 @@ public readonly record struct DapBreakpointRequest(string SourcePath, int Line, 
 /// 1-based column it starts at — the only thing that tells two targets on one line apart.</summary>
 public readonly record struct DapBreakpointTarget(Type ScopeType, int StatementIndex, int Column);
 
+/// <summary>Where one instrumented statement sits in the FILE: 1-based, both ends. The end is
+/// what makes "does this column fall inside the statement" answerable, as opposed to "does it
+/// start it".</summary>
+internal readonly record struct StatementSpan(int Line, int Column, int EndLine, int EndColumn);
+
 /// <summary>
 /// The answer to one <c>setBreakpoints</c> line. <see cref="Targets"/> holds EVERY statement
 /// the line resolves to, because a source line can carry more than one (#3820) — two
@@ -106,7 +111,7 @@ public static class DapBreakpointResolver
         // (label,id) -> every loaded scope type for that object, each with its own
         // (statement index -> absolute AL line) map.
         var byObject = new Dictionary<(string, int),
-            List<(Type Type, Dictionary<int, (int Line, int Column)> LineByStmt)>>();
+            List<(Type Type, Dictionary<int, StatementSpan> LineByStmt)>>();
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
         {
             Type[] types;
@@ -130,14 +135,17 @@ public static class DapBreakpointResolver
                 // than being shifted by a guess.
                 var lineOffset = sourceMap.LineOffset(label, id);
                 var instrumented = AlCoverageInstrumentedStatements.Find(t);
-                var lineByStmt = new Dictionary<int, (int Line, int Column)>();
+                var lineByStmt = new Dictionary<int, StatementSpan>();
                 foreach (var i in instrumented)
                 {
                     if (i < 0 || i >= spans.Length) continue; // defensive: BC shape drift
-                    // The column needs no offset: AlSourceLocationMap.LineOffset moves an
-                    // object's text DOWN the file, never across it.
-                    lineByStmt[i] = (AlSourceSpanCodec.AbsoluteFromLine(spans[i]) + lineOffset,
-                                     AlSourceSpanCodec.AbsoluteFromColumn(spans[i]));
+                    // Columns need no offset: AlSourceLocationMap.LineOffset moves an object's
+                    // text DOWN the file, never across it. Both LINES do.
+                    lineByStmt[i] = new StatementSpan(
+                        AlSourceSpanCodec.AbsoluteFromLine(spans[i]) + lineOffset,
+                        AlSourceSpanCodec.AbsoluteFromColumn(spans[i]),
+                        AlSourceSpanCodec.AbsoluteToLine(spans[i]) + lineOffset,
+                        AlSourceSpanCodec.AbsoluteToColumn(spans[i]));
                 }
                 if (!byObject.TryGetValue((label, id), out var list))
                     byObject[(label, id)] = list = new();
@@ -165,27 +173,46 @@ public static class DapBreakpointResolver
                 // Enumeration order is deliberately not relied on for anything: the set is
                 // collected whole, and registering all of it is what makes the arbitrary order
                 // stop mattering.
+                var onLine = new List<(DapBreakpointTarget Target, StatementSpan Span)>();
                 foreach (var objKey in objKeys)
                 {
                     if (!byObject.TryGetValue(objKey, out var scopes)) continue;
                     foreach (var (type, lineByStmt) in scopes)
                         foreach (var entry in lineByStmt)
                             if (entry.Value.Line == req.Line)
-                                targets.Add(new DapBreakpointTarget(
-                                    type, entry.Key, entry.Value.Column));
+                                onLine.Add((
+                                    new DapBreakpointTarget(type, entry.Key, entry.Value.Column),
+                                    entry.Value));
                 }
 
-                // An INLINE breakpoint names a column, which is DAP's own way of saying
-                // "this statement, not the others on the line" — so honour it rather than
-                // arming the whole line (#3879 review). Only an EXACT start-column match
-                // narrows: a column that lands mid-statement, or on whitespace, is a client
-                // pointing somewhere no statement begins, and answering that with nothing
-                // would be worse than answering with the line the user clicked on.
-                if (req.Column is int wantColumn)
+                // An INLINE breakpoint names a column, which is DAP's own way of saying "this
+                // statement, not the others on the line" — VS Code's inline breakpoints exist
+                // for exactly the several-statements-on-one-line case. Arming the whole line
+                // for one is the gutter behaviour applied to a request that said otherwise
+                // (#3879 review).
+                //
+                // Three steps, narrowest first:
+                //   1. a statement STARTING at the column — the client placed it precisely;
+                //   2. otherwise a statement CONTAINING it — the client pointed inside the
+                //      statement it meant, which is what a mid-token click produces;
+                //   3. otherwise every statement on the line, because a column in the
+                //      indentation names no statement at all and a breakpoint that silently
+                //      never fires is worse than the line the user clicked on.
+                //
+                // Step 3 is a relocation, so it is REPORTED: the response carries the column
+                // actually bound (see the handler), which is what keeps it from being the
+                // silent widening this cascade exists to avoid.
+                if (req.Column is int wantColumn && onLine.Count > 0)
                 {
-                    var atColumn = targets.Where(t => t.Column == wantColumn).ToList();
-                    if (atColumn.Count > 0) targets = atColumn;
+                    var starting = onLine.Where(t => t.Span.Column == wantColumn).ToList();
+                    var containing = starting.Count > 0 ? starting : onLine
+                        .Where(t => wantColumn >= t.Span.Column
+                                    && (t.Span.EndLine > t.Span.Line || wantColumn <= t.Span.EndColumn))
+                        .ToList();
+                    if (containing.Count > 0) onLine = containing;
                 }
+
+                targets.AddRange(onLine.Select(t => t.Target));
             }
 
             // ActualLine is the requested line whenever anything matched, because the match is

--- a/AlRunner/Infrastructure/DapBreakpointResolver.cs
+++ b/AlRunner/Infrastructure/DapBreakpointResolver.cs
@@ -16,11 +16,18 @@ using System.Reflection;
 
 namespace AlRunner.Infrastructure;
 
-public readonly record struct DapBreakpointRequest(string SourcePath, int Line);
+/// <summary>
+/// One requested breakpoint. <paramref name="Column"/> is DAP's optional
+/// <c>SourceBreakpoint.column</c> — an INLINE breakpoint, which is how a client says "this
+/// statement on the line, not the others". Null means the ordinary gutter breakpoint, which
+/// means the whole line (#3879 review).
+/// </summary>
+public readonly record struct DapBreakpointRequest(string SourcePath, int Line, int? Column = null);
 
 /// <summary>One armable statement: the emitted AL scope class and the statement's index
-/// within it, which is what <see cref="AlDapSession.SetBreakpoint"/> registers.</summary>
-public readonly record struct DapBreakpointTarget(Type ScopeType, int StatementIndex);
+/// within it, which is what <see cref="AlDapSession.SetBreakpoint"/> registers, plus the
+/// 1-based column it starts at — the only thing that tells two targets on one line apart.</summary>
+public readonly record struct DapBreakpointTarget(Type ScopeType, int StatementIndex, int Column);
 
 /// <summary>
 /// The answer to one <c>setBreakpoints</c> line. <see cref="Targets"/> holds EVERY statement
@@ -98,7 +105,8 @@ public static class DapBreakpointResolver
 
         // (label,id) -> every loaded scope type for that object, each with its own
         // (statement index -> absolute AL line) map.
-        var byObject = new Dictionary<(string, int), List<(Type Type, Dictionary<int, int> LineByStmt)>>();
+        var byObject = new Dictionary<(string, int),
+            List<(Type Type, Dictionary<int, (int Line, int Column)> LineByStmt)>>();
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
         {
             Type[] types;
@@ -122,11 +130,14 @@ public static class DapBreakpointResolver
                 // than being shifted by a guess.
                 var lineOffset = sourceMap.LineOffset(label, id);
                 var instrumented = AlCoverageInstrumentedStatements.Find(t);
-                var lineByStmt = new Dictionary<int, int>();
+                var lineByStmt = new Dictionary<int, (int Line, int Column)>();
                 foreach (var i in instrumented)
                 {
                     if (i < 0 || i >= spans.Length) continue; // defensive: BC shape drift
-                    lineByStmt[i] = AlSourceSpanCodec.AbsoluteFromLine(spans[i]) + lineOffset;
+                    // The column needs no offset: AlSourceLocationMap.LineOffset moves an
+                    // object's text DOWN the file, never across it.
+                    lineByStmt[i] = (AlSourceSpanCodec.AbsoluteFromLine(spans[i]) + lineOffset,
+                                     AlSourceSpanCodec.AbsoluteFromColumn(spans[i]));
                 }
                 if (!byObject.TryGetValue((label, id), out var list))
                     byObject[(label, id)] = list = new();
@@ -158,9 +169,22 @@ public static class DapBreakpointResolver
                 {
                     if (!byObject.TryGetValue(objKey, out var scopes)) continue;
                     foreach (var (type, lineByStmt) in scopes)
-                        foreach (var kv in lineByStmt)
-                            if (kv.Value == req.Line)
-                                targets.Add(new DapBreakpointTarget(type, kv.Key));
+                        foreach (var entry in lineByStmt)
+                            if (entry.Value.Line == req.Line)
+                                targets.Add(new DapBreakpointTarget(
+                                    type, entry.Key, entry.Value.Column));
+                }
+
+                // An INLINE breakpoint names a column, which is DAP's own way of saying
+                // "this statement, not the others on the line" — so honour it rather than
+                // arming the whole line (#3879 review). Only an EXACT start-column match
+                // narrows: a column that lands mid-statement, or on whitespace, is a client
+                // pointing somewhere no statement begins, and answering that with nothing
+                // would be worse than answering with the line the user clicked on.
+                if (req.Column is int wantColumn)
+                {
+                    var atColumn = targets.Where(t => t.Column == wantColumn).ToList();
+                    if (atColumn.Count > 0) targets = atColumn;
                 }
             }
 

--- a/AlRunner/Infrastructure/DapBreakpointResolver.cs
+++ b/AlRunner/Infrastructure/DapBreakpointResolver.cs
@@ -18,8 +18,25 @@ namespace AlRunner.Infrastructure;
 
 public readonly record struct DapBreakpointRequest(string SourcePath, int Line);
 
+/// <summary>One armable statement: the emitted AL scope class and the statement's index
+/// within it, which is what <see cref="AlDapSession.SetBreakpoint"/> registers.</summary>
+public readonly record struct DapBreakpointTarget(Type ScopeType, int StatementIndex);
+
+/// <summary>
+/// The answer to one <c>setBreakpoints</c> line. <see cref="Targets"/> holds EVERY statement
+/// the line resolves to, because a source line can carry more than one (#3820) — two
+/// statements on one physical line, two one-line procedures, or statements of two objects a
+/// file declares. Arming one of them makes the breakpoint fire only if execution happens to
+/// reach the one that was picked, and which one that was is arbitrary: the instrumented
+/// statement indexes come out of a HashSet, and type enumeration order is not a semantic
+/// ordering.
+///
+/// The DAP response still carries exactly ONE breakpoint per request, as the protocol
+/// requires — the fan-out is in what gets registered, not in what the client is told.
+/// </summary>
 public readonly record struct DapResolvedBreakpoint(
-    string SourcePath, int RequestedLine, bool Verified, int ActualLine, Type? ScopeType, int StatementIndex);
+    string SourcePath, int RequestedLine, bool Verified, int ActualLine,
+    IReadOnlyList<DapBreakpointTarget> Targets);
 
 public static class DapBreakpointResolver
 {
@@ -121,41 +138,38 @@ public static class DapBreakpointResolver
         foreach (var req in requests)
         {
             var full = Path.GetFullPath(req.SourcePath);
-            (Type Type, int Stmt, int Line)? match = null;
+            var targets = new List<DapBreakpointTarget>();
             if (byPath.TryGetValue(full, out var objKeys))
             {
-                // Every object the file declares, not just one.
+                // Every object the file declares, and within each, EVERY scope and EVERY
+                // instrumented statement whose absolute line is the requested one.
                 //
-                // The first exact match wins, and that is a real limitation rather than a
-                // proof of uniqueness (#3786 review). AL permits two statements on one
-                // physical line — CollectStatementTable's doc comment says so explicitly, and
-                // keeps them apart by id and column precisely because a line cannot — so a
-                // requested line can have more than one executable target, in one scope or
-                // across several. Binding one of them means a breakpoint on such a line stops
-                // only if execution reaches the target that was picked. #3820 tracks
-                // registering every match behind the single DAP breakpoint the protocol
-                // returns; it needs DapResolvedBreakpoint to carry a set, so it is not a
-                // widening of this change.
+                // This used to stop at the first exact match, which was a real limitation
+                // rather than a proof of uniqueness (#3786 review, filed as #3820). AL permits
+                // two statements on one physical line — CollectStatementTable's doc comment
+                // says so explicitly, and keeps them apart by id and column precisely because
+                // a line cannot — so a requested line can have more than one executable
+                // target, in one scope or across several.
+                //
+                // Enumeration order is deliberately not relied on for anything: the set is
+                // collected whole, and registering all of it is what makes the arbitrary order
+                // stop mattering.
                 foreach (var objKey in objKeys)
                 {
                     if (!byObject.TryGetValue(objKey, out var scopes)) continue;
                     foreach (var (type, lineByStmt) in scopes)
-                    {
                         foreach (var kv in lineByStmt)
-                        {
-                            if (kv.Value != req.Line) continue;
-                            match = (type, kv.Key, kv.Value);
-                            break;
-                        }
-                        if (match != null) break;
-                    }
-                    if (match != null) break;
+                            if (kv.Value == req.Line)
+                                targets.Add(new DapBreakpointTarget(type, kv.Key));
                 }
             }
 
-            result.Add(match is { } m
-                ? new DapResolvedBreakpoint(req.SourcePath, req.Line, true, m.Line, m.Type, m.Stmt)
-                : new DapResolvedBreakpoint(req.SourcePath, req.Line, false, 0, null, -1));
+            // ActualLine is the requested line whenever anything matched, because the match is
+            // an EXACT line comparison — there is no nearest-line heuristic here (see the file
+            // header), so every target in the set shares it.
+            result.Add(targets.Count > 0
+                ? new DapResolvedBreakpoint(req.SourcePath, req.Line, true, req.Line, targets)
+                : new DapResolvedBreakpoint(req.SourcePath, req.Line, false, 0, Array.Empty<DapBreakpointTarget>()));
         }
         return result;
     }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -5849,13 +5849,19 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
         var nowRegistered = new HashSet<Type>();
         foreach (var rb in resolved)
         {
-            if (!rb.Verified || rb.ScopeType == null) continue;
-            // A scope reached for the first time in THIS request may still
-            // carry breakpoints from a request naming a different file that
-            // declares the same object — clear before the first add, once.
-            if (nowRegistered.Add(rb.ScopeType))
-                AlRunner.Infrastructure.AlDapSession.ClearBreakpoints(rb.ScopeType);
-            AlRunner.Infrastructure.AlDapSession.SetBreakpoint(rb.ScopeType, rb.StatementIndex);
+            if (!rb.Verified) continue;
+            // EVERY target of the line, not one of them (#3820): a line carrying two
+            // statements has two, and arming one means the breakpoint fires only if
+            // execution reaches the one that was picked.
+            foreach (var target in rb.Targets)
+            {
+                // A scope reached for the first time in THIS request may still
+                // carry breakpoints from a request naming a different file that
+                // declares the same object — clear before the first add, once.
+                if (nowRegistered.Add(target.ScopeType))
+                    AlRunner.Infrastructure.AlDapSession.ClearBreakpoints(target.ScopeType);
+                AlRunner.Infrastructure.AlDapSession.SetBreakpoint(target.ScopeType, target.StatementIndex);
+            }
         }
         registeredScopesBySource[fullSrcPath] = nowRegistered;
 

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -5698,7 +5698,8 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
     // the compile makes the session deaf to `disconnect` and turns a compile that never
     // finishes into an adapter that never exits (#3846). DAP matches a response to its
     // request by `request_seq`, so answering later is within the protocol.
-    var deferredBreakpointRequests = new List<(int Seq, string Command, string SrcPath, List<int> Lines)>();
+    var deferredBreakpointRequests =
+        new List<(int Seq, string Command, string SrcPath, List<(int Line, int? Column)> Lines)>();
 
     // A test seam, and the only way to prove the paragraph above: an organically slow bundle
     // makes a flaky test, so this holds map preparation open for a known interval while the
@@ -5817,14 +5818,16 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
     // The whole of what `setBreakpoints` does once the map question is settled, lifted out of
     // the switch so a DEFERRED request is answered by exactly the same code as an immediate
     // one — two copies of this would drift, and the deferred path is the one nobody watches.
-    void AnswerSetBreakpoints(int seq, string command, string srcPath, List<int> lines)
+    void AnswerSetBreakpoints(int seq, string command, string srcPath, List<(int Line, int? Column)> lines)
     {
         // #3821: a request arriving between `initialized` and `launch` is the specification's
         // own sequence, and answering it against an empty map made every breakpoint
         // unverified. An empty list needs no map (see the call site).
         var bpCompileErr = lines.Count > 0 ? EnsureSourceMap() : null;
 
-        var requests = lines.Select(l => new AlRunner.Infrastructure.DapBreakpointRequest(srcPath, l)).ToList();
+        var requests = lines
+            .Select(l => new AlRunner.Infrastructure.DapBreakpointRequest(srcPath, l.Line, l.Column))
+            .ToList();
         var resolved = AlRunner.Infrastructure.DapBreakpointResolver.Resolve(requests, sourceMap);
 
         // Why an unverified breakpoint is unverified. DAP's Breakpoint has a
@@ -6066,12 +6069,19 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
                             transport.WriteResponse(msg.Seq, command, false, message: "setBreakpoints: missing source.path");
                             break;
                         }
-                        var lines = new List<int>();
+                        // (line, optional column). The column is DAP's inline breakpoint —
+                        // the client naming ONE statement on a line that carries several
+                        // (#3879 review). The legacy `lines` array has no column to carry.
+                        var lines = new List<(int Line, int? Column)>();
                         if (args.Value.TryGetProperty("breakpoints", out var bpsEl) && bpsEl.ValueKind == System.Text.Json.JsonValueKind.Array)
                             foreach (var bp in bpsEl.EnumerateArray())
-                                if (bp.TryGetProperty("line", out var lineEl)) lines.Add(lineEl.GetInt32());
+                                if (bp.TryGetProperty("line", out var lineEl))
+                                    lines.Add((lineEl.GetInt32(),
+                                        bp.TryGetProperty("column", out var colEl)
+                                            && colEl.ValueKind == System.Text.Json.JsonValueKind.Number
+                                            ? colEl.GetInt32() : null));
                         else if (args.Value.TryGetProperty("lines", out var legacyLinesEl) && legacyLinesEl.ValueKind == System.Text.Json.JsonValueKind.Array)
-                            foreach (var l in legacyLinesEl.EnumerateArray()) lines.Add(l.GetInt32());
+                            foreach (var l in legacyLinesEl.EnumerateArray()) lines.Add((l.GetInt32(), null));
 
                         // An EMPTY list resolves nothing — "remove every breakpoint in this
                         // source" needs no map — so it is answered now, whatever the compile

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -5693,6 +5693,18 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
     var sourceMapResolved = false;
     string? compileFailure = null;
 
+    // DAP's `initialize` lets the client say whether it counts columns from 1 or from 0
+    // (`columnsStartAt1`, default TRUE when absent). Everything below this line works in
+    // 1-based columns, which is what AlSourceSpanCodec.AbsoluteFromColumn produces, so a
+    // 0-based client's numbers are converted on the way in and back on the way out (#3879
+    // Copilot review). Without that, such a client's inline breakpoint lands one column left
+    // of the statement it meant.
+    //
+    // `linesStartAt1` has the identical problem and is NOT handled here: lines are reported
+    // by `stopped`, `stackTrace` and this response, so honouring it is a change across the
+    // whole surface rather than the one field this pull request adds (#3881).
+    var columnsStartAt1 = true;
+
     // setBreakpoints requests that arrived before the map could be built, waiting to be
     // answered. Answering one needs the compile, and BLOCKING this single-threaded loop for
     // the compile makes the session deaf to `disconnect` and turns a compile that never
@@ -5875,6 +5887,13 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
                 id = idx,
                 verified = rb.Verified,
                 line = rb.Verified ? rb.ActualLine : rb.RequestedLine,
+                // The column actually bound — the leftmost of the armed targets. A client that
+                // asked for a column no statement starts at can see where the breakpoint went,
+                // which is what keeps the resolver's widest fallback from being a silent
+                // relocation (#3879 Copilot review). Back into the client's own base.
+                column = rb.Verified && rb.Targets.Count > 0
+                    ? rb.Targets.Min(t => t.Column) - (columnsStartAt1 ? 0 : 1)
+                    : (int?)null,
                 message = rb.Verified ? null : unverifiedReason,
             }),
         });
@@ -6036,6 +6055,10 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
                 switch (command)
                 {
                     case "initialize":
+                        // Absent means true, per the specification.
+                        columnsStartAt1 = !(args != null
+                            && args.Value.TryGetProperty("columnsStartAt1", out var colBaseEl)
+                            && colBaseEl.ValueKind == System.Text.Json.JsonValueKind.False);
                         transport.WriteResponse(msg.Seq, command, true, new
                         {
                             supportsConfigurationDoneRequest = true,
@@ -6079,7 +6102,9 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
                                     lines.Add((lineEl.GetInt32(),
                                         bp.TryGetProperty("column", out var colEl)
                                             && colEl.ValueKind == System.Text.Json.JsonValueKind.Number
-                                            ? colEl.GetInt32() : null));
+                                            // To 1-based, which is what the resolver compares in.
+                                            ? colEl.GetInt32() + (columnsStartAt1 ? 0 : 1)
+                                            : null));
                         else if (args.Value.TryGetProperty("lines", out var legacyLinesEl) && legacyLinesEl.ValueKind == System.Text.Json.JsonValueKind.Array)
                             foreach (var l in legacyLinesEl.EnumerateArray()) lines.Add((l.GetInt32(), null));
 

--- a/docs/dap-mode.md
+++ b/docs/dap-mode.md
@@ -78,13 +78,32 @@ byte-for-byte, not just "the handshake succeeded".
 Session lifecycle is identical to the TCP transport from here on:
 
 1. `initialize` → capabilities, then an `initialized` event.
-2. `launch`/`attach` → compiles the bundle. The response does not return until
-   compilation finishes (success or failure), so a `setBreakpoints` request
-   right after has real statement indices to resolve against.
-3. `setBreakpoints` (per source file) → resolves each requested line to an
-   AL-compiler-instrumented statement via an exact absolute-line match — no
+2. `launch`/`attach` → waits for the compile. The response does not return until
+   compilation finishes (success or failure). **A `setBreakpoints` may also arrive
+   BEFORE `launch`** — that is the specification's own sequence, a client answering
+   the `initialized` event with its configuration — and it is answered against the
+   same compile, deferred rather than waited for so the loop stays able to read
+   `disconnect` (#3821, #3846).
+3. `setBreakpoints` (per source file) → resolves each requested line to the
+   AL-compiler-instrumented statements on it, via an exact absolute-line match — no
    "nearest line" heuristic. A line with no exact instrumented statement comes
-   back `verified: false` rather than silently relocated.
+   back `verified: false` rather than silently relocated, carrying a `message`
+   saying which reason applies: the bundle did not compile, or that line holds no
+   statement.
+
+   **Every statement on the line is armed, not one of them** (#3820). A line can
+   carry several — two statements separated by `;`, two one-line procedures, or
+   statements of two objects the file declares — so execution stops at each, in
+   the order it reaches them. The response still carries exactly one breakpoint
+   per request, as the protocol requires.
+
+   **`SourceBreakpoint.column` narrows that.** An inline breakpoint is DAP's way of
+   naming one statement on such a line, and it is honoured in three steps: a
+   statement *starting* at the column; failing that, the statement *containing* it
+   (a mid-token click); failing that, the whole line. The last is a relocation, so
+   the response reports the `column` actually bound. The client capability
+   `columnsStartAt1` is honoured for that field in both directions; its sibling
+   `linesStartAt1` is **not** honoured anywhere yet (#3881).
 4. `configurationDone` → AL execution begins.
 5. When a breakpointed statement's `StmtHit` fires, the AL execution thread
    blocks and a `stopped` event (`reason: "breakpoint"`) is sent.


### PR DESCRIPTION
Closes #3820

## What was wrong

`DapBreakpointResolver.Resolve` returned one `(ScopeType, StatementIndex)` per request and
stopped at the first exact line match:

```csharp
if (kv.Value != req.Line) continue;
match = (type, kv.Key, kv.Value);
break;
```

A source line can carry more than one executable target — two statements on one physical line,
two one-line procedures, or statements of two objects a file declares. Binding one of them
means the breakpoint fires only if execution reaches the one that was picked.

And which one that was is **arbitrary rather than "first in the file"**: the instrumented
statement indexes come out of a `HashSet`, and assembly and type enumeration order is not a
semantic ordering. So this was not a defect about a particular target winning; it was that the
others were never armed.

This is not a hypothesis about AL. `AlCoverageTracker.CollectStatementTable`'s own doc comment
states it, and keeps such statements apart by id and column precisely because a line cannot.

## The fix

`DapResolvedBreakpoint` now carries `IReadOnlyList<DapBreakpointTarget> Targets` instead of one
nullable `ScopeType` plus one `StatementIndex`. `Resolve` collects every exact match across
every object the file declares and every scope of each, and the `setBreakpoints` handler
registers all of them.

**The DAP response still carries exactly one breakpoint per request**, as the protocol
requires: `id`, `verified` and `line` are unchanged on the wire. The fan-out is in what gets
armed, not in what the client is told.

`ActualLine` is now simply the requested line whenever anything matched, because the match is
an exact line comparison — there is no nearest-line heuristic here (the resolver's file header
says why), so every target in a set shares it.

The only consumer of the old shape was the registration loop in `RunDapLoop`.

## Proving tests

`AlRunner.Tests/DapMultiTargetLineTests.cs`, against a new `Fixtures/DapMultiTarget` whose
line 29 is `Second := 2; First := First + Second;` — two assignments that both execute — with
line 28 as a single-statement control.

| fact | RED before | proves |
|---|---|---|
| `BreakpointOnALineWithTwoStatements_StopsAtEachOfThem` | exactly **one** stop; the second `stopped` event never arrives | two stops, in execution order, and the locals say which statement each one is in front of — `Second` is `0` at the first and `2` at the second, with `First` still `1`. An implementation that armed one target twice would give two stops with identical locals. |
| `BreakpointOnALineWithOneStatement_StopsExactlyOnce` | green before and after | the fact above is about multiple TARGETS, not about stopping twice: a one-statement line still stops once, and the run then exits 0 with no further `stopped` |

Both facts end by continuing to completion and asserting no further `stopped` event, so a
breakpoint left armed after the run would fail them.

### Mutation-checked

| mutation | result |
|---|---|
| register only `rb.Targets.Take(1)` in the handler | the two-statement fact reds **alone**; the control stays green |

I attempted a second slice — making `Resolve` itself keep only the first match — and **the
sandbox refused the command**: the inline script contained the substring `kv.Key`, which
matched a secret-detection rule (`secret.ext-pattern.key`). I did not retry or route around it.
That slice is partly covered anyway by the original RED baseline, which ran against the
unmodified resolver and unmodified handler together and showed the single stop.

## Local runs

- The five DAP suites: **21 passed, 0 failed**.
- With the source-scanning guards added to the filter (`~GuardTests`, `~CoverageTests`):
  **290 passed, 0 failed**. Those guards are in the filter deliberately — this PR adds a test
  file and a fixture, and a subsystem-only filter cannot see a guard that scans every source.

## Related, not folded

- #3526 — breakpoint replacement semantics. Its core defect was already fixed by the #3786
  review follow-up; two of its acceptance criteria still have no test. This PR changes the
  registration loop it concerns, and the existing replacement facts in `DapMultiObjectFileTests`
  stay green, but its remaining work is test-only coverage and gets no RED here.
- #3847 — `AlCoverageSourceMap.Build` reports an unreadable source as a bundle with no objects,
  so a missing map entry can mean "I could not read the sources". Upstream of this resolver,
  and the fix belongs in the builder.
- #3521 — building source attribution from BC syntax rather than a first-header regex. Same
  area, different layer, and it would rewrite what feeds this.

Corpus-NA: a debug-adapter breakpoint-registration fix; no AL-observable behaviour changes, and the corpus cannot express a DAP breakpoint binding.

*Opened by an agent (Claude Code) in a session run by @SShadowS.*

https://claude.ai/code/session_01JFQZHC5SEHnLxkc5USksaK
