### PR TITLE
fix(isolation): ResetSingleInstanceCache leaks the instance and its keep-alive handle into the session tree

### DIFF
--- a/AlRunner.Tests/SingleInstanceResetLeakTests.cs
+++ b/AlRunner.Tests/SingleInstanceResetLeakTests.cs
@@ -67,6 +67,12 @@ public class SingleInstanceResetLeakTests
 
             BcRuntime.ResetSingleInstanceCache();
 
+            int now = sessionTree.Children.Count;
+            Assert.True(now == before,
+                $"cycle {cycle}: session tree children before={before} after reset={now} " +
+                $"delta={now - before}. A delta of {2 * (cycle + 1)} is the #2181 leak " +
+                "(instance + keep-alive handle per reset).");
+
             // The reset invalidated the only AL handle holding it, so BC's refcount reaches
             // zero and disposes it.
             Assert.True(((ITreeObject)instance).Tree.IsDisposed,
@@ -101,6 +107,10 @@ public class SingleInstanceResetLeakTests
         var bound = new NavCodeunitHandle(root, ProbeId);
         var instance = Assert.IsType<Codeunit69001>(bound.Target);
         instance.Token = "HELD";
+
+        // The safety of disposing only the keep-alive handle rests on the instance being
+        // refcounted (TreeSharedObjectHandler); a Normal tree object never counts references.
+        Assert.Equal(TreeObjectType.Shared, ((ITreeObject)instance).Type);
 
         // NavCodeunitHandle(ITreeObject, NavCodeunit): assigns Target directly, bypassing
         // CreateTarget — the same shape as a copied handle.

--- a/AlRunner.Tests/SingleInstanceResetLeakTests.cs
+++ b/AlRunner.Tests/SingleInstanceResetLeakTests.cs
@@ -1,0 +1,178 @@
+// Pins the runner's SingleInstance bookkeeping against two leaks (#2181, #2185). Neither is
+// AL-observable — both are counts of runner-owned objects — so they are pinned here rather
+// than in the corpus. Probe codeunit: Codeunit69001 in SingleInstanceResetHandleInvalidationTests.cs.
+
+using System.Reflection;
+using AlRunner;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public class SingleInstanceResetLeakTests
+{
+    private const int ProbeId = 69001;
+    private const int Cycles = 20;
+
+    private readonly BcEngineFixture _engine;
+
+    public SingleInstanceResetLeakTests(BcEngineFixture engine) => _engine = engine;
+
+    private ITreeObject Session()
+    {
+        var session = BcRuntime.SkeletonSession as ITreeObject;
+        Assert.True(session != null,
+            "BcRuntime.SkeletonSession is null after the engine bootstrap — the cached instance " +
+            "is only session-rooted when a session exists, so this test would measure nothing.");
+        return session!;
+    }
+
+    private static ITreeObject Root()
+    {
+        var root = BcRuntime.RootTreeStub;
+        Assert.True(root != null, "BcRuntime.RootTreeStub is null after the engine bootstrap.");
+        return root!;
+    }
+
+    /// <summary>#2181: every reset used to leave the instance AND its keep-alive handle linked
+    /// into the session tree — exactly two children per cycle, forever.</summary>
+    [SkippableFact]
+    public void Reset_UnlinksTheCachedInstanceAndItsKeepAliveHandle_FromTheSessionTree()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        BcRuntime.ResetSingleInstanceCache();
+        var sessionTree = Session().Tree;
+        var root = Root();
+        int before = sessionTree.Children.Count;
+
+        Codeunit69001? previous = null;
+        // Left alive through every reset, so the bounded count below measures the reset and
+        // not this test's own cleanup. They are parented on the root, not the session.
+        var handles = new List<NavCodeunitHandle>();
+        for (int cycle = 0; cycle < Cycles; cycle++)
+        {
+            // An AL variable that resolves the codeunit and is still alive at the reset.
+            var handle = new NavCodeunitHandle(root, ProbeId);
+            var instance = Assert.IsType<Codeunit69001>(handle.Target);
+            Assert.NotSame(previous, instance);
+
+            // Resolving it must have linked something into the session (the harness can see
+            // growth), otherwise the bounded count below proves nothing.
+            Assert.True(sessionTree.Children.Count > before,
+                $"cycle {cycle}: resolving a SingleInstance codeunit added nothing to the session " +
+                "tree, so this test cannot observe the leak it exists to catch.");
+
+            BcRuntime.ResetSingleInstanceCache();
+
+            // The reset invalidated the only AL handle holding it, so BC's refcount reaches
+            // zero and disposes it.
+            Assert.True(((ITreeObject)instance).Tree.IsDisposed,
+                $"cycle {cycle}: the instance the reset dropped is still alive.");
+            handles.Add(handle);
+            previous = instance;
+        }
+
+        int after = sessionTree.Children.Count;
+        foreach (var h in handles) h.Dispose();
+        Assert.True(after == before,
+            $"session tree children: before={before} after {Cycles} cycles={after} " +
+            $"delta={after - before}. A delta of {2 * Cycles} is the #2181 leak " +
+            "(instance + keep-alive handle per reset).");
+    }
+
+    /// <summary>The hazard #2181's fix must respect: a handle that holds the instance without
+    /// ever going through CreateTarget (CloneReference / ALAssign / ALByValue build handles this
+    /// way) is not tracked, so the reset cannot invalidate it. It must keep a LIVE instance —
+    /// never a disposed one, which is the NRE the keep-alive handle exists to prevent.</summary>
+    [SkippableFact]
+    public void Reset_WhileAnUntrackedHandleHoldsTheInstance_LeavesItAliveUntilThatHandleGoes()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        BcRuntime.ResetSingleInstanceCache();
+        var sessionTree = Session().Tree;
+        var root = Root();
+        int before = sessionTree.Children.Count;
+
+        var bound = new NavCodeunitHandle(root, ProbeId);
+        var instance = Assert.IsType<Codeunit69001>(bound.Target);
+        instance.Token = "HELD";
+
+        // NavCodeunitHandle(ITreeObject, NavCodeunit): assigns Target directly, bypassing
+        // CreateTarget — the same shape as a copied handle.
+        var untracked = new NavCodeunitHandle(root, instance);
+
+        BcRuntime.ResetSingleInstanceCache();
+
+        Assert.False(((ITreeObject)instance).Tree.IsDisposed,
+            "the reset disposed an instance an untracked handle still references.");
+        var stillHeld = Assert.IsType<Codeunit69001>(untracked.Target);
+        Assert.Same(instance, stillHeld);
+        Assert.Equal("HELD", stillHeld.Token);
+
+        // The tracked handle still re-resolves to a fresh instance (#2143's invariant).
+        Assert.NotSame(instance, bound.Target);
+
+        // Once the last reference goes, BC's own refcount disposes and unlinks it.
+        untracked.Dispose();
+        Assert.True(((ITreeObject)instance).Tree.IsDisposed,
+            "the instance survived its last reference being dropped.");
+
+        bound.Dispose();
+        BcRuntime.ResetSingleInstanceCache();
+        Assert.Equal(before, sessionTree.Children.Count);
+    }
+
+    private static int BoundHandleCount()
+    {
+        var field = typeof(BcRuntime).GetField("_singleInstanceBoundHandles",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.True(field != null, "BcRuntime._singleInstanceBoundHandles not found — renamed?");
+        var list = (System.Collections.ICollection)field!.GetValue(null)!;
+        return list.Count;
+    }
+
+    /// <summary>#2185: with no reset (--isolation disabled) every resolution appended an entry
+    /// that was never pruned.</summary>
+    [SkippableFact]
+    public void WithoutReset_BoundHandleList_StaysBoundedAsHandlesAreDisposed()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        BcRuntime.ResetSingleInstanceCache();
+        var root = Root();
+
+        // A live handle bound before the churn: pruning must never drop it.
+        var survivor = new NavCodeunitHandle(root, ProbeId);
+        var first = Assert.IsType<Codeunit69001>(survivor.Target);
+
+        const int churn = 2000;
+        for (int i = 0; i < churn; i++)
+        {
+            var h = new NavCodeunitHandle(root, ProbeId);
+            Assert.Same(first, h.Target);
+            h.Dispose();
+        }
+
+        int count = BoundHandleCount();
+        Assert.True(count <= 256,
+            $"_singleInstanceBoundHandles holds {count} entries after {churn} resolve+dispose " +
+            $"cycles with no reset; about {churn + 1} is the #2185 leak.");
+
+        // Pruning kept the live entry: a reset still makes the survivor re-resolve.
+        BcRuntime.ResetSingleInstanceCache();
+        var fresh = new NavCodeunitHandle(root, ProbeId);
+        var second = Assert.IsType<Codeunit69001>(fresh.Target);
+        Assert.NotSame(first, second);
+        Assert.Same(second, survivor.Target);
+
+        survivor.Dispose();
+        fresh.Dispose();
+        BcRuntime.ResetSingleInstanceCache();
+    }
+}

--- a/AlRunner/Patches/CodeunitPatches.cs
+++ b/AlRunner/Patches/CodeunitPatches.cs
@@ -39,8 +39,9 @@ public static partial class BcRuntime
     // null and the next access NRE'd with no message inside BC (measured: Base App codeunit
     // 347 "Auto Format".GetGLSetup; `tree=DISPOSED` logged immediately before the NRE).
     // Real BC does not hit zero because the session itself holds a SingleInstance codeunit;
-    // this handle is that reference, and it is parented on the session so it lives exactly as
-    // long as the cache entry does.
+    // this handle is that reference, and it is parented on the session. Dropping the
+    // dictionary entry does NOT release it — the session tree still holds the handle — so
+    // ResetSingleInstanceCache disposes each handle, which is what decrements the count (#2181).
     private static readonly ConcurrentDictionary<int, Microsoft.Dynamics.Nav.Runtime.NavCodeunitHandle> _singleInstanceKeepAlive = new();
 
     // Every AL variable handle that has already resolved a SingleInstance codeunit through
@@ -81,9 +82,24 @@ public static partial class BcRuntime
     private static void TrackSingleInstanceBinding(Microsoft.Dynamics.Nav.Runtime.NavCodeunitHandle handle)
     {
         lock (_singleInstanceBoundHandlesLock)
+        {
+            // Under --isolation disabled no reset ever clears the list (#2185), so compact it
+            // whenever it doubles past what was live at the last compaction.
+            if (_singleInstanceBoundHandles.Count >= _singleInstanceBoundHandlesCompactAt)
+            {
+                // IsDisposed, not only a dead WeakReference: a disposed handle is still
+                // reachable until a GC runs, and the invalidation loop skips it anyway.
+                _singleInstanceBoundHandles.RemoveAll(w => !w.TryGetTarget(out var h) || h.IsDisposed);
+                _singleInstanceBoundHandlesCompactAt =
+                    Math.Max(SingleInstanceBoundHandlesMinCompactAt, _singleInstanceBoundHandles.Count * 2);
+            }
             _singleInstanceBoundHandles.Add(
                 new WeakReference<Microsoft.Dynamics.Nav.Runtime.NavCodeunitHandle>(handle));
+        }
     }
+
+    private const int SingleInstanceBoundHandlesMinCompactAt = 64;
+    private static int _singleInstanceBoundHandlesCompactAt = SingleInstanceBoundHandlesMinCompactAt;
 
     /// <summary>
     /// Drop every cached SingleInstance codeunit instance. Must run at the per-test-isolation
@@ -92,12 +108,23 @@ public static partial class BcRuntime
     /// </summary>
     public static void ResetSingleInstanceCache()
     {
-        // Invalidate the per-handle copies FIRST — see _singleInstanceBoundHandles. Doing it
-        // before the dictionaries are cleared matters only for readability; what matters for
-        // correctness is that no handle is left holding an instance the cache no longer has.
+        // Invalidate the per-handle copies FIRST — see _singleInstanceBoundHandles — so no
+        // handle is left holding an instance the cache no longer has.
         InvalidateBoundSingleInstanceHandles();
-        // Release the keep-alive references first: dropping them is what lets BC's refcount
-        // fall to zero and dispose the instances, which is the per-test cleanup real BC does.
+        // Only AFTER the invalidation above: until now the keep-alive handle is what stops
+        // those ClearReference calls from disposing the instance mid-loop.
+        //
+        // Dispose the keep-alive HANDLE, never the instance. Disposing the handle unlinks it
+        // from the session and drops its reference; BC's own refcount then disposes and
+        // unlinks the instance only if nothing else references it. A handle that copied the
+        // target without CreateTarget (CloneReference/ALAssign/ALByValue) is untracked, still
+        // counts, and keeps a LIVE instance rather than the disposed one described on
+        // _singleInstanceKeepAlive. Pinned by SingleInstanceResetLeakTests (#2181).
+        foreach (var keepAlive in _singleInstanceKeepAlive.Values)
+        {
+            if (!keepAlive.IsDisposed)
+                keepAlive.Dispose();
+        }
         _singleInstanceKeepAlive.Clear();
         _singleInstanceCache.Clear();
     }
@@ -130,6 +157,7 @@ public static partial class BcRuntime
                 handle.ClearReference();
             }
             _singleInstanceBoundHandles.Clear();
+            _singleInstanceBoundHandlesCompactAt = SingleInstanceBoundHandlesMinCompactAt;
         }
     }
 


### PR DESCRIPTION
Closes #2181
Closes #2185

Written by agent stma-auto2-7 on the account holder's behalf.

Corpus-NA: both defects are counts of runner-owned objects (session-tree children, a WeakReference list length) with no AL-observable effect; the AL-level SingleInstance lifetime is already green upstream (corpus 60237, 60922)

## What changed

Both fixes are in `AlRunner/Patches/CodeunitPatches.cs`.

**#2181.** `ResetSingleInstanceCache` called `_singleInstanceKeepAlive.Clear()`. The keep-alive handle is parented on the skeleton session, so dropping the dictionary entry did not release it, and every reset left the instance and its handle linked into the session tree. The reset now calls `Dispose()` on each keep-alive **handle**, and only after `InvalidateBoundSingleInstanceHandles()` has run.

It disposes the handle and never the instance. That is how I handled the hazard the issue describes. Disposing the handle drops one reference. BC's own refcount (`TreeSharedObjectHandler.InternalRemoveReferenceDisposeIfLast`, read on bc284; the hazard test asserts `((ITreeObject)instance).Type == TreeObjectType.Shared`, so the refcounting branch is measured, not assumed) then disposes and unlinks the instance only if nothing else points at it. A handle that copied the target without going through `CreateTarget` (`CloneReference`/`ALAssign`/`ALByValue`) is not tracked, but it still counts as a reference. So that instance stays alive and usable until the copied handle goes away. It never becomes the disposed-but-reachable instance that NREs. This means the copy paths don't need their own tracking. The misleading comment on `_singleInstanceKeepAlive` is corrected.

**#2185.** `TrackSingleInstanceBinding` now compacts the list whenever it reaches double the number of entries that were live after the last compaction (64 minimum). An entry is removed when its `WeakReference` is dead **or the handle is disposed**. A disposed handle can't re-resolve, and the invalidation loop already skips it. Checking `IsDisposed` keeps the compaction deterministic, because it doesn't depend on a GC having run. The reset also puts the threshold back to 64.

## Where the test lives

Runner-internal, so the tests are in `AlRunner.Tests`, not the corpus. Neither leak can be observed from AL. The AL-visible property, one SingleInstance instance per window and a fresh one after the reset, is unchanged. It is already covered upstream, and `SingleInstanceResetHandleInvalidationTests` pins it on the runner side.

New file: `AlRunner.Tests/SingleInstanceResetLeakTests.cs`, which reuses that file's `Codeunit69001` probe:

- `Reset_UnlinksTheCachedInstanceAndItsKeepAliveHandle_FromTheSessionTree` runs 20 resolve/reset cycles, with the AL handles left alive across the resets. It checks that the dropped instance is disposed, and that the session child count comes back to its starting value.
- `Reset_WhileAnUntrackedHandleHoldsTheInstance_LeavesItAliveUntilThatHandleGoes` covers the hazard. An untracked handle (`new NavCodeunitHandle(parent, instance)`, which skips `CreateTarget`) keeps a live instance with its state intact across the reset. The instance is disposed only once that handle is disposed.
- `WithoutReset_BoundHandleList_StaysBoundedAsHandlesAreDisposed` resolves and disposes 2000 handles with no reset and expects at most 256 entries. A survivor handle bound before the churn must still re-resolve at the next reset, which proves compaction keeps live entries.

## RED -> GREEN -> mutations

All runs used a Release build, `tools/engine-test-bootstrap.sh` after every build, and `--settings engine.runsettings`, with filter `FullyQualifiedName~SingleInstanceReset`. The filter selects 6 tests: the 3 new ones plus the 3 existing invalidation tests. Every red below is the assertion text, not a bootstrap refusal or a build error (0 `error CS`).

| state | result | failing assertion |
|---|---|---|
| RED (main's code, first version of the leak test, before the per-cycle count assertion was added) | `Failed: 3, Passed: 3` | `cycle 0: the instance the reset dropped is still alive`; `the instance survived its last reference being dropped`; `_singleInstanceBoundHandles holds 2001 entries after 2000 ...` |
| GREEN | `Failed: 0, Passed: 6` | |
| #2181 mutation C: skip `keepAlive.Dispose()` | `Failed: 2, Passed: 4` | `cycle 0: session tree children before=8 after reset=10 delta=2` (the #2181 measurement, 2 per reset); `the instance survived its last reference being dropped` |
| #2181 mutation A: also force-dispose the instances | `Failed: 1, Passed: 5` | only the hazard test: `the reset disposed an instance an untracked handle still references` |
| #2185 mutation B: drop the `IsDisposed` term | `Failed: 1, Passed: 5` | only the bound-list test: `holds 2001 entries` |
| #2185 mutation D: prune every entry | `Failed: 1, Passed: 5` | only the bound-list test: `Assert.Same()` failure on the survivor |

Mutation A reds the hazard test and leaves the leak test green. That shows the two #2181 tests measure different things. Mutations B and D together show the compaction removes disposed entries and keeps live ones.

## Wider runs (local, corpus `757263e91a36be36dd39f8c90e20a546cf7afa58`, platform apps 28.1)

The reset sits on the shared per-test path and now disposes objects, so I ran the whole corpus in all three isolation modes, both with this change and with `origin/main`'s `CodeunitPatches.cs`:

| isolation | this PR | main | failing sets |
|---|---|---|---|
| codeunit (default, `--strict`) | 3318P/6F | 3318P/6F | identical (the 6 are `Codeunit60976.ActiveSession_*`, tracked by #3233 / PR #3985) |
| test | 3304P/20F | 3304P/20F | identical |
| disabled | 3309P/15F | 3309P/15F | identical |

No new NREs in any mode. I did not run `runner-extras` locally; CI covers it.

Guards: `dotnet test --filter "FullyQualifiedName~GuardTests|FullyQualifiedName~SingleInstanceReset"` with the engine bootstrap gave `Failed: 0, Passed: 255`. In `tools/test_*.py`, `test_agent_self_freshness.py`, `test_corpus_checkout.py` and `test_preflight.py` fail on this box. Each one fails at `git commit` inside a temporary scratch repo (`1Password: agent returned an error`, commit signing), before any assertion runs. This PR doesn't touch any of them.

## Fix the shape

1. **Same pattern at another call site?** I searched `AlRunner/` for static collections holding tree objects or handles. The only ones are the three SingleInstance collections changed here, plus `EventSubscriberPatches._byKey`/`_byPageKey`, which hold the runner's own `SubscriberHandle`, not BC tree objects. The shared-object container leak with the same structure was fixed earlier (`SkeletonSharedObjectContainerLeakTests`).
2. **Sibling assumption?** `KeepSingleInstanceAlive` and `NavCodeunitHandle_CreateTarget` both assumed `Clear()` released the instance. The comment is corrected and the reset now disposes. When there is no skeleton session, no keep-alive handle is created, and the instance stays parented on the caller's handle, so nothing leaks there.
3. **Two writers, same invariant?** `ResetSingleInstanceCache` is the only code that clears these three collections, and it now keeps all of them in step. It invalidates bound handles, disposes keep-alive handles, clears both dictionaries and resets the compaction threshold. Nothing else found. `SetTestAssembly` clears `_codeunitTypeCache` but not the SingleInstance cache. I did not check whether a stale instance can survive an assembly switch. That is outside this change, and I have not measured it.

Queue scan (`SingleInstance`, `keep-alive`, `session tree`, `ResetPerTestState`): #2185 is folded in. #3524 (replacing the Codeunit.Run dispatcher) touches the same file but is an investigation with a different scope, so it is not folded. #3575 is about ApplicationAreas at the reset boundary, a different state.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
