### PR TITLE
feat(provisioning): content-verify the service-tier and platform-apps entry guards

### DIFF
--- a/AlRunner.Tests/EngineClosureSharingTests.cs
+++ b/AlRunner.Tests/EngineClosureSharingTests.cs
@@ -1,0 +1,193 @@
+// EngineClosureSharingTests — issue #3893.
+//
+// #3889 built ArtifactDirState, a four-way classification of a BC artifact directory over the
+// engine closure. It shipped with NO non-test consumer: three entry points still opened a
+// broken directory and failed deep, and tools/preflight.py re-implemented the closure list in
+// Python rather than calling the C# definition.
+//
+// The hard part was never the predicate — it was reach. ProvisioningCheck is 1,997 lines whose
+// closure pulls AppLoader, SafeDirectoryScan and BcArtifacts, and tools/metadata-ground-truth
+// is deliberately outside AlRunner.slnx (its own header: a reference "would put a compile of a
+// Microsoft app on every dotnet build"). So the tool could not ask the question and opened the
+// directory regardless. EngineClosure.cs exists to be linkable: System.IO and nothing else.
+//
+// These tests pin the two properties that keep it that way — the tool still links it, and the
+// runner still routes through it rather than keeping a second copy of the list.
+
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class EngineClosureSharingTests : IDisposable
+{
+    private readonly string _dir;
+
+    public EngineClosureSharingTests()
+    {
+        _dir = TestScratch.Dir("al-runner-engine-closure");
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    private static string RepoRoot()
+    {
+        var d = AppContext.BaseDirectory;
+        while (d != null && !File.Exists(Path.Combine(d, "AlRunner.slnx")))
+            d = Path.GetDirectoryName(d);
+        Assert.NotNull(d);
+        return d!;
+    }
+
+    private void WriteCompleteClosure()
+    {
+        foreach (var f in EngineClosure.CoreEngineDlls)
+            File.WriteAllText(Path.Combine(_dir, f), "x");
+        File.WriteAllText(Path.Combine(_dir, EngineClosure.ClosureSentinel), "x");
+    }
+
+    // ── the #3878 shape, which is the reason a DLL count is not the predicate ────────────
+
+    /// <summary>
+    /// 27.5.46862.48827's exact shape: it carries Ncl.dll (and 81 other DLLs) and is short
+    /// exactly the closure sentinel. Every "is this a service-tier directory" check — the
+    /// glob the provision entry guard used, the Ncl.dll probe a consumer would write — passes
+    /// on it, which is why the failure used to move to an assembly load instead of the
+    /// surface.
+    /// </summary>
+    [Fact]
+    public void CarriesNclButNotTheSentinel_IsIncomplete_AndNamesTheSentinel()
+    {
+        foreach (var f in EngineClosure.CoreEngineDlls)
+            File.WriteAllText(Path.Combine(_dir, f), "x");
+
+        var missing = EngineClosure.MissingFiles(_dir);
+
+        Assert.False(EngineClosure.IsComplete(_dir));
+        Assert.Equal(new[] { EngineClosure.ClosureSentinel }, missing);
+        // The checks that pass on this directory — the defect, asserted directly.
+        Assert.True(File.Exists(Path.Combine(_dir, "Microsoft.Dynamics.Nav.Ncl.dll")));
+        Assert.True(Directory.EnumerateFiles(_dir, "*.dll").Any());
+    }
+
+    [Fact]
+    public void CompleteClosure_IsComplete_AndNothingIsMissing()
+    {
+        WriteCompleteClosure();
+
+        Assert.True(EngineClosure.IsComplete(_dir));
+        Assert.Empty(EngineClosure.MissingFiles(_dir));
+    }
+
+    /// <summary>
+    /// 28.0.46665.54452's shape — zero engine DLLs, a platform-apps payload only (#2226's
+    /// split build). All six required files are named, not just the first.
+    /// </summary>
+    [Fact]
+    public void EmptyDirectory_ReportsEverySixRequiredFile()
+    {
+        var missing = EngineClosure.MissingFiles(_dir);
+
+        Assert.Equal(EngineClosure.CoreEngineDlls.Length + 1, missing.Count);
+        Assert.Contains(EngineClosure.ClosureSentinel, missing);
+        foreach (var f in EngineClosure.CoreEngineDlls) Assert.Contains(f, missing);
+    }
+
+    [Fact]
+    public void MissingDirectory_ReportsEverySixRequiredFile_RatherThanThrowing()
+    {
+        var gone = Path.Combine(_dir, "nope");
+
+        var missing = EngineClosure.MissingFiles(gone);
+
+        Assert.Equal(EngineClosure.CoreEngineDlls.Length + 1, missing.Count);
+        Assert.False(EngineClosure.IsComplete(gone));
+    }
+
+    // ── the reach properties #3893 is actually about ─────────────────────────────────────
+
+    /// <summary>
+    /// The gap #3893 reports, as a test: tools/metadata-ground-truth must be able to ask the
+    /// question. It cannot take a ProjectReference on AlRunner (its own csproj header says
+    /// why), so it links this one file. Deleting the link restores the fail-deep-inside-
+    /// Assembly.Load behaviour with nothing failing, which is exactly how #3889 shipped with
+    /// no consumer at all.
+    /// </summary>
+    [Fact]
+    public void MetadataGroundTruth_LinksEngineClosure_AndTakesNoProjectReferenceOnAlRunner()
+    {
+        var csproj = Path.Combine(RepoRoot(), "tools", "metadata-ground-truth",
+            "MetadataGroundTruth.csproj");
+        Assert.True(File.Exists(csproj), csproj);
+        var text = File.ReadAllText(csproj);
+
+        Assert.Contains("EngineClosure.cs", text);
+        // The constraint that made a link necessary rather than a reference. Matched as the
+        // XML ELEMENT, not the bare word — the csproj comment above the link explains why a
+        // reference is wrong and therefore contains the word itself.
+        Assert.DoesNotContain("<ProjectReference", text);
+    }
+
+    /// <summary>
+    /// The tool's entry point must consult the closure before BcHost.Install opens anything.
+    /// Ordering is the whole claim: a check after the install measures a process that has
+    /// already failed.
+    /// </summary>
+    [Fact]
+    public void MetadataGroundTruth_ChecksTheClosure_BeforeInstallingTheBcHost()
+    {
+        var program = Path.Combine(RepoRoot(), "tools", "metadata-ground-truth", "Program.cs");
+        var text = File.ReadAllText(program);
+
+        var check = text.IndexOf("EngineClosure.MissingFiles", StringComparison.Ordinal);
+        var install = text.IndexOf("BcHost.Install", StringComparison.Ordinal);
+
+        Assert.True(check >= 0, "tools/metadata-ground-truth must consult EngineClosure (#3893)");
+        Assert.True(install >= 0);
+        Assert.True(check < install,
+            $"the closure check (index {check}) must precede BcHost.Install (index {install}) — "
+            + "a check after the install measures a process that has already failed");
+    }
+
+    /// <summary>
+    /// ProvisioningCheck.Check must route through EngineClosure rather than keep a second
+    /// copy of the list. Two copies is the state #3893 reports one level up (preflight.py's
+    /// Python re-implementation): they agree until one is edited, and nothing says which.
+    /// Asserted behaviourally — the two must agree on a directory short exactly one file.
+    /// </summary>
+    [Fact]
+    public void ProvisioningCheckAndEngineClosure_AgreeOnTheSameDirectory()
+    {
+        foreach (var f in EngineClosure.CoreEngineDlls)
+            File.WriteAllText(Path.Combine(_dir, f), "x");
+
+        var report = ProvisioningCheck.Check("28.1.49838.53910", _dir);
+
+        Assert.False(report.Ok);
+        Assert.Equal(EngineClosure.MissingFiles(_dir), report.MissingFiles);
+
+        WriteCompleteClosure();
+        Assert.True(ProvisioningCheck.Check("28.1.49838.53910", _dir).Ok);
+        Assert.True(EngineClosure.IsComplete(_dir));
+    }
+
+    /// <summary>
+    /// ArtifactDirState — #3889's classifier, and the predicate the provision entry guard now
+    /// uses — must agree with EngineClosure, since it delegates through ProvisioningCheck.
+    /// </summary>
+    [Fact]
+    public void ArtifactDirState_AgreesWithEngineClosure_OnBothDirections()
+    {
+        Assert.False(ArtifactDirState.Classify(_dir).IsUsable);
+        Assert.False(EngineClosure.IsComplete(_dir));
+
+        WriteCompleteClosure();
+
+        Assert.True(ArtifactDirState.Classify(_dir).IsUsable);
+        Assert.True(EngineClosure.IsComplete(_dir));
+    }
+}

--- a/AlRunner.Tests/PlatformAppsEntryGuardTests.cs
+++ b/AlRunner.Tests/PlatformAppsEntryGuardTests.cs
@@ -1,0 +1,343 @@
+// PlatformAppsEntryGuardTests — issue #2661.
+//
+// `provision --platform-apps` and `--service-tier` kept the pre-#2558 entry guard: "does at
+// least one file matching a glob exist in the canonical directory". #2558 replaced exactly
+// that shape for `--test-apps` with a real manifest parse; these two modes were left behind
+// because, as the issue says, they "have no equivalent ready-made predicate".
+//
+// Both predicates now exist, and they are DIFFERENT questions — the measurement that decided
+// it is in the PR body and docs/provisioning.md#platform-apps-completeness. On the reporting
+// box, one artifact directory holds a complete 501-DLL engine closure AND a platform-apps
+// directory containing exactly one file, System.app:
+//
+//   28.1.49838.53910   dlls=501  ncl=Y  platform-apps=1   <- complete engine, short apps
+//   28.0.46665.54452   dlls=0    ncl=n  platform-apps=6   <- no engine, complete apps
+//
+// So ArtifactDirState (the engine closure) cannot answer for the platform-app half, and
+// PlatformAppsComplete is its sibling rather than a reuse of it.
+//
+// Fake .app writer rather than a network download: ProvisionExplicitModesTests covers the
+// real end-to-end path against the CDN. This is what lets the false-green shape be proven
+// deterministically.
+
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PlatformAppsEntryGuardTests : IDisposable
+{
+    private readonly string _dir;
+
+    public PlatformAppsEntryGuardTests()
+    {
+        _dir = TestScratch.Dir("al-runner-platform-apps-guard");
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    private static byte[] MakeMinimalNavxApp(string appId, string name, string publisher, string version)
+    {
+        var xml = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+              <App Id="{appId}" Name="{name}" Publisher="{publisher}" Version="{version}"/>
+            </Package>
+            """;
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = zip.CreateEntry("NavxManifest.xml");
+            using var es = entry.Open();
+            es.Write(Encoding.UTF8.GetBytes(xml));
+        }
+        var zipBytes = ms.ToArray();
+        var result = new byte[8 + zipBytes.Length];
+        result[0] = (byte)'N'; result[1] = (byte)'A'; result[2] = (byte)'V'; result[3] = (byte)'X';
+        BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
+        zipBytes.CopyTo(result, 8);
+        return result;
+    }
+
+    private void WriteApp(string name, string publisher = "Microsoft", string version = "28.1.49838.53910")
+        => File.WriteAllBytes(
+            Path.Combine(_dir, $"{publisher}_{name}_{version}.app"),
+            MakeMinimalNavxApp(Guid.NewGuid().ToString(), name, publisher, version));
+
+    private void WriteCompleteW1Set()
+    {
+        foreach (var n in ProvisioningCheck.W1PlatformAppNames) WriteApp(n);
+    }
+
+    // ── the reported false green ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The exact on-disk shape #2661 reports, taken from a real directory rather than
+    /// invented: 28.1.49838.53910/platform-apps holds one file, System.app, and nothing
+    /// else. The old glob ("does any *.app exist") accepts it as a complete provision
+    /// forever, so a re-run never re-attempts the download.
+    /// </summary>
+    [Fact]
+    public void OnlySystemAppPresent_IsNotComplete_AndNamesEveryMissingApp()
+    {
+        // System.app carries no NavxManifest at all — it is the platform symbol package,
+        // not one of the five core apps. That is why the glob and a manifest parse disagree.
+        File.WriteAllText(Path.Combine(_dir, "System.app"), "not a real NAVX package");
+
+        var verdict = ProvisioningCheck.PlatformAppsComplete(_dir, "w1", out var missing);
+
+        Assert.False(verdict);
+        // The old predicate's answer, asserted directly so the two are visibly different:
+        Assert.True(Directory.EnumerateFiles(_dir, "*.app").Any(),
+            "the glob the entry guard used to apply must still match — that IS the defect");
+        Assert.Equal(ProvisioningCheck.W1PlatformAppNames.OrderBy(x => x),
+                     missing.OrderBy(x => x));
+        Assert.False(ProvisioningCheck.PlatformAppsPresent(_dir, "w1"));
+    }
+
+    /// <summary>
+    /// The complete w1 core set is accepted — the guard must not force a re-download of a
+    /// directory that is genuinely provisioned, which is the failure mode a fix that simply
+    /// hard-errors would introduce.
+    /// </summary>
+    [Fact]
+    public void CompleteW1Set_IsComplete_AndNothingIsMissing()
+    {
+        WriteCompleteW1Set();
+
+        var verdict = ProvisioningCheck.PlatformAppsComplete(_dir, "w1", out var missing);
+
+        Assert.True(verdict);
+        Assert.Empty(missing);
+        Assert.True(ProvisioningCheck.PlatformAppsPresent(_dir, "w1"));
+    }
+
+    /// <summary>
+    /// One app short is short. Asserts the specific absent name, not merely "false" — a
+    /// predicate that answered false for everything would pass a bare assertion here.
+    /// </summary>
+    [Fact]
+    public void OneCoreAppMissing_IsNotComplete_AndNamesExactlyThatApp()
+    {
+        foreach (var n in ProvisioningCheck.W1PlatformAppNames)
+            if (n != "Business Foundation") WriteApp(n);
+
+        var verdict = ProvisioningCheck.PlatformAppsComplete(_dir, "w1", out var missing);
+
+        Assert.False(verdict);
+        Assert.Equal(new[] { "Business Foundation" }, missing);
+    }
+
+    /// <summary>
+    /// Publisher is load-bearing: a third party shipping an app called "Base Application"
+    /// does not provision Microsoft's. Mirrors TestToolkitPresent's own publisher filter.
+    /// </summary>
+    [Fact]
+    public void NonMicrosoftAppsOfTheRightNames_DoNotCount()
+    {
+        foreach (var n in ProvisioningCheck.W1PlatformAppNames) WriteApp(n, publisher: "Contoso");
+
+        var verdict = ProvisioningCheck.PlatformAppsComplete(_dir, "w1", out var missing);
+
+        Assert.False(verdict);
+        Assert.Equal(ProvisioningCheck.W1PlatformAppNames.Length, missing.Count);
+    }
+
+    [Fact]
+    public void MissingDirectory_IsNotComplete_AndNamesTheWholeSet()
+    {
+        var gone = Path.Combine(_dir, "does-not-exist");
+
+        var verdict = ProvisioningCheck.PlatformAppsComplete(gone, "w1", out var missing);
+
+        Assert.False(verdict);
+        Assert.Equal(ProvisioningCheck.W1PlatformAppNames.Length, missing.Count);
+        Assert.False(ProvisioningCheck.PlatformAppsPresent(gone, "w1"));
+    }
+
+    // ── the third state ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// guards-need-a-third-state.md: a country channel has no curated set to compare
+    /// against — ArtifactDownloader.IsWantedPlatformAppEntry takes EVERY Microsoft-published
+    /// app a country artifact ships, deliberately, so nothing enumerates what "complete"
+    /// means there. The predicate says "could not measure" rather than guessing, and both
+    /// guesses would be wrong in a different direction: false re-downloads a complete set on
+    /// every run, true restores the glob's false green as a measured-looking answer.
+    /// </summary>
+    [Fact]
+    public void CountryChannel_IsUnmeasurable_ReturnsNull_NotAVerdict()
+    {
+        WriteCompleteW1Set();
+
+        Assert.Null(ProvisioningCheck.PlatformAppsComplete(_dir, "us", out _));
+        Assert.Null(ProvisioningCheck.PlatformAppsComplete(_dir, "de", out _));
+        // ...and w1 on the same directory IS measurable, so null is about the channel and
+        // not about the directory being unreadable.
+        Assert.True(ProvisioningCheck.PlatformAppsComplete(_dir, "w1", out _));
+    }
+
+    /// <summary>
+    /// The unmeasurable case falls back to the pre-#2661 glob rather than to a verdict:
+    /// that is the honest answer for a country channel, and it must still discriminate an
+    /// empty directory from a populated one.
+    /// </summary>
+    [Fact]
+    public void CountryChannel_FallsBackToTheGlob_WhichStillSeparatesEmptyFromPopulated()
+    {
+        Assert.False(ProvisioningCheck.PlatformAppsPresent(_dir, "us"));
+
+        File.WriteAllText(Path.Combine(_dir, "anything.app"), "x");
+
+        Assert.True(ProvisioningCheck.PlatformAppsPresent(_dir, "us"));
+    }
+
+    // ── the entry guard actually uses it ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// ForceProvisionMode is the shared helper both modes route through. Wired with the new
+    /// predicate, a directory holding only System.app must NOT short-circuit — the download
+    /// has to run. This is the end #2661 reports: "the entry-guard precision" is all that was
+    /// left, the post-download re-check having already been generalized by #2558.
+    /// </summary>
+    [Fact]
+    public void EntryGuard_OnlySystemApp_DoesNotShortCircuit_RunsTheDownload()
+    {
+        File.WriteAllText(Path.Combine(_dir, "System.app"), "not a real NAVX package");
+        var downloadCalled = false;
+
+        var rc = ProgramSupport.ForceProvisionMode(
+            "Microsoft platform apps", _dir, "28.1.49838.53910", force: false,
+            isPresent: d => ProvisioningCheck.PlatformAppsPresent(d, "w1"),
+            download: (v, d, log) =>
+            {
+                downloadCalled = true;
+                foreach (var n in ProvisioningCheck.W1PlatformAppNames) WriteApp(n);
+                return 0;
+            });
+
+        Assert.Equal(0, rc);
+        Assert.True(downloadCalled,
+            "a directory holding only System.app must not read as a complete provision (#2661)");
+    }
+
+    /// <summary>
+    /// The inverse, so the guard is not simply "always download": a genuinely complete set
+    /// short-circuits and the download never runs.
+    /// </summary>
+    [Fact]
+    public void EntryGuard_CompleteSet_ShortCircuits_NeverCallsDownload()
+    {
+        WriteCompleteW1Set();
+        var downloadCalled = false;
+
+        var rc = ProgramSupport.ForceProvisionMode(
+            "Microsoft platform apps", _dir, "28.1.49838.53910", force: false,
+            isPresent: d => ProvisioningCheck.PlatformAppsPresent(d, "w1"),
+            download: (v, d, log) => { downloadCalled = true; return 0; });
+
+        Assert.Equal(0, rc);
+        Assert.False(downloadCalled, "a complete set must not be re-downloaded");
+    }
+
+    /// <summary>
+    /// #2558's post-download re-check, now biting for platform apps too: a download that
+    /// reports rc == 0 without landing the core set must fail loudly rather than exit 0 over
+    /// a short directory. Under the old glob this passed, because the partial download left
+    /// one .app behind.
+    /// </summary>
+    [Fact]
+    public void EntryGuard_DownloadReportsSuccessButLandsAShortSet_Fails()
+    {
+        var rc = ProgramSupport.ForceProvisionMode(
+            "Microsoft platform apps", _dir, "28.1.49838.53910", force: false,
+            isPresent: d => ProvisioningCheck.PlatformAppsPresent(d, "w1"),
+            download: (v, d, log) =>
+            {
+                WriteApp("Base Application"); // one of five: a partial extraction
+                return 0;
+            });
+
+        Assert.NotEqual(0, rc);
+        // ...and the old glob would have accepted it, which is why rc used to be 0.
+        Assert.True(Directory.EnumerateFiles(_dir, "*.app").Any());
+    }
+
+    /// <summary>
+    /// The service-tier branch of the same helper, wired to ArtifactDirState (#2661's other
+    /// half). A directory carrying Ncl.dll but short the closure sentinel — 27.5.46862.48827's
+    /// exact shape — must not short-circuit, though the old `any *.dll exists` glob accepts it.
+    /// </summary>
+    [Fact]
+    public void EntryGuard_ServiceTier_NclPresentButClosureShort_DoesNotShortCircuit()
+    {
+        foreach (var f in EngineClosure.CoreEngineDlls)
+            File.WriteAllText(Path.Combine(_dir, f), "x");
+        var downloadCalled = false;
+
+        var rc = ProgramSupport.ForceProvisionMode(
+            "BC service-tier engine DLLs", _dir, "27.5.46862.48827", force: false,
+            isPresent: d => ArtifactDirState.Classify(d).IsUsable,
+            download: (v, d, log) =>
+            {
+                downloadCalled = true;
+                File.WriteAllText(Path.Combine(d, EngineClosure.ClosureSentinel), "x");
+                return 0;
+            });
+
+        Assert.Equal(0, rc);
+        Assert.True(downloadCalled,
+            "82 DLLs incl. Ncl.dll but no closure sentinel is not a usable service tier (#3878)");
+        // The old predicate's answer, so the two are visibly different.
+        Assert.True(Directory.EnumerateFiles(_dir, "*.dll").Any());
+    }
+
+    [Fact]
+    public void EntryGuard_ServiceTier_CompleteClosure_ShortCircuits_NeverCallsDownload()
+    {
+        foreach (var f in EngineClosure.CoreEngineDlls)
+            File.WriteAllText(Path.Combine(_dir, f), "x");
+        File.WriteAllText(Path.Combine(_dir, EngineClosure.ClosureSentinel), "x");
+        var downloadCalled = false;
+
+        var rc = ProgramSupport.ForceProvisionMode(
+            "BC service-tier engine DLLs", _dir, "28.1.49838.53910", force: false,
+            isPresent: d => ArtifactDirState.Classify(d).IsUsable,
+            download: (v, d, log) => { downloadCalled = true; return 0; });
+
+        Assert.Equal(0, rc);
+        Assert.False(downloadCalled, "a complete engine closure must not be re-downloaded");
+    }
+
+    // ── the predicate must track the downloader, not a copy of its list ──────────────────
+
+    /// <summary>
+    /// The guard asks for exactly what the download promises. W1PlatformAppNames is derived
+    /// from ArtifactDownloader.W1PlatformAppPrefixes; if a prefix is added there and no name
+    /// here, the guard accepts a set that is short by the new app — a false green that no
+    /// other test would catch, because every existing fixture would still be complete.
+    /// </summary>
+    [Fact]
+    public void EveryDownloaderPrefixHasAMatchingName_AndViceVersa()
+    {
+        var prefixes = typeof(AlRunner.Provisioning.ArtifactDownloader)
+            .GetField("W1PlatformAppPrefixes",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
+            .GetValue(null) as string[];
+
+        Assert.NotNull(prefixes);
+        Assert.Equal(prefixes!.Length, ProvisioningCheck.W1PlatformAppNames.Length);
+
+        foreach (var name in ProvisioningCheck.W1PlatformAppNames)
+        {
+            var expected = $"microsoft_{name.ToLowerInvariant()}_";
+            Assert.Contains(expected, prefixes);
+        }
+    }
+}

--- a/AlRunner.Tests/TestPageClientPresenceTests.cs
+++ b/AlRunner.Tests/TestPageClientPresenceTests.cs
@@ -34,6 +34,15 @@ public sealed class TestPageClientPresenceTests
         catch (Exception ex) { selectionError = ex.Message; }
         TestArtifacts.SkipIf(selectionError != null,
             $"no BC service-tier artifact directory could be selected: {selectionError}");
+
+        // #3893: a selected directory is not a usable one. Selection can land on a
+        // partially-provisioned directory (27.5.46862.48827 carries Ncl.dll and 82 DLLs, and
+        // is short the closure sentinel) — this suite then failed inside Assembly.Load, and
+        // #3799 traced that by hand to an absent Framework.UI.dll. This is a presence audit,
+        // so a broken artifact directory is an environment fault, not a product defect: skip
+        // with the classifier's own explanation rather than reporting a false failure.
+        var state = AlRunner.Infrastructure.ArtifactDirState.Classify(dir);
+        TestArtifacts.SkipIf(!state.IsUsable, state.Explain());
         return dir;
     }
 

--- a/AlRunner/Infrastructure/EngineClosure.cs
+++ b/AlRunner/Infrastructure/EngineClosure.cs
@@ -1,0 +1,74 @@
+namespace AlRunner.Infrastructure;
+
+/// <summary>
+/// The files that make a BC artifact directory a usable service tier, and the pure
+/// filesystem check over them.
+///
+/// <para><b>Why this is its own file (#3893).</b> The list used to be private state inside
+/// <see cref="ProvisioningCheck"/>, a 1,997-line type whose wider closure reaches
+/// <c>AppLoader</c>, <c>SafeDirectoryScan</c> and <c>BcArtifacts</c>. That made the check
+/// unreachable from anything that is not the runner — and the entry points #3893 reports are
+/// exactly those: <c>tools/metadata-ground-truth</c> is deliberately outside
+/// <c>AlRunner.slnx</c> (a reference would put a runner build on every invocation), so it had
+/// no way to ask "is this directory usable" and opened it regardless, failing deep inside an
+/// assembly load.</para>
+///
+/// <para>Self-contained on purpose: no project reference, no AL types, nothing but
+/// <c>System.IO</c>. That is what lets a standalone tool link this ONE file
+/// (<c>&lt;Compile Include="…/EngineClosure.cs" /&gt;</c>) and share the runner's definition
+/// of "complete" rather than re-deriving it — which is how <c>tools/preflight.py</c> came to
+/// carry a Python re-implementation of the same list.</para>
+/// </summary>
+public static class EngineClosure
+{
+    /// <summary>
+    /// The engine DLLs the runner binds directly: the ALC resolver and the Cecil rewrite
+    /// both load them out of the artifact directory.
+    /// </summary>
+    public static readonly string[] CoreEngineDlls =
+    {
+        "Microsoft.Dynamics.Nav.Ncl.dll",
+        "Microsoft.Dynamics.Nav.Types.dll",
+        "Microsoft.Dynamics.Nav.Common.dll",
+        "Microsoft.Dynamics.Nav.Language.dll",
+        "Microsoft.Dynamics.Nav.CodeAnalysis.dll",
+    };
+
+    /// <summary>
+    /// Sentinel of the BC-app external closure the version-agnostic engine relies on being
+    /// served from the artifact directory — the exact DLL whose absence produced
+    /// FileLoadException 0x80131621. Its presence signals the full /service/ closure landed.
+    ///
+    /// <para>It is what separates the two broken shapes measured in #3878: 27.5.46862.48827
+    /// carries <c>Ncl.dll</c> and 82 DLLs and is short exactly this file, so every
+    /// "is this a service-tier directory" check passes and the failure moves to an assembly
+    /// load.</para>
+    /// </summary>
+    public const string ClosureSentinel = "Microsoft.Identity.ServiceEssentials.Core.dll";
+
+    /// <summary>
+    /// Every required file absent from <paramref name="serviceTierDir"/>, empty when the
+    /// closure is complete. A directory that does not exist reports the whole set missing.
+    /// Never throws — an unreadable path is the caller's third state to classify
+    /// (<see cref="ArtifactDirState"/>), not an exception from a list-of-strings function.
+    /// </summary>
+    public static IReadOnlyList<string> MissingFiles(string serviceTierDir)
+    {
+        var missing = new List<string>();
+        if (!Directory.Exists(serviceTierDir))
+        {
+            missing.AddRange(CoreEngineDlls);
+            missing.Add(ClosureSentinel);
+            return missing;
+        }
+        foreach (var dll in CoreEngineDlls)
+            if (!File.Exists(Path.Combine(serviceTierDir, dll)))
+                missing.Add(dll);
+        if (!File.Exists(Path.Combine(serviceTierDir, ClosureSentinel)))
+            missing.Add(ClosureSentinel);
+        return missing;
+    }
+
+    /// <summary>True when nothing is missing.</summary>
+    public static bool IsComplete(string serviceTierDir) => MissingFiles(serviceTierDir).Count == 0;
+}

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -21,21 +21,12 @@ namespace AlRunner.Infrastructure;
 /// </summary>
 public static class ProvisioningCheck
 {
-    // The engine DLLs the runner binds directly (must be present in the artifact dir so the
-    // ALC resolver and the Cecil rewrite can load them).
-    private static readonly string[] CoreEngineDlls =
-    {
-        "Microsoft.Dynamics.Nav.Ncl.dll",
-        "Microsoft.Dynamics.Nav.Types.dll",
-        "Microsoft.Dynamics.Nav.Common.dll",
-        "Microsoft.Dynamics.Nav.Language.dll",
-        "Microsoft.Dynamics.Nav.CodeAnalysis.dll",
-    };
+    // #3893: the list and the check moved to EngineClosure, a self-contained file a
+    // standalone tool can link without referencing the runner. These aliases keep the
+    // in-file spellings; EngineClosure is the single definition.
+    private static string[] CoreEngineDlls => EngineClosure.CoreEngineDlls;
 
-    // Sentinel of the BC-app external closure that the version-agnostic engine relies on
-    // being served from the artifact dir (it was the exact DLL whose absence/skew produced
-    // FileLoadException 0x80131621). Its presence signals the full /service/ closure landed.
-    private const string ClosureSentinel = "Microsoft.Identity.ServiceEssentials.Core.dll";
+    private const string ClosureSentinel = EngineClosure.ClosureSentinel;
 
     // ── Platform-app R2R check ────────────────────────────────────────────────
     // These Microsoft apps MUST be provided as R2R (publishedartifacts/*.dll) packages.
@@ -432,6 +423,95 @@ public static class ProvisioningCheck
             }
         }
         return false;
+    }
+
+    // ── Platform-apps completeness check (#2661) ──────────────────────────────
+    // The sibling of TestToolkitPresent for `provision --platform-apps`, and a DIFFERENT
+    // question from ArtifactDirState/Check, which measure the service-tier ENGINE closure.
+    // Measured on the reporting box: one directory (28.1.49838.53910) holds a complete
+    // 501-DLL engine closure AND a platform-apps directory containing only `System.app` —
+    // so the two halves are independently complete or short, and one predicate cannot
+    // answer for both. docs/provisioning.md#platform-apps-completeness has the survey.
+
+    /// <summary>
+    /// The w1 core set every <c>provision --platform-apps</c> download lands, by manifest
+    /// <c>Name</c>. Derived from <c>ArtifactDownloader.W1PlatformAppPrefixes</c> — the list
+    /// the downloader itself filters on — so the predicate asks for exactly what the
+    /// download promises. <c>PlatformAppSetMatchesDownloaderTests</c> pins the two together;
+    /// adding a prefix there without a name here would make the guard accept a short set.
+    /// </summary>
+    public static readonly string[] W1PlatformAppNames =
+    {
+        "Base Application",
+        "System Application",
+        "Business Foundation",
+        "Application",
+        "Application Test Library",
+    };
+
+    /// <summary>
+    /// True when <paramref name="dir"/> holds the complete Microsoft platform-app core set
+    /// for the w1 channel — every name in <see cref="W1PlatformAppNames"/> present as a
+    /// Microsoft-published <c>.app</c> whose manifest parses. A real manifest parse, not
+    /// "does any <c>*.app</c> file exist": that glob is what #2661 reports, and one
+    /// directory on the reporting box (28.1.49838.53910) holds exactly one file,
+    /// <c>System.app</c>, which the glob accepts as a complete provision forever.
+    ///
+    /// <para><b>Country channel returns the third state, not a verdict</b>
+    /// (<c>.claude/rules/guards-need-a-third-state.md</c>). A country artifact is not "w1
+    /// plus extras" — <c>ArtifactDownloader.IsWantedPlatformAppEntry</c> takes EVERY
+    /// Microsoft-published app the country artifact ships, deliberately so no per-country
+    /// list has to be hand-maintained. There is therefore no set to check completeness
+    /// against, and answering <c>false</c> would re-download a complete country set on
+    /// every run while answering <c>true</c> would restore the glob's false green. So
+    /// <paramref name="country"/> other than w1 yields <c>null</c> — "could not measure" —
+    /// and the caller keeps the glob for that channel, knowingly.</para>
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> complete, <c>false</c> short (with <paramref name="missing"/> naming
+    /// which), <c>null</c> when completeness is not measurable for this channel.
+    /// </returns>
+    public static bool? PlatformAppsComplete(
+        string dir, string? country, out IReadOnlyList<string> missing)
+    {
+        missing = Array.Empty<string>();
+
+        // Not w1: no curated set exists to compare against. Third state, deliberately not
+        // folded into either verdict — both would be wrong in a different direction.
+        if (!string.Equals(NormalizeCountry(country), "w1", StringComparison.Ordinal))
+            return null;
+
+        if (!Directory.Exists(dir))
+        {
+            missing = W1PlatformAppNames;
+            return false;
+        }
+
+        var present = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var appFile in AlRunner.Infrastructure.SafeDirectoryScan.Files(dir, "*.app"))
+        {
+            var m = AlRunner.AppLoader.ReadManifest(appFile);
+            if (m == null) continue;
+            if (!string.Equals(m.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase)) continue;
+            present.Add(m.Name);
+        }
+
+        var absent = W1PlatformAppNames.Where(n => !present.Contains(n)).ToList();
+        missing = absent;
+        return absent.Count == 0;
+    }
+
+    /// <summary>
+    /// <see cref="PlatformAppsComplete"/> as the <c>isPresent</c> predicate
+    /// <c>ForceProvisionMode</c> takes. The unmeasurable (non-w1) case falls back to the
+    /// pre-#2661 glob, which is the honest answer there: it is what the download promises
+    /// for a country channel, and nothing narrower is knowable.
+    /// </summary>
+    public static bool PlatformAppsPresent(string dir, string? country = null)
+    {
+        var verdict = PlatformAppsComplete(dir, country, out _);
+        if (verdict.HasValue) return verdict.Value;
+        return Directory.Exists(dir) && Directory.EnumerateFiles(dir, "*.app").Any();
     }
 
     /// <summary>
@@ -1813,20 +1893,10 @@ public static class ProvisioningCheck
     /// </summary>
     public static Report Check(string version, string serviceTierDir)
     {
-        var missing = new List<string>();
-        if (!Directory.Exists(serviceTierDir))
-        {
-            // The whole dir is gone — report every required file as missing.
-            missing.AddRange(CoreEngineDlls);
-            missing.Add(ClosureSentinel);
-            return new Report(version, serviceTierDir, missing);
-        }
-        foreach (var dll in CoreEngineDlls)
-            if (!File.Exists(Path.Combine(serviceTierDir, dll)))
-                missing.Add(dll);
-        if (!File.Exists(Path.Combine(serviceTierDir, ClosureSentinel)))
-            missing.Add(ClosureSentinel);
-        return new Report(version, serviceTierDir, missing);
+        // #3893: one definition of "complete", shared with tools/metadata-ground-truth,
+        // which links EngineClosure.cs rather than referencing the runner.
+        return new Report(version, serviceTierDir,
+            EngineClosure.MissingFiles(serviceTierDir).ToList());
     }
 
     /// <summary>

--- a/AlRunner/ProgramSupport/Provisioning.cs
+++ b/AlRunner/ProgramSupport/Provisioning.cs
@@ -425,18 +425,27 @@ internal static partial class ProgramSupport
         if (serviceTier)
         {
             var dir = AlRunner.Infrastructure.BcArtifacts.ArtifactDirFor(full);
+            // #2661: was `any *.dll exists`, which one directory on the reporting box
+            // (27.5.46862.48827, 82 DLLs incl. Ncl.dll but no closure sentinel) satisfies
+            // forever while failing deep inside an assembly load. ArtifactDirState reads
+            // the same engine closure the post-download re-check and the startup gate use.
             anyFailed |= ForceProvisionMode("BC service-tier engine DLLs", dir, full, force,
-                d => Directory.Exists(d) && Directory.EnumerateFiles(d, "*.dll").Any(),
+                d => AlRunner.Infrastructure.ArtifactDirState.Classify(d).IsUsable,
                 (v, d, log) => AlRunner.Provisioning.ArtifactDownloader.ServiceTier(v, d, log)) != 0;
         }
         if (platformApps)
         {
+            var country = AlRunner.Infrastructure.BcArtifacts.SelectedCountry;
             var dir = AlRunner.Infrastructure.ProvisioningCheck.PlatformAppsDirFor(
                 AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, full);
+            // #2661: was `any *.app exists` — 28.1.49838.53910's platform-apps dir holds
+            // only System.app and read as a complete provision. PlatformAppsPresent parses
+            // manifests for the downloader's own curated w1 set, and keeps the glob for a
+            // country channel, where no curated set exists to check against.
             anyFailed |= ForceProvisionMode("Microsoft platform apps", dir, full, force,
-                d => Directory.Exists(d) && Directory.EnumerateFiles(d, "*.app").Any(),
+                d => AlRunner.Infrastructure.ProvisioningCheck.PlatformAppsPresent(d, country),
                 (v, d, log) => AlRunner.Provisioning.ArtifactDownloader.PlatformApps(
-                    v, d, AlRunner.Infrastructure.BcArtifacts.SelectedCountry, log)) != 0;
+                    v, d, country, log)) != 0;
         }
         if (testApps)
         {

--- a/docs/provisioning.md
+++ b/docs/provisioning.md
@@ -1,0 +1,149 @@
+# What "provisioned" means, and how each half is measured
+
+`al-runner provision` fills two independent halves of one version directory: the
+**service-tier engine closure** and the **platform-app set**. They are provisioned by
+separate sub-steps, they can be complete or short independently, and — measured below —
+they routinely are. Each half therefore has its own completeness predicate, and a check
+over one of them answers wrongly for the other.
+
+This page holds the measurement behind that split, so the claim in the code is a citation
+rather than a restatement (`.claude/rules/loud-failures.md` § "The justification is a claim
+plus a citation, not the derivation behind it").
+
+| half | predicate | lives in |
+|---|---|---|
+| service-tier engine closure | `EngineClosure.MissingFiles` / `ArtifactDirState.Classify` | `AlRunner/Infrastructure/EngineClosure.cs` |
+| platform apps (w1) | `ProvisioningCheck.PlatformAppsComplete` | `AlRunner/Infrastructure/ProvisioningCheck.cs` |
+
+## <a name="platform-apps-completeness"></a>Platform-apps completeness is a different question from the engine closure
+
+Issue #2661 asked for a content-verified entry guard for `provision --platform-apps` and
+`--service-tier`, in place of the glob (`does at least one *.app` / `*.dll` exist) both
+modes still used. #3893 asked for the engine-closure classifier built by #3889 to get a
+non-test consumer. The open question when the two were batched was whether **one**
+predicate could serve both — whether `ArtifactDirState`, which reads the engine closure,
+extends to the platform-app half.
+
+It does not, and the evidence is on disk rather than inferred. Every provisioned directory
+on the reporting box, 2026-09-11:
+
+| version | engine DLLs | `Ncl.dll` | platform-apps | test-apps |
+|---|---|---|---|---|
+| 27.0.38460.53934 | 501 | yes | — | — |
+| 27.3.44313.53909 | 501 | yes | 5 | 0 |
+| **27.5.46862.48827** | **82** | **yes** | — | — |
+| 27.5.46862.53931 | 501 | yes | 5 | 103 |
+| 28.0.46665.54338 | 501 | yes | — | — |
+| **28.0.46665.54452** | **0** | **no** | **6** | — |
+| **28.1.49838.53910** | **501** | **yes** | **1** | — |
+| 28.1.49838.54308 | 501 | yes | 6 | 107 |
+| 28.2.50931.54319 | 501 | yes | — | 107 |
+| 28.3.52162.54347 | 501 | yes | — | — |
+| 28.4.53241.54346 | 501 | yes | — | — |
+| 28.4.53241.54407 | 501 | yes | 6 | — |
+| 28.4.53241.54447 | 501 | yes | — | 108 |
+
+Three rows carry the argument:
+
+- **`28.1.49838.53910`** — a **complete** 501-DLL engine closure beside a platform-apps
+  directory holding exactly **one** file, `System.app`. An engine-closure predicate calls
+  this directory usable, and for the engine it is; its platform-app half is short by all
+  five core apps.
+- **`28.0.46665.54452`** — the exact inverse: **zero** engine DLLs, a complete six-app
+  payload. This is #2226 materialising (`provision`'s two sub-steps resolved different
+  patch builds of one major.minor), not corruption — nothing here is broken, the halves
+  simply landed in different directories.
+- **`27.5.46862.48827`** — 82 DLLs **including** `Ncl.dll`, short exactly the closure
+  sentinel. It passes every "is this a service-tier directory" check and fails later,
+  inside an assembly load. This is the #3878 shape, and the reason the engine predicate is
+  a named-file closure rather than a DLL count.
+
+So the two halves are orthogonal, and one predicate over the engine closure would be wrong
+on directories that exist today. `PlatformAppsComplete` is a sibling of
+`EngineClosure.MissingFiles`, not a reuse of it.
+
+**`System.app` is the trap worth naming.** It is the platform symbol package, carries no
+`NavxManifest.xml`, and is not one of the five core apps. It satisfies the glob and fails a
+manifest parse — which is precisely why `28.1.49838.53910` read as a complete provision
+forever under the old guard and `provision --platform-apps` never re-attempted the
+download.
+
+### Why the set is not a DLL count, and not a marker file
+
+501 is one version's number, not a constant, so a threshold is fragile in both directions.
+Both broken shapes above are separated from all eleven healthy ones by the named closure
+alone, so no new on-disk marker was needed and none is written. That matters beyond
+tidiness: because the predicate reads the closure rather than a marker, it classifies
+directories **already on disk**, including the two that motivated the issues. A completion
+marker would only have applied to directories provisioned after it shipped.
+
+### Reproducing the survey
+
+```bash
+R=~/.local/share/al-runner/artifacts
+for d in "$R"/*/; do
+  v=$(basename "$d")
+  dlls=$(find "$d" -maxdepth 1 -name '*.dll' | wc -l)
+  pa=$( [ -d "$d/platform-apps" ] && find "$d/platform-apps" -maxdepth 1 -name '*.app' | wc -l || echo "-" )
+  ncl=$( [ -f "$d/Microsoft.Dynamics.Nav.Ncl.dll" ] && echo Y || echo n )
+  printf "%-20s dlls=%-4s ncl=%s platform-apps=%s\n" "$v" "$dlls" "$ncl" "$pa"
+done
+```
+
+`tools/preflight.py` reports the same classification for the engine half on every run, and
+reads its closure list out of `EngineClosure.cs` rather than transcribing it.
+
+## <a name="country-channel"></a>The country channel has no completeness answer
+
+`PlatformAppsComplete` returns `bool?`, and a `--country` other than `w1` yields **null**:
+"could not measure" (`.claude/rules/guards-need-a-third-state.md`).
+
+The w1 download filters on a **curated** five-app list
+(`ArtifactDownloader.W1PlatformAppPrefixes`), so "complete" is enumerable. A country
+artifact is not "w1 plus extras" — its Base/System Application are genuinely different
+files — and `IsWantedPlatformAppEntry` therefore takes **every** Microsoft-published app the
+country artifact ships under `Extensions/`, deliberately, so that no per-country list has to
+be hand-maintained for every country Microsoft ships. Nothing enumerates what complete means
+there.
+
+Both available guesses are wrong in a different direction, which is why the third state is
+not spelled as either:
+
+| answering | consequence |
+|---|---|
+| `false` | re-downloads a complete country set on every run |
+| `true` | restores the glob's false green, now wearing a measured-looking answer |
+
+So the caller keeps the glob for that channel, knowingly, and `PlatformAppsPresent`
+documents that it is doing so.
+
+## <a name="reach"></a>Why the closure check is its own file
+
+`EngineClosure.cs` depends on `System.IO` and nothing else. That is a constraint, not a
+style preference: `tools/metadata-ground-truth` is deliberately outside `AlRunner.slnx` —
+its own csproj header says a project reference "would put a compile of a Microsoft app on
+every `dotnet build`" — so it cannot reference the runner, and `ProvisioningCheck` (1,997
+lines, reaching `AppLoader`, `SafeDirectoryScan` and `BcArtifacts`) cannot be linked as a
+source file either. Before the split, the tool had no way to ask whether its artifact
+directory was usable, so it opened the directory regardless and failed deep inside an
+assembly load; the #3825 feasibility run contributed zero packages to every population for
+exactly this reason, and it read as a code fault.
+
+The tool now links that one file:
+
+```xml
+<Compile Include="../../AlRunner/Infrastructure/EngineClosure.cs" Link="Linked/EngineClosure.cs" />
+```
+
+**Adding a dependency to `EngineClosure.cs` breaks that link**, and the failure surfaces as
+a build error in a tool outside the solution — a long way from the edit that caused it.
+`AlRunner.Tests/EngineClosureSharingTests.cs` pins both the link and the
+check-before-install ordering.
+
+## Sister reading
+
+- [`provisioning-tiers.md`](provisioning-tiers.md) — which tier a run selects, and what an
+  unanswered CDN probe may buy
+- [`expectations.md`](expectations.md) — declaring surfaces the runner cannot support
+- `.claude/rules/guards-need-a-third-state.md` — why `PlatformAppsComplete` returns `bool?`
+- `.claude/rules/loud-failures.md` — why this measurement is here and not in the code

--- a/tools/metadata-ground-truth/MetadataGroundTruth.csproj
+++ b/tools/metadata-ground-truth/MetadataGroundTruth.csproj
@@ -24,6 +24,18 @@
     <ServiceTierPath>$(_ArtifactsRoot)$(_BCVersion)</ServiceTierPath>
   </PropertyGroup>
 
+  <!-- #3893: the engine-closure check, linked as a SOURCE file rather than through a
+       ProjectReference to AlRunner. A reference would pull the whole runner into a tool
+       deliberately kept out of AlRunner.slnx (see the header) and put a runner build on every
+       invocation. EngineClosure.cs is self-contained for exactly this reason — System.IO and
+       nothing else — so this one line shares the runner's definition of "complete" instead of
+       re-deriving it, which is how tools/preflight.py came to carry a Python copy of the same
+       list. AlRunner.Tests/EngineClosureSharingTests.cs pins the link. -->
+  <ItemGroup>
+    <Compile Include="../../AlRunner/Infrastructure/EngineClosure.cs"
+             Link="Linked/EngineClosure.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="10.0.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.0" />

--- a/tools/metadata-ground-truth/Program.cs
+++ b/tools/metadata-ground-truth/Program.cs
@@ -58,6 +58,25 @@ internal static class Program
             return 2;
         }
 
+        // #3893: check the closure before opening anything. A partially-provisioned directory
+        // used to fail deep inside an assembly load — the #3825 feasibility run contributed 0
+        // packages to every population for exactly this reason, and it read as a code fault.
+        // 27.5.46862.48827 is the live instance: it carries Ncl.dll and 82 DLLs, so every
+        // "is this a service-tier directory" check passes and only the closure sentinel says
+        // otherwise.
+        var missingClosure = AlRunner.Infrastructure.EngineClosure.MissingFiles(artifacts);
+        if (missingClosure.Count > 0)
+        {
+            Console.Error.WriteLine(
+                $"BC artifact directory {artifacts} is not a usable service tier — its engine "
+                + "closure is incomplete, so BC's compiler cannot be hosted out of it.");
+            foreach (var f in missingClosure)
+                Console.Error.WriteLine($"  missing: {Path.Combine(artifacts, f)}");
+            Console.Error.WriteLine(
+                $"  Fix: al-runner provision --service-tier --bc-version {Path.GetFileName(artifacts.TrimEnd('/'))} --force");
+            return 2;
+        }
+
         BcHost.Install(artifacts);
         try { return Generate(appPath, outDir, artifacts, declOnly, dotnetFirst); }
         catch (Exception ex)

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -2604,12 +2604,24 @@ def classify_corpus_checkout(reading: dict) -> CheckResult:
 ARTIFACTS_ROOT_ENV = "AL_RUNNER_ARTIFACTS_ROOT"
 ARTIFACTS_ROOT_REL = ".local/share/al-runner/artifacts"
 
-# The engine closure a usable service-tier directory must hold. Deliberately the
-# same set AlRunner/Infrastructure/ProvisioningCheck.cs requires, and NOT a DLL
-# count: 501 is one version's number, not a constant, so a threshold would be
-# fragile in both directions. Measured on the reporting box, this set separates
-# both broken directories from all 11 healthy ones.
-ARTIFACT_CLOSURE_FILES = (
+# The engine closure a usable service-tier directory must hold. NOT a DLL count:
+# 501 is one version's number, not a constant, so a threshold would be fragile in
+# both directions. Measured on the reporting box, this set separates both broken
+# directories from all 11 healthy ones.
+#
+# #3893: this list is READ OUT OF the C# definition rather than transcribed. It was
+# a hand-maintained copy of AlRunner/Infrastructure/ProvisioningCheck.cs's private
+# list, which is the shape the issue reports one level up — two copies agree until
+# one is edited, and nothing says which. The C# moved to EngineClosure.cs, whose
+# whole purpose is being readable from outside the runner; parsing its string
+# literals costs no build and no dotnet invocation.
+ENGINE_CLOSURE_CS = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "AlRunner", "Infrastructure", "EngineClosure.cs")
+
+# The transcription that WAS here, kept only as the drift check's expected value.
+# A mismatch is reported, never silently resolved toward either copy.
+_ARTIFACT_CLOSURE_FALLBACK = (
     "Microsoft.Dynamics.Nav.Ncl.dll",
     "Microsoft.Dynamics.Nav.Types.dll",
     "Microsoft.Dynamics.Nav.Common.dll",
@@ -2617,6 +2629,27 @@ ARTIFACT_CLOSURE_FILES = (
     "Microsoft.Dynamics.Nav.CodeAnalysis.dll",
     "Microsoft.Identity.ServiceEssentials.Core.dll",
 )
+
+
+def engine_closure_files(path: str = ENGINE_CLOSURE_CS) -> tuple:
+    """The closure set, read from EngineClosure.cs.
+
+    Returns the fallback when the file cannot be read -- a source checkout is not
+    guaranteed (preflight runs from an installed tree too), and refusing there
+    would swap a false green for a false red on a box that is fine. A file that
+    IS readable but yields no DLL names returns empty, so the caller can tell
+    "could not read" from "read, and it said nothing" rather than getting the
+    success answer for both (guards-need-a-third-state.md).
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            text = fh.read()
+    except OSError:
+        return _ARTIFACT_CLOSURE_FALLBACK
+    return tuple(dict.fromkeys(re.findall(r'"([A-Za-z0-9_.]+\.dll)"', text)))
+
+
+ARTIFACT_CLOSURE_FILES = engine_closure_files()
 
 _VERSION_DIR_RE = re.compile(r"^\d+(\.\d+){1,3}$")
 

--- a/tools/test_engine_closure_shared.py
+++ b/tools/test_engine_closure_shared.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""The closure list preflight uses must BE the C# one, not a copy of it (#3893).
+
+#3893 reports that ArtifactDirState had no non-test consumer, and that
+`tools/preflight.py` "re-implements the closure list in Python rather than calling
+the C# type". A transcribed list is right on the day it is written and drifts
+silently afterwards: both copies look authoritative, and nothing fails when they
+disagree -- preflight would keep reporting a directory complete against yesterday's
+definition of complete.
+
+So preflight now READS AlRunner/Infrastructure/EngineClosure.cs. These tests pin
+the three properties that makes rest on:
+
+  1. the read actually returns the six real files (a regex that matched nothing
+     would return empty and every directory would read as complete -- the
+     silent-default failure this repo's rules name repeatedly);
+  2. what it reads equals the transcription that used to be hardcoded, so this
+     change is provably behaviour-preserving today;
+  3. an unreadable source file falls back rather than refusing -- preflight runs
+     from installed trees with no C# sources, and a hard error there would swap a
+     false green for a false red (guards-need-a-third-state.md's constraint).
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import preflight  # noqa: E402
+
+
+class EngineClosureSharedTests(unittest.TestCase):
+
+    def test_the_cs_file_exists_where_preflight_looks_for_it(self):
+        # A positive control on the path itself. If this moves, test 4's fallback
+        # makes every other assertion here pass vacuously, so assert it directly.
+        self.assertTrue(os.path.isfile(preflight.ENGINE_CLOSURE_CS),
+                        f"EngineClosure.cs not found at {preflight.ENGINE_CLOSURE_CS}")
+
+    def test_reading_the_cs_yields_the_six_closure_files(self):
+        got = preflight.engine_closure_files()
+
+        self.assertEqual(6, len(got), f"expected six closure files, got {got}")
+        self.assertIn("Microsoft.Dynamics.Nav.Ncl.dll", got)
+        self.assertIn("Microsoft.Identity.ServiceEssentials.Core.dll", got)
+
+    def test_the_read_matches_the_transcription_it_replaces(self):
+        # Behaviour-preserving today, and the assertion that catches a C# edit
+        # nobody mirrored -- which is the entire point of reading rather than
+        # copying. When this fails, the C# moved: update the fallback to match.
+        self.assertEqual(
+            sorted(preflight._ARTIFACT_CLOSURE_FALLBACK),
+            sorted(preflight.engine_closure_files()))
+
+    def test_module_level_constant_is_the_read_not_the_fallback_object(self):
+        self.assertEqual(sorted(preflight._ARTIFACT_CLOSURE_FALLBACK),
+                         sorted(preflight.ARTIFACT_CLOSURE_FILES))
+
+    def test_an_unreadable_source_falls_back_rather_than_returning_empty(self):
+        # The constraint: preflight runs from installed trees with no C# sources.
+        # Empty here would make every directory read as a complete closure.
+        got = preflight.engine_closure_files("/nonexistent/EngineClosure.cs")
+
+        self.assertEqual(preflight._ARTIFACT_CLOSURE_FALLBACK, got)
+        self.assertEqual(6, len(got))
+
+    def test_a_readable_file_with_no_dll_names_reads_as_empty_not_as_the_fallback(self):
+        # The third state, kept distinct from both the success answer and the
+        # unreadable one: "I read it and it said nothing" is a different fact from
+        # "I could not read it", and collapsing them hides a broken parse.
+        import tempfile
+        with tempfile.NamedTemporaryFile("w", suffix=".cs", delete=False) as fh:
+            fh.write("namespace X; public static class EngineClosure { }\n")
+            path = fh.name
+        try:
+            self.assertEqual((), preflight.engine_closure_files(path))
+        finally:
+            os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #3893
Closes #2661

Two entry guards that accepted a broken artifact directory now check its contents, and #3889's classifier gets its first non-test consumers.

Filed and implemented by the agent loop `stma-auto-2`, not by a person.

## The measurement that decided the batching

The dispatch asked whether `ArtifactDirState` extends to the platform-apps half of #2661, or whether that needs a sibling predicate. **It needs a sibling**, and the evidence is on disk rather than inferred. Surveying all 13 provisioned directories on this box:

| version | engine DLLs | `Ncl.dll` | platform-apps |
|---|---|---|---|
| `28.1.49838.53910` | 501 | yes | **1** |
| `28.0.46665.54338` | 501 | yes | — |
| `28.0.46665.54452` | **0** | no | 6 |
| (10 others) | 501 | yes | 0–6 |

`28.1.49838.53910` carries a **complete** 501-DLL engine closure and a platform-apps directory holding exactly one file, `System.app`. `28.0.46665.54452` is the inverse. So the two halves are independently complete or short, `ArtifactDirState` (built on the engine closure) cannot answer for the platform-app half, and one predicate for both would be wrong on real directories sitting on this machine right now.

**This is still one PR**, per `batch-sibling-issues-by-file.md`: both predicates wire into the same `ForceProvisionMode` call sites in the same file, and splitting them is the rebase treadmill that rule exists to prevent. Each issue keeps its own RED→GREEN and its own mutation.

That `28.1.49838.53910` directory is also the live instance of #2661's reported defect — the old guard (`does any *.app exist`) reads one stray `System.app` as a complete provision forever, so `provision --platform-apps` never re-attempts the download. I did not invent a fixture for that; I found it and the test asserts its exact shape.

## What changed

**`AlRunner/Infrastructure/EngineClosure.cs` (new).** The closure list and its check, extracted from `ProvisioningCheck`'s private state. This is what made #3893 fixable at all: `ProvisioningCheck` is 1,997 lines whose closure reaches `AppLoader`, `SafeDirectoryScan` and `BcArtifacts`, and `tools/metadata-ground-truth` is deliberately outside `AlRunner.slnx` — its own header says a reference "would put a compile of a Microsoft app on every `dotnet build`". So the tool could not ask the question and opened the directory regardless. `EngineClosure.cs` depends on `System.IO` and nothing else, so the tool links the one file. `ProvisioningCheck.Check` now routes through it, so there is one definition rather than two.

**`ProvisioningCheck.PlatformAppsComplete` / `PlatformAppsPresent` (new).** A real manifest parse for the curated w1 core set, derived from `ArtifactDownloader.W1PlatformAppPrefixes` — the list the downloader itself filters on — so the guard asks for exactly what the download promises.

**The two entry guards** in `RunExplicitProvisionModes`: `--service-tier` moves from `any *.dll exists` to `ArtifactDirState.Classify(d).IsUsable`; `--platform-apps` from `any *.app exists` to `PlatformAppsPresent`. #2558 already generalized the post-download re-check to all three modes, so entry-guard precision was the only thing left, exactly as #2661 states.

**The three #3893 entry points.** `tools/metadata-ground-truth` checks the closure before `BcHost.Install` and exits 2 naming the directory, the missing files and the remedy. `TestPageClientPresenceTests` classifies the selected directory and skips with the classifier's explanation — a presence audit, so a broken artifact directory is an environment fault, not a product defect. The ad-hoc resolver probes (row 3) are covered by the same shared definition now being reachable.

**`tools/preflight.py`** reads the closure list out of `EngineClosure.cs` at runtime rather than using its hardcoded transcription. That transcription is the half of #3893 that says preflight "re-implements the closure list in Python rather than calling the C# type". **Precisely:** the transcription still exists, as `_ARTIFACT_CLOSURE_FALLBACK`, because preflight also runs from installed trees that carry no C# sources. What changed is that it went from a **silent** second copy to an **asserted** one — `test_engine_closure_shared.py` fails the moment the two disagree, so a C# edit nobody mirrored is now loud instead of invisible. That is the improvement; it is not full deduplication.

**`docs/provisioning.md` (new).** The 13-directory survey above, the country-channel reasoning and the `System.IO`-only constraint, versioned and re-runnable with the shell loop that produced the table. `ProvisioningCheck.cs` cites it by anchor. Added in review: the code cited `docs/provisioning.md#platform-apps-completeness` while the file did not exist — `tools/test_doc_pointers.py` exit 1 on the first head, exit 0 on `origin/main`, so the PR introduced it. Creating the file was the right fix rather than dropping the pointer: a measurement table belongs in `docs/` (`loud-failures.md` § "The justification is a claim plus a citation"), and it was living only in this PR body.

### A third state, not a guess

`PlatformAppsComplete` returns `bool?`. A **country** channel yields `null` — "could not measure" — because `IsWantedPlatformAppEntry` takes *every* Microsoft-published app a country artifact ships, deliberately, so nothing enumerates what complete means there. Both guesses would be wrong in a different direction: `false` re-downloads a complete country set on every run, `true` restores the glob's false green wearing a measured-looking answer. The caller keeps the glob for that channel, knowingly. `preflight.engine_closure_files` has the same split — an unreadable source falls back (installed trees carry no C# sources; refusing there swaps a false green for a false red), while a readable file yielding nothing returns empty, so a broken parse cannot read as success.

## RED → GREEN, and the mutations

Baseline for both new classes: **`Failed: 0, Passed: 21, Total: 21`**.

**#2661** — replaced `PlatformAppsComplete`'s core comparison with the glob it replaces. Mutation confirmed landed by re-reading the region; rebuilt; **`Failed: 5, Passed: 16, Total: 21`** → restored → `Failed: 0, Passed: 21`.

**#3893** — made `EngineClosure.MissingFiles` return the success answer unconditionally (`if (true) return Array.Empty<string>();`). Confirmed landed; **`Failed: 6, Passed: 15, Total: 21`** → restored → `Failed: 0, Passed: 21`.

**#3893, the wiring specifically** — because "the predicate exists but nothing calls it" *is* the reported defect, I mutated the call site too, removing the check from `metadata-ground-truth`'s `Main`. **`Failed: 1, Passed: 7, Total: 8`** (`EngineClosureSharingTests`), caught by the ordering assertion → restored.

**preflight** — broke the regex that reads the C# (`\.dll` → `\.NOPE`). Confirmed landed; **3 of 6 failed** (from `OK`) → restored → `OK`.

**The doc anchor** — renamed the `platform-apps-completeness` heading in the new doc. Confirmed landed; `test_doc_pointers.py` **exit 1**, and the message distinguishes the two failure modes: `anchor #platform-apps-completeness is not in that file`, where the original said `file does not exist`. So the guard checks anchors, not just filenames → restored → exit 0.

### End-to-end, on the real broken directory

Exit codes read **unpiped** (a `| head` leaves `$?` as `head`'s):

```
27.5.46862.48827 (82 DLLs, Ncl.dll present, sentinel absent)  -> exit 2
  "BC artifact directory ... is not a usable service tier — its engine closure is incomplete"
  "  missing: .../Microsoft.Identity.ServiceEssentials.Core.dll"
  "  Fix: al-runner provision --service-tier --bc-version 27.5.46862.48827 --force"

28.4.53241.54407 (healthy)                                     -> exit 1
  0 occurrences of that message: the guard does not fire, the tool proceeds and
  fails later on the real work
```

Both directions matter: the second is what shows the guard is not simply rejecting everything.

`preflight.py` after the change reads 6 closure files from the C# and still flags exactly `27.5.46862.48827` and `28.0.46665.54452` out of 13 — behaviour preserved, definition shared.

### Other runs

- `ProvisioningCheckTests`, `ArtifactDirStateTests`, `EnsureTestToolkitProvisionedTests`, `TestPageClientPresenceTests`, `TestArtifactsGateTests`: **`Failed: 0, Passed: 178, Total: 178`**. `TestPageClientPresenceTests` still *runs* rather than skipping on this box, confirming the added classify-skip does not wrongly skip a healthy directory.
- **Every `tools/test_*.py`** — the whole `tools/ unit tests` context, which is what the doc pointer had turned red: all pass, including `test_doc_pointers.py` (exit 0) and `test_matrix_docs_drift.py` (exit 0).
- `tools/preflight.py --agent-id stma-auto-2`: `11 passed, 6 warned, 0 failed, 1 skipped`.
- `tools/metadata-ground-truth` builds with the linked file and still takes no `ProjectReference`.

No `Corpus-PR:`/`Corpus-NA:` line: `check_corpus_linkage.sh` reports "No file in this diff can change what AL observes, so no corpus declaration is required." This is provisioning plumbing — nothing here is a claim about BC behaviour, so there is nothing for a service tier to adjudicate.

## Fix the shape, not just the reported line

**1. Does the same wrong pattern appear at another call site?** Yes — that is why this PR is two issues. `ForceProvisionMode`'s three call sites carried the same glob shape; #2558 fixed one, and I fixed the two it named as left behind. Beyond those three, the glob shape does not recur: `TestToolkitPresent`, `CheckPlatformApps` and `ProvisioningCheck.Check` are all already content checks.

**2. Does a sibling function make the same assumption?** `CheckPlatformApps` reads the same directory and answers a *different* question — "are the apps present as R2R" — and returns **Ok when they are absent**, by design (symbol-only apps get served by service-tier DLLs). That is correct for its own caller and would be a false green as an entry guard, which is precisely why #2661 says it "answers a different question". Left alone deliberately.

**3. If two code paths write the same state, do they maintain the same invariant?** This is where the real find was. Three places defined "a complete engine closure": `ProvisioningCheck`'s private list, `ArtifactDirState` (delegating to it, fine), and `preflight.py`'s Python transcription — which is a genuine second copy. Two copies agree until one is edited and nothing says which. Folded in: the Python side now reads the C# and asserts agreement with its own fallback, so drift fails a test instead of going unnoticed. The fallback is still a transcription (see above) — this converts a silent copy into a checked one rather than removing it, which is the honest description of what landed.

## The open-issue queue

Searched the open queue for `provision`, `ArtifactDirState`, `platform-apps` and `ForceProvisionMode`. Nothing else folds; what is adjacent and why it does not:

- **#2226** — `provision`'s platform-app sub-step targets the CDN's latest build, not the engine's, so one run provisions two BC builds. **This PR does not fix it and must not be read as fixing it.** `28.0.46665.54338` / `28.0.46665.54452` is #2226 materialising, and `ArtifactDirState` already reports that shape distinctly (`HasSiblingProvisionPayload`). The fix is in version *resolution*, not in a completeness predicate — different code, and folding it would make the diff two changes.
- **#2232**, **#2223** — both about whether a platform-apps download or Base App load should happen at all. Policy questions upstream of "is this directory complete"; no overlap in code.
- **#3811** — provisioning graph identity vs. the resolver. A different subsystem.

Searched for a duplicate of the defect itself by mechanism, observable and measurement (`glob`, `entry guard`, `System.app`, `closure sentinel`, `501`, `82 DLLs`), per `search-for-the-same-defect-first.md`: no second report of either defect.

## Deliberately not done

- **Neither anomalous directory was deleted.** `27.5.46862.48827` is cited as measurement provenance in roughly 20 files; deleting it orphans those citations silently. Both issues call for a guard, not a cleanup — and the guard is now the thing that makes the directory harmless.
- **No `--country` completeness check.** Genuinely unmeasurable, as above, and the predicate says so rather than guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
