### PR TITLE
docs(agents): the proving-test check is a mutation to run, not a question to ask

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -164,10 +164,13 @@ Done when every path you write to carries the issue number: the worktree as
 
 1. **RED** — write failing AL test. Run it. Confirm failure.
 2. **GREEN** — implement fix. Run again. Confirm pass.
+3. **MUTATE** — break the implementation (delete the guard, invert the condition, return the
+   default), rebuild, confirm the test goes **RED**, restore. Report both counts in the PR body:
+   `Failed: 1, Passed: 7` -> `Failed: 0, Passed: 8`. Once per closed issue.
 
 Branch: `agent/<AGENT-ID>/issue-<N>`.
 
-Tests must PROVE the feature: assert specific values, cover positive + negative cases. A test that passes with a no-op implementation is invalid. Proving-test rules and the run/flag reference are in the `al-runner-tests` skill — read it, don't guess the command. Two things that cost real CI runs when missed:
+Tests must PROVE the feature: assert specific values, cover positive + negative cases. A test that passes with a no-op implementation is invalid — and step 3 is how you find out, because *asking* whether it would has twice answered wrong here (`.claude/rules/tdd.md`, `docs/incidents/tdd.md`). **A test that names the thing is not a test that drives it**: a grep for the symbol finds assertions about a naming convention and reads as coverage. Proving-test rules and the run/flag reference are in the `al-runner-tests` skill — read it, don't guess the command. Two things that cost real CI runs when missed:
 
 - **`--package-cache "$HOME/.al-runner/platform-apps"` is required on every corpus run in this repo's CI** (`.github/workflows/bc-tests.yml`) — without it the runner build's default BC major and the corpus's platform apps don't line up, and the run aborts on a provisioning-gap message before executing a single test. If that directory doesn't exist yet, run `al-runner provision` (or pass `--auto-provision`), or fetch it with `tools/DownloadArtifacts` (exact invocation: the skill and `bc-tests.yml`).
 - **Never background a long-running command and end your turn** (`.claude/rules/no-backgrounding-long-commands.md`). A cold full-corpus run takes minutes; commit and push before starting anything long.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -29,10 +29,22 @@ are what a review is for, and every check below exists because its absence shipp
 
 ## 1. Does the proving test prove anything?
 
-Ask the question from `.claude/rules/tdd.md` directly: **would this test still pass if the
-implementation returned a default — 0, empty string, false, null?** If yes it is noise, however
-green.
+**Run the mutation `.claude/rules/tdd.md` requires; do not re-ask its question.** Break the
+implementation — delete the guard, invert the condition, return the default — rebuild, and see
+whether the test goes red. Asking instead of running has answered wrong twice here
+(`docs/incidents/tdd.md`): #3819's fixture *constructed* the relationship it was meant to prove,
+and #3882 shipped one proven guard beside one that left all 8 tests green when mutated out.
 
+The PR should report both counts. **Re-run at least the mutation the PR's own claim rests on** —
+a reported number nobody reproduced is the same evidence as no number.
+
+- **A test that names the thing is not a test that drives it.** #3882's unproven guard had two
+  test references to its stage name — one asserting a naming convention, one passing it as
+  routing data — and neither reached the `throw`. Grepping the symbol finds them and reads as
+  coverage.
+- **A guard behind a cache needs its test run twice against one cache root.** #3882's report
+  fired cold and was silent warm, because the cache HIT returns before the guard; CI provisions
+  fresh, so the legs would have stayed green forever.
 - Was RED actually observed, or only asserted? A PR that says "RED confirmed" without the
   failure text is unverified. A compile error counts as RED only for a contract that did not
   exist yet.


### PR DESCRIPTION
`.claude/rules/tdd.md` changed today (#3885, `a2a58c88`) to require **executing** the mutation
rather than asking whether a test would pass against a do-nothing implementation. The two agent
definitions that walk an author and a reviewer through that work still carried the old framing
— and `reviewer.md` carried the *opposite* instruction.

## What changed

**`impl-agent.md`** § "RED → GREEN" had two steps. It now has three:

```
3. MUTATE — break the implementation (delete the guard, invert the condition, return the
   default), rebuild, confirm the test goes RED, restore. Report both counts in the PR body:
   Failed: 1, Passed: 7 -> Failed: 0, Passed: 8. Once per closed issue.
```

Its existing line "a test that passes with a no-op implementation is invalid" was a true
assertion with nothing telling the agent how to find out; it now points at step 3.

**`reviewer.md`** § 1 said **"Ask the question from `.claude/rules/tdd.md` directly."** It now
requires running the mutation, states that a count nobody reproduced is the same evidence as no
count, and carries two traps measured this session:

- **A test that names the thing is not a test that drives it.** #3882's unproven guard had two
  test references to its stage name — one asserting a naming convention, one passing it as
  routing data — and neither reached the `throw`. Grepping the symbol finds them and reads as
  coverage.
- **A guard behind a cache needs its test run twice against one cache root.** #3882's report
  fired on a cold run and was silent on a warm one, because the cache HIT returns 80 lines
  before the guard. CI provisions fresh every leg, so those legs would have stayed green forever
  while every repeat local run was silently partial.

## Why this is worth a PR rather than relying on the rule

The rule is auto-loaded, so agents already receive it. What was missing is the step appearing
**where the agent is being walked through the work** — which is why it has had to be hand-written
into four dispatch briefs since the rule merged.

`reviewer.md` is the higher-leverage of the two: both instances behind #3885 were caught by a
**reviewer running the mutation**, never by an author asking the question. That is the file that
was instructing the opposite.

## Verification

Docs-only, so no BC legs run (`test-matrix.yml` measures the diff). `tools/test_doc_pointers.py`
passes. Both edits were applied through anchored replacements that abort rather than write blind
if the anchor is missing.

**No mutation reported for this PR**, and deliberately: the change is prose in two agent
definitions with no implementation to break. Saying so explicitly rather than omitting it,
since the PR is about that step existing.

## A tooling note, not fixed here

`rg -c "tdd" .claude/agents/impl-agent.md` — pointed **directly at the file** — returns nothing
and exits 0, while `command grep -c -i "tdd"` on the same path returns **2**. That is a third
silent-false-negative mode beyond the two `CLAUDE.md` documents, and again on a `.claude/` path.
Recorded on #3892; worth its own issue if it reproduces, since "confirm an empty result with the
other tool" is load-bearing advice throughout this repository.

## Queue scan

Searched for the mechanism (`mutation`, `proving test`, `no-op implementation`) and for
`impl-agent` / `reviewer` across open issues. #3885 is merged and is this change's parent; no
other open issue covers the agent definitions. Nothing to fold.

Closes #3892

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
