### PR TITLE
fix(metadata): derive the three MetaReport properties SymbolReference.json states

### DIFF
--- a/AlRunner.Tests/ReportSymbolNamespaceAndInherentMaskTests.cs
+++ b/AlRunner.Tests/ReportSymbolNamespaceAndInherentMaskTests.cs
@@ -1,0 +1,278 @@
+// ReportSymbolNamespaceAndInherentMaskTests — the three report-level properties
+// SymbolReference.json states that the Report derivation was dropping (#3808).
+//
+// THE GAP
+//   BcAppSymbolCache's ReportSymbol carried neither the report's Namespaces tree path nor
+//   either inherent-permission mask, so DependencyReportMetadata.EmitReportXml wrote no
+//   <ALNamespace>, <InherentEntitlements> or <InherentPermissions> element. BC's own
+//   MetaReport(XmlElement, …) reader therefore left its constructor defaults behind — null
+//   for the namespace and PermissionMask.None for both masks — for every report living in a
+//   precompiled dependency.
+//
+// WHAT BC'S READER ACTUALLY TAKES, which is what these assertions are written against
+//   Read off MetaReport..ctor in Microsoft.Dynamics.Nav.Types.dll 28.1.49838.53910:
+//     ALNAMESPACE          -> ALNamespace = val.InnerText                       (verbatim)
+//     INHERENTENTITLEMENTS -> Enum.Parse(typeof(PermissionMask), val.InnerText)
+//     INHERENTPERMISSIONS  -> Enum.Parse(typeof(PermissionMask), val.InnerText)
+//   So the masks go out as the DECODED NUMBER, not the AL letter spelling: "X" is not a
+//   PermissionMask member and Enum.Parse would throw on it.
+//
+// THE POPULATION, stated honestly because the two halves differ
+//   Measured over every .app in ~/.al-runner/platform-apps at 28.1.49838.53910, walking the
+//   Namespaces tree (the flat top-level Reports array is empty in both apps that ship any):
+//     * ALNamespace     — 660 of 660 reports sit under a namespace (Base Application 659,
+//       System Application 1). NOT a population of one.
+//     * the two masks   — 1 of 660 states either, and it spells both "X" (report 9810).
+//   The issue's "n = 1" is the metadata-equivalence harness's loaded bundle, which excludes
+//   Base Application on cost; it is not the population of the symbol files themselves.
+//
+//   Because no shipped report states a lowercase or mixed-case mask, the decoder's indirect
+//   bits are unexercised by the real population — so the fixture below states them anyway
+//   (see LowercaseMask/MixedCaseMask), which is the point of reusing the shared decoder
+//   rather than writing a second one that happens to be right on "X".
+
+using System.IO.Compression;
+using System.Text;
+using System.Xml;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// #1821: BcAppSymbolCache.Get() resolves its on-disk path through the process-global CacheRoots
+// override, so this joins CacheRootsSerialCollection like its sibling report tests.
+[Collection(CacheRootsSerialCollection.Name)]
+public sealed class ReportSymbolNamespaceAndInherentMaskTests
+{
+    // Report 9810 "Change Password" as System Application 28.1.49838.53910 actually states it:
+    // nested two deep, ProcessingOnly = 1, UseRequestPage = 0, both masks "X".
+    private const int ChangePassword = 9810;
+    // Declares nothing at all — the negative direction for all three properties.
+    private const int DeclaresNothing = 9811;
+    // The decoder arms no shipped report reaches. "x" is indirect Execute (bit 4+5 = 512) and
+    // "rX" is indirect Read (32) | direct Execute (16) = 48 — a case-collapsing parse answers
+    // 16 and 17 for these, which is the defect #3933 tracks on the page side.
+    private const int LowercaseMask = 9812;
+    private const int MixedCaseMask = 9813;
+    // At the ROOT of the symbol file rather than in the Namespaces tree: a report that is
+    // genuinely outside every namespace must answer no namespace, not an invented one.
+    private const int RootLevel = 9814;
+
+    private static readonly string SymbolReference = $$"""
+        {
+          "RuntimeVersion": "15.1",
+          "AppId": "3f1a77c6-2a4e-4a1f-9d6c-51e0a7b4c8d2",
+          "Name": "Report Namespace Fixture",
+          "Reports": [
+            { "Id": {{RootLevel}}, "Name": "Root Level", "DataItems": [] }
+          ],
+          "Namespaces": [
+            {
+              "Name": "System",
+              "Namespaces": [
+                {
+                  "Name": "Security",
+                  "Namespaces": [
+                    {
+                      "Name": "AccessControl",
+                      "Reports": [
+                        {
+                          "Id": {{ChangePassword}},
+                          "Name": "Change Password",
+                          "DataItems": [],
+                          "Properties": [
+                            { "Name": "ProcessingOnly", "Value": "1" },
+                            { "Name": "UseRequestPage", "Value": "0" },
+                            { "Name": "InherentEntitlements", "Value": "X" },
+                            { "Name": "InherentPermissions", "Value": "X" }
+                          ]
+                        },
+                        { "Id": {{DeclaresNothing}}, "Name": "Declares Nothing", "DataItems": [] },
+                        {
+                          "Id": {{LowercaseMask}},
+                          "Name": "Lowercase Mask",
+                          "DataItems": [],
+                          "Properties": [
+                            { "Name": "InherentEntitlements", "Value": "x" }
+                          ]
+                        },
+                        {
+                          "Id": {{MixedCaseMask}},
+                          "Name": "Mixed Case Mask",
+                          "DataItems": [],
+                          "Properties": [
+                            { "Name": "InherentPermissions", "Value": "rX" }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private static string WriteApp(string dir)
+    {
+        var appPath = Path.Combine(dir, Guid.NewGuid().ToString("N") + ".app");
+        using var zip = new FileStream(appPath, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(SymbolReference);
+        return appPath;
+    }
+
+    private static XmlElement Emit(BcAppSymbolCache.ReportSymbol report)
+    {
+        var doc = new XmlDocument();
+        doc.LoadXml(RecordPatches.EmitReportXml(report, sourceExprByColumn: null));
+        return doc.DocumentElement!;
+    }
+
+    private static string? Element(XmlElement root, string name)
+        => root.SelectSingleNode(name) is XmlNode n ? n.InnerText : null;
+
+    /// <summary>
+    /// The symbol side: ReportSymbol carries the tree path and both mask letter strings. The
+    /// masks stay the LETTERS here — decoding them at parse time would throw away the case
+    /// distinction the consumer needs.
+    /// </summary>
+    [Fact]
+    public void TheSymbolCarriesTheNamespacePathAndBothMaskLettersVerbatim()
+    {
+        var dir = TestScratch.Dir("al-runner-report-namespace-mask");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var reports = BcAppSymbolCache.Get(WriteApp(dir)).Reports;
+
+            var changePassword = Assert.Single(reports, r => r.Id == ChangePassword);
+            Assert.Equal("System.Security.AccessControl", changePassword.ALNamespace);
+            Assert.Equal("X", changePassword.InherentEntitlements);
+            Assert.Equal("X", changePassword.InherentPermissions);
+
+            // Negative: a report stating no mask must carry null, never an empty string that
+            // would decode to a mask of 0 and read as a declared "no permissions".
+            var nothing = Assert.Single(reports, r => r.Id == DeclaresNothing);
+            Assert.Equal("System.Security.AccessControl", nothing.ALNamespace);
+            Assert.Null(nothing.InherentEntitlements);
+            Assert.Null(nothing.InherentPermissions);
+
+            // Case is preserved, which is the whole reason the letters are carried rather than
+            // a decoded int computed at parse time.
+            Assert.Equal("x", Assert.Single(reports, r => r.Id == LowercaseMask).InherentEntitlements);
+            Assert.Equal("rX", Assert.Single(reports, r => r.Id == MixedCaseMask).InherentPermissions);
+
+            // Negative: a report outside every namespace states none.
+            Assert.Null(Assert.Single(reports, r => r.Id == RootLevel).ALNamespace);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The document BC's reader actually consumes. <c>&lt;ALNamespace&gt;</c> is taken verbatim
+    /// and both masks are parsed as <c>PermissionMask</c>, so the numbers below are what BC
+    /// resolves to <c>Execute</c> — the value the issue measured BC answering while the runner
+    /// answered <c>None</c>.
+    /// </summary>
+    [Fact]
+    public void TheEmittedDocumentStatesTheNamespaceAndTheDecodedMasks()
+    {
+        var dir = TestScratch.Dir("al-runner-report-namespace-mask-xml");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var reports = BcAppSymbolCache.Get(WriteApp(dir)).Reports;
+
+            var changePassword = Emit(Assert.Single(reports, r => r.Id == ChangePassword));
+            Assert.Equal("System.Security.AccessControl", Element(changePassword, "ALNamespace"));
+            // "X" -> bit 4 -> 16, which PermissionMask names Execute.
+            Assert.Equal("16", Element(changePassword, "InherentEntitlements"));
+            Assert.Equal("16", Element(changePassword, "InherentPermissions"));
+            // The properties that already agreed must keep agreeing — this document is the
+            // whole runtime metadata for the report, not just the three new elements.
+            Assert.Equal("1", Element(changePassword, "ProcessingOnly"));
+            Assert.Equal("0", Element(changePassword, "UseRequestPage"));
+
+            // Negative: an unstated mask writes NO element, so BC's reader keeps its own
+            // default. Writing <InherentEntitlements>0</InherentEntitlements> would be a claim
+            // the symbol file never made.
+            var nothing = Emit(Assert.Single(reports, r => r.Id == DeclaresNothing));
+            Assert.Null(Element(nothing, "InherentEntitlements"));
+            Assert.Null(Element(nothing, "InherentPermissions"));
+            Assert.Equal("System.Security.AccessControl", Element(nothing, "ALNamespace"));
+
+            // The decoder arms no shipped report reaches, asserted so a case-collapsing
+            // reimplementation fails here rather than shipping: "x" is 512, not 16, and "rX"
+            // is 48, not 17.
+            Assert.Equal("512", Element(Emit(Assert.Single(reports, r => r.Id == LowercaseMask)),
+                "InherentEntitlements"));
+            Assert.Equal("48", Element(Emit(Assert.Single(reports, r => r.Id == MixedCaseMask)),
+                "InherentPermissions"));
+
+            // Negative: no namespace stated means no element, not an empty one.
+            Assert.Null(Element(Emit(Assert.Single(reports, r => r.Id == RootLevel)), "ALNamespace"));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// A mask letter the table does not name raises the shared decoder's shape gap rather than
+    /// contributing no bit — a mask short one letter is indistinguishable from a narrower
+    /// permission the report really declared (loud-failures.md). Pinned here because this is a
+    /// second entry point into that decoder.
+    /// </summary>
+    [Fact]
+    public void AnUnreadableMaskLetterRefusesRatherThanDroppingTheCharacter()
+    {
+        var dir = TestScratch.Dir("al-runner-report-mask-gap");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var appPath = Path.Combine(dir, "gap.app");
+            using (var zip = new FileStream(appPath, FileMode.Create))
+            using (var za = new ZipArchive(zip, ZipArchiveMode.Create))
+            {
+                var entry = za.CreateEntry("SymbolReference.json");
+                using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+                w.Write($$"""
+                    {
+                      "RuntimeVersion": "15.1",
+                      "Namespaces": [
+                        {
+                          "Name": "System",
+                          "Reports": [
+                            {
+                              "Id": {{ChangePassword}},
+                              "Name": "Bad Mask",
+                              "DataItems": [],
+                              "Properties": [
+                                { "Name": "InherentPermissions", "Value": "Q" }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                    """);
+            }
+
+            var report = Assert.Single(BcAppSymbolCache.Get(appPath).Reports);
+            var ex = Assert.ThrowsAny<Exception>(() => RecordPatches.EmitReportXml(report, null));
+            Assert.Contains("'Q'", ex.Message);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/AlRunner.Tests/ReportSymbolNamespaceWarmCacheTests.cs
+++ b/AlRunner.Tests/ReportSymbolNamespaceWarmCacheTests.cs
@@ -1,0 +1,180 @@
+// ReportSymbolNamespaceWarmCacheTests — the three members #3808 added to ReportSymbol are
+// re-derived rather than replayed from a cache entry written before they existed.
+//
+// WHY THIS IS A SEPARATE FILE FROM ReportSymbolNamespaceAndInherentMaskTests
+//   A test class belongs to exactly one xunit collection, and this one needs the CacheRoots
+//   override to itself. The sibling asserts what the derivation ANSWERS, where a concurrent
+//   override can only turn a HIT into a MISS and the content-addressed key makes a re-parse
+//   reach the same result. This test asserts the MISS ITSELF — through
+//   ParseInvocationCountForTests and through which on-disk path exists afterwards — and that
+//   distinction is exactly what another thread's override destroys.
+//
+// WHICH DISCRIMINATOR APPLIES, AND WHY NO CacheVersion BUMP IS IN THIS CHANGE
+//   BcAppSymbolCache is keyed on path|hash:<content>|v<CacheVersion>|shape:<PayloadShape>. A
+//   PARSE-only change (same record shape, different answer) is invisible to the fingerprint and
+//   needs the integer bumped. A RECORD-SHAPE change re-keys on its own.
+//
+//   This is the second, and it was MEASURED rather than reasoned: ReportSymbol gained three
+//   members and is reachable from CachePayload through AppSymbols.Reports, so PayloadShape moved
+//   from b82cf78cd0b9123a on origin/main to d8c3506849475c13 here — read through the
+//   PayloadShapeForTests seam off BOTH builds, not computed once and assumed to have changed.
+//   (b82cf78cd0b9123a is the value #3917 left behind, which is the cross-check that the seam was
+//   reading main rather than a stale build.) So no bump is correct, and this test is what keeps
+//   that a fact rather than a claim.
+
+using System.IO.Compression;
+using System.Text;
+using System.Xml;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Reads the on-disk cache directly and asserts a MISS, so it needs CacheRoots to itself — see
+// this file's header and CacheRootsSerialCollection.
+[Collection(CacheRootsSerialCollection.Name)]
+public sealed class ReportSymbolNamespaceWarmCacheTests : IDisposable
+{
+    private const int ChangePassword = 9810;
+
+    private readonly string _root;
+
+    public ReportSymbolNamespaceWarmCacheTests()
+    {
+        _root = TestScratch.Dir("al-runner-report-namespace-warm-cache");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        RecordPatches.ResetForReload();
+        BcAppSymbolCache.ResetProcessCacheForTests();
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private static readonly string SymbolReference = $$"""
+        {
+          "RuntimeVersion": "15.1",
+          "AppId": "6b2d9f10-7c84-4e2a-9f3b-2d1c5a8e7b40",
+          "Name": "Report Namespace Warm Cache Fixture",
+          "Namespaces": [
+            {
+              "Name": "System",
+              "Namespaces": [
+                {
+                  "Name": "Security",
+                  "Namespaces": [
+                    {
+                      "Name": "AccessControl",
+                      "Reports": [
+                        {
+                          "Id": {{ChangePassword}},
+                          "Name": "Change Password",
+                          "DataItems": [],
+                          "Properties": [
+                            { "Name": "ProcessingOnly", "Value": "1" },
+                            { "Name": "UseRequestPage", "Value": "0" },
+                            { "Name": "InherentEntitlements", "Value": "X" },
+                            { "Name": "InherentPermissions", "Value": "X" }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private static XmlElement Emit(BcAppSymbolCache.ReportSymbol report)
+    {
+        var doc = new XmlDocument();
+        doc.LoadXml(RecordPatches.EmitReportXml(report, sourceExprByColumn: null));
+        return doc.DocumentElement!;
+    }
+
+    private static string? Element(XmlElement root, string name)
+        => root.SelectSingleNode(name) is XmlNode n ? n.InnerText : null;
+
+    /// <summary>
+    /// The warm-cache half (local-test-scope.md): there IS a cache between this parse and its
+    /// observable — <c>BcAppSymbolCache</c> — so a fix correct cold can be wrong warm, which is
+    /// what #3908 and #3913 were. This plants a payload at the path a PRE-FIX build wrote to and
+    /// asserts the current build does not serve it; the fingerprint being part of the key is
+    /// otherwise invisible, because the key is hashed into a filename.
+    /// </summary>
+    [Fact]
+    public void A_payload_written_before_the_report_gained_these_members_is_not_served_warm()
+    {
+        var appPath = Path.Combine(_root, "warm-cache.app");
+        using (var zip = new FileStream(appPath, FileMode.Create))
+        using (var za = new ZipArchive(zip, ZipArchiveMode.Create))
+        {
+            var entry = za.CreateEntry("SymbolReference.json");
+            using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+            w.Write(SymbolReference);
+        }
+
+        BcAppSymbolCache.ResetProcessCacheForTests();
+        var contentHash = BcAppSymbolCache.ComputeAppContentHash(appPath);
+
+        // The shape a build WITHOUT the three members produced. Hardcoded rather than computed
+        // from the live fingerprint, for the reason the codeunit sibling hardcodes its own: an
+        // expression that moves with the constant keeps planting the payload wherever the
+        // constant points, and the test then passes even when the change is reverted.
+        const string ShapeBeforeTheMembersWereAdded = "b82cf78cd0b9123a";
+        Assert.NotEqual(ShapeBeforeTheMembersWereAdded, BcAppSymbolCache.PayloadShapeForTests);
+
+        var stalePath = BcAppSymbolCache.CachePathForShapeForTests(
+            appPath, contentHash, BcAppSymbolCache.CacheVersionForTests, ShapeBeforeTheMembersWereAdded);
+        Directory.CreateDirectory(Path.GetDirectoryName(stalePath)!);
+
+        // A pre-fix payload: the report is present, with every one of the three members absent —
+        // exactly what a machine that ran the old build has on disk right now.
+        File.WriteAllText(stalePath, $$"""
+            {
+              "ContentHash": "{{contentHash}}",
+              "Tables": [], "Enums": [], "Queries": [], "Objects": [],
+              "Reports": [
+                { "Id": {{ChangePassword}}, "Name": "Change Password", "Caption": null,
+                  "ProcessingOnly": true, "UseRequestPage": false, "WordMergeDataItem": null,
+                  "DataItems": [], "ReferenceSourceFileName": null }
+              ],
+              "Pages": []
+            }
+            """);
+
+        Assert.Equal(0, BcAppSymbolCache.ParseInvocationCountForTests(appPath));
+
+        // The decisive assertion: all three are derived, which the stale payload cannot supply —
+        // it does not carry the members at all. Serving it would answer null, null, null.
+        var report = Assert.Single(BcAppSymbolCache.Get(appPath).Reports);
+        Assert.Equal("System.Security.AccessControl", report.ALNamespace);
+        Assert.Equal("X", report.InherentEntitlements);
+        Assert.Equal("X", report.InherentPermissions);
+        Assert.Equal(1, BcAppSymbolCache.ParseInvocationCountForTests(appPath));
+
+        // The test's own premise, asserted rather than assumed: a shape change MOVES the on-disk
+        // location, it does not patch the old file.
+        var currentPath = BcAppSymbolCache.CachePathForShapeForTests(
+            appPath, contentHash, BcAppSymbolCache.CacheVersionForTests, BcAppSymbolCache.PayloadShapeForTests);
+        Assert.NotEqual(stalePath, currentPath);
+        Assert.True(File.Exists(currentPath),
+            $"expected a fresh cache entry at the current-shape path {currentPath}");
+
+        // And the SECOND read — the actual warm run — answers the same thing, from that fresh
+        // entry rather than by parsing again. The emitted document is asserted here too, because
+        // that is the observable BC's reader consumes and it is downstream of the cache.
+        BcAppSymbolCache.ResetProcessCacheForTests();
+        var warm = Assert.Single(BcAppSymbolCache.Get(appPath).Reports);
+        Assert.Equal(1, BcAppSymbolCache.ParseInvocationCountForTests(appPath));
+        Assert.Equal("System.Security.AccessControl", warm.ALNamespace);
+
+        var xml = Emit(warm);
+        Assert.Equal("System.Security.AccessControl", Element(xml, "ALNamespace"));
+        Assert.Equal("16", Element(xml, "InherentEntitlements"));
+        Assert.Equal("16", Element(xml, "InherentPermissions"));
+    }
+}

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -778,7 +778,20 @@ internal static partial class BcAppSymbolCache
         // symbol file states it. The runtime metadata synthesizer uses it to read back
         // that ONE file for the column source expressions the symbol file omits — see
         // DependencyReportMetadata.cs.
-        string? ReferenceSourceFileName = null);
+        string? ReferenceSourceFileName = null,
+        // The Namespaces TREE PATH the report was reached through, not a property: the
+        // symbol file states no such property, and Microsoft puts every report in the tree
+        // — measured on 28.1.49838.53910, 660 of 660 reports across Base Application (659)
+        // and System Application (1) sit under a namespace and both flat top-level Reports
+        // arrays are empty (#3808).
+        string? ALNamespace = null,
+        // Carried as the AL mask LETTER string, decoded by the consumer through the shared
+        // TryDecodePermissionMaskLetters — case-significant, so the value is NOT normalised
+        // here. Measured on the report population specifically (same bundle): 1 of 660
+        // reports states either mask, and it spells both "X". The decoder's indirect bits
+        // are therefore unexercised on this kind, which is the reason to carry the letters
+        // verbatim rather than rest on a population that happens not to need them.
+        string? InherentEntitlements = null, string? InherentPermissions = null);
 
     /// <summary>One entry of a report's data-item tree, flattened in declaration order.</summary>
     internal sealed record ReportDataItemSymbol(
@@ -1363,7 +1376,7 @@ internal static partial class BcAppSymbolCache
         {
             foreach (var r in reportArray.EnumerateArray())
             {
-                var parsed = TryParseReportSymbol(r);
+                var parsed = TryParseReportSymbol(r, alNamespace);
                 if (parsed != null && !reports.ContainsKey(parsed.Id))
                     reports[parsed.Id] = parsed;
             }
@@ -2169,7 +2182,9 @@ internal static partial class BcAppSymbolCache
     /// inferred here — a shape the symbol file does not state is left null/absent for the
     /// caller to default, never invented.
     /// </summary>
-    private static ReportSymbol? TryParseReportSymbol(JsonElement report)
+    /// <param name="alNamespace">The dotted <c>Namespaces</c> tree path this report was reached
+    /// through, or null at the root — the only source for its ALNamespace (#3808).</param>
+    private static ReportSymbol? TryParseReportSymbol(JsonElement report, string? alNamespace)
     {
         if (!report.TryGetProperty("Id", out var idProp) || !idProp.TryGetInt32(out var reportId) || reportId <= 0)
             return null;
@@ -2179,6 +2194,9 @@ internal static partial class BcAppSymbolCache
         var props = SymbolProperties(report);
         props.TryGetValue("Caption", out var caption);
         props.TryGetValue("WordMergeDataItem", out var wordMergeDataItem);
+        // #3808 — carried verbatim; the letters are case-significant (see ReportSymbol's comment).
+        props.TryGetValue("InherentEntitlements", out var inherentEntitlements);
+        props.TryGetValue("InherentPermissions", out var inherentPermissions);
         // AL defaults: ProcessingOnly false, UseRequestPage true. The symbol file only
         // states a property when the AL source declared it.
         bool processingOnly = props.TryGetValue("ProcessingOnly", out var po)
@@ -2194,7 +2212,10 @@ internal static partial class BcAppSymbolCache
             : null;
 
         return new ReportSymbol(reportId, name, caption, processingOnly, useRequestPage,
-            wordMergeDataItem, dataItems, referenceSourceFileName);
+            wordMergeDataItem, dataItems, referenceSourceFileName,
+            string.IsNullOrWhiteSpace(alNamespace) ? null : alNamespace.Trim(),
+            string.IsNullOrWhiteSpace(inherentEntitlements) ? null : inherentEntitlements.Trim(),
+            string.IsNullOrWhiteSpace(inherentPermissions) ? null : inherentPermissions.Trim());
     }
 
     /// <summary>

--- a/AlRunner/Patches/DependencyReportMetadata.cs
+++ b/AlRunner/Patches/DependencyReportMetadata.cs
@@ -262,6 +262,7 @@ public static partial class RecordPatches
             w.WriteElementString("MetadataVersion", "130000");
             w.WriteElementString("ID", report.Id.ToString(System.Globalization.CultureInfo.InvariantCulture));
             w.WriteElementString("Name", report.Name);
+            WriteDerivableReportProperties(w, report);
 
             foreach (var di in report.DataItems)
                 WriteDataItem(w, di, sourceExprByColumn);
@@ -269,6 +270,38 @@ public static partial class RecordPatches
             w.WriteEndElement();
         }
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// The three report-level properties SymbolReference.json states that this derivation was
+    /// leaving at BC's own design-object defaults (#3808) — <c>ALNamespace</c> (null) and both
+    /// inherent masks (<c>None</c>).
+    ///
+    /// <para>BC's <c>MetaReport(XmlElement, …)</c> reader takes <c>ALNAMESPACE</c> as
+    /// <c>InnerText</c> verbatim and both masks through
+    /// <c>Enum.Parse(typeof(PermissionMask), InnerText)</c>, so the masks are written as the
+    /// DECODED NUMBER rather than the AL letter spelling — "X" is not a PermissionMask member
+    /// and would throw where the value the symbol file states is perfectly readable.</para>
+    ///
+    /// <para>Deliberately NOT written here: the <c>&lt;RequestPage&gt;</c> subtree, whose
+    /// element BC deserializes into a whole MetaPageDefinition. That is the other half of
+    /// #3808 and stays open — see docs/metadata-equivalence.md#reports.</para>
+    /// </summary>
+    private static void WriteDerivableReportProperties(XmlWriter w, BcAppSymbolCache.ReportSymbol report)
+    {
+        if (!string.IsNullOrEmpty(report.ALNamespace))
+            w.WriteElementString("ALNamespace", report.ALNamespace);
+
+        // The shared decoder, not a second one: the letters are CASE-SIGNIFICANT (uppercase is
+        // the direct bit, lowercase the indirect bit at n+5, so "X" is 16 and "x" is 512), and
+        // a case-collapsing reimplementation answers 48 as 17. See #3788 for the measurement
+        // and RecordPatches.CodeunitMetadataEquivalence.cs for the table.
+        if (TryDecodePermissionMaskLetters(report.InherentEntitlements, out var entitlements))
+            w.WriteElementString(
+                "InherentEntitlements", entitlements.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        if (TryDecodePermissionMaskLetters(report.InherentPermissions, out var permissions))
+            w.WriteElementString(
+                "InherentPermissions", permissions.ToString(System.Globalization.CultureInfo.InvariantCulture));
     }
 
     private static void WriteDataItem(

--- a/docs/metadata-equivalence.md
+++ b/docs/metadata-equivalence.md
@@ -1035,11 +1035,16 @@ issue. What it contributes is the instrument: a runner-side null now reports as
 in a corpus run.
 
 <a id="reports"></a>
-## Reports: one object, and the honesty that forces
+## Reports: one object in the bundle, and where that limit does and does not bind
 
-System Application ships **exactly one** report — 9810 `Change Password` — and Business
-Foundation ships none. Every number in this section is `n = 1`, and it is enough to say *that*
-the runner drops a member, never how often.
+The harness's loaded bundle holds **exactly one** report — 9810 `Change Password` in System
+Application; Business Foundation ships none. So every number the **comparison** produces is
+`n = 1`, and it is enough to say *that* the runner drops a member, never how often.
+
+That limit binds the comparison, not every question about reports. A question answerable from
+`SymbolReference.json` alone reaches Base Application's 659 reports too, because reading a symbol
+file costs nothing like compiling one — see "The population, which is two different numbers"
+below, where the two halves of #3808 come out at 660 and at 1.
 
 The oracle is `Types.Metadata.MetaReport(XmlElement, CreateRequestForm, int, int,
 RemoveItemsOnPageBasedOnLicenseAndApplicationArea)`; both delegates are optional and null is
@@ -1049,20 +1054,62 @@ metadata actually reads, since `RunnerXmlMetadataLoader` hands exactly this XML 
 than a test-only rendering, and never `AlReportMetadataRegistry`, which holds BC's emit-captured
 output and would compare BC against BC.
 
-**5 differences**, all tracked on #3808: both `Inherent*` masks (the `"X"` spelling
-`SymbolReference.json` states and `ReportSymbol` does not carry — the same property #3788
-records for codeunits and #3798 for queries, three kinds and one unparsed value), `ALNamespace`,
-and `RequestPageDefinition` counted twice because the differ walks the property and its backing
-field independently.
+**5 differences when #3808 was filed; 2 remain.** The three dropped properties — `ALNamespace`
+and both `Inherent*` masks — now agree, and `No_allowlist_entry_has_gone_stale` reporting all
+three as stale is the evidence that landed them. `RequestPageDefinition` stays, counted twice
+because the differ walks the property and its backing field independently.
 
-`RequestPageDefinition` is the one that is not merely a dropped property: BC emits a full
-`<RequestPage><PageDefinition>` subtree for report 9810 even though it declares
-`UseRequestPage = false` and `ProcessingOnly = true`. Whether BC does that for *every* report is
-**not answerable from this bundle** — one report — and Base Application, which would answer it,
-is excluded from `apps.json` on cost (257 s, 8.83 GiB), not because it cannot be compiled: the
-.NET reference it needs ships in the ASP.NET Core reference pack and is staged (#3876, correcting
-an earlier claim here that no BC artifact ships it). That question is left open on #3808 rather
-than closed by assumption.
+### The three that landed
+
+`ReportSymbol` now carries the `Namespaces` tree path and both mask letter strings, and
+`EmitReportXml` states them. BC's own reader decides the spelling: `MetaReport..ctor` takes
+`ALNAMESPACE` as `InnerText` verbatim and both masks through
+`Enum.Parse(typeof(PermissionMask), InnerText)`, so the masks are emitted as the **decoded
+number** — the AL letter `"X"` is not a `PermissionMask` member and would throw.
+
+The decode goes through the shared `RecordPatches.TryDecodePermissionMaskLetters`, the same one
+#3788 added for codeunits and #3798 reuses for queries — three kinds, one decoder. It is
+**case-sensitive**: uppercase is the direct bit, lowercase the indirect bit at `n+5`, so `X` is
+16, `x` is 512 and `rX` is 48. A case-collapsing reimplementation answers 16 and 17.
+
+### The population, which is two different numbers
+
+`ALNamespace` is **not** `n = 1`, and the issue's framing of it as such is the harness's loaded
+bundle rather than the symbol files. Walking the `Namespaces` tree of every `.app` in
+28.1.49838.53910:
+
+| | reports | stating a namespace | stating either mask |
+|---|---|---|---|
+| Base Application | 659 | 659 | 0 |
+| System Application | 1 | 1 | 1 (`"X"` for both) |
+| **total** | **660** | **660** | **1** |
+
+Both flat top-level `Reports` arrays are empty, so the tree path is the only source. Base
+Application is readable for a **symbol-file** question because it needs no emit — the 257 s and
+8.83 GiB is the cost of compiling it, which this question does not pay.
+
+So the mask work rests on one report and the namespace work on 660; and because no shipped
+report spells a lowercase or mixed-case mask, the decoder's indirect arms are unexercised by the
+real population. `ReportSymbolNamespaceAndInherentMaskTests` states `x` and `rX` anyway, so the
+case rule is driven rather than assumed from a population that happens not to need it.
+
+### `RequestPageDefinition`, and its two questions now answered
+
+BC emits a full `<RequestPage><PageDefinition>` subtree for report 9810 even though it declares
+`UseRequestPage = false` and `ProcessingOnly = true`. Both questions #3808 left open are now
+settled by measurement, and both say the gap is real:
+
+1. **Not one report, and not only the processing-only ones.** All **660 of 660** reports declare
+   a `RequestPage` node in `SymbolReference.json`, including all **24** that state
+   `UseRequestPage = 0`.
+2. **Something AL-observable reads it.** `NavTestExecution.TestHandleModalForm` constructs a
+   `NavTestRequestPage` whenever the form it is handling `IsRequestPage`, and
+   `NavTestRequestPage.LoadMetadata` returns exactly
+   `GetReportMetadata(objectId).RequestPageDefinition`. An AL `[RequestPageHandler]` on a
+   precompiled report therefore reaches the null.
+
+What remains unbuilt is the subtree itself, which is a page-definition renderer rather than a
+dropped property — so it stays tracked on #3808 rather than being closed with the three above.
 
 **What this comparison does not reach:** report 9810 has no data items and no columns, so the
 data-item and column derivation — the substantial part of `DependencyReportMetadata.cs` — is not

--- a/tests/expectations/metadata-equivalence/allowlist.json
+++ b/tests/expectations/metadata-equivalence/allowlist.json
@@ -1293,28 +1293,13 @@
       "Doc": "docs/metadata-equivalence.md#xmlports"
     },
     {
-      "member": "MetaReport.InherentEntitlements",
-      "reason": "BC resolves the report's InherentEntitlements mask to Execute; the runner answers None because BcAppSymbolCache's ReportSymbol does not carry the property at all. SymbolReference.json states it as the \"X\" mask spelling, and RecordPatches.CodeunitMetadataFromBcDocument.cs already parses that spelling for codeunits -- so this is a dropped property, not an underivable one. Same member and same \"X\" spelling as the codeunit gap (#3788) and the query gap (#3798); three kinds, one unparsed property. Measured on BC 28.1.49838.53910 on the single report System Application ships (9810 Change Password).",
-      "issue": 3808
-    },
-    {
-      "member": "MetaReport.InherentPermissions",
-      "reason": "The other half of the same dropped property: BC resolves Execute, the runner answers None. See MetaReport.InherentEntitlements immediately above -- one \"X\" mask in SymbolReference.json feeds both, and neither reaches ReportSymbol.",
-      "issue": 3808
-    },
-    {
-      "member": "MetaReport.ALNamespace",
-      "reason": "BC states the report's AL namespace (System.Security.AccessControl on report 9810); the runner answers null because ReportSymbol does not carry it. SymbolReference.json states the namespace -- it is what BcAppSymbolCache's own namespace walk already reads to build ObjectSymbol -- so this is derivable and simply not carried. Same member, same reason and same fix as MetaTable.ALNamespace (#3568), MetaPermissionSet.ALNamespace (#3806) and MetaEnum.ALNamespace (#3807).",
-      "issue": 3808
-    },
-    {
       "member": "MetaReport.RequestPageDefinition.<presence>",
-      "reason": "BC's emitted document carries a full <RequestPage><PageDefinition> subtree even for report 9810, which declares UseRequestPage = false and ProcessingOnly = true; DependencyReportMetadata.EmitReportXml writes no <RequestPage> element at all, so BC's reader leaves the property null on the runner's side. Two questions are deliberately OPEN rather than answered here, and they are on #3808: whether BC emits a request page for every report (unanswerable from this bundle -- System Application ships exactly ONE report, and Base Application, which would settle it, is excluded from apps.json on cost -- 257s and 8.83 GiB peak RSS -- rather than because its emit is impossible; the earlier claim here that it needs a .NET reference no BC artifact ships was disproved by #3876), and whether anything AL-observable reads MetaReport.RequestPageDefinition on a ProcessingOnly report. Declared as a tracked defect rather than out of scope precisely because neither is settled: an outOfScope claim here would be a guess wearing a classification.",
+      "reason": "BC's emitted document carries a full <RequestPage><PageDefinition> subtree even for report 9810, which declares UseRequestPage = false and ProcessingOnly = true; DependencyReportMetadata.EmitReportXml writes no <RequestPage> element at all, so BC's reader (MetaReport..ctor, REQUESTPAGE -> DeserializePageDefinition) leaves the property null on the runner's side. The two questions this entry recorded as OPEN are now both ANSWERED, and both answers say the gap is real (#3808). (1) Not one report, and not only the processing-only ones: walking the Namespaces tree of every .app in 28.1.49838.53910, 660 of 660 reports declare a RequestPage node in SymbolReference.json -- Base Application 659 plus System Application 1 -- including all 24 that state UseRequestPage = 0. Base Application is readable here for this question because it needs only the symbol file, not the emit that costs 257s and 8.83 GiB. (2) Something AL-observable does read it: NavTestExecution.TestHandleModalForm constructs a NavTestRequestPage whenever the form it is handling IsRequestPage, and NavTestRequestPage.LoadMetadata returns exactly GetReportMetadata(objectId).RequestPageDefinition -- so an AL [RequestPageHandler] on a precompiled report reaches this null. Still a tracked defect rather than out of scope, and now on measurement rather than on the absence of one; what remains unbuilt is the subtree itself, which is a page-definition renderer and not a dropped property.",
       "issue": 3808
     },
     {
       "member": "MetaReport.#requestPageDefinition.<presence>",
-      "reason": "The backing field of MetaReport.RequestPageDefinition. The differ walks the property and the field independently, so one absent subtree is reported twice; this entry exists so the second report is declared rather than left undeclared. Same fact, same issue -- see the property entry above for the two open questions.",
+      "reason": "The backing field of MetaReport.RequestPageDefinition. The differ walks the property and the field independently, so one absent subtree is reported twice; this entry exists so the second report is declared rather than left undeclared. Same fact, same issue -- see the property entry above, whose two formerly-open questions are now answered by measurement.",
       "issue": 3808
     },
     {


### PR DESCRIPTION
Part of #3808

Corpus-NA: precompiled-dependency metadata derivation; the observable is BC's MetaReport reader consuming a document the runner emits for a report that exists only inside a precompiled .app, which no corpus AL test can reach.

**Partial by design.** #3808 has two halves of different character. Half A — three dropped properties — is landed here. Half B — the missing `RequestPage` subtree — is **answered as a question rather than implemented**, so the issue stays open.

## Half A — the three dropped properties (landed)

`ReportSymbol` carried neither the report's `Namespaces` tree path nor either inherent-permission mask, so `EmitReportXml` wrote no `<ALNamespace>`, `<InherentEntitlements>` or `<InherentPermissions>` element and BC's reader kept its own defaults — `null` and `PermissionMask.None` — for every report in a precompiled dependency.

**BC's reader decides the spelling.** Read off `MetaReport..ctor` in `Microsoft.Dynamics.Nav.Types.dll` 28.1.49838.53910: `ALNAMESPACE` is taken as `InnerText` verbatim, both masks go through `Enum.Parse(typeof(PermissionMask), InnerText)`. So the masks are emitted as the **decoded number**, not the AL letter — `"X"` is not a `PermissionMask` member and would throw.

The decode reuses the shared `RecordPatches.TryDecodePermissionMaskLetters` (#3917), not a second decoder. It is case-sensitive: `X`→16, `x`→512, `rX`→48.

### A correction to the issue's stated population

The issue says everything here is `n = 1`. That is true of the **masks** and not of **`ALNamespace`** — `n = 1` is the equivalence harness's loaded bundle, not the symbol-file population. Walking the `Namespaces` tree of every `.app` in 28.1.49838.53910:

| | reports | stating a namespace | stating either mask |
|---|---|---|---|
| Base Application | 659 | 659 | 0 |
| System Application | 1 | 1 | 1 (`"X"` both) |
| **total** | **660** | **660** | **1** |

Both flat top-level `Reports` arrays are empty, so the tree path is the only source. Base Application is readable for a *symbol-file* question because it pays none of the 257 s / 8.83 GiB that compiling it costs.

Because no shipped report spells a lowercase or mixed-case mask, the decoder's indirect arms are unexercised by the real population — so the fixture states `x` and `rX` anyway, which is the point of reusing the shared decoder rather than one that happens to be right on `"X"`.

No `versionContingent` entry, per the issue's own reasoning: that flag is about a member's population depending on a per-object declaration, not about the population being small.

## Half B — `RequestPageDefinition`: answered, not implemented

The issue left two questions open and said answering them comes before building a renderer. Both are now answered by measurement, and **both say the gap is real**:

1. **Does BC emit a `<RequestPage>` for every report, or only 9810?** Every report. **660 of 660** declare a `RequestPage` node in `SymbolReference.json`, including all **24** that state `UseRequestPage = 0`. The issue called this unanswerable from the bundle because Base Application is excluded — true for the *emit*, but this question needs only the symbol file.
2. **Does anything AL-observable read `MetaReport.RequestPageDefinition` on a `ProcessingOnly` report?** Yes. `NavTestExecution.TestHandleModalForm` constructs a `NavTestRequestPage` whenever the form it handles `IsRequestPage`, and `NavTestRequestPage.LoadMetadata` is exactly `return …GetReportMetadata(ObjectId.ObjectNumber).RequestPageDefinition;`. An AL `[RequestPageHandler]` on a precompiled report reaches the null.

**Deliberately not built here.** What remains is a page-definition renderer, not a dropped property — a different kind of change needing its own design and its own tests. The two allowlist entries stay, with their reasons rewritten from "two questions are open" to the measurements above, so the entry now rests on evidence rather than on the absence of it. #3808 stays open for it.

## RED → GREEN, and a mutation per observable

RED is an **assertion** failure, not a build one: the symbol-side members were restored first so the test compiled, with only the emitter at `origin/main`.

| | result | `error CS` |
|---|---|---|
| RED (emitter at `origin/main`) | **Failed: 2, Passed: 1, Total: 3** — `Expected: "System.Security.AccessControl" / Actual: null` | 0 |
| GREEN | **Failed: 0, Passed: 3, Total: 3** | 0 |
| both report classes | **Failed: 0, Passed: 4, Total: 4** | 0 |

**One mutation per observable**, because one red proves something is covered, not which thing. Each was confirmed to have LANDED by re-reading the edited line, and each red is an assertion rather than a broken build:

| # | mutation | result | the failure |
|---|---|---|---|
| 1 | `ALNamespace` dropped at the parse | Failed: 2, Passed: 1 | `Expected: "System.Security.AccessControl" / Actual: null` |
| 2 | `InherentEntitlements` not emitted | Failed: 1, Passed: 2 | `Expected: "16" / Actual: null` |
| 3 | `InherentPermissions` not emitted | Failed: 2, Passed: 1 | `Expected: "16" / Actual: null` |
| 4 | shared decoder collapses case | Failed: 1, Passed: 2 | `Expected: "512" / Actual: "16"` |
| 5 | warm-cache test plants at the *current* shape | Failed: 1, Passed: 0 | `Expected: Not "d8c3506849475c13"` |

Mutation 4 is the #3933 shape, caught from the report side. Mutation 5 proves the warm-cache test's own premise is asserted rather than assumed — it cannot pass by planting at the path it then reads.

All five restored; tree clean; suite green.

## The cache case was measured, not reasoned

`ReportSymbol` gained three members and is reachable from `CachePayload` via `AppSymbols.Reports`, so `PayloadShape` re-keys on its own and **no `CacheVersion` bump is correct** — v42 stays. Read through the `PayloadShapeForTests` seam off **both** builds:

- `origin/main`: `b82cf78cd0b9123a`
- this branch: `d8c3506849475c13`

The main-side value is the one #3917 recorded, which cross-checks that the seam read main rather than a stale build. `ReportSymbolNamespaceWarmCacheTests` plants a pre-fix payload at the old-shape path and asserts the current build does not serve it.

## Allowlist: the harness's own verdict

`No_allowlist_entry_has_gone_stale`, running against BC's emitter output over the loaded bundle, reported all three members as STALE. That is the evidence for removing the entries — not a fixture.

**Failed: 1, Passed: 37 → Failed: 0, Passed: 38.**

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** This is the third kind with the same `"X"` property — codeunits (#3788), queries (#3798), reports (here). I did **not** write a fourth decoder; all three share `TryDecodePermissionMaskLetters`. The page side has an open case-collapse defect, **#3933**, which is not folded because its fix lands in a different file and it already has an owner.
2. **Sibling function with the same assumption?** `TryParseReportSymbol`'s siblings in the same walk: `TryParseQuerySymbol` is #3798/PR #3931 (open, same author), `TryParseEnumSymbol` is #3807, `TryParsePermissionSetSymbol` is #3806. Each needs its own record member and its own test, so they stay separate. `TryParsePageSymbol` and `TryParsePageExtensionSymbol` also take no `alNamespace` — same shape, not measured here, and not claimed.
3. **Two paths writing one state with different invariants?** The report route has one: `EmitReportXml` is the only producer, and `RunnerXmlMetadataLoader` hands that document to BC. Unlike the codeunit side (#3917), there is no second AL-observable rendering to keep in step — which is why this PR needs no virtual-table twin, and I checked rather than assumed.

**Queue scan** (`search-for-the-same-defect-first.md`), on the symbol, the observable, the mechanism and the measurement: `MetaReport`, `ReportSymbol`, `ALNamespace`, `InherentEntitlements`, `RequestPageDefinition`, `660`, `TryDecodePermissionMaskLetters`. Found #3806/#3807/#3568 (same member, other kinds — all separate files), #3798 (same author, open PR #3931), #3933 (page-side case collapse). **Nothing duplicates this issue**, and nothing folds: every candidate's fix lands in a different file.

## Not exercised, and not claimed

Report 9810 has no data items and no columns, so the data-item derivation in `DependencyReportMetadata.cs` — the substantial part of that file — is **not** touched by this comparison. The equivalence bundle measures one report; the 660-report figures above come from the symbol files, and I have labelled which is which throughout.

## Local runs

Built first, never `--no-build` against a stale tree. Engine-bootstrapped for the equivalence legs (the un-bootstrapped run reports 31 failures that assert nothing, which is the guard working).

- `tools/test_*.py` — all pass
- `GuardTests` — Failed: 0, Passed: 249 (includes the one-`<summary>`-per-`///`-run guard)
- `MetadataEquivalence` — Failed: 0, Passed: 38
- `BcAppSymbolCache` 49, `DependencyReport` 18, `ReportMetadata` 8, `CodeunitSymbolNamespace` 4, `QuerySymbol` 9 — all Failed: 0

<sub>Opened by the `impl-agent` `stma-auto-3`, an automated agent acting on the account holder's behalf.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
