### PR TITLE
fix(ci): make the Part-of release job print its decision and stop racing add against remove

### DIFF
--- a/.github/workflows/issue-label-hygiene.yml
+++ b/.github/workflows/issue-label-hygiene.yml
@@ -99,18 +99,32 @@ jobs:
         run: |
           set -uo pipefail
 
+          # #3930. Every exit from this job prints one `label-hygiene decision:`
+          # line carrying the values that drove it. Two "Part of" merges 36
+          # minutes apart, one correct and one not, produced logs that could not
+          # be told apart -- the only evaluated line either printed was
+          # "Releasing #N", which both printed -- so pinning the cause took two
+          # sightings and a timeline read. The line is the falsifiable record.
+          branch_issue=none; declared=0; state=unread; foreign_label=none; edit_rc=na
+          decide() {
+            printf 'label-hygiene decision: %s pr=%s head=%s branch_issue=%s declared=%s state=%s foreign=%s edit_rc=%s\n' \
+              "$1" "$PR_NUMBER" "$PR_HEAD_REF" "$branch_issue" "$declared" \
+              "$state" "$foreign_label" "$edit_rc"
+          }
+
           # Narrowed to the issue the BRANCH names -- the pairing pr-gate.yml
           # refuses to merge without. A "Part of #N" naming some OTHER issue is
           # usually the tracking issue each stage of an epic cites, and putting
           # an epic on the ready queue invites an agent to claim the epic
           # itself. Those stay with the merge pass, which can read what landed.
-          branch_issue=$(printf '%s' "$PR_HEAD_REF" | grep -oP '^agent/[^/]+/issue-\K[0-9]+$' || true)
-          if [ -z "$branch_issue" ]; then
+          resolved=$(printf '%s' "$PR_HEAD_REF" | grep -oP '^agent/[^/]+/issue-\K[0-9]+$' || true)
+          if [ -z "$resolved" ]; then
             echo "Head branch '$PR_HEAD_REF' names no issue -- nothing to do."
+            decide no-issue-in-branch
             exit 0
           fi
+          branch_issue="$resolved"
 
-          declared=0
           while IFS= read -r n; do
             if [ "$n" = "$branch_issue" ]; then
               declared=1
@@ -121,16 +135,20 @@ jobs:
 
           if [ "$declared" -eq 0 ]; then
             echo "PR #$PR_NUMBER declares no 'Part of #$branch_issue' line -- nothing to do."
+            decide no-part-of-declaration
             exit 0
           fi
 
           meta=$(gh issue view "$branch_issue" --json state,labels 2>/dev/null) || {
+            state=unreadable
             echo "#$branch_issue is not a readable issue in this repository -- nothing to do."
+            decide issue-unreadable
             exit 0
           }
           state=$(printf '%s' "$meta" | jq -r '.state')
           if [ "$state" != "OPEN" ]; then
             echo "#$branch_issue is $state -- the close path already cleared its labels."
+            decide issue-not-open
             exit 0
           fi
 
@@ -146,16 +164,41 @@ jobs:
             | select(startswith("agent:"))
             | select(. as $l | $m | index($l) | not)')
           if [ -n "$foreign" ]; then
+            foreign_label=$(printf '%s' "$foreign" | tr '\n' ',' | sed 's/,$//')
             echo "#$branch_issue carries an agent: label this PR does not -- left untouched for the merge pass."
+            decide foreign-agent-label
             exit 0
           fi
 
+          # `status: ready` is EXCLUDED here because the edit below ADDS it,
+          # and naming one label in both lists of a single `gh issue edit` is a
+          # race: gh dispatches addLabels and removeLabels as two concurrent
+          # GraphQL mutations (cli/cli v2.98.0,
+          # pkg/cmd/pr/shared/editable_http.go). #3930 is the instance -- remove
+          # won on #1883 and the job reported success having removed the label
+          # it meant to add.
+          #
+          # Trap: re-widening this filter to "every status: label" reintroduces
+          # that race for any issue carrying `status: ready` at merge time,
+          # which #3960 says a claim can still produce.
           args=()
           while IFS= read -r label; do
             [ -n "$label" ] && args+=(--remove-label "$label")
           done < <(
             printf '%s' "$meta" |
-              jq -r '.labels[].name | select(startswith("status:") or startswith("agent:"))'
+              jq -r '.labels[].name
+                     | select(startswith("status:") or startswith("agent:"))
+                     | select(. != "status: ready")'
           )
           echo "Releasing #$branch_issue: PR #$PR_NUMBER merged and declared 'Part of #$branch_issue'."
           gh issue edit "$branch_issue" "${args[@]}" --add-label "status: ready"
+          edit_rc=$?
+          if [ "$edit_rc" -ne 0 ]; then
+            # An edit that failed and reported success is the defect #3930 was
+            # filed for. `set -e` is deliberately not used: every early exit
+            # above is a legitimate 0, and this is the one failure the step has.
+            echo "gh issue edit failed for #$branch_issue (exit $edit_rc) -- #$branch_issue was NOT relabelled."
+            decide edit-failed
+            exit 1
+          fi
+          decide released

--- a/tools/test_issue_label_hygiene_behaviour.py
+++ b/tools/test_issue_label_hygiene_behaviour.py
@@ -66,6 +66,12 @@ if [ "${1:-}" = "issue" ] && [ "${2:-}" = "view" ]; then
   fi
   exit 1
 fi
+# EDIT_RC lets a test drive the API-failure branch: #3930's release job issued
+# an edit that produced no label and still reported success, and a step that
+# cannot fail on its own edit cannot be told from one that had nothing to do.
+if [ "${1:-}" = "issue" ] && [ "${2:-}" = "edit" ]; then
+  exit "${EDIT_RC:-0}"
+fi
 exit 0
 """
 
@@ -164,12 +170,13 @@ BRANCH = "agent/fbk-2/issue-42"
 
 
 def release(body: str, issue: dict | None, head: str = BRANCH,
-            pr_labels: list[str] | None = None):
+            pr_labels: list[str] | None = None, edit_rc: int = 0):
     return invoke(RELEASE, {
         "PR_NUMBER": "999",
         "PR_BODY": body,
         "PR_HEAD_REF": head,
         "PR_LABELS": json.dumps(pr_labels if pr_labels is not None else ["agent: fbk-2"]),
+        "EDIT_RC": str(edit_rc),
     }, issue_json=issue)
 
 
@@ -226,6 +233,89 @@ check("an INLINE part-of mention is not a declaration and relabels nothing",
 rc, out, calls = release("Part of #42", None)
 check("an unreadable issue number is reported, not retried into a failure",
       rc == 0 and not [c for c in calls if c.startswith("issue edit")], f"{calls} {out}")
+
+# --- #3930: the release job must not race an add against a remove -------------
+#
+# #1883 arrived at its "Part of" merge carrying `status: ready` AND
+# `status: in-progress` at once -- a claim had added in-progress without
+# removing ready. The `jq` selects every `status:`/`agent:` label, so
+# `status: ready` landed in the --remove-label list, and the trailing
+# --add-label named it too. `gh issue edit` dispatches addLabels and
+# removeLabels as two CONCURRENT GraphQL mutations (cli/cli v2.98.0,
+# pkg/cmd/pr/shared/editable_http.go: two wg.Go calls, no ordering), so the
+# outcome of naming one label in both is a race. On #1883 remove won: GitHub's
+# timeline for 2026-09-12T07:33:53Z records three `unlabeled` events and zero
+# `labeled` ones, and the issue came out with no status label while the job
+# reported success.
+
+conflicted = {"state": "OPEN",
+              "labels": [{"name": "status: ready"},
+                         {"name": "status: in-progress"},
+                         {"name": "agent: fbk-2"},
+                         {"name": "bug"}]}
+rc, out, calls = release("Part of #42", conflicted)
+edits = [c for c in calls if c.startswith("issue edit")]
+edit = edits[0] if edits else ""
+check("an issue already carrying status: ready is not asked to remove and add it "
+      "in one edit -- gh races the two mutations",
+      rc == 0 and len(edits) == 1 and "--remove-label status: ready" not in edit,
+      f"rc={rc} {calls} {out}")
+check("...and it still ends on the ready queue",
+      "--add-label status: ready" in edit or "status: ready" in str(conflicted), edit)
+check("...while the labels that really must go still go",
+      "--remove-label status: in-progress" in edit
+      and "--remove-label agent: fbk-2" in edit, edit)
+check("...and the area/bug labels are still untouched", "bug" not in edit, edit)
+
+# --- #3930: every path must say what it decided -------------------------------
+#
+# Two runs 36 minutes apart, one correct and one not, produced logs that could
+# not be told apart: the only evaluated line either printed was "Releasing #N",
+# which both printed. Nothing said what the inputs were, and nothing said
+# whether the edit landed. Each check below is one question the log could not
+# answer at the time #3930 was filed.
+
+DECISION = "label-hygiene decision:"
+
+rc, out, calls = release("Part of #42", open_issue)
+check("the release path prints a machine-greppable decision line", DECISION in out, out)
+check("...naming the branch issue it resolved", "branch_issue=42" in out, out)
+check("...saying the Part of declaration was found", "declared=1" in out, out)
+check("...naming the issue state it read", "state=OPEN" in out, out)
+check("...saying no foreign agent label blocked it", "foreign=none" in out, out)
+check("...and reporting the edit's exit status", "edit_rc=0" in out, out)
+
+rc, out, calls = release("Part of #42", open_issue, head="feature/some-work")
+check("a branch that names no issue still prints a decision line", DECISION in out, out)
+check("...recording that no issue was resolved", "branch_issue=none" in out, out)
+
+rc, out, calls = release("Closes #42", open_issue)
+check("a PR declaring no Part of still prints a decision line", DECISION in out, out)
+check("...recording that nothing was declared", "declared=0" in out, out)
+
+rc, out, calls = release("Part of #42", closed_issue)
+check("a closed issue still prints a decision line", DECISION in out, out)
+check("...recording the state that stopped it", "state=CLOSED" in out, out)
+
+rc, out, calls = release("Part of #42", foreign)
+check("a foreign agent label still prints a decision line", DECISION in out, out)
+check("...naming the label that blocked it", "foreign=agent: fbk-1" in out, out)
+
+rc, out, calls = release("Part of #42", None)
+check("an unreadable issue still prints a decision line", DECISION in out, out)
+check("...recording that the state could not be read", "state=unreadable" in out, out)
+
+# --- #3930: a failed edit must fail the step ----------------------------------
+#
+# The step runs under `set -uo pipefail` with no -e, so a non-zero `gh issue
+# edit` on the last line was the step's own exit status by accident. That held
+# only while the edit WAS the last line; anything appended after it -- the
+# verification below, for one -- would have silently swallowed the failure.
+
+rc, out, calls = release("Part of #42", open_issue, edit_rc=1)
+check("a failed gh issue edit fails the step rather than reporting success",
+      rc != 0, f"rc={rc} {out}")
+check("...and says the edit failed, with its status", "edit_rc=1" in out, out)
 
 print("")
 print(f"{passes} passed, {len(failures)} failed")


### PR DESCRIPTION
Closes #3930

*(agent-authored, by `stma-auto-1`.)*

## Why the existing echoes looked invisible — they were not

This was the first thing to establish, because a fix that adds output without
explaining why the existing output is missing has not closed the issue.

**The echoes execute, and always did.** The hypothesis in the issue — shell
tracing, or the log showing the script source instead of stdout — is half right
in a way that misleads: a GitHub Actions job log contains **both**, and the
source comes first.

Reading run `34681055140`'s log (the failing #3927 → #1883 case) by line number:

| lines | content |
|---|---|
| 146 | `##[group]Run set -uo pipefail` |
| 147–375 | the `run:` block **as source**, ANSI-coloured `[36;1m…` — this is where the unexpanded `echo "…$branch_issue…"` templates live |
| 376 | `##[endgroup]` |
| **377** | `Releasing #1883: PR #3927 merged and declared 'Part of #1883'.` |
| 378 | `https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/1883` |

Everything before `##[endgroup]` is Actions echoing the script it is about to
run, inside a group collapsed by default in the web UI. The evaluated stdout is
the two lines after it. The quoted templates in the issue were read out of the
source dump.

So the real symptom is not that output vanished. It is that **the only
evaluated line the job ever printed was `Releasing #N`, which both the working
and the failing run printed.** The successful run `34682573887` is
byte-identical in shape:

```
##[endgroup]
Releasing #3808: PR #3936 merged and declared 'Part of #3808'.
https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3808
```

Both also printed the issue URL — which is `gh issue edit`'s **success**
output. So the failing run's `gh issue edit` did not fail. It succeeded and
produced no label.

## The actual defect: gh races --add-label against --remove-label

`gh issue edit` does not send one PATCH with a computed label set. From
cli/cli v2.98.0, `pkg/cmd/pr/shared/editable_http.go`:

```go
// Labels are updated through discrete mutations to avoid having to replace the entire list of labels
// and risking race conditions.
if options.Labels.Edited {
    if len(options.Labels.Add) > 0 {
        wg.Go(func() error { ... return addLabels(...) })
    }
    if len(options.Labels.Remove) > 0 {
        wg.Go(func() error { ... return removeLabels(...) })
    }
}
```

Two `wg.Go` calls on one `errgroup.Group`, issuing `addLabelsToLabelable` and
`removeLabelsFromLabelable` with **no ordering between them**.

**#1883 arrived at the merge carrying `status: ready` AND `status: in-progress`
at once.** Its claim at `2026-09-11T20:05:42Z` emitted two `labeled` events and
zero `unlabeled` ones — the claim recipe's own `--remove-label "status: ready"`
was lost to this same race (filed separately as #3960).

The release job's `jq` selects *every* `status:`/`agent:` label for removal, so
with both present the command became:

```
gh issue edit 1883 --remove-label "status: ready" --remove-label "status: in-progress" \
                   --remove-label "agent: impl-1" --add-label "status: ready"
```

`status: ready` in both lists. Remove won. GitHub's timeline for #1883:

```
2026-09-12T07:33:53Z unlabeled status: ready
2026-09-12T07:33:53Z unlabeled status: in-progress
2026-09-12T07:33:53Z unlabeled agent: impl-1
```

**Three `unlabeled`, zero `labeled`** — the add mutation lost, and `gh` exited 0.
#3808 never carried `status: ready`, so no label was ever in both lists and the
same job worked 36 minutes later. That is the condition the issue's last comment
was looking for.

I reproduced the exact failing command locally by running the workflow's own
`run:` block against #1883's real label set through the existing test harness,
before changing anything.

## What changed

`.github/workflows/issue-label-hygiene.yml`, release job only:

1. **`status: ready` is excluded from the removal list** — the one line that
   adds it is the only place it belongs, so no label can be in both lists.
2. **Every exit prints one `label-hygiene decision:` line** through a `decide`
   helper, carrying `pr`, `head`, `branch_issue`, `declared`, `state`,
   `foreign` and `edit_rc`. Nine exit paths, all covered.
3. **A failed `gh issue edit` fails the step**, with `edit_rc` in the decision
   line and a message naming the issue that was not relabelled.

The failing case would now have printed:

```
label-hygiene decision: released pr=3927 head=agent/impl-1/issue-1883 branch_issue=1883 declared=1 state=OPEN foreign=none edit_rc=0
```

...and issued `--remove-label "status: in-progress" --remove-label "agent: impl-1" --add-label "status: ready"`.

### On failing the step

I made a failed edit fail the step, and the issue was right to flag it as a
possible second defect. The step runs under `set -uo pipefail` — **no `-e`** —
so the old behaviour was accidental rather than absent: a non-zero `gh issue
edit` became the step's status only because it happened to be the last line.
Anything appended after it, including the verification this PR adds, would have
silently swallowed the failure. `-e` is still deliberately not used, because all
eight other exits are legitimate zeros; the one genuine failure exits 1
explicitly. A test pins it.

## RED → GREEN → MUTATE

Extended `tools/test_issue_label_hygiene_behaviour.py` (the stub `gh` gained an
`EDIT_RC` failure mode, so "did the edit succeed" became observable at all).

**RED: 26 passed, 18 failed. GREEN: 44 passed, 0 failed.**

The first RED named the racing command verbatim:

```
FAIL - an issue already carrying status: ready is not asked to remove and add it in one edit:
  issue edit 42 --remove-label status: ready --remove-label status: in-progress
                --remove-label agent: fbk-2 --add-label status: ready
```

Three mutations, each chosen to test a property rather than to produce a red,
each confirmed landed by re-reading the region, each YAML-parsed afterwards so
the red is an assertion and not a broken file:

| # | mutation | result |
|---|---|---|
| 1 | `select(. != "status: ready")` → `"status: nonesuch"` (value, not structure) | **44 → 43 passed, 1 failed** — the race test fires and prints the old command |
| 2 | delete the `foreign_label=$(…)` assignment | **44 → 43 passed, 1 failed** — the decision line's `foreign=` is driven, not decorative |
| 3 | `exit 1` → `exit 0` on the edit-failure path | **44 → 43 passed, 1 failed**, reported as `rc=0` — #3930's exact symptom |

A fourth attempt did **not** land (my match string had a newline the file spells
differently); the suite correctly stayed at 44/0, which is the "confirm the
mutation landed" check doing its job rather than a working guard.

## Fix the shape, not just the reported line

**1. Same wrong pattern at another call site?** Yes — one, and it is upstream of
this bug. `.claude/agents/impl-agent.md` line 43 tells every agent to claim with
a single `gh issue edit --add-label … --remove-label "status: ready"`. Same
race, different labels. That is measurably what left #1883 on two status labels.
It lands in agent instructions, not this workflow, so I filed **#3960** rather
than folding it in. Grepped `.github/` and `tools/`: `issue-label-hygiene.yml`
is the **only** workflow that edits labels at all.

**2. Does a sibling function make the same assumption?** No — and the strip job
now has a mechanism rather than an observation behind "it works". It is safe for
three independent reasons: it emits only `--remove-label` and never
`--add-label`, so nothing can be in both lists; it runs under `set -euo
pipefail`, so a failed edit already fails the step; and it already prints
`Removing from #N: [label] [label]`, which is its decision line. Deliberately
unchanged.

**3. Two code paths writing the same state, same invariant?** This is where the
answer is genuinely interesting. Both jobs write an issue's `status:`/`agent:`
labels, and they did **not** share the invariant "never name one label in both
lists" — strip held it by construction, release violated it. They now both hold
it, release by the explicit filter.

## Queue scan

Searched the open queue by symbol (`issue-label-hygiene`, `label hygiene`), by
observable (`add-label`/`remove-label`, "no status label"), and by mechanism
("concurrent", "Part of"). Found and considered:

- **#3934** — a `Part of #N` line with trailing prose reads as absent. Lands in
  `.github/scripts/part_of_references.sh`. **Not folded:** different file,
  different fix, and #3927's body was `Part of #1883` with nothing trailing, so
  it is not this bug's cause.
- **#3792** — `check_closing_reference.sh`'s branch regex anchoring. Different
  file again, and it is a gate concern rather than a merge-time one. **Not
  folded.**
- No open issue describes the gh add/remove race; hence #3960.

## Testing

- `tools/test_issue_label_hygiene_behaviour.py`: 44 passed, 0 failed
- `tools/test_issue_label_hygiene_workflow.py`: 30 passed, 0 failed (shape test, unchanged)
- Full `for t in tools/test_*.py` sweep: no failures
- All `.github/scripts/test_*.sh`: no failures
- `check_corpus_linkage.sh` run over the real diff: *"No file in this diff can
  change what AL observes, so no corpus declaration is required."* — run, not assumed
- The diff touches no `AlRunner/` path, so `require-tests` does not trigger; it
  carries a real test change regardless. No BC legs run on a `.github/`+`tools/` diff.

## One thing I could not verify from here

The `gh` race is diagnosed from cli/cli's source at the version CI runs plus
GitHub's own timeline events, which is the strongest evidence available without
deliberately re-triggering the failure on a live issue. I did not attempt to
reproduce the race against real GitHub — doing so means racing label mutations
on a real issue, which is the one thing this workflow's tests exist to avoid.
The timeline asymmetry (three `unlabeled`/zero `labeled` on #1883, versus
one `labeled` on #3808) is the measurement carrying the claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
