### PR TITLE
docs(reuse): ask whether the runtime already holds the data, not only whether MS ships it

### DIFF
--- a/.claude/rules/precompiled-dll-respect.md
+++ b/.claude/rules/precompiled-dll-respect.md
@@ -41,7 +41,7 @@ Consequence: if a test failure points at our own AL output, the fix is either (a
 runtime engine the output calls into, or (b) in the compile pipeline that produced it — never
 in the cached DLL itself.
 
-## Reuse before you re-implement — check whether Microsoft already ships it
+## Reuse before you re-implement — check whether Microsoft already ships it, or already holds it
 
 **The best code is no code written at all.** "Fix" means **the outcome is correct**, not that we
 wrote the thing producing it. Code we do not write cannot rot, cannot drift as BC moves, and
@@ -67,6 +67,27 @@ an assumption, the assumption got written down as fact.
 
 **So when a load fails, the failure is the finding.** Do not let it become a shim without
 recording why the load failed, in terms a later reader can re-test.
+
+### The same question about DATA, not just components
+
+A shipped component is the obvious form. The sharper one: **before building machinery to
+reconstruct a value, check whether the running process already holds it.** One diagnostic print
+answers it.
+
+See #3825 for the instance. The issue recorded a page's `Name`/`SourceExpression` pair as
+*unrecoverable* for a precompiled page, and the agreed answer was to compile the shipped `.app`'s
+AL source with BC's own compiler — measured at **257 s and 8.83 GiB** for Base Application. The
+pair was in `NavForm.SourceExpressions` all along, populated by the `.app`'s own IL, present at
+the moment of the failing lookup. The missing piece was a **join**, not the data.
+
+**The trap is that the reconstruction route can be entirely correct and still be the wrong
+answer.** Base Application does compile, the measurements were sound, and the capability was
+worth having for other issues — none of which is evidence that the value was unavailable. A
+route that works is not proof that no cheaper one exists.
+
+**Check the runtime first, and record what you found either way**: a `dictCount=` print beside
+the failing lookup is cheaper than any reconstruction, and its absence is what let
+*unrecoverable* stand unchallenged in an issue body.
 
 History: docs/incidents/precompiled-dll-respect.md
 

--- a/.claude/rules/tdd.md
+++ b/.claude/rules/tdd.md
@@ -28,7 +28,9 @@ are claiming to prove:
    silently no-ops leaves the test **green**, which reads as "my test is broken" when it means
    "I changed nothing". Force a clean rebuild when you mutated a build input (`.csproj`, an
    MSBuild target, a generator), since an incremental build may skip the compile entirely.
-3. **Rebuild and re-run. Confirm RED.** Restore.
+3. **Rebuild and re-run. Confirm RED — and that the RED is the assertion, not the build.**
+   A mutation that breaks the compile also exits non-zero, and a run with compile errors prints
+   no `Total:` line at all. Check the error text says `Assert`, not `error CS`. Restore.
 4. **Report both numbers in the PR body** — `Failed: 1, Passed: 7` → `Failed: 0, Passed: 8`.
    A mutation whose result nobody can see is the same as one nobody ran.
 
@@ -47,6 +49,13 @@ fixed before merge, which is the outcome this step exists to produce.
 two references to `METADATA-EMIT-EXCLUDED` — one asserting the naming convention, one passing it
 as routing data. Both mention the stage; neither reaches the `throw`. A grep for the symbol
 finds them and reads as coverage, which is why the mutation is the check and the grep is not.
+
+**Trap: a mutation that breaks the build proves nothing, and it fails LOUDLY.** The landing
+check above catches the silent direction; this is the other one. Mutating a call site by text
+substitution produced `exit 1` with **10 `error CS`** lines and no `Total:` — a broken build
+wearing the shape of a caught regression. Measured twice on one guard in one hour (#3900), by an
+agent and its coordinator independently. Prefer mutating a **value** the assertion reads over
+editing code structure, and read the error text before believing a red.
 
 **Trap: a failed mutation and a working guard look identical.** Measured twice in one session
 (#3895): a backslash edit that a heredoc collapsed, so the file never changed; and a

--- a/docs/incidents/tdd.md
+++ b/docs/incidents/tdd.md
@@ -137,3 +137,36 @@ The coordinator had already written "EXIT=0" into a verification note before not
 had executed nothing. Same family as the mutation that does not land: **an action that silently
 did nothing reports success**, and the exit code cannot distinguish it from the real thing. The
 discriminator is the `Total:` line, which a no-match run does not print at all.
+
+
+## A mutation that breaks the build fails loudly and proves nothing (2026-09-11, #3900)
+
+The landing check added above catches the **silent** direction — a mutation that does not apply
+leaves the test green. This is the other direction, and it is easier to accept because it *looks*
+like the check working.
+
+Verifying #3900's null-forgiving ratchet (`Assert.Equal(92, converted)`), the coordinator removed
+one converted call site by text substitution. The run returned **exit 1** — the shape of a caught
+regression. It was 10 `error CS` lines:
+
+```
+RunnerPageInstance.cs(1336,37): error CS1002: ; expected
+RunnerPageInstance.cs(1336,37): error CS1513: } expected
+```
+
+A build that does not compile cannot exercise an assertion. The tell is the missing `Total:`
+line, the same discriminator the `--filter` trap uses: a run that never executed a test prints no
+summary.
+
+Re-done by mutating the **expected value** (`92 -> 91`) instead, which compiles and isolates the
+assertion: `0 compile errors`, `Expected: 91  Actual: 92`, `Failed: 1, Passed: 4, Total: 5`. That
+is what proves 92 is measured rather than asserted.
+
+**The implementing agent hit the same class independently, in the other direction**, and reported
+it rather than accepting the result: its first mutation *added* an unconverted line without
+removing a converted one, and the ratchet stayed green — correctly, since the converted count was
+still 92. It re-did the mutation as a real removal.
+
+Two people, one guard, one hour, two different ways for a mutation to prove nothing. The general
+form: **a mutation must change what the assertion reads, and nothing else.** Structural edits to
+code are the risky kind; a value the assertion consumes is the safe kind.


### PR DESCRIPTION
`precompiled-dll-respect.md` § "Reuse before you re-implement" asks whether Microsoft **ships a
component**. It never asks the adjacent question: whether the **running process already holds the
data** you are about to build machinery to reconstruct.

## The instance

**#3825** recorded a precompiled page's `Name`/`SourceExpression` pair as *unrecoverable*. The
agreed route was compiling the shipped `.app`'s AL source with BC's own compiler — **257 s and
8.83 GiB** for Base Application — which required unblocking that compile (#3876, PR #3883) and
would have required a consumer, a cache and a cost model.

The pair was in `NavForm.SourceExpressions` all along, populated by the `.app`'s own IL, present
at the moment of the failing lookup:

```
[DIAG-SRCEXPR] page 790 element 1511775225 Enabled raw='PageEditable' dictCount=7
  keys=[p790p790PageEditable, Control159866013, ...]
```

PR #3900 settles #3825 with neither a compile nor a cache. The implementing agent found it by
printing the dictionary before building the consumer it was dispatched to build.

## Why this is a second instance, not a restatement

The section's existing instance — `RunnerPageInstance`, ~9,246 lines re-implementing something
shipping in every artifact directory — is a **component on disk**. This one is **data in
memory**. A reader applying the rule as written would look for a DLL, correctly not find one, and
proceed by the rule's letter into the reconstruction.

## The part that makes it hard to catch

**The reconstruction route was entirely correct.** Base Application does compile, the
measurements were sound, and the capability is genuinely worth having for #3824, #2460's
containment question and the seven derivation-gap issues (#3788, #3798, #3805–#3809).

None of that is evidence the value was unavailable. **A route that works is not proof that no
cheaper one exists** — which is why "unrecoverable" stood unchallenged in an issue body through
several rounds of review, including mine.

## What changes

The heading gains "or already holds it", and a subsection states the data form: the #3825
instance, the trap above, and the remedy — a `dictCount=` print beside the failing lookup costs
one line and answers it, and its absence is what let the claim stand.

## Verification

Docs-only, so no BC legs run. `tools/test_doc_pointers.py` passes. Rule is 8,332 bytes, mid-pack
among nineteen.

**No mutation reported**, deliberately: prose in one file with no implementation to break.
Stating it rather than omitting it, since `tdd.md` now requires the step.

## Queue scan

Searched for `reuse`, `re-implement`, `already holds` and `SourceExpressions` across open issues;
nothing covers this. #3904 is this change's own issue. The related rule change tonight (#3897,
merged) was about a *third state* in guards, a different claim in a different file.

Closes #3904

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1


## Added after opening: a second trap, measured twice

`tdd.md` gains one more line. Its landing check (#3895) catches the **silent** direction — a
mutation that does not apply leaves the test green. This is the other direction:

**A mutation that breaks the build exits non-zero and proves nothing**, while wearing the shape
of a caught regression. Verifying #3900's ratchet, I removed a converted call site by text
substitution and got `exit 1` — which was **10 `error CS` lines**, not an assertion. The tell is
the missing `Total:` line, the same discriminator the `--filter` trap uses.

Re-done by mutating the **expected value** (`92 → 91`), which compiles and isolates the
assertion: `0 compile errors`, `Expected: 91  Actual: 92`, `Failed: 1, Passed: 4, Total: 5`.

The implementing agent hit the same class independently in the *opposite* direction and reported
it rather than accepting the result: its first mutation added an unconverted line without
removing a converted one, and the ratchet stayed green — correctly. **Two people, one guard, one
hour, two ways for a mutation to prove nothing.**

General form now in the rule: **a mutation must change what the assertion reads, and nothing
else.** Structural edits to code are the risky kind; a value the assertion consumes is the safe
kind.

This is `Part of #3904` rather than a separate issue — same file, same claim, and folding it
avoids a fourth rule PR in one session.
