### PR TITLE
docs: drop the 3 KB rule-size figure; the shape is the bar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,12 @@ a governance tool lands before the prose that cites it; and the incident that pr
 written to `docs/incidents/<rule>.md`, never into the rule. What stays in the rule is claim +
 citation + trap — what to do, what settled it, and the thing a later editor gets wrong
 (`.claude/rules/loud-failures.md` § "The justification is a claim plus a citation, not the
-derivation behind it"). A new rule is done when `.claude/rules/<name>.md` is under 3 KB and its
-incidents file is present.
+derivation behind it"). A new rule is done when it carries that shape — claim, citation, trap — with
+its derivation moved out and its incidents file present. **Keep it short, and treat length as a
+symptom rather than a bar**: a rule that has grown long is usually carrying a derivation that
+belongs in `docs/incidents/`, so move that and the length follows. There is deliberately no byte
+figure here; the one this sentence used to carry was met by 2 of the 14 rules its own introducing
+commit rewrote (#3952), so it cost an argument per rule and settled nothing.
 
 ## Code navigation: use these before grepping
 


### PR DESCRIPTION
Closes #3952

`CLAUDE.md` said a new rule is done when it is **under 3 KB** and its incidents file is present. Two clauses; only one was ever real.

## The byte figure was never met, including by the commit that introduced it

`87879acb` (#3729) added that sentence **and** rewrote 14 rules to the convention it was introducing, in one commit:

```
rules rewritten: 14      under 3 KB: 2      over: 12
```

`ci-verdicts.md` landed at 21,464 bytes. `guards-need-a-third-state.md` at 7,060 — and that one had been **created eight hours earlier the same day**, so it is a genuinely new rule, authored under the convention, at more than twice the bar.

Today: 7 of 22 rules are under 3 KB. Nothing enforces the number — it appears in exactly one place in the repository, the prose sentence itself.

## What replaces it

The **shape** — claim, citation, trap, derivation moved to `docs/incidents/` — which `87879acb` enforced in all 14 rewrites, plus the incidents-file clause, which every rule meets and which is checkable.

Length stays as a **symptom to read rather than a threshold to hit**: a rule that has grown long is usually carrying a derivation that belongs in `docs/incidents/`, so move that and the length follows.

## Why this disposition

The repo owner chose it over the alternatives in #3952: adding a drift test (would currently fail on **15 of 22** rules, so it needs grandfathering or a trimming programme nobody asked for) or leaving it as aspiration (keeps costing an argument per rule).

It cost one directly — PR #3951 trimmed a rule from 4,771 to 4,176 bytes, could not reach 3 KB without cutting one of four search keys, and a reviewer settled it only by reading this convention's origin commit.

`tools/test_doc_pointers.py` and every `tools/test_*.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
