### PR TITLE
fix(metadata): keep Object Metadata payload refusal armed across install-baseline replays

### DIFF
--- a/AlRunner.Tests/BackupRowProvenanceTests.cs
+++ b/AlRunner.Tests/BackupRowProvenanceTests.cs
@@ -21,19 +21,13 @@ namespace AlRunner.Tests;
 /// <para>Corpus codeunit 61202 (StefanMaron/BusinessCentral.AL.Language.Tests#197) has since
 /// measured 2000000001 on seven BC OnPrem legs and found it empty, so the projection is gone
 /// and with it both the ambiguity and the refusal: the only rows that table can hold now are a
-/// backup's, and those are exactly the rows a baseline SHOULD carry across a boundary.
-/// <c>IsProjectionOwnedSystemTableId</c> was deleted — it was defined as "2000000001 with no
-/// backup behind it", which now describes an empty table rather than a projection.</para>
+/// backup's, and those are exactly the rows a baseline SHOULD carry across a boundary.</para>
 ///
-/// <para>WHAT SURVIVES, AND WHY IT IS NOT DEAD CODE. The recorder does.
-/// <c>TestDataProvisioner.LoadOnDemand</c> is the only writer that can put rows into these
-/// tables and it is the only place that fact exists; nothing downstream of a store can
-/// reconstruct it. Issue #3236 is its named consumer — the same wrong-shaped question,
-/// <c>ProviderHasAnyRow</c>, still decides whether Object Metadata's (2000000071) #2771 payload
-/// refusal is armed, and an install-baseline restore replaying that table's synthesised rows
-/// disarms it. These tests drive the recorder's own entry points, the ones production uses,
-/// because the end-to-end path needs a BC database backup and CI has none. The inverted
-/// baseline claim IS driven end to end, in ObjectSystemTableEmptyRowSetTests.</para>
+/// <para>The recorder survives, and <c>IsProjectionOwnedSystemTableId</c> came back for Object
+/// Metadata (2000000071) under #3236: the install-baseline capture leaves that table out unless a
+/// backup owns its rows. The replay it prevents is driven end to end in
+/// tests/runner-extras/object-metadata-baseline-replay; the backup-owned rows need a BC database
+/// backup CI does not have, so they are pinned here at the predicate.</para>
 ///
 /// <para>Shares the process-global install-baseline statics with
 /// InstallBaselineAppendConcurrencyTests and TestDataBaselineAppendTests, so it joins their
@@ -187,6 +181,36 @@ public sealed class BackupRowProvenanceTests : IDisposable
         var ex = Assert.Throws<InvalidOperationException>(
             () => RecordPatches.AppendBaselineTable(new object(), AllObjTableId, new object(), Rows("X")));
         Assert.Contains("self-populating virtual table", ex.Message);
+    }
+
+    /// <summary>
+    /// #3236, the three configurations the issue names. Object Metadata with no backup behind it
+    /// holds only the runner's synthesis, so the capture must leave it out — covering both the
+    /// in-process replay and a disk file written by such a run. Once a backup owns its rows
+    /// (a --test-data load, or the process that wrote a disk-cache HIT's file) it is captured.
+    /// </summary>
+    [Fact]
+    public void ObjectMetadata_IsProjectionOwned_ExactlyWhileNoBackupOwnsItsRows()
+    {
+        Assert.True(RecordPatches.IsProjectionOwnedSystemTableId(ObjectMetadataTableId));
+
+        // A backup that loaded some OTHER table says nothing about this one.
+        RecordPatches.NoteBackupContributedRows(OrdinaryTableId);
+        Assert.True(RecordPatches.IsProjectionOwnedSystemTableId(ObjectMetadataTableId));
+
+        RecordPatches.NoteBackupContributedRows(ObjectMetadataTableId);
+        Assert.False(RecordPatches.IsProjectionOwnedSystemTableId(ObjectMetadataTableId));
+    }
+
+    /// <summary>The negative side: nothing else the capture walks is skipped by it. Object
+    /// (2000000001) has no projection since #3071, and an ordinary table's rows are install
+    /// output.</summary>
+    [Fact]
+    public void NoOtherTable_IsProjectionOwned()
+    {
+        Assert.False(RecordPatches.IsProjectionOwnedSystemTableId(ObjectTableId));
+        Assert.False(RecordPatches.IsProjectionOwnedSystemTableId(OrdinaryTableId));
+        Assert.False(RecordPatches.IsProjectionOwnedSystemTableId(AllObjTableId));
     }
 
     /// <summary>

--- a/AlRunner/Patches/RecordPatches.BackupRowProvenance.cs
+++ b/AlRunner/Patches/RecordPatches.BackupRowProvenance.cs
@@ -42,11 +42,8 @@
 // WHY THE RECORDER STAYS
 //   What it records is still true, still cheap, and still the only place the fact exists:
 //   TestDataProvisioner.LoadOnDemand is the one writer that can put rows into these tables, and
-//   nothing downstream of a store can reconstruct that afterwards. Issue #3236 is the named
-//   consumer — the SAME wrong-shaped question, ProviderHasAnyRow, still decides whether Object
-//   Metadata's (2000000071) #2771 payload refusal is armed, and an install-baseline restore
-//   replaying that table's synthesised rows disarms it. #3236 has the table and the reason
-//   BackupOwnsRowsFor alone is not the whole fix there.
+//   nothing downstream of a store can reconstruct that afterwards. Its consumer is
+//   IsProjectionOwnedSystemTableId below (#3236).
 //
 //   It deliberately does NOT weaken #2272's loud refusal. The self-populating virtual tables
 //   are refused by AppendBaselineTable whatever this file says.
@@ -74,6 +71,15 @@ public static partial class RecordPatches
     /// run. False for every table in a run without --test-data, and for a table the armed
     /// backup's plan does not offer or whose rows it holds none of.</summary>
     internal static bool BackupOwnsRowsFor(int tableId) => _backupContributedRows.ContainsKey(tableId);
+
+    /// <summary>True when <paramref name="tableId"/>'s rows in this run can only be the runner's
+    /// own synthesis: Object Metadata (2000000071) with no backup behind it. The install-baseline
+    /// capture leaves such a table out (#3236), because
+    /// <c>PopulateObjectMetadataSystemTable</c> reads a replay of its own rows as supplied ones and
+    /// disarms the #2771 payload refusal. A disk-cache HIT stays right: a file carries this table
+    /// only when a backup owned it in the process that wrote the file.</summary>
+    internal static bool IsProjectionOwnedSystemTableId(int tableId)
+        => tableId == ObjectMetadataSystemTableId && !BackupOwnsRowsFor(tableId);
 
     /// <summary>Drop everything recorded here. Paired with clearing
     /// <see cref="TestDataOnDemandLoader"/>: the two describe the same armed backup, and a

--- a/AlRunner/Patches/RecordPatches.BackupRowProvenance.cs
+++ b/AlRunner/Patches/RecordPatches.BackupRowProvenance.cs
@@ -36,8 +36,8 @@
 //     * PopulateObjectSystemTable no longer exists, and
 //     * CaptureInstallBaselineSnapshot no longer has to leave 2000000001 out — the only rows
 //       it can hold are a backup's, which a baseline SHOULD carry.
-//   IsProjectionOwnedSystemTableId went with them; it was defined as "2000000001 and no backup
-//   behind it", which now describes an empty table rather than a projection.
+//   IsProjectionOwnedSystemTableId went with them, and #3236 brought it back for Object
+//   Metadata (2000000071), whose synthesised row set does exist.
 //
 // WHY THE RECORDER STAYS
 //   What it records is still true, still cheap, and still the only place the fact exists:

--- a/AlRunner/Patches/RecordPatches.InstallBaseline.cs
+++ b/AlRunner/Patches/RecordPatches.InstallBaseline.cs
@@ -321,6 +321,7 @@ public static partial class RecordPatches
         // Diagnostic only (the PerfTrace line below). At most ten ids, so collecting them
         // unconditionally costs nothing worth gating.
         var skippedVirtual = new List<int>();
+        var skippedProjection = new List<int>();
         foreach (var (source, perTable) in _dataAccessByTable)
         {
             var tables = new List<BaselineTable>();
@@ -362,6 +363,16 @@ public static partial class RecordPatches
                 if (IsSelfPopulatingVirtualTableId(tableId))
                 {
                     skippedVirtual.Add(tableId);
+                    continue;
+                }
+
+                // #3236: a replay of Object Metadata's synthesised rows reads as backup rows to
+                // its populate and disarms the #2771 payload refusal. Not captured, the store is
+                // dropped at the boundary and re-synthesised. NOT IsSelfPopulatingVirtualTableId:
+                // AppendBaselineTable throws for those, and a backup can own this table's rows.
+                if (IsProjectionOwnedSystemTableId(tableId))
+                {
+                    skippedProjection.Add(tableId);
                     continue;
                 }
 
@@ -416,7 +427,8 @@ public static partial class RecordPatches
                       // #2272: named, not just counted — "which tables were left out" is the
                       // whole claim, and a bare count cannot distinguish "skipped AllObj" from
                       // "skipped something that should have been captured".
-                      $"skipped-self-populating [{string.Join(",", skippedVirtual)}]" +
+                      $"skipped-self-populating [{string.Join(",", skippedVirtual)}] " +
+                      $"skipped-projection-owned [{string.Join(",", skippedProjection)}]" +
                       // #1867: a content digest, not just counts — lets a diagnostic run compare
                       // "the dep+company baseline this app group got via a cache HIT" against
                       // "what a fresh, uncached capture for that same app group would have

--- a/AlRunner/Patches/RecordPatches.InstallBaselineDisk.cs
+++ b/AlRunner/Patches/RecordPatches.InstallBaselineDisk.cs
@@ -61,7 +61,10 @@ public static partial class RecordPatches
     // zero-length. A version-2 file is structurally readable under version-3 semantics right
     // up to the trailing-bytes check, which is exactly the "old file that still deserialises"
     // case the comment above says a cache cannot detect for itself.
-    internal const int InstallBaselineDiskSchemaVersion = 3;
+    // 3 -> 4 (#3236): same bytes, but a file may no longer carry Object Metadata (2000000071)
+    // unless a backup owned its rows; a version-3 file can hold the synthesised rows that
+    // disarm the payload refusal when restored.
+    internal const int InstallBaselineDiskSchemaVersion = 4;
 
     // Pool-entry kinds. Kind is stored per DISTINCT NavValue instance, not per row slot.
     private const byte KindBytes = 1;       // NavValue.GetBytes() + NavValue.CreateNavValueFromBytes

--- a/AlRunner/Patches/RecordPatches.NoSourceColumns.cs
+++ b/AlRunner/Patches/RecordPatches.NoSourceColumns.cs
@@ -234,19 +234,11 @@ public static partial class RecordPatches
     // #3184 is the same again one file over. Per-run derived state that the reload path did not
     // know it owned is the recurring defect here, not a one-off.
     //
-    // KNOWN, TRACKED, AND NOT FIXED HERE: issue #3236. The reload clear above bounds the
-    // LIFETIME of this flag; it does not make the way the flag is DERIVED correct. The arm
-    // condition is ProviderHasAnyRow(), a property of the store — and an install-baseline
-    // restore replays this projection's OWN synthesised rows into a brand-new provider, where
-    // the populate runs again (it runs on every access, and its once-guard is keyed on the
-    // provider), reads its own replayed output as somebody else's rows, and arms the flag over
-    // synthesised data. That is exactly the wrong-shaped question #2875 removed for Object
-    // (2000000001); RecordPatches.BackupRowProvenance.cs's header argues it in full, and
-    // TestDataProvisioner.cs's NoteBackupContributedRows call site repeats it at the writer.
-    // It is not fixed here because neither available predicate is complete on its own —
-    // BackupOwnsRowsFor() is right for the replay case and wrong for an install-baseline
-    // DISK-cache hit, where the backup's rows are restored in a process whose on-demand loader
-    // never ran. #3236 has the table and the suggested direction.
+    // The arm condition, ProviderHasAnyRow(), is a property of the store, so it is right only
+    // while no install-baseline restore can replay the runner's OWN synthesised rows into it.
+    // CaptureInstallBaselineSnapshot guarantees that by leaving the table out unless a backup
+    // owns its rows (IsProjectionOwnedSystemTableId, #3236). Capture a synthesised 2000000071
+    // again and this flag arms over synthesised data.
     private static volatile bool _objectMetadataRowsAreReal;
 
     /// <summary>

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1256,12 +1256,15 @@ of rows that should not have existed:
 A `--test-data` backup's rows still land: 2000000001 has no branch in `GetDataAccessForTableCore`
 any more and takes the generic fall-through, which is the same `GetOrCreateHydratedDataAccess`
 call the deleted branch made, minus the populate, with the same #2788 hand-out ordering. It is
-consequently captured into and restored from the install baseline like its sibling 2000000071,
-rather than being excluded from it: #2875's exclusion existed to stop a *projection* being
+consequently captured into and restored from the install baseline, rather than being excluded
+from it: #2875's exclusion existed to stop a *projection* being
 replayed into a fresh provider and read back as a backup's rows, and there is no projection to
 mistake. The provenance recorder #2875 introduced stays — `TestDataProvisioner.LoadOnDemand` is
-the only place that fact exists, and **issue #3236** is its named consumer for the same
-wrong-shaped question on Object Metadata.
+the only place that fact exists, and Object Metadata (2000000071) consumes it: that table DOES
+have a projection, so the capture leaves it out unless a backup owns its rows
+(`IsProjectionOwnedSystemTableId`, #3236). Captured, a replay of the synthesised rows read as a
+backup's and switched off the payload-column refusal; `tests/runner-extras/object-metadata-baseline-replay`
+pins that it stays on across a boundary.
 
 `tests/runner-extras/object-system-table` asserts the runner-side behaviour — that the emptiness
 is a per-table policy rather than a missing inventory (`AllObj` is read in the same session and

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -2258,3 +2258,20 @@ codeunit carrying this AL is one BC minor away from failing every leg's compile.
 Measured 6P/0F/0E on the whole bundle, not computed from the diff.
 
 Written by an agent (Claude, `fbk-3`).
+
+## runner-extras `object-metadata-baseline-replay` NEW, 6 (#3236)
+
+A new bundle. An install trigger reads Object Metadata (2000000071), which puts the runner's
+synthesised rows into the install baseline. Before the fix every codeunit-boundary restore
+replayed them into a new provider, the populate took them for supplied rows, and the #2771
+payload refusal switched off: four of the six tests failed (`2P/4F`). The capture now leaves the
+table out unless a backup owns its rows.
+
+Six tests, three per codeunit so the pair proves the restore in either execution order: a scalar
+payload column and a BLOB payload column still refuse by name, and the key columns still read
+(the control a fix that dropped the rows would fail).
+
+Measured 6P/0F/0E on the whole bundle, cold and warm against one cache root, not computed from
+the diff.
+
+Written by an agent (Claude, `stma-auto2-6`).

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -32,6 +32,7 @@
         "navapp-installed-app-system-table": { "tests": 6 },
         "navapp-moduleinfo-dep": { "tests": 0 },
         "navapp-moduleinfo-main": { "tests": 15 },
+        "object-metadata-baseline-replay": { "tests": 6 },
         "object-metadata-system-table": { "tests": 6 },
         "object-system-table": { "tests": 3 },
         "page-enum-control-modal": { "tests": 4 },

--- a/tests/runner-extras/object-metadata-baseline-replay/OmbrAssert.Codeunit.al
+++ b/tests/runner-extras/object-metadata-baseline-replay/OmbrAssert.Codeunit.al
@@ -1,0 +1,31 @@
+// Standalone Assert — this suite must stand alone, it does not import from tests/al-language.
+codeunit 65580 "OMBR Assert"
+{
+    procedure AreEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        if Format(Expected) <> Format(Actual) then
+            Error('Expected %1 but got %2: %3', Format(Expected), Format(Actual), Msg);
+    end;
+
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then Error('Expected true: %1', Msg);
+    end;
+
+    procedure IsFalse(Condition: Boolean; Msg: Text)
+    begin
+        if Condition then Error('Expected false: %1', Msg);
+    end;
+
+    procedure ExpectedError(Fragment: Text)
+    begin
+        if StrPos(GetLastErrorText(), Fragment) = 0 then
+            Error('Expected error containing ''%1'' but got ''%2''', Fragment, GetLastErrorText());
+    end;
+
+    procedure NotExpectedError(Fragment: Text)
+    begin
+        if StrPos(GetLastErrorText(), Fragment) > 0 then
+            Error('Error must NOT contain ''%1'', but got ''%2''', Fragment, GetLastErrorText());
+    end;
+}

--- a/tests/runner-extras/object-metadata-baseline-replay/OmbrInstaller.Codeunit.al
+++ b/tests/runner-extras/object-metadata-baseline-replay/OmbrInstaller.Codeunit.al
@@ -1,0 +1,16 @@
+// Issue #3236. Reading Object Metadata inside an install trigger is what puts the table in the
+// install baseline: the capture walks every store that exists when install seeding ends, and
+// the first access to 2000000071 is what creates this one and fills it with synthesised rows.
+codeunit 65581 "OMBR Installer"
+{
+    Subtype = Install;
+
+    trigger OnInstallAppPerCompany()
+    var
+        ObjectMetadata: Record "Object Metadata";
+    begin
+        ObjectMetadata.SetRange("Object Type", ObjectMetadata."Object Type"::Table);
+        if ObjectMetadata.IsEmpty() then
+            Error('Object Metadata must already hold its synthesised rows inside an install trigger.');
+    end;
+}

--- a/tests/runner-extras/object-metadata-baseline-replay/OmbrTestsA.Codeunit.al
+++ b/tests/runner-extras/object-metadata-baseline-replay/OmbrTestsA.Codeunit.al
@@ -1,0 +1,59 @@
+// Issue #3236. Two identical codeunits on purpose: the runner does not promise to run test
+// codeunits in id order, and whichever of the two runs second starts from a codeunit-boundary
+// restore of an install baseline that carries Object Metadata's synthesised rows. Before the
+// fix that replay disarmed the #2771 refusal for the rest of the process, so the payload reads
+// below answered blank. Each codeunit asserts on entry, so the pair proves it in either order.
+codeunit 65582 "OMBR Tests A"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit "OMBR Assert";
+
+    [Test]
+    procedure PayloadScalar_StillRefuses_AfterBaselineRestore_A()
+    var
+        ObjectMetadata: Record "Object Metadata";
+        Sink: Text;
+    begin
+        FindOwnRow(ObjectMetadata);
+
+        asserterror Sink := Format(ObjectMetadata."Metadata Version");
+        Assert.ExpectedError('out-of-scope: Object Metadata."Metadata Version" (system table 2000000071)');
+
+        asserterror Sink := Format(ObjectMetadata."Has Subscribers");
+        Assert.ExpectedError('out-of-scope: Object Metadata."Has Subscribers" (system table 2000000071)');
+    end;
+
+    [Test]
+    procedure PayloadBlob_StillRefuses_AfterBaselineRestore_A()
+    var
+        ObjectMetadata: Record "Object Metadata";
+    begin
+        FindOwnRow(ObjectMetadata);
+
+        asserterror ObjectMetadata.CalcFields(Metadata);
+        Assert.ExpectedError('out-of-scope: Object Metadata."Metadata" (system table 2000000071)');
+    end;
+
+    [Test]
+    procedure KeyColumns_StillRead_AfterBaselineRestore_A()
+    var
+        ObjectMetadata: Record "Object Metadata";
+    begin
+        // The control: the fix must not refuse or drop the rows themselves. FindLast landing on
+        // the highest listed id fails against an empty or single-placeholder store.
+        ObjectMetadata.SetRange("Object Type", ObjectMetadata."Object Type"::Table);
+        Assert.IsTrue(ObjectMetadata.FindLast(), 'FindLast over Object Type = Table must succeed after a restore.');
+        Assert.AreEqual(2000000400, ObjectMetadata."Object ID", 'FindLast must land on the highest application-database table id.');
+        Assert.IsTrue(ObjectMetadata."Emit Version" >= 27000, 'Emit Version has a real source and must still read.');
+    end;
+
+    local procedure FindOwnRow(var ObjectMetadata: Record "Object Metadata")
+    begin
+        ObjectMetadata.SetRange("Object Type", ObjectMetadata."Object Type"::Table);
+        ObjectMetadata.SetRange("Object ID", 2000000071);
+        Assert.IsTrue(ObjectMetadata.FindFirst(), 'Object Metadata must have a row for its own table id.');
+    end;
+}

--- a/tests/runner-extras/object-metadata-baseline-replay/OmbrTestsB.Codeunit.al
+++ b/tests/runner-extras/object-metadata-baseline-replay/OmbrTestsB.Codeunit.al
@@ -1,0 +1,59 @@
+// Issue #3236. Two identical codeunits on purpose: the runner does not promise to run test
+// codeunits in id order, and whichever of the two runs second starts from a codeunit-boundary
+// restore of an install baseline that carries Object Metadata's synthesised rows. Before the
+// fix that replay disarmed the #2771 refusal for the rest of the process, so the payload reads
+// below answered blank. Each codeunit asserts on entry, so the pair proves it in either order.
+codeunit 65583 "OMBR Tests B"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit "OMBR Assert";
+
+    [Test]
+    procedure PayloadScalar_StillRefuses_AfterBaselineRestore_B()
+    var
+        ObjectMetadata: Record "Object Metadata";
+        Sink: Text;
+    begin
+        FindOwnRow(ObjectMetadata);
+
+        asserterror Sink := Format(ObjectMetadata."Metadata Version");
+        Assert.ExpectedError('out-of-scope: Object Metadata."Metadata Version" (system table 2000000071)');
+
+        asserterror Sink := Format(ObjectMetadata."Has Subscribers");
+        Assert.ExpectedError('out-of-scope: Object Metadata."Has Subscribers" (system table 2000000071)');
+    end;
+
+    [Test]
+    procedure PayloadBlob_StillRefuses_AfterBaselineRestore_B()
+    var
+        ObjectMetadata: Record "Object Metadata";
+    begin
+        FindOwnRow(ObjectMetadata);
+
+        asserterror ObjectMetadata.CalcFields(Metadata);
+        Assert.ExpectedError('out-of-scope: Object Metadata."Metadata" (system table 2000000071)');
+    end;
+
+    [Test]
+    procedure KeyColumns_StillRead_AfterBaselineRestore_B()
+    var
+        ObjectMetadata: Record "Object Metadata";
+    begin
+        // The control: the fix must not refuse or drop the rows themselves. FindLast landing on
+        // the highest listed id fails against an empty or single-placeholder store.
+        ObjectMetadata.SetRange("Object Type", ObjectMetadata."Object Type"::Table);
+        Assert.IsTrue(ObjectMetadata.FindLast(), 'FindLast over Object Type = Table must succeed after a restore.');
+        Assert.AreEqual(2000000400, ObjectMetadata."Object ID", 'FindLast must land on the highest application-database table id.');
+        Assert.IsTrue(ObjectMetadata."Emit Version" >= 27000, 'Emit Version has a real source and must still read.');
+    end;
+
+    local procedure FindOwnRow(var ObjectMetadata: Record "Object Metadata")
+    begin
+        ObjectMetadata.SetRange("Object Type", ObjectMetadata."Object Type"::Table);
+        ObjectMetadata.SetRange("Object ID", 2000000071);
+        Assert.IsTrue(ObjectMetadata.FindFirst(), 'Object Metadata must have a row for its own table id.');
+    end;
+}

--- a/tests/runner-extras/object-metadata-baseline-replay/app.json
+++ b/tests/runner-extras/object-metadata-baseline-replay/app.json
@@ -1,0 +1,18 @@
+{
+  "id": "0e0669ab-b144-435a-b805-4819094ab5cd",
+  "name": "Runner Extras - Object Metadata Baseline Replay",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Issue #3236: the #2771 refusal on Object Metadata's (2000000071) nine payload columns must survive a codeunit-boundary install-baseline restore.",
+  "description": "An install trigger that reads Object Metadata puts the runner's own synthesised rows into the store the install baseline captures. Before #3236 every boundary restore replayed those rows into a brand-new provider, the populate read them as rows somebody else supplied, and the payload columns answered blank instead of refusing. This suite pins the runner-side refusal, which no service tier can see (a tier has a real payload). Target is OnPrem because Object Metadata is Scope = OnPrem (AL0296).",
+  "dependencies": [],
+  "idRanges": [
+    {
+      "from": 65580,
+      "to": 65589
+    }
+  ],
+  "platform": "27.0.0.0",
+  "runtime": "15.0",
+  "target": "OnPrem"
+}


### PR DESCRIPTION
Closes #3236

Written by agent stma-auto2-6, an automated agent acting on the account holder's behalf.

Corpus-NA: runner-only refusal; a service tier has the real Object Metadata payload and cannot observe the runner declining to invent one, and the row set was already adjudicated by corpus PR #179

## What was wrong

When an install trigger reads Object Metadata (2000000071), the install baseline captured the runner's own synthesised rows. Every codeunit-boundary restore then put those rows into a new provider. `PopulateObjectMetadataSystemTable` saw rows, took them for rows a backup supplied, and called `MarkObjectMetadataRowsAreReal()`. After that, the nine payload columns answered blank instead of refusing (the #2771 refusal) for the rest of the process.

**Reachability, now measured.** The coordinator's comment on the issue said this was unmeasured in either direction. It is reachable without `--test-data` or `--server`: one `Subtype = Install` codeunit that reads the table is enough. With `AL_RUNNER_PERF=1` on the new bundle before the fix: `InstallBaseline.Capture 8 table(s), 50 row(s)` (43 of the 50 are Object Metadata), then `InstallBaseline.Restore 50 row(s)` at each boundary. With the installer file removed, the same bundle passed 6/6.

## The fix

`CaptureInstallBaselineSnapshot` now skips 2000000071 when `IsProjectionOwnedSystemTableId` is true, which means Object Metadata with no `--test-data` backup that owns its rows (`BackupOwnsRowsFor`, recorded by `TestDataProvisioner.LoadOnDemand`). If the table is not captured, the boundary drops the store and the next access synthesises it again, so the refusal stays on. The gate in `RecordPatches.ObjectMetadataSystemTable.cs` did not change.

Here is the issue's three-configuration table with this change:

| configuration | result |
|---|---|
| synthesised rows, then a baseline restore | not captured, so nothing is replayed and the refusal stays on (**proven end to end, bundle below**) |
| `--test-data` load, then a replay | backup owns the rows, so they are captured and replayed, and the refusal turns off over real rows |
| disk-cache HIT restoring backup rows, loader never ran | the file carries 2000000071 only if a backup owned it in the process that wrote the file, so the refusal turns off over real rows. Older files that could hold synthesised rows are not read: `InstallBaselineDiskSchemaVersion` goes from 3 to 4, following that file's own rule for a same-bytes semantic change. The key's `RunnerFingerprint` content hash would also reject them |

Rows 2 and 3 need a BC database backup, which this machine and CI do not have. They are pinned at the predicate in C# (below), not end to end.

I did not add the table to `IsSelfPopulatingVirtualTableId`. `AppendBaselineTable` throws for those ids, and the `--test-data` loader appends 2000000071 when it loads rows for it. The existing `ObjectAndItsSiblingAndAnOrdinaryTable_AreAllAppendableWithoutProvenance` still passes.

## RED -> GREEN

New bundle `tests/runner-extras/object-metadata-baseline-replay` (ids 65580-65589; I checked open PRs for collisions and found none). It has an install codeunit that reads the table, and two identical test codeunits so the claim holds in either run order. Each codeunit checks that a scalar payload column refuses, that a BLOB payload column refuses, and a control that the key columns still read (FindLast lands on 2000000400).

- RED (origin/main build): `2P/4F/0E across 6 tests`. All four payload tests fail with `An error was expected inside an ASSERTERROR statement`; both controls pass.
- GREEN: `6P/0F/0E`, cold and then warm against one `--cache` root. It is also `6P/0F/0E` when run in one invocation next to `object-metadata-system-table`, and after rebasing on b0d5a598. `object-system-table` 3/3 and `install-trigger-seed` 3/3 are unchanged.
- C# `BackupRowProvenanceTests`: added `ObjectMetadata_IsProjectionOwned_ExactlyWhileNoBackupOwnsItsRows` and `NoOtherTable_IsProjectionOwned`, 9 tests in total (7 existing + 2 new). After the rebase and the schema bump, `BackupRowProvenanceTests` together with `InstallBaselineDiskCacheTests` gave `Failed: 0, Passed: 14, Skipped: 0, Total: 14`.
- Cost: the capture on this bundle drops from `8 table(s), 50 row(s)` to `7 table(s), 7 row(s)` (`skipped-projection-owned [2000000071]`). At each boundary the next access synthesises 43 rows instead of the restore inserting them.

## Mutation (executed)

Measured before the rebase onto b0d5a598, which touches only session code. I inverted the polarity of the predicate (`&& !BackupOwnsRowsFor` became `&& BackupOwnsRowsFor`), confirmed the diff, and rebuilt:
- bundle: `2P/4F/0E`, the same four payload tests red on the assertion and both `KeyColumns` controls green. That shows the tests separate the refusal from the rows.
- C#: `Failed: 1, Passed: 8, Total: 9`. The red one is `ObjectMetadata_IsProjectionOwned_ExactlyWhileNoBackupOwnsItsRows` (`Assert.True() Failure`). `NoOtherTable_IsProjectionOwned` stays green, which is correct because inverting the polarity does not change the answer for other tables.

Restored, rebuilt, and back to green.

## Corpus

No corpus test is owed. The claim is that the runner refuses to invent a payload it has no source for. A service tier has the real payload, so it cannot see this. Nothing here says what BC returns. The row set and emit version were adjudicated upstream by corpus PR #179 and are unchanged.

## Fix the shape

1. **Same wrong pattern at another call site?** `ProviderHasAnyRow` is used as a provenance test only in `PopulateObjectMetadataSystemTable`. Object (2000000001) was the other instance, and #3071 removed its projection. The other projected tables (AllObj, Field, Table/Page/Report Metadata and similar) are already excluded from capture by `IsSelfPopulatingVirtualTableId`, and none of them has a refusal gate that reads the store.
2. **Sibling making the same assumption?** The disk codec (`InstallBaselineDisk.cs` write filter, round-trip digest, persistable digest) filters the captured snapshot. Because the capture now leaves the table out, the disk file cannot hold synthesised 2000000071 rows either. The two writers agree without changing the filter in that file. The only change there is the schema-version bump. `AppendBaselineTable` is the other writer of the baseline lists, and only the backup loader calls it, after `NoteBackupContributedRows`.
3. **Two paths writing the same state, same invariant?** The capture (install output) and the append (backup rows) now agree that a baseline carries 2000000071 only when a backup owns it.

**Left out, on purpose.** The hydration window in the coordinator's comment: `MaterialiseObjectMetadataStoreCore` returns before the populate while a store is awaiting `--test-data` hydration. The flag is off there, but the store is empty, so a read fails on the row lookup before it reaches the refusal. This change does not affect it, and I have no reproducer for it.

**Queue scan.** I searched for "Object Metadata", "install baseline replay" and "ProviderHasAnyRow". Related but different: #3766 (no service-tier verdict for 2000000071, a corpus question), #3254 (install-baseline cache key component not pinned by a test, a different defect in the same subsystem), #2279 (cross-app-group AllObj rows). None of them lands in the lines this change touches.

## Where the prose went

I replaced the 13-line "KNOWN, TRACKED, AND NOT FIXED HERE: #3236" block in `RecordPatches.NoSourceColumns.cs` with a 5-line statement of the invariant. I also corrected the stale "IsProjectionOwnedSystemTableId went with them" notes in `RecordPatches.BackupRowProvenance.cs`, `BackupRowProvenanceTests.cs` and `docs/limitations.md`.

## Local runs not green, all environmental

- `tools/test_agent_self_freshness.py`, `test_corpus_checkout.py`, `test_preflight.py`: each fails at `git commit` in a scratch repository (`1Password: failed to fill whole buffer`, commit signing on this box).
- `GuardTests` 248/249 and three rows in the wider filter: `bc-engine-serial` refuses to run because `tools/engine-test-bootstrap.sh` was not run. None of these touch the changed files.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
