### PR TITLE
test(compiler): drive ReadEnumExtensible and ReadEnumImplementationFallback from a compiled AL enum

### DIFF
--- a/AlRunner.Tests/EnumCompilerSymbolPropertyCaptureTests.cs
+++ b/AlRunner.Tests/EnumCompilerSymbolPropertyCaptureTests.cs
@@ -1,0 +1,208 @@
+// EnumCompilerSymbolPropertyCaptureTests — issue #3912.
+//
+// THE GAP THIS CLOSES
+// Two compiler-side readers in BcCompiler.CaptureOutputter had no test that drives them:
+//
+//   * ReadEnumExtensible            (#3807) — the enum's declared `Extensible` property
+//   * ReadEnumImplementationFallback (#2306) — the enum-level DefaultImplementation and
+//                                              UnknownValueImplementation codeunit lists
+//
+// Demonstrated on the issue rather than inferred: mutating ReadEnumExtensible to
+// `return null;` unconditionally, rebuilt in Release with 0 `error CS`, left
+// EnumExtensibleAndImplementationRenderTests at Failed: 0, Passed: 6, Total: 6.
+//
+// WHY THE EXISTING TESTS DO NOT COVER IT, AND ARE STILL RIGHT
+// EnumExtensibleAndImplementationRenderTests constructs an EnumSymbol directly and asserts
+// what the metadata-equivalence RENDER states; EnumDefaultImplementationTests constructs an
+// AlEnumOptionMetadata directly and asserts the three-step resolution BC's
+// NCLEnumMetadata.GetImplementationCodeunitId performs. Both are correctly scoped to their own
+// observable. Neither reaches BcCompiler, so the path FROM BC's compiler symbol TO the
+// registry record — which is what these two readers are — was unmeasured at both ends.
+//
+// This is a RUNNER-MECHANISM test, not a claim about what real BC does: every assertion is
+// about what OUR capture pipeline stores in AlEnumMetadataRegistry after BC's own compiler has
+// parsed the AL. The BC-side claims these values feed (an enum's DefaultImplementation
+// resolving an interface cast, an extensible enum accepting an enumextension) are Base App /
+// AL-language behaviour and are the corpus's to adjudicate, per
+// .claude/rules/bc-behavior-tests-go-upstream.md.
+//
+// THE THREE-WAY ANSWER IS THE POINT
+// Entry.Extensible is `bool?`, not `bool`, because BC's own emitter keeps "declared false" and
+// "declared nothing" apart (12 of 144 emitted enum documents state no Extensible attribute).
+// IApplicationObjectTypeSymbol.IsExtensible is `GetBooleanPropertyValue(Extensible) ??
+// ExtensibleByDefault` and CANNOT tell those two apart, which is exactly why ReadEnumExtensible
+// reads the PROPERTY. A test asserting only true/false would pass against a reader that had
+// silently regressed to IsExtensible — so the absent case is asserted for both readers.
+//
+// ONE FIXTURE, BOTH READERS: a single AL enum can declare Extensible, DefaultImplementation and
+// UnknownValueImplementation at once, so the "declared" half of both readers is one compile.
+// The "absent" half needs sibling enums that declare nothing, which live in the same compile.
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class EnumCompilerSymbolPropertyCaptureTests : IDisposable
+{
+    private readonly string _root;
+    private readonly BcEngineFixture _engine;
+
+    // 90500-90509. Enum, codeunit and interface ids live in separate AL object-type
+    // namespaces, so the block is read as one range here only for legibility.
+    private const int ImplAId = 90501;
+    private const int ImplBId = 90502;
+    private const int DeclaresEverythingId = 90503;
+    private const int DeclaresExtensibleFalseId = 90504;
+    private const int DeclaresNothingId = 90505;
+
+    public EnumCompilerSymbolPropertyCaptureTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = TestScratch.Dir("al-runner-enum-compiler-symbol-capture-tests");
+        Directory.CreateDirectory(_root);
+        AlEnumMetadataRegistry.Clear();
+    }
+
+    public void Dispose()
+    {
+        AlEnumMetadataRegistry.Clear();
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    /// <summary>
+    /// One compile carrying all three states of both readers. Enum 90503 declares
+    /// <c>Extensible = true</c> plus both implementation fallbacks; 90504 declares
+    /// <c>Extensible = false</c> and no fallbacks; 90505 declares neither.
+    /// </summary>
+    private AlEnumMetadataRegistry.Entry Compile(int id)
+    {
+        File.WriteAllText(Path.Combine(_root, "EnumPropertyCapture.al"), $$"""
+            interface "EnumPropCapture Thing"
+            {
+                procedure Hello(): Integer;
+            }
+
+            codeunit {{ImplAId}} "EnumPropCapture Impl A" implements "EnumPropCapture Thing"
+            {
+                procedure Hello(): Integer begin exit(1); end;
+            }
+
+            codeunit {{ImplBId}} "EnumPropCapture Impl B" implements "EnumPropCapture Thing"
+            {
+                procedure Hello(): Integer begin exit(2); end;
+            }
+
+            enum {{DeclaresEverythingId}} "EnumPropCapture Declares All" implements "EnumPropCapture Thing"
+            {
+                Extensible = true;
+                DefaultImplementation = "EnumPropCapture Thing" = "EnumPropCapture Impl A";
+                UnknownValueImplementation = "EnumPropCapture Thing" = "EnumPropCapture Impl B";
+                value(0; Alpha) { }
+            }
+
+            enum {{DeclaresExtensibleFalseId}} "EnumPropCapture Extensible False"
+            {
+                Extensible = false;
+                value(0; Alpha) { }
+            }
+
+            enum {{DeclaresNothingId}} "EnumPropCapture Declares Nothing"
+            {
+                value(0; Alpha) { }
+            }
+            """);
+
+        var output = new BcCompiler().Emit(new[] { _root }, "EnumPropCaptureModule");
+        Assert.True(output.Sources.Count > 0,
+            $"Expected the fixture to emit; diagnostics: {string.Join(" | ", output.Diagnostics.Take(10))}");
+
+        Assert.True(AlEnumMetadataRegistry.TryGet(id, out var entry),
+            $"Expected enum {id} to be registered in AlEnumMetadataRegistry after emit");
+        return entry;
+    }
+
+    [SkippableFact]
+    public void ReadEnumExtensible_CapturesDeclaredTrue_FromTheCompilerSymbol()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        Assert.Equal(true, Compile(DeclaresEverythingId).Extensible);
+    }
+
+    [SkippableFact]
+    public void ReadEnumExtensible_CapturesDeclaredFalse_NotNull()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        // `false` and `null` are different answers. A reader that folded a declared false into
+        // "declares nothing" would make the render omit an attribute BC's own emitter states
+        // for 31 of 142 base enums.
+        Assert.Equal(false, Compile(DeclaresExtensibleFalseId).Extensible);
+    }
+
+    [SkippableFact]
+    public void ReadEnumExtensible_AnEnumDeclaringNone_CapturesNull_NotAlsOwnDefault()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        // The state IApplicationObjectTypeSymbol.IsExtensible cannot express: AL's own default
+        // for a non-implementing enum is false, so a reader that used IsExtensible would answer
+        // `false` here and this assertion is what separates the two implementations.
+        Assert.Null(Compile(DeclaresNothingId).Extensible);
+    }
+
+    [SkippableFact]
+    public void ReadEnumImplementationFallback_CapturesBothDeclaredCodeunitIds()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var entry = Compile(DeclaresEverythingId);
+
+        // The reader resolves the AL `Interface = Codeunit` form to the implementing codeunit's
+        // OBJECT ID, one per interface-declaration index. Distinct ids for the two properties,
+        // so a reader that read one property and answered for both would fail here.
+        Assert.Equal(new[] { ImplAId }, entry.DefaultImplementations);
+        Assert.Equal(new[] { ImplBId }, entry.UnknownImplementations);
+    }
+
+    [SkippableFact]
+    public void ReadEnumImplementationFallback_AnEnumDeclaringNone_CapturesNullForBoth()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var entry = Compile(DeclaresNothingId);
+
+        // Null, not an empty array: "declares none" is what AlEnumOptionMetadata's three-step
+        // fallback reads as "no enum-level implementer", and what the render omits the
+        // attribute for (#2306, #3807).
+        Assert.Null(entry.DefaultImplementations);
+        Assert.Null(entry.UnknownImplementations);
+    }
+
+    [SkippableFact]
+    public void TheCapturedFallbacks_ResolveThroughAlEnumOptionMetadata()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var entry = Compile(DeclaresEverythingId);
+
+        // The consumer end, driven from the COMPILED entry rather than a hand-built one: a
+        // known ordinal with no per-value Implementation takes DefaultImplementation, an
+        // unknown ordinal takes UnknownValueImplementation. That split is the whole reason the
+        // two are read as separate properties, and EnumDefaultImplementationTests proves it
+        // only against constructed inputs.
+        var meta = new AlEnumOptionMetadata(entry.Name, entry.Id, entry.Options, entry.Indexes,
+            entry.Implementations, entry.Captions,
+            entry.DefaultImplementations, entry.UnknownImplementations);
+
+        Assert.Equal(ImplAId, meta.GetImplementationCodeunitIdPublic(0, 0));
+        Assert.Equal(ImplBId, meta.GetImplementationCodeunitIdPublic(7, 0));
+    }
+}


### PR DESCRIPTION
Closes #3912

Pure test coverage. No runner behaviour changes — the diff is one new file under
`AlRunner.Tests/` and nothing else.

## What was unmeasured

Two compiler-side readers in `BcCompiler.CaptureOutputter` had no test that drove them:
`ReadEnumExtensible` (#3807) and `ReadEnumImplementationFallback` (#2306). The existing
tests are correctly scoped to their own observables and simply do not reach `BcCompiler`:
`EnumExtensibleAndImplementationRenderTests` constructs an `EnumSymbol` and asserts the
metadata-equivalence render; `EnumDefaultImplementationTests` constructs an
`AlEnumOptionMetadata` and asserts BC's three-step resolution. The path **from BC's
compiler symbol to the registry record** — which is what these two readers are — was
unmeasured at both ends.

## What the new tests do

`AlRunner.Tests/EnumCompilerSymbolPropertyCaptureTests.cs`, six tests in the
`bc-engine-serial` collection. Each compiles a real AL fixture through
`new BcCompiler().Emit(...)` and asserts what lands in `AlEnumMetadataRegistry` —
so a broken reader is the only way to fail them.

Both readers owe a **three-way** answer, and all three states are asserted:

| | `Extensible` | `DefaultImplementation` / `UnknownValueImplementation` |
|---|---|---|
| declared | `true` (enum 90503) | `[90501]` / `[90502]` |
| declared, other value | `false` (enum 90504) | — |
| absent | `null` (enum 90505) | `null` / `null` |

The **absent** case is the one that matters and the one a naive test would miss.
`IApplicationObjectTypeSymbol.IsExtensible` is `GetBooleanPropertyValue(Extensible) ??
ExtensibleByDefault`, so it answers `false` for an enum that declares nothing. Asserting
`null` there is exactly what separates the reader that exists from the one a regression
would substitute — and it is why `Entry.Extensible` is `bool?` rather than `bool`.

The two implementation-fallback properties resolve to **distinct** codeunit ids (90501 vs
90502), so a reader that read one property and answered for both fails.

A sixth test drives the captured fallbacks through `AlEnumOptionMetadata` from the
**compiled** entry, rather than a hand-built one, joining the two halves that were each
proven only in isolation.

### One fixture, both readers

**One fixture served both.** A single AL enum can declare `Extensible`,
`DefaultImplementation` and `UnknownValueImplementation` at once, so the "declared" half
of both readers is one enum in one compile (90503). The "absent" half needs enums that
declare nothing, and those are sibling objects in the *same* compile (90504, 90505) — so
it is one `.al` file and one `Emit` call, not two fixtures. Object ids 90500-90509,
verified free.

## Mutation testing — one per reader, separately

Each mutation changed a returned **value** and left the structure alone, so neither could
pass as a caught regression by breaking the build. Each was confirmed to have landed by
re-reading the mutated region, and each build reported **0 `error CS`**.

**Baseline (unmutated):** `Failed: 0, Passed: 6, Total: 6`, `Skipped: 0`.

**Mutation 1 — `ReadEnumExtensible`.** `return t == "1" || ...` → `_ = t; return null;`

```
Failed: 2, Passed: 4, Skipped: 0, Total: 6
  ReadEnumExtensible_CapturesDeclaredTrue_FromTheCompilerSymbol  Expected: True  Actual: null
  ReadEnumExtensible_CapturesDeclaredFalse_NotNull               Expected: False Actual: null
```

**Mutation 2 — `ReadEnumImplementationFallback`.**
`return ids.Count > 0 ? ids.ToArray() : null;` → `return ids.Count > 0 ? null : null;`

```
Failed: 2, Passed: 4, Skipped: 0, Total: 6
  ReadEnumImplementationFallback_CapturesBothDeclaredCodeunitIds  Expected: [90501] Actual: null
  TheCapturedFallbacks_ResolveThroughAlEnumOptionMetadata         Expected: 90501   Actual: -1
```

Both REDs are `Assert.Equal()` failures, not `error CS`, and both runs printed a `Total:`
line. The two mutations fail **disjoint** test sets, which is the point: one red would not
have told us which reader was covered. Restored after each; `git status` confirms
`BcCompiler.cs` is untouched in the pushed diff.

## Cache: measured, and it is a real cache

Not assumed either way. A probe showed `BcCompiler.Emit` over an unchanged tree costs
**309 ms then 1 ms then 0 ms** in one process — an in-process cache HIT — and that
`AlEnumMetadataRegistry` still refills correctly after a `Clear()` on the warm path. So
there *is* a cache between the reader and the observable, exactly the condition
`local-test-scope.md` names.

The discriminating run: **the suite was run twice against one cache root with mutation 1
still applied**, and stayed red both times — `Failed: 2, Passed: 4` on run A and run B.
The test is therefore not correct-cold-and-wrong-warm. Green was likewise confirmed twice
warm after restoring: `Failed: 0, Passed: 6` on both.

No `PayloadShape` or `CacheVersion` change: this PR adds no persisted record and changes
no parse, so neither applies. `BcAppSymbolCache`'s `CacheVersion 42` is the
precompiled-dependency symbol cache and is not on this path — these fixtures are
source-compiled with no dependencies.

## Fix the shape, not just the reported line

1. **Does the same wrong pattern appear at another call site?** The gap is *missing
   coverage*, not a wrong pattern, so the question becomes: which other values does
   `CaptureOutputter.AddApplicationObject` read that nothing drives? The other three
   enum-side readers are already driven from a real compile —
   `ReadEnumValueCaption` and the options/indexes capture by
   `EnumCaptionCaptureTests`, `ReadEnumValueImplementations` by the per-value assertions
   there. These two were the remainder.
2. **Does a sibling function make the same assumption?** `ReadEnumImplementationFallback`
   is called twice with different `PropertyKind` values, and that is the sibling: the
   fixture gives the two properties **different** codeunit ids so the two calls cannot be
   confused for one another.
3. **If two code paths write the same state, do they maintain the same invariant?** Yes,
   and this is the one genuinely left out — see below.

## Deliberately not folded in

**The enum sidecar round trip.** The issue asks whether it folds in. It is a *different
observable*: `SaveSidecar`/`LoadSidecar` in `EnumMetadataPatches.cs` is the second writer
of `Entry.Extensible` (lines 347-350 and 465), and the PR #3911 reviewer's finding —
deleting `Extensible` from both writers and both readers leaves the whole suite green —
is about that path, not this one. The coordinator's own note on #3912 is precisely that a
single mutation which goes red tells you *something* is covered and not *which*: folding
the sidecar in here without its own separate mutation would repeat that error. It also
lives in a different file. Not fixed here, and it is not left unsaid — reported to the
coordinator so it can be filed or assigned.

**Queue scan (`batch-sibling-issues-by-file.md`, `search-for-the-same-defect-first.md`):**
searched the open queue on the symbol (`ReadEnumExtensible`,
`ReadEnumImplementationFallback`), the observable (`Extensible`), the mechanism
("sidecar round trip") and the subsystem (`BcCompiler CaptureOutputter`). #3912 is the
only issue on either reader. #3579 and #3809 touch enums but land in dependency-sidecar
and extension-delta code, not in these readers; nothing else folds.

## Checks run

- `AlRunner.Tests --filter FullyQualifiedName~EnumCompilerSymbolPropertyCaptureTests` →
  `Failed: 0, Passed: 6, Skipped: 0, Total: 6`
- `--filter FullyQualifiedName~Enum` (the whole adjacent surface) →
  `Failed: 0, Passed: 151, Skipped: 0, Total: 151`
- `--filter FullyQualifiedName~GuardTests` →
  `Failed: 0, Passed: 249, Skipped: 0, Total: 249`
- every `tools/test_*.py` — all pass, `test_doc_summary_uniqueness.py` included
- `check_corpus_linkage.sh` over the real diff → *"No file in this diff can change what AL
  observes, so no corpus declaration is required."* The diff touches no non-`.md` file
  under `AlRunner/`, so neither the corpus-linkage gate nor the `Tests updated` gate's
  trigger fires; the new file satisfies the latter regardless.

All runs used `tools/engine-test-bootstrap.sh` plus `--settings engine.runsettings`, redone
after every build. `Skipped: 0` throughout, so no result here is a silent skip standing in
for a pass.

Implemented by the agent loop `stma-auto-3`, not by a person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
