### PR TITLE
fix(cli): an unlinked working directory no longer crashes the expectations auto-probe

### DIFF
--- a/AlRunner.Tests/UnlinkedWorkingDirectoryTests.cs
+++ b/AlRunner.Tests/UnlinkedWorkingDirectoryTests.cs
@@ -1,0 +1,241 @@
+// UnlinkedWorkingDirectoryTests — issue #3120.
+//
+// A process whose working directory has been removed (`cd d && rm -rf d && exec …`) has a
+// cwd getcwd(2) cannot name, so Environment.CurrentDirectory throws FileNotFoundException.
+// Every bundle path the runner needs is absolute by then, so the run can complete: the
+// working directory only ever fed a secondary expectations probe, a bundle's display label
+// and coverage's relative filenames. These tests pin that the run does complete, and what
+// each of those three says instead.
+//
+// Not a corpus claim: an unreadable working directory is an OS/process state AL can neither
+// produce nor observe. The unlinked-cwd launcher is copied from CacheRootStartupFailureTests,
+// whose helpers are private to that file.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class UnlinkedWorkingDirectoryTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string FixtureDir =
+        Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures", "RecordTriggerXRec");
+
+    // ── unit: the helper and the resolver ─────────────────────────────────────────────
+
+    [Fact]
+    public void TryGet_WhenTheReaderThrowsFileNotFound_ReturnsNull()
+    {
+        Assert.Null(WorkingDirectory.TryGet(() => throw new FileNotFoundException("Unable to find the specified file.")));
+    }
+
+    [Fact]
+    public void TryGet_WhenTheReaderThrowsUnauthorizedAccess_ReturnsNull()
+    {
+        Assert.Null(WorkingDirectory.TryGet(() => throw new UnauthorizedAccessException()));
+    }
+
+    [Fact]
+    public void TryGet_WhenTheReaderAnswers_ReturnsItsValue()
+    {
+        Assert.Equal("/some/dir", WorkingDirectory.TryGet(() => "/some/dir"));
+    }
+
+    [Fact]
+    public void DisplayPath_WithAReadableWorkingDirectory_IsRelativeToIt()
+    {
+        var sep = Path.DirectorySeparatorChar;
+        var root = Path.GetFullPath(Path.Combine(Path.GetPathRoot(Environment.SystemDirectory) ?? "/", "wd"));
+        Assert.Equal($"bundles{sep}a", WorkingDirectory.DisplayPath(Path.Combine(root, "bundles", "a"), root));
+    }
+
+    [Fact]
+    public void DisplayPath_WithNoWorkingDirectory_IsTheAbsolutePathUnchanged()
+    {
+        var abs = Path.GetFullPath(Path.Combine(Path.GetPathRoot(Environment.SystemDirectory) ?? "/", "wd", "bundles", "a"));
+        Assert.Equal(abs, WorkingDirectory.DisplayPath(abs, currentDirectory: null));
+    }
+
+    [Fact]
+    public void Resolve_WithNoWorkingDirectory_StillWalksUpFromTheBundle()
+    {
+        var root = TestScratch.Dir("al-runner-unlinked-cwd-resolve");
+        var expectations = Path.Combine(root, "tests", "expectations");
+        var bundle = Path.Combine(root, "suites", "one");
+        Directory.CreateDirectory(expectations);
+        Directory.CreateDirectory(bundle);
+
+        Assert.Equal(expectations, ExpectationsDirectoryResolution.Resolve(new[] { bundle }, currentDirectory: null));
+    }
+
+    [Fact]
+    public void Resolve_WithNoWorkingDirectoryAndNoManifest_ReturnsNull()
+    {
+        var bundle = TestScratch.Dir("al-runner-unlinked-cwd-resolve-none");
+        Directory.CreateDirectory(bundle);
+
+        Assert.Null(ExpectationsDirectoryResolution.Resolve(new[] { bundle }, currentDirectory: null));
+    }
+
+    [Fact]
+    public void NotFoundMessage_WithAReadableWorkingDirectory_NamesTheCwdCandidate()
+    {
+        var cwd = Path.GetFullPath(Path.Combine(Path.GetPathRoot(Environment.SystemDirectory) ?? "/", "wd"));
+        var message = ExpectationsDirectoryResolution.BuildNotFoundMessage(cwd, bundleCount: 2);
+
+        Assert.Contains($"probed {Path.Combine(cwd, "tests", "expectations")} and the ancestor tree of 2 bundle path(s)", message, StringComparison.Ordinal);
+        Assert.DoesNotContain("working directory could not be read", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NotFoundMessage_WithNoWorkingDirectory_SaysItWasNotProbed()
+    {
+        var message = ExpectationsDirectoryResolution.BuildNotFoundMessage(currentDirectory: null, bundleCount: 1);
+
+        Assert.Contains("probed the ancestor tree of 1 bundle path(s)", message, StringComparison.Ordinal);
+        Assert.Contains("the working directory could not be read, so it was not probed", message, StringComparison.Ordinal);
+        Assert.Contains("Pass --expectations DIR", message, StringComparison.Ordinal);
+    }
+
+    // ── end to end: a run from an unlinked working directory ─────────────────────────
+
+    /// <summary>
+    /// The reported crash (Program.cs expectations auto-probe, exit 134) and the next one a
+    /// run met once past it (the per-bundle label, also exit 134). The loaded-from line is
+    /// the discriminator for the probe: it proves the bundle-ancestor walk found the repo's
+    /// manifest rather than the probe being skipped.
+    /// </summary>
+    [SkippableFact]
+    public void AutoProbe_FromAnUnlinkedWorkingDirectory_FindsTheBundleAncestorManifestAndRunCompletes()
+    {
+        SkipUnlessLinux();
+        TestArtifacts.SkipIfMissing();
+
+        var (exit, output) = RunFromUnlinkedWorkingDirectory(new[] { FixtureDir, "--no-cache" });
+
+        AssertNotAnUnhandledCrash(exit, output);
+        Assert.Contains(
+            $"[expectations] loaded ", output, StringComparison.Ordinal);
+        Assert.Contains(
+            $" from {Path.Combine(RepoRoot, "tests", "expectations")}", output, StringComparison.Ordinal);
+        Assert.True(exit == 0 && output.Contains("pass:        1", StringComparison.Ordinal),
+            $"the run must complete from an unlinked working directory:\n{output}");
+        // The bundle label falls back to the absolute path.
+        Assert.Contains($"[1/1] {FixtureDir} ", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The "no manifest found" branch, which read the working directory a second time to
+    /// name its candidate. Reached only with a bundle that has no tests/expectations
+    /// ancestor, so the fixture is copied out of the repository.
+    /// </summary>
+    [SkippableFact]
+    public void AutoProbe_FromAnUnlinkedWorkingDirectory_WithNoManifestAnywhere_SaysTheWorkingDirectoryWasNotProbed()
+    {
+        SkipUnlessLinux();
+        TestArtifacts.SkipIfMissing();
+
+        var bundle = CopyFixtureOutOfTheRepository("al-runner-unlinked-cwd-nomanifest");
+        Assert.Null(ExpectationsDirectoryResolution.Resolve(new[] { bundle }, currentDirectory: null));
+
+        var (exit, output) = RunFromUnlinkedWorkingDirectory(new[] { bundle, "--no-cache" });
+
+        AssertNotAnUnhandledCrash(exit, output);
+        Assert.Contains("[expectations] no tests/expectations manifest found", output, StringComparison.Ordinal);
+        Assert.Contains("the working directory could not be read, so it was not probed", output, StringComparison.Ordinal);
+        Assert.True(exit == 0 && output.Contains("pass:        1", StringComparison.Ordinal),
+            $"the run must complete from an unlinked working directory:\n{output}");
+    }
+
+    /// <summary>
+    /// The coverage source map is built relative to the working directory. With none, the
+    /// report names each file by its absolute path, which the report's <c>&lt;source&gt;.</c>
+    /// root still resolves.
+    /// </summary>
+    [SkippableFact]
+    public void Coverage_FromAnUnlinkedWorkingDirectory_WritesAbsoluteFilenames()
+    {
+        SkipUnlessLinux();
+        TestArtifacts.SkipIfMissing();
+
+        var bundle = CopyFixtureOutOfTheRepository("al-runner-unlinked-cwd-coverage");
+        var coverageDir = TestScratch.Dir("al-runner-unlinked-cwd-coverage-out");
+        Directory.CreateDirectory(coverageDir);
+        var coverageOut = Path.Combine(coverageDir, "cobertura.xml");
+
+        var (exit, output) = RunFromUnlinkedWorkingDirectory(
+            new[] { bundle, "--no-cache", "--coverage", "--coverage-out", coverageOut });
+
+        AssertNotAnUnhandledCrash(exit, output);
+        Assert.True(exit == 0 && output.Contains("pass:        1", StringComparison.Ordinal),
+            $"the run must complete from an unlinked working directory:\n{output}");
+        Assert.True(File.Exists(coverageOut), $"coverage report must be written:\n{output}");
+        var xml = File.ReadAllText(coverageOut);
+        Assert.Contains(
+            $"filename=\"{Path.Combine(bundle, "XRecProbeTests.Codeunit.al").Replace('\\', '/')}\"",
+            xml, StringComparison.Ordinal);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────────────
+
+    private static string CopyFixtureOutOfTheRepository(string prefix)
+    {
+        var bundle = TestScratch.Dir(prefix);
+        Directory.CreateDirectory(bundle);
+        foreach (var file in Directory.GetFiles(FixtureDir))
+            File.Copy(file, Path.Combine(bundle, Path.GetFileName(file)));
+        return bundle;
+    }
+
+    private static void SkipUnlessLinux()
+        => Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux),
+            "unlinking a live working directory is a Unix behaviour; Windows refuses to remove it");
+
+    private static void AssertNotAnUnhandledCrash(int exit, string output)
+    {
+        Assert.DoesNotContain("Unhandled exception", output, StringComparison.Ordinal);
+        // 128 + SIGABRT(6): what CoreCLR's default unhandled-exception handler produces.
+        Assert.NotEqual(134, exit);
+    }
+
+    private static (int Exit, string Output) RunFromUnlinkedWorkingDirectory(string[] runnerArgs)
+    {
+        var doomed = Path.Combine(TestScratch.Dir("al-runner-unlinked-cwd"), "doomed");
+        Directory.CreateDirectory(doomed);
+
+        var extra = TestBuildConfig.BcVersionArg.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var script = new StringBuilder();
+        script.Append("rm -rf ").Append(ShellQuote(doomed)).Append(" && exec dotnet ");
+        script.Append(ShellQuote(TestBuildConfig.RunArgs(ProjectPath).Trim('"')));
+        foreach (var a in runnerArgs.Concat(extra)) script.Append(' ').Append(ShellQuote(a));
+
+        var psi = new ProcessStartInfo("/bin/sh")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = doomed,
+        };
+        psi.ArgumentList.Add("-c");
+        psi.ArgumentList.Add(script.ToString());
+
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(300_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (p.ExitCode, sb.ToString());
+    }
+
+    private static string ShellQuote(string s) => "'" + s.Replace("'", "'\\''") + "'";
+}

--- a/AlRunner/Infrastructure/ExpectationsDirectoryResolution.cs
+++ b/AlRunner/Infrastructure/ExpectationsDirectoryResolution.cs
@@ -35,10 +35,11 @@ public static class ExpectationsDirectoryResolution
     /// <summary>
     /// Probes for <c>&lt;ancestor&gt;/tests/expectations</c>, walking UP from each
     /// bundle root's absolute path first (in the order given), then from
-    /// <paramref name="currentDirectory"/>. Returns the first existing directory
+    /// <paramref name="currentDirectory"/> — skipped when it is null, i.e. the working
+    /// directory could not be read (#3120). Returns the first existing directory
     /// found, or null if none of the probed locations exist.
     /// </summary>
-    public static string? Resolve(IReadOnlyList<string> bundleRoots, string currentDirectory)
+    public static string? Resolve(IReadOnlyList<string> bundleRoots, string? currentDirectory)
     {
         foreach (var root in bundleRoots)
         {
@@ -50,10 +51,28 @@ public static class ExpectationsDirectoryResolution
             if (found != null) return found;
         }
 
+        if (currentDirectory == null) return null;
         string cwdStart;
         try { cwdStart = Path.GetFullPath(currentDirectory); }
         catch { return null; }
         return TryWalkUp(cwdStart);
+    }
+
+    /// <summary>
+    /// The stderr line printed when <see cref="Resolve"/> found nothing (#1984). With a null
+    /// <paramref name="currentDirectory"/> (#3120) it names no cwd candidate and says why.
+    /// </summary>
+    public static string BuildNotFoundMessage(string? currentDirectory, int bundleCount)
+    {
+        var bundlesProbed = bundleCount > 0 ? $"the ancestor tree of {bundleCount} bundle path(s)" : null;
+        var probed = currentDirectory != null
+            ? Path.Combine(Path.GetFullPath(currentDirectory), "tests", "expectations")
+              + (bundlesProbed != null ? " and " + bundlesProbed : "")
+            : (bundlesProbed ?? "nothing")
+              + "; the working directory could not be read, so it was not probed";
+        return $"[expectations] no tests/expectations manifest found (probed {probed}) — " +
+               "expect-oos / expect-fail-known-gap / expect-divergence classification is OFF " +
+               "this run. Pass --expectations DIR to set it explicitly.";
     }
 
     /// <summary>

--- a/AlRunner/Infrastructure/WorkingDirectory.cs
+++ b/AlRunner/Infrastructure/WorkingDirectory.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+
+namespace AlRunner.Infrastructure;
+
+/// <summary>
+/// Reads the process working directory without letting an unreadable one abort the run
+/// (#3120). <c>Environment.CurrentDirectory</c> calls getcwd(2), which fails with ENOENT once
+/// the directory has been removed (<c>cd d &amp;&amp; rm -rf d &amp;&amp; exec …</c>), and the
+/// resulting FileNotFoundException escaped top-level statements as exit 134. Every read of the
+/// working directory in the run path goes through <see cref="TryGet()"/>; callers treat
+/// <c>null</c> as "no working directory" rather than as an error.
+/// </summary>
+public static class WorkingDirectory
+{
+    /// <summary>The working directory, or <c>null</c> when the OS cannot name it.</summary>
+    public static string? TryGet() => TryGet(static () => Environment.CurrentDirectory);
+
+    internal static string? TryGet(Func<string> read)
+    {
+        try { return read(); }
+        catch (IOException) { return null; }
+        catch (UnauthorizedAccessException) { return null; }
+    }
+
+    /// <summary>
+    /// <paramref name="absolutePath"/> relative to <paramref name="currentDirectory"/>, or the
+    /// absolute path itself when there is no working directory to be relative to.
+    /// </summary>
+    public static string DisplayPath(string absolutePath, string? currentDirectory)
+        => currentDirectory == null ? absolutePath : Path.GetRelativePath(currentDirectory, absolutePath);
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -917,25 +917,19 @@ AlRunner.Infrastructure.ExpectationManifest? expectations = null;
     }
     if (expectationsDir == null)
     {
-        expectationsDir = AlRunner.Infrastructure.ExpectationsDirectoryResolution.Resolve(bundles, Environment.CurrentDirectory);
+        // #3120: an unreadable working directory is "no cwd candidate", not a crash.
+        var probeCwd = AlRunner.Infrastructure.WorkingDirectory.TryGet();
+        expectationsDir = AlRunner.Infrastructure.ExpectationsDirectoryResolution.Resolve(bundles, probeCwd);
         if (expectationsDir == null)
         {
             // #1984: this used to be silent — an explicit --expectations miss exits 2
             // loudly, but the auto-probed default just left `expectations` null and
             // every expect-oos/expect-divergence test in the run flipped to a plain
             // FAIL with nothing in the output to say why. Diagnosable, not inferred.
-            var cwdCandidate = Path.Combine(Path.GetFullPath(Environment.CurrentDirectory), "tests", "expectations");
-            // #2097: deferred — see `deferredStartupLines`'s declaration above. Captured
-            // into a local now: `bundles` itself is never mutated again after arg
-            // parsing, but capturing its count here (rather than reading `bundles.Count`
-            // fresh inside the closure) keeps this consistent with every other deferred
-            // line's rule of freezing values at queue time, not at flush time.
-            var bundleCountForPrint = bundles.Count;
-            deferredStartupLines.Add(() => Console.Error.WriteLine(
-                $"[expectations] no tests/expectations manifest found (probed {cwdCandidate}" +
-                (bundleCountForPrint > 0 ? $" and the ancestor tree of {bundleCountForPrint} bundle path(s)" : "") +
-                ") — expect-oos / expect-fail-known-gap / expect-divergence classification is OFF " +
-                "this run. Pass --expectations DIR to set it explicitly."));
+            // #2097: deferred — see `deferredStartupLines`'s declaration above. The message is
+            // built now, so the closure prints exactly what this generation probed.
+            var notFoundMessage = AlRunner.Infrastructure.ExpectationsDirectoryResolution.BuildNotFoundMessage(probeCwd, bundles.Count);
+            deferredStartupLines.Add(() => Console.Error.WriteLine(notFoundMessage));
         }
     }
     if (expectationsDir != null)
@@ -2430,7 +2424,7 @@ foreach (var bundle in bundles)
 {
     i2++;
     var bundleAbs = Path.GetFullPath(bundle);
-    var rel = Path.GetRelativePath(Environment.CurrentDirectory, bundleAbs);
+    var rel = AlRunner.Infrastructure.WorkingDirectory.DisplayPath(bundleAbs, AlRunner.Infrastructure.WorkingDirectory.TryGet());
     AlRunner.Infrastructure.PhaseLog.BeginBundle(rel, i2);
 
     // Watch mode re-runs the SAME process across edits, so drop the previous
@@ -4570,7 +4564,7 @@ if (coverageEnabled)
     // working directory so cobertura's <source> (".") lines up with the filename
     // attributes, matching v1's convention.
     var coverageSourceMap = AlRunner.Infrastructure.AlCoverageSourceMap.Build(
-        bundles, relativeTo: Directory.GetCurrentDirectory());
+        bundles, relativeTo: AlRunner.Infrastructure.WorkingDirectory.TryGet());   // #3120: null → absolute filenames
     var coverageStatements = AlRunner.Infrastructure.AlCoverageTracker.Collect(coverageSourceMap);
     List<AlRunner.Infrastructure.AlCoverageReport.FileCoverage>? coverageFiles = null;
     var coverageProblem = AlRunner.Infrastructure.OutputPaths.TryWrite("--coverage-out", coverageOutputPath,
@@ -5032,8 +5026,8 @@ return strictExitCode ? computedExitCode : 0;
         {
             if (cancellationToken.IsCancellationRequested) break;
             bundleIndex++;
-            var relBundle = Path.GetRelativePath(
-                Environment.CurrentDirectory, Path.GetFullPath(bundleDir));
+            var relBundle = AlRunner.Infrastructure.WorkingDirectory.DisplayPath(
+                Path.GetFullPath(bundleDir), AlRunner.Infrastructure.WorkingDirectory.TryGet());
             AlRunner.Infrastructure.PhaseLog.BeginBundle(relBundle, bundleIndex);
             // #2603: see the two comments above. An earlier bundle fell back, or a dependency of
             // this bundle is listed after it and changed this cycle — either way this bundle must


### PR DESCRIPTION
Closes #3120

Written by agent `stma-auto2-1` on the account holder's behalf.

## What changed

If the runner starts in a working directory that has been deleted (`cd d && rm -rf d && exec …`), it no longer crashes with exit 134. It treats "the working directory can't be read" as "there is no working directory" and finishes the run.

- New `AlRunner/Infrastructure/WorkingDirectory.cs`. `TryGet()` returns `null` when getcwd(2) fails (it catches `IOException` and `UnauthorizedAccessException`). `DisplayPath(abs, cwd)` returns the absolute path when `cwd` is null.
- `ExpectationsDirectoryResolution.Resolve` now accepts a null cwd and skips only the cwd probe. The bundle-ancestor walk from #1984 still runs.
- `ExpectationsDirectoryResolution.BuildNotFoundMessage` builds the "[expectations] no manifest found" line. The wording is unchanged when a cwd exists. When there is none, the line says `the working directory could not be read, so it was not probed` instead of naming a candidate path.
- In `Program.cs`, every read of the working directory now goes through the helper: the expectations probe, the not-found message, the per-bundle label in the normal run loop and in the server loop, and the coverage source map's `relativeTo`. With no cwd, coverage filenames are absolute, and the report's `<source>.</source>` root still resolves them.

### Which of the issue's two options, and why

The issue offered two options: exit 2, or fall back to the bundle-ancestor probe. I chose the fallback because I measured that the run can actually finish. I patched the first two crash sites locally and ran the `RecordTriggerXRec` fixture from a deleted working directory. The result was `pass: 1`, exit 0. Every bundle path is absolute at that point, so the working directory only fed a secondary probe, a display label and coverage's relative filenames. Failing with exit 2 would turn a run that can finish into a failure.

The issue names line 843 (now 913/920). After that crash is fixed, the next crash is in the per-bundle label (`Path.GetRelativePath(Environment.CurrentDirectory, …)`, measured at `Program.cs:2433`, also exit 134). So fixing only the reported line would still have crashed.

## RED → GREEN

`dotnet test AlRunner.Tests -c Release --filter FullyQualifiedName~UnlinkedWorkingDirectoryTests` (12 tests: 9 unit, 3 end-to-end that start the runner from a deleted working directory, Linux only):

- RED, with the helper in place but `Program.cs` not yet using it (commit db4a4e0a): `Failed: 3, Passed: 9, Total: 12`. All 3 end-to-end tests failed on `Assert.DoesNotContain("Unhandled exception")`.
- GREEN (commit 7e92b6a9): `Failed: 0, Passed: 12, Total: 12`.

## Mutations

Each mutation changed one value or call and was rebuilt with `0 Error(s)`. Every red was an `Assert.` failure, not a build error. Each file was restored afterwards.

| mutation | result | tests that went red |
|---|---|---|
| probe: `probeCwd = Environment.CurrentDirectory` | `Failed: 3, Passed: 9` | the 3 end-to-end tests (crash) |
| per-bundle label back to `GetRelativePath(Environment.CurrentDirectory, …)` | `Failed: 3, Passed: 9` | the 3 end-to-end tests (crash, after the probe) |
| coverage `relativeTo: Directory.GetCurrentDirectory()` | `Failed: 1, Passed: 11` | only `Coverage_…WritesAbsoluteFilenames` |
| not-found message: drop the "could not be read" clause | `Failed: 2, Passed: 10` | the `NotFoundMessage_WithNoWorkingDirectory` unit test and the no-manifest end-to-end test |
| helper: catch `InvalidOperationException` instead of `IOException` | `Failed: 4, Passed: 8` | the `TryGet` FileNotFound unit test and the 3 end-to-end tests |

The probe mutation and the label mutation fail the same 3 tests. The first test's `[expectations] loaded … from <repo>/tests/expectations` assertion is what shows the bundle-ancestor walk ran, rather than the probe being skipped.

**Not covered end to end:** the server-mode per-bundle label (the `relBundle` site in the `--server` loop). It calls the same `DisplayPath`/`TryGet` pair, which the unit tests cover. I measured this: reverting only that call site to `Path.GetRelativePath(Environment.CurrentDirectory, …)` left the filter at `Failed: 0, Passed: 12`. I didn't start a `--server` session from a deleted working directory, because that harness costs much more than this one call site is worth.

## Other tests run locally

- `--settings engine.runsettings` (after `tools/engine-test-bootstrap.sh`), filtered to `UnlinkedWorkingDirectoryTests | ExpectationsDirectoryResolution | ExpectationManifestWiring | CacheRootStartupFailure | GuardTests | Coverage | CliDocumentation`: `Failed: 0, Passed: 397, Total: 397`.
- `tools/test_*.py`: 3 failed on this machine, all at `git commit` inside a scratch repo the test creates. `test_agent_self_freshness` and `test_corpus_checkout` print `error: 1Password: agent returned an error` (local commit signing). `test_preflight` fails the same way with exit 128 at its `lag_repo` commit. This PR touches nothing under `tools/`.

**Caching:** all three end-to-end tests use `--no-cache`, so they only exercise a cold run. No cache sits between this change and what the tests check. The probe, the not-found line and both bundle labels all run before any cache lookup, and the coverage source map is scanned from the bundle roots on every run.

## Fix the shape

1. **Same pattern at other call sites?** I listed every `Environment.CurrentDirectory` / `Directory.GetCurrentDirectory()` read under `AlRunner/` with `rg`, excluding comment lines. There were five, all in `Program.cs`, and all five now go through the helper. The only remaining direct read is inside `WorkingDirectory.TryGet`.
2. **Sibling functions with the same assumption?** `ExpectationsDirectoryResolution.Resolve` already caught a failing `GetFullPath(currentDirectory)`, but its caller crashed while computing the argument. It now takes `string?`. `AlCoverageSourceMap.Build` already handled `relativeTo: null` as absolute paths, so it needed no change.
3. **Two paths writing the same state with different guards?** The normal run loop and the server loop both compute the bundle label, and both now use `DisplayPath`. Relative user inputs (a relative bundle or `--cache` from a deleted working directory) can't be resolved at all. I checked the bundle case on this branch: a relative bundle `relbundle` from a deleted working directory exits 2 with `al-runner: not a usable path: relbundle` / `FileNotFoundException`. #3111's tests already cover `--cache`. This PR doesn't change either.

**Issue queue scan** (`working directory`, `getcwd`, `CurrentDirectory`, `exit 134`, `Unhandled exception`): the only match on this defect is #3120 itself. #2114 (a missing `$HOME`, the same crash shape) was already fixed. Nothing to fold in.

## Corpus

No corpus test applies. A deleted working directory is an OS/process state that AL code can't produce or observe. The diff doesn't touch `Patches/`, `Rewriters/`, `NclCecilRewrite*`, `BcCompiler*` or `BcAssembler.cs`, so the corpus-linkage gate doesn't apply. The proving tests are in `AlRunner.Tests/UnlinkedWorkingDirectoryTests.cs`. Its unlinked-cwd launcher is copied from `CacheRootStartupFailureTests`, where the helpers are private.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
