### PR TITLE
docs(rules): two ways a correct comment still produces a wrong belief

### DIFF
--- a/.claude/rules/loud-failures.md
+++ b/.claude/rules/loud-failures.md
@@ -77,6 +77,22 @@ measurement is in docs/incidents/loud-failures.md).
 3. **The trap, if there is one** — the thing a later editor would get wrong. "Re-check the call
    count if a BC version changes shape" is worth its line; the scan that produced the count is not.
 
+**Spell out a member list long enough to miscount, and never truncate one.** A comment reading
+`DataTransfer.{AddFieldValue,AddConstantValue,AddSourceFilter,AddJoin,` — running past a line
+break mid-list — generated wrong expansions in both directions: the PR body citing it, and its
+coordinator, read out **seven** members including a phantom `AddSourceValue`, when there were
+**eight** and the real member `AddSourceFilter` sat in the very line being misread (#3927). Both
+errors look entirely plausible downstream, so nothing catches them. The danger needs **both**
+properties — enough members to lose count, and truncation hiding where the list ends: measured
+over `AlRunner/**/*.cs`, 20 comments use brace shorthand and only that one had both, so short
+complete forms like `{get,set}` and `{TKey,TValue}` are fine and clearer than the expansion.
+
+**And a symbol search does not find prose describing what a symbol did.** Deleting a member and
+grepping its name to zero verifies symbol references only: `RunnerPageInstance` cited "BcRuntime's
+DataTransfer-out-of-context message", naming no symbol, and survived a sweep that correctly
+reported no references left (#3927). When you delete something a comment may *describe*, search
+for the behaviour's words too, not only its identifier.
+
 **What belongs elsewhere**, with the pointer left behind:
 
 | | goes to |


### PR DESCRIPTION
Part of #3940

Two ways a comment can be *correct* and still produce a wrong belief downstream. Both were caught by the repo owner reviewing PR #3927; both are mine.

## 1. A truncated brace-shorthand member list

```
// The AL `DataTransfer.{AddFieldValue,AddConstantValue,AddSourceFilter,AddJoin,
```

Expanded by hand: **seven** members including a phantom **`AddSourceValue`**. Truth: **eight**, and the real member `AddSourceFilter` is *in the line being misread*. The wrong expansion reached the PR body and my dispatch brief, and I repeated "seven orphaned hooks" in two further review briefs. Three rounds of review did not catch it, because a plausible member list is not something a reviewer re-derives.

## 2. A symbol grep does not find prose

I deleted `MakeDataTransferException`, swept for dangling references, and reported "0 references remain in `AlRunner/`". True and insufficient — `RunnerPageInstance` cited *"BcRuntime's DataTransfer-out-of-context message"*, naming no symbol, so the grep could not see it.

## The rule is scoped to what I measured, not to what the incident felt like

My first draft said *"never write a member list a reader has to expand"*. Then I ran the scan: **20 brace-shorthand comments in `AlRunner/**/*.cs`, and exactly one had the dangerous shape.** The rest are `{get,set}`, `{TKey,TValue}`, `{Constant,Field,Source}` — nothing to miscount, nothing hidden, and genuinely clearer than the expansion.

The defect needs **both** properties: enough members to lose count, **and** truncation hiding where the list ends. So the rule now says that, and the first draft is not what ships — a rule condemning `{get,set}` would have been a worse rule sourced to a real incident.

**No CI guard**, deliberately: one instance of the dangerous shape against 19 benign hits would be a check that is mostly false positives, which is a check people learn to ignore. #3940 stays open noting that a second occurrence would change that.

No test: rules prose. The measurement behind it is in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
