### PR TITLE
fix(guard): the metadata-equivalence allowlist's cited issues must be open

### DIFF
--- a/.github/scripts/check_expectation_gap_issues.py
+++ b/.github/scripts/check_expectation_gap_issues.py
@@ -152,6 +152,13 @@ from dataclasses import dataclass
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
 DEFAULT_MANIFEST_DIR = os.path.join(REPO_ROOT, "tests", "expectations")
+# The metadata-equivalence allowlist is a SECOND issue-citing manifest, one
+# directory down and with a different schema (#3975). load_known_gap_entries()
+# lists MANIFEST_DIR non-recursively, so nothing here could see it: 193 of its
+# entries cited an issue and 44 of those issues were closed, invisible to every
+# check in this file. See docs/metadata-equivalence.md#allowlist-issue-hygiene.
+ALLOWLIST_SUBDIR = "metadata-equivalence"
+ALLOWLIST_NAME = "allowlist.json"
 DEFAULT_REPO = "StefanMaron/BusinessCentral.AL.Runner"
 
 # --------------------------------------------------------------------------
@@ -304,6 +311,113 @@ def load_known_gap_entries(manifest_dir: str) -> list[GapEntry]:
     return entries
 
 
+@dataclass(frozen=True)
+class AllowlistEntry:
+    """One `differences` entry of the metadata-equivalence allowlist citing an issue.
+
+    Shaped to substitute for GapEntry in the two consumers below, so the sweep
+    and the gate treat both manifests identically rather than growing a second
+    copy of either.
+    """
+    source_file: str
+    member: str
+    issue: str
+    owner: str
+    repo: str
+    number: int
+
+    @property
+    def key(self) -> tuple[str, str, int]:
+        return (self.owner.lower(), self.repo.lower(), self.number)
+
+    # The gate's message names an entry as "<codeunit>.<method>"; an allowlist
+    # entry is identified by its member instead. Presenting it through the same
+    # two attributes keeps one formatting path rather than branching on type.
+    @property
+    def codeunit(self) -> str:
+        return "member"
+
+    @property
+    def method(self) -> str:
+        return self.member
+
+
+def load_allowlist_entries(manifest_dir: str) -> list[AllowlistEntry]:
+    """Every issue-citing `differences` entry of the metadata-equivalence allowlist.
+
+    Three states, deliberately distinct (guards-need-a-third-state.md):
+
+      * the file is ABSENT          -> [] , a pass. A checkout predating the
+                                       metadata harness legitimately has none,
+                                       and failing on it would be a false red.
+      * the file is UNREADABLE      -> ManifestError (exit 2). Folding this into
+                                       the row above would put the broken case
+                                       back on the exit-0 path.
+      * an entry cites NO issue     -> skipped, a pass. Measured on the shipped
+                                       file: 77 of 270 entries carry no `issue`
+                                       and every one carries `outOfScope` or
+                                       `oracleLimitation` instead. The file's own
+                                       comment block declares four mutually
+                                       exclusive reason KINDS, of which `issue`
+                                       is one -- so absence is a different valid
+                                       kind, never a finding.
+
+    An `issue` that is PRESENT and unresolvable is the fourth case and raises:
+    a citation nothing can resolve tracks nothing, and silently skipping it is
+    how an entry stops being checked without anyone deciding that it should.
+    """
+    path = os.path.join(manifest_dir, ALLOWLIST_SUBDIR, ALLOWLIST_NAME)
+    if not os.path.isfile(path):
+        return []
+
+    try:
+        with open(path, encoding="utf-8") as fh:
+            doc = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ManifestError(
+            f"{ALLOWLIST_SUBDIR}/{ALLOWLIST_NAME}: could not be read as JSON ({exc}). The "
+            "file is present, so this is a broken manifest rather than an absent one -- "
+            "refusing to report a pass without having read it.") from exc
+
+    if not isinstance(doc, dict):
+        raise ManifestError(
+            f"{ALLOWLIST_SUBDIR}/{ALLOWLIST_NAME}: top level must be a JSON object with a "
+            f"'differences' array (got {type(doc).__name__}).")
+    diffs = doc.get("differences")
+    if not isinstance(diffs, list):
+        raise ManifestError(
+            f"{ALLOWLIST_SUBDIR}/{ALLOWLIST_NAME}: 'differences' must be a JSON array (got "
+            f"{type(diffs).__name__}). Without it there is nothing to check, and reporting "
+            "a pass would assert something this run never read.")
+
+    entries: list[AllowlistEntry] = []
+    rel = f"{ALLOWLIST_SUBDIR}/{ALLOWLIST_NAME}"
+    for i, raw in enumerate(diffs):
+        if not isinstance(raw, dict):
+            raise ManifestError(f"{rel}: differences[{i}] is not a JSON object.")
+        issue = raw.get("issue")
+        if issue is None:
+            continue
+        member = str(raw.get("member") or f"differences[{i}]")
+        if not isinstance(issue, (str, int)) or not str(issue).strip():
+            raise ManifestError(
+                f"{rel}: entry '{member}' has an empty or non-scalar 'issue'. An entry either "
+                "cites a tracked issue or declares another reason kind (outOfScope, "
+                "oracleLimitation, cannotExpress) -- an empty citation is neither.")
+        # A bare number is how this file cites: "issue": 3784.
+        text = str(issue).strip()
+        ref = text if text.startswith(("#", "http")) or "/" in text else f"#{text}"
+        triple = _parse_ref(ref, *default_owner_repo())
+        if triple is None:
+            raise ManifestError(
+                f"{rel}: entry '{member}' has issue '{text}', which is not a resolvable "
+                "GitHub issue reference (expected a number, #N, owner/repo#N, or a full "
+                ".../issues/N URL). A citation nothing can resolve tracks nothing.")
+        entries.append(AllowlistEntry(rel, member, text, *triple))
+
+    return entries
+
+
 # --------------------------------------------------------------------------
 # The non-blocking sweep -- the only part that touches the network
 # --------------------------------------------------------------------------
@@ -338,14 +452,29 @@ def issue_state(owner: str, repo: str, number: int) -> str | None:
         return None
 
 
-def report_closed_issues(entries: list[GapEntry]) -> int:
-    """Warn about entries linking an already-closed issue. NEVER fails the job."""
-    if not entries:
+def _describe(entry) -> str:
+    """'file (what)' for either manifest kind, so one message path serves both."""
+    if isinstance(entry, AllowlistEntry):
+        return f"{entry.source_file} ({entry.member})"
+    return f"{entry.source_file} ({entry.codeunit}.{entry.method})"
+
+
+def report_closed_issues(entries: list[GapEntry],
+                         allow_entries: list[AllowlistEntry] | None = None) -> int:
+    """Warn about entries linking an already-closed issue. NEVER fails the job.
+
+    Sweeps both issue-citing manifests together: an entry is an entry, and the
+    remedy a reader needs is the same in each -- check whether the declaration
+    still holds, then delete it or re-target it at open work.
+    """
+    allow_entries = list(allow_entries or [])
+    combined = list(entries) + allow_entries
+    if not combined:
         print("No expect-fail-known-gap entries in the manifest -- nothing to sweep.")
         return 0
 
-    by_issue: dict[tuple[str, str, int], list[GapEntry]] = {}
-    for e in entries:
+    by_issue: dict[tuple[str, str, int], list] = {}
+    for e in combined:
         by_issue.setdefault(e.key, []).append(e)
 
     closed = unresolved = 0
@@ -353,7 +482,7 @@ def report_closed_issues(entries: list[GapEntry]) -> int:
         group = by_issue[key]
         owner, repo, number = group[0].owner, group[0].repo, group[0].number
         state = issue_state(owner, repo, number)
-        where = ", ".join(sorted({f"{e.source_file} ({e.codeunit}.{e.method})" for e in group}))
+        where = ", ".join(sorted({_describe(e) for e in group}))
         if state is None:
             unresolved += 1
             print(f"::warning::Could not determine the state of {owner}/{repo}#{number}, so "
@@ -363,14 +492,15 @@ def report_closed_issues(entries: list[GapEntry]) -> int:
         elif state == "closed":
             closed += 1
             print(f"::warning::{owner}/{repo}#{number} is CLOSED, but {len(group)} "
-                  f"expect-fail-known-gap entr{'y' if len(group) == 1 else 'ies'} still link "
+                  f"expectation entr{'y' if len(group) == 1 else 'ies'} still link "
                   f"it: {where}. A closed issue does not by itself prove the entry is stale "
                   "(#2858: it may have closed as a duplicate, or with the gap still open), so "
                   "this is a lead and not a verdict -- check whether the test now passes, then "
                   "either delete the entry or re-target it at the issue tracking what remains.")
 
-    print(f"Swept {len(by_issue)} linked issue(s) across {len(entries)} entr"
-          f"{'y' if len(entries) == 1 else 'ies'}: {closed} closed, {unresolved} unresolved.")
+    print(f"Swept {len(by_issue)} linked issue(s) across {len(entries)} expect-fail-known-gap "
+          f"and {len(allow_entries)} allowlist entr"
+          f"{'y' if len(combined) == 1 else 'ies'}: {closed} closed, {unresolved} unresolved.")
     return 0
 
 
@@ -384,12 +514,13 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         entries = load_known_gap_entries(manifest_dir)
+        allow_entries = load_allowlist_entries(manifest_dir)
     except ManifestError as exc:
         print(f"::error::{exc}", file=sys.stderr)
         return 2
 
     if report:
-        return report_closed_issues(entries)
+        return report_closed_issues(entries, allow_entries)
 
     title = os.environ.get("PR_TITLE", "")
     body = os.environ.get("PR_BODY", "")
@@ -408,10 +539,24 @@ def main(argv: list[str] | None = None) -> int:
     for triple, source, line in refs:
         closing.setdefault((triple[0].lower(), triple[1].lower(), triple[2]), (source, line))
 
-    offenders = [(e, closing[e.key]) for e in entries if e.key in closing]
+    offenders = [(e, closing[e.key]) for e in entries + allow_entries if e.key in closing]
 
     if offenders:
         for entry, (source, line) in offenders:
+            if isinstance(entry, AllowlistEntry):
+                print(
+                    f"::error file=tests/expectations/{entry.source_file}::This PR closes "
+                    f"{entry.owner}/{entry.repo}#{entry.number} (from the PR {source}: "
+                    f"\"{line}\"), but tests/expectations/{entry.source_file} still declares "
+                    f"member '{entry.member}' as a difference citing that same issue. An "
+                    "allowlist entry's 'issue' is what makes it a TRACKED gap rather than a "
+                    "permanent exemption (#3975), so closing the issue while the entry stands "
+                    "converts one into the other silently. Settle it here: delete the entry if "
+                    "this fix removes the difference, re-target it at the OPEN issue tracking "
+                    "what remains, rewrite the reason as outOfScope/oracleLimitation if it is "
+                    "genuinely permanent, or drop the closing reference.",
+                    file=sys.stderr)
+                continue
             print(
                 f"::error file=tests/expectations/{entry.source_file}::This PR closes "
                 f"{entry.owner}/{entry.repo}#{entry.number} (from the PR {source}: "
@@ -427,13 +572,13 @@ def main(argv: list[str] | None = None) -> int:
                 "PR does not actually close the issue.",
                 file=sys.stderr)
         one = len(offenders) == 1
-        print(f"::error::{len(offenders)} expect-fail-known-gap entr{'y' if one else 'ies'} "
+        print(f"::error::{len(offenders)} expectation entr{'y' if one else 'ies'} "
               f"link{'s' if one else ''} an issue this PR closes.", file=sys.stderr)
         return 1
 
-    print(f"Checked {len(entries)} expect-fail-known-gap entr"
-          f"{'y' if len(entries) == 1 else 'ies'} in {manifest_dir} against "
-          f"{len(closing)} closing reference(s) declared by this PR: no overlap.")
+    print(f"Checked {len(entries)} expect-fail-known-gap and {len(allow_entries)} allowlist "
+          f"entr{'y' if len(entries) + len(allow_entries) == 1 else 'ies'} in {manifest_dir} "
+          f"against {len(closing)} closing reference(s) declared by this PR: no overlap.")
     return 0
 
 

--- a/.github/scripts/test_check_expectation_gap_issues.py
+++ b/.github/scripts/test_check_expectation_gap_issues.py
@@ -246,6 +246,7 @@ def run_report(files: dict[str, object], states: dict[tuple[str, str, int], str 
 
 
 key = ("StefanMaron", "BusinessCentral.AL.Runner", 2361)
+key3784 = ("StefanMaron", "BusinessCentral.AL.Runner", 3784)
 
 rc, out = run_report({"known-gaps-x.json": [gap(f"{ISSUE}/2361")]}, {key: "closed"})
 check("an entry linking a CLOSED issue is reported as a warning", "::warning" in out, out)
@@ -263,6 +264,169 @@ check("an unreachable API is LOUD about not having checked, and still does not f
       rc == 0 and "::warning" in out and "could not" in out.lower(), f"rc={rc}: {out}")
 check("...and says explicitly that the sweep did not run for that entry",
       "2361" in out, out)
+
+
+# ---------------------------------------------------------------------------
+print()
+print("The metadata-equivalence allowlist (#3975)")
+# ---------------------------------------------------------------------------
+
+# The allowlist is a SECOND manifest citing issues, in a subdirectory, with a
+# different schema: {"comment": [...], "differences": [{"member", "reason",
+# "issue"}]}. Its `issue` carries exactly the meaning `Issue` carries in a
+# known-gaps entry -- this is a tracked defect, expected to go away -- so an
+# entry citing a closed issue has quietly become a permanent exemption.
+#
+# Every case below builds the condition deliberately, for the reason in this
+# file's docstring: asserting over whatever the shipped allowlist contains today
+# would go green the moment someone fixed the 44.
+
+def allow(*entries, comment=("synthetic",)):
+    return {"comment": list(comment), "differences": list(entries)}
+
+
+def diff(member="MetaTable.Thing", reason="constructed by the test suite",
+         issue=None, **extra):
+    e = {"member": member, "reason": reason}
+    if issue is not None:
+        e["issue"] = issue
+    e.update(extra)
+    return e
+
+
+def run_allow(allowlist, *, states=None, title="", body="", commits="",
+              argv=None, subdir="metadata-equivalence",
+              gaps=None, raw=None):
+    """Write a synthetic allowlist into MANIFEST_DIR/<subdir>/ and run the guard."""
+    original = cegi.issue_state
+    if states is not None:
+        cegi.issue_state = lambda owner, repo, n: states.get((owner, repo, n))
+    env_keys = ("PR_TITLE", "PR_BODY", "PR_COMMITS", "GITHUB_REPOSITORY")
+    saved = {k: os.environ.get(k) for k in env_keys}
+    try:
+        with tempfile.TemporaryDirectory() as md:
+            for name, content in (gaps or {}).items():
+                with open(os.path.join(md, name), "w", encoding="utf-8") as fh:
+                    fh.write(json.dumps(content, indent=2))
+            if allowlist is not None or raw is not None:
+                sub = os.path.join(md, subdir)
+                os.makedirs(sub, exist_ok=True)
+                text = raw if raw is not None else json.dumps(allowlist, indent=2)
+                with open(os.path.join(sub, "allowlist.json"), "w", encoding="utf-8") as fh:
+                    fh.write(text)
+            os.environ["PR_TITLE"] = title
+            os.environ["PR_BODY"] = body
+            os.environ["PR_COMMITS"] = commits
+            os.environ["GITHUB_REPOSITORY"] = "StefanMaron/BusinessCentral.AL.Runner"
+            out, err = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = cegi.main([md] + list(argv or []))
+            return rc, out.getvalue() + err.getvalue()
+    finally:
+        cegi.issue_state = original
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+REPORT = ["--report-closed-issues"]
+
+# --- the sweep sees allowlist entries at all -------------------------------
+
+rc, out = run_allow(allow(diff(issue=f"{ISSUE}/3784")), states={key3784: "closed"},
+                    argv=REPORT)
+check("an allowlist entry citing a CLOSED issue is reported", "::warning" in out, out)
+check("...naming the issue", "3784" in out, out)
+check("...naming the allowlist file so the reader can find the entry",
+      "allowlist.json" in out, out)
+check("...and the member, so they know WHICH entry", "MetaTable.Thing" in out, out)
+check("...and does not fail the job: the sweep is advisory (#2858)", rc == 0, f"rc={rc}: {out}")
+
+rc, out = run_allow(allow(diff(issue=f"{ISSUE}/3784")), states={key3784: "open"},
+                    argv=REPORT)
+check("an allowlist entry citing an OPEN issue produces no warning",
+      rc == 0 and "::warning" not in out, f"rc={rc}: {out}")
+
+# The distinguishing test: this is what a guard reading only the top-level
+# known-gaps-*.json cannot do, and it is the whole defect in #3975.
+rc, out = run_allow(allow(diff(issue=f"{ISSUE}/3784")), states={key3784: "closed"},
+                    gaps={"known-gaps-x.json": [gap(f"{ISSUE}/2361")]},
+                    argv=REPORT)
+check("the allowlist is swept even when a known-gaps file is present",
+      "3784" in out and "allowlist.json" in out, out)
+
+rc, out = run_allow(allow(diff(issue=f"{ISSUE}/3784"), diff(member="M2", issue=f"{ISSUE}/3784")),
+                    states={key3784: "closed"}, argv=REPORT)
+check("several entries citing one closed issue are grouped into one warning",
+      out.count("::warning") == 1 and "2 " in out, out)
+
+# --- the third state: the measurement failed, not the subject ---------------
+
+rc, out = run_allow(allow(diff(issue=f"{ISSUE}/3784")), states={}, argv=REPORT)
+check("an unresolvable issue is LOUD rather than read as 'open'",
+      rc == 0 and "::warning" in out and "could not" in out.lower(), f"rc={rc}: {out}")
+check("...and names the allowlist entry it could not check",
+      "3784" in out and "allowlist.json" in out, out)
+
+# --- a missing `issue` is LEGITIMATE, and must stay a pass ------------------
+#
+# Established by reading the shipped file rather than assumed: 77 of its 270
+# entries carry no `issue`, and every one of them carries `outOfScope` or
+# `oracleLimitation` instead. The allowlist's own comment block declares four
+# mutually-exclusive reason KINDS, of which `issue` is one. So absence is a
+# different, valid kind -- not a finding. A guard that failed on it would be a
+# false red on 77 correct entries, which is guards-need-a-third-state.md's
+# "a genuinely absent thing must stay a pass".
+
+rc, out = run_allow(allow(diff(outOfScope=True, Doc="docs/x.md#y")),
+                    states={}, argv=REPORT)
+check("an entry with no 'issue' at all is a clean pass, not a finding",
+      rc == 0 and "::warning" not in out, f"rc={rc}: {out}")
+
+rc, out = run_allow(allow(diff(outOfScope=True, Doc="docs/x.md#y"),
+                          diff(member="M2", issue=f"{ISSUE}/3784")),
+                    states={key3784: "closed"}, argv=REPORT)
+check("...and does not stop the entries beside it being swept", "3784" in out, out)
+
+# --- a broken allowlist is exit 2, never a pass -----------------------------
+
+rc, out = run_allow(None, raw="{not json", argv=REPORT)
+check("an allowlist that will not parse is exit 2, not a pass", rc == 2, f"rc={rc}: {out}")
+
+rc, out = run_allow({"comment": [], "differences": {"not": "a list"}}, argv=REPORT)
+check("an allowlist whose 'differences' is not an array is exit 2", rc == 2, f"rc={rc}: {out}")
+
+rc, out = run_allow(allow(diff(issue="see the issue tracker")), argv=REPORT)
+check("an 'issue' that is not a resolvable reference is exit 2, not skipped",
+      rc == 2, f"rc={rc}: {out}")
+check("...and the message names the unresolvable value",
+      "see the issue tracker" in out, out)
+
+rc, out = run_allow(allow(diff(issue=f"{ISSUE}/3784")), states={key3784: "open"},
+                    argv=REPORT)
+check("a passing sweep says how many allowlist entries it scanned",
+      "1 allowlist" in out, out)
+
+# An allowlist file that is absent entirely is a legitimate state (a checkout
+# predating the metadata harness), and must not be confused with one that is
+# there and unreadable.
+rc, out = run_allow(None, gaps={"known-gaps-x.json": [gap(f"{ISSUE}/2361")]},
+                    states={("StefanMaron", "BusinessCentral.AL.Runner", 2361): "open"},
+                    argv=REPORT)
+check("no allowlist file at all is a pass (absence is legitimate, unreadable is not)",
+      rc == 0, f"rc={rc}: {out}")
+
+# --- the blocking half covers the allowlist too ----------------------------
+
+rc, out = run_allow(allow(diff(issue=f"{ISSUE}/3784")), body="Closes #3784\n")
+check("a PR that CLOSES the issue an allowlist entry cites fails the gate",
+      rc == 1, f"rc={rc}: {out}")
+check("...naming the allowlist and the member", "allowlist.json" in out and "MetaTable.Thing" in out, out)
+
+rc, out = run_allow(allow(diff(issue=f"{ISSUE}/3784")), body="Closes #2361\n")
+check("...and a PR closing an unrelated issue passes", rc == 0, f"rc={rc}: {out}")
 
 
 # ---------------------------------------------------------------------------
@@ -333,6 +497,21 @@ _has_gap_file = any(f.startswith("known-gaps-") and f.endswith(".json")
                     for f in os.listdir(shipped))
 check("shipped known-gaps-*.json files yield entries (else the check above is vacuous)",
       (not _has_gap_file) or len(entries) > 0, f"gap files={_has_gap_file}, entries={len(entries)}")
+
+# The shipped allowlist, same reasoning: proves the extraction works against the
+# REAL schema, which the synthetic cases above cannot. #3975 measured 193 of its
+# 270 entries citing an issue across 9 distinct issues; asserting the exact
+# number would break every time an entry is added, so this asserts the shape --
+# the file is found, entries come back, and each resolves to a real reference.
+_allow_entries = cegi.load_allowlist_entries(shipped)
+print(f"  note shipped allowlist carries {len(_allow_entries)} issue-citing entr"
+      f"{'y' if len(_allow_entries) == 1 else 'ies'}")
+_allow_file = os.path.join(shipped, "metadata-equivalence", "allowlist.json")
+check("the shipped metadata-equivalence allowlist yields issue-citing entries",
+      (not os.path.isfile(_allow_file)) or len(_allow_entries) > 0,
+      f"file={os.path.isfile(_allow_file)}, entries={len(_allow_entries)}")
+check("every shipped allowlist citation resolves to a real issue reference",
+      all(e.number > 0 and e.owner and e.repo for e in _allow_entries), "")
 
 
 print()

--- a/docs/metadata-equivalence.md
+++ b/docs/metadata-equivalence.md
@@ -1520,6 +1520,67 @@ value, the runner's. It is the working specification for the reader work.
 
 `AL_RUNNER_METADATA_GROUND_TRUTH` overrides where bundles are read from and written to.
 
+<a id="allowlist-issue-hygiene"></a>
+## An entry's `issue` must stay OPEN, and a guard now says so
+
+An allowlist entry carries exactly one KIND of reason, and `issue` is the kind that means
+*tracked defect, expected to go away*. The other three — `outOfScope`, `oracleLimitation`,
+`cannotExpress` — mean the difference is permanent and correct. So a closed `issue` is not a
+small inaccuracy: it silently converts the first kind into the second, with the entry still
+reading like tracked work.
+
+Nothing caught that until #3975. `MetadataEquivalenceHarnessTests.No_allowlist_entry_has_gone_stale`
+exists and works, and it answers a **different** question: whether the declared difference still
+*occurs*. An entry whose difference is alive and whose issue is dead is, to that guard, perfectly
+healthy — which is why the gap was invisible while a green tick sat next to it.
+
+Measured on 2026-09-12: 193 of the file's 270 entries cite an `issue`, across 9 distinct issues,
+of which **four were closed, accounting for 44 entries** — #3784 (33), #3798 (4), #3806 (4),
+#3807 (3).
+
+### Where the check lives
+
+`.github/scripts/check_expectation_gap_issues.py`, which already did this for
+`tests/expectations/known-gaps-*.json` and could not see the allowlist: it lists the manifest
+directory **non-recursively**, and the allowlist is one directory down with a different schema.
+Extending that script rather than writing a second one means both manifests get the same two
+halves, already placed:
+
+| half | workflow | gates? |
+|---|---|---|
+| this PR closes issue N and an entry cites N | `pr-gate.yml` | yes (pending-required) — offline, deterministic |
+| an entry cites an already-closed issue | `pr-check.yml --report-closed-issues` | **no**, advisory on purpose |
+
+The sweep is advisory because it reads `api.github.com`, and `ci-verdicts.md` is explicit that a
+required context which can go red on a third-party outage blocks every merge in the repository
+for something no author can fix. The second reason is #2858's: a closed issue does not by itself
+prove an entry is stale — it can close as a duplicate, or with the gap still open — so this is a
+lead, never a verdict.
+
+### The three states
+
+`load_allowlist_entries()` separates the ways the *measurement* can fail from the ways the
+subject can be broken (`.claude/rules/guards-need-a-third-state.md`):
+
+| the file / entry | verdict | why |
+|---|---|---|
+| allowlist absent | **pass** | a checkout predating the metadata harness legitimately has none |
+| present, unreadable | **exit 2** | folding this into the row above puts the broken case back on the exit-0 path |
+| entry cites no `issue` | **pass** | a different, valid reason kind — see below |
+| `issue` present but unresolvable | **exit 2** | a citation nothing can resolve tracks nothing |
+| issue state unreadable | **warning, rc 0** | not "open", and not a failure of the allowlist either |
+
+**A missing `issue` is legitimate, and that was established by reading the file rather than
+assumed**: 77 of the 270 entries carry none, and every one of them carries `outOfScope` or
+`oracleLimitation` instead. A guard failing on absence would be a false red on 77 correct
+entries.
+
+### The 44 are not fixed by this
+
+Deliberately. Each needs a live issue, or a reason rewritten to say why it is a permanent
+exemption — judgement per cluster, not a sweep. The guard lands first so the drift does not
+resume the day after they are fixed.
+
 <a id="a-single-unresolved-dotnet-reference-costs-the-whole-app"></a>
 ## A single unresolved .NET reference costs the whole app
 


### PR DESCRIPTION
Closes #3975

Opened by an agent (`stma-auto-3`).

An allowlist entry carries exactly one KIND of reason. `issue` means *tracked defect, expected to go away*; `outOfScope`, `oracleLimitation` and `cannotExpress` mean the difference is permanent and correct. A **closed** citation silently converts the first into the second, and nothing checked for it.

## The measurement, re-derived

Independently of the issue body, by loading the JSON and querying each citation's state:

```
total entries: 270      citing an issue: 193      distinct issues: 9      no issue: 77
```

| issue | state | entries |
|---|---|---|
| **#3784** | **CLOSED** | **33** |
| #3798 | CLOSED | 4 |
| #3806 | CLOSED | 4 |
| #3807 | CLOSED | 3 |
| #3568, #3788, #3797, #3808, #3926 | open | 149 |

**44 entries across four closed issues** — the issue's figures confirmed exactly. The guard reproduces them from live API state:

```
Swept 14 linked issue(s) across 14 expect-fail-known-gap and 193 allowlist entries: 4 closed, 0 unresolved.
```

## Where the guard went, and why

**Into `.github/scripts/check_expectation_gap_issues.py`**, not a new tool and not the C# harness.

That script already performs exactly this check for `tests/expectations/known-gaps-*.json` and simply **could not see the allowlist**: it lists the manifest directory **non-recursively**, and the allowlist sits one level down in `metadata-equivalence/` with a different schema. The baseline run on `main` reads `Swept 5 linked issue(s) across 14 entries` — 193 entries invisible to it.

Extending it means the allowlist inherits both halves, each **already placed and already reasoned about**, with **no workflow edit at all**:

| half | workflow | gates? |
|---|---|---|
| this PR closes issue N and an entry cites N | `pr-gate.yml` | yes (pending-required) — offline, deterministic |
| an entry cites an already-closed issue | `pr-check.yml --report-closed-issues` | **no — advisory** |

Not the C# harness: `MetadataEquivalenceHarnessTests` needs a Release build, `engine-test-bootstrap.sh` and generated ground truth, so the check would run only where those exist — and it would have to grow its own network access, issue-reference parser and advisory/required split, all of which this script already has.

**Advisory is deliberate, and matches the precedent this repo already set.** `Required-context list must match the live branch ruleset` is advisory for the same reason, stated in `pr-check.yml`: it reads `api.github.com`, and a required context that can go red on a third-party outage blocks every merge in the repository for something no author can fix. The second reason is #2858's: a closed issue does not by itself *prove* an entry is stale — it can close as a duplicate, or with the gap still open — so this is a lead, never a verdict.

## The third state, enumerated

Ways the *measurement* can fail, kept distinct from ways the subject can be broken (`guards-need-a-third-state.md`):

| condition | verdict | why not the success state |
|---|---|---|
| allowlist file absent | **pass (0)** | a checkout predating the metadata harness legitimately has none; failing would be a false red |
| present but unreadable | **exit 2** | folding this into the row above puts the broken case back on the exit-0 path |
| `differences` not an array | **exit 2** | nothing to check; a pass would assert something never read |
| entry cites no `issue` | **pass (0)** | a different, valid reason kind — established, not assumed; see below |
| `issue` present, unresolvable | **exit 2** | a citation nothing can resolve tracks nothing |
| issue state unreadable (API down/rate-limited/404) | **`::warning::`, rc 0** | **not** "open", and **not** a failure of the allowlist either — it names what it could not establish |

### Is a missing `issue` legitimate? Established by reading the file

**Yes.** 77 of the 270 entries carry no `issue`, and **every one** carries `outOfScope` (74) or `oracleLimitation` (3) instead. The file's own comment block declares the four mutually exclusive reason kinds. A guard failing on absence would be a false red on 77 correct entries. Mutation 4 below demonstrates that concretely.

## RED -> GREEN

`python3 .github/scripts/test_check_expectation_gap_issues.py`

| | |
|---|---|
| RED | **`Failed: 16, Passed: 48`** (plus `AttributeError: no attribute 'load_allowlist_entries'`) |
| GREEN | **`Failed: 0, Passed: 66`** |

Assertion failures, not build breaks. The suite builds each condition deliberately in a temp directory, so it proves the guard rather than describing today's shipped file — and it additionally asserts against the real file (`note shipped allowlist carries 193 issue-citing entries`) so the extraction is pinned to the real schema.

## Mutations — each chosen to test a property

Each landed (verified by re-reading the region), each RED was an **assertion**, all restored (`grep -c MUTATION` -> 0).

| # | mutation | property tested | result |
|---|---|---|---|
| 1 | `elif state == "closed" and False` | does it **actually query issue state**, or just parse? | **`Failed: 9, Passed: 57`** |
| 2 | `if state is None and False` | is the **third state** real, or collapsed into the pass? | **`Failed: 4, Passed: 62`** |
| 3 | unreadable allowlist `return []` | is **unreadable** distinguished from **absent**? | **`Failed: 1, Passed: 65`** |
| 4 | missing `issue` raises instead of skipping | is **absence a legitimate pass**? | **`Failed: 4, Passed: 60`** |

Mutation 4 is the sharpest: it fails against the **shipped** file too (`the shipped tests/expectations/ manifest parses cleanly  rc=2`), which is independent confirmation that the 77 no-`issue` entries are real and that treating absence as a finding would be a false red.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** I walked every `.json` under `tests/expectations/` checking which cite issues. Six do: five `known-gaps-*.json` (already covered) and the allowlist (this PR). The rest — `oos-*.json`, `divergence-session.json`, `apps.json`, `test-count-baseline.json` — cite none. **The allowlist was the only issue-citing manifest the guard could not see; there is no third.**
2. **Sibling function with the same assumption?** Yes, and it is the root cause: `load_known_gap_entries()` lists the manifest directory **non-recursively**. Any future issue-citing manifest in a subdirectory would be invisible the same way. Rather than a recursive walk — which would silently redefine what every existing assertion covers — the new loader targets the allowlist by name, and the point is written down at `docs/metadata-equivalence.md#allowlist-issue-hygiene` so the next subdirectory manifest is a known decision rather than a rediscovery.
3. **Two paths writing the same state, same invariant?** The sweep and the gate both consume entries, and both now take **both** kinds through one path (`_describe()`, one `by_issue` map, one offenders list) rather than a second copy of either. The gate's *message* branches per kind, because the remedies differ — an allowlist entry can legitimately be rewritten as `outOfScope`, which is not a remedy for a known-gap entry.

**Queue scan (`search-for-the-same-defect-first.md`)**: searched by symbol (`check_expectation_gap_issues`), observable (`metadata-equivalence allowlist`, `cited issue is open`) and mechanism (`stale entry closed issue`). Everything returned is either #3975 itself or one of the *cited* issues (#3568, #3788, #3797, #3808) — those are the tracked metadata gaps, not duplicate reports of this guard gap. **No sibling issue folds in; nothing else lands in this file.**

## The 44 remain — filed as #3988

#3975's deliverable is the guard, so this closes it. The 44 entries are **deliberately not fixed here**: each needs a live issue, or a reason rewritten to say why it is a permanent exemption. That is judgement per cluster across four different subsystems, not a sweep. Filed as **#3988**, which stays open.

One thing #3975 flagged that I did not settle either, and #3988 records it: whether all 44 differences are still *occurring*. `No_allowlist_entry_has_gone_stale` passing on `main` implies they are, but I did not confirm that guard covers every one of the 44 rather than a subset.

## Tests run

- `.github/scripts/test_check_expectation_gap_issues.py` — 66 checks, RED -> GREEN above
- all 21 `tools/test_*.py` — pass
- all `.github/scripts/test_*.py` and `test_*.sh` — pass
- `check_corpus_linkage.sh` against this diff: *"No file in this diff can change what AL observes, so no corpus declaration is required."*

No `AlRunner/` path is touched, so `require-tests` does not trigger and no BC leg runs the matrix on content.

Corpus-NA: this changes a CI guard over a JSON manifest's issue citations; nothing here is observable from AL, and no service tier can adjudicate whether a GitHub issue is open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
