### PR TITLE
feat(provisioning): classify an artifact directory before a consumer opens it

### DIFF
--- a/AlRunner.Tests/ArtifactDirStateTests.cs
+++ b/AlRunner.Tests/ArtifactDirStateTests.cs
@@ -319,4 +319,55 @@ public sealed class ArtifactDirStateTests : IDisposable
             }
         }
     }
+
+    /// <summary>
+    /// #2226's signature, found while answering "do two code paths write the same state
+    /// with different invariants?" — and the real explanation of the second broken
+    /// directory on the reporting box. `provision`'s platform-app sub-step resolved build
+    /// 28.0.46665.54452 while its service-tier sub-step resolved 28.0.46665.54338, so one
+    /// major.minor is split across two directories, each complete for its own half:
+    ///
+    ///   28.0.46665.54338   Ncl.dll present, platform-apps/ absent
+    ///   28.0.46665.54452   Ncl.dll absent,  platform-apps/ holding all 6 apps (120 MB)
+    ///
+    /// Still Partial — it is not a usable service tier — but the message must not imply
+    /// corruption, because nothing here is corrupt and the payload is genuinely usable.
+    /// This is also why the directory survives AutoProvision's RemoveIfEmpty cleanup:
+    /// that only deletes a directory holding NOTHING, and this one holds platform-apps/.
+    /// </summary>
+    [Fact]
+    public void Classify_PayloadOnlyDir_IsPartial_ButNotDescribedAsCorrupt()
+    {
+        var dir = VersionDir("28.0.46665.54452");
+        var payload = Path.Combine(dir, "platform-apps");
+        Directory.CreateDirectory(payload);
+        File.WriteAllText(Path.Combine(payload, "Microsoft_Base Application_28.0.46665.54452.app"), "x");
+
+        var state = ArtifactDirState.Classify(dir);
+
+        Assert.Equal(ArtifactDirStatus.Partial, state.Status);
+        Assert.False(state.HasEngineEntrypoint);
+        Assert.True(state.HasSiblingProvisionPayload);
+
+        var text = state.Explain();
+        Assert.Contains("#2226", text);
+        Assert.Contains("payload here is usable", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The negative half: a directory with neither engine DLLs nor a payload is the plain
+    /// empty-leftover shape and must NOT claim the #2226 split, which would be a diagnosis
+    /// nothing measured.
+    /// </summary>
+    [Fact]
+    public void Classify_TrulyEmptyDir_DoesNotClaimTheSplitBuildCause()
+    {
+        var dir = VersionDir("28.0.46665.54452");
+
+        var state = ArtifactDirState.Classify(dir);
+
+        Assert.Equal(ArtifactDirStatus.Partial, state.Status);
+        Assert.False(state.HasSiblingProvisionPayload);
+        Assert.DoesNotContain("#2226", state.Explain());
+    }
 }

--- a/AlRunner.Tests/ArtifactDirStateTests.cs
+++ b/AlRunner.Tests/ArtifactDirStateTests.cs
@@ -1,0 +1,322 @@
+// ArtifactDirStateTests — #3878. A partially-provisioned artifact directory used to be
+// indistinguishable from a complete one until a consumer failed deep inside an assembly
+// load, so the failure looked like a code fault.
+//
+// The three shapes these pin are the ones measured on the reporting box, not invented:
+//
+//   27.5.46862.48827   82 DLLs, Ncl.dll PRESENT, closure sentinel absent   -> Partial
+//   28.0.46665.54452    0 DLLs, Ncl.dll absent, holds only platform-apps/  -> Partial
+//   28.4.53241.54407  501 DLLs, everything present                         -> Complete
+//   (a version never provisioned at all)                                   -> Absent
+//
+// The two broken shapes are NOT the same failure, which is the whole point of the
+// classification: the 82-DLL directory passes an "is this a service-tier directory"
+// check (it carries Ncl.dll) and fails later, deeper and less legibly; the empty one is
+// correctly rejected by such a check. A guard built only for the first does not fire on
+// the second.
+
+using Xunit;
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Tests;
+
+public sealed class ArtifactDirStateTests : IDisposable
+{
+    private readonly string _root;
+
+    public ArtifactDirStateTests()
+    {
+        _root = TestScratch.Dir("al-runner-artifact-state");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private string VersionDir(string version)
+    {
+        var d = Path.Combine(_root, version);
+        Directory.CreateDirectory(d);
+        return d;
+    }
+
+    private static void Touch(string dir, string name)
+        => File.WriteAllText(Path.Combine(dir, name), "x");
+
+    /// <summary>The complete engine closure: the five core engine DLLs + the closure sentinel.</summary>
+    private static void WriteCompleteClosure(string dir)
+    {
+        foreach (var f in new[]
+        {
+            "Microsoft.Dynamics.Nav.Ncl.dll",
+            "Microsoft.Dynamics.Nav.Types.dll",
+            "Microsoft.Dynamics.Nav.Common.dll",
+            "Microsoft.Dynamics.Nav.Language.dll",
+            "Microsoft.Dynamics.Nav.CodeAnalysis.dll",
+            "Microsoft.Identity.ServiceEssentials.Core.dll",
+        }) Touch(dir, f);
+    }
+
+    // ── The four states, each asserted on the shape that produces it ──────────
+
+    [Fact]
+    public void Classify_CompleteClosure_IsComplete()
+    {
+        var dir = VersionDir("28.4.53241.54407");
+        WriteCompleteClosure(dir);
+
+        var state = ArtifactDirState.Classify(dir);
+
+        Assert.Equal(ArtifactDirStatus.Complete, state.Status);
+        Assert.True(state.IsUsable);
+        Assert.Empty(state.MissingFiles);
+    }
+
+    /// <summary>
+    /// The issue's subject: Ncl.dll present, so every "is this a service-tier directory"
+    /// check passes, but the closure is short. Must be Partial — NOT Absent, and NOT
+    /// Complete.
+    /// </summary>
+    [Fact]
+    public void Classify_NclPresentButClosureShort_IsPartial_NotAbsent()
+    {
+        var dir = VersionDir("27.5.46862.48827");
+        WriteCompleteClosure(dir);
+        File.Delete(Path.Combine(dir, "Microsoft.Identity.ServiceEssentials.Core.dll"));
+
+        var state = ArtifactDirState.Classify(dir);
+
+        Assert.Equal(ArtifactDirStatus.Partial, state.Status);
+        Assert.False(state.IsUsable);
+        // The directory LOOKS like a service tier — that is exactly why it is dangerous.
+        Assert.True(state.HasEngineEntrypoint);
+        Assert.Contains("Microsoft.Identity.ServiceEssentials.Core.dll", state.MissingFiles);
+        // ...and it is not confused with the empty shape below.
+        Assert.Single(state.MissingFiles);
+    }
+
+    /// <summary>
+    /// The second broken shape the coordinator measured and the issue body does not name:
+    /// zero DLLs, no Ncl.dll, only a platform-apps/ subdirectory. It must classify as
+    /// Partial too — the directory exists and something put it there — and must be
+    /// distinguishable from the 82-DLL shape by HasEngineEntrypoint.
+    /// </summary>
+    [Fact]
+    public void Classify_EmptyButForPlatformApps_IsPartial_AndHasNoEngineEntrypoint()
+    {
+        var dir = VersionDir("28.0.46665.54452");
+        Directory.CreateDirectory(Path.Combine(dir, "platform-apps"));
+
+        var state = ArtifactDirState.Classify(dir);
+
+        Assert.Equal(ArtifactDirStatus.Partial, state.Status);
+        Assert.False(state.IsUsable);
+        Assert.False(state.HasEngineEntrypoint);
+        Assert.Contains("Microsoft.Dynamics.Nav.Ncl.dll", state.MissingFiles);
+        // All six, not one: this is a categorically worse shape than the 82-DLL one.
+        Assert.Equal(6, state.MissingFiles.Count);
+    }
+
+    /// <summary>
+    /// The constraint from guards-need-a-third-state.md: "a genuinely absent thing must
+    /// stay a legitimate state". A version that was never provisioned is Absent, and
+    /// Absent is NOT Partial — the remedy differs (provision it, vs. repair/re-fetch a
+    /// directory something already wrote to).
+    /// </summary>
+    [Fact]
+    public void Classify_NeverProvisioned_IsAbsent_NotPartial()
+    {
+        var dir = Path.Combine(_root, "28.9.99999.99999");
+
+        var state = ArtifactDirState.Classify(dir);
+
+        Assert.Equal(ArtifactDirStatus.Absent, state.Status);
+        Assert.False(state.IsUsable);
+        Assert.NotEqual(ArtifactDirStatus.Partial, state.Status);
+    }
+
+    /// <summary>
+    /// The distinction the existing ProvisioningCheck.Check cannot draw: a directory that
+    /// does not exist and one that exists but is empty both produce "all six missing".
+    /// Same missing-file list, different status, different remedy.
+    /// </summary>
+    [Fact]
+    public void Classify_AbsentAndEmpty_ShareAMissingListButNotAStatus()
+    {
+        var absent = Path.Combine(_root, "28.9.99999.99999");
+        var empty = VersionDir("28.0.46665.54452");
+
+        var a = ArtifactDirState.Classify(absent);
+        var e = ArtifactDirState.Classify(empty);
+
+        Assert.Equal(a.MissingFiles.Count, e.MissingFiles.Count);
+        Assert.NotEqual(a.Status, e.Status);
+    }
+
+    // ── The third state: could not measure ───────────────────────────────────
+
+    /// <summary>
+    /// guards-need-a-third-state.md, point 5: "prove the third state fires". A path that
+    /// exists but is not a directory cannot be measured — it is neither a legitimately
+    /// absent version nor a partial one — so it must report Unreadable rather than
+    /// resolving toward either Complete (a false green) or Absent (which would send the
+    /// reader to `provision`, a remedy that cannot fix a file sitting where a directory
+    /// belongs).
+    /// </summary>
+    [Fact]
+    public void Classify_PathIsAFileNotADirectory_IsUnreadable()
+    {
+        var path = Path.Combine(_root, "28.4.53241.54407");
+        File.WriteAllText(path, "not a directory");
+
+        var state = ArtifactDirState.Classify(path);
+
+        Assert.Equal(ArtifactDirStatus.Unreadable, state.Status);
+        Assert.False(state.IsUsable);
+        Assert.NotEqual(ArtifactDirStatus.Absent, state.Status);
+        Assert.NotEqual(ArtifactDirStatus.Complete, state.Status);
+    }
+
+    [Fact]
+    public void Classify_UnreadableNamesWhatCouldNotBeEstablished()
+    {
+        var path = Path.Combine(_root, "28.4.53241.54407");
+        File.WriteAllText(path, "not a directory");
+
+        var state = ArtifactDirState.Classify(path);
+
+        // The message must send the reader to the right remedy, which for this shape is
+        // "something is in the way", never "download it again".
+        Assert.Contains("not a directory", state.Explain(), StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(path, state.Explain());
+    }
+
+    // ── The message each broken shape produces ───────────────────────────────
+
+    [Fact]
+    public void Explain_Partial_NamesTheDirectoryAndTheMissingFile()
+    {
+        var dir = VersionDir("27.5.46862.48827");
+        WriteCompleteClosure(dir);
+        File.Delete(Path.Combine(dir, "Microsoft.Identity.ServiceEssentials.Core.dll"));
+
+        var text = ArtifactDirState.Classify(dir).Explain();
+
+        // Names the directory, so the reader knows WHICH one is broken — the thing three
+        // separate diagnoses had to re-derive.
+        Assert.Contains(dir, text);
+        Assert.Contains("Microsoft.Identity.ServiceEssentials.Core.dll", text);
+        Assert.Contains("partially provisioned", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Explain_Absent_DoesNotClaimTheDirectoryIsBroken()
+    {
+        var dir = Path.Combine(_root, "28.9.99999.99999");
+
+        var text = ArtifactDirState.Classify(dir).Explain();
+
+        Assert.Contains(dir, text);
+        // An absent version is a legitimate state; calling it "partially provisioned"
+        // would send the reader looking for corruption that is not there.
+        Assert.DoesNotContain("partially provisioned", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── Scanning a whole artifacts root ──────────────────────────────────────
+
+    /// <summary>
+    /// What a cycle-start probe needs: every version directory under the root, classified,
+    /// with the broken ones nameable without opening an assembly. Reproduces the box's
+    /// measured shape — two broken among healthy ones.
+    /// </summary>
+    [Fact]
+    public void ScanRoot_NamesOnlyTheBrokenDirectories()
+    {
+        WriteCompleteClosure(VersionDir("28.4.53241.54407"));
+        WriteCompleteClosure(VersionDir("27.5.46862.53931"));
+
+        var short82 = VersionDir("27.5.46862.48827");
+        WriteCompleteClosure(short82);
+        File.Delete(Path.Combine(short82, "Microsoft.Identity.ServiceEssentials.Core.dll"));
+
+        Directory.CreateDirectory(Path.Combine(VersionDir("28.0.46665.54452"), "platform-apps"));
+
+        var results = ArtifactDirState.ScanRoot(_root);
+
+        Assert.Equal(4, results.Count);
+        var broken = results.Where(r => !r.IsUsable).Select(r => Path.GetFileName(r.Directory)).OrderBy(x => x).ToList();
+        Assert.Equal(new[] { "27.5.46862.48827", "28.0.46665.54452" }, broken);
+
+        var healthy = results.Where(r => r.IsUsable).Select(r => Path.GetFileName(r.Directory)).OrderBy(x => x).ToList();
+        Assert.Equal(new[] { "27.5.46862.53931", "28.4.53241.54407" }, healthy);
+    }
+
+    /// <summary>
+    /// The constraint again, at root level: an artifacts root that does not exist is a
+    /// legitimate state (nothing provisioned yet) and yields no results rather than
+    /// throwing. A fix that hard-errors here would swap a false green for a false red.
+    /// </summary>
+    [Fact]
+    public void ScanRoot_MissingRoot_IsEmpty_NotAThrow()
+    {
+        var results = ArtifactDirState.ScanRoot(Path.Combine(_root, "no-such-root"));
+
+        Assert.Empty(results);
+    }
+
+    /// <summary>
+    /// Non-version-named entries under the root (the test-data dir, a stray file) are not
+    /// artifact directories and must not be reported as broken ones.
+    /// </summary>
+    [Fact]
+    public void ScanRoot_IgnoresNonVersionNamedEntries()
+    {
+        WriteCompleteClosure(VersionDir("28.4.53241.54407"));
+        Directory.CreateDirectory(Path.Combine(_root, "scratch"));
+        File.WriteAllText(Path.Combine(_root, "README.txt"), "x");
+
+        var results = ArtifactDirState.ScanRoot(_root);
+
+        Assert.Single(results);
+        Assert.Equal("28.4.53241.54407", Path.GetFileName(results[0].Directory));
+    }
+
+    // ── Against the real artifacts root, when one exists ─────────────────────
+
+    /// <summary>
+    /// #3878's actual subject: the directories on the developer's own disk. Skips on a
+    /// machine with no artifacts root (CI legs provision into a different layout), so it
+    /// is a local sharpener rather than a CI gate — but where a root DOES exist, every
+    /// directory it classifies Complete must really hold the engine entrypoint, and every
+    /// Partial one must name at least one missing file. A classifier that answered
+    /// Complete for a directory without Ncl.dll would be exactly the false green this
+    /// change exists to remove.
+    /// </summary>
+    [Fact]
+    public void ScanRoot_OnTheRealArtifactsRoot_NeverReportsCompleteWithoutTheEngine()
+    {
+        var root = Environment.GetEnvironmentVariable(BcArtifacts.ArtifactsRootEnvVar);
+        if (string.IsNullOrWhiteSpace(root))
+            root = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                BcArtifacts.ArtifactsRoot_Rel);
+        if (!Directory.Exists(root)) return;   // nothing provisioned here; nothing to assert
+
+        foreach (var r in ArtifactDirState.ScanRoot(root))
+        {
+            if (r.Status == ArtifactDirStatus.Complete)
+            {
+                Assert.True(r.HasEngineEntrypoint,
+                    $"{r.Directory} classified Complete without Microsoft.Dynamics.Nav.Ncl.dll");
+                Assert.Empty(r.MissingFiles);
+            }
+            else if (r.Status == ArtifactDirStatus.Partial)
+            {
+                Assert.NotEmpty(r.MissingFiles);
+                Assert.Contains("partially provisioned", r.Explain(), StringComparison.OrdinalIgnoreCase);
+            }
+        }
+    }
+}

--- a/AlRunner.Tests/ArtifactDirStateTests.cs
+++ b/AlRunner.Tests/ArtifactDirStateTests.cs
@@ -294,17 +294,29 @@ public sealed class ArtifactDirStateTests : IDisposable
     /// Complete for a directory without Ncl.dll would be exactly the false green this
     /// change exists to remove.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public void ScanRoot_OnTheRealArtifactsRoot_NeverReportsCompleteWithoutTheEngine()
     {
+        // A bare `return;` here would report Passed having asserted nothing — the very
+        // silent-success shape this class exists to stop, one level up. TestArtifacts
+        // SKIPS locally (a dev box may legitimately have provisioned nothing) and FAILS
+        // on CI, where artifacts are provisioned by construction, so "every artifact-gated
+        // test skipped and the leg is green" cannot happen either.
+        TestArtifacts.SkipIfMissing();
+
         var root = Environment.GetEnvironmentVariable(BcArtifacts.ArtifactsRootEnvVar);
         if (string.IsNullOrWhiteSpace(root))
             root = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
                 BcArtifacts.ArtifactsRoot_Rel);
-        if (!Directory.Exists(root)) return;   // nothing provisioned here; nothing to assert
+        TestArtifacts.SkipIfDirectoryMissing(root, "the BC artifacts root");
 
-        foreach (var r in ArtifactDirState.ScanRoot(root))
+        var results = ArtifactDirState.ScanRoot(root);
+        // Non-vacuity: a root that classifies nothing means this assertion measured nothing,
+        // which must not read as a pass (TestArtifactsGateTests takes the same line).
+        Assert.NotEmpty(results);
+
+        foreach (var r in results)
         {
             if (r.Status == ArtifactDirStatus.Complete)
             {

--- a/AlRunner/Infrastructure/ArtifactDirState.cs
+++ b/AlRunner/Infrastructure/ArtifactDirState.cs
@@ -65,10 +65,10 @@ public enum ArtifactDirStatus
 public static class ArtifactDirState
 {
     /// <summary>
-    /// The five core engine DLLs plus the closure sentinel — the same set
-    /// <see cref="ProvisioningCheck.Check"/> requires, read through it rather than
-    /// duplicated, so the two can never drift into disagreeing about what "complete"
-    /// means.
+    /// One directory's verdict: its <see cref="Status"/>, the closure files absent from it,
+    /// whether it carries the engine entrypoint (what makes the two broken shapes different
+    /// from each other), and — for <see cref="ArtifactDirStatus.Unreadable"/> — why the
+    /// measurement could not be made.
     /// </summary>
     public sealed record Result(
         string Directory,

--- a/AlRunner/Infrastructure/ArtifactDirState.cs
+++ b/AlRunner/Infrastructure/ArtifactDirState.cs
@@ -1,0 +1,222 @@
+namespace AlRunner.Infrastructure;
+
+/// <summary>
+/// What one BC artifact version directory actually is. Four states, not two — see
+/// <c>.claude/rules/guards-need-a-third-state.md</c>.
+///
+/// <para><see cref="Absent"/> and <see cref="Unreadable"/> are deliberately distinct.
+/// <see cref="ProvisioningCheck.Check"/> reports both as "all six files missing", but the
+/// remedies differ: an absent version is provisioned, while a path blocked by a file needs
+/// the obstruction removed first, and `provision` cannot do that.</para>
+/// </summary>
+public enum ArtifactDirStatus
+{
+    /// <summary>The engine closure is complete. The only usable state.</summary>
+    Complete,
+
+    /// <summary>
+    /// Nothing is there. A legitimate state, never an error by itself — the version was
+    /// simply never provisioned.
+    /// </summary>
+    Absent,
+
+    /// <summary>
+    /// The directory exists and something wrote to it, but the engine closure is short.
+    /// This is the #3878 shape: it can carry <c>Ncl.dll</c> and pass every "is this a
+    /// service-tier directory" check while still failing deep inside an assembly load.
+    /// </summary>
+    Partial,
+
+    /// <summary>
+    /// The third state: the directory could not be measured at all. Distinct from
+    /// <see cref="Complete"/> (which would be a false green) and from
+    /// <see cref="Absent"/> (which would send the reader to the wrong remedy).
+    /// </summary>
+    Unreadable,
+}
+
+/// <summary>
+/// Classifies a BC artifact version directory before a consumer opens anything in it.
+///
+/// <para><b>Why this exists (#3878).</b> A partially-provisioned directory used to be
+/// indistinguishable from a complete one until something failed deep inside an assembly
+/// load, at which point the failure read as a code fault. It cost three separate
+/// diagnoses of one cause in a single session: a `load_assembly` failure traced to an
+/// absent <c>Framework.UI.dll</c>, a feasibility measurement that contributed zero
+/// packages, and a resolver probe that died with exit 134 on an absent
+/// <c>Mono.Cecil.dll</c>.</para>
+///
+/// <para><b>What distinguishes complete from partial, and why it is not a DLL count.</b>
+/// 501 is one version's number, not a constant, so a threshold would be fragile in both
+/// directions. The predicate is the one
+/// <see cref="ProvisioningCheck.Check"/> already uses and that the download path already
+/// re-checks after every fetch: the five core engine DLLs plus the closure sentinel
+/// <c>Microsoft.Identity.ServiceEssentials.Core.dll</c>. Measured against the two broken
+/// directories on the reporting box, that predicate already separates both from every
+/// healthy one — 27.5.46862.48827 is short exactly the sentinel, and 28.0.46665.54452 is
+/// short all six. So no new on-disk marker is needed and none is written: the signal was
+/// already there, unread by anything outside the runner's own startup path.</para>
+///
+/// <para>The consequence worth stating plainly: because this reads the closure rather
+/// than a marker, it classifies directories <b>already on disk</b> — including the two
+/// that motivated the issue. A completion marker would have applied only to directories
+/// provisioned after it shipped.</para>
+/// </summary>
+public static class ArtifactDirState
+{
+    /// <summary>
+    /// The five core engine DLLs plus the closure sentinel — the same set
+    /// <see cref="ProvisioningCheck.Check"/> requires, read through it rather than
+    /// duplicated, so the two can never drift into disagreeing about what "complete"
+    /// means.
+    /// </summary>
+    public sealed record Result(
+        string Directory,
+        ArtifactDirStatus Status,
+        IReadOnlyList<string> MissingFiles,
+        bool HasEngineEntrypoint,
+        string? UnreadableReason)
+    {
+        /// <summary>True only for <see cref="ArtifactDirStatus.Complete"/>.</summary>
+        public bool IsUsable => Status == ArtifactDirStatus.Complete;
+
+        /// <summary>
+        /// One line per fact, naming the directory and what is wrong with it — so a
+        /// consumer reports "this artifact directory is broken" instead of letting a
+        /// FileNotFoundException from inside an assembly load stand in for it.
+        /// </summary>
+        public string Explain()
+        {
+            switch (Status)
+            {
+                case ArtifactDirStatus.Complete:
+                    return $"BC artifact directory {Directory} holds a complete engine closure.";
+
+                case ArtifactDirStatus.Absent:
+                    // Deliberately NOT "partially provisioned": nothing is broken here.
+                    return $"BC artifact directory {Directory} does not exist — that version is not provisioned. "
+                         + $"Fix: {BcArtifacts.ProvisionHint()}";
+
+                case ArtifactDirStatus.Unreadable:
+                    return $"BC artifact directory {Directory} could not be inspected: {UnreadableReason}. "
+                         + "This is not a missing download — remove or rename whatever occupies that path first.";
+
+                default:
+                    var lines = new List<string>
+                    {
+                        $"BC artifact directory {Directory} is partially provisioned — it exists but its engine closure is incomplete.",
+                    };
+                    if (HasEngineEntrypoint)
+                        // The dangerous shape: it looks like a service tier, so consumers
+                        // accept it and fail later, deeper and less legibly.
+                        lines.Add("  It carries Microsoft.Dynamics.Nav.Ncl.dll, so it passes a presence check and fails later inside an assembly load.");
+                    else
+                        lines.Add("  It does not carry Microsoft.Dynamics.Nav.Ncl.dll, so it is not a usable service-tier directory at all.");
+                    lines.Add("  Missing:");
+                    foreach (var f in MissingFiles)
+                        lines.Add($"    - {Path.Combine(Directory, f)}");
+                    lines.Add($"  Fix: al-runner provision --service-tier --bc-version {Path.GetFileName(Directory)} --force");
+                    return string.Join(Environment.NewLine, lines);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The engine entrypoint every "is this a service-tier directory" check keys on. Its
+    /// presence is what makes the 82-DLL shape pass such a check and fail later; its
+    /// absence is what makes the zero-DLL shape fail one immediately. Recorded so the two
+    /// broken shapes stay distinguishable rather than collapsing into one "broken".
+    /// </summary>
+    private const string EngineEntrypoint = "Microsoft.Dynamics.Nav.Ncl.dll";
+
+    /// <summary>
+    /// Classify one artifact version directory. Never throws: an I/O failure is the
+    /// <see cref="ArtifactDirStatus.Unreadable"/> third state, reported with its reason,
+    /// rather than an exception a caller would have to guess the meaning of.
+    /// </summary>
+    public static Result Classify(string versionDir)
+    {
+        if (string.IsNullOrWhiteSpace(versionDir))
+            return new Result(versionDir ?? "", ArtifactDirStatus.Unreadable,
+                Array.Empty<string>(), false, "no path was supplied");
+
+        // A file sitting where a directory belongs is NOT an absent version: `provision`
+        // cannot fix it, so it must not be reported as something `provision` would fix.
+        if (File.Exists(versionDir) && !Directory.Exists(versionDir))
+            return new Result(versionDir, ArtifactDirStatus.Unreadable,
+                Array.Empty<string>(), false, "the path is a file, not a directory");
+
+        bool exists;
+        try
+        {
+            exists = Directory.Exists(versionDir);
+        }
+        catch (Exception ex)
+        {
+            return new Result(versionDir, ArtifactDirStatus.Unreadable,
+                Array.Empty<string>(), false, ex.Message);
+        }
+
+        // Ask ProvisioningCheck rather than re-listing the closure here: one definition of
+        // "complete", shared with the startup gate and the post-download re-check.
+        var version = Path.GetFileName(versionDir.TrimEnd(
+            Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        ProvisioningCheck.Report report;
+        bool hasEntrypoint;
+        try
+        {
+            report = ProvisioningCheck.Check(version, versionDir);
+            hasEntrypoint = exists && File.Exists(Path.Combine(versionDir, EngineEntrypoint));
+        }
+        catch (Exception ex)
+        {
+            return new Result(versionDir, ArtifactDirStatus.Unreadable,
+                Array.Empty<string>(), false, ex.Message);
+        }
+
+        if (!exists)
+            // The genuinely-absent case stays a legitimate state, per
+            // guards-need-a-third-state.md's constraint. Note it shares its missing-file
+            // list with the empty-directory case below and is still a different status.
+            return new Result(versionDir, ArtifactDirStatus.Absent,
+                report.MissingFiles, false, null);
+
+        return report.Ok
+            ? new Result(versionDir, ArtifactDirStatus.Complete, report.MissingFiles, hasEntrypoint, null)
+            : new Result(versionDir, ArtifactDirStatus.Partial, report.MissingFiles, hasEntrypoint, null);
+    }
+
+    /// <summary>
+    /// Classify every version-named directory under an artifacts root, newest first.
+    ///
+    /// <para>A root that does not exist yields an empty list rather than throwing — a
+    /// machine with nothing provisioned is a legitimate state, and a probe that hard-errors
+    /// there would swap a false green for a false red.</para>
+    ///
+    /// <para>Entries whose names do not parse as a version are skipped: the root also holds
+    /// non-artifact directories, and reporting one as a broken artifact directory would be
+    /// a false positive.</para>
+    /// </summary>
+    public static IReadOnlyList<Result> ScanRoot(string artifactsRootDir)
+    {
+        if (string.IsNullOrWhiteSpace(artifactsRootDir) || !Directory.Exists(artifactsRootDir))
+            return Array.Empty<Result>();
+
+        List<string> dirs;
+        try
+        {
+            dirs = Directory.EnumerateDirectories(artifactsRootDir).ToList();
+        }
+        catch
+        {
+            return Array.Empty<Result>();
+        }
+
+        return dirs
+            .Select(d => (Dir: d, Ver: Version.TryParse(Path.GetFileName(d), out var v) ? v : null))
+            .Where(t => t.Ver != null)
+            .OrderByDescending(t => t.Ver)
+            .Select(t => Classify(t.Dir))
+            .ToList();
+    }
+}

--- a/AlRunner/Infrastructure/ArtifactDirState.cs
+++ b/AlRunner/Infrastructure/ArtifactDirState.cs
@@ -75,7 +75,8 @@ public static class ArtifactDirState
         ArtifactDirStatus Status,
         IReadOnlyList<string> MissingFiles,
         bool HasEngineEntrypoint,
-        string? UnreadableReason)
+        string? UnreadableReason,
+        bool HasSiblingProvisionPayload = false)
     {
         /// <summary>True only for <see cref="ArtifactDirStatus.Complete"/>.</summary>
         public bool IsUsable => Status == ArtifactDirStatus.Complete;
@@ -110,6 +111,15 @@ public static class ArtifactDirState
                         // The dangerous shape: it looks like a service tier, so consumers
                         // accept it and fail later, deeper and less legibly.
                         lines.Add("  It carries Microsoft.Dynamics.Nav.Ncl.dll, so it passes a presence check and fails later inside an assembly load.");
+                    else if (HasSiblingProvisionPayload)
+                        // #2226: `provision`'s platform-app and service-tier sub-steps can
+                        // resolve to DIFFERENT patch builds of one major.minor, leaving a
+                        // directory that is a complete platform-apps cache and an empty
+                        // service tier. Nothing here is corrupt, so the message must not
+                        // send the reader looking for corruption.
+                        lines.Add("  It carries no engine DLLs at all, only a platform-apps/test-apps payload — "
+                                + "the service tier for this major.minor landed under a different patch directory (#2226). "
+                                + "The payload here is usable; this directory is simply not a service tier.");
                     else
                         lines.Add("  It does not carry Microsoft.Dynamics.Nav.Ncl.dll, so it is not a usable service-tier directory at all.");
                     lines.Add("  Missing:");
@@ -128,6 +138,14 @@ public static class ArtifactDirState
     /// broken shapes stay distinguishable rather than collapsing into one "broken".
     /// </summary>
     private const string EngineEntrypoint = "Microsoft.Dynamics.Nav.Ncl.dll";
+
+    /// <summary>
+    /// The runner-owned payload subdirectories `provision` writes beside an engine closure.
+    /// Their presence in a directory with no engine DLLs is the #2226 signature: the
+    /// platform-app sub-step resolved a different patch build from the service-tier one, so
+    /// one major.minor ends up split across two directories, each complete for its own half.
+    /// </summary>
+    private static readonly string[] SiblingPayloadDirs = { "platform-apps", "test-apps" };
 
     /// <summary>
     /// Classify one artifact version directory. Never throws: an I/O failure is the
@@ -163,10 +181,13 @@ public static class ArtifactDirState
             Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
         ProvisioningCheck.Report report;
         bool hasEntrypoint;
+        bool hasPayload;
         try
         {
             report = ProvisioningCheck.Check(version, versionDir);
             hasEntrypoint = exists && File.Exists(Path.Combine(versionDir, EngineEntrypoint));
+            hasPayload = exists && SiblingPayloadDirs.Any(
+                sub => Directory.Exists(Path.Combine(versionDir, sub)));
         }
         catch (Exception ex)
         {
@@ -182,8 +203,8 @@ public static class ArtifactDirState
                 report.MissingFiles, false, null);
 
         return report.Ok
-            ? new Result(versionDir, ArtifactDirStatus.Complete, report.MissingFiles, hasEntrypoint, null)
-            : new Result(versionDir, ArtifactDirStatus.Partial, report.MissingFiles, hasEntrypoint, null);
+            ? new Result(versionDir, ArtifactDirStatus.Complete, report.MissingFiles, hasEntrypoint, null, hasPayload)
+            : new Result(versionDir, ArtifactDirStatus.Partial, report.MissingFiles, hasEntrypoint, null, hasPayload);
     }
 
     /// <summary>

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -2598,6 +2598,134 @@ def classify_corpus_checkout(reading: dict) -> CheckResult:
         remedy=remedy, data=reading)
 
 
+# --------------------------------------------------------------------------
+# artifacts root (#3878)
+# --------------------------------------------------------------------------
+ARTIFACTS_ROOT_ENV = "AL_RUNNER_ARTIFACTS_ROOT"
+ARTIFACTS_ROOT_REL = ".local/share/al-runner/artifacts"
+
+# The engine closure a usable service-tier directory must hold. Deliberately the
+# same set AlRunner/Infrastructure/ProvisioningCheck.cs requires, and NOT a DLL
+# count: 501 is one version's number, not a constant, so a threshold would be
+# fragile in both directions. Measured on the reporting box, this set separates
+# both broken directories from all 11 healthy ones.
+ARTIFACT_CLOSURE_FILES = (
+    "Microsoft.Dynamics.Nav.Ncl.dll",
+    "Microsoft.Dynamics.Nav.Types.dll",
+    "Microsoft.Dynamics.Nav.Common.dll",
+    "Microsoft.Dynamics.Nav.Language.dll",
+    "Microsoft.Dynamics.Nav.CodeAnalysis.dll",
+    "Microsoft.Identity.ServiceEssentials.Core.dll",
+)
+
+_VERSION_DIR_RE = re.compile(r"^\d+(\.\d+){1,3}$")
+
+
+def artifacts_root_path() -> str:
+    """Where the artifact cache lives, honouring the relocation knob."""
+    env = os.environ.get(ARTIFACTS_ROOT_ENV, "").strip()
+    if env:
+        return env
+    return os.path.join(os.path.expanduser("~"), ARTIFACTS_ROOT_REL)
+
+
+def artifacts_reading(root: str) -> dict:
+    """Classify every version directory under `root`. Never raises.
+
+    Four outcomes, mirroring ArtifactDirState:
+      absent      -- no artifacts root; a legitimate state on a fresh box
+      ok          -- every version directory holds a complete closure
+      partial     -- at least one directory exists but is short of the closure
+      unreadable  -- the root exists and could not be listed (the third state)
+    """
+    if not root:
+        return {"status": "unreadable", "broken": [], "total": 0,
+                "error": "no artifacts root path could be derived", "root": root}
+    if os.path.isfile(root):
+        return {"status": "unreadable", "broken": [], "total": 0,
+                "error": "the artifacts root path is a file, not a directory", "root": root}
+    if not os.path.isdir(root):
+        return {"status": "absent", "broken": [], "total": 0, "error": "", "root": root}
+    try:
+        names = sorted(os.listdir(root))
+    except OSError as exc:
+        return {"status": "unreadable", "broken": [], "total": 0,
+                "error": str(exc), "root": root}
+
+    broken, total = [], 0
+    for name in names:
+        if not _VERSION_DIR_RE.match(name):
+            continue
+        path = os.path.join(root, name)
+        if not os.path.isdir(path):
+            continue
+        total += 1
+        try:
+            missing = [f for f in ARTIFACT_CLOSURE_FILES
+                       if not os.path.isfile(os.path.join(path, f))]
+        except OSError as exc:
+            return {"status": "unreadable", "broken": [], "total": total,
+                    "error": f"{name}: {exc}", "root": root}
+        if missing:
+            broken.append(name)
+    return {"status": "partial" if broken else "ok",
+            "broken": broken, "total": total, "error": "", "root": root}
+
+
+def classify_artifacts(reading: dict) -> CheckResult:
+    """Turn an artifacts reading into a verdict.
+
+    WARN rather than FAIL throughout: a broken artifact directory does not stop a
+    cycle -- 11 healthy directories sat beside the two broken ones -- it just has
+    to be VISIBLE, so nobody spends a third diagnosis re-deriving it.
+    """
+    status, broken = reading["status"], reading["broken"]
+    root = reading.get("root", "")
+    if status == "ok":
+        return CheckResult(
+            name="artifacts", status="PASS",
+            summary=f"{reading['total']} artifact director{'y' if reading['total'] == 1 else 'ies'}, "
+                    f"all holding a complete engine closure",
+            command="ls ~/.local/share/al-runner/artifacts")
+    if status == "absent":
+        # The guards-need-a-third-state.md constraint: genuinely absent stays a
+        # pass. A box that has provisioned nothing is not a broken box.
+        return CheckResult(
+            name="artifacts", status="PASS",
+            summary="no artifacts root on this box -- nothing provisioned yet",
+            command="ls ~/.local/share/al-runner/artifacts",
+            detail=["Not an error: a run provisions what it needs."])
+    if status == "unreadable":
+        # Deliberately NOT folded into "absent": that case sends the reader to
+        # `provision`, which cannot fix a root it is unable to read.
+        return CheckResult(
+            name="artifacts", status="WARN",
+            summary=f"the artifacts root could not be inspected: {reading['error']}",
+            command=f"ls -la {root}",
+            detail=["This is not 'nothing is provisioned' -- the measurement itself "
+                    "failed, so no directory here has been checked either way."],
+            remedy="Fix the path or its permissions, then re-run preflight.",
+            data=reading)
+    return CheckResult(
+        name="artifacts", status="WARN",
+        summary=f"{len(broken)} of {reading['total']} artifact directories are partially "
+                f"provisioned: {', '.join(broken)}",
+        command="ls ~/.local/share/al-runner/artifacts",
+        detail=["A partially-provisioned directory carries no marker saying so, and one "
+                "that still holds Ncl.dll passes every 'is this a service-tier directory' "
+                "check before failing deep inside an assembly load (#3878).",
+                "Named here so a measurement that lands on one is recognised as "
+                "provisioning rather than as a code fault.",
+                "Do not delete these: 27.5.46862.48827 is cited as measurement "
+                "provenance in about 20 files."],
+        remedy="al-runner provision --service-tier --bc-version <version> --force",
+        data=reading)
+
+
+def check_artifacts() -> CheckResult:
+    return classify_artifacts(artifacts_reading(artifacts_root_path()))
+
+
 def check_corpus_checkout(repo: str) -> CheckResult:
     return classify_corpus_checkout(corpus_checkout_reading(repo))
 
@@ -2995,6 +3123,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         check_push(repo, identity),
         check_commit(repo),
         check_github(slug),
+        check_artifacts(),
         check_corpus_checkout(repo),
         check_corpus(repo, args.with_corpus),
     ]

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -2682,6 +2682,15 @@ def classify_artifacts(reading: dict) -> CheckResult:
     status, broken = reading["status"], reading["broken"]
     root = reading.get("root", "")
     if status == "ok":
+        # A root that exists but holds no version directory is still a pass -- nothing is
+        # broken -- but "0 directories, all complete" is vacuously true and reads as a
+        # measurement of something. Say what was actually found.
+        if reading["total"] == 0:
+            return CheckResult(
+                name="artifacts", status="PASS",
+                summary="the artifacts root exists but holds no version directory yet",
+                command="ls ~/.local/share/al-runner/artifacts",
+                detail=["Not an error: a run provisions what it needs."])
         return CheckResult(
             name="artifacts", status="PASS",
             summary=f"{reading['total']} artifact director{'y' if reading['total'] == 1 else 'ies'}, "

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -2272,6 +2272,58 @@ check("...and --agent-id is still a real flag on preflight.py itself",
 # -------------------------------------------------- END agent-id-wiring (#3746)
 
 
+# -------------------------------------------------- artifacts probe (#3878)
+# A partially-provisioned artifact directory used to be indistinguishable from a
+# complete one until a consumer failed deep inside an assembly load. preflight
+# had no artifacts check at all (measured: 0 occurrences of "artifact" in a
+# 154 KB file), so the breakage was found mid-measurement, three times in one
+# session, rather than at cycle start.
+#
+# The classification is proven in C# (AlRunner.Tests/ArtifactDirStateTests.cs)
+# against the real closure predicate. What is proven HERE is the disposition:
+# which status each reading maps to, including the third state.
+
+def _art(status, broken=(), total=0, error=""):
+    return {"status": status, "broken": list(broken), "total": total, "error": error}
+
+
+check("artifacts: a root where every directory is complete PASSes",
+      pf.classify_artifacts(_art("ok", total=11)).status == "PASS",
+      f"got {pf.classify_artifacts(_art('ok', total=11)).status}")
+
+# The constraint from guards-need-a-third-state.md: a genuinely absent root is a
+# legitimate state, not a broken measurement. A box that has provisioned nothing
+# is fine; refusing it would swap a false green for a false red.
+_absent = pf.classify_artifacts(_art("absent"))
+check("artifacts: no artifacts root at all is a PASS, not a failure",
+      _absent.status == "PASS", f"got {_absent.status}: {_absent.summary}")
+
+# The issue's subject: broken directories are named, so nobody re-derives which.
+_partial = pf.classify_artifacts(_art("partial", broken=["27.5.46862.48827", "28.0.46665.54452"], total=13))
+check("artifacts: a partially-provisioned directory WARNs",
+      _partial.status == "WARN", f"got {_partial.status}")
+check("artifacts: ...and names every broken directory in the summary or detail",
+      all(d in (_partial.summary + " " + " ".join(_partial.detail))
+          for d in ("27.5.46862.48827", "28.0.46665.54452")),
+      f"summary={_partial.summary!r} detail={_partial.detail!r}")
+check("artifacts: ...and does not propose deleting them",
+      "rm -rf" not in _partial.remedy and "rm -rf" not in " ".join(_partial.detail),
+      f"remedy={_partial.remedy!r}")
+
+# The third state, proven to fire: a root that could not be read is NOT reported
+# as the success state and NOT folded into "absent" (whose remedy is `provision`,
+# which cannot fix an unreadable path).
+_unreadable = pf.classify_artifacts(_art("unreadable", error="permission denied"))
+check("artifacts: an unreadable root is neither PASS nor the absent case",
+      _unreadable.status == "WARN" and "permission denied" in
+      (_unreadable.summary + " " + " ".join(_unreadable.detail)),
+      f"got {_unreadable.status}: {_unreadable.summary!r}")
+check("artifacts: ...and says the measurement failed rather than that nothing is provisioned",
+      _unreadable.summary != _absent.summary,
+      "the unreadable and absent summaries are identical, so the third state is spelled as row 1")
+# -------------------------------------------------- END artifacts probe (#3878)
+
+
 print()
 if FAILURES:
     print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -2321,6 +2321,17 @@ check("artifacts: an unreadable root is neither PASS nor the absent case",
 check("artifacts: ...and says the measurement failed rather than that nothing is provisioned",
       _unreadable.summary != _absent.summary,
       "the unreadable and absent summaries are identical, so the third state is spelled as row 1")
+
+# An artifacts root that EXISTS but holds no version directory used to summarise as
+# "0 artifact directories, all holding a complete engine closure" -- vacuously true and
+# misleading. It is still a PASS (nothing is broken), but it must say what it found.
+_empty_root = pf.classify_artifacts(_art("ok", total=0))
+check("artifacts: an existing-but-empty root PASSes",
+      _empty_root.status == "PASS", f"got {_empty_root.status}")
+check("artifacts: ...without claiming 0 directories are 'all complete'",
+      "all holding" not in _empty_root.summary,
+      f"summary reads {_empty_root.summary!r}")
+
 # -------------------------------------------------- END artifacts probe (#3878)
 
 


### PR DESCRIPTION
Closes #3878

Written by the agent loop `stma-auto-2`, not by a person.

## The finding that shaped the fix

**The signal was already on disk. Nothing outside the runner's own startup was reading it.**

`ProvisioningCheck.Check` — the existing engine-closure predicate — already separates both
broken directories from all eleven healthy ones on this box. Run by hand against the real
artifacts root:

| directory | DLLs | `Check` verdict | missing |
|---|---|---|---|
| `27.5.46862.48827` | 82 | not Ok | 1 — the closure sentinel |
| `28.0.46665.54452` | 0 | not Ok | all 6 |
| the other 11 | 501 | Ok | none |

So **no completion marker was needed and none is written.** That matters for the question the
issue asks directly: a marker would only have covered directories provisioned *after* it
shipped, whereas reading the closure classifies **the two directories already on disk** — the
ones that motivated the issue. Both are detected today.

What was actually missing was reach and resolution. `Check` has exactly two call sites, both
inside `Program.cs` / `Provisioning.cs`; the three diagnoses in the issue were a test, a
feasibility harness and a resolver probe, none of which go through startup. And `Check`
answers two states, so three distinct real situations collapse into one "not Ok".

## What changed

**1. `AlRunner/Infrastructure/ArtifactDirState.cs` — four states, not two.**

`Complete` / `Absent` / `Partial` / `Unreadable`, with `Explain()` naming the directory and the
remedy. It delegates completeness to `ProvisioningCheck.Check` rather than duplicating the file
list, so the two cannot drift apart on what "complete" means.

`Absent` and `Unreadable` are deliberately distinct. `Check` reports a directory that does not
exist and one that exists but is empty **identically** — "all six missing" — yet the remedies
differ: one is `provision`, and the other cannot be fixed by `provision` at all. Per
`guards-need-a-third-state.md`, a genuinely absent root stays a **PASS**; only an unmeasurable
one becomes the third state.

**2. `tools/preflight.py` — `check_artifacts`, caught at cycle start.**

preflight had no artifacts probe whatsoever. Measured two ways on a 154 KB file: `command grep
-cE "artifact"` → **0**, and a Python `re.findall(r'artifact', re.I)` → **0**, against a
positive control of **12** `check_` functions. That is the whole reason the breakage was found
mid-measurement three times. Live on this box:

```
WARN  artifacts   2 of 13 artifact directories are partially provisioned:
                  27.5.46862.48827, 28.0.46665.54452
```

`WARN`, not `FAIL`: eleven healthy directories sat beside the two broken ones, so the cost was
invisibility, not unusability. The detail explicitly says **not** to delete them, because
`27.5.46862.48827` is measurement provenance in about twenty files.

## Both broken shapes, which are not the same failure

This was the crux, and it is now measured rather than assumed. A guard keyed on "does it carry
`Ncl.dll`" — the obvious one — **fires on the empty directory and misses the 82-DLL one**. I
proved that by building exactly that guard as mutation 2 below: the empty-directory test kept
passing while the 82-DLL tests failed. Real output, both shapes distinguished:

```
28.0.46665.54452 ... It carries no engine DLLs at all, only a platform-apps/test-apps payload
                     — the service tier for this major.minor landed under a different patch
                     directory (#2226). The payload here is usable.
27.5.46862.48827 ... It carries Microsoft.Dynamics.Nav.Ncl.dll, so it passes a presence check
                     and fails later inside an assembly load.
```

## The three "fix the shape" answers

**1. Same wrong pattern at another call site?** No, and the reason is worth recording. The two
`Check` call sites reach it through `BcArtifacts.SelectedVersion`/`ServiceTierDir`, which throw
if selection found nothing — so the absent/empty conflation cannot reach either. The runner's
own run path is correctly guarded, which is *why* all three reported failures were in tools and
tests. I also confirmed `--bc-version 27.5` selects the healthy `27.5.46862.53931`, not the
broken `48827`: selection orders by version and `53931 > 48827`. No mis-selection exists today.

**2. Sibling function with the same assumption?** Yes — `ProvisioningCheck.Check` itself, and it
is left alone on purpose. Its callers are unaffected (see 1), and changing its shape would touch
`Program.cs`, which another agent holds. `ArtifactDirState` adds the resolution beside it.

**3. Two paths writing one state with different invariants?** **Yes, and this found the real
cause of the second broken directory.** `provision`'s platform-app and service-tier sub-steps
resolve to different patch builds of one major.minor (#2226), splitting 28.0 across two
directories, each complete for its own half:

```
28.0.46665.54338   Ncl.dll present,  platform-apps/ absent
28.0.46665.54452   Ncl.dll absent,   platform-apps/ holding all 6 apps (120 MB)
```

That also explains why `AutoProvision`'s `RemoveIfEmpty` never reclaimed it: that cleanup
deletes a directory holding **nothing**, and this one holds `platform-apps/`. It is still
`Partial` — it is not a usable service tier — but the message no longer implies corruption,
because there is none. Two tests pin both directions, including the negative: a truly empty
directory must **not** claim the #2226 cause.

## RED → GREEN, and three executed mutations

RED was real: the first build failed with 42 × `CS0103`/`CS0246`, the type not existing.

All three were re-run against the **final** 15-test suite, so every number below comes from one
state rather than from the moment each mutation was first written:

| mutation | what it removed | result |
|---|---|---|
| 1 — third state disabled | the file-blocking-the-path branch | `Failed: 2, Passed: 13` → `Failed: 0, Passed: 15` |
| 2 — completeness keyed on `Ncl.dll` alone | the actual closure check | `Failed: 4, Passed: 11` → `Failed: 0, Passed: 15` |
| 3 — split-build detection disabled | `hasPayload` | `Failed: 1, Passed: 14` → `Failed: 0, Passed: 15` |

Mutation 1 proves the third state fires — the two failures were exactly the two third-state
tests. Mutation 2 is the load-bearing one: it *is* the naive "does it carry `Ncl.dll`" guard,
and under it the empty-directory test still passes while the 82-DLL tests fail — the miss,
reproduced. Its fourth failure is the real-disk test, which catches that the actual
`28.0.46665.54452` would be misclassified `Complete`.

`preflight.py`'s guard was mutated the same way, folding `unreadable` into the success state.
It failed with a message stating the defect in the rule's own words: *"the unreadable and absent
summaries are identical, so the third state is spelled as row 1"*.

## Tests

- `AlRunner.Tests/ArtifactDirStateTests.cs` — 15 tests: `Failed: 0, Passed: 15, Skipped: 0`.
  Includes one that runs against the **real** artifacts root and skips cleanly where none
  exists, so it sharpens locally without gating CI.
- `tools/test_preflight.py` — 9 new checks, `all checks passed` (counted two ways: 9 in the source block, 9 `ok` lines at runtime).
- Regression over the surrounding surface (`ProvisioningCheckTests`, `BcArtifactSelectionTests`,
  `AutoProvisionCleanupTests`, `ArtifactsRootEnvOverrideTests`, this class):
  `Failed: 0, Passed: 177, Skipped: 0`.

## Queue scan

Searched for `ProvisioningCheck`, `artifact directory`, `partially-provisioned`, `provisioning
marker`, `82 DLLs` and `501`. Nothing folds:

- **#2661** (entry-guard precision for `provision --platform-apps`/`--service-tier`) is the
  nearest, and it is genuinely distinct: it lands in `Program.cs`'s `RunExplicitProvisionModes`,
  a file another agent holds, and it says the service-tier *post-download* re-check already
  applies. That is the `provision` subcommand's entry guard; this is consumer-side detection.
- **#2226** is named in the code and in answer 3 above — this PR explains a symptom of it and
  does not fix it. The split-build behaviour is unchanged.

## What this does NOT do — tracked as #3893

**`ArtifactDirState` has no non-test consumer in this PR.** Raised in review and confirmed with
the language server rather than a grep (`tools/lsp-query.py callers ArtifactDirState`, exit 0 —
a real answer, not a server failure): every call site is in the test file. `tools/preflight.py`
re-implements the closure list in Python; its one mention of the type, at line 2635, is a
docstring.

That matters, because none of #3878's three motivating diagnoses goes through preflight. I
confirmed two of the three by reading them:

| entry point | today | fails as |
|---|---|---|
| `TestPageClientPresenceTests.cs` | `ServiceTierDir` (line 33) → `Assembly.Load` (line 76), nothing between | the #3799 load failure |
| `tools/metadata-ground-truth/Program.cs` | dir from `--artifacts`/`AL_RUNNER_SERVICE_TIER`, no completeness check | the #3825 zero-package run |
| ad-hoc resolver probes | open the dir directly | exit 134 (#3876, as reported) |

`rg` over both trees for `ProvisioningCheck` and `ArtifactDirState` returns nothing, so neither
consults any completeness predicate.

So on this box the behaviour that actually changes is preflight's — the gap at the point of
failure is **#3893**, not closed here. Wiring it in touches `Program.cs` and the harnesses,
which the review explicitly did not ask for; #3878 is still closed, because the classification
and the cycle-start probe are what it asked for.

## The CI failure this PR caused, and what it says

BC 27.5 went red at `08f07cff` on the repo's own guard,
`TestArtifactsGateTests.NoTestSilentlyReturnsWhenItsEnvironmentIsUnavailable`: the real-disk
test ended a `if (!Directory.Exists(root))` branch with a bare `return;`, which reports
**Passed having asserted nothing** — the exact silent-success shape this PR exists to stop, one
level up. Worth stating plainly rather than burying: I shipped the defect I was fixing.

Now `TestArtifacts.SkipIfMissing()` on a `[SkippableFact]`. All three branches measured
directly, not reasoned about:

| state | result |
|---|---|
| unprovisioned, off CI | `SkipException` — reported skipped, not passed |
| unprovisioned, **on CI** | `FailException` — a red leg |
| this box (13 version dirs) | no throw; the assertions run |

The middle row is why this beats a plain skip, and it answers the reviewer's question about the
artifact version rolling mid-session: artifacts are provisioned by construction on a CI leg, so
if provisioning ever moves, the leg goes **red** rather than every artifact-gated test skipping
into a green run. Also added `Assert.NotEmpty(results)` — a root that classifies no directory
measured nothing and must not read as a pass.

**Was the early return ever reached locally? No.** This box has 13 version directories, so the
branch never executed here; only the static guard could see it, which is why local runs were
green. The artifact roll to `46862.54554` is not implicated.

## Two review items, both fixed

- The `Result` record's doc comment described the closure file list rather than the record; it
  had drifted one declaration. Now describes `Result`.
- An artifacts root that exists but holds no version directory summarised as *"0 artifact
  directories, all holding a complete engine closure"* — vacuously true. Now: *"the artifacts
  root exists but holds no version directory yet"*, still `PASS`, with its own RED → GREEN in
  `tools/test_preflight.py`.

## Scope

No BC-observable behaviour changes, so no corpus test is owed; `check_corpus_linkage.sh` agrees
("No file in this diff can change what AL observes"). Nothing is deleted from disk, and no
DLL-count threshold is introduced — 501 is one version's number, not a constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
