### PR TITLE
docs(rules): commit search-for-the-same-defect-first, finished to the convention

### DIFF
--- a/.claude/rules/batch-sibling-issues-by-file.md
+++ b/.claude/rules/batch-sibling-issues-by-file.md
@@ -56,6 +56,8 @@ claimed the same way and its `Closes #M` added to the draft's body (`.claude/age
 
 ## Sister rules
 
+- `search-for-the-same-defect-first.md` — the other axis: the same **defect** filed twice in
+  different words, which a file-keyed scan cannot find. Run both.
 - `check-open-prs-before-claiming.md` — the other pre-claim queue read: an open PR carrying
   `Closes #N` means N is taken, whatever its labels say. Run both scans at the same moment.
 - `branch-and-pr.md` — "one open PR per impl agent", reconciled above

--- a/.claude/rules/search-for-the-same-defect-first.md
+++ b/.claude/rules/search-for-the-same-defect-first.md
@@ -1,0 +1,73 @@
+# Before implementing, search for other issues reporting the SAME defect
+
+`batch-sibling-issues-by-file.md` tells you to scan the queue for issues whose fix lands in the
+**same file**. This rule is the other axis: **the same defect, filed more than once, in different
+words.** Two issues can describe one root cause and share no file, no symbol and no vocabulary — so
+a file-keyed scan cannot find them, and neither can a title search using the words *you* would have
+chosen.
+
+## The rule
+
+**Before you implement, search the open queue for the defect you are about to fix — by its
+mechanism, not by its title.** Then say what you found in the PR body, including when you found
+nothing.
+
+Search on at least three of these, because any one of them alone misses:
+
+- **The symbol or member** the defect lives on (`NCLMetaTable`, `SymbolReference`, `MetaField.Editable`).
+- **The observable** — what AL or a caller actually sees wrongly (`Editable` answers true,
+  `TableNo = 0`, a key count of 2 instead of 3).
+- **The mechanism** — the shape, not the surface: "swallowed into a cached null", "latched before the
+  work", "a failed lookup reads as absent".
+- **The measurement** — a distinctive count is the single best search key a repository like this
+  has. `71 members`, `1,018 tests`, `356 failures`: whoever filed the sibling almost certainly quoted
+  their number too.
+
+When you find one, decide and **record the decision on the issue**: fold it in (with its own
+RED→GREEN, per `batch-sibling-issues-by-file.md`), or state why it is genuinely distinct. Both
+outcomes are useful; a silent overlap is not.
+
+## Why this is not covered by the labels
+
+A label is only as good as the sweep that applied it, and sweeps are built from whatever the
+sweeper happened to key on. Measured on this repository: `area: metadata-conversion` had been
+applied from the `blocked-by: metadata-emitter` label, so it inherited that label's blind spot
+and **three issues on the same route carried no area label at all** — #3568, #3590 and #3491,
+three of twenty-three, and #3568 was the same measurement programme as the issue it was missing
+from. Each would have been found by a *different* one of the four keys above, which is why the
+rule asks for three. Derivation: docs/incidents/search-for-the-same-defect-first.md.
+
+So: **the labels are a starting point, never the answer to "has this been reported?"** Search the
+text.
+
+## The two failure modes this prevents
+
+- **Two agents fixing one defect from opposite ends.** Both PRs green, both correct, and they
+  conflict — or worse, they do not, and the second's proving test passes for free because the
+  first already fixed it. A test that passes for the wrong reason is what `tdd.md` calls noise.
+- **A partial fix that closes the wrong issue.** A describes the symptom, B the root cause.
+  Fixing A and closing it leaves B open with no owner and no record that the cause is known — or
+  closes B by association when only A's surface was tested.
+
+## Say so even when you find nothing
+
+"I searched for X, Y and Z and found nothing" is a real result and belongs in the PR body: it
+says which stones were turned, and it is the difference between *no duplicate exists* and
+*nobody looked*. An absence you did not measure is not a finding (`no-assumption-fixes.md`).
+
+**Confirm every empty result a second way.** `grep` here is a shell function that rejects flags
+and exits 0 with no output; `rg` skips dot-directories without `--hidden`; and `gh issue list
+--search` matches differently from a `--jq` filter over titles. A zero from one query is not
+evidence (`verify-execution-not-the-tick.md`).
+
+## Sister rules
+
+- `batch-sibling-issues-by-file.md` — the same scan keyed on **file**; run both, they find
+  different things
+- `check-open-prs-before-claiming.md` — an open PR carrying `Closes #N` means the issue is taken,
+  whatever its labels say
+- `no-assumption-fixes.md` — understand the defect before fixing it; a thin issue is not foldable
+  until it is diagnosed
+- `verify-execution-not-the-tick.md` — why a zero from a single query is not an answer
+
+History: docs/incidents/search-for-the-same-defect-first.md

--- a/docs/incidents/search-for-the-same-defect-first.md
+++ b/docs/incidents/search-for-the-same-defect-first.md
@@ -1,0 +1,59 @@
+# Incidents behind `search-for-the-same-defect-first.md`
+
+## The measurement that produced the rule
+
+Taken while the repository owner was asking whether the metadata-conversion cluster had been
+filed more than once. The `area: metadata-conversion` label had been applied by a sweep keyed on
+the `blocked-by: metadata-emitter` label — so the sweep inherited that label's blind spot, and
+**three issues on the same route carried no area label at all**:
+
+| issue | why the label sweep missed it |
+|---|---|
+| **#3568** — the SymbolReference derivation disagrees with BC's metadata emitter on **71 more members** | filed *from the first run of the harness built for #3533*, so it is the direct continuation of that work — and it carried **no labels whatsoever** |
+| **#3590** — `BuildNCLMetaTable` swallows every construction failure into a cached null | labelled `bug`, which says what it is and not what it belongs to |
+| **#3491** — 2,702 lines re-implementing BC's own AL expression parsers | a research issue, so no `status:` and no area |
+
+Three of twenty-three. #3568 is the one that mattered most, because it is the same measurement
+programme as the issue it was missing from.
+
+**What generalises:** a label is only as good as the sweep that applied it, and a sweep is built
+from whatever the sweeper happened to key on. A label set derived from another label inherits
+that label's omissions, and nothing in the result looks incomplete.
+
+## Why the search keys are the four in the rule
+
+Each of the three above would have been found by a different key, which is why the rule asks for
+at least three:
+
+- **#3568** by its **measurement** — `71 members` is a distinctive string, and whoever files a
+  sibling almost certainly quotes their own count too.
+- **#3590** by its **mechanism** — "swallowed into a cached null" shares no vocabulary with the
+  issue it duplicates.
+- **#3491** by neither label nor title, only by the **symbol** its work touches.
+
+A title search using the words *you* would have chosen finds none of them.
+
+## The confirm-every-empty-result clause
+
+Added because two of this repository's search tools return a clean zero when they have failed
+rather than when nothing matched: `grep` here resolves to a shell **function** that rejects `-E`
+and exits 0 with no output, and `rg` skips dot-directories unless passed `--hidden` — which is
+where everything governing agent behaviour lives. `CLAUDE.md` § 3 and § 3b own both.
+
+`gh issue list --search` also matches differently from a `--jq` filter over titles, so the two
+disagree on the same query. A zero from one is not evidence.
+
+## Why the rule was untracked for so long (#3888)
+
+The rule file lived in exactly one working tree, auto-loaded into every agent session on that
+box, and was never committed: 4,771 bytes, not tracked, not ignored, no history, no
+`History:` line, and no incidents file. Agents there obeyed an instruction no reviewer reading
+the repository could see, and a fresh clone silently did not have it.
+
+It is the shape `guards-need-a-third-state.md` describes, one level up: someone searching the
+repository for "where is this written down?" gets a correct empty answer about a rule that is
+actively in force.
+
+**The class was checked, not just the instance.** `git ls-files --others --exclude-standard
+.claude/` returned exactly one path — this file — so no other rule, skill, agent or hook was in
+the same state.


### PR DESCRIPTION
Closes #3888

`.claude/rules/search-for-the-same-defect-first.md` existed in exactly one working tree, was **auto-loaded into every agent session on that box**, and had never been committed. Verified on this machine: 4,771 bytes, `NOT TRACKED`, `NOT ignored`, no `git log` history, no `History:` line, no incidents file.

So agents there obeyed an instruction no reviewer reading the repository could see, and a fresh clone silently did not have it. It is the shape `guards-need-a-third-state.md` describes one level up: someone searching the repository for *"where is this written down?"* gets a correct empty answer about a rule that is actively in force.

**The class was checked, not just the instance** — the issue asked for that, and it is the part most likely to be skipped:

```
git ls-files --others --exclude-standard .claude/   →  exactly one path
```

No other rule, skill, agent or hook is in this state. A bounded fix, and a useful negative.

## Finished rather than deleted

The issue left both dispositions open. The content is sound and non-duplicative — it argues the *same defect, different words* axis against `batch-sibling-issues-by-file.md`'s *same file* axis, and each of the three issues in its measurement (#3568, #3590, #3491) would have been found by a **different** one of its four search keys, which is what justifies asking for three.

Per `CLAUDE.md` § "How a rule is written":

- **Derivation moved out** to `docs/incidents/search-for-the-same-defect-first.md`, leaving claim + citation + trap in the rule.
- **`History:` line added**, which every other rule carries.
- **Cross-referenced** from `batch-sibling-issues-by-file.md`'s sister list, so it is reachable from the rule it names as its sibling axis.

## One thing I did not achieve, stated plainly

The convention says a rule is done when it is **under 3 KB**. This is **4,176 bytes** after trimming, down from 4,771.

I stopped cutting rather than remove substance to hit the number, because the number does not describe this repository: **only 7 of 22 rules are under 3 KB**, and `ci-verdicts.md` is 24 KB. At 4,176 this sits 11th of 22 — smaller than eight existing rules including `loud-failures.md` and `guards-need-a-third-state.md`.

If the reviewer reads 3 KB as a hard bar rather than an aspiration for new rules, say so and I will cut further — but I would be removing one of the four search keys or the failure-mode section, and I do not think either is padding.

`tools/test_doc_pointers.py` passes and every `tools/test_*.py` passes.

**Unrelated, noticed while committing:** three untracked `Probe.Codeunit.al` / `Probe.Page.al` / `Probe.Table.al` files sit at the repository root — scratch from earlier work, not mine and not touched here, but they are the same *untracked leftover* class and somebody should decide whether they are ignored or deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
