### PR TITLE
docs(tdd): a filter or mutation target matching the wrong thing beats one matching nothing

### DIFF
--- a/.claude/rules/tdd.md
+++ b/.claude/rules/tdd.md
@@ -76,6 +76,17 @@ green and looks like the system working.
 the `Total:` line from every run, and treat a run with no `Total:` line as *unverified* rather
 than green — the exit code cannot tell you the difference.
 
+**The harder half: a filter or a mutation target that matches the WRONG thing rather than
+nothing.** A zero is at least conspicuous; a plausible number is not. Both measured on #3923 in
+one pass: `~ExtensionRuntimeDeltasTests` returned **8** of 9, because the file declares a second
+class (`…BcReaderTests`) the filter excluded — and a mutation aimed at
+`TryBuildExtensionRuntimeDeltasXml` left every test green, because the tests call
+`TryBuildExtensionRuntimeDeltasXmlForApp`, whose name has the first as a **prefix**. Mutating the
+right one gave 7 of 9 red.
+
+So: **count the tests you expected**, and after a mutation that leaves things green, check the
+symbol you edited is the one the test path calls before concluding the test is weak.
+
 **Trap: CI catches the opposite error, never this one.** A test that fails when it should pass
 is red within minutes; one that passes when it should fail is caught only if somebody looks,
 and until then it reads as coverage while protecting nothing.


### PR DESCRIPTION
`tdd.md`'s filter trap covers a filter matching **nothing** — `No test matches`, exit 0. The
harder half is matching **the wrong thing**: a zero is conspicuous, a plausible number is not.

Both halves happened in one verification pass on PR #3923. Both were mine.

## 1. A filter that matched 8 of 9

`--filter "FullyQualifiedName~ExtensionRuntimeDeltasTests"` reported `Total: 8` against the
author's 9. The file declares **two** classes — `ExtensionRuntimeDeltasTests` and
`ExtensionRuntimeDeltasBcReaderTests` — and the filter excluded the second.

A count that is *one short* reads as a discrepancy to explain, and the natural explanation, "a
test was skipped", is exactly wrong.

## 2. A mutation that landed on a real but wrong method

Aiming at `TryBuildExtensionRuntimeDeltasXml` and inserting `return null;` compiled cleanly and
left **all 9 green** — which reads as "these tests do not prove the fix". The tests call
`TryBuildExtensionRuntimeDeltasXmlForApp`, whose name has the first as a **prefix**. Mutating
that gives `Failed: 7, Passed: 2`, matching the author exactly.

**This is the more dangerous half**: a green after a mutation is the documented signal for an
unproven test, so the wrong conclusion is the *supported* one. Had I reported it, the author
would have been sent to fix tests that were already correct.

## Why no existing trap covers it

- *"a filter that matches nothing is a silent pass"* — this matched something.
- *"a failed mutation and a working guard look identical"* — the mutation landed somewhere real.
- *"a correct instrument reading the wrong subject"* is the right family, but its instances are
  about **scope** (a checkout, an empty container, a repo-wide query). This is about
  **identity** — one symbol whose name is a prefix of another.

## What changes

Extends the existing filter trap rather than adding a seventh: **count the tests you expected**,
and after a mutation that leaves things green, **check the symbol you edited is the one the test
path calls** before concluding the test is weak.

**Not** tooling to resolve mutation targets — both instances were caught in under a minute by
asking whether the number matched expectation. The remedy is the check.

## Verification

Docs-only, one file, +11/-0. `tools/test_doc_pointers.py` passes; rule is 6,473 bytes.

Pre-push checks run, both from my own errors today: `git diff --stat origin/main...HEAD` against a
freshly fetched `main` (#3907), and a closing-keyword scan (only `Closes #3928`).

**No mutation reported**, deliberately: prose with no implementation to break.

Closes #3928

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
