### PR TITLE
docs(skill): a non-blocking review finding waits for the gating leg

### DIFF
--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -368,6 +368,14 @@ more; what a second run can still change is the corpus itself, so a runner PR wh
 predates a corpus merge is measured against the older corpus. Read the `corpus: <sha> (<ref>)`
 line the legs print before arming, and re-run rather than carrying an old verdict forward.
 
+**A push restarts the matrix, so a non-blocking finding waits for the gating leg.** A reviewer's
+"worth fixing eventually" item on a PR whose required BC legs are mid-flight costs ~15 minutes of
+matrix, and that cost is invisible while you are reading a trivial diff. Push it when the legs
+have reported, not while they run — and never on a PR that is unblocking others, where the delay
+is multiplied by every PR behind it. Measured twice in one session (#3923, #3927), both times a
+comment-only change that was correct, verified, and still the wrong moment. **"Trivial" describes
+the diff, never the schedule**, and the schedule is what is scarce near a merge.
+
 **Expectation-manifest drift is dispatched from here, and only from here.** A known-gap entry left behind after its issue closed, or a red `main` from manifest drift, gets one implementation agent per drift, briefed to carry the entry's key, `<CodeunitName>.<Method>` from the manifest entry, in both the issue title and the PR title, after `gh pr list --state open --search "\"<CodeunitName>.<Method>\" in:title" --json number,title` returns no title containing that key; when it returns one, that PR is the fix in flight. Done when exactly one open PR title carries the key. An implementation agent that finds a drift comments and keeps its own task (`.claude/agents/impl-agent.md`).
 
 ## Measurement rules


### PR DESCRIPTION
Part of #3937

A push restarts the BC matrix. Acting on a reviewer's explicitly **non-blocking** finding while the required legs are still running costs ~15 minutes of matrix — and that cost is invisible while you are reading a two-line diff, because the diff is what you are looking at and the queue is not.

Measured twice in one session, both times by me as coordinator:

| PR | the finding | what it cost |
|---|---|---|
| **#3923** | four allowlist `reason` strings were identical 1,933-char blocks duplicating a doc section | `BC 27.5` — the only leg that could settle a 27.5-only fix nobody could reproduce locally — went ~15 min further out |
| **#3927** | two doc comments cited a symbol the branch had deleted | restarted the matrix while that PR was the critical path for **three** other PRs (#3922) |

Both changes were correct, verified, and touched no code, no test and no flag. Both were still the wrong moment — and when the PR is unblocking others, the delay is multiplied by every PR behind it.

## Scope

Skill prose only, in "The merge bar". #3937 stays open for the part I did **not** measure: whether a non-blocking finding needs a separate push at all, or could be folded into the next required change or carried as a follow-up. If most could, the rule could be stronger than "wait for the leg". I am not claiming that without the measurement.

No test: this is coordinator guidance in a skill file, not behaviour a test can pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
