### PR TITLE
docs(tdd): choose the mutation to test a property, not to produce a red

### DIFF
--- a/.claude/rules/tdd.md
+++ b/.claude/rules/tdd.md
@@ -73,6 +73,20 @@ than green — the exit code cannot tell you the difference.
 is red within minutes; one that passes when it should fail is caught only if somebody looks,
 and until then it reads as coverage while protecting nothing.
 
+**Choose the mutation to test a property, not to produce a red.** A mutation that reds *everything*
+proves coverage exists; one that reds *exactly the right subset* proves the tests discriminate — and
+only the second is worth anything on a coverage PR. Measured on PR #3947, where a reviewer replaced
+both of the author's mutations and each replacement established something the original could not:
+returning `null` from a `bool?` reader reds all three tests, while **inverting** the boolean preserves
+`null`, so the absent-case test correctly stays GREEN — which is what proves that test is pinned to
+`null` rather than riding along. And `? null : null` on a reader reds its tests whatever the fixture
+holds, while making the reader **read the wrong one of two properties** produced
+`Expected: [90502] / Actual: [90501]`, validating that the fixture's two ids are actually distinct —
+a fixture with one id repeated would have passed the author's mutation and looked covered.
+
+**Corollary: re-running the author's mutation is the weakest check a reviewer can make.** It tests
+the same hypothesis by the same route. Pick your own.
+
 A required step, not a tool: no framework, no CI job. One rebuild.
 
 ## Sister rules


### PR DESCRIPTION
Part of #3949

`tdd.md` required a mutation and said how to run one safely — confirm it landed, confirm the RED is an assertion and not `error CS`, report both numbers. It said nothing about **which** mutation to choose, and that turns out to decide how much the exercise is worth.

## The measurement

PR #3947 is a pure coverage PR. Its reviewer, asked to prefer its own mutation over re-running the author's, replaced both — and each replacement proved something the original could not:

| observable | author's | reviewer's | what the difference proved |
|---|---|---|---|
| `ReadEnumExtensible` (`bool?`) | `return null;` | **invert the boolean** | `null` reds all three tests. Inverting *preserves* `null`, so the absent-case test correctly stays **GREEN** — which is what proves that test is pinned to `null` rather than riding along. |
| `ReadEnumImplementationFallback` | `ids.Count > 0 ? null : null` | **ignore the `kind` argument** — both properties non-null, wrong one read | `Expected: [90502] / Actual: [90501]`, validating the fixture's two ids are genuinely distinct. A fixture repeating one id would have passed the author's mutation and looked covered. |

Both still failed **disjoint** test sets, which is #3912's own point: one red proves *something* is covered, not *which* thing.

## The general form

**A mutation that reds everything proves coverage exists. One that reds exactly the right subset proves the tests discriminate.** On a coverage PR the second is the deliverable.

The corollary is about review: re-running the author's mutation tests the same hypothesis by the same route. It confirms the author ran what they said and adds no independent information.

## Scope

Guidance, not a gate — deliberately. #3949 records what I did **not** measure: whether past coverage PRs here used all-red mutations that would fail this standard. A scan of merged PR bodies for mutation results where the failing count equals the whole suite would say whether this is a recurring weakness. Without that number, hardening it into a check would be guessing at a threshold.

No test: rules prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
