### PR TITLE
fix(ordering): break the test-codeunit object-id tie on an ordinal type name, not the GetTypes() index

### DIFF
--- a/AlRunner.Tests/TestCodeunitOrderingContractTests.cs
+++ b/AlRunner.Tests/TestCodeunitOrderingContractTests.cs
@@ -54,8 +54,46 @@ public sealed class TestCodeunitOrderingContractTests
     /// <summary>Not an AL object at all — no attribute, and the name's suffix is not digits.</summary>
     private sealed class CodeunitHelpers { }
 
-    /// <summary>Second unresolvable type, so "keeps their relative input order" is testable.</summary>
+    /// <summary>
+    /// Second and third unresolvable types. Three of them, not two, because the answer has to be
+    /// distinguishable from the input array: with only two, half of all input orders already ARE
+    /// the sorted order, so a tiebreak that just kept the input would pass half the permutations.
+    /// Their ordinal order (AnotherNotAnAlObject, CodeunitHelpers, NotAnAlObject) is deliberately
+    /// NOT this file's declaration order, which is what a tiebreak on Type.MetadataToken would
+    /// follow. That is the only thing separating "the answer is a function of the types" from
+    /// "the answer is the compiler's TypeDef layout", and the layout is what #2801 already cost
+    /// a red CI leg.
+    /// </summary>
     private sealed class NotAnAlObject { }
+
+    private sealed class AnotherNotAnAlObject { }
+
+    /// <summary>
+    /// Two unresolvable types that share a SIMPLE name and differ only in their container. The
+    /// key is <c>Type.FullName</c>, and this pair is what tells that apart from <c>Type.Name</c>:
+    /// a Name-only key sees "Helper" twice, cannot separate them, and falls straight back to
+    /// input order — the defect, reintroduced one level down. Not hypothetical for this method:
+    /// BC's compiler-generated nested types are exactly the population the unresolved branch
+    /// orders, and their simple names collide freely across containers.
+    /// </summary>
+    private sealed class AlphaContainer { internal sealed class Helper { } }
+
+    private sealed class ZetaContainer { internal sealed class Helper { } }
+
+    /// <summary>
+    /// Differ only in the case of the final letter, which is what separates an ORDINAL
+    /// comparison from a culture-aware one: ordinal puts 'I' (0x49) before 'i' (0x69), while
+    /// every common culture — and the invariant culture — puts the lowercase letter first. The
+    /// near-identical names are deliberate, not a typo.
+    ///
+    /// <para>The fact below asserts the ORDINAL answer, so it needs no
+    /// <c>CultureInfo.CurrentCulture</c> override and cannot make the suite depend on the
+    /// machine's locale: under globalization-invariant mode a culture-aware comparer degrades to
+    /// ordinal and the fact still passes, it simply stops discriminating.</para>
+    /// </summary>
+    private sealed class FallbackI { }
+
+    private sealed class Fallbacki { }
 
     /// <summary>
     /// Stand-in for BC's <c>Microsoft.Dynamics.Nav.Runtime.ApplicationObjectIdAttribute</c>.
@@ -84,6 +122,56 @@ public sealed class TestCodeunitOrderingContractTests
     /// </summary>
     [ApplicationObjectId(62800)]
     private sealed class Codeunit62899 { }
+
+    /// <summary>
+    /// Resolves to 62800 by the NAME shape, which is the id <see cref="Codeunit62899"/> resolves
+    /// to by its attribute — so the two tie on the primary key. This is the only tie between
+    /// RESOLVED types that the runner's own inputs can construct, and #3217's tiebreak decides it.
+    /// </summary>
+    private sealed class Codeunit62800 { }
+
+    /// <summary>
+    /// Runs the helper over every permutation of <paramref name="types"/> and asserts all of them
+    /// produced <paramref name="expected"/> — the single assertion that makes the output a
+    /// function of the type SET rather than of the array those types arrived in. Deliberately the
+    /// same shape as <c>TestMethodOrderingContractTests.AssertOrderIsPermutationInvariant</c>:
+    /// this is the same defect one level up, and it is checked the same way.
+    /// </summary>
+    private static void AssertOrderIsPermutationInvariant(Type[] types, string[] expected)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var permutationCount = 0;
+
+        foreach (var permutation in Permutations(types))
+        {
+            permutationCount++;
+            var ordered = TestExecutor.OrderTestCodeunitsByObjectId(permutation);
+            seen.Add(string.Join(",", ordered.Select(Describe)));
+
+            // Ordering may never change WHAT runs. A tiebreak that dropped or duplicated a type
+            // could still be "deterministic" and satisfy the sequence check on its own.
+            Assert.Equal(
+                permutation.Select(Describe).OrderBy(x => x, StringComparer.Ordinal).ToArray(),
+                ordered.Select(Describe).OrderBy(x => x, StringComparer.Ordinal).ToArray());
+        }
+
+        Assert.True(permutationCount > 1, "the sweep must cover more than one input order");
+        Assert.True(seen.Count == 1,
+            "codeunit order must be a function of the types, not of the Assembly.GetTypes() array "
+            + $"they arrived in. {permutationCount} input permutations produced {seen.Count} "
+            + "different orders:\n  " + string.Join("\n  ", seen.OrderBy(x => x, StringComparer.Ordinal)));
+        Assert.Equal(string.Join(",", expected), seen.Single());
+    }
+
+    /// <summary>
+    /// A label unique per TYPE rather than per simple name, with this class's own prefix dropped
+    /// so a failure message stays readable. <c>Type.Name</c> will not do: AlphaContainer.Helper
+    /// and ZetaContainer.Helper are two distinct types with one simple name, and describing them
+    /// by it would hide a wrong answer from the sequence check AND a dropped type from the
+    /// no-drop check.
+    /// </summary>
+    private static string Describe(Type t) =>
+        (t.FullName ?? t.Name).Replace("AlRunner.Tests.TestCodeunitOrderingContractTests+", "");
 
     private static int[] IdsOf(IEnumerable<Type> types) =>
         types.Select(t => t.Name.StartsWith("Codeunit", StringComparison.Ordinal)
@@ -130,26 +218,103 @@ public sealed class TestCodeunitOrderingContractTests
         Assert.Equal(6, seen);
     }
 
+    // ── the tiebreak among types the primary key cannot separate (#3217) ─────────────
+    //
+    // The primary key — ascending AL object id — is #2801's rule and is unchanged. What these
+    // pin is the SECOND key, which used to be `.ThenBy(x => x.i)`: the type's index in the
+    // Assembly.GetTypes() array. That is the same undefined reflection order #2801 existed to
+    // get rid of, so the helper was total and deterministic for everything that resolved, and
+    // undefined for everything that did not. Same defect, same fix and same proof shape as
+    // #3201 one level down, in OrderTestMethodsBySourceDeclaration.
+
     /// <summary>
-    /// The documented "stable, and total" half. A type whose object id cannot be read sorts
-    /// AFTER everything that resolved, and two such types keep their relative input order —
-    /// so feeding the pair both ways round is the only way to tell "stable" from "happens to
-    /// come out that way".
+    /// TOTAL fallback: not one object id resolves. The old tiebreak returned these in whatever
+    /// order they were handed over, so the answer was the CLR's to choose. They still sort after
+    /// everything that resolved — that half is unchanged and is pinned by the mixed case below.
     /// </summary>
     [Fact]
-    public void UnresolvableTypes_SortLast_AndKeepTheirRelativeInputOrder()
+    public void NoObjectIdResolves_OrderIsStillAFunctionOfTheTypes()
     {
-        var helpersFirst = TestExecutor.OrderTestCodeunitsByObjectId(
-            new[] { typeof(CodeunitHelpers), typeof(Codeunit62803), typeof(NotAnAlObject), typeof(Codeunit62801) });
-        Assert.Equal(
-            new[] { typeof(Codeunit62801), typeof(Codeunit62803), typeof(CodeunitHelpers), typeof(NotAnAlObject) },
-            helpersFirst);
+        AssertOrderIsPermutationInvariant(
+            new[] { typeof(NotAnAlObject), typeof(CodeunitHelpers), typeof(AnotherNotAnAlObject) },
+            new[] { "AnotherNotAnAlObject", "CodeunitHelpers", "NotAnAlObject" });
+    }
 
-        var helpersSecond = TestExecutor.OrderTestCodeunitsByObjectId(
-            new[] { typeof(NotAnAlObject), typeof(Codeunit62803), typeof(CodeunitHelpers), typeof(Codeunit62801) });
-        Assert.Equal(
-            new[] { typeof(Codeunit62801), typeof(Codeunit62803), typeof(NotAnAlObject), typeof(CodeunitHelpers) },
-            helpersSecond);
+    /// <summary>
+    /// PARTIAL fallback, and the "sorts last" half of the documented contract: every type whose
+    /// id resolved leads, in ascending id order, and the unresolvable tail behind it is ordered
+    /// by a key of its own rather than by the array position it arrived in.
+    /// </summary>
+    [Fact]
+    public void UnresolvableTypes_SortLast_AndAmongThemselvesDeterministically()
+    {
+        AssertOrderIsPermutationInvariant(
+            new[]
+            {
+                typeof(CodeunitHelpers), typeof(Codeunit62803),
+                typeof(NotAnAlObject), typeof(Codeunit62801), typeof(AnotherNotAnAlObject),
+            },
+            new[]
+            {
+                "Codeunit62801", "Codeunit62803",
+                "AnotherNotAnAlObject", "CodeunitHelpers", "NotAnAlObject",
+            });
+    }
+
+    /// <summary>
+    /// The third instance of the same shape, and the one that is reachable with ids that DO
+    /// resolve: <see cref="Codeunit62800"/> resolves to 62800 by name and
+    /// <see cref="Codeunit62899"/> resolves to 62800 by its <c>[ApplicationObjectId]</c>, so the
+    /// primary key cannot separate them and the tiebreak decides which runs first.
+    /// </summary>
+    [Fact]
+    public void TypesSharingOneObjectId_TieBreakDeterministically()
+    {
+        AssertOrderIsPermutationInvariant(
+            new[] { typeof(Codeunit62899), typeof(Codeunit62800), typeof(Codeunit62801) },
+            new[] { "Codeunit62800", "Codeunit62899", "Codeunit62801" });
+    }
+
+    /// <summary>
+    /// The key is <c>Type.FullName</c>, not <c>Type.Name</c>. Both of these are called
+    /// <c>Helper</c>, so a Name-only tiebreak compares them equal, keeps whichever order it was
+    /// handed, and answers differently for the two input permutations.
+    /// </summary>
+    [Fact]
+    public void TypesSharingASimpleName_AreSeparatedByTheirFullName()
+    {
+        AssertOrderIsPermutationInvariant(
+            new[] { typeof(ZetaContainer.Helper), typeof(AlphaContainer.Helper) },
+            new[] { "AlphaContainer+Helper", "ZetaContainer+Helper" });
+    }
+
+    /// <summary>
+    /// The comparison is ORDINAL. A culture-aware comparer is deterministic too, so every other
+    /// fact here passes against one — and it would put this pair the other way round on any
+    /// machine whose culture data is loaded, which is the "holds across machines" half of the
+    /// contract rather than a style preference.
+    /// </summary>
+    [Fact]
+    public void TheUnresolvedTieBreak_IsOrdinal_NotCultureAware()
+    {
+        AssertOrderIsPermutationInvariant(
+            new[] { typeof(Fallbacki), typeof(FallbackI) },
+            new[] { "FallbackI", "Fallbacki" });
+    }
+
+    /// <summary>
+    /// NEGATIVE CONTROL, and the reason the three facts above cannot be satisfied by deleting the
+    /// id lookup and sorting by name. A resolved id outranks the tiebreak however the names
+    /// compare: <c>Codeunit62899</c> carries attribute id 62800 and so must run FIRST, which is
+    /// the exact reverse of its ordinal name order against <c>Codeunit62801</c>. Passes both
+    /// before and after #3217 by design — it pins the #2801 rule the fix must leave alone.
+    /// </summary>
+    [Fact]
+    public void ResolvedObjectIds_OutrankTheNameTieBreak()
+    {
+        AssertOrderIsPermutationInvariant(
+            new[] { typeof(Codeunit62801), typeof(Codeunit62803), typeof(Codeunit62899) },
+            new[] { "Codeunit62899", "Codeunit62801", "Codeunit62803" });
     }
 
     /// <summary>

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -1172,13 +1172,41 @@ public sealed class TestExecutor
     /// <c>CodeUnit Metadata</c> (keyed on <c>ID</c>) since v27 and <c>AllObjWithCaption</c>
     /// (keyed on "Object Type", "Object ID") before it; both are keyed on the object ID.</para>
     ///
-    /// <para><b>Stable, and total.</b> A type whose object ID cannot be read — every
-    /// non-codeunit type in the assembly, plus BC's compiler-generated nested types — keeps
-    /// its relative <c>GetTypes()</c> position and sorts after everything that resolved. Only
-    /// test codeunits are ever executed (<c>IsTestCodeunit</c>), so this changes the order
-    /// tests run in and nothing else. Deliberately does NOT touch method order inside a
-    /// codeunit: <see cref="OrderTestMethodsBySourceDeclaration"/> already pins that to source
-    /// declaration order, which is a different rule and stays.</para>
+    /// <para><b>Total, and independent of reflection order (#3217).</b> A type for which neither
+    /// a readable <c>[ApplicationObjectId]</c> nor the <c>Codeunit&lt;digits&gt;</c> name shape
+    /// yields an id — <see cref="TryReadAlObjectId"/> is syntactic and asks nothing about the
+    /// type beyond those two — sorts after every type that resolved one, and ties among those
+    /// break on an ordinal <c>Type.FullName</c> comparison. That tie used to break on the type's
+    /// index in the <c>Assembly.GetTypes()</c> array: the primary key fixed the order of
+    /// everything that resolved and left everything else in exactly the undefined order this
+    /// method exists to remove. The name key is the one #3201 settled on for methods, for the
+    /// reason given there — the metadata token IS the compiler's TypeDef layout, so tie-breaking
+    /// on it reproduces #2801, while a name comparison depends on nothing but the types
+    /// themselves. <c>FullName</c> and not <c>Name</c>, because BC's compiler-generated nested
+    /// types collide freely on the simple name; it is unique among one assembly's types by CLI
+    /// metadata, and every production call site passes types from ONE assembly's
+    /// <c>GetTypes()</c> — or, in <see cref="Run"/>, the loadable subset left after a
+    /// <c>ReflectionTypeLoadException</c> — so the key is total for every input the runner
+    /// produces.</para>
+    ///
+    /// <para><b>Not a claim about BC</b>, exactly as
+    /// <see cref="OrderMethodsByDeclarationLine"/>'s fallback is not. A valid AL app cannot
+    /// define two codeunits with one object id, so real BC has neither a duplicate-id order to
+    /// reproduce nor unresolved objects to have a fallback for. What the name key decides is only
+    /// the order among types THIS RUNNER could not resolve, plus an id collision its own synthetic
+    /// inputs can construct — neither of which has a BC counterpart. The ascending-id rule above
+    /// is the part that mirrors Microsoft, and it is unchanged.</para>
+    ///
+    /// <para>The three call sites are not affected alike. <see cref="Run"/> executes only test
+    /// codeunits (<c>IsTestCodeunit</c>), so there this decides the order tests run in and
+    /// nothing else. <see cref="DiscoverTests"/> applies the same eligibility filter but
+    /// executes nothing — it returns <c>"{Codeunit}.{Method}"</c> keys — so there it decides
+    /// only the order those names come back in.
+    /// Server-mode <c>execute</c> (<c>Program.RunFirstCodeunitOnRun</c>, below) shares the order
+    /// to choose which — preferably NON-test — codeunit's <c>OnRun</c> runs, so there it decides
+    /// which code runs at all. Deliberately does NOT touch method order inside a codeunit:
+    /// <see cref="OrderTestMethodsBySourceDeclaration"/> already pins that to source declaration
+    /// order, which is a different rule and stays.</para>
     ///
     /// <para><b>Internal, not private</b>, for two reasons. <c>Program.RunFirstCodeunitOnRun</c>
     /// (server-mode <c>execute</c>) picks WHICH codeunit's <c>OnRun</c> to run out of the same
@@ -1193,10 +1221,8 @@ public sealed class TestExecutor
     /// </summary>
     internal static Type[] OrderTestCodeunitsByObjectId(Type[] types) =>
         types
-            .Select((t, i) => (t, i, id: TryReadAlObjectId(t)))
-            .OrderBy(x => x.id ?? int.MaxValue)
-            .ThenBy(x => x.i)
-            .Select(x => x.t)
+            .OrderBy(t => TryReadAlObjectId(t) ?? int.MaxValue)
+            .ThenBy(t => t.FullName ?? t.Name, StringComparer.Ordinal)
             .ToArray();
 
     /// <summary>


### PR DESCRIPTION
`OrderTestCodeunitsByObjectId` sorts a freshly-loaded test assembly's types by ascending AL
object id — Microsoft's own suite order, and the point of issue #2801 — but broke ties with
`.ThenBy(x => x.i)`, the type's index in the `Assembly.GetTypes()` array. The CLR does not
define that array's order. So the method was total and deterministic for everything that
resolved an id, and undefined for everything that did not: the very order it exists to remove,
left in place one key down.

Same defect the method-level `OrderTestMethodsBySourceDeclaration` had, and it takes the same
key — an ordinal comparison of a name derived from the type, never the metadata token, because
the token **is** the compiler's TypeDef layout and tie-breaking on it would reproduce the
27.5-green / 28.4-red split that started this.

```diff
-        .Select((t, i) => (t, i, id: TryReadAlObjectId(t)))
-        .OrderBy(x => x.id ?? int.MaxValue)
-        .ThenBy(x => x.i)
-        .Select(x => x.t)
+        .OrderBy(t => TryReadAlObjectId(t) ?? int.MaxValue)
+        .ThenBy(t => t.FullName ?? t.Name, StringComparer.Ordinal)
```

`FullName` and not `Name`: BC's compiler-generated nested types collide freely on the simple
name, and they are exactly the population the unresolved branch orders.

## Two ties reach the second key

- **Neither type resolves an id.** `TryReadAlObjectId` is syntactic — an
  `[ApplicationObjectId]` attribute, else the `Codeunit<digits>` name shape — so this is every
  type in the assembly that is not an AL object, BC's compiler-generated nested types, and the
  shape the method's own comment names: a `CodeunitHelpers`-style class that satisfies
  `IsTestCodeunit`'s `StartsWith("Codeunit")` but whose suffix is not digits, carrying a
  `[Test]` method.
- **Both types resolve the *same* id** — not mentioned in the issue, and reachable with ids
  that do resolve. One type's attribute id and another type's name can name one object:
  `Codeunit62899` carrying `[ApplicationObjectId(62800)]` ties with a plain `Codeunit62800`.

## Scope: no behaviour change in a real run

A valid AL app cannot define two codeunits with one object id, and the compiler derives each
emitted type's name from its id, so neither tie is reachable from real AL output — the
tiebreak decides only the relative order of types that never execute. The rewritten doc comment
now says that explicitly, and says the name key is **not** a claim about BC: real BC has
neither a duplicate-id order to reproduce nor unresolved objects to have a fallback for. The
ascending-id rule is the part that mirrors Microsoft, and it is untouched.

`Program.RunFirstCodeunitOnRun` (server-mode `execute`) shares the helper, and there the order
decides *which codeunit's `OnRun` runs at all* rather than only the order — so in the tie case
it goes from a coin flip to a defined answer.

## Proof

`TestCodeunitOrderingContractTests` gains the permutation-invariance helper its method-level
sibling already uses: every input permutation must produce **one** answer, and that answer must
be the expected sequence. Measured on the pre-fix code, the three determinism facts reported

| fact | permutations | distinct answers |
|---|---|---|
| `NoObjectIdResolves_OrderIsStillAFunctionOfTheTypes` | 6 | 6 |
| `UnresolvableTypes_SortLast_AndAmongThemselvesDeterministically` | 120 | 6 |
| `TypesSharingOneObjectId_TieBreakDeterministically` | 6 | 2 |

and one after it. `ResolvedObjectIds_OutrankTheNameTieBreak` is the negative control and passes
on both sides of the change, so the facts cannot be satisfied by dropping the id lookup and
sorting by name.

`UnresolvableTypes_SortLast_AndKeepTheirRelativeInputOrder` is **replaced**, not extended: it
asserted the defect. Its other half — unresolvable types sort after everything that resolved —
is carried by `UnresolvableTypes_SortLast_AndAmongThemselvesDeterministically`, which feeds two
resolvable and three unresolvable types and pins all five positions across 120 permutations.

### Mutation matrix

Each row was applied to the committed green state, rebuilt, and run.

| mutation | what it models | facts that fail |
|---|---|---|
| delete the `.ThenBy` line | the old behaviour (LINQ `OrderBy` is stable, so ties keep input order) | the 3 determinism facts |
| `.ThenBy(t => t.MetadataToken)` | a *different* deterministic key — the one rejected above | the 3 determinism facts |
| `.ThenBy(t => t.Name, …)` | the simple name instead of the full name | `TypesSharingASimpleName_AreSeparatedByTheirFullName` |
| `.ThenBy(…, StringComparer.CurrentCulture)` | deterministic per-locale, not across machines | `TheUnresolvedTieBreak_IsOrdinal_NotCultureAware` |

Rows 2-4 are the ones worth having. Row 2 shows the facts pin the **name** key rather than
merely "some deterministic key" — the fixture types' declaration order is deliberately not
their ordinal name order, which is what lets a token key be told apart from a name key. Rows 3
and 4 each fail exactly one fact, and both mutations passed *every* fact before those two facts
existed.

Local runs, all green: the two ordering contract classes, `ServerExecuteCodeunitSelectionTests`,
and the three end-to-end guards (`TestCodeunitExecutionOrderTests`,
`AlObjectEmitOrderDeterminismTests`, `SuiteAbortOnTimeoutTests`) — 39 tests, run twice against
one cache root. No unrelated failures surfaced, so there is nothing to attribute.

## External review

Reviewed adversarially by GPT-5.6 before opening (full text not attached; findings and
responses below). It found nothing blocking and confirmed independently that no
BC-compiler-produced input changes order under this patch. Three findings were real and are
fixed in this diff:

1. **The facts compared `Type.Name`, so `.ThenBy(t => t.Name, …)` passed all of them.** Real:
   two nested types both called `Helper` in different containers are one label under `Name`.
   Fixed — the helper now describes types by `FullName`, and a fact drives that pair.
2. **Nothing pinned `StringComparer.Ordinal`.** Real. Fixed with a case-differing pair
   (`FallbackI` / `Fallbacki`); ordinal puts `I` before `i`, every culture-aware comparer does
   the reverse. The review proposed `Reflection.Emit` plus a `CurrentCulture` override — not
   needed, and avoided deliberately: the fact asserts the *ordinal* answer, so it cannot make
   the suite depend on the machine's locale, and under globalization-invariant mode it still
   passes, it just stops discriminating.
3. **Four XML-doc statements were false or too broad.** All real, all corrected: "every
   non-codeunit type" (`TryReadAlObjectId` is type-agnostic); "both call sites" (there are
   three, and `Run` passes the loadable subset left after a `ReflectionTypeLoadException`, not
   the raw array); "this changes the order tests run in and nothing else" (false for
   server-mode `execute`, and that sentence predates this PR); and the missing "not a claim
   about BC" qualification the sibling method carries. One further phrase — that a name
   comparison "holds across BC versions" — was too strong for compiler-generated names, which
   carry version-dependent numbering, and is now scoped to the comparison rather than the names.

One suggestion was **not** taken: a loud diagnostic when two *executable* codeunits resolve to
one id. It would be more truthful than silently ordering them, but the condition is
unreachable from a valid AL app, so it would be a guard for a state the compiler cannot
produce. Noted here rather than filed, so a maintainer can disagree cheaply.

Corpus-NA: runner-internal execution ordering; the tiebreak decides the order among types real
BC never has, so no service tier can adjudicate it.

## Queue scan

Per `batch-sibling-issues-by-file.md`, the open-issue queue was scanned for anything landing in
`AlRunner/TestExecutor.cs` before starting. Issue #3217 is the only one of the 234 open issues
whose fix lands there. Nothing folded.

Closes #3217

---

Opened by an agent (`impl-1`, single-operator loop) on the account holder's behalf.

https://claude.ai/code/session_01GiwJXvJDKAPYzdjZCNLs8o
