### PR TITLE
fix(log): classify every hyphenated component tag and gate the one chatter site

### DIFF
--- a/AlRunner.Tests/LogHyphenatedTagContractTests.cs
+++ b/AlRunner.Tests/LogHyphenatedTagContractTests.cs
@@ -23,7 +23,7 @@ public sealed class LogHyphenatedTagContractTests
     public enum Kind { Loud, OptIn, VerboseGated }
 
     /// <param name="Anchor">Required when one file carries the tag at sites of different kinds.</param>
-    /// <param name="Gate">OptIn only: the switch that must appear within <see cref="GateWindow"/> lines above.</param>
+    /// <param name="Gate">OptIn only: a regex for the switch an `if (` line within <see cref="GateWindow"/> lines above must test.</param>
     public sealed record Site(string File, string Tag, Kind Kind, string? Anchor = null, string? Gate = null);
 
     private const int GateWindow = 40;
@@ -64,21 +64,21 @@ public sealed class LogHyphenatedTagContractTests
         // --- OptIn: printed only when a switch the user set asks for it.
         new("AlRunner/BcCompiler.cs", "BcCompiler-diag", Kind.OptIn, Gate: "BCCOMPILER_DIAG"),
         new("AlRunner/BcCompiler.cs", "DIAG-RETRY", Kind.OptIn, Gate: "AL_RUNNER_DIAG_EMITRETRY"),
-        new("AlRunner/Program.cs", "FCE-NRE", Kind.OptIn, Gate: "AL_RUNNER_TRACE_NRE"),
+        new("AlRunner/Program.cs", "FCE-NRE", Kind.OptIn, Gate: @"\btraceNre\b"),
         new("AlRunner/Patches/RecordPatches.AggregatePermissionSetVirtualTable.cs", "aggregate-permission-set", Kind.OptIn, Gate: "AL_RUNNER_TRACE_AGGREGATE_PERMISSION_SET"),
         new("AlRunner/Patches/RecordPatches.AllProfileVirtualTable.cs", "all-profile", Kind.OptIn, Gate: "AL_RUNNER_TRACE_ALL_PROFILE"),
         new("AlRunner/Infrastructure/AlDapSession.cs", "dap-step-trace", Kind.OptIn, Gate: "_traceEnabled"),
-        new("AlRunner/DependencyMetadataProducer.cs", "dep-metadata", Kind.OptIn, Anchor: "{message}", Gate: "AL_RUNNER_TRACE_DEP_METADATA"),
-        new("AlRunner/BcAssembler.cs", "emit-timing", Kind.OptIn, Gate: "timing"),
-        new("AlRunner/BcCompiler.cs", "emit-timing", Kind.OptIn, Gate: "BCCOMPILER_TIMING"),
-        new("AlRunner/BcCompiler.Incremental.cs", "emit-timing", Kind.OptIn, Gate: "BCCOMPILER_TIMING"),
+        new("AlRunner/DependencyMetadataProducer.cs", "dep-metadata", Kind.OptIn, Anchor: "{message}", Gate: @"\bt == ""[12]"""),
+        new("AlRunner/BcAssembler.cs", "emit-timing", Kind.OptIn, Gate: @"\btiming\b"),
+        new("AlRunner/BcCompiler.cs", "emit-timing", Kind.OptIn, Gate: @"BCCOMPILER_TIMING|\b_timing\b"),
+        new("AlRunner/BcCompiler.Incremental.cs", "emit-timing", Kind.OptIn, Gate: @"\btiming\b"),
         new("AlRunner/Program.cs", "first-chance", Kind.OptIn, Gate: "fcFilter"),
         new("AlRunner/Infrastructure/JmpHook.cs", "hook-audit", Kind.OptIn, Gate: "_audit"),
         new("AlRunner/Program.cs", "instrumentation-counters", Kind.OptIn, Gate: "AL_RUNNER_DUMP_INSTRUMENTATION_COUNTERS"),
         new("AlRunner/MemoryCensus.cs", "mem-census", Kind.OptIn, Gate: "Enabled"),
-        new("AlRunner/Patches/ObjectMetadataRegistry.cs", "object-metadata", Kind.OptIn, Gate: "AL_RUNNER_TRACE_OBJECT_METADATA"),
-        new("AlRunner/Patches/RunnerPageInstance.cs", "option-captions", Kind.OptIn, Gate: "AL_RUNNER_TRACE_PAGE_METADATA"),
-        new("AlRunner/Patches/PageMetadataRegistry.cs", "page-metadata", Kind.OptIn, Gate: "AL_RUNNER_TRACE_PAGE_METADATA"),
+        new("AlRunner/Patches/ObjectMetadataRegistry.cs", "object-metadata", Kind.OptIn, Gate: @"\btrace == "),
+        new("AlRunner/Patches/RunnerPageInstance.cs", "option-captions", Kind.OptIn, Gate: @"\(trace\)"),
+        new("AlRunner/Patches/PageMetadataRegistry.cs", "page-metadata", Kind.OptIn, Gate: @"\btrace == "),
         new("AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs", "page-metadata", Kind.OptIn, Gate: "AL_RUNNER_TRACE_PAGE_METADATA_SOURCE"),
         new("AlRunner/Patches/RecordPatches.RealPageMetadata.cs", "page-metadata", Kind.OptIn, Gate: "AL_RUNNER_TRACE_PAGE_METADATA"),
         new("AlRunner/Patches/RecordPatches.PageTriggerMetadata.cs", "page-trigger-audit", Kind.OptIn, Gate: "Enabled"),
@@ -89,11 +89,11 @@ public sealed class LogHyphenatedTagContractTests
         new("AlRunner/Patches/RecordPatches.PermissionSystemTable.cs", "permission-table", Kind.OptIn, Gate: "AL_RUNNER_TRACE_PERMISSION_TABLE"),
         new("AlRunner/Patches/RecordPatches.MetaQueryFromBcDocument.cs", "query-metadata", Kind.OptIn, Gate: "AL_RUNNER_TRACE_QUERY_METADATA_SOURCE"),
         new("AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs", "report-metadata", Kind.OptIn, Gate: "AL_RUNNER_TRACE_REPORT_METADATA"),
-        new("AlRunner/BcCompiler.cs", "shared-refs", Kind.OptIn, Gate: "BCCOMPILER_TIMING"),
-        new("AlRunner/Patches/RecordPatches.NclMetaTableFromBcDocument.cs", "table-metadata", Kind.OptIn, Gate: "AL_RUNNER_TRACE_TABLE_METADATA_SOURCE"),
-        new("AlRunner/Patches/RecordPatches.TableMetadataVirtualTable.cs", "table-metadata", Kind.OptIn, Gate: "AL_RUNNER_TRACE_TABLE_METADATA"),
+        new("AlRunner/BcCompiler.cs", "shared-refs", Kind.OptIn, Gate: @"\btiming\b"),
+        new("AlRunner/Patches/RecordPatches.NclMetaTableFromBcDocument.cs", "table-metadata", Kind.OptIn, Gate: @"\blevel != "),
+        new("AlRunner/Patches/RecordPatches.TableMetadataVirtualTable.cs", "table-metadata", Kind.OptIn, Gate: @"\btrace\b"),
         new("AlRunner/Patches/RecordPatches.RealXmlPortMetadata.cs", "xmlport-metadata", Kind.OptIn, Gate: "AL_RUNNER_TRACE_XMLPORT_METADATA"),
-        new("AlRunner/Patches/XmlPortMetadataRegistry.cs", "xmlport-metadata", Kind.OptIn, Gate: "AL_RUNNER_TRACE_XMLPORT_METADATA"),
+        new("AlRunner/Patches/XmlPortMetadataRegistry.cs", "xmlport-metadata", Kind.OptIn, Gate: @"\btrace == "),
 
         // --- VerboseGated: internal chatter on a healthy run. Hidden by its own call-site gate.
         new("AlRunner/Infrastructure/AssemblyTypeIndex.cs", "type-index", Kind.VerboseGated, Anchor: "falling back to Assembly.GetTypes()"),
@@ -207,8 +207,13 @@ public sealed class LogHyphenatedTagContractTests
         var ungated = ScanProductionSource()
             .Select(f => (f, site: Resolve(f)))
             .Where(x => x.site is { Kind: Kind.OptIn })
-            .Where(x => !Window(x.f, GateWindow, 0).Any(l => l.Contains(x.site!.Gate!, StringComparison.Ordinal)))
-            .Select(x => $"{x.f.File}:{x.f.Line + 1} [{x.f.Tag}] expected gate '{x.site!.Gate}'")
+            // The token must sit in an `if (` line: a field or local declaring the switch nearby
+            // is not a gate, and matching it alone let a deleted `if (!_audit) return;` pass.
+            .Where(x => !Window(x.f, GateWindow, 0).Any(l =>
+                !l.TrimStart().StartsWith("//", StringComparison.Ordinal)
+                && l.Contains("if (", StringComparison.Ordinal)
+                && Regex.IsMatch(l, x.site!.Gate!)))
+            .Select(x => $"{x.f.File}:{x.f.Line + 1} [{x.f.Tag}] expected an `if (` testing '{x.site!.Gate}'")
             .ToList();
         Assert.True(ungated.Count == 0,
             "an OptIn trace lost its switch and now prints on every run:\n  " + string.Join("\n  ", ungated));

--- a/AlRunner.Tests/LogHyphenatedTagContractTests.cs
+++ b/AlRunner.Tests/LogHyphenatedTagContractTests.cs
@@ -1,0 +1,243 @@
+// LogHyphenatedTagContractTests — issue #2257.
+//
+// Log's ComponentTag pattern has no `-` in its character class, so a hyphenated tag is never
+// filtered: its call site alone decides whether it prints. That is the contract, not an
+// accident, because every hyphenated call site in AlRunner/ is one of three kinds and a
+// widened pattern breaks two of them — a Loud line (a failure or a result) would vanish at
+// default verbosity, and an OptIn trace (behind AL_RUNNER_TRACE_*, BCCOMPILER_TIMING, …) would
+// print nothing when its switch is set, because the switch does not set Log.Verbose.
+// Chatter is gated with `if (Log.Verbose)` at the site instead (#2239's lever).
+// Classification and the reasoning per tag: docs/log-filter.md#hyphenated-tags.
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Serial: swaps the process-wide Console writers and Log.Verbose. See ConsoleFilterSerialCollection.
+[Collection(ConsoleFilterSerialCollection.Name)]
+public sealed class LogHyphenatedTagContractTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    public enum Kind { Loud, OptIn, VerboseGated }
+
+    /// <param name="Anchor">Required when one file carries the tag at sites of different kinds.</param>
+    /// <param name="Gate">OptIn only: the switch that must appear within <see cref="GateWindow"/> lines above.</param>
+    public sealed record Site(string File, string Tag, Kind Kind, string? Anchor = null, string? Gate = null);
+
+    private const int GateWindow = 40;
+
+    private static readonly Site[] Declared =
+    {
+        // --- Loud: a failure, a refusal, or a result the user asked for. Must print by default.
+        new("AlRunner/Infrastructure/AlNavNameReflection.cs", "al-locals", Kind.Loud),
+        new("AlRunner/Infrastructure/InProcessAppPackager.cs", "bc-floor", Kind.Loud),
+        new("AlRunner/Program.cs", "count-baseline", Kind.Loud),
+        new("AlRunner/Program.cs", "count-out", Kind.Loud),
+        new("AlRunner/DependencyLoader.cs", "dep-load-fail", Kind.Loud),
+        new("AlRunner/Infrastructure/DependencyLoadException.cs", "dep-load-fail", Kind.Loud),
+        new("AlRunner/DependencyLoader.cs", "dep-metadata", Kind.Loud),
+        new("AlRunner/DependencyMetadataProducer.cs", "dep-metadata", Kind.Loud, Anchor: "cache write failed"),
+        new("AlRunner/DependencyMetadataProducer.cs", "dep-metadata-fail", Kind.Loud),
+        new("AlRunner/InstallTriggerRunner.cs", "install-trigger", Kind.Loud),
+        new("AlRunner/Patches/ApplicationObjectBasePatches.cs", "oos-in-try", Kind.Loud),
+        new("AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs", "page-control-field", Kind.Loud),
+        new("AlRunner/Infrastructure/PhaseLog.cs", "phase-log", Kind.Loud),
+        new("AlRunner/Infrastructure/ProvisioningCheck.cs", "provision-gap", Kind.Loud),
+        new("AlRunner/Patches/RecordPatches.ReportRowFromBcDocument.cs", "report-metadata", Kind.Loud),
+        new("AlRunner/Infrastructure/ServiceTierDllIndex.cs", "servicetier-dll", Kind.Loud, Anchor: "failed to load"),
+        new("AlRunner/Infrastructure/ServiceTierDllIndex.cs", "servicetier-dll", Kind.Loud, Anchor: "index skip"),
+        // [source-dep] is the source-sibling twin of the exempt [layered] progress lines, and
+        // CacheRootsIsolationTests asserts `[source-dep] WROTE` in a default-verbosity run.
+        new("AlRunner/ProgramSupport/SiblingCompile.cs", "source-dep", Kind.Loud),
+        new("AlRunner/Infrastructure/AlCoverageSourceMap.cs", "source-map", Kind.Loud),
+        new("AlRunner/Infrastructure/MissingTestDataDiagnosis.cs", "test-data", Kind.Loud),
+        new("AlRunner/Infrastructure/TestDataNormalization.cs", "test-data", Kind.Loud),
+        new("AlRunner/TestDataProvisioner.cs", "test-data", Kind.Loud),
+        new("AlRunner/TestExecutor.cs", "test-exec", Kind.Loud),
+        // Unlike the two gated siblings below, these three mean event subscribers were NOT registered.
+        new("AlRunner/Infrastructure/AssemblyTypeIndex.cs", "type-index", Kind.Loud, Anchor: "cannot be registered"),
+        new("AlRunner/Infrastructure/AssemblyTypeIndex.cs", "type-index", Kind.Loud, Anchor: "GetMethods failed"),
+        new("AlRunner/Infrastructure/AssemblyTypeIndex.cs", "type-index", Kind.Loud, Anchor: "no matching declared MethodInfo"),
+
+        // --- OptIn: printed only when a switch the user set asks for it.
+        new("AlRunner/BcCompiler.cs", "BcCompiler-diag", Kind.OptIn, Gate: "BCCOMPILER_DIAG"),
+        new("AlRunner/BcCompiler.cs", "DIAG-RETRY", Kind.OptIn, Gate: "AL_RUNNER_DIAG_EMITRETRY"),
+        new("AlRunner/Program.cs", "FCE-NRE", Kind.OptIn, Gate: "AL_RUNNER_TRACE_NRE"),
+        new("AlRunner/Patches/RecordPatches.AggregatePermissionSetVirtualTable.cs", "aggregate-permission-set", Kind.OptIn, Gate: "AL_RUNNER_TRACE_AGGREGATE_PERMISSION_SET"),
+        new("AlRunner/Patches/RecordPatches.AllProfileVirtualTable.cs", "all-profile", Kind.OptIn, Gate: "AL_RUNNER_TRACE_ALL_PROFILE"),
+        new("AlRunner/Infrastructure/AlDapSession.cs", "dap-step-trace", Kind.OptIn, Gate: "_traceEnabled"),
+        new("AlRunner/DependencyMetadataProducer.cs", "dep-metadata", Kind.OptIn, Anchor: "{message}", Gate: "AL_RUNNER_TRACE_DEP_METADATA"),
+        new("AlRunner/BcAssembler.cs", "emit-timing", Kind.OptIn, Gate: "timing"),
+        new("AlRunner/BcCompiler.cs", "emit-timing", Kind.OptIn, Gate: "BCCOMPILER_TIMING"),
+        new("AlRunner/BcCompiler.Incremental.cs", "emit-timing", Kind.OptIn, Gate: "BCCOMPILER_TIMING"),
+        new("AlRunner/Program.cs", "first-chance", Kind.OptIn, Gate: "fcFilter"),
+        new("AlRunner/Infrastructure/JmpHook.cs", "hook-audit", Kind.OptIn, Gate: "_audit"),
+        new("AlRunner/Program.cs", "instrumentation-counters", Kind.OptIn, Gate: "AL_RUNNER_DUMP_INSTRUMENTATION_COUNTERS"),
+        new("AlRunner/MemoryCensus.cs", "mem-census", Kind.OptIn, Gate: "Enabled"),
+        new("AlRunner/Patches/ObjectMetadataRegistry.cs", "object-metadata", Kind.OptIn, Gate: "AL_RUNNER_TRACE_OBJECT_METADATA"),
+        new("AlRunner/Patches/RunnerPageInstance.cs", "option-captions", Kind.OptIn, Gate: "AL_RUNNER_TRACE_PAGE_METADATA"),
+        new("AlRunner/Patches/PageMetadataRegistry.cs", "page-metadata", Kind.OptIn, Gate: "AL_RUNNER_TRACE_PAGE_METADATA"),
+        new("AlRunner/Patches/RecordPatches.PageControlFieldFromBcDocument.cs", "page-metadata", Kind.OptIn, Gate: "AL_RUNNER_TRACE_PAGE_METADATA_SOURCE"),
+        new("AlRunner/Patches/RecordPatches.RealPageMetadata.cs", "page-metadata", Kind.OptIn, Gate: "AL_RUNNER_TRACE_PAGE_METADATA"),
+        new("AlRunner/Patches/RecordPatches.PageTriggerMetadata.cs", "page-trigger-audit", Kind.OptIn, Gate: "Enabled"),
+        new("AlRunner/Patches/RecordPatches.TableTriggerMetadata.cs", "table-trigger-audit", Kind.OptIn, Gate: "Enabled"),
+        new("AlRunner/Patches/RecordPatches.cs", "parse-counts", Kind.OptIn, Gate: "AL_RUNNER_TRACE_PARSE_COUNTS"),
+        new("AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs", "perm-metadata", Kind.OptIn, Gate: "AL_RUNNER_DIAG_PERMMETA"),
+        new("AlRunner/Patches/RecordPatches.PermissionSetFromBcDocument.cs", "perm-metadata", Kind.OptIn, Gate: "AL_RUNNER_DIAG_PERMMETA"),
+        new("AlRunner/Patches/RecordPatches.PermissionSystemTable.cs", "permission-table", Kind.OptIn, Gate: "AL_RUNNER_TRACE_PERMISSION_TABLE"),
+        new("AlRunner/Patches/RecordPatches.MetaQueryFromBcDocument.cs", "query-metadata", Kind.OptIn, Gate: "AL_RUNNER_TRACE_QUERY_METADATA_SOURCE"),
+        new("AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs", "report-metadata", Kind.OptIn, Gate: "AL_RUNNER_TRACE_REPORT_METADATA"),
+        new("AlRunner/BcCompiler.cs", "shared-refs", Kind.OptIn, Gate: "BCCOMPILER_TIMING"),
+        new("AlRunner/Patches/RecordPatches.NclMetaTableFromBcDocument.cs", "table-metadata", Kind.OptIn, Gate: "AL_RUNNER_TRACE_TABLE_METADATA_SOURCE"),
+        new("AlRunner/Patches/RecordPatches.TableMetadataVirtualTable.cs", "table-metadata", Kind.OptIn, Gate: "AL_RUNNER_TRACE_TABLE_METADATA"),
+        new("AlRunner/Patches/RecordPatches.RealXmlPortMetadata.cs", "xmlport-metadata", Kind.OptIn, Gate: "AL_RUNNER_TRACE_XMLPORT_METADATA"),
+        new("AlRunner/Patches/XmlPortMetadataRegistry.cs", "xmlport-metadata", Kind.OptIn, Gate: "AL_RUNNER_TRACE_XMLPORT_METADATA"),
+
+        // --- VerboseGated: internal chatter on a healthy run. Hidden by its own call-site gate.
+        new("AlRunner/Infrastructure/AssemblyTypeIndex.cs", "type-index", Kind.VerboseGated, Anchor: "falling back to Assembly.GetTypes()"),
+        new("AlRunner/Infrastructure/ServiceTierDllIndex.cs", "servicetier-dll", Kind.VerboseGated, Anchor: "indexed "),
+    };
+
+    /// <summary>A hyphenated-tag string literal found in production source.</summary>
+    private sealed record Found(string File, string Tag, int Line, string[] Lines, string Rendered);
+
+    private static readonly Regex HyphenTagLiteral = new(
+        "(?:\\$@|@\\$|\\$|@)?\"(?<lit>\\[(?<tag>[A-Za-z][A-Za-z0-9._+]*-[A-Za-z0-9._+-]*)\\](?:[^\"\\\\]|\\\\.)*)\"",
+        RegexOptions.Compiled);
+
+    private static List<Found> ScanProductionSource()
+    {
+        var root = Path.Combine(RepoRoot, "AlRunner");
+        Assert.True(Directory.Exists(root), $"production source not found at {root}");
+        var found = new List<Found>();
+        foreach (var path in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+        {
+            var rel = Path.GetRelativePath(RepoRoot, path).Replace('\\', '/');
+            if (rel.Contains("/obj/") || rel.Contains("/bin/")) continue;
+            var lines = File.ReadAllLines(path);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (lines[i].TrimStart().StartsWith("//", StringComparison.Ordinal)) continue;
+                foreach (Match m in HyphenTagLiteral.Matches(lines[i]))
+                {
+                    var rendered = Regex.Replace(m.Groups["lit"].Value, @"\{[^{}]*\}", "<value>");
+                    found.Add(new Found(rel, m.Groups["tag"].Value, i, lines, rendered));
+                }
+            }
+        }
+        // Guard against a scan that silently matched nothing (moved tree, broken pattern).
+        Assert.True(found.Count >= 50, $"scan found only {found.Count} hyphenated-tag literals; expected ~100");
+        return found;
+    }
+
+    private static IEnumerable<Site> Matching(Found f) => Declared.Where(d =>
+        d.File == f.File && d.Tag == f.Tag &&
+        (d.Anchor == null || Window(f, 3, 3).Any(l => l.Contains(d.Anchor, StringComparison.Ordinal))));
+
+    private static IEnumerable<string> Window(Found f, int before, int after) =>
+        f.Lines.Skip(Math.Max(0, f.Line - before)).Take(Math.Min(f.Line, before) + 1 + after);
+
+    /// <summary>Sites in one (file, tag) group with anchors win over an anchor-less entry.</summary>
+    private static Site? Resolve(Found f)
+    {
+        var hits = Matching(f).ToList();
+        var anchored = hits.Where(h => h.Anchor != null).ToList();
+        if (anchored.Count == 1) return anchored[0];
+        return anchored.Count == 0 && hits.Count == 1 ? hits[0] : null;
+    }
+
+    private static string FilterOnce(string line, bool verbose)
+    {
+        var savedOut = Console.Out;
+        var savedErr = Console.Error;
+        var savedVerbose = Log.Verbose;
+        var sink = new StringWriter();
+        try
+        {
+            Console.SetOut(sink);
+            Console.SetError(sink);
+            Log.Install();
+            Log.Verbose = verbose;
+            Console.Error.WriteLine(line);
+            return sink.ToString();
+        }
+        finally
+        {
+            Log.Verbose = savedVerbose;
+            Console.SetOut(savedOut);
+            Console.SetError(savedErr);
+        }
+    }
+
+    [Fact]
+    public void EveryHyphenatedTagSite_IsClassified_AndNoDeclarationIsStale()
+    {
+        var found = ScanProductionSource();
+        var unclassified = found.Where(f => Resolve(f) == null)
+            .Select(f => $"{f.File}:{f.Line + 1} [{f.Tag}] ({Matching(f).Count()} matching declaration(s))")
+            .ToList();
+        Assert.True(unclassified.Count == 0,
+            "hyphenated-tag call sites need a visibility decision in Declared (Loud / OptIn / VerboseGated):\n  "
+            + string.Join("\n  ", unclassified));
+
+        var used = found.Select(Resolve).Where(s => s != null).ToHashSet();
+        var stale = Declared.Where(d => !used.Contains(d)).Select(d => $"{d.File} [{d.Tag}] {d.Anchor}").ToList();
+        Assert.True(stale.Count == 0, "declarations matching no call site:\n  " + string.Join("\n  ", stale));
+    }
+
+    /// <summary>Loud and OptIn lines must reach the terminal without --verbose, read from the real call site.</summary>
+    [Fact]
+    public void LoudAndOptInSites_SurviveTheDefaultFilter()
+    {
+        var eaten = ScanProductionSource()
+            .Where(f => Resolve(f) is { Kind: Kind.Loud or Kind.OptIn })
+            .Where(f => !FilterOnce(f.Rendered, verbose: false).Contains(f.Rendered, StringComparison.Ordinal))
+            .Select(f => $"{f.File}:{f.Line + 1} {f.Rendered}")
+            .ToList();
+        Assert.True(eaten.Count == 0,
+            "the default filter drops lines whose visibility their call site already decided:\n  "
+            + string.Join("\n  ", eaten));
+    }
+
+    [Fact]
+    public void OptInSites_AreBehindTheirSwitch()
+    {
+        var ungated = ScanProductionSource()
+            .Select(f => (f, site: Resolve(f)))
+            .Where(x => x.site is { Kind: Kind.OptIn })
+            .Where(x => !Window(x.f, GateWindow, 0).Any(l => l.Contains(x.site!.Gate!, StringComparison.Ordinal)))
+            .Select(x => $"{x.f.File}:{x.f.Line + 1} [{x.f.Tag}] expected gate '{x.site!.Gate}'")
+            .ToList();
+        Assert.True(ungated.Count == 0,
+            "an OptIn trace lost its switch and now prints on every run:\n  " + string.Join("\n  ", ungated));
+    }
+
+    [Fact]
+    public void VerboseGatedSites_CarryAnExplicitLogVerboseGate()
+    {
+        var sites = ScanProductionSource().Where(f => Resolve(f) is { Kind: Kind.VerboseGated }).ToList();
+        Assert.True(sites.Count >= 3, $"expected at least 3 VerboseGated sites, found {sites.Count}");
+        var ungated = sites
+            .Where(f => !Window(f, 3, 0).Any(l =>
+                !l.TrimStart().StartsWith("//", StringComparison.Ordinal) && l.Contains("Log.Verbose", StringComparison.Ordinal)))
+            .Select(f => $"{f.File}:{f.Line + 1} {f.Rendered}")
+            .ToList();
+        Assert.True(ungated.Count == 0,
+            "internal chatter with a hyphenated tag prints at default verbosity unless its call site gates it:\n  "
+            + string.Join("\n  ", ungated));
+    }
+
+    /// <summary>The four tag shapes the filter distinguishes (#2257, point 2).</summary>
+    [Theory]
+    [InlineData("[Cecil] rewriting NavDialog", false)]            // plain: suppressed
+    [InlineData("[Foo.Bar] dotted component", false)]             // dotted: suppressed
+    [InlineData("[dep-load-fail] X v1: EMIT-FAIL — boom", true)]  // hyphenated: call site decides
+    [InlineData("[bc] selected BC 28.1", true)]                   // exemption list
+    public void TagShapes_DefaultVerbosity(string line, bool visible)
+    {
+        Assert.Equal(visible, FilterOnce(line, verbose: false).Contains(line, StringComparison.Ordinal));
+        Assert.Contains(line, FilterOnce(line, verbose: true));
+    }
+}

--- a/AlRunner/Infrastructure/ServiceTierDllIndex.cs
+++ b/AlRunner/Infrastructure/ServiceTierDllIndex.cs
@@ -176,7 +176,9 @@ public static class ServiceTierDllIndex
         }
         catch { /* index cache is an optimization; ignore write failures */ }
 
-        Console.Error.WriteLine($"[servicetier-dll] indexed {map.Count} objects across {dlls.Count} DLLs in {Path.GetFileName(dir)}");
+        // Hyphenated tags bypass Log's filter, so this healthy-run chatter needs its own gate (#2257).
+        if (AlRunner.Log.Verbose)
+            Console.Error.WriteLine($"[servicetier-dll] indexed {map.Count} objects across {dlls.Count} DLLs in {Path.GetFileName(dir)}");
         return map;
     }
 

--- a/AlRunner/Log.cs
+++ b/AlRunner/Log.cs
@@ -62,17 +62,11 @@ public static class Log
     // word, so `[dep]` is exempt and `[deps]` is a different tag that is not (deliberately —
     // see #2750). Two further properties of the pattern are easy to misread:
     //
-    //   * the tag character class `[A-Za-z0-9._+]` has NO HYPHEN, so every hyphenated tag —
-    //     `[test-data]`, `[provision-gap]`, `[count-baseline]`, `[dep-load-fail]`, … — fails
-    //     the pattern and passes through whether or not anyone intended it. That is
-    //     load-bearing and pinned by LogUserFacingTagsTests; do not "tidy" the class.
-    //     It is ALSO accidental for most of them: punctuation, not intent, decides. #2257
-    //     owns that — it tracks the whole set and the per-tag decision each one needs, and
-    //     it is where the count lives, so this comment does not carry a number that would
-    //     rot here. Re-measured 2026-09-06 for that issue: 30 distinct hyphenated tags
-    //     across 83 console-output call sites, several plainly internal (`[type-index]`,
-    //     `[emit-timing]`, `[mem-census]`, `[instrumentation-counters]`, `[DIAG-RETRY]`).
-    //     Retagging that set is #2257's job, deliberately not this change's.
+    //   * the tag character class `[A-Za-z0-9._+]` has NO HYPHEN, so a hyphenated tag is never
+    //     filtered and its call site alone decides visibility. Do not add `-`: it would hide
+    //     every failure line using one and silence every AL_RUNNER_TRACE_*-style switch, which
+    //     does not set Verbose. LogHyphenatedTagContractTests classifies each such call site
+    //     (see docs/log-filter.md#hyphenated-tags); a new one fails there until classified.
     //   * only the START of the value is examined, so a multi-line WriteLine is decided
     //     entirely by its first line.
     //

--- a/docs/log-filter.md
+++ b/docs/log-filter.md
@@ -1,0 +1,52 @@
+# Log's component-tag filter
+
+`AlRunner/Log.cs` wraps stdout and stderr and drops a line that starts with a `[Tag]` unless
+`--verbose` (or `AL_RUNNER_VERBOSE=1`) is set. A short exemption list (`[bc]`, `[dep]`,
+`[warn]`, …) stays visible. The reasons for each exemption are in the comment above the pattern.
+
+## Hyphenated tags
+
+The tag character class is `[A-Za-z0-9._+]`, with no hyphen, so a tag such as
+`[dep-load-fail]` never matches and is never filtered. Its call site decides whether it prints.
+Issue #2257 decided to keep it that way after classifying every call site, because a widened
+pattern breaks two of the three kinds below:
+
+| kind | what it is | why the filter must not touch it |
+|---|---|---|
+| **Loud** | a failure, a refusal, or a result the user asked for | hidden by default, it turns a real problem into silence |
+| **OptIn** | a trace behind its own switch (`AL_RUNNER_TRACE_*`, `AL_RUNNER_DIAG_*`, `BCCOMPILER_TIMING`, `AL_RUNNER_HOOK_AUDIT`, a feature's `Enabled` flag) | the switch does not set `Log.Verbose`, so a filtered trace prints nothing when asked for |
+| **VerboseGated** | chatter on a healthy run | hidden by an explicit `if (Log.Verbose)` at its call site, the lever #2239 used |
+
+`AlRunner.Tests/LogHyphenatedTagContractTests.cs` holds the classification. It scans
+`AlRunner/**/*.cs` for string literals that begin with a hyphenated `[tag]`, and fails when a
+site is unclassified, when a declaration matches nothing, when a Loud or OptIn line would not
+survive the default filter, when an OptIn line has no `if (` testing its switch within 40 lines,
+or when a VerboseGated line has no `Log.Verbose` gate right above it. The gate checks read
+source text, so they are proximity checks rather than proof of control flow.
+
+### Classification as of #2257
+
+Population: 42 distinct tags in string literals under `AlRunner/` (comment lines excluded). This
+is larger than the 26 in the issue and the 30 in an earlier count because it includes
+upper-case tags (`[DIAG-RETRY]`, `[FCE-NRE]`, `[BcCompiler-diag]`), return values printed
+elsewhere (`[provision-gap]`, `[test-exec]` warnings), and exception messages (`[al-locals]`).
+
+- **Loud:** `al-locals`, `bc-floor`, `count-baseline`, `count-out`, `dep-load-fail`,
+  `dep-metadata` (bad switch value, cache write failure), `dep-metadata-fail`,
+  `install-trigger`, `oos-in-try`, `page-control-field`, `phase-log`, `provision-gap`,
+  `report-metadata` (document parse fallback), `servicetier-dll` (load failure, index skip),
+  `source-dep`, `source-map`, `test-data`, `test-exec`, `type-index` (subscribers not
+  registered).
+- **OptIn:** `BcCompiler-diag`, `DIAG-RETRY`, `FCE-NRE`, `aggregate-permission-set`,
+  `all-profile`, `dap-step-trace`, `dep-metadata` (trace), `emit-timing`, `first-chance`,
+  `hook-audit`, `instrumentation-counters`, `mem-census`, `object-metadata`,
+  `option-captions`, `page-metadata`, `page-trigger-audit`, `parse-counts`, `perm-metadata`,
+  `permission-table`, `query-metadata`, `report-metadata` (trace), `shared-refs`,
+  `table-metadata`, `table-trigger-audit`, `xmlport-metadata`.
+- **VerboseGated:** `type-index` (reflection fallback), `servicetier-dll` (the "indexed N
+  objects" summary).
+
+`[source-dep]` is Loud because it is the source-sibling twin of the exempt `[layered]` progress
+lines, and `CacheRootsIsolationTests` asserts `[source-dep] WROTE` in a run without `--verbose`.
+
+Tags without a hyphen are a separate question, tracked in #2221.


### PR DESCRIPTION
Closes #2257

Written by agent stma-auto2-5 on the account holder's behalf.

## What changed

I did not add `-` to the tag character class. I classified every hyphenated call site instead, and gated the one that was actually chatter.

- `AlRunner.Tests/LogHyphenatedTagContractTests.cs` (new): scans `AlRunner/**/*.cs` for string literals starting with a hyphenated `[tag]` and holds a per-site decision, **Loud**, **OptIn** or **VerboseGated**. It fails when:
  - a site is unclassified, or a declaration matches nothing;
  - a Loud or OptIn line (the real literal read from source, holes replaced) does not survive the default filter;
  - an OptIn line has no `if (` testing its switch within 40 lines above it;
  - a VerboseGated line has no `Log.Verbose` gate right above it.
  
  The census works as a ratchet. A later PR that adds a hyphenated tag, or moves one to a new file, fails `EveryHyphenatedTagSite_IsClassified_AndNoDeclarationIsStale` until it adds a declaration. That is intentional: it forces the visibility decision this issue says nobody was making.
  
  It also has four tag-shape cases (plain, dotted, hyphenated, exempt), which is point 2 of the issue.
- `AlRunner/Infrastructure/ServiceTierDllIndex.cs`: `[servicetier-dll] indexed N objects across M DLLs` printed on every index rebuild. It now sits behind `if (AlRunner.Log.Verbose)`.
- `AlRunner/Log.cs`: the hyphen bullet said the behavior was accidental and pending #2257. It now states the decision in five lines and points to the doc.
- `docs/log-filter.md` (new, `#hyphenated-tags`): the three kinds, what the test checks, and the full classification. Log.cs's 16-line diff is the trimmed comment; the reasoning went here.

## Why not widen the pattern

Widening it breaks two of the three kinds:

1. **Loud lines disappear at default verbosity.** Examples: `[dep-load-fail]`, `[install-trigger]`, `[test-exec] SUITE ABORTED`, `[provision-gap]`, `[test-data]` and `[count-baseline]`. `LogUserFacingTagsTests` already pins `[provision-gap]` as surviving *because of* the hyphen.
2. **OptIn traces go quiet even when their switch is on.** `AL_RUNNER_TRACE_*`, `AL_RUNNER_DIAG_*`, `BCCOMPILER_TIMING`, `AL_RUNNER_HOOK_AUDIT` and the rest do not set `Log.Verbose`, so `AL_RUNNER_HOOK_AUDIT=1` (which CLAUDE.md tells agents to use) would print nothing.
3. **Subprocess tests assert these tags in runs without `--verbose`.** A sweep of `AlRunner.Tests` found `CacheRootsIsolationTests` (`[source-dep] WROTE`), `CountBaselineIntegrationTests` and `SuiteAbortOnTimeoutTests` (`[count-baseline]`), `MissingTestDataDiagnosisTests` and `MaskedTriggerErrorDiagnosisTests` (`[test-data]`), `WatchCrossBundleModuleIdentityTests` (`[install-trigger]`), `WatchPageMetadataReloadDeleteTests` (`[page-metadata]`) and `ObjectMetadataRegistryIsolationGuardTests` (`[object-metadata]`).

This follows the direction #2750, #2239 and #3068 already took: decide visibility at the call site, not in the regex.

## Tag classification

Population: 42 distinct tags in non-comment string literals under `AlRunner/`. That is more than the issue's 26 and Log.cs's earlier 30. The difference is upper-case tags (`DIAG-RETRY`, `FCE-NRE`, `BcCompiler-diag`), return values printed by a caller (`provision-gap`, a `test-exec` warning) and exception messages (`al-locals`).

- **Loud (19):** al-locals, bc-floor, count-baseline, count-out, dep-load-fail, dep-metadata (bad switch value, cache write failure), dep-metadata-fail, install-trigger, oos-in-try, page-control-field, phase-log, provision-gap, report-metadata (parse fallback), servicetier-dll (load failure, index skip), source-dep, source-map, test-data, test-exec, type-index (subscribers not registered)
- **OptIn (25):** BcCompiler-diag, DIAG-RETRY, FCE-NRE, aggregate-permission-set, all-profile, dap-step-trace, dep-metadata (trace), emit-timing, first-chance, hook-audit, instrumentation-counters, mem-census, object-metadata, option-captions, page-metadata, page-trigger-audit, parse-counts, perm-metadata, permission-table, query-metadata, report-metadata (trace), shared-refs, table-metadata, table-trigger-audit, xmlport-metadata
- **VerboseGated (2 tags, 3 sites):** type-index (reflection fallback, already gated by #2239), servicetier-dll (index summary, gated here)

Several tags are mixed within one file, which is why the test classifies per site. Two judgment calls a reviewer may want to check:
- `[source-dep]` is Loud because it is the source-sibling twin of the exempt `[layered]` progress lines, and a default-verbosity test asserts it.
- The three unconditional `[type-index]` sites are Loud, not chatter: each says event subscribers were not registered, which changes AL behavior.

## RED -> GREEN and mutations

All runs: `dotnet test AlRunner.Tests --filter FullyQualifiedName~LogHyphenatedTagContractTests`.

- **RED** (before the gate): `Failed: 1, Passed: 7, Total: 8`. `VerboseGatedSites_CarryAnExplicitLogVerboseGate` named `ServiceTierDllIndex.cs:179`.
- **GREEN:** `Failed: 0, Passed: 8, Total: 8`.
- **Mutation 1, the naive fix** (add `-` to the class in Log.cs): `Failed: 2, Passed: 6`. `LoudAndOptInSites_SurviveTheDefaultFilter` listed 124 eaten literals across all 42 tags, and the hyphenated shape case also failed. The census, OptIn-gate and VerboseGated tests stayed green, which is the subset I expected. With `LogUserFacingTagsTests` in the filter, its `[provision-gap]` case also failed (`Failed: 3, Passed: 19`). Restored.
- **Mutation 2** (my gate changed to `if (true)`): `Failed: 1, Passed: 7`, only the VerboseGated test. Restored.
- **Mutation 3** (`JmpHook.ReportOrphanedHooks`'s `if (!_audit) return;` changed to `if (false) return;`): my first version of the OptIn check stayed **green**. It only looked for the token nearby, and the `_audit` field declaration was within the window. I tightened the check to require an `if (` line testing the switch (commit 0135486c), and the mutation then gave `Failed: 1, Passed: 7` with all four `[hook-audit]` sites named. Restored.

Limit: the gate checks read source text. They prove the switch is tested near the line, not that control flow depends on it.

## Other runs

- Sibling classes `LogUserFacingTagsTests`, `LoudDiagnosisReachesTheUserTests`, and this class together: `Failed: 0, Passed: 66`.
- The `GuardTests` filter plus the log classes: `Failed: 1, Passed: 320`. The failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned`: the engine bootstrap is not wired into this local test host (`engine.runsettings`). That is environmental; CI runs that bootstrap step.
- `tools/test_*.py`: `test_agent_self_freshness.py`, `test_preflight.py` and `test_corpus_checkout.py` fail locally because `git commit` in their scratch repos hits 1Password commit signing (`error: 1Password: agent returned an error`). This diff touches no `tools/` file.
- I did not run the unfiltered suite or any AL bundle. The only runtime change is one line that is now silent by default.

## Fix the shape

1. **Same wrong pattern elsewhere?** I scanned every hyphenated-tag literal (the test now does that on every run). The only unconditional chatter left was the `servicetier-dll` summary. The other ungated sites report failures or results.
2. **Sibling functions with the same assumption?** `AssemblyTypeIndex`'s two #2239 gates were correct. The comment there that says the other tags were "filed separately" still points at this issue and stays accurate.
3. **Two paths writing the same state with different invariants?** Tags that print from several files (`page-metadata`, `table-metadata`, `report-metadata`, `test-data`, `dep-load-fail`) are classified per file, and each file's sites keep one consistent gate. `report-metadata` is OptIn in the virtual table and Loud in the document parse fallback, on purpose.

## Queue scan

I searched on `Log.cs`, the `area: log-filter` label, "hyphen tag" and "verbose suppressed". Only #2221 shares the area. I did not fold it in: it asks to invert the default, or to guard all ~119 tags including the single-word ones, and reviewing that means reasoning about a different set of lines. This PR does not change the exemption list or the single-word behavior. I left a comment on #2221.

None of the changed paths are on the corpus-linkage gate list. The change is runner logging only, which no AL test on a service tier can observe, so the proving tests live in `AlRunner.Tests`.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
