### PR TITLE
fix(enum): state Extensible and the implementation lists the enum derivation drops

### DIFF
--- a/AlRunner.Tests/EnumExtensibleAndImplementationRenderTests.cs
+++ b/AlRunner.Tests/EnumExtensibleAndImplementationRenderTests.cs
@@ -1,0 +1,357 @@
+// EnumExtensibleAndImplementationRenderTests — #3807.
+//
+// Four members BC's ObjectMetadataEmitter states about an enum and the runner's
+// SymbolReference.json derivation did not:
+//
+//     MetaEnum.Extensible                    31 of 142 base enums, answered false for all 31
+//     MetaEnumValue.InterfaceImplementation  32 values, answered [] for all 32
+//     MetaEnum.DefaultImplementation          3 enums
+//     MetaEnum.UnknownImplementation          1 enum
+//
+// The last three were already PARSED (#2306) and merely never rendered; Extensible was not
+// carried by EnumSymbol at all, so AlEnumMetadataRegistry.Entry had nothing to state and BC's
+// MetaEnum(XmlNode) applied its own default of false.
+//
+// THE OPEN QUESTION THE ISSUE RAISED, AND HOW IT WAS SETTLED
+//   #3807 asked whether BC's <Value> shape can express InterfaceImplementation at all, or
+//   whether only the emitter's own form carries it. Types.Metadata.MetaEnumValue(XmlNode)
+//   answers it: the constructor reads an `Implementation` ATTRIBUTE on <Value> into
+//   InterfaceImplementation, and MetaEnum(XmlNode) reads `Extensible`, `DefaultImplementation`
+//   and `UnknownImplementation` as attributes on the <Enum> root. All four are expressible.
+//   Derivation and the per-binary counts: the PR body for #3807.
+//
+// TWO SPELLINGS THAT ARE NOT INTERCHANGEABLE, both read off those constructors:
+//   * Extensible goes through MetaBase.Int32Value, which is Int32.Parse with "" and "undefined"
+//     mapped to 0. So the attribute must be "1"/"0"; writing "true" makes BC THROW, not default.
+//   * The implementation lists are split on MetaBase.SplitChar and Int32.Parse'd per part, so a
+//     comma-joined id list is the shape — the same one SymbolReference.json states.
+//
+// This is a RUNNER-MECHANISM test, not a BC-behaviour claim: it pins that the runner's own
+// derivation and render carry these values. It reads the render back through BC's own
+// MetaEnum(XmlNode) — resolved by reflection, exactly as
+// MetadataEquivalenceReportEnumPermissionSetOracleTests does — so the assertions are about
+// what BC sees rather than about our XML text.
+using System.Reflection;
+using System.Xml;
+using AlRunner;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class EnumExtensibleAndImplementationRenderTests
+{
+    private readonly BcEngineFixture _engine;
+
+    public EnumExtensibleAndImplementationRenderTests(BcEngineFixture engine) => _engine = engine;
+
+    private static Type MetaEnumType()
+        => Type.GetType("Microsoft.Dynamics.Nav.Types.Metadata.MetaEnum, Microsoft.Dynamics.Nav.Types")
+           ?? throw new InvalidOperationException("MetaEnum is not reachable.");
+
+    /// <summary>The runner's render, read back through BC's own <c>MetaEnum(XmlNode)</c>.</summary>
+    private static object ReadBackThroughBc(XmlElement root)
+    {
+        var ctor = MetaEnumType().GetConstructor(new[] { typeof(XmlNode) })
+                   ?? throw new InvalidOperationException("MetaEnum has no (XmlNode) constructor.");
+        return ctor.Invoke(new object?[] { root })!;
+    }
+
+    private static int[] IntArray(object parsed, string property)
+    {
+        var value = parsed.GetType().GetProperty(property)!.GetValue(parsed)!;
+        return ((System.Collections.IEnumerable)value).Cast<int>().ToArray();
+    }
+
+    /// <summary>Every <c>MetaEnumValue</c> the parse produced, keyed by its <c>Ordinal</c> —
+    /// never by position: BC's emitter writes an enum's values in NAME order, so index and
+    /// ordinal coincide only by accident.</summary>
+    private static Dictionary<int, object> ValuesByOrdinal(object parsed)
+    {
+        var values = parsed.GetType().GetProperty("Values")!.GetValue(parsed)!;
+        var result = new Dictionary<int, object>();
+        foreach (var v in (System.Collections.IEnumerable)values)
+        {
+            var ordinal = (int)v.GetType().GetProperty("Ordinal")!.GetValue(v)!;
+            result[ordinal] = v;
+        }
+        return result;
+    }
+
+    private static int[] InterfaceImplementation(object metaEnumValue)
+    {
+        var value = metaEnumValue.GetType().GetProperty("InterfaceImplementation")!.GetValue(metaEnumValue)!;
+        return ((System.Collections.IEnumerable)value).Cast<int>().ToArray();
+    }
+
+    private static string? Name(object metaEnumValue)
+        => (string?)metaEnumValue.GetType().GetProperty("Name")!.GetValue(metaEnumValue);
+
+    // The shape of a real System Application enum that declares all four: Extensible = 1, a
+    // per-value Implementation, and both enum-level fallbacks. Modelled on enum 1465
+    // "Encryption Algorithm", the issue's named example for DefaultImplementation and
+    // UnknownImplementation, widened with Extensible so one document covers all four members.
+    private const string SymbolJson = """
+        {
+          "Id": 1465,
+          "Name": "Encryption Algorithm",
+          "Properties": [
+            { "Name": "Extensible", "Value": "1" },
+            { "Name": "DefaultImplementation", "Value": "1467" },
+            { "Name": "UnknownValueImplementation", "Value": "1467" }
+          ],
+          "Values": [
+            { "Name": "Aes", "Ordinal": 0,
+              "Properties": [ { "Name": "Implementation", "Value": "1467" } ] },
+            { "Name": "TripleDES", "Ordinal": 1,
+              "Properties": [ { "Name": "Implementation", "Value": "1468" } ] },
+            { "Name": "NoImplementer", "Ordinal": 2 }
+          ]
+        }
+        """;
+
+    // The same enum with Extensible declared FALSE — the 99-of-129 case in 28.1, and the
+    // negative direction that stops "write 1 unconditionally" passing.
+    private const string NotExtensibleJson = """
+        {
+          "Id": 9005,
+          "Name": "User Plan Experience",
+          "Properties": [ { "Name": "Extensible", "Value": "0" } ],
+          "Values": [ { "Name": "Basic", "Ordinal": 0 } ]
+        }
+        """;
+
+    // An enum declaring NO Extensible property at all — 12 of 142 in 28.1. AL's own default is
+    // false (CodeAnalysis ApplicationObjectTypeSymbol.ExtensibleByDefault => false, with no enum
+    // override), which is also MetaEnum's default, so absent and "0" must agree.
+    private const string SilentJson = """
+        {
+          "Id": 60001,
+          "Name": "Declares Nothing",
+          "Values": [ { "Name": "Only", "Ordinal": 0 } ]
+        }
+        """;
+
+    private static BcAppSymbolCache.EnumSymbol Parse(string json)
+    {
+        var parsed = BcAppSymbolCache.ParseEnumSymbolForTest(
+            System.Text.Json.JsonDocument.Parse(json).RootElement);
+        Assert.NotNull(parsed);
+        return parsed!;
+    }
+
+    /// <summary>Registers a parsed symbol exactly as the precompiled-dependency path does
+    /// (RecordPatches.AddBcAppPath), then renders it.</summary>
+    private static XmlElement RegisterAndRender(BcAppSymbolCache.EnumSymbol e)
+    {
+        AlEnumMetadataRegistry.Register(
+            e.Id, e.Name, e.Options.ToArray(), e.Indexes.ToArray(),
+            e.Implementations.Select(i => i.ToArray()).ToArray(),
+            e.Captions?.ToArray(),
+            e.DefaultImplementations?.ToArray(),
+            e.UnknownImplementations?.ToArray(),
+            e.Extensible);
+
+        var xml = RecordPatches.TryBuildEnumMetadataEquivalenceXml(e.Id);
+        Assert.NotNull(xml);
+        var doc = new XmlDocument();
+        doc.LoadXml(xml!);
+        return doc.DocumentElement!;
+    }
+
+    /// <summary>
+    /// The parse arm: <c>Extensible</c> reaches <see cref="BcAppSymbolCache.EnumSymbol"/> at all.
+    /// Before #3807 the record had no such member, so this is the member that did not exist.
+    /// Needs no BC engine — it reads JSON only.
+    /// </summary>
+    [Fact]
+    public void TheSymbolParse_CarriesExtensible_InAllThreeStates()
+    {
+        Assert.True(Parse(SymbolJson).Extensible);
+        Assert.False(Parse(NotExtensibleJson).Extensible);
+        // The THIRD state, and the one a plain bool would destroy: an enum declaring the
+        // property not at all is null, not false. BC's own emitter keeps the distinction —
+        // 12 of its 144 enum documents state no Extensible attribute — so folding null into
+        // false here would make the render state an attribute BC leaves off.
+        Assert.Null(Parse(SilentJson).Extensible);
+
+        // The three that were already parsed, asserted here so a regression in the parse is
+        // distinguishable from a regression in the render below.
+        var e = Parse(SymbolJson);
+        Assert.Equal(new[] { 1467 }, e.DefaultImplementations);
+        Assert.Equal(new[] { 1467 }, e.UnknownImplementations);
+        Assert.Equal(new[] { 1467 }, e.Implementations[0]);
+        Assert.Equal(new[] { 1468 }, e.Implementations[1]);
+        Assert.Empty(e.Implementations[2]);
+    }
+
+    /// <summary>
+    /// The render arm, read back through BC's OWN <c>MetaEnum(XmlNode)</c> — the same
+    /// constructor the metadata-equivalence harness reads both sides with, so a passing
+    /// assertion here is a statement about what BC sees, not about our XML text.
+    /// </summary>
+    [SkippableFact]
+    public void TheRender_StatesAllFourMembers_AsBcsOwnReaderSeesThem()
+    {
+        Skip.IfNot(_engine.Ready, _engine.SkipReason);
+        AlEnumMetadataRegistry.Clear();
+        try
+        {
+            var parsed = ReadBackThroughBc(RegisterAndRender(Parse(SymbolJson)));
+
+            // The three enum-level members, as BC's own reader answers them.
+            Assert.True((bool)parsed.GetType().GetProperty("Extensible")!.GetValue(parsed)!);
+            Assert.Equal(new[] { 1467 }, IntArray(parsed, "DefaultImplementation"));
+            Assert.Equal(new[] { 1467 }, IntArray(parsed, "UnknownImplementation"));
+
+            var byOrdinal = ValuesByOrdinal(parsed);
+            Assert.Equal(new[] { 1467 }, InterfaceImplementation(byOrdinal[0]));
+            Assert.Equal(new[] { 1468 }, InterfaceImplementation(byOrdinal[1]));
+            // A value declaring none stays EMPTY — "declares none" is a different statement
+            // from "declares 0", and writing a 0 would make BC resolve codeunit 0.
+            Assert.Empty(InterfaceImplementation(byOrdinal[2]));
+
+            // The names survive alongside, so a render that dropped the Values subtree while
+            // adding attributes cannot pass.
+            Assert.Equal("Aes", Name(byOrdinal[0]));
+            Assert.Equal("TripleDES", Name(byOrdinal[1]));
+            Assert.Equal(3, byOrdinal.Count);
+        }
+        finally
+        {
+            AlEnumMetadataRegistry.Clear();
+        }
+    }
+
+    /// <summary>
+    /// The negative direction of the render: an enum that declares none of the four must leave
+    /// every one of them OFF the document, so BC applies its own default rather than reading a
+    /// value the runner manufactured. This is what stops "always write Extensible=1" and
+    /// "always write Implementation=0" from passing the test above.
+    /// </summary>
+    [SkippableFact]
+    public void TheRender_LeavesUndeclaredMembersOff_RatherThanStatingADefault()
+    {
+        Skip.IfNot(_engine.Ready, _engine.SkipReason);
+        AlEnumMetadataRegistry.Clear();
+        try
+        {
+            var root = RegisterAndRender(Parse(SilentJson));
+
+            // Not merely "BC answers false" — the ATTRIBUTE is absent, which is the
+            // distinction between deriving a value and letting BC default it. An always-write
+            // render would answer false here too, and this is the assertion that catches it.
+            Assert.False(root.HasAttribute("Extensible"));
+            Assert.False(root.HasAttribute("DefaultImplementation"));
+            Assert.False(root.HasAttribute("UnknownImplementation"));
+            Assert.False(((XmlElement)root.SelectSingleNode("Values/Value")!).HasAttribute("Implementation"));
+
+            var parsed = ReadBackThroughBc(root);
+            Assert.False((bool)parsed.GetType().GetProperty("Extensible")!.GetValue(parsed)!);
+            Assert.Empty(IntArray(parsed, "DefaultImplementation"));
+            Assert.Empty(IntArray(parsed, "UnknownImplementation"));
+            Assert.Empty(InterfaceImplementation(ValuesByOrdinal(parsed)[0]));
+        }
+        finally
+        {
+            AlEnumMetadataRegistry.Clear();
+        }
+    }
+
+    /// <summary>
+    /// An enum declaring <c>Extensible = 0</c> states the attribute and BC reads false from it —
+    /// the direction that separates "derived false" from "defaulted false". Together with the
+    /// test above, these pin that all three states of the property (true / false / undeclared)
+    /// survive to BC distinctly.
+    /// </summary>
+    [SkippableFact]
+    public void AnExplicitlyNonExtensibleEnum_StatesZero_AndBcReadsFalse()
+    {
+        Skip.IfNot(_engine.Ready, _engine.SkipReason);
+        AlEnumMetadataRegistry.Clear();
+        try
+        {
+            var root = RegisterAndRender(Parse(NotExtensibleJson));
+            Assert.Equal("0", root.GetAttribute("Extensible"));
+
+            var parsed = ReadBackThroughBc(root);
+            Assert.False((bool)parsed.GetType().GetProperty("Extensible")!.GetValue(parsed)!);
+        }
+        finally
+        {
+            AlEnumMetadataRegistry.Clear();
+        }
+    }
+
+    /// <summary>
+    /// The render's shape against BC's OWN emitter documents, which is the only evidence that
+    /// distinguishes "the attribute is absent" from "the attribute says 0". It is the mistake
+    /// this test exists to hold: an unconditional <c>Extensible</c> answers false for an
+    /// undeclared enum, agrees with BC's default, and is still wrong — BC's emitter omits the
+    /// attribute on 12 of its 144 enum documents, so writing "0" there manufactures a
+    /// difference the harness would report as the runner's.
+    ///
+    /// <para>Measured against whatever bundle this box carries rather than against a literal,
+    /// so the claim stays true on every BC build. Skips when no bundle is present.</para>
+    /// </summary>
+    [SkippableFact]
+    public void TheEmittersOwnDocuments_OmitExtensibleOnSomeEnums_AndStateImplementationOnValues()
+    {
+        var bundles = MetadataEquivalenceBundleGate.RequireBundles();
+
+        var declared = 0;
+        var undeclared = 0;
+        var valuesWithImplementation = 0;
+        foreach (var bundle in bundles)
+            foreach (var obj in bundle.Objects.Where(o => o.Kind == "Enum"))
+            {
+                var doc = new XmlDocument();
+                doc.Load(Path.Combine(bundle.Directory, obj.File));
+                var root = doc.DocumentElement!;
+                // A base enum only: an enumextension states bare <Value> children and no
+                // Extensible, and counting those as "undeclared base enums" would make the
+                // assertion below pass for the wrong reason.
+                if (root.GetElementsByTagName("Values").Count == 0) continue;
+
+                if (root.HasAttribute("Extensible")) declared++; else undeclared++;
+                foreach (XmlNode v in root.GetElementsByTagName("Value"))
+                    if (v is XmlElement ve && ve.HasAttribute("Implementation")) valuesWithImplementation++;
+            }
+
+        Skip.If(declared + undeclared == 0, "no bundle on this box carries a base-enum document.");
+
+        // Both directions are real, which is what makes the render's conditional correct:
+        // some base enums state the attribute and some state none.
+        Assert.True(declared > 0, "no emitted base enum states Extensible — the render's '1'/'0' has no referent.");
+        Assert.True(undeclared > 0,
+            "every emitted base enum states Extensible, so an unconditional render would be " +
+            "faithful and this test's reason for existing is gone. Re-read the emitter output.");
+
+        // And the answer to #3807's open question, in BC's own output rather than in the
+        // decompiled reader: <Value> DOES carry Implementation.
+        Assert.True(valuesWithImplementation > 0,
+            "no emitted enum value states Implementation — the per-value render has no referent.");
+    }
+
+    /// <summary>
+    /// <c>Extensible</c> must be written as <c>"1"</c>, never <c>"true"</c>: BC parses it with
+    /// <c>MetaBase.Int32Value</c>, which is <c>Int32.Parse</c> with only <c>""</c> and
+    /// <c>"undefined"</c> mapped to 0. A <c>"true"</c> would make BC's constructor THROW, so the
+    /// spelling is load-bearing and a boolean-looking render fails loudly rather than quietly
+    /// answering false. Needs no BC engine — it reads the runner's own XML text.
+    /// </summary>
+    [Fact]
+    public void Extensible_IsWrittenAsOne_BecauseBcInt32ParsesIt()
+    {
+        AlEnumMetadataRegistry.Clear();
+        try
+        {
+            Assert.Equal("1", RegisterAndRender(Parse(SymbolJson)).GetAttribute("Extensible"));
+        }
+        finally
+        {
+            AlEnumMetadataRegistry.Clear();
+        }
+    }
+}

--- a/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
+++ b/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
@@ -251,14 +251,21 @@ public sealed class MetadataEquivalenceHarnessTests
                             && d.ObjectKey.StartsWith(objectPrefix, StringComparison.Ordinal))
                 .ToArray();
 
-            // #3807 FIXED this one, and the hazard above is exactly why the replacement is an
-            // assertion rather than a deletion. EnumSymbol now carries the DECLARED Extensible
-            // — nullable, so "declares false" and "declares nothing" stay apart — and the
-            // render states the attribute only when the symbol file did, which is what BC's
-            // own emitter does (12 of its 144 enum documents omit it). The manufactured-
-            // agreement mutation described above is what an unconditional render IS, so the
-            // claim worth holding now is that NO difference survives in either direction:
-            // agreement reached by deriving the value, not by writing BC's answer over ours.
+            // #3807 FIXED this one: EnumSymbol now carries the declared Extensible and the
+            // render states it, so the 31 enums that disagreed agree, in both directions.
+            //
+            // THIS ASSERTION IS WEAKER THAN THE ONE IT REPLACED, deliberately and with the
+            // limit written down rather than left to be discovered. It does NOT catch the
+            // manufactured-agreement mutation described above — making the render write
+            // Extensible unconditionally leaves this Empty and all 13 tests in this class
+            // green, measured. The reason is structural: both sides here are MetaEnum OBJECTS
+            // and MetaEnum.Extensible is a plain bool, so BC's ABSENT attribute reads back as
+            // false on BC's side too and a runner writing "0" agrees with it. The difference
+            // lives in the XML, which this harness does not compare.
+            //
+            // Where that property IS held: EnumExtensibleAndImplementationRenderTests asserts
+            // on HasAttribute against the rendered document, and goes RED on that mutation.
+            // See docs/metadata-equivalence.md#enum-extensible-conditional.
             Assert.Empty(On("MetaEnum.Extensible", "Enum "));
 
             // ALNamespace is stated by SymbolReference.json for all three kinds and carried by

--- a/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
+++ b/AlRunner.Tests/MetadataEquivalenceHarnessTests.cs
@@ -251,11 +251,15 @@ public sealed class MetadataEquivalenceHarnessTests
                             && d.ObjectKey.StartsWith(objectPrefix, StringComparison.Ordinal))
                 .ToArray();
 
-            // EnumSymbol carries no Extensible at all, so the render states none and BC's own
-            // default of false stands on the runner's side — on every enum, including the 111
-            // where false is also BC's answer and no difference is reported.
-            AssertConstantAnswer(report, On("MetaEnum.Extensible", "Enum "),
-                "MetaEnum.Extensible", bc: "True", runner: "False");
+            // #3807 FIXED this one, and the hazard above is exactly why the replacement is an
+            // assertion rather than a deletion. EnumSymbol now carries the DECLARED Extensible
+            // — nullable, so "declares false" and "declares nothing" stay apart — and the
+            // render states the attribute only when the symbol file did, which is what BC's
+            // own emitter does (12 of its 144 enum documents omit it). The manufactured-
+            // agreement mutation described above is what an unconditional render IS, so the
+            // claim worth holding now is that NO difference survives in either direction:
+            // agreement reached by deriving the value, not by writing BC's answer over ours.
+            Assert.Empty(On("MetaEnum.Extensible", "Enum "));
 
             // ALNamespace is stated by SymbolReference.json for all three kinds and carried by
             // none of the three symbol records, so the runner answers null everywhere. Asserted

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -3103,10 +3103,15 @@ public sealed partial class BcCompiler
                 else
                 {
                     // #2306 — the enum-level fallbacks apply to the base enum only; an
-                    // enumextension declares neither, so RegisterExtension takes none.
+                    // enumextension declares neither, so RegisterExtension takes none. #3807 —
+                    // Extensible is the same: a base-enum-only property, and the DECLARED one
+                    // rather than IApplicationObjectTypeSymbol.IsExtensible, which folds AL's
+                    // default in and would lose the "declares nothing" state BC's own emitter
+                    // keeps (12 of 144 emitted enum documents state no Extensible attribute).
                     AlEnumMetadataRegistry.Register(enumSym.Id, enumSym.Name, options, indexes, implementations, captions,
                         ReadEnumImplementationFallback(enumSym, NavCA.PropertyKind.DefaultImplementation),
-                        ReadEnumImplementationFallback(enumSym, NavCA.PropertyKind.UnknownValueImplementation));
+                        ReadEnumImplementationFallback(enumSym, NavCA.PropertyKind.UnknownValueImplementation),
+                        ReadEnumExtensible(enumSym));
                 }
             }
             // Capture the per-report runtime metadata XML the emit pipeline hands us
@@ -3361,6 +3366,29 @@ public sealed partial class BcCompiler
         /// "Alt. Cust VAT Reg. Doc." is written — one value, no per-value Implementation.
         /// Null means the enum declares none.
         /// </summary>
+        /// <summary>
+        /// The enum's DECLARED <c>Extensible</c> property (#3807), or null when it declares
+        /// none. Deliberately the property rather than
+        /// <c>IApplicationObjectTypeSymbol.IsExtensible</c>, which is
+        /// <c>GetBooleanPropertyValue(Extensible) ?? ExtensibleByDefault</c> and so cannot tell
+        /// a declared <c>false</c> from an absent one — a distinction BC's emitter preserves
+        /// and the metadata-equivalence render depends on.
+        /// </summary>
+        private static bool? ReadEnumExtensible(NavCA.IEnumBaseTypeSymbol enumSymbol)
+        {
+            try
+            {
+                var text = enumSymbol.GetProperty(NavCA.PropertyKind.Extensible)?.ValueText;
+                if (string.IsNullOrWhiteSpace(text)) return null;
+                var t = text.Trim();
+                return t == "1" || string.Equals(t, "true", StringComparison.OrdinalIgnoreCase);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
         private static int[]? ReadEnumImplementationFallback(NavCA.IEnumBaseTypeSymbol enumSymbol, NavCA.PropertyKind kind)
         {
             try

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -3358,15 +3358,6 @@ public sealed partial class BcCompiler
         }
 
         /// <summary>
-        /// Read an AL enum's own <c>DefaultImplementation</c> / <c>UnknownImplementation</c>
-        /// property, in the same comma-separated codeunit-id shape as a value's
-        /// <c>Implementation</c> (issue #2306). These are the enum-level fallbacks BC's
-        /// <c>NCLEnumMetadata.GetImplementationCodeunitId</c> uses when a value declares no
-        /// implementation of its own, which is how Base App 205
-        /// "Alt. Cust VAT Reg. Doc." is written — one value, no per-value Implementation.
-        /// Null means the enum declares none.
-        /// </summary>
-        /// <summary>
         /// The enum's DECLARED <c>Extensible</c> property (#3807), or null when it declares
         /// none. Deliberately the property rather than
         /// <c>IApplicationObjectTypeSymbol.IsExtensible</c>, which is
@@ -3389,6 +3380,15 @@ public sealed partial class BcCompiler
             }
         }
 
+        /// <summary>
+        /// Read an AL enum's own <c>DefaultImplementation</c> / <c>UnknownImplementation</c>
+        /// property, in the same comma-separated codeunit-id shape as a value's
+        /// <c>Implementation</c> (issue #2306). These are the enum-level fallbacks BC's
+        /// <c>NCLEnumMetadata.GetImplementationCodeunitId</c> uses when a value declares no
+        /// implementation of its own, which is how Base App 205
+        /// "Alt. Cust VAT Reg. Doc." is written — one value, no per-value Implementation.
+        /// Null means the enum declares none.
+        /// </summary>
         private static int[]? ReadEnumImplementationFallback(NavCA.IEnumBaseTypeSymbol enumSymbol, NavCA.PropertyKind kind)
         {
             try

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -836,8 +836,16 @@ internal static partial class BcAppSymbolCache
     // DefaultImplementations / UnknownImplementations are the ENUM-level fallbacks, one list
     // per enum (indexed by interface-declaration index), not one per value — see issue #2306
     // and AlEnumOptionMetadata.GetImplementationCodeunitIdPublic.
+    // Extensible is the AL `Extensible` property (#3807), read from the same Properties bag as
+    // DefaultImplementation. NULLABLE, because "declares false" and "declares nothing" are
+    // states BC's own emitter keeps apart: of 144 emitted enum documents in 28.1 and 28.4, 31
+    // state "1", 99 state "0" and 12 base enums state the attribute NOT AT ALL — the same 12
+    // whose SymbolReference.json omits the property. Collapsing null to false would make the
+    // render state an attribute BC leaves off, which is a manufactured difference in the
+    // direction this derivation exists to avoid.
     internal sealed record EnumSymbol(int Id, string Name, List<string> Options, List<int> Indexes, List<List<int>> Implementations, List<string?>? Captions = null,
-        List<int>? DefaultImplementations = null, List<int>? UnknownImplementations = null);
+        List<int>? DefaultImplementations = null, List<int>? UnknownImplementations = null,
+        bool? Extensible = null);
 
     // Parsed query SymbolReference.json shape. A query is a tree of dataitems; the root
     // dataitem(s) live under the query's "Elements", nested dataitems under "DataItems".
@@ -2512,9 +2520,37 @@ internal static partial class BcAppSymbolCache
         // Enum-level fallbacks. Both are written the same way a value's Implementation is —
         // a comma-separated list of codeunit ids, one per interface the enum implements.
         var enumProps = SymbolProperties(enumType);
+        // #3807 — Extensible is written as "1"/"0" in the same bag, and absent stays absent.
+        // Measured on 28.1.49838.53910 and 28.4.53241.54407 (two distinct binaries, identical
+        // counts): of 142 System Application + Business Foundation enums, 130 state the
+        // property and 31 of those state "1". The runner carried it nowhere at all, so BC
+        // applied its own default of false for all 142 — right for 111 by accident and wrong
+        // for the 31 that are extensible.
         return new EnumSymbol(id, name, options, indexes, implementations, captions,
             SymbolCodeunitIdList(enumProps, "DefaultImplementation"),
-            SymbolCodeunitIdList(enumProps, "UnknownValueImplementation"));
+            SymbolCodeunitIdList(enumProps, "UnknownValueImplementation"),
+            SymbolBoolean(enumProps, "Extensible"));
+    }
+
+    /// <summary>
+    /// The named property read as an AL boolean, or <c>null</c> when the enum declares it not
+    /// at all — a third state the caller must keep, not collapse (see
+    /// <see cref="EnumSymbol"/>'s <c>Extensible</c>).
+    ///
+    /// <para>Both spellings are accepted because both occur: <c>SymbolReference.json</c> states
+    /// <c>Extensible</c> as <c>"1"</c>/<c>"0"</c> on every one of the 130 System Application +
+    /// Business Foundation enums that declare it (measured on 28.1 and 28.4), while AL source
+    /// and several other property bags spell booleans <c>"true"</c>/<c>"false"</c>. An
+    /// unrecognised spelling reads as <c>false</c> rather than <c>true</c> or null: it IS a
+    /// declaration, so it is not the absent case, and the true direction is the one that
+    /// changes what AL is allowed to do.</para>
+    /// </summary>
+    private static bool? SymbolBoolean(Dictionary<string, string> props, string propertyName)
+    {
+        if (!props.TryGetValue(propertyName, out var text) || string.IsNullOrWhiteSpace(text))
+            return null;
+        var t = text.Trim();
+        return t == "1" || string.Equals(t, "true", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>The named property read as a comma-separated list of codeunit ids, or null

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -2537,6 +2537,14 @@ internal static partial class BcAppSymbolCache
     /// at all — a third state the caller must keep, not collapse (see
     /// <see cref="EnumSymbol"/>'s <c>Extensible</c>).
     ///
+    /// <para><b>Why this is not <c>SymbolBoolFalse</c>, which the page side uses for the
+    /// SAME property name.</b> That reader folds absence into the AL default, and its comment
+    /// gives the reason: BC's emitter writes a page's <c>Extensible</c> unconditionally, so
+    /// absent and default-valued are the same document. For ENUMS the emitter does not — 12 of
+    /// 144 emitted enum documents state no <c>Extensible</c> attribute at all (28.1 and 28.4) —
+    /// so folding here would make the render state an attribute BC omits. The divergence is
+    /// measured, not accidental.</para>
+    ///
     /// <para>Both spellings are accepted because both occur: <c>SymbolReference.json</c> states
     /// <c>Extensible</c> as <c>"1"</c>/<c>"0"</c> on every one of the 130 System Application +
     /// Business Foundation enums that declare it (measured on 28.1 and 28.4), while AL source

--- a/AlRunner/Patches/EnumMetadataPatches.cs
+++ b/AlRunner/Patches/EnumMetadataPatches.cs
@@ -63,8 +63,14 @@ public static class AlEnumMetadataRegistry
     // by interface-declaration index exactly like a value's own Implementations entry (issue
     // #2306). They are not parallel to Options — one list per enum, not per value. An empty
     // array means the enum declares none, which is how most enums are written.
+    // Extensible is the enum's own AL `Extensible` property (#3807) — a property of the BASE
+    // enum only, so the merge in TryGet takes the base entry's and an enumextension carries
+    // none. NULLABLE: "declares false" and "declares nothing" are states BC's own emitter
+    // keeps apart (12 of 144 emitted enum documents omit the attribute), so collapsing them
+    // would make the render state something BC leaves off.
     public sealed record Entry(int Id, string Name, string[] Options, int[] Indexes, int[][] Implementations, string?[]? Captions = null,
-        int[]? DefaultImplementations = null, int[]? UnknownImplementations = null);
+        int[]? DefaultImplementations = null, int[]? UnknownImplementations = null,
+        bool? Extensible = null);
 
     // Base-enum registrations, keyed by the enum's own object Id. This also
     // absorbs precompiled-dependency enums (RegisterFromAppPath) and cache
@@ -90,7 +96,7 @@ public static class AlEnumMetadataRegistry
     /// collisions are quarantined upstream. Enumextension values are tracked
     /// separately — see <see cref="RegisterExtension"/>.</summary>
     public static void Register(int id, string name, string[] options, int[] indexes, int[][]? implementations = null, string?[]? captions = null,
-        int[]? defaultImplementations = null, int[]? unknownImplementations = null)
+        int[]? defaultImplementations = null, int[]? unknownImplementations = null, bool? extensible = null)
     {
         if (options == null || indexes == null) return;
         if (options.Length != indexes.Length) return;
@@ -100,7 +106,7 @@ public static class AlEnumMetadataRegistry
         if (captions != null && captions.Length != options.Length)
             captions = null;
         _byId[id] = new Entry(id, name ?? string.Empty, options, indexes, implementations, captions,
-            defaultImplementations, unknownImplementations);
+            defaultImplementations, unknownImplementations, extensible);
     }
 
     /// <summary>
@@ -175,8 +181,14 @@ public static class AlEnumMetadataRegistry
         foreach (var ext in extensions)
             AddValues(ext);
 
+        // Extensible, like the two implementation fallbacks, is a property of the BASE enum:
+        // an enumextension declares none and RegisterExtension takes none, so an extension
+        // present without its base leaves this NULL — "nobody said" — rather than inventing a
+        // value (#3807). BC's emitter does the same: its two enumextension documents state no
+        // Extensible attribute either.
         entry = new Entry(id, name, options.ToArray(), indexes.ToArray(), implementations.ToArray(), captions.ToArray(),
-            baseEntry?.DefaultImplementations, baseEntry?.UnknownImplementations);
+            baseEntry?.DefaultImplementations, baseEntry?.UnknownImplementations,
+            baseEntry?.Extensible);
         return true;
     }
 
@@ -220,7 +232,8 @@ public static class AlEnumMetadataRegistry
                     enumSymbol.Implementations.Select(i => i.ToArray()).ToArray(),
                     enumSymbol.Captions?.ToArray(),
                     enumSymbol.DefaultImplementations?.ToArray(),
-                    enumSymbol.UnknownImplementations?.ToArray());
+                    enumSymbol.UnknownImplementations?.ToArray(),
+                    enumSymbol.Extensible);
         }
         catch (Exception ex) when (ex is not AlRunner.Infrastructure.BcAppSymbolReadException)
         {
@@ -331,6 +344,10 @@ public static class AlEnumMetadataRegistry
                 // from this build anyway.
                 defaultImplementations = r.Entry.DefaultImplementations,
                 unknownImplementations = r.Entry.UnknownImplementations,
+                // #3807 — the enum's declared Extensible, as a NULLABLE bool: absent from the
+                // sidecar and read back as null means "declares none", which is a different
+                // statement from a declared false and is the one the render leaves off.
+                extensible = r.Entry.Extensible,
                 // #2709 — null for a base registration; the base enum id it extends for an
                 // enumextension's own (unmerged) entry. Absent/null on replay means "plain
                 // Register", exactly like a pre-#2709 sidecar (which never carried this
@@ -355,6 +372,20 @@ public static class AlEnumMetadataRegistry
         int k = 0;
         foreach (var v in el.EnumerateArray()) ids[k++] = v.GetInt32();
         return ids.Length > 0 ? ids : null;
+    }
+
+    /// <summary>A sidecar's optional boolean property, or null when absent or JSON null —
+    /// "declares none", which for <c>Extensible</c> is a different statement from a declared
+    /// false and is the one the metadata render leaves off (issue #3807).</summary>
+    private static bool? ReadNullableBool(System.Text.Json.JsonElement parent, string name)
+    {
+        if (!parent.TryGetProperty(name, out var el)) return null;
+        return el.ValueKind switch
+        {
+            System.Text.Json.JsonValueKind.True => true,
+            System.Text.Json.JsonValueKind.False => false,
+            _ => null,
+        };
     }
 
     /// <summary>
@@ -430,7 +461,8 @@ public static class AlEnumMetadataRegistry
                 RegisterExtension(extendsTargetId.Value, name, opts, idxs, implementations, captions);
             else
                 Register(id, name, opts, idxs, implementations, captions,
-                    ReadIdList(e, "defaultImplementations"), ReadIdList(e, "unknownImplementations"));
+                    ReadIdList(e, "defaultImplementations"), ReadIdList(e, "unknownImplementations"),
+                    ReadNullableBool(e, "extensible"));
             count++;
         }
         return count;

--- a/AlRunner/Patches/RecordPatches.BcAppFallback.cs
+++ b/AlRunner/Patches/RecordPatches.BcAppFallback.cs
@@ -475,7 +475,8 @@ public static partial class RecordPatches
             // per-value Captions (#1775) and the enum-level DefaultImplementation /
             // UnknownValueImplementation fallbacks (#2306) were both being dropped,
             // which is why Base App enum 205 "Alt. Cust VAT Reg. Doc." could not be cast
-            // to its interface.
+            // to its interface. Extensible (#3807) is the same shape: 31 of 142 base enums
+            // declare it true and the registry could not state it at all.
             foreach (var enumSymbol in symbols.Enums)
                 AlRunner.AlEnumMetadataRegistry.Register(
                     enumSymbol.Id,
@@ -485,7 +486,8 @@ public static partial class RecordPatches
                     enumSymbol.Implementations.Select(i => i.ToArray()).ToArray(),
                     enumSymbol.Captions?.ToArray(),
                     enumSymbol.DefaultImplementations?.ToArray(),
-                    enumSymbol.UnknownImplementations?.ToArray());
+                    enumSymbol.UnknownImplementations?.ToArray(),
+                    enumSymbol.Extensible);
             // Invalidate the indexes so newly-added .app gets picked up on next miss.
             InvalidateBcAppIndexes();
         }

--- a/AlRunner/Patches/RecordPatches.ReportEnumPermissionSetMetadataEquivalence.cs
+++ b/AlRunner/Patches/RecordPatches.ReportEnumPermissionSetMetadataEquivalence.cs
@@ -137,9 +137,17 @@ public static partial class RecordPatches
     /// constructor then applies BC's default and the reported difference is a true statement
     /// about what the runner does not know. Writing BC's value into any element would
     /// manufacture agreement — which is the whole failure mode this harness exists to catch.
-    /// Measured on BC 28.1.49838.53910: <c>Extensible</c> is absent here because
-    /// <see cref="BcAppSymbolCache.EnumSymbol"/> does not carry it at all (#3807), not because
-    /// it is unknowable.</para>
+    /// <c>ALNamespace</c> and the enum-level <c>CaptionML</c> are absent for exactly that
+    /// reason: <see cref="BcAppSymbolCache.EnumSymbol"/> carries neither (#3807).</para>
+    ///
+    /// <para><b>Four members ARE derived (#3807)</b>, all four stated verbatim in
+    /// <c>SymbolReference.json</c> and all four expressible in the shape BC's own reader
+    /// parses: <c>Extensible</c>, <c>DefaultImplementation</c> and <c>UnknownImplementation</c>
+    /// as attributes on this root, and a value's <c>Implementation</c> as an attribute on
+    /// <c>&lt;Value&gt;</c>. That last one was the issue's open question and this is its answer
+    /// — <c>MetaEnumValue(XmlNode)</c> reads an <c>Implementation</c> attribute into
+    /// <c>InterfaceImplementation</c>. An enum declaring none of them still states none, so the
+    /// harness's "left off, never defaulted" contract above is unchanged.</para>
     /// </summary>
     internal static string? TryBuildEnumMetadataEquivalenceXml(int enumId)
     {
@@ -150,6 +158,26 @@ public static partial class RecordPatches
         doc.AppendChild(root);
         root.SetAttribute("ID", entry.Id.ToString(CultureInfo.InvariantCulture));
         root.SetAttribute("Name", entry.Name);
+
+        // "1"/"0", never "true"/"false": BC reads this through MetaBase.Int32Value, which is
+        // Int32.Parse with only "" and "undefined" mapped to 0, so a boolean spelling makes
+        // MetaEnum's constructor THROW rather than default.
+        //
+        // CONDITIONAL, matching BC's emitter rather than BC's default: of 144 emitted enum
+        // documents in 28.1 and 28.4, 31 state "1", 99 state "0" and 12 base enums state the
+        // attribute not at all — the same 12 whose SymbolReference.json omits the property.
+        // Writing "0" for those would state something BC leaves off, which is the manufactured
+        // agreement this file's header forbids, in the direction that is hardest to notice.
+        if (entry.Extensible is { } extensible)
+            root.SetAttribute("Extensible", extensible ? "1" : "0");
+
+        // Both enum-level implementation fallbacks (#2306), comma-joined: BC splits on
+        // MetaBase.SplitChar and Int32.Parse's each part. Null means "declares none" and stays
+        // OFF the document, because an empty attribute would still be an assertion.
+        if (entry.DefaultImplementations is { Length: > 0 } defaults)
+            root.SetAttribute("DefaultImplementation", string.Join(",", defaults));
+        if (entry.UnknownImplementations is { Length: > 0 } unknowns)
+            root.SetAttribute("UnknownImplementation", string.Join(",", unknowns));
 
         var values = doc.CreateElement("Values");
         root.AppendChild(values);
@@ -164,6 +192,16 @@ public static partial class RecordPatches
             value.SetAttribute(
                 "Ordinal",
                 (i < entry.Indexes.Length ? entry.Indexes[i] : i).ToString(CultureInfo.InvariantCulture));
+
+            // The value's own `Implementation` (#2306, rendered at #3807) — already parsed and
+            // previously dropped. This IS the shape BC's emitter writes: enum 1465's emitted
+            // document states <Value Name="Aes" Ordinal="0" Implementation="1467">, and
+            // MetaEnumValue(XmlNode) reads that attribute into InterfaceImplementation.
+            // An empty list means "declares none" and stays off, because writing an empty
+            // attribute sets InterfaceImplementation to Empty explicitly rather than leaving
+            // BC's own default — the same statement here, but not on a value BC did state.
+            if (i < entry.Implementations.Length && entry.Implementations[i] is { Length: > 0 } valueImplementations)
+                value.SetAttribute("Implementation", string.Join(",", valueImplementations));
 
             // Caption null means "this value declares none" (#1775), which is a different
             // statement from "declares an empty one" — so nothing is written for a null and

--- a/AlRunner/ProgramSupport/Suites.cs
+++ b/AlRunner/ProgramSupport/Suites.cs
@@ -31,6 +31,9 @@ internal static partial class ProgramSupport
                 // be cast to its interface on a cache HIT.
                 defaultImplementations = r.Entry.DefaultImplementations,
                 unknownImplementations = r.Entry.UnknownImplementations,
+                // #3807 — the enum's declared Extensible. Nullable: absent means "declares
+                // none", which the metadata render leaves off rather than stating as false.
+                extensible = r.Entry.Extensible,
                 // #2709 — null for a base registration; the base enum id an enumextension's
                 // own (unmerged) entry targets otherwise. See SnapshotRaw.
                 extends = r.ExtendsTargetId,
@@ -102,6 +105,20 @@ internal static partial class ProgramSupport
             return ids.Length > 0 ? ids : null;
         }
 
+        // A sidecar's optional boolean property, or null when absent or JSON null — "declares
+        // none", which for Extensible the metadata render leaves off rather than stating as
+        // false (issue #3807).
+        static bool? ReadNullableBool(System.Text.Json.JsonElement parent, string name)
+        {
+            if (!parent.TryGetProperty(name, out var el)) return null;
+            return el.ValueKind switch
+            {
+                System.Text.Json.JsonValueKind.True => true,
+                System.Text.Json.JsonValueKind.False => false,
+                _ => null,
+            };
+        }
+
         var json = File.ReadAllText(path);
         using var doc = System.Text.Json.JsonDocument.Parse(json);
         if (!doc.RootElement.TryGetProperty("enums", out var arr)
@@ -165,7 +182,8 @@ internal static partial class ProgramSupport
                 AlEnumMetadataRegistry.RegisterExtension(extendsTargetId.Value, name, opts, idxs, implementations, captions);
             else
                 AlEnumMetadataRegistry.Register(id, name, opts, idxs, implementations, captions,
-                    ReadIdList(e, "defaultImplementations"), ReadIdList(e, "unknownImplementations"));
+                    ReadIdList(e, "defaultImplementations"), ReadIdList(e, "unknownImplementations"),
+                    ReadNullableBool(e, "extensible"));
             count++;
         }
         // v4: replay per-report metadata XML (absent in pre-v4 sidecars — fine,

--- a/docs/metadata-equivalence.md
+++ b/docs/metadata-equivalence.md
@@ -1109,7 +1109,22 @@ harness does not use it.
 
 **Every value's `Name` and `Ordinal` agrees on 141 of 142 enums**, over 3,491 values, and every
 declared per-value `Caption` reaches BC's `CaptionML`. **4,328 differences**, of which the
-non-`TranslationKey` remainder is 6 members tracked on #3807.
+non-`TranslationKey` remainder was 6 members tracked on #3807.
+
+**Four of those six are closed** (#3807): `MetaEnum.Extensible`,
+`MetaEnumValue.InterfaceImplementation`, `MetaEnum.DefaultImplementation` and
+`MetaEnum.UnknownImplementation` are now derived and rendered, and the four allowlist entries
+are gone. All four were stated verbatim in `SymbolReference.json` and all four are expressible
+in the shape BC's own reader parses — the enum-level three as attributes on the `<Enum>` root,
+a value's as an `Implementation` attribute on `<Value>`, which is also the shape BC's emitter
+writes. The two that remain are `MetaEnum.ALNamespace` and the enum-level `CaptionML`, neither
+of which `EnumSymbol` carries.
+
+`Extensible` is rendered **conditionally**, and that is not a detail: of 144 emitted enum
+documents on 28.1.49838.53910 and 28.4.53241.54407, 31 state `"1"`, 99 state `"0"` and 12 base
+enums state the attribute not at all — the same 12 whose `SymbolReference.json` omits the
+property. An unconditional render would write `"0"` for those twelve and manufacture a
+difference, which is the failure mode the section below describes from the other direction.
 
 <a id="enum-values-pair-by-ordinal"></a>
 ### Enum values pair by `Ordinal`, and the one that does not is the finding
@@ -1151,6 +1166,12 @@ because that field keys on the value being absent-or-null and both sides here ar
 What does work is the claim the table-side members already make — the runner answers a
 **constant**, and that constant *is* the defect —
 `The_new_kinds_reader_answers_the_constant_that_IS_the_defect`.
+
+Since #3807 closed the `Extensible` gap, that test asserts the opposite for this member —
+`Assert.Empty` over its differences — which holds the same property from the other side: an
+unconditional render is *exactly* the manufactured agreement described above, and it now
+reports 12 differences rather than zero. The constant-answer assertions for the members still
+open are unchanged.
 
 <a id="enum-extension-documents"></a>
 ### Two `<Enum>` documents are enum EXTENSIONS, and are skipped rather than compared

--- a/docs/metadata-equivalence.md
+++ b/docs/metadata-equivalence.md
@@ -1120,11 +1120,28 @@ a value's as an `Implementation` attribute on `<Value>`, which is also the shape
 writes. The two that remain are `MetaEnum.ALNamespace` and the enum-level `CaptionML`, neither
 of which `EnumSymbol` carries.
 
-`Extensible` is rendered **conditionally**, and that is not a detail: of 144 emitted enum
-documents on 28.1.49838.53910 and 28.4.53241.54407, 31 state `"1"`, 99 state `"0"` and 12 base
-enums state the attribute not at all — the same 12 whose `SymbolReference.json` omits the
-property. An unconditional render would write `"0"` for those twelve and manufacture a
-difference, which is the failure mode the section below describes from the other direction.
+<a id="enum-extensible-conditional"></a>
+#### `Extensible` is rendered conditionally, and this harness cannot see the difference
+
+Of 144 emitted enum documents on 28.1.49838.53910 and 28.4.53241.54407, 31 state `Extensible="1"`,
+99 state `"0"` and **12 base enums state the attribute not at all** — the same 12 whose
+`SymbolReference.json` omits the property (1480, 1921, 1990, 1991, 1993, 1994, 1995, 2301, 2351,
+2915, 8704, 8761). The render matches that: it writes the attribute only when the symbol file
+declared it, so `EnumSymbol.Extensible` and `Entry.Extensible` are `bool?` rather than `bool`.
+
+**Measured: making the render unconditional changes not one difference, and every harness test
+stays green.** Both sides of this comparison are `MetaEnum` *objects*, and `MetaEnum.Extensible`
+is a plain `bool` — so BC's absent attribute is read back as `false` on BC's side too, and a
+runner writing `"0"` agrees with it. The difference exists only in the XML, which nothing here
+compares. This is the same class as the two findings below, and it is recorded rather than
+fixed: the conditional is justified by BC's emitter output, not by any test in this harness.
+
+So the property is held where it *is* observable —
+`EnumExtensibleAndImplementationRenderTests.TheRender_LeavesUndeclaredMembersOff_RatherThanStatingADefault`
+asserts on `HasAttribute` against the rendered XML, and
+`TheEmittersOwnDocuments_OmitExtensibleOnSomeEnums_AndStateImplementationOnValues` asserts that
+BC's own bundles really do contain both kinds of document. Mutating the render to unconditional
+turns the first of those RED; it leaves all 13 harness tests green.
 
 <a id="enum-values-pair-by-ordinal"></a>
 ### Enum values pair by `Ordinal`, and the one that does not is the finding
@@ -1168,10 +1185,11 @@ What does work is the claim the table-side members already make — the runner a
 `The_new_kinds_reader_answers_the_constant_that_IS_the_defect`.
 
 Since #3807 closed the `Extensible` gap, that test asserts the opposite for this member —
-`Assert.Empty` over its differences — which holds the same property from the other side: an
-unconditional render is *exactly* the manufactured agreement described above, and it now
-reports 12 differences rather than zero. The constant-answer assertions for the members still
-open are unchanged.
+`Assert.Empty` over its differences — which is a real claim (the 31 that disagreed now agree)
+but a **weaker** one than the constant-answer assertion it replaced. It does not catch an
+unconditional render, because that produces no difference at all here; see
+[above](#enum-extensible-conditional) for the measurement and for where that property is
+actually held. The constant-answer assertions for the members still open are unchanged.
 
 <a id="enum-extension-documents"></a>
 ### Two `<Enum>` documents are enum EXTENSIONS, and are skipped rather than compared

--- a/tests/expectations/metadata-equivalence/allowlist.json
+++ b/tests/expectations/metadata-equivalence/allowlist.json
@@ -1402,26 +1402,6 @@
       "issue": 3806
     },
     {
-      "member": "MetaEnum.Extensible",
-      "reason": "BC answers True on 31 of 142 enums; the runner answers False on all of them, because BcAppSymbolCache.EnumSymbol does not carry Extensible at all -- the record is (Id, Name, Options, Indexes, Implementations, Captions, DefaultImplementations, UnknownImplementations) and nothing reads the property. The value IS in SymbolReference.json, in the same Properties bag TryParseEnumSymbol already reads DefaultImplementation and UnknownValueImplementation from a few lines away, so this is a dropped property rather than an underivable one. Not cosmetic: Extensible = false is what makes an enum refuse an enumextension, so the runner currently answers 'not extensible' for 31 enums that are. The other 111 agree only because the runner's constant happens to match.",
-      "issue": 3807
-    },
-    {
-      "member": "MetaEnumValue.InterfaceImplementation",
-      "reason": "BC states a value's interface-implementation codeunit ids (e.g. [306] on enum 397); the runner states []. The runner DOES parse these -- TryParseEnumSymbol reads a value's Implementation property into implementations[i] and AlEnumOptionMetadata uses them for GetImplementationCodeunitIdPublic (#2306) -- so the data is present and it is the <Value> render that has no element for it. Whether BC's <Value> shape can express it at all still needs checking before this is called a derivation gap; #3807 records that caveat rather than asserting either way.",
-      "issue": 3807
-    },
-    {
-      "member": "MetaEnum.DefaultImplementation",
-      "reason": "The enum-level interface fallback: BC states [1467] on enum 1465, the runner states []. EnumSymbol carries the list (#2306) and the <Enum> render states no element for it -- the same not-rendered-though-parsed shape as MetaEnumValue.InterfaceImplementation above, one level up.",
-      "issue": 3807
-    },
-    {
-      "member": "MetaEnum.UnknownImplementation",
-      "reason": "The other enum-level interface fallback, on the same enum 1465 and with the same cause as MetaEnum.DefaultImplementation immediately above: EnumSymbol carries it, the render does not state it.",
-      "issue": 3807
-    },
-    {
       "member": "MetaEnum.ALNamespace",
       "reason": "BC states the enum's AL namespace (System.Text on enum 59); the runner answers null on all 142 because EnumSymbol does not carry it. Derivable and simply not carried. Same member and same fix as MetaTable.ALNamespace (#3568), MetaReport.ALNamespace (#3808) and MetaPermissionSet.ALNamespace (#3806).",
       "issue": 3807


### PR DESCRIPTION
Closes #3807

Corpus-NA: the four members have no AL-observable consumer — TryBuildEnumMetadataEquivalenceXml's only callers are the equivalence harness and this PR's tests, so no corpus test can express the claim; see "Why Corpus-NA and not a corpus PR" below for the measurement

Authored by agent `stma-auto-3`.

The enum derivation states all four members BC's `ObjectMetadataEmitter` states and the runner
dropped. **All four close; none is deferred.** The issue's open question is settled, and the
answer is positive.

## The open question, settled

#3807 asked whether BC's `<Value>` shape can express `InterfaceImplementation` at all, or
whether only the emitter's own form carries it. **It can, and the emitter uses exactly that
shape.** Two independent measurements:

- `Types.Metadata.MetaEnumValue(XmlNode)` reads an `Implementation` **attribute** on `<Value>`
  into `InterfaceImplementation`; `MetaEnum(XmlNode)` reads `Extensible`,
  `DefaultImplementation` and `UnknownImplementation` as attributes on the `<Enum>` root.
- BC's own emitted document for System Application enum 1465 states it literally:
  `<Value Name="Aes" Ordinal="0" Implementation="1467">`, under a root carrying
  `Extensible="0" UnknownImplementation="1467" DefaultImplementation="1467"`.

So there is no split: the implementation trio is not a separate arm to defer.

## What changed

`EnumSymbol` gains `Extensible` (the record carried it nowhere), `AlEnumMetadataRegistry.Entry`
mirrors it, and the render states all four. Wired through every path that registers an enum —
`RecordPatches.AddBcAppPath` (the live precompiled-dependency route),
`AlEnumMetadataRegistry.RegisterFromAppPath` (the sibling that reads the same symbol),
`BcCompiler`'s emit capture, and **both** cache-sidecar writer/reader pairs, so the value
survives a cache HIT.

**`Extensible` is `bool?`, not `bool`, and that is the load-bearing decision.** I first wrote it
as `bool` with an unconditional render — false is AL's own default, so it looked right. BC's
emitted documents say otherwise: of 144 enum documents on **28.1.49838.53910 and
28.4.53241.54407** (two distinct binaries, identical counts), 31 state `"1"`, 99 state `"0"`, and
**12 base enums state the attribute not at all** — precisely the 12 whose `SymbolReference.json`
omits the property (1480, 1921, 1990, 1991, 1993, 1994, 1995, 2301, 2351, 2915, 8704, 8761).
Writing `"0"` for those manufactures a difference, which is the one thing the equivalence harness
exists to prevent. Caught by reading the emitter's own output, not by review.

**Which population the 12 describes**, since a reader re-deriving it will get 14: of the 144
documents, `Extensible` is absent on **14 documents = 12 base enums + 2 enumextensions** (327
"No. Series Copilot Cap." and 2015 "Entity Text Capability" — the two the issue itself calls out
as enumextension-shaped). Both counts are correct; the 12 is the one the render's conditional is
about, because an enumextension registers through `RegisterExtension`, which carries no
`Extensible` at all. Identical on both binaries.

`Extensible` is written `"1"`/`"0"`, never `"true"`: BC parses it with `MetaBase.Int32Value`,
which is `Int32.Parse` with only `""` and `"undefined"` mapped to 0 — a boolean spelling makes
`MetaEnum`'s constructor **throw**.

**No `CacheVersion` bump, and I checked rather than assumed.** `EnumSymbol` gaining
`bool? Extensible` is a record-shape change, and the `bc-symbols` cache key carries
`shape:<PayloadShape>` — a structural fingerprint over `CachePayload` that nobody maintains by
hand. Measured by printing `PayloadShapeForTests` from a scratch worktree at `origin/main` and
from this branch: **`815628200cf1876e` → `ccb081fbed1589bf`**. So this branch cannot read
`main`'s entries or PR #3908's, and it leaves `CacheVersion` at 40 where #3908 takes 41 — no
collision in either direction. (`CacheVersion` remains for the case a fingerprint cannot see: the
parse changing while the shape does not.)

## The measurement that confirms the fix end to end

Independently of my fixtures, the metadata-equivalence harness compares the runner's derivation
against BC's emitter output over the real System Application + Business Foundation bundles. After
the fix, its own guards demanded the allowlist be updated:

```
these allowlist entries no longer match any difference — the derivation now agrees with BC on
them, so remove the entries:
MetaEnum.Extensible
MetaEnumValue.InterfaceImplementation
MetaEnum.DefaultImplementation
MetaEnum.UnknownImplementation
```

All four entries are removed. `MetaEnum.ALNamespace`, the enum-level `CaptionML` and
`MetaEnum.MetadataToken` stay — still real gaps, still on #3807's sibling list, out of scope here.

## RED → GREEN, and the mutations

RED baseline (a probe using only the pre-fix API, deleted before commit): `Total tests: 1,
Failed: 1`, failing on `Assert` — not `error CS` — with the diagnostic showing the defect
directly:

```
RENDER: <Enum ID="1465" Name="Encryption Algorithm"><Values><Value Name="Aes" Ordinal="0" />…
BC READS BACK: Extensible=False Default=[] Unknown=[] valueImpls=[ | ]
```

GREEN: `Failed: 0, Passed: 6, Skipped: 0, Total: 6`.

Three mutations, each rebuilt, each confirmed landed by reading the diff, each verified to fail
on an assertion with **0 `error CS`** lines in the build:

| mutation | result |
|---|---|
| A — `SymbolBoolean` never returns true | `Failed: 3, Passed: 3, Total: 6` (`Assert.True` Expected True / Actual False) |
| B — render a value's `Implementation` as `"0"` | `Failed: 1, Passed: 5, Total: 6` (`Assert.Equal` Expected `[1467]` / Actual `[0]`) |
| C — render `Extensible` unconditionally | `Failed: 1, Passed: 5, Total: 6` (`Assert.False` Expected False / Actual True) |

Wider: `Failed: 0, Passed: 172, Skipped: 0, Total: 172` over
`~Enum|~MetadataEquivalence`, and `Failed: 0, Passed: 115, Skipped: 0, Total: 115` over
`~Sidecar|~SymbolCache|~BcAppSymbol|~Suites|~DependencyLoader|~FloorOnlyBundle`. Every run
quotes its own `Total:`; none reported `No test matches`.

## One negative result, recorded rather than papered over

I replaced the harness's `AssertConstantAnswer` for `MetaEnum.Extensible` with `Assert.Empty`,
and initially wrote in the docs that an unconditional render would now show 12 differences.
**I measured it, and that claim was wrong.** Making the render unconditional leaves **all 13**
harness tests green.

The reason is structural: both sides of that comparison are `MetaEnum` *objects* and
`MetaEnum.Extensible` is a plain `bool`, so BC's absent attribute reads back as `false` on BC's
side too, and a runner writing `"0"` agrees with it. The difference exists only in the XML,
which the harness does not compare. The docs and the test comment now say exactly this, and
point at `EnumExtensibleAndImplementationRenderTests`, which asserts on `HasAttribute` against
the rendered document and **does** go RED on that mutation (measured above, mutation C, and
re-measured alongside the harness: harness `Failed: 0, Passed: 13` / render test `Failed: 1,
Passed: 5` on the same mutated build).

## Why Corpus-NA and not a corpus PR

`Extensible` decides whether an enum accepts an enumextension, so this reads like a BC-behaviour
claim. It is not, for a reason I measured rather than assumed: **`Entry.Extensible` has no
runtime consumer.** `TryBuildEnumMetadataEquivalenceXml`'s only callers are
`MetadataEquivalenceHarness` and this PR's tests, and no runtime path reads the field — it flows
parse → registry → sidecar → render. So no AL a corpus test could write observes it, and a
corpus test asserting "this enum is extensible" would pass on the runner before this PR as
readily as after.

The corpus already covers the AL-observable half and passes: `TestEnumExtTests.Codeunit.al`
(codeunit 60888) exercises `Extensible = true` enums with real enumextensions through
`Ordinals()`/`Names()` merging. Corpus checked out at `0b40d3ed29a304a32299d038b611d3e924958324`
(master) to confirm this. If a runtime consumer is ever added, that is the point at which a
corpus test becomes both possible and required.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — `AlEnumMetadataRegistry.RegisterFromAppPath`
   reads the same `EnumSymbol` and dropped the same fields. Fixed, though it has no live callers
   today (#3143), because a future caller would inherit the gap silently.
2. **Sibling function with the same assumption?** Yes, two cache-sidecar writer/reader pairs
   (`Suites.cs` and `EnumMetadataPatches.cs`), each of which would have dropped `Extensible` on a
   cache HIT. Both carry it now, with a `ReadNullableBool` sibling to the existing `ReadIdList`.
3. **Two paths writing the same state, same invariant?** Checked, and found a deliberate
   divergence worth recording: the **page** side reads the same property name through
   `SymbolBoolFalse`, folding absence into the default, because BC's emitter writes a page's
   `Extensible` unconditionally. For enums it does not (the 12 above). Both are now correct for
   their own kind, and `SymbolBoolean`'s doc comment says why they differ so the next reader does
   not "fix" one to match the other.

## Queue scan

Searched the open queue on `Extensible`, `InterfaceImplementation`, `EnumSymbol`,
`AlEnumMetadataRegistry` and `TryBuildEnumMetadataEquivalenceXml`. Nothing folds:

- **#3805** — the other enum issue, in PR #3908, one expression in the same method. Its author
  recorded on #3807 why it should not fold; I agree and did not re-litigate. No textual conflict
  arose (that PR deletes a `nextOrdinal` accumulator; this one adds a parameter at the end of the
  same constructor call).
- **#3788 / #3798 / #3806 / #3808 / #3809** — the same *shape* (BC's emitter states a value, the
  derivation does not), but each in a different object kind and a different file. Different code,
  so no fold under `batch-sibling-issues-by-file.md`.
- **#3825** — the route that would supersede all seven by consuming BC's compiled documents
  directly. Read it first, per the coordinator's note; that consumer does not exist yet, so the
  derivation is still what answers and this gap was live.
- No open issue reports this same defect in different words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
