### PR TITLE
fix(metadata): derive the MetaQuery properties SymbolReference.json states

### DIFF
--- a/AlRunner.Tests/QuerySymbolDerivedMetaQueryPropertiesTests.cs
+++ b/AlRunner.Tests/QuerySymbolDerivedMetaQueryPropertiesTests.cs
@@ -1,0 +1,338 @@
+// QuerySymbolDerivedMetaQueryPropertiesTests — a query in a precompiled dependency states the
+// inherent masks it declares, the caption BC derives, the constants BC's emitter assigns, and
+// the operator on every dataitem link.
+//
+// THE DEFECT THIS PINS (#3798, found by the Query metadata-equivalence comparison, #3782)
+//   The runner's MetaQuery design object — the one NCLMetaQuery.CreateDynamicQuery consumes, so
+//   what AL actually gets — left eight members at their defaults while BC's own emitter states
+//   a value. Measured on BC 28.1.49838.53910 over System Application's 7 queries; every
+//   STRUCTURAL member already agreed exactly (column ids, FieldNo, ColumnType, MethodType,
+//   QueryColumnIndex, DataItemLinkType, DataItemTable), so this is entirely about the
+//   query-level scalars and the one link property.
+//
+// CAPTION IS THE MEMBER THAT NEEDED SETTLING, AND THE ANSWER INVERTS THE ISSUE'S READING
+//   #3798 records query 777 as a case where "the runner is arguably right": the symbol file
+//   says Caption='RoleCenter from Plans', BC answers 'Role Center from Plans' (the object
+//   NAME), so the runner looked like it was reporting the declared caption faithfully.
+//
+//   It is not. BC's emitter writes NO <Caption> element at all — 0 of the 1,218 documents in
+//   the System Application ground-truth bundle carry one, against 113 carrying <CaptionML>, so
+//   the property cannot be coming from a declared caption on any object of any kind. Feeding
+//   BC's own MetaQuery(XmlNode,0,0) three synthesised documents isolates what does drive it:
+//
+//     <Name>My Name</Name>                                  -> Caption='My Name'
+//     <Name>My Name</Name><CaptionML>ENU=My Caption</...>    -> Caption='My Name'   (ML ignored)
+//     <Name>My Name</Name><Caption>My Caption</Caption>      -> Caption='My Name'   (elem ignored)
+//     <CaptionML>ENU=My Caption</CaptionML>, no <Name>       -> Caption=''
+//
+//   So Caption tracks Name unconditionally on the document route, and the declared caption
+//   reaches AL through CaptionML — a MultiLanguage object this design object does not carry.
+//   Writing the symbol file's caption into Caption answers something BC never answers, on BOTH
+//   of the issue's two situations rather than just the three undeclared ones.
+//
+// THE MASK POPULATION IS MEASURED ON QUERIES, NOT INHERITED FROM #3788
+//   #3788's codeunit sweep found one lowercase mask in 1,167; a coordinator note on #3798 then
+//   corrected the surrounding figure twice. Re-measured here on the kind this file is about, BC
+//   28.4.53241.54407, Base Application (154 queries) + System Application (7): 6 of 161 state a
+//   mask and ALL SIX spell it "X". No lowercase form occurs on queries in Microsoft's shipped
+//   packages at all.
+//
+//   That is a reason to assert the lowercase and mixed-case forms HERE rather than to skip
+//   them: the decoder is shared with the codeunit direction, the query population exercises
+//   only its direct-bit path, and an indirect-bit regression would therefore be invisible to
+//   every query in every Microsoft app. The fixture declares "x" and "rX" for exactly that.
+//
+// WHY A RUNNER-SIDE MECHANISM TEST
+//   BC's own emitter output is the ground truth here and the metadata-equivalence harness
+//   compares against it on every unit-test leg. What no AL test can reach is the
+//   PRECOMPILED-dependency route: a bundle's own queries are source-parsed and take the BC
+//   document route (#3608), so the symbol-file spelling never arises. This file drives that
+//   route directly, the same argument CodeunitSymbolNamespaceAndInherentMaskTests makes.
+
+using System.IO.Compression;
+using System.Reflection;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Reaches the RecordPatches AL parse statics, which are process-wide and which xunit's
+// parallel collections can clear or repopulate between a write and a read (#1696, #1712).
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class QuerySymbolDerivedMetaQueryPropertiesTests : IDisposable
+{
+    private const int DirectExecute = 61072;
+    private const int IndirectExecute = 61073;
+    private const int MixedCaseMask = 61074;
+    private const int DeclaresNoMask = 61075;
+    private const int CaptionDiffersFromName = 61076;
+
+    private const int LinkedTable = 61077;
+
+    private readonly string _root;
+
+    public QuerySymbolDerivedMetaQueryPropertiesTests()
+    {
+        _root = TestScratch.Dir("al-runner-query-derived-properties");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        RecordPatches.ResetForReload();
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    /// <summary>
+    /// Queries sit in the <c>Namespaces</c> tree the way Microsoft's packages write them —
+    /// System Application's flat top-level <c>Queries</c> array is empty and all 7 of its
+    /// queries are reached through the tree, so a fixture using the flat array would exercise a
+    /// path no shipped app takes.
+    /// </summary>
+    private static readonly string SymbolReference = $$"""
+        {
+          "RuntimeVersion": "15.1",
+          "AppId": "6f1d9c84-3f2a-4e77-9c51-2a7b4e08d913",
+          "Name": "Query Derived Properties Fixture",
+          "Tables": [
+            {
+              "Id": {{LinkedTable}},
+              "Name": "Derived Query Source",
+              "Fields": [
+                { "Id": 1, "Name": "Code", "TypeDefinition": { "Name": "Code", "Length": 20 } },
+                { "Id": 2, "Name": "Amount", "TypeDefinition": { "Name": "Decimal" } }
+              ]
+            }
+          ],
+          "Namespaces": [
+            {
+              "Name": "System",
+              "Namespaces": [
+                {
+                  "Name": "Derived",
+                  "Queries": [
+                    {
+                      "Id": {{DirectExecute}},
+                      "Name": "Direct Execute Query",
+                      "Properties": [
+                        { "Name": "InherentEntitlements", "Value": "X" },
+                        { "Name": "InherentPermissions", "Value": "X" }
+                      ],
+                      "Elements": [
+                        {
+                          "Id": 1, "Name": "Root", "RelatedTable": "Derived Query Source",
+                          "Columns": [ { "Id": 11, "Name": "Code_Col", "SourceColumn": "Code" } ]
+                        }
+                      ]
+                    },
+                    {
+                      "Id": {{IndirectExecute}},
+                      "Name": "Indirect Execute Query",
+                      "Properties": [
+                        { "Name": "InherentEntitlements", "Value": "x" }
+                      ],
+                      "Elements": [
+                        {
+                          "Id": 1, "Name": "Root", "RelatedTable": "Derived Query Source",
+                          "Columns": [ { "Id": 11, "Name": "Code_Col", "SourceColumn": "Code" } ]
+                        }
+                      ]
+                    },
+                    {
+                      "Id": {{MixedCaseMask}},
+                      "Name": "Mixed Case Query",
+                      "Properties": [
+                        { "Name": "InherentPermissions", "Value": "rX" }
+                      ],
+                      "Elements": [
+                        {
+                          "Id": 1, "Name": "Root", "RelatedTable": "Derived Query Source",
+                          "Columns": [ { "Id": 11, "Name": "Code_Col", "SourceColumn": "Code" } ]
+                        }
+                      ]
+                    },
+                    {
+                      "Id": {{DeclaresNoMask}},
+                      "Name": "No Mask Query",
+                      "Properties": [],
+                      "Elements": [
+                        {
+                          "Id": 1, "Name": "Root", "RelatedTable": "Derived Query Source",
+                          "Columns": [ { "Id": 11, "Name": "Code_Col", "SourceColumn": "Code" } ]
+                        }
+                      ]
+                    },
+                    {
+                      "Id": {{CaptionDiffersFromName}},
+                      "Name": "Role Center from Plans",
+                      "Properties": [
+                        { "Name": "Caption", "Value": "RoleCenter from Plans" }
+                      ],
+                      "Elements": [
+                        {
+                          "Id": 1, "Name": "Root", "RelatedTable": "Derived Query Source",
+                          "Columns": [ { "Id": 11, "Name": "Code_Col", "SourceColumn": "Code" } ],
+                          "DataItems": [
+                            {
+                              "Id": 2, "Name": "Child", "RelatedTable": "Derived Query Source",
+                              "Properties": [
+                                { "Name": "SqlJoinType", "Value": "InnerJoin" },
+                                { "Name": "DataItemLink", "Value": "Code = Root.Code" }
+                              ],
+                              "Columns": [ { "Id": 12, "Name": "Amount_Col", "SourceColumn": "Amount" } ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private void Register()
+    {
+        var appPath = Path.Combine(_root, "query-derived.app");
+        using (var zip = new FileStream(appPath, FileMode.Create))
+        using (var za = new ZipArchive(zip, ZipArchiveMode.Create))
+        {
+            var entry = za.CreateEntry("SymbolReference.json");
+            using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+            w.Write(SymbolReference);
+        }
+        RecordPatches.ResetForReload();
+        RecordPatches.AddBcAppPath(appPath);
+    }
+
+    /// <summary>
+    /// The runner's own MetaQuery design object for one query — the same object
+    /// <c>NCLMetaQuery.CreateDynamicQuery</c> consumes and the metadata-equivalence harness
+    /// compares, so this reads the fix's actual output rather than a second derivation written
+    /// for the test.
+    /// </summary>
+    private static object Design(int queryId)
+    {
+        var design = RecordPatches.TryBuildQueryMetadataEquivalenceDesign(queryId);
+        Assert.True(design is not null,
+            $"the runner built no MetaQuery design for query {queryId} — that null is #3499's " +
+            "shape and means this test measured nothing at all, not that a property is wrong.");
+        return design!;
+    }
+
+    private static object? Read(object design, string property)
+    {
+        var p = design.GetType().GetProperty(property, BindingFlags.Public | BindingFlags.Instance);
+        Assert.True(p is not null,
+            $"Types.Metadata.MetaQuery has no '{property}' property on this BC build — the " +
+            "member this test pins has changed shape, so re-measure before trusting either side.");
+        return p!.GetValue(design);
+    }
+
+    /// <summary>
+    /// The mask letters the symbol file states become the numeric permission BC's emitter
+    /// writes, with CASE preserved. The three spellings are asserted against three DIFFERENT
+    /// expected values, so a case-collapsing parse — the natural thing to reach for, since
+    /// SymbolProperties matches the property NAME case-insensitively — fails on two of them
+    /// rather than passing on an aggregate.
+    /// </summary>
+    [Fact]
+    public void The_inherent_mask_letters_a_query_declares_become_the_permission_BC_answers()
+    {
+        Register();
+
+        // "X" -> bit 4 = Execute. The only spelling that occurs on queries in Microsoft's own
+        // packages (6 of 161 measured on 28.4.53241.54407), so it alone proves the common case.
+        Assert.Equal("Execute", Read(Design(DirectExecute), "InherentEntitlements")!.ToString());
+        Assert.Equal("Execute", Read(Design(DirectExecute), "InherentPermissions")!.ToString());
+
+        // "x" -> bit 9 = IndirectExecute, a DIFFERENT value reached only by preserving case.
+        // A case-insensitive parse answers Execute here, which is what makes this the decisive
+        // assertion rather than the one above.
+        Assert.Equal("IndirectExecute", Read(Design(IndirectExecute), "InherentEntitlements")!.ToString());
+
+        // "rX" -> IndirectRead | Execute. Asserted because a parse that special-cased single
+        // characters would still get both of the above right and this one wrong.
+        Assert.Equal("Execute, IndirectRead", Read(Design(MixedCaseMask), "InherentPermissions")!.ToString());
+
+        // A query declaring no mask keeps BC's own enum default rather than gaining a value.
+        Assert.Equal("None", Read(Design(DeclaresNoMask), "InherentEntitlements")!.ToString());
+        Assert.Equal("None", Read(Design(DeclaresNoMask), "InherentPermissions")!.ToString());
+    }
+
+    /// <summary>
+    /// Caption answers the query's NAME, not the caption the symbol file declares — the
+    /// inversion this file's header measures. The fixture reproduces System Application's query
+    /// 777 exactly, the case #3798 recorded as one where the runner was arguably right.
+    /// </summary>
+    [Fact]
+    public void Caption_answers_the_query_name_and_not_the_declared_caption()
+    {
+        Register();
+
+        // The two strings differ by one space, which is the whole point: a fix that wrote the
+        // declared caption through would answer 'RoleCenter from Plans' and pass any assertion
+        // that merely checked Caption was non-empty.
+        Assert.Equal("Role Center from Plans", Read(Design(CaptionDiffersFromName), "Caption"));
+        Assert.NotEqual("RoleCenter from Plans", Read(Design(CaptionDiffersFromName), "Caption"));
+
+        // A query declaring NO caption gets its name too, rather than the null the runner used
+        // to answer for System Application's three undeclared queries.
+        Assert.Equal("No Mask Query", Read(Design(DeclaresNoMask), "Caption"));
+    }
+
+    /// <summary>
+    /// The constants BC's emitter writes into every query document unconditionally. Each is
+    /// asserted to its own value, so a fix that set one and left the rest defaulted cannot pass.
+    /// </summary>
+    [Fact]
+    public void The_constants_BCs_emitter_assigns_are_stated_rather_than_left_defaulted()
+    {
+        Register();
+        var design = Design(DeclaresNoMask);
+
+        Assert.Equal("https://learn.microsoft.com/dynamics365/business-central/", Read(design, "HelpLink"));
+
+        // BC writes an EMPTY element for these three, which its own reader turns into "" —
+        // never null. Asserted as "" specifically: null would be the value the runner used to
+        // answer, and Assert.Empty accepts both.
+        Assert.Equal(string.Empty, Read(design, "QueryCategory"));
+        Assert.Equal(string.Empty, Read(design, "APIGroup"));
+        Assert.Equal(string.Empty, Read(design, "APIPublisher"));
+    }
+
+    /// <summary>
+    /// Every dataitem link states the operator BC states. AL has no syntax for anything but
+    /// equality today, so the constant is faithful — and the property was left null on all four
+    /// links in the ground-truth bundle.
+    /// </summary>
+    [Fact]
+    public void A_dataitem_link_states_the_equality_operator_BC_states()
+    {
+        Register();
+        var design = Design(CaptionDiffersFromName);
+
+        var dataItems = (System.Collections.IList)Read(design, "DataItems")!;
+        Assert.Equal(2, dataItems.Count);
+
+        // The nested dataitem is the one carrying the link; the root declares none.
+        var child = dataItems[1]!;
+        var links = (System.Collections.IList)child.GetType()
+            .GetProperty("DataItemLinks", BindingFlags.Public | BindingFlags.Instance)!
+            .GetValue(child)!;
+        Assert.Single(links);
+
+        var link = links[0]!;
+        Assert.Equal("=", link.GetType()
+            .GetProperty("LinkOperator", BindingFlags.Public | BindingFlags.Instance)!
+            .GetValue(link));
+
+        // The link still resolves the two field numbers it did before — a LinkOperator set on a
+        // link that stopped joining correctly would be a regression this assertion catches.
+        Assert.Equal(1, link.GetType().GetProperty("SourceFieldNo")!.GetValue(link));
+        Assert.Equal(1, link.GetType().GetProperty("DestinationFieldNo")!.GetValue(link));
+    }
+}

--- a/AlRunner.Tests/QuerySymbolDerivedPropertiesWarmCacheTests.cs
+++ b/AlRunner.Tests/QuerySymbolDerivedPropertiesWarmCacheTests.cs
@@ -1,0 +1,181 @@
+// QuerySymbolDerivedPropertiesWarmCacheTests — the two members #3798 added to QuerySymbol are
+// re-derived rather than replayed from a cache entry written before they existed.
+//
+// WHY A SEPARATE FILE FROM QuerySymbolDerivedMetaQueryPropertiesTests
+//   A test class belongs to exactly one xunit collection, and this one needs a different one
+//   from its sibling. The sibling asserts what the design object ANSWERS, where a concurrent
+//   CacheRoots override can only turn a HIT into a MISS — the key is content-addressed, so a
+//   re-parse of the same bytes reaches the same result.
+//
+//   This test asserts the MISS ITSELF, through ParseInvocationCountForTests and through which
+//   on-disk path exists afterwards, which is exactly what another thread's override destroys.
+//   So it joins CacheRootsSerialCollection and gets the process-static override to itself.
+//   Same split, same reason, as CodeunitSymbolNamespaceWarmCacheTests.
+//
+// WHY IT EXISTS AT ALL, AND WHY NO CacheVersion BUMP IS IN THIS CHANGE
+//   BcAppSymbolCache is keyed on path|hash:<content>|v<CacheVersion>|shape:<PayloadShape>, so
+//   there IS a cache between this parse and its observable and a fix correct cold can be wrong
+//   warm — what #3908 and #3913 were (local-test-scope.md).
+//
+//   A PARSE-only change (same record shape, different answer) is invisible to the fingerprint
+//   and needs the integer bumped. A RECORD-SHAPE change re-keys on its own. Which of the two
+//   this is was MEASURED, not reasoned: QuerySymbol gained two members and is reachable from
+//   CachePayload, so PayloadShape moved from b82cf78cd0b9123a on origin/main to the current
+//   value, read through the PayloadShapeForTests seam off both builds. No bump is therefore
+//   correct — and this test is what keeps that a fact rather than a claim, because the
+//   fingerprint being in the key is otherwise invisible: the key is hashed into a filename.
+
+using System.IO.Compression;
+using System.Reflection;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Reads the on-disk cache directly and asserts a MISS, so it needs CacheRoots to itself — see
+// this file's header and CacheRootsSerialCollection.
+[Collection(CacheRootsSerialCollection.Name)]
+public sealed class QuerySymbolDerivedPropertiesWarmCacheTests : IDisposable
+{
+    private const int DirectExecute = 61078;
+    private const int LinkedTable = 61079;
+
+    private readonly string _root;
+
+    public QuerySymbolDerivedPropertiesWarmCacheTests()
+    {
+        _root = TestScratch.Dir("al-runner-query-derived-warm-cache");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        RecordPatches.ResetForReload();
+        BcAppSymbolCache.ResetProcessCacheForTests();
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private static readonly string SymbolReference = $$"""
+        {
+          "RuntimeVersion": "15.1",
+          "AppId": "9b2e7c15-6d84-4a30-8f19-3c5d7e2a604b",
+          "Name": "Query Warm Cache Fixture",
+          "Tables": [
+            {
+              "Id": {{LinkedTable}},
+              "Name": "Warm Query Source",
+              "Fields": [
+                { "Id": 1, "Name": "Code", "TypeDefinition": { "Name": "Code", "Length": 20 } }
+              ]
+            }
+          ],
+          "Namespaces": [
+            {
+              "Name": "System",
+              "Queries": [
+                {
+                  "Id": {{DirectExecute}},
+                  "Name": "Warm Direct Execute",
+                  "Properties": [
+                    { "Name": "InherentEntitlements", "Value": "X" },
+                    { "Name": "InherentPermissions", "Value": "X" }
+                  ],
+                  "Elements": [
+                    {
+                      "Id": 1, "Name": "Root", "RelatedTable": "Warm Query Source",
+                      "Columns": [ { "Id": 11, "Name": "Code_Col", "SourceColumn": "Code" } ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private static string? MaskOf(int queryId, string property)
+    {
+        var design = RecordPatches.TryBuildQueryMetadataEquivalenceDesign(queryId);
+        Assert.True(design is not null, $"the runner built no MetaQuery design for query {queryId}");
+        return design!.GetType()
+            .GetProperty(property, BindingFlags.Public | BindingFlags.Instance)!
+            .GetValue(design)?.ToString();
+    }
+
+    /// <summary>
+    /// A payload written by a build that predates the two members is not served warm: the shape
+    /// change moves the on-disk location, so the current build misses, re-parses, and derives
+    /// the masks the stale payload could not have supplied.
+    /// </summary>
+    [Fact]
+    public void A_payload_written_before_QuerySymbol_gained_the_masks_is_not_served_warm()
+    {
+        var appPath = Path.Combine(_root, "warm-query.app");
+        using (var zip = new FileStream(appPath, FileMode.Create))
+        using (var za = new ZipArchive(zip, ZipArchiveMode.Create))
+        {
+            var entry = za.CreateEntry("SymbolReference.json");
+            using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+            w.Write(SymbolReference);
+        }
+
+        BcAppSymbolCache.ResetProcessCacheForTests();
+        var contentHash = BcAppSymbolCache.ComputeAppContentHash(appPath);
+
+        // The shape a build WITHOUT the two members produced — origin/main at 487c5925.
+        // Hardcoded rather than read from the live fingerprint: an expression that moves with
+        // the constant keeps planting the payload wherever the constant points, and the test
+        // then passes even when the change is reverted.
+        const string ShapeBeforeTheMasksWereAdded = "b82cf78cd0b9123a";
+        Assert.NotEqual(ShapeBeforeTheMasksWereAdded, BcAppSymbolCache.PayloadShapeForTests);
+
+        var stalePath = BcAppSymbolCache.CachePathForShapeForTests(
+            appPath, contentHash, BcAppSymbolCache.CacheVersionForTests, ShapeBeforeTheMasksWereAdded);
+        Directory.CreateDirectory(Path.GetDirectoryName(stalePath)!);
+
+        // A pre-fix payload: the query is present with its structure intact, and BOTH masks are
+        // absent from the record — exactly what a machine that ran the old build holds now.
+        File.WriteAllText(stalePath, $$"""
+            {
+              "ContentHash": "{{contentHash}}",
+              "Tables": [], "Enums": [],
+              "Queries": [
+                { "Id": {{DirectExecute}}, "Name": "Warm Direct Execute", "QueryType": null,
+                  "Caption": null, "OrderBy": null, "TopNumberOfRowsToReturn": 0,
+                  "DataItems": [] }
+              ],
+              "Objects": [], "Reports": null, "Pages": null
+            }
+            """);
+
+        Assert.Equal(0, BcAppSymbolCache.ParseInvocationCountForTests(appPath));
+
+        RecordPatches.ResetForReload();
+        RecordPatches.AddBcAppPath(appPath);
+
+        // The decisive assertion: the mask is derived, which the stale payload cannot supply —
+        // it does not carry the member at all, so serving it would answer None.
+        Assert.Equal("Execute", MaskOf(DirectExecute, "InherentEntitlements"));
+        Assert.Equal(1, BcAppSymbolCache.ParseInvocationCountForTests(appPath));
+
+        // The test's own premise, asserted rather than assumed: a shape change MOVES the
+        // on-disk location, it does not patch the old file.
+        var currentPath = BcAppSymbolCache.CachePathForShapeForTests(
+            appPath, contentHash, BcAppSymbolCache.CacheVersionForTests, BcAppSymbolCache.PayloadShapeForTests);
+        Assert.NotEqual(stalePath, currentPath);
+        Assert.True(File.Exists(currentPath),
+            $"expected a fresh cache entry at the current-shape path {currentPath}");
+
+        // And the SECOND read — the actual warm run — answers the same thing, from that fresh
+        // entry rather than by parsing again. Caption is asserted here too: it is derived in the
+        // BUILDER rather than the parse, so a HIT that restored the record correctly could still
+        // answer wrongly if the derivation sat on the parse side.
+        BcAppSymbolCache.ResetProcessCacheForTests();
+        RecordPatches.ResetForReload();
+        RecordPatches.AddBcAppPath(appPath);
+        Assert.Equal("Execute", MaskOf(DirectExecute, "InherentEntitlements"));
+        Assert.Equal("Execute", MaskOf(DirectExecute, "InherentPermissions"));
+        Assert.Equal("Warm Direct Execute", MaskOf(DirectExecute, "Caption"));
+    }
+}

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -882,9 +882,17 @@ internal static partial class BcAppSymbolCache
     // dataitem(s) live under the query's "Elements", nested dataitems under "DataItems".
     // Column/Filter Id is the BC-compiler-assigned column id baked into precompiled callers
     // (NavQuery.ValidateExpectedType(columnId,...)/GetColumnValueSafe) — it MUST be used verbatim.
+    // InherentEntitlements / InherentPermissions (#3798) are carried as the AL mask LETTER
+    // string, decoded by the consumer — case-significant, for the reason the codeunit sweep in
+    // VisitSymbolContainer states. Measured on the query population specifically (BC
+    // 28.4.53241.54407, Base Application + System Application): 6 of 161 queries state a mask
+    // and all 6 spell it "X". No lowercase form occurs on this kind, so the decoder's indirect
+    // bits are unexercised here — which is why the value is carried verbatim rather than
+    // normalised, instead of resting on a population that happens not to need it.
     internal sealed record QuerySymbol(
         int Id, string Name, string? QueryType, string? Caption, string? OrderBy,
-        int TopNumberOfRowsToReturn, List<QueryDataItemSymbol> DataItems);
+        int TopNumberOfRowsToReturn, List<QueryDataItemSymbol> DataItems,
+        string? InherentEntitlements = null, string? InherentPermissions = null);
 
     // DataItemTableFilter (#3571) is the AL `DataItemTableFilter = <Field> = const(...)/
     // filter(...) [, ...]` property, carried verbatim ("Status = const(Open)"). It restricts the
@@ -2289,6 +2297,9 @@ internal static partial class BcAppSymbolCache
         props.TryGetValue("QueryType", out var queryType);
         props.TryGetValue("Caption", out var caption);
         props.TryGetValue("OrderBy", out var orderBy);
+        // #3798 — carried verbatim; the letters are case-significant (see QuerySymbol's comment).
+        props.TryGetValue("InherentEntitlements", out var inherentEntitlements);
+        props.TryGetValue("InherentPermissions", out var inherentPermissions);
         int top = 0;
         if (props.TryGetValue("TopNumberOfRows", out var topText) && int.TryParse(topText, out var t)) top = t;
 
@@ -2300,7 +2311,9 @@ internal static partial class BcAppSymbolCache
                 var di = TryParseQueryDataItem(el);
                 if (di != null) dataItems.Add(di);
             }
-        return new QuerySymbol(queryId, name, queryType, caption, orderBy, top, dataItems);
+        return new QuerySymbol(queryId, name, queryType, caption, orderBy, top, dataItems,
+            string.IsNullOrWhiteSpace(inherentEntitlements) ? null : inherentEntitlements.Trim(),
+            string.IsNullOrWhiteSpace(inherentPermissions) ? null : inherentPermissions.Trim());
     }
 
     private static QueryDataItemSymbol? TryParseQueryDataItem(JsonElement el)

--- a/AlRunner/Patches/RecordPatches.NclMetaQueryBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaQueryBuilder.cs
@@ -182,7 +182,7 @@ public static partial class RecordPatches
         SetProp(mq, "ReadState", "ReadUncommitted");
         SetProp(mq, "QueryType", string.IsNullOrEmpty(sym.QueryType) ? "Normal" : sym.QueryType!);
         SetProp(mq, "TopNumberOfRowsToReturn", sym.TopNumberOfRowsToReturn);
-        if (!string.IsNullOrEmpty(sym.Caption)) TrySetProp(mq, "Caption", sym.Caption);
+        ApplyDerivableQueryProperties(mq, sym);
 
         // Flatten the dataitem tree (root first, then nested) into the flat DataItems list.
         // resultColumnIndex is shared across all dataitems (filters do NOT consume a slot).
@@ -374,6 +374,75 @@ public static partial class RecordPatches
         return mq;
     }
 
+    /// <summary>
+    /// The query-level properties BC's emitter states that the SymbolReference derivation was
+    /// leaving at their design-object defaults (#3798). Three sources, and the difference
+    /// matters when reading the assertions:
+    ///
+    /// <list type="bullet">
+    /// <item><b>Caption tracks Name</b>, never the declared caption. BC's emitter writes no
+    /// <c>&lt;Caption&gt;</c> element at all — 0 of 1,218 documents in the System Application
+    /// ground-truth bundle carry one, against 113 carrying <c>&lt;CaptionML&gt;</c> — and
+    /// feeding BC's own reader a synthesised document shows it setting Caption from
+    /// <c>&lt;Name&gt;</c> while ignoring both a <c>&lt;Caption&gt;</c> element and a
+    /// disagreeing <c>&lt;CaptionML&gt;</c>. Query 777 is the case that settles it: the symbol
+    /// file says "RoleCenter from Plans", BC answers "Role Center from Plans" (the name).</item>
+    /// <item><b>The two inherent masks</b> come from the symbol file's own letter string,
+    /// decoded by the shared <see cref="TryDecodePermissionMaskLetters"/> so the case-sensitive
+    /// spelling cannot drift from the codeunit direction.</item>
+    /// <item><b>HelpLink and the three empty strings</b> are constants BC's emitter writes
+    /// unconditionally — identical on all 7 queries of the bundle.</item>
+    /// </list>
+    ///
+    /// <para>Deliberately NOT set here: <c>APIVersion</c>, which BC answers "beta" for 4 of the
+    /// 7 and null for the 3 declaring <c>Access = Internal</c>, with nothing stated in the
+    /// symbol file either way — the correlation is real on a population of 7 and the mechanism
+    /// is unmeasured, so it stays on #3798 rather than being guessed. <c>CaptionML</c> needs a
+    /// MultiLanguage whose language id would be invented, and <c>RuntimeInfo</c> is read-only on
+    /// the design object.</para>
+    ///
+    /// <para>See docs/metadata-equivalence.md#queries.</para>
+    /// </summary>
+    private static void ApplyDerivableQueryProperties(object mq, BcAppSymbolCache.QuerySymbol sym)
+    {
+        // BC's reader sets Caption from the document's <Name>, so the runner states the name
+        // too. The declared caption reaches AL through CaptionML, which this design object does
+        // not carry — writing it into Caption would answer something BC never answers.
+        if (!string.IsNullOrEmpty(sym.Name)) TrySetProp(mq, "Caption", sym.Name);
+
+        // SetProp, not TrySetProp: these two are what AL observes as the query's inherent
+        // permission, and both are measured present on every BC build a leg runs. TrySetProp
+        // swallows a missing property, which would turn a Types.dll shape change back into the
+        // silent None this fixes rather than a loud failure (loud-failures.md).
+        if (TryDecodePermissionMaskLetters(sym.InherentEntitlements, out var entitlements))
+            SetProp(mq, "InherentEntitlements", entitlements);
+        if (TryDecodePermissionMaskLetters(sym.InherentPermissions, out var permissions))
+            SetProp(mq, "InherentPermissions", permissions);
+
+        TrySetProp(mq, "HelpLink", QueryHelpLink);
+        // BC writes <QueryCategory/>, <APIGroup/> and <APIPublisher/> — an EMPTY element, which
+        // its reader turns into "" rather than null. The design object's own default is already
+        // "", so these are stated for the same reason the others are: the property is set from
+        // one place, and a future default change cannot silently reopen the difference.
+        TrySetProp(mq, "QueryCategory", string.Empty);
+        TrySetProp(mq, "APIGroup", string.Empty);
+        TrySetProp(mq, "APIPublisher", string.Empty);
+    }
+
+    /// <summary>
+    /// The documentation URL BC's emitter writes into every query document unconditionally —
+    /// identical on all 7 queries of the System Application ground-truth bundle, and not read
+    /// from anything the AL declares.
+    /// </summary>
+    private const string QueryHelpLink = "https://learn.microsoft.com/dynamics365/business-central/";
+
+    /// <summary>
+    /// The operator BC states on every <c>&lt;DataItemLink&gt;</c> it emits. AL has no syntax
+    /// for anything but equality today, so the constant is faithful rather than a guess — and
+    /// leaving it null made the runner's link disagree with BC's on all 4 links in the bundle.
+    /// </summary>
+    private const string DataItemLinkEqualsOperator = "=";
+
     // Depth-first flatten: root dataitem(s) then their nested children, preserving order so
     // the engine reconstructs the join tree (root=None, child join types follow).
     private static IEnumerable<BcAppSymbolCache.QueryDataItemSymbol> FlattenDataItems(
@@ -466,6 +535,9 @@ public static partial class RecordPatches
         SetProp(dl, "SourceDataItemName", sourceDataItem);
         SetProp(dl, "SourceFieldNo", srcFieldNo);
         SetProp(dl, "DestinationFieldNo", destFieldNo);
+        // #3798 — the equality this method just parsed, stated the way BC states it. The
+        // property was left null while BC answered "=" on every link it emits.
+        TrySetProp(dl, "LinkOperator", DataItemLinkEqualsOperator);
         return dl;
     }
 

--- a/docs/metadata-equivalence.md
+++ b/docs/metadata-equivalence.md
@@ -865,46 +865,78 @@ than a case to handle.
 
 ### What the query comparison found
 
-7 queries, **616 differences**, of which 553 are the seven already-declared `TranslationKey.*`
-members — they match on signature, so a query carries them like any other object. The real
-remainder is **63 differences across 12 members**.
+7 queries, and the structural result is the strongest the harness has produced for any kind.
 
 **Every structural member agrees exactly** — zero differences on `MetaQueryColumn.*`,
 `MetaQueryDataItem.*` and `MetaQueryOrderBy.*`, including every compiler-assigned column id,
 `FieldNo`, `ColumnType`, `MethodType`, `QueryColumnIndex`, `DataItemLinkType` and
-`DataItemTable`. That is the strongest positive result the harness has produced for any kind,
-and `The_query_structural_tree_still_agrees_with_BC_exactly` pins it: those ids are handed
-verbatim to `NavQuery.ValidateExpectedType` and `GetColumnByNo` by precompiled callers, so a
-regression is an AL-visible wrong answer.
+`DataItemTable`. `The_query_structural_tree_still_agrees_with_BC_exactly` pins it: those ids are
+handed verbatim to `NavQuery.ValidateExpectedType` and `GetColumnByNo` by precompiled callers,
+so a regression is an AL-visible wrong answer.
 
-| member | x | BC | runner | derivable from |
-|---|---:|---|---|---|
-| `MetaQuery.InherentEntitlements` | 4 | `Execute` | `None` | `InherentEntitlements = "X"`, 4 of 4 |
-| `MetaQuery.InherentPermissions` | 4 | `Execute` | `None` | `InherentPermissions = "X"`, 4 of 4 |
-| `MetaQuery.Caption` | 4 | see below | see below | both sides, see below |
-| `MetaQuery.HelpLink` | 7 | the docs URL | `<null>` | a constant BC writes unconditionally |
-| `MetaQuery.APIGroup` / `APIPublisher` / `QueryCategory` | 7 each | `<empty>` | `<null>` | a null/empty distinction only |
-| `MetaQuery.APIVersion` | 4 | `beta` | `<null>` | a constant on non-API queries |
-| `MetaQuery.RuntimeInfo.<presence>` | 7 | present | `<null>` | not stated in the symbol file |
-| `MetaQuery.CaptionML.<presence>` (+`#captionML`) | 4 + 4 | present | `<null>` | the flat `Caption`, plus the language id |
-| `MetaQueryDataItemLink.LinkOperator` | 4 | `=` | `<null>` | stated in BC's document; AL has no other operator |
+The query-level scalars did not agree, and #3798 closed eight of the twelve members that
+differed. Measured on BC 28.1.49838.53910: **35 non-`TranslationKey` differences across 12
+members, now 19 across 4.**
 
-`Caption` is two different situations, which is why it is tracked rather than called a defect in
-one direction:
+#### The eight #3798 closed
+
+| member | x | BC | derived from |
+|---|---:|---|---|
+| `MetaQuery.InherentEntitlements` | 4 | `Execute` | `InherentEntitlements = "X"` in the symbol file |
+| `MetaQuery.InherentPermissions` | 4 | `Execute` | `InherentPermissions = "X"` in the symbol file |
+| `MetaQuery.Caption` | 4 | the object **name** | `Name` — see below |
+| `MetaQuery.HelpLink` | 7 | the docs URL | a constant BC writes unconditionally |
+| `MetaQuery.APIGroup` / `APIPublisher` / `QueryCategory` | 7 each | `<empty>` | the same, as `""` |
+| `MetaQueryDataItemLink.LinkOperator` | 4 | `=` | a constant; AL has no other operator |
+
+The two masks decode through `RecordPatches.TryDecodePermissionMaskLetters`, shared with the
+codeunit direction so the **case-sensitive** spelling cannot drift: uppercase is the direct bit,
+lowercase the indirect bit at n+5, so `"X"` is 16 and `"x"` is 512. Measured on the query
+population specifically — BC 28.4.53241.54407, Base Application (154 queries) + System
+Application (7) — **6 of 161 queries state a mask and all 6 spell it `"X"`**. No lowercase form
+occurs on this kind in Microsoft's shipped packages, which is why
+`QuerySymbolDerivedMetaQueryPropertiesTests` asserts `"x"` and `"rX"` from a fixture: the shared
+decoder's indirect-bit path is otherwise unexercised by every query in every Microsoft app.
+
+<a id="query-caption-tracks-name"></a>
+#### `MetaQuery.Caption` answers the NAME, not the declared caption
+
+This was recorded as a case where the runner might be right, and the measurement inverts it.
 
 ```
 Query 777  Name='Role Center from Plans'  CaptionML='ENU=RoleCenter from Plans'
            symbol Caption='RoleCenter from Plans'
-           BC's MetaQuery.Caption = 'Role Center from Plans'   runner = 'RoleCenter from Plans'
-Query 8888 Name='Outbox Emails'  no CaptionML at all  symbol states no Caption
-           BC's MetaQuery.Caption = 'Outbox Emails'            runner = <null>
+           BC's MetaQuery.Caption = 'Role Center from Plans'   (the NAME)
 ```
 
-On 777 BC's `Caption` property reports the object **name** while the runner reports the
-**declared caption** — which is what both the symbol file and BC's own `CaptionML` say. On
-8888/8889/8890 nothing is declared and BC falls back to `Name`. Both are derivable; which is
-correct depends on what AL observes through this property, and that is worth settling before
-changing anything. All of it is tracked on **#3798**.
+BC's emitter writes **no `<Caption>` element at all** — 0 of the System Application bundle's
+1,218 documents carry one, against 113 carrying `<CaptionML>` — so the property cannot be coming
+from a declared caption on any object of any kind. Feeding BC's own `MetaQuery(XmlNode,0,0)`
+synthesised documents isolates what does drive it:
+
+| document | `Caption` |
+|---|---|
+| `<Name>My Name</Name>` | `My Name` |
+| `<Name>My Name</Name><CaptionML>ENU=My Caption</CaptionML>` | `My Name` — the ML is ignored |
+| `<Name>My Name</Name><Caption>My Caption</Caption>` | `My Name` — the element is ignored |
+| `<CaptionML>ENU=My Caption</CaptionML>`, no `<Name>` | `` (empty) |
+
+So `Caption` tracks `Name` unconditionally on the document route, and the declared caption
+reaches AL through `CaptionML` instead — which is why that member stays open below. Writing the
+symbol file's caption into `Caption` answered something BC never answers, on **both** of the two
+situations rather than only the three undeclared ones.
+
+#### The four still open
+
+| member | x | BC | runner | why it is not a straight fix |
+|---|---:|---|---|---|
+| `MetaQuery.APIVersion` | 4 | `beta` | `<null>` | the symbol file states it for none of the 7; BC assigns it, and the split correlates exactly with `Access = Internal` on a population of 7 — a correlation, not a measured mechanism |
+| `MetaQuery.RuntimeInfo.<presence>` | 7 | present | `<null>` | **read-only** on the design object (`CanWrite=false`), so the SymbolReference route cannot state it; BC's constructor builds it while parsing |
+| `MetaQuery.CaptionML.<presence>` (+`#captionML`) | 4 + 4 | present | `<null>` | needs a `MultiLanguage` with a language id the symbol file's flat string does not carry |
+
+`APIVersion` is the one worth re-measuring on a wider population: four queries declaring no
+`Access` get `beta` and three declaring `Access = Internal` get nothing, which is suggestive and
+not established. All four are tracked on **#3798**.
 
 <a id="xmlports"></a>
 ## XmlPorts

--- a/tests/expectations/metadata-equivalence/allowlist.json
+++ b/tests/expectations/metadata-equivalence/allowlist.json
@@ -1242,80 +1242,28 @@
       "versionContingent": true
     },
     {
-      "member": "MetaQuery.InherentEntitlements",
-      "reason": "Measured on BC 28.1.49838.53910 over System Application's 7 queries (#3782 step 3), comparing BC's own MetaQuery(XmlNode,0,0) against the runner's own MetaQuery design object -- the one NCLMetaQuery.CreateDynamicQuery consumes, so this is what AL gets. BC answers Execute, the runner answers the enum default None. SymbolReference.json states InherentEntitlements with value 'X' for 4 of the 7 queries and BC answers Execute for exactly those 4 -- presence agrees 4 of 4. The 'X' mask spelling is the one RecordPatches.CodeunitMetadataFromBcDocument.cs already parses from BC's document, and #3788 records the same finding on the codeunit side. NOT direction-scoped: None is BC's own enum default, a real value rather than absent, so bc-only would not match it.",
-      "issue": 3798,
-      "Doc": "docs/metadata-equivalence.md#queries",
-      "versionContingent": true
-    },
-    {
-      "member": "MetaQuery.InherentPermissions",
-      "reason": "Measured on BC 28.1.49838.53910 over System Application's 7 queries (#3782 step 3), comparing BC's own MetaQuery(XmlNode,0,0) against the runner's own MetaQuery design object -- the one NCLMetaQuery.CreateDynamicQuery consumes, so this is what AL gets. BC answers Execute, the runner answers None. Same measurement as InherentEntitlements: the symbol file states InherentPermissions='X' for 4 of 7 and presence agrees 4 of 4. NOT direction-scoped, for the same reason.",
-      "issue": 3798,
-      "Doc": "docs/metadata-equivalence.md#queries",
-      "versionContingent": true
-    },
-    {
-      "member": "MetaQuery.Caption",
-      "reason": "Measured on BC 28.1.49838.53910 over System Application's 7 queries (#3782 step 3), comparing BC's own MetaQuery(XmlNode,0,0) against the runner's own MetaQuery design object -- the one NCLMetaQuery.CreateDynamicQuery consumes, so this is what AL gets. Four differences and they are TWO different situations, which is why this is tracked rather than called a defect in one direction. On query 777 BC answers 'Role Center from Plans' (the object NAME) while the runner answers 'RoleCenter from Plans' -- which is what the symbol file states AND what BC's own <CaptionML> states, so the runner is reporting the declared caption and BC's Caption property is reporting the name. On 8888/8889/8890 nothing is declared, BC's document carries no <CaptionML> at all, BC falls back to Name and the runner answers null. Both are derivable; which is correct depends on what AL observes through this property, and that is worth settling before changing anything.",
-      "issue": 3798,
-      "Doc": "docs/metadata-equivalence.md#queries",
-      "versionContingent": true
-    },
-    {
-      "member": "MetaQuery.HelpLink",
-      "reason": "Measured on BC 28.1.49838.53910 over System Application's 7 queries (#3782 step 3). BC's emitter ASSIGNS this rather than copying it from AL, and SymbolReference.json states nothing for it -- checked per query, not inferred from the member's name. Not underivable: three of these are constants BC writes unconditionally and could be set without reading anything. Tracked rather than declared permanent. This member is the docs URL BC's emitter writes unconditionally -- identical on all 7 queries.",
-      "issue": 3798,
-      "Doc": "docs/metadata-equivalence.md#queries"
-    },
-    {
-      "member": "MetaQuery.APIGroup",
-      "reason": "Measured on BC 28.1.49838.53910 over System Application's 7 queries (#3782 step 3). BC's emitter ASSIGNS this rather than copying it from AL, and SymbolReference.json states nothing for it -- checked per query, not inferred from the member's name. Not underivable: three of these are constants BC writes unconditionally and could be set without reading anything. Tracked rather than declared permanent. This member is BC writes <empty> and the runner leaves null; a null/empty distinction only.",
-      "issue": 3798,
-      "Doc": "docs/metadata-equivalence.md#queries"
-    },
-    {
-      "member": "MetaQuery.APIPublisher",
-      "reason": "Measured on BC 28.1.49838.53910 over System Application's 7 queries (#3782 step 3). BC's emitter ASSIGNS this rather than copying it from AL, and SymbolReference.json states nothing for it -- checked per query, not inferred from the member's name. Not underivable: three of these are constants BC writes unconditionally and could be set without reading anything. Tracked rather than declared permanent. This member is BC writes <empty> and the runner leaves null.",
-      "issue": 3798,
-      "Doc": "docs/metadata-equivalence.md#queries"
-    },
-    {
-      "member": "MetaQuery.QueryCategory",
-      "reason": "Measured on BC 28.1.49838.53910 over System Application's 7 queries (#3782 step 3). BC's emitter ASSIGNS this rather than copying it from AL, and SymbolReference.json states nothing for it -- checked per query, not inferred from the member's name. Not underivable: three of these are constants BC writes unconditionally and could be set without reading anything. Tracked rather than declared permanent. This member is BC writes <empty> and the runner leaves null.",
-      "issue": 3798,
-      "Doc": "docs/metadata-equivalence.md#queries"
-    },
-    {
       "member": "MetaQuery.APIVersion",
-      "reason": "Measured on BC 28.1.49838.53910 over System Application's 7 queries (#3782 step 3). BC's emitter ASSIGNS this rather than copying it from AL, and SymbolReference.json states nothing for it -- checked per query, not inferred from the member's name. Not underivable: three of these are constants BC writes unconditionally and could be set without reading anything. Tracked rather than declared permanent. This member is BC writes 'beta' on the 4 non-API queries and the runner leaves null.",
+      "reason": "Measured on BC 28.1.49838.53910 over System Application's 7 queries, re-measured after #3798 landed the eight members that WERE derivable. BC answers 'beta' for the 4 queries that declare no Access property and <null> for the 3 declaring Access = Internal, while SymbolReference.json states no APIVersion for ANY of the 7 -- checked per query in the shipped symbol file, not inferred from the member's name, and confirmed against the AL sources the app ships (no query declares the property). So BC ASSIGNS this and the split correlates exactly with Access, but the correlation rests on a population of 7 and the mechanism is unmeasured: nothing establishes that Access is what drives it rather than something else those 4 share. #3798 deliberately did not guess it. Settling it needs a population declaring Access and APIVersion independently.",
       "issue": 3798,
       "Doc": "docs/metadata-equivalence.md#queries",
       "versionContingent": true
     },
     {
       "member": "MetaQuery.RuntimeInfo.<presence>",
-      "reason": "Measured on BC 28.1.49838.53910 over System Application's 7 queries (#3782 step 3). BC's emitter ASSIGNS this rather than copying it from AL, and SymbolReference.json states nothing for it -- checked per query, not inferred from the member's name. Not underivable: three of these are constants BC writes unconditionally and could be set without reading anything. Tracked rather than declared permanent. This member is the MetaRuntimeInfo BC attaches to every query; the runner's design object has none.",
+      "reason": "Measured on BC 28.1.49838.53910 over System Application's 7 queries, re-measured after #3798. The MetaRuntimeInfo BC attaches to every query; the runner's design object has none. NOT derivable the way this issue's other members were, and the reason is mechanical rather than a missing input: Types.Metadata.MetaQuery.RuntimeInfo is READ-ONLY on the design object (CanWrite=false, measured through the property directly), so the SymbolReference route cannot state it at all -- BC's own constructor builds it while parsing the document. Closing it means constructing a MetaRuntimeInfo, which is the same work the codeunit <Methods> gap needs, and it is tracked with that rather than here.",
       "issue": 3798,
       "Doc": "docs/metadata-equivalence.md#queries"
     },
     {
       "member": "MetaQuery.CaptionML.<presence>",
-      "reason": "Measured on BC 28.1.49838.53910 over System Application's 7 queries (#3782 step 3), comparing BC's own MetaQuery(XmlNode,0,0) against the runner's own MetaQuery design object -- the one NCLMetaQuery.CreateDynamicQuery consumes, so this is what AL gets. This member is the MultiLanguage caption object. BC builds it from the document's <CaptionML>ENU=...; the runner sets the flat Caption string and no MultiLanguage, so rendering one would mean inventing the language id. Derivable (BC states only ENU/1033 across all 7) and deliberately not guessed. Four occurrences: the three queries declaring no caption have none on either side.",
+      "reason": "Measured on BC 28.1.49838.53910 over System Application's 7 queries, re-measured after #3798 settled the sibling Caption member. This is the MultiLanguage caption object, and it is where the DECLARED caption actually reaches AL: BC's MetaQuery.Caption tracks the object NAME unconditionally (0 of the bundle's 1,218 emitted documents state a <Caption> element at all, and feeding BC's reader a synthesised document shows it ignoring both a <Caption> element and a disagreeing <CaptionML>), so #3798 set Caption from Name and left this one open. BC builds it from the document's <CaptionML>ENU=...; the runner would have to construct a MultiLanguage and state a language id. Derivable in principle -- BC states only ENU/1033 across all 7 -- and deliberately not guessed, because the symbol file's flat Caption string carries no language at all and inventing 1033 would state something the input does not. Four occurrences: the three queries declaring no caption have none on either side.",
       "issue": 3798,
       "Doc": "docs/metadata-equivalence.md#queries",
       "versionContingent": true
     },
     {
       "member": "MetaQuery.#captionML.<presence>",
-      "reason": "Measured on BC 28.1.49838.53910 over System Application's 7 queries (#3782 step 3), comparing BC's own MetaQuery(XmlNode,0,0) against the runner's own MetaQuery design object -- the one NCLMetaQuery.CreateDynamicQuery consumes, so this is what AL gets. This member is the field backing CaptionML -- the SAME object under a second signature, because BC backs the property with it and the differ walks both. BC builds it from the document's <CaptionML>ENU=...; the runner sets the flat Caption string and no MultiLanguage, so rendering one would mean inventing the language id. Derivable (BC states only ENU/1033 across all 7) and deliberately not guessed. Four occurrences: the three queries declaring no caption have none on either side.",
-      "issue": 3798,
-      "Doc": "docs/metadata-equivalence.md#queries",
-      "versionContingent": true
-    },
-    {
-      "member": "MetaQueryDataItemLink.LinkOperator",
-      "reason": "Measured on BC 28.1.49838.53910 over System Application's 7 queries (#3782 step 3), comparing BC's own MetaQuery(XmlNode,0,0) against the runner's own MetaQuery design object -- the one NCLMetaQuery.CreateDynamicQuery consumes, so this is what AL gets. BC answers '=' and the runner answers null, on all 4 dataitem links in the bundle. BC's document states it as <LinkOperator>=</LinkOperator> and ParseDataItemLink in RecordPatches.NclMetaQueryBuilder.cs does not set the property. AL has no syntax for any other operator today, so a constant would be faithful -- which is exactly why leaving it null is a defect rather than a scope boundary. The ONLY difference anywhere in the query structural tree: every column id, FieldNo, ColumnType, MethodType, QueryColumnIndex, DataItemLinkType and DataItemTable agrees exactly on all 7 queries.",
+      "reason": "The SAME object as MetaQuery.CaptionML under a second signature -- BC backs the property with a field and the differ walks both, so one absent caption object is reported twice. Declared separately because the allowlist matches on the signature; it clears with the same fix. See the CaptionML entry for why #3798 settled Caption from Name and left this open.",
       "issue": 3798,
       "Doc": "docs/metadata-equivalence.md#queries",
       "versionContingent": true


### PR DESCRIPTION
Closes #3798

Corpus-NA: precompiled-dependency route only — a corpus query is source-compiled, so `BuildMetaQueryDesign` returns BC's own captured document (#3608) before reaching the SymbolReference derivation this changes; verified at the call site, not assumed.

The runner's `MetaQuery` design object — the one `NCLMetaQuery.CreateDynamicQuery` consumes, so what AL actually gets — left twelve members at their defaults while BC's emitter states a value. **Eight are now derived, four stay tracked**, each with the reason it is not a straight fix.

Measured against BC's own ground truth: **35 non-`TranslationKey` differences across 12 members → 19 across 4.** Every structural member already agreed and still does.

## `Caption` — the member the issue asked to settle, and the answer inverts its reading

#3798 recorded query 777 as a case where *"the runner is arguably right"*: the symbol file says `Caption='RoleCenter from Plans'`, BC answers `'Role Center from Plans'` (the name), so the runner looked faithful to the declared caption.

It is not. Two measurements settle it:

- **BC's emitter writes no `<Caption>` element at all** — 0 of the System Application bundle's 1,218 documents carry one, against 113 carrying `<CaptionML>`. The property cannot be coming from a declared caption on any object of any kind.
- **Feeding BC's own `MetaQuery(XmlNode,0,0)` synthesised documents** isolates what does drive it:

| document | BC's `Caption` |
|---|---|
| `<Name>My Name</Name>` | `My Name` |
| `<Name>My Name</Name><CaptionML>ENU=My Caption</CaptionML>` | `My Name` — the ML is ignored |
| `<Name>My Name</Name><Caption>My Caption</Caption>` | `My Name` — the element is ignored |
| `<CaptionML>ENU=My Caption</CaptionML>`, no `<Name>` | `` (empty) |

So `Caption` tracks `Name` unconditionally, and the declared caption reaches AL through `CaptionML` — which stays open below, because rendering one means inventing a language id the symbol file's flat string does not carry. The runner was wrong on **both** of the issue's two situations, not right on one.

## The eight closed

| member | x | BC | derived from |
|---|---:|---|---|
| `InherentEntitlements` / `InherentPermissions` | 4 each | `Execute` | the `"X"` the symbol file states |
| `Caption` | 4 | the object **name** | `Name` |
| `HelpLink` | 7 | the docs URL | a constant BC writes unconditionally |
| `APIGroup` / `APIPublisher` / `QueryCategory` | 7 each | `<empty>` | the same, as `""` |
| `MetaQueryDataItemLink.LinkOperator` | 4 | `=` | a constant; AL has no other operator |

The masks reuse `RecordPatches.TryDecodePermissionMaskLetters` (#3917) rather than a second decoder, so the case-sensitive spelling cannot drift from the codeunit direction. `SetProp`, not `TrySetProp`, for those two: they are what AL observes, and `TrySetProp` swallows a missing property, which would turn a `Types.dll` shape change back into the silent `None` this fixes.

**I measured the mask population on queries rather than reusing the figure from #3788's thread** (which was corrected twice there). BC 28.4.53241.54407, Base Application (154) + System Application (7) = 161 queries: **6 state a mask and all 6 spell it `"X"`. No lowercase form occurs on this kind at all.** That is why the fixture asserts `"x"` and `"rX"` — the shared decoder's indirect-bit path is otherwise unexercised by every query in every Microsoft app.

## The four left open, and why each is not a guess away

- **`APIVersion`** — the symbol file states it for none of the 7, and the AL sources declare it nowhere. BC answers `beta` for the 4 with no `Access` property and nothing for the 3 declaring `Access = Internal`. That correlation is exact on a population of 7 and the **mechanism is unmeasured**; nothing establishes `Access` is what drives it. Deliberately not guessed.
- **`RuntimeInfo`** — **read-only on the design object** (`CanWrite=false`, measured directly), so the SymbolReference route cannot state it at all. Same work as the codeunit `<Methods>` gap.
- **`CaptionML` / `#captionML`** — needs a `MultiLanguage` with a language id the flat `Caption` string does not carry. BC states only ENU/1033 across all 7, so it is derivable in principle, and inventing 1033 would state something the input does not.

## RED → GREEN, and four mutations

`Failed: 4, Passed: 0` → `Failed: 0, Passed: 4` (`Total: 4` on both; each RED was an `Assert`, not `error CS`).

| mutation | result |
|---|---|
| collapse the mask case (`IndexOf(char.ToUpperInvariant(c))`) | `Failed: 1, Passed: 3` — `IndirectExecute` vs `Execute` |
| `Caption` back to the declared caption | `Failed: 1, Passed: 3` — the one-space difference on 777 |
| drop `LinkOperator` | `Failed: 1, Passed: 3` |
| drop the masks at the query parser | `Failed: 1, Passed: 3` |

Every mutation was confirmed to have **landed** and to have built with **0 `error CS`**.

**One mutation went green and it was my target, not the test.** Dropping the masks by replacing a `props.TryGetValue` pair matched `PageSymbol`'s parser first — `str.replace` hit the wrong of several identical pairs — and all 4 passed. Re-aimed at the unique `new QuerySymbol(...)` return with a `count(old)==1` assertion, it went red. Exactly the trap `tdd.md` records; recording it because a green mutation reads as a weak test and was not one.

## Cache: measured, no `CacheVersion` bump

`QuerySymbol` gained two members — a record **shape** change — so `PayloadShape` re-keys on its own. Read through the `PayloadShapeForTests` seam off both builds: **`b82cf78cd0b9123a` → `ba1a5b51c0906b10`**. `CacheVersion` stays 42.

`QuerySymbolDerivedPropertiesWarmCacheTests` keeps that a fact rather than a claim: it plants a pre-fix payload at the old-shape path and asserts the current build misses, re-parses, and derives masks the stale payload could not supply. **A fifth mutation** reverting the record to its pre-fix shape turned that test red (`Failed: 1, Passed: 0`) at the `NotEqual("b82cf78cd0b9123a")` assertion — so the shape really moved, and really moved back.

Cold and warm runs both green (`local-test-scope.md`: there is a cache between this parse and its observable).

## Fix the shape — the three questions

1. **Same wrong pattern at another call site?** **Yes, and it is filed as #3933.** `DependencyPageMetadataXml.EmitInherentMask` decodes with `char.ToUpperInvariant(c) switch`, a case-collapsing parse that answers 16 for `x` and 17 for `rX`. It is **latent**: measured across every shipped app at 28.4.53241.54407, pages carry 210 masks and **zero** lowercase, so nothing observable is wrong today and the page comparison is green on this member. Different file, different consumer, and no failing measurement for this PR's RED to move — so filed, not folded (`batch-sibling-issues-by-file.md`).
2. **Sibling function with the same assumption?** Tables carry **98** lowercase masks, by far the largest population — and nothing reads them: `BcAppSymbolCache.ParsedTable` has no mask field, so there is no decode to be wrong. A separate gap from #3933. Reports carry 2 masks, both `"X"`, tracked on #3808.
3. **Two paths writing the same state with different invariants?** Yes, and both now agree: the BC-document route (#3608) and the SymbolReference route both produce a `MetaQuery`, and the eight members above were stated by the first and defaulted by the second. That divergence is what the harness measured.

**Queue scan** (`search-for-the-same-defect-first.md`): searched `InherentEntitlements`, "permission mask case", and the metadata-conversion area. #3788 (codeunits, merged as #3917) and #3808 (reports) share the mask property on other kinds and land in other files; #3568 and #3562 are the wider programme. Nothing duplicates this.

## Also

- Removed the 8 converged allowlist entries; rewrote the 4 remaining with what is actually known, including the `CanWrite=false` fact for `RuntimeInfo` and the honest "correlation, not mechanism" statement for `APIVersion`.
- `docs/metadata-equivalence.md#queries` rewritten to the post-fix state, with the Caption derivation table under a `#query-caption-tracks-name` anchor.

## Ran

- new tests, cold and warm: `Failed: 0, Passed: 5`
- `MetadataEquivalence*` (harness against BC's ground truth): `Failed: 0, Passed: 38`
- `~GuardTests`: `Failed: 0, Passed: 249`
- `~BcAppSymbolCache|~Query|~MetaQuery`: `Failed: 0, Passed: 130`
- `for t in tools/test_*.py`: all pass

<sub>Implemented by the `impl-agent` `stma-auto-3`, an automated agent acting on the account holder's behalf.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
