### PR TITLE
fix(skeleton-tenant): seed the null lock objects and IC-replication flag, and delete the 7 orphaned NavDataTransfer hooks

### DIFF
--- a/AlRunner.Tests/BcShapeMethodLookupTests.cs
+++ b/AlRunner.Tests/BcShapeMethodLookupTests.cs
@@ -312,13 +312,20 @@ public sealed class BcShapeMethodLookupTests
     // change — this one counts what REMAINS (falls), that one counts what has been CONVERTED
     // (rises, 87 -> 88 for this same site). #3581 updated one and missed the other, so check
     // both.
+    //
+    // 71 -> 70 by #3927, which DELETED rather than converted: the seven orphaned NavDataTransfer
+    // `Hook(...)` registrations went, taking the name-only `navDataTransferType.GetMethod(name, ...)`
+    // in the stub loop with them. Two GetMethod sites left the diff and the count fell by ONE —
+    // the other passes an explicit signature, which this scan never counted. A deletion moves
+    // only this counter: BcInternalsNullForgivingGuardTests' `converted` is computed from the
+    // source rather than hardcoded, so it needs no matching edit here.
 
     /// <summary>
     /// Every remaining name-only method lookup that could reach a Microsoft-shipped type. Lower
     /// it as sites are converted; it may never rise. On a mismatch the assertion prints the
     /// per-file breakdown, which is the number to put here.
     /// </summary>
-    private const int NameOnlyBcTypedMethodLookups = 71;
+    private const int NameOnlyBcTypedMethodLookups = 70;
 
     /// <summary>The floor is not cosmetic: a scan that silently narrowed to a handful of files
     /// would report a small number and read as progress. AlRunner/ holds ~195 sources.</summary>

--- a/AlRunner.Tests/SkeletonTenantLockObjectsTests.cs
+++ b/AlRunner.Tests/SkeletonTenantLockObjectsTests.cs
@@ -1,0 +1,121 @@
+// Issue #1883 — the skeleton tenant's unconstructed lock objects and IC-replication flag.
+//
+// NavSystemTenant is built with GetUninitializedObject, so every field initialiser BC's ctor
+// would have run is skipped. For a `readonly object` that means `lock (null)`, which does not
+// NRE: it reaches Monitor.ReliableEnter and raises ArgumentNullException("Value cannot be
+// null."), a stack naming System.Threading rather than anything BC or runner.
+//
+// Measured on 28.1 through NavDataTransfer.CheckIsOpen ->
+// NavTenant.IsIntelligentCloudReplicationEnabled: every AL DataTransfer call after SetTables
+// raised that CLR exception instead of BC's own "DataTransfer is only usable during upgrade
+// and installation code." AL error.
+//
+// Runner-mechanism tests: a real service tier runs the real ctor, so none of this arises
+// upstream. The BC-behaviour half is corpus codeunit 60875.
+using System;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class SkeletonTenantLockObjectsTests
+{
+    private readonly BcEngineFixture _engine;
+    public SkeletonTenantLockObjectsTests(BcEngineFixture engine) => _engine = engine;
+
+    private const BindingFlags F = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
+    private object SkeletonTenant()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+        var session = NavCurrentThread.Session;
+        Assert.True(session != null, "the skeleton session is not wired — nothing to assert about.");
+        var tenant = session!.GetType().GetProperty("Tenant", F)?.GetValue(session);
+        Assert.True(tenant != null, "the skeleton session has no Tenant — see InjectSkeletonSystemTenant.");
+        return tenant!;
+    }
+
+    private static FieldInfo[] ReadonlyObjectFields(object tenant)
+    {
+        var found = new System.Collections.Generic.List<FieldInfo>();
+        for (var t = tenant.GetType(); t != null; t = t.BaseType)
+        {
+            found.AddRange(t.GetFields(F).Where(f =>
+                f.DeclaringType == t && f.FieldType == typeof(object) && f.IsInitOnly));
+            if (t.Name == "NavTenant") break;
+        }
+        return found.ToArray();
+    }
+
+    [SkippableFact]
+    public void EveryReadonlyObjectFieldOnTheSkeletonTenant_IsANonNullLockTarget()
+    {
+        var tenant = SkeletonTenant();
+        var fields = ReadonlyObjectFields(tenant);
+
+        // Without this the assertion below passes on an empty set — the failure mode where the
+        // walk read the wrong type and measured nothing at all. BC 28.1 declares seven; a floor
+        // rather than an equality so a BC build adding one does not fail for being fixed too.
+        Assert.True(fields.Length >= 5,
+            $"expected NavTenant to declare several readonly object lock fields, found {fields.Length} — "
+            + "the field walk is reading the wrong type, so the null check below proves nothing.");
+
+        var nulls = fields.Where(f => f.GetValue(tenant) == null).Select(f => f.Name).ToArray();
+        Assert.True(nulls.Length == 0,
+            "these lock fields are null on the skeleton tenant, so any BC body locking one raises "
+            + "ArgumentNullException out of Monitor.ReliableEnter instead of doing its job: "
+            + string.Join(", ", nulls));
+    }
+
+    /// <summary>
+    /// The observable the DataTransfer cluster depends on. BC's getter returns the cached value
+    /// when it has one; with none it locks, and on a tenant with no database answers false.
+    /// Seeding false is that same answer taken one line earlier.
+    /// </summary>
+    [SkippableFact]
+    public void IsIntelligentCloudReplicationEnabled_AnswersFalse_RatherThanThrowing()
+    {
+        var tenant = SkeletonTenant();
+        var prop = tenant.GetType().GetProperty("IsIntelligentCloudReplicationEnabled", F);
+        Assert.True(prop != null, "NavTenant.IsIntelligentCloudReplicationEnabled is gone — see #1883.");
+
+        object? value;
+        try
+        {
+            value = prop!.GetValue(tenant);
+        }
+        catch (TargetInvocationException ex)
+        {
+            throw new Xunit.Sdk.XunitException(
+                "reading IsIntelligentCloudReplicationEnabled on the skeleton tenant threw "
+                + $"{ex.InnerException?.GetType().Name}: {ex.InnerException?.Message}. BC's own body answers "
+                + "false for a tenant with no database; it cannot get there while the skeleton is "
+                + "unconstructed (#1883).");
+        }
+
+        Assert.Equal(false, value);
+    }
+
+    /// <summary>
+    /// The premise that makes false BC's own answer rather than a stand-in: BC returns false
+    /// whenever the database Lazy was never materialised, without opening a connection. If a BC
+    /// build ever gave the skeleton a database, the seeded value would stop being derivable and
+    /// this fails rather than going quietly wrong.
+    /// </summary>
+    [SkippableFact]
+    public void TheSkeletonTenantHasNoDatabase_WhichIsWhyFalseIsBcsOwnAnswer()
+    {
+        var tenant = SkeletonTenant();
+        var navTenant = tenant.GetType();
+        while (navTenant != null && navTenant.Name != "NavTenant") navTenant = navTenant.BaseType;
+        Assert.True(navTenant != null, "NavSystemTenant no longer derives from NavTenant — see #1883.");
+
+        var database = navTenant!.GetField("database", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.True(database != null, "NavTenant.database is gone — see #1883.");
+        Assert.Null(database!.GetValue(tenant));
+    }
+}

--- a/AlRunner.Tests/SkeletonTenantLockObjectsTests.cs
+++ b/AlRunner.Tests/SkeletonTenantLockObjectsTests.cs
@@ -11,7 +11,7 @@
 // and installation code." AL error.
 //
 // Runner-mechanism tests: a real service tier runs the real ctor, so none of this arises
-// upstream. The BC-behaviour half is corpus codeunit 60875.
+// upstream. The BC-behaviour half is corpus codeunit 60992 (corpus PR #327).
 using System;
 using System.Linq;
 using System.Reflection;
@@ -58,8 +58,9 @@ public sealed class SkeletonTenantLockObjectsTests
         var fields = ReadonlyObjectFields(tenant);
 
         // Without this the assertion below passes on an empty set — the failure mode where the
-        // walk read the wrong type and measured nothing at all. BC 28.1 declares seven; a floor
-        // rather than an equality so a BC build adding one does not fail for being fixed too.
+        // walk read the wrong type and measured nothing at all. 28.0 and 28.1 both declare seven;
+        // a floor rather than an equality because a count is version-specific, and a field BC adds
+        // is caught by name in EverySeededLockField_IsOnTheAuditedRoster below instead.
         Assert.True(fields.Length >= 5,
             $"expected NavTenant to declare several readonly object lock fields, found {fields.Length} — "
             + "the field walk is reading the wrong type, so the null check below proves nothing.");
@@ -69,6 +70,30 @@ public sealed class SkeletonTenantLockObjectsTests
             "these lock fields are null on the skeleton tenant, so any BC body locking one raises "
             + "ArgumentNullException out of Monitor.ReliableEnter instead of doing its job: "
             + string.Join(", ", nulls));
+    }
+
+    /// <summary>
+    /// The seeder matches on shape, not on a name list, so a lock field an unmeasured BC version
+    /// declares is still seeded rather than left null. This is what keeps that breadth from being
+    /// silent: anything seeded that <c>BcRuntime.AuditedTenantLockFields</c> does not name fails
+    /// here by name, so a <c>readonly object</c> BC adds later gets audited before it ships
+    /// holding a value the runner invented.
+    /// </summary>
+    [SkippableFact]
+    public void EverySeededLockField_IsOnTheAuditedRoster()
+    {
+        SkeletonTenant();   // skips when the engine is not ready; also proves the bootstrap ran
+
+        Assert.True(BcRuntime.SeededTenantLockFields.Count > 0,
+            "nothing is recorded as seeded, so the assertion below would pass without measuring "
+            + "anything — the BcRuntime statics read here are not the ones this process bootstrapped.");
+
+        Assert.True(BcRuntime.UnauditedSeededLockFields.Count == 0,
+            "the skeleton tenant carries readonly object field(s) the #1883 audit does not cover, and "
+            + "the runner has given each one a new object(): "
+            + string.Join(", ", BcRuntime.UnauditedSeededLockFields)
+            + ". Confirm each is only ever a lock target and add it to BcRuntime.AuditedTenantLockFields, "
+            + "or stop seeding it.");
     }
 
     /// <summary>

--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -1745,16 +1745,16 @@ public static partial class BcRuntime
         // NCLEnumMetadata.Create(int), NavCodeunitHandle.CreateTarget, NavCodeunit.get_MetaCodeunit,
         // and NCLMetaCodeunit.get_IsEventManualBinding are all Cecil-owned (see NclCecilRewrite.cs).
 
-        // NavDataTransfer (#1883 cluster audit) — SetTables used to be Hook()ed to a no-op and
-        // Add{Field,Constant,Source}Value / AddJoin / CopyFields / CopyRows / Clear to stubs
-        // throwing a hardcoded copy of BC's "DataTransfer is only usable during upgrade and
-        // installation code." All seven were orphaned (JmpHook is off by default), so BC's real
-        // bodies were already running — and once the skeleton tenant can answer
-        // IsIntelligentCloudReplicationEnabled (MetadataPatches steps 3¾ and 3⅞) they are strictly
-        // more faithful than the stubs were: BC raises that same message from its own resource,
-        // tells "SetTables must first be called before calling other methods on DataTransfer."
-        // apart from it, and would honour a real install/upgrade context, which a hardcoded throw
-        // never could. Deleted outright rather than left as dead call sites.
+        // NavDataTransfer (#1883 cluster audit) — eight JmpHook registrations used to live here:
+        // SetTables to a no-op, and AddFieldValue, AddConstantValue, AddSourceFilter, AddJoin,
+        // CopyFields, CopyRows, Clear to stubs throwing a hardcoded copy of BC's "DataTransfer is
+        // only usable during upgrade and installation code." All eight were orphaned (JmpHook is
+        // off by default), so BC's real bodies were already running — and once the skeleton tenant
+        // can answer IsIntelligentCloudReplicationEnabled (MetadataPatches steps 3¾ and 3⅞) they
+        // beat the stubs: BC raises that message from its own resource, tells "SetTables must first
+        // be called before calling other methods on DataTransfer." apart from it, and would honour
+        // a real install/upgrade context, which a hardcoded throw never could. Deleted outright
+        // rather than left as dead call sites; corpus codeunit 60992 adjudicates the behaviour.
 
 
         // ALTaskScheduler.CheckCodeUnit / ALCanCreateTask / CanCreateTask (scope.md §3.6,

--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -1745,61 +1745,17 @@ public static partial class BcRuntime
         // NCLEnumMetadata.Create(int), NavCodeunitHandle.CreateTarget, NavCodeunit.get_MetaCodeunit,
         // and NCLMetaCodeunit.get_IsEventManualBinding are all Cecil-owned (see NclCecilRewrite.cs).
 
-        // NavDataTransfer.SetTables — uses NCLMetadata.GetMetaTableById to validate source/dest
-        // tables before staging the transfer. Validation is meaningless in headless mode (the
-        // actual data move happens via patched RecordImpl). No-op so AL DataTransfer.SetTables
-        // calls succeed and downstream Add{Constant,Field,Source}Value can proceed against
-        // skeleton-managed buffers.
-        var navDataTransferType = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.NavDataTransfer");
-        if (navDataTransferType != null)
-        {
-            var setTables = navDataTransferType.GetMethod("SetTables",
-                BindingFlags.NonPublic | BindingFlags.Instance, null,
-                new[] { typeof(int), typeof(int) }, null);
-            if (setTables != null)
-                Hook(setTables, nameof(NoOp3), "NavDataTransfer.SetTables");
+        // NavDataTransfer (#1883 cluster audit) — SetTables used to be Hook()ed to a no-op and
+        // Add{Field,Constant,Source}Value / AddJoin / CopyFields / CopyRows / Clear to stubs
+        // throwing a hardcoded copy of BC's "DataTransfer is only usable during upgrade and
+        // installation code." All seven were orphaned (JmpHook is off by default), so BC's real
+        // bodies were already running — and once the skeleton tenant can answer
+        // IsIntelligentCloudReplicationEnabled (MetadataPatches steps 3¾ and 3⅞) they are strictly
+        // more faithful than the stubs were: BC raises that same message from its own resource,
+        // tells "SetTables must first be called before calling other methods on DataTransfer."
+        // apart from it, and would honour a real install/upgrade context, which a hardcoded throw
+        // never could. Deleted outright rather than left as dead call sites.
 
-            // The AL `DataTransfer.{AddFieldValue,AddConstantValue,AddSourceFilter,AddJoin,
-            // CopyFields,CopyRows,Clear}` builtins are not usable outside upgrade/install code.
-            // Throw a BC exception so AL `asserterror` observes the same contract.
-            var thrownNames = new System.Collections.Generic.HashSet<string> {
-                "AddFieldValue", "AddConstantValue", "AddSourceFilter", "AddJoin",
-                "CopyFields", "CopyRows", "Clear"
-            };
-            var hookNames = new System.Collections.Generic.List<string>(
-                new[] { "AddFieldValue", "AddConstantValue", "AddSourceFilter",
-                        "AddJoin", "CopyFields", "CopyRows", "Clear" });
-            foreach (var name in hookNames)
-            {
-                var m = navDataTransferType.GetMethod(name,
-                    BindingFlags.NonPublic | BindingFlags.Instance);
-                if (m == null) continue;
-                var ps = m.GetParameters().Length;
-                bool throwHere = thrownNames.Contains(name);
-                string? hook;
-                if (m.ReturnType == typeof(void))
-                {
-                    hook = ps switch
-                    {
-                        0 => throwHere ? nameof(ThrowDataTransfer_OneArg) : nameof(NoOp_OneArg),
-                        1 => throwHere ? nameof(ThrowDataTransfer_2Args) : nameof(NoOp2),
-                        2 => throwHere ? nameof(ThrowDataTransfer_3Args) : nameof(NoOp3),
-                        3 => throwHere ? nameof(ThrowDataTransfer_4Args) : nameof(NoOp4),
-                        _ => null
-                    };
-                }
-                else if (m.ReturnType == typeof(int))
-                {
-                    hook = ps switch
-                    {
-                        0 => throwHere ? nameof(ThrowDataTransferReturnInt_OneArg) : nameof(ReturnZero_OneArg),
-                        _ => null
-                    };
-                }
-                else hook = null;
-                if (hook != null) Hook(m, hook, $"NavDataTransfer.{name}");
-            }
-        }
 
         // ALTaskScheduler.CheckCodeUnit / ALCanCreateTask / CanCreateTask (scope.md §3.6,
         // #1733) are now Cecil-owned (see NclCecilRewrite.cs, CecilOwned + the ALTaskScheduler

--- a/AlRunner/Patches/HelperShims.cs
+++ b/AlRunner/Patches/HelperShims.cs
@@ -148,28 +148,6 @@ public static partial class BcRuntime
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)] public static object? ReturnNull_OneArg(object a) => null;
-    [MethodImpl(MethodImplOptions.NoInlining)] public static int ReturnZero_OneArg(object? a) => 0;
-
-    // DataTransfer throw helpers — match BC's "DataTransfer is only usable during
-    // upgrade and installation code." error so AL tests can `asserterror` + assert
-    // the message. Signatures mirror the NoOpN family (receiver + N-1 args).
-    private static System.Exception MakeDataTransferException()
-    {
-        var t = System.Type.GetType(
-            "Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLDialogException, Microsoft.Dynamics.Nav.Types");
-        const string msg = "DataTransfer is only usable during upgrade and installation code.";
-        if (t != null)
-        {
-            var ctor = t.GetConstructor(new[] { typeof(string) });
-            if (ctor != null) return (System.Exception)ctor.Invoke(new object[] { msg });
-        }
-        return new System.InvalidOperationException(msg);
-    }
-    [MethodImpl(MethodImplOptions.NoInlining)] public static void ThrowDataTransfer_OneArg(object? a) => throw MakeDataTransferException();
-    [MethodImpl(MethodImplOptions.NoInlining)] public static void ThrowDataTransfer_2Args(object? a, object? b) => throw MakeDataTransferException();
-    [MethodImpl(MethodImplOptions.NoInlining)] public static void ThrowDataTransfer_3Args(object? a, object? b, object? c) => throw MakeDataTransferException();
-    [MethodImpl(MethodImplOptions.NoInlining)] public static void ThrowDataTransfer_4Args(object? a, object? b, object? c, object? d) => throw MakeDataTransferException();
-    [MethodImpl(MethodImplOptions.NoInlining)] public static int ThrowDataTransferReturnInt_OneArg(object? a) => throw MakeDataTransferException();
 
     // TestPage field DrillDown() on a control with no OnDrillDown trigger — real BC (confirmed
     // 27.5 and 28.3, see al-language TestPageFieldDrillDown_Tests.FieldDrillDownWithNoTriggerIsRefused)

--- a/AlRunner/Patches/HelperShims.cs
+++ b/AlRunner/Patches/HelperShims.cs
@@ -152,8 +152,8 @@ public static partial class BcRuntime
     // TestPage field DrillDown() on a control with no OnDrillDown trigger — real BC (confirmed
     // 27.5 and 28.3, see al-language TestPageFieldDrillDown_Tests.FieldDrillDownWithNoTriggerIsRefused)
     // raises this exact fixed platform error regardless of TableRelation/UI state, so it is
-    // reproducible faithfully in-process. Public (unlike MakeDataTransferException) because
-    // RunnerPageInstance.RaiseOnDrillDown, in a different file/class, needs it too.
+    // reproducible faithfully in-process. Public because RunnerPageInstance.RaiseOnDrillDown,
+    // in a different file/class, needs it too.
     internal static System.Exception MakeNavDrilldownActionNotSupportedException()
     {
         var t = System.Type.GetType(

--- a/AlRunner/Patches/MetadataPatches.cs
+++ b/AlRunner/Patches/MetadataPatches.cs
@@ -326,14 +326,6 @@ public static partial class BcRuntime
     public static object? SkeletonSystemTenant => _skeletonSystemTenant;
 
     /// <summary>
-    /// Called from ApplyAllPatches *after* the real NavEnvironment ctor has run successfully
-    /// (`InstantiateStandaloneNavEnvironment(true,false)`). At that point
-    /// <c>NavEnvironment.Instance.Tenants</c> is a real, non-null <c>NavTenantCollection</c> —
-    /// but its <c>systemTenant</c> field is null because <c>AddSystemTenant</c> requires a real
-    /// SQL connection. We manufacture a skeleton via <c>GetUninitializedObject</c> and write it
-    /// into the field directly.
-    /// </summary>
-    /// <summary>
     /// Assign a fresh <c>new object()</c> to every null <c>readonly</c> field of exactly type
     /// <see cref="object"/> declared on <paramref name="instance"/>'s type and its bases up to
     /// and including <paramref name="stopAfter"/>. Returns the field names that were seeded.
@@ -363,6 +355,14 @@ public static partial class BcRuntime
         return seeded;
     }
 
+    /// <summary>
+    /// Called from ApplyAllPatches *after* the real NavEnvironment ctor has run successfully
+    /// (`InstantiateStandaloneNavEnvironment(true,false)`). At that point
+    /// <c>NavEnvironment.Instance.Tenants</c> is a real, non-null <c>NavTenantCollection</c> —
+    /// but its <c>systemTenant</c> field is null because <c>AddSystemTenant</c> requires a real
+    /// SQL connection. We manufacture a skeleton via <c>GetUninitializedObject</c> and write it
+    /// into the field directly.
+    /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void InjectSkeletonSystemTenant(Assembly navNcl)
     {

--- a/AlRunner/Patches/MetadataPatches.cs
+++ b/AlRunner/Patches/MetadataPatches.cs
@@ -333,6 +333,36 @@ public static partial class BcRuntime
     /// SQL connection. We manufacture a skeleton via <c>GetUninitializedObject</c> and write it
     /// into the field directly.
     /// </summary>
+    /// <summary>
+    /// Assign a fresh <c>new object()</c> to every null <c>readonly</c> field of exactly type
+    /// <see cref="object"/> declared on <paramref name="instance"/>'s type and its bases up to
+    /// and including <paramref name="stopAfter"/>. Returns the field names that were seeded.
+    /// </summary>
+    /// <remarks>
+    /// Enumerated rather than named: a name list silently stops covering a field BC adds, and the
+    /// symptom (<c>ArgumentNullException</c> out of <c>Monitor.ReliableEnter</c>) does not name the
+    /// skeleton. The filter is what keeps it faithful — a <c>readonly</c> field of exactly
+    /// <c>object</c> carries no value a caller can read, so the only thing it can be is a lock
+    /// token, and BC's ctor gives each one its own <c>new object()</c>.
+    /// </remarks>
+    internal static List<string> SeedNullReadonlyLockObjects(object instance, Type stopAfter)
+    {
+        var seeded = new List<string>();
+        for (var t = instance.GetType(); t != null; t = t.BaseType)
+        {
+            foreach (var f in t.GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (f.DeclaringType != t) continue;
+                if (f.FieldType != typeof(object) || !f.IsInitOnly) continue;
+                if (f.GetValue(instance) != null) continue;
+                FieldPoke.SetInstance(f, instance, new object());
+                seeded.Add(t.Name + "." + f.Name);
+            }
+            if (t == stopAfter) break;
+        }
+        return seeded;
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void InjectSkeletonSystemTenant(Assembly navNcl)
     {
@@ -485,6 +515,53 @@ public static partial class BcRuntime
         }
         else
             Console.Error.WriteLine("[BcRuntime] InjectSkeletonSystemTenant: NavTenant.disposingGate field NOT FOUND — NavSession.Open() will still NRE");
+
+        // 3¾. Seed NavTenant's plain `readonly object` LOCK fields — the same GetUninitializedObject
+        //      gap as disposingGate above, in the shape BC uses five more times on this one type.
+        //      A null lock target does not NRE: `lock (null)` reaches Monitor.ReliableEnter and
+        //      raises ArgumentNullException("Value cannot be null."), whose stack names
+        //      System.Threading.Monitor rather than anything BC, so it reads as a threading fault
+        //      rather than as unconstructed skeleton state (#1883).
+        //      Measured on 28.1: NavDataTransfer.CheckIsOpen -> NavTenant.IsIntelligentCloudReplicationEnabled
+        //      locks isIntelligentCloudReplicationEnabledLockObj, so every AL DataTransfer call
+        //      after SetTables raised that ArgumentNullException instead of BC's own
+        //      "only valid during upgrade and install" AL error — and being a CLR exception rather
+        //      than an AL one, AL `asserterror` observed the wrong message and a [TryFunction]
+        //      did not catch it at all.
+        //      A fresh `new object()` is what BC's own ctor assigns to each of them, and a
+        //      `readonly object` field is a lock token by construction — nothing can read a value
+        //      out of it — so BC's real body then computes the answer itself (here:
+        //      !IsDatabaseInitialized => false, BC's own verdict for a tenant with no database).
+        var seededLocks = SeedNullReadonlyLockObjects(_skeletonSystemTenant!, navTenantType);
+        if (seededLocks.Count > 0)
+            Console.Error.WriteLine(
+                "[BcRuntime] InjectSkeletonSystemTenant: seeded " + seededLocks.Count
+                + " null readonly lock object(s) on the skeleton tenant: " + string.Join(", ", seededLocks));
+
+        // 3⅞. Seed NavTenant.isIntelligentCloudReplicationEnabled = false — the answer BC's own
+        //      getter computes for a tenant whose database Lazy was never materialised, taken
+        //      one line earlier so the lazy path is not entered at all.
+        //
+        //      BC: `if (cached.HasValue) return cached.Value;` then, under the lock,
+        //      `if (!IsDatabaseInitialized || …) return false;` and only otherwise does it open a
+        //      SQL connection. IsDatabaseInitialized reads `database.IsValueCreated`, and the
+        //      skeleton's `database` field is null (asserted in SkeletonTenantLockObjectsTests),
+        //      so BC NREs on the way to a branch that would have answered false. Pre-seeding the
+        //      cache with that same false is observably equivalent and reaches no database —
+        //      the runner has no Intelligent Cloud replication to report.
+        //
+        //      Without it every AL `DataTransfer` call after SetTables raised a CLR exception out
+        //      of NavTenant instead of BC's own "only valid during upgrade and install" AL error,
+        //      which AL `asserterror` could not observe faithfully (#1883).
+        var icrField = navTenantType.GetField("isIntelligentCloudReplicationEnabled",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        if (icrField != null)
+            FieldPoke.SetInstance(icrField, _skeletonSystemTenant!, (bool?)false);
+        else
+            Console.Error.WriteLine(
+                "[BcRuntime] InjectSkeletonSystemTenant: NavTenant.isIntelligentCloudReplicationEnabled "
+                + "NOT FOUND — DataTransfer outside upgrade/install will still fail inside NavTenant");
+
         var treeBackingField = navTenantType.GetField("<Tree>k__BackingField",
             BindingFlags.NonPublic | BindingFlags.Instance);
         if (treeBackingField != null && _skeletonRootScope != null)

--- a/AlRunner/Patches/MetadataPatches.cs
+++ b/AlRunner/Patches/MetadataPatches.cs
@@ -326,6 +326,36 @@ public static partial class BcRuntime
     public static object? SkeletonSystemTenant => _skeletonSystemTenant;
 
     /// <summary>
+    /// The <c>readonly object</c> fields audited as lock tokens, so a fresh <c>new object()</c> is
+    /// what BC's own ctor would have put there. Read off <c>NavTenant</c> in two independent
+    /// binaries, 28.0 (11282232 bytes) and 28.1 (11294560 bytes), which agree on exactly these
+    /// seven; <c>NavSystemTenant</c> declares none of its own. Six are observed as <c>lock</c> or
+    /// <c>MonitorLock</c> targets inside <c>NavTenant</c>; <c>DeviceUserLock</c> has no use there
+    /// at all, so its evidence is its declaration — <c>internal object DeviceUserLock { get; } =
+    /// new object();</c>, locked by some other Ncl type.
+    /// </summary>
+    internal static readonly string[] AuditedTenantLockFields =
+    {
+        "<DeviceUserLock>k__BackingField",
+        "<AppGroupLock>k__BackingField",
+        "isIntelligentCloudReplicationEnabledLockObj",
+        "refreshStateSync",
+        "universalCodeCompliantLockObject",
+        "dataInitializationObj",
+        "stateSyncRoot",
+    };
+
+    /// <summary>Every field <see cref="SeedNullReadonlyLockObjects"/> seeded on the skeleton
+    /// tenant. Non-empty after bootstrap, which is how a test tells "nothing was unaudited" apart
+    /// from "nothing was measured".</summary>
+    internal static IReadOnlyList<string> SeededTenantLockFields { get; private set; } = Array.Empty<string>();
+
+    /// <summary>The subset of <see cref="SeededTenantLockFields"/> that
+    /// <see cref="AuditedTenantLockFields"/> does not name. Empty on an audited BC version;
+    /// <c>SkeletonTenantLockObjectsTests</c> fails on anything else.</summary>
+    internal static IReadOnlyList<string> UnauditedSeededLockFields { get; private set; } = Array.Empty<string>();
+
+    /// <summary>
     /// Assign a fresh <c>new object()</c> to every null <c>readonly</c> field of exactly type
     /// <see cref="object"/> declared on <paramref name="instance"/>'s type and its bases up to
     /// and including <paramref name="stopAfter"/>. Returns the field names that were seeded.
@@ -333,13 +363,15 @@ public static partial class BcRuntime
     /// <remarks>
     /// Enumerated rather than named: a name list silently stops covering a field BC adds, and the
     /// symptom (<c>ArgumentNullException</c> out of <c>Monitor.ReliableEnter</c>) does not name the
-    /// skeleton. The filter is what keeps it faithful — a <c>readonly</c> field of exactly
-    /// <c>object</c> carries no value a caller can read, so the only thing it can be is a lock
-    /// token, and BC's ctor gives each one its own <c>new object()</c>.
+    /// skeleton. So <see cref="AuditedTenantLockFields"/> is a review roster, NOT the filter —
+    /// seeding narrowed to it would leave a lock field an unmeasured BC version declares null.
+    /// Anything seeded that the roster does not name is recorded and announced instead, which is
+    /// what stops a future non-lock <c>readonly object</c> field being given a value silently.
     /// </remarks>
     internal static List<string> SeedNullReadonlyLockObjects(object instance, Type stopAfter)
     {
         var seeded = new List<string>();
+        var unaudited = new List<string>();
         for (var t = instance.GetType(); t != null; t = t.BaseType)
         {
             foreach (var f in t.GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance))
@@ -349,9 +381,17 @@ public static partial class BcRuntime
                 if (f.GetValue(instance) != null) continue;
                 FieldPoke.SetInstance(f, instance, new object());
                 seeded.Add(t.Name + "." + f.Name);
+                if (Array.IndexOf(AuditedTenantLockFields, f.Name) < 0) unaudited.Add(t.Name + "." + f.Name);
             }
             if (t == stopAfter) break;
         }
+        SeededTenantLockFields = seeded;
+        UnauditedSeededLockFields = unaudited;
+        if (unaudited.Count > 0)
+            Console.Error.WriteLine(
+                "[BcRuntime] InjectSkeletonSystemTenant: seeded " + unaudited.Count + " readonly object field(s) "
+                + "that BcRuntime.AuditedTenantLockFields does not name: " + string.Join(", ", unaudited)
+                + " — audit each as a lock target and add it to that roster, or stop seeding it.");
         return seeded;
     }
 

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -2091,7 +2091,7 @@ internal sealed partial class RunnerPageInstance
     /// real BC 27.5 and 28.3 in al-language's TestPageFieldDrillDown_Tests
     /// (FieldDrillDownWithNoTriggerIsRefused). That is reproducible in-process with no UI, so
     /// it is raised as a genuine AL error via NavNCLDialogException (same mechanism as
-    /// BcRuntime's DataTransfer-out-of-context message), not a RunnerOutOfScopeException —
+    /// SessionPatches.MakeStartSessionNotAllowedInTestException), not a RunnerOutOfScopeException —
     /// this is not a capability the runner lacks, it is exactly what BC itself does here.
     /// </summary>
     internal void RaiseOnDrillDown(int controlId)

--- a/AlRunner/Patches/SessionPatches.cs
+++ b/AlRunner/Patches/SessionPatches.cs
@@ -348,9 +348,8 @@ public static partial class BcRuntime
     /// <para>Deliberately NOT <c>RunnerOutOfScopeException</c>: that type announces a runner
     /// limitation and is what <c>tests/expectations/</c> classifies as an out-of-scope signal.
     /// This refusal is the opposite — real BC behaviour faithfully reproduced, which no
-    /// expectation entry should ever mark out of scope. Same shape and reasoning as
-    /// <c>MakeDataTransferException</c>. (Trappability is NOT the distinction, and an earlier
-    /// version of this comment said it was: <c>RunnerOutOfScopeException</c> is a plain
+    /// expectation entry should ever mark out of scope. (Trappability is NOT the distinction,
+    /// and an earlier version of this comment said it was: <c>RunnerOutOfScopeException</c> is a plain
     /// <c>System.Exception</c>, and <c>asserterror</c> catches it too — the runner's asserterror
     /// replacement is an unfiltered <c>catch (Exception)</c>. See
     /// <c>RunnerOutOfScopeException.cs</c>'s header and issue #2871.)</para>


### PR DESCRIPTION
Part of #1883

The NavDataTransfer cluster (7 of the 69 orphaned `Hook(...)` registrations).
#1883 stays open; 62 orphans remain.

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/327

## The audit, and what it found

The cluster is `NavDataTransfer`: `SetTables` hooked to a no-op, and
`Add{Field,Constant,Source}Value` / `AddJoin` / `CopyFields` / `CopyRows` / `Clear` hooked to stubs
throwing a hardcoded copy of BC's *"DataTransfer is only usable during upgrade and installation
code."* All seven were orphaned, so BC's real bodies were already running.

Rather than read the bodies and decide, each was driven individually from AL — one `[TryFunction]`
per entry point, reporting the exact outcome. On pristine `origin/main` (df1aeadb):

| AL call | what BC's unpatched body actually did |
|---|---|
| `SetTables(A, B)` | **accepted** — validated and staged the pair |
| `AddFieldValue` *before* `SetTables` | `SetTables must first be called before calling other methods on DataTransfer.` |
| `AddFieldValue`, `AddConstantValue`, `AddSourceFilter`, `AddJoin`, `CopyFields`, `CopyRows` *after* `SetTables` | **`ArgumentNullException: Value cannot be null.`** at `System.Threading.Monitor.ReliableEnter` |

So the cluster is neither "all harmless" nor "all bugs": one was already faithful, one was already
*better* than the stub, and six were a real defect the orphaned hooks had been masking.

The six share one frame. `NavDataTransfer.CheckIsOpen` reads
`session.Tenant.IsIntelligentCloudReplicationEnabled`, and the skeleton `NavSystemTenant` is built
with `RuntimeHelpers.GetUninitializedObject` — so every field initialiser BC's ctor would have run
is skipped. Two of those gaps sit on that path:

1. `private readonly object … = new object()` lock fields stay **null**, and `lock (null)` does not
   NRE — it reaches `Monitor.ReliableEnter` and raises `ArgumentNullException`, a stack naming
   `System.Threading` rather than anything BC or runner. **Seven** such fields on `NavTenant`.
2. `isIntelligentCloudReplicationEnabled` has no cached value, so the getter takes the lazy path and
   NREs in `IsDatabaseInitialized` on the null `database` Lazy.

Being CLR exceptions rather than AL errors, neither was observable faithfully from AL: a
`[TryFunction]` did not catch them at all, and `asserterror` saw `Value cannot be null.`

## The fix

`InjectSkeletonSystemTenant` (`AlRunner/Patches/MetadataPatches.cs`), beside the existing
`disposingGate` seed that is the same gap in the same shape:

- **step 3¾** — `SeedNullReadonlyLockObjects` assigns a fresh `new object()` to every null
  `readonly` field of exactly type `object`, walking the hierarchy to `NavTenant`. Enumerated, not
  named: a name list silently stops covering a field BC adds, and it caught two auto-property
  backing fields (`DeviceUserLock`, `AppGroupLock`) that a grep for `private readonly object` misses.
  A `readonly object` field holds no value a caller can read, so the only thing it can be is a lock
  token, and BC's ctor gives each one its own `new object()`.
- **step 3⅞** — `isIntelligentCloudReplicationEnabled = false`. This is BC's own answer, taken one
  line earlier: its getter returns `false` under the lock whenever `!IsDatabaseInitialized`, without
  opening a connection, and the skeleton's `database` field is null (asserted, not assumed —
  `TheSkeletonTenantHasNoDatabase_WhichIsWhyFalseIsBcsOwnAnswer`).

BC's real bodies then produce the refusal themselves — which is **strictly better than the stubs**:
they raise the message from BC's own resource, tell *"SetTables must first be called…"* apart from
it, and would honour a real install/upgrade context, which a hardcoded throw never could. So the
seven registrations and the five `ThrowDataTransfer*` shims plus `MakeDataTransferException` are
dead code and are deleted outright, not left as no-op call sites. `ReturnZero_OneArg` lost its last
reference with them and goes too.

`AL_RUNNER_HOOK_AUDIT=1`: **69 → 62** orphaned registrations.

## RED → GREEN

**AL, full corpus** (3317 tests incl. the 8 new corpus tests, BC 28.1.49838.54487, corpus
`666cd0372ded0450b71028cb2e61eb52a0f5f964` + corpus PR #327). Two runs per tree against one cache
root each; identical both times, cold and warm:

| tree | result |
|---|---|
| `origin/main` df1aeadb | **Failed: 6, Passed: 3311** |
| this branch | **Failed: 0, Passed: 3317** |

The six are exactly the six after-`SetTables` entry points, each reporting
`Expected: DataTransfer is only usable during upgrade and installation code.. Actual: Value cannot
be null.` No other corpus test changed state in either direction. `tests/runner-extras`: 432/432 on
both trees.

**Worth recording:** corpus codeunit 60875's `DataTransfer_CopyRows_OutsideUpgrade_Throws`
**passed on the broken baseline.** It wraps `SetTables` and `CopyRows` in one `asserterror` and
asserts only `GetLastErrorText() <> ''`, so a CLR exception satisfied it. That is why the upstream
half of this work is eight new tests rather than a runner-local one, and why they assert the
message rather than its non-emptiness.

**Mutation, executed** (`AlRunner.Tests`, `--settings` engine bootstrap, 3 tests in the class):

| mutation | result |
|---|---|
| `SeedNullReadonlyLockObjects`: `GetValue(instance) != null` → `== null` (nothing gets seeded) | **Failed: 1, Passed: 2** — RED names all seven null fields |
| step 3⅞: `(bool?)false` → `(bool?)null` | **Failed: 1, Passed: 2** — RED reports the `NullReferenceException` |
| restored | **Failed: 0, Passed: 3** |

Both REDs are the assertion, not a build error; the tree was verified clean after restoring. A
first attempt at mutation 1 (`typeof(object)` → `typeof(string)`) is *not* counted: it made the
bootstrap itself throw, so the tests went red for the wrong reason — noted because it is exactly
tdd.md's "a mutation that breaks the build proves nothing".

**Targeted C# suites:** `~Skeleton|~MetadataPatches|~HookAudit|~JmpHook` → Failed: 0, Passed: 49,
Skipped: 0. `~Patches|~Tenant|~Session|~BcEngine` → Failed: 0, Passed: 176, Skipped: 0. Run wider
than the default because `InjectSkeletonSystemTenant` is on every runner invocation's startup path.

## Fix the shape

**1. Does the same wrong pattern appear at another call site?** Yes, and it is why step 3¾
enumerates instead of naming the one field `CheckIsOpen` hit: `NavTenant` carries **seven** null
lock fields, and several of them (`refreshStateSync`, `universalCodeCompliantLockObject`,
`dataInitializationObj`, `stateSyncRoot`, `AppGroupLock`) are locked elsewhere in the same type.
All are covered now.

**2. Does a sibling function make the same assumption?** Yes — `NavTenant.UniversalCodeCompliant`
has the identical lazy-cache-under-a-lock shape. Measured: with the lock seeded it gets past
`Monitor` and reaches `Database.SecurityAndLicense`, which the skeleton has no database for. So
this PR converts a misleading threading error there into an honest missing-database one; it does
not make that property answer, and nothing here claims it does.

**3. Do two paths that write the same state keep the same invariant?** They did not:
`InjectSkeletonSystemTenant` already seeded `disposingGate` — a lock-ish gate, same root cause —
case by case, while every plain `object` lock stayed null. The enumeration closes that asymmetry.

**Not folded, filed instead: #3932.** `NCLMetadata` (3 lock fields, 5 lock sites) and `NavSession`
(1 field, 4 sites) are built with `GetUninitializedObject` too and carry the same nulls — measured
with `ilspycmd` on the 28.1.49838.54487 `Ncl.dll` (one binary; not re-measured across the 27.x/28.x
boundary). The fix is one call each and carries no semantic risk, but **nothing observed reaches
those locks**, so seeding them would ship an unmeasured behaviour change — and finding 2 above is
the evidence that seeding a lock is not automatically the whole fix. #3932 records the four fields
and what would close it.

**Open-issue queue scan:** no open issue mentions `DataTransfer`, the lock shape, or
`GetUninitializedObject`. #3174 and #3352 are the nearest neighbours — the skeleton session's null
`Permissions` — the same *class* of gap but a different field and a different fix, landing in a
different part of the file. Nothing foldable.

## Where the prose went

Two comment blocks in `MetadataPatches.cs` exceed ten lines: the step 3¾ and 3⅞ justifications.
Both stay in code, because they are the `loud-failures.md` audit justification for a value the
runner supplies to BC, and the next person editing those lines needs the claim and its citation at
the line. The derivation — the per-method AL probe table, the A/B numbers, the mutation results —
is in this body, not in the file.

## Environment note, not part of the diff

`tools/engine-test-bootstrap.sh` cannot run on Windows: it writes `DOTNET_STARTUP_HOOKS` as POSIX
paths joined with `:`, and .NET rejects that (`startup hook simple assembly name … is invalid`).
The `bc-engine-serial` tests above were run with a hand-written runsettings using Windows paths and
`;`. Left alone deliberately — out of scope for this PR, and CI is unaffected since it runs on
Linux.

---

Authored by agent **impl-1**.

https://claude.ai/code/session_01GiwJXvJDKAPYzdjZCNLs8o
