### PR TITLE
docs(page): ParseMemberNames needs no systemaction or fileuploadaction entries

### DIFF
--- a/AlRunner.Tests/PrecompiledPageMemberNameTests.cs
+++ b/AlRunner.Tests/PrecompiledPageMemberNameTests.cs
@@ -73,6 +73,14 @@ public class EmittedIdentifierTests
     // The keyword check runs on the MANGLED result — "New Item" mangles to New_Item, which is
     // no keyword, so no prefix.
     [InlineData("New Item", "New_Item")]
+    // Every name BC's compiler allows on a systemaction (AL0810: PromptDialog and
+    // ConfigurationDialog) mangles to itself. RecordPatches.ParseMemberNames relies on this to
+    // leave systemactions out of its walk (#2200); a new allowed name that mangles breaks that.
+    [InlineData("Attach", "Attach")]
+    [InlineData("Cancel", "Cancel")]
+    [InlineData("Generate", "Generate")]
+    [InlineData("Ok", "Ok")]
+    [InlineData("Regenerate", "Regenerate")]
     public void EmittedIdentifier_MatchesBcsOwnEmitter(string declaredName, string expected)
         => Assert.Equal(expected, RunnerPageInstance.EmittedIdentifier(declaredName));
 }

--- a/AlRunner/Patches/RecordPatches.AlPageParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlPageParser.cs
@@ -214,6 +214,10 @@ public static partial class RecordPatches
 
         foreach (var field in obj.DescendantNodes().OfType<NavSyntax.PageFieldSyntax>())
             Add(IdentText(field.Name));
+        // PageActionSyntax only, on purpose: its two trigger-carrying siblings need no entry (#2200).
+        // systemaction names are a closed compiler list of plain identifiers (AL0810), so the
+        // backward scan in FindTriggerOnTarget already resolves them; a fileuploadaction is not a
+        // TestPage member at all (AL0132) and is reached only through an actionref, by name.
         foreach (var action in obj.DescendantNodes().OfType<NavSyntax.PageActionSyntax>())
             Add(IdentText(action.Name));
         return map;


### PR DESCRIPTION
Closes #2200

_Written by agent stma-auto2-2 on the account holder's behalf._

Corpus-NA: both hypothesized shapes are refused by BC's own compiler (AL0810 for a systemaction name that would need mangling, AL0132 for a fileuploadaction on a TestPage), so no corpus test can construct them

The one related shape that the corpus can express is an actionref promoting a fileuploadaction. That is #3990, and this PR does not change it.

## Answer: negative. The walk is correct as it is; this PR records why and pins the premise.

#2200 asked for a reproducer before any change: a `systemaction` or `fileuploadaction` whose AL name needs mangling, invoked through TestPage. I tried to build one. BC's compiler refuses both constructions, so the #1968 shape cannot reach `ParseMemberNames` from either sibling.

### systemaction: the names are a closed list of plain identifiers

A probe page per PageType with `systemaction(Bogus)` gave:

- `AL0213: An area of type 'SystemActions' is only valid on pages of type(s) 'ConfigurationDialog, PromptDialog'`
- `AL0810: ... The allowed names in a 'PromptDialog' page are: 'Attach, Cancel, Generate, Ok, Regenerate'.`
- `AL0810: ... The allowed names in a 'ConfigurationDialog' page are: 'Cancel, Ok'.`
- every other PageType: allowed names `''`.

`systemaction("Some Name")` is refused with the same AL0810. Each allowed name is a plain identifier and not a C# reserved word, so `EmittedIdentifier(name) == name`. The backward scan in `FindTriggerOnTarget` un-mangles `Generate_a45_OnAction` to `Generate` and hashes the same member id the forward arm would. An entry in the map would change nothing. The existing corpus test `PromptDialog_GenerateInvoke_FiresOnActionAndReportsCancel` (handlers/TestPageBuiltInActions_Tests.al) drives that path end to end, and since the map holds no systemaction entry, it runs through the backward scan. I ran it on this branch, against corpus `5fca7f22f02562877892238ff635f0054123c1e8` and the BC 28.1.49838.53910 artifact: `PASS  Codeunit60338.PromptDialog_GenerateInvoke_FiresOnActionAndReportsCancel`, `Tests: 1 total, pass: 1, fail: 0`.

### fileuploadaction: not a TestPage member at all

`TP.UploadPlain.Invoke()` and `TP."Upload Files".Invoke()` on a page declaring those fileuploadactions both fail with `AL0132: 'TestPage FU Page' does not contain a definition for ...`. The only TestPage route to such a trigger is an `actionref`, and #2199's `FindTriggerByName` resolves an actionref's target **by name** and passes that name straight to `FindTriggerOnTarget`. It never reads the `ParseMemberNames` map.

### Which compilers

The runner ships no `Microsoft.Dynamics.Nav.CodeAnalysis.dll`; it loads the one from the selected artifact. I ran both probes against three distinct compiler binaries: 27.0.38460.53934 (sha256 `71923cc3…`), 28.1.49838.53910 (`5fbb36d5…`) and 28.4.53241.54407 (`47e4d187…`). The AL0810 lists and the AL0132 refusals were identical on all three.

## What changed

- `AlRunner/Patches/RecordPatches.AlPageParser.cs`: a four-line comment above the `PageActionSyntax` walk saying why the two siblings need no entry. No code change.
- `AlRunner.Tests/PrecompiledPageMemberNameTests.cs`: five `[InlineData]` rows asserting that every compiler-allowed systemaction name mangles to itself. That identity is the premise the comment rests on. If a later BC adds an allowed name that mangles, or the reserved-word set grows to cover one, this test goes red.

## Tests

There is no RED → GREEN, because there is no defect to fix. The new rows pin a premise.

- `dotnet test --filter FullyQualifiedName~EmittedIdentifierTests`: `Failed: 0, Passed: 29, Total: 29` (24 existing rows plus 5 new).
- **Mutation:** added `"GENERATE"` to `EmitterReservedIdentifiers` in `RunnerPageInstance.cs`, which is a value change, not a structural one. Rebuilt with `0 Error(s)`. Result: `Failed: 1, Passed: 28, Total: 29`. The single failure was the `Generate` row, with `Expected: "Generate" / Actual: "_Generate"`. Restored; `git status --porcelain` came back empty.

## Fix the shape

1. **Same wrong pattern at another call site?** The map has one consumer, `TryGetPageMemberName`, which three `FindTriggerOnTarget` call sites use (`FindTrigger` twice and `TryRaiseExtensionOnlyAction`). All three reach only members a TestPage can name, and that set contains neither sibling except systemaction, whose names are covered above. `RecordPatches.ExtensionRuntimeDeltasMetadataEquivalence` reads a `MemberIdToName` too, but it is the SymbolReference-side `BcAppSymbolCache` map, not this walk.
2. **Sibling function with the same assumption?** Yes, and I found a real defect there, a different one. An `actionref` promoting a `fileuploadaction` compiles and is invokable. The runner refuses it because `FindTriggerThroughActionRef` looks for an arity-0 `_OnAction`, while the emitted trigger is `Upload_Files_a45_OnAction(NavObjectList<NavFileUpload> files)`. The refusal is loud, but its "declares no OnAction trigger" wording is wrong. Filed as #3990 and not folded in: the fix lands in `RunnerPageInstance`, not the parser, and it needs a corpus verdict on what BC does first.
3. **Two paths writing the same state, same invariant?** `ParseDeclaredSystemActions` walks `PageSystemActionSyntax` for #3283's built-in-OK question. That is a separate set with a separate reader, and it does not feed member-name resolution.

**Queue scan** (`fileuploadaction`, `FileUpload`, `systemaction`, `ParseMemberNames`, `PageActionWithTriggersBaseSyntax`, `declares no OnAction trigger`, `arity`, `NavFileUpload`): no open duplicate of #2200. #2113, #1968, #2723 and #2517 are the closed ancestors, and #3990 is new from this work.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
