### PR TITLE
fix(coverage): report the sources the scan could not read instead of mapping them as object-free

### DIFF
--- a/AlRunner.Tests/CoverageSourceMapScanFailureTests.cs
+++ b/AlRunner.Tests/CoverageSourceMapScanFailureTests.cs
@@ -355,9 +355,15 @@ public sealed class CoverageSourceMapScanFailureTests : IDisposable
         var map = AlCoverageSourceMap.Build(new[] { asFile }, relativeTo: null);
 
         var failure = Assert.Single(map.ScanFailures);
-        Assert.Equal(SourceScanFailureKind.Root, failure.Kind);
         Assert.Contains("is a file", failure.Reason, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("does not exist", failure.Reason, StringComparison.OrdinalIgnoreCase);
+        // File, not Root: Root means a container and gets containment, so classifying a file
+        // root as one made it claim paths "under" a file (#3884 Copilot review).
+        Assert.Equal(SourceScanFailureKind.File, failure.Kind);
+        Assert.Equal("no executable AL statement on this line in this file",
+            DapUnverifiedReason.For(null, map, Path.Combine(asFile, "Child.al")));
+        Assert.Contains("is a file",
+            DapUnverifiedReason.For(null, map, asFile), StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/AlRunner.Tests/CoverageSourceMapScanFailureTests.cs
+++ b/AlRunner.Tests/CoverageSourceMapScanFailureTests.cs
@@ -1,0 +1,270 @@
+// CoverageSourceMapScanFailureTests — #3847: AlCoverageSourceMap.Build could not say "I could
+// not read the sources", so it said "those objects have no executable statements" instead.
+//
+// Two silent skips produced a map that is SUCCESSFULLY short:
+//
+//     if (!Directory.Exists(root)) continue;                        // a root that is not there
+//     catch (IOException) { return Array.Empty<ParsedObject>(); }   // a file that cannot be read
+//
+// Neither is distinguishable from a bundle that genuinely declares nothing mappable — which is
+// a legitimate state, so `Count == 0` cannot be the check either. Both consumers turn a
+// missing entry into a confident negative: coverage reports the statements uncovered, and DAP
+// answers `verified: false` with the message `no executable AL statement on this line in this
+// file`, a specific claim about the AL made on the strength of a read that did not happen.
+//
+// `.claude/rules/guards-need-a-third-state.md` applied to a builder rather than a guard: the
+// genuinely-absent case stays a pass, and only the UNMEASURABLE one becomes the third state.
+
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class CoverageSourceMapScanFailureTests : IDisposable
+{
+    private readonly BcEngineFixture _engine;
+    private readonly string _root;
+
+    public CoverageSourceMapScanFailureTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = TestScratch.Dir("al-runner-sourcemap-scan-failure");
+        Directory.CreateDirectory(_root);
+    }
+
+    private void RequireEngine() =>
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    /// <summary>
+    /// The constraint that keeps the fix from trading one defect for another: a root that
+    /// exists and declares nothing mappable is a REAL state, and stays a clean pass. If this
+    /// went red the fix would have swapped a false green for a false red.
+    /// </summary>
+    [SkippableFact]
+    public void Build_ARootWithNothingMappable_ReportsNoFailures()
+    {
+        RequireEngine();
+        // An interface carries no executable code, so it is legitimately absent from the map.
+        File.WriteAllText(Path.Combine(_root, "Empty.Interface.al"), """
+        interface "Cov Scan Nothing"
+        {
+            procedure Unused(): Integer
+        }
+        """);
+
+        var map = AlCoverageSourceMap.Build(new[] { _root }, relativeTo: _root);
+
+        Assert.Empty(map.ScanFailures);
+        Assert.Equal(0, map.Count);
+    }
+
+    /// <summary>
+    /// RED before the fix: <c>ScanFailures</c> does not exist, and the root is skipped by a
+    /// bare <c>continue</c> that leaves nothing behind. A root the caller named and that is not
+    /// there is not the same as a root with nothing in it — the caller asserted it exists.
+    /// </summary>
+    [SkippableFact]
+    public void Build_ARootThatIsNotThere_IsReportedRatherThanSkippedSilently()
+    {
+        RequireEngine();
+        var missing = Path.Combine(_root, "no-such-directory");
+
+        var map = AlCoverageSourceMap.Build(new[] { _root, missing }, relativeTo: _root);
+
+        var failure = Assert.Single(map.ScanFailures);
+        Assert.Equal(missing, failure.Path);
+        Assert.Contains("does not exist", failure.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The one that produces the wrong ANSWER rather than a short map: a file that is there and
+    /// cannot be read parsed as "this file declares no objects", so its objects were missing
+    /// from the map and every consumer blamed the AL.
+    ///
+    /// The file is locked with <see cref="FileShare.None"/> for the duration, which is how
+    /// <c>File.ReadAllText</c> is made to throw deterministically rather than by permissions,
+    /// which differ per platform and per CI user.
+    /// </summary>
+    [SkippableFact]
+    public void Build_AnAlFileThatCannotBeRead_IsReportedRatherThanReadingAsNoObjects()
+    {
+        RequireEngine();
+        var readable = Path.Combine(_root, "Readable.Codeunit.al");
+        File.WriteAllText(readable, """
+        codeunit 63660 "Cov Scan Readable"
+        {
+            procedure Value(): Integer
+            begin
+                exit(5);
+            end;
+        }
+        """);
+        var locked = Path.Combine(_root, "Locked.Codeunit.al");
+        File.WriteAllText(locked, """
+        codeunit 63661 "Cov Scan Locked"
+        {
+            procedure Value(): Integer
+            begin
+                exit(6);
+            end;
+        }
+        """);
+
+        AlSourceLocationMap map;
+        using (new FileStream(locked, FileMode.Open, FileAccess.Read, FileShare.None))
+            map = AlCoverageSourceMap.Build(new[] { _root }, relativeTo: _root);
+
+        // The readable file's object is still mapped — one unreadable file does not cost the
+        // rest of the scan.
+        Assert.True(map.ContainsKey(("CodeUnit", 63660)));
+        // And the unreadable one is NOT reported as an object-free file.
+        Assert.False(map.ContainsKey(("CodeUnit", 63661)));
+        var failure = Assert.Single(map.ScanFailures);
+        Assert.Equal(locked, failure.Path);
+        Assert.Contains("could not be read", failure.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── the consumer: what the debugger tells the user ──────────────────────────────────
+
+    /// <summary>
+    /// The whole point of the third state, at the place the wrong claim was made. A breakpoint
+    /// in a file the scan could not read used to come back "no executable AL statement on this
+    /// line in this file" — a measured-sounding fact about AL that nobody read.
+    /// </summary>
+    [SkippableFact]
+    public void UnverifiedReason_ForAFileThatCouldNotBeRead_SaysSoRatherThanBlamingTheLine()
+    {
+        RequireEngine();
+        var locked = Path.Combine(_root, "Locked.Codeunit.al");
+        File.WriteAllText(locked, """
+        codeunit 63670 "Cov Reason Locked"
+        {
+            procedure Value(): Integer
+            begin
+                exit(7);
+            end;
+        }
+        """);
+
+        AlSourceLocationMap map;
+        using (new FileStream(locked, FileMode.Open, FileAccess.Read, FileShare.None))
+            map = AlCoverageSourceMap.Build(new[] { _root }, relativeTo: null);
+
+        var reason = DapUnverifiedReason.For(compileFailure: null, map, locked);
+
+        Assert.Contains("could not be read", reason, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("no executable AL statement", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The measured answer must survive: a file that WAS read, on a line with no statement,
+    /// still says exactly that. Without this the fix could turn every unverified breakpoint
+    /// into "could not be read", which is the opposite false claim.
+    /// </summary>
+    [SkippableFact]
+    public void UnverifiedReason_ForAFileThatWasRead_StillBlamesTheLine()
+    {
+        RequireEngine();
+        var readable = Path.Combine(_root, "Readable.Codeunit.al");
+        File.WriteAllText(readable, """
+        codeunit 63671 "Cov Reason Readable"
+        {
+            procedure Value(): Integer
+            begin
+                exit(8);
+            end;
+        }
+        """);
+
+        var map = AlCoverageSourceMap.Build(new[] { _root }, relativeTo: null);
+
+        var reason = DapUnverifiedReason.For(compileFailure: null, map, readable);
+
+        Assert.Equal("no executable AL statement on this line in this file", reason);
+    }
+
+    /// <summary>
+    /// A scan failure elsewhere must not be reported against an unrelated file. The failure
+    /// list is process-wide for one Build call, so without a path test every unverified
+    /// breakpoint in the bundle would inherit one unreadable file's excuse.
+    /// </summary>
+    [SkippableFact]
+    public void UnverifiedReason_ForAReadableFileBesideAnUnreadableOne_StillBlamesTheLine()
+    {
+        RequireEngine();
+        var readable = Path.Combine(_root, "Readable.Codeunit.al");
+        File.WriteAllText(readable, """
+        codeunit 63672 "Cov Reason Other"
+        {
+            procedure Value(): Integer
+            begin
+                exit(9);
+            end;
+        }
+        """);
+        var locked = Path.Combine(_root, "Locked.Codeunit.al");
+        File.WriteAllText(locked, """
+        codeunit 63673 "Cov Reason Locked Other"
+        {
+            procedure Value(): Integer
+            begin
+                exit(10);
+            end;
+        }
+        """);
+
+        AlSourceLocationMap map;
+        using (new FileStream(locked, FileMode.Open, FileAccess.Read, FileShare.None))
+            map = AlCoverageSourceMap.Build(new[] { _root }, relativeTo: null);
+
+        Assert.Single(map.ScanFailures);
+        Assert.Equal("no executable AL statement on this line in this file",
+            DapUnverifiedReason.For(compileFailure: null, map, readable));
+        Assert.Contains("could not be read",
+            DapUnverifiedReason.For(compileFailure: null, map, locked),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// A file UNDER a directory the scan could not enter. The failure names the directory, not
+    /// the file, so equality alone would miss every source beneath it — and those are exactly
+    /// the sources nothing measured.
+    /// </summary>
+    [SkippableFact]
+    public void UnverifiedReason_ForAFileUnderAnUnscannedRoot_SaysSoRatherThanBlamingTheLine()
+    {
+        RequireEngine();
+        var missingRoot = Path.Combine(_root, "gone");
+        var underIt = Path.Combine(missingRoot, "src", "Thing.Codeunit.al");
+
+        var map = AlCoverageSourceMap.Build(new[] { _root, missingRoot }, relativeTo: null);
+
+        Assert.Single(map.ScanFailures);
+        var reason = DapUnverifiedReason.For(compileFailure: null, map, underIt);
+        Assert.Contains("could not be read", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// A compile failure outranks both: nothing bound because nothing compiled, and saying the
+    /// source was unreadable instead would send the user to the wrong place.
+    /// </summary>
+    [SkippableFact]
+    public void UnverifiedReason_WhenTheBundleDidNotCompile_SaysThatFirst()
+    {
+        RequireEngine();
+        var missingRoot = Path.Combine(_root, "gone");
+        var map = AlCoverageSourceMap.Build(new[] { missingRoot }, relativeTo: null);
+        Assert.Single(map.ScanFailures);
+
+        var reason = DapUnverifiedReason.For("error AL0134: nope", map, Path.Combine(missingRoot, "X.al"));
+
+        Assert.Contains("did not compile", reason, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("AL0134", reason, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner.Tests/CoverageSourceMapScanFailureTests.cs
+++ b/AlRunner.Tests/CoverageSourceMapScanFailureTests.cs
@@ -69,10 +69,11 @@ public sealed class CoverageSourceMapScanFailureTests : IDisposable
     /// bare <c>continue</c> that leaves nothing behind. A root the caller named and that is not
     /// there is not the same as a root with nothing in it — the caller asserted it exists.
     /// </summary>
-    [SkippableFact]
+    [Fact]
     public void Build_ARootThatIsNotThere_IsReportedRatherThanSkippedSilently()
     {
-        RequireEngine();
+        // No RequireEngine: a root that is not there is never opened, so nothing parses AL.
+        // The third state must still be provable on a box with no BC artifacts (#3884 review).
         var missing = Path.Combine(_root, "no-such-directory");
 
         var map = AlCoverageSourceMap.Build(new[] { _root, missing }, relativeTo: _root);
@@ -236,10 +237,9 @@ public sealed class CoverageSourceMapScanFailureTests : IDisposable
     /// the file, so equality alone would miss every source beneath it — and those are exactly
     /// the sources nothing measured.
     /// </summary>
-    [SkippableFact]
+    [Fact]
     public void UnverifiedReason_ForAFileUnderAnUnscannedRoot_SaysSoRatherThanBlamingTheLine()
     {
-        RequireEngine();
         var missingRoot = Path.Combine(_root, "gone");
         var underIt = Path.Combine(missingRoot, "src", "Thing.Codeunit.al");
 
@@ -254,10 +254,9 @@ public sealed class CoverageSourceMapScanFailureTests : IDisposable
     /// A compile failure outranks both: nothing bound because nothing compiled, and saying the
     /// source was unreadable instead would send the user to the wrong place.
     /// </summary>
-    [SkippableFact]
+    [Fact]
     public void UnverifiedReason_WhenTheBundleDidNotCompile_SaysThatFirst()
     {
-        RequireEngine();
         var missingRoot = Path.Combine(_root, "gone");
         var map = AlCoverageSourceMap.Build(new[] { missingRoot }, relativeTo: null);
         Assert.Single(map.ScanFailures);
@@ -266,5 +265,125 @@ public sealed class CoverageSourceMapScanFailureTests : IDisposable
 
         Assert.Contains("did not compile", reason, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("AL0134", reason, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// #3884 review: the arm nothing of mine proved. SafeDirectoryScan has always reported the
+    /// directories it could not enter and this caller discarded them with <c>out _</c>; that
+    /// forwarding is what the fix restores, and deleting the loop again would leave a test of
+    /// SafeDirectoryScan itself perfectly green.
+    ///
+    /// Permission bits cannot produce the condition here — they do not bite on Windows or for
+    /// a root CI user, which is why the four InaccessibleDirectoryScanTests rows skip — so the
+    /// scanner is injected instead. This is the forwarding, not the scanning.
+    /// </summary>
+    [Fact]
+    public void Build_ADirectoryTheScannerCouldNotEnter_IsForwardedAsAFailure()
+    {
+        var unreadable = Path.Combine(_root, "locked-subdir");
+
+        var map = AlCoverageSourceMap.Build(
+            new[] { _root }, relativeTo: null,
+            (string root, out IReadOnlyList<string> inaccessible) =>
+            {
+                inaccessible = new[] { unreadable };
+                return Array.Empty<string>();
+            });
+
+        var failure = Assert.Single(map.ScanFailures);
+        Assert.Equal(unreadable, failure.Path);
+        Assert.Equal(SourceScanFailureKind.Directory, failure.Kind);
+        Assert.True(map.IsIncomplete);
+    }
+
+    /// <summary>
+    /// The scanner reporting nothing inaccessible is a clean pass — the constraint again, at
+    /// the seam: injecting a scanner must not itself manufacture a failure.
+    /// </summary>
+    [Fact]
+    public void Build_AScannerThatReportsNothingInaccessible_ReportsNoFailures()
+    {
+        var map = AlCoverageSourceMap.Build(
+            new[] { _root }, relativeTo: null,
+            (string root, out IReadOnlyList<string> inaccessible) =>
+            {
+                inaccessible = Array.Empty<string>();
+                return Array.Empty<string>();
+            });
+
+        Assert.Empty(map.ScanFailures);
+        Assert.False(map.IsIncomplete);
+    }
+
+    /// <summary>
+    /// #3884 review: containment belongs to a ROOT or a DIRECTORY, which cover the sources
+    /// beneath them — never to a FILE, which covers exactly one path. A file failure used as a
+    /// prefix claimed paths "under" a file, which is a shape a DAP client can ask about even
+    /// when the filesystem cannot hold it.
+    /// </summary>
+    [Fact]
+    public void UnverifiedReason_ForAPathUnderAFileFailure_StillBlamesTheLine()
+    {
+        var locked = Path.Combine(_root, "Locked.Codeunit.al");
+        var map = AlCoverageSourceMap.Build(
+            new[] { _root }, relativeTo: null,
+            (string root, out IReadOnlyList<string> inaccessible) =>
+            {
+                inaccessible = Array.Empty<string>();
+                return Array.Empty<string>();
+            });
+        map.AddScanFailure(locked, "the file could not be read (test)", SourceScanFailureKind.File);
+
+        // The file itself is covered...
+        Assert.Contains("could not be read",
+            DapUnverifiedReason.For(null, map, locked), StringComparison.OrdinalIgnoreCase);
+        // ...and a path lexically beneath it is not.
+        Assert.Equal("no executable AL statement on this line in this file",
+            DapUnverifiedReason.For(null, map, Path.Combine(locked, "Child.al")));
+    }
+
+    /// <summary>
+    /// #3884 review: a root supplied as a FILE said "the source root does not exist", which is
+    /// false — it does exist, and the remedy is different.
+    /// </summary>
+    [Fact]
+    public void Build_ARootThatIsAFile_SaysSoRatherThanThatItIsAbsent()
+    {
+        var asFile = Path.Combine(_root, "not-a-directory.al");
+        File.WriteAllText(asFile, "// not a directory\n");
+
+        var map = AlCoverageSourceMap.Build(new[] { asFile }, relativeTo: null);
+
+        var failure = Assert.Single(map.ScanFailures);
+        Assert.Equal(SourceScanFailureKind.Root, failure.Kind);
+        Assert.Contains("is a file", failure.Reason, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("does not exist", failure.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// #3884 review: the warning is per BUILD, not per process. A path that failed, was
+    /// repaired, and failed again is a new event — a process-wide memo of warned paths
+    /// swallowed the second one, and under --server and --watch the process outlives many
+    /// builds.
+    ///
+    /// Asserted on the map rather than on stderr: what the memo suppressed was the WARNING,
+    /// but the contract that matters to a caller is that every build reports its own failures.
+    /// </summary>
+    [Fact]
+    public void Build_TheSameRootFailingTwice_IsReportedBothTimes()
+    {
+        var missing = Path.Combine(_root, "gone-then-back");
+
+        var first = AlCoverageSourceMap.Build(new[] { missing }, relativeTo: null);
+        Assert.Single(first.ScanFailures);
+
+        Directory.CreateDirectory(missing);
+        var repaired = AlCoverageSourceMap.Build(new[] { missing }, relativeTo: null);
+        Assert.Empty(repaired.ScanFailures);
+
+        Directory.Delete(missing);
+        var again = AlCoverageSourceMap.Build(new[] { missing }, relativeTo: null);
+        Assert.Single(again.ScanFailures);
+        Assert.True(again.IsIncomplete);
     }
 }

--- a/AlRunner.Tests/IncompleteCoverageOutcomeTests.cs
+++ b/AlRunner.Tests/IncompleteCoverageOutcomeTests.cs
@@ -1,0 +1,54 @@
+// IncompleteCoverageOutcomeTests — #3884: the exit-code policy for a coverage report built
+// from a source map that could not read everything.
+//
+// The policy exists because three callers have to agree on it — the CLI `--coverage` path,
+// the server's `runTests`, and the server's `execute` — and two of the three shipped
+// disagreeing, because the decision was written inline at each site where nothing could test
+// it and nothing made them match.
+
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class IncompleteCoverageOutcomeTests
+{
+    /// <summary>
+    /// The rule this whole change is an instance of: could-not-measure must not leave on the
+    /// exit-0 path (`.claude/rules/guards-need-a-third-state.md`). A coverage number computed
+    /// over an unknown subset of the sources is not a coverage number.
+    /// </summary>
+    [Fact]
+    public void AnIncompleteMapWithAReport_EscalatesACleanRunToTwo()
+        => Assert.Equal(2, IncompleteCoverageOutcome.Apply(0, mapIsIncomplete: true, coverageWasProduced: true));
+
+    /// <summary>
+    /// The constraint, in the direction that matters most: a complete scan must stay a pass.
+    /// A policy that escalated unconditionally would turn every green run red.
+    /// </summary>
+    [Fact]
+    public void ACompleteMap_LeavesACleanRunAlone()
+        => Assert.Equal(0, IncompleteCoverageOutcome.Apply(0, mapIsIncomplete: false, coverageWasProduced: true));
+
+    /// <summary>
+    /// A run that is ALREADY failing keeps its own code. The caller's first problem is the one
+    /// they have — a failing test, a compile error — and overwriting it with 2 would lose it.
+    /// </summary>
+    [Theory]
+    [InlineData(1)]  // a test failed
+    [InlineData(3)]  // a bundle did not compile
+    [InlineData(4)]  // a count-baseline mismatch
+    public void ARunThatIsAlreadyFailing_KeepsItsOwnCode(int already)
+        => Assert.Equal(already,
+            IncompleteCoverageOutcome.Apply(already, mapIsIncomplete: true, coverageWasProduced: true));
+
+    /// <summary>
+    /// No coverage artifact, no claim about one. When the write failed, or the caller never
+    /// asked for coverage, the run has a different and louder problem and this is not the
+    /// thing to report — the CLI's unwritable-output path already owns that case
+    /// (#3884 Copilot review).
+    /// </summary>
+    [Fact]
+    public void AnIncompleteMapWithNoReport_ChangesNothing()
+        => Assert.Equal(0, IncompleteCoverageOutcome.Apply(0, mapIsIncomplete: true, coverageWasProduced: false));
+}

--- a/AlRunner.Tests/ServerAffectedSelectionMultiSourcePathsTests.cs
+++ b/AlRunner.Tests/ServerAffectedSelectionMultiSourcePathsTests.cs
@@ -327,4 +327,102 @@ public class ServerAffectedSelectionMultiSourcePathsTests
         Assert.Contains(selection2.GetProperty("changedObjects").EnumerateArray().Select(x => x.GetString()),
             x => x != null && x.Contains("Multi Affected Helper2A SX", StringComparison.Ordinal));
     }
+
+    /// <summary>
+    /// #3884: the defect the exit code cannot reach. An incomplete source scan does not merely
+    /// make the response's coverage table short — it poisons the affected-test SELECTION
+    /// baseline, silently.
+    ///
+    /// <para>CollectPerTestStatementTable drops a statement whose object never reached the
+    /// source map, so what survives is a NON-EMPTY, entirely mappable list: indistinguishable
+    /// from a test that genuinely only touched those objects, and the `unmappable` check cannot
+    /// see what was discarded upstream. Store that as a baseline and a later edit to the source
+    /// that could not be read intersects nothing, so the test that calls into it is SKIPPED —
+    /// a wrong answer, produced quietly, which is precisely what the third state exists to
+    /// prevent.</para>
+    ///
+    /// <para>The scan happens between compilation and the response, which no test can time from
+    /// outside the process — locking the file earlier fails the compile instead. Hence
+    /// AL_RUNNER_TEST_FORCE_SCAN_FAILURE_ONCE, which fires on the FIRST build only: request 1
+    /// is poisoned, request 2 is clean, so request 2 running OnlyA proves request 1 invalidated
+    /// its baseline rather than that request 2 poisoned itself.</para>
+    ///
+    /// <para><b>What this fact does and does not pin.</b> It asserts the POISONING is real and
+    /// reaches the client: the forced failure is reported, the response is not a clean run, and
+    /// OnlyA's per-test coverage has genuinely lost its HelperA statement while OnlyB's keeps
+    /// its HelperB one — which is the mechanism, measured rather than argued.</para>
+    ///
+    /// <para>It does NOT pin the guard that invalidates the baseline. Measured: with that guard
+    /// reverted this fixture still runs both tests on request 2, so an assertion on ran/skipped
+    /// would pass either way — the shape `ci-verdicts.md` calls an answer that could not have
+    /// come out any other way, and a green one here would be worse than no fact at all. Pinning
+    /// it needs a fixture where the poisoned baseline demonstrably narrows, which this one does
+    /// not produce; tracked as follow-up rather than asserted vacuously.</para>
+    /// </summary>
+    [SkippableFact]
+    public async Task AffectedOnly_AfterAnIncompleteScan_RunsEverythingRatherThanTrustingTheBaseline()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = TestScratch.Dir("al-runner-server-affected-incomplete-scan");
+        Directory.CreateDirectory(root);
+        var appDir = MakeAppBundleTwoHelpers(root);
+        var testAppDir = MakeTestApp2Bundle(root);
+
+        await using var server = await CliServer.StartAsync(
+            new[] { "--no-cache" },
+            extraEnv: new Dictionary<string, string>
+            {
+                ["AL_RUNNER_TEST_FORCE_SCAN_FAILURE_ONCE"] = Path.Combine(appDir, "HelperA.al"),
+            });
+
+        // Request 1: both tests run, and the scan reports a failure — so no usable baseline
+        // may be recorded from it.
+        var lines1 = await server.SendRequestStreamingAsync(RunTestsRequest2(appDir, testAppDir));
+        var (events1, summary1) = ProtocolV2Streaming.Split(lines1);
+        Assert.Equal(2, events1.Count);
+        Assert.True(summary1.TryGetProperty("sourceScanFailures", out var failures1),
+            $"the forced scan failure did not reach the response: {string.Join(" | ", lines1)}");
+        Assert.Equal(1, failures1.GetArrayLength());
+        // And it is not published as a clean run.
+        Assert.Equal(2, summary1.GetProperty("exitCode").GetInt32());
+
+        // The poisoning is REAL, not just reported: OnlyA calls into HelperA, and its per-test
+        // coverage has lost that statement because HelperA's objects never reached the map.
+        // OnlyB, whose helper was readable, keeps its HelperB statement — so this is the
+        // discarded-upstream case the `unmappable` check cannot see, and not an empty table.
+        var perTest1 = summary1.GetProperty("perTestCoverage");
+        var onlyA = perTest1.EnumerateArray()
+            .Single(t => t.GetProperty("test").GetString()!.EndsWith(".OnlyA", StringComparison.Ordinal));
+        var onlyB = perTest1.EnumerateArray()
+            .Single(t => t.GetProperty("test").GetString()!.EndsWith(".OnlyB", StringComparison.Ordinal));
+        var filesA = onlyA.GetProperty("coverage").EnumerateArray()
+            .Select(c => c.GetProperty("file").GetString() ?? "").ToList();
+        var filesB = onlyB.GetProperty("coverage").EnumerateArray()
+            .Select(c => c.GetProperty("file").GetString() ?? "").ToList();
+        Assert.DoesNotContain(filesA, f => f.EndsWith("HelperA.al", StringComparison.OrdinalIgnoreCase));
+        Assert.NotEmpty(filesA);   // non-empty and entirely mappable: the dangerous shape
+        Assert.Contains(filesB, f => f.EndsWith("HelperB.al", StringComparison.OrdinalIgnoreCase));
+
+        File.WriteAllText(Path.Combine(appDir, "HelperA.al"), """
+        codeunit 60380 "Multi Affected Helper2A SX"
+        {
+            procedure ValueA(): Integer
+            var
+                X: Integer;
+            begin
+                X := 1;
+                exit(X);
+            end;
+        }
+        """);
+
+        // Request 2's own scan is clean — the seam fires once — so a later failure here would
+        // mean the seam leaked into a second build.
+        var lines2 = await server.SendRequestStreamingAsync(RunTestsRequest2(appDir, testAppDir));
+        var (_, summary2) = ProtocolV2Streaming.Split(lines2);
+        Assert.False(summary2.TryGetProperty("sourceScanFailures", out _),
+            $"request 2's scan should be clean: {string.Join(" | ", lines2)}");
+        Assert.Equal(0, summary2.GetProperty("exitCode").GetInt32());
+    }
 }

--- a/AlRunner.Tests/ServerProtocolAckSummaryTests.cs
+++ b/AlRunner.Tests/ServerProtocolAckSummaryTests.cs
@@ -119,4 +119,82 @@ public class ServerProtocolAckSummaryTests
         Assert.True(sel.GetProperty("forcedFull").GetBoolean());
         Assert.Equal("change model unavailable", sel.GetProperty("reason").GetString());
     }
+
+    // ── sourceScanFailures (#3847/#3884) ────────────────────────────────────────────────
+
+    /// <summary>
+    /// #3884 Copilot review: the wire field had no direct test, and this class is where the
+    /// Summary/Execute field contracts are pinned. A regression that renamed the field, or
+    /// dropped `kind`, would have passed everything else in the PR.
+    /// </summary>
+    [Fact]
+    public void Summary_WithScanFailures_CarriesPathReasonAndKind()
+    {
+        var failures = new[]
+        {
+            new AlRunner.Infrastructure.SourceScanFailure(
+                "/src/gone", "the source root does not exist",
+                AlRunner.Infrastructure.SourceScanFailureKind.Root),
+            new AlRunner.Infrastructure.SourceScanFailure(
+                "/src/app/Locked.al", "the file could not be read (IOException: locked)",
+                AlRunner.Infrastructure.SourceScanFailureKind.File),
+        };
+
+        var json = ServerProtocol.Summary(
+            new[] { PassResult }, exitCode: 2, cached: false, sourceScanFailures: failures);
+
+        using var doc = JsonDocument.Parse(json);
+        var arr = doc.RootElement.GetProperty("sourceScanFailures");
+        Assert.Equal(2, arr.GetArrayLength());
+        Assert.Equal("/src/gone", arr[0].GetProperty("path").GetString());
+        Assert.Equal("the source root does not exist", arr[0].GetProperty("reason").GetString());
+        Assert.Equal("Root", arr[0].GetProperty("kind").GetString());
+        // The kind a client must NOT treat as a prefix.
+        Assert.Equal("File", arr[1].GetProperty("kind").GetString());
+    }
+
+    /// <summary>
+    /// Absent, never an empty array — the convention `coverage` and `companyInitFailures`
+    /// already use, so a client that does not know the field sees no change at all. An empty
+    /// array would read as "the scan reported something", which is the opposite of the truth.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]  // null
+    [InlineData(true)]   // empty
+    public void Summary_WithNoScanFailures_OmitsTheFieldEntirely(bool empty)
+    {
+        var json = ServerProtocol.Summary(
+            new[] { PassResult }, exitCode: 0, cached: false,
+            sourceScanFailures: empty
+                ? Array.Empty<AlRunner.Infrastructure.SourceScanFailure>()
+                : null);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.False(doc.RootElement.TryGetProperty("sourceScanFailures", out _));
+    }
+
+    /// <summary>The execute response carries the same field, with the same omission rule —
+    /// it is a separate serializer and the two have drifted before.</summary>
+    [Fact]
+    public void Execute_CarriesScanFailures_AndOmitsThemWhenThereAreNone()
+    {
+        var failures = new[]
+        {
+            new AlRunner.Infrastructure.SourceScanFailure(
+                "/src/sub", "the directory could not be read",
+                AlRunner.Infrastructure.SourceScanFailureKind.Directory),
+        };
+
+        using (var doc = JsonDocument.Parse(
+            ServerProtocol.Execute(new[] { PassResult }, exitCode: 2, sourceScanFailures: failures)))
+        {
+            var arr = doc.RootElement.GetProperty("sourceScanFailures");
+            Assert.Equal(1, arr.GetArrayLength());
+            Assert.Equal("Directory", arr[0].GetProperty("kind").GetString());
+        }
+
+        using (var doc = JsonDocument.Parse(
+            ServerProtocol.Execute(new[] { PassResult }, exitCode: 0)))
+            Assert.False(doc.RootElement.TryGetProperty("sourceScanFailures", out _));
+    }
 }

--- a/AlRunner/Infrastructure/AlCoverageSourceMap.cs
+++ b/AlRunner/Infrastructure/AlCoverageSourceMap.cs
@@ -10,9 +10,14 @@ using NavSyntax = Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 
 namespace AlRunner.Infrastructure;
 
+/// <summary>What a scan failure names. Only <see cref="Root"/> and <see cref="Directory"/>
+/// cover the sources BENEATH them; a <see cref="File"/> failure covers exactly one path, so a
+/// consumer must not treat it as a prefix (#3884 review).</summary>
+public enum SourceScanFailureKind { Root, Directory, File }
+
 /// <summary>Something the scan could not read, and why. Never a parse failure or an object
 /// kind the map does not carry — those are measurements, and this is the absence of one.</summary>
-public readonly record struct SourceScanFailure(string Path, string Reason);
+public readonly record struct SourceScanFailure(string Path, string Reason, SourceScanFailureKind Kind);
 
 /// <summary>
 /// (object label, object id) → the declaring file, readable as the plain
@@ -71,13 +76,13 @@ public sealed class AlSourceLocationMap : IReadOnlyDictionary<(string Label, int
     internal void Add(string label, int id, string path, int lineOffset) =>
         _entries[(label, id)] = (path, lineOffset);
 
-    internal void AddScanFailure(string path, string reason)
+    internal void AddScanFailure(string path, string reason, SourceScanFailureKind kind)
     {
         // Deduplicated: one root can be named by two callers, and a locked file is reached
         // once per scan but a scan can run per bundle.
         foreach (var existing in _scanFailures)
             if (existing.Path == path) return;
-        _scanFailures.Add(new SourceScanFailure(path, reason));
+        _scanFailures.Add(new SourceScanFailure(path, reason, kind));
     }
 
     /// <summary>Lines to add to a decoded [SourceSpans] line of this object to get its file
@@ -130,6 +135,24 @@ public static class AlCoverageSourceMap
     /// </para>
     /// </summary>
     public static AlSourceLocationMap Build(IEnumerable<string> roots, string? relativeTo = null)
+        => Build(roots, relativeTo, static (string root, out IReadOnlyList<string> inaccessible)
+            => SafeDirectoryScan.Files(root, "*.al", out inaccessible));
+
+    /// <summary>
+    /// How <see cref="Build"/> lists a root: the .al files under it, and the directories it
+    /// could not enter. A seam, not a policy — the production implementation is
+    /// <see cref="SafeDirectoryScan.Files(string, string, out IReadOnlyList{string}, SearchOption)"/>
+    /// and nothing else may be passed outside tests.
+    ///
+    /// <para>It exists because the inaccessible-directory arm is otherwise untestable without
+    /// permission bits, which do not bite on Windows or for a root CI user — and a test of
+    /// SafeDirectoryScan alone would stay green if THIS method stopped forwarding what it
+    /// reports, which is exactly the defect (#3884 review).</para>
+    /// </summary>
+    internal delegate IReadOnlyList<string> RootScanner(string root, out IReadOnlyList<string> inaccessible);
+
+    internal static AlSourceLocationMap Build(
+        IEnumerable<string> roots, string? relativeTo, RootScanner scan)
     {
         var map = new AlSourceLocationMap();
         var symbolsByAppJson = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
@@ -139,16 +162,23 @@ public static class AlCoverageSourceMap
             if (!Directory.Exists(root))
             {
                 // Not the same as a root with nothing in it: the caller named this path, so
-                // its absence is an unmeasured scan rather than an empty one (#3847).
-                map.AddScanFailure(root, "the source root does not exist");
+                // its absence is an unmeasured scan rather than an empty one (#3847). A path
+                // that IS there but is a file says so rather than "does not exist", which was
+                // false and sent the reader looking for the wrong thing (#3884 review).
+                map.AddScanFailure(root,
+                    File.Exists(root)
+                        ? "the source root is a file, and a source root must be a directory"
+                        : "the source root does not exist",
+                    SourceScanFailureKind.Root);
                 continue;
             }
             // SafeDirectoryScan has always been able to say which directories it could not
             // enter; this scan discarded the answer with `out _`, which is the shape #3847 is
             // about — the mechanism existed and the caller threw it away.
-            var files = SafeDirectoryScan.Files(root, "*.al", out var inaccessible);
+            var files = scan(root, out var inaccessible);
             foreach (var dir in inaccessible)
-                map.AddScanFailure(dir, "the directory could not be read, so any AL under it was not scanned");
+                map.AddScanFailure(dir, "the directory could not be read, so any AL under it was not scanned",
+                    SourceScanFailureKind.Directory);
             foreach (var file in files)
             {
                 var appJson = NearestAppJson(Path.GetDirectoryName(file)!, appJsonByDir);
@@ -161,33 +191,35 @@ public static class AlCoverageSourceMap
                 var parsed = ParseObjects(file, symbols, out var readFailure);
                 foreach (var o in parsed)
                     map.Add(o.Label, o.Id, path, o.LineOffset);
-                if (readFailure != null) map.AddScanFailure(file, readFailure);
+                if (readFailure != null)
+                    map.AddScanFailure(file, readFailure, SourceScanFailureKind.File);
             }
         }
-        WarnOnce(map);
+        Warn(map);
         return map;
     }
 
-    private static readonly HashSet<string> _warned = new();
-
     /// <summary>
-    /// Says out loud, once per path per process, that part of the scan did not happen. Here
-    /// rather than at each of the five call sites, because every one of them would otherwise
-    /// have to remember — and the consumer that forgets is the one that reports a confident
-    /// negative about AL nobody read (#3847).
+    /// Says out loud that part of the scan did not happen. Here rather than at each of the five
+    /// call sites, because every one of them would otherwise have to remember — and the
+    /// consumer that forgets is the one that reports a confident negative about AL nobody read
+    /// (#3847).
+    ///
+    /// <para>Once per BUILD, not once per process. A process-wide memo of warned paths was the
+    /// first version and it is wrong twice over (#3884 review): under --server and --watch the
+    /// process is long-lived, so a path that failed, was repaired, and failed AGAIN is a new
+    /// event that the memo silently swallows — and the memo grows for the life of the process,
+    /// one entry per distinct path any request ever named. AddScanFailure already
+    /// de-duplicates within one map, which is the honest scope for "do not say it twice".</para>
     ///
     /// Console.Error, not Console.Out: under --dap stdio, stdout IS the protocol channel.
     /// </summary>
-    private static void WarnOnce(AlSourceLocationMap map)
+    private static void Warn(AlSourceLocationMap map)
     {
         foreach (var failure in map.ScanFailures)
-        {
-            lock (_warned)
-                if (!_warned.Add(failure.Path)) continue;
             Console.Error.WriteLine(
                 $"[source-map] {failure.Path}: {failure.Reason}. Objects it declares are absent "
                 + "from the source map, so coverage and the debugger cannot attribute them.");
-        }
     }
 
     /// <summary>The nearest app.json in <paramref name="dir"/> or an ancestor, or null. The
@@ -214,8 +246,29 @@ public static class AlCoverageSourceMap
         string file, IReadOnlyList<string> symbols, out string? readFailure)
     {
         readFailure = null;
-        var info = new FileInfo(file);
-        var key = $"{file}|{info.Length}|{info.LastWriteTimeUtc.Ticks}|{string.Join(",", symbols)}";
+        // The FINGERPRINT read is guarded too. FileInfo.Length and LastWriteTimeUtc hit the
+        // filesystem, so a file deleted between the directory enumeration and this line, or one
+        // whose metadata the filesystem refuses, threw out of Build instead of becoming the
+        // third state this whole change is about (#3884 review).
+        string key;
+        try
+        {
+            var info = new FileInfo(file);
+            key = $"{file}|{info.Length}|{info.LastWriteTimeUtc.Ticks}|{string.Join(",", symbols)}";
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            readFailure = $"the file's metadata could not be read ({ex.GetType().Name}: {ex.Message})";
+            return Array.Empty<ParsedObject>();
+        }
+
+        // A cache hit is a PREVIOUS measurement of a file whose path, length, modification
+        // time and preprocessor symbols are all unchanged, and it is accepted as one: this
+        // does not re-open the file, so a file that has become unreadable since without
+        // changing its fingerprint reports its old objects and no failure. Stated because it
+        // is the one way ScanFailures can be empty while a fresh read would fail (#3884
+        // review); the alternative is an open() per file per build, which is the cost this
+        // memo exists to avoid.
         if (_parsed.TryGetValue(key, out var cached)) return cached;
 
         string content;

--- a/AlRunner/Infrastructure/AlCoverageSourceMap.cs
+++ b/AlRunner/Infrastructure/AlCoverageSourceMap.cs
@@ -10,6 +10,10 @@ using NavSyntax = Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 
 namespace AlRunner.Infrastructure;
 
+/// <summary>Something the scan could not read, and why. Never a parse failure or an object
+/// kind the map does not carry — those are measurements, and this is the absence of one.</summary>
+public readonly record struct SourceScanFailure(string Path, string Reason);
+
 /// <summary>
 /// (object label, object id) → the declaring file, readable as the plain
 /// <c>IReadOnlyDictionary&lt;(Label, Id), string&gt;</c> the older consumers take, plus
@@ -36,10 +40,6 @@ namespace AlRunner.Infrastructure;
 /// </para>
 /// (#3713; CoverageMultiObjectFileTests pins the header shapes that settled both.)
 /// </summary>
-/// <summary>Something the scan could not read, and why. Never a parse failure or an object
-/// kind the map does not carry — those are measurements, and this is the absence of one.</summary>
-public readonly record struct SourceScanFailure(string Path, string Reason);
-
 public sealed class AlSourceLocationMap : IReadOnlyDictionary<(string Label, int Id), string>
 {
     private readonly Dictionary<(string Label, int Id), (string Path, int LineOffset)> _entries = new();

--- a/AlRunner/Infrastructure/AlCoverageSourceMap.cs
+++ b/AlRunner/Infrastructure/AlCoverageSourceMap.cs
@@ -155,9 +155,12 @@ public static class AlCoverageSourceMap
         IEnumerable<string> roots, string? relativeTo, RootScanner scan)
     {
         var map = new AlSourceLocationMap();
+        // Materialised once: `roots` may be a lazy sequence, and Warn needs the same list the
+        // scan walked in order to tell a recovery from a root it never looked at.
+        var rootList = roots as IReadOnlyList<string> ?? roots.ToList();
         var symbolsByAppJson = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
         var appJsonByDir = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
-        foreach (var root in roots)
+        foreach (var root in rootList)
         {
             if (!Directory.Exists(root))
             {
@@ -165,17 +168,31 @@ public static class AlCoverageSourceMap
                 // its absence is an unmeasured scan rather than an empty one (#3847). A path
                 // that IS there but is a file says so rather than "does not exist", which was
                 // false and sent the reader looking for the wrong thing (#3884 review).
+                // A root that IS there but is a file covers exactly one path, so it is a File
+                // failure — Root means a container, and DapUnverifiedReason applies containment
+                // to a container, which would have claimed `<that file>/Child.al` (#3884
+                // Copilot review).
+                var rootIsFile = File.Exists(root);
                 map.AddScanFailure(root,
-                    File.Exists(root)
+                    rootIsFile
                         ? "the source root is a file, and a source root must be a directory"
                         : "the source root does not exist",
-                    SourceScanFailureKind.Root);
+                    rootIsFile ? SourceScanFailureKind.File : SourceScanFailureKind.Root);
                 continue;
             }
             // SafeDirectoryScan has always been able to say which directories it could not
             // enter; this scan discarded the answer with `out _`, which is the shape #3847 is
             // about — the mechanism existed and the caller threw it away.
             var files = scan(root, out var inaccessible);
+            // The Directory.Exists above and this scan are not atomic. A root that went away
+            // in between comes back from the scanner as an ordinary empty listing with nothing
+            // inaccessible — a clean partial map, which is the very race this third state
+            // exists to expose (#3884 Copilot review). Re-checking costs one stat and only
+            // fires when the directory is gone, so a genuinely empty one stays a pass.
+            if (files.Count == 0 && inaccessible.Count == 0 && !Directory.Exists(root))
+                map.AddScanFailure(root,
+                    "the source root disappeared while it was being scanned",
+                    SourceScanFailureKind.Root);
             foreach (var dir in inaccessible)
                 map.AddScanFailure(dir, "the directory could not be read, so any AL under it was not scanned",
                     SourceScanFailureKind.Directory);
@@ -195,9 +212,13 @@ public static class AlCoverageSourceMap
                     map.AddScanFailure(file, readFailure, SourceScanFailureKind.File);
             }
         }
-        Warn(map);
+        Warn(map, rootList);
         return map;
     }
+
+    /// <summary>Paths whose failure has already been announced and has not recovered since.
+    /// Bounded by the number of CURRENTLY failing paths, not by how many a process ever saw.</summary>
+    private static readonly HashSet<string> _announced = new(StringComparer.Ordinal);
 
     /// <summary>
     /// Says out loud that part of the scan did not happen. Here rather than at each of the five
@@ -205,21 +226,50 @@ public static class AlCoverageSourceMap
     /// consumer that forgets is the one that reports a confident negative about AL nobody read
     /// (#3847).
     ///
-    /// <para>Once per BUILD, not once per process. A process-wide memo of warned paths was the
-    /// first version and it is wrong twice over (#3884 review): under --server and --watch the
-    /// process is long-lived, so a path that failed, was repaired, and failed AGAIN is a new
-    /// event that the memo silently swallows — and the memo grows for the life of the process,
-    /// one entry per distinct path any request ever named. AddScanFailure already
-    /// de-duplicates within one map, which is the honest scope for "do not say it twice".</para>
+    /// <para>On the TRANSITION into failure, which is the only spelling two reviews could both
+    /// live with (#3884). Once per process swallows a path that failed, was repaired, and
+    /// failed again — a real event under --server and --watch, where the process outlives many
+    /// builds — and grows by every path any request ever named. Once per build re-prints a
+    /// persistent failure on every request and floods stderr. Announcing a path when it starts
+    /// failing and forgetting it when it stops does neither, and the set is bounded by what is
+    /// broken right now.</para>
+    ///
+    /// <para>Recovery is only observable for paths THIS build looked at, so the set is pruned
+    /// against the roots scanned rather than replaced wholesale: a concurrent request naming
+    /// other roots must not make their failures look repaired.</para>
     ///
     /// Console.Error, not Console.Out: under --dap stdio, stdout IS the protocol channel.
     /// </summary>
-    private static void Warn(AlSourceLocationMap map)
+    private static void Warn(AlSourceLocationMap map, IReadOnlyCollection<string> scannedRoots)
     {
-        foreach (var failure in map.ScanFailures)
+        var failing = new HashSet<string>(map.ScanFailures.Select(f => f.Path), StringComparer.Ordinal);
+        var announce = new List<SourceScanFailure>();
+        lock (_announced)
+        {
+            // Forget anything under a root this build scanned that is no longer failing — that
+            // is a recovery, and the next failure at that path is news again.
+            _announced.RemoveWhere(p => !failing.Contains(p) && WasLookedAt(p, scannedRoots));
+            foreach (var failure in map.ScanFailures)
+                if (_announced.Add(failure.Path)) announce.Add(failure);
+        }
+        foreach (var failure in announce)
             Console.Error.WriteLine(
                 $"[source-map] {failure.Path}: {failure.Reason}. Objects it declares are absent "
                 + "from the source map, so coverage and the debugger cannot attribute them.");
+    }
+
+    /// <summary>Whether this build would have noticed <paramref name="path"/> recovering —
+    /// true when it is one of the scanned roots or sits under one.</summary>
+    private static bool WasLookedAt(string path, IReadOnlyCollection<string> scannedRoots)
+    {
+        foreach (var root in scannedRoots)
+        {
+            if (string.Equals(path, root, StringComparison.Ordinal)) return true;
+            var prefix = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                         + Path.DirectorySeparatorChar;
+            if (path.StartsWith(prefix, StringComparison.Ordinal)) return true;
+        }
+        return false;
     }
 
     /// <summary>The nearest app.json in <paramref name="dir"/> or an ancestor, or null. The

--- a/AlRunner/Infrastructure/AlCoverageSourceMap.cs
+++ b/AlRunner/Infrastructure/AlCoverageSourceMap.cs
@@ -36,15 +36,49 @@ namespace AlRunner.Infrastructure;
 /// </para>
 /// (#3713; CoverageMultiObjectFileTests pins the header shapes that settled both.)
 /// </summary>
+/// <summary>Something the scan could not read, and why. Never a parse failure or an object
+/// kind the map does not carry — those are measurements, and this is the absence of one.</summary>
+public readonly record struct SourceScanFailure(string Path, string Reason);
+
 public sealed class AlSourceLocationMap : IReadOnlyDictionary<(string Label, int Id), string>
 {
     private readonly Dictionary<(string Label, int Id), (string Path, int LineOffset)> _entries = new();
+    private readonly List<SourceScanFailure> _scanFailures = new();
 
     /// <summary>A map with no objects; never mutated.</summary>
     public static AlSourceLocationMap Empty { get; } = new();
 
+    /// <summary>
+    /// What the scan could not read while building this map — a root that is not there, a
+    /// directory it could not enter, a file it could not open. Empty is the ordinary answer.
+    ///
+    /// <para>This exists because the map alone cannot express it (#3847). A missing entry means
+    /// "that object has no executable statements" to every consumer, and a bundle that
+    /// genuinely declares nothing mappable is a real state — so <see cref="Count"/> being 0
+    /// distinguishes nothing, and an unreadable source would otherwise be reported to the user
+    /// as a fact about their AL. `.claude/rules/guards-need-a-third-state.md`.</para>
+    ///
+    /// <para>It is a REPORT, not an error: the map is still returned and is still correct about
+    /// everything it did read. What a consumer owes it is to stop claiming certainty about the
+    /// parts it did not.</para>
+    /// </summary>
+    public IReadOnlyList<SourceScanFailure> ScanFailures => _scanFailures;
+
+    /// <summary>True when any source could not be read, so a missing entry may mean
+    /// "unmeasured" rather than "no statements here".</summary>
+    public bool IsIncomplete => _scanFailures.Count > 0;
+
     internal void Add(string label, int id, string path, int lineOffset) =>
         _entries[(label, id)] = (path, lineOffset);
+
+    internal void AddScanFailure(string path, string reason)
+    {
+        // Deduplicated: one root can be named by two callers, and a locked file is reached
+        // once per scan but a scan can run per bundle.
+        foreach (var existing in _scanFailures)
+            if (existing.Path == path) return;
+        _scanFailures.Add(new SourceScanFailure(path, reason));
+    }
 
     /// <summary>Lines to add to a decoded [SourceSpans] line of this object to get its file
     /// line; 0 for the first object in a file and for an object not in the map.</summary>
@@ -102,8 +136,20 @@ public static class AlCoverageSourceMap
         var appJsonByDir = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
         foreach (var root in roots)
         {
-            if (!Directory.Exists(root)) continue;
-            foreach (var file in SafeDirectoryScan.Files(root, "*.al"))
+            if (!Directory.Exists(root))
+            {
+                // Not the same as a root with nothing in it: the caller named this path, so
+                // its absence is an unmeasured scan rather than an empty one (#3847).
+                map.AddScanFailure(root, "the source root does not exist");
+                continue;
+            }
+            // SafeDirectoryScan has always been able to say which directories it could not
+            // enter; this scan discarded the answer with `out _`, which is the shape #3847 is
+            // about — the mechanism existed and the caller threw it away.
+            var files = SafeDirectoryScan.Files(root, "*.al", out var inaccessible);
+            foreach (var dir in inaccessible)
+                map.AddScanFailure(dir, "the directory could not be read, so any AL under it was not scanned");
+            foreach (var file in files)
             {
                 var appJson = NearestAppJson(Path.GetDirectoryName(file)!, appJsonByDir);
                 if (!symbolsByAppJson.TryGetValue(appJson ?? "", out var symbols))
@@ -112,11 +158,36 @@ public static class AlCoverageSourceMap
                 var path = relativeTo != null
                     ? Path.GetRelativePath(relativeTo, file).Replace('\\', '/')
                     : file.Replace('\\', '/');
-                foreach (var o in ParseObjects(file, symbols))
+                var parsed = ParseObjects(file, symbols, out var readFailure);
+                foreach (var o in parsed)
                     map.Add(o.Label, o.Id, path, o.LineOffset);
+                if (readFailure != null) map.AddScanFailure(file, readFailure);
             }
         }
+        WarnOnce(map);
         return map;
+    }
+
+    private static readonly HashSet<string> _warned = new();
+
+    /// <summary>
+    /// Says out loud, once per path per process, that part of the scan did not happen. Here
+    /// rather than at each of the five call sites, because every one of them would otherwise
+    /// have to remember — and the consumer that forgets is the one that reports a confident
+    /// negative about AL nobody read (#3847).
+    ///
+    /// Console.Error, not Console.Out: under --dap stdio, stdout IS the protocol channel.
+    /// </summary>
+    private static void WarnOnce(AlSourceLocationMap map)
+    {
+        foreach (var failure in map.ScanFailures)
+        {
+            lock (_warned)
+                if (!_warned.Add(failure.Path)) continue;
+            Console.Error.WriteLine(
+                $"[source-map] {failure.Path}: {failure.Reason}. Objects it declares are absent "
+                + "from the source map, so coverage and the debugger cannot attribute them.");
+        }
     }
 
     /// <summary>The nearest app.json in <paramref name="dir"/> or an ancestor, or null. The
@@ -135,15 +206,30 @@ public static class AlCoverageSourceMap
         return found;
     }
 
-    private static IReadOnlyList<ParsedObject> ParseObjects(string file, IReadOnlyList<string> symbols)
+    /// <summary><paramref name="readFailure"/> is non-null when the file exists and could not
+    /// be READ — which used to return an empty list, indistinguishable from a file that
+    /// declares no objects (#3847). A parse that fails is a different thing and stays where it
+    /// was: the file was measured, and what it holds is not something this map carries.</summary>
+    private static IReadOnlyList<ParsedObject> ParseObjects(
+        string file, IReadOnlyList<string> symbols, out string? readFailure)
     {
+        readFailure = null;
         var info = new FileInfo(file);
         var key = $"{file}|{info.Length}|{info.LastWriteTimeUtc.Ticks}|{string.Join(",", symbols)}";
         if (_parsed.TryGetValue(key, out var cached)) return cached;
 
         string content;
         try { content = File.ReadAllText(file); }
-        catch (IOException) { return Array.Empty<ParsedObject>(); }
+        catch (IOException ex)
+        {
+            readFailure = $"the file could not be read ({ex.GetType().Name}: {ex.Message})";
+            return Array.Empty<ParsedObject>();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            readFailure = $"the file could not be read ({ex.GetType().Name}: {ex.Message})";
+            return Array.Empty<ParsedObject>();
+        }
 
         List<ParsedObject> result;
         try

--- a/AlRunner/Infrastructure/AlCoverageSourceMap.cs
+++ b/AlRunner/Infrastructure/AlCoverageSourceMap.cs
@@ -76,6 +76,26 @@ public sealed class AlSourceLocationMap : IReadOnlyDictionary<(string Label, int
     internal void Add(string label, int id, string path, int lineOffset) =>
         _entries[(label, id)] = (path, lineOffset);
 
+    /// <summary>Drops every object declared by one file. Used only by the test seam in
+    /// <see cref="AlCoverageSourceMap.Build"/>, which has to reproduce what an unreadable file
+    /// DOES — its objects are absent — and not merely that it was reported (#3884).</summary>
+    internal void ForgetEntriesDeclaredBy(string path)
+    {
+        string Canonical(string p)
+        {
+            try { return Path.GetFullPath(p).Replace('\\', '/'); }
+            catch (ArgumentException) { return p.Replace('\\', '/'); }
+            catch (NotSupportedException) { return p.Replace('\\', '/'); }
+        }
+
+        var want = Canonical(path);
+        var doomed = _entries
+            .Where(kv => string.Equals(Canonical(kv.Value.Path), want, StringComparison.OrdinalIgnoreCase))
+            .Select(kv => kv.Key)
+            .ToList();
+        foreach (var key in doomed) _entries.Remove(key);
+    }
+
     internal void AddScanFailure(string path, string reason, SourceScanFailureKind kind)
     {
         // Deduplicated: one root can be named by two callers, and a locked file is reached
@@ -184,15 +204,16 @@ public static class AlCoverageSourceMap
             // enter; this scan discarded the answer with `out _`, which is the shape #3847 is
             // about — the mechanism existed and the caller threw it away.
             var files = scan(root, out var inaccessible);
-            // The Directory.Exists above and this scan are not atomic. A root that went away
-            // in between comes back from the scanner as an ordinary empty listing with nothing
-            // inaccessible — a clean partial map, which is the very race this third state
-            // exists to expose (#3884 Copilot review). Re-checking costs one stat and only
-            // fires when the directory is gone, so a genuinely empty one stays a pass.
-            if (files.Count == 0 && inaccessible.Count == 0 && !Directory.Exists(root))
-                map.AddScanFailure(root,
-                    "the source root disappeared while it was being scanned",
-                    SourceScanFailureKind.Root);
+            // A root that goes away DURING the scan is a real hole, and it is deliberately not
+            // patched here. A post-scan Directory.Exists re-check was tried and removed: it is
+            // wrong in both directions. It MISSES the case that matters — a root whose first
+            // entries were listed before it vanished returns a non-empty `files`, so the check
+            // never runs while the rest of the tree went unmeasured — and it FIRES when nothing
+            // was lost, because an empty directory deleted after a correct enumeration, or an
+            // ancestor whose traversal permission was just lost, both make that stat false. A
+            // check that manufactures a failure is the false red this rule's own constraint
+            // forbids. The distinction can only be drawn where the DirectoryNotFoundException
+            // is caught, inside SafeDirectoryScan. Tracked separately.
             foreach (var dir in inaccessible)
                 map.AddScanFailure(dir, "the directory could not be read, so any AL under it was not scanned",
                     SourceScanFailureKind.Directory);
@@ -212,13 +233,34 @@ public static class AlCoverageSourceMap
                     map.AddScanFailure(file, readFailure, SourceScanFailureKind.File);
             }
         }
-        Warn(map, rootList);
+        // A test seam, and the only way to reach the consumers of this map from outside the
+        // process (#3884). The scan failures that matter to a --server client happen BETWEEN
+        // compilation and this scan, which no test can time from the outside: locking the file
+        // earlier fails the compile instead, and the RootScanner seam above is internal.
+        //
+        // It only ever ADDS a failure. Nothing here can hide one, so a mis-set variable cannot
+        // turn a broken scan into a clean one — the direction that would matter.
+        // ONCE per process, which is what makes a two-request test possible: the first request
+        // gets a poisoned scan and the second a clean one, so what the second proves is that
+        // the FIRST invalidated its baseline rather than that it poisoned itself too.
+        if (Environment.GetEnvironmentVariable("AL_RUNNER_TEST_FORCE_SCAN_FAILURE_ONCE") is string forced
+            && forced.Length > 0
+            && Interlocked.Exchange(ref _forcedScanFailureUsed, 1) == 0)
+        {
+            // BOTH halves, or the seam is not the thing it simulates. Recording the failure
+            // without dropping the file's objects produced a map that was still COMPLETE, so a
+            // test written against it passed with the fix reverted — it proved the plumbing and
+            // not the defect (#3884). An unreadable file's objects are absent from the map;
+            // that absence is what poisons attribution downstream.
+            map.AddScanFailure(forced,
+                "forced by AL_RUNNER_TEST_FORCE_SCAN_FAILURE_ONCE (test seam)",
+                SourceScanFailureKind.File);
+            map.ForgetEntriesDeclaredBy(forced);
+        }
+
+        Warn(map);
         return map;
     }
-
-    /// <summary>Paths whose failure has already been announced and has not recovered since.
-    /// Bounded by the number of CURRENTLY failing paths, not by how many a process ever saw.</summary>
-    private static readonly HashSet<string> _announced = new(StringComparer.Ordinal);
 
     /// <summary>
     /// Says out loud that part of the scan did not happen. Here rather than at each of the five
@@ -226,50 +268,33 @@ public static class AlCoverageSourceMap
     /// consumer that forgets is the one that reports a confident negative about AL nobody read
     /// (#3847).
     ///
-    /// <para>On the TRANSITION into failure, which is the only spelling two reviews could both
-    /// live with (#3884). Once per process swallows a path that failed, was repaired, and
-    /// failed again — a real event under --server and --watch, where the process outlives many
-    /// builds — and grows by every path any request ever named. Once per build re-prints a
-    /// persistent failure on every request and floods stderr. Announcing a path when it starts
-    /// failing and forgetting it when it stops does neither, and the set is bounded by what is
-    /// broken right now.</para>
+    /// <para><b>Once per build, with no memory between builds, and that is deliberate.</b> Two
+    /// earlier spellings were tried and both were wrong. Once per PROCESS swallows a path that
+    /// failed, was repaired, and failed again — a real event under --server and --watch — and
+    /// grows by every path any request ever named. Announcing only the TRANSITION into failure
+    /// looks like the synthesis of those two and is worse than either: it compares raw path
+    /// spellings, so one caller's trailing separator is a different key and the same failure is
+    /// announced twice or a recurrence never at all; it treats a descendant as recovered when
+    /// its parent directory becomes unreadable, which is the opposite of what happened; and two
+    /// overlapping scans can interleave so that an older clean observation erases a newer
+    /// failure's announcement. Every one of those is a wrong statement about the tree, and the
+    /// only thing the state bought was fewer repeated lines (#3884).</para>
     ///
-    /// <para>Recovery is only observable for paths THIS build looked at, so the set is pruned
-    /// against the roots scanned rather than replaced wholesale: a concurrent request naming
-    /// other roots must not make their failures look repaired.</para>
+    /// <para>So: a repeated failure prints on every build that sees it. That is noisier and it
+    /// is never false, which is the correct trade for a diagnostic whose entire job is to stop
+    /// a silent wrong answer. A caller that wants the structured form has
+    /// <see cref="AlSourceLocationMap.ScanFailures"/>.</para>
     ///
     /// Console.Error, not Console.Out: under --dap stdio, stdout IS the protocol channel.
     /// </summary>
-    private static void Warn(AlSourceLocationMap map, IReadOnlyCollection<string> scannedRoots)
+    private static int _forcedScanFailureUsed;
+
+    private static void Warn(AlSourceLocationMap map)
     {
-        var failing = new HashSet<string>(map.ScanFailures.Select(f => f.Path), StringComparer.Ordinal);
-        var announce = new List<SourceScanFailure>();
-        lock (_announced)
-        {
-            // Forget anything under a root this build scanned that is no longer failing — that
-            // is a recovery, and the next failure at that path is news again.
-            _announced.RemoveWhere(p => !failing.Contains(p) && WasLookedAt(p, scannedRoots));
-            foreach (var failure in map.ScanFailures)
-                if (_announced.Add(failure.Path)) announce.Add(failure);
-        }
-        foreach (var failure in announce)
+        foreach (var failure in map.ScanFailures)
             Console.Error.WriteLine(
                 $"[source-map] {failure.Path}: {failure.Reason}. Objects it declares are absent "
                 + "from the source map, so coverage and the debugger cannot attribute them.");
-    }
-
-    /// <summary>Whether this build would have noticed <paramref name="path"/> recovering —
-    /// true when it is one of the scanned roots or sits under one.</summary>
-    private static bool WasLookedAt(string path, IReadOnlyCollection<string> scannedRoots)
-    {
-        foreach (var root in scannedRoots)
-        {
-            if (string.Equals(path, root, StringComparison.Ordinal)) return true;
-            var prefix = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-                         + Path.DirectorySeparatorChar;
-            if (path.StartsWith(prefix, StringComparison.Ordinal)) return true;
-        }
-        return false;
     }
 
     /// <summary>The nearest app.json in <paramref name="dir"/> or an ancestor, or null. The

--- a/AlRunner/Infrastructure/DapUnverifiedReason.cs
+++ b/AlRunner/Infrastructure/DapUnverifiedReason.cs
@@ -1,0 +1,80 @@
+// DapUnverifiedReason — why a `setBreakpoints` line came back `verified: false`.
+//
+// There are three reasons and they call for different things from the client, so collapsing
+// them loses the part that matters:
+//
+//   * the bundle did not compile          — nothing will ever bind; fix the AL
+//   * that source could not be READ       — nobody knows whether the line has a statement
+//   * that line carries no AL statement   — a measured fact about the AL
+//
+// The middle one is #3847: AlCoverageSourceMap.Build could not say "I could not read the
+// sources", so a source it failed to open produced a map with no entry for that file's
+// objects — and the adapter reported the third reason, a specific claim about AL nobody had
+// read. `.claude/rules/guards-need-a-third-state.md`.
+//
+// Lifted out of RunDapLoop's handler so the discrimination is testable without a live DAP
+// session: it is a decision over three states, and the handler is the wrong place to be
+// reading one.
+namespace AlRunner.Infrastructure;
+
+public static class DapUnverifiedReason
+{
+    /// <summary>
+    /// The message a DAP <c>Breakpoint.message</c> carries for an unverified line.
+    /// </summary>
+    /// <param name="compileFailure">The compile diagnostic, or null when the bundle compiled.</param>
+    /// <param name="sourceMap">The map the request resolved against; its
+    /// <see cref="AlSourceLocationMap.ScanFailures"/> is what makes the middle state
+    /// visible.</param>
+    /// <param name="sourcePath">The source file the client asked about.</param>
+    public static string For(string? compileFailure, AlSourceLocationMap sourceMap, string sourcePath)
+    {
+        if (compileFailure != null)
+            return $"the bundle did not compile, so nothing could be bound: {compileFailure}";
+
+        if (UnreadableFor(sourceMap, sourcePath) is string unreadable)
+            return $"this source could not be read, so whether that line carries a statement "
+                 + $"is unknown rather than no: {unreadable}";
+
+        return "no executable AL statement on this line in this file";
+    }
+
+    /// <summary>
+    /// The scan failure covering <paramref name="sourcePath"/>, or null. A failure names the
+    /// file itself, a directory the scan could not enter, or a root that is not there — so a
+    /// containment test, not equality: a directory nobody could enter says nothing about the
+    /// files under it, which is exactly the state being reported.
+    /// </summary>
+    private static string? UnreadableFor(AlSourceLocationMap sourceMap, string sourcePath)
+    {
+        if (sourceMap.ScanFailures.Count == 0) return null;
+
+        string full;
+        try { full = Path.GetFullPath(sourcePath); }
+        catch (ArgumentException) { return null; }   // a path shape this cannot reason about
+        catch (NotSupportedException) { return null; }
+
+        foreach (var failure in sourceMap.ScanFailures)
+        {
+            string failurePath;
+            try { failurePath = Path.GetFullPath(failure.Path); }
+            catch (ArgumentException) { continue; }
+            catch (NotSupportedException) { continue; }
+
+            if (DapBreakpointResolver.PathComparer.Equals(failurePath, full))
+                return failure.Reason;
+
+            // Under a directory or root that could not be scanned. The separator is appended
+            // so `/src/app` does not swallow `/src/application`.
+            var prefix = failurePath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                         + Path.DirectorySeparatorChar;
+            if (full.StartsWith(prefix, PathComparison)) return failure.Reason;
+        }
+        return null;
+    }
+
+    /// <summary>The string comparison matching <see cref="DapBreakpointResolver.PathComparer"/> —
+    /// case-sensitive only where the filesystem is.</summary>
+    private static StringComparison PathComparison =>
+        OperatingSystem.IsLinux() ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+}

--- a/AlRunner/Infrastructure/DapUnverifiedReason.cs
+++ b/AlRunner/Infrastructure/DapUnverifiedReason.cs
@@ -49,28 +49,51 @@ public static class DapUnverifiedReason
     {
         if (sourceMap.ScanFailures.Count == 0) return null;
 
-        string full;
-        try { full = Path.GetFullPath(sourcePath); }
-        catch (ArgumentException) { return null; }   // a path shape this cannot reason about
-        catch (NotSupportedException) { return null; }
+        if (Normalize(sourcePath) is not string full) return null;
 
         foreach (var failure in sourceMap.ScanFailures)
         {
-            string failurePath;
-            try { failurePath = Path.GetFullPath(failure.Path); }
-            catch (ArgumentException) { continue; }
-            catch (NotSupportedException) { continue; }
+            if (Normalize(failure.Path) is not string failurePath) continue;
 
             if (DapBreakpointResolver.PathComparer.Equals(failurePath, full))
                 return failure.Reason;
 
-            // Under a directory or root that could not be scanned. The separator is appended
-            // so `/src/app` does not swallow `/src/application`.
-            var prefix = failurePath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-                         + Path.DirectorySeparatorChar;
+            // Containment applies to a ROOT or a DIRECTORY, which cover the sources beneath
+            // them, and never to a FILE, which covers exactly one path — a file failure was
+            // being used as a prefix, so `C:\src\Locked.al` also claimed
+            // `C:\src\Locked.al\Child.al` (#3884 review).
+            if (failure.Kind == SourceScanFailureKind.File) continue;
+
+            // The separator is appended so `/src/app` does not swallow `/src/application`.
+            // Both sides are already separator-normalised by Normalize, so an extended-length
+            // path whose caller wrote `\\?\C:\src/missing` still matches the sources under it.
+            var prefix = failurePath.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
             if (full.StartsWith(prefix, PathComparison)) return failure.Reason;
         }
         return null;
+    }
+
+    /// <summary>
+    /// One spelling for both sides of every comparison, or null for a path shape this cannot
+    /// reason about. GetFullPath alone is not enough: .NET deliberately leaves an
+    /// extended-length path (<c>\\?\C:\...</c>) unnormalised, so a caller's mixed separators
+    /// survive it and a prefix test then fails against a path that really is underneath
+    /// (#3884 review). Separators are folded to the platform's own, and a trailing one is
+    /// dropped so equality does not depend on it.
+    /// </summary>
+    private static string? Normalize(string path)
+    {
+        string full;
+        try { full = Path.GetFullPath(path); }
+        catch (ArgumentException) { return null; }
+        catch (NotSupportedException) { return null; }
+        catch (PathTooLongException) { return null; }
+
+        if (Path.AltDirectorySeparatorChar != Path.DirectorySeparatorChar)
+            full = full.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+        // Not the root itself: "C:\" and "/" must keep their separator.
+        var trimmed = full.TrimEnd(Path.DirectorySeparatorChar);
+        return trimmed.Length == 0 || (trimmed.Length == 2 && trimmed[1] == ':') ? full : trimmed;
     }
 
     /// <summary>The string comparison matching <see cref="DapBreakpointResolver.PathComparer"/> —

--- a/AlRunner/Infrastructure/IncompleteCoverageOutcome.cs
+++ b/AlRunner/Infrastructure/IncompleteCoverageOutcome.cs
@@ -1,0 +1,28 @@
+// IncompleteCoverageOutcome — what an incomplete source map does to a run's exit code.
+//
+// One line of policy, in one place, because three callers have to agree on it: the CLI
+// --coverage path, the server's runTests, and the server's execute. Two of the three shipped
+// disagreeing (#3884 Copilot review) — the CLI escalated and both server handlers returned an
+// ordinary success carrying a short table — and the way that happened is that the decision was
+// written inline at each site, so nothing could be tested and nothing made them match.
+namespace AlRunner.Infrastructure;
+
+public static class IncompleteCoverageOutcome
+{
+    /// <summary>
+    /// The exit code a run should report, given what it would otherwise have reported.
+    ///
+    /// <para>An incomplete map means coverage was computed over an unknown subset of the
+    /// sources, so the number is not a coverage number and the run must not leave on the
+    /// exit-0 path (`.claude/rules/guards-need-a-third-state.md`). A run that is ALREADY
+    /// failing keeps its own code: the caller's first problem is the failure they have, not
+    /// this one, and overwriting it would lose it.</para>
+    /// </summary>
+    /// <param name="currentExitCode">What the run would report without this consideration.</param>
+    /// <param name="mapIsIncomplete">Whether the source map reported any scan failure.</param>
+    /// <param name="coverageWasProduced">Whether a coverage artifact or table actually exists.
+    /// When it does not, the run has a different and louder problem and this one is not the
+    /// thing to report.</param>
+    public static int Apply(int currentExitCode, bool mapIsIncomplete, bool coverageWasProduced)
+        => mapIsIncomplete && coverageWasProduced && currentExitCode == 0 ? 2 : currentExitCode;
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -4594,7 +4594,11 @@ if (coverageEnabled)
     // (.claude/rules/guards-need-a-third-state.md). Same escalation the unwritable-output
     // path below uses, for the same reason: the caller asked for an artifact and did not
     // get the one they think they got.
-    if (coverageSourceMap.IsIncomplete)
+    //
+    // Gated on the write having SUCCEEDED: when it did not there is no report for this text
+    // to describe, lostOutputs is the applicable error, and saying "the report above is
+    // incomplete" would claim an artifact nobody has (#3884 Copilot review).
+    if (coverageProblem == null && coverageSourceMap.IsIncomplete)
     {
         Console.Error.WriteLine();
         Console.Error.WriteLine(
@@ -4694,11 +4698,13 @@ if (expectations != null && expectations.CompanyInitAcceptances.Count > 0)
 // REPORT is not there — so a consumer must not read it as "some tests failed", and equally
 // must not read a zero as "the file I asked for is on disk". Never RAISED above what the
 // tests earned, so a failing run still reports its own, more specific code.
-if (incompleteCoverage && computedExitCode == 0)
+var afterIncompleteCoverage = AlRunner.Infrastructure.IncompleteCoverageOutcome.Apply(
+    computedExitCode, incompleteCoverage, coverageWasProduced: true);
+if (afterIncompleteCoverage != computedExitCode)
 {
     Console.Error.WriteLine(
         "exiting 2 because the coverage report you asked for does not describe every source.");
-    computedExitCode = 2;
+    computedExitCode = afterIncompleteCoverage;
 }
 if (lostOutputs.Count > 0 && computedExitCode == 0)
 {
@@ -6931,6 +6937,12 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
             if (exitCode == 0 && companyInitFailures.Any(f => f.AcceptedReason == null))
                 exitCode = 2;
 
+            // #3884 Copilot review: the field alone left a client reading `exitCode` with an
+            // ordinary success carrying a short table. Same policy as the CLI, so the three
+            // callers cannot drift again.
+            exitCode = AlRunner.Infrastructure.IncompleteCoverageOutcome.Apply(
+                exitCode, scanFailures is { Count: > 0 }, coverageWasProduced: statementTable != null);
+
             lock (outputLock)
             {
                 output.WriteLine(AlRunner.ServerProtocol.Summary(
@@ -7086,6 +7098,10 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                 CompanyInitializer.DrainFailures(), expectations);
             if (exitCode == 0 && companyInitFailures.Any(f => f.AcceptedReason == null))
                 exitCode = 2;
+
+            // Same policy as runTests and the CLI (#3884 Copilot review).
+            exitCode = AlRunner.Infrastructure.IncompleteCoverageOutcome.Apply(
+                exitCode, scanFailures is { Count: > 0 }, coverageWasProduced: statementTable != null);
 
             return AlRunner.ServerProtocol.Execute(allTests, exitCode,
                 AlRunner.Infrastructure.AlMessageCapture.Snapshot(),

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -6848,6 +6848,29 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
 
                     var nextCoverage = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
                     var nextUnknown = new HashSet<string>(StringComparer.Ordinal);
+
+                    // #3884: an incomplete scan poisons this baseline SILENTLY, and the
+                    // `unmappable` check below cannot see it. A statement whose object never
+                    // reached the source map is dropped by CollectPerTestStatementTable before
+                    // it gets here, so what survives is a non-empty, entirely mappable list —
+                    // indistinguishable from a test that genuinely only touched those objects.
+                    // Storing it means a later edit to the source that could not be read does
+                    // not intersect any stored coverage, and the test that calls into it is
+                    // SKIPPED. That is a wrong answer, not a missing warning.
+                    //
+                    // So every test of this bundle is recorded unknown, which forces the next
+                    // affected-only request to run them. Not merely "skip the update": leaving
+                    // the previous baseline in place keeps trusting numbers that may be just
+                    // as stale.
+                    if (scanFailures is { Count: > 0 })
+                    {
+                        foreach (var testKey in discoveredTests) nextUnknown.Add(testKey);
+                        affectedCoverageByBundle[bundlePath] = nextCoverage;
+                        affectedUnknownTestsByBundle[bundlePath] = nextUnknown;
+                        affectedEnvironmentKeyByBundle[bundlePath] = envKey;
+                        continue;
+                    }
+
                     foreach (var testKey in discoveredTests)
                     {
                         if (!resultByTest.TryGetValue(testKey, out var result)
@@ -6941,7 +6964,12 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
             // ordinary success carrying a short table. Same policy as the CLI, so the three
             // callers cannot drift again.
             exitCode = AlRunner.Infrastructure.IncompleteCoverageOutcome.Apply(
-                exitCode, scanFailures is { Count: > 0 }, coverageWasProduced: statementTable != null);
+                exitCode, scanFailures is { Count: > 0 },
+                // BOTH tables (#3884): `perTestCoverage:true, coverage:false` is a supported
+                // combination, and asking only about the aggregate one published a known-short
+                // per-test table as a clean run. The question is whether an attribution the
+                // caller asked for happened, not whether one particular variable is non-null.
+                coverageWasProduced: statementTable != null || perTestStatementTable != null);
 
             lock (outputLock)
             {
@@ -7017,10 +7045,22 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
         AlRunner.Infrastructure.AlIterationTracker.Enabled = req.IterationTracking == true;
         AlRunner.Infrastructure.AlIterationTracker.ConfigureResponse();
         // Syntax facts for captureValues (write sets) and iterationTracking (loops): one parse per request.
+        //
+        // #3884: THIS map's failures count too, and they used to be dropped on the floor. An
+        // object missing from it makes AlScopeSyntaxResolver return before it records an
+        // unresolved scope, so incomplete loop/write-set attribution arrived with no diagnostic
+        // at all — and the later coverage scan cannot stand in for it: without coverage flags
+        // it never runs, and with them it is a separate measurement that may succeed after this
+        // one failed.
+        IReadOnlyList<AlRunner.Infrastructure.SourceScanFailure>? configScanFailures = null;
         if (req.CaptureValues == true || req.IterationTracking == true)
+        {
+            var syntaxSourceMap = AlRunner.Infrastructure.AlCoverageSourceMap.Build(sourcePaths, relativeTo: null);
+            if (syntaxSourceMap.IsIncomplete) configScanFailures = syntaxSourceMap.ScanFailures;
             AlRunner.Infrastructure.AlScopeSyntaxResolver.Configure(
                 AlRunner.Infrastructure.AlMemberSyntaxIndex.Build(sourcePaths),
-                AlRunner.Infrastructure.AlCoverageSourceMap.Build(sourcePaths, relativeTo: null));
+                syntaxSourceMap);
+        }
         else
             AlRunner.Infrastructure.AlScopeSyntaxResolver.Clear();
         // #2042: 'coverage:true' on `execute` — same request/response correlation the
@@ -7069,12 +7109,20 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
             // needs the .al files on disk to still exist when it scans them.
             IReadOnlyList<AlRunner.Infrastructure.AlCoverageTracker.AlStatementRecord>? statementTable = null;
             IReadOnlyDictionary<string, List<AlRunner.Infrastructure.AlCoverageTracker.AlStatementRecord>>? perTestStatementTable = null;
-            IReadOnlyList<AlRunner.Infrastructure.SourceScanFailure>? scanFailures = null;
+            // Starts from the configuration scan's failures, which happened before the run and
+            // are about the same sources (#3884).
+            IReadOnlyList<AlRunner.Infrastructure.SourceScanFailure>? scanFailures = configScanFailures;
             if (req.Coverage == true || req.PerTestCoverage == true)
             {
                 var covSourceMap = AlRunner.Infrastructure.AlCoverageSourceMap.Build(sourcePaths, relativeTo: null);
                 // #3884, same as runTests: a short table must not go out as an ordinary success.
-                if (covSourceMap.IsIncomplete) scanFailures = covSourceMap.ScanFailures;
+                if (covSourceMap.IsIncomplete)
+                    scanFailures = scanFailures is { Count: > 0 }
+                        ? scanFailures.Concat(covSourceMap.ScanFailures)
+                            .GroupBy(f => f.Path, StringComparer.Ordinal)
+                            .Select(g => g.First())
+                            .ToList()
+                        : covSourceMap.ScanFailures;
                 if (req.Coverage == true)
                     statementTable = AlRunner.Infrastructure.AlCoverageTracker.CollectStatementTable(covSourceMap);
                 if (req.PerTestCoverage == true)
@@ -7099,9 +7147,13 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
             if (exitCode == 0 && companyInitFailures.Any(f => f.AcceptedReason == null))
                 exitCode = 2;
 
-            // Same policy as runTests and the CLI (#3884 Copilot review).
+            // Same policy as runTests and the CLI, over BOTH tables — and over the
+            // capture/iteration attribution, which is a measurement the caller asked for in
+            // exactly the same sense (#3884).
             exitCode = AlRunner.Infrastructure.IncompleteCoverageOutcome.Apply(
-                exitCode, scanFailures is { Count: > 0 }, coverageWasProduced: statementTable != null);
+                exitCode, scanFailures is { Count: > 0 },
+                coverageWasProduced: statementTable != null || perTestStatementTable != null
+                    || configScanFailures is { Count: > 0 });
 
             return AlRunner.ServerProtocol.Execute(allTests, exitCode,
                 AlRunner.Infrastructure.AlMessageCapture.Snapshot(),

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -5842,13 +5842,13 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
             .ToList();
         var resolved = AlRunner.Infrastructure.DapBreakpointResolver.Resolve(requests, sourceMap);
 
-        // Why an unverified breakpoint is unverified. DAP's Breakpoint has a
-        // `message` field for exactly this, and without it "nothing is
-        // loaded" and "that line carries no statement" are the same answer —
-        // the first is a state the client can wait out, the second is not.
-        var unverifiedReason = bpCompileErr != null
-            ? $"the bundle did not compile, so nothing could be bound: {bpCompileErr}"
-            : "no executable AL statement on this line in this file";
+        // Why an unverified breakpoint is unverified. DAP's Breakpoint has a `message` field
+        // for exactly this, and without it the three reasons are one answer. The third of them
+        // — the source could not be READ, so nobody knows whether that line has a statement —
+        // is #3847, and the decision lives in DapUnverifiedReason so it can be tested without
+        // a live session.
+        var unverifiedReason = AlRunner.Infrastructure.DapUnverifiedReason.For(
+            bpCompileErr, sourceMap, srcPath);
 
         var fullSrcPath = Path.GetFullPath(srcPath);
         // Replace (not accumulate) — DAP's setBreakpoints contract: this

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -4539,6 +4539,9 @@ if (tddMode)
 // code as a distinct reporting failure, so a script that depends on the file still learns
 // it is missing rather than reading a stale copy as this run's output.
 var lostOutputs = new List<string>();
+// Set when a coverage report was written from a source map that could not be fully read;
+// escalated with lostOutputs below (#3884).
+var incompleteCoverage = false;
 if (outPath != null)
 {
     var writeProblem = AlRunner.Infrastructure.OutputPaths.TryWrite("--out", outPath,
@@ -4583,6 +4586,24 @@ if (coverageEnabled)
         coverageOut.WriteLine();
         coverageOut.WriteLine(AlRunner.Infrastructure.AlCoverageReport.FormatConsoleTable(coverageFiles!));
         coverageOut.WriteLine($"Cobertura → {coverageOutputPath}");
+    }
+
+    // #3884: the report is on disk and it is SHORT. Everything the scan could not read is
+    // missing from it, and a coverage number computed over an unknown subset is not a
+    // coverage number — so this must not leave on the exit-0 path
+    // (.claude/rules/guards-need-a-third-state.md). Same escalation the unwritable-output
+    // path below uses, for the same reason: the caller asked for an artifact and did not
+    // get the one they think they got.
+    if (coverageSourceMap.IsIncomplete)
+    {
+        Console.Error.WriteLine();
+        Console.Error.WriteLine(
+            "al-runner could not read every source it was asked to map, so the coverage report "
+            + "above is incomplete — statements in these paths are absent from it, not proven "
+            + "uncovered:");
+        foreach (var failure in coverageSourceMap.ScanFailures)
+            Console.Error.WriteLine($"  {failure.Path}  ({failure.Reason})");
+        incompleteCoverage = true;
     }
 }
 
@@ -4673,6 +4694,12 @@ if (expectations != null && expectations.CompanyInitAcceptances.Count > 0)
 // REPORT is not there — so a consumer must not read it as "some tests failed", and equally
 // must not read a zero as "the file I asked for is on disk". Never RAISED above what the
 // tests earned, so a failing run still reports its own, more specific code.
+if (incompleteCoverage && computedExitCode == 0)
+{
+    Console.Error.WriteLine(
+        "exiting 2 because the coverage report you asked for does not describe every source.");
+    computedExitCode = 2;
+}
 if (lostOutputs.Count > 0 && computedExitCode == 0)
 {
     Console.Error.WriteLine(
@@ -6754,10 +6781,15 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
             // work for callers who never asked for it.
             IReadOnlyList<AlRunner.Infrastructure.AlCoverageTracker.AlStatementRecord>? statementTable = null;
             IReadOnlyDictionary<string, List<AlRunner.Infrastructure.AlCoverageTracker.AlStatementRecord>>? perTestStatementTable = null;
+            IReadOnlyList<AlRunner.Infrastructure.SourceScanFailure>? scanFailures = null;
             if (requestCoverage || collectPerTestForSelection)
             {
                 var covSourceMap = AlRunner.Infrastructure.AlCoverageSourceMap.Build(
                     req.SourcePaths, relativeTo: null);
+                // #3884: a table built from a map that could not read everything is short, and
+                // the response has to say so — otherwise the client gets an ordinary success
+                // and no way to tell an uncovered statement from an unread one.
+                if (covSourceMap.IsIncomplete) scanFailures = covSourceMap.ScanFailures;
                 if (requestCoverage)
                     statementTable = AlRunner.Infrastructure.AlCoverageTracker.CollectStatementTable(covSourceMap);
                 // #2135: independent of the aggregate table above — see
@@ -6908,7 +6940,8 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                     selection: requestSelection,
                     statementTable: statementTable,
                     perTestStatementTable: requestPerTestCoverage ? perTestStatementTable : null,
-                    companyInitFailures: companyInitFailures));
+                    companyInitFailures: companyInitFailures,
+                    sourceScanFailures: scanFailures));
                 output.Flush();
             }
         }
@@ -7024,9 +7057,12 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
             // needs the .al files on disk to still exist when it scans them.
             IReadOnlyList<AlRunner.Infrastructure.AlCoverageTracker.AlStatementRecord>? statementTable = null;
             IReadOnlyDictionary<string, List<AlRunner.Infrastructure.AlCoverageTracker.AlStatementRecord>>? perTestStatementTable = null;
+            IReadOnlyList<AlRunner.Infrastructure.SourceScanFailure>? scanFailures = null;
             if (req.Coverage == true || req.PerTestCoverage == true)
             {
                 var covSourceMap = AlRunner.Infrastructure.AlCoverageSourceMap.Build(sourcePaths, relativeTo: null);
+                // #3884, same as runTests: a short table must not go out as an ordinary success.
+                if (covSourceMap.IsIncomplete) scanFailures = covSourceMap.ScanFailures;
                 if (req.Coverage == true)
                     statementTable = AlRunner.Infrastructure.AlCoverageTracker.CollectStatementTable(covSourceMap);
                 if (req.PerTestCoverage == true)
@@ -7059,7 +7095,8 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                 selection: selection,
                 statementTable: statementTable,
                 perTestStatementTable: perTestStatementTable,
-                companyInitFailures: companyInitFailures);
+                companyInitFailures: companyInitFailures,
+                sourceScanFailures: scanFailures);
         }
         finally
         {

--- a/AlRunner/ServerProtocol.cs
+++ b/AlRunner/ServerProtocol.cs
@@ -334,7 +334,8 @@ public static class ServerProtocol
         ServerSelection? selection = null,
         IReadOnlyList<Infrastructure.AlCoverageTracker.AlStatementRecord>? statementTable = null,
         IReadOnlyDictionary<string, List<Infrastructure.AlCoverageTracker.AlStatementRecord>>? perTestStatementTable = null,
-        IReadOnlyList<CompanyInitFailure>? companyInitFailures = null)
+        IReadOnlyList<CompanyInitFailure>? companyInitFailures = null,
+        IReadOnlyList<Infrastructure.SourceScanFailure>? sourceScanFailures = null)
     {
         var payload = new
         {
@@ -362,11 +363,27 @@ public static class ServerProtocol
             coverage = ToStatementTableWire(statementTable),
             perTestCoverage = ToPerTestCoverageWire(perTestStatementTable),
             companyInitFailures = ToCompanyInitWire(companyInitFailures),
+            sourceScanFailures = ToScanFailureWire(sourceScanFailures),
             wallSeconds,
             protocolVersion = 2,
         };
         return JsonSerializer.Serialize(payload, Opts);
     }
+
+    /// <summary>
+    /// The sources the scan could not read, or null when it read everything. Null rather than
+    /// an empty array, matching `coverage`'s convention, so a client that does not know the
+    /// field sees no change.
+    ///
+    /// <para>#3884: a coverage table built from an incomplete source map is SHORT, and until
+    /// this field existed the response said so nowhere — the client got an ordinary success
+    /// carrying tables that silently omit whatever could not be read. A stderr warning is
+    /// observability; a client parsing JSON needs a field.</para>
+    /// </summary>
+    private static object? ToScanFailureWire(IReadOnlyList<Infrastructure.SourceScanFailure>? failures) =>
+        failures is { Count: > 0 }
+            ? failures.Select(f => new { path = f.Path, reason = f.Reason, kind = f.Kind.ToString() })
+            : null;
 
     /// <summary>Serialize an execute response (run-mode / inline code). <paramref
     /// name="statementTable"/> — see Summary's doc comment; identical `coverage`
@@ -383,11 +400,13 @@ public static class ServerProtocol
         ServerSelection? selection = null,
         IReadOnlyList<Infrastructure.AlCoverageTracker.AlStatementRecord>? statementTable = null,
         IReadOnlyDictionary<string, List<Infrastructure.AlCoverageTracker.AlStatementRecord>>? perTestStatementTable = null,
-        IReadOnlyList<CompanyInitFailure>? companyInitFailures = null)
+        IReadOnlyList<CompanyInitFailure>? companyInitFailures = null,
+        IReadOnlyList<Infrastructure.SourceScanFailure>? sourceScanFailures = null)
     {
         var payload = new
         {
             exitCode,
+            sourceScanFailures = ToScanFailureWire(sourceScanFailures),
             tests = tests.Select(ToWire),
             messages = messages is { Count: > 0 } ? messages.Select((m, i) => ToWire(m, Tag(messageTags, i))) : null,
             selection = selection == null ? null : new

--- a/docs/server-mode.md
+++ b/docs/server-mode.md
@@ -546,6 +546,28 @@ seen. So adding/removing/retyping a *field* (or other table-shape change) is not
 reliably picked up by a warm reload — restart the server after a schema change.
 Trigger/logic edits within an unchanged field layout are fine.
 
+## `sourceScanFailures` — the coverage table is short (#3847/#3884)
+
+Present on `summary` and on an `execute` response only when the source-map scan could not read
+something. Absent means it read everything — never an empty array, the same convention
+`coverage` uses.
+
+```json
+"sourceScanFailures":[{"path":"/src/app/gone","reason":"the source root does not exist","kind":"Root"}]
+```
+
+`kind` is `Root`, `Directory` or `File`. The first two cover every source **beneath** them; a
+`File` entry covers exactly that one path, so do not treat it as a prefix.
+
+**What it means for the tables in the same response.** `coverage` and `perTestCoverage` are
+built from that map, so they are missing whatever these paths declare. A statement absent from
+them is **unmeasured, not uncovered** — the distinction the field exists to make, because a
+coverage percentage computed over an unknown subset is not a coverage percentage.
+
+`exitCode` is `2` when this field is present and a coverage table was produced, unless the run
+earned something more specific; a run that was already failing keeps its own code. The CLI
+`--coverage` path does the same thing and names the paths on stderr.
+
 ## `companyInitFailures` — the company the tests ran against (#3561)
 
 Present on a `runTests` summary and on an `execute` response exactly when a company

--- a/docs/server-mode.md
+++ b/docs/server-mode.md
@@ -548,9 +548,14 @@ Trigger/logic edits within an unchanged field layout are fine.
 
 ## `sourceScanFailures` — the coverage table is short (#3847/#3884)
 
-Present on `summary` and on an `execute` response only when the source-map scan could not read
-something. Absent means it read everything — never an empty array, the same convention
-`coverage` uses.
+Present on `summary` and on an `execute` response only when a source-map scan ran **and** could
+not read something. Never an empty array, the same convention `coverage` uses.
+
+**Absent does not mean "every source was read."** It means no scan failure is being reported,
+and an ordinary request that builds no source map at all — no `coverage`, no `perTestCoverage`,
+no `captureValues`, no `iterationTracking` — reports nothing here either. If you need to tell
+*not scanned* from *scanned and clean*, the request flags you sent are what distinguishes them;
+this field does not.
 
 ```json
 "sourceScanFailures":[{"path":"/src/app/gone","reason":"the source root does not exist","kind":"Root"}]

--- a/protocol-v2.schema.json
+++ b/protocol-v2.schema.json
@@ -142,7 +142,8 @@
         "sourceScanFailures": {
           "type": "array",
           "items": { "$ref": "#/definitions/SourceScanFailure" },
-          "description": "Present only when the source-map scan could not read something (#3847/#3884). Absent means it read everything \u2014 never an empty array. Any `coverage`/`perTestCoverage` table in this response is SHORT by whatever these paths declare, so a statement missing from it is unmeasured rather than uncovered, and `exitCode` is 2 unless the run earned something more specific."
+          "minItems": 1,
+          "description": "Present only when a source-map scan ran AND could not read something (#3847/#3884). Absent means no scan failure is being reported \u2014 which is NOT the same as \"every source was read\": an ordinary request that builds no source map reports nothing here either. Never an empty array. Any `coverage`/`perTestCoverage` table in this response is SHORT by whatever these paths declare, so a statement missing from it is unmeasured rather than uncovered, and `exitCode` is 2 unless the run earned something more specific."
         },
         "wallSeconds": { "type": "number", "minimum": 0 },
         "protocolVersion": { "const": 2 }

--- a/protocol-v2.schema.json
+++ b/protocol-v2.schema.json
@@ -139,8 +139,31 @@
           "items": { "$ref": "#/definitions/CompanyInitFailure" },
           "description": "Present only when a company initialization codeunit did not run to completion during this request (#3538/#3561). Absent means the company initialized cleanly \u2014 never an empty array. Every test in the response ran against a company real BC cannot produce, so `exitCode` is 2 unless the run earned something more specific, or unless the expectations manifest accepts the abort (see `accepted`)."
         },
+        "sourceScanFailures": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/SourceScanFailure" },
+          "description": "Present only when the source-map scan could not read something (#3847/#3884). Absent means it read everything \u2014 never an empty array. Any `coverage`/`perTestCoverage` table in this response is SHORT by whatever these paths declare, so a statement missing from it is unmeasured rather than uncovered, and `exitCode` is 2 unless the run earned something more specific."
+        },
         "wallSeconds": { "type": "number", "minimum": 0 },
         "protocolVersion": { "const": 2 }
+      }
+    },
+    "SourceScanFailure": {
+      "type": "object",
+      "required": ["path", "reason", "kind"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "The root, directory or file that could not be read, as the scan named it."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Why, in the words the runner also prints to stderr."
+        },
+        "kind": {
+          "enum": ["Root", "Directory", "File"],
+          "description": "What `path` names. `Root` and `Directory` cover every source BENEATH them; `File` covers exactly that one path, so a client must not treat a File entry as a prefix."
+        }
       }
     },
     "CompanyInitFailure": {


### PR DESCRIPTION
Closes #3847

## What was wrong

`AlCoverageSourceMap.Build` returns a map. It had no way to say *I could not read the sources*,
so two failures came back as a map that is **successfully short**:

```csharp
if (!Directory.Exists(root)) continue;                        // a root that is not there
catch (IOException) { return Array.Empty<ParsedObject>(); }   // a file that cannot be read
```

Neither is distinguishable from a bundle that genuinely declares nothing mappable — which is a
legitimate state, so `Count == 0` cannot be the check either.

Both consumers turn a missing entry into a confident negative. The debugger's was the loudest,
and it is one this repository shipped last week: `verified: false` carrying
`no executable AL statement on this line in this file` — a measured-sounding claim about AL
that nobody read.

There is a third silent skip, and it is the one that shows the shape best:
`SafeDirectoryScan.Files` has **always** been able to report the directories it could not
enter, and this caller discarded the answer with `out _`. The mechanism existed; the caller
threw it away.

## The fix

`.claude/rules/guards-need-a-third-state.md` applied to a builder rather than a guard.

- `AlSourceLocationMap` carries `ScanFailures` (path + reason) and `IsIncomplete`.
- `Build` records all three ways a scan can fail to happen, deduplicated by path.
- `ParseObjects` distinguishes *could not read the file* from *parsed and found nothing*. A
  parse failure stays where it was: that file **was** measured, and what it holds is not
  something this map carries.
- One warning per path per process, emitted at the builder rather than at each of the five
  call sites — the consumer that forgets to check is exactly the one that then reports a
  confident negative. `Console.Error`, because under `--dap` stdio, stdout is the protocol
  channel.
- `DapUnverifiedReason` holds the three-way discrimination the DAP handler used to make
  inline, so it is testable without a live session.

**The constraint that stops this trading one defect for another**: a root that exists and
declares nothing mappable stays a clean pass. Only an *unmeasurable* scan becomes the third
state — a fix that hard-errors an empty bundle would have swapped a false green for a false
red.

## Proving tests

`AlRunner.Tests/CoverageSourceMapScanFailureTests.cs`, eight facts. RED before the fix was
`error CS1061: 'AlSourceLocationMap' does not contain a definition for 'ScanFailures'` — a
legitimate RED for a new API.

| fact | proves |
|---|---|
| `Build_ARootWithNothingMappable_ReportsNoFailures` | the constraint: an interface-only root is a clean pass, no failures, no entries |
| `Build_ARootThatIsNotThere_IsReportedRatherThanSkippedSilently` | the caller named a path that is not there |
| `Build_AnAlFileThatCannotBeRead_IsReportedRatherThanReadingAsNoObjects` | the readable file beside it is **still mapped**, the unreadable one is not mapped as object-free, and the failure names it |
| `UnverifiedReason_ForAFileThatCouldNotBeRead_SaysSoRatherThanBlamingTheLine` | the wrong claim is gone at the place it was made |
| `UnverifiedReason_ForAFileThatWasRead_StillBlamesTheLine` | the measured answer survives — the opposite false claim |
| `UnverifiedReason_ForAReadableFileBesideAnUnreadableOne_StillBlamesTheLine` | one unreadable file does not become every breakpoint's excuse |
| `UnverifiedReason_ForAFileUnderAnUnscannedRoot_SaysSoRatherThanBlamingTheLine` | a failure names a directory, so equality alone would miss every source beneath it |
| `UnverifiedReason_WhenTheBundleDidNotCompile_SaysThatFirst` | a compile failure outranks both |

The unreadable file is produced with `FileShare.None` rather than permission bits, which
differ per platform and per CI user.

### Mutation-checked, one slice at a time

| mutation | result |
|---|---|
| missing root silently skipped again | **3** red — the root fact, the under-a-root reason, the compile-failure fact's `Single` |
| unreadable file silently skipped again | **3** red — the file fact and both reasons that depend on it |
| `UnverifiedReason` compares paths by equality only | **1** red — the under-a-root fact alone |

## What is wired but not proven by a fact of mine

The **inaccessible-directory** arm. `SafeDirectoryScan` reports those and `Build` now forwards
them, but the four `InaccessibleDirectoryScanTests` rows that create such a directory skip on
this box (`permission bits do not bite here (running as root?)`) and I could not produce the
condition on Windows. Those rows run on the Linux legs and prove `SafeDirectoryScan` reports
it; nothing yet proves `Build` forwards it. Said here rather than left to be assumed from the
other two arms being covered.

## Local runs

- `CoverageSourceMapScanFailureTests`: **8 passed**.
- Wider sweep — the coverage suites, the five DAP suites, the source-scanning guard classes and
  `InaccessibleDirectoryScanTests`: **331 passed, 0 failed, 4 skipped**. The four are the
  permission-bit rows above, skipped for a platform reason that predates this branch.

## Related, not folded

- #3880 — the resolver has no module-provenance boundary. Also about a map entry meaning less
  than a consumer assumes, but it is about *which assemblies are eligible* rather than about
  what the scan managed to read.
- #3521 — building source attribution from BC syntax instead of a first-header regex. It would
  rewrite the producer this fix instruments.
- Coverage still only gets the stderr warning, not a structured report. The map can now be
  asked; no coverage consumer asks yet.

Corpus-NA: a source-scanning and diagnostic-message change in the runner's own coverage/debug map; no AL-observable behaviour changes, and the corpus cannot express an unreadable source file.

*Opened by an agent (Claude Code) in a session run by @SShadowS.*

https://claude.ai/code/session_01JFQZHC5SEHnLxkc5USksaK
