### PR TITLE
docs(tdd): confirm the mutation landed — a failed mutation leaves the test GREEN

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -38,6 +38,12 @@ and #3882 shipped one proven guard beside one that left all 8 tests green when m
 The PR should report both counts. **Re-run at least the mutation the PR's own claim rests on** —
 a reported number nobody reproduced is the same evidence as no number.
 
+**Confirm your own mutation landed before believing it.** A mutation that silently no-ops leaves
+the test green, which reads as "this test is broken" — the opposite of the truth. Measured twice
+in one session (#3895): a backslash a heredoc collapsed, so the file never changed; and a `-p:`
+override on an incremental build that skipped `CoreCompile`. Re-read the mutated region, and
+force a clean rebuild when the thing you mutated is a build input.
+
 - **A test that names the thing is not a test that drives it.** #3882's unproven guard had two
   test references to its stage name — one asserting a naming convention, one passing it as
   routing data — and neither reached the `throw`. Grepping the symbol finds them and reads as

--- a/.claude/rules/tdd.md
+++ b/.claude/rules/tdd.md
@@ -24,8 +24,12 @@ are claiming to prove:
 
 1. **Mutate the implementation, not the test** — delete the guard, invert the condition, or
    return the default.
-2. **Rebuild and re-run. Confirm RED.** Restore.
-3. **Report both numbers in the PR body** — `Failed: 1, Passed: 7` → `Failed: 0, Passed: 8`.
+2. **Confirm the mutation LANDED** — re-read the mutated region or diff it. A mutation that
+   silently no-ops leaves the test **green**, which reads as "my test is broken" when it means
+   "I changed nothing". Force a clean rebuild when you mutated a build input (`.csproj`, an
+   MSBuild target, a generator), since an incremental build may skip the compile entirely.
+3. **Rebuild and re-run. Confirm RED.** Restore.
+4. **Report both numbers in the PR body** — `Failed: 1, Passed: 7` → `Failed: 0, Passed: 8`.
    A mutation whose result nobody can see is the same as one nobody ran.
 
 Once **per closed issue**, matching the per-issue RED→GREEN that
@@ -43,6 +47,12 @@ fixed before merge, which is the outcome this step exists to produce.
 two references to `METADATA-EMIT-EXCLUDED` — one asserting the naming convention, one passing it
 as routing data. Both mention the stage; neither reaches the `throw`. A grep for the symbol
 finds them and reads as coverage, which is why the mutation is the check and the grep is not.
+
+**Trap: a failed mutation and a working guard look identical.** Measured twice in one session
+(#3895): a backslash edit that a heredoc collapsed, so the file never changed; and a
+`-p:` override whose build was incremental and skipped `CoreCompile`, reporting the clean
+number. A failed *search* returns nothing and looks like a finding; a failed *mutation* returns
+green and looks like the system working.
 
 **Trap: CI catches the opposite error, never this one.** A test that fails when it should pass
 is red within minutes; one that passes when it should fail is caught only if somebody looks,

--- a/.claude/rules/tdd.md
+++ b/.claude/rules/tdd.md
@@ -54,6 +54,12 @@ finds them and reads as coverage, which is why the mutation is the check and the
 number. A failed *search* returns nothing and looks like a finding; a failed *mutation* returns
 green and looks like the system working.
 
+**Trap: a filter that matches nothing is a silent pass.** `dotnet test --filter
+"FullyQualifiedName~SomeTests"` prints `No test matches the given testcase filter` and **exits
+0**. Measured on #3882, where the filename and the four class names inside it differ. So quote
+the `Total:` line from every run, and treat a run with no `Total:` line as *unverified* rather
+than green — the exit code cannot tell you the difference.
+
 **Trap: CI catches the opposite error, never this one.** A test that fails when it should pass
 is red within minutes; one that passes when it should fail is caught only if somebody looks,
 and until then it reads as coverage while protecting nothing.

--- a/docs/incidents/tdd.md
+++ b/docs/incidents/tdd.md
@@ -117,3 +117,23 @@ while a failed mutation returns green and looks like the system working correctl
 Both were caught by the person running them noticing the result was too clean, and both were
 reported rather than quietly fixed — which is the only reason there are two instances to write
 down instead of one.
+
+
+## A filter that matches nothing is a silent pass (2026-09-11)
+
+Found while verifying #3882's fix. Running
+
+```
+dotnet test AlRunner.Tests/AlRunner.Tests.csproj \
+  --filter "FullyQualifiedName~DependencyEmitExclusionLoudnessTests"
+```
+
+printed `No test matches the given testcase filter` and **exited 0**. The filter was the
+*filename*; the file declares four classes under different names
+(`DependencyEmitExclusionMessageTests`, `...StageRoutingTests`, `...EndToEndTests`,
+`DependencyMetadataPartialEmitTests`).
+
+The coordinator had already written "EXIT=0" into a verification note before noticing the run
+had executed nothing. Same family as the mutation that does not land: **an action that silently
+did nothing reports success**, and the exit code cannot distinguish it from the real thing. The
+discriminator is the `Total:` line, which a no-match run does not print at all.

--- a/docs/incidents/tdd.md
+++ b/docs/incidents/tdd.md
@@ -78,3 +78,42 @@ gone on asserting a false relationship indefinitely.
 No mutation-testing framework, no tooling, no new CI job. The change is to which check is
 **required** and that its result is **reported**, so a reviewer can see a number instead of
 re-deriving it. Both instances were caught by a human-directed mutation taking one rebuild.
+
+
+## The mutation that does not land (2026-09-11, #3895)
+
+Requiring an executed mutation (above) created a second-order failure the first rule did not
+anticipate: **a mutation that silently fails to apply leaves the test green**, and green after a
+mutation is indistinguishable from "my test does not catch this" without looking at the file.
+
+Two instances in the session that introduced the requirement, by different mechanisms:
+
+**The edit never reached the file.** A reviewer mutating a backslash in `AlRunner.csproj` got a
+passing test twice and nearly reported a working parity test as broken. In Python source `'\\'`
+*is* the single-backslash string, and a shell heredoc collapsed it again, so the "mutated" file
+was byte-identical. The third attempt landed and gave the real answer:
+
+```
+MUTATED_RC=1
+Assert.Equal() Failure: Strings differ
+Expected: ...Replace('\\','/')...
+Actual:   ...Replace('\','/')...
+```
+
+**The build never reran.** Disabling the analyzer target with
+`-p:EnableAspNetCoreAnalyzers=false` reported `AD0001=0`, reading as "the target is a no-op".
+The build was incremental and had skipped `CoreCompile`; a forced clean rebuild showed the
+analyzers present. The same session also produced two *invalid* mutations of a third kind:
+renaming a target carrying `BeforeTargets="CoreCompile"` does not disable it, and wiping `obj/`
+wipes the restore.
+
+So three distinct ways to not-mutate, all presenting as one green test.
+
+**Why this is not the existing false-zero class.** `CLAUDE.md` and
+`verify-execution-not-the-tick.md` cover a zero from a **query**. Here the instrument is an
+**edit**, and the direction is worse: a failed search returns nothing and looks like a finding,
+while a failed mutation returns green and looks like the system working correctly.
+
+Both were caught by the person running them noticing the result was too clean, and both were
+reported rather than quietly fixed — which is the only reason there are two instances to write
+down instead of one.


### PR DESCRIPTION
#3885 made the mutation a **step to run** rather than a question to ask. That created a
second-order failure the rule did not anticipate: **a mutation that silently fails to apply
leaves the test green**, and green-after-a-mutation is indistinguishable from "my test does not
catch this" without looking at the file. The signal inverts.

## Two instances, one session, different mechanisms

**The edit never reached the file.** A reviewer mutating a backslash in `AlRunner.csproj` got a
passing test **twice** and nearly reported a working parity test as broken. In Python source
`'\\'` *is* the single-backslash string, and a shell heredoc collapsed it again — so the
"mutated" file was byte-identical to the original. The third attempt landed:

```
MUTATED_RC=1
Assert.Equal() Failure: Strings differ
Expected: ...Replace('\\','/')...
Actual:   ...Replace('\','/')...
```

**The build never reran.** Disabling the analyzer target with
`-p:EnableAspNetCoreAnalyzers=false` reported `AD0001=0`, reading as "the target is a no-op".
The build was **incremental and had skipped `CoreCompile`**; a forced clean rebuild showed the
analyzers present all along.

Two further invalid mutations from the same session are in the incidents file: renaming a target
carrying `BeforeTargets="CoreCompile"` does not disable it, and wiping `obj/` wipes the restore.
**Three distinct ways to not-mutate, all presenting as one green test.**

## Why this is not the existing false-zero class

`CLAUDE.md` and `verify-execution-not-the-tick.md` cover a zero from a **query**. Here the
instrument is an **edit** — and the direction is worse. A failed search returns nothing and
looks like a finding, so it gets investigated. A failed mutation returns **green** and looks
like the system working correctly, so it does not.

## What changes

`tdd.md` gains a confirm-it-landed step before the rebuild, plus the clean-rebuild rule when the
mutated thing is a build input (`.csproj`, an MSBuild target, a generator). `reviewer.md` carries
the same note, since a reviewer runs the mutation on someone else's tree — and both instances
here were a reviewer's.

**No tooling.** It is a confirmation on an edit that was already being made.

## Verification

Docs-only, so no BC legs run. `tools/test_doc_pointers.py` passes.

**No mutation reported for this PR**, and deliberately: it is prose in three files with no
implementation to break. Stating that rather than omitting it, since the PR is about that step.

One thing worth recording: **the first version of the incidents file had this exact bug.** I
over-escaped inside a Python `"""` string and wrote 4 and 2 backslashes where the rendered text
needed 2 and 1. Caught by reading the file back with `repr` rather than trusting the write —
which is the step this PR adds. The counts are now verified programmatically (`Expected` = 2,
`Actual` = 1).

## Queue scan

Searched open issues for the mechanism (`mutation`, `landed`, `incremental build`, `heredoc`)
and confirmed `command grep -c -i "mutation"` returns 4 in `tdd.md` and 2 in `reviewer.md` while
neither mentions landing — with a positive control, since an empty result from one tool is not
evidence here. #3885 is this change's parent and is merged; #3892 (agent definitions) is merged.
Nothing to fold.

Closes #3895

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1


## Added after review dispatch: a third instance, same class

`dotnet test --filter "FullyQualifiedName~DependencyEmitExclusionLoudnessTests"` prints
`No test matches the given testcase filter` and **exits 0**. The filter was the *filename*; that
file declares four classes under different names.

I hit this verifying #3882 and had already written `EXIT=0` into a verification note before
noticing the run had executed nothing. It is the same shape as the two mutation instances — **an
action that silently did nothing reports success** — so it is folded in here rather than filed
separately. The discriminator is the `Total:` line, which a no-match run does not print at all.
