### PR TITLE
fix(page-metadata): decode the page inherent-permission mask case-sensitively, so a lowercase letter answers the indirect bit

### DIFF
--- a/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
+++ b/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
@@ -2000,4 +2000,191 @@ public class DependencyPageMetadataXmlTests
         var properties = (XmlElement)doc.DocumentElement!.SelectSingleNode("m:Properties", ns)!;
         return (XmlElement)properties.SelectSingleNode("m:SourceObject", ns)!;
     }
+
+    // #3933. Pages carrying a lowercase mask: no Microsoft page ships one (210 masks across
+    // every shipped app at BC 28.4.53241.54407, all "X"), so the fixture is what makes the
+    // case-significant decode observable at all — the same argument
+    // QuerySymbolDerivedMetaQueryPropertiesTests makes for a kind whose real population is
+    // entirely uppercase.
+    private const int MaskUpperPageId = 88123801;
+    private const int MaskLowerPageId = 88123802;
+    private const int MaskMixedPageId = 88123803;
+    private const int MaskUnreadablePageId = 88123804;
+
+    private const string InherentMaskSymbolReference = """
+        {
+          "RuntimeVersion": "15.1",
+          "Pages": [
+            {
+              "Id": 88123801,
+              "Name": "DPX Mask Upper",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "InherentEntitlements", "Value": "X" },
+                { "Name": "InherentPermissions", "Value": "RIMDX" }
+              ]
+            },
+            {
+              "Id": 88123802,
+              "Name": "DPX Mask Lower",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "InherentEntitlements", "Value": "x" },
+                { "Name": "InherentPermissions", "Value": "rimdx" }
+              ]
+            },
+            {
+              "Id": 88123803,
+              "Name": "DPX Mask Mixed",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "InherentEntitlements", "Value": "rX" },
+                { "Name": "InherentPermissions", "Value": "rimdX" }
+              ]
+            },
+            {
+              "Id": 88123804,
+              "Name": "DPX Mask Unreadable",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "InherentEntitlements", "Value": "Q" },
+                { "Name": "InherentPermissions", "Value": "X" }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private static XmlElement ReadPagePropertiesFor(int pageId)
+    {
+        var xml = RecordPatches.TryBuildDependencyPageMetadata(pageId);
+        Assert.NotNull(xml);
+        var doc = new XmlDocument();
+        doc.LoadXml(xml!);
+        return (XmlElement)doc.DocumentElement!.SelectSingleNode("m:Properties", MetaNs(doc))!;
+    }
+
+    /// <summary>
+    /// The uppercase direction, which the case-collapsing decode already got right — here so
+    /// the lowercase assertions below are a statement about CASE rather than about the decode
+    /// working at all.
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_UppercaseInherentMask_AnswersTheDirectBits()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-mask-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, InherentMaskSymbolReference));
+
+            var properties = ReadPagePropertiesFor(MaskUpperPageId);
+
+            // X = Execute = 1 << 4.
+            Assert.Equal("16", properties.GetAttribute("InherentEntitlements"));
+            // RIMDX = the five direct bits = 1|2|4|8|16.
+            Assert.Equal("31", properties.GetAttribute("InherentPermissions"));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    /// <summary>
+    /// #3933's defect. Case is SIGNIFICANT in an AL permission mask: uppercase is the direct
+    /// bit, lowercase the indirect bit at n+5 over "RIMDX". The page decode collapsed case
+    /// with <c>char.ToUpperInvariant</c>, so <c>"x"</c> answered 16 (Execute) where BC's own
+    /// emitter answers 512 (IndirectExecute) — a page reading as holding a direct permission
+    /// it does not have.
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_LowercaseInherentMask_AnswersTheIndirectBitsNotTheDirectOnes()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-mask-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, InherentMaskSymbolReference));
+
+            var properties = ReadPagePropertiesFor(MaskLowerPageId);
+
+            // x = IndirectExecute = 1 << (4 + 5) = 512, NOT 16.
+            Assert.Equal("512", properties.GetAttribute("InherentEntitlements"));
+            // rimdx = the five indirect bits = 32|64|128|256|512 = 992, NOT 31.
+            Assert.Equal("992", properties.GetAttribute("InherentPermissions"));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    /// <summary>
+    /// The mixed spelling, which is the shape 97 of Microsoft's 98 lowercase-bearing TABLE
+    /// masks take (<c>"rX"</c>, <c>"rimdX"</c>) and therefore the spelling an ISV page is
+    /// likeliest to carry. A collapsing decode answers 17 and 31; BC answers 48 and 496.
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_MixedCaseInherentMask_CombinesDirectAndIndirectBits()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-mask-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, InherentMaskSymbolReference));
+
+            var properties = ReadPagePropertiesFor(MaskMixedPageId);
+
+            // rX = IndirectRead (32) | Execute (16) = 48, NOT 17.
+            Assert.Equal("48", properties.GetAttribute("InherentEntitlements"));
+            // rimdX = the four indirect bits (32|64|128|256 = 480) | Execute (16) = 496, NOT 31.
+            Assert.Equal("496", properties.GetAttribute("InherentPermissions"));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    /// <summary>
+    /// The error-behaviour half of #3933, and the reason the shared decoder's THROW is not
+    /// reused here. A throw out of <see cref="RecordPatches.TryBuildDependencyPageMetadata"/>
+    /// is swallowed into a NULL metadata document — measured on this exact builder when
+    /// EmitSourceTableViewXml threw InvalidOperationException (see the "ORDER IS LOAD-BEARING"
+    /// note in DependencyPageMetadataXml.cs) — after which BC NREs in
+    /// GetFrozenPageDefinitionWithExtensionWithoutMergedMultiLanguage and
+    /// RunnerPageInstance.TryCreateRecordless silently demotes the whole TestPage to the
+    /// navigation mock. So on this path a throw is the SILENT answer and the diagnostic is
+    /// the loud one; the attribute is omitted, said, and the rest of the page survives.
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_UnreadableInherentMaskLetter_IsOmittedAndSaidWithoutLosingTheDocument()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-mask-tests");
+        Directory.CreateDirectory(dir);
+        var previousError = Console.Error;
+        var captured = new StringWriter();
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, InherentMaskSymbolReference));
+
+            // Only this test asks for this page id and the document is memoized per id, so
+            // the one and only build happens inside the capture.
+            Console.SetError(captured);
+            var properties = ReadPagePropertiesFor(MaskUnreadablePageId);
+            Console.SetError(previousError);
+
+            Assert.False(properties.HasAttribute("InherentEntitlements"),
+                "a letter nobody can read must not be invented into a mask");
+            // The document survives, and the readable sibling mask on the same page is
+            // unaffected — the property a throw would have destroyed.
+            Assert.Equal("16", properties.GetAttribute("InherentPermissions"));
+            Assert.Equal("List", properties.GetAttribute("PageType"));
+
+            var diagnostic = captured.ToString();
+            Assert.Contains("InherentEntitlements", diagnostic);
+            Assert.Contains(MaskUnreadablePageId.ToString(), diagnostic);
+            // The unreadable value itself, so the reader can see WHAT the file said.
+            Assert.Contains("Q", diagnostic);
+            // The readable one must not be reported as a problem.
+            Assert.DoesNotContain("InherentPermissions", diagnostic);
+        }
+        finally
+        {
+            Console.SetError(previousError);
+            Directory.Delete(dir, recursive: true);
+        }
+    }
 }

--- a/AlRunner/Patches/DependencyPageMetadataXml.cs
+++ b/AlRunner/Patches/DependencyPageMetadataXml.cs
@@ -335,49 +335,49 @@ public static partial class RecordPatches
     /// One inherent-permission mask: the symbol file states AL permission LETTERS
     /// (<c>InherentEntitlements = X</c>) and BC's <c>PageProperties</c> holds an
     /// <c>Int32</c>, so the letters are decoded against
-    /// <c>Microsoft.Dynamics.Nav.Types.PermissionMask</c> — <c>Read 1, Insert 2, Modify 4,
-    /// Delete 8, Execute 16</c>. That enum is what makes this a DECODE of a stated value
-    /// rather than a guess at an absent one.
+    /// <c>Microsoft.Dynamics.Nav.Types.PermissionMask</c> through the shared
+    /// <see cref="TryDecodePermissionMaskLettersCore"/> — <c>Read 1, Insert 2, Modify 4,
+    /// Delete 8, Execute 16</c>, and the same five again as INDIRECT bits at n+5 for a
+    /// lowercase letter. That enum is what makes this a DECODE of a stated value rather than
+    /// a guess at an absent one.
     ///
-    /// <para>Measured on Base Application + System Application + Business Foundation at BC
-    /// 28.4.53241.54407 (2,852 pages): the only value either property ever takes is
-    /// <c>"X"</c> — 101 + 99 occurrences — which BC's emitter writes as <c>16</c>. The other
-    /// four letters are implemented because the decode is total and cheap, not because a page
-    /// stating them was observed; that is why an unknown letter refuses rather than
-    /// contributing nothing.</para>
+    /// <para><b>Case is significant and must not be normalised</b> (#3933). This decoded with
+    /// <c>char.ToUpperInvariant</c> until then, so <c>"x"</c> answered 16 where BC answers 512
+    /// and <c>"rX"</c> answered 17 where BC answers 48 — a page reading as holding a DIRECT
+    /// permission it does not have. Latent when fixed: measured across every shipped app at BC
+    /// 28.4.53241.54407, pages carry 210 masks and all 210 are <c>"X"</c>, so no Microsoft page
+    /// reached it; an ISV page declaring one does. The codeunit direction has a real instance
+    /// (System Application codeunit 2516), which is what settled the spelling — see
+    /// docs/codeunit-metadata-from-bc.md#permission-mask-spelling.</para>
     ///
-    /// <para>A letter this cannot read is REFUSED and SAID, never folded into 0 — the same
+    /// <para>A letter this cannot read is OMITTED and SAID, never folded into 0 — the same
     /// choice, and the same reason, as the unreadable-boolean and wrong-shape-DataCaptionFields
     /// arms of <see cref="EmitSourceObjectPropertiesXml"/>. Both a mask of 0 and an absent
     /// attribute are answers BC can tell apart (the <c>Specified</c> bit its setter raises),
     /// so inventing either from a value nobody could read would be a silent wrong answer on a
-    /// surface with no way to fail.</para>
+    /// surface with no way to fail. It deliberately does NOT reuse the shared decoder's throw:
+    /// on this builder a throw is the quieter answer, because it returns a null document and
+    /// demotes the whole TestPage — the trade is stated once at
+    /// <see cref="TryDecodePermissionMaskLettersCore"/>.</para>
     /// </summary>
     private static void EmitInherentMask(
         XmlWriter w, BcAppSymbolCache.PageSymbol page, string attribute, string? stated)
     {
         if (string.IsNullOrWhiteSpace(stated)) return;
 
-        int mask = 0;
-        foreach (var c in stated)
+        // The shared decoder's arithmetic, and NOT its throw — see
+        // TryDecodePermissionMaskLettersCore for why the policy splits here.
+        if (!TryDecodePermissionMaskLettersCore(stated, out var mask, out var unreadable))
         {
-            if (c == ' ' || c == ',') continue;
-            int bit = char.ToUpperInvariant(c) switch
-            {
-                'R' => 1, 'I' => 2, 'M' => 4, 'D' => 8, 'X' => 16,
-                _ => 0,
-            };
-            if (bit == 0)
-            {
-                Console.Error.WriteLine(
-                    $"[RecordPatches] page {page.Id} \"{page.Name}\": {attribute} \"{stated}\" "
-                    + "is not the R/I/M/D/X permission-letter list BC reads — omitted, so the "
-                    + "page reads as declaring none");
-                return;
-            }
-            mask |= bit;
+            Console.Error.WriteLine(
+                $"[RecordPatches] page {page.Id} \"{page.Name}\": {attribute} \"{stated}\" "
+                + $"states '{unreadable}', which is not one of the {PermissionMaskLetters} "
+                + "permission letters BC reads in either case — omitted, so the page reads as "
+                + "declaring none");
+            return;
         }
 
+        if (mask == 0) return;
         w.WriteAttributeString(attribute, mask.ToString(System.Globalization.CultureInfo.InvariantCulture));
     }
 

--- a/AlRunner/Patches/RecordPatches.CodeunitMetadataEquivalence.cs
+++ b/AlRunner/Patches/RecordPatches.CodeunitMetadataEquivalence.cs
@@ -113,8 +113,36 @@ public static partial class RecordPatches
     /// </remarks>
     private static bool TryDecodePermissionMaskLetters(string? letters, out int mask)
     {
+        if (TryDecodePermissionMaskLettersCore(letters, out mask, out var unreadable)) return mask != 0;
+
+        throw CodeunitMetadataShapeGap(
+            $"SymbolReference.json states an inherent mask '{letters}', whose character '{unreadable}' is "
+            + $"not one of the permission letters '{PermissionMaskLetters}' in either case — the "
+            + "runner cannot read a mask it cannot spell, and dropping the character would answer "
+            + "a narrower permission than the codeunit declares");
+    }
+
+    /// <summary>
+    /// The mask arithmetic alone, with the unreadable-letter POLICY left to the caller: true
+    /// when every character decoded, false with <paramref name="unreadableLetter"/> naming the
+    /// first one that did not. Case is significant — see
+    /// <see cref="TryDecodePermissionMaskLetters"/>, which owns the full claim and its
+    /// citation.
+    ///
+    /// <para>Two callers, two policies, and the split is deliberate (#3933). The codeunit and
+    /// query directions THROW, because a <c>RunnerOutOfScopeException</c> there reaches the AL
+    /// author as the test's failure message. <c>EmitInherentMask</c> omits and says, because a
+    /// throw out of <see cref="TryBuildDependencyPageMetadata"/> is swallowed into a null
+    /// metadata document and silently demotes the whole TestPage — measured on that builder,
+    /// see the "ORDER IS LOAD-BEARING" note in DependencyPageMetadataXml.cs. Sharing the
+    /// arithmetic and not the policy is what keeps a loud failure loud on both paths.</para>
+    /// </summary>
+    private static bool TryDecodePermissionMaskLettersCore(
+        string? letters, out int mask, out char unreadableLetter)
+    {
         mask = 0;
-        if (string.IsNullOrWhiteSpace(letters)) return false;
+        unreadableLetter = '\0';
+        if (string.IsNullOrWhiteSpace(letters)) return true;
 
         foreach (var c in letters.Trim())
         {
@@ -124,13 +152,11 @@ public static partial class RecordPatches
             var indirect = PermissionMaskLetters.IndexOf(char.ToUpperInvariant(c));
             if (indirect >= 0 && char.IsLower(c)) { mask |= 1 << (indirect + PermissionMaskLetters.Length); continue; }
 
-            throw CodeunitMetadataShapeGap(
-                $"SymbolReference.json states an inherent mask '{letters}', whose character '{c}' is "
-                + $"not one of the permission letters '{PermissionMaskLetters}' in either case — the "
-                + "runner cannot read a mask it cannot spell, and dropping the character would answer "
-                + "a narrower permission than the codeunit declares");
+            unreadableLetter = c;
+            mask = 0;
+            return false;
         }
 
-        return mask != 0;
+        return true;
     }
 }


### PR DESCRIPTION
Closes #3933

Corpus-NA: the defect is in the runner's own reconstruction of a PageDefinition document that real BC produces natively at publish time; a service tier reads BC's emitter, never EmitInherentMask, so no corpus test can reach this code path

`DependencyPageMetadataXml.EmitInherentMask` decoded the AL permission mask with
`char.ToUpperInvariant(c) switch`, collapsing case. The mask is case-**significant**:
uppercase is the direct bit, lowercase the indirect bit at n+5 over `RIMDX`. So `x`
answered 16 where BC answers 512, and `rX` answered 17 where BC answers 48 — a page
reading as holding a **direct** permission it does not have.

## It removes a latent defect; it does not fix an observable one

Measured in the issue on BC 28.4.53241.54407 across every shipped app: pages carry
**210 masks, all `X`, zero lowercase**. So nothing observable was wrong, and the page
metadata-equivalence comparison already agreed with BC on this member. The defect is
reachable by any ISV page declaring a lowercase mask, and by a future Microsoft page.
That is the whole claim — this PR does not move any existing measurement.

## What changed

`RecordPatches.TryDecodePermissionMaskLetters` (#3917) is the correct shared decoder,
already reused by the codeunit and query directions. I did **not** write a third one.

**No widening or move was needed.** The issue suggested making the decoder `internal`
or relocating it, on the basis that it is `private` to `RecordPatches`. It is — but
`EmitInherentMask` is `RecordPatches.EmitInherentMask`: `DependencyPageMetadataXml.cs`
declares `public static partial class RecordPatches`, the same partial class. Both
already sat inside it, so `private` was always reachable from the page side.

I split the decoder into arithmetic and policy instead, for the reason below:

- `TryDecodePermissionMaskLettersCore(letters, out mask, out unreadableLetter)` — the
  case-correct bit arithmetic, returning false and naming the offending character
  rather than deciding what to do about it.
- `TryDecodePermissionMaskLetters` — unchanged public behaviour: wraps `Core` and
  throws the same `CodeunitMetadataShapeGap` with the same message. The codeunit
  direction's own refusal test
  (`AMaskLetterTheRunnerCannotSpell_IsRefused_NotAnsweredAsANarrowerPermission`)
  passes untouched.
- `EmitInherentMask` — calls `Core` and keeps omit-and-warn.

## The error-behaviour decision, and the evidence for it

**Decision: pages keep omit-and-warn. The shared decoder's throw is deliberately not
reused there.** The issue flagged this as the implementer's call, so here is what
settled it rather than a preference.

The page code's doc comment argued for refusal (*"REFUSED and SAID"*) while the code
omitted and warned. Working out what that was protecting against decides it — and it
inverts the usual rule:

**On this builder a throw is the *quieter* answer, not the louder one.** The
`ORDER IS LOAD-BEARING` note in `DependencyPageMetadataXml.cs` records a measured
instance on this exact path: when `EmitSourceTableViewXml` threw
`InvalidOperationException`, *"the throw came back as a NULL metadata document"*, BC
then NRE'd in `NCLMetaForm.GetFrozenPageDefinitionWithExtensionWithoutMergedMultiLanguage`,
and — per the `<SourceObject>` note a few lines above — `RunnerPageInstance.TryCreateRecordless`
catches that and **silently demotes the whole TestPage to the navigation mock**, where
every action answers `Enabled = true` and `Invoke()` is a literal no-op.

So reusing the throw would trade one unreadable *attribute* for a silently wrong
*entire page* — exactly the failure `loud-failures.md` exists to prevent. The rule is
satisfied by the diagnostic, not by the exception: `loud-failures.md` forbids silently
returning a default, and omit-and-warn returns no value at all and says so on stderr.
The two sibling arms the comment cites (`UnreadableBooleanProperties`, the
wrong-shape `DataCaptionFields`) make the same choice for the same reason.

The codeunit and query directions have no such swallow — their
`RunnerOutOfScopeException` reaches the AL author as the test's failure message — so
they keep the throw. Sharing the arithmetic and not the policy is what keeps a loud
failure loud on both paths. I corrected the page comment's "REFUSED" to "OMITTED",
since it did not describe the code.

## RED -> GREEN

`dotnet test AlRunner.Tests --filter "FullyQualifiedName~DependencyPageMetadataXmlTests"`

- **RED**: `Failed: 2, Passed: 38, Total: 40` — `Expected "512" / Actual "16"` and
  `Expected "48" / Actual "17"`, the exact values the issue predicted.
- **GREEN**: `Failed: 0, Passed: 40, Total: 40`.

Four new tests against a fixture page, since no shipped page declares a lowercase mask
— the same argument `QuerySymbolDerivedMetaQueryPropertiesTests` makes for a kind whose
real population is entirely uppercase (reviewed and accepted on #3931):

- uppercase `X`/`RIMDX` -> 16/31 (so the lowercase assertions are about **case**, not
  about the decode working at all)
- lowercase `x`/`rimdx` -> 512/992
- mixed `rX`/`rimdX` -> 48/496 — the shape 97 of Microsoft's 98 lowercase-bearing
  **table** masks take, and so the spelling an ISV page is likeliest to carry
- unreadable `Q` -> attribute omitted, diagnostic naming the page, the attribute and
  the offending character, **and the rest of the document intact** (the sibling mask
  still answers 16, `PageType` still `List`) — the property a throw would have destroyed

## Mutation, per observable

Two observables, one mutation each, each confirmed landed by re-reading the region and
each checked for `Assert` rather than `error CS`:

1. **The case-sensitive decode** — changed the indirect offset value
   `1 << (indirect + PermissionMaskLetters.Length)` to `1 << (indirect + 0)`, collapsing
   case back. `Failed: 2, Passed: 38` with `Expected "512"/Actual "16"` and
   `Expected "48"/Actual "17"`. Restored.
2. **The page's omit-and-warn** — forced the decode result to `true` so an unreadable
   letter folds in silently. `Failed: 1, Passed: 39`, failing on `Assert.Contains` for
   the missing diagnostic. Restored; `Failed: 0, Passed: 40` after.

A first attempt at mutation 2 (`if (false && ...)`) produced **4 `error CS` lines and no
`Total:`** — a broken build wearing the shape of a caught regression. Discarded and
redone as a value mutation, per `tdd.md`.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** No. The case-collapsing
   `ToUpperInvariant` switch existed only here; grepping the shape found the shared
   decoder (already correct, #3917) and nothing else. This PR removes the last copy, so
   there is now exactly one mask decoder in the codebase.
2. **Does a sibling function make the same assumption?** No. `EmitInherentMask`'s two
   call sites are the only mask consumers in the page file; the other `Emit*` helpers
   read booleans, strings and field-number lists.
3. **Two paths writing the same state with different invariants?** This PR removes
   exactly that: the page path and the codeunit/query path decoded the same symbol-file
   value by different rules and disagreed for every lowercase letter. They now share the
   arithmetic and differ only in the documented policy above.

**Queue scan** (`DependencyPageMetadataXml`, `EmitInherentMask`, `inherent`,
`permission mask`): nothing folds. #3247, #3824 and #2200 touch the same file but are
control-tree/action concerns needing different reasoning; #3788 is the codeunit
direction, already fixed by #3917.

## Out of scope, and deliberately not folded

Tables carry **98 lowercase masks** — by far the largest population — but nothing reads
them: `BcAppSymbolCache.ParsedTable` has no mask field at all, so there is no decode to
be wrong. The issue states this is a separate gap; it is not folded in.

## Cache

**Measured, not reasoned about.** No shape change and no parse-only change, so
`CacheVersion` stays 42 and no bump is needed:

- `InherentEntitlements`/`InherentPermissions` are already parsed and cached as
  **strings**; the decode happens downstream at XML-emit time. No cached record's shape
  changed, so `PayloadShape` is unaffected — and the parse is untouched, so this is not
  the parse-only case that would make `CacheVersion` the sole discriminator.
- `_depPageMetadataXml` is an in-process `ConcurrentDictionary`, not disk-backed.
- Ran the suite twice against one cache root: `Failed: 0, Passed: 40` cold and
  `Failed: 0, Passed: 40` warm.

## Also run

- `for t in tools/test_*.py` — all pass, including `test_doc_summary_uniqueness.py`
  (the new methods were appended before the class's closing brace, stranding no `///`).
- `dotnet test --filter "FullyQualifiedName~GuardTests"` — `Failed: 0, Passed: 249`,
  after `tools/engine-test-bootstrap.sh` + `--settings engine.runsettings`. The first
  attempt hit the bootstrap refusal, which is the loud form of #3078/#3835.
- Shared-decoder regression: `CodeunitMetadata|MetaQuery|QuerySymbol|DependencyPageMetadataXml`
  bootstrapped — `Failed: 0, Passed: 74`.

## Where the prose went

The comment blocks are the claim, its citation and the trap; the decision's derivation
is in this PR body. The one cross-file pointer is `EmitInherentMask` ->
`TryDecodePermissionMaskLettersCore`, where the two-policy trade is stated once.

*Implemented by agent `stma-auto-2` acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
