### PR TITLE
docs(ci): the count baseline is one number per group plus absentOn, not a per-version count

### DIFF
--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -827,9 +827,15 @@ jobs:
           # --count-baseline (#1880), same rationale as the al-language corpus leg
           # above. runner-extras genuinely has fewer tests on BC 27.0/27.3/27.5 than
           # 28.x (some AL surfaces are gated on preprocessor symbols only defined from
-          # 28.0 on) — tests/expectations/count-baseline/test-count-baseline.json
-          # carries a per-BC-version expected count for exactly that reason, not a
-          # single global value.
+          # 28.0 on). tests/expectations/count-baseline/test-count-baseline.json
+          # expresses that with ONE count per group plus an `absentOn` list naming the
+          # versions where a group does not run at all — not a per-version count per
+          # group, which is what this comment used to claim and no group has (#3903).
+          # So a leg's expected total is sum(tests) minus the tests of every group
+          # whose absentOn names that version. Bumping a baseline after adding tests
+          # means changing ONE number, and re-deriving that sum is what makes the
+          # change checkable — deliberately stated as the formula rather than today's
+          # totals, which no drift test pins and which go stale on the next suite.
           #
           # The exit code is EXPLAINED here, not left bare (#3350). This is the only
           # step in the matrix that still passes --count-baseline, so it is the only


### PR DESCRIPTION
`bc-tests.yml:830` claimed `tests/expectations/count-baseline/test-count-baseline.json`:

> carries a **per-BC-version expected count** for exactly that reason, **not a single global
> value**.

**No group does.** Every group carries one `tests` integer; per-version variation is expressed by
an `absentOn` list naming the versions where a group does not run at all.

## Measured

```
groups                     73
sum of `tests`            432
groups with `absentOn`      5   (4 + 0 + 1 + 3 + 3 = 11 tests, all ["27.0","27.3","27.5"])
432 - 11                  421   <- exactly what BC 27.0 reports
```

The *reason* the old comment gave is real — runner-extras genuinely runs fewer tests on 27.x —
but the mechanism it named is not the one in use.

## Why it matters

Someone bumping the baseline after adding tests reads that comment and looks for a per-version
entry to edit. There is none, so they either hunt for structure that does not exist, or invent a
27.x sibling beside the single number. Both start from the comment being wrong rather than the
file being unclear.

## The formula, not the instance

The replacement states **sum(tests) minus the tests of every group whose `absentOn` names that
version**, and deliberately does *not* state today's totals. I wrote `432 - 11 = 421` first and
took it back out: no drift test pins those numbers, and they go stale on the next suite added.
This repository has ~10 drift tests precisely because a number in prose rots silently — stating
the derivation instead is what survives.

## Verification

`tools/test_matrix_docs_drift.py` → exit 0 (`all matrix-documentation and worktree-path checks
passed`). `tools/test_doc_pointers.py` → exit 0. YAML re-parsed with `yaml.safe_load` after the
edit. One file, +9/-3, comment lines only.

Pre-push checks run, both from errors I made earlier today: `git diff --stat origin/main...HEAD`
against a freshly fetched `main` (#3907), and a closing-keyword scan (only `Closes #3903`).

**No mutation reported**, deliberately: a comment has no implementation to break.

## Provenance

Found by the implementing agent on #3805 while bumping the baseline for four new AL tests. It
kept the fix out of that diff and reported it instead — the right call, and the reason it is a
clean one-file change here.

Closes #3903

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
