### PR TITLE
docs(verify): the fourth instrument failure is a correct tool reading the wrong subject

### DIFF
--- a/.claude/rules/verify-execution-not-the-tick.md
+++ b/.claude/rules/verify-execution-not-the-tick.md
@@ -68,6 +68,27 @@ So when a query about a run returns something surprising, re-derive it a second 
 reporting it, and treat the instrument with the suspicion you would give the subject: a tool that
 cannot be wrong in the direction you are reading is not evidence.
 
+### The fourth mechanism: a correct instrument reading the WRONG SUBJECT
+
+The three above are instruments that malfunction. This one works perfectly and answers a
+different question than the one asked — so its output is well-formed, plausible, and wrong.
+Three instances in one issue's work (#3805 / corpus #325), each caught by someone doubting a
+surprising result rather than by the instrument:
+
+| the measurement | what it read | what it should have read |
+|---|---|---|
+| "which object ids are free?" | the corpus checkout **inside the runner worktree**, resolved per run and older than `master` | the branch being pushed to |
+| "how many enum values omit `Ordinal`?" | the top-level `EnumTypes` array, which is **empty** | the `Namespaces` tree, where the enums live |
+| "are any ids duplicated?" | the id alone, repo-wide | `(object kind, id)`, scoped to one `app.json`'s `idRanges` |
+
+The first produced an id that was genuinely free in the tree measured and taken in the tree
+pushed to. The second produced an all-zeros table. The third produced **61 duplicates** that do
+not exist, because a codeunit and a table may share an id.
+
+**Ask what the query read, not only what it returned.** A checkout resolved elsewhere, a
+container that is empty because the data moved, and a scope wider than the thing being validated
+all return clean answers to a question nobody asked.
+
 
 ## Which legs were ever going to run it
 


### PR DESCRIPTION
`verify-execution-not-the-tick.md` § "Where this discipline actually fails: on the instrument"
records three ways an instrument **malfunctions**. There is a fourth: **the instrument works
perfectly and reads the wrong subject.**

Its output is well-formed, plausible, and answers a question nobody asked — and unlike the other
three it **survives re-running**, because the instrument is deterministic and gives the same
clean wrong answer every time.

## Three instances, one issue's work

From #3805 and corpus PR #325, each caught by someone doubting a surprising result rather than by
the instrument:

| the measurement | what it read | what it should have read |
|---|---|---|
| "which object ids are free?" | the corpus checkout **inside the runner worktree** — resolved per run, older than `master` | the branch being pushed to |
| "how many enum values omit `Ordinal`?" | the top-level `EnumTypes` array, which is **empty** | the `Namespaces` tree, where the enums live |
| "are any ids duplicated?" | the id alone, repo-wide | `(object kind, id)`, scoped to one `app.json`'s `idRanges` |

1. produced an id **genuinely free in the tree measured and taken in the tree pushed to** — the
   corpus is resolved per run (#3737), so a worktree's copy can lag `master` by the very commit
   that claims the id. Cost: a red lint gate.
2. produced an all-zeros table that looked exactly like a finding about the data.
3. produced **61 duplicates that do not exist** — a codeunit 60023 and a table 60023 legitimately
   coexist. That same scan offered `61203` as free, which is true repo-wide and sits inside the
   **OnPrem** app's range `[61200, 61299]`; using it in the cloud app would have reproduced the
   same `AL0297` from the other direction.

**Instance 3 was mine**, supplied to the implementing agent as a correction, and the agent
corrected me back with the per-`app.json` ranges. Worth stating because the coordinator's numbers
are the ones least likely to be re-checked.

## What changes

A subsection under the existing instrument heading, with the table and the general form: *a
checkout resolved elsewhere, a container that is empty because the data moved, and a scope wider
than the thing being validated all return clean answers to a question nobody asked.*

The operative instruction is one line: **ask what the query read, not only what it returned.**

## Verification

Docs-only, so no BC legs run. `tools/test_doc_pointers.py` passes. One file, +21/-0. Rule is
6,864 bytes.

Pre-push checks run, both from errors I made earlier today: `git diff --stat origin/main...HEAD`
against a freshly fetched `main` (one file, no deletions — #3907), and a scan for closing keywords
beside any issue number other than the target (only `Closes #3909`).

**No mutation reported**, deliberately: prose in one file with no implementation to break.

## Queue scan

Searched open issues for `instrument`, `wrong input`, `false zero` and `verify-execution`;
nothing covers this. Tonight's other rule changes were `tdd.md` (#3885, #3895, #3904) and
`guards-need-a-third-state.md` (#3897) — different files, different claims. Nothing to fold.

Closes #3909

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
