### PR TITLE
fix(metadata): PermissionSet Assignable defaults to false when the property is absent, as BC's own reader does

### DIFF
--- a/AlRunner.Tests/BcAppSymbolCachePermissionSetTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCachePermissionSetTests.cs
@@ -14,10 +14,13 @@
 //     "PermissionSets" finds 2 entries in Base Application 28.1 and ZERO in System
 //     Application 28.1 — which is where SUPER lives. Measured against the real .app files,
 //     not assumed.
-//  2. `Assignable` is not always stated. Base Application 28.1's "D365 Basic - Edit" (208)
-//     declares no Assignable property and is assignable; "LOCAL" (1001) declares
-//     `Assignable = false`. AL's default is true, matching table 2000000250's own field 4
-//     (`InitValue = true`).
+//  2. `Assignable` is not always stated, and an absent one reads as FALSE — what BC's own
+//     reader answers, not AL's source-language default (#2417, #3806). Base Application 28.1's
+//     "D365 Basic - Edit" (208) and "D365 Basic - Read" (209) and System Application's
+//     "System Execute - Basic" (68) declare none; "LOCAL" (1001) declares `Assignable = false`.
+//     Table 2000000250's field 4 carries `InitValue = true`, which is an AL initial value for a
+//     NEW record and does not describe how BC reads an emitted document — the reading that made
+//     this wrong for four issues.
 //
 // The shapes below mirror what those real .app symbol files state, including SUPER's caption
 // and the System Application's app id. The .app shape (a plain zip holding
@@ -97,6 +100,10 @@ public class BcAppSymbolCachePermissionSetTests
                       "Properties": [
                         { "Name": "Caption", "Value": "Dynamics 365 Basic - Edit access" }
                       ]
+                    },
+                    {
+                      "Id": 68,
+                      "Name": "System Execute - Basic"
                     }
                   ]
                 }
@@ -117,8 +124,8 @@ public class BcAppSymbolCachePermissionSetTests
             var symbols = BcAppSymbolCache.Get(appPath);
 
             Assert.NotNull(symbols.PermissionSets);
-            // Both the nested three and the root-level one; a root-only read would find 1.
-            Assert.Equal(4, symbols.PermissionSets!.Count);
+            // Both the nested four and the root-level one; a root-only read would find 1.
+            Assert.Equal(5, symbols.PermissionSets!.Count);
 
             var super = Assert.Single(symbols.PermissionSets, p => p.Name == "SUPER");
             Assert.Equal(31, super.Id);
@@ -142,8 +149,26 @@ public class BcAppSymbolCachePermissionSetTests
         }
     }
 
+    /// <summary>
+    /// An ABSENT <c>Assignable</c> reads as FALSE, in both shapes the real symbol files use, and
+    /// an explicit "1" still reads as true — so a reader that simply answered false everywhere
+    /// would fail here (#2417, #3806).
+    ///
+    /// <para>CLAIM: BC's own reader never defaults this to true. <c>MetaPermissionSet.Create</c>
+    /// assigns <c>Assignable</c> only inside <c>case 10: if (name == "Assignable")</c>, and
+    /// <c>MetaPermissionSet()</c> initialises only Permissions/Included/Excluded — so an absent
+    /// attribute leaves <c>default(bool)</c>, which is false. Measured on
+    /// Microsoft.Dynamics.Nav.Types.dll 28.1.49838.53910 (sha256 c91ede8f…); #3806 measured the
+    /// same build's reader answering <c>Assignable = False</c> for set 68.</para>
+    ///
+    /// <para>TRAP: there are TWO absent shapes and a fixture with only one proves half the fix.
+    /// Base Application 208/209 state a <c>Properties</c> array with no <c>Assignable</c> key;
+    /// System Application 68 states no <c>Properties</c> key at all. Measured across the real
+    /// 28.1 .app files: 436 permission sets, 121 state "1", 312 state "0", and exactly these 3
+    /// state none.</para>
+    /// </summary>
     [Fact]
-    public void PermissionSets_AssignableDefaultsToTrue_AndAnExplicitFalseIsHonored()
+    public void PermissionSets_AbsentAssignableReadsAsFalse_AndAnExplicitTrueIsHonored()
     {
         var dir = TestScratch.Dir("al-runner-bcsym-permset-tests");
         Directory.CreateDirectory(dir);
@@ -156,10 +181,23 @@ public class BcAppSymbolCachePermissionSetTests
             var agentObjects = Assert.Single(permissionSets, p => p.Name == "Agent - Objects");
             Assert.False(agentObjects.Assignable);
 
-            // Declares no Assignable property at all — AL's default is true.
+            // Declares Assignable = 1 — the direction that fails if the fix over-corrects to
+            // "always false".
+            var super = Assert.Single(permissionSets, p => p.Name == "SUPER");
+            Assert.True(super.Assignable);
+
+            // Absent shape 1: a Properties array that carries no Assignable key (Base
+            // Application 208 "D365 Basic - Edit", verbatim).
             var basicEdit = Assert.Single(permissionSets, p => p.Name == "D365 Basic - Edit");
-            Assert.True(basicEdit.Assignable);
+            Assert.False(basicEdit.Assignable);
+            // The rest of the parse is untouched by the defaulting change.
             Assert.Equal("Dynamics 365 Basic - Edit access", basicEdit.Caption);
+
+            // Absent shape 2: no Properties key whatsoever — System Application 68
+            // "System Execute - Basic", the exact set #2417 was filed about.
+            var systemExecuteBasic = Assert.Single(permissionSets, p => p.Name == "System Execute - Basic");
+            Assert.Equal(68, systemExecuteBasic.Id);
+            Assert.False(systemExecuteBasic.Assignable);
         }
         finally
         {

--- a/AlRunner.Tests/BuiltMetadataCacheBundleBoundaryTests.cs
+++ b/AlRunner.Tests/BuiltMetadataCacheBundleBoundaryTests.cs
@@ -362,6 +362,57 @@ public sealed class BuiltMetadataCacheBundleBoundaryTests : IDisposable
         return path;
     }
 
+    /// <summary>
+    /// The AL-source parser defaults an UNDECLARED <c>Assignable</c> to false, matching what
+    /// BC's own reader answers for the document BC emits from that same declaration (#2417,
+    /// #3806) — and an explicit <c>Assignable = true</c> is still honoured, so a parser that
+    /// simply answered false everywhere fails the second half.
+    ///
+    /// <para>TRAP: this parser's value is consumed by
+    /// <c>ComposeSourcePermissionSet</c> only on the fallback path — when no BC document is
+    /// registered, i.e. a COMPILE-CACHE HIT. So a parser disagreeing with the document route
+    /// makes one permission set answer false on a cold run and true on a warm one, which is a
+    /// cache-dependent wrong answer nothing downstream can detect.</para>
+    /// </summary>
+    [Fact]
+    public void AlSourceParser_UndeclaredAssignableIsFalse_AndAnExplicitTrueIsHonored()
+    {
+        var dir = Path.Combine(_root, "assignable-default");
+        Directory.CreateDirectory(dir);
+        // The parser drops a declaration whose owning app.json it cannot find, so the manifest
+        // is load-bearing. No "application" property — that is the Base Application floor,
+        // which no-base-app-in-csharp-tests.md forbids in a C# fixture.
+        File.WriteAllText(Path.Combine(dir, "app.json"),
+            """
+            {
+              "id": "b3f1c0de-7931-4a11-9c7e-000000079942",
+              "name": "BMCB Assignable App",
+              "publisher": "AL Runner",
+              "version": "1.0.0.0"
+            }
+            """);
+
+        // Declares NO Assignable — the shape of Base Application 208/209 and System
+        // Application 68, the three real sets that state none.
+        var undeclaredPath = Path.Combine(dir, "BmcbUndeclared.PermissionSet.al");
+        File.WriteAllText(undeclaredPath,
+            "permissionset 79960 \"BMCB Undeclared Assignable\"\n"
+            + "{\n    Caption = 'BMCB Undeclared Assignable';\n}\n");
+        ParseOneSourceFile(undeclaredPath);
+
+        // Declares Assignable = true explicitly.
+        var declaredPath = WritePermissionSet(dir, 79961, "BMCB Declared Assignable");
+        ParseOneSourceFile(declaredPath);
+
+        // Asserted, not assumed: if the sweep had not picked these up, the claims below would
+        // be about an empty dictionary rather than about the defaulting rule.
+        Assert.Equal(79960, PermissionSetNamed("BMCB Undeclared Assignable").Id);
+        Assert.Equal(79961, PermissionSetNamed("BMCB Declared Assignable").Id);
+
+        Assert.False(PermissionSetNamed("BMCB Undeclared Assignable").Assignable);
+        Assert.True(PermissionSetNamed("BMCB Declared Assignable").Assignable);
+    }
+
     private static RecordPatches.ParsedAlProfile ProfileNamed(string profileId)
         => Assert.Single(RecordPatches.ParsedProfiles.Where(p => p.ProfileId == profileId));
 

--- a/AlRunner.Tests/PermissionSetFromBcDocumentTests.cs
+++ b/AlRunner.Tests/PermissionSetFromBcDocumentTests.cs
@@ -275,7 +275,6 @@ public class PermissionSetFromBcDocumentWiringTests : IDisposable
         Assert.Equal(TableId, grant.ObjectId);      // the id AL source never states
         Assert.Equal(15, grant.Value);              // RIMD
     }
-
 }
 
 /// <summary>

--- a/AlRunner.Tests/PermissionSetFromBcDocumentTests.cs
+++ b/AlRunner.Tests/PermissionSetFromBcDocumentTests.cs
@@ -130,15 +130,27 @@ public class PermissionSetFromBcDocumentTests : IDisposable
     }
 
     /// <summary>
-    /// Assignable="0" must read as false, and an ABSENT Assignable must read as AL's own
-    /// default of true — not as false. The two directions are asserted together because a
-    /// reader that ignored the attribute entirely would pass either one alone.
+    /// <c>Assignable="0"</c> and an ABSENT <c>Assignable</c> both read as false, and
+    /// <c>Assignable="1"</c> reads as true — so a reader that ignored the attribute entirely
+    /// fails the third assertion rather than passing by accident (#2417, #3806).
+    ///
+    /// <para>CLAIM: this matches BC's own reader on the identical document.
+    /// <c>MetaPermissionSet.Create</c> assigns the property only inside
+    /// <c>case 10: if (name == "Assignable")</c>, and the constructor never touches it, so an
+    /// absent attribute leaves <c>default(bool)</c> — false. Measured on
+    /// Microsoft.Dynamics.Nav.Types.dll 28.1.49838.53910 (sha256 c91ede8f…).</para>
+    ///
+    /// <para>TRAP: this test previously asserted <c>true</c> here, reasoning from AL's
+    /// source-language default. That default governs what the COMPILER emits, not what BC's
+    /// reader does with a document that states nothing — and BC's emitter does omit the
+    /// attribute (set 68 of the 178 #3806 measured).</para>
     /// </summary>
     [Fact]
-    public void AssignableFalseAndAbsentAreDifferentAnswers()
+    public void AssignableFalseAndAbsentBothReadAsFalse_AndAnExplicitTrueIsHonored()
     {
         const int notAssignable = SetWithEverything + 200;
         const int unstated = SetWithEverything + 201;
+        const int assignable = SetWithEverything + 202;
 
         AlObjectMetadataRegistry.Register(
             RecordPatches.BcPermissionSetMetadataKind, notAssignable, "PSD NotAssignable",
@@ -152,9 +164,16 @@ public class PermissionSetFromBcDocumentTests : IDisposable
              <PermissionSet ID="{unstated}" Name="PSD Unstated"
                             xmlns="urn:schemas-microsoft-com:dynamics:NAV:MetaObjects" />
              """);
+        AlObjectMetadataRegistry.Register(
+            RecordPatches.BcPermissionSetMetadataKind, assignable, "PSD Assignable",
+            $"""
+             <PermissionSet ID="{assignable}" Name="PSD Assignable" Assignable="1"
+                            xmlns="urn:schemas-microsoft-com:dynamics:NAV:MetaObjects" />
+             """);
 
         Assert.False(RecordPatches.TryReadPermissionSetFromBcDocument(notAssignable, "PSD NotAssignable")!.Assignable);
-        Assert.True(RecordPatches.TryReadPermissionSetFromBcDocument(unstated, "PSD Unstated")!.Assignable);
+        Assert.False(RecordPatches.TryReadPermissionSetFromBcDocument(unstated, "PSD Unstated")!.Assignable);
+        Assert.True(RecordPatches.TryReadPermissionSetFromBcDocument(assignable, "PSD Assignable")!.Assignable);
     }
 
     /// <summary>

--- a/AlRunner.Tests/PermissionSetFromBcDocumentTests.cs
+++ b/AlRunner.Tests/PermissionSetFromBcDocumentTests.cs
@@ -275,6 +275,7 @@ public class PermissionSetFromBcDocumentWiringTests : IDisposable
         Assert.Equal(TableId, grant.ObjectId);      // the id AL source never states
         Assert.Equal(15, grant.Value);              // RIMD
     }
+
 }
 
 /// <summary>

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -279,7 +279,19 @@ internal static partial class BcAppSymbolCache
     //
     // 41 was confirmed free immediately before pushing, per v39's own warning: origin/main read
     // 40, and a sweep of all 252 remote branches carrying this file found none above 40.
-    private const int CacheVersion = 41;
+    // v42: a permission set stating no Assignable is read as FALSE rather than true (#2417,
+    // #3806) — what BC's own MetaPermissionSet.Create answers, since it assigns the property
+    // only when the attribute is present. The same trap as v35, v36, v38, v39, v40 and v41:
+    // PermissionSetSymbol.Assignable is a bool either way, so PayloadShape cannot see that the
+    // VALUE changed, and a warm box would replay Assignable=true — the exact pre-fix wrong
+    // answer, from cache, on a green build. Measured across the real 28.1 .app symbol files:
+    // 436 permission sets, of which 3 state no Assignable — Base Application 208 "D365 Basic -
+    // Edit" and 209 "D365 Basic - Read" (a Properties array with no Assignable key) and System
+    // Application 68 "System Execute - Basic" (no Properties key at all).
+    //
+    // 42 was confirmed free immediately before pushing, per v39's own warning: origin/main read
+    // 41, and a sweep of every remote branch carrying this file found none above 41.
+    private const int CacheVersion = 42;
     private static readonly ConcurrentDictionary<string, AppSymbols> ProcessCache = new(StringComparer.OrdinalIgnoreCase);
     // Issue #1820's path -> content-hash memo now lives in
     // RunnerFingerprint._fileContentHashes (#2955), because AppLoader's persisted r2r-chunks
@@ -1150,13 +1162,22 @@ internal static partial class BcAppSymbolCache
                     if (string.IsNullOrEmpty(name)) continue;
                     var props = SymbolProperties(el);
                     props.TryGetValue("Caption", out var caption);
-                    // AL's `Assignable` defaults to true; only an explicit false flips it
-                    // (Base Application's "LOCAL" states `Assignable = false`, while
-                    // "D365 Basic - Edit" states nothing and is assignable). Table
-                    // 2000000250's own field 4 carries `InitValue = true` for the same reason.
+                    // CLAIM: an absent `Assignable` is FALSE, which is what BC's own reader
+                    // answers — not AL's source-language default of true. BC's
+                    // Types.Metadata.MetaPermissionSet.Create assigns Assignable only inside
+                    // `case 10: if (name == "Assignable")`, and MetaPermissionSet() initialises
+                    // only Permissions/Included/Excluded, so an absent attribute leaves
+                    // default(bool). Read off Microsoft.Dynamics.Nav.Types.dll 28.1.49838.53910;
+                    // #3806 measured that reader answering False for set 68, and #2417 traced
+                    // the true answer to a ModifyLength crash in the Aggregate Permission Set
+                    // provider, whose Assignable=true filter real BC never lets that row past.
+                    //
+                    // TRAP: table 2000000250's field 4 carries `InitValue = true`, which is the
+                    // initial value of a NEW AL record and says nothing about reading an emitted
+                    // document. Citing it is what kept this wrong.
                     props.TryGetValue("Access", out var access);
                     into.TryAdd(id, new PermissionSetSymbol(
-                        id, name, caption, !SymbolBoolFalse(props, "Assignable"),
+                        id, name, caption, SymbolBool(props, "Assignable"),
                         ReadPermissions(el),
                         ReadIncludedPermissionSets(props),
                         access));

--- a/AlRunner/Patches/RecordPatches.AlPermissionSetParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlPermissionSetParser.cs
@@ -96,11 +96,16 @@ public static partial class RecordPatches
             }
 
             var props = permissionSet.PropertyList;
-            // AL's `Assignable` property defaults to true when a permission set declares
-            // none — same rule BcAppSymbolCache.CollectPermissionSets already applies for
-            // precompiled dependency .apps, so a source-compiled and a precompiled
-            // declaration of the same shape answer identically.
-            var assignable = !PropIs(props, "Assignable", "false");
+            // An UNDECLARED `Assignable` is false, matching BcAppSymbolCache.CollectPermissionSets
+            // and TryReadPermissionSetFromBcDocument, so a source-compiled and a precompiled
+            // declaration of the same shape still answer identically (#2417, #3806). The shared
+            // rule is BC's own reader: MetaPermissionSet.Create assigns the property only when
+            // the attribute is present, leaving default(bool).
+            //
+            // TRAP: this value reaches ComposeSourcePermissionSet only on the FALLBACK path,
+            // when no BC document is registered — a compile-cache HIT. Letting it disagree with
+            // the document route would make one set answer false cold and true warm.
+            var assignable = PropIs(props, "Assignable", "true");
 
             _parsedPermissionSets[(appId, name)] = new ParsedAlPermissionSet(
                 id, name, PropertyTextFrom(PropValue(props, "Caption")), assignable, appId, appName,

--- a/AlRunner/Patches/RecordPatches.PermissionSetFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionSetFromBcDocument.cs
@@ -24,6 +24,15 @@
 //   AL rather than BC's emitter: a probe declaring the property gets it back on the document.
 //   See docs/permission-set-from-bc-document.md#excluded-permission-sets.
 //
+// CLAIM — an ABSENT Assignable attribute reads as FALSE, not as AL's source-language default
+//   of true (#2417, #3806). BC's own Types.Metadata.MetaPermissionSet.Create assigns the
+//   property only inside `case 10: if (name == "Assignable")`, and MetaPermissionSet()
+//   initialises only Permissions/Included/Excluded — so an absent attribute leaves
+//   default(bool). Read off Microsoft.Dynamics.Nav.Types.dll 28.1.49838.53910 (sha256
+//   c91ede8f…); #3806 measured that same reader answering False for PermissionSet 68, the one
+//   document of 178 that omits the attribute. AL's default governs what the COMPILER emits,
+//   which is a different question from what BC's reader does with a document stating nothing.
+//
 // TRAP — nothing in the derivation became dead code, so do not delete it as unreachable. The
 //   registry is keyed by id (the parser is the inventory), BC's document does not state
 //   AppId/AppName, and Emit runs only on a compile-cache MISS, leaving the derivation the live
@@ -101,10 +110,9 @@ public static partial class RecordPatches
             // rest of the runner carries is the ENU text alone, which is what the AL `Caption`
             // property stated and what "Metadata Permission Set".Name reports.
             EnuFromCaptionMl((string?)root.Attribute("CaptionML")),
-            // Assignable is emitted as "1"/"0". AL's own default when a set declares none is
-            // true, and BC states the attribute on every set the compiler emits — so an
-            // absent attribute takes AL's default rather than reading as false.
-            ParseBcBool((string?)root.Attribute("Assignable"), defaultValue: true),
+            // Assignable is emitted as "1"/"0", and an ABSENT attribute is false — the same
+            // answer BC's own reader gives this document (see the CLAIM in the header).
+            ParseBcBool((string?)root.Attribute("Assignable"), defaultValue: false),
             ReadPermissions(root),
             // The NAME list stays null on this route: BC states ids, and filling both would
             // give BuildIncludeList two sources to disagree about.

--- a/tests/expectations/metadata-equivalence/allowlist.json
+++ b/tests/expectations/metadata-equivalence/allowlist.json
@@ -1382,11 +1382,6 @@
       "issue": 3806
     },
     {
-      "member": "MetaPermissionSet.Assignable",
-      "reason": "PermissionSet 68 'System Execute - Basic' only: BC answers False, the runner answers True. THIS IS THE MEASUREMENT #2417 ASKED FOR, and it is a measurement rather than an inference -- #2417 states the question must be settled against BC itself and not by reading SymbolReference.json. BC's own emitted document for 68 is the only one of 178 carrying no Assignable attribute at all (the distribution is 140 x \"0\", 37 x \"1\", 1 x absent), and BC's own MetaPermissionSet.Create resolved that absence to False. So BC's reader defaults absent -> false and CollectPermissionSets's absent -> true is wrong, exactly as #2417 predicted. The fix lands in BcAppSymbolCache/RecordPatches.MetadataPermissionSetVirtualTable rather than in the harness, so it is tracked on #3806 which records the answer and points at #2417. Deliberately NOT versionContingent despite matching a single object: the criterion is that the member's population depends on a per-object declaration, and this one does -- but it is one object on every BC build measured, and an entry that stopped matching would mean either the fix landed or BC changed its default, both of which must be loud.",
-      "issue": 3806
-    },
-    {
       "member": "MetaPermissionSet.ALNamespace",
       "reason": "BC states the permission set's AL namespace; the runner answers null on all 178 because PermissionSetSymbol does not carry it. Derivable -- SymbolReference.json states the namespace -- and simply not carried. Same member and same fix as MetaTable.ALNamespace (#3568), MetaReport.ALNamespace (#3808) and MetaEnum.ALNamespace (#3807).",
       "issue": 3806


### PR DESCRIPTION
Closes #3806
Closes #2417

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/326

An absent `Assignable` on a permission set now reads as **false**, on all three code paths that derive one — which is what BC's own reader answers.

## What settled it

#3806 measured BC's `MetaPermissionSet.Create` answering `Assignable = False` for PermissionSet 68, the one document of 178 that omits the attribute. I confirmed the **mechanism** behind that measurement by reading the IL, because a single measured value and a structural property are different strengths of claim:

```csharp
case 10:
    if (name == "Assignable")
        metaPermissionSet.Assignable = MetaBase.BooleanValue(val.Value);
    break;
```

`Create` assigns `Assignable` **only inside that branch**, and `MetaPermissionSet()` initialises only `Permissions`, `IncludedPermissionSets` and `ExcludedPermissionSets`. So an absent attribute leaves `default(bool)` — false — for every document, not just set 68.

Read off `Microsoft.Dynamics.Nav.Types.dll` **28.1.49838.53910** (sha256 `c91ede8f…`). That is **one binary**: 28.4's `Types.dll` is a different file (`9a264a90…`, same 3781944 bytes), and I could not load it as a context in this session, so I make no cross-version independence claim. The 28.1 reading and #3806's harness measured the same binary.

The AL-source default of `true` is real but answers a different question: it governs what the **compiler emits**, not what BC's **reader** does with a document stating nothing — and BC's emitter does omit the attribute. Table 2000000250's `InitValue = true` is the initial value of a *new* AL record and says nothing about reading an emitted document; citing it is what kept this wrong.

## The scope is wider than one set — measured, not assumed

#3806's harness covered System Application + Business Foundation (178 sets) and found one difference. Reading the real 28.1 `.app` symbol files across **all three** shipped apps found **three**:

| app | id | name | shape |
|---|---|---|---|
| Base Application | 208 | `D365 Basic - Edit` | `Properties` array, no `Assignable` key |
| Base Application | 209 | `D365 Basic - Read` | same |
| System Application | 68 | `System Execute - Basic` | **no `Properties` key at all** |

436 permission sets total: 121 state `"1"`, 312 state `"0"`, 3 state none. Both absent shapes are pinned, because a fixture carrying only one proves half the fix. #2417 asks specifically about the second shape.

## Fix the shape — the three questions

**1. Does the same wrong pattern appear at another call site?** **Yes, twice more.** Grepping the shape rather than the reported symptom found three paths writing `PermissionSetSymbol.Assignable`:

| path | was | now |
|---|---|---|
| `BcAppSymbolCache.CollectPermissionSets` (precompiled `.app`) | `!SymbolBoolFalse(…)` | `SymbolBool(…)` |
| `TryReadPermissionSetFromBcDocument` (BC's emitted document) | `defaultValue: true` | `defaultValue: false` |
| `RecordPatches.AlPermissionSetParser` (AL source text) | `!PropIs(…,"false")` | `PropIs(…,"true")` |

Only the first is named by either issue.

**2. Does a sibling function make the same assumption?** The document route's comment explicitly justified `defaultValue: true` as AL's default, and the AL-source parser's comment justified itself *by citing `CollectPermissionSets`*. Fixing only the reported site would have left two paths disagreeing with it and with each other.

**3. If two code paths write the same state, do they maintain the same invariant?** **They did not, and the third one mattered most.** `ComposeSourcePermissionSet` prefers BC's document and falls back to the AL-source parser **only when no document is registered — a compile-cache HIT**. So before this change the same permission set would answer `false` on a cold run and `true` on a warm one. A cache-dependent `Assignable` is exactly the class of wrong answer nothing downstream detects.

## RED → GREEN, with the mutation results

Three mutations, one per route. Each mutation was a **value** change confirmed present in `git diff` before rebuilding, and every RED was checked to be an `Assert` failure with `0 Error(s)` — not `error CS`.

| route | RED | GREEN | mutation |
|---|---|---|---|
| `CollectPermissionSets` + document (combined) | `Failed: 2, Passed: 7, Skipped: 0, Total: 9` | `Failed: 0, Passed: 9, Skipped: 0, Total: 9` | — |
| `CollectPermissionSets` alone | — | — | `Failed: 1, Passed: 3, Skipped: 0, Total: 4` |
| document route alone | — | — | `Failed: 1, Passed: 4, Skipped: 0, Total: 5` |
| AL-source parser | `Failed: 1, Passed: 0, Skipped: 0, Total: 1` | `Failed: 0, Passed: 1, Skipped: 0, Total: 1` | `Failed: 1, Passed: 0, Skipped: 0, Total: 1` |

Each test asserts **both directions** — an explicit `Assignable = true` still answers true — so a reader that simply answered false everywhere fails rather than passing.

Wider surface, run with `engine.runsettings` after `tools/engine-test-bootstrap.sh` (a Debug run fails inside `BcEngineUnbootstrappedGuard`): **`Failed: 0, Passed: 199, Skipped: 0, Total: 199`**.

## The strongest evidence is not my fixtures

`MetadataEquivalenceHarnessTests.No_allowlist_entry_has_gone_stale` **failed** after the fix, reporting `MetaPermissionSet.Assignable` as a stale allowlist entry. That harness compares the runner's `MetaPermissionSet` against BC's own `MetaPermissionSet.Create` over all **178 real** permission-set documents — so it is BC's emitter, not my fixture, reporting that the derivation now agrees. #2417's own comment predicted exactly this failure as the signal that the fix had landed. The entry is removed in this PR.

## The cache question, settled by measurement

The brief's trap: a **parse-only** change leaves `PayloadShape` untouched, making `CacheVersion` the only discriminator. I measured `PayloadShape` on both sides via the `PayloadShapeForTests` reflection seam rather than reasoning about it, and rather than searching the fingerprint for a member name (a 16-character hash cannot answer that):

| | `origin/main` (`6e4e3eec`) | this branch |
|---|---|---|
| `PayloadShape` | `ccb081fbed1589bf` | `ccb081fbed1589bf` — **identical** |
| `CacheVersion` | 41 | **42** |

So the fingerprint re-keys nothing here and the bump is what does the work. Without it a warm box would replay `Assignable=true` from cache on a green build — the failure mode that silently unapplied PR #3908. **42 confirmed free** immediately before pushing: `origin/main` reads 41, and a sweep of every remote branch carrying the file found none above 41.

## The other three members of #3806 — deliberately not folded

#3806 reports 527 differences across 4 members. `Assignable` is fixed; the other three keep their allowlist entries and stay open on #3806, because each needs materially different reasoning than a defaulting correction:

- **`Name`** (170 differences) — **the runner is arguably not the one that is wrong.** BC's reader upper-cases; the document does not. The open question is *where* the upper-casing belongs, not which spelling is right, and the runner is internally case-insensitive here. Changing it is a behavioural decision about a `Code[20]`/`Code[30]` role id crossing into BC, not a defaulting fix.
- **`ALNamespace`** (178) — a value `PermissionSetSymbol` does not carry at all. Adding it changes the **record shape**, so `PayloadShape` re-keys on its own and the cache reasoning is different. It is also the same missing member as `MetaTable`/`MetaReport`/`MetaEnum` `ALNamespace` (#3568, #3807, #3808) and belongs with those.
- **`CaptionML`** (178) — the caption text is already carried; what is missing is the `MultiLanguage`-with-language-id **shape**, the same gap as the `MetaField.CaptionML` entry.

Folding any of these would stop this being one coherent change a reviewer can hold in their head. `MetadataToken` is correctly excluded by #3806 itself — a document-format version, already declared allowlist-wide.

## Duplicate search

Searched the open queue by symbol (`Assignable`, `CollectPermissionSets`), by observable (`permission set` in title), and by the distinctive measurement. Found #2417 and #3806, both claimed here, plus #2886/#2910 (different defect: those tables return *no rows*) and #3562 (the tracking issue for retiring the hand-derivation, which stays open). No other issue reports this defect.

## Corpus

The claim is BC-observable, so it owes an upstream test — and the corpus **can** express it, which I checked rather than assumed: all four existing permission-set fixtures state `Assignable` explicitly, so nothing covered the absent case. Corpus PR #326 adds a fixture declaring none, and asks the question through **two independent observables** (2000000250's column, and the 2000000004 walk, which applies the assignable filter), each alongside a declared-true contrast row.

If the service tier disagrees with these assertions, **the corpus tests are what change** — the assertions record what I measured BC's reader doing, and a tier outranks a reading of IL.

Runner-side, the `Tests updated` gate is satisfied by mechanism tests under `AlRunner.Tests/` that pin this build's own plumbing, which no service tier can answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
