### PR TITLE
docs(scope): record MockAzureKeyVaultSecretProvider as an unobtainable DotNet type

### DIFF
--- a/AlRunner.Tests/UnobtainableDotNetTypeAttributionTests.cs
+++ b/AlRunner.Tests/UnobtainableDotNetTypeAttributionTests.cs
@@ -1,0 +1,134 @@
+// UnobtainableDotNetTypeAttributionTests — #3890.
+//
+// CLAIM: some AL0185 emit-exclusions name a .NET type that ships in NO Business Central
+// artifact, so the drop is permanent and identical on every run. The report has to say which,
+// or every reader re-investigates a settled question; and it must say so ONLY for types a scan
+// actually cleared, so an unknown drop is never dressed up as a known one.
+//
+// CITATION: docs/limitations.md#unobtainable-dotnet-types carries the scan — 0 of 501 DLLs on
+// two independent binary sets, positive control FileExtensionContentTypeProvider = 3 — and the
+// reason it cannot be staged: nothing declares an assembly() block for it.
+//
+// TRAP, for whoever edits this next: the attribution must key on the TYPE NAME the diagnostic
+// quotes, never on the codeunit or file. One type is referenced by four Microsoft test apps, so
+// keying on the object would explain one drop and leave three unexplained.
+
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class UnobtainableDotNetTypeAttributionTests
+{
+    private const string RealDiagnostic =
+        "SourceFile(/tmp/deps/Microsoft_Tests-TestLibraries/LibraryAzureKVMockMgmt.Codeunit.al@10:42): "
+        + "error AL0185: DotNet 'MockAzureKeyVaultSecretProvider' is missing";
+
+    /// <summary>The positive case, verbatim from a real run (BC 28.1, manual-binding-dep).</summary>
+    [Fact]
+    public void TheRealDiagnostic_IsAttributedToTheDocumentedRecord()
+    {
+        var s = DependencyLoader.AttributeToUnobtainableType(new[] { RealDiagnostic });
+
+        Assert.NotNull(s);
+        Assert.Contains("MockAzureKeyVaultSecretProvider", s);
+        Assert.Contains("ships in none of Business Central's artifacts", s);
+        Assert.Contains("docs/limitations.md#unobtainable-dotnet-types", s);
+        // The reader's actual question is "is this mine to fix?" — the answer must be explicit.
+        Assert.Contains("rather than a provisioning gap", s);
+    }
+
+    /// <summary>
+    /// The negative that matters most: an AL0185 for ANY other type stays unattributed, because
+    /// an unrecognised missing type may well be fixable (#3876 staged one). Attributing broadly
+    /// would tell a reader to stop looking at a real, solvable gap.
+    /// </summary>
+    [Fact]
+    public void ADifferentMissingType_IsNotAttributed()
+    {
+        var other = RealDiagnostic.Replace(
+            "MockAzureKeyVaultSecretProvider", "FileExtensionContentTypeProvider");
+
+        Assert.Null(DependencyLoader.AttributeToUnobtainableType(new[] { other }));
+    }
+
+    /// <summary>
+    /// A diagnostic naming the type for a DIFFERENT reason than AL0185 is not this record.
+    /// Without the code check, any message quoting the name would claim the documented verdict.
+    /// </summary>
+    [Fact]
+    public void TheSameTypeUnderADifferentDiagnosticCode_IsNotAttributed()
+    {
+        var notAl0185 = RealDiagnostic.Replace("AL0185", "AL0432");
+
+        Assert.Null(DependencyLoader.AttributeToUnobtainableType(new[] { notAl0185 }));
+    }
+
+    /// <summary>A substring of the name must not match: the quotes are part of the key.</summary>
+    [Fact]
+    public void APrefixOfTheTypeName_IsNotAttributed()
+    {
+        var prefixed = RealDiagnostic.Replace(
+            "'MockAzureKeyVaultSecretProvider'", "'MockAzureKeyVaultSecretProviderFactory'");
+
+        Assert.Null(DependencyLoader.AttributeToUnobtainableType(new[] { prefixed }));
+    }
+
+    [Fact]
+    public void NoDiagnosticsAtAll_IsNotAttributed()
+    {
+        Assert.Null(DependencyLoader.AttributeToUnobtainableType(Array.Empty<string>()));
+        Assert.Null(DependencyLoader.AttributeToUnobtainableType(new string?[] { null }!));
+    }
+
+    /// <summary>
+    /// The attribution has to reach the message the run actually prints — the unit above proves
+    /// the helper, this proves it is WIRED. Also pins that the generic text survives: the
+    /// denominator (#3875's "of 70") is what makes the drop a finding at all.
+    /// </summary>
+    [Fact]
+    public void TheFullDependencyMessage_CarriesBothTheDenominatorAndTheAttribution()
+    {
+        var msg = DependencyLoader.BuildDependencyEmitExcludedDetail(
+            new[] { "Codeunit .\"Library - Azure KV Mock Mgmt.\"" }, 202, new[] { RealDiagnostic });
+
+        Assert.Contains("1 of this dependency's 203 object(s)", msg);
+        Assert.Contains("provides only 202", msg);
+        Assert.Contains("docs/limitations.md#unobtainable-dotnet-types", msg);
+    }
+
+    /// <summary>An ordinary partial emit must NOT gain the attribution sentence.</summary>
+    [Fact]
+    public void AnUnrelatedPartialEmit_GainsNoAttributionSentence()
+    {
+        var msg = DependencyLoader.BuildDependencyEmitExcludedDetail(
+            new[] { "Codeunit .\"Something Else\"" }, 9,
+            new[] { "error AL0185: DotNet 'SomeOtherType' is missing" });
+
+        Assert.Contains("1 of this dependency's 10 object(s)", msg);
+        Assert.DoesNotContain("unobtainable-dotnet-types", msg);
+    }
+
+    /// <summary>
+    /// Every listed type must be recorded in docs/limitations.md, or the message cites an anchor
+    /// whose table does not mention it. A list entry asserts a scan was run; this is what keeps
+    /// the assertion honest as the list grows.
+    /// </summary>
+    [Fact]
+    public void EveryListedType_AppearsUnderTheDocumentedAnchor()
+    {
+        var doc = File.ReadAllText(Path.Combine(RepoRoot(), "docs", "limitations.md"));
+        var section = doc[doc.IndexOf("unobtainable-dotnet-types", StringComparison.Ordinal)..];
+
+        Assert.NotEmpty(DependencyLoader.UnobtainableDotNetTypes);
+        foreach (var t in DependencyLoader.UnobtainableDotNetTypes)
+            Assert.Contains(t, section);
+    }
+
+    // The four-up idiom every other source-reading test here uses. NOT a .git walk: in a git
+    // WORKTREE .git is a file, so Directory.Exists never matches and the walk silently runs off
+    // to a parent checkout -- reading a stale docs/limitations.md that has none of this branch's
+    // edits. Measured while writing this test (#3890).
+    private static string RepoRoot() => Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+}

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -1165,8 +1165,46 @@ public sealed class DependencyLoader
         if (excludedDiagnostics.Count > 0)
             sb.Append(" AL diagnostics that identified the dropped object(s): ")
               .Append(string.Join(" | ", excludedDiagnostics));
+        var attributed = AttributeToUnobtainableType(excludedDiagnostics);
+        if (attributed != null) sb.Append(' ').Append(attributed);
         return sb.ToString();
     }
+
+    /// <summary>
+    /// CLAIM: some AL0185 drops name a .NET type Microsoft ships in NO artifact, so they are
+    /// permanent and identical on every run and every BC version — not a provisioning fault a
+    /// reader should go looking for. Saying which turns a recurring report into a bounded,
+    /// attributable one; every other AL0185 keeps the unattributed text, because an
+    /// unrecognised one may well be fixable.
+    ///
+    /// CITATION: docs/limitations.md#unobtainable-dotnet-types, which carries the scan and the
+    /// positive control. Returns null when nothing matches — an unknown drop must never be
+    /// dressed up as a known one (guards-need-a-third-state.md).
+    ///
+    /// TRAP: match on the TYPE NAME the diagnostic quotes, never on the object or file name.
+    /// One type is referenced by four Microsoft test apps (#3890), so keying on the codeunit
+    /// would attribute one of them and silently leave the other three unexplained.
+    /// </summary>
+    internal static string? AttributeToUnobtainableType(IReadOnlyList<string> excludedDiagnostics)
+    {
+        if (excludedDiagnostics == null) return null;
+        foreach (var type in UnobtainableDotNetTypes)
+            foreach (var d in excludedDiagnostics)
+                if (d != null && d.Contains($"'{type}'", StringComparison.Ordinal)
+                    && d.Contains("AL0185", StringComparison.Ordinal))
+                    return $"DotNet '{type}' ships in none of Business Central's artifacts — it is a "
+                         + "test-harness type the service tier injects, so this drop is permanent and "
+                         + "expected here rather than a provisioning gap to chase; see "
+                         + "docs/limitations.md#unobtainable-dotnet-types (#3890).";
+        return null;
+    }
+
+    /// <summary>Types measured absent from every shipped artifact. Deliberately a short,
+    /// evidence-backed list rather than a pattern: an entry asserts a scan was run.</summary>
+    internal static readonly string[] UnobtainableDotNetTypes =
+    {
+        "MockAzureKeyVaultSecretProvider",
+    };
 
     /// <summary>
     /// True for the stages <see cref="DependencyMetadataProducer"/> raises. Matched on the

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -393,6 +393,47 @@ What still holds, and is BC's rule rather than the runner's:
 `docs/scope.md` §3.14 listed the AL `DotNet` surface as out of scope for the same stale
 reason; it is corrected alongside this section.
 
+### DotNet types Microsoft ships in no artifact — permanent `AL0185` drops
+
+<a id="unobtainable-dotnet-types"></a>
+
+The section above covers a `DotNet` type that fails to *resolve*. This one covers a narrower
+and permanent case: a type Microsoft's own AL references that is present in **no shipped
+artifact at all**, so there is nothing to provision and no host on which it resolves.
+
+| AL type | Referenced by | Status |
+|---|---|---|
+| `MockAzureKeyVaultSecretProvider` | Microsoft's `Tests-TestLibraries` (`Library - Azure KV Mock Mgmt.`), and `Tests-Integration`, `Tests-Misc` directly | Ships nowhere; permanently dropped |
+
+**Measured** (#3890), on the full artifact tree rather than its top level:
+
+- `MockAzureKeyVaultSecretProvider` appears in **0** of the **501** DLLs of
+  `28.4.53241.54407`, and 0 of 501 in `28.1.49838.54308` — two independent binary sets.
+- Positive control, because a zero from a pattern one chose is not evidence:
+  `FileExtensionContentTypeProvider` returns **3** assemblies in each. The instrument works.
+- The 108 shipped `.app` packages embed **no** DLLs at all, so it is not hiding in one.
+- Only two test-helper assemblies ship — `Microsoft.Dynamics.Nav.Client.TestPageClient.dll`
+  and `Microsoft.Dynamics.Nav.PermissionTestHelper.dll` — and neither carries it.
+
+**Why it cannot be staged.** `Ncl.dll` declares the *interface*
+`Microsoft.Dynamics.Nav.Runtime.Encryption.IAzureKeyVaultSecretProvider`, and **no** type whose
+name contains `Mock` exists anywhere in it (checked on 28.4 and 27.5, which are different
+binaries). The implementation is supplied by Microsoft's own test host, not by the artifacts.
+
+The decisive detail is in the AL itself: `Tests-TestLibraries/dotnet.al` declares
+`PermissionTestHelper` against a real shipped assembly — and that one resolves — while
+**nothing anywhere declares an `assembly(...)` block for the mock**. A `DotNet` variable with
+no declaration block is exactly what `AL0185` reports, so this is not a missing reference pack
+the runner could add; the reference does not exist to be satisfied.
+
+**What the runner does.** The object is dropped, and `DependencyLoader` reports the drop at
+default verbosity and again in the run summary, on cold runs and cache hits alike (#2247,
+#3882), naming this record so the reader can stop looking. It does **not** refuse the load:
+`Tests-TestLibraries` provides 202 of its 203 objects, the survivors are what the provisioning
+chain depends on, and refusing would take down work that passes today — the same over-refusal
+#3476 removed from the bundle path. AL that actually touches the dropped codeunit still fails
+loudly, with `NavNCLMissingMethodException`.
+
 ### `System.Drawing` — Windows-only in .NET 8, so it never runs on a Linux or macOS host
 
 <a id="system-drawing"></a>


### PR DESCRIPTION
Closes #3890

Authored by the agent loop `stma-auto-1`, not by a person.

## The finding, and why it changes the issue's framing

The title says "silently drops". **That is no longer true** — #3882 made this path report at
discovery *and* in the run summary, on cold runs and cache hits alike. I re-measured rather
than assuming: the drop is loud in both directions today.

What is still missing is the other half of the brief's option 2: the drop is *reported* but not
*recorded*. Nothing said the type is permanently unobtainable, so every reader who meets the
message re-investigates a question that is already settled.

**I chose option 2 (legitimate drop, made attributable), and deliberately not option 1.**

## Does the type genuinely ship nowhere? Yes — re-measured, with controls

The issue's measurement reproduces exactly, and I extended it:

| scan | result |
|---|---|
| `MockAzureKeyVaultSecretProvider` in 28.4.53241.54407 | **0 of 501** DLLs |
| same, in 28.1.49838.54308 (a **different** binary set) | **0 of 501** |
| positive control `FileExtensionContentTypeProvider` | **3** in each — the instrument works |
| DLLs embedded in the 108 shipped `.app` packages | **0** — it is not hiding in one |
| test-helper DLLs that ship at all | only `Client.TestPageClient.dll`, `PermissionTestHelper.dll` |

My first scan (`xargs command grep -l`) returned **zero for the positive control too**. That
is a broken instrument, not a finding; I discarded it and redid the scan in Python. Reporting
the first number would have been a false zero in the shape of a result.

**Two structural confirmations, from BC's own metadata rather than a byte grep.**
`Ncl.dll` declares the *interface* `…Runtime.Encryption.IAzureKeyVaultSecretProvider`, and
`search_types("Mock")` returns **zero types** on both `bc284` and `bc275` — different binaries.
BC ships no test-mock types in the service-tier runtime at all.

**The decisive detail is in the AL itself.** `Tests-TestLibraries/dotnet.al` declares
`PermissionTestHelper` against a real shipped assembly, and that one resolves — while
**nothing anywhere declares an `assembly(...)` block for the mock**. `AL0185` is precisely
"a `DotNet` variable with no declaration block". So this is not a reference pack the runner
could stage as #3876 did; the reference does not exist to be satisfied. It is a
provisioning/scope fact, not a compile bug.

## What loads this app today, and does this break it?

`tests/runner-extras/manual-binding-dep` depends on `Tests-TestLibraries`, and the app is
load-bearing across the provisioning chain (`ProvisioningCheck`, `Provisioning`,
`ServiceTierDllIndex`). Measured before and after, cold and warm against one cache root:

- before: `3P/0F/0E`, EMIT-EXCLUDED reported; warm run replays it `(from a cached compile)`
- after: `3P/0F/0E`, same report **plus** the attribution sentence

**This is exactly why option 1 is wrong.** Refusing the load would take down a bundle that
passes today over 1 of 203 objects — the same over-refusal #3476 removed from the bundle path,
and which `DependencyLoader`'s own guard comment already records. `ExcludedObjectTriage` also
correctly declines to clear it (a codeunit without `Subtype = Test`), so there is no existing
mechanism arguing for a hard failure. AL that actually touches the dropped codeunit still
fails loudly with `NavNCLMissingMethodException`.

## RED → GREEN → MUTATE

`AlRunner.Tests/UnobtainableDotNetTypeAttributionTests.cs` — 8 tests, positive and negative.

Two mutations, each chosen to test a **property** rather than to produce a red. Both landed
(re-read after editing), both failed on `Assert`, **0 `error CS`** in either:

| mutation | result | what it proves |
|---|---|---|
| empty `UnobtainableDotNetTypes` | `Failed: 3, Passed: 5` | reds exactly the 3 positive-path tests; the 5 negatives correctly stay green |
| weaken the match to a bare `Contains(type)` | `Failed: 2, Passed: 6` | reds **exactly** `APrefixOfTheTypeName_IsNotAttributed` and `TheSameTypeUnderADifferentDiagnosticCode_IsNotAttributed` — the tests discriminate |

Restored → `Failed: 0, Passed: 8`. Full neighbouring surface
(`UnobtainableDotNetType` + `DependencyEmitExclusion` + `ExcludedObjectTriage` +
`EmitExclusionLoudness`): **`Failed: 0, Passed: 34, Skipped: 0`**. All `tools/test_*.py` pass.
End-to-end run confirms the sentence reaches real output.

**A bug the mutation discipline caught in my own test.** `EveryListedType_AppearsUnderTheDocumentedAnchor`
first resolved the repo root by walking for a `.git` **directory**. In a git worktree `.git` is a
**file**, so the walk ran off to a parent checkout and read a `docs/limitations.md` without this
branch's edits — a correct instrument reading the wrong subject. Switched to the four-up idiom
every other source-reading test here uses, and left the reason at the line.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** The other two exclusion paths are deliberately
   different and both correct: `Program.cs` (bundle) refuses via `ExcludedObjectTriage`, and
   `DependencyMetadataProducer` throws because its output is cached and replayed. Only the
   dependency path continues, which is the one that needed the record. No change there.
2. **Sibling function with the same assumption?** `BuildDependencyEmitExcludedDetail` is the
   single message builder for this path; the attribution is wired into it, so cold and warm
   runs and the summary all inherit it — verified in the end-to-end run above.
3. **Two paths writing the same state?** The report is cached and replayed
   (`PublishSourceDependencyCache`). Since the attribution is built inside the message, the
   warm path carries it with no second invariant to maintain.

**Queue scan (`search-for-the-same-defect-first.md`).** Searched `AL0185`, "Azure Key Vault",
"silently drops object", "DotNet type missing". Nothing reports this defect —
#3876 is the same *class* (a missing DotNet type) but a different, genuinely stageable
assembly, which is the contrast this record exists to draw. Nothing folded in.

## Scope of the claim

The list is deliberately one entry, not a pattern: an entry asserts a scan was run, and
`EveryListedType_AppearsUnderTheDocumentedAnchor` fails if a future entry is added without a
matching docs record. Any other `AL0185` keeps the unattributed text, because an unrecognised
missing type may well be fixable — telling a reader to stop looking at a solvable gap is the
failure mode I most wanted to avoid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
