### PR TITLE
docs(guards): the same absence can be a legitimate skip locally and a red leg on CI

### DIFF
--- a/.claude/rules/guards-need-a-third-state.md
+++ b/.claude/rules/guards-need-a-third-state.md
@@ -14,7 +14,7 @@ The number is a convention; `tools/corpus-pass-count.py` spells the third state 
 label instead. What is not negotiable is that it is **distinct from the success state**, and
 that the message says which of the three it is.
 
-## The three that get this right — copy one of them
+## The four that get this right — copy one of them
 
 - **`tools/ci-wait.py`, exit 3** — the model to copy is `rollup_is_final`, which returns
   `True`/`False`/**`None`**, with `None` "deliberately distinct from False: an unknown must
@@ -31,6 +31,14 @@ that the message says which of the three it is.
   so "not in this leg's suite" and "this leg never reached the test phase" cannot be read as
   "your tests did not run". A zero has three meanings and a bare grep gives all three the same
   answer.
+- **`TestArtifacts.SkipIfMissingIn`** — the third state where the *same* condition is a
+  legitimate pass in one environment and a defect in another. Artifacts missing on a dev box is
+  an honest skip; on a CI leg it is impossible by construction, so it **fails** there instead.
+  Its own comment says why a visible skip is not enough: *"if the workflow moves where it
+  provisions artifacts, `Present` answers false for EVERY test, all of them skip — visibly, with
+  an accurate reason — and the leg is still GREEN."* A correct per-test answer, and the run above
+  it still asserts nothing. Deliberately scoped to that gate rather than a blanket `Skipped: 0`
+  assertion, which would fail every local run for a correct reason.
 
 ## The worked example: three-way discrimination (#3299, #3681, PR #3683, #3737)
 
@@ -58,6 +66,11 @@ would otherwise have produced the same corpus.
 **A genuinely absent thing must stay a pass. Only an *unmeasurable* one becomes the third
 state.** A fix that hard-errors a submodule-free repository has swapped a false green for a
 false red.
+
+**But "genuinely absent" can depend on where you are running.** `SkipIfMissingIn` above is the
+case: the same missing directory is a legitimate absence locally and a provisioning defect on
+CI, so one verdict for both would be wrong in one of them. Ask which environments the condition
+can legitimately occur in before deciding it is a pass.
 
 `tools/agent_self_freshness.py` has the sharper form, splitting "could not establish" into
 three and refusing only one (#3296):


### PR DESCRIPTION
`guards-need-a-third-state.md` lists three implementations to copy, and its constraint section
says **a genuinely absent thing must stay a pass**. Both are right, and both quietly assume
"absent" means the same thing wherever it is observed.

`AlRunner.Tests/TestArtifacts.cs`'s `SkipIfMissingIn` already handles the case the rule does not
describe — **the same condition is a legitimate pass in one environment and a defect in
another**:

| state | verdict |
|---|---|
| artifacts missing, dev box | `SkipException` — an honest skip |
| artifacts missing, **CI leg** | `Assert.Fail` — a red leg |
| artifacts present | assertions run |

## Why a *visible* skip is not enough, in the file's own words

> if the workflow moves where it provisions artifacts, `Present` answers false for EVERY test,
> all of them skip — visibly, with an accurate reason — and the leg is still GREEN.

That is the rule's own failure mode displaced one level up. Every test gives a correct per-test
answer; the **run** still asserts nothing, and the drift guards all still pass because nothing
about the per-class gates changed.

## How it surfaced

PR #3889 shipped a bare `return;` in a real-disk test — reporting **Passed having asserted
nothing** — and `TestArtifactsGateTests.NoTestSilentlyReturnsWhenItsEnvironmentIsUnavailable`
caught it on its first encounter with the new file. Fifth silent-success instance of the session
(#3895), and the first caught by a guard rather than by a person.

I suggested "use `TestArtifacts.SkipIf*`", which fixes the test. The implementing agent used
`SkipIfMissing`, which fixes the layer above it too. **The better answer was already in the
codebase and not in the rule** — that gap is what this PR closes.

## What changes

- The list becomes **four**, with `SkipIfMissingIn` as the environment-dependent model.
- The constraint section gains one qualification: *"genuinely absent" can depend on where you are
  running* — ask which environments the condition can legitimately occur in before deciding it is
  a pass.

The per-gate scoping the source file flags is preserved in the rule: this is deliberately **not**
a blanket `Skipped: 0` assertion in the workflow, which would fail every local run for a correct
and unrelated reason.

## Verification

Docs-only, so no BC legs run. `tools/test_doc_pointers.py` passes. Rule is 8,865 bytes — larger
than I would like, but it is the fourth-largest of nineteen and the addition is one list entry
plus one paragraph.

**No mutation reported**, deliberately: prose in one file with no implementation to break. Stating
it rather than omitting it, since `tdd.md` now requires the step.

## Queue scan

Searched open issues for `third state`, `skip`, `SkipIfMissing` and `TestArtifacts`; #3895 is the
session's tracking issue for the silent-success class and is merged. Nothing to fold — this is a
different file and a different claim.

Closes #3897

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
