### PR TITLE
docs(verify): the wrong-subject instance that travels is a coordinator's correction

### DIFF
--- a/.claude/rules/tdd.md
+++ b/.claude/rules/tdd.md
@@ -50,6 +50,13 @@ two references to `METADATA-EMIT-EXCLUDED` — one asserting the naming conventi
 as routing data. Both mention the stage; neither reaches the `throw`. A grep for the symbol
 finds them and reads as coverage, which is why the mutation is the check and the grep is not.
 
+**Trap: one red proves something is covered, not WHICH thing.** A fix that feeds two
+observables owes a mutation per observable. #3917 fixed a derivation reaching both an equivalence
+projection and the AL-observable virtual table; reverting **only** the AL-observable half left
+**252 tests green**, because all three new test files reached the projection alone. Its own body
+argued the two-rendering point correctly and it still tested one — so awareness does not close
+this, and a single red that says "the fix is covered" is the shape to distrust (#3912).
+
 **Trap: a mutation that breaks the build proves nothing, and it fails LOUDLY.** The landing
 check above catches the silent direction; this is the other one. Mutating a call site by text
 substitution produced `exit 1` with **10 `error CS`** lines and no `Total:` — a broken build

--- a/.claude/rules/verify-execution-not-the-tick.md
+++ b/.claude/rules/verify-execution-not-the-tick.md
@@ -89,6 +89,18 @@ not exist, because a codeunit and a table may share an id.
 container that is empty because the data moved, and a scope wider than the thing being validated
 all return clean answers to a question nobody asked.
 
+**A fourth instance, and the one least likely to be re-checked: the coordinator's own number,
+supplied while correcting an agent.** Told that a permission mask was case-sensitive on one
+codeunit, the coordinator "corrected" the scale to 27 lowercase-bearing entries. All 27 were on
+**Tables**; the scan walked every `Properties` bag without tracking which object kind owned it,
+and the issue's surface was codeunits, where the true count is **one**. The agent re-derived the
+figure instead of relaying it and found the split.
+
+Two things make that shape worse than an agent's own miss. A correction arrives with authority,
+so it is taken rather than tested — and it had already been relayed onto two sibling issues
+before anyone checked it. **Re-derive a number you are about to hand someone as a correction, on
+the population THEY are working**, not the one your query happened to cover.
+
 
 ## Which legs were ever going to run it
 

--- a/docs/incidents/tdd.md
+++ b/docs/incidents/tdd.md
@@ -170,3 +170,38 @@ still 92. It re-did the mutation as a real removal.
 Two people, one guard, one hour, two different ways for a mutation to prove nothing. The general
 form: **a mutation must change what the assertion reads, and nothing else.** Structural edits to
 code are the risky kind; a value the assertion consumes is the safe kind.
+
+
+## One red proves something is covered, not which thing (2026-09-11, #3917 / #3912)
+
+`tdd.md` already carries *a test that names the thing is not a test that drives it* — a test that
+mentions a symbol without reaching it. This is the adjacent failure: tests that **do** drive real
+code and **do** go red under mutation, while covering only one of two observables.
+
+**#3912** recorded the first instance: mutating `ReadEnumExtensible` to `return null` left six
+tests green, because they exercise the render rather than the compiler-side reader.
+
+**#3917** is the second and the sharper one. A codeunit derivation feeds two independent
+renderings — an equivalence **projection** (numeric mask) and the AL-observable **virtual table**
+(letter string). A reviewer reverted only the AL-observable half:
+
+```
+~CodeunitMetadata|~CodeunitSymbol|~MetadataEquivalence   Failed: 0, Passed: 56
+~VirtualTable|~AllObj|~Inherent|~Namespace              Failed: 0, Passed: 196
+```
+
+252 tests green with the rendering AL actually reads reverted. All three new test files reference
+the virtual-table rendering zero times.
+
+**What makes it sharp: the PR's own body argued the point correctly.** It said fixing only the
+projection *"would have closed the issue while leaving `CodeUnit Metadata` still answering BC's
+default to AL"*. The author identified the trap, wrote it down, fixed both renderings in the
+code — and tested one.
+
+So awareness does not close this, and neither does prose. What closes it is running the mutation
+**per observable**. A single red tells you the fix is covered somewhere; it does not tell you
+where, and "somewhere" is exactly what a reader infers as "everywhere".
+
+Generalises past enums and codeunits: wherever a derivation feeds both an equivalence projection
+and an AL-observable surface — pages, queries, reports, permission sets — those are two
+observables and each owes its own red.


### PR DESCRIPTION
`verify-execution-not-the-tick.md` gained a section today (#3909) on **a correct instrument
reading the wrong subject**, with three instances. All three are self-inflicted and
self-contained. **A fourth occurred within the hour, and it is the variant that travels.**

## The instance — mine

An implementing agent reported the `InherentEntitlements` / `InherentPermissions` mask is
case-sensitive, measured on **one** codeunit (2516, stating `x`).

I "corrected" the scale to **27 lowercase-bearing entries**, called mixed case "the common form",
and relayed it onto #3798 and #3808 as scale evidence. Re-measured with the owning object kind
tracked:

```
Codeunits  {'X': 16}                     lowercase-bearing 0
Pages      {'X': 10}                     lowercase-bearing 0
Tables     {'rX': 26, 'Rimdx': 1, ...}   lowercase-bearing 27
```

**All 27 are on Tables.** My scan walked every `Properties` bag without tracking which kind owned
it. The issue's surface was codeunits, where the true count is **one** — the agent's original
figure. It re-derived rather than relaying, which is what surfaced the split. Both sibling
comments are corrected.

## Why this variant earns a line

1. **A correction arrives with authority.** The agent has just been told its number was
   understated; the default is to take it. This one was re-derived — but that was the agent's
   discipline, not a property of the process.
2. **It had already propagated** to two issues as scale evidence for work not yet started, before
   anyone checked it.

The three existing instances stay where they occurred. This one reached three issues.

## What changes

One paragraph, with the operative rule: **re-derive a number you are about to hand someone as a
correction, on the population THEY are working**, not the one your query happened to cover.

**Not** a process change making receivers re-derive every relayed figure — that inverts the cost
and slows every dispatch. The burden belongs on the sender.

## Verification

Docs-only. `tools/test_doc_pointers.py` passes. One file, +12/-0; the rule is 7,756 bytes.

Pre-push checks run, both from my own errors today: `git diff --stat origin/main...HEAD` against a
freshly fetched `main` (#3907), and a closing-keyword scan (only `Closes #3920`).

**No mutation reported**, deliberately: prose with no implementation to break.

Closes #3920

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1


## Added after opening: a second trap, folded in

`tdd.md` gains one more line, from a finding an hour later.

It already carries *a test that names the thing is not a test that drives it* — a test mentioning
a symbol without reaching it. This is the adjacent failure: tests that **do** drive real code and
**do** go red under mutation, while covering only **one of two observables**.

#3917's codeunit derivation feeds an equivalence **projection** (numeric mask) and the
AL-observable **virtual table** (letter string) — independent code. A reviewer reverted only the
AL-observable half:

```
~CodeunitMetadata|~CodeunitSymbol|~MetadataEquivalence   Failed: 0, Passed: 56
~VirtualTable|~AllObj|~Inherent|~Namespace              Failed: 0, Passed: 196
```

**252 tests green with the rendering AL actually reads reverted.** I confirmed the cause: all
three new test files reference that rendering **zero** times.

**What makes it worth a rule rather than a review note: the PR's own body argued the point
correctly.** It said fixing only the projection *"would have closed the issue while leaving
`CodeUnit Metadata` still answering BC's default to AL"*. The author identified the trap, wrote it
down, fixed both renderings in code — and tested one. Awareness did not close it; neither would
more prose. Running the mutation **per observable** does.

Folded here as `Part of #3920` rather than a fourth rule PR this session — same file, same
class of claim, and #3912 tracks the underlying instances.
