### PR TITLE
fix(server): clear superseded unresolved table relations

### DIFF
--- a/AlRunner.Tests/ServerTableRelationReloadTests.cs
+++ b/AlRunner.Tests/ServerTableRelationReloadTests.cs
@@ -61,29 +61,42 @@ public sealed class ServerTableRelationReloadTests(ITestOutputHelper output)
                 codeunit 70782 "SRR Tests"
                 {
                     Subtype = Test;
+                    var Assert: Codeunit "SRR Assert";
                     [Test] procedure ValidRelation()
                     var Subject: Record "SRR Subject";
                     begin
                         Subject.Validate("Target Code", 'PRESENT');
-                        if Subject."Target Code" <> 'PRESENT' then Error('Wrong relation value');
+                        Assert.AreEqual('PRESENT', Subject."Target Code", 'valid relation');
                     end;
                     [Test] procedure MissingRelation()
                     var Subject: Record "SRR Subject";
                     begin
                         asserterror Subject.Validate("Target Code", 'MISSING');
-                        if StrPos(GetLastErrorText(), 'cannot be found') = 0 then
-                            Error('Expected normal missing target error, got %1', GetLastErrorText());
+                        Assert.ExpectedError('cannot be found');
                     end;
                     [Test] procedure DependencyLogic()
                     var Logic: Codeunit "SRR Logic";
                     begin
-                        if Logic.Twice(21) <> 42 then Error('Wrong dependency result');
+                        Assert.AreEqual('42', Format(Logic.Twice(21)), 'dependency result');
                     end;
                     [Test] procedure InstallSeed()
                     var Target: Record "SRR Target";
                     begin
                         Target.Get('PRESENT');
-                        if Target.Marker <> 37 then Error('Wrong install seed');
+                        Assert.AreEqual('37', Format(Target.Marker), 'install seed');
+                    end;
+                }
+                codeunit 70783 "SRR Assert"
+                {
+                    procedure AreEqual(Expected: Text; Actual: Text; Context: Text)
+                    begin
+                        if Expected <> Actual then
+                            Error('%1: expected %2, actual %3', Context, Expected, Actual);
+                    end;
+                    procedure ExpectedError(Part: Text)
+                    begin
+                        if StrPos(GetLastErrorText(), Part) = 0 then
+                            Error('Expected error containing %1, actual %2', Part, GetLastErrorText());
                     end;
                 }
                 """);

--- a/AlRunner.Tests/ServerTableRelationReloadTests.cs
+++ b/AlRunner.Tests/ServerTableRelationReloadTests.cs
@@ -1,0 +1,176 @@
+using System.Text.Json;
+using AlRunner.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AlRunner.Tests;
+
+public sealed class ServerTableRelationReloadTests(ITestOutputHelper output)
+{
+    // A dedicated process is essential: #3964 only fails on the first request, even
+    // when the compile cache is already warm. Target is deliberately not a sibling.
+    [SkippableFact]
+    public async Task PackagedSiblingRelations_WorkOnFirstAndRepeatedRequests_InColdAndWarmServers()
+    {
+        TestArtifacts.SkipIfMissing();
+        var root = TestScratch.Dir("al-runner-server-relation-reload");
+        try
+        {
+            var target = Path.Combine(root, "external", "target");
+            var subject = Path.Combine(root, "source", "subject");
+            var tests = Path.Combine(root, "source", "tests");
+            var packages = Path.Combine(root, "packages");
+            var targetId = Guid.NewGuid();
+            var subjectId = Guid.NewGuid();
+            WriteApp(target, targetId, "SRR Target", []);
+            WriteApp(subject, subjectId, "SRR Subject", [(targetId, "SRR Target")]);
+            WriteApp(tests, Guid.NewGuid(), "SRR Tests", [(targetId, "SRR Target"), (subjectId, "SRR Subject")]);
+            File.WriteAllText(Path.Combine(target, "Target.al"), """
+                table 70780 "SRR Target"
+                {
+                    fields { field(1; Code; Code[20]) { } field(2; Marker; Integer) { } }
+                    keys { key(PK; Code) { Clustered = true; } }
+                }
+                codeunit 70780 "SRR Install"
+                {
+                    Subtype = Install;
+                    trigger OnInstallAppPerCompany()
+                    var Target: Record "SRR Target";
+                    begin
+                        Target.Code := 'PRESENT'; Target.Marker := 37; Target.Insert();
+                    end;
+                }
+                """);
+            File.WriteAllText(Path.Combine(subject, "Subject.al"), """
+                table 70781 "SRR Subject"
+                {
+                    fields
+                    {
+                        field(1; Code; Code[20]) { }
+                        field(2; "Target Code"; Code[20]) { TableRelation = "SRR Target".Code; }
+                    }
+                    keys { key(PK; Code) { Clustered = true; } }
+                }
+                codeunit 70781 "SRR Logic"
+                {
+                    procedure Twice(Value: Integer): Integer
+                    begin exit(Value * 2); end;
+                }
+                """);
+            File.WriteAllText(Path.Combine(tests, "Tests.al"), """
+                codeunit 70782 "SRR Tests"
+                {
+                    Subtype = Test;
+                    [Test] procedure ValidRelation()
+                    var Subject: Record "SRR Subject";
+                    begin
+                        Subject.Validate("Target Code", 'PRESENT');
+                        if Subject."Target Code" <> 'PRESENT' then Error('Wrong relation value');
+                    end;
+                    [Test] procedure MissingRelation()
+                    var Subject: Record "SRR Subject";
+                    begin
+                        asserterror Subject.Validate("Target Code", 'MISSING');
+                        if StrPos(GetLastErrorText(), 'cannot be found') = 0 then
+                            Error('Expected normal missing target error, got %1', GetLastErrorText());
+                    end;
+                    [Test] procedure DependencyLogic()
+                    var Logic: Codeunit "SRR Logic";
+                    begin
+                        if Logic.Twice(21) <> 42 then Error('Wrong dependency result');
+                    end;
+                    [Test] procedure InstallSeed()
+                    var Target: Record "SRR Target";
+                    begin
+                        Target.Get('PRESENT');
+                        if Target.Marker <> 37 then Error('Wrong install seed');
+                    end;
+                }
+                """);
+            Directory.CreateDirectory(packages);
+            Package(target, packages, targetId, "SRR Target", 70780, false);
+            Package(subject, packages, subjectId, "SRR Subject", 70781, true);
+            var cache = Path.Combine(root, "cache");
+            var results = new List<(List<JsonElement> Events, JsonElement Summary, bool Cached, string Diagnostic)>();
+            foreach (var coverage in new[] { false, true })
+            {
+                await using var server = await CliServer.StartAsync(["--cache", cache, "--package-cache", packages]);
+                var request = JsonSerializer.Serialize(new
+                {
+                    command = "runTests", sourcePaths = new[] { tests },
+                    packagePaths = new[] { packages }, coverage
+                });
+                for (var i = 0; i < 3; i++)
+                {
+                    var lines = await server.SendRequestStreamingAsync(request, TimeSpan.FromSeconds(180));
+                    var (events, summary) = ProtocolV2Streaming.Split(lines);
+                    var diagnostic = $"coverage={coverage}, request={i + 1}: {string.Join("\n", lines)}\n{server.StdErr}";
+                    output.WriteLine($"coverage={coverage}, request={i + 1}: {summary}");
+                    output.WriteLine(string.Join(", ", events.Select(e => $"{e.GetProperty("name")}={e.GetProperty("status")}")));
+                    results.Add((events, summary, coverage || i > 0, diagnostic));
+                }
+            }
+            // Finish both lifecycles before asserting so a regression exposes first-request
+            // failures on BOTH cold and already-populated caches, plus subsequent recovery.
+            Assert.All(results, result =>
+            {
+                var (events, summary, cached, diagnostic) = result;
+                Assert.True(summary.GetProperty("exitCode").GetInt32() == 0, diagnostic);
+                Assert.Equal(4, events.Count);
+                Assert.Equal(new[] { "DependencyLogic", "InstallSeed", "MissingRelation", "ValidRelation" },
+                    events.Select(e => e.GetProperty("name").GetString()!.Split('.').Last()).OrderBy(n => n).ToArray());
+                Assert.All(events, e => Assert.True(e.GetProperty("status").GetString() == "pass", diagnostic));
+                Assert.Equal(4, summary.GetProperty("passed").GetInt32());
+                Assert.Equal(0, summary.GetProperty("failed").GetInt32());
+                Assert.Equal(0, summary.GetProperty("errors").GetInt32());
+                Assert.Equal(4, summary.GetProperty("total").GetInt32());
+                Assert.Equal(cached, summary.GetProperty("cached").GetBoolean());
+            });
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { /* best-effort scratch cleanup */ }
+        }
+    }
+
+    private static void WriteApp(string directory, Guid id, string name, (Guid Id, string Name)[] dependencies)
+    {
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(Path.Combine(directory, "app.json"), JsonSerializer.Serialize(new
+        {
+            id, name, publisher = "AL Runner", version = "1.0.0.0", platform = "1.0.0.0", runtime = "14.0",
+            idRanges = new[] { new { from = 70780, to = 70789 } },
+            dependencies = dependencies.Select(d => new { id = d.Id, name = d.Name, publisher = "AL Runner", version = "1.0.0.0" })
+        }));
+    }
+
+    // Like SymbolAppFixture, supply actual registrable symbols, rather than the
+    // source-only packages synthesized by the sibling pre-pass. Sources remain embedded.
+    // The type spelling and Twice(Integer): Integer signature id match BC-emitted
+    // SymbolReference.json for this AL declaration; executable code and authoritative
+    // table documents are compiled from the embedded source by the tested runner.
+    private static void Package(string source, string packages, Guid id, string name, int tableId, bool subject)
+    {
+        var symbols = JsonSerializer.SerializeToUtf8Bytes(new
+        {
+            AppId = id, Name = name, Publisher = "AL Runner", Version = "1.0.0.0", RuntimeVersion = "14.0",
+            Tables = new[] { new {
+                Id = tableId, Name = name,
+                Fields = new object[] {
+                    new { Id = 1, Name = "Code", TypeDefinition = new { Name = "Code[20]" } },
+                    new { Id = 2, Name = subject ? "Target Code" : "Marker", TypeDefinition = new { Name = subject ? "Code[20]" : "Integer" },
+                        Properties = subject ? new[] { new { Name = "TableRelation", Value = "\"SRR Target\".Code" } } : [] }
+                },
+                Keys = new[] { new { Name = "PK", FieldNames = new[] { "Code" }, Properties = new[] { new { Name = "Clustered", Value = "1" } } } }
+            } },
+            Codeunits = subject
+                ? new object[] { new { Id = tableId, Name = "SRR Logic", Methods = new[] { new {
+                    Id = 1516892452, Name = "Twice", ReturnTypeDefinition = new { Name = "Integer" },
+                    Parameters = new[] { new { Name = "Value", TypeDefinition = new { Name = "Integer" } } }
+                } } } }
+                : new object[] { new { Id = tableId, Name = "SRR Install", Properties = new[] { new { Name = "Subtype", Value = "Install" } } } }
+        });
+        var identity = InProcessAppPackager.ReadIdentity(Path.Combine(source, "app.json"))!;
+        InProcessAppPackager.EmitAppPackageToFile(source, identity, Path.Combine(packages, name + ".app"), symbols);
+    }
+}

--- a/AlRunner.Tests/TableRelationUnresolvedRefusalTests.cs
+++ b/AlRunner.Tests/TableRelationUnresolvedRefusalTests.cs
@@ -92,6 +92,113 @@ public sealed class TableRelationUnresolvedRefusalTests : IDisposable
         try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
     }
 
+    [SkippableTheory]
+    [InlineData(false, "relation")]
+    [InlineData(true, "relation")]
+    [InlineData(false, "plain")]
+    [InlineData(true, "plain")]
+    [InlineData(false, "invalid")]
+    [InlineData(true, "invalid")]
+    public void BcDocumentReplacement_DropsOnlySupersededRelationNotes(bool freshFactory, string documentKind)
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "BC engine unavailable");
+        var childTableId = 94210 + (freshFactory ? 3 : 0)
+            + (documentKind == "plain" ? 1 : documentKind == "invalid" ? 2 : 0);
+        RecordPatches.ResetForReload();
+        AlObjectMetadataRegistry.Clear();
+        try
+        {
+            var child = BuildChildTable(childTableId);
+            Assert.True(RecordPatches.TryGetUnresolvedRelationReference(childTableId, 3, out _));
+            Assert.True(child.TryGetFieldByNo(5, out var omittedField));
+            Assert.True(RecordPatches.TryGetUnresolvedRelationReference(childTableId, 5, out _));
+            const int untouchedId = 94202;
+            var otherDir = Path.Combine(_root, "other");
+            Directory.CreateDirectory(otherDir);
+            File.WriteAllText(Path.Combine(otherDir, "Other.al"), $$"""
+                table {{untouchedId}} "TRU Still Unresolved"
+                {
+                    fields {
+                        field(1; Code; Code[20]) { }
+                        field(3; Ref; Code[20]) { TableRelation = "TRU Absent Parent".Code; }
+                    }
+                    keys { key(PK; Code) { } }
+                }
+                """);
+            RecordPatches.AddSourceDir(otherDir);
+            var untouched = RecordPatches.GetOrBuildNCLMetaTable(untouchedId);
+            Assert.NotNull(untouched);
+            Assert.True(untouched.TryGetFieldByNo(3, out var stillUnresolved));
+            Assert.Contains("tablerelation-reference-unresolved",
+                Assert.Throws<RunnerOutOfScopeException>(() => EvaluateRelation(stillUnresolved)).Reason);
+
+            // BC 28.1 emitted shape, reduced from issue #3964's Subject.app. The numeric
+            // target identity arrives after derivation, as it does during sibling discovery.
+            var document = $$"""
+                <MetaTable MetadataVersion="130000" ID="{{childTableId}}" Name="TRU Child"
+                    DataPerCompany="1" xmlns="urn:schemas-microsoft-com:dynamics:NAV:MetaObjects">
+                  <Fields>
+                    <Field ID="1" Name="Entry No." Datatype="Integer" />
+                    <Field ID="3" Name="Unresolved Ref" Datatype="Code" DataLength="20" ValidateTableRelation="1">
+                      <TableRelations TableID="{{ParentTableId}}" TableName="TRU Parent" FieldID="1" />
+                    </Field>
+                  </Fields>
+                  <Keys><Key Key="Field1" KeyName="PK" Clustered="1" /></Keys>
+                  <FieldGroups />
+                </MetaTable>
+                """;
+            if (documentKind == "plain")
+                document = System.Text.RegularExpressions.Regex.Replace(document, "<TableRelations[^>]+/>", "");
+            if (documentKind == "invalid") document = "<invalid";
+            AlObjectMetadataRegistry.Register("Table", childTableId, "TRU Child", document);
+            var loadError = Record.Exception(() =>
+            {
+                if (freshFactory)
+                {
+                    var group = typeof(RecordPatches).GetMethod("ResolveNavAppBaseGroup",
+                        BindingFlags.NonPublic | BindingFlags.Static)!.Invoke(null, null);
+                    child = (NCLMetaTable)typeof(RecordPatches).GetMethod("BuildNCLMetaTableFromBcDocument",
+                        BindingFlags.NonPublic | BindingFlags.Static)!.Invoke(null, new object?[] { childTableId, group })!;
+                }
+                else
+                {
+                    RecordPatches.RebuildTablesFromBcMetadataAll();
+                    Assert.Same(child, RecordPatches.GetOrBuildNCLMetaTable(childTableId));
+                }
+            });
+            if (documentKind == "invalid")
+            {
+                Assert.IsType<TargetInvocationException>(loadError);
+                Assert.IsType<System.Xml.XmlException>(loadError!.GetBaseException());
+                Assert.True(RecordPatches.TryGetUnresolvedRelationReference(childTableId, 3, out _));
+            }
+            else
+            {
+                Assert.Null(loadError);
+                Assert.True(child.TryGetFieldByNo(3, out var resolved));
+                if (documentKind == "relation")
+                {
+                    Assert.Single(resolved.FieldRelations);
+                    Assert.Equal(ParentTableId, resolved.FieldRelations[0].SourceTableId);
+                }
+                else Assert.Empty(resolved.FieldRelations);
+                Assert.False(RecordPatches.TryGetUnresolvedRelationReference(childTableId, 3, out _));
+                // This pins the runner guard; the original server AL fixture proves validation.
+                RecordPatches.RecordImpl_UnresolvedRelationGuardForEvaluate(null, resolved);
+            }
+            Assert.True(RecordPatches.TryGetUnresolvedRelationReference(childTableId, 5, out _));
+            Assert.Contains("TRU Absent Parent",
+                Assert.Throws<RunnerOutOfScopeException>(() => EvaluateRelation(omittedField)).Message);
+            Assert.Contains("TRU Absent Parent",
+                Assert.Throws<RunnerOutOfScopeException>(() => EvaluateRelation(stillUnresolved)).Message);
+        }
+        finally
+        {
+            AlObjectMetadataRegistry.Clear();
+            RecordPatches.ResetForReload();
+        }
+    }
+
     [SkippableFact]
     public void EvaluateRelationOnAFieldWhoseRelationDidNotResolve_RefusesNamingTheTableAndTheField()
     {
@@ -178,7 +285,7 @@ public sealed class TableRelationUnresolvedRefusalTests : IDisposable
     /// looks like from the builder's point of view, and the only way to reach that state at all
     /// (AL that names an absent table does not compile) — and one declaring no relation.
     /// </summary>
-    private NCLMetaTable BuildChildTable()
+    private NCLMetaTable BuildChildTable(int childTableId = ChildTableId)
     {
         var srcDir = Path.Combine(_root, "src");
         Directory.CreateDirectory(srcDir);
@@ -193,7 +300,7 @@ public sealed class TableRelationUnresolvedRefusalTests : IDisposable
             }
             """);
         File.WriteAllText(Path.Combine(srcDir, "Child.al"), $$"""
-            table {{ChildTableId}} "TRU Child"
+            table {{childTableId}} "TRU Child"
             {
                 fields
                 {
@@ -207,6 +314,10 @@ public sealed class TableRelationUnresolvedRefusalTests : IDisposable
                         TableRelation = "TRU Absent Parent"."Code";
                     }
                     field({{NoRelationFieldId}}; "Plain Code"; Code[20]) { }
+                    field(5; "Omitted Ref"; Code[20])
+                    {
+                        TableRelation = "TRU Absent Parent".Code;
+                    }
                 }
                 keys { key(PK; "Entry No.") { Clustered = true; } }
             }
@@ -221,8 +332,8 @@ public sealed class TableRelationUnresolvedRefusalTests : IDisposable
         for (var attempt = 1; attempt <= 3; attempt++)
         {
             RecordPatches.AddSourceDir(srcDir);
-            child = RecordPatches.EnsureTableInMetadataCache(ChildTableId)
-                    ?? RecordPatches.NCLMetadata_GetMetaTableById(skeleton!, ChildTableId, false, 0);
+            child = RecordPatches.EnsureTableInMetadataCache(childTableId)
+                    ?? RecordPatches.NCLMetadata_GetMetaTableById(skeleton!, childTableId, false, 0);
             if (child != null
                 && child.TryGetFieldByNo(ResolvableRelationFieldId, out _)
                 && child.TryGetFieldByNo(UnresolvableRelationFieldId, out _)
@@ -231,7 +342,7 @@ public sealed class TableRelationUnresolvedRefusalTests : IDisposable
         }
 
         Assert.Fail(
-            $"table {ChildTableId} did not come back carrying all three fields after three "
+            $"table {childTableId} did not come back carrying all three fields after three "
             + "register-and-rebuild attempts; it has field(s): "
             + (child == null
                 ? "<no metatable at all>"

--- a/AlRunner/Patches/RecordPatches.NclMetaTableFromBcDocument.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableFromBcDocument.cs
@@ -134,7 +134,7 @@ public static partial class RecordPatches
         // NREs in NCLMetaTable.get_PrimaryKey. LoadMetadata is what Populate would have
         // called; NCLMetaApplicationObject.LoadMetadata (the base call it starts with) has an
         // empty body, so nothing is skipped by entering one level down.
-        _mNclMetaTableLoadMetadata!.Invoke(built, Array.Empty<object?>());
+        LoadBcTableDocument(built);
 
         // The two bookkeeping assignments Populate() makes around LoadMetadata. metadataLoaded
         // is what stops NCLMetadata.GetMetaApplicationObjectInternal calling the no-op'd
@@ -256,7 +256,17 @@ public static partial class RecordPatches
         AlRunner.Infrastructure.FieldPoke.SetInstance(
             RequireObjectLoaderBackingField(built.GetType()),
             built, RunnerMetaApplicationObjectLoader.Instance);
+        LoadBcTableDocument(built);
+    }
+
+    private static void LoadBcTableDocument(NCLMetaTable built)
+    {
         _mNclMetaTableLoadMetadata!.Invoke(built, Array.Empty<object?>());
+        // BC's successfully loaded document replaces the derivation, including a field
+        // that now declares no relation (#3964). Retire only those superseded notes;
+        // a failed load or a different table must retain its unresolved-reference refusal.
+        foreach (var field in built.Fields)
+            ClearUnresolvedRelationReference(built.TableId, field.FieldNo);
     }
 
     private static FieldInfo? _fNclMetaAppObjObjectLoader;


### PR DESCRIPTION
Closes #3964

Authored by Codex agent fbk-1.

Sibling discovery can derive a table before dependency metadata arrives, leaving an unresolved TableRelation note. Loading BC's authoritative document replaced the fields but kept that note, so the first server request refused valid relations and returned the wrong error for missing rows. I now retire notes for the fields actually loaded, after successful loading, through one helper shared by fresh construction and in-place reload. Notes for other tables, omitted fields, and failed loads remain intact.

Corpus-NA: this regression concerns runner-only early metadata derivation and later document replacement across server requests; the existing corpus and official Windows fixture already measure the underlying AL relation semantics.

Historical CI before the latest rebase: [run 34723565362](https://github.com/StefanMaron/BusinessCentral.AL.Runner/actions/runs/34723565362) for 45718e01b178862b002971882b7c437353eacb7b completed with a failed required BC aggregate. All three BC legs failed only `Run al-language corpus`; this is not a green CI verdict.

- BC 27.0.38460.54596 and 27.5.46862.54600 each have 13 corpus failures. Every case name and exact message equals the corresponding job on the exact main base aaf8c3cc15add93579462cfaa3ffc80fc97e3f78 in [run 34723412156](https://github.com/StefanMaron/BusinessCentral.AL.Runner/actions/runs/34723412156).
- BC 28.4.53241.54585 has 13 corpus failures. All 13 case names and exact messages occur among the 17 failures on main 391df30ace470a69781a948740ed8a190e2b7e29 in [completed floor job 103633754100](https://github.com/StefanMaron/BusinessCentral.AL.Runner/actions/runs/34722187003/job/103633754100). Four baseline-only AllObjWithCaption failures are absent from this PR; this is a matching subset against an older main head, not exact-base full-set equality.
- All comparisons use the same corpus 10cb5913a40f77396e06c6cadebceeda9c88517c and corresponding exact BC version. The remaining failures concern dialog handlers, Active Session rows, and AllObj ownership; no new corpus failure appears in this PR's three legs.
- Both CI C# suite steps succeeded. The uploaded TRX on each of BC 27.5 and 28.4 records all 10 relevant tests passed: the durable server lifecycle test plus the nine engine cases. Server-reload integration also passed.
- That older run remains red. Current main now includes the Active Session and dialog-handler fixes and the upstream AllObj known-gap manifest. The rebased head needs its own required CI verdict; no old green or red verdict is carried forward. This PR changes no expectations or unrelated runtime behavior.

Local validation on BC 28.1.49838.53910:

- Durable automatic `ServerTableRelationReloadTests`: only the Tests source bundle is executed; source-embedded Subject.app also has a sibling source tree, while Target source is outside discovery. The fixture uses a custom late-registered Target instead of BaseApp and executes ValidRelation, MissingRelation (the specific normal missing-row error), DependencyLogic (42), and InstallSeed (37). Three requests run in a cold server with coverage off, then three in a fresh server sharing the same cache with coverage on. All six requests must report exactly four named passes, zero failures/errors, and the expected cache status.
- Server lifecycle mutation, suppressing stale-note retirement: C# Failed: 1, Passed: 0; both servers fail only ValidRelation/MissingRelation on request one (2 passed/2 failed), then all four pass on requests two and three. Restoring the fix: C# Failed: 0, Passed: 1; all 24 AL executions pass.
- Current head d906cf87421e03d38baa74b9701ba34b75487651 is rebased without conflicts onto main 775e3d0263582f50477de12cd20c903acdb3a7fe; all four contribution patches remain identical by range-diff. Fresh build: 0 errors. Fresh integration run: 53 passed, 0 failed/skipped, covering the server lifecycle, 24 relation/metadata/CalcFormula cases, 15 BaseApp-floor guards, 5 platform-field cases, and 8 package-replacement/sibling-reload/cross-bundle-replay cases. Disabling stale-note retirement on this base still produces the original two relation failures only on each server's first request (C# 1 failed); later requests pass. After restoring and rebuilding, 264 tests passed with 0 failures/skips: server lifecycle, nine engine cases and 254 repository guards. All 23 tools/test_*.py scripts passed: 19 natively on Windows, four unchanged under WSL/Linux after Windows path assumptions prevented those scripts from completing there. Preflight and scratch-isolation used a clean archive of this exact head. Prior broader-run figures below remain attributed to their earlier revisions.
- Focused engine suite: RED Failed: 4, Passed: 5; GREEN Failed: 0, Passed: 9, no skips. Six new cases cover both load paths with a relation, no relation, and malformed XML. The tests assert real loaded metadata and runner bookkeeping/guard behavior, not a simulated BC validation verdict.
- Additional pre-rebase adjacent run: 24 passed, 0 failed, 0 skipped across TableRelationUnresolvedRefusalTests, TableRelationUnrepresentableShapeRefusalTests, CalcFormulaUnresolvedRefusalTests, and all seven TableMetadataFromBcDocumentTests (including source/dependency cold-cache and warm-cache cases).
- Independent review at 839fee5a: no findings; reviewer reproduced 9/9 green, both-call bypass 4 failed/5 passed, overbroad cleanup 4 failed/5 passed, before-load cleanup 2 failed/7 passed, and restored 9/9 green.
- Registry-isolation, parser-static-isolation, and BaseApp-floor guards: 66 passed, 0 failed, 0 skipped.
- Factory-only cleanup bypass mutation: Failed: 2, Passed: 7 (only factory relation/plain cases fail). Reload-only bypass: Failed: 2, Passed: 7 (only reload relation/plain cases fail). Both mutations restored.
- The coordinator reran the original four-test AL fixture before the fix: first request 2 passed/2 failed, then 4/4 on requests two and three. A new server using the same hot compile cache again failed the first request, separating request lifecycle from compilation.
- Patched original server, coverage=false: all four tests pass on all three requests (cached=false/true/true), including normal missing-row refusal.
- Fresh patched server using the same hot cache, coverage=true: all four tests pass on all three requests, cached=true throughout.
- Official Microsoft Windows container: all four original tests executed and passed (ValidRelation, MissingRelation, DependencyLogic, InstallSeed). Application 28.1.49838.53910, platform 28.0.53872.0, mcr.microsoft.com/businesscentral:ltsc2025, image digest sha256:698d1b0a3c50387e1d74403a62ff2b0e9410df436f07c65f06fdec9bf07f4832. The installed reproduction was reused for this named execution.
- Existing corpus run 34650448787, SHA 5fca7f22f02562877892238ff635f0054123c1e8: 10 FieldRef_Relation_ methods and 3 Validate_RelationWithWhereFieldLink_ methods passed on each of eight cloud BC legs; the OnPrem suite excludes them. Results were counted with corpus-pass-count.py.

Shape review: both document load sites now maintain the same invariant; the derivation's BuildMetaField already clears successfully resolved notes. CalcFormula has separate bookkeeping and remains outside this TableRelation fix. Searches by TableRelation, unresolved-reference diagnostics, the document-loader file, and cold/warm lifecycle found no duplicate of this defect. Related #2789 covers conditional/rename/name-resolution concerns, #3491 parser replacement research, #3568 metadata-member equivalence, #3367 CalcFormula parse refusals, and #3204 extension-specific corpus coverage; these need different fixes and are not included. The server replay/performance items #3250, #3254, and #3774 are also separate.


Dependency-change acceptance was originally isolated against the pre-fix baseline: both baseline and candidate retained the old dependency result after replacing the package in the same server, while a fresh process executed the changed result. That separate defect was tracked in #3974 and has since landed upstream via PR #4008. The fresh integration run on the current rebased head passes both packaged-dependency replacement tests, covering unchanged-version and version-bumped replacements in cold and same-cache warm servers. The original bounded disposition remains recorded in [issue #3964](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3964#issuecomment-5648603100).
