### PR TITLE
fix(deps): Base Application's metadata emit is a cost question, not a hard blocker

### DIFF
--- a/AlRunner.Tests/DependencyMetadataProducerTests.cs
+++ b/AlRunner.Tests/DependencyMetadataProducerTests.cs
@@ -85,10 +85,15 @@ public sealed class DependencyMetadataProducerTests
     // ---- exclusions ----------------------------------------------------------------
 
     /// <summary>
-    /// Base Application is excluded because its emit produces ZERO objects without a
-    /// PublicKeyToken=null copy of Microsoft.AspNetCore.StaticFiles that no BC artifact ships —
-    /// a hard blocker, not a cost decision. tests/expectations/metadata-equivalence/apps.json
-    /// records the same exclusion for the same reason.
+    /// Base Application is excluded on COST — 257s and 8.83 GiB peak RSS on the dependency-load
+    /// path, against ~6s for Business Foundation and ~13s for System Application.
+    ///
+    /// <para>This doc comment used to say the emit was impossible without a
+    /// <c>PublicKeyToken=null</c> copy of <c>Microsoft.AspNetCore.StaticFiles</c> that no BC
+    /// artifact ships. #3876 disproved that: the assembly ships in the ASP.NET Core reference
+    /// pack, both csprojs now stage it, and the emit produces 7,842 documents with
+    /// <c>errors=0</c>. The assertion below is unchanged — only the reason behind it is — and
+    /// removing the exclusion is now a sizing decision rather than a blocked one.</para>
     /// </summary>
     [Fact]
     public void BaseApplication_IsNeverCompiled()

--- a/AlRunner.Tests/DotNetShimProbingTests.cs
+++ b/AlRunner.Tests/DotNetShimProbingTests.cs
@@ -260,6 +260,33 @@ public sealed class DotNetShimProbingTests : IDisposable
             var v2 = PackageVersion(generator, pkg);
             Assert.Equal(v1, v2);
         }
+
+        // And the analyzer-drop CONDITION, character for character.
+        //
+        // Filename and version parity alone is not enough, and that is measured rather than
+        // asserted: the first version of this test compared exactly those two things and passed
+        // while the two Replace() calls genuinely disagreed — the runner had Replace('\\','/')
+        // and the generator Replace('\','/'). MSBuild does not treat a backslash as an escape,
+        // so the doubled form looks for a literal two-backslash run, finds none in a Windows
+        // path, and the analyzers are not dropped. Both forms work on a POSIX path, so every CI
+        // leg is green either way and only a Windows developer build regresses — which is
+        // exactly the divergence a parity test exists to catch.
+        Assert.Equal(AnalyzerDropCondition(runner), AnalyzerDropCondition(generator));
+    }
+
+    /// <summary>
+    /// The <c>Condition</c> of the <c>Analyzer Remove</c> item, read out of csproj text. Same
+    /// reasoning as <see cref="PackageVersion"/>: the point is to compare what the two files
+    /// DECLARE, so this reads the source rather than evaluating MSBuild.
+    /// </summary>
+    private static string AnalyzerDropCondition(string csproj)
+    {
+        var m = System.Text.RegularExpressions.Regex.Match(
+            csproj, "<Analyzer\\s+Remove=\"@\\(Analyzer\\)\"\\s+Condition=\"([^\"]+)\"");
+        Assert.True(m.Success,
+            "no <Analyzer Remove=\"@(Analyzer)\" Condition=...> found. Both projects drop the " +
+            "AspNetCore ref pack's analyzers; without it every build carries 882 AD0001 (#3876).");
+        return m.Groups[1].Value;
     }
 
     /// <summary>

--- a/AlRunner.Tests/DotNetShimProbingTests.cs
+++ b/AlRunner.Tests/DotNetShimProbingTests.cs
@@ -1,4 +1,4 @@
-// DotNetShimProbingTests — issue #3745.
+// DotNetShimProbingTests — issues #3745 (Newtonsoft.Json) and #3876 (AspNetCore.StaticFiles).
 //
 // RUNNER-MECHANISM test. The claim is about the runner's own compile configuration, not about
 // what Business Central does, so a service tier cannot adjudicate it and there is nothing for
@@ -25,6 +25,15 @@
 //   naming the cause. So ordering is not a detail here, it is the fix, and OrderPutsShimsFirst
 //   is the assertion that fails if a later edit appends the shim directory instead of
 //   prepending it.
+//
+//   THE SECOND SHIM, #3876: Base Application's dotnet.al declares
+//   assembly(Microsoft.AspNetCore.StaticFiles), which BC ships in no artifact, so its emit
+//   produced zero objects too — the same atomic-per-module shape. Staging that one file from the
+//   ASP.NET Core reference pack takes it to errors=0, objects=7850, 7,842 documents. It binds
+//   despite AL0451 naming `PublicKeyToken=null` because the AL declaration states NO token and
+//   BC's AssemblyLocatorBase.IsAssemblyCompatible guards its token check on the search name
+//   carrying one — asymmetric, not token-blind. docs/dependency-metadata-from-bc.md has the
+//   measurement and the locator detail.
 //
 //   These are unit tests over the probing-path construction, deliberately not a full System
 //   Application compile: that compile is ~14s and needs provisioned BC artifacts, so it belongs
@@ -106,6 +115,84 @@ public sealed class DotNetShimProbingTests : IDisposable
         var text = File.ReadAllText(shim, System.Text.Encoding.Latin1);
         Assert.Contains(".NETStandard,Version=v2.0", text);
         Assert.DoesNotContain(".NETCoreApp,Version=v6.0", text);
+    }
+
+    /// <summary>
+    /// The second shim, and the one that makes Base Application emittable at all (#3876).
+    ///
+    /// <para>Base Application's <c>src/Modules/System/DotNetAliases/dotnet.al</c> line 23
+    /// declares <c>assembly(Microsoft.AspNetCore.StaticFiles)</c> for
+    /// <c>FileExtensionContentTypeProvider</c>. BC ships no copy of that assembly in its
+    /// artifacts, so the declaration phase raised AL0451 + AL0185 and the app produced ZERO
+    /// objects — recorded in three places as a permanent blocker. It is not: the assembly is an
+    /// ordinary part of the ASP.NET Core reference pack.</para>
+    ///
+    /// <para>Asserted on the real build output, like the Newtonsoft case above and for the same
+    /// reason: a test staging its own copy would pass with the csproj item deleted. The
+    /// <c>FileExtensionContentTypeProvider</c> assertion is what stops a same-named file
+    /// satisfying this — it is the one type the AL declaration names, so a file without it
+    /// would leave AL0185 in place while the filename assertion still went green.</para>
+    /// </summary>
+    [Fact]
+    public void BuildStagesTheAspNetCoreStaticFilesShimBesideTheRunnerBinary()
+    {
+        var dir = Path.Combine(RunnerOutputDir(), "dotnet-shims");
+        Assert.True(Directory.Exists(dir), $"no dotnet-shims directory at {dir}");
+
+        var shim = Path.Combine(dir, "Microsoft.AspNetCore.StaticFiles.dll");
+        Assert.True(File.Exists(shim),
+            $"Microsoft.AspNetCore.StaticFiles.dll missing from {dir}. AlRunner.csproj stages it " +
+            "from the Microsoft.AspNetCore.App.Ref package; without it Base Application's " +
+            "metadata emit yields zero objects (#3876).");
+
+        var name = AssemblyName.GetAssemblyName(shim);
+        Assert.Equal("Microsoft.AspNetCore.StaticFiles", name.Name);
+
+        // The type BC's dotnet.al actually names. A same-named assembly lacking it would still
+        // leave AL0185 'FileExtensionContentTypeProvider is missing' and emit nothing.
+        var text = File.ReadAllText(shim, System.Text.Encoding.Latin1);
+        Assert.Contains("FileExtensionContentTypeProvider", text);
+    }
+
+    /// <summary>
+    /// The reference pack is NOT an SDK component, and that is the whole reason the csproj takes
+    /// it as a <c>PackageReference</c> rather than as a path.
+    ///
+    /// <para>A CI leg installs the SDK with <c>actions/setup-dotnet</c>, which lays down
+    /// <c>Microsoft.NETCore.App.Ref</c> and <c>NETStandard.Library.Ref</c> under
+    /// <c>$DOTNET_ROOT/packs</c> and does NOT lay down <c>Microsoft.AspNetCore.App.Ref</c>. So
+    /// <see cref="BcCompiler"/>'s <c>EnumerateDotNetRefAssemblyDirs</c>, which reads exactly that
+    /// <c>packs</c> directory, can never supply this assembly — the staged shim is the only
+    /// route, and a future edit that "simplifies" the shim away in favour of the ref-pack
+    /// enumeration would pass on a developer box and fail on CI.</para>
+    ///
+    /// <para>This asserts the mechanism, not the machine: it pins that the ref-pack enumeration
+    /// does not yield an AspNetCore directory, which is what makes the shim load-bearing. It is
+    /// deliberately not an assertion that the pack is absent from this box, because a developer
+    /// who has restored it into <c>~/.nuget</c> still gets nothing from
+    /// <c>EnumerateDotNetRefAssemblyDirs</c>.</para>
+    /// </summary>
+    [Fact]
+    public void TheRefAssemblyEnumerationNeverSuppliesAspNetCore_SoTheShimIsTheOnlyRoute()
+    {
+        var m = typeof(BcCompiler).GetMethod(
+                    "EnumerateDotNetRefAssemblyDirs", BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "BcCompiler.EnumerateDotNetRefAssemblyDirs not found. If it was renamed, this " +
+                    "test and the reasoning behind the AspNetCore shim need to move with it.");
+        var refDirs = ((IEnumerable<string>)m.Invoke(null, null)!).ToList();
+
+        Assert.DoesNotContain(refDirs,
+            d => d.Replace('\\', '/').Contains("/Microsoft.AspNetCore.App.Ref/",
+                     StringComparison.OrdinalIgnoreCase));
+
+        // And the assembly is not reachable from any directory that enumeration does yield —
+        // the positive half, so this cannot pass merely because the enumeration came back empty.
+        foreach (var d in refDirs)
+            Assert.False(File.Exists(Path.Combine(d, "Microsoft.AspNetCore.StaticFiles.dll")),
+                $"{d} carries Microsoft.AspNetCore.StaticFiles.dll — if the SDK now ships the " +
+                "ASP.NET Core reference pack, the staged shim may be redundant; re-measure " +
+                "before removing it (#3876).");
     }
 
     /// <summary>

--- a/AlRunner.Tests/DotNetShimProbingTests.cs
+++ b/AlRunner.Tests/DotNetShimProbingTests.cs
@@ -216,6 +216,83 @@ public sealed class DotNetShimProbingTests : IDisposable
     }
 
     /// <summary>
+    /// The runner and the ground-truth generator must stage the SAME shim set.
+    ///
+    /// <para>Two projects build a DotNet probing list — <c>AlRunner.csproj</c> for the runner and
+    /// <c>tools/metadata-ground-truth/MetadataGroundTruth.csproj</c> for the generator — and the
+    /// generator's output is the ORACLE the runner's metadata derivation is measured against
+    /// (<c>MetadataEquivalenceHarnessTests</c>). A shim present in one and not the other means
+    /// the two sides compile the same Microsoft app against different reference sets, so a
+    /// difference the harness reports would be an artifact of the drift rather than a defect in
+    /// the runner — and it would look exactly like a real finding.</para>
+    ///
+    /// <para>Asserted against the csproj SOURCES rather than two build outputs, because the
+    /// generator is deliberately not in <c>AlRunner.slnx</c> and is not built by
+    /// <c>dotnet test</c>: there is no output to compare on a normal run. #3745 staged the first
+    /// shim in both; #3876 added the second and this test, because nothing was holding them
+    /// together.</para>
+    /// </summary>
+    [Fact]
+    public void TheRunnerAndTheGroundTruthGeneratorStageTheSameShimSet()
+    {
+        var root = RepoRoot();
+        var runner = File.ReadAllText(Path.Combine(root, "AlRunner", "AlRunner.csproj"));
+        var generator = File.ReadAllText(Path.Combine(
+            root, "tools", "metadata-ground-truth", "MetadataGroundTruth.csproj"));
+
+        // The shim files each project stages, by the file name that lands in dotnet-shims.
+        string[] expected = { "Newtonsoft.Json.dll", "Microsoft.AspNetCore.StaticFiles.dll" };
+
+        foreach (var dll in expected)
+        {
+            Assert.True(runner.Contains(dll, StringComparison.Ordinal),
+                $"AlRunner.csproj does not stage {dll} into dotnet-shims.");
+            Assert.True(generator.Contains(dll, StringComparison.Ordinal),
+                $"MetadataGroundTruth.csproj does not stage {dll} into dotnet-shims. The " +
+                "generator produces the ground truth the runner is measured against, so a shim " +
+                "in one project and not the other compares two different reference sets (#3876).");
+        }
+
+        // And the same package versions, so the two do not bind different builds of one assembly.
+        foreach (var pkg in new[] { "Newtonsoft.Json", "Microsoft.AspNetCore.App.Ref" })
+        {
+            var v1 = PackageVersion(runner, pkg);
+            var v2 = PackageVersion(generator, pkg);
+            Assert.Equal(v1, v2);
+        }
+    }
+
+    /// <summary>
+    /// The <c>Version</c> of a <c>PackageReference</c>, read out of csproj text. Deliberately a
+    /// regex over the source rather than an MSBuild evaluation: the point is to compare what the
+    /// two files DECLARE, and an evaluation would need the generator project restored, which a
+    /// normal <c>dotnet test</c> run does not do.
+    /// </summary>
+    private static string PackageVersion(string csproj, string package)
+    {
+        var m = System.Text.RegularExpressions.Regex.Match(
+            csproj,
+            "<PackageReference\\s+Include=\"" + System.Text.RegularExpressions.Regex.Escape(package) +
+            "\"\\s+Version=\"([^\"]+)\"");
+        Assert.True(m.Success, $"no <PackageReference Include=\"{package}\" Version=...> found");
+        return m.Groups[1].Value;
+    }
+
+    /// <summary>
+    /// The repository root, walked up from the test assembly's location by looking for a marker
+    /// that exists in a checkout and nowhere else — so this works under any configuration or
+    /// output layout, like <see cref="RunnerOutputDir"/> above.
+    /// </summary>
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "AlRunner.slnx")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+
+    /// <summary>
     /// The runner project's build output. Derived from the location of the assembly under test
     /// rather than from a path relative to the source tree, so it stays correct under any
     /// configuration or target-framework layout.

--- a/AlRunner/AlRunner.csproj
+++ b/AlRunner/AlRunner.csproj
@@ -213,11 +213,19 @@
        the analyzer item group, and they then throw AD0001 on every build (882 of them) looking
        for ASP.NET Core types nothing here references. The pack is wanted for ONE file, so
        dropping its analyzers outright is exactly the intent. Measured: a CLEAN rebuild, because
-       an incremental one skips CoreCompile and reports 0 whatever this target does. -->
+       an incremental one skips CoreCompile and reports 0 whatever this target does.
+
+       Replace('\','/') takes ONE backslash. MSBuild does not treat a backslash as an escape
+       here, so '\\' matches a literal two-backslash sequence, finds none in a Windows path and
+       leaves it unconverted — after which Contains('/microsoft.aspnetcore.app.ref/') is false
+       and the analyzers are NOT dropped. Measured in a standalone MSBuild project:
+       DOUBLE on a Windows path -> unchanged, contains False; SINGLE -> converted, True; both
+       True on a POSIX path, which is why every CI leg passes either way and only a Windows
+       developer build regresses. -->
   <Target Name="DropAspNetCoreRefPackAnalyzers" BeforeTargets="CoreCompile">
     <ItemGroup>
       <Analyzer Remove="@(Analyzer)"
-                Condition="$([System.String]::Copy('%(Analyzer.FullPath)').Replace('\\','/').Contains('/microsoft.aspnetcore.app.ref/'))" />
+                Condition="$([System.String]::Copy('%(Analyzer.FullPath)').Replace('\','/').Contains('/microsoft.aspnetcore.app.ref/'))" />
     </ItemGroup>
   </Target>
 

--- a/AlRunner/AlRunner.csproj
+++ b/AlRunner/AlRunner.csproj
@@ -166,7 +166,9 @@
        never loaded into the runner's own load chain, so nothing here can perturb the BC
        engine bind.
 
-       Today that is one file, and it earns its place. System Application's
+       Two files today, one per app that would otherwise emit nothing.
+
+       Newtonsoft.Json — System Application's
        SamplingPerfProfilerImpl calls JsonSerializer.Deserialize(TextReader, Type). The service
        tier ships only the net6.0 build of Newtonsoft.Json, whose TextReader parameter is typed
        against System.Runtime 6.0.0.0; no .NET 6 reference assemblies exist on a net8 box, so
@@ -175,14 +177,49 @@
        The netstandard2.0 build of the SAME Newtonsoft version binds against netstandard, which
        does resolve.
 
+       Microsoft.AspNetCore.StaticFiles — Base Application's dotnet.al:23 declares
+       assembly(Microsoft.AspNetCore.StaticFiles) for FileExtensionContentTypeProvider, and BC
+       ships no copy in its artifacts, so the whole app emitted zero objects (#3876). Exactly
+       one file, because that line is the only AspNetCore assembly the app declares — read out
+       of the shipped package, not assumed. Staging the pack's other 137 DLLs would put them
+       ahead of the service tier for no declared reference.
+
+       The AL declaration carries NO PublicKeyToken, and that is what makes an ordinary
+       strong-named ref-pack copy bind: AssemblyLocatorBase.IsAssemblyCompatible guards its
+       token comparison on the SEARCH name having a non-empty token, so a request without one
+       is not token-checked. It is asymmetric, NOT token-blind — a request naming the wrong
+       token is still rejected, and a wrong simple name always is. The `PublicKeyToken=null` in
+       the AL0451 text is DotNetUtilities.GetPublicKeyToken's rendering of an absent token, not
+       a demand for a null-token assembly; three documents read it as the latter and recorded
+       the app as permanently unemittable (#3876 measured all of this against the real locator).
+
        ExcludeAssets="all": referenced for its FILE, never linked. A package reference rather
        than a path into ~/.nuget so a CI leg's success does not depend on what happened to be
        cached on the machine — the same choice tools/metadata-ground-truth makes, and this
-       shim is the one its CopyDotNetShims target proved out. -->
+       shim is the one its CopyDotNetShims target proved out. The AspNetCore ref pack makes
+       that reasoning load-bearing rather than decorative: unlike Microsoft.NETCore.App.Ref it
+       is NOT an SDK component — it is absent from $DOTNET_ROOT/packs on a setup-dotnet leg —
+       so a ~/.nuget path would work here and fail on CI. 8.0.30 to match the leg's 8.0.x
+       runtime; 8.0.25, 9.0.19 and 10.0.11 bind identically, so the pin is for predictability
+       rather than necessity. -->
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3"
                       GeneratePathProperty="true" ExcludeAssets="all" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.App.Ref" Version="8.0.30"
+                      GeneratePathProperty="true" ExcludeAssets="all" PrivateAssets="all" />
   </ItemGroup>
+
+  <!-- The AspNetCore ref pack ships Roslyn analyzers. ExcludeAssets does not keep them out of
+       the analyzer item group, and they then throw AD0001 on every build (882 of them) looking
+       for ASP.NET Core types nothing here references. The pack is wanted for ONE file, so
+       dropping its analyzers outright is exactly the intent. Measured: a CLEAN rebuild, because
+       an incremental one skips CoreCompile and reports 0 whatever this target does. -->
+  <Target Name="DropAspNetCoreRefPackAnalyzers" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)"
+                Condition="$([System.String]::Copy('%(Analyzer.FullPath)').Replace('\\','/').Contains('/microsoft.aspnetcore.app.ref/'))" />
+    </ItemGroup>
+  </Target>
 
   <!-- Staged as CONTENT rather than by a bare <Copy>, so the shim travels with al-runner.dll
        into every output that references this project — AlRunner.Tests' output above all, where
@@ -192,6 +229,13 @@
   <ItemGroup Condition="'$(PkgNewtonsoft_Json)' != ''">
     <Content Include="$(PkgNewtonsoft_Json)/lib/netstandard2.0/Newtonsoft.Json.dll"
              Link="dotnet-shims/Newtonsoft.Json.dll"
+             CopyToOutputDirectory="PreserveNewest"
+             Pack="true" PackagePath="tools/$(TargetFramework)/any/dotnet-shims/" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(PkgMicrosoft_AspNetCore_App_Ref)' != ''">
+    <Content Include="$(PkgMicrosoft_AspNetCore_App_Ref)/ref/net8.0/Microsoft.AspNetCore.StaticFiles.dll"
+             Link="dotnet-shims/Microsoft.AspNetCore.StaticFiles.dll"
              CopyToOutputDirectory="PreserveNewest"
              Pack="true" PackagePath="tools/$(TargetFramework)/any/dotnet-shims/" />
   </ItemGroup>

--- a/AlRunner/DependencyMetadataProducer.cs
+++ b/AlRunner/DependencyMetadataProducer.cs
@@ -51,15 +51,25 @@
 //   netstandard2.0 build into dotnet-shims and BcCompiler probes it ahead of the tier; the app
 //   produces 1,218 documents in ~11-13 s (docs/dependency-metadata-from-bc.md).
 //
-// NOT BASE APPLICATION
-//   Base Application ships 8,025 AL files and is deliberately excluded. Its emit needs a
-//   PublicKeyToken=null copy of Microsoft.AspNetCore.StaticFiles that no BC artifact ships,
-//   and without it the emitter produces ZERO objects — a hard blocker, not a cost question.
-//   #3745's shim does NOT reach it: that is a different assembly, absent from the artifacts
-//   entirely rather than present in a build that does not bind.
-//   tests/expectations/metadata-equivalence/apps.json records the same exclusion for the same
-//   reason. EmitProducedNothing below is what turns that into a loud failure rather than an
-//   empty cache entry that would read as "this app has no metadata".
+// NOT BASE APPLICATION — a COST decision, which is a correction (#3876)
+//   Base Application ships 8,025 AL files and is excluded here. This block used to say its emit
+//   was impossible: that it needed a PublicKeyToken=null copy of Microsoft.AspNetCore.StaticFiles
+//   which no BC artifact ships, "a hard blocker, not a cost question". That was wrong, and the
+//   wrongness was self-reinforcing — two other records cited this one and this one cited them.
+//
+//   The assembly is an ordinary part of the ASP.NET Core reference pack, which both csprojs now
+//   stage into dotnet-shims; the `PublicKeyToken=null` in the AL0451 text is BC rendering an
+//   ABSENT token in the AL declaration, not demanding a null-token build. Measured through that
+//   staging: errors=0, objects=7850, 7,842 documents, 257s, peak RSS 8.83 GiB.
+//   docs/dependency-metadata-from-bc.md § "Base Application: a cost question after all" has the
+//   locator mechanism and why the pack cannot come from the SDK.
+//
+//   So the entry stays for the reason that is now MEASURED rather than inferred: 257s and
+//   8.83 GiB on the dependency-load path of every run that resolves the app, against ~6s for
+//   Business Foundation and ~13s for System Application. Removing it is a deliberate
+//   cost/sizing decision with a 16 GB CI runner in the balance, not a consequence of this fix
+//   — see #3876. EmitProducedNothing below is what turns a failed compile into a loud failure
+//   rather than an empty cache entry that would read as "this app has no metadata".
 
 using System;
 using System.Collections.Generic;
@@ -77,9 +87,10 @@ namespace AlRunner;
 internal static class DependencyMetadataProducer
 {
     /// <summary>
-    /// Apps this producer never compiles, by name. Base Application is the only entry and it
-    /// is not a cost decision — see the header. Matched on the manifest name so a differently
-    /// versioned or differently published copy is still excluded.
+    /// Apps this producer never compiles, by name. Base Application is the only entry, and it
+    /// IS a cost decision — 257s and 8.83 GiB peak RSS, measured; the "hard blocker" this used
+    /// to cite was disproved by #3876. See the header. Matched on the manifest name so a
+    /// differently versioned or differently published copy is still excluded.
     /// </summary>
     private static readonly HashSet<string> NeverCompile =
         new(StringComparer.OrdinalIgnoreCase) { "Base Application" };

--- a/docs/dependency-metadata-from-bc.md
+++ b/docs/dependency-metadata-from-bc.md
@@ -88,17 +88,107 @@ cause.** With the shim in place they become 62 × AL0327 for control-add-in reso
 producer's work directory does not carry, which are non-fatal: the emit produces all 1,218
 documents anyway.
 
-Note what this does **not** fix: Base Application's blocker is a different assembly
-(`Microsoft.AspNetCore.StaticFiles` with `PublicKeyToken=null`, which no BC artifact ships at
-all — verified absent from the 28.1 artifacts) and it remains excluded.
+Base Application needed a second shim of the same shape, for a different assembly —
+`Microsoft.AspNetCore.StaticFiles`, which no BC artifact ships. See the next section; it is the
+same mechanism and the same one-file fix.
 
-### Base Application: a hard blocker, not a cost question
+### Base Application: a cost question after all (#3876)
 
-Excluded in code by name, and it is **not** about the ~9 GB peak RSS of compiling it. Its emit
-needs a `PublicKeyToken=null` copy of `Microsoft.AspNetCore.StaticFiles` that no BC artifact
-ships, and without it the emitter produces **zero objects**.
-`tests/expectations/metadata-equivalence/apps.json` records the same exclusion for the same
-reason, and attributes it to this issue.
+**This section said the opposite until #3876 measured it**, and the correction matters more
+than the fix: three places in this repository recorded Base Application's metadata emit as
+permanently impossible, each citing the other two. The narrow claim they rested on was true and
+the conclusion drawn from it was not.
+
+**What is true:** BC ships no copy of `Microsoft.AspNetCore.StaticFiles` in its artifacts, and
+without one the declaration phase raises `AL0451` + `AL0185` and the emit produces zero objects.
+
+**What does not follow:** that the assembly is unobtainable. It is an ordinary part of the
+**ASP.NET Core reference pack**, and staging that one file takes the emit from nothing to
+`errors=0`, `objects=7850`, **7,842 documents** — measured four times now, twice by the agent
+that filed #3876, once by the agent that measured the mechanism, and once through the shipped
+staging rather than a flag:
+
+```
+[decl]  15084ms  errors=0
+[emit] 227480ms  success=True objects=7850 errors=0
+[bundle] 7842 document(s)
+EXIT=0  wall=257s  peak VmHWM=9,263,480 kB = 8.83 GiB
+```
+
+`AlRunner.csproj` and `MetadataGroundTruth.csproj` now stage it into `dotnet-shims` beside the
+Newtonsoft shim above, by `PackageReference` on `Microsoft.AspNetCore.App.Ref` 8.0.30.
+
+#### Why the `PublicKeyToken=null` in the error message misled three documents
+
+`AL0451` names `'Microsoft.AspNetCore.StaticFiles, PublicKeyToken=null'`, and all three records
+read that as *"BC needs a null-token build of this assembly"*. It is not a requirement; it is
+how BC renders **the absence of a token in the AL declaration**. From
+`DotNetUtilities.GetPublicKeyToken`:
+
+```csharp
+if (publicKeyToken == null || publicKeyToken.Length == 0)
+    return "null";
+```
+
+The shipped source agrees. Base Application's `src/Modules/System/DotNetAliases/dotnet.al` has
+exactly three `assembly()` declarations and exactly one `PublicKeyToken` line — on `Ncl`, at
+line 7. Line 23 declares `assembly(Microsoft.AspNetCore.StaticFiles)` with **no** token.
+
+So the ref pack's ordinary strong-named copy (`PublicKeyToken=adb9793829ddae60`) binds. The
+mechanism is **asymmetric matching, not a token-blind resolver** — the distinction matters,
+because the token-blind reading would mean any assembly of the right name satisfies the
+reference. From the AL compiler's `AssemblyLocatorBase.IsAssemblyCompatible`:
+
+```csharp
+if (!searchName.Name.Equals(assemblyBeingEvaluated.Name))
+    return false;
+byte[] publicKeyToken = searchName.PublicKeyToken;
+if (publicKeyToken != null && publicKeyToken.Length != 0
+    && !IsPublicKeyTokenCompatible(publicKeyToken, assemblyBeingEvaluated.PublicKeyToken))
+    return false;
+```
+
+| the search name | the candidate's token | result |
+|---|---|---|
+| carries no token | anything | **not checked** |
+| carries a token | different | rejected |
+| wrong simple name | anything | rejected |
+
+A wrong token is still rejected and a wrong simple name always is; the resolver is the **AL
+compiler's** (`Microsoft.Dynamics.Nav.CodeAnalysis.dll`), not `Ncl.dll`'s. Measured directly
+against that locator across 4 distinct compiler binaries × 4 ref-pack versions, 16/16 uniform
+(#3876).
+
+#### The reference pack is not an SDK component, so it arrives as a package
+
+This is the part a future edit is most likely to get wrong. Unlike `Microsoft.NETCore.App.Ref`
+and `NETStandard.Library.Ref`, which `BcCompiler.EnumerateDotNetRefAssemblyDirs` finds under
+`$DOTNET_ROOT/packs`, **`Microsoft.AspNetCore.App.Ref` is not laid down by the .NET SDK** —
+verified absent from `$DOTNET_ROOT/packs` on a box that has four versions of it cached in
+`~/.nuget`. CI legs use `actions/setup-dotnet` with `8.0.x`, which would not produce it either.
+
+So a hardcoded `~/.nuget` path passes locally and fails on CI. The `PackageReference` +
+`GeneratePathProperty` + `ExcludeAssets="all"` pattern is what makes NuGet restore it on any
+machine, and `AlRunner.Tests/DotNetShimProbingTests` pins that the ref-pack enumeration never
+supplies this assembly, so the staged shim stays the only route.
+
+One wrinkle worth knowing: the pack ships Roslyn analyzers, and `ExcludeAssets="all"` does not
+keep them out of the `Analyzer` item group. They then throw **882 `AD0001` warnings** per build
+looking for ASP.NET Core types nothing here references. Both projects drop them in a
+`DropAspNetCoreRefPackAnalyzers` target. Measure that on a **clean** rebuild — an incremental
+one skips `CoreCompile` and reports zero whatever the target does.
+
+#### What this does not change: the app is still not in `apps.json`
+
+The compile is now possible; whether to spend it on every unit-test leg is a separate,
+deliberate decision, and #3876 does not take it. `tools/gen-metadata-ground-truth.sh` reads
+`tests/expectations/metadata-equivalence/apps.json` and runs on the unit-test legs
+(`bc-tests.yml`), where Business Foundation costs ~3 s and System Application ~14 s. Base
+Application costs **257 s and 8.83 GiB peak RSS**. A standard `ubuntu-latest` runner has 16 GB,
+so it fits — but alongside everything else on that leg the margin is thin, and an OOM there
+presents as a killed step with no diagnostic rather than a legible failure. That is a sizing
+call for a human, so `apps.json` still omits the app — now saying *why it is omitted*, rather
+than that it is impossible.
 
 ## The platform floor
 

--- a/docs/metadata-equivalence.md
+++ b/docs/metadata-equivalence.md
@@ -696,16 +696,18 @@ marked, so the next six kinds do not rediscover this one leg at a time.
 <a id="what-the-page-measurement-does-not-cover"></a>
 ### What the page measurement does not cover
 
-**One BC build, two apps.** Base Application's ~4,000 pages are not measured at all: `apps.json`
-excludes it because its emit needs a `PublicKeyToken=null` copy of `Microsoft.AspNetCore.StaticFiles`
-that no BC artifact ships (#3549). None of the figures above is evidence about the pages most AL
-tests actually touch.
+**One BC build, two apps.** Base Application's ~4,000 pages are not measured at all, because
+`apps.json` excludes it. None of the figures above is evidence about the pages most AL tests
+actually touch.
 
-**Base Application is not covered.** Its emit needs a `PublicKeyToken=null` copy of
-`Microsoft.AspNetCore.StaticFiles` that no BC artifact ships, and without it BC's emitter
-produces zero objects for the whole app (#3549). The generator treats a zero-object emit as a
-failure rather than writing an empty bundle, and `apps.json` says why Base Application is absent
-rather than listing it and failing every leg.
+**Base Application is not covered — on cost, not because it cannot be compiled.** This section
+used to say its emit needed a `PublicKeyToken=null` copy of `Microsoft.AspNetCore.StaticFiles`
+that no BC artifact ships. **#3876 disproved that**: the assembly ships in the ASP.NET Core
+reference pack, both csprojs stage it, and the emit produces 7,842 documents with `errors=0`.
+What keeps the app out of `apps.json` is that this file drives a step on the unit-test legs where
+it would cost **257 s and 8.83 GiB peak RSS** against ~3 s and ~14 s for the two apps listed — a
+sizing decision on a 16 GB runner, recorded in `apps.json` itself. The generator still treats a
+zero-object emit as a failure rather than writing an empty bundle.
 
 <a id="codeunits"></a>
 ## Codeunits: the runner has no `MetaCodeunit`, so its derivation is projected into one
@@ -1025,8 +1027,10 @@ field independently.
 `<RequestPage><PageDefinition>` subtree for report 9810 even though it declares
 `UseRequestPage = false` and `ProcessingOnly = true`. Whether BC does that for *every* report is
 **not answerable from this bundle** — one report — and Base Application, which would answer it,
-is excluded from `apps.json` because its emit needs a .NET reference no BC artifact ships
-(#3549). That question is left open on #3808 rather than closed by assumption.
+is excluded from `apps.json` on cost (257 s, 8.83 GiB), not because it cannot be compiled: the
+.NET reference it needs ships in the ASP.NET Core reference pack and is staged (#3876, correcting
+an earlier claim here that no BC artifact ships it). That question is left open on #3808 rather
+than closed by assumption.
 
 **What this comparison does not reach:** report 9810 has no data items and no columns, so the
 data-item and column derivation — the substantial part of `DependencyReportMetadata.cs` — is not

--- a/docs/where-metadata-comes-from.md
+++ b/docs/where-metadata-comes-from.md
@@ -69,18 +69,21 @@ measurements: loading the Base Application floor costs about **70 seconds cold a
 runner invocation**. For an app that already ships a working DLL, recompiling it would be spending a
 compile to learn what `SymbolReference.json` already states.
 
-**And for Base Application specifically it is not merely expensive — it does not work at all.** From
-`tests/expectations/metadata-equivalence/apps.json`, which is why that app is absent from the
-equivalence harness:
+**And for Base Application specifically the cost IS the reason** — which is a correction. This
+section used to say the compile "does not work at all", quoting
+`tests/expectations/metadata-equivalence/apps.json` on a `PublicKeyToken=null` copy of
+`Microsoft.AspNetCore.StaticFiles` that no BC artifact ships. **#3876 disproved that**: the
+assembly ships in the ASP.NET Core reference pack, both csprojs now stage it, and the emit is
+clean — `errors=0`, `objects=7850`, 7,842 documents.
 
-> Base Application is deliberately ABSENT. Its emit needs a `PublicKeyToken=null` copy of
-> `Microsoft.AspNetCore.StaticFiles` that no BC artifact ships, and without it the emitter produces
-> **ZERO objects** (issue #3549).
+Note what the old text did, because it is instructive: it warned against "stating the cost as the
+reason", having itself stated an incorrect blocker as the reason. The cost was the reason all
+along — **257 s and 8.83 GiB peak RSS**, against ~6 s for Business Foundation and ~13 s for
+System Application.
 
-So the symbol-file route is not a cost-saving fallback for this app. It is the only route that
-produces anything. (Compiling Base Application is separately expensive — roughly 2 minutes and ~9 GB
-peak RSS — but that is the *cost*, not the reason, and stating the cost as the reason has misled a
-reader of this repository before.)
+So the symbol-file route IS a cost-saving fallback for this app, and a compile is available when
+something needs BC's own answer. `docs/dependency-metadata-from-bc.md` §
+"Base Application: a cost question after all" has the measurement and the resolver mechanism.
 
 **So for this shape the answer is the symbol file, and the symbol file is held to a standard rather
 than treated as second-class.**

--- a/tests/expectations/metadata-equivalence/allowlist.json
+++ b/tests/expectations/metadata-equivalence/allowlist.json
@@ -80,8 +80,10 @@
     "27.5 happened to hit. See docs/metadata-equivalence.md#one-build-measured-three-evaluated.",
     "",
     "Measurement caveat: ONE BC build and TWO apps. Base Application's ~4,000 pages are not measured",
-    "at all -- apps.json excludes it because its emit needs a .NET reference no BC artifact ships",
-    "(#3549) -- so nothing here is evidence about the pages most AL tests actually touch.",
+    "at all -- apps.json excludes it on COST (257s, 8.83 GiB peak RSS), not because it cannot be",
+    "compiled: this line used to say its emit needs a .NET reference no BC artifact ships, which",
+    "#3876 disproved -- the reference ships in the ASP.NET Core reference pack and is staged. So",
+    "nothing here is evidence about the pages most AL tests actually touch.",
     "",
     "The seven pre-existing TranslationKey.* entries already covered the page side without being",
     "touched: they match on member signature, and pages carry the same TranslationKey type.",
@@ -1366,7 +1368,7 @@
     },
     {
       "member": "MetaReport.RequestPageDefinition.<presence>",
-      "reason": "BC's emitted document carries a full <RequestPage><PageDefinition> subtree even for report 9810, which declares UseRequestPage = false and ProcessingOnly = true; DependencyReportMetadata.EmitReportXml writes no <RequestPage> element at all, so BC's reader leaves the property null on the runner's side. Two questions are deliberately OPEN rather than answered here, and they are on #3808: whether BC emits a request page for every report (unanswerable from this bundle -- System Application ships exactly ONE report, and Base Application, which would settle it, is excluded from apps.json because its emit needs a .NET reference no BC artifact ships, #3549), and whether anything AL-observable reads MetaReport.RequestPageDefinition on a ProcessingOnly report. Declared as a tracked defect rather than out of scope precisely because neither is settled: an outOfScope claim here would be a guess wearing a classification.",
+      "reason": "BC's emitted document carries a full <RequestPage><PageDefinition> subtree even for report 9810, which declares UseRequestPage = false and ProcessingOnly = true; DependencyReportMetadata.EmitReportXml writes no <RequestPage> element at all, so BC's reader leaves the property null on the runner's side. Two questions are deliberately OPEN rather than answered here, and they are on #3808: whether BC emits a request page for every report (unanswerable from this bundle -- System Application ships exactly ONE report, and Base Application, which would settle it, is excluded from apps.json on cost -- 257s and 8.83 GiB peak RSS -- rather than because its emit is impossible; the earlier claim here that it needs a .NET reference no BC artifact ships was disproved by #3876), and whether anything AL-observable reads MetaReport.RequestPageDefinition on a ProcessingOnly report. Declared as a tracked defect rather than out of scope precisely because neither is settled: an outOfScope claim here would be a guess wearing a classification.",
       "issue": 3808
     },
     {

--- a/tests/expectations/metadata-equivalence/apps.json
+++ b/tests/expectations/metadata-equivalence/apps.json
@@ -6,10 +6,20 @@
     "than it claims. Add an app only once tools/gen-metadata-ground-truth.sh produces a bundle",
     "for it on a clean box.",
     "",
-    "Base Application is deliberately ABSENT. Its emit needs a PublicKeyToken=null copy of",
-    "Microsoft.AspNetCore.StaticFiles that no BC artifact ships, and without it the emitter",
-    "produces ZERO objects (issue #3549). Listing it here would fail every leg; leaving it out",
-    "and saying so is the honest state."
+    "Base Application is still ABSENT, but NOT because its emit is impossible. This comment",
+    "used to say it needed a PublicKeyToken=null copy of Microsoft.AspNetCore.StaticFiles that",
+    "no BC artifact ships. Issue #3876 disproved that: the assembly ships in the ASP.NET Core",
+    "reference pack, both csprojs now stage it into dotnet-shims, and the emit is clean --",
+    "errors=0, objects=7850, 7,842 documents. The `PublicKeyToken=null` in the AL0451 text is",
+    "BC rendering an ABSENT token in the AL declaration, not demanding a null-token build.",
+    "",
+    "It stays absent on COST, which is a sizing decision rather than a blocked one. This file",
+    "drives tools/gen-metadata-ground-truth.sh, which runs on the UNIT-TEST legs of",
+    ".github/workflows/bc-tests.yml. Business Foundation costs ~3s there and System Application",
+    "~14s; Base Application costs 257s and 8.83 GiB peak RSS. A standard ubuntu-latest runner",
+    "has 16 GB, so it fits -- but alongside the rest of that leg the margin is thin, and an OOM",
+    "presents as a killed step with no diagnostic rather than a legible failure. Adding it is a",
+    "deliberate call for a human to make, with those numbers in hand (#3876)."
   ],
   "apps": [
     {

--- a/tools/metadata-ground-truth/MetadataGroundTruth.csproj
+++ b/tools/metadata-ground-truth/MetadataGroundTruth.csproj
@@ -28,11 +28,26 @@
     <PackageReference Include="System.Text.Json" Version="10.0.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.0" />
 
-    <!-- Referenced for its FILE, never linked (ExcludeAssets=all). See the DotNetShims target
-         below for why the netstandard2.0 build specifically. -->
+    <!-- Referenced for their FILES, never linked (ExcludeAssets=all). See the DotNetShims
+         target below for why the netstandard2.0 Newtonsoft build specifically, and why the
+         AspNetCore ref pack has to arrive as a package rather than a ~/.nuget path. -->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3"
                       GeneratePathProperty="true" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.App.Ref" Version="8.0.30"
+                      GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
+
+  <!-- The AspNetCore ref pack ships Roslyn analyzers. ExcludeAssets does not keep them out of
+       the analyzer item group, and they then throw AD0001 on every build (882 of them) looking
+       for ASP.NET Core types nothing here references. The pack is wanted for ONE file, so
+       dropping its analyzers outright is exactly the intent. Measured: a CLEAN rebuild,
+       because an incremental one skips CoreCompile and reports 0 whatever this target does. -->
+  <Target Name="DropAspNetCoreRefPackAnalyzers" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)"
+                Condition="$([System.String]::Copy('%(Analyzer.FullPath)').Replace('\','/').Contains('/microsoft.aspnetcore.app.ref/'))" />
+    </ItemGroup>
+  </Target>
 
   <!-- .NET assemblies BC's AL binder must see BEFORE the service tier's own copies.
        Program.cs puts this directory at the head of the probing paths automatically.
@@ -47,11 +62,29 @@
        costs the entire ground truth. The netstandard2.0 build of the SAME Newtonsoft version
        binds against netstandard, which does resolve.
 
+       Microsoft.AspNetCore.StaticFiles is the second, and it is what makes Base Application
+       emittable at all (#3876). Its dotnet.al:23 declares assembly(Microsoft.AspNetCore.
+       StaticFiles) for FileExtensionContentTypeProvider; BC ships no copy, so AL0451 + AL0185
+       killed the declaration phase and the app produced ZERO objects. With this one file
+       staged: errors=0, objects=7850, 7,842 documents. Exactly one file, because that line is
+       the only AspNetCore assembly the app declares.
+
+       Why an ordinary strong-named ref-pack copy satisfies a reference whose AL0451 text says
+       PublicKeyToken=null: the AL declaration states no token, and
+       AssemblyLocatorBase.IsAssemblyCompatible guards its token comparison on the SEARCH name
+       carrying a non-empty one. Asymmetric, not token-blind — a wrong token is still rejected,
+       a wrong simple name always is. `null` there is DotNetUtilities.GetPublicKeyToken's
+       rendering of an absent token, which three documents in this repo read as a demand for a
+       null-token assembly (docs/dependency-metadata-from-bc.md).
+
        Deliberately a package reference rather than a path into ~/.nuget: a CI leg has no reason
        to have that package cached, and probing for one would make the generator's success
-       depend on what happened to be on the machine. -->
+       depend on what happened to be on the machine. The AspNetCore ref pack makes that
+       decisive rather than tidy — unlike Microsoft.NETCore.App.Ref it is NOT an SDK component
+       and is absent from $DOTNET_ROOT/packs on a setup-dotnet leg, so a ~/.nuget path would
+       pass locally and fail on CI. -->
   <Target Name="CopyDotNetShims" AfterTargets="Build">
-    <Copy SourceFiles="$(PkgNewtonsoft_Json)/lib/netstandard2.0/Newtonsoft.Json.dll"
+    <Copy SourceFiles="$(PkgNewtonsoft_Json)/lib/netstandard2.0/Newtonsoft.Json.dll;$(PkgMicrosoft_AspNetCore_App_Ref)/ref/net8.0/Microsoft.AspNetCore.StaticFiles.dll"
           DestinationFolder="$(OutDir)dotnet-shims" SkipUnchangedFiles="true" />
   </Target>
 


### PR DESCRIPTION
Closes #3876

Corpus-NA: build configuration plus documentation. The change decides which .NET assembly BC's AL binder resolves a DotNet declaration from while compiling a Microsoft app's own shipped source; the corpus compiles and runs its own apps and has no way to express that. The gate agrees — `check_corpus_linkage.sh` reports "no file in this diff can change what AL observes".

Seven places in this repository recorded Base Application's metadata emit as permanently impossible. It is not. Staging one file — `Microsoft.AspNetCore.StaticFiles.dll` from the ASP.NET Core reference pack — takes the emit from zero objects to **`errors=0`, `objects=7850`, 7,842 documents**.

## What changed

| file | change |
|---|---|
| `AlRunner/AlRunner.csproj` | `PackageReference` on `Microsoft.AspNetCore.App.Ref` 8.0.30 + `Content` staging of the one DLL into `dotnet-shims`, beside the existing Newtonsoft shim |
| `tools/metadata-ground-truth/MetadataGroundTruth.csproj` | the same, through its `CopyDotNetShims` target |
| both | a `DropAspNetCoreRefPackAnalyzers` target — see "the analyzer wrinkle" below |
| `AlRunner/DependencyMetadataProducer.cs` | the `NOT BASE APPLICATION` header and the `NeverCompile` doc comment: the exclusion **stays**, its stated reason changes from a false blocker to a measured cost |
| `tests/expectations/metadata-equivalence/apps.json` | same correction; the app list is deliberately unchanged |
| `docs/dependency-metadata-from-bc.md` | the "hard blocker" section rewritten, with the measurement and the resolver mechanism |
| `docs/where-metadata-comes-from.md`, `docs/metadata-equivalence.md` (×3), `allowlist.json` (×2) | four further records of the same false claim, found by scanning — not in the issue |
| `AlRunner.Tests/DotNetShimProbingTests.cs` | three new tests |

## The mechanism, because the issue body states it wrongly

The issue says the ref pack supplies a `PublicKeyToken=null` assembly. It does not — the file is strong-named `adb9793829ddae60`. Two coordinator comments correct this and I verified both halves independently rather than accepting them.

**`PublicKeyToken=null` in the `AL0451` text is display formatting for "the AL declaration specified no token"**, from `DotNetUtilities.GetPublicKeyToken`, which returns the literal string `"null"` for an empty token. Verified at the source side, parsed out of the shipped package rather than read from a comment: Base Application's `src/Modules/System/DotNetAliases/dotnet.al` has exactly three `assembly()` declarations and exactly one `PublicKeyToken` line — line 7, on `Ncl`. Line 23 declares `assembly(Microsoft.AspNetCore.StaticFiles)` with **no** token. That is also why one file suffices: it is the only AspNetCore assembly the app declares.

**Matching is asymmetric, not token-blind.** From the AL compiler's `AssemblyLocatorBase.IsAssemblyCompatible`, the token comparison is guarded on the *search* name carrying a non-empty token:

| search name | candidate token | result |
|---|---|---|
| carries no token | anything | **not checked** |
| carries a token | different | rejected |
| wrong simple name | anything | rejected |

So a wrong token is still rejected and a wrong simple name always is. I have deliberately **not** written "obtainable via a simple-name match" anywhere, because that phrasing implies the token is ignored, which the third row disproves. The resolver is the AL compiler's (`Microsoft.Dynamics.Nav.CodeAnalysis.dll`), not `Ncl.dll`'s.

## RED → GREEN, and the mutation checks

**RED**, `--decl-only` against Base Application 28.1.49838.53910, exit code read directly:

```
[decl] 13646ms  errors=2       EXIT=1
   [AL0451] An assembly named 'Microsoft.AspNetCore.StaticFiles, PublicKeyToken=null' could not be found…
   [AL0185] DotNet 'FileExtensionContentTypeProvider' is missing
```

**GREEN**, full emit **through the shipped staging** — no `--dotnet-first` flag, which is the difference from the three earlier reproductions:

```
[decl]  15084ms  errors=0
[emit] 227480ms  success=True objects=7850 errors=0
[bundle] 7842 document(s)
EXIT=0  wall=257s  peak VmHWM=9,263,480 kB = 8.83 GiB
```

Confirmed a second, differently-shaped way: 7,843 files on disk in the bundle directory = 7,842 documents + 1 `manifest.json`. The counts reconcile. This is the fourth independent reproduction of `objects=7850 / 7,842 documents` and it confirms the coordinator's 8.77 GiB within sampling noise.

**Three new tests, two mutation-checked.**

1. `BuildStagesTheAspNetCoreStaticFilesShimBesideTheRunnerBinary` — asserts on the **real build output**, so a test staging its own copy cannot pass it, and asserts the file contains `FileExtensionContentTypeProvider`: a same-named assembly lacking that type would leave `AL0185` in place while a filename-only assertion went green.
   **Mutation:** deleting the `Content` item from `AlRunner.csproj` → `Failed: 1, Passed: 6`, failing test exactly this one, exit 1.
2. `TheRefAssemblyEnumerationNeverSuppliesAspNetCore_SoTheShimIsTheOnlyRoute` — pins that `BcCompiler.EnumerateDotNetRefAssemblyDirs`, which reads `$DOTNET_ROOT/packs`, never yields this assembly. That is what makes the shim load-bearing and what would fail if someone "simplified" it away. Has a positive half too, so it cannot pass merely because the enumeration came back empty.
3. `TheRunnerAndTheGroundTruthGeneratorStageTheSameShimSet` — see "fix the shape" Q3. Compares the staged file set, the package versions **and the analyzer-drop `Condition` character for character**.
   **Mutations, both → `Failed: 1, Passed: 0`, exit 1:** removing the shim + package from the generator csproj; and reintroducing the doubled-backslash `Replace` on the runner side (the review finding below).

## CI resolution — the part flagged as the risk

**The reference pack is not an SDK component.** Verified on this box: `$DOTNET_ROOT/packs` holds only `Microsoft.NETCore.App.Host.arch-x64`, `Microsoft.NETCore.App.Ref` and `NETStandard.Library.Ref`. No `Microsoft.AspNetCore.App.Ref`. It exists only under `~/.nuget`. So a hardcoded `~/.nuget` path would pass here and fail on a `setup-dotnet` leg — which is why this uses the `PackageReference` + `GeneratePathProperty` + `ExcludeAssets="all"` pattern already proven in `AlRunner.csproj` for the Newtonsoft shim.

**I established this locally rather than asserting it.** Restoring with `NUGET_PACKAGES` pointed at an **empty directory** — no `~/.nuget` to fall back on, i.e. a cold CI leg:

```
=== empty packages dir: 0 entries ===
RESTORE_RC=0
=== did the pack land? ===  8.0.30
BUILD_RC=0   AD0001=0
=== staged from the cold cache ===  Microsoft.AspNetCore.StaticFiles.dll, Newtonsoft.Json.dll
=== hash matches the pack ===  9d17abe641e1ac6c / 9d17abe641e1ac6c
```

Restore downloaded the pack from nuget.org, the build staged the file, and the staged file is byte-identical to the pack copy. Both projects do this. That is the full chain a CI leg walks, measured.

**Version pin:** 8.0.30, matching the legs' `8.0.x` runtime. 8.0.25, 9.0.19 and 10.0.11 are four genuinely distinct files (hashes `7df5b684…`, `9d17abe6…`, `7fe13a92…`, `82753c5c…`) and all four bind, so the pin is for predictability, not necessity.

**The analyzer wrinkle, which I would have missed without a clean rebuild.** The pack ships Roslyn analyzers and `ExcludeAssets="all"` does **not** keep them out of the `Analyzer` item group; they then throw `AD0001` warnings per build looking for ASP.NET Core types nothing here references. **The count of 882 is my measurement alone** — the reviewer independently confirmed the exclusion works and the direction is right (`PROBE_TOTAL_ANALYZERS: 15 → 8`) but did not reproduce that figure, so it should not be read as jointly confirmed. Both projects now drop them in a `DropAspNetCoreRefPackAnalyzers` target. Two things I tried first and rejected, recorded because the second is a trap: `IncludeAssets="none"` (no effect) and `-p:EnableAspNetCoreAnalyzers=false`, which **appeared** to work — it reported `AD0001=0` — purely because the build was incremental and skipped `CoreCompile`. A forced clean rebuild showed 882 under both. Every analyzer figure quoted here is from a clean rebuild.

## Review finding: the analyzer-drop condition was broken on Windows

The coordinator caught a real defect at review, and the direction is the opposite of the obvious one. My two `DropAspNetCoreRefPackAnalyzers` targets disagreed — the runner had `Replace('\\','/')` and the generator `Replace('\','/')` — because my patch script doubled the backslash on one side and not the other.

**`'\\'` is the broken form.** MSBuild does not treat a backslash as an escape here, so it looks for a literal two-backslash sequence, finds none in a Windows path, and leaves the path unconverted; `Contains('/microsoft.aspnetcore.app.ref/')` is then false and the analyzers are **not** dropped. I reproduced this in a standalone MSBuild project rather than reasoning about the escaping:

```
DOUBLE win : C:\pkg\microsoft.aspnetcore.app.ref\8.0.30\x.dll     <- unchanged
SINGLE win : C:/pkg/microsoft.aspnetcore.app.ref/8.0.30/x.dll
DOUBLE win contains: False      <- the target never fires
SINGLE win contains: True
DOUBLE nix contains: True
SINGLE nix contains: True
```

So the fix goes to `AlRunner.csproj`, not to the generator. **Not a CI issue** — every leg is Linux, where both forms work, which is exactly why it would have shipped silently; it is the runner that a developer builds on Windows, and there the 882 warnings would have come back with nothing failing. The single-backslash form now carries a comment stating the constraint and the measurement.

**The parity test was the second half of that finding, and it deserved the criticism.** It compared staged filenames and package versions, so it passed while the two targets genuinely disagreed — a parity test that misses a real divergence between the two files it exists to keep in step. It now also compares the `Analyzer Remove` `Condition` character for character, and I mutation-checked it against *the exact divergence that shipped*: reintroducing the doubled backslash on line 228 gives `Failed: 1, Passed: 0`, exit 1, where the filename/version-only version passed.

## Memory, and what this does NOT put on a unit-test leg

**Nothing.** `tests/expectations/metadata-equivalence/apps.json` still lists only Business Foundation and System Application, and `DependencyMetadataProducer.NeverCompile` still excludes Base Application.

That is deliberate, and it is the answer to the brief's third requirement. `apps.json` drives `tools/gen-metadata-ground-truth.sh`, which runs at `bc-tests.yml:507` on the unit-test legs, where the two listed apps cost ~3 s and ~14 s. Base Application costs **257 s and 8.83 GiB**. A standard `ubuntu-latest` runner has 16 GB, so it fits — but alongside the rest of that leg the margin is thin, and an OOM there presents as a killed step with no diagnostic rather than a legible failure. That is a sizing call for a human with the numbers in hand, not a side effect of correcting a false record. Both files now say *why* the app is omitted instead of saying it is impossible.

The `NeverCompile` entry is the same judgement: `DependencyMetadataProducer.Ensure` sits on the dependency-load path of **every run** that resolves Base Application, so removing it would put a 257 s / 8.83 GiB compile into ordinary runs. Its stated reason changes from a false blocker to a measured cost; the behaviour does not.

## Fix the shape

**Q1 — does the same wrong pattern appear elsewhere?** **Yes, and this is the main finding beyond the fix.** The issue named three records. Scanning for the claim itself rather than for the files found **seven**:

- `docs/where-metadata-comes-from.md:76` — the sharpest one. It said the compile "does not work at all", *and* warned the reader against "stating the cost as the reason", having itself stated an incorrect blocker as the reason. The cost was the reason all along.
- `docs/metadata-equivalence.md` lines 700, 704 and 1028.
- `tests/expectations/metadata-equivalence/allowlist.json` lines 83 and 1369.

All four were correcting each other in a loop — precisely the `precompiled-dll-respect.md` § "Reuse before you re-implement" shape the issue itself cites. Correcting only the three named would have left the loop intact and the next reader with four documented reasons not to look again. A re-scan now returns only text inside the corrections.

**Q2 — does a sibling function make the same assumption?** Yes: `BcCompiler.EnumerateDotNetRefAssemblyDirs` assumes `$DOTNET_ROOT/packs` supplies every reference pack a DotNet declaration might need. That assumption is true for the two packs it names and false in general — it is exactly why this shim is needed — and test 2 above pins it so a future edit cannot quietly rely on it.

**Q3 — two code paths writing the same state?** Yes, and it had no guard. `AlRunner.csproj` and `MetadataGroundTruth.csproj` each build a DotNet probing list, and the generator's output is the **oracle** the runner's derivation is measured against in `MetadataEquivalenceHarnessTests`. A shim in one and not the other means the two sides compile the same Microsoft app against different reference sets — and a difference the harness then reported would be an artifact of the drift while looking exactly like a real finding. #3745 staged the first shim in both by hand with nothing holding them together; test 3 now does, covering both the file set and the package versions.

**Queue scan.** Searched the open queue for `AspNetCore`, `StaticFiles`, `NeverCompile`, `DependencyMetadataProducer`, `metadata-equivalence` and Base-Application-metadata. Nothing folds in: #2247 is `DependencyLoader.cs` and is held by another agent, #3816 is the harness headline count, and #3549/#3562/#3825 are the tracking and consumer issues this unblocks rather than duplicates. `DependencyLoader.cs` is untouched by this PR.

## Tests run

Local, `--no-build --settings engine.runsettings` (CI generates that in its own step; a rebuild silently drops the bootstrap — see below), second runs quoted:

```
DotNetShimProbingTests                                     Failed: 0, Passed:   8
  + DependencyMetadataProducer + MetadataEquivalence       Failed: 0, Passed:  65
  + BcCompiler + DependencyResolver + DependencyLoader     Failed: 0, Passed: 207
tools/: doc_pointers, comment_density, line_endings, text_encoding,
        doc_summary_uniqueness, matrix_docs_drift                    all RC=0
```

`Skipped: 0` on every one. The three filters are nested, so 8 / 65 / 207 are cumulative rather than independent. The 207 is unchanged from the pre-review run because all three new tests were already in `c0918b04`; today's commit changes one assertion's *content*, not the test count — confirmed by enumerating the class's test names (8 distinct) rather than inferring it from the total.

**One measurement worth recording, because it produced a wrong-looking answer twice.** An earlier run of the 207-test filter reported `Failed: 68`. That was **not** this change: running with `--settings` but *without* `--no-build` rebuilds, which restores a pristine `bin/Microsoft.Dynamics.Nav.Ncl.dll` and undoes the Cecil rewrite `tools/engine-test-bootstrap.sh` installs — the script's own warning. Confirmed causally rather than assumed: re-running the bootstrap and repeating the identical filter gives `Failed: 0, Passed: 207`, twice. An earlier 31-failure run had the same cause with the guard's own message attached.

## Left out deliberately

- **Base Application is not added to `apps.json` and `NeverCompile` keeps its entry** — the sizing decision above.
- **`DependencyLoader.cs` untouched** — another agent holds it on #2247.
- **The full leg-by-leg locator matrix** (4 compiler binaries × 4 ref-pack versions) is cited in `docs/dependency-metadata-from-bc.md` rather than reproduced in a code comment. I did not re-run it; it is the coordinator's measurement and I have attributed it as such. What I re-measured myself is stated above.

Implemented by the agent loop `stma-auto-11`, not by a person. Session `6cc4d969`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
