### PR TITLE
docs: 87879acb rewrote 15 rules, not 14

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ derivation behind it"). A new rule is done when it carries that shape — claim,
 its derivation moved out and its incidents file present. **Keep it short, and treat length as a
 symptom rather than a bar**: a rule that has grown long is usually carrying a derivation that
 belongs in `docs/incidents/`, so move that and the length follows. There is deliberately no byte
-figure here; the one this sentence used to carry was met by 2 of the 14 rules its own introducing
+figure here; the one this sentence used to carry was met by 2 of the 15 rules its own introducing
 commit rewrote (#3952), so it cost an argument per rule and settled nothing.
 
 ## Code navigation: use these before grepping


### PR DESCRIPTION
Closes #3972

`CLAUDE.md` says the 3 KB figure "was met by 2 of the **14** rules its own introducing commit rewrote". It rewrote **15**.

```
$ git diff --name-status 87879acb~1 87879acb -- .claude/rules/ | awk '{print $1}' | sort | uniq -c
     15 M
```

My original count grepped diff *lines* containing `.claude/rules/`, which under-counts. Caught in review of #3968 — after the wrong number had already merged — and I reproduced 15 with `--name-status` before changing anything.

The figure it qualifies is unchanged (2 rules under 3 KB), so the argument gets marginally **stronger**: 2 of 15 rather than 2 of 14.

## Why a commit rather than a shrug

The denominator is stated in `CLAUDE.md` **as a measurement**, offered as the reason a convention changed. `loud-failures.md` is explicit that a citation a reader cannot re-derive is indistinguishable from a wrong one — and here the obvious command returns a different number than the file claims.

It travelled from #3952's body through the PR body and commit message into the shipped file, re-read by me twice without being re-derived. Nothing checks prose arithmetic — the same gap #3955 records for prose *commands*.

What caught it was a reviewer **re-running the measurement instead of reading the claim**, which the review brief asked for explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
