### PR TITLE
fix(permissions): IsUserSuperInAllCompanies NREs on the skeleton session's null Permissions

### DIFF
--- a/AlRunner.Tests/NavDotNetReflectedInvokeRedirectTests.cs
+++ b/AlRunner.Tests/NavDotNetReflectedInvokeRedirectTests.cs
@@ -1,0 +1,82 @@
+// Runner-mechanism tests for #3174. What AL observes from
+// NavUserAccountHelper.IsUserSuperInAllCompanies is a BC-behaviour claim and lives upstream in
+// the corpus (al-language-onprem codeunit 61203). These pin the runner's own plumbing: that the
+// rewritten Ncl routes NavDotNet.Invoke<T>'s reflective call through the redirect, and that the
+// redirect leaves every other member's invocation, including its exception shape, untouched.
+using System.Reflection;
+using AlRunner.Patches;
+using Microsoft.Dynamics.Nav.Runtime;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class NavDotNetReflectedInvokeRedirectTests
+{
+    private readonly BcEngineFixture _engine;
+
+    public NavDotNetReflectedInvokeRedirectTests(BcEngineFixture engine) => _engine = engine;
+
+    private static IReadOnlyList<MethodReference> CallsInLoadedNavDotNetInvoke()
+    {
+        var location = typeof(ITreeObject).Assembly.Location;
+        Assert.False(string.IsNullOrEmpty(location), "the loaded Ncl has no file location to read");
+        using var module = ModuleDefinition.ReadModule(location, new ReaderParameters { ReadWrite = false });
+        var navDotNet = module.GetType("Microsoft.Dynamics.Nav.Runtime.NavDotNet")!;
+        var invoke = navDotNet.Methods.Single(m => m.Name == "Invoke" && m.HasGenericParameters && m.Parameters.Count == 6);
+        return invoke.Body.Instructions
+            .Where(i => (i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt) && i.Operand is MethodReference)
+            .Select(i => (MethodReference)i.Operand)
+            .ToList();
+    }
+
+    [SkippableFact]
+    public void LoadedNcl_NavDotNetInvoke_CallsTheRedirect_AndNoLongerCallsMethodBaseInvoke()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var calls = CallsInLoadedNavDotNetInvoke();
+
+        Assert.Single(calls, c => c.Name == nameof(NavDotNetPatches.InvokeReflectedMember)
+                                  && c.DeclaringType.FullName == typeof(NavDotNetPatches).FullName);
+        Assert.DoesNotContain(calls, c => c.Name == "Invoke"
+                                          && c.DeclaringType.FullName == "System.Reflection.MethodBase"
+                                          && c.Parameters.Count == 2);
+    }
+
+    private static int Twice(int x) => checked(x * 2);
+
+    [Fact]
+    public void Redirect_AnyOtherMember_ReturnsWhatReflectionReturns()
+    {
+        var method = typeof(NavDotNetReflectedInvokeRedirectTests).GetMethod(nameof(Twice), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        Assert.Equal(42, NavDotNetPatches.InvokeReflectedMember(method, null, new object?[] { 21 }));
+    }
+
+    [Fact]
+    public void Redirect_AnyOtherMember_KeepsTheTargetInvocationExceptionBcCatches()
+    {
+        var method = typeof(NavDotNetReflectedInvokeRedirectTests).GetMethod(nameof(Twice), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        var ex = Assert.Throws<TargetInvocationException>(
+            () => NavDotNetPatches.InvokeReflectedMember(method, null, new object?[] { int.MaxValue }));
+        Assert.IsType<OverflowException>(ex.InnerException);
+    }
+
+    public static bool IsUserSuperInAllCompanies() => false;
+
+    [Fact]
+    public void Redirect_SameMemberNameOnAnotherType_IsInvokedNotAnswered()
+    {
+        // Same name and arity as the NavUserAccountHelper member; only the declaring type
+        // differs, so this reaches the real body (false) instead of the session lookup, which
+        // would throw here with no BC session on the thread.
+        var method = typeof(NavDotNetReflectedInvokeRedirectTests).GetMethod(nameof(IsUserSuperInAllCompanies))!;
+
+        Assert.Equal(false, NavDotNetPatches.InvokeReflectedMember(method, null, Array.Empty<object>()));
+    }
+}

--- a/AlRunner.Tests/NavDotNetReflectedInvokeRedirectTests.cs
+++ b/AlRunner.Tests/NavDotNetReflectedInvokeRedirectTests.cs
@@ -1,6 +1,7 @@
 // Runner-mechanism tests for #3174. What AL observes from
-// NavUserAccountHelper.IsUserSuperInAllCompanies is a BC-behaviour claim and lives upstream in
-// the corpus (al-language-onprem codeunit 61203). These pin the runner's own plumbing: that the
+// NavUserAccountHelper.IsUserSuperInAllCompanies is a BC-behaviour claim with NO service-tier
+// verdict: the corpus tier cannot compile DotNet (#4014), and these tests do not pin the decision
+// logic in RecordPatches.IsUserSuperInAllCompanies. They pin only the runner's plumbing: that the
 // rewritten Ncl routes NavDotNet.Invoke<T>'s reflective call through the redirect, and that the
 // redirect leaves every other member's invocation, including its exception shape, untouched.
 using System.Reflection;

--- a/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
@@ -831,6 +831,37 @@ public static partial class NclCecilRewrite
                          "NavSession", "Guid", "PermissionSetKey", "String"),
                 H(recordPatches, "PermissionManagement_IsPermissionSetAssignedAsync"));
 
+            // ── NavDotNet.Invoke<T>: the reflective MethodInfo.Invoke (#3174) ──────────────
+            // NavUserAccountHelper.IsUserSuperInAllCompanies is `Session.Permissions
+            // .IsSuperForAllCompanies` — no Ncl hop in its body, and Permissions is null here.
+            // AL reaches it only through this call site, so the one `callvirt
+            // MethodBase::Invoke(object, object[])` is redirected to a static with the same
+            // stack shape that answers that one member and invokes every other unchanged.
+            // Imports one memberRef (the helper); adds nothing else to Ncl.
+            {
+                var navDotNetT = nclMod.GetType(Rt + "NavDotNet")
+                    ?? throw new InvalidOperationException("[Cecil] NavDotNet not found — Ncl shape changed; do not commit");
+                var invokeT = navDotNetT.Methods.SingleOrDefault(mm =>
+                        mm.Name == "Invoke" && mm.HasGenericParameters && mm.Parameters.Count == 6 && mm.HasBody)
+                    ?? throw new InvalidOperationException("[Cecil] NavDotNet.Invoke<T>(6 params) not found — Ncl shape changed; do not commit");
+                var reflectiveInvokes = invokeT.Body.Instructions.Where(i =>
+                        i.OpCode == OpCodes.Callvirt && i.Operand is MethodReference mr
+                        && mr.Name == "Invoke" && mr.DeclaringType.FullName == "System.Reflection.MethodBase"
+                        && mr.Parameters.Count == 2)
+                    .ToList();
+                if (reflectiveInvokes.Count != 1)
+                    throw new InvalidOperationException(
+                        $"[Cecil] NavDotNet.Invoke<T> has {reflectiveInvokes.Count} MethodBase.Invoke(object, object[]) "
+                        + "call sites, expected 1 — Ncl shape changed; do not commit (#3174)");
+                var redirect = nclMod.ImportReference(
+                    typeof(AlRunner.Patches.NavDotNetPatches).GetMethod(
+                        nameof(AlRunner.Patches.NavDotNetPatches.InvokeReflectedMember),
+                        BindingFlags.Public | BindingFlags.Static)
+                    ?? throw new InvalidOperationException("[Cecil] NavDotNetPatches.InvokeReflectedMember not found — do not commit"));
+                invokeT.Body.GetILProcessor().Replace(reflectiveInvokes[0], Instruction.Create(OpCodes.Call, redirect));
+                Console.Error.WriteLine("[Cecil] Redirected NavDotNet.Invoke<T> MethodBase.Invoke → NavDotNetPatches.InvokeReflectedMember (#3174)");
+            }
+
             // ── PermissionManagement.GetEffectivePermissionForObjectAsync (#2382) ────────
             // The SAME null as its sibling above, one method over: the real body ends in
             // `session.Permissions.GetEffectivePermissionForObject(...)`. It made

--- a/AlRunner/Patches/NavDotNetPatches.cs
+++ b/AlRunner/Patches/NavDotNetPatches.cs
@@ -47,18 +47,13 @@ public static class NavDotNetPatches
     internal const string IsUserSuperInAllCompaniesName = "IsUserSuperInAllCompanies";
 
     /// <summary>
-    /// Replaces the one <c>methodInfo.Invoke(serverHandle.Instance, array)</c> inside
-    /// <c>NavDotNet.Invoke&lt;T&gt;</c>, the reflective call every AL DotNet method/property
-    /// invocation ends in (#3174). Every member except the one below is invoked exactly as BC
-    /// invoked it, so exceptions still arrive wrapped in TargetInvocationException for BC's
-    /// own catch blocks.
-    ///
-    /// Observably equivalent: <c>NavUserAccountHelper.IsUserSuperInAllCompanies()</c> is
-    /// <c>Session.Permissions.IsSuperForAllCompanies</c>, whose Ncl getter answers false under
-    /// effective (lowered) test permissions, true for a NAV admin user, and otherwise whether an
-    /// all-companies System-scope SUPER Access Control row exists for the user
-    /// (NavUserPermissions.FetchRolesFromId). The runner's Permissions is null, so the same
-    /// decision is computed from the same table — see RecordPatches.IsUserSuperInAllCompanies.
+    /// Stands in for the one <c>methodInfo.Invoke(instance, args)</c> in <c>NavDotNet.Invoke&lt;T&gt;</c>,
+    /// where every AL DotNet call ends (#3174). Any other member is invoked unchanged, so its
+    /// exceptions still reach BC's catch blocks as TargetInvocationException.
+    /// Observably equivalent: <c>NavUserAccountHelper.IsUserSuperInAllCompanies()</c> reads the null
+    /// <c>Session.Permissions</c>; the answer is the decision BC's
+    /// <c>NavUserPermissions.IsSuperForAllCompanies</c> makes, from the same Access Control rows
+    /// (corpus al-language-onprem codeunit 61203).
     /// </summary>
     public static object? InvokeReflectedMember(System.Reflection.MethodBase method, object? target, object?[]? arguments)
     {

--- a/AlRunner/Patches/NavDotNetPatches.cs
+++ b/AlRunner/Patches/NavDotNetPatches.cs
@@ -42,4 +42,33 @@ public static class NavDotNetPatches
         if (ex is AlRunner.Infrastructure.RunnerOutOfScopeException oos)
             System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(oos).Throw();
     }
+
+    internal const string NavUserAccountHelperTypeName = "Microsoft.Dynamics.Nav.NavUserAccount.NavUserAccountHelper";
+    internal const string IsUserSuperInAllCompaniesName = "IsUserSuperInAllCompanies";
+
+    /// <summary>
+    /// Replaces the one <c>methodInfo.Invoke(serverHandle.Instance, array)</c> inside
+    /// <c>NavDotNet.Invoke&lt;T&gt;</c>, the reflective call every AL DotNet method/property
+    /// invocation ends in (#3174). Every member except the one below is invoked exactly as BC
+    /// invoked it, so exceptions still arrive wrapped in TargetInvocationException for BC's
+    /// own catch blocks.
+    ///
+    /// Observably equivalent: <c>NavUserAccountHelper.IsUserSuperInAllCompanies()</c> is
+    /// <c>Session.Permissions.IsSuperForAllCompanies</c>, whose Ncl getter answers false under
+    /// effective (lowered) test permissions, true for a NAV admin user, and otherwise whether an
+    /// all-companies System-scope SUPER Access Control row exists for the user
+    /// (NavUserPermissions.FetchRolesFromId). The runner's Permissions is null, so the same
+    /// decision is computed from the same table — see RecordPatches.IsUserSuperInAllCompanies.
+    /// </summary>
+    public static object? InvokeReflectedMember(System.Reflection.MethodBase method, object? target, object?[]? arguments)
+    {
+        if (method.IsStatic
+            && method.Name == IsUserSuperInAllCompaniesName
+            && (arguments == null || arguments.Length == 0)
+            && method.DeclaringType?.FullName == NavUserAccountHelperTypeName)
+        {
+            return RecordPatches.IsUserSuperInAllCompanies(Microsoft.Dynamics.Nav.Runtime.NavCurrentThread.Session);
+        }
+        return method.Invoke(target, arguments);
+    }
 }

--- a/AlRunner/Patches/NavDotNetPatches.cs
+++ b/AlRunner/Patches/NavDotNetPatches.cs
@@ -52,8 +52,8 @@ public static class NavDotNetPatches
     /// exceptions still reach BC's catch blocks as TargetInvocationException.
     /// Observably equivalent: <c>NavUserAccountHelper.IsUserSuperInAllCompanies()</c> reads the null
     /// <c>Session.Permissions</c>; the answer is the decision BC's
-    /// <c>NavUserPermissions.IsSuperForAllCompanies</c> makes, from the same Access Control rows
-    /// (corpus al-language-onprem codeunit 61203).
+    /// <c>NavUserPermissions.IsSuperForAllCompanies</c> makes (bc284 decompile), from the same Access
+    /// Control rows. No corpus verdict: the corpus tier cannot compile DotNet (#3174, corpus PR 330).
     /// </summary>
     public static object? InvokeReflectedMember(System.Reflection.MethodBase method, object? target, object?[]? arguments)
     {

--- a/AlRunner/Patches/RecordPatches.PermissionSetAssignment.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionSetAssignment.cs
@@ -158,6 +158,29 @@ public static partial class RecordPatches
         NavSession session, Guid userSecurityId, PermissionSetKey permissionSet, string companyName)
         => new(IsPermissionSetAssignedCore(session, userSecurityId, permissionSet, companyName));
 
+    /// <summary>
+    /// <c>NavUserPermissions.IsSuperForAllCompanies</c> for the session's own user, reached from
+    /// <c>NavUserAccountHelper.IsUserSuperInAllCompanies</c> via NavDotNetPatches (#3174). Mirrors
+    /// BC's getter in order: effective test permissions in use → false; NAV admin user → true;
+    /// otherwise the all-companies SUPER assignment, answered by the same core as
+    /// <c>IsPermissionSetAssigned</c> so the two can never disagree about one user.
+    /// BC's permission-system-disabled arm (a SQL setting) has no runner state and is not modelled.
+    /// </summary>
+    internal static bool IsUserSuperInAllCompanies(NavSession session)
+    {
+        // BC reads session.TestExecution unguarded; a session with no test execution has no
+        // effective permissions to be in use.
+        if (session.TestExecution != null && NavTestExecution.UseEffectivePermissions(session))
+            return false;
+
+        var user = session.User;
+        if (user.IsNavAdminUser)
+            return true;
+
+        return IsPermissionSetAssignedCore(
+            session, user.Id, new PermissionSetKey(SuperRoleId, Guid.Empty, PermissionScope.System), string.Empty);
+    }
+
     private static bool IsPermissionSetAssignedCore(
         NavSession session, Guid userSecurityId, PermissionSetKey permissionSet, string companyName)
     {

--- a/AlRunner/Patches/RecordPatches.PermissionSetAssignment.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionSetAssignment.cs
@@ -172,7 +172,11 @@ public static partial class RecordPatches
         if (session.TestExecution != null && NavTestExecution.UseEffectivePermissions(session))
             return false;
 
-        var user = session.User;
+        NavUser? user;
+        try { user = session.User; }
+        catch (NullReferenceException) { user = null; } // no Authenticator: no user, as IsSkeletonSessionUser
+        if (user == null)
+            return false;
         if (user.IsNavAdminUser)
             return true;
 

--- a/AlRunner/Patches/RecordPatches.PermissionSetAssignment.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionSetAssignment.cs
@@ -109,9 +109,8 @@
 //   seed. IsSuper must answer true in both, or codeunit 9002 refuses a `User.Modify` that every
 //   real BC test tier allows. The Access-Control arm is checked FIRST, so wherever the row does
 //   exist it — not this fact — is what answers.
-//   AlRunner#3174 tracks the one reader this fix cannot reach:
-//   NavUserAccountHelper.IsUserSuperInAllCompanies is `Session.Permissions.IsSuperForAllCompanies`
-//   with no Ncl hop in it at all, so no rewrite of Ncl can answer it.
+//   NavUserAccountHelper.IsUserSuperInAllCompanies has no Ncl hop in its body; it is answered
+//   by IsUserSuperInAllCompanies below, reached from NavDotNetPatches.InvokeReflectedMember (#3174).
 //
 // PRECOMPILED-DLL RESPECT
 //   `PermissionManagement` is in Ncl.dll — the runtime engine, ours to rewrite per

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -876,8 +876,12 @@ reads back true, grant something else and it reads back false.
 
 Entitlements are not modeled at all, so a permission set that a real tier would report as
 assigned *via an entitlement* rather than via `Access Control` reads as not assigned here.
-`NavUserAccountHelper.IsUserSuperInAllCompanies` still raises, because its body has no Ncl hop
-the runner can rewrite — AlRunner#3174.
+`NavUserAccountHelper.IsUserSuperInAllCompanies` (reachable from an OnPrem app's `DotNet`
+variable) reads the same null cache with no Ncl method in its body, so the runner answers it at
+`NavDotNet`'s reflective invoke instead (AlRunner#3174), with the decision BC's
+`NavUserPermissions.IsSuperForAllCompanies` makes: `false` while effective test permissions are in
+use (`Permissions Mock`), `true` for a NAV admin user, otherwise the all-companies SUPER row
+answered exactly as `IsSuper` is above. BC's "permission system disabled" setting is not modelled.
 
 ### `Record "Time Zone"` — ids follow the HOST, so they are IANA ids on Linux
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -878,10 +878,13 @@ Entitlements are not modeled at all, so a permission set that a real tier would 
 assigned *via an entitlement* rather than via `Access Control` reads as not assigned here.
 `NavUserAccountHelper.IsUserSuperInAllCompanies` (reachable from an OnPrem app's `DotNet`
 variable) reads the same null cache with no Ncl method in its body, so the runner answers it at
-`NavDotNet`'s reflective invoke instead (AlRunner#3174), with the decision BC's
-`NavUserPermissions.IsSuperForAllCompanies` makes: `false` while effective test permissions are in
-use (`Permissions Mock`), `true` for a NAV admin user, otherwise the all-companies SUPER row
-answered exactly as `IsSuper` is above. BC's "permission system disabled" setting is not modelled.
+`NavDotNet`'s reflective invoke instead (AlRunner#3174). The answer follows the order of
+`NavUserPermissions.IsSuperForAllCompanies` as read from the BC 28.4 decompile: `false` while
+effective test permissions are in use (`Permissions Mock`), `true` for a NAV admin user,
+otherwise the all-companies SUPER row answered exactly as `IsSuper` is above. BC's "permission
+system disabled" setting is not modelled. **No service tier has checked this decision, and no
+test pins it**: the corpus CI cannot compile a `DotNet` test (AlRunner#4014), and the runner's own
+tests cover only the invoke redirect, not which branch answers.
 
 ### `Record "Time Zone"` — ids follow the HOST, so they are IANA ids on Linux
 


### PR DESCRIPTION
Closes #3174

Written by agent stma-auto2-3 on the account holder's behalf.

Corpus-NA: the corpus harness compiles apps without /assemblyprobingpaths, so no DotNet test can compile on its tier (corpus PR 330 closed, AL0185 on all 8 OnPrem legs)

## What changed

`NavUserAccountHelper.IsUserSuperInAllCompanies()` is `Session.Permissions.IsSuperForAllCompanies`. `NavSession.Permissions` is null in the runner, so any AL that called it got `NavNCLDotNetInvokeException ... Object reference not set to an instance of an object`.

The issue says there is no Ncl method to rewrite. That's true of the helper's body, but not of the call path. AL can only reach the helper through a `DotNet` variable (OnPrem target), and the emitted code is `h.InvokeStaticMethod<bool>("IsUserSuperInAllCompanies", ...)`. That call ends in `NavDotNet.Invoke<T>`, which is in Ncl, at one reflective `methodInfo.Invoke(serverHandle.Instance, array)`.

- `NclCecilRewrite.Runtime.cs`: replaces that one `callvirt MethodBase::Invoke(object, object[])` with a call to `NavDotNetPatches.InvokeReflectedMember`. The stack shape is the same. The rewrite throws "do not commit" if the call-site count is ever not exactly 1. `compare_symbols` shows the body of `NavDotNet.Invoke<T>` is identical between bc270 and bc284.
- `NavDotNetPatches.InvokeReflectedMember`: if the method is static, named `IsUserSuperInAllCompanies`, takes no arguments and is declared on `Microsoft.Dynamics.Nav.NavUserAccount.NavUserAccountHelper`, it returns the runner's answer. Every other method goes through `method.Invoke(target, arguments)` as before, so BC's `TargetInvocationException` catch still gets the same exceptions.
- `RecordPatches.IsUserSuperInAllCompanies`: follows the order of BC's `NavUserPermissions.IsSuperForAllCompanies` getter, decompiled on bc284:
  1. `NavTestExecution.UseEffectivePermissions(session)` → `false`. The runner already stores effective permission sets for real (#3343 rewrite).
  2. `user.IsNavAdminUser` → `true`.
  3. Otherwise, the all-companies SUPER assignment: `NavUserPermissions.FetchRolesFromId` sets the flag only for a SUPER row with a blank company, System scope and no app ID. The runner answers this with the same `IsPermissionSetAssignedCore` that `IsPermissionSetAssigned` (#3039) uses, so `IsSuper` and `IsUserSuperInAllCompanies` can't disagree about the session user.

  If the session has no user (no Authenticator), the answer is `false`, which is how `IsSkeletonSessionUser` in the same file already handles that case. Without this, the NRE would just move here.

  I left out BC's `EnsurePermissionSetupVersionCorrect` and `IsPermissionSystemEnabled` arms. Both are SQL-backed and the runner has no state for them. `docs/limitations.md` now says so.
- `docs/limitations.md` § permission-set-assignment and the header in `RecordPatches.PermissionSetAssignment.cs` no longer say this reader raises.

## Tests

**Corpus: no service-tier verdict exists.** Corpus PR 330 put the three AL tests (codeunit 61203: `true` for the test-tier user, agreement with the all-companies SUPER `Access Control` row, `false` under `Permissions Mock`) in the OnPrem app. In run 34720020104, all 8 OnPrem legs failed to compile them with `AL0185: DotNet 'NavUserAccountHelper' is missing`, so that corpus PR is now closed without merging.

The cause is the harness, not reachability. `MsDyn365Bc.On.Linux`'s `bc-test-from-source.yml` runs `AL compile` with no `/assemblyprobingpaths` and has no input for one. With the same alc 17.0.34.45391 and BC 28.4 symbols, I got `AL0185` without probing paths and a clean compile with `/assemblyprobingpaths:<28.4 artifacts>`, for both an own `dotnet` block and System Application's alias. So the call is reachable from any OnPrem app compiled against the service tier's assemblies (as Base Application's page 9033 is), but the corpus can't express a `DotNet` test until the harness gains probing paths.

This means the three-branch decision below rests on BC's decompiled getter (`NavUserPermissions.IsSuperForAllCompanies` / `FetchRolesFromId`, bc284), not on a service-tier run. The follow-up that would settle it is that harness change, and then re-adding codeunit 61203. The RED/GREEN and mutation A figures below come from running that codeunit locally against the runner; they are runner evidence, not a BC verdict.

The runner accepting what the harness rejects is not a compiler divergence. The runner hands BC's compiler the artifacts directory as a probing path, just as an OnPrem developer setup or the service tier's own publish does. The harness's compile is the configuration missing the path.

**Runner mechanism (`AlRunner.Tests/NavDotNetReflectedInvokeRedirectTests`, 4 tests):** the loaded, rewritten Ncl's `NavDotNet.Invoke<T>` calls the redirect and no longer calls `MethodBase.Invoke`. Any other method returns what reflection returns. Its exceptions stay wrapped in `TargetInvocationException`. A method with the same name on another type gets invoked rather than answered.

### RED → GREEN (local, corpus base 5fca7f22 + codeunit 61203 from the closed corpus PR, BC 28.1.49838.53910)

- RED, with the redirect not applied (same as `main`): `0P/3F/0E across 3 tests`. All three fail with `NavNCLDotNetInvokeException ... Object reference not set to an instance of an object`.
- GREEN: `3P/0F/0E across 3 tests`. I ran it twice against one `--cache` root and got the same result both times.
- Full corpus with the fix (internals fixture + Cloud + OnPrem as separate roots): `3317P/0F/0E` + `32P/0F/0E`, 3348 total, 0 failures. This also covers the DotNet invoke path the redirect now sits on.

### Mutations (executed)

- **A: delete the effective-permissions branch.** Corpus codeunit 61203 gives `2P/1F`. Only `..._FalseWhileEffectiveTestPermissionsAreInUse` fails, with `Assert.IsFalse failed. Effective test permissions must make the user not SUPER in all companies.` That's the expected subset. Restored.
- **B: comment out the IL replace (pre-fix).** Corpus gives `0P/3F`. Mechanism tests give `Failed: 1, Passed: 3`: `LoadedNcl_NavDotNetInvoke_CallsTheRedirect_...` fails with `Assert.Single() Failure`. Restored: `Failed: 0, Passed: 4`.
- **C: drop the declaring-type check.** Mechanism tests give `Failed: 1, Passed: 3`: `Redirect_SameMemberNameOnAnotherType_IsInvokedNotAnswered` fails. Restored.

Also ran: `FullyQualifiedName~GuardTests|~NavDotNetReflectedInvokeRedirectTests` gives `Passed: 253, Failed: 0`. For `tools/test_*.py`, three fail locally (`test_agent_self_freshness`, `test_corpus_checkout`, `test_preflight`), all at `git commit` in a temp repo with `1Password: agent returned an error` (global commit signing on this machine). That's the environment, not this diff.

## Fix the shape

1. **Same wrong pattern at another call site?** In the decompiled `NavUserAccountHelper` (28.4), `IsUserSuperInAllCompanies` is the only member that reads `Session.Permissions` itself. The permission members AL actually calls (`IsPermissionSetAssigned`, `GetEffectivePermissionForObject`) pass the session into Ncl and are already answered there (#3039, #2382). `GetEntitlementPermissionsForObject*` goes through Ncl too, and #3352 already tracks it. I also searched the W1 28 source for AL calls to `NavUserAccountHelper.*`: page 9033 is the only caller of this method, and it raises an error on `not IsSaaS()` before it gets to the call. `IsSessionAdminSession` reads `Session.AdminSession` and passes in the runner, which I measured with a scratch OnPrem probe. `GetAllowedCompanies(Guid)`, which the issue names, has no AL caller in W1 28, so there's no reproducer. I didn't touch it, per `no-assumption-fixes.md`.
2. **Sibling making the same assumption?** #3352 lists the 28 Ncl methods that dereference null `Permissions`. It belongs to the other loop (`agent: stma-auto-24`), so I left it alone. `IsUserSuperInAllCompanies` isn't in its table because that table only lists Ncl methods.
3. **Two paths, same invariant?** "Is the session user SUPER in all companies" is now answered by `IsSuper` (through `IsPermissionSetAssigned`) and `IsUserSuperInAllCompanies`. Both go through `IsPermissionSetAssignedCore` with a blank company, including its stated-SUPER floor, so they share one invariant. The one intended difference is BC's own: `IsUserSuperInAllCompanies` answers `false` under effective test permissions.

## Queue scan

I searched for `NavUserAccountHelper`, `Session.Permissions`, `IsSuperForAllCompanies`, `null permission`, `GetAllowedCompanies` and `NavDotNet Invoke`:
- #3352: the survey above. Not folded (other loop, and Ncl-side methods).
- #3222: static System.Drawing members still fail with the bare message. It's the same Ncl method (`NavDotNet.Invoke<T>`), but a different edit: it needs platform-refusal classification in the catch blocks, not a call substitution, and it needs its own reproducer. Not folded, so this diff stays one reviewable change. Whoever takes it will find `InvokeReflectedMember` already at the call site.
- #2910 / #2886: Permission tables return no rows. Different surface.

## Where the prose went

No comment block over ten lines. The mechanism and the scoping are in `docs/limitations.md` § permission-set-assignment and in this body.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
