### PR TITLE
fix(dap): honour linesStartAt1, and report the frame column in the client's base

### DIFF
--- a/AlRunner.Tests/DapLineBaseTests.cs
+++ b/AlRunner.Tests/DapLineBaseTests.cs
@@ -33,6 +33,15 @@ public class DapLineBaseTests
     /// <summary>`First := 1;` — one statement, so one stop. 1-based, as the file is numbered.</summary>
     private const int SingleStatementLine = 35;
 
+    /// <summary>`procedure Seven() ... end;  procedure Nine() ... end;` — two one-line
+    /// procedures, so a breakpoint here arms two scopes and each stop has a caller. 1-based.
+    /// </summary>
+    private const int TwoProceduresLine = 26;
+
+    /// <summary>`Total := Seven() + Nine();` — the statement that calls both, and so the line
+    /// the CALLER frame sits on at each of those stops. 1-based.</summary>
+    private const int CallerOfTheTwoProceduresLine = 48;
+
     /// <summary>The blank line after the two one-line procedures: no executable AL statement
     /// on it. 1-based. Its predecessor, line 26, carries two — which is what makes the number
     /// a 0-based client writes for it discriminating.</summary>
@@ -212,14 +221,15 @@ public class DapLineBaseTests
     }
 
     /// <summary>
-    /// A 1-based client — the default, and what every real client in use today sends — is
-    /// unchanged by the conversion. Sending nothing at all for either capability must be the
-    /// same conversation as before: line 35 asked for, line 35 verified, line 35 reported by
-    /// the <c>stopped</c> event and by the frame, column 1 on the frame.
+    /// A client that sends <c>linesStartAt1: true</c> explicitly is unchanged by the
+    /// conversion: line 35 asked for, line 35 verified, line 35 reported by the <c>stopped</c>
+    /// event and by the frame, column 1 on the frame.
     ///
     /// <para>This is the control the in/out conversions are measured against: a fix that
     /// converted unconditionally, or that subtracted where it should add, turns this red while
-    /// leaving the 0-based facts green.</para>
+    /// leaving the 0-based facts green. It does NOT cover the absent-property default — this
+    /// helper sends both booleans — which is what
+    /// <see cref="DefaultBases_WhenTheClientSendsNeitherProperty_AreOneBased"/> is for.</para>
     /// </summary>
     [SkippableFact]
     public async Task OneBasedClient_IsUnaffected_AndTheFrameColumnStaysOne()
@@ -351,12 +361,17 @@ public class DapLineBaseTests
     /// leaving this one path 1-based would keep every other fact green — which is exactly the
     /// shape that makes a test suite read as coverage while protecting nothing.
     ///
-    /// <para>RED against <c>origin/main</c>, where the legacy path did not convert: a 0-based
-    /// client's 34 was read as 1-based 34, resolved against the <c>begin</c>, and came back
-    /// unverified. GREEN: verified, echoed as 34, and the stop is at the statement it meant —
-    /// pinned by the locals, since <c>First</c> is still 0 in front of <c>First := 1;</c>.</para>
+    /// <para>RED against <c>origin/main</c>, and NOT for the reason this comment first gave.
+    /// The legacy path did not merely skip the conversion there — it was unreachable, because
+    /// an unbraced <c>else</c> bound it to the inner <c>if (bp.TryGetProperty("line"))</c>. So
+    /// the request resolved nothing and came back <c>{"success":true,"breakpoints":[]}</c>, and
+    /// this fact failed indexing element zero rather than on a wrong line number. GREEN:
+    /// verified, echoed as 34, and the stop is at the statement it meant — pinned by the
+    /// locals, since <c>First</c> is still 0 in front of <c>First := 1;</c>.</para>
     ///
-    /// <para>Raised by GitHub Copilot's automatic review of PR #3899.</para>
+    /// <para>Raised by GitHub Copilot's automatic review of PR #3899; the account above was
+    /// corrected after an adversarial review (gpt-6-astra) caught it describing a defect that
+    /// was never there.</para>
     /// </summary>
     [SkippableFact]
     public async Task ZeroBasedClient_UsingTheLegacyLinesArray_BindsAndReportsInItsOwnBase()
@@ -396,6 +411,121 @@ public class DapLineBaseTests
 
         var contSeq = dap.SendRequest("continue", new { threadId = 1 });
         await dap.ReadUntilResponseAsync(contSeq);
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60));
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+
+    /// <summary>
+    /// The specification's default, driven as a client actually sends it: an <c>initialize</c>
+    /// carrying NEITHER <c>linesStartAt1</c> nor <c>columnsStartAt1</c> means both are true.
+    ///
+    /// <para>Every other fact here sends both properties explicitly, so a regression reading an
+    /// absent property as <c>false</c> would leave the whole suite green while breaking every
+    /// client that omits them — which is most of them. Raised by an adversarial review of
+    /// PR #3899 (gpt-6-astra).</para>
+    /// </summary>
+    [SkippableFact]
+    public async Task DefaultBases_WhenTheClientSendsNeitherProperty_AreOneBased()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var dap = await DapClient.StartAsync(FixtureSrc);
+        await using var _ = dap;
+
+        // No `linesStartAt1`, no `columnsStartAt1`. That absence is the whole fact.
+        var initSeq = dap.SendRequest("initialize", new { adapterID = "al-runner-tests" });
+        var initEvents = new List<JsonElement>();
+        var initResp = await dap.ReadUntilResponseAsync(initSeq, initEvents);
+        Assert.True(initResp.GetProperty("success").GetBoolean(), initResp.ToString());
+        if (!initEvents.Any(e => e.GetProperty("event").GetString() == "initialized"))
+            await dap.ReadUntilEventAsync("initialized");
+
+        var launchSeq = dap.SendRequest("launch", new { });
+        var launchResp = await dap.ReadUntilResponseAsync(launchSeq, timeout: TimeSpan.FromSeconds(120));
+        Assert.True(launchResp.GetProperty("success").GetBoolean(),
+            $"launch failed: {launchResp}\n--- stderr ---\n{dap.StdErr}");
+
+        var bpSeq = dap.SendRequest("setBreakpoints", new
+        {
+            source = new { path = Path.Combine(FixtureSrc, SourceFileName) },
+            breakpoints = new[] { new { line = SingleStatementLine } },
+        });
+        var bpResp = await dap.ReadUntilResponseAsync(bpSeq);
+        var bp = bpResp.GetProperty("body").GetProperty("breakpoints")[0];
+        Assert.True(bp.GetProperty("verified").GetBoolean(),
+            $"{bpResp}\n--- stderr ---\n{dap.StdErr}");
+        Assert.Equal(SingleStatementLine, bp.GetProperty("line").GetInt32());
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal(SingleStatementLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
+
+        var stSeq = dap.SendRequest("stackTrace", new { threadId = 1 });
+        var stResp = await dap.ReadUntilResponseAsync(stSeq);
+        var topFrame = stResp.GetProperty("body").GetProperty("stackFrames")[0];
+        Assert.Equal(SingleStatementLine, topFrame.GetProperty("line").GetInt32());
+        Assert.Equal(1, topFrame.GetProperty("column").GetInt32());
+
+        var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq);
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60));
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+
+    /// <summary>
+    /// EVERY frame converts, not just the paused one. A breakpoint inside a one-line procedure
+    /// gives a stack with a caller, and the caller's line comes from a different branch of
+    /// <c>AlDapStackWalker.Walk</c> than frame 0's — `ResolveCurrentLine` rather than the
+    /// paused statement index.
+    ///
+    /// <para>So a conversion applied only where the paused line is computed would answer this
+    /// suite's other facts correctly and still hand a 0-based client a 1-based caller. Line 26
+    /// declares <c>Seven()</c> and <c>Nine()</c>; both are armed (#3820), and the call that
+    /// reaches them is line 48, so a 0-based client must be told 25 and 47.</para>
+    ///
+    /// <para>Raised by an adversarial review of PR #3899 (gpt-6-astra).</para>
+    /// </summary>
+    [SkippableFact]
+    public async Task ZeroBasedClient_ACallerFrame_ConvertsToo()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dap, bpResp) = await StartAndSetBreakpointAsync(
+            TwoProceduresLine - 1, linesStartAt1: false);
+        await using var _ = dap;
+        Assert.True(bpResp.GetProperty("body").GetProperty("breakpoints")[0]
+            .GetProperty("verified").GetBoolean(), $"{bpResp}\n--- stderr ---\n{dap.StdErr}");
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        // Seven() then Nine(), in call order; both stops have the same caller line.
+        foreach (var expectedFrame in new[] { "Seven", "Nine" })
+        {
+            var stopped = await dap.ReadUntilEventAsync("stopped", TimeSpan.FromSeconds(60));
+            Assert.Equal(TwoProceduresLine - 1, stopped.GetProperty("body").GetProperty("line").GetInt32());
+
+            var stSeq = dap.SendRequest("stackTrace", new { threadId = 1 });
+            var stResp = await dap.ReadUntilResponseAsync(stSeq);
+            var frames = stResp.GetProperty("body").GetProperty("stackFrames");
+            Assert.True(frames.GetArrayLength() >= 2,
+                $"expected a caller frame behind {expectedFrame}: {stResp}");
+
+            var top = frames[0];
+            var frameName = top.GetProperty("name").GetString() ?? "";
+            Assert.True(frameName.Contains(expectedFrame, StringComparison.OrdinalIgnoreCase),
+                $"paused frame is '{frameName}', not {expectedFrame}: {stResp}");
+            Assert.Equal(TwoProceduresLine - 1, top.GetProperty("line").GetInt32());
+
+            // The caller, whose line comes from the scope's own live StatementNumber.
+            Assert.Equal(CallerOfTheTwoProceduresLine - 1, frames[1].GetProperty("line").GetInt32());
+
+            var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+            await dap.ReadUntilResponseAsync(contSeq);
+        }
+
         var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60));
         Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
     }

--- a/AlRunner.Tests/DapLineBaseTests.cs
+++ b/AlRunner.Tests/DapLineBaseTests.cs
@@ -249,4 +249,60 @@ public class DapLineBaseTests
         var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60));
         Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
     }
+
+    /// <summary>
+    /// A second <c>initialize</c> must be refused, so a base negotiated once cannot move under
+    /// breakpoints that were armed and acknowledged in it. DAP permits <c>initialize</c> only
+    /// as the first request and only once; nothing enforced that here, and until lines were
+    /// converted the only thing a repeat could move was a column.
+    ///
+    /// <para>RED before the guard: the second request succeeds and flips the line base, so the
+    /// <c>stopped</c> event reports 35 for the breakpoint the adapter had already acknowledged
+    /// as 34 — the client is shown two different numbers for one breakpoint it set once. GREEN:
+    /// the second request fails with a message, the negotiated base stands, and the stop is
+    /// still reported at 34.</para>
+    ///
+    /// <para>Raised by an adversarial review of PR #3899 (gpt-5.6-sol), which reached it through
+    /// the deferred-breakpoint path: a request deferred while the source map is being built
+    /// stores numbers already converted into the base in force when it arrived, so a base that
+    /// changes before <c>DrainDeferredBreakpoints</c> runs would answer in a base the request
+    /// was not written in. Refusing the repeat closes both routes at the one point they share.
+    /// </para>
+    /// </summary>
+    [SkippableFact]
+    public async Task ASecondInitialize_IsRefused_SoTheNegotiatedLineBaseCannotMove()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dap, bpResp) = await StartAndSetBreakpointAsync(
+            SingleStatementLine - 1, linesStartAt1: false);
+        await using var _ = dap;
+        Assert.Equal(SingleStatementLine - 1,
+            bpResp.GetProperty("body").GetProperty("breakpoints")[0].GetProperty("line").GetInt32());
+
+        var reinitSeq = dap.SendRequest("initialize",
+            new { adapterID = "al-runner-tests", linesStartAt1 = true, columnsStartAt1 = true });
+        var reinitResp = await dap.ReadUntilResponseAsync(reinitSeq);
+        Assert.False(reinitResp.GetProperty("success").GetBoolean(),
+            $"a second initialize must be refused: {reinitResp}");
+        Assert.Contains("initialize", reinitResp.GetProperty("message").GetString() ?? "",
+            StringComparison.OrdinalIgnoreCase);
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        // Still the base the session was initialized in, not the one the refused request asked for.
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal(SingleStatementLine - 1, stopped.GetProperty("body").GetProperty("line").GetInt32());
+
+        var stSeq = dap.SendRequest("stackTrace", new { threadId = 1 });
+        var stResp = await dap.ReadUntilResponseAsync(stSeq);
+        Assert.Equal(SingleStatementLine - 1, stResp.GetProperty("body").GetProperty("stackFrames")[0]
+            .GetProperty("line").GetInt32());
+
+        var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq);
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60));
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
 }

--- a/AlRunner.Tests/DapLineBaseTests.cs
+++ b/AlRunner.Tests/DapLineBaseTests.cs
@@ -77,6 +77,45 @@ public class DapLineBaseTests
         }
     }
 
+    /// <summary>Drives the same session with the LEGACY <c>lines[]</c> array instead of
+    /// <c>breakpoints[]</c>. DAP's older spelling carries a bare line and no column, and it is
+    /// a separate parse in the handler — so it is a separate conversion, which is why it needs
+    /// its own session rather than a parameter on the one above.</summary>
+    private static async Task<(DapClient Dap, JsonElement BpResponse)> StartAndSetLegacyLineBreakpointAsync(
+        int line, bool linesStartAt1)
+    {
+        var dap = await DapClient.StartAsync(FixtureSrc);
+        try
+        {
+            var initSeq = dap.SendRequest("initialize",
+                new { adapterID = "al-runner-tests", linesStartAt1 });
+            var initEvents = new List<JsonElement>();
+            var initResp = await dap.ReadUntilResponseAsync(initSeq, initEvents);
+            Assert.True(initResp.GetProperty("success").GetBoolean(), initResp.ToString());
+            if (!initEvents.Any(e => e.GetProperty("event").GetString() == "initialized"))
+                await dap.ReadUntilEventAsync("initialized");
+
+            var launchSeq = dap.SendRequest("launch", new { });
+            var launchResp = await dap.ReadUntilResponseAsync(launchSeq, timeout: TimeSpan.FromSeconds(120));
+            Assert.True(launchResp.GetProperty("success").GetBoolean(),
+                $"launch failed: {launchResp}\n--- stderr ---\n{dap.StdErr}");
+
+            var bpSeq = dap.SendRequest("setBreakpoints", new
+            {
+                source = new { path = Path.Combine(FixtureSrc, SourceFileName) },
+                lines = new[] { line },
+            });
+            var bpResp = await dap.ReadUntilResponseAsync(bpSeq);
+            Assert.True(bpResp.GetProperty("success").GetBoolean(), bpResp.ToString());
+            return (dap, bpResp);
+        }
+        catch
+        {
+            await dap.DisposeAsync();
+            throw;
+        }
+    }
+
     /// <summary>
     /// RED before the fix: the breakpoint is unverified. A 0-based client naming
     /// <c>First := 1;</c> as line 34 had that number compared against 1-based spans, so it
@@ -299,6 +338,61 @@ public class DapLineBaseTests
         var stResp = await dap.ReadUntilResponseAsync(stSeq);
         Assert.Equal(SingleStatementLine - 1, stResp.GetProperty("body").GetProperty("stackFrames")[0]
             .GetProperty("line").GetInt32());
+
+        var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq);
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60));
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+
+    /// <summary>
+    /// The legacy <c>lines[]</c> array is a second, independent parse of the same request, and
+    /// it converts too. Nothing in the rest of this suite sends that spelling, so a regression
+    /// leaving this one path 1-based would keep every other fact green — which is exactly the
+    /// shape that makes a test suite read as coverage while protecting nothing.
+    ///
+    /// <para>RED against <c>origin/main</c>, where the legacy path did not convert: a 0-based
+    /// client's 34 was read as 1-based 34, resolved against the <c>begin</c>, and came back
+    /// unverified. GREEN: verified, echoed as 34, and the stop is at the statement it meant —
+    /// pinned by the locals, since <c>First</c> is still 0 in front of <c>First := 1;</c>.</para>
+    ///
+    /// <para>Raised by GitHub Copilot's automatic review of PR #3899.</para>
+    /// </summary>
+    [SkippableFact]
+    public async Task ZeroBasedClient_UsingTheLegacyLinesArray_BindsAndReportsInItsOwnBase()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dap, bpResp) = await StartAndSetLegacyLineBreakpointAsync(
+            SingleStatementLine - 1, linesStartAt1: false);
+        await using var _ = dap;
+
+        var bp = bpResp.GetProperty("body").GetProperty("breakpoints")[0];
+        Assert.True(bp.GetProperty("verified").GetBoolean(),
+            $"{bpResp}\n--- stderr ---\n{dap.StdErr}");
+        Assert.Equal(SingleStatementLine - 1, bp.GetProperty("line").GetInt32());
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal(SingleStatementLine - 1, stopped.GetProperty("body").GetProperty("line").GetInt32());
+
+        var stSeq = dap.SendRequest("stackTrace", new { threadId = 1 });
+        var stResp = await dap.ReadUntilResponseAsync(stSeq);
+        var topFrame = stResp.GetProperty("body").GetProperty("stackFrames")[0];
+        Assert.Equal(SingleStatementLine - 1, topFrame.GetProperty("line").GetInt32());
+
+        var frameId = topFrame.GetProperty("id").GetInt32();
+        var scSeq = dap.SendRequest("scopes", new { frameId });
+        var scResp = await dap.ReadUntilResponseAsync(scSeq);
+        var variablesReference = scResp.GetProperty("body").GetProperty("scopes")[0]
+            .GetProperty("variablesReference").GetInt32();
+        var varSeq = dap.SendRequest("variables", new { variablesReference });
+        var varResp = await dap.ReadUntilResponseAsync(varSeq);
+        var locals = varResp.GetProperty("body").GetProperty("variables").EnumerateArray()
+            .ToDictionary(v => v.GetProperty("name").GetString()!, v => v.GetProperty("value").GetString());
+        Assert.Equal("0", locals["First"]);
 
         var contSeq = dap.SendRequest("continue", new { threadId = 1 });
         await dap.ReadUntilResponseAsync(contSeq);

--- a/AlRunner.Tests/DapLineBaseTests.cs
+++ b/AlRunner.Tests/DapLineBaseTests.cs
@@ -1,0 +1,252 @@
+// DapLineBaseTests — #3881: the DAP loop ignored `linesStartAt1`.
+//
+// DAP's `initialize` lets a client say whether it counts lines from 1 or from 0. Absent means
+// 1, per the specification. `RunDapLoop` never read the field, and every line it compared or
+// reported was 1-based — the numbering `AlSourceSpanCodec.AbsoluteFromLine` produces:
+//
+//   * `setBreakpoints` resolved the requested line against 1-based spans, so a 0-based
+//     client's breakpoint landed one line ABOVE the statement it meant;
+//   * the breakpoint response's `line`, the `stopped` event's `line` and every `stackTrace`
+//     frame's `line` went back 1-based whatever the client had asked for.
+//
+// PR #3879 fixed the sibling capability `columnsStartAt1` for the one field it introduced, so
+// until this landed the adapter converted columns and not lines — harder to reason about than
+// converting neither. It also left `stackTrace`'s own hardcoded `column = 1` unconverted,
+// which is the same defect one surface over and is fixed here with it.
+//
+// The fixture is Fixtures/DapMultiTarget, shared with DapMultiTargetLineTests: line 35 is
+// `First := 1;`, the single-statement control, and line 36 carries two statements. A 0-based
+// client names them 34 and 35.
+
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class DapLineBaseTests
+{
+    private static readonly string FixtureSrc = Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "DapMultiTarget"));
+
+    private const string SourceFileName = "MultiTarget.Codeunit.al";
+
+    /// <summary>`First := 1;` — one statement, so one stop. 1-based, as the file is numbered.</summary>
+    private const int SingleStatementLine = 35;
+
+    /// <summary>The blank line after the two one-line procedures: no executable AL statement
+    /// on it. 1-based. Its predecessor, line 26, carries two — which is what makes the number
+    /// a 0-based client writes for it discriminating.</summary>
+    private const int BlankLine = 27;
+
+    /// <summary>Drives initialize / launch / setBreakpoints with the client's own line base
+    /// and returns the live session together with the setBreakpoints response. Line numbers
+    /// passed in are in the CLIENT's base, exactly as a real client would send them.</summary>
+    private static async Task<(DapClient Dap, JsonElement BpResponse)> StartAndSetBreakpointAsync(
+        int line, bool linesStartAt1, bool columnsStartAt1 = true)
+    {
+        var dap = await DapClient.StartAsync(FixtureSrc);
+        try
+        {
+            var initSeq = dap.SendRequest("initialize",
+                new { adapterID = "al-runner-tests", linesStartAt1, columnsStartAt1 });
+            var initEvents = new List<JsonElement>();
+            var initResp = await dap.ReadUntilResponseAsync(initSeq, initEvents);
+            Assert.True(initResp.GetProperty("success").GetBoolean(), initResp.ToString());
+            var sawInitialized = initEvents.Any(e => e.GetProperty("event").GetString() == "initialized")
+                || (await dap.ReadUntilEventAsync("initialized")).GetProperty("event").GetString() == "initialized";
+            Assert.True(sawInitialized);
+
+            var launchSeq = dap.SendRequest("launch", new { });
+            var launchResp = await dap.ReadUntilResponseAsync(launchSeq, timeout: TimeSpan.FromSeconds(120));
+            Assert.True(launchResp.GetProperty("success").GetBoolean(),
+                $"launch failed: {launchResp}\n--- stderr ---\n{dap.StdErr}");
+
+            var bpSeq = dap.SendRequest("setBreakpoints", new
+            {
+                source = new { path = Path.Combine(FixtureSrc, SourceFileName) },
+                breakpoints = new[] { new { line } },
+            });
+            var bpResp = await dap.ReadUntilResponseAsync(bpSeq);
+            Assert.True(bpResp.GetProperty("success").GetBoolean(), bpResp.ToString());
+            return (dap, bpResp);
+        }
+        catch
+        {
+            await dap.DisposeAsync();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// RED before the fix: the breakpoint is unverified. A 0-based client naming
+    /// <c>First := 1;</c> as line 34 had that number compared against 1-based spans, so it
+    /// resolved against the `begin` above it — which carries no instrumented statement — and
+    /// the client was told the line it asked for has no executable AL on it.
+    ///
+    /// <para>GREEN: verified, and every line that crosses the wire comes back in the client's
+    /// own base — the breakpoint response, the <c>stopped</c> event and the <c>stackTrace</c>
+    /// frame all say 34. The locals pin WHICH statement the pause is in front of: the stop is
+    /// before the statement's own effect, so First is still 0.</para>
+    /// </summary>
+    [SkippableFact]
+    public async Task ZeroBasedClient_BreakpointOnItsOwnLineNumber_BindsTheStatementAndReportsItBack()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dap, bpResp) = await StartAndSetBreakpointAsync(
+            SingleStatementLine - 1, linesStartAt1: false);
+        await using var _ = dap;
+
+        var bp = bpResp.GetProperty("body").GetProperty("breakpoints")[0];
+        Assert.True(bp.GetProperty("verified").GetBoolean(),
+            $"{bpResp}\n--- stderr ---\n{dap.StdErr}");
+        Assert.Equal(SingleStatementLine - 1, bp.GetProperty("line").GetInt32());
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal(SingleStatementLine - 1, stopped.GetProperty("body").GetProperty("line").GetInt32());
+
+        var stSeq = dap.SendRequest("stackTrace", new { threadId = 1 });
+        var stResp = await dap.ReadUntilResponseAsync(stSeq);
+        var topFrame = stResp.GetProperty("body").GetProperty("stackFrames")[0];
+        Assert.Equal(SingleStatementLine - 1, topFrame.GetProperty("line").GetInt32());
+
+        // The pause is BEFORE `First := 1;` runs, so the assignment has not happened yet.
+        // Without this an adapter that bound some other statement of the procedure would
+        // satisfy the line assertions above by echoing the requested number back.
+        var frameId = topFrame.GetProperty("id").GetInt32();
+        var scSeq = dap.SendRequest("scopes", new { frameId });
+        var scResp = await dap.ReadUntilResponseAsync(scSeq);
+        var variablesReference = scResp.GetProperty("body").GetProperty("scopes")[0]
+            .GetProperty("variablesReference").GetInt32();
+        var varSeq = dap.SendRequest("variables", new { variablesReference });
+        var varResp = await dap.ReadUntilResponseAsync(varSeq);
+        var locals = varResp.GetProperty("body").GetProperty("variables").EnumerateArray()
+            .ToDictionary(v => v.GetProperty("name").GetString()!, v => v.GetProperty("value").GetString());
+        Assert.Equal("0", locals["First"]);
+
+        var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq);
+        var events = new List<JsonElement>();
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60), events);
+        Assert.DoesNotContain(events, e => e.GetProperty("event").GetString() == "stopped");
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+
+    /// <summary>
+    /// The refusal direction, and the one that shows the old behaviour ARMING something rather
+    /// than merely mis-numbering it. A 0-based client writes 26 for the blank line 27; read as
+    /// 1-based, 26 is the line carrying the fixture's two one-line procedures.
+    ///
+    /// <para>RED before the fix: verified, and two scopes armed — the client is told a
+    /// breakpoint is set on a blank line, and execution then stops somewhere it never asked
+    /// for. GREEN: unverified, with the number it sent echoed back and a message saying why.
+    /// A refusal fact anchored on a line that reads the same in both bases would pass either
+    /// way and prove nothing, which is why this one is anchored on a line whose NEIGHBOUR
+    /// resolves.</para>
+    /// </summary>
+    [SkippableFact]
+    public async Task ZeroBasedClient_ALineWhosePredecessorResolves_IsRefusedRatherThanArmed()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dap, bpResp) = await StartAndSetBreakpointAsync(
+            BlankLine - 1, linesStartAt1: false);
+        await using var _ = dap;
+
+        var bp = bpResp.GetProperty("body").GetProperty("breakpoints")[0];
+        Assert.False(bp.GetProperty("verified").GetBoolean(),
+            $"{bpResp}\n--- stderr ---\n{dap.StdErr}");
+        Assert.Equal(BlankLine - 1, bp.GetProperty("line").GetInt32());
+        Assert.False(string.IsNullOrWhiteSpace(bp.GetProperty("message").GetString()),
+            $"an unverified breakpoint must say why: {bpResp}");
+
+        // Nothing is armed, so the run goes straight through to `exited` with no stop.
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+        var events = new List<JsonElement>();
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(120), events);
+        Assert.DoesNotContain(events, e => e.GetProperty("event").GetString() == "stopped");
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+
+    /// <summary>
+    /// A 1-based client — the default, and what every real client in use today sends — is
+    /// unchanged by the conversion. Sending nothing at all for either capability must be the
+    /// same conversation as before: line 35 asked for, line 35 verified, line 35 reported by
+    /// the <c>stopped</c> event and by the frame, column 1 on the frame.
+    ///
+    /// <para>This is the control the in/out conversions are measured against: a fix that
+    /// converted unconditionally, or that subtracted where it should add, turns this red while
+    /// leaving the 0-based facts green.</para>
+    /// </summary>
+    [SkippableFact]
+    public async Task OneBasedClient_IsUnaffected_AndTheFrameColumnStaysOne()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dap, bpResp) = await StartAndSetBreakpointAsync(
+            SingleStatementLine, linesStartAt1: true);
+        await using var _ = dap;
+
+        var bp = bpResp.GetProperty("body").GetProperty("breakpoints")[0];
+        Assert.True(bp.GetProperty("verified").GetBoolean(),
+            $"{bpResp}\n--- stderr ---\n{dap.StdErr}");
+        Assert.Equal(SingleStatementLine, bp.GetProperty("line").GetInt32());
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal(SingleStatementLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
+
+        var stSeq = dap.SendRequest("stackTrace", new { threadId = 1 });
+        var stResp = await dap.ReadUntilResponseAsync(stSeq);
+        var topFrame = stResp.GetProperty("body").GetProperty("stackFrames")[0];
+        Assert.Equal(SingleStatementLine, topFrame.GetProperty("line").GetInt32());
+        Assert.Equal(1, topFrame.GetProperty("column").GetInt32());
+
+        var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq);
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60));
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+
+    /// <summary>
+    /// The sibling capability on the surface PR #3879 did not reach: <c>stackTrace</c> writes
+    /// <c>column = 1</c> for every frame, unconverted, so a client that counts columns from 0
+    /// is told a frame starts one column right of where it does.
+    ///
+    /// <para>RED before the fix: 1. GREEN: 0, the 0-based spelling of the same first column.
+    /// Filed as part of #3881 rather than separately because it is the identical conversion at
+    /// the identical boundary, in the handler the line conversion has to touch anyway.</para>
+    /// </summary>
+    [SkippableFact]
+    public async Task ZeroBasedColumnsClient_FrameColumn_ComesBackInItsOwnBase()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dap, bpResp) = await StartAndSetBreakpointAsync(
+            SingleStatementLine, linesStartAt1: true, columnsStartAt1: false);
+        await using var _ = dap;
+
+        Assert.True(bpResp.GetProperty("body").GetProperty("breakpoints")[0]
+            .GetProperty("verified").GetBoolean(), $"{bpResp}\n--- stderr ---\n{dap.StdErr}");
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+        await dap.ReadUntilEventAsync("stopped");
+
+        var stSeq = dap.SendRequest("stackTrace", new { threadId = 1 });
+        var stResp = await dap.ReadUntilResponseAsync(stSeq);
+        Assert.Equal(0, stResp.GetProperty("body").GetProperty("stackFrames")[0]
+            .GetProperty("column").GetInt32());
+
+        var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq);
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60));
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+}

--- a/AlRunner.Tests/DapPreLaunchBreakpointTests.cs
+++ b/AlRunner.Tests/DapPreLaunchBreakpointTests.cs
@@ -339,4 +339,87 @@ public class DapPreLaunchBreakpointTests
             + $"--- stderr ---\n{dap.StdErr}");
         Assert.Equal(SecondObjectSecondStatementLine, bp.GetProperty("line").GetInt32());
     }
+
+    /// <summary>
+    /// A request that jumps the deferral queue must not be overtaken by the one it replaced.
+    /// An EMPTY breakpoint list needs no source map, so it is answered immediately — which is
+    /// right, and was the whole reason for that fast path — but a non-empty request for the
+    /// SAME source may still be sitting in the deferred queue, and draining it later re-arms
+    /// what the empty request had just removed.
+    ///
+    /// <para>RED before the fix: the run stops at
+    /// <see cref="SecondObjectSecondStatementLine"/>, on a breakpoint the client removed before
+    /// execution began and was told was removed. The client's last word about this source was
+    /// "no breakpoints"; the adapter's was the request before it.</para>
+    ///
+    /// <para>GREEN: no <c>stopped</c> event at all, and the run exits 0. Both requests are
+    /// still answered — a superseded request is not an unanswered one — but they are answered
+    /// in the order they were sent, so the empty one is last and wins.</para>
+    ///
+    /// <para>The ordering is only observable while the map is being prepared, which is what
+    /// AL_RUNNER_DAP_TEST_DELAY_MAP_MS holds open; an organically slow bundle would make this
+    /// flaky. Raised by an adversarial review of PR #3899 (gpt-6-astra).</para>
+    /// </summary>
+    [SkippableFact]
+    public async Task AnEmptyBreakpointListIsNotOvertakenByTheDeferredRequestItReplaced()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        await using var dap = await StartAndInitializeAsync(HoldMapPreparation(4_000));
+        var srcPath = Path.Combine(FixtureSrc, SourceFileName);
+
+        // Deferred by construction: the map is held, and this list is non-empty.
+        dap.SendRequest("setBreakpoints", new
+        {
+            source = new { path = srcPath },
+            breakpoints = new[] { new { line = SecondObjectSecondStatementLine } },
+        });
+
+        // "Remove every breakpoint in this source" — DAP's own spelling for it, and the
+        // client's last word about this file.
+        dap.SendRequest("setBreakpoints", new
+        {
+            source = new { path = srcPath },
+            breakpoints = Array.Empty<object>(),
+        });
+
+        // Neither response is read here, deliberately. Which of the two arrives first is the
+        // very thing under test — answered-in-order when this is right, clear-first when it is
+        // not — so a fixed read order would decide the outcome by how this client behaves
+        // rather than by how the adapter does (it drops a response it is not waiting for, so
+        // reading the wrong one first discards the other and then waits out the clock). That a
+        // deferred request IS answered at all is pinned by
+        // ABreakpointRequestDeferredForTheMap_IsAnsweredWhenTheMapArrives above; what is left
+        // to this fact is what the adapter ARMS, which the run itself reports.
+        // The `launch` read below drains both responses on its way past them.
+        var launchSeq = dap.SendRequest("launch", new { });
+        var launchResp = await dap.ReadUntilResponseAsync(launchSeq, timeout: TimeSpan.FromSeconds(120));
+        Assert.True(launchResp.GetProperty("success").GetBoolean(),
+            $"launch failed: {launchResp}\n--- stderr ---\n{dap.StdErr}");
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        // The failing shape is a PAUSE, not a wrong number, so the read has to be bounded and
+        // its timeout reported as the finding rather than as a flake: a run that stops at the
+        // removed breakpoint never reaches `exited` at all, because nothing continues it.
+        var events = new List<JsonElement>();
+        JsonElement exited;
+        try
+        {
+            exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60), events);
+        }
+        catch (TimeoutException)
+        {
+            var stopped = events.FirstOrDefault(
+                e => e.GetProperty("event").GetString() == "stopped");
+            Assert.Fail(stopped.ValueKind == JsonValueKind.Object
+                ? $"the run stopped at a breakpoint the client had removed: {stopped}"
+                : $"no `exited` within 60s and no `stopped` either; events: "
+                    + string.Join(" | ", events.Select(e => e.GetProperty("event").GetString())));
+            throw;   // unreachable; Assert.Fail does not return
+        }
+        Assert.DoesNotContain(events, e => e.GetProperty("event").GetString() == "stopped");
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
 }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -5740,6 +5740,14 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
     // surface cannot be forgotten without the others disagreeing with it.
     var linesStartAt1 = true;
     var columnsStartAt1 = true;
+    // DAP permits `initialize` as the first request and only once, and a second one is
+    // refused rather than honoured (#3899 review): these two are negotiated ONCE and then
+    // answered against for the rest of the session, so letting a repeat move them shows the
+    // client two different numbers for one breakpoint it set once. The deferred path makes
+    // that concrete — a request parked while the source map builds carries numbers already
+    // converted in the base that was in force when it arrived, and DrainDeferredBreakpoints
+    // answers it later.
+    var initializeAnswered = false;
 
     // 0 is not a line: AlDapStackWalker reports it for a frame it could not map, and the
     // `stopped` handler reports it when the walk threw. Converting that sentinel would send a
@@ -6042,6 +6050,13 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
                 allThreadsStopped = true,
                 // In the client's own base (#3881). A walk that threw leaves `line` at 0, the
                 // sentinel ToClientLine passes through rather than converting to -1.
+                //
+                // For a 0-based client that sentinel collides with a legal coordinate: the
+                // first line of a file is also 0. `line` is not a property DAP's StoppedEvent
+                // defines, and the failed walk is separately reported — an `output` event says
+                // why, and the following `stackTrace` returns no frames — so the conversation
+                // still distinguishes them; this one field does not. #3901 carries it, with
+                // the source-less-frame defect it belongs with.
                 line = ToClientLine(line),
             });
             AlRunner.Infrastructure.AlDapSession.Trace("STOPPED-HANDLER write-event(stopped) ok");
@@ -6105,6 +6120,16 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
                 switch (command)
                 {
                     case "initialize":
+                        if (initializeAnswered)
+                        {
+                            transport.WriteResponse(msg.Seq, command, false,
+                                message: "initialize: this session is already initialized. DAP "
+                                    + "allows initialize only as the first request and only once; "
+                                    + "the line and column bases negotiated then are what every "
+                                    + "later response answers in.");
+                            break;
+                        }
+                        initializeAnswered = true;
                         // Absent means true, per the specification — for both.
                         linesStartAt1 = !(args != null
                             && args.Value.TryGetProperty("linesStartAt1", out var lineBaseEl)

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -6174,7 +6174,18 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
                         // the client naming ONE statement on a line that carries several
                         // (#3879 review). The legacy `lines` array has no column to carry.
                         var lines = new List<(int Line, int? Column)>();
+                        // BRACES, and they are load-bearing. Without them C#'s dangling-else
+                        // binds the `else` below to the INNER `if (bp.TryGetProperty("line"))`
+                        // — so the legacy branch sat inside the loop over `breakpoints`, and
+                        // could run only for a request that HAD a `breakpoints` array carrying
+                        // an element with no `line`. A request sending `lines[]` alone reached
+                        // neither branch and was answered `breakpoints: []` with success: true
+                        // — every legacy breakpoint silently dropped, and the client told the
+                        // request succeeded. It compiles, it reads correctly, and nothing drove
+                        // it: found by adding the coverage GitHub Copilot's review of PR #3899
+                        // asked for.
                         if (args.Value.TryGetProperty("breakpoints", out var bpsEl) && bpsEl.ValueKind == System.Text.Json.JsonValueKind.Array)
+                        {
                             foreach (var bp in bpsEl.EnumerateArray())
                                 if (bp.TryGetProperty("line", out var lineEl))
                                     // Both to 1-based, which is what the resolver compares in.
@@ -6183,10 +6194,13 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
                                             && colEl.ValueKind == System.Text.Json.JsonValueKind.Number
                                             ? FromClientColumn(colEl.GetInt32())
                                             : null));
+                        }
                         else if (args.Value.TryGetProperty("lines", out var legacyLinesEl) && legacyLinesEl.ValueKind == System.Text.Json.JsonValueKind.Array)
+                        {
                             // The legacy array carries no column, and its lines are in the
                             // client's base exactly as `breakpoints[].line` is.
                             foreach (var l in legacyLinesEl.EnumerateArray()) lines.Add((FromClientLine(l.GetInt32()), null));
+                        }
 
                         // An EMPTY list resolves nothing — "remove every breakpoint in this
                         // source" needs no map — so it is answered now, whatever the compile

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -5726,17 +5726,30 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
     var sourceMapResolved = false;
     string? compileFailure = null;
 
-    // DAP's `initialize` lets the client say whether it counts columns from 1 or from 0
-    // (`columnsStartAt1`, default TRUE when absent). Everything below this line works in
-    // 1-based columns, which is what AlSourceSpanCodec.AbsoluteFromColumn produces, so a
-    // 0-based client's numbers are converted on the way in and back on the way out (#3879
-    // Copilot review). Without that, such a client's inline breakpoint lands one column left
-    // of the statement it meant.
+    // DAP's `initialize` lets the client say whether it counts lines and columns from 1 or
+    // from 0 (`linesStartAt1` / `columnsStartAt1`, both default TRUE when absent). Everything
+    // below this line works in the 1-based numbering AlSourceSpanCodec.AbsoluteFromLine and
+    // AbsoluteFromColumn produce, so a 0-based client's numbers are converted on the way in
+    // and back on the way out (#3879 Copilot review for columns, #3881 for lines). Without
+    // that, such a client's breakpoint lands one line above — or one column left of — the
+    // statement it meant, and is then told about stops in a numbering it did not ask for.
     //
-    // `linesStartAt1` has the identical problem and is NOT handled here: lines are reported
-    // by `stopped`, `stackTrace` and this response, so honouring it is a change across the
-    // whole surface rather than the one field this pull request adds (#3881).
+    // Lines cross the wire at FOUR places, which is what made this bigger than the column
+    // half: the setBreakpoints request, its response, the `stopped` event and every
+    // `stackTrace` frame. One converter per direction, used at every one of them, so a
+    // surface cannot be forgotten without the others disagreeing with it.
+    var linesStartAt1 = true;
     var columnsStartAt1 = true;
+
+    // 0 is not a line: AlDapStackWalker reports it for a frame it could not map, and the
+    // `stopped` handler reports it when the walk threw. Converting that sentinel would send a
+    // 0-based client -1, so it is passed through unchanged in both converters.
+    int ToClientLine(int oneBasedLine) =>
+        linesStartAt1 || oneBasedLine <= 0 ? oneBasedLine : oneBasedLine - 1;
+    int FromClientLine(int clientLine) => linesStartAt1 ? clientLine : clientLine + 1;
+    int ToClientColumn(int oneBasedColumn) =>
+        columnsStartAt1 || oneBasedColumn <= 0 ? oneBasedColumn : oneBasedColumn - 1;
+    int FromClientColumn(int clientColumn) => columnsStartAt1 ? clientColumn : clientColumn + 1;
 
     // setBreakpoints requests that arrived before the map could be built, waiting to be
     // answered. Answering one needs the compile, and BLOCKING this single-threaded loop for
@@ -5919,13 +5932,15 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
             {
                 id = idx,
                 verified = rb.Verified,
-                line = rb.Verified ? rb.ActualLine : rb.RequestedLine,
+                // Back into the client's own base — including on the unverified path, where the
+                // number echoed is the one the client sent rather than the 1-based reading of it.
+                line = ToClientLine(rb.Verified ? rb.ActualLine : rb.RequestedLine),
                 // The column actually bound — the leftmost of the armed targets. A client that
                 // asked for a column no statement starts at can see where the breakpoint went,
                 // which is what keeps the resolver's widest fallback from being a silent
                 // relocation (#3879 Copilot review). Back into the client's own base.
                 column = rb.Verified && rb.Targets.Count > 0
-                    ? rb.Targets.Min(t => t.Column) - (columnsStartAt1 ? 0 : 1)
+                    ? ToClientColumn(rb.Targets.Min(t => t.Column))
                     : (int?)null,
                 message = rb.Verified ? null : unverifiedReason,
             }),
@@ -6025,7 +6040,9 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
                 reason,
                 threadId = 1,
                 allThreadsStopped = true,
-                line,
+                // In the client's own base (#3881). A walk that threw leaves `line` at 0, the
+                // sentinel ToClientLine passes through rather than converting to -1.
+                line = ToClientLine(line),
             });
             AlRunner.Infrastructure.AlDapSession.Trace("STOPPED-HANDLER write-event(stopped) ok");
             if (walkError != null)
@@ -6088,7 +6105,10 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
                 switch (command)
                 {
                     case "initialize":
-                        // Absent means true, per the specification.
+                        // Absent means true, per the specification — for both.
+                        linesStartAt1 = !(args != null
+                            && args.Value.TryGetProperty("linesStartAt1", out var lineBaseEl)
+                            && lineBaseEl.ValueKind == System.Text.Json.JsonValueKind.False);
                         columnsStartAt1 = !(args != null
                             && args.Value.TryGetProperty("columnsStartAt1", out var colBaseEl)
                             && colBaseEl.ValueKind == System.Text.Json.JsonValueKind.False);
@@ -6132,14 +6152,16 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
                         if (args.Value.TryGetProperty("breakpoints", out var bpsEl) && bpsEl.ValueKind == System.Text.Json.JsonValueKind.Array)
                             foreach (var bp in bpsEl.EnumerateArray())
                                 if (bp.TryGetProperty("line", out var lineEl))
-                                    lines.Add((lineEl.GetInt32(),
+                                    // Both to 1-based, which is what the resolver compares in.
+                                    lines.Add((FromClientLine(lineEl.GetInt32()),
                                         bp.TryGetProperty("column", out var colEl)
                                             && colEl.ValueKind == System.Text.Json.JsonValueKind.Number
-                                            // To 1-based, which is what the resolver compares in.
-                                            ? colEl.GetInt32() + (columnsStartAt1 ? 0 : 1)
+                                            ? FromClientColumn(colEl.GetInt32())
                                             : null));
                         else if (args.Value.TryGetProperty("lines", out var legacyLinesEl) && legacyLinesEl.ValueKind == System.Text.Json.JsonValueKind.Array)
-                            foreach (var l in legacyLinesEl.EnumerateArray()) lines.Add((l.GetInt32(), null));
+                            // The legacy array carries no column, and its lines are in the
+                            // client's base exactly as `breakpoints[].line` is.
+                            foreach (var l in legacyLinesEl.EnumerateArray()) lines.Add((FromClientLine(l.GetInt32()), null));
 
                         // An EMPTY list resolves nothing — "remove every breakpoint in this
                         // source" needs no map — so it is answered now, whatever the compile
@@ -6189,8 +6211,12 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
                                 id = f.Id,
                                 name = f.ScopeName,
                                 source = f.SourcePath != null ? new { path = f.SourcePath, name = Path.GetFileName(f.SourcePath) } : null,
-                                line = f.Line,
-                                column = 1,
+                                line = ToClientLine(f.Line),
+                                // The first column of the line. It was written as a literal 1,
+                                // so a 0-based client was told every frame starts one column
+                                // right of where it does — the same defect as the line half,
+                                // on the surface #3879 did not reach (#3881).
+                                column = ToClientColumn(1),
                             }),
                             totalFrames = lastFrames.Count,
                         });

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -5955,6 +5955,19 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
         });
     }
 
+    // Two spellings of one file — "./Foo.al" from one request and an absolute path from the
+    // next — have to compare equal, or a replacement would queue behind nothing and overtake
+    // the request it replaces after all. GetFullPath is what AnswerSetBreakpoints already
+    // keys its registry by; a path it cannot resolve falls back to itself, so an unusable
+    // path is compared rather than throwing here and losing the request.
+    static string NormalizeSourcePath(string path)
+    {
+        try { return Path.GetFullPath(path); }
+        catch (ArgumentException) { return path; }
+        catch (NotSupportedException) { return path; }
+        catch (PathTooLongException) { return path; }
+    }
+
     // Answers everything deferred, in arrival order. Called only where the map question is
     // already settled — the read race, launch, configurationDone — so it never blocks for
     // longer than the caller was going to anyway.
@@ -6209,7 +6222,20 @@ int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? std
                         // able to read `disconnect` (#3846). The deferred request is answered
                         // by DrainDeferredBreakpoints, from the read race below or from
                         // launch / configurationDone.
-                        if (lines.Count > 0 && !MapAnswerAvailable())
+                        //
+                        // ...but that fast path must not OVERTAKE a request for the same
+                        // source already in the queue (#3899 review). Each setBreakpoints is
+                        // the complete set for its source from then on, so the LAST one the
+                        // client sent has to be the one that stands: answering an empty list
+                        // immediately while a non-empty one for that file is still parked
+                        // cleared the file and then re-armed it on the drain, stopping
+                        // execution at a breakpoint the client had removed and been told was
+                        // removed. Queueing behind it costs the empty request its fast answer
+                        // and keeps arrival order, which is the thing that decides the result.
+                        var queuedForThisSource = deferredBreakpointRequests.Any(
+                            d => AlRunner.Infrastructure.DapBreakpointResolver.PathComparer
+                                .Equals(NormalizeSourcePath(d.SrcPath), NormalizeSourcePath(srcPath)));
+                        if ((lines.Count > 0 && !MapAnswerAvailable()) || queuedForThisSource)
                         {
                             deferredBreakpointRequests.Add((msg.Seq, command, srcPath, lines));
                             break;

--- a/docs/dap-mode.md
+++ b/docs/dap-mode.md
@@ -102,8 +102,22 @@ Session lifecycle is identical to the TCP transport from here on:
    statement *starting* at the column; failing that, the statement *containing* it
    (a mid-token click); failing that, the whole line. The last is a relocation, so
    the response reports the `column` actually bound. The client capability
-   `columnsStartAt1` is honoured for that field in both directions; its sibling
-   `linesStartAt1` is **not** honoured anywhere yet (#3881).
+   `columnsStartAt1` is honoured for that field in both directions.
+
+   **Both client bases are honoured, everywhere a number crosses the wire** (#3881).
+   `initialize` carries `linesStartAt1` and `columnsStartAt1`, each defaulting to
+   true when absent, and the adapter converts into its own 1-based numbering on the
+   way in and back into the client's on the way out — at the `setBreakpoints`
+   request (`breakpoints[].line`, `breakpoints[].column`, and the legacy `lines[]`
+   array), the breakpoint response's `line` and `column`, the `stopped` event's
+   `line`, and every `stackTrace` frame's `line` and `column`. A line of 0 is the
+   sentinel for a frame that could not be mapped, not a coordinate, so it is passed
+   through rather than converted; #3901 carries what that costs a 0-based client.
+
+   **A second `initialize` is refused**, with a message saying why. DAP allows it
+   only as the first request and only once, and the two bases are negotiated there
+   and answered against for the rest of the session — honouring a repeat would move
+   the numbering under breakpoints already armed and acknowledged.
 4. `configurationDone` → AL execution begins.
 5. When a breakpointed statement's `StmtHit` fires, the AL execution thread
    blocks and a `stopped` event (`reason: "breakpoint"`) is sent.

--- a/docs/dap-mode.md
+++ b/docs/dap-mode.md
@@ -88,8 +88,10 @@ Session lifecycle is identical to the TCP transport from here on:
    AL-compiler-instrumented statements on it, via an exact absolute-line match — no
    "nearest line" heuristic. A line with no exact instrumented statement comes
    back `verified: false` rather than silently relocated, carrying a `message`
-   saying which reason applies: the bundle did not compile, or that line holds no
-   statement.
+   saying which of THREE reasons applies: the bundle did not compile, the source
+   could not be READ during map preparation so nobody knows what is on that line
+   (#3847), or that line holds no statement. The three are chosen in
+   `AlRunner/Infrastructure/DapUnverifiedReason.cs`, which is where to add a fourth.
 
    **Every statement on the line is armed, not one of them** (#3820). A line can
    carry several — two statements separated by `;`, two one-line procedures, or
@@ -114,6 +116,12 @@ Session lifecycle is identical to the TCP transport from here on:
    sentinel for a frame that could not be mapped, not a coordinate, so it is passed
    through rather than converted; #3901 carries what that costs a 0-based client.
 
+   Two things to keep straight about that sentinel. The `stopped` event's `line` is an
+   **adapter extension** — DAP's own `StoppedEvent` has no such property, and a
+   specification-following client reads the location from `stackTrace`. And the
+   sentinel is **internal** line 0: for a client that counts from 0, client line 0 is a
+   real coordinate, which is exactly the collision #3901 records.
+
    **A second `initialize` is refused**, with a message saying why. DAP allows it
    only as the first request and only once, and the two bases are negotiated there
    and answered against for the rest of the session — honouring a repeat would move
@@ -128,7 +136,9 @@ Session lifecycle is identical to the TCP transport from here on:
    again. `next` (step over) / `stepIn` / `stepOut` (issue #2045) each arm a
    depth-based condition instead — the AL execution thread stops at the first
    subsequent `StmtHit` that "qualifies" for the command sent, and the
-   `stopped` event's `reason` is `"step"` rather than `"breakpoint"`. See
+   `stopped` event's `reason` is `"step"` — unless the statement it lands on also
+   carries a breakpoint, which takes precedence and reports `"breakpoint"`
+   (`AlDapSession.OnStmtHit`). See
    `AlRunner/Infrastructure/AlDapSession.cs`'s file header for exactly what
    "qualifies" means for each. The depth signal is a manual walk of
    `NavMethodScope.ParentScope` (the same chain `AlDapStackWalker` already


### PR DESCRIPTION
Closes #3881

## What was wrong

DAP's `initialize` carries `linesStartAt1` — absent means true, per the specification.
`RunDapLoop` never read it, and every line it compared or reported was the 1-based numbering
`AlSourceSpanCodec.AbsoluteFromLine` produces. So a client that counts lines from 0:

- had its `setBreakpoints` line compared against 1-based spans, landing one line **above** the
  statement it meant;
- was told about stops in a numbering it had not asked for, by the breakpoint response, the
  `stopped` event and every `stackTrace` frame.

PR #3879 honoured the sibling capability `columnsStartAt1` for the one field it introduced, so
until now the adapter converted columns and not lines — harder to reason about than converting
neither, which is why #3881 was filed rather than half-done there.

It also left one column surface unconverted, on the same handler this change has to touch:
`stackTrace` wrote `column = 1` as a literal, so a 0-based client was told every frame starts
one column right of where it does. Fixed here with it.

## What changed

`AlRunner/Program.cs`, `RunDapLoop` only. One converter per direction per capability, used at
every boundary a number crosses the wire:

| boundary | direction |
|---|---|
| `setBreakpoints` request — `breakpoints[].line` and the legacy `lines[]` | in |
| the breakpoint response's `line` (verified **and** unverified) | out |
| the `stopped` event's `line` | out |
| `stackTrace` frames' `line` and `column` | out |

`ToClientLine` passes **0 through unconverted**: it is not a line but the sentinel
`AlDapStackWalker` reports for a frame it could not map, and the `stopped` handler reports when
the walk threw. Converting it would send a 0-based client `-1`.

## Proof

`AlRunner.Tests/DapLineBaseTests.cs`, four facts over the shared `Fixtures/DapMultiTarget`
bundle. **RED before the fix: `Failed: 3, Passed: 1`. GREEN: `Failed: 0, Passed: 4`.**

- `ZeroBasedClient_BreakpointOnItsOwnLineNumber_BindsTheStatementAndReportsItBack` — a 0-based
  client names `First := 1;` as line 34; the breakpoint verifies, and the response, the
  `stopped` event and the frame all say 34. Locals pin *which* statement the pause is in front
  of (`First` is still `0`), so an adapter that bound something else and echoed the number back
  would not pass.
- `ZeroBasedClient_ALineWhosePredecessorResolves_IsRefusedRatherThanArmed` — the refusal
  direction, anchored so that it cannot pass either way: 0-based 26 is the blank line 27, but
  read as 1-based it is the line carrying two one-line procedures. Before the fix the client is
  told a breakpoint is set on a blank line and execution stops somewhere it never asked for;
  after, it is unverified, with the number it sent and a message saying why, and the run reaches
  `exited` with no `stopped` event.
- `OneBasedClient_IsUnaffected_AndTheFrameColumnStaysOne` — the control. A fix that converted
  unconditionally, or subtracted where it should add, turns this red while leaving the 0-based
  facts green.
- `ZeroBasedColumnsClient_FrameColumn_ComesBackInItsOwnBase` — the `stackTrace` column half.

### Mutation check

Five slices, each reverted on its own, rebuilt, re-run against the four facts, restored
(`tdd.md` § "Run the mutation; do not just ask the question"). Each mutation was confirmed on
disk by re-reading the file before the build. Green is `Failed: 0, Passed: 4`:

| slice reverted | result |
|---|---|
| the request's `FromClientLine` | `Failed: 2, Passed: 2` |
| the breakpoint response's `ToClientLine` | `Failed: 2, Passed: 2` |
| the `stopped` event's `ToClientLine` | `Failed: 1, Passed: 3` |
| the `stackTrace` frame line's `ToClientLine` | `Failed: 1, Passed: 3` |
| the frame column's `ToClientColumn` | `Failed: 1, Passed: 3` |
| the second-`initialize` guard (added in review, see below) | `Failed: 1, Passed: 4` of 5 |
| the braces on the `breakpoints[]` branch (added in review, see below) | `Failed: 1, Passed: 5` of 6 |
| the deferral-ordering guard `|| queuedForThisSource` | reproduces the stop at a removed breakpoint |
| the absent-capability default (`absent` read as false) | `Failed: 1, Passed: 7` of 8 |
| the frame line's `ToClientLine`, re-measured with the caller fact | `Failed: 4, Passed: 4` of 8 |

No slice is unpinned. The last row is against the five-fact suite; the five above it against
the four facts as first pushed.

## Acted on the review

An adversarial review (gpt-5.6-sol, `high`) found **nothing blocking** and confirmed every
conversion direction, the complete wire-surface audit (no other line or column leaves the
adapter), and the refusal fact's anchoring. Two findings, both acted on:

- **Fixed here** — a second `initialize` was answered like the first, re-reading both
  capabilities and moving the numbering under breakpoints already armed and acknowledged. DAP
  allows `initialize` once, as the first request; it is now refused with a message.
  `ASecondInitialize_IsRefused_SoTheNegotiatedLineBaseCannotMove` is the fact, RED before the
  guard (the repeat succeeded and the stop came back as 35 for a breakpoint acknowledged as 34).
- **Filed as #3901** — a stack frame whose object is not in the source map goes out with
  `source: null` **and** a positive line and column, where DAP says both must be 0. It is on
  this diff's boundary but predates it, it is a wire-shape decision rather than a base
  conversion, and proving it needs a DAP fixture with an unmapped frame: all four `Fixtures/Dap*`
  bundles declare `"dependencies": []`. The `stopped` event's non-standard `body.line`
  sentinel ambiguity for a 0-based client is filed with it, and named in a comment at the line
  that passes the sentinel through.

## A defect the Copilot review surfaced

GitHub Copilot asked for coverage of the legacy `lines[]` spelling, on the grounds that a
regression leaving that path 1-based would keep the rest of the suite green. The test written
for it **failed against the code it was written to pin**: a `setBreakpoints` carrying
`lines: [34]` and no `breakpoints` array resolved nothing and was answered
`{"success":true,"body":{"breakpoints":[]}}` — every legacy breakpoint dropped, with the client
told its request succeeded.

A dangling `else`. Unbraced, the `else` binds to the **inner** `if (bp.TryGetProperty("line"))`,
so the legacy branch sat inside the loop over `breakpoints` and could run only for a request
that had a `breakpoints` array carrying an element with no `line`. `git show
origin/main:AlRunner/Program.cs` has the identical structure, so the legacy spelling has never
worked. Fixed with braces; the new fact catches it (mutation row above).

`docs/dap-mode.md` also still said `linesStartAt1` is honoured nowhere — the statement this
change makes false. Replaced with what the adapter now does, including the `0` sentinel and the
refused second `initialize`.

## Second review (gpt-6-astra), and what it changed

Nothing blocking. Two further production defects, three test/documentation weaknesses, all
real; the full item-by-item response is in a PR comment.

- **Fixed** — an empty breakpoint list was **overtaken by the deferred request it replaced**:
  the empty list needs no source map so it was answered at once, while a non-empty request for
  the same source sat in the deferred queue and re-armed on the drain. The run then stopped at
  a breakpoint the client had removed and been told was removed. An empty list now queues
  behind a pending request for that source, keeping arrival order; both are still answered.
- **Fixed** — the suite could not see an absent-capability regression (every fact sent both
  properties explicitly), and no fact checked a **caller** frame under a 0-based base, whose
  line comes from a different branch of the stack walker. Two new facts; the mutation numbers
  above measure both gaps.
- **Corrected** — two accounts in the suite were wrong. The legacy fact described a defect that
  was never there (`origin/main` returned no breakpoints at all rather than an unverified one),
  and the 1-based control claimed to send nothing for either capability while sending both.
- **Filed as #3906** — the paused frame's Locals scope goes out as `variablesReference: 0`,
  which DAP defines as "no children", so a conforming client never asks for the locals of the
  frame the developer is stopped in. Not this PR's code, and not #3901.
- **Scope, stated plainly** — the reviewer's position, which I take: the legacy repair is
  *restoring legacy breakpoint support*, not merely converting legacy line numbers. It also
  changes three malformed shapes: `breakpoints:[{}] + lines:[35]` used to arm 35 and now
  acknowledges an empty set, a mixed array with a missing-`line` element used to append the
  legacy array once per such element, and `lines:[35,"bad"]` used to succeed-and-clear and now
  fails loudly. The first is a compatibility break for a client using a shape that violates
  `SourceBreakpoint`'s required `line`; not preserved.

## Failures that are not this change

- `ProvisionExplicitModesTests.TestApps_OnlyUnrelatedAppPresent_DoesNotShortCircuit_DownloadsTheRealSet`
  fails identically on a **pristine `origin/main` worktree at `01cb7d60`** — same assertion,
  same message (`"t test-toolkit apps already present at C:"`), 0.9 s both times. Pre-existing,
  not touched by this diff.
- `DapMultiObjectFileTests.BreakpointOnAFirstObjectStatement_StopsInThatObject_NotTheSecondsSameRelativeLine`
  fails only when six DAP suites run together on this box (2 m for that one row); alone the
  whole class is `Failed: 0, Passed: 5` in 18 s. Load-dependent on a local run, not a verdict.

## The sibling I did not fold

**#3526** ("Make DAP breakpoint state source-owned so replacement requests actually replace
it") lands in this same handler, so it was read before this was written. Its central defect —
clearing only the scopes the *new* request resolves, so an empty replacement cleared nothing —
was already fixed by the `registeredScopesBySource` work in #3786's review, and two of its
acceptance criteria are pinned today by `DapMultiObjectFileTests`
(`SetBreakpointsWithAnEmptyList_DisarmsWhatThePreviousRequestArmed`,
`MovingABreakpointBetweenTwoObjectsOfOneFile_LeavesOnlyTheNewOneArmed`). What it asks for that
nothing pins is a replacement containing **only unverified** lines, another source's
breakpoints staying untouched, and the same over the stdio transport. Folding it would mean
adding facts that are green before and after this change — no RED, so no `Closes`
(`batch-sibling-issues-by-file.md` point 3). Measured on the issue instead.

**#3880** (the resolver's missing module-provenance boundary) also names
`DapBreakpointResolver.cs`, but its fix is a boundary on which assemblies are eligible and
needs a session with two loaded copies of one AL object — different reasoning, different file,
not folded.

*Opened by an agent (Claude Code, impl-3) in a session run by @SShadowS.*

https://claude.ai/code/session_01JFQZHC5SEHnLxkc5USksaK
