### PR TITLE
test(testpage): pin the RunPageLink count-mismatch refusal in LinksFromSymbols

### DIFF
--- a/AlRunner.Tests/ActionRunPageLinkRefusalTests.cs
+++ b/AlRunner.Tests/ActionRunPageLinkRefusalTests.cs
@@ -1,0 +1,338 @@
+// ActionRunPageLinkRefusalTests — drives the RunPageLink count-mismatch refusal in
+// RunnerPageInstance.LinksFromSymbols (issue #3274).
+//
+// WHAT WAS MISSING
+//   #3248 introduced the refusal and #3267 widened it, but nothing executed it. A grep for
+//   DeclaredRunPageLinkEntries across AlRunner.Tests found only ActionRunPageLinkUnreadableEntryTests,
+//   which pins the SYMBOL-CACHE side -- that the parser counts declared entries correctly and
+//   carries unreadable ones by text. That is the guard's INPUT. Nothing asserted what the
+//   consumer does with it, so deleting the comparison turned no test red.
+//
+// WHY THE GUARD MATTERS, AND WHY IT FAILS CLOSED
+//   An action's RunPageLink is a CONJUNCTION: every entry narrows the target's rowset.
+//   Applying only the entries the parser could read drops a conjunct, so the target opens
+//   showing MORE rows than real BC shows. That is a silently wrong rowset, not a visibly
+//   missing one -- which is why the refusal is loud rather than a best-effort partial link.
+//
+// WHY THIS IS A C# TEST AND NOT AN END-TO-END AL ONE
+//   LinksFromSymbols is reached only through ResolveRunTargetFromSymbols, which reads an
+//   action's RunObject/RunPageLink out of a dependency .app's SymbolReference.json. A page the
+//   runner compiled from AL source takes ResolveRunTargetFromMetadata instead -- BC's own
+//   compiled ActionDefinition, where the target is already a kind and a numeric id and there
+//   is no property TEXT left to fail to parse. So the AL route needs a precompiled dependency
+//   AND a live BC page-action invoke.
+//
+//   That end-to-end route is blocked on this machine by an unrelated defect, filed as #3977:
+//   every runner-extras suite that invokes a page action -- including the merged, CI-gated
+//   tests/runner-extras/testpage-promoted-actionref -- dies in BC's own
+//   Codeunit2000000002.OnInvokeAsync with "Could not load file or assembly
+//   'Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.5'", because the dependency resolver probes
+//   the service-tier directory by NAME and the provisioned artifacts carry 10.0.0.2. Both
+//   failures surface through GetLastErrorText(), so an AL asserterror cannot tell this guard's
+//   refusal from that FileLoadException -- the AL test would have been unfalsifiable here.
+//
+//   Pinning the method directly is the established answer to exactly this shape: see
+//   RecordPatchesGetPageControlFieldMapDependencyTests, whose header records the same decision
+//   for the same reason (an arm AL cannot reach, pinned against the method instead).
+//
+//   A precompiled-dependency runner-extras suite for this WAS built and discarded rather than
+//   shipped unverified: the fixtures (a hand-built SymbolReference.json carrying the unreadable
+//   entry, plus a Tier-1 .deps-bin DLL) compiled and loaded, and both tests reached real runner
+//   behaviour, but #3977 made the refusal arm unfalsifiable on this machine -- it could not be
+//   distinguished from the FileLoadException. The PR body records the recipe so it can be
+//   rebuilt once #3977 is fixed; shipping a test whose RED nobody has seen is what tdd.md's
+//   mutation step exists to prevent.
+//
+// NOT A CLAIM ABOUT BC
+//   Nothing here asserts what Business Central does. The subject is how this runner reads
+//   SymbolReference.json -- a Microsoft build artifact a real service tier never reads at all,
+//   because a real tier has the compiled page metadata this code path substitutes for. So this
+//   owes no corpus PR, for the same structural reason ActionRunPageLinkUnreadableEntryTests
+//   does not.
+using System.IO.Compression;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// BcAppSymbolCache.Get() and RecordPatches' dependency state resolve through the
+// process-global CacheRoots override, the same reason the sibling dependency suites serialise.
+[Collection(CacheRootsSerialCollection.Name)]
+public class ActionRunPageLinkRefusalTests
+{
+    private static string WriteApp(string dir, string symbolReferenceJson)
+    {
+        var appPath = Path.Combine(dir, Guid.NewGuid().ToString("N") + ".app");
+        using var zip = new FileStream(appPath, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(symbolReferenceJson);
+        return appPath;
+    }
+
+    // Ids distinct from every other fixture in this suite: RecordPatches' dependency state is
+    // process-global, so a shared id risks reading back another test's payload.
+    private const int HostPageId = 88231801;
+    private const int TargetPageId = 88231802;
+
+    // The target's source table, so the entries the guard lets through resolve to real field
+    // numbers rather than to 0 for an unrelated reason.
+    private const string SymbolReference = """
+        {
+          "RuntimeVersion": "17.0",
+          "Tables": [
+            {
+              "Id": 88231800,
+              "Name": "ARPLR Row",
+              "Fields": [
+                { "Id": 1, "Name": "No.", "TypeDefinition": { "Name": "Code[20]" }, "Properties": [] },
+                { "Id": 2, "Name": "Document No.", "TypeDefinition": { "Name": "Code[20]" }, "Properties": [] },
+                { "Id": 3, "Name": "Amount", "TypeDefinition": { "Name": "Decimal" }, "Properties": [] }
+              ],
+              "Keys": [ { "Name": "PK", "FieldNames": [ "No." ], "Properties": [] } ],
+              "Properties": []
+            }
+          ],
+          "Pages": [
+            {
+              "Id": 88231801,
+              "Name": "ARPLR Host",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "SourceTable", "Value": "88231800" }
+              ]
+            },
+            {
+              "Id": 88231802,
+              "Name": "ARPLR Target",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "SourceTable", "Value": "88231800" }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private static void WithLoadedDependency(Action body)
+    {
+        var dir = TestScratch.Dir("al-runner-action-runpagelink-refusal-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, SymbolReference));
+            body();
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    // LinksFromSymbols is a private INSTANCE method, but the only instance state it reads is
+    // _pageId, and only to name the page in the refusal message. Everything else it touches is
+    // static (RecordPatches.ResolveSourceTableIdForAnyPage / TryResolveDependencyFieldId). So
+    // an uninitialised instance is enough to execute it, and avoids needing a live NavForm --
+    // which would drag in the BC engine this whole file exists to stay out of.
+    //
+    // _pageId is set by hand so the message's page number is a real assertion rather than 0.
+    private static object Invoke(BcAppSymbolCache.ActionRunObjectSymbol spec, int actionId = 4242)
+    {
+        var type = typeof(RunnerPageInstance);
+        var instance = RuntimeHelpers.GetUninitializedObject(type);
+        type.GetField("_pageId", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(instance, HostPageId);
+
+        var method = type.GetMethod("LinksFromSymbols", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException(
+                "RunnerPageInstance.LinksFromSymbols not found — this test pins that method, so a "
+                + "rename must fail here rather than silently pin nothing.");
+
+        try
+        {
+            return method.Invoke(instance, new object?[] { actionId, spec, TargetPageId })!;
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            throw tie.InnerException;
+        }
+    }
+
+    /// <summary>
+    /// ARM 1 — the count comparison. The spec declares two entries and the parse carries one,
+    /// with no unreadable text alongside it, so `parsed.Count != DeclaredRunPageLinkEntries` is
+    /// the ONLY condition of the three that can fire. That isolation is the point: it is what
+    /// makes this test go green again when the null arm or the unreadable arm is broken, and
+    /// red only when the count arm is.
+    ///
+    /// <para>The shape is not hypothetical. It is what a parser gap on perfectly legal AL
+    /// produces — #3267, where a directive-aware splitter and a bare comma splitter disagreed
+    /// on the entry count of a link that was completely readable.</para>
+    /// </summary>
+    [Fact]
+    public void ParsedFewerEntriesThanDeclared_IsRefusedRatherThanAppliedPartially()
+        => WithLoadedDependency(() =>
+        {
+            var spec = new BcAppSymbolCache.ActionRunObjectSymbol(
+                ObjectName: "ARPLR Target",
+                RunPageOnRec: false,
+                DeclaredRunPageLinkEntries: 2,
+                RunPageLink: new List<BcAppSymbolCache.PageSubFormLinkSymbol>
+                {
+                    new("Document No.", "field", "\"No.\"", false),
+                },
+                UnreadableRunPageLinkEntries: null);
+
+            var ex = Assert.Throws<RunnerOutOfScopeException>(() => Invoke(spec));
+
+            // The surface, so the message says WHICH action on WHICH page refused.
+            Assert.Contains("TestPage action 4242", ex.Message);
+            Assert.Contains(HostPageId.ToString(), ex.Message);
+            Assert.Contains("not-yet-implemented", ex.Message);
+            Assert.Contains("ARPLR Target", ex.Message);
+
+            // The two counts — the refusal's whole subject. Asserting BOTH numbers is what
+            // makes this a proof the comparison ran: a guard that refused unconditionally
+            // could not state that it read 1 of 2.
+            Assert.Contains("RunPageLink of 2 entr(ies)", ex.Message);
+            Assert.Contains("could read 1 of them", ex.Message);
+
+            // The reason it fails closed rather than applying the readable half.
+            Assert.Contains("would show MORE rows than real BC", ex.Message);
+
+            // No unreadable text was carried, so the message must not invent an entry list.
+            // This is what keeps arm 1 distinguishable from arm 3 in the message itself.
+            Assert.DoesNotContain("could not read:", ex.Message);
+        });
+
+    /// <summary>
+    /// ARM 2 — the null parse. `HasRunPageLink` is true (entries were declared) but the parser
+    /// produced no list at all, which is a different failure from producing a short one and
+    /// reaches a different operand of the same `if`. The message must still state the shortfall,
+    /// with the parsed count read as 0 rather than throwing on the null.
+    /// </summary>
+    [Fact]
+    public void ParsedNull_WithEntriesDeclared_IsRefusedAndReportsZeroRead()
+        => WithLoadedDependency(() =>
+        {
+            var spec = new BcAppSymbolCache.ActionRunObjectSymbol(
+                ObjectName: "ARPLR Target",
+                RunPageOnRec: false,
+                DeclaredRunPageLinkEntries: 3,
+                RunPageLink: null,
+                UnreadableRunPageLinkEntries: null);
+
+            var ex = Assert.Throws<RunnerOutOfScopeException>(() => Invoke(spec));
+
+            Assert.Contains("RunPageLink of 3 entr(ies)", ex.Message);
+            // `parsed?.Count ?? 0` — the null-coalesce is the arm-specific behaviour, and a
+            // guard that dereferenced the null instead would throw NullReferenceException here.
+            Assert.Contains("could read 0 of them", ex.Message);
+            Assert.Contains("would show MORE rows than real BC", ex.Message);
+        });
+
+    /// <summary>
+    /// ARM 3 — unreadable entries, with the counts AGREEING. #3267 added this arm precisely so
+    /// the refusal does not depend on the count alone; here the count arm cannot fire, so only
+    /// the unreadable arm can. The entry TEXT must reach the message, because the count alone
+    /// leaves a developer to open SymbolReference.json to find out which entry was lost.
+    /// </summary>
+    [Fact]
+    public void UnreadableEntriesCarried_WithCountsAgreeing_IsStillRefused_AndNamesTheEntries()
+        => WithLoadedDependency(() =>
+        {
+            var spec = new BcAppSymbolCache.ActionRunObjectSymbol(
+                ObjectName: "ARPLR Target",
+                RunPageOnRec: false,
+                // 1 declared, 1 parsed — the count arm is satisfied and cannot fire.
+                DeclaredRunPageLinkEntries: 1,
+                RunPageLink: new List<BcAppSymbolCache.PageSubFormLinkSymbol>
+                {
+                    new("Document No.", "field", "\"No.\"", false),
+                },
+                UnreadableRunPageLinkEntries: new List<string> { "\"Amount\" whenever(42)" });
+
+            var ex = Assert.Throws<RunnerOutOfScopeException>(() => Invoke(spec));
+
+            Assert.Contains("RunPageLink of 1 entr(ies)", ex.Message);
+            Assert.Contains("could read 1 of them", ex.Message);
+            // The text itself, which is this arm's whole contribution over the count arm.
+            Assert.Contains("could not read: \"Amount\" whenever(42)", ex.Message);
+        });
+
+    /// <summary>
+    /// THE NEGATIVE DIRECTION, and the reason it is not optional: a guard that refused every
+    /// action would satisfy all three tests above while breaking every RunPageLink in the
+    /// repository. A spec whose counts agree and which carries no unreadable text must get
+    /// past the guard and produce APPLIED links — asserted on the resolved field numbers and
+    /// kinds, not merely on the absence of a throw.
+    /// </summary>
+    [Fact]
+    public void EveryDeclaredEntryRead_IsAppliedRatherThanRefused()
+        => WithLoadedDependency(() =>
+        {
+            var spec = new BcAppSymbolCache.ActionRunObjectSymbol(
+                ObjectName: "ARPLR Target",
+                RunPageOnRec: false,
+                DeclaredRunPageLinkEntries: 2,
+                RunPageLink: new List<BcAppSymbolCache.PageSubFormLinkSymbol>
+                {
+                    new("Document No.", "field", "\"No.\"", false),
+                    new("Amount", "const", "42", false),
+                },
+                UnreadableRunPageLinkEntries: null);
+
+            var links = (System.Collections.IEnumerable)Invoke(spec);
+            var applied = links.Cast<object>().ToList();
+
+            Assert.Equal(2, applied.Count);
+
+            // Both entries resolved against the dependency's own table: "Document No." is field
+            // 2 and "Amount" is field 3 in the SymbolReference above. Reading the values proves
+            // the links were BUILT, not merely counted — a guard that returned an empty list
+            // would also "not throw".
+            static (int TargetFieldNo, string Kind, int HostFieldNo, string Value) Read(object link)
+            {
+                var t = link.GetType();
+                return ((int)t.GetProperty("TargetFieldNo")!.GetValue(link)!,
+                        t.GetProperty("Kind")!.GetValue(link)!.ToString()!,
+                        (int)t.GetProperty("HostFieldNo")!.GetValue(link)!,
+                        (string)t.GetProperty("Value")!.GetValue(link)!);
+            }
+
+            var first = Read(applied[0]);
+            Assert.Equal(2, first.TargetFieldNo);
+            Assert.Equal("FIELD", first.Kind);
+            // The host side of a field(...) entry resolves against the HOST page's table, which
+            // is the same table here, so "No." is field 1.
+            Assert.Equal(1, first.HostFieldNo);
+
+            var second = Read(applied[1]);
+            Assert.Equal(3, second.TargetFieldNo);
+            Assert.Equal("CONST", second.Kind);
+            Assert.Equal("42", second.Value);
+        });
+
+    /// <summary>
+    /// The other negative direction: an action declaring NO RunPageLink at all must return the
+    /// empty list before the guard is consulted. Without this row, a guard that threw whenever
+    /// DeclaredRunPageLinkEntries was 0 would refuse every plain RunObject action in the
+    /// repository and no test above would notice.
+    /// </summary>
+    [Fact]
+    public void NoRunPageLinkDeclared_ReturnsNoLinksWithoutConsultingTheGuard()
+        => WithLoadedDependency(() =>
+        {
+            var spec = new BcAppSymbolCache.ActionRunObjectSymbol(
+                ObjectName: "ARPLR Target",
+                RunPageOnRec: true,
+                DeclaredRunPageLinkEntries: 0,
+                RunPageLink: null,
+                UnreadableRunPageLinkEntries: null);
+
+            var links = (System.Collections.IEnumerable)Invoke(spec);
+            Assert.Empty(links.Cast<object>());
+        });
+}


### PR DESCRIPTION
Closes #3274

`RunnerPageInstance.LinksFromSymbols` refuses an action's `RunPageLink` when the
symbol-file parser could not read every declared entry. Nothing executed that
refusal: the existing `ActionRunPageLinkUnreadableEntryTests` pins the guard's
**input** (that the parser counts declared entries correctly and carries unreadable
ones by text), never what the consumer does with it. Deleting the comparison turned
no test red.

This is a pure coverage change. **`AlRunner/` is untouched** — `git diff
origin/main...HEAD` is one new file.

## The guard has THREE arms, not the two in the issue body

The issue was filed against `parsed == null || parsed.Count != Declared…`. Since
#3267 the condition on `main` is:

```csharp
if (parsed == null || parsed.Count != spec.DeclaredRunPageLinkEntries
    || unreadable is { Count: > 0 })
```

All three are separate observables, so each gets its own test and its own mutation.

## RED → GREEN, and the mutations

Every mutation was chosen to red exactly one arm and leave the others green —
proving the tests *discriminate*, not merely that coverage exists. Deleting the whole
`if` would red every arm indistinguishably.

Each mutation was re-read in the file after applying, to confirm it landed; each RED
was checked to be an `Assert` failure and not `error CS`.

| # | mutation | result | what it establishes |
|---|---|---|---|
| baseline | none | `Failed: 0, Passed: 5, Total: 5` | |
| 1 | drop `parsed.Count != Declared…`, keep the other two | `Failed: 1, Passed: 4` — only `ParsedFewerEntriesThanDeclared`, `Assert.Throws() Failure: No exception was thrown` | the **count** arm is driven, and arms 2/3 stay green |
| 2 | drop `parsed == null`, keep the other two | `Failed: 1, Passed: 4` — only `ParsedNull_WithEntriesDeclared`, `Assert.Throws() Failure: Exception type was not an exact match / NullReferenceException` | the **null** arm is driven, and is load-bearing rather than defensive: without it a null parse crashes instead of refusing |
| 3 | drop `unreadable is { Count: > 0 }`, keep the other two | `Failed: 1, Passed: 4` — only `UnreadableEntriesCarried_WithCountsAgreeing`, `Assert.Throws() Failure: No exception was thrown` | the **unreadable** arm is driven independently of the count |
| 4 | replace the whole condition with `if (true)` | `Failed: 1, Passed: 4` — only `EveryDeclaredEntryRead_IsAppliedRatherThanRefused` | the negative row is load-bearing: a refuse-everything guard does not pass |

Restored after each; `git status` on `AlRunner/` is empty, so the restore is
byte-exact rather than merely re-applied. Post-rebase re-run: `Failed: 0, Passed: 5,
Skipped: 0, Total: 5`.

The tests assert the message's **specific content** — both counts (`RunPageLink of 2
entr(ies)` / `could read 1 of them`), the target name, the page id, the
fail-closed reason, and the unreadable entry text — never a bare `Assert.Throws`.
Mutation 1's green arms 2/3 are what show those assertions are not interchangeable.

## Is the guard reachable? Yes — and the AL route was built, then withdrawn

**Reachable.** All three arms execute and throw the documented refusal, which the
mutations above measure directly. This is not a never-fire path.

I also built the end-to-end AL route the issue body describes: a `runner-extras`
suite with a genuinely precompiled dependency (hand-built `SymbolReference.json`
carrying `"Amount" whenever(42)` — text no AL compiler would emit — plus a Tier-1
`.deps-bin` DLL, following `testpage-precompiled-dep-control`'s recipe). It compiled,
loaded, and both tests reached real runner behaviour.

**It was withdrawn rather than shipped unverified**, because its refusal arm is
unfalsifiable on this machine. Every `runner-extras` suite that invokes a page action
— including the merged, CI-gated `tests/runner-extras/testpage-promoted-actionref` —
dies in BC's own `Codeunit2000000002.OnInvokeAsync`:

```
EXEC-FAIL: Could not load file or assembly 'Microsoft.Bcl.AsyncInterfaces,
Version=10.0.0.5, ...'. (0x80131621)
```

Reproduced on a plain `main` checkout (`3e5438e4`), on `--bc-version` 28.1 and 28.4,
with and without `--package-cache`. Root cause measured, not guessed: the resolver at
`DependencyLoader.cs:1266-1268` probes the service-tier directory **by name** and
returns whatever it finds, and `AssemblyName.GetAssemblyName` reports the provisioned
copies as `10.0.0.2` against BC's `10.0.0.5` request. Filed as **#3977**.

Both that `FileLoadException` and the guard's refusal surface through
`GetLastErrorText()`, so an AL `asserterror` could not tell them apart — the test
would have passed for the wrong reason. Shipping a test whose RED nobody has seen is
what `tdd.md`'s mutation step exists to prevent, so the suite is not in this diff;
the recipe is recorded in the new file's header so it can be rebuilt once #3977 is
fixed.

Pinning the method directly is the established answer to this exact shape —
`RecordPatchesGetPageControlFieldMapDependencyTests`'s header records the same
decision, for the same reason, on the sibling code path.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** The sibling is
   `MockTestPage.SubPageLinks`, which applies a *part's* `SubPageLink` through the
   same parser and the same `PageSubFormLinkSymbol` triple. It is **already covered**
   — `PagePartSymbol.UnreadableSubPageLinkEntries` exists precisely because #3248 did
   that half first; this guard was the arm left behind. Nothing further to fix.
2. **Does a sibling function make the same assumption?** `LinksFromMetadata`, the
   other producer of `ActionRunLink`, reads BC's compiled `ActionDefinition` where the
   target is already a resolved id and kind. There is no property *text* to fail to
   parse, so the count-mismatch shape cannot arise there. Correctly absent, not missing.
3. **Two code paths writing the same state with different invariants?** Both producers
   feed one `ActionRunLink` list applied by one `ApplyLink` switch. That switch already
   refuses an unknown `FilterType` loudly, so the invariant ("every link that reaches
   application is complete and of a known kind") is maintained on both paths.

## Queue scan

Searched the open queue by symbol (`LinksFromSymbols`, `DeclaredRunPageLinkEntries`,
`ActionRunObject`), by observable (`RunPageLink`), and by mechanism. Two neighbours in
this file, **neither folded**:

- **#2943** — an action's `RunObject` naming a report/codeunit/xmlport/query. Already
  claimed (`agent: stma-auto-32`, `status: in-progress`).
- **#3223** — a `RunObject` action targeting a dialog page raises the wrong exception.
  A behaviour change on the modal arm, needing its own diagnosis; folding it would put
  two unrelated changes in a coverage-only diff.

No duplicate of #3274 itself exists — searched by symbol, by the `71`-style count
shape, and by "no test pins"; the only hit is #3274.

## Cache

Measured rather than assumed: the proving tests were run **twice against one cache
root**, `Failed: 0, Passed: 5` both times. `BcAppSymbolCache` is content-addressed and
each test writes a fresh `.app` under `TestScratch.Dir`, so no `PayloadShape` or
`CacheVersion` question arises — this PR adds no cache key terms.

## Gates

- `for t in tools/test_*.py` — all pass.
- `tools/test_doc_summary_uniqueness.py` — `352 files, 2912 doc blocks`, all checks passed.
- `dotnet test --filter "FullyQualifiedName~ActionRunPageLink|FullyQualifiedName~DependencyPageShape"` — `Failed: 0, Passed: 14, Total: 14`.
- `check_corpus_linkage.sh` over the real diff — *"No file in this diff can change what AL observes"*, exit 0. No `Corpus-PR:`/`Corpus-NA:` line is required, and none is claimed: the subject is how the runner reads `SymbolReference.json`, a Microsoft build artifact a real BC service tier never reads, so this owes no corpus test for the same structural reason `ActionRunPageLinkUnreadableEntryTests` does not.
- `require-tests` is satisfied by the new `AlRunner.Tests/` file; the diff touches no `AlRunner/` path, so the gate does not trigger in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
