### PR TITLE
fix(tools): isolate scratch git repositories in tests from the global signing config

### DIFF
--- a/.github/scripts/test_pr_changed_files.sh
+++ b/.github/scripts/test_pr_changed_files.sh
@@ -20,6 +20,11 @@
 
 set -uo pipefail
 
+# Scratch commits must not reach the user's global/system config: a signing box
+# otherwise fails or blocks on every commit below (#4001).
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_NOSYSTEM=1
+unset GIT_CONFIG_PARAMETERS GIT_CONFIG_COUNT
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT="$SCRIPT_DIR/pr_changed_files.sh"
 WORKFLOW_DIR="$(cd "$SCRIPT_DIR/../workflows" && pwd)"

--- a/tools/scratch_git_config.py
+++ b/tools/scratch_git_config.py
@@ -1,0 +1,27 @@
+"""Cut a test process's git off from the user's global and system config (#4001).
+
+Test suites that build throwaway repositories call `isolate()` before their first
+git command. Without it, a box with `commit.gpgsign=true` sends every scratch
+commit through the user's signer, which fails or waits for a prompt; CI has no
+such config, so only a local run shows it. `tools/test_scratch_repo_git_isolation.py`
+reproduces that config on CI and runs every such suite under it.
+
+Process-wide on purpose: a per-call `env=` misses every bare `subprocess.run(["git",
+...])` and every tool under test that shells out to git. Suites set `user.name` /
+`user.email` per scratch repository, so no identity is lost.
+"""
+from __future__ import annotations
+
+import os
+
+_INJECTED = ("GIT_CONFIG_PARAMETERS", "GIT_CONFIG_COUNT")
+
+
+def isolate() -> None:
+    os.environ["GIT_CONFIG_GLOBAL"] = os.devnull
+    os.environ["GIT_CONFIG_SYSTEM"] = os.devnull
+    os.environ["GIT_CONFIG_NOSYSTEM"] = "1"
+    # `git -c` from a parent process travels in these; drop them with the files.
+    for name in list(os.environ):
+        if name in _INJECTED or name.startswith(("GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_")):
+            del os.environ[name]

--- a/tools/test_agent_self_freshness.py
+++ b/tools/test_agent_self_freshness.py
@@ -29,6 +29,8 @@ import tempfile
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, HERE)
+import scratch_git_config  # noqa: E402
+scratch_git_config.isolate()  # scratch commits must not reach the user's signer (#4001)
 import agent_self_freshness as asf  # noqa: E402
 
 _spec = importlib.util.spec_from_file_location("ci_wait", os.path.join(HERE, "ci-wait.py"))

--- a/tools/test_corpus_checkout.py
+++ b/tools/test_corpus_checkout.py
@@ -25,6 +25,9 @@ import sys
 import tempfile
 
 HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+import scratch_git_config  # noqa: E402
+scratch_git_config.isolate()  # scratch commits must not reach the user's signer (#4001)
 _spec = importlib.util.spec_from_file_location("corpus_checkout",
                                                os.path.join(HERE, "corpus-checkout.py"))
 cc = importlib.util.module_from_spec(_spec)

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -29,6 +29,9 @@ import sys
 import tempfile
 
 HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+import scratch_git_config  # noqa: E402
+scratch_git_config.isolate()  # scratch commits must not reach the user's signer (#4001)
 _spec = importlib.util.spec_from_file_location("preflight", os.path.join(HERE, "preflight.py"))
 pf = importlib.util.module_from_spec(_spec)
 # Registered before exec: @dataclass resolves its own module through

--- a/tools/test_scratch_repo_git_isolation.py
+++ b/tools/test_scratch_repo_git_isolation.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Suites that build throwaway git repositories must not inherit the user's git config (#4001).
+
+On a box with `commit.gpgsign=true` every scratch `git commit` went through the
+user's signer: three tools/ suites died at their first commit, and
+.github/scripts/test_pr_changed_files.sh blocked while the signer waited for an
+approval prompt. CI runners have no signing config, so CI never saw it.
+
+This guard gives CI that config: it runs every scratch-repo suite under a global
+config that forces signing through a program that always fails. A suite that
+isolates itself (tools/scratch_git_config.py, or the `export` in the shell suite)
+drops that file and passes; one that does not fails here the same way it fails
+on a signing box.
+
+The census half keeps the list honest: every test suite that runs `git commit`
+must be in SUITES, so a new scratch-repo suite cannot skip the guard by omission.
+
+Run: python3 tools/test_scratch_repo_git_isolation.py
+"""
+from __future__ import annotations
+
+import glob
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+
+# path (relative to ROOT) -> the line the suite prints only when it fully passed
+SUITES = {
+    "tools/test_agent_self_freshness.py": "all checks passed",
+    "tools/test_corpus_checkout.py": "all corpus-checkout tests passed",
+    "tools/test_preflight.py": "all checks passed",
+    ".github/scripts/test_pr_changed_files.sh": "failed: 0",
+}
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        FAILURES.append(name)
+
+
+# A `commit` verb handed to git: an argv element ("commit" / 'commit') in Python,
+# or `git [-C dir] commit` in shell. Comment lines are skipped.
+_ARGV_COMMIT = re.compile(r"""["']commit["']""")
+_SHELL_COMMIT = re.compile(r"""\bgit\b(\s+-C\s+\S+)*\s+commit\b""")
+
+
+def commits_in_scratch_repo(path: str) -> bool:
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            s = line.strip()
+            if s.startswith("#"):
+                continue
+            if _ARGV_COMMIT.search(line) and ("git" in line or "_g(" in line):
+                return True
+            if _SHELL_COMMIT.search(line):
+                return True
+    return False
+
+
+print("census: every suite that commits in a scratch repository is guarded")
+candidates = sorted(glob.glob(os.path.join(ROOT, "tools", "test_*.py"))
+                    + glob.glob(os.path.join(ROOT, ".github", "scripts", "test_*")))
+check("the census glob matched suites at all", len(candidates) > 10, str(len(candidates)))
+found = {os.path.relpath(p, ROOT).replace(os.sep, "/") for p in candidates
+         if os.path.abspath(p) != os.path.abspath(__file__) and commits_in_scratch_repo(p)}
+check("every committing suite is in SUITES", found <= set(SUITES),
+      f"unguarded: {sorted(found - set(SUITES))}")
+check("every entry in SUITES still commits (no stale entry)", set(SUITES) <= found,
+      f"stale: {sorted(set(SUITES) - found)}")
+
+
+with tempfile.TemporaryDirectory(prefix="scratch-git-isolation-") as tmp:
+    hostile = os.path.join(tmp, "hostile-gitconfig")
+    failing_signer = "false"
+    with open(hostile, "w", encoding="utf-8") as fh:
+        fh.write("[commit]\n\tgpgsign = true\n[tag]\n\tgpgsign = true\n"
+                 f"[gpg]\n\tformat = openpgp\n\tprogram = {failing_signer}\n"
+                 "[user]\n\tname = hostile\n\temail = hostile@example.invalid\n")
+    env = dict(os.environ, GIT_CONFIG_GLOBAL=hostile)
+    env.pop("GIT_CONFIG_NOSYSTEM", None)
+
+    print("control: the hostile config really breaks an unisolated scratch commit")
+    probe = os.path.join(tmp, "probe")
+    subprocess.run(["git", "init", "-q", probe], env=env, check=True, capture_output=True)
+    ctl = subprocess.run(["git", "-C", probe, "commit", "-q", "--allow-empty", "-m", "x"],
+                         env=env, capture_output=True, text=True)
+    # Without this the guard could pass because the config did nothing.
+    check("an unisolated commit fails under the hostile config", ctl.returncode != 0,
+          f"rc={ctl.returncode} -- the hostile config did not bite; every result below is vacuous")
+
+    print("each scratch-repo suite passes under the hostile global config")
+    for rel, success_line in SUITES.items():
+        path = os.path.join(ROOT, rel)
+        argv = ["bash", path] if rel.endswith(".sh") else [sys.executable, path]
+        try:
+            p = subprocess.run(argv, cwd=ROOT, env=env, capture_output=True, text=True,
+                               encoding="utf-8", errors="replace", timeout=300,
+                               stdin=subprocess.DEVNULL)
+            tail = "\n".join((p.stdout + p.stderr).strip().splitlines()[-6:])
+            check(f"{rel} passes with a signing global config",
+                  p.returncode == 0 and success_line in p.stdout,
+                  f"rc={p.returncode}\n{tail}")
+        except subprocess.TimeoutExpired:
+            check(f"{rel} passes with a signing global config", False,
+                  "timed out after 300s (a signer waiting for input looks like this)")
+
+print()
+if FAILURES:
+    print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")
+    sys.exit(1)
+print("all checks passed")


### PR DESCRIPTION
Closes #4001

_Written by agent stma-auto2-1 on the account holder's behalf._

## What changed

Four test suites commit in throwaway git repositories and read the user's global git config while doing it. On a box with `commit.gpgsign=true`, every scratch commit went to the user's signer, which either failed right away or waited for a prompt. CI runners have no signing config, so only local runs broke.

- **`tools/scratch_git_config.py`** (new, no `test_` prefix so `pr-gate.yml`'s glob does not run it as a suite): `isolate()` sets `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` to `os.devnull`, sets `GIT_CONFIG_NOSYSTEM=1`, and drops `GIT_CONFIG_PARAMETERS` / `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_*` / `GIT_CONFIG_VALUE_*`.
- **`tools/test_agent_self_freshness.py`, `tools/test_corpus_checkout.py`, `tools/test_preflight.py`**: call `isolate()` at import time, before any git command.
- **`.github/scripts/test_pr_changed_files.sh`**: the same, as an `export` after `set -uo pipefail`.
- **`tools/test_scratch_repo_git_isolation.py`** (new guard): writes a global config that forces signing through `false` (`commit.gpgsign`, `tag.gpgsign`, `gpg.program=false`) and runs each of the four suites under it, checking the exit code and the suite's own success line. It also has two other parts:
  - a **control** that checks an unisolated commit really fails under that config. Without it, a git that ignored the config would make every check below pass without testing anything.
  - a **census** that scans `tools/test_*.py` and `.github/scripts/test_*` for suites that run `git commit` and requires the found set to equal the guarded list, in both directions. A new scratch-repo suite can't skip the guard by being left off the list.

Why process-wide instead of passing `env=` per call: `test_agent_self_freshness.py` has about a dozen bare `subprocess.run(["git", ...])` calls outside its `git()` helper, and `test_preflight.py` has no single helper (two different `_g` bindings, plus sections with their own `env`). A per-call fix would be incomplete from the start, and the next section someone adds would miss it. Before settling on this, I ran all three suites with `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1` set from outside, which is the same process-wide change. All three passed (`all checks passed` / `all corpus-checkout tests passed` / `all checks passed`, rc=0). Every commit site sets `user.name`/`user.email` per repository, so dropping global config loses no identity.

## The reported "hang" in `test_pr_changed_files.sh` has the same cause, so it is folded in

A process listing taken while it was stuck showed the script waiting on the signer, not on anything in the test: `git -C /tmp/... commit -qm "P: the pull request"` had been running for 33 s under `/opt/1Password/op-ssh-sign -Y sign ...`. When 1Password answers right away, the commit fails in about 0.1 s instead (`passed: 12, failed: 7`). So it is either a failure or a block, depending on the signer's state.

## RED -> GREEN

Measured on this box (global `commit.gpgsign=true`, `gpg.format=ssh`, `gpg.ssh.program=/opt/1Password/op-ssh-sign`) with the real global config, no override.

Suites, before (on `3e5438e4`; none of the four files or the tools they test changed between that commit and this branch's base `b0d5a598`) -> after (this branch):

| suite | before | after |
|---|---|---|
| `tools/test_agent_self_freshness.py` | rc=1, `RuntimeError: git commit -m v1 -> 128: error: 1Password: agent returned an error` | rc=0, `all checks passed` |
| `tools/test_corpus_checkout.py` | rc=1, `CalledProcessError ... 'commit', '-qm', 'first' ... exit status 128` | rc=0, `all corpus-checkout tests passed` |
| `tools/test_preflight.py` | rc=1, `CalledProcessError: ['git', 'commit', '-q', '-m', 'base'] ... 128` (aborts in `lag_repo()`, so the later sections never ran) | rc=0, `all checks passed` |
| `.github/scripts/test_pr_changed_files.sh` | rc=1, `passed: 12, failed: 7`, or blocked for 33+ s on a single commit | rc=0, `passed: 19, failed: 0` |

The guard, which also reproduces the problem on CI: before the fix, rc=1 with 4 `ok` (census 3 + control 1) and 4 `FAIL` (all four suites, `gpg failed to sign the data`), summary `FAILED: 4 check(s)` -> after, rc=0 with 8 `ok`, summary `all checks passed`. The guard runs `test_preflight.py` a second time inside the `tools/ unit tests` job, about 5 s more.

## Mutations (each reverted afterwards)

I checked that each mutation fails only the check it targets:

| mutation | guard result |
|---|---|
| `isolate()` call in `test_corpus_checkout.py` replaced with `pass` | rc=1, **only** `tools/test_corpus_checkout.py passes with a signing global config` FAILs; the other 7 pass |
| the `export` line in `test_pr_changed_files.sh` replaced with `:` | rc=1, **only** the `test_pr_changed_files.sh` check FAILs; the other 7 pass |
| `test_corpus_checkout.py` removed from `SUITES` | rc=1, **only** the census FAILs: `unguarded: ['tools/test_corpus_checkout.py']` |

## Fix the shape

1. **Same pattern at other call sites?** I scanned `tools/*.py`, `.github/scripts/*`, `AlRunner.Tests/**/*.cs` and `tests/**/*.sh` for git `commit|merge|tag|am|cherry-pick|rebase|revert`. Only these four suites create commits. The other matches were `echo`/prose (`check_ci_skip_directives.sh`, `check_closing_reference.sh`, `generate_changelog.py`, `test_line_endings.py`, `agent_self_freshness.py`), or C# tests asserting on workflow YAML strings (`PublishReleaseTagDecouplingTests`, `ReleaseTestParityTests`) that never run git. The census in the new guard keeps this answer current.
2. **Sibling assumptions?** `git merge --no-ff` in the shell suite signs under `commit.gpgsign` too. Isolating the whole config covers it, along with `tag.gpgsign`, `push.gpgSign`, a global `core.hooksPath`, and anything else a user config could add.
3. **Two paths writing the same state with different invariants?** Yes, inside `test_preflight.py`: the squash, submodule-reap and retired-gitlink sections already set `GIT_CONFIG_GLOBAL`, while `lag_repo()`, the `_corpus` section and the `_own_tmp` branch-ownership section did not. The process-wide call gives all of them the same guarantee. The existing per-section `env` constructions inherit it and stay as they were.

Deliberately untouched: `tools/preflight.py`'s `commit.gpgsign` check (around lines 1536-1569). It checks whether the agent's **real** commits can be signed, which is a separate question from this issue.

## Queue scan

Searched open and closed issues for `gpgsign`, "commit signing scratch repo", "test_pr_changed_files hang", "signing tools tests fail locally" and "scratch repo git commit". Nothing covers this. #2911 (preflight as a tool) and #3953 (stray probe files) came up and are unrelated.

## What I ran locally

- The four suites and the new guard, as above.
- Every `tools/test_*.py` and `.github/scripts/test_*.py`: all pass.
- Every `.github/scripts/test_*.sh`: all pass.
- `dotnet test AlRunner.Tests --filter "FullyQualifiedName~GuardTests"`: `Failed: 1, Passed: 248, Total: 249`. The one failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned` (`BcEngineUnbootstrappedGuard.AssertBootstrapWasRun`). It fails because the BC engine bootstrap step hasn't been run on this box, and it is unrelated to this change, which touches no C#.

No `Corpus-PR:`/`Corpus-NA:` line: the diff touches only `tools/` and `.github/scripts/`, outside the corpus-linkage gate's paths, and it makes no BC-behavior claim.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
