### PR TITLE
fix(metadata): an enum value's absent Ordinal means zero, not the previous ordinal plus one

### DIFF
--- a/AlRunner.Tests/BcAppSymbolCacheEnumOrdinalVersionTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCacheEnumOrdinalVersionTests.cs
@@ -1,0 +1,202 @@
+// BcAppSymbolCacheEnumOrdinalVersionTests — proves the CacheVersion bump for #3805's
+// enum-ordinal parse change actually invalidates a stale on-disk entry, instead of
+// silently replaying the bug the change was made to fix.
+//
+// Gap being fixed
+// ----------------
+// TryParseEnumSymbol used to read a value stating no `Ordinal` as "the previous value's
+// ordinal plus one"; SymbolReference.json omits the property exactly when the ordinal is
+// ZERO, so the fallback is the constant 0 (#3805).
+//
+// That change alters the PARSE, not the record shape: EnumSymbol.Indexes is a List<int>
+// either way. The cache key is `{fullPath}|hash:{contentHash}|v{CacheVersion}|shape:
+// {PayloadShape}` (BcAppSymbolCache.BuildKey), so with the .app's bytes unchanged, `path`,
+// `hash` and `shape` are all identical before and after — leaving CacheVersion as the ONLY
+// discriminator. Without the bump, a machine whose cache was written by the previous build
+// keeps matching the same key and replays the OLD ordinals forever: the fix ships fully
+// deployed and does nothing on any warm box.
+//
+// This is the trap the constant's own comment block records five times over, and v36 is
+// this very method (#3594, TryParseEnumSymbol, shape unchanged).
+//
+// Why the wrong answer is worse than a wrong number: the old rule gives System Application
+// 2616 "Printer Paper Kind" a DUPLICATE ordinal — Custom and GermanStandardFanfold both at
+// 40 — and AlEnumMetadataRegistry.TryGet's merge dedupes on ordinal, so the collision drops
+// a value rather than merely mis-numbering it.
+//
+// Test strategy
+// -------------
+// A test that writes and reads back a FRESH entry cannot catch a missing version bump — a
+// fresh entry always carries the new ordinals, whichever number the key embeds. So this
+// plants the payload a PREVIOUS-version build would have written (the real .app's content
+// hash, but Indexes holding the old rule's answer) at the exact previous-version-keyed
+// path, then calls Get() with the current code and asserts both that the correct ordinal
+// survives AND that the .app was genuinely reparsed rather than served as a HIT.
+//
+// The stale path is located through BcAppSymbolCache.CachePathForVersionForTests, the seam
+// that delegates to the same private CachePath formula Get() uses, never a copy of it —
+// see BcAppSymbolCacheQueryMethodVersionTests' header for why a copy would pass for the
+// wrong reason.
+//
+// One trap worth naming, because it silently invalidates this measurement: a zip embeds an
+// mtime, so REWRITING the .app between the two reads moves the content hash and therefore
+// the whole key — the run then shows the fixed value and looks exactly like "no cache
+// problem". The .app here is written once.
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// #1821: Get() resolves its on-disk path through the process-global CacheRoots override,
+// so this joins CacheRootsSerialCollection for the same reason the sibling cache tests do.
+[Collection(CacheRootsSerialCollection.Name)]
+public sealed class BcAppSymbolCacheEnumOrdinalVersionTests
+{
+    // The shape that discriminates the two rules, reduced from System Application 2616:
+    // values NOT in ordinal order, and the value stating no Ordinal at the END rather than
+    // at index 0. Under the old rule "Custom" takes 40 — colliding with Fanfold; under the
+    // current one it is 0.
+    private const int FanfoldOrdinal = 40;
+
+    private static string NewTempDir()
+    {
+        var dir = TestScratch.FlatDir("bc-symbol-cache-enum-ordinal-version-tests-");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static string WriteApp(string dir, string fileName, string enumName)
+    {
+        var appPath = Path.Combine(dir, fileName);
+        using (var zip = new FileStream(appPath, FileMode.Create))
+        using (var za = new ZipArchive(zip, ZipArchiveMode.Create))
+        {
+            var entry = za.CreateEntry("SymbolReference.json");
+            using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+            w.Write($$"""
+                {
+                  "RuntimeVersion": "15.1",
+                  "EnumTypes": [
+                    {
+                      "Id": 90310,
+                      "Name": "{{enumName}}",
+                      "Values": [
+                        { "Name": "A3", "Ordinal": 8 },
+                        { "Name": "GermanStandardFanfold", "Ordinal": 40 },
+                        { "Name": "Custom" }
+                      ]
+                    }
+                  ]
+                }
+                """);
+        }
+        return appPath;
+    }
+
+    [Fact]
+    public void Get_StalePreviousVersionEntryWithTheOldOrdinalRule_IsIgnored_AndTheAppIsReparsed()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var enumName = "CVT Paper Kind " + Guid.NewGuid().ToString("N");
+            var appPath = WriteApp(dir, "enum-" + Guid.NewGuid().ToString("N") + ".app", enumName);
+
+            BcAppSymbolCache.ResetProcessCacheForTests();
+            var contentHash = BcAppSymbolCache.ComputeAppContentHash(appPath);
+
+            // The exact path a CacheVersion=40 build would have written to for this same
+            // .app content — a real machine's cache, unchanged .app bytes, pre-#3805 build.
+            //
+            // 40 is HARDCODED, deliberately, and must not be rewritten as
+            // `CacheVersionForTests - 1`. That expression moves with the constant, so it
+            // keeps planting the payload one version below whatever the constant says and
+            // the test passes even when the bump is reverted — measured: mutating 41 back
+            // to 40 left both tests GREEN. A literal is what makes the mutation bite, and
+            // it is why the sibling v13 test hardcodes 13.
+            const int VersionCarryingTheOldOrdinalRule = 40;
+            var staleCachePath = BcAppSymbolCache.CachePathForVersionForTests(
+                appPath, contentHash, VersionCarryingTheOldOrdinalRule);
+            Directory.CreateDirectory(Path.GetDirectoryName(staleCachePath)!);
+
+            // A payload carrying the OLD rule's answer: Custom got 40 by "previous + 1",
+            // colliding with GermanStandardFanfold. Shape-identical to a current payload,
+            // which is exactly why PayloadShape cannot discriminate it.
+            File.WriteAllText(staleCachePath, $$"""
+                {
+                  "ContentHash": "{{contentHash}}",
+                  "Tables": [],
+                  "Enums": [
+                    {
+                      "Id": 90310, "Name": "{{enumName}}",
+                      "Options": [ "A3", "GermanStandardFanfold", "Custom" ],
+                      "Indexes": [ 8, 40, 40 ],
+                      "Implementations": [ [], [], [] ],
+                      "Captions": [ null, null, null ],
+                      "DefaultImplementations": null, "UnknownImplementations": null
+                    }
+                  ],
+                  "Queries": [], "Objects": null, "Reports": null, "Pages": null
+                }
+                """);
+
+            Assert.Equal(0, BcAppSymbolCache.ParseInvocationCountForTests(appPath));
+
+            var symbols = BcAppSymbolCache.Get(appPath);
+
+            var parsed = Assert.Single(symbols.Enums, e => e.Name == enumName);
+
+            // The decisive assertions. Custom is 0 — only possible if the stale entry was
+            // NOT served — and the .app was genuinely reparsed rather than the stale file
+            // being read as a HIT.
+            Assert.Equal(new[] { "A3", "GermanStandardFanfold", "Custom" }, parsed.Options);
+            Assert.Equal(new[] { 8, FanfoldOrdinal, 0 }, parsed.Indexes);
+            Assert.Equal(1, BcAppSymbolCache.ParseInvocationCountForTests(appPath));
+
+            // The consequence, asserted directly: no two values share an ordinal. The stale
+            // payload violates this, so serving it could not satisfy this line.
+            Assert.Equal(parsed.Indexes.Count, parsed.Indexes.Distinct().Count());
+
+            // Prove the test's own premise rather than only the outcome: a version bump
+            // MOVES the on-disk location, it does not patch the old file.
+            var currentCachePath = BcAppSymbolCache.CachePathForVersionForTests(
+                appPath, contentHash, BcAppSymbolCache.CacheVersionForTests);
+            Assert.NotEqual(staleCachePath, currentCachePath);
+            Assert.True(File.Exists(currentCachePath),
+                $"Expected a fresh cache entry at the current-version path {currentCachePath}");
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    /// <summary>
+    /// Negative companion: a FRESH entry already carrying the correct ordinals must still be
+    /// served as a genuine HIT, so the bump does not turn every enum lookup into an
+    /// unconditional reparse. Two Get() calls across a simulated separate process
+    /// (ProcessCache cleared) must reparse only once.
+    /// </summary>
+    [Fact]
+    public void Get_FreshEntryWithTheCorrectOrdinals_IsAGenuineHitOnTheSecondCall()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var enumName = "CVT Paper Kind Hit " + Guid.NewGuid().ToString("N");
+            var appPath = WriteApp(dir, "enum-hit-" + Guid.NewGuid().ToString("N") + ".app", enumName);
+
+            BcAppSymbolCache.ResetProcessCacheForTests();
+            var first = BcAppSymbolCache.Get(appPath);
+            Assert.Equal(new[] { 8, FanfoldOrdinal, 0 }, Assert.Single(first.Enums, e => e.Name == enumName).Indexes);
+            Assert.Equal(1, BcAppSymbolCache.ParseInvocationCountForTests(appPath));
+
+            // A separate process would have an empty ProcessCache but the same on-disk entry.
+            BcAppSymbolCache.ResetProcessCacheForTests();
+            var second = BcAppSymbolCache.Get(appPath);
+
+            Assert.Equal(new[] { 8, FanfoldOrdinal, 0 }, Assert.Single(second.Enums, e => e.Name == enumName).Indexes);
+            Assert.Equal(1, BcAppSymbolCache.ParseInvocationCountForTests(appPath));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+}

--- a/AlRunner.Tests/FloorOnlyBundleEnumFieldTests.cs
+++ b/AlRunner.Tests/FloorOnlyBundleEnumFieldTests.cs
@@ -124,4 +124,58 @@ public sealed class FloorOnlyBundleEnumFieldTests
         Assert.Equal(new[] { "Draft", "Queued" }, parsedWithValues!.Options);
         Assert.Equal(new[] { 0, 5 }, parsedWithValues.Indexes);
     }
+
+    /// <summary>
+    /// #3805 — a value stating no <c>Ordinal</c> has ordinal ZERO, not "the previous ordinal
+    /// plus one". The symbol file omits the property exactly when the value is 0, the same
+    /// absent-means-default convention <c>PermissionSymbol</c> records for <c>PermissionObject</c>.
+    ///
+    /// <para>The source-order rule agrees with that on 680 of the 681 absent-Ordinal values
+    /// shipped in 28.1, which is why it survived; it disagrees on System Application enum 2616
+    /// "Printer Paper Kind", whose 68 values BC emits in NAME order with <c>Custom</c> last and
+    /// stating no <c>Ordinal</c>. Its 67 declared ordinals mirror
+    /// <c>System.Drawing.Printing.PaperKind</c> exactly, in which <c>Custom</c> is 0, and 0 is the
+    /// one ordinal no declared value claims. Measured on two independent binaries, 28.1 and 28.4.
+    /// Derivation: the PR body for #3805.</para>
+    /// </summary>
+    [Fact]
+    public void AbsentOrdinal_MeansZero_NotThePreviousOrdinalPlusOne()
+    {
+        // The shape of System Application 2616, reduced to the part that discriminates: values
+        // NOT in ordinal order, and the absent Ordinal at the END rather than at index 0.
+        var nameOrdered = System.Text.Json.JsonDocument.Parse("""
+            { "Id": 2616, "Name": "Printer Paper Kind", "Values": [
+                { "Name": "A3", "Ordinal": 8 },
+                { "Name": "A4", "Ordinal": 9 },
+                { "Name": "GermanStandardFanfold", "Ordinal": 40 },
+                { "Name": "Custom" } ] }
+            """).RootElement;
+
+        var parsed = AlRunner.Patches.BcAppSymbolCache.ParseEnumSymbolForTest(nameOrdered);
+
+        Assert.NotNull(parsed);
+        Assert.Equal(new[] { "A3", "A4", "GermanStandardFanfold", "Custom" }, parsed!.Options);
+
+        // The whole claim: Custom is 0. The source-order rule answers 41 here.
+        Assert.Equal(new[] { 8, 9, 40, 0 }, parsed.Indexes);
+
+        // ...and the consequence that makes the wrong answer more than a wrong number: an AL
+        // enum's ordinals are distinct, so a rule producing a collision is wrong by construction.
+        Assert.Equal(parsed.Indexes.Count, parsed.Indexes.Distinct().Count());
+
+        // The NEGATIVE direction, which is what stops "read 0 for everything" passing: a value
+        // that DOES state an ordinal keeps it, including a 0 stated explicitly, and a later
+        // absent one does not inherit its neighbour.
+        var mixed = System.Text.Json.JsonDocument.Parse("""
+            { "Id": 60000, "Name": "Mixed", "Values": [
+                { "Name": "Explicit", "Ordinal": 0 },
+                { "Name": "Seven", "Ordinal": 7 },
+                { "Name": "AlsoZero" } ] }
+            """).RootElement;
+
+        var parsedMixed = AlRunner.Patches.BcAppSymbolCache.ParseEnumSymbolForTest(mixed);
+
+        Assert.NotNull(parsedMixed);
+        Assert.Equal(new[] { 0, 7, 0 }, parsedMixed!.Indexes);
+    }
 }

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -268,7 +268,18 @@ internal static partial class BcAppSymbolCache
     //
     // 40 was confirmed free immediately before pushing, per v39's own warning: origin/main read
     // 39, and no open agent branch carried a value above 38.
-    private const int CacheVersion = 40;
+    // v41: an enum value stating no Ordinal is read as 0 rather than the previous ordinal plus
+    // one (#3805). The same trap as v35, v36, v38, v39 and v40, and v36 is this very method:
+    // EnumSymbol.Indexes is a List<int> either way, so PayloadShape cannot see that System
+    // Application 2616 "Printer Paper Kind" went from 67 distinct ordinals across 68 values to
+    // 68. Without the bump a warm box replays the old parse and hands out a DUPLICATE ordinal —
+    // TryGet's merge dedupes on ordinal, so the collision drops a value rather than mis-numbering
+    // it. Measured on 28.1 and 28.4: 681 and 684 values state no Ordinal, and none of the 3,649
+    // (3,701) states one explicitly as zero.
+    //
+    // 41 was confirmed free immediately before pushing, per v39's own warning: origin/main read
+    // 40, and a sweep of all 252 remote branches carrying this file found none above 40.
+    private const int CacheVersion = 41;
     private static readonly ConcurrentDictionary<string, AppSymbols> ProcessCache = new(StringComparer.OrdinalIgnoreCase);
     // Issue #1820's path -> content-hash memo now lives in
     // RunnerFingerprint._fileContentHashes (#2955), because AppLoader's persisted r2r-chunks

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -2476,7 +2476,6 @@ internal static partial class BcAppSymbolCache
         var indexes = new List<int>();
         var implementations = new List<List<int>>();
         var captions = new List<string?>();
-        var nextOrdinal = 0;
         foreach (var value in hasValues
                      ? values.EnumerateArray().Cast<JsonElement>()
                      : Enumerable.Empty<JsonElement>())
@@ -2484,9 +2483,16 @@ internal static partial class BcAppSymbolCache
             var optionName = value.TryGetProperty("Name", out var optionNameProp)
                 ? optionNameProp.GetString() ?? string.Empty
                 : string.Empty;
+            // #3805 — absent `Ordinal` means ZERO, the symbol file's absent-means-default
+            // convention (the same one PermissionSymbol records for PermissionObject). It is
+            // NOT "the previous ordinal plus one": the values are not necessarily emitted in
+            // ordinal order, and System Application 2616 "Printer Paper Kind" emits them in
+            // NAME order with Custom (ordinal 0) last, where the source-order rule answered 40
+            // and collided with GermanStandardFanfold. Measured on 28.1 and 28.4: 681 values
+            // state no Ordinal and this rule agrees with BC's emitted metadata on all of them.
             var ordinal = value.TryGetProperty("Ordinal", out var ordinalProp) && ordinalProp.TryGetInt32(out var explicitOrdinal)
                 ? explicitOrdinal
-                : nextOrdinal;
+                : 0;
             options.Add(optionName);
             indexes.Add(ordinal);
             var implementationIds = new List<int>();
@@ -2507,7 +2513,6 @@ internal static partial class BcAppSymbolCache
             captions.Add(props.TryGetValue("Caption", out var captionText) && !string.IsNullOrEmpty(captionText)
                 ? captionText
                 : null);
-            nextOrdinal = ordinal + 1;
         }
         // Enum-level fallbacks. Both are written the same way a value's Implementation is —
         // a comma-separated list of codeunit ids, one per interface the enum implements.

--- a/tests/expectations/metadata-equivalence/allowlist.json
+++ b/tests/expectations/metadata-equivalence/allowlist.json
@@ -1435,11 +1435,6 @@
       "member": "MetaEnum.MetadataToken",
       "reason": "BC's emitted document opens with MetadataVersion=\"130000\" and every one of BC's own readers copies it into MetadataToken; the runner states no metadata-format version anywhere, so BC's default of 0 stands on the runner's side. Measured on BC 28.1.49838.53910: 178 of 178 permission sets and 142 of 142 enums, i.e. EVERY object of both kinds and never a subset -- which is what shows this is a property of the document format rather than of any object's declaration. It is derivable trivially (write the same constant), and it is not stated because nothing in the runner consumes a metadata-format version. Tracked with the rest of each kind's derivation gap. NOT declared for MetaTable or PageDefinition: those two routes already agree, so this is genuinely a property of the kinds added in #3782 steps 5-7.",
       "issue": 3807
-    },
-    {
-      "member": "MetaEnumValue.Ordinal",
-      "reason": "Enum 2616 'Printer Paper Kind' only: BC answers ordinal 0 for the value 'Custom', the runner answers 40. SymbolReference.json omits Ordinal exactly when it is ZERO -- the same absent-means-default convention PermissionSymbol's own doc comment records for PermissionObject -- and TryParseEnumSymbol reads an absent Ordinal as 'previous + 1' instead, which is an AL SOURCE-order convention. Measured across three shipped apps on BC 28.1.49838.53910: 671 values carry no Ordinal and the rule is wrong on exactly one, because 2616 is the only enum BC emits in an order that is not ordinal order (its values are name-sorted: A2=66, A3=8, A4=9, ...). The consequence is worse than a wrong number: ordinal 40 ends up claimed by both GermanStandardFanfold and Custom, so the enum has 67 distinct ordinals across 68 values and two AL enum members become indistinguishable by value. Fixed by reading an absent Ordinal as 0 (#3805), one line in BcAppSymbolCache -- deliberately not folded into #3782's harness PR, which touches no parser.",
-      "issue": 3805
     }
   ]
 }


### PR DESCRIPTION
Closes #3805

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/325

Implemented by an agent (`stma-auto-2`).

`BcAppSymbolCache.TryParseEnumSymbol` read a value stating no `Ordinal` as **the previous value's ordinal plus one**. `SymbolReference.json` omits the property exactly when the ordinal is **0**, so the correct fallback is the constant `0`.

## The convention, established from real symbol files rather than taken on trust

The brief was explicit that this is the whole fix, so I measured it rather than believing the issue. I extracted `SymbolReference.json` from every shipped platform app of **two independent binary sets** — 28.1.49838.53910 and 28.4.53241.54407 — and replayed both rival rules against BC's own declared ordinals. (The top-level `EnumTypes` array is empty in these files; the enums live in the `Namespaces` tree, which my first pass missed and which returned an all-zeros table that read exactly like a finding. The numbers below are from the corrected walk.)

| | 28.1 | 28.4 |
|---|---:|---:|
| enums with values | 718 | 721 |
| enum values total | 3,649 | 3,701 |
| values **stating** `Ordinal` | 2,968 | 3,017 |
| values **omitting** `Ordinal` | 681 | 684 |
| values stating `Ordinal` explicitly as **0** | **0** | **0** |

**That last row is the claim, and it is the strongest evidence available**: across 7,350 enum values over two BC majors, not one states an ordinal of zero. 2,968 + 681 = 3,649 exactly, so the property is present precisely when it is non-zero. Absent means 0.

**Why `previous + 1` survived for so long**: on 28.1, 680 of the 681 absent values sit at **index 0**, where both rules answer 0 (28.4: 683 of 684). The rules disagree on exactly **one** enum in each set.

### The discriminating case

System Application **2616 `Printer Paper Kind`** (`System.Device`), 68 values, emitted in **name** order — `A2=66, A3=8, A4=9, A5=11, A6=70, …` — with `Custom` **last** and stating no `Ordinal`.

- `absent = 0` → 68 distinct ordinals across 68 values.
- `absent = prev + 1` → `Custom` gets **40**, already held by `GermanStandardFanfold` at index 23. **67 distinct ordinals across 68 values.**

Three further checks, each independent of believing either rule beforehand:

1. **`0` is the one ordinal no declared value claims** in that enum. The emitter omitted exactly the value whose ordinal is 0.
2. **A duplicate ordinal is impossible for an AL enum by construction**, so the rule producing one is wrong whatever the convention.
3. **The enum mirrors `System.Drawing.Printing.PaperKind`** — `Letter=1, Legal=5, A3=8, A4=9, A5=11, Tabloid=3, Ledger=4, Statement=6, Executive=7` all match exactly, and `Custom` is **0** in .NET.

If the convention had come out the other way I would have stopped and said so; it did not.

## RED → GREEN → mutation

`AlRunner.Tests/FloorOnlyBundleEnumFieldTests.cs`, `AbsentOrdinal_MeansZero_NotThePreviousOrdinalPlusOne`, driving `ParseEnumSymbolForTest` — the seam that already exists for this parser.

| step | result |
|---|---|
| **RED** (before the fix) | `Failed: 1, Passed: 0, Skipped: 0, Total: 1` — `Expected: [8, 9, 40, 0]` / `Actual: [8, 9, 40, 41]` |
| **GREEN** (after the fix) | `Failed: 0, Passed: 5, Skipped: 0, Total: 5` (whole class) |
| **MUTATION** — fallback `0` → `1` | `Failed: 1, Passed: 4, Skipped: 0, Total: 5`, **`error CS` count 0**, failure text `Assert.Equal() Failure`, `Actual: [8, 9, 40, 1]` |
| **restored** | `Failed: 0, Passed: 5, Skipped: 0, Total: 5` |

The mutation is a **value** change, not a structural edit, so the red is the assertion rather than a broken build — I checked the `error CS` count was 0 and that a `Total:` line was present, and confirmed the mutation landed by diffing against a copy held outside the repository (md5 `acc71d03…` → `3cbe2919…` → `acc71d03…`).

The test also covers the negative direction — an explicit `Ordinal: 0` is kept, a stated `7` is kept, and a later absent one does **not** inherit its neighbour — so "read 0 for everything" cannot pass it.

## The CacheVersion bump — a second defect, found in review

**The fix as first pushed was silently unapplied on any warm box, and I had missed it.**

`BuildKey` is `{fullPath}|hash:{contentHash}|v{CacheVersion}|shape:{PayloadShape}`. My change alters the **parse**, not the record shape — `EnumSymbol.Indexes` is a `List<int>` either way — so with the `.app`'s bytes unchanged, `path`, `hash` and `shape` are all identical before and after, leaving `CacheVersion` as the only discriminator. A machine with a cache written by the previous build kept matching the same key and replayed the old ordinals forever.

This is the trap the constant's own comment block records five times, and **v36 is this very method** (#3594, `TryParseEnumSymbol`, shape unchanged). Bumped to **41**.

**41 confirmed free the way v39's warning prescribes**: `origin/main` reads 40, and a sweep of every remote branch found none above it — 252 branches carry the file, with `origin/main = 40` as a positive control. (My first sweep printed a confident "41 is free" from `grep -oE '[0-9]+$'`, which matches nothing because the line ends in `;` — it reported **0 branches carrying the file** and I nearly took it. Same class as the `EnumTypes` near-miss.)

### The proving test, and the mutation that exposed it

`AlRunner.Tests/BcAppSymbolCacheEnumOrdinalVersionTests.cs`, modelled on the v13 sibling: it plants the payload a v40 build would have written — `Indexes: [8, 40, 40]`, the old rule's duplicate — at the v40-keyed path, then asserts `Get()` ignores it, reparses (`ParseInvocationCountForTests == 1`), and answers `[8, 40, 0]` with no repeated ordinal. A negative companion proves a fresh entry is still a genuine HIT rather than an unconditional reparse.

| step | result |
|---|---|
| GREEN | `Failed: 0, Passed: 2, Skipped: 0, Total: 2` |
| **MUTATION** — `CacheVersion` 41 → 40 | `Failed: 1, Passed: 1, Total: 2`, **0 `error CS`**, `Expected: [8, 40, 0]` / `Actual: [8, 40, 40]` |
| restored | `Failed: 0, Passed: 2, Total: 2` |

**The first version of this test did not survive its own mutation, and that is worth recording.** I wrote the stale version as `CacheVersionForTests - 1`, which *moves with the constant* — so reverting the bump merely shifted the planted payload to v39 and **both tests stayed green**. A hardcoded `40` is what makes the mutation bite, and it is why the sibling v13 test hardcodes 13. A failed mutation returns green and looks like the system working; only running it showed the difference.

## The stale allowlist entry

`tests/expectations/metadata-equivalence/allowlist.json` carried a `MetaEnumValue.Ordinal` entry keyed `"issue": 3805` whose reason described exactly this difference. With the fix in, `No_allowlist_entry_has_gone_stale` failed on both legs — **confirmation wearing a red tick**: the #3782 harness independently agrees the runner now matches BC.

Removed, as a clean 5-line deletion with no reformatting. Its own RED → GREEN, with the entry restored and then removed:

| | result |
|---|---|
| entry present | `Failed: 1, Passed: 0, Total: 1`, naming `MetaEnumValue.Ordinal` |
| entry removed | `Failed: 0, Passed: 1, Total: 1` |

The two blockers interact: without the bump, whether that test fires at all depends on the box's cache state, so fixing only one would not have made the green trustworthy.

## Other tests run

Run in Release with the in-process engine bootstrapped (`tools/engine-test-bootstrap.sh` + `--settings engine.runsettings`):

- `~Enum|~BcAppSymbolCache|~MetadataEquivalence|~RecordShapeFingerprint` — **`Failed: 0, Passed: 224, Skipped: 0, Total: 224`** (after both fixes)
- the three proving surfaces together — **`Failed: 0, Passed: 8, Skipped: 0, Total: 8`**
- `FullyQualifiedName~Enum` — **`Failed: 0, Passed: 136, Skipped: 0, Total: 136`**

Worth recording: an unbootstrapped Debug run of the first filter reported `Failed: 15`. All fifteen were the `bc-engine-serial` guard refusing to skip silently, not my change — the bootstrap cleared every one. That guard behaved exactly as designed.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** No. I swept `AlRunner/` for the carry-forward shape (`nextOrdinal`, `nextId`, `nextIndex`) with a positive control confirming the search worked. The remaining sites are `TddGeneration.cs` (picking an unused id for a **new** member), `BackupReaderServe.cs` and `AlIterationSegmenter.cs` (monotonic counters), and `RecordPatches.RecordLinkTable.cs` (next free record-link id). All are **generation**, where `previous + 1` is correct by construction. This was the only *reading* instance.
2. **Sibling function making the same assumption?** No. The enum-level lists read through `SymbolCodeunitIdList` treat an absent property as "declares none" (null), which is the same absent-means-default convention correctly applied. The per-value `Caption` read does likewise.
3. **Two code paths writing the same state with different invariants?** Not for this property — `TryParseEnumSymbol` is the only producer of `EnumSymbol.Indexes`.

I also removed the now-unused `nextOrdinal` accumulator rather than leaving it in place, so the wrong rule cannot be reintroduced by reusing a variable that is already there.

## Sibling issues — the fold decision, stated deliberately

**#3807 is NOT folded in, and it is not a close call.** It is the same object kind and nominally the same method, which is why it was worth looking at hard, but the fixes do not land in the same code:

| | #3805 (this PR) | #3807 |
|---|---|---|
| what changes | one expression inside `TryParseEnumSymbol` | the **shape** of the `EnumSymbol` record — it carries neither `Extensible` nor `ALNamespace` at all |
| blast radius | the parser only | `EnumSymbol` **and** `AlEnumMetadataRegistry.Entry` which mirrors it, **and** the render side, which has no element for the implementation lists it already parses |
| open question | none — settled by measurement | whether BC's `<Value>` shape can express `InterfaceImplementation` at all; #3807 says this "needs checking before this is called a derivation gap" |

Folding it would put a one-expression fix and a multi-file record-shape change behind one review, and #3807 carries an unresolved question of its own. That is `batch-sibling-issues-by-file.md` point 4 — materially different reasoning to review — so they stay separate. #3807 keeps `status: ready` and is untouched by me.

The other five from the same #3782 harness — **#3788** (codeunit), **#3798** (query), **#3806** (permission set), **#3808** (report), **#3809** (extension runtime deltas) — are all different object kinds parsed by different methods. None shares this fix's code.

**Searched for the same defect filed twice**, by symbol, by observable and by measurement (`Printer Paper Kind`, `enum ordinal in:title`): only #3805 came back, and the queries were confirmed working against a positive control. No duplicate.

## Closes exactly one issue

This PR closes **#3805 only**. The other six cluster issues stay open.

## Corpus linkage

`Corpus-PR:` above is a real test, not gate-satisfaction. An enum value's ordinal is what AL sees, the corpus app declares a System Application dependency so enum 2616 is reachable from corpus AL, and the enum is in `System.Device` with no `Access` restriction and no `Scope = OnPrem`. So the claim **is** expressible upstream and a real service tier can adjudicate it — corpus PR #325, codeunit 60036, four tests.

One thing I deliberately left out of the corpus test: **`Format()`**. Enum 2616's captions differ from its names, and the corpus's existing `Enum_Format_ReturnsName` uses fixture enum 60009 whose names and captions are **identical** — so it does not settle which of the two `Format()` returns, and neither would a guess from me. I noted it in the corpus PR as a separate question rather than asserting it.

**This PR should not merge before corpus PR #325 does.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
