### PR TITLE
test(expectations): tests/expectations file prefix and entry Mode must agree

### DIFF
--- a/AlRunner.Tests/ExpectationFilePrefixTests.cs
+++ b/AlRunner.Tests/ExpectationFilePrefixTests.cs
@@ -1,0 +1,163 @@
+// The file prefix under tests/expectations/ and each entry's Mode must agree (#3114).
+// Enforced here, over the shipped directory, and deliberately NOT in LoadFromDirectory: the
+// runner also loads a user's own manifest (--expectations <dir>, or ./tests/expectations by
+// default), whose file names are that project's business. See docs/expectations.md#layout.
+
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class ExpectationFilePrefixTests : IDisposable
+{
+    private readonly string _dir = TestScratch.FlatDir("al-runner-prefix-");
+
+    public ExpectationFilePrefixTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    // One loadable entry per mode; each carries exactly the fields that mode requires.
+    private static string Entry(string mode, string codeunit = "Cu", string method = "M") => mode switch
+    {
+        "expect-oos" =>
+            $@"{{""codeunitId"":1,""CodeunitName"":""{codeunit}"",""Method"":""{method}"",""Mode"":""expect-oos"",""Reason"":""http-egress""}}",
+        "expect-fail-known-gap" =>
+            $@"{{""codeunitId"":1,""CodeunitName"":""{codeunit}"",""Method"":""{method}"",""Mode"":""expect-fail-known-gap"","
+            + @"""Issue"":""https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3114""}",
+        "expect-divergence" =>
+            $@"{{""codeunitId"":1,""CodeunitName"":""{codeunit}"",""Method"":""{method}"",""Mode"":""expect-divergence"","
+            + @"""Reason"":""task-scheduler"",""Doc"":""docs/scope.md#jobs""}",
+        "skip" =>
+            $@"{{""codeunitId"":1,""CodeunitName"":""{codeunit}"",""Method"":""{method}"",""Mode"":""skip""}}",
+        "accept-partial-company-init" =>
+            $@"{{""codeunitId"":2,""CodeunitName"":""{codeunit}"",""Method"":""*"",""Mode"":""accept-partial-company-init"","
+            + @"""Reason"":""ships without the dependency codeunit 2 needs""}",
+        _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null),
+    };
+
+    private void Write(string fileName, params string[] entries)
+        => File.WriteAllText(Path.Combine(_dir, fileName), "[" + string.Join(",", entries) + "]");
+
+    [Theory]
+    [InlineData("oos-http.json", "expect-oos")]
+    [InlineData("known-gaps-pages.json", "expect-fail-known-gap")]
+    [InlineData("divergence-session.json", "expect-divergence")]
+    [InlineData("disabled-compile.json", "skip")]
+    [InlineData("accept-company-init.json", "accept-partial-company-init")]
+    public void PrefixAndModeAgree_NoViolation(string fileName, string mode)
+    {
+        Write(fileName, Entry(mode));
+        Assert.Empty(ExpectationManifest.FilePrefixViolations(_dir));
+    }
+
+    /// <summary>Each prefix holding an entry of a different mode is reported, naming the file, the
+    /// entry, the mode it has and the mode its file name promises.</summary>
+    [Theory]
+    [InlineData("oos-http.json", "expect-fail-known-gap", "expect-oos")]
+    [InlineData("known-gaps-pages.json", "expect-oos", "expect-fail-known-gap")]
+    [InlineData("divergence-session.json", "expect-oos", "expect-divergence")]
+    [InlineData("disabled-compile.json", "expect-fail-known-gap", "skip")]
+    [InlineData("accept-company-init.json", "skip", "accept-partial-company-init")]
+    public void PrefixAndModeDisagree_IsReported(string fileName, string actualMode, string promisedMode)
+    {
+        Write(fileName, Entry(actualMode));
+        var v = Assert.Single(ExpectationManifest.FilePrefixViolations(_dir));
+        Assert.Contains(fileName, v);
+        Assert.Contains($"Mode={actualMode}", v);
+        Assert.Contains(promisedMode, v);
+    }
+
+    /// <summary>Per entry, not per file: the pr-gate python check for known-gaps files fires only
+    /// when NO entry in the file matches, so one stray entry among correct ones passed it.</summary>
+    [Fact]
+    public void OneStrayEntryAmongAgreeingOnes_IsReportedAlone()
+    {
+        Write("known-gaps-pages.json",
+            Entry("expect-fail-known-gap", "Good", "A"),
+            Entry("expect-oos", "Stray", "B"));
+        var v = Assert.Single(ExpectationManifest.FilePrefixViolations(_dir));
+        Assert.Contains("Stray.B", v);
+    }
+
+    /// <summary>The third state: a name matching no known prefix is not a pass, because nothing can
+    /// say which mode it should hold. With a loadable entry in it...</summary>
+    [Fact]
+    public void UnrecognisedPrefix_IsReported()
+    {
+        Write("my-gaps.json", Entry("expect-fail-known-gap"));
+        var v = Assert.Single(ExpectationManifest.FilePrefixViolations(_dir));
+        Assert.Contains("my-gaps.json", v);
+        Assert.Contains("no recognised prefix", v);
+        Assert.Contains("known-gaps-", v);
+    }
+
+    /// <summary>...and without one: an empty file under an unrecognised name still misleads.</summary>
+    [Fact]
+    public void UnrecognisedPrefix_OnAnEmptyFile_IsReported()
+    {
+        Write("gaps.json");
+        Assert.Contains("gaps.json", Assert.Single(ExpectationManifest.FilePrefixViolations(_dir)));
+    }
+
+    /// <summary>A known prefix with no entries left stays legal: deleting the last entry and leaving
+    /// <c>[]</c> behind must not fail a PR (#3114).</summary>
+    [Fact]
+    public void RecognisedPrefix_OnAnEmptyFile_IsNotAViolation()
+    {
+        Write("known-gaps-pages.json");
+        Assert.Empty(ExpectationManifest.FilePrefixViolations(_dir));
+    }
+
+    [Fact]
+    public void MissingDirectory_IsNotAViolation()
+    {
+        Assert.Empty(ExpectationManifest.FilePrefixViolations(Path.Combine(_dir, "absent")));
+    }
+
+    /// <summary>A mode added without a prefix would make every file of that mode unrecognised, and
+    /// two prefixes for one mode would let the directory disagree with itself.</summary>
+    [Fact]
+    public void EveryMode_HasExactlyOnePrefix()
+    {
+        foreach (var mode in Enum.GetValues<ExpectationMode>())
+            Assert.Single(ExpectationManifest.FilePrefixes, p => p.Mode == mode);
+    }
+
+    [Theory]
+    [InlineData("oos-http.json", ExpectationMode.ExpectOos)]
+    [InlineData("known-gaps-pages.json", ExpectationMode.ExpectFailKnownGap)]
+    [InlineData("divergence-session.json", ExpectationMode.ExpectDivergence)]
+    [InlineData("disabled-compile.json", ExpectationMode.Skip)]
+    [InlineData("accept-company-init.json", ExpectationMode.AcceptPartialCompanyInit)]
+    public void ModeForFileName_ReadsThePrefix(string fileName, ExpectationMode mode)
+        => Assert.Equal(mode, ExpectationManifest.ModeForFileName(fileName));
+
+    [Theory]
+    [InlineData("my-gaps.json")]
+    [InlineData("oos-.json")]      // a prefix with no area names nothing
+    [InlineData("oos.json")]
+    [InlineData("known-gaps-pages.txt")]
+    public void ModeForFileName_UnrecognisedName_IsNull(string fileName)
+        => Assert.Null(ExpectationManifest.ModeForFileName(fileName));
+
+    /// <summary>The shipped directory itself. Vacuity guard: it must actually hold entries and files,
+    /// or zero violations would be the answer to an empty question.</summary>
+    [Fact]
+    public void ShippedManifest_EveryFilePrefixAgreesWithItsEntries()
+    {
+        var repoRoot = Path.GetFullPath(
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var dir = Path.Combine(repoRoot, "tests", "expectations");
+
+        Assert.NotEmpty(Directory.GetFiles(dir, "*.json"));
+        Assert.NotEmpty(ExpectationManifest.LoadFromDirectory(dir).Entries);
+
+        var violations = ExpectationManifest.FilePrefixViolations(dir);
+        Assert.True(violations.Count == 0,
+            "tests/expectations file prefixes disagree with their entries:\n  " + string.Join("\n  ", violations));
+    }
+}

--- a/AlRunner/Infrastructure/ExpectationManifest.cs
+++ b/AlRunner/Infrastructure/ExpectationManifest.cs
@@ -465,8 +465,8 @@ public sealed class ExpectationManifest
             foreach (var e in byFile[name])
                 if (e.Mode != promised.Value)
                     violations.Add($"{name}: {e.CodeunitName}.{e.Method} has Mode={ModeName(e.Mode)} but the "
-                        + $"file name promises {ModeName(promised.Value)}; move the entry to a "
-                        + $"{FilePrefixes.First(p => p.Mode == e.Mode).Prefix}<area>.json file");
+                        + $"file name promises {ModeName(promised.Value)}; move the entry to "
+                        + $"{FilePrefixes.First(p => p.Mode == e.Mode).Prefix}<area>.json");
         }
         return violations;
     }

--- a/AlRunner/Infrastructure/ExpectationManifest.cs
+++ b/AlRunner/Infrastructure/ExpectationManifest.cs
@@ -413,6 +413,74 @@ public sealed class ExpectationManifest
         return new ExpectationManifest(entries);
     }
 
+    /// <summary>
+    /// The file-name prefix each mode lives under in <c>tests/expectations/</c> (#3114). A
+    /// repository convention, checked by <c>ExpectationFilePrefixTests</c> over the shipped
+    /// directory — never by <see cref="LoadFromDirectory"/>, which also loads a user's own
+    /// manifest whose file names are not ours to dictate.
+    /// </summary>
+    public static IReadOnlyList<(string Prefix, ExpectationMode Mode)> FilePrefixes { get; } = new[]
+    {
+        ("oos-", ExpectationMode.ExpectOos),
+        ("known-gaps-", ExpectationMode.ExpectFailKnownGap),
+        ("divergence-", ExpectationMode.ExpectDivergence),
+        ("disabled-", ExpectationMode.Skip),
+        ("accept-", ExpectationMode.AcceptPartialCompanyInit),
+    };
+
+    /// <summary>The mode a manifest file name promises, or null when it carries no recognised
+    /// <c>&lt;prefix&gt;&lt;area&gt;.json</c> shape.</summary>
+    public static ExpectationMode? ModeForFileName(string fileName)
+    {
+        if (!fileName.EndsWith(".json", StringComparison.Ordinal)) return null;
+        var stem = fileName[..^".json".Length];
+        foreach (var (prefix, mode) in FilePrefixes)
+            if (stem.StartsWith(prefix, StringComparison.Ordinal) && stem.Length > prefix.Length)
+                return mode;
+        return null;
+    }
+
+    /// <summary>
+    /// Every disagreement between a file's prefix and the entries it holds, one message each. An
+    /// unrecognised name is a violation even when the file is empty; a recognised prefix on an
+    /// empty file is not; a missing directory has nothing to disagree.
+    /// </summary>
+    public static IReadOnlyList<string> FilePrefixViolations(string manifestDir)
+    {
+        var violations = new List<string>();
+        if (!Directory.Exists(manifestDir)) return violations;
+
+        var byFile = LoadFromDirectory(manifestDir).Entries.ToLookup(e => e.SourceFile);
+        var known = string.Join(", ", FilePrefixes.Select(p => $"{p.Prefix}<area>.json"));
+        foreach (var path in Directory.EnumerateFiles(manifestDir, "*.json").OrderBy(p => p))
+        {
+            var name = Path.GetFileName(path);
+            var promised = ModeForFileName(name);
+            if (promised == null)
+            {
+                violations.Add($"{name}: no recognised prefix, so nothing says which Mode it may hold "
+                    + $"(expected one of {known})");
+                continue;
+            }
+            foreach (var e in byFile[name])
+                if (e.Mode != promised.Value)
+                    violations.Add($"{name}: {e.CodeunitName}.{e.Method} has Mode={ModeName(e.Mode)} but the "
+                        + $"file name promises {ModeName(promised.Value)}; move the entry to a "
+                        + $"{FilePrefixes.First(p => p.Mode == e.Mode).Prefix}<area>.json file");
+        }
+        return violations;
+    }
+
+    private static string ModeName(ExpectationMode mode) => mode switch
+    {
+        ExpectationMode.ExpectOos => "expect-oos",
+        ExpectationMode.ExpectFailKnownGap => "expect-fail-known-gap",
+        ExpectationMode.ExpectDivergence => "expect-divergence",
+        ExpectationMode.Skip => "skip",
+        ExpectationMode.AcceptPartialCompanyInit => "accept-partial-company-init",
+        _ => throw new InvalidOperationException($"Unhandled ExpectationMode: {mode}"),
+    };
+
     private static List<ExpectationEntry> LoadFile(string path, string relName)
     {
         var raw = File.ReadAllText(path);

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -147,6 +147,11 @@ tests/expectations/
   accept-<area>.json      ← run-level conditions this project accepts (#3561)
 ```
 
+The prefix and every entry's `Mode` must agree, and a file name with none of these
+prefixes is refused: `AlRunner.Tests/ExpectationFilePrefixTests.cs` checks the shipped
+directory (#3114). The loader does not, because `--expectations` also loads a project's
+own manifest, whose file names are not this repository's convention to impose.
+
 One file per area. Sharding matches Microsoft's
 `ALAppExtensions/Build/DisabledTests/` convention so anyone familiar with the
 BC ecosystem recognises the shape — we extend the schema with extra fields

--- a/tests/expectations/README.md
+++ b/tests/expectations/README.md
@@ -39,9 +39,11 @@ exemption: the run that owns the suite still audits the entry in full. See
 
 The file prefix and the entry's `Mode` must agree — the prefix is what a human
 scanning the directory reads. Moving an entry between modes means moving it
-between files. A `known-gaps-*.json` holding entries that are not
-`expect-fail-known-gap` fails the guard below, because that disagreement would
-silence the whole file for it.
+between files. `AlRunner.Tests/ExpectationFilePrefixTests.cs` checks every entry
+against its file's prefix, and fails on a file name carrying none of the five
+prefixes; a recognised file left holding `[]` is fine (#3114). Separately, a
+`known-gaps-*.json` none of whose entries is `expect-fail-known-gap` fails the
+guard below, because that disagreement would silence the whole file for it.
 
 ## A PR that closes a gap issue must delete or re-target its entry
 


### PR DESCRIPTION
Closes #3114

Written by agent `stma-auto2-8` on the account holder's behalf.

## What changed

- `ExpectationManifest.FilePrefixes`: the five prefixes, one per mode (`oos-`, `known-gaps-`, `divergence-`, `disabled-`, `accept-`).
- `ExpectationManifest.ModeForFileName`: the mode a `<prefix><area>.json` name promises, or null.
- `ExpectationManifest.FilePrefixViolations(dir)`: one message per disagreement. It checks each entry against its file's prefix, and it reports a file name with no recognised prefix even when the file is empty. A recognised file holding `[]` passes, and so does a missing directory.
- `AlRunner.Tests/ExpectationFilePrefixTests.cs`: 26 tests. They cover all five prefixes in both directions, one stray entry among agreeing ones, the unrecognised-name case (with and without entries), a recognised empty file, a missing directory, a check that every `ExpectationMode` has exactly one prefix, and the shipped `tests/expectations/` directory (with a guard against an empty directory passing).
- One paragraph each in `docs/expectations.md` § Layout and `tests/expectations/README.md`.

**Violations in the current manifest: 0.** I counted per file with a python scan of all 10 files, then checked again with the new shipped-directory test. No entries had to move.

## Where it is enforced, and why not in the loader

The check runs as a test in `AlRunner.Tests`. That suite runs on the unit legs, which feed the required `BC test matrix passed` context, so it blocks the merge. `LoadFromDirectory` does not call it. The runner also loads a project's own manifest (`--expectations <dir>`, or `./tests/expectations` by default). If the loader required our prefixes, the shipped runner would abort startup with exit 2 on a user's `my-gaps.json`. It would also break existing tests that load fixture manifests named `divergence-x.json` (with `accept-partial-company-init` entries), `classification.json`, and so on. The prefix rule is a convention for this repository's directory, not part of the manifest format.

Extending `.github/scripts/check_expectation_gap_issues.py` was the other option. I did not take it because that job is not in `main`'s ruleset, so it only annotates PRs. Its existing known-gaps check (line 296) fires only when *no* entry in a file matches. The new check works per entry, so it is strictly stronger, and the two never disagree. I left the python check as is because it also resolves issue links.

## RED -> GREEN

- RED, with the three members as no-op stubs (empty table, `null`, empty list): `Failed: 14, Passed: 12, Total: 26`. The 12 that pass are 7 no-violation controls, 4 null-name cases, and `ShippedManifest_EveryFilePrefixAgreesWithItsEntries`. A no-op satisfies all of them, and the shipped test passes it *vacuously*: an empty violation list counts as agreement. The rename probe under Mutations is what shows that test actually catches a disagreement.
- GREEN: `Failed: 0, Passed: 35, Total: 35` (the 26 new tests plus the 9 in `ExpectationManifestSchemaTests`).

## Mutations (each one executed and then restored)

Each mutation was picked to fail a specific subset of tests, not just to cause some failure:

1. Unrecognised-prefix branch reports nothing (`continue` without `Add`): `Failed: 2, Passed: 24`. Exactly the two unrecognised-name tests fail.
2. `stem.Length > prefix.Length` changed to `>=` (so a prefix with no area is accepted): `Failed: 1, Passed: 25`. Only `ModeForFileName_UnrecognisedName_IsNull("oos-.json")` fails.
3. Mode comparison disabled (`e.Mode != promised.Value && false`): `Failed: 6, Passed: 20`. The five disagree cases and the stray-entry test fail.

I also ran the shipped-directory test against the real directory in both directions. Renaming `oos-http.json` to `divergence-http.json` failed it with `divergence-http.json: Test HttpClient.HttpClient_Get_ValidUrl_ReturnsSuccessResponse has Mode=expect-oos but the file name promises expect-divergence`. Adding an empty `zz-probe.json` failed it with the no-recognised-prefix message. I restored both. My first run of the rename probe passed by mistake: `--no-build` ran the binary still built with mutation 3. After a rebuild it failed as it should.

## Other local runs

- `dotnet test --filter GuardTests|ExpectationFilePrefixTests|ExpectationManifestSchemaTests` after a build: `Failed: 1, Passed: 283`. The one failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned`, which refuses because this machine did not run `tools/engine-test-bootstrap.sh`. It is an environment issue, not related to this change.
- `tools/test_*.py`: three fail locally (`test_agent_self_freshness`, `test_corpus_checkout`, `test_preflight`). The two I read fail at `git commit` inside temp repos because the 1Password signing agent returned an error. None of them touch the files in this diff.

Known gap, not fixed here: the prefix list now lives in three places (`FilePrefixes`, `tests/expectations/README.md`, `docs/expectations.md` § Layout). `EveryMode_HasExactlyOnePrefix` pins only the code, so the two markdown copies can drift without failing anything.

## Fix the shape

1. **Same wrong pattern at another call site?** The only other place that selects by prefix is `check_expectation_gap_issues.py`'s known-gaps check, discussed above. `count-baseline/` is a subdirectory, and the non-recursive scan never reads it.
2. **Sibling making the same assumption?** `LoadFromDirectory` loads any `*.json` whatever its name. That is correct for user manifests, and this PR leaves it alone on purpose.
3. **Two paths writing the same state with different invariants?** Now both the python known-gaps check and this test enforce the prefix rule. They agree: every file the python check rejects, this test rejects too.

## Queue scan

I searched open issues for `SourceFile`, `ExpectationManifest`, `prefix Mode expectations`, `known-gaps file name`, and `oos- divergence- disabled-`. None of them report the same defect. #3130 (`--count-baseline` silently skips a declared suite) turned up under `ExpectationManifest`. **I did not fold it in.** Its fix goes in `CountBaseline.cs` and `Program.cs`, needs a way to say which suites each invocation covers, and its own body calls that a design decision. That is a different file and a different kind of review.

No corpus test applies: this is the runner's own manifest convention, not a claim about BC behavior.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
