### PR TITLE
docs(skill): re-read every armed PR's verdict on each sweep

### DIFF
--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -155,6 +155,13 @@ exit **1**, **3** or **4** does not. Measured on PR #3959, where a reviewer arme
 so prominently rather than quietly, and was right — the coordinator's brief had over-specified the
 condition, not the reviewer's judgement (#3961).
 
+**Arming at exit 2 is safe; it is not self-correcting. Re-read every armed PR's verdict on each
+sweep.** `--auto` holds a red PR rather than merging it, so nothing breaks — but nothing tells you
+either, and an armed PR that goes red merges the instant a fix pushes on top, against a verdict
+nobody gave the new head. Measured on #3978: armed at exit 2 with 0 failing, two BC legs reported
+`Failed: 2, Passed: 5506` twenty minutes later, and the coordinator found it only by sweeping.
+**Disarm before dispatching the repair**, then re-arm on a fresh verdict.
+
 Arm **only** when all of these hold. Any one missing means report it to the coordinator instead:
 
 - **The PR is on a branch this loop owns.** Check the **branch prefix**, never the author field


### PR DESCRIPTION
Part of #4006

PR #3978 was reviewed thoroughly, armed at `ci-wait.py` **exit 2** (checks running, 0 failing), and left to land. Twenty minutes later its `BC 27.5` and `BC 28.4` legs reported `Failed: 2, Passed: 5506` — deterministic, the same two tests on both, a real defect.

**Nothing surfaced that.** `--auto` held correctly, so nothing merged and nothing broke — but no signal is emitted when an armed PR goes red. The reviewer has returned, the coordinator has moved on, and the PR sits armed and failing until someone looks. I found it on a routine sweep, which should not be luck.

## Not an argument against #3961

Arming at exit 2 stays right: `--auto` holds at `BLOCKED` until required checks pass, and demanding exit 0 forces a hand-back — which is where a verdict goes stale, the exact cost the "arm in the same pass" instruction exists to avoid.

The gap is the **after-state**. Arming is safe but **not self-correcting**.

## The sharp edge

An armed PR that has gone red **merges the moment a fix is pushed on top** — arming survives a push, so the new head inherits an approval given to the old one. Same mechanism as #3991 (an agent pushing to someone else's armed PR) reached from the other direction: there the *head* moved under an arming, here the *verdict* did.

Hence the sequence: **disarm → dispatch the fix → re-arm on a fresh verdict.** Pushing a fix to a still-armed red PR is how an unreviewed head merges.

## Scope

One paragraph beside the exit-code rule. #4006 stays open for what I did **not** measure: how long an armed PR typically sits red before anyone looks. I caught #3978 within ~20 minutes because I sweep every tick; a coordinator reviewing in larger batches could leave one indefinitely — and the consequence there is not a bad merge but a **silently stalled PR**, which is harder to notice than a failure. If that window is routinely long, the fix should be mechanical rather than procedural.

All `tools/test_*.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
