### PR TITLE
docs(tdd): require running the mutation, not asking whether a test would pass without the fix

### DIFF
--- a/.claude/rules/tdd.md
+++ b/.claude/rules/tdd.md
@@ -10,6 +10,51 @@ Every feature, fix, or mock change requires a test. No exceptions.
 - Positive: correct input → expected value (`Assert.AreEqual`).
 - Negative: invalid input → specific error (`asserterror` + `Assert.ExpectedError('...')`).
 
-**Tests must prove, not just pass.** Ask: would this test still pass if the implementation always returned a default value (0, `''`, `false`)? If yes, it is noise — strengthen it. Assert specific concrete values, never `Assert.IsTrue(true, ...)` or bare `asserterror` without an expected message.
+**Tests must prove, not just pass.** Assert concrete values, never `Assert.IsTrue(true, ...)`
+or bare `asserterror` without an expected message.
 
-The only valid exception is a "no-op stub" test where the *entire* claim is "this does not crash" — name it `*_NoThrow` / `*_IsNoOp` so the limited claim is explicit.
+The only valid exception is a "no-op stub" test where the *entire* claim is "this does not
+crash" — name it `*_NoThrow` / `*_IsNoOp` so the limited claim is explicit.
+
+## Run the mutation; do not just ask the question
+
+"Would this test still pass if the implementation did nothing?" is a question this rule used
+to leave you to answer by reasoning. **Execute it instead**, once per guard or behaviour you
+are claiming to prove:
+
+1. **Mutate the implementation, not the test** — delete the guard, invert the condition, or
+   return the default.
+2. **Rebuild and re-run. Confirm RED.** Restore.
+3. **Report both numbers in the PR body** — `Failed: 1, Passed: 7` → `Failed: 0, Passed: 8`.
+   A mutation whose result nobody can see is the same as one nobody ran.
+
+Once **per closed issue**, matching the per-issue RED→GREEN that
+`batch-sibling-issues-by-file.md` already requires.
+
+**Citation.** Two instances in one session, both caught only by an executed mutation
+(`docs/incidents/tdd.md`). #3819's fixture *constructed* the relationship it was meant to prove
+— `FakeExpression(id, name)` asserting `Name` holds the raw AL identifier, which it does not —
+so every test passed against a join that resolved nothing for 7,173 declarations. #3882 carried
+two guards at review time: mutating `DependencyLoader.LoadOne` gave `Failed: 1, Passed: 7`;
+mutating `DependencyMetadataProducer.Ensure` left **all 8 green** — a gap found in review and
+fixed before merge, which is the outcome this step exists to produce.
+
+**Trap: a test that names the thing is not a test that drives it.** #3882's second guard had
+two references to `METADATA-EMIT-EXCLUDED` — one asserting the naming convention, one passing it
+as routing data. Both mention the stage; neither reaches the `throw`. A grep for the symbol
+finds them and reads as coverage, which is why the mutation is the check and the grep is not.
+
+**Trap: CI catches the opposite error, never this one.** A test that fails when it should pass
+is red within minutes; one that passes when it should fail is caught only if somebody looks,
+and until then it reads as coverage while protecting nothing.
+
+A required step, not a tool: no framework, no CI job. One rebuild.
+
+## Sister rules
+
+- `batch-sibling-issues-by-file.md` — one RED→GREEN per closed issue; folding never exempts
+- `guards-need-a-third-state.md` — a refusal path with no test is indistinguishable from a
+  never-fire path: this rule, applied to the third state
+- `loud-failures.md` — what a patch must justify, and in what form
+
+History: docs/incidents/tdd.md

--- a/docs/incidents/tdd.md
+++ b/docs/incidents/tdd.md
@@ -1,0 +1,80 @@
+# Incidents behind `tdd.md`
+
+## Two tests that passed against implementations doing nothing (2026-09-11)
+
+`tdd.md` has always carried the right question — *would this test still pass if the
+implementation always returned a default value?* — as something to **ask**. In one session
+the honest answer was **yes** twice, and in neither case did asking surface it. Both were
+found by executing the mutation: remove the implementation, rebuild, observe that the tests
+stay green.
+
+### Instance 1 — PR #3819 (#3504): the fixture constructed the relationship under test
+
+The change translated a declaration read from `SymbolReference.json` into the key BC's live
+binding table uses, by matching the raw AL identifier against each registered expression's
+`Name`.
+
+The unit fixtures were built as `FakeExpression("p790p790PageEditable", "PageEditable")` —
+that is, they *asserted* that `Name` holds the raw AL identifier and the key holds the mangled
+`Id`. Instrumenting page 790's live binding table on 28.1 showed otherwise:
+
+```
+[rv] key='p790p790PageEditable'  name='p790p790PageEditable'
+[rv] key='Control159866013'      name='GLAccTotaling'
+```
+
+`Name` holds the mangled `Id` for exactly the population the fix targeted. The join therefore
+fell through to `return declared;` for **all 7,173 expression-bound declarations** — a no-op.
+The four accompanying AL tests all declared *literals*, which short-circuit before the lookup
+runs, so they could not have exercised it either.
+
+Three rounds of discussion treated the join's **correctness** without anyone noticing it never
+executed. What settled it was dumping the live table, reproduced 3/3 and twice more on a
+pristine uninstrumented rebuild.
+
+The commit that removed the join (`eef47c8a`) states it directly: *"every test passed anyway
+because the unit fake CONSTRUCTED the relationship it was meant to prove … tdd.md's question
+answered the wrong way: the tests did pass against an implementation that did nothing."*
+
+A second measurement from the same commit is why no repair was attempted: across the 92
+`<Expression>` entries in 2,272 captured page-metadata documents, 59 needed a join, and page
+60265 registers **two** keys for one identifier (`Control144826568` and `p60265p60265HideIt`,
+both `SourceExpression='HideIt'`). The relation is one-to-many, so no mangling rule
+reconstructs it.
+
+### Instance 2 — PR #3882 (#2247): one of two guards was unproven at review
+
+The PR adds a loud failure on a partial dependency emit at two call sites.
+
+| guard | mutation result |
+|---|---|
+| `DependencyLoader.LoadOne` (`EMIT-EXCLUDED`) | `Failed: 1, Passed: 7` — sound |
+| `DependencyMetadataProducer.Ensure` (`METADATA-EMIT-EXCLUDED`) | **all 8 green**, across two runs |
+
+Confirmed a second, differently-shaped way: the only test references to the second stage name
+assert the **naming convention** (`Assert.True(DependencyLoader.IsMetadataStage("METADATA-EMIT-EXCLUDED"))`)
+or pass it as routing data. Nothing drives the throw.
+
+The contrast is what makes the case: the same PR, the same author, the same session, one guard
+proven and one not — and the difference was invisible until the mutation ran.
+
+This one was caught in review and fixed before merge, so it never reached `main`. That is the
+outcome the step exists to produce, and it is why the instance is worth recording: nothing
+other than the mutation distinguished the two guards.
+
+### Why asking is weaker than doing
+
+The question is answered by reasoning about code you have just written while believing it
+works, which is when introspection is least reliable. Executing the mutation is one rebuild and
+is not a judgement call: the test goes red or it does not.
+
+Note the asymmetry in cost. A test that fails when it should pass is found immediately, by CI.
+A test that passes when it should fail is found only if someone looks — and it then protects
+nothing for as long as it exists, while *reading* like coverage. #3819's fixtures would have
+gone on asserting a false relationship indefinitely.
+
+### Scope deliberately not taken
+
+No mutation-testing framework, no tooling, no new CI job. The change is to which check is
+**required** and that its result is **reported**, so a reviewer can see a number instead of
+re-deriving it. Both instances were caught by a human-directed mutation taking one rebuild.


### PR DESCRIPTION
`tdd.md` has always carried the right question — *would this test still pass if the
implementation always returned a default value?* — as something to **ask**. Twice in one
session the honest answer was **yes**, and asking surfaced neither. Both were found by
executing the mutation: remove the implementation, rebuild, watch the tests stay green.

## The two instances

**#3819 — the fixture constructed the relationship under test.** The unit fake was
`FakeExpression("p790p790PageEditable", "PageEditable")`, which *asserts* that `Name` holds
the raw AL identifier. Instrumenting page 790's live binding table shows it holds the mangled
`Id` for exactly the population the fix targeted, so the join resolved nothing for **all 7,173
expression-bound declarations**. The four AL tests declared literals, which short-circuit
before the lookup. Three rounds of discussion covered the join's *correctness* without anyone
noticing it never executed.

**#3882 — two guards in one PR, one proven and one not.**

| guard | mutation result |
|---|---|
| `DependencyLoader.LoadOne` (`EMIT-EXCLUDED`) | `Failed: 1, Passed: 7` — sound |
| `DependencyMetadataProducer.Ensure` (`METADATA-EMIT-EXCLUDED`) | **all 8 green**, twice |

Confirmed a second, differently-shaped way: the only test references to the second stage name
assert the **naming convention** (`IsMetadataStage`) or pass it as routing data — nothing
reaches the `throw`. Caught in review and fixed before merge, so it never reached `main`.
That is the outcome this step produces, and it is why the instance is worth recording: nothing
except the mutation distinguished the two guards.

## What changes

`tdd.md` gains a step, not a tool:

1. Mutate the **implementation**, not the test.
2. Rebuild, re-run, confirm RED, restore.
3. **Report both numbers in the PR body.** A mutation whose result nobody can see is the same
   as one nobody ran.

Once per closed issue, matching the per-issue RED→GREEN `batch-sibling-issues-by-file.md`
already requires.

**No mutation-testing framework, no CI job, no new tooling.** Both instances were caught by a
human-directed mutation costing one rebuild. Automating it is a separate question this PR
deliberately does not open.

## Why this is a rule and not advice

`CLAUDE.md` sets the bar at two independent instances or a cited measurement; this has both,
in one session, by different authors on different subsystems. The asymmetry is what justifies
the rebuild: a test that fails when it should pass is red in CI within minutes, while one that
passes when it should fail is caught only if somebody looks — and until then it reads as
coverage while protecting nothing.

## Conventions followed

- `docs/incidents/tdd.md` **created** — `tdd.md` had no incidents file, which
  `CLAUDE.md` § "How a rule is written" requires. The derivation lives there; the rule keeps
  claim + citation + trap.
- Rule is 3,185 bytes. The 3 KB guidance is for a new rule; `tdd.md` is an existing one and
  now sits smaller than 15 of the 19 rules in `.claude/rules/`.
- `tools/test_doc_pointers.py` passes (66 links, 13 anchors, 123 `Doc` values).

## Queue scan

Searched the open queue for the mechanism (`mutation`, `test proves nothing`, `passes without
the fix`) and for `tdd`; `rg --hidden` over `.claude/` confirms the word "mutat" appears in no
rule or agent definition today, against a positive control that returns matches. No sibling
issue found — this is the first time it has been written down.

Closes #3885

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
