### PR TITLE
fix(virtual-tables): AllObjWithCaption reports the owning app like AllObj

### DIFF
--- a/AlRunner.Tests/AllObjWithCaptionAppIdKindTests.cs
+++ b/AlRunner.Tests/AllObjWithCaptionAppIdKindTests.cs
@@ -1,0 +1,53 @@
+// AllObjWithCaptionAppIdKindTests — issue #3106.
+//
+// The BC-behaviour claim (AllObjWithCaption's App ID is the owning app's manifest id, empty for
+// an enum) is asserted upstream in corpus codeunit 60802 (corpus PR #329). This file pins the
+// runner-local kind set RecordPatches.AllObjWithCaptionKindCarriesAppId implements, so a later
+// "every kind with an owner gets its App ID" simplification fails here rather than only on the
+// enum corpus test. Source of the set: AllObjWithCaptionDataProvider.GetCaptionAndSubtype.
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class AllObjWithCaptionAppIdKindTests
+{
+    [Theory]
+    [InlineData("TableData")]
+    [InlineData("Table")]
+    [InlineData("Report")]
+    [InlineData("XMLport")]
+    [InlineData("Page")]
+    [InlineData("Query")]
+    [InlineData("Codeunit")]
+    [InlineData("PageExtension")]
+    [InlineData("TableExtension")]
+    [InlineData("EnumExtension")]
+    [InlineData("PermissionSetExtension")]
+    [InlineData("ReportExtension")]
+    public void KindWithAnOwnerArmInBc_CarriesAppId(string kind)
+    {
+        Assert.True(RecordPatches.AllObjWithCaptionKindCarriesAppId(kind));
+    }
+
+    [Theory]
+    [InlineData("Enum")]
+    [InlineData("PermissionSet")]
+    [InlineData("Profile")]
+    [InlineData("ProfileExtension")]
+    [InlineData("QueryExtension")]
+    [InlineData("System")]
+    [InlineData("Interface")]
+    public void KindWithNoOwnerArmInBc_HasEmptyAppId(string kind)
+    {
+        Assert.False(RecordPatches.AllObjWithCaptionKindCarriesAppId(kind));
+    }
+
+    [Fact]
+    public void KindMatching_IgnoresCaseAndSpacing()
+    {
+        // The inventory spells kinds as the parsers and symbol files do ("XMLport", "xmlport").
+        Assert.True(RecordPatches.AllObjWithCaptionKindCarriesAppId("xmlport"));
+        Assert.True(RecordPatches.AllObjWithCaptionKindCarriesAppId("Table Extension"));
+    }
+}

--- a/AlRunner/Patches/RecordPatches.AllObjWithCaptionVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AllObjWithCaptionVirtualTable.cs
@@ -96,38 +96,45 @@ public static partial class RecordPatches
         // than an assumption.
         var ordinals = EnsureAllObjWithCaptionObjectTypeOrdinals(metaTable);
         var done = _awcPopulatedByProvider.GetValue(provider, static _ => new ConcurrentDictionary<(int, int), byte>());
+        // Built lazily after the `done` guard, as PopulateAllObjVirtualTable does (#3117).
+        Dictionary<(string Kind, int Id), Guid>? ownerIndex = null;
 
         foreach (var (kind, id, name, caption, subtype) in EnumerateKnownAlObjects())
         {
             if (id <= 0) continue;
-            if (!ordinals.TryGetValue(NormalizeObjectTypeName(kind), out var typeOrdinal))
+            var normalized = NormalizeObjectTypeName(kind);
+            if (!ordinals.TryGetValue(normalized, out var typeOrdinal))
                 // This AL object kind has no ordinal in THIS BC version's option set.
                 // Real BC would not list it either — skipping is faithful, inventing an
                 // ordinal is not.
                 continue;
             if (!done.TryAdd((typeOrdinal, id), 0))
                 continue;
+            // #3106: the same owner AllObj stamps, so the two tables agree on 60/61.
+            ownerIndex ??= BuildObjectOwnerIndex();
+            var owningAppId = ownerIndex.TryGetValue((normalized, id), out var owner) ? owner : Guid.Empty;
 
             InsertVirtualRow(provider, metaTable,
                 new object[] { AllObjWithCaptionVirtualTableId, typeOrdinal, id, 0 },
                 field => BuildAllObjWithCaptionValue(field, typeOrdinal, id, name,
                     // AL's own default caption is the object name. Applied here, once.
                     string.IsNullOrEmpty(caption) ? name : caption,
-                    ObjectSubtypeTextFor(kind, subtype)));
+                    ObjectSubtypeTextFor(kind, subtype),
+                    owningAppId,
+                    AllObjWithCaptionKindCarriesAppId(kind)));
         }
     }
 
     /// <summary>
     /// One column of an AllObjWithCaption row, matched by the metatable's own FIELD NAME so
     /// the mapping tracks whatever the System package in the resolved artifact declares
-    /// rather than a hardcoded field-number table. Every other column (App Package ID, App
-    /// Runtime Package ID, Object Namespace, …) gets BC's own default, which is exactly what
-    /// AllObjWithCaptionDataProvider emits for a base object with no app package and no
-    /// namespace.
+    /// rather than a hardcoded field-number table. Every other column (AL Namespace, …) gets
+    /// BC's own default, which is exactly what AllObjWithCaptionDataProvider emits for an
+    /// object with no namespace.
     /// </summary>
     private static object? BuildAllObjWithCaptionValue(
         NCLMetaField field, int typeOrdinal, int objectId, string objectName, string objectCaption,
-        string objectSubtype)
+        string objectSubtype, Guid owningAppId, bool kindCarriesAppId)
     {
         switch (NormalizeObjectTypeName(field.FieldName ?? string.Empty))
         {
@@ -145,10 +152,37 @@ public static partial class RecordPatches
                 // provider. Truncated through the field's own defined length, same as every
                 // other text column here, rather than to a written-down 30.
                 return _aovNavTextCreateTruncated!.Invoke(null, new object?[] { field.FieldDefinedLength, objectSubtype ?? string.Empty });
+            // #3106. Observably equivalent to AllObjWithCaptionDataProvider: 60/61 come from the
+            // same per-object entry AllObj reads, so they carry the values InsertAllObjRow writes;
+            // App ID is the owning app's MANIFEST id (OwningApp.AppId), un-derived, and only for
+            // the kinds GetCaptionAndSubtype resolves an owner for. An unknown owner stays
+            // Guid.Empty, which is also BC's answer when OwningApp is null.
+            // Corpus: 60802 AllObjWithCaption_*App* (corpus PR #329).
+            case "apppackageid":
+                return NavValue.CreateNavValueFromObject(field, AppPackageIdentity.PackageIdFor(owningAppId));
+            case "appruntimepackageid":
+                return NavValue.CreateNavValueFromObject(field, AppPackageIdentity.RuntimePackageIdFor(owningAppId));
+            case "appid":
+                return NavValue.CreateNavValueFromObject(field, kindCarriesAppId ? owningAppId : Guid.Empty);
             default:
                 return _aovGetDefaultNavValue!.Invoke(null, new object?[] { field, false });
         }
     }
+
+    /// <summary>
+    /// True for the object kinds whose AllObjWithCaption "App ID" BC fills:
+    /// AllObjWithCaptionDataProvider.GetCaptionAndSubtype sets the owner for TableData, Table,
+    /// Report, XMLport, Page, Query, Codeunit and the five extension kinds it also resolves a
+    /// target id for, and leaves it null for every other kind (Enum, PermissionSet, Profile,
+    /// System, …) — same body in the 27.x and 28.4 Ncl.dll. Trap: do not widen this to "every
+    /// kind with an owner"; an Enum's package columns are filled while its App ID is empty.
+    /// </summary>
+    internal static bool AllObjWithCaptionKindCarriesAppId(string kind)
+        => NormalizeObjectTypeName(kind) switch
+        {
+            "tabledata" or "table" or "report" or "xmlport" or "page" or "query" or "codeunit" => true,
+            _ => ExtensionTargetObjectKind(kind) != null,
+        };
 
     /// <summary>
     /// The text BC puts in "Object Subtype" for one object, given the subtype the runner's


### PR DESCRIPTION
Closes #3106

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/329

Written by agent stma-auto2-2 on the account holder's behalf.

## What changed

`PopulateAllObjWithCaptionVirtualTable` now stamps the three owning-app columns it used to leave at the type default:

- **App Package ID (60) / App Runtime Package ID (61)**: `AppPackageIdentity.PackageIdFor` / `RuntimePackageIdFor` of the owner from `BuildObjectOwnerIndex`, the same index and the same values `InsertAllObjRow` writes for AllObj. There is no second derivation. The index is built lazily after the `done` guard, the same placement AllObj uses (#3117).
- **App ID (62)**: the owner's manifest app id itself, not derived, and only for the kinds BC fills it for: TableData, Table, Report, XMLport, Page, Query, Codeunit and the five extension kinds (`AllObjWithCaptionKindCarriesAppId`). Every other kind (Enum, PermissionSet, Profile, System, ...) gets `Guid.Empty`.

The diff is limited to `RecordPatches.AllObjWithCaptionVirtualTable.cs` plus a new C# test. `RecordPatches.DataAccessDispatch.cs` is not touched, because its existing call already reaches the populator. That keeps this PR clear of #3985.

## Which evidence supports which claim

- **Mechanism (read from code):** `AllObjWithCaptionDataProvider.GetCaptionAndSubtype` in Ncl.dll. `compare_symbols` shows no body change between the bc270 and bc284 contexts, which are two distinct binaries. Buffer slots 5/6 come from the same `AllObjectSnapshotEntry` AllObj reads. Slot 7 is `OwningApp?.AppId`, set only in the switch arms listed above.
- **Measurement:** corpus PR #329 adds four tests to codeunit 60802. They cover App ID for this app's own table, page and codeunit; 60/61 equal to AllObj for an own table; App ID equal to Base Application's id for Customer; and an empty App ID for the Base Application enum "Sales Document Type". Its eight cloud legs are the verdict. Until they report, the kind set rests on the decompiled code.

The issue's three questions: (1) yes, 60/61 equal AllObj's, because both come from one snapshot entry; (2) App ID is the manifest id, and the runner already held it, since `BuildObjectOwnerIndex` keys on the raw app id; (3) for an object with no owner, all three columns are empty. The runner already writes that as `Guid.Empty`. The corpus tests do not assert a platform object, because I have no measured value for one.

## RED -> GREEN (local, corpus 28138cc7da40d1a19efe98b1bf315a1060cf315a = PR #329 head, BC 28.1 platform apps)

`--test AllObjWithCaption_` on `tests/al-language/tests/al-language`:

- RED (before the fix): `Tests: 19 total, pass: 15, fail: 4`. All four new tests failed on their assertions, e.g. `Expected:<{A1B2C3D4-...}> Actual:<{00000000-...}> App ID of a table this app declares must be this app's id`.
- GREEN: `Tests: 19 total, pass: 19, fail: 0`. Ran twice against one `--cache` root with the same result, and again after rebasing onto b0d5a598 (`--test AllObj`: 25/25).
- Full corpus with the fix, `--strict`: `3321 total, pass 3321, fail 0` (2 pass-oos, 12 pass-known-gap, 1 pass-divergence).

Every local run above used the 28.1 platform apps only. The PR legs (27.0, 27.5, 28.4) are the cross-version measurement; the `compare_symbols` result above covers the provider body on both Ncl binaries.

## Mutations (executed; each rebuilt, `0 Error(s)`, reds are Assert failures)

1. App ID arm returns `PackageIdFor(owningAppId)` instead of the raw id: `19 total, pass 16, fail 3`. The failures are OwnObjects_AppIdIsThisModulesId, OwnTable_PackageIdsEqualAllObj (the "App ID is not the runtime package id" assertion) and BaseApplicationTable_AppIdIsBaseApplication. The enum test stays green, as it should.
2. Kind gate forced to `true`: `19 total, pass 18, fail 1`. Only FindEnum_BaseApplicationEnum_AppIdIsEmpty fails (`Expected:<{00000000-...}> Actual:<{437DBF0E-...}>`).
3. C# `AllObjWithCaptionKindCarriesAppId` default arm widened to `true`: `Failed: 7, Passed: 13, Total: 20`, exactly the seven negative cases. Restored: `Passed: 20, Total: 20`.

## Tests updated gate

The BC claim lives upstream. `AlRunner.Tests/AllObjWithCaptionAppIdKindTests.cs` pins the runner's own kind set (20 cases), so a later "every kind with an owner gets an App ID" simplification fails locally, not only on the corpus enum test.

Guards: `GuardTests` 248/249. The one failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned`, because the engine bootstrap was not run on this box. `tools/test_agent_self_freshness.py`, `test_corpus_checkout.py` and `test_preflight.py` fail locally because their temp repos cannot commit on this box (the 1Password signing agent). None of these touch the files in this diff.

## Fix the shape

1. **Same wrong pattern at another call site?** The other virtual tables that report package ids (Published Application, NAV App Installed App, NavApp extra tables) already use `AppPackageIdentity`. AllObjWithCaption was the one populator that shared AllObj's inventory but not its owner. Nothing else found.
2. **Sibling making the same assumption?** Yes. `BuildObjectOwnerIndex`'s emitted-assembly pass only indexes Record/Codeunit/Page/Report/Query/XmlPort type prefixes, so source-compiled extensions, enums and permission sets have no owner in AllObj or AllObjWithCaption. This is not folded: it changes AllObj's answer too and needs its own corpus measurement. Filed as #4000.
3. **Two writers, one invariant?** AllObj and AllObjWithCaption now derive 60/61 from the same index and the same `AppPackageIdentity` call. The corpus tests assert that equality directly.

## Queue scan

I searched the open issues for `AllObjWithCaption`, `App Runtime Package ID`, `owning app` and `BuildObjectOwnerIndex`. The only overlap is #2279 (AllObj/Table Metadata list another app group's objects). It is a different mechanism (registry accumulation across bundles in the run loop) and is not folded; the reasoning is recorded on #2279.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
