### PR TITLE
fix(metadata): read BC's own platform-field metadata instead of the ctor defaults

### DIFF
--- a/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
+++ b/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
@@ -263,7 +263,17 @@ public sealed class BcInternalsNullForgivingGuardTests
         // site, which is why these are shape-checked rather than `?.`. The enclosing
         // BcShapeGapException catch still drops the one unreadable binding from the index rather
         // than costing the page every other one — what changed is that the gap is named.
-        Assert.Equal(92, converted);
+        //
+        // 92 -> 95 for the three reads that copy BC's own platform-field metadata off
+        // SystemFieldsHelper in RecordPatches.NclMetaTableBuilder.cs (#3568): MetaField.Id, the
+        // three SystemFieldsHelper properties, and the per-member MetaField read. Measured on
+        // both distinct Types.dll binaries the CI legs cover — 27.5.46862.48827 and
+        // 28.4.53241.54447 — the helper declares exactly those three properties and no others,
+        // each holding a non-null value, so a null means Microsoft moved a member. Absorbing it
+        // would silently restore the positional-ctor defaults the conversion exists to replace,
+        // which is "answer WRONG instead of failing" rather than a neutral sentinel. Absence of
+        // the helper TYPE stays a legitimate null, and is deliberately NOT shape-checked.
+        Assert.Equal(95, converted);
     }
 
     /// <summary>

--- a/AlRunner.Tests/SystemFieldMetadataOracleTests.cs
+++ b/AlRunner.Tests/SystemFieldMetadataOracleTests.cs
@@ -1,0 +1,269 @@
+// SystemFieldMetadataOracleTests — RED→GREEN guard for the SYSTEM-FIELD cluster of #3568.
+//
+// The runner appends BC's six platform-defined fields itself (SystemParsedFields plus the
+// synthetic `timestamp` in RecordPatches.NclMetaTableBuilder.cs) and builds each one through
+// MetaField's POSITIONAL constructor. BC builds the same six from boilerplate XML through
+// MetaField(XmlNode, string). The two constructors do not agree, and where the positional one
+// was never passed a value the ctor's own default stood — so four members were the ctor's
+// default rather than BC's answer, on every table the runner builds:
+//
+//     TestRelations          False        vs BC True   (all six fields)
+//     AllowInCustomizations  ToBeClassified vs AsReadOnly (the five 2000000000-block fields)
+//     ValidateRelation       True         vs BC False  (SystemCreatedBy / SystemModifiedBy)
+//     ClrType                ""           vs the real CLR type (all six)
+//
+// THE ORACLE IS BC'S OWN CODE, not a table written here. SystemFieldsHelper.SystemIdField,
+// .SystemRowVersionField and .AuditFields are the MetaField[] BC's own runtime hands to
+// MetaTable when it adds platform fields, so these tests read the expected value out of
+// Microsoft.Dynamics.Nav.Types at run time and compare the runner's field against it. A BC
+// version that changes one of these values changes both sides together, which is the point:
+// the claim under test is "the runner's six agree with BC's six", not a list of constants
+// somebody transcribed.
+//
+// Measured on 28.1.49838.53910 over Business Foundation + System Application (150 tables) by
+// the metadata-equivalence harness: TestRelations 900 differences, AllowInCustomizations 750,
+// ValidateRelation 300, and 750 of ClrType's 1,888. See docs/metadata-equivalence.md.
+
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class SystemFieldMetadataOracleTests
+{
+    private readonly BcEngineFixture _engine;
+
+    public SystemFieldMetadataOracleTests(BcEngineFixture engine) => _engine = engine;
+
+    /// <summary>The six field ids BC's platform adds, in the order BC's helper exposes them.</summary>
+    private const int TimestampId = 0;
+    private const int SystemIdId = 2000000000;
+    private const int SystemCreatedAtId = 2000000001;
+    private const int SystemCreatedById = 2000000002;
+    private const int SystemModifiedAtId = 2000000003;
+    private const int SystemModifiedById = 2000000004;
+
+    private static Type MetaFieldType() =>
+        Type.GetType("Microsoft.Dynamics.Nav.Types.Metadata.MetaField, Microsoft.Dynamics.Nav.Types")
+        ?? throw new InvalidOperationException("MetaField is not reachable.");
+
+    private static Type SystemFieldsHelperType() =>
+        Type.GetType("Microsoft.Dynamics.Nav.Types.Metadata.SystemFieldsHelper, Microsoft.Dynamics.Nav.Types")
+        ?? throw new InvalidOperationException("SystemFieldsHelper is not reachable.");
+
+    private static object? Read(object metaField, string property) =>
+        MetaFieldType().GetProperty(property, BindingFlags.Public | BindingFlags.Instance)!
+            .GetValue(metaField);
+
+    /// <summary>
+    /// BC's own six platform MetaFields, keyed by id. This is the ORACLE — every expected value
+    /// in this file comes from here rather than from a constant, so the assertions track BC.
+    /// </summary>
+    private static Dictionary<int, object> BcPlatformFields()
+    {
+        var helper = SystemFieldsHelperType();
+        const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static;
+        var result = new Dictionary<int, object>();
+
+        void Absorb(string propertyName)
+        {
+            var value = helper.GetProperty(propertyName, flags)?.GetValue(null)
+                        ?? throw new InvalidOperationException(
+                            $"SystemFieldsHelper.{propertyName} is not reachable — the oracle for "
+                            + "this test would be empty, which would make every assertion vacuous.");
+            foreach (var field in value is Array array ? array.Cast<object>() : new[] { value })
+                result[(int)Read(field, "Id")!] = field;
+        }
+
+        Absorb("SystemIdField");
+        Absorb("SystemRowVersionField");
+        Absorb("AuditFields");
+        return result;
+    }
+
+    /// <summary>
+    /// The runner's own six, read off a real built table. Table 2000000001 is not usable here
+    /// (it is refused as a system table), so this drives an ordinary parsed table and reads the
+    /// platform fields the builder appended to it.
+    /// </summary>
+    private static Dictionary<int, object> RunnerPlatformFields(int tableId)
+    {
+        var ncl = RecordPatches.GetOrBuildNCLMetaTable(tableId)
+                  ?? throw new InvalidOperationException($"the runner built no metadata for table {tableId}");
+        var original = ncl.GetType()
+            .GetMethod("GetMetaTableOriginal", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!
+            .Invoke(ncl, null)!;
+        var fields = (IEnumerable)original.GetType()
+            .GetProperty("Fields", BindingFlags.Public | BindingFlags.Instance)!
+            .GetValue(original)!;
+
+        var result = new Dictionary<int, object>();
+        foreach (var field in fields)
+        {
+            var id = (int)Read(field!, "Id")!;
+            if (id == TimestampId || id >= SystemIdId) result[id] = field!;
+        }
+        return result;
+    }
+
+    private static int FixtureTable()
+    {
+        // A table the runner parses from AL source, so the builder runs its own append path
+        // rather than replaying one of BC's emitted documents.
+        const int tableId = 61893;
+        var parse = typeof(RecordPatches).GetMethod("TryParseTableFile",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        parse.Invoke(null, new object?[]
+        {
+            // TryParseTableFile(string text, string? filePath = null) — reflection does not
+            // apply optional-parameter defaults, so filePath is passed explicitly.
+            $$"""
+            table {{tableId}} "ALT System Field Oracle"
+            {
+                fields
+                {
+                    field(1; "Code"; Code[10]) { }
+                    field(2; "Description"; Text[100]) { }
+                }
+                keys { key(PK; "Code") { Clustered = true; } }
+            }
+            """,
+            null
+        });
+        return tableId;
+    }
+
+    /// <summary>
+    /// The oracle is real. If SystemFieldsHelper stopped yielding fields — a renamed member, a
+    /// BC version that moved them — every comparison below would silently compare an empty
+    /// dictionary against an empty one and pass. This fails first instead.
+    /// </summary>
+    [SkippableFact]
+    public void Bcs_own_platform_fields_are_readable_and_carry_the_values_the_runner_must_match()
+    {
+        Skip.IfNot(_engine.Ready, _engine.SkipReason);
+
+        var bc = BcPlatformFields();
+        Assert.Equal(6, bc.Count);
+
+        // Every one of the six answers TestRelations = true, from the shared attribute block
+        // BC formats into its boilerplate XML (TestTableRelation="1").
+        foreach (var (id, field) in bc)
+            Assert.True((bool)Read(field, "TestRelations")!, $"BC field {id} should answer TestRelations=true");
+
+        // AsReadOnly on the 2000000000 block only — MetaField's ctor sets it from
+        // `if (Id >= 2000000000)`, so the id-0 timestamp keeps ToBeClassified.
+        Assert.Equal("ToBeClassified", Read(bc[TimestampId], "AllowInCustomizations")!.ToString());
+        foreach (var id in new[] { SystemIdId, SystemCreatedAtId, SystemCreatedById, SystemModifiedAtId, SystemModifiedById })
+            Assert.Equal("AsReadOnly", Read(bc[id], "AllowInCustomizations")!.ToString());
+
+        // ValidateTableRelation="0" on exactly the two audit-by fields, which also carry the
+        // relation to User (2000000120); the other four state "1" and carry none.
+        Assert.Equal(false, Read(bc[SystemCreatedById], "ValidateRelation"));
+        Assert.Equal(false, Read(bc[SystemModifiedById], "ValidateRelation"));
+        Assert.Equal(true, Read(bc[SystemIdId], "ValidateRelation"));
+
+        // ClrType is computed by MetaField's ctor from the declared Datatype.
+        Assert.Equal("System.Guid", Read(bc[SystemIdId], "ClrType"));
+        Assert.Equal("System.Int64", Read(bc[TimestampId], "ClrType"));
+        Assert.Equal("System.DateTime", Read(bc[SystemCreatedAtId], "ClrType"));
+    }
+
+    /// <summary>
+    /// TestRelations: BC answers true on all six. This was the ctor default (false) on all six,
+    /// 900 differences across the 150 measured tables.
+    /// </summary>
+    [SkippableFact]
+    public void Every_platform_field_answers_TestRelations_as_BC_does()
+    {
+        Skip.IfNot(_engine.Ready, _engine.SkipReason);
+
+        var bc = BcPlatformFields();
+        var runner = RunnerPlatformFields(FixtureTable());
+        Assert.Equal(6, runner.Count);
+
+        foreach (var (id, expected) in bc)
+        {
+            Assert.True(runner.ContainsKey(id), $"the runner built no platform field {id}");
+            Assert.Equal(Read(expected, "TestRelations"), Read(runner[id], "TestRelations"));
+        }
+    }
+
+    /// <summary>
+    /// AllowInCustomizations: AsReadOnly on the five, ToBeClassified on the id-0 timestamp.
+    /// Asserting BOTH halves is what makes this a test of the id rule rather than of a constant
+    /// — blanket AsReadOnly would pass a five-field check and fail here.
+    /// </summary>
+    [SkippableFact]
+    public void Every_platform_field_answers_AllowInCustomizations_as_BC_does()
+    {
+        Skip.IfNot(_engine.Ready, _engine.SkipReason);
+
+        var bc = BcPlatformFields();
+        var runner = RunnerPlatformFields(FixtureTable());
+
+        foreach (var (id, expected) in bc)
+        {
+            Assert.True(runner.ContainsKey(id), $"the runner built no platform field {id}");
+            Assert.Equal(
+                Read(expected, "AllowInCustomizations")!.ToString(),
+                Read(runner[id], "AllowInCustomizations")!.ToString());
+        }
+
+        // The negative half, stated separately so a regression to a blanket value is named.
+        Assert.Equal("ToBeClassified", Read(runner[TimestampId], "AllowInCustomizations")!.ToString());
+        Assert.Equal("AsReadOnly", Read(runner[SystemIdId], "AllowInCustomizations")!.ToString());
+    }
+
+    /// <summary>
+    /// ValidateRelation: false on SystemCreatedBy/SystemModifiedBy, true on the other four.
+    /// Both directions asserted — a blanket false would be as wrong as the blanket true that
+    /// produced the 300 differences.
+    /// </summary>
+    [SkippableFact]
+    public void Every_platform_field_answers_ValidateRelation_as_BC_does()
+    {
+        Skip.IfNot(_engine.Ready, _engine.SkipReason);
+
+        var bc = BcPlatformFields();
+        var runner = RunnerPlatformFields(FixtureTable());
+
+        foreach (var (id, expected) in bc)
+        {
+            Assert.True(runner.ContainsKey(id), $"the runner built no platform field {id}");
+            Assert.Equal(Read(expected, "ValidateRelation"), Read(runner[id], "ValidateRelation"));
+        }
+
+        Assert.Equal(false, Read(runner[SystemCreatedById], "ValidateRelation"));
+        Assert.Equal(false, Read(runner[SystemModifiedById], "ValidateRelation"));
+        Assert.Equal(true, Read(runner[SystemIdId], "ValidateRelation"));
+        Assert.Equal(true, Read(runner[TimestampId], "ValidateRelation"));
+    }
+
+    /// <summary>
+    /// ClrType: BC computes it in MetaField's ctor from the Datatype, so the runner must state
+    /// the same string rather than the ctor's empty-string default. Reads BC's own answer per
+    /// id — a hardcoded table here would be a second implementation of the thing under test.
+    /// </summary>
+    [SkippableFact]
+    public void Every_platform_field_answers_ClrType_as_BC_does()
+    {
+        Skip.IfNot(_engine.Ready, _engine.SkipReason);
+
+        var bc = BcPlatformFields();
+        var runner = RunnerPlatformFields(FixtureTable());
+
+        foreach (var (id, expected) in bc)
+        {
+            Assert.True(runner.ContainsKey(id), $"the runner built no platform field {id}");
+            var want = (string)Read(expected, "ClrType")!;
+            Assert.False(string.IsNullOrEmpty(want),
+                $"BC's ClrType for field {id} is empty — the oracle would assert nothing");
+            Assert.Equal(want, Read(runner[id], "ClrType"));
+        }
+    }
+}

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -750,9 +750,51 @@ public static partial class RecordPatches
             // resolves to true), so only the explicit opt-out needs passing. It matters even
             // when the relation itself was not captured — the flag alone is what suppresses
             // rename propagation on a field whose relation a tableextension adds later.
+            //
+            // #3568 — on a PLATFORM field the declaration is Microsoft's, not the AL author's:
+            // BC's boilerplate states ValidateTableRelation="0" for SystemCreatedBy and
+            // SystemModifiedBy and "1" for the other four, so BC's own value wins over the
+            // ParsedField default. 300 differences across the 150 measured tables.
+            if (p.Name == "validateRelation"
+                && BcPlatformFieldValue(f.FieldId, "ValidateRelation") is bool bcValidateRelation)
+            {
+                args[i] = (bool?)bcValidateRelation;
+                continue;
+            }
             if (p.Name == "validateRelation" && !f.RelationValidate)
             {
                 args[i] = (bool?)false;
+                continue;
+            }
+            // #3568 — three further members BC computes for its own platform fields and the
+            // positional ctor defaults instead. Each is copied from BC's instance rather than
+            // restated, so a BC version that changes one moves both sides together:
+            //   testRelations          BC's shared attribute block states TestTableRelation="1"
+            //                          on all six; the ctor default is false (900 differences).
+            //   allowInCustomizations  MetaField's ctor sets AsReadOnly from `Id >= 2000000000`,
+            //                          leaving the id-0 timestamp ToBeClassified (750).
+            //   clrType                MetaField's ctor computes it via
+            //                          CommonTypeInformation.ResolveClrType(Type); the
+            //                          positional ctor defaults it to "" (750 of ClrType's 1,888).
+            // A field that is NOT one of the six is unaffected: BcPlatformFieldValue answers
+            // null and the argument falls through to the ctor default exactly as before.
+            if (p.Name == "testRelations"
+                && BcPlatformFieldValue(f.FieldId, "TestRelations") is bool bcTestRelations)
+            {
+                args[i] = bcTestRelations;
+                continue;
+            }
+            if (p.Name == "allowInCustomizations"
+                && BcPlatformFieldValue(f.FieldId, "AllowInCustomizations") is { } bcAllowInCustomizations)
+            {
+                args[i] = bcAllowInCustomizations;
+                continue;
+            }
+            if (p.Name == "clrType"
+                && BcPlatformFieldValue(f.FieldId, "ClrType") is string bcClrType
+                && !string.IsNullOrEmpty(bcClrType))
+            {
+                args[i] = bcClrType;
                 continue;
             }
             if (p.Name == "optionString" && !string.IsNullOrEmpty(f.OptionMembers))
@@ -1258,6 +1300,76 @@ public static partial class RecordPatches
         new ParsedField(2000000004, "SystemModifiedBy", "Guid",     0,
             Editable: false, DataClassificationName: "EndUserPseudonymousIdentifiers"),
     };
+
+    /// <summary>
+    /// BC's OWN six platform <c>MetaField</c>s, keyed by field id, read once out of
+    /// <c>SystemFieldsHelper</c> in <c>Microsoft.Dynamics.Nav.Types</c>.
+    ///
+    /// <para>These fields are Microsoft's, not this runner's, so their metadata is read from
+    /// Microsoft rather than restated here (precompiled-dll-respect.md, "reuse before you
+    /// re-implement"). <c>SystemFieldsHelper</c> builds them by parsing boilerplate XML through
+    /// <c>MetaField(XmlNode, string)</c>; the runner builds its own through MetaField's
+    /// POSITIONAL constructor, whose defaults differ from what that XML produces. Four members
+    /// were therefore the positional ctor's default rather than BC's answer on every table
+    /// (#3568): <c>TestRelations</c>, <c>AllowInCustomizations</c>, <c>ValidateRelation</c> and
+    /// <c>ClrType</c>. Copying them from BC's instance keeps the two in step across BC
+    /// versions, where six transcribed constants would not.</para>
+    ///
+    /// <para>Null when the helper cannot be reached — an older or reshaped
+    /// <c>Types.dll</c>. Callers leave the ctor defaults standing in that case, which is
+    /// exactly the pre-#3568 behaviour, so a missing helper degrades rather than throwing.</para>
+    /// </summary>
+    private static IReadOnlyDictionary<int, object>? BcPlatformMetaFields =>
+        _bcPlatformMetaFields ??= LoadBcPlatformMetaFields();
+
+    private static IReadOnlyDictionary<int, object>? _bcPlatformMetaFields;
+
+    private static IReadOnlyDictionary<int, object>? LoadBcPlatformMetaFields()
+    {
+        try
+        {
+            var helper = _tMetaField?.Assembly
+                .GetType("Microsoft.Dynamics.Nav.Types.Metadata.SystemFieldsHelper");
+            if (helper == null || _tMetaField == null) return null;
+
+            const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static;
+            var idProp = _tMetaField.GetProperty("Id", BindingFlags.Public | BindingFlags.Instance);
+            if (idProp == null) return null;
+
+            var map = new Dictionary<int, object>();
+            foreach (var propertyName in new[] { "SystemIdField", "SystemRowVersionField", "AuditFields" })
+            {
+                var value = helper.GetProperty(propertyName, flags)?.GetValue(null);
+                if (value == null) continue;
+                foreach (var field in value is Array array ? array.Cast<object>() : new[] { value })
+                    if (field != null && idProp.GetValue(field) is int id) map[id] = field;
+            }
+            return map.Count > 0 ? map : null;
+        }
+        catch
+        {
+            // A reflection failure here is not a reason to fail table construction: every
+            // member it feeds has a working pre-#3568 default. It IS worth a verbose line,
+            // because the symptom otherwise is four metadata members quietly reverting.
+            Console.Error.WriteLine(
+                "[RecordPatches] SystemFieldsHelper is not readable; the platform fields keep "
+                + "MetaField's own ctor defaults for TestRelations / AllowInCustomizations / "
+                + "ValidateRelation / ClrType (#3568).");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// The value BC's own platform <c>MetaField</c> carries for <paramref name="property"/>, or
+    /// null when this is not one of the six or the helper was unreadable.
+    /// </summary>
+    private static object? BcPlatformFieldValue(int fieldId, string property)
+    {
+        if (BcPlatformMetaFields is not { } map || !map.TryGetValue(fieldId, out var field))
+            return null;
+        return _tMetaField?.GetProperty(property, BindingFlags.Public | BindingFlags.Instance)
+            ?.GetValue(field);
+    }
 
     /// <summary>
     /// BC's SIXTH system field, which is not shaped like the other five and must not be

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -1315,60 +1315,78 @@ public static partial class RecordPatches
     /// <c>ClrType</c>. Copying them from BC's instance keeps the two in step across BC
     /// versions, where six transcribed constants would not.</para>
     ///
-    /// <para>Null when the helper cannot be reached — an older or reshaped
-    /// <c>Types.dll</c>. Callers leave the ctor defaults standing in that case, which is
-    /// exactly the pre-#3568 behaviour, so a missing helper degrades rather than throwing.</para>
+    /// <para>Null only when the <b>type</b> is absent — an older or reshaped
+    /// <c>Types.dll</c> that ships no <c>SystemFieldsHelper</c> at all. Callers leave the ctor
+    /// defaults standing then, which is exactly the pre-#3568 behaviour. A helper that IS
+    /// present but whose members have moved refuses instead: see
+    /// <see cref="LoadBcPlatformMetaFields"/>.</para>
     /// </summary>
     private static IReadOnlyDictionary<int, object>? BcPlatformMetaFields =>
         _bcPlatformMetaFields ??= LoadBcPlatformMetaFields();
 
     private static IReadOnlyDictionary<int, object>? _bcPlatformMetaFields;
 
+    /// <summary>
+    /// Reads the six platform <c>MetaField</c>s, or refuses.
+    ///
+    /// <para>Absence of the helper TYPE is a legitimate answer and returns null; every member
+    /// lookup below is an explicit refusal, because absence there is a defect rather than an
+    /// answer. Measured on both distinct <c>Types.dll</c> binaries the CI legs cover —
+    /// 27.5.46862.48827 (sha256 <c>f79286e9…</c>) and 28.4.53241.54447 (<c>ba117ca1…</c>) —
+    /// <c>SystemFieldsHelper</c> declares exactly these three properties and no others, each
+    /// holding a non-null value, and <c>MetaField</c> declares <c>Id</c>. So a null here means
+    /// Microsoft moved a member, and absorbing it would silently restore the ctor defaults this
+    /// method exists to replace — the "answer WRONG instead of failing" shape of #3663
+    /// (#3647/#3656/#3660 for what it costs).</para>
+    /// </summary>
     private static IReadOnlyDictionary<int, object>? LoadBcPlatformMetaFields()
     {
-        try
-        {
-            var helper = _tMetaField?.Assembly
-                .GetType("Microsoft.Dynamics.Nav.Types.Metadata.SystemFieldsHelper");
-            if (helper == null || _tMetaField == null) return null;
+        const string Surface = "platform field metadata (SystemId / SystemRowVersion / audit fields)";
 
-            const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static;
-            var idProp = _tMetaField.GetProperty("Id", BindingFlags.Public | BindingFlags.Instance);
-            if (idProp == null) return null;
+        var helper = _tMetaField?.Assembly
+            .GetType("Microsoft.Dynamics.Nav.Types.Metadata.SystemFieldsHelper");
+        if (helper == null || _tMetaField == null) return null;
 
-            var map = new Dictionary<int, object>();
-            foreach (var propertyName in new[] { "SystemIdField", "SystemRowVersionField", "AuditFields" })
-            {
-                var value = helper.GetProperty(propertyName, flags)?.GetValue(null);
-                if (value == null) continue;
-                foreach (var field in value is Array array ? array.Cast<object>() : new[] { value })
-                    if (field != null && idProp.GetValue(field) is int id) map[id] = field;
-            }
-            return map.Count > 0 ? map : null;
-        }
-        catch
+        const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static;
+        var idProp = BcShape.Property(
+            _tMetaField, "Id", BindingFlags.Public | BindingFlags.Instance, Surface,
+            "the platform MetaFields cannot be keyed by field id without it (#3568)");
+
+        var map = new Dictionary<int, object>();
+        foreach (var propertyName in new[] { "SystemIdField", "SystemRowVersionField", "AuditFields" })
         {
-            // A reflection failure here is not a reason to fail table construction: every
-            // member it feeds has a working pre-#3568 default. It IS worth a verbose line,
-            // because the symptom otherwise is four metadata members quietly reverting.
-            Console.Error.WriteLine(
-                "[RecordPatches] SystemFieldsHelper is not readable; the platform fields keep "
-                + "MetaField's own ctor defaults for TestRelations / AllowInCustomizations / "
-                + "ValidateRelation / ClrType (#3568).");
-            return null;
+            var value = BcShape.Property(helper, propertyName, flags, Surface,
+                            "BC's own value for TestRelations / AllowInCustomizations / "
+                            + "ValidateRelation / ClrType is read from it (#3568)")
+                        .GetValue(null)
+                ?? throw new BcShapeGapException(
+                    Surface, $"SystemFieldsHelper.{propertyName}",
+                    "read as null, so BC's own platform-field metadata cannot be read — it holds "
+                    + "a MetaField on every BC build the runner has seen (#3568)");
+
+            foreach (var field in value is Array array ? array.Cast<object>() : new[] { value })
+                if (field != null && idProp.GetValue(field) is int id) map[id] = field;
         }
+        return map.Count > 0 ? map : null;
     }
 
     /// <summary>
     /// The value BC's own platform <c>MetaField</c> carries for <paramref name="property"/>, or
-    /// null when this is not one of the six or the helper was unreadable.
+    /// null when this is not one of the six or <c>SystemFieldsHelper</c> is absent entirely.
+    /// A <c>MetaField</c> property that has MOVED refuses rather than answering null, for the
+    /// reason on <see cref="LoadBcPlatformMetaFields"/>.
     /// </summary>
     private static object? BcPlatformFieldValue(int fieldId, string property)
     {
-        if (BcPlatformMetaFields is not { } map || !map.TryGetValue(fieldId, out var field))
+        if (BcPlatformMetaFields is not { } map || !map.TryGetValue(fieldId, out var field)
+            || _tMetaField == null)
             return null;
-        return _tMetaField?.GetProperty(property, BindingFlags.Public | BindingFlags.Instance)
-            ?.GetValue(field);
+
+        return BcShape.Property(
+            _tMetaField, property, BindingFlags.Public | BindingFlags.Instance,
+            "platform field metadata (SystemId / SystemRowVersion / audit fields)",
+            "BC's own value for this member is copied onto the runner's platform MetaField (#3568)")
+            .GetValue(field);
     }
 
     /// <summary>

--- a/tests/expectations/metadata-equivalence/allowlist.json
+++ b/tests/expectations/metadata-equivalence/allowlist.json
@@ -35,10 +35,17 @@
     "would be a number nobody measured. Direction narrows categorically instead.",
     "",
     "Measured on BC 28.1.49838.53910 over Business Foundation (12 tables) and System Application",
-    "(138 tables): 67,344 differences across 65 members. #3568 removed six of them -- 688",
-    "differences on MetaKey.KeyName / Clustered / Unique / SumIndexFields, MetaKey.DebuggerDisplay",
-    "and FieldMetadataRelation.Name -- see docs/metadata-equivalence.md#keys. Per-member counts",
-    "and examples are on issue #3568.",
+    "(138 tables): 64,494 differences across 63 members. #3568 has removed twelve members so far.",
+    "Six were the KEY cluster -- 688 differences on MetaKey.KeyName / Clustered / Unique /",
+    "SumIndexFields, MetaKey.DebuggerDisplay and FieldMetadataRelation.Name, see",
+    "docs/metadata-equivalence.md#keys. Four more were the PLATFORM-FIELD cluster, 2,850",
+    "differences: MetaField.TestRelations (900) and MetaField.ValidateRelation (300) are now zero",
+    "and their entries are gone, while MetaField.AllowInCustomizations fell 755 -> 5 and",
+    "MetaField.ClrType 1,888 -> 988, both keeping an entry for their DECLARED-field half. The",
+    "runner appends BC's six platform fields itself and built them through MetaField's POSITIONAL",
+    "ctor, whose defaults differ from the XmlNode ctor BC's SystemFieldsHelper uses; it now copies",
+    "those four members off BC's own instance rather than restating them, so a BC version that",
+    "changes one moves both sides together. Per-member counts and examples are on issue #3568.",
     "",
     "PageDefinition was added to the comparison by #3782 step 1, and the 117 entries below are the",
     "result. Measured on BC 28.1.49838.53910 over Business Foundation and System Application (235",
@@ -240,7 +247,7 @@
     },
     {
       "member": "MetaField.ClrType",
-      "reason": "BC states the field's real CLR type and the runner states the empty string on all 1,888 fields. ClrType is not an XML attribute at all — BC derives it itself — and it is a PURE FUNCTION of Datatype, which the symbol file does carry and the runner already reads: measured over 988 observations, all 16 Datatypes map to exactly one ClrType each (BigInteger->System.Int64, GUID->System.Guid, Code/Text/DateFormula->System.String, Option/Integer->System.Int32, BLOB/RecordID->System.Byte[], Media->NSMediaWrapper, and so on). Recoverable with no app data.",
+      "reason": "BC states the field's real CLR type and the runner states the empty string on the 988 DECLARED fields. ClrType is not an XML attribute at all - BC derives it itself in MetaField's ctor via CommonTypeInformation.ResolveClrType(Type) - and it is a PURE FUNCTION of Datatype, which the symbol file does carry and the runner already reads: measured over 988 observations, all 16 Datatypes map to exactly one ClrType each (BigInteger->System.Int64, GUID->System.Guid, Code/Text/DateFormula->System.String, Option/Integer->System.Int32, BLOB/RecordID->System.Byte[], Media->NSMediaWrapper, and so on). Recoverable with no app data. The 900 PLATFORM-field occurrences are gone (#3568), copied from BC's own SystemFieldsHelper instance; ResolveClrType is public and static, so the declared fields are reachable the same way rather than by transcribing the table above.",
       "issue": 3568
     },
     {
@@ -325,13 +332,8 @@
       "issue": 3568
     },
     {
-      "member": "MetaField.TestRelations",
-      "reason": "BC answers true on a field with no declared TestTableRelation; the runner answers false. AL's real default, not the constructor's.",
-      "issue": 3568
-    },
-    {
       "member": "MetaField.AllowInCustomizations",
-      "reason": "BC answers AsReadOnly where the runner answers ToBeClassified. The symbol file states AllowInCustomizations only where it is non-default, so this is the AL default being wrong rather than a value being lost.",
+      "reason": "BC answers AsReadOnly where the runner answers ToBeClassified, on the 5 DECLARED fields whose AL states it. The symbol file states AllowInCustomizations only where it is non-default, so this is the AL default being wrong rather than a value being lost. The 750 PLATFORM-field occurrences are gone (#3568): MetaField's own ctor sets AsReadOnly from `Id >= 2000000000`, and the runner now copies the value off BC's own SystemFieldsHelper instance rather than leaving the positional ctor's ToBeClassified default standing.",
       "issue": 3568
     },
     {
@@ -339,11 +341,6 @@
       "reason": "BC gives SystemCreatedBy and SystemModifiedBy a TableRelation to User (2000000120); the runner gives them none. This is the difference already observable from plain AL as FieldRef.Relation() answering 0 — see #3549. Direction-scoped to BC-present / runner-absent; the runner inventing a relation BC does not have would be a different defect and is not covered.",
       "issue": 3568,
       "direction": "bc-only"
-    },
-    {
-      "member": "MetaField.ValidateRelation",
-      "reason": "BC answers false on the platform-added system fields; the runner answers true. Restricted to the fields BC adds, not to declared ones.",
-      "issue": 3568
     },
     {
       "member": "MetaKey.ALNamespace",


### PR DESCRIPTION
Part of #3568

Corpus-NA: no AL-observable value changes. The four members are copied onto the runner's platform MetaFields from BC's own SystemFieldsHelper instances, and each one's AL surface is either unreachable or insensitive to the move — see "Why Corpus-NA and not a corpus PR" below, which names the BC member that decides each one. The proving claim is "the runner's six platform fields agree with BC's six", a runner-side mechanism claim whose oracle is BC's own code.

Filed by an agent (`agent: stma-auto-2`).

## The re-measurement first, because the issue's number is stale

The brief asked for the current count against the body's 71. Measured on this branch's parent (`4e0e2ee5`), BC 28.1.49838.53910, Business Foundation + System Application, 150 tables:

| | |
|---|---|
| issue body (Sept, pre-#3545) | 71 members |
| **allowlist entries carrying `"issue": 3568` on current `main`** | **55 members, 41,278 differences** |
| of those, stale (already agreeing with BC) | **0** |

**None of the 55 was already closed.** This session's merged derivations — #3917 codeunits, #3931 queries, #3936 reports, #3944 pages, #3923 extension deltas — all landed on *other object kinds*. The table side had not moved since #3780 (the key cluster). The drop from 71 to 55 is entirely #3545 (Editable, field DataClassification), #3594 (EnumTypeId, moved to its own issue), #3780's six key members, and the seven TranslationKey members declared out of scope by the owner.

Total table differences before this PR: **67,344 across 65 members** — which is exactly what the allowlist header already recorded, so the harness and the record agree.

## What this PR lands: the platform-field cluster

The runner appends BC's six platform fields itself — `SystemId` (2000000000), the four audit fields (…001–…004), and the synthetic `timestamp` at **id 0** — and builds each through `MetaField`'s **positional** constructor. BC builds the same six from boilerplate XML through `MetaField(XmlNode, string)`. The two constructors disagree, and where the positional one was never passed a value, the ctor's own default stood:

| member | positional ctor default | BC | differences |
|---|---|---|---:|
| `TestRelations` | `False` | `True` (all six) | 900 |
| `AllowInCustomizations` | `ToBeClassified` | `AsReadOnly` on the …000 block, `ToBeClassified` on id 0 | 750 |
| `ValidateRelation` | `True` | `False` on SystemCreatedBy/ModifiedBy only | 300 |
| `ClrType` | `""` | the real CLR type | 900 of its 1,888 |

**The fix reads Microsoft's values rather than restating them** (`precompiled-dll-respect.md`, "reuse before you re-implement"). `SystemFieldsHelper.SystemIdField`, `.SystemRowVersionField` and `.AuditFields` are the `MetaField[]` BC's own runtime hands to `MetaTable`; `BcPlatformMetaFields` reads them once and `BuildMetaField` copies the four members off them. Six transcribed constants would drift as BC moves; a copy cannot.

### What settled each value

Read out of `Microsoft.Dynamics.Nav.Types` 28.1.49838.53910, not inferred:

- **`SystemFieldsHelper`'s boilerplate XML** states `ValidateTableRelation="0"` and a `<TableRelations TableID="2000000120" TableName="User">` child on exactly SystemCreatedBy and SystemModifiedBy, and `"1"` on the other four — which is the 300 = 150 × 2.
- **The `{0}`..`{3}` placeholder** those templates format in is a shared attribute block containing `TestTableRelation="1"`, appearing six times — which is the 900 = 150 × 6.
- **`MetaField(XmlNode, string)` ends with** `if (Id >= 2000000000) AllowInCustomizations = AsReadOnly;` and `ClrType = CommonTypeInformation.ResolveClrType(Type).ToString();` — the id rule that leaves id 0 alone, and the derivation that makes `ClrType` a pure function of the datatype.

**One inference I had to correct mid-task, because it is the kind that survives review.** I first read `TestTableRelation` as absent from the templates and concluded BC's `true` came from a field initializer. Constructing both ctor paths by reflection showed `TestRelations=False` on *both*, so that was wrong; the value comes from the shared placeholder block. The corrected reading was then confirmed by instantiating BC's own helper and printing all six fields, which is what the test now uses as its oracle.

### Measured effect

| | before | after |
|---|---:|---:|
| table differences | 67,344 | **64,494** |
| members | 65 | **63** |
| `MetaField.TestRelations` | 900 | **0** |
| `MetaField.ValidateRelation` | 300 | **0** |
| `MetaField.AllowInCustomizations` | 755 | 5 |
| `MetaField.ClrType` | 1,888 | 988 |

**2,850 differences removed, and nothing else moved** — no other member's count changed in either direction. The two zeroed entries are deleted from the allowlist (the stale-entry check demanded it, which is how the fix is confirmed rather than asserted); the two partial ones keep an entry whose reason now says the platform half is gone and the declared half remains.

## RED → GREEN

`AlRunner.Tests/SystemFieldMetadataOracleTests.cs`, five tests.

```
RED    Failed: 4, Passed: 1     (the oracle test passes; the four comparisons fail)
GREEN  Failed: 0, Passed: 5
```

Each RED was an `Assert.Equal()` failure naming the pair — `Expected: True / Actual: False`, `Expected: System.Guid / Actual: <empty>` — never `error CS`, and never the sub-millisecond `REFUSING TO SKIP` shape (#3957): `Skipped: 0`, durations 171–193 ms, bootstrapped before every run.

The first test is deliberately not a comparison: it asserts BC's own six are readable and carry the values the other four compare against. Without it, a `SystemFieldsHelper` that stopped yielding fields would make every comparison an empty-vs-empty pass.

### Mutations — one per observable, each chosen to test a property

Per `tdd.md`'s "choose the mutation to test a property, not to produce a red" (#3949). Every mutation was confirmed landed by re-reading the region, and every build was checked for `error CS` (0 in all four).

| # | mutation | result | what it establishes |
|---|---|---|---|
| 1 | `args[i] = !bcTestRelations` | `Failed: 1, Passed: 4` | reds **only** TestRelations — the four tests discriminate per member rather than sharing one failure |
| 2 | read BC's `"Name"` instead of `"ClrType"` | `Failed: 1, Passed: 4`<br>`Expected: System.Guid / Actual: $systemId` | the per-id lookup is real and the oracle's values are **distinct**; an oracle echoing one value would have passed |
| 3 | blanket `AsReadOnly` (ignore BC's id-0 exception) | `Failed: 1, Passed: 4`<br>`Expected: "ToBeClassified" / Actual: "AsReadOnly"` | the id-0 exception is **pinned**, not riding along on a uniform value |
| 4 | `args[i] = !bcValidateRelation` | `Failed: 1, Passed: 4` | inverting rather than nulling, so the four `true` fields stay correct and only the two `false` ones move |

Mutations 2 and 3 are the ones worth reading: both would have passed against a weaker test that asserted a single constant, and both name a property of the fixture rather than merely proving coverage exists.

## Why Corpus-NA and not a corpus PR

I checked each member's AL surface in `Ncl.dll` rather than assuming. `NCLMetaField.CreateFromMetaField` does pass all four into `NCLMetaField`, so they reach the runtime — but:

- **`AllowInCustomizations`** reaches AL only through the Field virtual table (2000000041), where `FieldDataProvider.GetFieldRecordBuffer` writes `NavBoolean.Create(field.AllowInCustomizations != AllowInCustomizations.Never)`. Both the old `ToBeClassified` and the new `AsReadOnly` are `!= Never`, so **the AL-visible column is unchanged**.
- **`ValidateRelation`** gates relation checking on fields that still carry **no relations at all** — `MetaField.Relations.<presence>` is 300 before and after this change, unchanged by it. The flag governs an empty set.
- **`TestRelations`** is a `FieldFlags` bit exposed as a property; `GetFieldRecordBuffer` does not write it to any column.
- **`ClrType`** likewise has no column in the Field virtual table.

So this changes what the equivalence harness measures and not what AL reads, which is the runner-side mechanism claim the test asserts. If a reviewer disagrees on any one of the four, the member to challenge is `ValidateRelation`, because it is the only one whose BC consumer could gate behaviour — and the reason it cannot here is the still-open 300.

## The survey: what the other 53 members are

The brief asked for a map, and said a complete map with no fix is a legitimate result. This is the map. **53 members, 38,428 differences**, in seven groups by cause — every one of the 53 falls in exactly one, none unclassified.

| group | members | diffs | cause | where a fix lands |
|---|---:|---:|---|---|
| **A** null vs `""` | 18 | 32,168 | `MetaField`'s positional ctor declares those string params `= ""`; BC's XmlNode ctor leaves them null | **nowhere — recommend one allowlist entry**; see below |
| **B** `ALNamespace` | 3 | 1,364 | the symbol file has no such attribute, but its `Namespaces` tree *is* the value | `BcAppSymbolCache.VisitSymbolContainer` (the codeunit half already landed in #3788) |
| **C** caption / ML objects | 4 | 1,128 | the file carries `Caption`; BC's runtime form is a `MultiLanguage` the runner does not build | `BuildMetaField` / builder |
| **D** stated in the file, not read | 18 | 871 | `InherentEntitlements`, `ReplicateData`, `Scope`, `Access`, `NotBlank`, `FieldGroups`, `DataCaptionFields`, `DrillDownFormId`, obsolete pairs … | `ParsedField`/`ParsedTable` need slots, then reader + builder |
| **E** encoded default / spelling | 5 | 1,083 | `LOOKUP` vs `Lookup`, `None` vs `Undefined`, source text vs ordinal | builder, per member |
| **F** platform-field policy | 4 | 1,588 | `$systemId` naming, `PlatformDefinedFieldsAdded`, the User relation, `ClrType`'s declared half | `SystemParsedFields` — **the cluster this PR opened** |
| **G** BC-derived key spec | 1 | 226 | `MetaKey.Name` is the positional field spec BC regenerates | none — already documented as unobservable |

Three things worth acting on, which I did **not** fold in because each lands in a different file and would make this diff unreviewable (`batch-sibling-issues-by-file.md` folds on *file*, not subsystem):

1. **Group A is 47% of what remains and the recommendation is an allowlist entry, not code.** A prior measurement on this issue established that no AL surface distinguishes `null` from `""` here: every one of the 18 is a `string` AL sees only as a `NavText`, and `NavText.Create(null)` and `NavText.Create("")` are `Equals`-identical. Of the 18, only five even reach `NCLMetaField`'s ctor, and `OptionString` is the one member where passing null is *less* safe (`NCLOptionMetadata.Create` calls `.Length` unguarded). That finding is already recorded on #3568; consolidating the 18 entries behind one citation is a tidy-up PR, not a fix.
2. **Group D is the largest genuine reader gap** — 18 members the symbol file states and the runner discards. It needs `ParsedField`/`ParsedTable` record slots plus parser and builder work, in `RecordPatches.AlSourceParser.cs` and `BcAppSymbolCache.cs`. That is a different file set from this PR and is the natural next cluster.
3. **Group F's remaining 4** are the rest of the cluster this PR opened, and they are the only ones that would legitimately fold into this file later: `ClrType`'s declared half is reachable through the same public `CommonTypeInformation.ResolveClrType` this PR relies on, and `PlatformDefinedFieldsAdded` is a flag set beside `SystemParsedFields`.

I did not file new issues, because #3568 is already the tracking record for all of them and every group above is represented by live allowlist entries pointing at it — filing seven more would fragment a record the allowlist already keeps honest. If the coordinator would prefer group D and group A as separate issues, say so and I will split them out with these numbers.

## Same-defect search

Searched the open queue for `ClrType`, `AllowInCustomizations`, `TestRelations`, `SystemFieldsHelper`, `platform field` and `NclMetaTableBuilder`, by mechanism rather than title (`search-for-the-same-defect-first.md`). **No duplicate.** The nearest neighbours are #3491 and #3562, which propose retiring the hand-derivation wholesale in favour of BC's own document route — a strategic alternative to this whole issue, not the same defect. This PR is compatible with either outcome: it deletes runner-side guesswork rather than adding more of it.

## Fix the shape, not just the reported line

- **Same wrong pattern at another call site?** Yes, and that is why the fix is keyed on field id rather than on four literals: all six platform fields flow through one `BuildMetaField` loop, so every member BC computes for them was wrong the same way. I checked the other positional-ctor arguments the loop sets and found no further member where BC's platform value differs and the runner states its own — `Editable` and `DataClassification` were already handled by #3545.
- **Does a sibling function make the same assumption?** `BuildNCLMetaTableFromBcDocument` is the other route to a built table, and it does **not**: it replays BC's own emitted document, so it never constructs these fields itself. That asymmetry is the point of #3549/#3562.
- **Two paths writing the same state, same invariant?** The id-0 `timestamp` field is appended separately from `SystemParsedFields` (they are different declarations for a good reason — #3307). Both now get their values from the same BC lookup, so the invariant is maintained in one place rather than two, and mutation 3 is the test that would catch them drifting apart.

## Local verification

Built first, never `--no-build`; `tools/engine-test-bootstrap.sh` re-run after every build.

| run | result |
|---|---|
| `SystemFieldMetadataOracleTests` | `Failed: 0, Passed: 5, Skipped: 0` |
| `~MetadataEquivalence` (all) | `Failed: 0, Passed: 38, Skipped: 0` |
| `~GuardTests` | `Failed: 0, Passed: 249, Skipped: 0` |
| `~RecordPatches\|~MetaTable\|~FieldVirtualTable\|~SystemField` | `Failed: 0, Passed: 66, Skipped: 0` |
| `for t in tools/test_*.py` | all pass |
| **warm second run** (same cache root) | `Failed: 0, Passed: 43, Skipped: 0` — 11 s vs 19 s cold |

The warm run is per `local-test-scope.md`: metadata sits behind `BcAppSymbolCache`, so "is there a cache between my change and its observable?" is yes. The change is in the **builder**, which runs after cache load, so it is neither a record-shape nor a parse change — the diff adds no `CacheVersion` or `PayloadShape` line, and `BcAppSymbolCache.cs` is untouched. The warm run confirms that empirically rather than by argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
