### PR TITLE
fix(hook): a grep over dotnet test output is not a source lookup

### DIFF
--- a/.claude/hooks/prefer-code-navigation.py
+++ b/.claude/hooks/prefer-code-navigation.py
@@ -81,7 +81,14 @@ WRITES_CS = re.compile(r'<<|>>?\s*\S*\.cs\b|\bsed\s+(?:-\w+\s+)*-i\b')
 TARGETS_CS = re.compile(r'AlRunner[\w./-]*|--include[= ]\S*\.cs|\*\.cs|\.cs\b')
 # Things that are legitimately grep's job, not a symbol lookup.
 NOT_A_SYMBOL_LOOKUP = re.compile(
-    r'\.(log|json|trx|txt|md|xml|al)\b|/tmp/|scratchpad|git log|gh \w|dmesg|journalctl')
+    r'\.(log|json|trx|txt|md|xml|al)\b|/tmp/|scratchpad|git log|gh \w|dmesg|journalctl'
+    # A grep whose input is a BUILD OR TEST RUN filters that command's stdout, not
+    # source. `dotnet test AlRunner.Tests --filter X | command grep Total` is the
+    # shape tdd.md asks for on every mutation -- it requires quoting the `Total:`
+    # line -- and blocking it sent agents to `# hook:allow-grep`, an override whose
+    # name says "grep" for a command that greps no file. An override reached for
+    # routinely on false positives is one reached for reflexively on a true one (#3994).
+    r'|\bdotnet\s+(?:test|run|build|publish)\b')
 
 ADVISORY_HEADER = "Code-navigation reminder (advisory, nothing was blocked).\n"
 BLOCK_HEADER = (

--- a/.claude/hooks/prefer-code-navigation.py
+++ b/.claude/hooks/prefer-code-navigation.py
@@ -88,7 +88,13 @@ NOT_A_SYMBOL_LOOKUP = re.compile(
     # line -- and blocking it sent agents to `# hook:allow-grep`, an override whose
     # name says "grep" for a command that greps no file. An override reached for
     # routinely on false positives is one reached for reflexively on a true one (#3994).
-    r'|\bdotnet\s+(?:test|run|build|publish)\b')
+    # ...but ONLY when the search reads that command's STDOUT, i.e. the dotnet
+    # invocation is `|`-connected to it. Matching `dotnet test` anywhere in the
+    # string would exempt `grep ... AlRunner/ # after dotnet test` -- a plain-text
+    # opt-out with no name and, unlike `# hook:allow-grep`, no trace -- and
+    # `dotnet build AlRunner; sed -n 1,50p AlRunner/Program.cs`, a READ, which the
+    # docstring records as the dominant cost (533 of 940 calls).
+    r'|\bdotnet\s+(?:test|run|build|publish)\b(?:(?!;|&&)[^|])*\|')
 
 ADVISORY_HEADER = "Code-navigation reminder (advisory, nothing was blocked).\n"
 BLOCK_HEADER = (

--- a/tools/test_agent_workflow_hooks.py
+++ b/tools/test_agent_workflow_hooks.py
@@ -233,8 +233,22 @@ NAV_ALLOWED = [
     ("writing a C# file with a heredoc", "cat > AlRunner/New.cs <<EOF\nclass X {}\nEOF"),
     ("git log over the C# tree", "git log --oneline -5 -- AlRunner"),
 ]
+# The dotnet exemption is PIPE-connected only: `dotnet test` appearing anywhere in
+# the string would make the literal text an untraceable opt-out (#3994 review).
+NAV_BLOCKED_DESPITE_DOTNET = [
+    ("dotnet test in a trailing comment",
+     "command grep -rn 'Editable' AlRunner/ # after dotnet test"),
+    ("a read chained after a build",
+     "dotnet build AlRunner; sed -n '1,50p' AlRunner/Program.cs"),
+    ("a source grep chained with &&",
+     "dotnet test AlRunner.Tests && command grep -n 'Foo' AlRunner/Patches/Bar.cs"),
+]
 for name, cmd in NAV_ALLOWED:
     ok, d = allows(NAV, cmd, cwd=WORKTREE)
+    check(name, ok, d)
+
+for name, cmd in NAV_BLOCKED_DESPITE_DOTNET:
+    ok, d = blocks(NAV, cmd, "context-pack.py", cwd=WORKTREE)
     check(name, ok, d)
 
 print("\nboth hooks are actually registered -- a hook nothing invokes blocks nothing")

--- a/tools/test_agent_workflow_hooks.py
+++ b/tools/test_agent_workflow_hooks.py
@@ -223,6 +223,13 @@ NAV_ALLOWED = [
     ("searching markdown", "rg --hidden 'clean status' .claude"),
     ("searching AL sources", "command grep -n 'SaveAsXml' tests/al-language/foo.al"),
     ("build output trimmed with tail", "dotnet build AlRunner -c Release | tail -5"),
+    # tdd.md asks for the `Total:` line from every mutation run, and the natural
+    # way to get it is a grep over `dotnet test` stdout. That greps no file (#3994).
+    ("test output filtered with grep",
+     "dotnet test AlRunner.Tests --filter X 2>&1 | command grep -E 'Failed:'"),
+    ("test output filtered by project path",
+     "dotnet test AlRunner.Tests/AlRunner.Tests.csproj --no-build | command grep Total"),
+    ("dotnet run output filtered", "dotnet run --project AlRunner | command grep PASS"),
     ("writing a C# file with a heredoc", "cat > AlRunner/New.cs <<EOF\nclass X {}\nEOF"),
     ("git log over the C# tree", "git log --oneline -5 -- AlRunner"),
 ]


### PR DESCRIPTION
Closes #3994

`prefer-code-navigation.py` blocked the exact shape `tdd.md` asks for on every mutation:

```bash
dotnet test AlRunner.Tests --filter X 2>&1 | command grep -E "Failed:"
```

`tdd.md` requires quoting the `Total:` line from every run, and the natural way to get it is a grep over `dotnet test` stdout. **That grep names no file** — but `TEXT_SEARCH` sees the `grep` and `TARGETS_CS` sees the project name, so the pair reads as a source search.

Agents reached for `# hook:allow-grep` instead — an override whose *name* says "grep" for a command that greps no file. **An override reached for routinely on false positives is one reached for reflexively on a true one**, which erodes a hook whose `BLOCKED` path is otherwise deliberately narrow and doing real work.

## Where the fix went, and why not `TARGETS_CS`

`NOT_A_SYMBOL_LOOKUP`, beside the existing `.log` / `.trx` / `scratchpad` exclusions. Those exist for precisely this category — a grep whose subject is output rather than source. **The distinction is the verb (execute vs search), not the path**, so widening a path regex would have been the wrong lever.

## Two corrections to my own diagnosis, both from reading the call site I skipped

1. **A bare `dotnet test AlRunner.Tests` was never blocked.** My issue body claimed `TARGETS_CS` matching the project name was sufficient; line 132 ANDs it with `TEXT_SEARCH`. Measured: `searching=False`. Only the *pipeline* form fires.
2. **My first mutation did not land.** `sed` matched nothing and returned `rc=0`, which looked exactly like the fix working — `tdd.md`'s documented trap. Redone in Python and confirmed by re-reading the file: **rc=2 mutated, rc=0 restored, marker gone.**

Both corrections are recorded on #3994 next to the original reasoning rather than replacing it.

## Verification

Driven end-to-end through the real hook with an `impl-agent` payload:

| command | before | after |
|---|---|---|
| `dotnet test … \| command grep Total` | **rc=2 blocked** | rc=0 allowed |
| `command grep -n foo AlRunner/Patches/Bar.cs` | rc=2 | **rc=2 still blocked** |
| `rg --hidden pattern AlRunner/` | rc=2 | **rc=2 still blocked** |

Three cases added to `tools/test_agent_workflow_hooks.py`, beside the existing `dotnet build … | tail -5` case which is the same category. **All three fail with the exclusion reverted**; all `tools/test_*.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
