### PR TITLE
test(enum-sidecar): drive the SaveSidecar/LoadSidecar round trip for Extensible and both implementation fallbacks

### DIFF
--- a/AlRunner.Tests/EnumSidecarEnumLevelPropertyRoundTripTests.cs
+++ b/AlRunner.Tests/EnumSidecarEnumLevelPropertyRoundTripTests.cs
@@ -1,0 +1,221 @@
+// EnumSidecarEnumLevelPropertyRoundTripTests — issue #3948.
+//
+// A RUNNER-MECHANISM test, not a claim about BC: it pins that AlEnumMetadataRegistry's
+// sidecar round trip (SaveSidecar -> LoadSidecar) carries the three ENUM-LEVEL properties
+// — Extensible (#3807) and the two implementation fallbacks DefaultImplementations /
+// UnknownImplementations (#2306) — through a save+reload cycle with their values intact.
+//
+// Why it exists. Entry.Extensible has TWO writers. #3947 covered the compile-time one
+// (BcCompiler.ReadEnumExtensible / ReadEnumImplementationFallback, symbol -> record); this
+// is the other, the persisted sidecar. Measured on this branch before the tests were
+// written: replacing SaveSidecar's `extensible = r.Entry.Extensible` with a constant null
+// left the whole enum/sidecar surface green at Failed: 0, Passed: 181 — i.e. no test
+// anywhere reached this path. The same held for the read side.
+//
+// Why the nullable states are the subject rather than an edge case. Extensible is a
+// `bool?`, and the three states are genuinely distinct: null means "the enum declares no
+// Extensible property at all", which the metadata render LEAVES OFF, while a declared
+// false is rendered as a stated zero (see Entry's own doc comment and
+// EnumExtensibleAndImplementationRenderTests). A round trip that collapsed absent-to-false
+// would be invisible to a test that only ever asserted true — so each state gets its own
+// assertion, and the absent case additionally asserts through a sidecar written with NO
+// `extensible` property at all, which is what a legacy file looks like.
+//
+// Scope note: the merged-read path (TryGet taking the BASE entry's Extensible, an
+// enumextension carrying none) is asserted by EnumExtensionSidecarRoundTripTests and by
+// the render tests; what is new here is that the PERSISTED FORM preserves the value.
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class EnumSidecarEnumLevelPropertyRoundTripTests : IDisposable
+{
+    private readonly string _root;
+
+    public EnumSidecarEnumLevelPropertyRoundTripTests()
+    {
+        _root = TestScratch.Dir("al-runner-enum-sidecar-enum-level-props");
+        Directory.CreateDirectory(_root);
+        AlEnumMetadataRegistry.Clear();
+    }
+
+    public void Dispose()
+    {
+        AlEnumMetadataRegistry.Clear();
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    // Three ids so one sidecar can carry all three Extensible states at once and a
+    // cross-contaminating bug (every entry reading the first entry's value) shows up as a
+    // mismatch rather than as three tests that happen to agree.
+    private const int ExtensibleTrueId = 61501;
+    private const int ExtensibleFalseId = 61502;
+    private const int ExtensibleAbsentId = 61503;
+
+    private static readonly string[] Options = { "Zero", "One" };
+    private static readonly int[] Indexes = { 0, 1 };
+
+    /// <summary>Registers the three enums — declared-true, declared-false and
+    /// declares-nothing — writes ONE sidecar holding all three, then clears the registry so
+    /// the reload is the only thing that can put the values back. Returns the path.</summary>
+    private string WriteSidecarWithAllThreeExtensibleStates()
+    {
+        AlEnumMetadataRegistry.Clear();
+        AlEnumMetadataRegistry.Register(ExtensibleTrueId, "Extensible True", Options, Indexes,
+            extensible: true);
+        AlEnumMetadataRegistry.Register(ExtensibleFalseId, "Extensible False", Options, Indexes,
+            extensible: false);
+        AlEnumMetadataRegistry.Register(ExtensibleAbsentId, "Extensible Absent", Options, Indexes,
+            extensible: null);
+
+        var path = Path.Combine(_root, "three-states.enum-registry.json");
+        var written = AlEnumMetadataRegistry.SaveSidecar(path,
+            new[] { ExtensibleTrueId, ExtensibleFalseId, ExtensibleAbsentId });
+        Assert.Equal(3, written);
+
+        AlEnumMetadataRegistry.Clear();
+        Assert.False(AlEnumMetadataRegistry.TryGet(ExtensibleTrueId, out _),
+            "the registry must be empty before the reload, or the assertions below could be "
+            + "satisfied by the pre-save registration instead of by the round trip");
+        return path;
+    }
+
+    [Fact]
+    public void RoundTrip_ExtensibleTrue_SurvivesSaveAndLoad()
+    {
+        var path = WriteSidecarWithAllThreeExtensibleStates();
+
+        var replayed = AlEnumMetadataRegistry.LoadSidecar(path);
+        Assert.Equal(3, replayed);
+
+        Assert.True(AlEnumMetadataRegistry.TryGet(ExtensibleTrueId, out var entry));
+        // Positive: the concrete value, not merely "has a value" — a round trip that
+        // collapsed true to false would satisfy `HasValue`.
+        Assert.True(entry.Extensible.HasValue, "a declared Extensible must not come back as absent");
+        Assert.True(entry.Extensible!.Value);
+    }
+
+    [Fact]
+    public void RoundTrip_ExtensibleFalse_SurvivesAsFalse_NotAsAbsent()
+    {
+        var path = WriteSidecarWithAllThreeExtensibleStates();
+
+        Assert.Equal(3, AlEnumMetadataRegistry.LoadSidecar(path));
+
+        Assert.True(AlEnumMetadataRegistry.TryGet(ExtensibleFalseId, out var entry));
+        // The discriminating pair: a declared false must come back as a VALUE that is
+        // false, never as null. Collapsing it to null would make the render leave the
+        // member off, which is what BC does for an enum that declares nothing — a
+        // different statement about a different enum.
+        Assert.True(entry.Extensible.HasValue,
+            "a declared `Extensible = false` must round-trip as a stated false, not as \"declares none\"");
+        Assert.False(entry.Extensible!.Value);
+    }
+
+    [Fact]
+    public void RoundTrip_ExtensibleAbsent_StaysNull_RatherThanBecomingFalse()
+    {
+        var path = WriteSidecarWithAllThreeExtensibleStates();
+
+        Assert.Equal(3, AlEnumMetadataRegistry.LoadSidecar(path));
+
+        Assert.True(AlEnumMetadataRegistry.TryGet(ExtensibleAbsentId, out var entry));
+        // The other half of the pair above: "declares nothing" must not acquire a value.
+        // A `?? false` anywhere on either side of the round trip fails exactly here and
+        // nowhere else.
+        Assert.Null(entry.Extensible);
+    }
+
+    [Fact]
+    public void RoundTrip_AllThreeStatesInOneSidecar_StayDistinct()
+    {
+        // Guards against the whole-file failure mode the three per-state tests cannot see
+        // individually: a reader that applies the FIRST entry's value to every entry, or a
+        // writer that emits one shared value, passes any single-state test.
+        var path = WriteSidecarWithAllThreeExtensibleStates();
+
+        Assert.Equal(3, AlEnumMetadataRegistry.LoadSidecar(path));
+
+        Assert.True(AlEnumMetadataRegistry.TryGet(ExtensibleTrueId, out var t));
+        Assert.True(AlEnumMetadataRegistry.TryGet(ExtensibleFalseId, out var f));
+        Assert.True(AlEnumMetadataRegistry.TryGet(ExtensibleAbsentId, out var a));
+
+        Assert.Equal(new bool?[] { true, false, null },
+            new[] { t.Extensible, f.Extensible, a.Extensible });
+    }
+
+    [Fact]
+    public void LoadSidecar_EntryWithNoExtensibleProperty_ReadsAsAbsent_NotAsFalse()
+    {
+        // The legacy/back-compat shape: a sidecar written before #3807 carries no
+        // `extensible` property at all. ReadNullableBool's "absent" branch is a different
+        // code path from its JSON-null branch, and both must land on null — the state the
+        // render leaves off. Written by hand rather than by SaveSidecar because this build
+        // always emits the property.
+        var path = Path.Combine(_root, "legacy-no-extensible.enum-registry.json");
+        File.WriteAllText(path,
+            "{\"enums\":[{\"id\":61504,\"name\":\"Legacy No Extensible\",\"options\":[\"A\",\"B\"],"
+            + "\"indexes\":[0,1],\"implementations\":[[],[]],\"captions\":[null,null]}]}");
+
+        Assert.Equal(1, AlEnumMetadataRegistry.LoadSidecar(path));
+
+        Assert.True(AlEnumMetadataRegistry.TryGet(61504, out var entry));
+        Assert.Equal("Legacy No Extensible", entry.Name);
+        Assert.Null(entry.Extensible);
+    }
+
+    [Fact]
+    public void RoundTrip_DefaultAndUnknownImplementationFallbacks_SurviveSaveAndLoad()
+    {
+        // Same file, same round trip, same persisted shape as Extensible — #2306's two
+        // enum-level fallbacks are written and read by the identical SaveSidecar /
+        // LoadSidecar pair, so they belong to this fixture rather than to one of their own.
+        // Distinct, non-overlapping codeunit id lists so a reader that swapped the two
+        // properties produces a mismatch rather than a coincidence.
+        const int Id = 61505;
+        var defaults = new[] { 90501 };
+        var unknowns = new[] { 90502 };
+
+        AlEnumMetadataRegistry.Clear();
+        AlEnumMetadataRegistry.Register(Id, "Fallback Enum", Options, Indexes,
+            defaultImplementations: defaults, unknownImplementations: unknowns, extensible: true);
+
+        var path = Path.Combine(_root, "fallbacks.enum-registry.json");
+        Assert.Equal(1, AlEnumMetadataRegistry.SaveSidecar(path, new[] { Id }));
+        AlEnumMetadataRegistry.Clear();
+
+        Assert.Equal(1, AlEnumMetadataRegistry.LoadSidecar(path));
+        Assert.True(AlEnumMetadataRegistry.TryGet(Id, out var entry));
+
+        Assert.Equal(defaults, entry.DefaultImplementations);
+        Assert.Equal(unknowns, entry.UnknownImplementations);
+        // Negative: the two must not have been read from each other's property.
+        Assert.NotEqual(entry.DefaultImplementations, entry.UnknownImplementations);
+    }
+
+    [Fact]
+    public void RoundTrip_EnumDeclaringNoFallbacks_ReadsAsNull_NotAsEmptyArray()
+    {
+        // ReadIdList's "absent or empty means declares none" convention, pinned across the
+        // round trip: an enum with no DefaultImplementation must not come back carrying an
+        // empty array, because null and empty reach different render branches (#2306).
+        const int Id = 61506;
+
+        AlEnumMetadataRegistry.Clear();
+        AlEnumMetadataRegistry.Register(Id, "No Fallbacks", Options, Indexes,
+            defaultImplementations: null, unknownImplementations: null, extensible: false);
+
+        var path = Path.Combine(_root, "no-fallbacks.enum-registry.json");
+        Assert.Equal(1, AlEnumMetadataRegistry.SaveSidecar(path, new[] { Id }));
+        AlEnumMetadataRegistry.Clear();
+
+        Assert.Equal(1, AlEnumMetadataRegistry.LoadSidecar(path));
+        Assert.True(AlEnumMetadataRegistry.TryGet(Id, out var entry));
+
+        Assert.Null(entry.DefaultImplementations);
+        Assert.Null(entry.UnknownImplementations);
+        // And the Extensible on the same entry is still the declared false — the two
+        // properties are read by different helpers and must not interfere.
+        Assert.False(entry.Extensible!.Value);
+    }
+}


### PR DESCRIPTION
Closes #3948

Filed and implemented by the agent `stma-auto-2`.

Coverage only — no behaviour change. `AlRunner.Tests/EnumSidecarEnumLevelPropertyRoundTripTests.cs` is the whole diff; nothing under `AlRunner/` is touched.

## The gap, re-measured before writing anything

`Entry.Extensible` has two writers. #3947 closed the compile-time one (`BcCompiler.ReadEnumExtensible`); the sidecar round trip — `SaveSidecar` writing `extensible = r.Entry.Extensible` at `EnumMetadataPatches.cs:350`, `LoadSidecar` reading it back through `ReadNullableBool` at :380 — was the remaining path that survived mutation.

I reproduced that on this branch rather than taking it on trust. Replacing the write with a constant `null`, rebuilt and **bootstrapped**, left the whole enum/sidecar surface green:

```
Failed: 0, Passed: 181, Skipped: 0, Total: 181
```

**One correction worth recording, because it nearly inverted the result.** My first attempt at that same mutation reported `Failed: 18, Passed: 163` and looked like the path was already covered. All 18 failed in `< 1 ms` with `[bc-engine-serial] REFUSING TO SKIP` — the unbootstrapped-engine guard, not assertions. The 181-green figure above is the post-bootstrap one and is the real premise. This is the trap #3078/#3835 describe, and it fires in the *opposite* direction from the documented one: here it manufactured a fake RED that would have closed the issue as already-covered.

## What the tests do

Seven tests drive the real `SaveSidecar` → `LoadSidecar` pair. None construct an `Entry` and assert the render — the shape of gap this cluster is about. Each writes a sidecar, calls `AlEnumMetadataRegistry.Clear()`, and asserts the value came back from the file; the fixture asserts the registry is empty before the reload, so no assertion can be satisfied by the pre-save registration.

**The three nullable states, each reachable and each asserted separately.** `Extensible` is a `bool?` where `null` ("declares nothing", which the render leaves off) and a declared `false` (rendered as a stated zero) are different statements about different enums:

| state | test | the claim |
|---|---|---|
| `true` | `RoundTrip_ExtensibleTrue_SurvivesSaveAndLoad` | the concrete value, not merely `HasValue` |
| `false` | `RoundTrip_ExtensibleFalse_SurvivesAsFalse_NotAsAbsent` | must not collapse to `null` |
| `null` (registered) | `RoundTrip_ExtensibleAbsent_StaysNull_RatherThanBecomingFalse` | must not acquire a value; a `?? false` fails exactly here |
| `null` (property absent from the JSON) | `LoadSidecar_EntryWithNoExtensibleProperty_ReadsAsAbsent_NotAsFalse` | `ReadNullableBool`'s absent branch is a different code path from its JSON-null branch |

`RoundTrip_AllThreeStatesInOneSidecar_StayDistinct` puts all three in **one** sidecar and asserts `[true, false, null]` as a collection, which is what catches a reader applying the first entry's value to every entry — a failure mode no single-state test can see.

## Both mutation pairs, and what each established

Each mutation was applied alone (the other side verified unmutated at line 350), rebuilt, **re-bootstrapped after the build**, and confirmed to land by re-reading the line. `error CS` count was 0 on every build, so every RED is an assertion, not a broken compile.

| | mutation | result | what it established |
|---|---|---|---|
| **A — write** | invert the boolean, **preserving `null`** (`HasValue ? !Value : null`) | `Failed: 4, Passed: 3` | `Expected: [True, False, null]` / `Actual: [False, True, null]` |
| **B — read** | `ReadNullableBool` reads `name + "_MUTATED"` | `Failed: 4, Passed: 3` | `Expected: [True, False, null]` / `Actual: [null, null, null]` |

Restored: `Failed: 0, Passed: 7, Skipped: 0, Total: 7`.

**The mutations were chosen to test a property, not to produce a red** (`tdd.md`, from #3947's review). Returning a constant `null` from the writer reds all three state tests and cannot distinguish them. Inverting **preserves `null`**, so `RoundTrip_ExtensibleAbsent_StaysNull` correctly stays **GREEN** — and that green is what proves the absent test is pinned to `null` rather than riding along on a mutation that reds everything.

**The two REDs are not interchangeable, which is the point of running both.** They fail the same four tests but with different signatures: a broken write yields `[False, True, null]` (values transposed, still three distinct states), a broken read yields `[null, null, null]` (everything collapsed to absent). One red would have proven "something is covered", not which direction — the error #3912 exists to fix.

The green pair under each mutation is also the right pair: `LoadSidecar_EntryWithNoExtensibleProperty_...` stays green under A because it bypasses `SaveSidecar` entirely (hand-written legacy JSON), confirming it exercises the read path alone.

## The two implementation fallbacks: one fixture, decided rather than assumed

`DefaultImplementations` and `UnknownImplementations` are written and read by the **identical** `SaveSidecar`/`LoadSidecar` pair, so they share this fixture rather than getting one of their own. Two tests: distinct non-overlapping id lists (`[90501]` vs `[90502]`) so a reader that swapped the two properties produces a mismatch rather than a coincidence, plus a negative asserting the two are not equal to each other; and `RoundTrip_EnumDeclaringNoFallbacks_ReadsAsNull_NotAsEmptyArray`, pinning `ReadIdList`'s null-vs-empty convention (#2306), since null and empty reach different render branches.

Both mutations red `RoundTrip_EnumDeclaringNoFallbacks_...` too, because that test also asserts the declared `false` on the same entry — deliberate: it pins that the two properties are read by different helpers and do not interfere.

## Cache

Measured, not assumed, per `local-test-scope.md`'s "is there a cache between my change and its observable?". **Ran twice against one cache root: `7/7` both runs, identical.** The answer is "no cache", and structurally so: each test writes its sidecar into a fresh per-test `TestScratch.Dir` and calls `SaveSidecar`/`LoadSidecar` directly in-process, so no AL-output cache sits between write and read. No `CacheVersion` bump — I changed no cached record shape and no parse.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** `ReadNullableBool` has exactly one caller (the `extensible` read). The sibling registries — `AlObjectMetadataRegistry`, `AlPageMetadataRegistry`, `AlReportMetadataRegistry`, `AlXmlPortMetadataRegistry`, `AlReportLayoutRegistry` — each have their own `SaveSidecar`/`LoadSidecar` pair. Whether their enum-level properties are equally uncovered is a real question this PR does not answer; it is a different file per registry, so it is not foldable here, and I did not fold it.
2. **Sibling functions with the same assumption?** Yes, and they are in this PR: `ReadIdList` sits beside `ReadNullableBool`, is read by the same `LoadSidecar` loop, and shares the "absent/empty means declares none" convention. That is why the fallbacks are in this fixture rather than deferred.
3. **Two paths writing the same state, same invariant?** `Register` and `RegisterExtension` both write `Entry`, and only `Register` takes `extensible` — deliberate, since `Extensible` is a property of the base enum and `TryGet` takes `baseEntry?.Extensible`. Already asserted by `EnumExtensionSidecarRoundTripTests` and the render tests; unchanged here.

## Queue scan

Searched the open queue by symbol (`Extensible`, `LoadSidecar`, `SaveSidecar`, `EnumMetadataPatches`), by mechanism (`round trip`), and by observable (`DefaultImplementation`). `LoadSidecar`/`SaveSidecar`/`EnumMetadataPatches` each return only #3948 and #3912 — and #3912 is closed by #3947.

**Not folded, with the reason:** #3579 (`fix(enum): include extensions of existing IDs in dependency sidecars`) is adjacent in subject but lands in `DependencyLoader.cs`'s before/after id-diff scoping, a different file, and is a **behaviour** change rather than coverage. Folding a behaviour fix into a coverage PR is what the scope note on #3948 forbids. Nothing else in the queue lands in `EnumMetadataPatches.cs`.

## Findings

**No defect found.** All three nullable states survive the round trip today, and both implementation fallbacks do. The issue was a genuine coverage gap, not a latent bug — the path was correct and simply unprotected.

## Test runs

| run | result |
|---|---|
| baseline, bootstrapped, enum+sidecar | `Failed: 0, Passed: 181, Skipped: 0, Total: 181` |
| premise: write mutated to constant null | `Failed: 0, Passed: 181` — the uncovered path |
| new file, GREEN | `Failed: 0, Passed: 7, Skipped: 0, Total: 7` |
| mutation A (write, inverting) | `Failed: 4, Passed: 3, Skipped: 0, Total: 7` |
| mutation B (read, wrong property) | `Failed: 4, Passed: 3, Skipped: 0, Total: 7` |
| restored | `Failed: 0, Passed: 7, Skipped: 0, Total: 7` |
| warm second run, same cache root | `Failed: 0, Passed: 7, Skipped: 0, Total: 7` |
| enum+sidecar surface with the new file | `Failed: 0, Passed: 188, Skipped: 0, Total: 188` (181 + 7, no regressions) |
| `~GuardTests` | `Failed: 0, Passed: 249, Skipped: 0, Total: 249` |
| `tools/test_*.py` | all pass |

Every run above was bootstrapped (`tools/engine-test-bootstrap.sh` re-run after **every** build) and executed with `--settings engine.runsettings`; `Skipped: 0` on all of them. Test counts were checked against the seven `[Fact]` methods, so the filter matched the intended class rather than silently matching nothing.

No corpus declaration: the diff touches only `AlRunner.Tests/`, confirmed by running `.github/scripts/check_corpus_linkage.sh` over the real diff — *"No file in this diff can change what AL observes, so no corpus declaration is required."*

**CI note:** `main` is red from the unrelated corpus-ordering issue #3922, so the BC legs are expected to inherit six `Codeunit60992` failures per leg until #3927 merges. Not chased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
