### PR TITLE
docs(impl-agent): say so when you push to a PR you did not open

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -321,6 +321,14 @@ do not merge.
 
 The coordinator watches CI and resumes you or dispatches a fresh agent if the PR goes red.
 
+**If you pushed to a PR you did not open, say so in your handback and check whether its
+auto-merge is armed** — `gh pr view <N> --json autoMergeRequest`. Arming **survives a push**, so
+a commit added to an armed PR merges on a verdict nobody gave it, against a review of an earlier
+head. Landing work on an existing PR is often right — a file that exists only on that branch
+cannot be edited from a second branch without conflicting the moment either merges (#3980) — but
+the coordinator has to re-verify the new head, and can only do that if it knows the head moved.
+Reporting the SHA you pushed is not enough on its own; name the PR and whether it was armed.
+
 Before you return, confirm all four and state them in your report:
 
 1. The branch is pushed (`git push` succeeded; `git status` shows nothing unpushed).


### PR DESCRIPTION
Closes #3991

PR #3971 had auto-merge **armed** against `7deb99e4` on a reviewer's verdict. A different agent — investigating #3980 — pushed a 16-line docstring to it, and the head became `190ab591` **with arming intact**. A commit nobody had reviewed was queued to merge on the earlier head's verdict.

Nothing bad resulted: the change was pure docstring, I verified the scope (`1 file changed, 16 insertions(+)`, no deletions), read all 16 lines, and re-ran the guard at the new head — `10 passed, 0 failed`, identical to the reviewed result. The specific risk was real though: the new text quotes `--add-label`/`--remove-label` in backticks, and this guard has an exemption letting test files carry both literals, so prose could have silently widened it.

## Why the agent could not have known

`impl-agent.md` never mentions arming — the word does not appear. Step 5's contract is *"mark it ready, label it, return"*, written for an agent that **opened** its own PR. An agent landing work on an existing PR is outside that contract.

It did report its head SHA. **That is not enough**: a SHA reads as "here is where my work is", not "an armed PR now points somewhere new". The coordinator needs to know *which PR* moved and *whether it was armed*.

## Why the fix is not "don't push to other PRs"

Landing there was **correct**. `tools/test_no_racing_label_edit.py` exists only on that branch — #3971 creates it — so a second branch would have created the same file independently and conflicted the moment either merged. The agent reasoned that out unprompted.

The asymmetry: pushing is usually right, and the cost of not announcing it is a **silent** unreviewed merge — the PR goes green, `--auto` fires, and nothing in the log distinguishes a reviewed head from an unreviewed one.

So: push when it is right, and say so loudly enough that the coordinator re-verifies.

## Scope

One paragraph in Step 5. #3991 records what I did **not** measure: how often this has already happened. The signature would be a merged PR whose final commit came from a different agent than its opener, with an arming timestamp earlier than that commit — recoverable from the API. If it is common, the stronger fix is the coordinator disarming on any head move rather than relying on the agent to report it.

All 21 `tools/test_*.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
