### PR TITLE
docs: a private member in another file is usually still reachable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,24 @@ where an agent deleted a stale waiver recording exactly this hazard and then mad
 waiver had described.
 
 
+**2d. A `private` member in another file is usually still reachable — the file is not the class.**
+
+`RecordPatches` is ONE `partial class` spread over **94 files**; `BcRuntime` over 24,
+`NclCecilRewrite` and `ProgramSupport` over 9 each, `LiveNavTestPage` 8, `RunnerPageInstance` 4. So
+a `private` member declared in one of those files is accessible from every other file declaring the
+same class, and "it is private, and it is in a different file" is two true statements whose
+conjunction implies something false.
+
+Measured cost: issue #3933 advised widening a `private` decoder to `internal` or moving it, and the
+coordinator repeated that in a dispatch brief; the calling file declared the same `partial class`
+and had access all along (#3945). Nothing contradicts the reading until someone tries the call, and
+the edit it argues for — widening visibility, or a new shared location — is a real diff in a hot
+file.
+
+```bash
+command grep -n "partial class" <the-calling-file>   # same class? then you already have access
+```
+
 **3. `grep` here is a shell function, and it fails silently.**
 
 `grep` resolves to a shell **function**, not `/usr/bin/grep`. It rejects `-E`, `--include` and


### PR DESCRIPTION
Part of #3945

`RecordPatches` is **one `partial class` spread over 94 files**. A `private` member declared in any of them is reachable from the other 93 — so *"it is private, and it is in a different file"* is two true statements whose conjunction implies something false.

Measured over `AlRunner/**/*.cs`:

| partial class | files |
|---|---|
| **`RecordPatches`** | **94** |
| `BcRuntime` | 24 |
| `NclCecilRewrite`, `ProgramSupport` | 9 each |
| `LiveNavTestPage` | 8 |
| `RunnerPageInstance` | 4 |

## What it cost

Issue #3933's "Suggested fix" advised widening a `private` decoder to `internal` **or moving it to a shared location**, because it looked unreachable from the calling file. I repeated that in the dispatch brief. The calling file declares the same `partial class` and had access all along — the implementing agent checked the premise instead of acting on it.

The edit it argues for is not free: widening a member's visibility, or relocating it, is a real diff in a hot file that needs review and leaves a member more visible than anything requires.

## Why it belongs in the navigation section

It is the same class as the two traps already there — `grep` exiting 0 with no output, `rg` skipping dot-directories: **a reading that looks like a finding and has nothing contradicting it.** Here the tell is that this repository's navigation is file-oriented (`context-pack.py`, graphify, grep over paths), so the file is the unit you reason about, and for these six classes it is not the boundary that matters.

The check is one command against the calling file.

No test: this is navigation guidance in `CLAUDE.md`. The 94/24/9/8/4 figures are reproducible with the scan in #3945.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
