### PR TITLE
fix(testpage): resolve an expression-bound property on a precompiled page by joining on the live binding's Name

### DIFF
--- a/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
+++ b/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
@@ -249,7 +249,21 @@ public sealed class BcInternalsNullForgivingGuardTests
         // engine-bootstrap step that registers the platform SystemApp package: its failure used
         // to log and return, so "registration failed" was spelled as "initialization succeeded"
         // and the run continued without the NCL-internal system tables (#3581).
-        Assert.Equal(90, converted);
+        //
+        // 90 -> 92 for the Id and Name reads on a registered source expression in
+        // RunnerPageInstance.cs (#3825). Both are new sites rather than converted `!`/`?.` ones:
+        // they join a precompiled page's DECLARED identifier ("PageEditable", from the symbol
+        // file) to the binding table BC's own IL keyed by the compiler's spelling
+        // ("p790p790PageEditable"). A null from either has to mean "BC no longer exposes this
+        // member", which is a shape gap that must refuse — NOT "this expression does not match",
+        // which is precisely the silent non-match that made every expression-bound
+        // Editable/Visible/Enabled on a precompiled page unresolvable in the first place. Read
+        // through the bare reflection call, a renamed member would degrade the join back to that
+        // original symptom with nothing saying so; the two are indistinguishable at the call
+        // site, which is why these are shape-checked rather than `?.`. The enclosing
+        // BcShapeGapException catch still drops the one unreadable binding from the index rather
+        // than costing the page every other one — what changed is that the gap is named.
+        Assert.Equal(92, converted);
     }
 
     /// <summary>

--- a/AlRunner.Tests/ExpressionBindingNameJoinTests.cs
+++ b/AlRunner.Tests/ExpressionBindingNameJoinTests.cs
@@ -1,0 +1,148 @@
+// ExpressionBindingNameJoinTests — the runner-side mechanism behind issue #3825.
+//
+// THE DEFECT
+// ----------
+// A PRECOMPILED page states its control/action properties in SymbolReference.json, which carries
+// the identifier the AL author wrote (`Enabled = PageEditable`). The binding table BC fills at
+// runtime — NavForm.SourceExpressions, populated by the .app's own RegisterSourceExpression IL —
+// is keyed by the COMPILER's spelling. RunnerPageInstance looked the declared identifier up as a
+// key and nothing else, so every expression-bound property on a precompiled page missed and was
+// refused, naming the expression (`'PageEditable' is not a name the page publishes a binding for`).
+//
+// A source-compiled page never hit this: its declarations and its binding table both come from
+// the same emitted metadata, so the key lookup hits.
+//
+// WHAT THE .app ACTUALLY SHIPS, MEASURED
+// --------------------------------------
+// Reading Base Application 28.1.49838.53910's five R2R assemblies with Cecil — no compile —
+// the (id, name) argument pairs passed to RegisterSourceExpression are all present:
+//
+//     pages 2,610   pages registering bindings 1,847   registered pairs 18,075
+//       p<id>p<id>* 6,126     Control<hash>* 11,595     other 354
+//
+// and Page790.OnMetadataLoaded carries exactly:
+//
+//     RegisterSourceExpression("p790p790PageEditable" , "p790p790PageEditable")
+//     RegisterSourceExpression("Control159866013"     , "GLAccTotaling")
+//     RegisterSourceExpression("Control1520916075"    , "Rec.GetBalance()")
+//
+// That splits the join into the two arms this file pins, and the split is the whole finding:
+//
+//   * a VALUE-SOURCE binding carries the raw identifier in `Name`, so it is READ off the object;
+//   * a PROPERTY binding registers the mangled spelling as BOTH arguments — the raw identifier is
+//     nowhere on the object — so it is reached by composing the candidate key and asking the
+//     table whether it EXISTS.
+//
+// All 6,126 of the p<id>p<id> registrations have id == name (0 counterexamples), and no page
+// registers a duplicate key (0 of 2,610), so a hit is unambiguous.
+//
+// WHY THE SECOND ARM IS NOT "RE-IMPLEMENTING THE MANGLING"
+// --------------------------------------------------------
+// It never derives a value. It derives a CANDIDATE and requires the table to contain it, so a
+// wrong guess resolves nothing and the caller refuses exactly as before. That is the difference
+// between reading Microsoft's own registration and owning a naming rule across every BC version
+// (precompiled-dll-respect.md § "Reuse before you re-implement"), and it is why the negative
+// arms below matter more than the positive ones.
+//
+// WHAT IS DELIBERATELY NOT HERE
+// -----------------------------
+// Whether real BC answers true or false for a given page's property is a claim about BC and is
+// not pinned here; the AL arms in tests/runner-extras/testpage-precompiled-member-names drive the
+// resolution end to end against Base Application page 790.
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class ExpressionBindingNameJoinTests
+{
+    // A stand-in for NavFormSourceExpression carrying the two properties the join reads. The
+    // runner resolves both by NAME through BcShape rather than against a BC type, so a shape with
+    // the same members exercises the real lookup path.
+    private sealed class FakeBinding
+    {
+        public string Id { get; init; } = "";
+        public string Name { get; init; } = "";
+    }
+
+    // Page 790's real registrations, exactly as the Cecil trace above reports them.
+    private static System.Collections.IDictionary Page790Bindings() => new System.Collections.Hashtable
+    {
+        ["p790p790PageEditable"] = new FakeBinding { Id = "p790p790PageEditable", Name = "p790p790PageEditable" },
+        ["Control159866013"] = new FakeBinding { Id = "Control159866013", Name = "GLAccTotaling" },
+        ["Control1520916075"] = new FakeBinding { Id = "Control1520916075", Name = "Rec.GetBalance()" },
+    };
+
+    [Fact]
+    public void TheIndexKeysEveryBindingByItsName_NotByItsRegisteredKey()
+    {
+        var byName = RunnerPageInstance.BuildBindingsByName(Page790Bindings());
+
+        // The value-source bindings are reachable by the raw AL identifier, which is the half of
+        // the join that needs no composed key at all.
+        Assert.True(byName.ContainsKey("GLAccTotaling"));
+        Assert.True(byName.ContainsKey("Rec.GetBalance()"));
+
+        // And the property binding is indexed under the only Name it has — the mangled one. This
+        // is the measured asymmetry: `PageEditable` is NOT a key here, which is exactly why the
+        // second arm of the join exists.
+        Assert.True(byName.ContainsKey("p790p790PageEditable"));
+        Assert.False(byName.ContainsKey("PageEditable"));
+
+        Assert.Equal(3, byName.Count);
+    }
+
+    [Fact]
+    public void ABindingWhoseNameIsMissingOrBlankIsLeftOutRatherThanCostingTheWholeIndex()
+    {
+        var bindings = new System.Collections.Hashtable
+        {
+            ["Control1"] = new FakeBinding { Id = "Control1", Name = "Good" },
+            ["Control2"] = new FakeBinding { Id = "Control2", Name = "" },
+            ["Control3"] = new object(),   // no Name property at all
+            ["Control4"] = null!,
+        };
+
+        var byName = RunnerPageInstance.BuildBindingsByName(bindings);
+
+        // The readable one survives; the three unreadable ones are simply absent. An unreadable
+        // binding must not cost the page every other binding — the caller's key lookup still
+        // works for those, and an identifier that needed the join refuses loudly, naming itself.
+        Assert.True(byName.ContainsKey("Good"));
+        Assert.Single(byName);
+    }
+
+    [Fact]
+    public void TheIndexIsCaseSensitive_SoTwoGlobalsDifferingOnlyInCaseDoNotResolveToEachOther()
+    {
+        var byName = RunnerPageInstance.BuildBindingsByName(new System.Collections.Hashtable
+        {
+            ["Control1"] = new FakeBinding { Id = "Control1", Name = "Flag" },
+        });
+
+        Assert.True(byName.ContainsKey("Flag"));
+        Assert.False(byName.ContainsKey("flag"));
+        Assert.False(byName.ContainsKey("FLAG"));
+    }
+
+    // The one-to-many shape, which is normal rather than exceptional: one global bound to two
+    // controls registers twice under a single Name. The index must answer rather than throw.
+    [Fact]
+    public void TwoBindingsSharingOneNameResolveToOneEntryRatherThanThrowing()
+    {
+        var byName = RunnerPageInstance.BuildBindingsByName(new System.Collections.Hashtable
+        {
+            ["Control1"] = new FakeBinding { Id = "Control1", Name = "Shared" },
+            ["Control2"] = new FakeBinding { Id = "Control2", Name = "Shared" },
+        });
+
+        Assert.True(byName.ContainsKey("Shared"));
+        Assert.Single(byName);
+    }
+
+    [Fact]
+    public void AnEmptyBindingTableProducesAnEmptyIndexRatherThanFailing()
+    {
+        Assert.Empty(RunnerPageInstance.BuildBindingsByName(new System.Collections.Hashtable()));
+    }
+}

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -1013,9 +1013,17 @@ internal sealed partial class RunnerPageInstance
     ///
     /// <para>This narrows a refusal introduced by this change; it does not widen the pre-#3504
     /// silent default. A declaration the runner CAN resolve still gates the invoke exactly as
-    /// before, including the literal <c>Enabled = false</c> that corpus codeunit 60583 pins.
-    /// #3825 removes the unresolvable case entirely, at which point this method collapses back
-    /// into <see cref="ActionEnabled"/>.</para>
+    /// before, including the literal <c>Enabled = false</c> that corpus codeunit 60583 pins.</para>
+    ///
+    /// <para>#3825 resolved the population this was written for — an expression naming a binding
+    /// the page registers now answers, so the warning below no longer fires for it — but this
+    /// method STAYS, because unresolvable declarations still exist and #3825 did not make them
+    /// impossible: a client expression the compiler DROPPED (a procedure call, AL0573; see
+    /// <see cref="ClientExpressionTheCompilerDropped"/>), and an expression naming something the
+    /// page publishes no binding for. Collapsing this back into <see cref="ActionEnabled"/> would
+    /// turn each of those from "this one property is unreadable" into "this action's OnAction
+    /// never runs", which is the strictly larger loss the paragraph above rejects. Delete it only
+    /// once a measurement shows the unresolvable set is empty.</para>
     /// </summary>
     internal bool ActionEnabledForInvoke(int actionId)
     {

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -1175,14 +1175,21 @@ internal sealed partial class RunnerPageInstance
         // the FIRST one, so "TestPage page N element M — Visible" made the untyped recovery path
         // report the api as "TestPage page N element M" and fold "Visible" into the reason. Same
         // defect #2945 fixed for Feature Key Modify, live at all three sites here (#2999).
-        if (atOpen && _expressionValuesAtOpen.TryGetValue(raw, out var frozen))
+        // TryFrozenValue, not a bare TryGetValue: the snapshot is keyed by the REGISTERED key, so
+        // on a precompiled page — where `raw` is the raw AL identifier — a direct lookup misses
+        // and a control's own Visible would silently fall through to the LIVE value, losing the
+        // frozen-at-open semantics this arm exists for (#3825).
+        if (atOpen && TryFrozenValue(raw, out var frozen))
             return frozen is bool fb
                 ? fb
                 : throw TestPageShapeGap.ControlProperty(
                     $"TestPage {propertyName} on page {_pageId} element {elementId}",
                     $"expression '{raw}' evaluated to '{frozen ?? "null"}', which is not a Boolean");
 
-        var expression = _sourceExpressions[raw];
+        // ?? BindingRegisteredUnderName: on a PRECOMPILED page `raw` is the raw AL identifier the
+        // symbol file states, while the live table is keyed by the compiler's mangled id, so the
+        // key lookup alone misses every expression-bound property there (#3825).
+        var expression = _sourceExpressions[raw] ?? BindingRegisteredUnderName(raw);
         if (expression != null)
         {
             var direct = GetValue(expression);
@@ -1288,13 +1295,47 @@ internal sealed partial class RunnerPageInstance
     /// </summary>
     private bool ResolveExpressionIdentifierAtOpen(string name, bool quoted, out object? value)
     {
-        if (_expressionValuesAtOpen.TryGetValue(name, out value)) return true;
+        if (TryFrozenValue(name, out value)) return true;
         return ResolveExpressionIdentifier(name, quoted, out value);
+    }
+
+    /// <summary>
+    /// The open-time value of <paramref name="name"/>, which may be either the registered key or
+    /// the raw AL identifier the binding was registered under. Both spellings reach the same
+    /// snapshot entry — see <see cref="BindingRegisteredUnderName"/> for why a precompiled page
+    /// only ever has the second.
+    /// </summary>
+    private bool TryFrozenValue(string name, out object? value)
+    {
+        if (_expressionValuesAtOpen.TryGetValue(name, out value)) return true;
+
+        if (BindingRegisteredUnderName(name) is { } expression
+            && ReadBindingId(expression) is { } id
+            && _expressionValuesAtOpen.TryGetValue(id, out value))
+            return true;
+
+        value = null;
+        return false;
+    }
+
+    /// <summary>The binding's registered key, or null when the runner cannot read it — the same
+    /// shape-tolerance <see cref="BuildBindingsByName"/> applies to <c>Name</c>.</summary>
+    private static string? ReadBindingId(object expression)
+    {
+        try
+        {
+            return BcShape.Property(
+                expression.GetType(), "Id", BcShape.AnyInstance,
+                surface: "TestPage expression-bound property",
+                detail: "the runner reads a binding's registered key to find its open-time value")
+                .GetValue(expression) as string;
+        }
+        catch (AlRunner.Infrastructure.BcShapeGapException) { return null; }
     }
 
     private bool ResolveExpressionIdentifier(string name, bool quoted, out object? value)
     {
-        var expression = _sourceExpressions[name];
+        var expression = _sourceExpressions[name] ?? BindingRegisteredUnderName(name);
         if (expression != null)
         {
             value = GetValue(expression)?.ClientObject;
@@ -1303,6 +1344,93 @@ internal sealed partial class RunnerPageInstance
 
         value = null;
         return false;
+    }
+
+    /// <summary>
+    /// The registered binding a PRECOMPILED page's declared identifier refers to — the join that
+    /// #3825 is about. Two lookups, because BC registers the two populations differently.
+    ///
+    /// <para>WHY A JOIN IS NEEDED AT ALL. A source-compiled page's declarations and its binding
+    /// table both come from the same emitted metadata, so the caller's key lookup hits. A
+    /// precompiled page states its declarations in <c>SymbolReference.json</c>, which carries the
+    /// identifier the AL author wrote (<c>Enabled = PageEditable</c>), while the table
+    /// <c>NavForm.RegisterSourceExpression</c> filled from the <c>.app</c>'s own IL is keyed by
+    /// the compiler's spelling. Both halves are in memory; only the join was missing.</para>
+    ///
+    /// <para>1. BY <c>Name</c>. A value-source binding registers
+    /// <c>(id: "Control159866013", name: "GLAccTotaling")</c> — the raw identifier IS the
+    /// <c>Name</c>, so it is read off the object rather than computed.</para>
+    ///
+    /// <para>2. BY THE MANGLED KEY, looked up and not derived. A property binding registers
+    /// <c>(id: "p790p790PageEditable", name: "p790p790PageEditable")</c> — <b>both arguments are
+    /// the mangled form and the raw identifier is nowhere on the object</b>, so step 1 cannot
+    /// reach it. This composes the candidate key and asks the table whether it EXISTS. The
+    /// distinction from re-implementing the compiler's mangling is the whole point: a wrong guess
+    /// misses and the caller refuses loudly, naming the expression, exactly as before — it can
+    /// never invent a binding or silently answer from the wrong one.</para>
+    ///
+    /// <para>Measured on Base Application 28.1.49838.53910, reading the shipped <c>.app</c>'s IL
+    /// with Cecil across all five of its assemblies (2,610 pages, 18,075 registered pairs):
+    /// every one of the <b>6,126</b> <c>p&lt;id&gt;p&lt;id&gt;</c> registrations has
+    /// <c>id == name</c> (0 counterexamples), and <b>no page registers a duplicate key</b>
+    /// (0 of 2,610), so a hit is unambiguous. The 6,126 independently reproduces the figure the
+    /// compile-route measurement on #3825 reached from BC's emitted documents.</para>
+    ///
+    /// <para>TRAP: do not "simplify" step 2 into deriving the key and using it without checking
+    /// that it exists. Existence is what keeps this a read of Microsoft's own registration
+    /// instead of a mangling rule this repository would then own across every BC version
+    /// (<c>precompiled-dll-respect.md</c> § "Reuse before you re-implement").</para>
+    ///
+    /// <para>Built once per page instance and cached, including the negative, because the table
+    /// is filled during construction and does not grow afterwards.</para>
+    /// </summary>
+    private object? BindingRegisteredUnderName(string name)
+    {
+        _bindingsByName ??= BuildBindingsByName(_sourceExpressions);
+        if (_bindingsByName.TryGetValue(name, out var byName)) return byName;
+
+        // The compiler-mangled spelling, looked UP rather than derived — see the remarks.
+        return _sourceExpressions[$"p{_pageId}p{_pageId}{name}"];
+    }
+
+    private Dictionary<string, object>? _bindingsByName;
+
+    internal static Dictionary<string, object> BuildBindingsByName(System.Collections.IDictionary expressions)
+    {
+        // Ordinal, matching the key lookup beside it: an AL identifier's case is fixed by the
+        // compiler on both sides of this join, and a case-insensitive match here would let two
+        // distinct globals differing only in case resolve to each other.
+        var byName = new Dictionary<string, object>(StringComparer.Ordinal);
+        foreach (System.Collections.DictionaryEntry entry in expressions)
+        {
+            if (entry.Value is not { } expression) continue;
+            string? name;
+            try
+            {
+                name = BcShape.Property(
+                    expression.GetType(), "Name", BcShape.AnyInstance,
+                    surface: "TestPage expression-bound property",
+                    detail: "the runner joins a precompiled page's declared identifier to the "
+                          + "binding BC registered under it")
+                    .GetValue(expression) as string;
+            }
+            catch (AlRunner.Infrastructure.BcShapeGapException)
+            {
+                // A binding whose shape the runner cannot read is left out of the index rather
+                // than costing the page every other binding: the caller's key lookup still
+                // works, and an identifier that needed this join refuses loudly, naming itself.
+                continue;
+            }
+
+            if (string.IsNullOrEmpty(name)) continue;
+            // First wins. Name is not unique per page even though the registered KEY is (measured:
+            // 0 duplicate keys across Base Application's 2,610 pages) - a global bound to two
+            // controls registers twice under one Name. Both entries' getters read the same page
+            // field, so either answers identically; this keeps the result a read rather than a
+            // reconciliation, and never throws on a shape that is normal.
+            if (!byName.ContainsKey(name)) byName[name] = expression;
+        }
+        return byName;
     }
 
     /// <summary>
@@ -2072,6 +2200,10 @@ internal sealed partial class RunnerPageInstance
         // all failed. The constructor still takes one, so a page whose OnOpenPage never runs
         // still has a snapshot rather than none.
         _expressionValuesAtOpen = SnapshotExpressionValues(_sourceExpressions);
+        // Dropped alongside the snapshot, for the same reason it is re-taken: anything that
+        // registered a binding between construction and here must be in the name index too, and
+        // a memoized index (including its negatives) would keep answering from before OnOpenPage.
+        _bindingsByName = null;
     }
 
     /// <summary>

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -65,7 +65,7 @@
         "testpage-lookup-tablerelation-oos": { "tests": 3 },
         "testpage-precompiled-declared-editable": { "tests": 9 },
         "testpage-precompiled-dep-control": { "tests": 2 },
-        "testpage-precompiled-member-names": { "tests": 8 },
+        "testpage-precompiled-member-names": { "tests": 12 },
         "testpage-promoted-actionref": { "tests": 18 },
         "testpage-procedure-bound-property": { "tests": 6 },
         "testpage-same-value-modify": { "tests": 6 },

--- a/tests/runner-extras/testpage-precompiled-member-names/PmnAssert.Codeunit.al
+++ b/tests/runner-extras/testpage-precompiled-member-names/PmnAssert.Codeunit.al
@@ -16,6 +16,18 @@ codeunit 64570 "PMN Assert"
             Error('Assert.AreEqual failed. Expected:<%1> Actual:<%2>. %3', Expected, Actual, Msg);
     end;
 
+    procedure IsTrue(Actual: Boolean; Msg: Text)
+    begin
+        if not Actual then
+            Error('Assert.IsTrue failed. Expected:<true> Actual:<false>. %1', Msg);
+    end;
+
+    procedure IsFalse(Actual: Boolean; Msg: Text)
+    begin
+        if Actual then
+            Error('Assert.IsFalse failed. Expected:<false> Actual:<true>. %1', Msg);
+    end;
+
     /// <summary>The last error text must CONTAIN Expected - a substring match, so a test
     /// can pin the meaningful part of a message that also carries a variable id.</summary>
     procedure ExpectedError(Expected: Text)

--- a/tests/runner-extras/testpage-precompiled-member-names/PmnTests.Codeunit.al
+++ b/tests/runner-extras/testpage-precompiled-member-names/PmnTests.Codeunit.al
@@ -20,6 +20,18 @@
 //                                                            three-entry RunPageLink resolved from
 //                                                            the symbol file, then applied
 //   - 31   "Item List", action "Item Substitutions"          (RunObject naming an AMBIGUOUS name)
+//
+// #3825 added four arms for an EXPRESSION-BOUND Editable/Visible/Enabled, which is a different
+// claim from trigger dispatch and shares these pages because they are the precompiled surface
+// already reachable here. A precompiled page states the property as the raw AL identifier
+// (`Enabled = PageEditable`) while the binding table its own .app IL fills is keyed by the
+// compiler's spelling (`p790p790PageEditable`), so the lookup missed and the read refused.
+// The arms cover both properties and both directions, so neither answer can be a default:
+//   - 790  "G/L Account Categories", five actions Enabled = PageEditable   -> true  (OpenEdit)
+//   - 9900 "Import Data", IncludeAllCompanies Editable = ContainsCompanies -> false (unset at open)
+//   - 1810 "Data Migration Entities", Selected Visible = not HideSelected  -> true  (COMPOUND)
+//        and Balance Visible = ShowBalance                                 -> false (same page)
+//   - 790  GetBalance Editable = false (literal)                           -> still false
 codeunit 64571 "PMN Precompiled Member Tests"
 {
     Subtype = Test;
@@ -137,6 +149,46 @@ codeunit 64571 "PMN Precompiled Member Tests"
             'action Indent declares Enabled = PageEditable, true on a page opened for edit');
         Assert.IsTrue(GLAccountCategories.Outdent.Enabled(),
             'action Outdent declares Enabled = PageEditable, true on a page opened for edit');
+    end;
+
+    [Test]
+    procedure ExpressionBoundEditable_OnPrecompiledBasePage_ReadsFalseWhenTheGlobalIsFalse()
+    var
+        ImportData: TestPage "Import Data";
+    begin
+        // [GIVEN] Base Application page 9900 "Import Data" opened. Its IncludeAllCompanies
+        // control declares `Editable = ContainsCompanies`, a page global that only
+        // OnAssistEdit/OnValidate assign - so at open it still holds Boolean's default.
+        ImportData.OpenEdit();
+
+        // [THEN] The control reads NOT editable. This is the arm that makes the pair prove
+        // something: the same mechanism answers true for page 790's actions above and false
+        // here, so it is reading the global rather than defaulting in either direction. It
+        // also covers Editable, where the arm above covers Enabled.
+        Assert.IsFalse(ImportData.IncludeAllCompanies.Editable(),
+            'IncludeAllCompanies declares Editable = ContainsCompanies, false before any company is loaded');
+    end;
+
+    [Test]
+    procedure CompoundExpressionVisible_OnPrecompiledBasePage_ResolvesItsOperands()
+    var
+        DataMigrationEntities: TestPage "Data Migration Entities";
+    begin
+        // [GIVEN] Base Application page 1810, whose OnOpenPage sets both of its globals
+        // false: `ShowBalance := false; HideSelected := false;`.
+        DataMigrationEntities.OpenView();
+
+        // [THEN] A COMPOUND property text resolves. `Visible = not HideSelected` reaches
+        // PageControlExpression, whose identifier resolution is the same join - so the
+        // operand resolves and `not false` evaluates to true. This is the arm showing the
+        // fix is not limited to a property that is one bare name.
+        Assert.IsTrue(DataMigrationEntities.Selected.Visible(),
+            'Selected declares Visible = not HideSelected, and OnOpenPage sets HideSelected false');
+
+        // [AND] the bare-name sibling on the same page answers the other way, from the same
+        // mechanism - so neither direction is a default.
+        Assert.IsFalse(DataMigrationEntities.Balance.Visible(),
+            'Balance declares Visible = ShowBalance, and OnOpenPage sets ShowBalance false');
     end;
 
     [Test]

--- a/tests/runner-extras/testpage-precompiled-member-names/PmnTests.Codeunit.al
+++ b/tests/runner-extras/testpage-precompiled-member-names/PmnTests.Codeunit.al
@@ -114,6 +114,47 @@ codeunit 64571 "PMN Precompiled Member Tests"
     end;
 
     [Test]
+    procedure ExpressionBoundEnabled_OnPrecompiledBasePage_ReadsTrueWhenTheGlobalIsTrue()
+    var
+        GLAccountCategories: TestPage "G/L Account Categories";
+    begin
+        // [GIVEN] Page 790 opened for EDIT. Its OnOpenPage assigns
+        // `PageEditable := CurrPage.Editable`, which is true on an editable page.
+        GLAccountCategories.OpenEdit();
+
+        // [THEN] Every one of the five actions declaring `Enabled = PageEditable` READS
+        // true. Reading Enabled() is the arm that refused before #3825: the declared value
+        // arrives from the symbol file as the raw AL identifier 'PageEditable' while the
+        // live binding table is keyed 'p790p790PageEditable', so the lookup missed and the
+        // runner raised RunnerOutOfScopeException rather than answering.
+        Assert.IsTrue(GLAccountCategories.New.Enabled(),
+            'action New declares Enabled = PageEditable, true on a page opened for edit');
+        Assert.IsTrue(GLAccountCategories.MoveUp.Enabled(),
+            'action MoveUp declares Enabled = PageEditable, true on a page opened for edit');
+        Assert.IsTrue(GLAccountCategories.MoveDown.Enabled(),
+            'action MoveDown declares Enabled = PageEditable, true on a page opened for edit');
+        Assert.IsTrue(GLAccountCategories.Indent.Enabled(),
+            'action Indent declares Enabled = PageEditable, true on a page opened for edit');
+        Assert.IsTrue(GLAccountCategories.Outdent.Enabled(),
+            'action Outdent declares Enabled = PageEditable, true on a page opened for edit');
+    end;
+
+    [Test]
+    procedure ExpressionBoundEnabled_OnPrecompiledBasePage_DoesNotMakeALiteralFalseAnswerTrue()
+    var
+        GLAccountCategories: TestPage "G/L Account Categories";
+    begin
+        // [GIVEN] The same page, whose GetBalance control declares a literal Editable = false.
+        GLAccountCategories.OpenEdit();
+
+        // [THEN] The join did not make everything answer true. A control the page declares
+        // non-editable still reports false, so the fix added a resolution rather than a
+        // blanket default - the failure mode #3819's removed name-join actually had.
+        Assert.IsFalse(GLAccountCategories.GetBalance.Editable(),
+            'the GetBalance control declares Editable = false and must still report false');
+    end;
+
+    [Test]
     procedure SpacedControlName_OnPrecompiledBasePage_RunsItsPageOnValidate()
     var
         PermissionSetAssignments: TestPage "Permission Set Assignments";


### PR DESCRIPTION
Closes #3825

Corpus-NA: the claim is about the PRECOMPILED-dependency path. A corpus page compiles from source and takes the source-parsed branch, so the condition cannot be constructed upstream — the same reason recorded in tests/runner-extras/testpage-precompiled-declared-editable/README.md.

## The issue's premise was wrong, and the fix is far smaller than it asked for

The issue says the `Name`/`SourceExpression` pair is **absent** for a precompiled page, and concludes that only a 257 s / 8.83 GiB Base Application compile can supply it. Before building that consumer I measured whether the pair is really unrecoverable.

**It is already in the process's memory at the moment of the failing lookup.**

Instrumenting `EvaluateProperty` and running the issue's own failing case (BC 28.1.49838.53910):

```
[DIAG-SRCEXPR] page 790 element 1511775225 Enabled raw='PageEditable' dictCount=7
  keys=[p790p790PageEditable, Control92721813_DynamicCaption, Control194347254_DynamicCaption,
        Control159866013, Control1353499353_DynamicCaption, Control1520916075,
        Control1520916075_Format]
```

`NavForm.SourceExpressions` holds seven live entries **including the one being looked for**. The registration IL already runs for a precompiled page — `RunnerFormInit.ShouldRegisterSourceExpressions` is as wide as `ShouldResolveMasterPage`, which admits one through `HasDependencyPageMetadata`. The two sides simply spell the binding differently:

| side | value |
|---|---|
| what `SymbolReference.json` declares (`raw`) | `PageEditable` |
| what the live table is keyed by | `p790p790PageEditable` |

So the missing piece was the **join**, not the data. No compile, no cached artifact, no cost model.

## What the `.app` actually ships

Reading Base Application 28.1.49838.53910's five R2R assemblies with Cecil — no compile — the `(id, name)` pairs passed to `RegisterSourceExpression` are all present:

| | |
|---|---|
| pages | 2,610 |
| pages registering bindings | 1,847 |
| **registered pairs** | **18,075** |
| `p<id>p<id>*` | **6,126** |
| `Control<hash>*` | 11,595 |
| other | 354 |

The **6,126** independently reproduces the figure the compile-route measurement on #3825 reached from BC's emitted documents — two routes, same number.

## The join is two arms, because BC registers two populations differently

This is the part I got wrong on the first attempt, and the mutation is what caught it. Page 790's IL:

```
RegisterSourceExpression("p790p790PageEditable" , "p790p790PageEditable")
RegisterSourceExpression("Control159866013"     , "GLAccTotaling")
RegisterSourceExpression("Control1520916075"    , "Rec.GetBalance()")
```

- **A value-source binding carries the raw identifier in `Name`** — read off the object.
- **A property binding registers the mangled spelling as BOTH arguments.** The raw identifier is nowhere on the object, so a `Name` index alone cannot reach it. My first implementation was exactly that, and it resolved `GLAccTotaling` while still refusing `PageEditable`.

So the second arm composes the candidate key and asks the table whether it **exists**. Measured: all **6,126** `p<id>p<id>` registrations have `id == name` (0 counterexamples), and **no page registers a duplicate key** (0 of 2,610), so a hit is unambiguous.

**Why that is not re-implementing the mangling the owner rejected.** It never derives a value, only a candidate, and requires Microsoft's own registration to contain it. A wrong guess resolves nothing and the caller refuses loudly exactly as before — it cannot invent a binding or answer from the wrong one. That property is pinned by the negative arms, not just asserted.

## RED -> GREEN, with the mutation

**AL (`tests/runner-extras/testpage-precompiled-member-names`, BC 28.1.49838.53910)**

RED, before the fix — `Failed: 2, Passed: 0`, failing with the issue's own message:

```
the property is bound to expression 'PageEditable', which cannot be evaluated:
'PageEditable' is not a name the page publishes a binding for
```

GREEN, full suite — `pass: 12, fail: 0, error: 0`.

Four new arms, covering two properties and both directions so neither answer can be a default:

| page | declaration | expected |
|---|---|---|
| 790 five actions | `Enabled = PageEditable` (set from `CurrPage.Editable`) | **true** |
| 9900 `IncludeAllCompanies` | `Editable = ContainsCompanies` (unset at open) | **false** |
| 1810 `Selected` | `Visible = not HideSelected` — **compound** | **true** |
| 1810 `Balance` | `Visible = ShowBalance`, same page | **false** |
| 790 `GetBalance` | `Editable = false` literal | **still false** |

**Which suite proves which arm — they do NOT overlap, and the mutations show it.**

| arm | proved by | mutated | result |
|---|---|---|---|
| 2 — mangled-candidate lookup | the **AL** suite | `return _sourceExpressions[$"p{_pageId}p{_pageId}{name}"];` -> `return null;` (confirmed present at line 1401, clean rebuild) | `Failed: 0, Passed: 12` -> **`Failed: 3, Passed: 9`**, restored -> `Failed: 0, Passed: 12` |
| 1 — `Name` index | the **C#** tests | `if (!byName.ContainsKey(name))` -> `if (false)` (confirmed present at line 1431) | `Total: 5, Failed: 0, Passed: 5` -> **`Failed: 4, Passed: 1`**, restored -> `Failed: 0, Passed: 5` |

The three AL tests that go red under the arm-2 mutation are exactly `ExpressionBoundEnabled_...ReadsTrueWhenTheGlobalIsTrue`, `ExpressionBoundEditable_...ReadsFalseWhenTheGlobalIsFalse` and `CompoundExpressionVisible_...ResolvesItsOperands`. The one C# survivor under the arm-1 mutation is the empty-table case, which correctly does not depend on insertion.

**Stated plainly because a reviewer will check it: `ExpressionBindingNameJoinTests` covers arm 1 only.** Mutating arm 2 leaves all five of those tests green — `BindingRegisteredUnderName` is a private instance method needing a live `NavForm`, so the C# tests reach `BuildBindingsByName` and not the composed-key lookup. **The AL suite is the only thing that proves arm 2**, which is why the arm-2 mutation was run against the AL suite rather than the C# one. Neither suite alone covers the fix.

## The compound-expression caveat on the issue is already closed

The issue records **1,942 compound property values (1.1%)** as a distinct population "needing an evaluator, not lookup", to be scoped separately. That evaluator already exists: `PageControlExpression` is a full AL client-expression parser (AL precedence, `not`/`and`/`or`, comparisons, quoted identifiers), and its identifier resolution goes through the same `Resolve` callback this fix repairs. So compound values built from resolvable operands resolve too — `1810 Selected` above is the proving arm. No separate issue is needed.

Declared-property population in Base Application 28.1, from the symbol file:

| | declared | literal | bare identifier | compound |
|---|---|---|---|---|
| action `Enabled` | 1,129 | 13 | 625 | 491 |
| control `Editable` | 6,228 | 5,179 | 695 | 354 |
| control `Visible` | 14,771 | 10,283 | 3,888 | 600 |

## The BC-internals ratchet: 90 -> 92

`BcInternalsNullForgivingGuardTests.TheConvertedSites_AreStillConverted` counts sites reading a BC-internal member through the shape-checked helper. This adds **2** — the `Id` and `Name` reads on a registered source expression — so the ratchet moves in the direction it exists to encourage.

**Why these two are shape-checked rather than `?.`.** A null from either has to mean *"BC no longer exposes this member"*, which is a shape gap that must refuse. Read through bare reflection it would instead degrade the join to *"this expression does not match"* — which is exactly this issue's original symptom, the silent non-match that left every expression-bound property on a precompiled page unresolvable. At the call site those two are indistinguishable, so the helper is what keeps them apart. The enclosing `BcShapeGapException` catch still drops one unreadable binding from the index rather than costing the page every other one; what changed is that the gap is named.

**Verified rather than assumed**, in three steps:

- the count reproduced locally before the edit — `Expected: 90, Actual: 92`, `Failed: 1, Passed: 4, Total: 5`;
- **the prose does not inflate it**: `CountConverted` is a raw substring count and the file records that trap, so I checked — 0 occurrences of the literal `BcShape.Property(` in my added comment (the only `BcShape` token there is `BcShapeGapException`, which does not match);
- **the ratchet still ratchets**: removing one converted site takes converted **92 -> 91** *and* raises the unconverted counter **66 -> 67**, so both halves of the population catch a regression. Restored: `Total: 5, Failed: 0, Passed: 5`.

## Count baseline

`tests/expectations/count-baseline/test-count-baseline.json`: `runner-extras` / `testpage-precompiled-member-names` **8 -> 12**, for the four arms added here. BC 27.0 was red on exit **4** (a count mismatch, not a test failure): `GROWTH: expected 417, actual 421`.

Confirmed three ways rather than by counting `[Test]` attributes alone — the run summary's `Tests: 12 total`, 12 distinct `PASS` lines, and 12 `[Test]` attributes all agree. The arithmetic closes on the leg that failed: the file's 73 groups sum to 432, of which 11 tests carry `absentOn: ["27.0","27.3","27.5"]`, giving **421** on 27.0 — exactly the "actual" reported, against a pre-bump sum of 417.

One number to change: these entries are a single global `tests` count, and per-version variation is expressed as `absentOn`, not as per-version counts. (The comment at `.github/workflows/bc-tests.yml:830` says this file "carries a per-BC-version expected count ... not a single global value" — that is stale; no group in the file has per-version counts. Not corrected here, to keep this diff to the fix.)

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** No. The other four `_sourceExpressions[...]` reads (`TryGetSourceExpression` x3, `TryGetControlFormat`) key by **control id**, a different question that already has its own three-step fallback including a precompiled arm. Only the two identifier-keyed reads had the defect, and both are fixed.
2. **Sibling function making the same assumption?** Yes, and it is fixed: the at-open snapshot `_expressionValuesAtOpen` is keyed by the registered key, so a control's own `Visible` on a precompiled page would have missed and silently fallen through to the **live** value, losing the frozen-at-open semantics. `TryFrozenValue` now resolves both spellings.
3. **Two paths writing the same state with different invariants?** The snapshot is re-taken after `OnOpenPage`; the name index is now invalidated at the same point, so a memoized index (including its negatives) cannot answer from before the trigger ran.

## What I deliberately did NOT do

- **`ActionEnabledForInvoke` stays.** The issue asks for it to be deleted once the unresolvable case is gone. It is not gone: a client expression the compiler **dropped** (a procedure call, AL0573) and a name the page publishes no binding for still refuse. Collapsing it would turn "one property is unreadable" into "this action's OnAction never runs" — the strictly larger loss it exists to prevent. Its doc comment now records that, and what would justify deleting it.
- **#3875 / #3876 are no longer prerequisites for this issue.** They keep their value for #3562's wider programme; this route does not need them.
- **No issue folded in.** #2596 and #3824 land in this file but are both `status: blocked`, and #2596 carries a foreign `agent: impl-1` label. #3824 needs the containment hierarchy, which this join does not supply, so it stays genuinely distinct.

## Test scope

- AL suite `testpage-precompiled-member-names`: `pass: 12, fail: 0`.
- `testpage-precompiled-declared-editable`: `pass: 9, fail: 0` — including both `*_RefusesLoudlyRatherThanGuessing` arms, so the refusal is still loud where nothing publishes a binding.
- `testpage-precompiled-dep-control`: `pass: 2, fail: 0`.
- Filtered `AlRunner.Tests` over the changed surface, run through `tools/engine-test-bootstrap.sh` with `--no-build --settings`: `Total: 545, Failed: 1, Passed: 544`.

**That one failure is pre-existing and unrelated** — `TestPageTemporalValueTests.TryResolve_RoundTripSpelling_ForADateTimeControl_KeepsTheTimeOfDay`, expecting `14:30:00` and getting `13:30:00`, a one-hour DST offset. Verified by running it on an unmodified `origin/main` worktree under the same bootstrapped engine: `Failed: 1, Passed: 17` there too. My diff touches no temporal code.

Without the bootstrap the same filter reports 16 failures, all `< 1 ms`; 15 of those are the pristine-`Ncl.dll` trap the bootstrap exists to remove, not results.

---

Implemented by the agent `stma-auto-11`, not by a person. Session `861252a6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
