### PR TITLE
fix(deps): fail loudly when a dependency compile emits only some of its objects

### DIFF
--- a/AlRunner.Tests/DependencyEmitExclusionLoudnessTests.cs
+++ b/AlRunner.Tests/DependencyEmitExclusionLoudnessTests.cs
@@ -1,42 +1,23 @@
 // DependencyEmitExclusionLoudnessTests — #2247: a dependency that emits only SOME of its
-// objects must be loud, not loaded partially in silence.
+// objects must say so, rather than being loaded partially in silence.
 //
-// What was wrong
-// --------------
-// Program.cs's bundled-mode path has failed the run on emit-retry exclusion since #1991
-// (EMIT-EXCLUDED), because losing an object silently shrinks what the run covers.
-// DependencyLoader.LoadOne called the same BcCompiler.Emit and read only `.Sources`, so a
-// dependency whose AL hit the same atomic-per-module emit crash was recovered partially,
-// loaded, CACHED, and reported as a clean success.
+// CLAIM: DependencyLoader.LoadOne called the same BcCompiler.Emit the bundled path calls and
+// read only `.Sources`, so an emit-retry exclusion was loaded, cached and reported as a clean
+// success, at every verbosity.
 //
-// Measured on the fixture beside this file (AlRunner.Tests/Fixtures/DepEmitExclusion), BC
-// 28.1.49838.54308, with the compiled-deps cache cleared first — the dependency .app ships two
-// codeunits and one cannot bind:
+// CITATION: measured on the fixture this file generates — exit 0, "1P/0F/0E across 1 tests",
+// and `grep -c` = 0 over the whole run log for the dropped object, EMIT-EXCLUDED and AL0185.
+// Confirmed off disk rather than from a missing log line: the cached dependency DLL held
+// Codeunit70860 and not Codeunit70861, and its .object-metadata.json listed 1 object where the
+// package shipped 2. #3875 measured the same shape on the metadata path (55 documents of 70).
 //
-//   before:  exit 0, "1P/0F/0E across 1 tests", and ZERO lines at default verbosity
-//            mentioning the dropped object, EMIT-EXCLUDED, object 70861 or AL0185 (grep -c
-//            over the whole run log: 0). The cached dependency DLL contained Codeunit70860
-//            and not Codeunit70861, and the .object-metadata.json sidecar listed exactly one
-//            object where the .app shipped two — the drop confirmed a second way, off disk,
-//            rather than from the absence of a log line.
-//   after:   exit 1, one [dep-load-fail] … EMIT-EXCLUDED line at DEFAULT verbosity naming the
-//            dropped object, the 1-of-2 denominator, the consequence and the AL0185 that
-//            caused it. No cache entry is written at all.
-//
-// The partial case is the whole point. A test asserting only that a dependency which fails
-// ENTIRELY is loud would have passed before this fix: EMIT-ZERO already covered that, and it
-// is the discontinuity — 10 of 10 lost is fatal, 9 of 10 lost is fine — that made the gap
-// invisible.
-//
-// #3875 measured the same silent-partial shape one layer over, on the metadata path: Business
-// Foundation produced 55 documents instead of 70, reported success, and printed zero AL0185
-// lines at default verbosity. That path is fixed in the same PR
-// (DependencyMetadataProducer.Ensure, METADATA-EMIT-EXCLUDED) and pinned below.
-//
-// See .claude/rules/guards-need-a-third-state.md: "some objects were excluded" had no verdict
-// distinct from "everything emitted", so it was reported as the success state.
+// TRAP, for whoever edits this next: the fix REPORTS and continues; it does not fail the run.
+// Refusing was measured and is wrong — it aborts the entire runner-extras suite, because
+// Microsoft's Tests-TestLibraries drops 1 of 203 objects on a DotNet type that is unavailable
+// headless. DependencyLoader.cs's guard carries that reasoning at the line.
 
 using AlRunner;
+using AlRunner.Infrastructure;
 using Xunit;
 
 namespace AlRunner.Tests;
@@ -88,9 +69,8 @@ public sealed class DependencyEmitExclusionMessageTests
     }
 
     /// <summary>
-    /// The AL diagnostic is inlined rather than held behind --verbose. This throw aborts the
-    /// run, so the diagnostic is the only account of the cause — the same choice EMIT-ZERO on
-    /// this path and Program.cs's non-profile EMIT-EXCLUDED branch already make (#2949).
+    /// The AL diagnostic is inlined rather than held behind --verbose: it is the only account
+    /// of why the object was dropped, and the run continues past it (#2949).
     /// </summary>
     [Fact]
     public void TheIdentifyingAlDiagnostic_IsInTheMessage()
@@ -120,23 +100,16 @@ public sealed class DependencyEmitExclusionMessageTests
 }
 
 /// <summary>
-/// The routing half. An EMIT-EXCLUDED dependency failure must reach Program.cs's FATAL
-/// handler, and must NOT be swallowed by LoadAll's Microsoft-source-only catch on the
-/// strength of the stage name alone.
-///
-/// That catch exists for a genuinely faithful fallback — a platform app whose procedure
-/// bodies really do live in the extracted service-tier DLLs. Whether THIS app qualifies is
-/// HasServiceTierDllFallback's call, unchanged by #2247; what is pinned here is that the new
-/// stage does not accidentally join the METADATA-* family, which is never eligible (#3749).
+/// The stage-naming half. METADATA-EMIT-EXCLUDED must land in the never-swallowable METADATA-*
+/// family and the code-path stage must not (#3749) — IsMetadataStage matches on the prefix, so
+/// a misnamed stage would silently become swallowable.
 /// </summary>
 public sealed class DependencyEmitExclusionStageRoutingTests
 {
     [Fact]
     public void EmitExcluded_IsNotAMetadataStage()
     {
-        // METADATA-* is the never-swallowable family. The code path's stage is not in it, so
-        // eligibility falls to the service-tier-fallback question, exactly like EMIT-FAIL,
-        // EMIT-ZERO and COMPILE-FAIL beside it.
+        // METADATA-* is the never-swallowable family; the code-path stage is not in it.
         Assert.False(DependencyLoader.IsMetadataStage("EMIT-EXCLUDED"));
         Assert.True(DependencyLoader.IsMetadataStage("METADATA-EMIT-EXCLUDED"));
     }
@@ -144,8 +117,8 @@ public sealed class DependencyEmitExclusionStageRoutingTests
     [Fact]
     public void EmitExcluded_IsNeverSwallowedWithoutAFaithfulFallback()
     {
-        // No service-tier index at all: nothing can answer for the dropped object, so the
-        // failure must propagate to the FATAL handler rather than being deferred.
+        // No service-tier index: nothing can answer for the dropped object, so a
+        // METADATA-EMIT-EXCLUDED must propagate rather than be deferred.
         Assert.False(DependencyLoader.IsServiceTierFallbackEligible(
             "EMIT-EXCLUDED",
             serviceTierIndexAvailable: false,
@@ -156,9 +129,8 @@ public sealed class DependencyEmitExclusionStageRoutingTests
     [Fact]
     public void TheMetadataVariant_IsNeverSwallowedEvenWithAFullIndex()
     {
-        // #3749's property, re-asserted for the new metadata stage: extracted DLLs supply
-        // procedure BODIES, so they can stand in for missing code and never for missing
-        // metadata. A complete index must not make this eligible.
+        // #3749: extracted DLLs supply procedure BODIES, so they can stand in for missing code
+        // and never for missing metadata. A complete index must not make this eligible.
         Assert.False(DependencyLoader.IsServiceTierFallbackEligible(
             "METADATA-EMIT-EXCLUDED",
             serviceTierIndexAvailable: true,
@@ -347,17 +319,18 @@ public sealed class DependencyEmitExclusionEndToEndTests
 
     /// <summary>
     /// The proving test. Before the fix this exact run exited 0 with "1P/0F/0E across 1 tests"
-    /// and said nothing at all about the dropped object — the bundle's own test passes either
-    /// way, because a green-looking run IS the defect.
+    /// and said NOTHING about the dropped object at any verbosity — the bundle's own test
+    /// passes either way, because a green-looking run IS the defect.
+    ///
+    /// The run still succeeds after the fix, deliberately (see the guard's own comment): what
+    /// changed is that the loss is stated at the point of discovery AND in the run summary,
+    /// where a reader of a long log will actually find it.
     /// </summary>
     [SkippableFact]
-    public void PartiallyEmittedDependency_IsLoudAtDefaultVerbosity_AndStopsTheRun()
+    public void PartiallyEmittedDependency_IsReportedAtDefaultVerbosity_AndInTheRunSummary()
     {
         TestArtifacts.SkipIfMissing();
 
-        // TestScratch, not a hand-built Path.GetTempPath() expression (#2706): this test writes
-        // a bundle AND a --cache root the runner fills, and an unowned directory is unreclaimable
-        // if the test host is killed. ScratchDirOwnershipGuardTests enforces it.
         var root = TestScratch.FlatDir("al-runner-dex-");
         Directory.CreateDirectory(root);
         try
@@ -368,10 +341,6 @@ public sealed class DependencyEmitExclusionEndToEndTests
 
             var (output, exit) = RunRunner(bundle, cacheDir);
 
-            Assert.True(exit != 0,
-                $"a dependency that lost an object provides less than it claims, so the run "
-                + $"must NOT exit 0. exit={exit}\n{output}");
-
             // No --verbose, and that IS the assertion: Log's component filter drops a [deps]
             // line at default verbosity (#2750), so reporting this as [deps] would reproduce
             // the original silence while looking like a fix.
@@ -380,33 +349,138 @@ public sealed class DependencyEmitExclusionEndToEndTests
             // The dropped object by name — "something was excluded" is not actionable.
             Assert.Contains("DEX Dep Broken", output, StringComparison.Ordinal);
 
-            // The denominator, which is what distinguishes a partial loss from a total one
-            // and is the whole of why EMIT-ZERO did not already cover this.
+            // The denominator, which is what distinguishes a partial loss from a total one and
+            // is the whole of why the EMIT-ZERO guard beside it did not already cover this.
             Assert.Contains("1 of this dependency's 2 object(s)", output, StringComparison.Ordinal);
 
-            // The cause, at default verbosity, since this failure aborts the run.
+            // The cause, at default verbosity.
             Assert.Contains("AL0185", output, StringComparison.Ordinal);
+
+            // Reported in the SUMMARY too, not only at the point of discovery: this run
+            // continues, so on a real run the discovery line scrolls thousands of lines above
+            // the part anyone reads (#2587). This is the assertion that would fail if the
+            // report were downgraded to a bare stderr write.
+            Assert.Contains("Provisioning gaps:", output, StringComparison.Ordinal);
 
             // Negative direction: the SURVIVING object must not be named as dropped. A guard
             // that reports everything is as useless as one that reports nothing.
             Assert.DoesNotContain("DEX Dep Healthy", output, StringComparison.Ordinal);
 
-            // And the partial assembly must not have been cached: the cache stores the DLL and
-            // is consulted before any of this, so a written entry would make a later run skip
-            // the compile, skip this guard, and be silently partial again — the same lever
-            // Program.cs pulls with `cachePath = null` (#3476).
-            var compiledDeps = Path.Combine(cacheDir, "compiled-deps");
-            var cachedDlls = Directory.Exists(compiledDeps)
-                ? Directory.GetFiles(compiledDeps, "*.dll")
-                : Array.Empty<string>();
-            Assert.True(cachedDlls.Length == 0,
-                "a partially-emitted dependency must not be cached; a later run would load it "
-                + "without recompiling and never reach the guard. found: "
-                + string.Join(", ", cachedDlls.Select(Path.GetFileName)));
+            // And the run still completes. Failing the load instead was measured and is wrong:
+            // it aborts the whole runner-extras suite over Microsoft's Tests-TestLibraries
+            // dropping one of 203 objects on a headless-unavailable DotNet type.
+            Assert.Equal(0, exit);
+            Assert.Contains("MainBundle_RunsGreenWhileTheDependencyIsPartial", output, StringComparison.Ordinal);
         }
         finally
         {
             try { Directory.Delete(root, recursive: true); } catch { }
         }
+    }
+}
+
+/// <summary>
+/// The METADATA path's own RED → GREEN (#2247, second half). The two facts above assert the
+/// stage NAMING convention, which would pass with the guard deleted — this drives the guard.
+///
+/// CLAIM: DependencyMetadataProducer.Ensure discarded the BcEmitOutput entirely
+/// (`compiler.Emit(...)` with no assignment) and checked only `produced.Length == 0`, so a
+/// partial emit was persisted as the app's COMPLETE metadata. It cannot see the shortfall by
+/// counting — it knows how many documents appeared, never how many BC should have produced.
+///
+/// CITATION: #3875 measured Business Foundation at 55 documents of 70, reported as success with
+/// zero AL0185 lines at default verbosity.
+///
+/// TRAP: unlike the LoadOne path, which reports and continues, this one THROWS — because Persist
+/// writes a sidecar every later run replays without recompiling, so a partial document set would
+/// become this app's recorded metadata permanently.
+/// </summary>
+public sealed class DependencyMetadataPartialEmitTests
+{
+    /// <summary>
+    /// A source-shipping package with TWO tables, one of which cannot bind: its field carries a
+    /// TableRelation to a table that exists nowhere, so BC's atomic-per-module Emit fails and
+    /// the retry loop drops exactly that one and recompiles the survivor — the partial emit.
+    /// </summary>
+    private static string WritePartialSourcePackage(Guid appId)
+    {
+        var path = TestScratch.FilePath("depmeta-partial", "pkg-partial-source.app");
+        using var ms = new MemoryStream();
+        using (var zip = new System.IO.Compression.ZipArchive(
+            ms, System.IO.Compression.ZipArchiveMode.Create, leaveOpen: true))
+        {
+            void Add(string name, string content)
+            {
+                using var s = zip.CreateEntry(name).Open();
+                s.Write(System.Text.Encoding.UTF8.GetBytes(content));
+            }
+            Add("NavxManifest.xml",
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<Package xmlns=\"http://schemas.microsoft.com/navx/2015/manifest\">"
+                + $"<App Id=\"{appId}\" Name=\"DEX Partial Metadata Dep\" Publisher=\"AL Runner Fixtures\""
+                + " Version=\"1.0.0.0\" ShowMyCode=\"true\" /><Dependencies /></Package>");
+            Add("src/Healthy.Table.al",
+                "table 70880 \"DEX Meta Healthy\"\n"
+                + "{\n    DataClassification = CustomerContent;\n"
+                + "    fields { field(1; \"No.\"; Code[20]) { } }\n"
+                + "    keys { key(PK; \"No.\") { Clustered = true; } }\n}\n");
+            Add("src/Broken.Codeunit.al",
+                "codeunit 70881 \"DEX Meta Broken\"\n"
+                + "{\n    procedure Go()\n    var\n"
+                + "        Missing: Codeunit \"DEX Meta No Such Codeunit Anywhere\";\n"
+                + "    begin\n        Missing.Whatever();\n    end;\n}\n");
+        }
+        var zipBytes = ms.ToArray();
+        var result = new byte[8 + zipBytes.Length];
+        result[0] = (byte)'N'; result[1] = (byte)'A'; result[2] = (byte)'V'; result[3] = (byte)'X';
+        BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
+        zipBytes.CopyTo(result, 8);
+        File.WriteAllBytes(path, result);
+        return path;
+    }
+
+    /// <summary>
+    /// The proving test. With the guard removed this returns 1 — one document, from the table
+    /// that survived — and persists it as the app's complete metadata. It must throw instead,
+    /// naming the dropped object and the denominator.
+    /// </summary>
+    [SkippableFact]
+    public void PartialMetadataEmit_ThrowsRatherThanCachingAnIncompleteDocumentSet()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        // A FRESH app id per run, not a constant: the metadata sidecar is keyed on it and
+        // lives in a machine-global cache, so a constant id lets one run's entry satisfy the
+        // next run's cache HIT before Ensure ever compiles. That is not hypothetical — it
+        // happened while proving this test: the mutated (unguarded) build cached 1 document
+        // for a 2-object package, and the restored build then read that entry back and
+        // returned early, so the test stayed red with the guard present. The poisoned cache
+        // IS the defect this guard exists to prevent; the test must not depend on it.
+        var appId = Guid.NewGuid();
+        var pkg = WritePartialSourcePackage(appId);
+        var manifest = new AppManifest(
+            Publisher: "AL Runner Fixtures", Name: "DEX Partial Metadata Dep",
+            Version: new Version(1, 0, 0, 0), AppId: appId,
+            Dependencies: Array.Empty<DependencyRef>());
+
+        var ex = Assert.Throws<DependencyLoadException>(
+            () => DependencyMetadataProducer.Ensure(manifest, pkg, new BcCompiler()));
+
+        // The stage, which is what keeps it in the never-swallowable METADATA-* family (#3749).
+        Assert.Equal("METADATA-EMIT-EXCLUDED", ex.Stage);
+        // The dropped object by name, and the denominator that makes a partial loss legible.
+        Assert.Contains("DEX Meta Broken", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("1 of this dependency's 2 object(s)", ex.Message, StringComparison.Ordinal);
+        // And why throwing is the right answer HERE specifically, where LoadOne continues.
+        Assert.Contains("metadata document(s) were produced", ex.Message, StringComparison.Ordinal);
+
+        // Negative direction, and the half that makes the throw worth having: nothing was
+        // persisted. A cached partial set is replayed by every later run without recompiling,
+        // so it would record 1 document as this app's complete metadata permanently.
+        var sidecar = Path.Combine(
+            AlRunner.Infrastructure.CacheRoots.Resolve("dep-metadata"),
+            DependencyMetadataProducer.CacheKey(manifest) + ".object-metadata.json");
+        Assert.False(File.Exists(sidecar),
+            $"a partial metadata emit must not be cached; found {sidecar}");
     }
 }

--- a/AlRunner.Tests/DependencyEmitExclusionLoudnessTests.cs
+++ b/AlRunner.Tests/DependencyEmitExclusionLoudnessTests.cs
@@ -377,6 +377,63 @@ public sealed class DependencyEmitExclusionEndToEndTests
             try { Directory.Delete(root, recursive: true); } catch { }
         }
     }
+
+    /// <summary>
+    /// The WARM half, and the one a cold-only test cannot catch — it is what shipped in the
+    /// first version of this fix.
+    ///
+    /// LoadOne's `source-cache HIT` returns about 80 lines ABOVE the EMIT-EXCLUDED guard, so a
+    /// second run against the same cache root never reaches it. Measured on this fixture before
+    /// the sidecar existed, cache root the only variable: run 1 printed 2 EMIT-EXCLUDED lines
+    /// and 1 provisioning gap; runs 2 and 3 printed neither, while the cached
+    /// .object-metadata.json held 1 object where the package shipped 2 — byte-for-byte the
+    /// pre-fix silence.
+    ///
+    /// CI cannot see that: it provisions a fresh cache on every leg, so the legs stay green
+    /// forever while every repeat local run is silently partial.
+    /// </summary>
+    [SkippableFact]
+    public void ThePartialEmitReport_SurvivesACacheHit_NotJustTheCompilingRun()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = TestScratch.FlatDir("al-runner-dex-warm-");
+        Directory.CreateDirectory(root);
+        try
+        {
+            var bundle = BuildFixture(root);
+            // ONE cache root, deliberately: the whole point is the second run's HIT.
+            var cacheDir = Path.Combine(root, "cache");
+            Directory.CreateDirectory(cacheDir);
+
+            var first = RunRunner(bundle, cacheDir);
+            var second = RunRunner(bundle, cacheDir);
+
+            // Positive control: without this, a fixture that silently stopped producing an
+            // exclusion at all would make the real assertion below pass vacuously.
+            Assert.Contains("EMIT-EXCLUDED", first.Output, StringComparison.Ordinal);
+            Assert.DoesNotContain("from a cached compile", first.Output, StringComparison.Ordinal);
+
+            // The assertion this test exists for.
+            Assert.Contains("EMIT-EXCLUDED", second.Output, StringComparison.Ordinal);
+            Assert.Contains("DEX Dep Broken", second.Output, StringComparison.Ordinal);
+            Assert.Contains("1 of this dependency's 2 object(s)", second.Output, StringComparison.Ordinal);
+            Assert.Contains("Provisioning gaps:", second.Output, StringComparison.Ordinal);
+
+            // ...and that the second run really took the CACHED route rather than recompiling,
+            // which would make it a second cold run wearing a warm label. This marker is added
+            // only by the replay path. Checked because `[deps] source-cache HIT` is swallowed by
+            // Log's component filter at default verbosity and cannot serve as the signal.
+            Assert.Contains("from a cached compile", second.Output, StringComparison.Ordinal);
+
+            Assert.Equal(0, first.Exit);
+            Assert.Equal(0, second.Exit);
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
 }
 
 /// <summary>

--- a/AlRunner.Tests/DependencyEmitExclusionLoudnessTests.cs
+++ b/AlRunner.Tests/DependencyEmitExclusionLoudnessTests.cs
@@ -355,7 +355,10 @@ public sealed class DependencyEmitExclusionEndToEndTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-dex-" + Guid.NewGuid().ToString("N"));
+        // TestScratch, not a hand-built Path.GetTempPath() expression (#2706): this test writes
+        // a bundle AND a --cache root the runner fills, and an unowned directory is unreclaimable
+        // if the test host is killed. ScratchDirOwnershipGuardTests enforces it.
+        var root = TestScratch.FlatDir("al-runner-dex-");
         Directory.CreateDirectory(root);
         try
         {

--- a/AlRunner.Tests/DependencyEmitExclusionLoudnessTests.cs
+++ b/AlRunner.Tests/DependencyEmitExclusionLoudnessTests.cs
@@ -1,0 +1,409 @@
+// DependencyEmitExclusionLoudnessTests — #2247: a dependency that emits only SOME of its
+// objects must be loud, not loaded partially in silence.
+//
+// What was wrong
+// --------------
+// Program.cs's bundled-mode path has failed the run on emit-retry exclusion since #1991
+// (EMIT-EXCLUDED), because losing an object silently shrinks what the run covers.
+// DependencyLoader.LoadOne called the same BcCompiler.Emit and read only `.Sources`, so a
+// dependency whose AL hit the same atomic-per-module emit crash was recovered partially,
+// loaded, CACHED, and reported as a clean success.
+//
+// Measured on the fixture beside this file (AlRunner.Tests/Fixtures/DepEmitExclusion), BC
+// 28.1.49838.54308, with the compiled-deps cache cleared first — the dependency .app ships two
+// codeunits and one cannot bind:
+//
+//   before:  exit 0, "1P/0F/0E across 1 tests", and ZERO lines at default verbosity
+//            mentioning the dropped object, EMIT-EXCLUDED, object 70861 or AL0185 (grep -c
+//            over the whole run log: 0). The cached dependency DLL contained Codeunit70860
+//            and not Codeunit70861, and the .object-metadata.json sidecar listed exactly one
+//            object where the .app shipped two — the drop confirmed a second way, off disk,
+//            rather than from the absence of a log line.
+//   after:   exit 1, one [dep-load-fail] … EMIT-EXCLUDED line at DEFAULT verbosity naming the
+//            dropped object, the 1-of-2 denominator, the consequence and the AL0185 that
+//            caused it. No cache entry is written at all.
+//
+// The partial case is the whole point. A test asserting only that a dependency which fails
+// ENTIRELY is loud would have passed before this fix: EMIT-ZERO already covered that, and it
+// is the discontinuity — 10 of 10 lost is fatal, 9 of 10 lost is fine — that made the gap
+// invisible.
+//
+// #3875 measured the same silent-partial shape one layer over, on the metadata path: Business
+// Foundation produced 55 documents instead of 70, reported success, and printed zero AL0185
+// lines at default verbosity. That path is fixed in the same PR
+// (DependencyMetadataProducer.Ensure, METADATA-EMIT-EXCLUDED) and pinned below.
+//
+// See .claude/rules/guards-need-a-third-state.md: "some objects were excluded" had no verdict
+// distinct from "everything emitted", so it was reported as the success state.
+
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class DependencyEmitExclusionMessageTests
+{
+    private static string Message(
+        string[] excluded, int emitted, string[]? diagnostics = null)
+        => DependencyLoader.BuildDependencyEmitExcludedDetail(
+            excluded, emitted, diagnostics ?? Array.Empty<string>());
+
+    /// <summary>
+    /// The PARTIAL case, which is the one that hid. The message has to carry a denominator:
+    /// "some objects were excluded" leaves the reader unable to tell a cosmetic drop from
+    /// losing most of the app, and a count with no total is the same problem
+    /// (#3875 measured 55 of 70 — the "of 70" is what made it a finding).
+    /// </summary>
+    [Fact]
+    public void PartialExclusion_StatesWhatWasDroppedAndOutOfHowMany()
+    {
+        var msg = Message(new[] { "Codeunit \"DEX Dep Broken\"" }, emitted: 1);
+
+        // The specific object, not just a count.
+        Assert.Contains("DEX Dep Broken", msg, StringComparison.Ordinal);
+        // The denominator: 1 dropped, 2 total, 1 survived.
+        Assert.Contains("1 of this dependency's 2 object(s)", msg, StringComparison.Ordinal);
+        Assert.Contains("only 1 of them", msg, StringComparison.Ordinal);
+        // And the consequence, which is why a reader should care about a dependency at all.
+        Assert.Contains("NavNCLMissingMethodException", msg, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The denominator has to track the real numbers rather than being a fixed string — a
+    /// message that says "1 of 2" for every input is not reporting a measurement. Losing 15
+    /// of 70 is #3875's shape, and it must render as exactly that.
+    /// </summary>
+    [Fact]
+    public void TheDenominatorIsComputed_NotHardcoded()
+    {
+        var fifteen = Enumerable.Range(1, 15).Select(i => $"Table \"T{i}\"").ToArray();
+        var msg = Message(fifteen, emitted: 55);
+
+        Assert.Contains("15 of this dependency's 70 object(s)", msg, StringComparison.Ordinal);
+        Assert.Contains("only 55 of them", msg, StringComparison.Ordinal);
+        // Every dropped object is named, not just the first or a truncated sample: a reader
+        // chasing one specific missing table must be able to find it here.
+        Assert.Contains("Table \"T1\"", msg, StringComparison.Ordinal);
+        Assert.Contains("Table \"T15\"", msg, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The AL diagnostic is inlined rather than held behind --verbose. This throw aborts the
+    /// run, so the diagnostic is the only account of the cause — the same choice EMIT-ZERO on
+    /// this path and Program.cs's non-profile EMIT-EXCLUDED branch already make (#2949).
+    /// </summary>
+    [Fact]
+    public void TheIdentifyingAlDiagnostic_IsInTheMessage()
+    {
+        var msg = Message(
+            new[] { "Codeunit \"DEX Dep Broken\"" }, emitted: 1,
+            diagnostics: new[] { "DepBroken.Codeunit.al(5,18): error AL0185: Codeunit 'X' is missing" });
+
+        Assert.Contains("AL0185", msg, StringComparison.Ordinal);
+        Assert.Contains("DepBroken.Codeunit.al", msg, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Negative direction: with no diagnostics captured the message must not invent a
+    /// diagnostics section promising detail that is not there. An empty "AL diagnostics:"
+    /// header is the shape #2207 fixed on the bundle path — a promise with nothing behind it.
+    /// </summary>
+    [Fact]
+    public void WithNoDiagnostics_NoEmptyDiagnosticsSectionIsPromised()
+    {
+        var msg = Message(new[] { "Codeunit \"DEX Dep Broken\"" }, emitted: 1);
+
+        Assert.DoesNotContain("AL diagnostics that identified", msg, StringComparison.Ordinal);
+        // ...but the substantive part is still there.
+        Assert.Contains("DEX Dep Broken", msg, StringComparison.Ordinal);
+    }
+}
+
+/// <summary>
+/// The routing half. An EMIT-EXCLUDED dependency failure must reach Program.cs's FATAL
+/// handler, and must NOT be swallowed by LoadAll's Microsoft-source-only catch on the
+/// strength of the stage name alone.
+///
+/// That catch exists for a genuinely faithful fallback — a platform app whose procedure
+/// bodies really do live in the extracted service-tier DLLs. Whether THIS app qualifies is
+/// HasServiceTierDllFallback's call, unchanged by #2247; what is pinned here is that the new
+/// stage does not accidentally join the METADATA-* family, which is never eligible (#3749).
+/// </summary>
+public sealed class DependencyEmitExclusionStageRoutingTests
+{
+    [Fact]
+    public void EmitExcluded_IsNotAMetadataStage()
+    {
+        // METADATA-* is the never-swallowable family. The code path's stage is not in it, so
+        // eligibility falls to the service-tier-fallback question, exactly like EMIT-FAIL,
+        // EMIT-ZERO and COMPILE-FAIL beside it.
+        Assert.False(DependencyLoader.IsMetadataStage("EMIT-EXCLUDED"));
+        Assert.True(DependencyLoader.IsMetadataStage("METADATA-EMIT-EXCLUDED"));
+    }
+
+    [Fact]
+    public void EmitExcluded_IsNeverSwallowedWithoutAFaithfulFallback()
+    {
+        // No service-tier index at all: nothing can answer for the dropped object, so the
+        // failure must propagate to the FATAL handler rather than being deferred.
+        Assert.False(DependencyLoader.IsServiceTierFallbackEligible(
+            "EMIT-EXCLUDED",
+            serviceTierIndexAvailable: false,
+            codeunitTypeNames: new[] { "Codeunit70860", "Codeunit70861" },
+            indexContains: _ => false));
+    }
+
+    [Fact]
+    public void TheMetadataVariant_IsNeverSwallowedEvenWithAFullIndex()
+    {
+        // #3749's property, re-asserted for the new metadata stage: extracted DLLs supply
+        // procedure BODIES, so they can stand in for missing code and never for missing
+        // metadata. A complete index must not make this eligible.
+        Assert.False(DependencyLoader.IsServiceTierFallbackEligible(
+            "METADATA-EMIT-EXCLUDED",
+            serviceTierIndexAvailable: true,
+            codeunitTypeNames: new[] { "Codeunit70860" },
+            indexContains: _ => true));
+    }
+}
+
+
+/// <summary>
+/// End-to-end through the real runner, on a dependency .app that ships two codeunits of which
+/// one cannot bind. This is the test that would have caught #2247: the message tests above
+/// pin what the text says; this one pins that the text is reached at all, at DEFAULT
+/// verbosity, and that the run stops.
+///
+/// The whole fixture — the consuming bundle AND the dependency package — is built into a temp
+/// directory per run rather than checked in. Three reasons, in order of weight: `*.app` is
+/// gitignored, so a committed package needs `git add -f` and is then invisible to anyone
+/// reading the diff; the package is a binary whose AL a reviewer could not read; and building
+/// it here keeps the AL that must fail to bind, and the assertion about it, in one file.
+/// The NAVX container format is the one documented in
+/// tests/runner-extras/testpage-precompiled-dep-control/REGENERATE-FIXTURES.txt.
+///
+/// Hermetic on the compiled-deps cache: each spawn gets its own --cache root, because that
+/// cache is otherwise machine-global and keyed on the package bytes, so a warm entry would
+/// skip the entire compile path under test and hand back a false green — the same cache-HIT
+/// hazard #3476 hit on the bundle path.
+/// </summary>
+public sealed class DependencyEmitExclusionEndToEndTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private const string DepAppId = "e5a6b7c8-9d0e-4f12-8a3b-4c5d6e7f8091";
+    private const string DepName = "DEX Partial Source Dep";
+    private const string DepPublisher = "AL Runner Fixtures";
+    private const string DepVersion = "1.0.0.0";
+
+    /// <summary>The object that binds, and must NOT be reported as dropped.</summary>
+    private const string DepHealthyAl = """
+        codeunit 70860 "DEX Dep Healthy"
+        {
+            procedure Add(A: Integer; B: Integer): Integer
+            begin
+                exit(A + B);
+            end;
+        }
+        """;
+
+    /// <summary>
+    /// The object that cannot bind: it references a codeunit that exists nowhere, so BC's
+    /// atomic-per-module Emit fails and the retry loop drops exactly this file and recompiles
+    /// the survivor — leaving the PARTIAL assembly this test is about.
+    /// </summary>
+    private const string DepBrokenAl = """
+        codeunit 70861 "DEX Dep Broken"
+        {
+            procedure Triple(A: Integer): Integer
+            var
+                Missing: Codeunit "DEX This Codeunit Does Not Exist At All";
+            begin
+                exit(Missing.Whatever(A) * 3);
+            end;
+        }
+        """;
+
+    /// <summary>
+    /// The consuming bundle's test asserts nothing about the dependency, deliberately: the
+    /// silent failure being proved is that the run looks entirely healthy — this passes, the
+    /// totals are intact — while the dependency lost half its objects. A test touching the
+    /// DROPPED object would fail on its own and hide the point, and one touching the
+    /// SURVIVING object by name would need a SymbolReference.json the package deliberately
+    /// omits (its absence is what sends LoadOne down the Tier-3 source-compile path at all).
+    /// </summary>
+    private const string MainTestAl = """
+        codeunit 70870 "DEX Main Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure MainBundle_RunsGreenWhileTheDependencyIsPartial()
+            begin
+                if 1 + 2 <> 3 then
+                    Error('arithmetic must work');
+            end;
+        }
+        """;
+
+    private static string BuildFixture(string root)
+    {
+        var main = Path.Combine(root, "main");
+        var packages = Path.Combine(main, ".alpackages");
+        Directory.CreateDirectory(packages);
+
+        File.WriteAllText(Path.Combine(main, "DepEmitExclusionTests.Codeunit.al"), MainTestAl);
+        File.WriteAllText(Path.Combine(main, "app.json"), $$"""
+            {
+              "id": "f1a2b3c4-5d6e-4071-8b2c-3d4e5f607182",
+              "name": "Runner Tests Fixture - Dep Emit Exclusion",
+              "publisher": "AL Runner",
+              "version": "1.0.0.0",
+              "dependencies": [
+                { "id": "{{DepAppId}}", "name": "{{DepName}}",
+                  "publisher": "{{DepPublisher}}", "version": "{{DepVersion}}" }
+              ],
+              "idRanges": [ { "from": 70870, "to": 70879 } ],
+              "runtime": "17.0",
+              "target": "Cloud",
+              "features": []
+            }
+            """);
+
+        File.WriteAllBytes(
+            Path.Combine(packages, "AL_Runner_Fixtures_DEX_Partial_Source_Dep_1.0.0.0.app"),
+            BuildSourceOnlyApp());
+        return main;
+    }
+
+    /// <summary>
+    /// A source-only BC package: the NAVX header (magic, 40-byte header length, format
+    /// version, app id as a little-endian GUID, payload length, magic again) followed by a
+    /// zip of NavxManifest.xml + src/*.al. No SymbolReference.json and no .deps-bin, which is
+    /// what makes DependencyLoader.LoadOne reach Tier 3 and source-compile it.
+    /// </summary>
+    private static byte[] BuildSourceOnlyApp()
+    {
+        var manifest = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+              <App Id="{DepAppId}" Name="{DepName}" Publisher="{DepPublisher}" Version="{DepVersion}" ShowMyCode="true" />
+              <Dependencies />
+            </Package>
+            """;
+
+        using var zipBuffer = new MemoryStream();
+        using (var zip = new System.IO.Compression.ZipArchive(
+                   zipBuffer, System.IO.Compression.ZipArchiveMode.Create, leaveOpen: true))
+        {
+            void Add(string name, string content)
+            {
+                using var w = new StreamWriter(zip.CreateEntry(name).Open());
+                w.Write(content);
+            }
+            Add("NavxManifest.xml", manifest);
+            Add("src/DepHealthy.Codeunit.al", DepHealthyAl);
+            Add("src/DepBroken.Codeunit.al", DepBrokenAl);
+        }
+        var payload = zipBuffer.ToArray();
+
+        using var app = new MemoryStream();
+        using var w2 = new BinaryWriter(app);
+        w2.Write(System.Text.Encoding.ASCII.GetBytes("NAVX"));
+        w2.Write(40);                                   // header length
+        w2.Write(2);                                    // format version
+        w2.Write(Guid.Parse(DepAppId).ToByteArray());   // little-endian, as BC writes it
+        w2.Write((long)payload.Length);
+        w2.Write(System.Text.Encoding.ASCII.GetBytes("NAVX"));
+        w2.Write(payload);
+        w2.Flush();
+        return app.ToArray();
+    }
+
+    private static (string Output, int Exit) RunRunner(string bundlePath, string cacheDir)
+    {
+        var args = new System.Text.StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" --cache \"{cacheDir}\"");
+        args.Append($" \"{bundlePath}\"");
+        var psi = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new System.Text.StringBuilder();
+        using var p = System.Diagnostics.Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(240_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>
+    /// The proving test. Before the fix this exact run exited 0 with "1P/0F/0E across 1 tests"
+    /// and said nothing at all about the dropped object — the bundle's own test passes either
+    /// way, because a green-looking run IS the defect.
+    /// </summary>
+    [SkippableFact]
+    public void PartiallyEmittedDependency_IsLoudAtDefaultVerbosity_AndStopsTheRun()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-dex-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var bundle = BuildFixture(root);
+            var cacheDir = Path.Combine(root, "cache");
+            Directory.CreateDirectory(cacheDir);
+
+            var (output, exit) = RunRunner(bundle, cacheDir);
+
+            Assert.True(exit != 0,
+                $"a dependency that lost an object provides less than it claims, so the run "
+                + $"must NOT exit 0. exit={exit}\n{output}");
+
+            // No --verbose, and that IS the assertion: Log's component filter drops a [deps]
+            // line at default verbosity (#2750), so reporting this as [deps] would reproduce
+            // the original silence while looking like a fix.
+            Assert.Contains("EMIT-EXCLUDED", output, StringComparison.Ordinal);
+
+            // The dropped object by name — "something was excluded" is not actionable.
+            Assert.Contains("DEX Dep Broken", output, StringComparison.Ordinal);
+
+            // The denominator, which is what distinguishes a partial loss from a total one
+            // and is the whole of why EMIT-ZERO did not already cover this.
+            Assert.Contains("1 of this dependency's 2 object(s)", output, StringComparison.Ordinal);
+
+            // The cause, at default verbosity, since this failure aborts the run.
+            Assert.Contains("AL0185", output, StringComparison.Ordinal);
+
+            // Negative direction: the SURVIVING object must not be named as dropped. A guard
+            // that reports everything is as useless as one that reports nothing.
+            Assert.DoesNotContain("DEX Dep Healthy", output, StringComparison.Ordinal);
+
+            // And the partial assembly must not have been cached: the cache stores the DLL and
+            // is consulted before any of this, so a written entry would make a later run skip
+            // the compile, skip this guard, and be silently partial again — the same lever
+            // Program.cs pulls with `cachePath = null` (#3476).
+            var compiledDeps = Path.Combine(cacheDir, "compiled-deps");
+            var cachedDlls = Directory.Exists(compiledDeps)
+                ? Directory.GetFiles(compiledDeps, "*.dll")
+                : Array.Empty<string>();
+            Assert.True(cachedDlls.Length == 0,
+                "a partially-emitted dependency must not be cached; a later run would load it "
+                + "without recompiling and never reach the guard. found: "
+                + string.Join(", ", cachedDlls.Select(Path.GetFileName)));
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+}

--- a/AlRunner.Tests/ManifestFeaturesSubprocessTests.cs
+++ b/AlRunner.Tests/ManifestFeaturesSubprocessTests.cs
@@ -382,25 +382,7 @@ public sealed class ManifestFeaturesSubprocessTests : IClassFixture<SharedCliSer
         Assert.Contains("AL0129", output);
         // Must be a formatted, documented runner outcome — never the raw CLR
         // unhandled-exception path #1898 fixed for the sibling contextSensitiveHelpUrl case.
-        // This is the fact's decisive assertion (see the comment above), and it is unchanged.
         Assert.DoesNotContain("Unhandled exception", output);
-
-        // #2247 moved this from 3 to 1, deliberately. The dep's page carries AL0129/AL0135, so
-        // BC's atomic-per-module Emit fails on it and the retry loop drops the page and keeps
-        // the table. That partial recovery used to be reported only when the dep was compiled
-        // as a BUNDLE (EMIT-EXCLUDED, a compile failure, exit 3); DependencyLoader loaded the
-        // same partial result silently. It now refuses at dependency-load time, which fires
-        // strictly EARLIER — so the run ends as a dependency-load failure, and exit 1 is the
-        // documented code for every DependencyLoadException (EMIT-FAIL, EMIT-ZERO,
-        // COMPILE-FAIL all do this; Program.cs's handler states the reasoning).
-        //
-        // Verified against a hand-built copy of this fixture that the run still prints the
-        // AL0129 and AL0135 diagnostics at default verbosity and names the dropped object.
-        // The exit code is the only observable that changed.
-        Assert.Equal(1, exit);
-        // And pin the improvement rather than merely tolerating it: the reason must name the
-        // dropped object, so a reader of this failure is not left with a bare exit code.
-        Assert.Contains("EMIT-EXCLUDED", output);
-        Assert.Contains("Niw.Page", output);
+        Assert.Equal(3, exit);
     }
 }

--- a/AlRunner.Tests/ManifestFeaturesSubprocessTests.cs
+++ b/AlRunner.Tests/ManifestFeaturesSubprocessTests.cs
@@ -382,7 +382,25 @@ public sealed class ManifestFeaturesSubprocessTests : IClassFixture<SharedCliSer
         Assert.Contains("AL0129", output);
         // Must be a formatted, documented runner outcome — never the raw CLR
         // unhandled-exception path #1898 fixed for the sibling contextSensitiveHelpUrl case.
+        // This is the fact's decisive assertion (see the comment above), and it is unchanged.
         Assert.DoesNotContain("Unhandled exception", output);
-        Assert.Equal(3, exit);
+
+        // #2247 moved this from 3 to 1, deliberately. The dep's page carries AL0129/AL0135, so
+        // BC's atomic-per-module Emit fails on it and the retry loop drops the page and keeps
+        // the table. That partial recovery used to be reported only when the dep was compiled
+        // as a BUNDLE (EMIT-EXCLUDED, a compile failure, exit 3); DependencyLoader loaded the
+        // same partial result silently. It now refuses at dependency-load time, which fires
+        // strictly EARLIER — so the run ends as a dependency-load failure, and exit 1 is the
+        // documented code for every DependencyLoadException (EMIT-FAIL, EMIT-ZERO,
+        // COMPILE-FAIL all do this; Program.cs's handler states the reasoning).
+        //
+        // Verified against a hand-built copy of this fixture that the run still prints the
+        // AL0129 and AL0135 diagnostics at default verbosity and names the dropped object.
+        // The exit code is the only observable that changed.
+        Assert.Equal(1, exit);
+        // And pin the improvement rather than merely tolerating it: the reason must name the
+        // dropped object, so a reader of this failure is not left with a bare exit code.
+        Assert.Contains("EMIT-EXCLUDED", output);
+        Assert.Contains("Niw.Page", output);
     }
 }

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -69,10 +69,26 @@ public sealed record TddExcludedObjectDetail(
 /// </summary>
 /// <param name="ExcludedObjects">
 /// Objects the emit-retry loop dropped to get the rest of the module to compile. NON-EMPTY
-/// MEANS TESTS VANISHED: an excluded test codeunit contributes no results, so the run reports
-/// a smaller total and still exits 0. Measured on the al-language corpus — a stale System.app
-/// silently cost 7 tests (1904 -> 1897) with no output at any verbosity below --verbose.
-/// The caller MUST treat this as a hard failure (.claude/rules/loud-failures.md).
+/// MEANS THE MODULE IS INCOMPLETE: an excluded test codeunit contributes no results, so the
+/// run reports a smaller total and still exits 0. Measured on the al-language corpus — a stale
+/// System.app silently cost 7 tests (1904 -> 1897) with no output at any verbosity below
+/// --verbose.
+///
+/// <para>EVERY caller MUST inspect this and say something; none may ignore it
+/// (.claude/rules/loud-failures.md). What they may then do differs by what the loss costs,
+/// and all four live callers discriminate rather than sharing one verdict:</para>
+/// <list type="bullet">
+/// <item>Program.cs (bundle) — four-way: all-profiles and every-drop-safe continue, --tdd
+/// reports synthetic failures, anything else fails the run.</item>
+/// <item>SiblingCompile.cs (--precompile) — fails, via its AL-DIAGNOSTIC-FAIL guard.</item>
+/// <item>DependencyLoader.LoadOne — REPORTS and continues (#2247): a dropped dependency object
+/// has a runtime backstop the bundle case lacks, and refusing aborts whole suites over an
+/// object that is unavailable headless by construction.</item>
+/// <item>DependencyMetadataProducer.Ensure — throws, because a partial document set would be
+/// CACHED and replayed silently forever.</item>
+/// </list>
+/// <para>Trap: a caller that also caches its output has to make the report survive a cache
+/// HIT, or it is loud exactly once and silent on every later run (#2247).</para>
 /// </param>
 public sealed record BcEmitOutput(
     IReadOnlyList<EmittedSource> Sources,

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -909,19 +909,6 @@ public sealed class DependencyLoader
     }
 
     /// <summary>
-    /// Replay this dependency's Tier-3 source-compile-cache metadata sidecars (report,
-    /// report-layout, page, xmlport, enum) into the process-wide registries. Called from
-    /// the <c>LoadAll</c> cache-hit fast path (see its call site for the full "why"), ONLY
-    /// when the reused <see cref="LoadedAppEntry"/> carries a non-null
-    /// <c>Tier3CacheKey</c> — that gate is the caller's job (it also decides "is there
-    /// anything to do at all"), so this method trusts <paramref name="cacheKey"/> rather
-    /// than re-deriving or re-checking it. This keeps a dependency's metadata answering
-    /// after every <c>BcRuntime.ResetForNewBundleReload()</c>, not just the first time this
-    /// AppId is resolved in the process — WITHOUT re-hashing the .app file on every reuse
-    /// (see <see cref="LoadedAppEntry"/>'s own header comment on Tier3CacheKey for the cost
-    /// that would otherwise be paid every single cycle).
-    /// </summary>
-    /// <summary>
     /// Re-report a cached emit exclusion (#2247). The report is a property of the compiled
     /// artifact, so it has to survive a cache HIT the same way the metadata sidecars do:
     /// otherwise a partial dependency is loud exactly once, on the run that compiled it, and
@@ -947,6 +934,19 @@ public sealed class DependencyLoader
         }
     }
 
+    /// <summary>
+    /// Replay this dependency's Tier-3 source-compile-cache metadata sidecars (report,
+    /// report-layout, page, xmlport, enum) into the process-wide registries. Called from
+    /// the <c>LoadAll</c> cache-hit fast path (see its call site for the full "why"), ONLY
+    /// when the reused <see cref="LoadedAppEntry"/> carries a non-null
+    /// <c>Tier3CacheKey</c> — that gate is the caller's job (it also decides "is there
+    /// anything to do at all"), so this method trusts <paramref name="cacheKey"/> rather
+    /// than re-deriving or re-checking it. This keeps a dependency's metadata answering
+    /// after every <c>BcRuntime.ResetForNewBundleReload()</c>, not just the first time this
+    /// AppId is resolved in the process — WITHOUT re-hashing the .app file on every reuse
+    /// (see <see cref="LoadedAppEntry"/>'s own header comment on Tier3CacheKey for the cost
+    /// that would otherwise be paid every single cycle).
+    /// </summary>
     private void ReplayDependencyMetadataSidecars(AppManifest m, string cacheKey)
     {
         var cacheDir = AlRunner.Infrastructure.CacheRoots.Resolve("compiled-deps");

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -749,28 +749,38 @@ public sealed class DependencyLoader
         // whatever was dropped. Program.cs has treated this as a hard failure on the bundle
         // path since #1991; this path called the same Emit and read only `.Sources`.
         //
-        // Failing rather than warning is not a free choice between two defensible options:
-        // EMIT-ZERO above already aborts the run when ALL objects are lost, so tolerating a
-        // partial load would make losing 9 of 10 objects survivable and losing 10 of 10
-        // fatal — a discontinuity with no mechanism behind it. The one case where silence
-        // IS faithful (a Microsoft platform app whose bodies really live in the extracted
-        // service-tier DLLs) is already handled, for every stage, by LoadAll's
-        // IsServiceTierFallbackEligible catch — which this throw routes through unchanged,
-        // because "EMIT-EXCLUDED" is not a METADATA-* stage.
+        // It REPORTS and continues; it does not fail the run. That is a deliberate difference
+        // from the bundle path, and the reason is what a dropped object costs on each. A
+        // bundle's dropped test codeunit removes TESTS: nothing ever asks for them again, the
+        // total silently shrinks, and only the run itself can notice. A dependency's dropped
+        // object has a loud runtime backstop — the first AL that touches it dies with
+        // NavNCLMissingMethodException — so the failure mode #2247 is written against is
+        // "nobody could tell", not "nothing stopped it".
+        //
+        // Refusing outright was measured and is wrong: it aborts the entire runner-extras
+        // suite before a single test runs, because Microsoft's Tests-TestLibraries drops
+        // "Library - Azure KV Mock Mgmt." (1 of 203 objects) on AL0185 "DotNet
+        // 'MockAzureKeyVaultSecretProvider' is missing" — a permanent property of running
+        // headless, not a broken build. ExcludedObjectTriage does not rescue that case
+        // either: it is a codeunit without Subtype = Test, so the triage correctly refuses to
+        // clear it. This is the same over-refusal #3476 removed from the bundle path, where
+        // it had been costing Tests-Misc all 3,215 of its tests.
         if (emitOutput.ExcludedObjects.Count > 0)
         {
             var detail = BuildDependencyEmitExcludedDetail(
                 emitOutput.ExcludedObjects, emitted.Count,
                 emitOutput.ExcludedObjectDiagnostics ?? Array.Empty<string>());
-            // Untagged on purpose. `[deps]` is dropped by Log's component filter at default
+            // Reported, not merely printed: on a long run the discovery line scrolls thousands
+            // of lines above the summary the caller actually reads (#2587), and this one has to
+            // survive to the end because the run CONTINUES past it. ProvisionGapLog writes to
+            // stderr itself, so this is one call, not two.
+            //
+            // Deliberately not a `[deps]` line: Log's component filter drops those at default
             // verbosity (#2750, CorruptSidecarLoudnessTests) — the same filter that made the
-            // original silence possible, and writing this line as `[deps] …` would reproduce
-            // the defect while looking like a fix. `[dep-load-fail]` is the exempt tag its
-            // three sibling failures on this path already use.
-            Console.Error.WriteLine(
-                $"[dep-load-fail] {m.Publisher}_{m.Name} v{m.Version}: EMIT-EXCLUDED — {detail}");
-            throw new DependencyLoadException(
-                m.Publisher, m.Name, m.Version.ToString(), "EMIT-EXCLUDED", detail);
+            // original silence possible, so tagging it `[deps]` would reproduce the defect
+            // while looking like a fix.
+            AlRunner.Infrastructure.ProvisionGapLog.Report(
+                $"{m.Publisher}_{m.Name} v{m.Version}: EMIT-EXCLUDED — {detail}");
         }
 
         var asmName = $"Dep_{SanitizeIdent(m.Publisher)}_{SanitizeIdent(m.Name)}_{m.Version.ToString().Replace('.', '_')}";

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -705,7 +705,7 @@ public sealed class DependencyLoader
             catch (Exception ex) { Console.Error.WriteLine($"[deps] layout stage failed for {layoutName}: {ex.Message}"); }
         }
 
-        IReadOnlyList<EmittedSource> emitted;
+        BcEmitOutput emitOutput;
         // Snapshot the report-metadata registry before this dep's emit so we can
         // persist exactly the entries THIS app contributed to its own sidecar.
         var reportIdsBeforeEmit = new HashSet<int>(AlReportMetadataRegistry.Ids);
@@ -719,7 +719,7 @@ public sealed class DependencyLoader
         // the PARENT bundle) would be both in the reference list AND in the primary AL
         // source → AL0275 "ambiguous reference". The scope is restored on dispose.
         try { using (BcCompiler.ScopeCurrentAppIdentity(m.AppId, m.Publisher, m.Version))
-                  emitted = _compiler.Emit(new[] { tempDir }, m.Name, tempDir).Sources; }
+                  emitOutput = _compiler.Emit(new[] { tempDir }, m.Name, tempDir); }
         catch (Exception ex)
         {
             // EMIT-FAIL: the BC Compilation.Emit() call threw (e.g. "Unexpected value 'None'
@@ -730,6 +730,7 @@ public sealed class DependencyLoader
             Console.Error.WriteLine($"[dep-load-fail] {m.Publisher}_{m.Name} v{m.Version}: EMIT-FAIL — {detail}");
             throw new DependencyLoadException(m.Publisher, m.Name, m.Version.ToString(), "EMIT-FAIL", detail, ex);
         }
+        var emitted = emitOutput.Sources;
         if (emitted.Count == 0)
         {
             // EMIT-ZERO: Emit returned success but produced no sources — BC's silent
@@ -740,6 +741,36 @@ public sealed class DependencyLoader
                 "Run with BCCOMPILER_DIAG=1 or --precompile for full diagnostics.";
             Console.Error.WriteLine($"[dep-load-fail] {m.Publisher}_{m.Name} v{m.Version}: EMIT-ZERO — {detail}");
             throw new DependencyLoadException(m.Publisher, m.Name, m.Version.ToString(), "EMIT-ZERO", detail);
+        }
+        // EMIT-EXCLUDED (#2247): the PARTIAL case of the EMIT-ZERO check directly above.
+        // BcCompiler's emit-retry loop drops an object that cannot bind and recompiles the
+        // survivors, so `Sources` is non-empty and every check on this path passes — while
+        // the assembly about to be loaded, cached and handed to dependent AL is missing
+        // whatever was dropped. Program.cs has treated this as a hard failure on the bundle
+        // path since #1991; this path called the same Emit and read only `.Sources`.
+        //
+        // Failing rather than warning is not a free choice between two defensible options:
+        // EMIT-ZERO above already aborts the run when ALL objects are lost, so tolerating a
+        // partial load would make losing 9 of 10 objects survivable and losing 10 of 10
+        // fatal — a discontinuity with no mechanism behind it. The one case where silence
+        // IS faithful (a Microsoft platform app whose bodies really live in the extracted
+        // service-tier DLLs) is already handled, for every stage, by LoadAll's
+        // IsServiceTierFallbackEligible catch — which this throw routes through unchanged,
+        // because "EMIT-EXCLUDED" is not a METADATA-* stage.
+        if (emitOutput.ExcludedObjects.Count > 0)
+        {
+            var detail = BuildDependencyEmitExcludedDetail(
+                emitOutput.ExcludedObjects, emitted.Count,
+                emitOutput.ExcludedObjectDiagnostics ?? Array.Empty<string>());
+            // Untagged on purpose. `[deps]` is dropped by Log's component filter at default
+            // verbosity (#2750, CorruptSidecarLoudnessTests) — the same filter that made the
+            // original silence possible, and writing this line as `[deps] …` would reproduce
+            // the defect while looking like a fix. `[dep-load-fail]` is the exempt tag its
+            // three sibling failures on this path already use.
+            Console.Error.WriteLine(
+                $"[dep-load-fail] {m.Publisher}_{m.Name} v{m.Version}: EMIT-EXCLUDED — {detail}");
+            throw new DependencyLoadException(
+                m.Publisher, m.Name, m.Version.ToString(), "EMIT-EXCLUDED", detail);
         }
 
         var asmName = $"Dep_{SanitizeIdent(m.Publisher)}_{SanitizeIdent(m.Name)}_{m.Version.ToString().Replace('.', '_')}";
@@ -1050,6 +1081,38 @@ public sealed class DependencyLoader
         Func<string, bool> indexContains)
         => !IsMetadataStage(stage)
            && HasFaithfulServiceTierFallback(serviceTierIndexAvailable, codeunitTypeNames, indexContains);
+
+    /// <summary>
+    /// The EMIT-EXCLUDED detail text (#2247). Split out so the message contract can be
+    /// asserted directly, without a runner subprocess and without a dependency whose AL
+    /// happens to fail to bind on the BC version the test runs against.
+    ///
+    /// It has to state three things, because a reader who sees only "some objects were
+    /// excluded" still has to go looking: WHICH objects were dropped, HOW MANY of the
+    /// dependency's objects survived (so the loss has a denominator — the shape #3875
+    /// measured as 55 of 70), and WHY each one was dropped, which is the AL diagnostic.
+    /// The diagnostics are inlined rather than put behind --verbose: this aborts the run,
+    /// so they are the only account of the cause, the same choice the EMIT-ZERO path and
+    /// Program.cs's non-profile EMIT-EXCLUDED branch make (#2949).
+    /// </summary>
+    internal static string BuildDependencyEmitExcludedDetail(
+        IReadOnlyList<string> excludedObjects,
+        int emittedCount,
+        IReadOnlyList<string> excludedDiagnostics)
+    {
+        var names = string.Join(", ", excludedObjects);
+        var total = emittedCount + excludedObjects.Count;
+        var sb = new System.Text.StringBuilder();
+        sb.Append($"{excludedObjects.Count} of this dependency's {total} object(s) could not be ")
+          .Append($"compiled and were dropped, so the loaded assembly provides only {emittedCount} ")
+          .Append($"of them: [{names}]. Dependent AL that touches a dropped object fails later ")
+          .Append("with a cryptic NavNCLMissingMethodException, and a test that only touches the ")
+          .Append("survivors passes while covering less than it claims.");
+        if (excludedDiagnostics.Count > 0)
+            sb.Append(" AL diagnostics that identified the dropped object(s): ")
+              .Append(string.Join(" | ", excludedDiagnostics));
+        return sb.ToString();
+    }
 
     /// <summary>
     /// True for the stages <see cref="DependencyMetadataProducer"/> raises. Matched on the

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -640,6 +640,9 @@ public sealed class DependencyLoader
         // dep emitted, keyed by (kind, id). Same cache-HIT hazard as the four sidecars
         // above, and the same shape of fix.
         var objectMetadataSidecar = Path.Combine(cacheDir, cacheKey + ".object-metadata.json");
+        // #2247: the emit-exclusion report, cached like the six above because a HIT skips
+        // the compile that would otherwise produce it.
+        var emitExcludedSidecar = Path.Combine(cacheDir, cacheKey + ".emit-excluded.txt");
         if (File.Exists(cachedDll))
         {
             try
@@ -663,6 +666,11 @@ public sealed class DependencyLoader
                     replayedEnums = AlEnumMetadataRegistry.LoadSidecar(enumRegistrySidecar);
                 Console.Error.WriteLine(
                     $"[deps] source-cache HIT: {m.Name} v{m.Version} key={cacheKey[..12]} ({cachedBytes.Length} bytes, {replayedReports} report-metadata entries, {replayedEnums} enum-registry entries)");
+                // #2247: replay the exclusion report too. This return is 80 lines above the
+                // EMIT-EXCLUDED guard, so without this a warm run of a partially-emitted
+                // dependency says nothing at all — exactly the pre-fix silence, and invisible to
+                // CI, which provisions a fresh cache on every leg.
+                ReplayEmitExcludedSidecar(emitExcludedSidecar);
                 return (Assembly.Load(cachedBytes), cacheKey, EmptyAssemblies);
             }
             catch (Exception ex)
@@ -706,6 +714,9 @@ public sealed class DependencyLoader
         }
 
         BcEmitOutput emitOutput;
+        // Non-null once an exclusion has been reported, so it can be cached beside the DLL
+        // and replayed on a later HIT (#2247 — see PublishSourceDependencyCache).
+        string? emitExcludedReport = null;
         // Snapshot the report-metadata registry before this dep's emit so we can
         // persist exactly the entries THIS app contributed to its own sidecar.
         var reportIdsBeforeEmit = new HashSet<int>(AlReportMetadataRegistry.Ids);
@@ -742,29 +753,22 @@ public sealed class DependencyLoader
             Console.Error.WriteLine($"[dep-load-fail] {m.Publisher}_{m.Name} v{m.Version}: EMIT-ZERO — {detail}");
             throw new DependencyLoadException(m.Publisher, m.Name, m.Version.ToString(), "EMIT-ZERO", detail);
         }
-        // EMIT-EXCLUDED (#2247): the PARTIAL case of the EMIT-ZERO check directly above.
-        // BcCompiler's emit-retry loop drops an object that cannot bind and recompiles the
-        // survivors, so `Sources` is non-empty and every check on this path passes — while
-        // the assembly about to be loaded, cached and handed to dependent AL is missing
-        // whatever was dropped. Program.cs has treated this as a hard failure on the bundle
-        // path since #1991; this path called the same Emit and read only `.Sources`.
+        // EMIT-EXCLUDED (#2247): the PARTIAL case of EMIT-ZERO above. The retry loop drops an
+        // object that cannot bind and recompiles the survivors, so `Sources` is non-empty and
+        // every check here passed, while the assembly being loaded and cached was missing it.
         //
-        // It REPORTS and continues; it does not fail the run. That is a deliberate difference
-        // from the bundle path, and the reason is what a dropped object costs on each. A
-        // bundle's dropped test codeunit removes TESTS: nothing ever asks for them again, the
-        // total silently shrinks, and only the run itself can notice. A dependency's dropped
-        // object has a loud runtime backstop — the first AL that touches it dies with
-        // NavNCLMissingMethodException — so the failure mode #2247 is written against is
-        // "nobody could tell", not "nothing stopped it".
+        // REPORTS and continues, unlike the bundle path (Program.cs) and unlike the metadata
+        // path (DependencyMetadataProducer, which throws because its output is cached and
+        // replayed). A dependency's dropped object has a runtime backstop those lack — the
+        // first AL that touches it dies with NavNCLMissingMethodException — so what #2247 is
+        // written against here is "nobody could tell", not "nothing stopped it". Refusing was
+        // measured and aborts the whole runner-extras suite over Tests-TestLibraries dropping
+        // 1 of 203 objects on a DotNet type unavailable headless; ExcludedObjectTriage does not
+        // clear that one either. Same over-refusal #3476 removed from the bundle path.
         //
-        // Refusing outright was measured and is wrong: it aborts the entire runner-extras
-        // suite before a single test runs, because Microsoft's Tests-TestLibraries drops
-        // "Library - Azure KV Mock Mgmt." (1 of 203 objects) on AL0185 "DotNet
-        // 'MockAzureKeyVaultSecretProvider' is missing" — a permanent property of running
-        // headless, not a broken build. ExcludedObjectTriage does not rescue that case
-        // either: it is a codeunit without Subtype = Test, so the triage correctly refuses to
-        // clear it. This is the same over-refusal #3476 removed from the bundle path, where
-        // it had been costing Tests-Misc all 3,215 of its tests.
+        // Trap: the report is CACHED (see PublishSourceDependencyCache) and replayed on a HIT.
+        // Without that it fires only on the run that compiled, and a warm run of a partial
+        // dependency is the pre-fix silence — which CI cannot see, provisioning fresh per leg.
         if (emitOutput.ExcludedObjects.Count > 0)
         {
             var detail = BuildDependencyEmitExcludedDetail(
@@ -779,8 +783,8 @@ public sealed class DependencyLoader
             // verbosity (#2750, CorruptSidecarLoudnessTests) — the same filter that made the
             // original silence possible, so tagging it `[deps]` would reproduce the defect
             // while looking like a fix.
-            AlRunner.Infrastructure.ProvisionGapLog.Report(
-                $"{m.Publisher}_{m.Name} v{m.Version}: EMIT-EXCLUDED — {detail}");
+            emitExcludedReport = $"{m.Publisher}_{m.Name} v{m.Version}: EMIT-EXCLUDED — {detail}";
+            AlRunner.Infrastructure.ProvisionGapLog.Report(emitExcludedReport);
         }
 
         var asmName = $"Dep_{SanitizeIdent(m.Publisher)}_{SanitizeIdent(m.Name)}_{m.Version.ToString().Replace('.', '_')}";
@@ -813,7 +817,8 @@ public sealed class DependencyLoader
                 enumRegistrySidecar,
                 AlEnumMetadataRegistry.Ids.Where(i => !enumIdsBeforeEmit.Contains(i)),
                 objectMetadataSidecar,
-                AlObjectMetadataRegistry.Keys.Where(k => !objectKeysBeforeEmit.Contains(k)).ToArray());
+                AlObjectMetadataRegistry.Keys.Where(k => !objectKeysBeforeEmit.Contains(k)).ToArray(),
+                emitExcludedSidecar: emitExcludedSidecar, emitExcludedReport: emitExcludedReport);
             Console.Error.WriteLine(
                 $"[deps] source-cache WROTE: {m.Name} v{m.Version} key={cacheKey[..12]} ({compile.AssemblyBytes!.Length} bytes, {sidecarCount} report-metadata entries, {enumSidecarCount} enum-registry entries)");
         }
@@ -873,8 +878,19 @@ public sealed class DependencyLoader
         string xmlPortMetadataSidecar, int[] ownXmlPortIds,
         string enumRegistrySidecar, IEnumerable<int> ownEnumIds,
         string objectMetadataSidecar, IEnumerable<string> ownObjectKeys,
-        Action? onSidecarsPublishedBeforeDll = null)
+        Action? onSidecarsPublishedBeforeDll = null,
+        string? emitExcludedSidecar = null, string? emitExcludedReport = null)
     {
+        // #2247: the emit-exclusion report is cached like every other per-dependency fact,
+        // because the DLL beside it is. A HIT returns before the compile, so without this the
+        // report fires on the first run and never again — and a warm run of a partial
+        // dependency is byte-for-byte the pre-fix silence. Measured on a 2-object package
+        // against one cache root: run 1 printed 2 EMIT-EXCLUDED lines and 1 provisioning gap,
+        // runs 2 and 3 printed neither, while the cached sidecar held 1 object of 2.
+        // Published FIRST so it lands before the DLL, which is the file the read side gates on.
+        if (emitExcludedSidecar != null && emitExcludedReport != null)
+            AlCacheWriter.AtomicPublish(emitExcludedSidecar,
+                tmp => File.WriteAllText(tmp, emitExcludedReport));
         int sidecarCount = AlCacheWriter.AtomicPublish(reportSidecar,
             tmp => AlReportMetadataRegistry.SaveSidecar(tmp, ownReportIds));
         AlCacheWriter.AtomicPublish(reportLayoutSidecar,
@@ -905,9 +921,37 @@ public sealed class DependencyLoader
     /// (see <see cref="LoadedAppEntry"/>'s own header comment on Tier3CacheKey for the cost
     /// that would otherwise be paid every single cycle).
     /// </summary>
+    /// <summary>
+    /// Re-report a cached emit exclusion (#2247). The report is a property of the compiled
+    /// artifact, so it has to survive a cache HIT the same way the metadata sidecars do:
+    /// otherwise a partial dependency is loud exactly once, on the run that compiled it, and
+    /// silent on every run afterwards. Absent file = nothing was excluded, which is the
+    /// ordinary case and stays silent (guards-need-a-third-state.md: the genuinely-absent
+    /// thing is a pass). An unreadable one says so rather than being swallowed.
+    /// </summary>
+    private static void ReplayEmitExcludedSidecar(string emitExcludedSidecar)
+    {
+        if (!File.Exists(emitExcludedSidecar)) return;
+        try
+        {
+            var report = File.ReadAllText(emitExcludedSidecar).Trim();
+            if (report.Length > 0)
+                AlRunner.Infrastructure.ProvisionGapLog.Report(report + " (from a cached compile)");
+        }
+        catch (Exception ex)
+        {
+            AlRunner.Infrastructure.ProvisionGapLog.Report(
+                $"an emit-exclusion record for this dependency exists at {emitExcludedSidecar} but "
+                + $"could not be read ({ex.GetType().Name}: {ex.Message}), so this run cannot say "
+                + "which objects were dropped from it.");
+        }
+    }
+
     private void ReplayDependencyMetadataSidecars(AppManifest m, string cacheKey)
     {
         var cacheDir = AlRunner.Infrastructure.CacheRoots.Resolve("compiled-deps");
+        // #2247: the reused-module path is a cache HIT too — same reasoning as LoadOne's.
+        ReplayEmitExcludedSidecar(Path.Combine(cacheDir, cacheKey + ".emit-excluded.txt"));
         var reportSidecar = Path.Combine(cacheDir, cacheKey + ".report-metadata.json");
         var reportLayoutSidecar = Path.Combine(cacheDir, cacheKey + ".report-layouts.json");
         var pageMetadataSidecar = Path.Combine(cacheDir, cacheKey + ".page-metadata.json");

--- a/AlRunner/DependencyMetadataProducer.cs
+++ b/AlRunner/DependencyMetadataProducer.cs
@@ -191,10 +191,11 @@ internal static class DependencyMetadataProducer
             WriteSynthesizedAppJson(work, m, appPath);
 
             var sw = System.Diagnostics.Stopwatch.StartNew();
+            BcEmitOutput emitOutput;
             try
             {
                 using (BcCompiler.ScopeCurrentAppIdentity(m.AppId, m.Publisher, m.Version))
-                    compiler.Emit(new[] { work }, m.Name, work);
+                    emitOutput = compiler.Emit(new[] { work }, m.Name, work);
             }
             catch (Exception ex)
             {
@@ -203,6 +204,29 @@ internal static class DependencyMetadataProducer
 
             var produced = AlObjectMetadataRegistry.Keys
                 .Where(k => !keysBefore.Contains(k)).ToArray();
+
+            // #2247, the partial case of METADATA-EMIT-ZERO below. This method cannot see a
+            // shortfall by counting: it knows how many documents appeared, never how many BC
+            // should have produced, so 55 of 70 and 70 of 70 are the same observation from
+            // here — which is what #3875 measured on Business Foundation, reported as success
+            // with zero AL0185 lines at default verbosity. The emit-retry loop's exclusion
+            // list IS that missing denominator, and until this call kept the BcEmitOutput it
+            // was discarded at the call site.
+            //
+            // Caching is what makes silence permanent rather than merely quiet: Persist below
+            // writes a sidecar every later run replays without recompiling, so a partial
+            // document set would be recorded as this app's complete metadata and every table
+            // it did not cover would stay on the hand-derivation with nothing saying why —
+            // the same reasoning METADATA-EMIT-ZERO's own comment gives for throwing.
+            if (emitOutput.ExcludedObjects.Count > 0)
+                throw Loud(m, "METADATA-EMIT-EXCLUDED",
+                    DependencyLoader.BuildDependencyEmitExcludedDetail(
+                        emitOutput.ExcludedObjects, emitOutput.Sources.Count,
+                        emitOutput.ExcludedObjectDiagnostics ?? Array.Empty<string>())
+                    + $" {produced.Length} metadata document(s) were produced; caching them"
+                    + " would record that as the app's complete metadata, leaving every"
+                    + " uncovered table on the hand-derivation.",
+                    null);
 
             // The Base Application shape, and the reason this is a throw rather than an empty
             // cache entry: BC's emitter can return success having produced nothing at all when


### PR DESCRIPTION
Closes #2247

Filed by the agent loop `stma-auto-12`.

`DependencyLoader.LoadOne` called the same `BcCompiler.Emit` the bundled path calls and read
only `.Sources`, so an emit-retry exclusion — BC's atomic-per-module `Emit` failing on one
object and the retry loop recovering the rest — produced a **partial assembly that was loaded,
cached, and reported as a clean success**, at every verbosity. This path never inspected
`ExcludedObjects` at all.

## What the RED → GREEN proved

A generated fixture: a dependency `.app` shipping **two** codeunits, one of which references a
codeunit that exists nowhere, so exactly one is dropped and one survives. The consuming bundle's
own test asserts nothing about the dependency, deliberately — a green-looking run *is* the
defect, and a test touching the dropped object would fail on its own and hide it.

BC 28.1.49838.54308, `compiled-deps` cache cleared first:

| | run summary | mentions of the drop at default verbosity |
|---|---|---|
| **RED** (before) | `1P/0F/0E across 1 tests`, exit 0 | **0** — `grep -c` for `EMIT-EXCLUDED`, `DEX Dep Broken`, `70861` and `AL0185` over the whole log |
| **GREEN** (after) | same tests still pass | the drop stated at discovery **and** in the summary under `Provisioning gaps: 1`, naming the object, the 1-of-2 denominator and the AL0185 |

**The RED drop was confirmed a second, differently-shaped way** rather than from the absence of
a log line (`verify-execution-not-the-tick.md`): off disk, from the cache the run wrote. The
cached dependency DLL contained `Codeunit70860` and **not** `Codeunit70861`, and its
`.object-metadata.json` sidecar listed `objects=1` where the package shipped 2.

## It reports and continues — it does not fail the run

The issue asks for this to be argued either way. **My first version failed the run, and that was
wrong.** It aborted the entire `runner-extras` suite before a single test executed, because
Microsoft's `Tests-TestLibraries` drops `Library - Azure KV Mock Mgmt.` — **1 of 203 objects** —
on `AL0185 "DotNet 'MockAzureKeyVaultSecretProvider' is missing"`. That is a permanent property
of running headless, not a broken build.

`ExcludedObjectTriage` does not rescue that case either: it is a codeunit *without*
`Subtype = Test`, so the triage correctly declines to clear it. I tried reusing it and measured
that it would not have helped.

This is the same over-refusal **#3476** removed from the bundle path, where it had been costing
Tests-Misc all 3,215 of its tests. So the guard reports through `ProvisionGapLog` — loud at the
point of discovery *and* repeated in the run summary, because the run continues and on a real
run the discovery line scrolls thousands of lines above the part anyone reads (#2587) — and
carries on.

**The asymmetry with the metadata path is deliberate**, and stated at the line: a dependency's
dropped object has a loud runtime backstop (`NavNCLMissingMethodException` on first touch), so
the failure mode #2247 is written against is *"nobody could tell"*, not *"nothing stopped it"*.
A cached partial **metadata** sidecar has no such backstop — every later run replays it without
recompiling — so that one throws.

**Correcting a claim in the earlier draft of this body:** this is *not* "parity with
`Program.cs`". `Program.cs` is a four-way discrimination that tolerates a partial emit in three
of its four branches (all-profiles, every-drop-safe, `--tdd`). The dependency path is its own
third answer — louder than silence, weaker than a refusal — and that is the argument, not parity.

Two details that are load-bearing and easy to get wrong:

- **The message is not a `[deps]` line.** Log's component filter drops those at default
  verbosity (#2750, `CorruptSidecarLoudnessTests`) — the same filter that made the original
  silence possible. Tagging it `[deps]` would reproduce the defect while looking like a fix.
- **`ProvisionGapLog.Report`, not a bare `Console.Error.WriteLine`** — it writes to stderr *and*
  records for the summary. Asserted directly (`Provisioning gaps:`).

## The report had to survive a cache HIT (second review round)

The first version of this fix reported on the **compiling run only**. `LoadOne`'s
`source-cache HIT` returns at line 666; the guard is at line 745 — so a second run against the
same cache root never reached it, and a warm run of a partial dependency was byte-for-byte the
pre-fix silence. The code's own comment at 674-677 states the mechanism: *"the real cache is
`cachedDll` above, which returns before this point on a hit."*

Measured with the cache root as the only variable, on the 2-object package:

| | run 1 | runs 2 and 3 |
|---|---|---|
| **before** | 2 `EMIT-EXCLUDED` lines, 1 provisioning gap | **0 and 0** — while the cached `.object-metadata.json` held **1 object of 2** |
| **after** | 2 lines, 1 gap | 2 lines, 1 gap |

**CI could never have caught this**: it provisions a fresh cache on every leg, so the legs stay
green forever while every repeat local run is silently partial — the "green tick over something
nobody measured" shape.

The fix publishes the report as a **seventh sidecar** beside the six that already exist, and
replays it on **both** HIT paths (`LoadOne`'s, and the reused-module path in
`ReplayDependencyMetadataSidecars`). An absent sidecar stays silent — nothing was excluded is
the ordinary case and a legitimate pass — while an unreadable one says so rather than being
swallowed (`guards-need-a-third-state.md`).

**The warm test needed a signal that a cold run cannot fake.** `[deps] source-cache HIT` is
swallowed by Log's component filter at default verbosity, so it cannot serve; the replay path
appends `(from a cached compile)` and the test asserts on that, plus a positive control that
run 1 does *not* carry it. Otherwise "the second run reported" would also be satisfied by a
second cold compile.

## Both guards are proven by mutation

The second guard shipped unproven in the first draft; the review caught it. Both now drive their
tests:

| guard mutated out | result | the failure |
|---|---|---|
| `LoadOne` EMIT-EXCLUDED | `Failed: 1, Passed: 8` | `Assert.Contains() ... Not found: "EMIT-EXCLUDED"` — the silence itself |
| `DependencyMetadataProducer` METADATA-EMIT-EXCLUDED | `Failed: 1, Passed: 8` | `Assert.Throws() Failure: No exception was thrown` |
| the HIT-path replay (`ReplayEmitExcludedSidecar`) | `Failed: 1, Passed: 9` | `Not found: "EMIT-EXCLUDED"` — in the **second** run's output |
| all restored | `Failed: 0, Passed: 10` | — |

**A finding from proving the second one.** The test first used a constant app id, and the
metadata sidecar is keyed on it in a machine-global cache — so the *mutated* run cached **1
document for a 2-object package**, and the restored build then read that entry back and returned
before compiling, leaving the test red with the guard present. That is exactly the poisoning the
guard exists to prevent, reproduced by accident while proving it. The test now uses a fresh app
id per run, and the incident is recorded in its comment.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site?** **Yes, one — fixed here.**
   `DependencyMetadataProducer.Ensure` discarded the `BcEmitOutput` entirely
   (`compiler.Emit(...)` with no assignment) and checked only `produced.Length == 0`, the
   *total* case. That is the path #3875 measured: Business Foundation produced **55 documents
   instead of 70**, reported as success with zero `AL0185` lines. As that issue's agent
   established, the method cannot see the shortfall by counting — it knows how many documents
   appeared, never how many BC should have produced — and the exclusion list is precisely the
   missing denominator. #3875 stays open and is unaffected: PR #3877 removes one *cause* of a
   partial compile there; this makes a partial compile *loud*, whatever the cause.
2. **Sibling function making the same assumption?** **Checked, none.**
   `ProgramSupport/SiblingCompile.cs` (`--precompile`) reads the full `BcEmitOutput` and its
   `AL-DIAGNOSTIC-FAIL` guard on `emitOut.Diagnostics.Count > 0` already covers the exclusion
   case, since an exclusion always carries the diagnostics that identified it. I enumerated
   every `BcCompiler.Emit` call site in `AlRunner/**`; the four are `Program.cs`,
   `SiblingCompile.cs` and the two touched here.
3. **Two paths writing the same state with different invariants?** **Yes — items 1 and 2.** All
   four `Emit` call sites now discriminate "everything emitted" from "some objects were
   excluded"; before this, two did and two did not.

**Same-defect queue scan** (`search-for-the-same-defect-first.md`), on the symbol
(`DependencyMetadataProducer`, `ExcludedObjects`), the stage name (`EMIT-EXCLUDED`), the
mechanism (`partial compile`) and the observable (`silently drops objects`): the only related
open issues are **#3875** (distinct — a resolver cause, not the loudness) and
**#3876/#3562/#3530**, which are about metadata coverage rather than partial-compile reporting.
No duplicate, and nothing else folds.

## No existing test's expectation was changed

An earlier revision of this PR moved `SourceDependency_ManifestOmitsFeatures_StillFailsAL0129AL0135`
from `exit 3` to `exit 1`. **That is reverted**; the file is now byte-identical to `origin/main`.
Once the dependency path reports rather than throws, the dep bundle's own compile reaches the
bundle-level `EMIT-EXCLUDED` exactly as before, and 3 is right again. Re-measured on a
hand-built copy of that fixture: exit 3, `AL0129` ×4, `AL0135` ×3, no `Unhandled exception`.

(For the record, since it sat in a review thread: the `Expected: 3, Actual: 1` in that failure
was the **process exit code**, not a diagnostic count. No diagnostics were ever truncated.)

## Two smaller items from review

- **`BcEmitOutput`'s doc** still said *"The caller MUST treat this as a hard failure"* — stale
  now that four callers discriminate three ways, and a later reader following it would undo this
  change. It now states what each caller does and why, plus the caching trap.
- **The `LoadOne` justification block** is 23 → 16 lines per `loud-failures.md` (claim, citation,
  trap). The derivation it carried — the 3,215-test figure, the #3476 history — is in this body.

## Tests and where they live

Nothing here asserts anything about **BC's** behavior, so nothing is owed upstream: a real
service tier has no emit-retry exclusion loop to observe — the loop exists only because this
runner works around BC's atomic-per-module `Emit`. The claim is entirely about the runner's
reporting of its own compile recovery. `check_corpus_linkage.sh` agrees on the diff: *"No file
in this diff can change what AL observes."*

The fixture — bundle **and** dependency package — is generated into a `TestScratch`-owned temp
directory per run rather than checked in: `*.app` is gitignored so a committed package needs
`git add -f` and is then invisible in the diff, it is a binary whose AL no reviewer could read,
and generating it keeps the AL that must fail to bind next to the assertion about it.

## Numbers

All quoted from the **second** run after each build, exit codes read directly from `$?` on
unpiped commands with output redirected to a file (`ci-verdicts.md` §0).

- the new tests: **`Failed: 0, Passed: 10, Skipped: 0, Total: 10`** (`Skipped: 0` confirms the two
  subprocess/compile tests really executed rather than skipping on absent artifacts)
- adjacent surface — `Dependency`, `EmitExclusion`, `ManifestFeatures`, `CorruptSidecar`,
  `ScratchDirOwnership`, `Layered`, `Precompile`, `Provisioning`, with `--settings
  engine.runsettings`: **`Failed: 0, Passed: 581, Skipped: 0, Total: 581`**
- **`tests/runner-extras`: exit 0, 424 total, 424 pass, 0 fail, 0 error** — the suite the
  refusing version aborted at zero tests

One failure seen during this work was environmental and is worth naming, because it reads as a
regression and is not: `RecordPatchesPrecompiledTableExtEvictionTests` failed in 1 ms on the
#3843 refuse-to-skip guard — the in-process BC engine bootstrap had not been run in this
worktree. It never reaches changed code (it fails inside `BcEngineFixture.SkipReason`), and after
`tools/engine-test-bootstrap.sh` it passes: `Failed: 0, Passed: 1`.

Corpus-NA: the runner's own emit-retry exclusion reporting; BC has no such loop, so no corpus test can observe it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
