### PR TITLE
fix(session): StartSession validates its timeout argument as BC does

### DIFF
--- a/AlRunner.Tests/StartSessionTimeoutValidationTests.cs
+++ b/AlRunner.Tests/StartSessionTimeoutValidationTests.cs
@@ -1,0 +1,131 @@
+// StartSessionTimeoutValidationTests — the validation arm of StartSession's timeout argument
+// (#3291), the follow-up the SCOPE AUDIT note on ALSession_ALStartSessionAsyncImpl records.
+//
+// BC computes the EFFECTIVE timeout (the argument, else NavSession.DefaultBackgroundTimeout)
+// and raises above int.MaxValue milliseconds. Decompiled from ALSession.ALStartSessionAsyncImpl
+// in the shipped Ncl.dll:
+//
+//     if (timeoutTs.TotalMilliseconds > 2147483647.0)
+//         throw new NavNCLArgumentOutOfRangeException(PrivacyClassification.SystemMetadata,
+//             string.Format(CultureInfo.CurrentCulture, Lang.TooLargeTimeoutALStartSession,
+//                           timeoutTs.TotalMilliseconds, int.MaxValue));
+//
+// WHY THIS TEST IS HERE AND NOT IN THE CORPUS
+//
+// "BC raises above int.MaxValue ms" is a plain statement about BC, so bc-behavior-tests-go-
+// upstream.md would normally send it to the al-language corpus. It cannot go there, and the
+// reason is BC's own statement order rather than any corpus fixture. In BC's body the
+// TestIsolation guard throws BEFORE this check (and outside the try), so a [Test] body under
+// any isolation other than Disabled is refused first and never reaches the timeout at all —
+// which is exactly what corpus codeunit 60397 measures on all eight legs. The corpus declares
+// no Subtype = TestRunner codeunit and its CI drives the harness by codeunit_range with no
+// isolation input, so every corpus test runs under TestIsolation = Codeunit; and 60397's own
+// header records that switching it to Disabled would invalidate what four other codeunits
+// measure. The install-trigger route is closed too: it runs outside a [Test] body, but BC's
+// AppInstallationContext check returns false before the timeout check.
+//
+// So this is a runner-side MECHANISM test, per .claude/agents/impl-agent.md: it pins the
+// runner's own C# behaviour rather than restating the BC claim. The BC claim itself is
+// evidenced by the decompiled body above and by the boundary constants below, both read from
+// the shipped binaries.
+
+using System;
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class StartSessionTimeoutValidationTests
+{
+    // BC's boundary, from the decompiled comparison: STRICTLY greater than int.MaxValue ms
+    // raises. int.MaxValue itself is accepted, which is what makes the two tests below a
+    // boundary pair rather than a single direction.
+    private const long MaxMs = int.MaxValue;          // 2147483647
+    private const long OverMs = (long)int.MaxValue + 1;
+
+    // The substring of BC's own message. The full text lives in Lang.TooLargeTimeoutALStartSession
+    // inside Microsoft.Dynamics.Nav.Language.dll, which ships in the artifacts:
+    //
+    //   "The specified timeout of {0} ms is longer than the maximum supported timeout in
+    //    StartSession, which is {1} ms."
+    //
+    // Measured byte-identical on the two DISTINCT Language.dll binaries in the artifact set
+    // (sha256 0de0bc55… covering 27.0/27.5, and 37fd45cc… covering 28.4).
+    private const string BcMessageSubstring =
+        "is longer than the maximum supported timeout in StartSession";
+
+    [Fact]
+    public void ATimeoutAboveIntMaxValue_Raises()
+    {
+        var ex = Record.Exception(
+            () => BcRuntime.ValidateStartSessionTimeoutMs(OverMs));
+
+        Assert.NotNull(ex);
+        Assert.Contains(BcMessageSubstring, ex!.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheRaisedException_IsBcsOwnNavNCLArgumentOutOfRangeException()
+    {
+        // The TYPE is load-bearing, not decoration: BC's throw sits INSIDE the try whose catch
+        // returns false for a NavBaseException under DataError.TrapError. Measured with Cecil on
+        // Microsoft.Dynamics.Nav.Types.dll for two distinct binaries (27.5 and 28.4):
+        //   NavNCLArgumentOutOfRangeException -> NavNCLException -> NavException
+        //     -> NavBaseException -> System.Exception
+        // So a wrong exception type would silently change TrapError's answer from false to a
+        // propagating throw, which is a different defect from throwing nothing.
+        var ex = Record.Exception(
+            () => BcRuntime.ValidateStartSessionTimeoutMs(OverMs));
+
+        Assert.NotNull(ex);
+        Assert.Equal(
+            "Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLArgumentOutOfRangeException",
+            ex!.GetType().FullName);
+    }
+
+    [Fact]
+    public void TheMessage_NamesBothTheOfferedValueAndTheCap()
+    {
+        // BC formats Lang.TooLargeTimeoutALStartSession with {0} = the offered timeout and
+        // {1} = int.MaxValue. Pinning both numbers is what stops a "faithful" message that
+        // silently reports the cap as the offered value, or omits the offered value entirely —
+        // either would read as correct in a log while telling the AL author nothing actionable.
+        var ex = Record.Exception(
+            () => BcRuntime.ValidateStartSessionTimeoutMs(OverMs));
+
+        Assert.NotNull(ex);
+        Assert.Contains(OverMs.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            ex!.Message, StringComparison.Ordinal);
+        Assert.Contains(MaxMs.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ATimeoutExactlyAtIntMaxValue_IsAccepted()
+    {
+        // The negative direction, and the half a one-sided test cannot distinguish: BC compares
+        // with > rather than >=, so the cap itself is legal. A guard written with >= would pass
+        // every "it raises" test above while breaking an ordinary caller sitting on the bound.
+        BcRuntime.ValidateStartSessionTimeoutMs(MaxMs);
+    }
+
+    [Theory]
+    [InlineData(0L)]          // AL's default/blank duration
+    [InlineData(1L)]
+    [InlineData(60_000L)]     // a minute, an ordinary caller
+    public void AnOrdinaryTimeout_IsAccepted(long ms)
+    {
+        // Guards the direction that matters most in practice: this arm must not convert every
+        // StartSession with a sane timeout into a refusal.
+        BcRuntime.ValidateStartSessionTimeoutMs(ms);
+    }
+
+    [Fact]
+    public void ANullTimeout_IsAccepted_BecauseBcFallsBackToItsDefaultBackgroundTimeout()
+    {
+        // BC's null-coalesce (timeout?.Value ?? NavSession.DefaultBackgroundTimeout) means an
+        // absent argument can never trip the check — the default is far below the cap. Passing
+        // null here is the runner's spelling of "no argument supplied".
+        BcRuntime.ValidateStartSessionTimeoutMs(null);
+    }
+}

--- a/AlRunner/BcAssembler.cs
+++ b/AlRunner/BcAssembler.cs
@@ -624,7 +624,7 @@ namespace AlRunnerShim
             int objectId,
             Microsoft.Dynamics.Nav.Runtime.NavDuration timeout)
             => global::AlRunner.BcRuntime.AlRunnerStartSession(
-                errorLevel, sessionId, objectId, null, null);
+                errorLevel, sessionId, objectId, null, null, timeout?.Value);
 
         public static bool ALSession_ALStartSession(
             Microsoft.Dynamics.Nav.Types.DataError errorLevel,
@@ -633,7 +633,7 @@ namespace AlRunnerShim
             Microsoft.Dynamics.Nav.Runtime.NavDuration timeout,
             string companyName)
             => global::AlRunner.BcRuntime.AlRunnerStartSession(
-                errorLevel, sessionId, objectId, companyName, null);
+                errorLevel, sessionId, objectId, companyName, null, timeout?.Value);
 
         public static bool ALSession_ALStartSession(
             Microsoft.Dynamics.Nav.Types.DataError errorLevel,
@@ -643,7 +643,7 @@ namespace AlRunnerShim
             string companyName,
             Microsoft.Dynamics.Nav.Runtime.NavRecord record)
             => global::AlRunner.BcRuntime.AlRunnerStartSession(
-                errorLevel, sessionId, objectId, companyName, record);
+                errorLevel, sessionId, objectId, companyName, record, timeout?.Value);
 
         public static bool ALSession_ALStartSession(
             Microsoft.Dynamics.Nav.Types.DataError errorLevel,
@@ -662,7 +662,7 @@ namespace AlRunnerShim
             Microsoft.Dynamics.Nav.Runtime.NavRecord record,
             Microsoft.Dynamics.Nav.Runtime.NavDuration timeout)
             => global::AlRunner.BcRuntime.AlRunnerStartSession(
-                errorLevel, sessionId, objectId, companyName, record);
+                errorLevel, sessionId, objectId, companyName, record, timeout?.Value);
 
         // ───────────────────────────────────────────────────────────────────────
         // NavForm.Run (static, non-modal) — Page.Run.

--- a/AlRunner/Patches/SessionPatches.cs
+++ b/AlRunner/Patches/SessionPatches.cs
@@ -330,16 +330,6 @@ public static partial class BcRuntime
     private static int _alRunnerSessionCounter;
 
     /// <summary>
-    /// In-scope (§3.9) replacement entry point for every ALSession.ALStartSession overload.
-    /// The real implementation enqueues an async session via NavCurrentThread/Diagnostics
-    /// which NRE on the skeleton runtime. Our model is "inline-synchronous execution":
-    /// look up the codeunit by id, instantiate it under the skeleton tree-root, invoke
-    /// OnRun once, then return true with a fresh non-zero session id. Failures under
-    /// DataError.TrapError swallow the exception and return false (matching BC semantics
-    /// where a trapped StartSession returns false without rethrowing).
-    /// </summary>
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    /// <summary>
     /// BC's refusal for <c>StartSession</c> called inside a test codeunit under any isolation mode
     /// other than <c>Disabled</c> (#2805), carried as <c>NavNCLDialogException</c> — the AL
     /// <c>Error()</c> carrier, so AL <c>asserterror</c> traps it and <c>GetLastErrorText</c>
@@ -371,6 +361,120 @@ public static partial class BcRuntime
             if (ctor != null) return (System.Exception)ctor.Invoke(new object[] { msg });
         }
         return new System.InvalidOperationException(msg);
+    }
+
+    /// <summary>
+    /// BC's validation arm for <c>StartSession</c>'s timeout argument (#3291): an effective
+    /// timeout above <see cref="int.MaxValue"/> milliseconds raises
+    /// <c>NavNCLArgumentOutOfRangeException</c> carrying BC's own message.
+    ///
+    /// <para>AUDIT — observably equivalent because the exception TYPE, the boundary and the text
+    /// are all BC's rather than approximations of it. The type is loaded from the shipped
+    /// <c>Microsoft.Dynamics.Nav.Types</c> and the message from
+    /// <c>Lang.TooLargeTimeoutALStartSession</c> in the shipped
+    /// <c>Microsoft.Dynamics.Nav.Language</c>, so neither can drift from what a service tier
+    /// says. Citation: <c>ALSession.ALStartSessionAsyncImpl</c>, whose body compares
+    /// <c>timeoutTs.TotalMilliseconds &gt; 2147483647.0</c>; issue #3291.</para>
+    ///
+    /// <para>TRAP — the comparison is strictly greater-than, so <c>int.MaxValue</c> itself is
+    /// legal; and <paramref name="timeoutMs"/> null means "no argument supplied", which BC
+    /// null-coalesces to <c>NavSession.DefaultBackgroundTimeout</c> — far below the cap, so it
+    /// can never raise. Both directions are pinned in
+    /// <c>AlRunner.Tests/StartSessionTimeoutValidationTests.cs</c>.</para>
+    ///
+    /// <para>TRAP — this throw sits where BC's does, INSIDE the try, so <c>TrapError</c> turns it
+    /// into <c>false</c>. That depends on the exception deriving from <c>NavBaseException</c>,
+    /// which it does; it is the opposite of the #2805 isolation guard, which precedes the try and
+    /// is deliberately not trappable. Do not move this call outside the try.</para>
+    /// </summary>
+    public static void ValidateStartSessionTimeoutMs(long? timeoutMs)
+    {
+        // No argument supplied → BC uses DefaultBackgroundTimeout, which is below the cap.
+        if (timeoutMs == null) return;
+        if (timeoutMs.Value <= int.MaxValue) return;
+
+        throw MakeStartSessionTimeoutTooLargeException(timeoutMs.Value);
+    }
+
+    /// <summary>
+    /// Builds BC's <c>NavNCLArgumentOutOfRangeException</c> for an oversized
+    /// <c>StartSession</c> timeout, preferring Microsoft's own resource string and exception
+    /// type over any copy of them (<c>precompiled-dll-respect.md</c> § "Reuse before you
+    /// re-implement").
+    /// </summary>
+    internal static System.Exception MakeStartSessionTimeoutTooLargeException(long timeoutMs)
+    {
+        // BC formats with {0} = the offered timeout in ms and {1} = int.MaxValue, using
+        // CurrentCulture. TotalMilliseconds is a double in BC, and a whole-millisecond value
+        // formats identically either way for every value that can reach here.
+        var format = TooLargeTimeoutFormat
+            // Fallback text, used only if the shipped resource cannot be read. Byte-identical
+            // to Lang.TooLargeTimeoutALStartSession as measured on the two distinct
+            // Language.dll binaries in the artifact set (27.0/27.5 and 28.4).
+            ?? "The specified timeout of {0} ms is longer than the maximum supported timeout "
+               + "in StartSession, which is {1} ms.";
+
+        var msg = string.Format(CultureInfo.CurrentCulture, format, timeoutMs, int.MaxValue);
+
+        var t = System.Type.GetType(
+            "Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLArgumentOutOfRangeException, "
+            + "Microsoft.Dynamics.Nav.Types");
+        if (t != null)
+        {
+            // BC uses the (PrivacyClassification, string) overload. Resolve the enum by name so
+            // this does not need a compile-time reference to the classification type.
+            var pc = System.Type.GetType(
+                "Microsoft.Dynamics.Nav.Types.PrivacyClassification, Microsoft.Dynamics.Nav.Types");
+            if (pc != null)
+            {
+                var ctor = t.GetConstructor(new[] { pc, typeof(string) });
+                if (ctor != null)
+                {
+                    object? systemMetadata = null;
+                    try { systemMetadata = System.Enum.Parse(pc, "SystemMetadata"); }
+                    catch { /* unexpected enum shape → fall through to the (string) ctor */ }
+                    if (systemMetadata != null)
+                        return (System.Exception)ctor.Invoke(new[] { systemMetadata, (object)msg });
+                }
+            }
+
+            var strCtor = t.GetConstructor(new[] { typeof(string) });
+            if (strCtor != null)
+                return (System.Exception)strCtor.Invoke(new object[] { msg });
+        }
+
+        return new System.ArgumentOutOfRangeException("timeout", msg);
+    }
+
+    private static string? _tooLargeTimeoutFormat;
+    private static bool _tooLargeTimeoutFormatResolved;
+
+    /// <summary>
+    /// <c>Lang.TooLargeTimeoutALStartSession</c>, read from the shipped
+    /// <c>Microsoft.Dynamics.Nav.Language</c> assembly. Null when it cannot be resolved, which
+    /// the caller answers with the measured literal rather than a different sentence.
+    /// </summary>
+    private static string? TooLargeTimeoutFormat
+    {
+        get
+        {
+            if (_tooLargeTimeoutFormatResolved) return _tooLargeTimeoutFormat;
+            _tooLargeTimeoutFormatResolved = true;
+            try
+            {
+                var lang = System.Type.GetType(
+                    "Microsoft.Dynamics.Nav.Common.Language.Lang, Microsoft.Dynamics.Nav.Language");
+                var p = lang?.GetProperty(
+                    "TooLargeTimeoutALStartSession",
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+                _tooLargeTimeoutFormat = p?.GetValue(null) as string;
+            }
+            catch
+            {
+                _tooLargeTimeoutFormat = null;
+            }
+            return _tooLargeTimeoutFormat;
+        }
     }
 
     /// <summary>
@@ -465,14 +569,34 @@ public static partial class BcRuntime
         Microsoft.Dynamics.Nav.Runtime.NavDuration timeout,
         object invokeRunAsync)
         => new System.Threading.Tasks.ValueTask<bool>(
-            AlRunnerStartSession(errorLevel, sessionId, objectId, companyName, record));
+            AlRunnerStartSession(
+                errorLevel, sessionId, objectId, companyName, record, TimeoutMs(timeout)));
 
+    /// <summary>
+    /// BC's <c>timeout?.Value</c>: the argument's milliseconds, or null when no timeout was
+    /// supplied. <c>NavDuration</c> is a reference type on this seam, so a null argument is how
+    /// an omitted AL parameter arrives.
+    /// </summary>
+    private static long? TimeoutMs(Microsoft.Dynamics.Nav.Runtime.NavDuration? timeout)
+        => timeout?.Value;
+
+    /// <summary>
+    /// In-scope (§3.9) replacement entry point for every ALSession.ALStartSession overload.
+    /// The real implementation enqueues an async session via NavCurrentThread/Diagnostics
+    /// which NRE on the skeleton runtime. Our model is "inline-synchronous execution":
+    /// look up the codeunit by id, instantiate it under the skeleton tree-root, invoke
+    /// OnRun once, then return true with a fresh non-zero session id. Failures under
+    /// DataError.TrapError swallow the exception and return false (matching BC semantics
+    /// where a trapped StartSession returns false without rethrowing).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static bool AlRunnerStartSession(
         Microsoft.Dynamics.Nav.Types.DataError errorLevel,
         Microsoft.Dynamics.Nav.Runtime.ByRef<int> sessionId,
         int objectId,
         string? companyName,
-        Microsoft.Dynamics.Nav.Runtime.NavRecord? record)
+        Microsoft.Dynamics.Nav.Runtime.NavRecord? record,
+        long? timeoutMs = null)
     {
         // #2805 — BC's TestIsolation guard, and it goes FIRST, outside the try, exactly where BC
         // puts it. Decompiled from ALSession.ALStartSessionAsyncImpl (bc281):
@@ -510,6 +634,12 @@ public static partial class BcRuntime
         bool trap = errorLevel == Microsoft.Dynamics.Nav.Types.DataError.TrapError;
         try
         {
+            // #3291 — BC's timeout validation, and its position is load-bearing in two ways.
+            // It is INSIDE the try, so TrapError turns it into false exactly as BC does; and it
+            // precedes the session-id allocation below, so a refused call leaves the caller's
+            // by-ref untouched, which is the same ordering the #2805 guard above depends on.
+            ValidateStartSessionTimeoutMs(timeoutMs);
+
             var cuType = FindCodeunitTypePublic(objectId);
             if (cuType == null)
             {


### PR DESCRIPTION
Closes #3291

Corpus-NA: the timeout check is unreachable from the corpus; BC raises the TestIsolation refusal first, and the corpus declares no TestRunner and runs only under TestIsolation = Codeunit

*Implemented by agent `stma-auto-3` (automated implementation agent).*

`StartSession` accepts a `timeout` argument. Real BC validates it and raises above `int.MaxValue` milliseconds; the runner dropped the argument entirely, validation included, so AL passing an absurd timeout got no error where a service tier gives one. That is the `loud-failures.md` shape in its clearest form — a value the caller passed, discarded, with AL seeing success.

This is the recorded follow-up for the SCOPE AUDIT note on `ALSession_ALStartSessionAsyncImpl` from #3225.

## The boundary, reproduced

`> 2147483647.0` ms raises; `int.MaxValue` itself is accepted. From `ALSession.ALStartSessionAsyncImpl` in the shipped `Ncl.dll`:

```csharp
if (timeoutTs.TotalMilliseconds > 2147483647.0)
    throw new NavNCLArgumentOutOfRangeException(PrivacyClassification.SystemMetadata,
        string.Format(CultureInfo.CurrentCulture, Lang.TooLargeTimeoutALStartSession,
                      timeoutTs.TotalMilliseconds, int.MaxValue));
```

The exception type and message the runner now produces, captured from a real run:

```
Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLArgumentOutOfRangeException
The specified timeout of 2147483648 ms is longer than the maximum supported timeout in StartSession, which is 2147483647 ms.
```

## Two things the issue body did not have, both of which changed the fix

**The exception derives from `NavBaseException`, so `TrapError` semantics depend on it.** Measured with Cecil against `Microsoft.Dynamics.Nav.Types.dll` on two *distinct* binaries (27.5 and 28.4):

```
NavNCLArgumentOutOfRangeException -> NavNCLException -> NavException -> NavBaseException -> System.Exception
```

BC's throw sits **inside** the `try` whose `catch` returns `false` for a trapped `NavBaseException`. So `TrapError` yields `false` and `ThrowError` propagates — the opposite of the #2805 isolation guard, where the throw precedes the `try` and `trap` is deliberately not consulted. The placement in this diff mirrors that, and the doc comment says not to move it.

**The message is not an inlined literal.** `Lang.TooLargeTimeoutALStartSession` lives in `Microsoft.Dynamics.Nav.Language.dll`, which ships in the artifacts. So the runner reads Microsoft's own resource instead of carrying a copy (`precompiled-dll-respect.md` § "Reuse before you re-implement"), with the measured literal as a fallback only if the lookup fails. Byte-identical across the two distinct `Language.dll` binaries in the artifact set (sha256 `0de0bc55…` covering 27.0/27.5, `37fd45cc…` covering 28.4).

## Why the proving test is not in the corpus

`bc-behavior-tests-go-upstream.md` would normally send "BC raises above `int.MaxValue` ms" upstream. I tested that claim rather than asserting it, and it is the genuinely-inexpressible case — because of BC's own statement order, not anything about the corpus fixtures. In BC's body the order is:

1. `timeoutTs` computed;
2. the **TestIsolation guard** throws — outside the `try`;
3. the **install/upgrade** check returns `false` — also outside it;
4. *then* the timeout check, first statement **inside** the `try`.

Step 2 shadows step 4 for any `[Test]` body not under `TestIsolation = Disabled`. Two measured properties of the corpus close it:

- the corpus declares **no `Subtype = TestRunner` codeunit at all**, and `ci.yml` drives the reusable workflow by `codeunit_range` with no test-runner or isolation input — so every corpus test runs under the harness's `TestIsolation = Codeunit`;
- corpus codeunit 60397 (`TestStartSessionRecord.al`) documents that choice as load-bearing: switching to `Disabled` would change what 60897, `TestIsolationGlobalVariableScope`, `TestTransactionModelAutoRollback` and `TestEventManualBindingCrossCodeunit` measure. Its header already anticipated this work — "before the timeout check".

The install-trigger route is closed too: it runs outside a `[Test]` body, but step 3 returns `false` before step 4, and an install trigger cannot report an `asserterror` result anyway.

So the proving test is a runner-side **mechanism test** under `AlRunner.Tests/`, which is the path `impl-agent.md` names for exactly this case. The BC claim itself rests on the decompiled body plus the type hierarchy and resource string read from the shipped binaries. Corpus resolved at `5fca7f22f02562877892238ff635f0054123c1e8` (master) for the checks above.

## RED -> GREEN

`dotnet test AlRunner.Tests --filter "FullyQualifiedName~StartSessionTimeoutValidationTests"`

- **RED** (no-op stub in place of the validation): `Failed: 3, Passed: 5, Total: 8` — failures are `Assert`, not `error CS`. The 5 that passed are the accept-direction tests, which a no-op satisfies by construction; that is why the raise-direction tests carry the proof.
- **GREEN**: `Failed: 0, Passed: 8, Total: 8`.

## Mutations — one per observable, each chosen to discriminate

Each mutation changes a **value**, not code structure, and each landed check was a re-read of the region. All three red *exactly one* test and leave the others green, which is what shows the tests measure different properties rather than riding along together.

| # | mutation | result | what it proves |
|---|---|---|---|
| 1 | `<= int.MaxValue` -> `< int.MaxValue` | `Failed: 1, Passed: 7` — only `ATimeoutExactlyAtIntMaxValue_IsAccepted` | the boundary test is pinned to `>` rather than passing incidentally; the three raise-direction tests cannot see an off-by-one |
| 2 | message formats the cap in place of the offered value | `Failed: 1, Passed: 7` — only `TheMessage_NamesBothTheOfferedValueAndTheCap` | `ATimeoutAboveIntMaxValue_Raises` stays GREEN (the BC substring is still present), so the two tests are not duplicates |
| 3 | resolve `NavNCLDialogException` instead | `Failed: 1, Passed: 7` — only `TheRaisedException_IsBcsOwnNavNCLArgumentOutOfRangeException` | catches "throws the wrong type", a *different* defect from "throws nothing", and only one test sees it — it is what decides `TrapError`'s answer |

All three restored; re-verified `Failed: 0, Passed: 8`.

## Cache

There is a cache between the change and its observable — `TooLargeTimeoutFormat` memoizes the resource lookup in a static — so I ran it warm rather than assuming (`local-test-scope.md`). Cold and warm agree, and a third call with a *different* timeout produces a correspondingly different message, so the memo holds only the format string and not the formatted result. That is the #3908 shape (a key with no term for the varying input) and it does not apply here.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site — yes, four of them.** `BcAssembler.cs` has four `ALSession_ALStartSession` polyfill overloads taking a `NavDuration timeout`, and every one discarded it. The issue named only the precompiled seam. All four now pass `timeout?.Value` through, so the source-compiled and precompiled paths cannot diverge again. Each of the four edits was asserted to match exactly once.
2. **Sibling functions sharing the assumption — checked.** `AlRunnerStartSession` is the single funnel both paths reach, so the validation is decided in one place, as the #2805 guard already is.
3. **Two paths writing the same state — this is that fix.** The precompiled seam and the polyfills are the two paths; before this they maintained different invariants about the timeout argument.

**Bonus, found by a guard rather than by me:** `tools/test_doc_summary_uniqueness.py` flagged a doc block with two `<summary>` elements. It is pre-existing on `main` — `AlRunnerStartSession`'s doc comment and its `[MethodImpl(MethodImplOptions.NoInlining)]` attribute were stranded from the member, and `origin/main` confirms that method carries no attribute. The guard was silent only because the two `///` runs were separated; my insertion joined them. Fixed as the guard's own message instructs — moved back onto the member, not deleted. Guard now reports `no doc block carries two <summary> elements (352 files, 2916 doc blocks)`.

## Siblings scanned, not folded

Searched the open queue four ways (`StartSession`, `timeout`, `SessionPatches`, `NavNCLArgumentOutOfRangeException`). Two issues land in this same file and neither is folded, each for a mechanism reason rather than for size:

- **#3292** — BC refuses `StartSession` during install/upgrade. Needs install-state modelling the runner does not have; the runner never populates `AppInstallationContext`, so copying the guard would be dead code that looked like coverage.
- **#2751** — `AlRunnerStartSession` passes `null` for the record. Needs the record threaded through the worker dispatch, a different edit with a different proving test.

Neither has an open PR. No duplicate of this defect exists in the queue; the four searches are named here so the absence is attributable.

## Tests run

- `StartSessionTimeoutValidationTests` — `Failed: 0, Passed: 8, Skipped: 0`
- `~GuardTests` — `Failed: 0, Passed: 249, Skipped: 0` (Release, `--settings engine.runsettings`)
- `~Session` — `Failed: 0, Passed: 26, Skipped: 0`, 41s (Release, `--settings engine.runsettings`)
- `tools/test_*.py` — all pass

The two failures seen before bootstrapping were `BcEngineUnbootstrappedGuard` REFUSING TO SKIP (#3078/#3835), not the code: after `tools/engine-test-bootstrap.sh` plus a Release build they pass, with `Skipped: 0` and non-trivial durations on every run quoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
