### PR TITLE
docs(impl-agent): run the repository's own guards before pushing

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -226,6 +226,27 @@ General rule: `.claude/rules/local-test-scope.md`. Concretely:
 
 The unfiltered suite is for CI; it spends most of its time in tests that spawn the runner as a subprocess, which the filter above skips.
 
+4. **The repository's own guards, if you added or moved a file.** They are fast, they do not
+   spawn the runner, and they catch things about *your new file* that no test of your feature
+   will:
+
+   ```bash
+   for t in tools/test_*.py; do python3 "$t" >/dev/null || echo "FAILED: $t"; done   # ~30s
+   dotnet test AlRunner.Tests --filter "FullyQualifiedName~GuardTests"               # 228 tests
+   ```
+
+   There are 21 of each. Four fired on a new file in one session, each costing a round trip: a
+   bare `return;` reporting `Passed` having asserted nothing; a doc comment stranded from its
+   member by an inserted method; a test class touching the parse statics from outside the serial
+   collection (#1696's four-of-five-legs flake); and a dangling `docs/` anchor. **None of them
+   was a defect in the feature** — all four were properties of the file that carried it.
+
+   **Build first; do not pass `--no-build` here.** Several of these guards assert against the
+   *current* tree — a ratchet count, a converted-site census, an artifact readiness probe — so a
+   stale binary fails them for reasons that have nothing to do with your change and read exactly
+   like findings. Measured: three of the 228 failed against a build 15 hours behind `main`, all
+   three spuriously.
+
 Then push. A pull request runs **three** BC legs — 27.0, 27.5 and 28.4, from `.github/pr-bc-versions.txt` — not the eight in `.github/bc-versions.txt`; those eight run on push to `main`, on `main-verdict-floor.yml`'s 30-minute cadence, and on the release path (#3141, #3200). Every leg runs the corpus, all of `runner-extras`, the xmlport isolation guard and server-mode. The full `AlRunner.Tests` suite runs only on the unit legs — the newest minor of each major, 27.5 and 28.4 — two legs of whichever matrix ran, not the whole matrix (#2674). All of it in parallel with you rather than in front of you.
 
 **Do not count legs to decide a PR is green.** The aggregate `BC test matrix passed` is what gates — renamed from the old aggregate by #3200, because a narrowed matrix under the old name asserted something the run had not measured — alongside the other required contexts. `tools/ci-wait.py` reads that list live from the branch ruleset on every call; read it from there, never out of a document, this one included (`.claude/rules/ci-verdicts.md`).


### PR DESCRIPTION
The repository carries **21 `tools/test_*.py` guards and 21 `*GuardTests.cs` classes** (228 test
methods). `impl-agent.md` never told an agent to run them — its pre-push section lists three
targeted filters, then says CI will do the rest.

**Four fired on a new file in one session**, each costing a round trip:

| guard | what it caught |
|---|---|
| `TestArtifactsGateTests` | a bare `return;` reporting **`Passed`** having asserted nothing — in the artifact-guard PR itself (#3889) |
| doc-summary uniqueness | a doc comment **stranded** from its member by an inserted method (#3882, #3911) |
| `ParserStaticsIsolationGuardTests` | a test class touching the parse statics from outside the serial collection — #1696's four-of-five-legs flake (#3917) |
| `test_doc_pointers.py` | a dangling `docs/` anchor (#3902) |

**None was a defect in the feature.** All four were properties of the *file that carried it* —
the class no test of the feature will find, and precisely what these guards exist for.

## Cost, measured

```
for t in tools/test_*.py; do python3 "$t" >/dev/null || echo "FAILED: $t"; done
  28s, 0 failures on a clean main

dotnet test AlRunner.Tests --filter "FullyQualifiedName~GuardTests"
  Total: 228, 7s
```

Half a minute against a round trip that costs a CI leg and a re-dispatch.

## The trap in my own remedy

My first draft used `--no-build`. Against a local build **15 hours behind `main`**, three of the
228 failed — a ratchet count, a converted-site census, and an artifact readiness probe — **all
three spuriously**, and all three reading exactly like findings.

Several of these guards assert against the *current tree* by construction, so a stale binary is
worse than no run. The guidance now says build first and says why, with that measurement.

## Deliberately not proposed

- **A pre-push hook.** The guards already gate in CI; the value here is shortening the feedback
  loop, not adding a second enforcement point.
- **Running the full suite locally.** `local-test-scope.md` argues against it and is right — this
  is a narrow, fast filter, not the suite.

## Verification

Docs-only, one file, +21/-0. `tools/test_doc_pointers.py` passes. Both prescribed commands were
run before being written down — that is where the 28s, the 228 and the stale-build failure all
come from.

Pre-push checks run, both from my own errors today: `git diff --stat origin/main...HEAD` against a
freshly fetched `main` (#3907), and a closing-keyword scan (only `Closes #3924`).

**No mutation reported**, deliberately: prose with no implementation to break.

Closes #3924

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
