### PR TITLE
docs(local-test-scope): the warm-run exception is about caches you are behind, not caches you edit

### DIFF
--- a/.claude/rules/local-test-scope.md
+++ b/.claude/rules/local-test-scope.md
@@ -10,8 +10,24 @@ Two genuine exceptions:
 
 - **Establishing a RED baseline.** Before a fix, run the specific suite your
   change is meant to move, to confirm the failure is real and reproducible.
-- **Cache-sensitive changes.** A warm second run has caught real defects here
-  (e.g. AL queries broken only on a compile-cache hit) that a single cold run
-  cannot surface — run twice when your change touches caching.
+- **Anything behind a cache — which is wider than "changes to caching".** A warm
+  second run has caught real defects here that a single cold run cannot surface.
+  **Run twice against ONE cache root**, and read both runs.
+
+  The condition used to be "when your change touches caching", and that is the
+  half that fails: three defects in one session were each correct cold and wrong
+  warm, and none of their authors thought they were touching a cache.
+
+  | PR | the change | what a warm run showed |
+  |---|---|---|
+  | #3882 | a loud-failure guard | fired cold, **silent warm** — the cache HIT returned 80 lines before the guard |
+  | #3908 | a parse fix | the fixed code **replayed the buggy value** from cache; the key had no term for the parse |
+  | #3913 | a property default | answered `false` cold, `true` warm — a third call site reached only on a HIT |
+
+  **CI cannot catch these**: it provisions fresh every leg, so the legs stay green
+  forever while every repeat local run is wrong. All three were caught in review.
+
+  So ask *"is there a cache between my change and its observable?"*, not *"did I
+  edit cache code?"* — and when the answer is yes, the proving test runs twice.
 
 See the `al-runner-tests` skill for run commands and flags.


### PR DESCRIPTION
`local-test-scope.md` named the right exception and gated it on the wrong condition:

> **Cache-sensitive changes.** … **run twice when your change touches caching.**

**Three defects in one session were each correct cold and wrong warm, and none of their authors
thought they were touching a cache.**

| PR | the change | what a warm run showed |
|---|---|---|
| #3882 | a loud-failure guard | fired cold, **silent warm** — `LoadOne`'s cache HIT returns at line 666, the guard sits at 745 |
| #3908 | a parse fix | the fixed code **replayed the buggy value** from cache: `BuildKey` is `path\|hash\|v<CacheVersion>\|shape`, and a parse change moves none of them |
| #3913 | a property default | answered `false` cold and `true` warm — `ComposeSourcePermissionSet` reaches the AL-source parser **only** on a compile-cache HIT |

A guard, a parse, and a default. Each author would have answered "no" to *did your change touch
caching?* — correctly — and the fix would still have been wrong on every repeat run.

## Why CI is not the backstop here

**CI provisions fresh on every leg.** The legs stay green forever while every warm local run is
wrong. All three were caught in review; none by the matrix. That inverts the usual trade, where
CI catches what a local run misses.

## What changes

The condition becomes **"is there a cache between my change and its observable?"** rather than
*"did I edit cache code?"*, and the remedy is explicit: **run twice against one cache root, and
read both runs.** A second *cold* run proves nothing — it has to be the same root.

**Not** a blanket "always run twice", which would double every local run for the majority of
changes with no cache between them. The rule stays a condition; the condition gets the right
test.

## Evidence bar

`CLAUDE.md` § "How a rule is written" wants two independent instances or a cited measurement.
This has three, in three subsystems, all measured with PRs and line numbers on record. I logged
the first as a one-instance observation on #2247 this afternoon, explicitly so a second would
have something to join — it got two within the day.

## Verification

Docs-only. `tools/test_doc_pointers.py` passes. One file, +19/-3; the rule is 1,837 bytes and
remains among the smallest in `.claude/rules/`.

Pre-push checks run, both from my own errors earlier today: `git diff --stat origin/main...HEAD`
against a freshly fetched `main` (#3907) and a closing-keyword scan (only `Closes #3915`).

**No mutation reported**, deliberately: prose with no implementation to break.

Closes #3915

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
