### PR TITLE
docs(skill): arming does not require a green verdict

### DIFF
--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -146,6 +146,15 @@ at that instant.
 gh pr merge <N> --repo <owner>/<repo> --squash --auto
 ```
 
+**Arming does NOT require a green verdict, and a brief that demands one is wrong.** `--auto` exists
+for the not-yet-green case: it holds the PR at `BLOCKED` until every required check passes, and a
+red aggregate means no merge. So `ci-wait.py` exit **2** — checks still running, nothing failing —
+is a perfectly good moment to arm, and insisting on exit 0 forces a second round trip in which the
+verdict goes stale, which is the cost this whole section exists to avoid. Exit **0 or 2** arms;
+exit **1**, **3** or **4** does not. Measured on PR #3959, where a reviewer armed at exit 2, said
+so prominently rather than quietly, and was right — the coordinator's brief had over-specified the
+condition, not the reviewer's judgement (#3961).
+
 Arm **only** when all of these hold. Any one missing means report it to the coordinator instead:
 
 - **The PR is on a branch this loop owns.** Check the **branch prefix**, never the author field


### PR DESCRIPTION
Part of #3961

Every review brief I wrote this session demanded `tools/ci-wait.py <PR> --timeout 0` exit **0** before arming auto-merge. The skill never required that, and the condition is wrong.

`--auto` **holds rather than bypasses** — the skill says so in its own words two paragraphs above the arming list: the command arms when checks are pending and merges when they are already green, and `gh` picks between them. A red required check means no merge either way.

So exit **2** — checks still running, nothing failing — is a perfectly good moment to arm. Demanding exit 0 forces the reviewer to hand back and someone to re-read later, **which is precisely the staleness the "arm in the same pass" instruction exists to prevent.** The brief re-introduced the problem the section was written to solve.

## The measurement

PR #3959: the reviewer finished with 9/9 complete, 0 failing, only `BC test matrix passed` outstanding. It armed at exit 2 and **flagged the deviation prominently rather than burying it**. `mergeStateStatus` stayed `BLOCKED`; the PR is held, not merged. Its judgement was right and my brief was wrong.

Exit **0 or 2** arms; **1**, **3**, **4** do not — the discrimination `ci-verdicts.md` already supplies.

## Scope

One paragraph above the arming list. #3961 stays open for what I did **not** measure: whether any PR this session was genuinely delayed rather than merely made to wait one sweep. I believe #3944, #3947 and #3956 all sat at exit 2 with MERGE verdicts before I merged them by hand, but I have not reconstructed the timings and am not claiming it.

No test: skill prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
