### PR TITLE
fix(server): execute the replaced dependency codeunit after a package is recompiled in --server

### DIFF
--- a/AlRunner.Tests/ServerPackagedDependencyReplacementTests.cs
+++ b/AlRunner.Tests/ServerPackagedDependencyReplacementTests.cs
@@ -1,0 +1,265 @@
+// ServerPackagedDependencyReplacementTests — issue #3974.
+//
+// One --server process, one source bundle (the tests), and a dependency supplied as a packaged
+// `.app` with embedded source that is REWRITTEN AT THE SAME PATH between requests. The dependency
+// answers Twice(21); the test asserts 42 and names the value it saw, so a PASS after the package
+// changed to `Value * 3` means a previous request's module executed.
+//
+// Distinct from ServerCrossAppStaleGenerationTests (#1901), which passes the dependency as a
+// second SOURCE directory: here the dependency arrives through DependencyLoader's Tier-3 package
+// path, whose module name carries the app version.
+//
+// Two branches, one fact each, because they are two different reuse decisions:
+//   * version bumped with the package  -> the old `Dep_..._<old version>` module stayed eligible
+//     for AL object lookup beside the new one;
+//   * version unchanged, content changed -> LoadAll reused the cached module without asking
+//     whether the package at that path still held the bytes it was compiled from.
+//
+// Each fact runs its sequence on a cold server, then again on a fresh server sharing the same
+// --cache root (compiled-deps HITs), per .claude/rules/local-test-scope.md. The fresh server's
+// first request is also the "changed package in a new process" control.
+
+using System.Text.Json;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ServerPackagedDependencyReplacementTests
+{
+    private sealed record Fixture(string SubjectDir, string PackageDir, string TestsDir, string CacheDir, string AppPath);
+
+    private static Fixture Create(string tag, string subjectAppId, string testsAppId, int idBase)
+    {
+        // The dependency's source lives under a different scratch root than the tests, so sibling
+        // source discovery cannot supply it: the package is the only route.
+        var subjectDir = TestScratch.Dir($"al-runner-3974-{tag}-subject-src");
+        var root = TestScratch.Dir($"al-runner-3974-{tag}");
+        var packageDir = Path.Combine(root, "packages");
+        var testsDir = Path.Combine(root, "tests");
+        var cacheDir = Path.Combine(root, ".cache");
+        Directory.CreateDirectory(subjectDir);
+        Directory.CreateDirectory(packageDir);
+        Directory.CreateDirectory(testsDir);
+
+        File.WriteAllText(Path.Combine(testsDir, "app.json"), $$"""
+        {
+          "id": "{{testsAppId}}",
+          "name": "Repro3974 Tests {{tag}}",
+          "publisher": "Repro3974",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{subjectAppId}}", "name": "Repro3974 Subject {{tag}}", "publisher": "Repro3974", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": {{idBase + 5}}, "to": {{idBase + 9}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(testsDir, "Tests.Codeunit.al"), $$"""
+        codeunit {{idBase + 5}} "Repro3974 Tests {{tag}}"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure DependencyLogic()
+            var
+                Logic: Codeunit "Repro3974 Logic {{tag}}";
+                Actual: Integer;
+            begin
+                Actual := Logic.Twice(21);
+                if Actual <> 42 then
+                    Error('dependency result: expected 42, actual %1', Actual);
+            end;
+        }
+        """);
+
+        var appPath = Path.Combine(packageDir, $"Repro3974_Subject_{tag}.app");
+        return new Fixture(subjectDir, packageDir, testsDir, cacheDir, appPath);
+    }
+
+    /// <summary>
+    /// The dependency's compile-time symbols, in the shape BC's own compiler writes into a
+    /// package. The method Id is BC's: copied from the SymbolReference.json `al compile` produced
+    /// for this exact signature, `Twice(Value: Integer): Integer`; the dependent's compiled call
+    /// dispatches by that id, so it must match what the Tier-3 source compile emits.
+    /// </summary>
+    private static byte[] SymbolReference(string appId, string tag, int idBase, string version) =>
+        System.Text.Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new
+        {
+            RuntimeVersion = "14.0",
+            Codeunits = new object[]
+            {
+                new
+                {
+                    Methods = new object[]
+                    {
+                        new
+                        {
+                            ReturnTypeDefinition = new { Name = "Integer" },
+                            Parameters = new object[] { new { Name = "Value", TypeDefinition = new { Name = "Integer" } } },
+                            Id = 1516892452,
+                            Name = "Twice",
+                        },
+                    },
+                    Id = idBase,
+                    Name = $"Repro3974 Logic {tag}",
+                },
+            },
+            AppId = appId,
+            Name = $"Repro3974 Subject {tag}",
+            Publisher = "Repro3974",
+            Version = version,
+        }));
+
+    /// <summary>Rewrite the dependency's source and re-package it at the SAME .app path.</summary>
+    private static void PublishSubject(Fixture f, string subjectAppId, string tag, int idBase, string version, int multiplier)
+    {
+        File.WriteAllText(Path.Combine(f.SubjectDir, "app.json"), $$"""
+        {
+          "id": "{{subjectAppId}}",
+          "name": "Repro3974 Subject {{tag}}",
+          "publisher": "Repro3974",
+          "version": "{{version}}",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": {{idBase}}, "to": {{idBase + 4}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(f.SubjectDir, "Logic.Codeunit.al"), $$"""
+        codeunit {{idBase}} "Repro3974 Logic {{tag}}"
+        {
+            procedure Twice(Value: Integer): Integer
+            begin
+                exit(Value * {{multiplier}});
+            end;
+        }
+        """);
+        var identity = InProcessAppPackager.ReadIdentity(Path.Combine(f.SubjectDir, "app.json"))
+            ?? throw new InvalidOperationException("fixture app.json did not parse");
+        var before = File.Exists(f.AppPath) ? File.GetLastWriteTimeUtc(f.AppPath) : DateTime.MinValue;
+        InProcessAppPackager.EmitAppPackageToFile(
+            f.SubjectDir, identity, f.AppPath, SymbolReference(subjectAppId, tag, idBase, version));
+        // `* 2` and `* 3` package to the same byte length; move mtime forward explicitly so no
+        // (inode, size, mtime) file identity can mistake the rewrite for the previous file.
+        var after = before == DateTime.MinValue ? DateTime.UtcNow : before.AddSeconds(5);
+        File.SetLastWriteTimeUtc(f.AppPath, after);
+    }
+
+    private static string Req(Fixture f) => JsonSerializer.Serialize(new
+    {
+        command = "runTests",
+        sourcePaths = new[] { f.TestsDir },
+        packagePaths = new[] { f.PackageDir },
+        coverage = false,
+    });
+
+    /// <summary>
+    /// Run one request and assert its single test's verdict. <paramref name="expectedActual"/>
+    /// null means PASS (the dependency answered 42); otherwise the failure must name that value,
+    /// which is what says WHICH compile of the dependency executed.
+    /// </summary>
+    private static async Task AssertRequest(CliServer server, Fixture f, string label, int? expectedActual)
+    {
+        var lines = await server.SendRequestStreamingAsync(Req(f), TimeSpan.FromSeconds(240));
+        var (events, summary) = ProtocolV2Streaming.Split(lines);
+        var joined = string.Join("\n", lines);
+        var ev = events.SingleOrDefault(e => e.GetProperty("name").GetString()!.EndsWith("DependencyLogic"));
+        Assert.True(ev.ValueKind == JsonValueKind.Object,
+            $"{label}: DependencyLogic did not run.\n{joined}\n--- stderr ---\n{server.StdErr}");
+        var status = ev.GetProperty("status").GetString();
+        var message = ev.TryGetProperty("message", out var m) ? m.GetString() ?? "" : "";
+        if (expectedActual is null)
+        {
+            Assert.True(status == "pass", $"{label}: expected PASS (answer 42), got {status}: {message}");
+            Assert.Equal(0, summary.GetProperty("failed").GetInt32());
+        }
+        else
+        {
+            Assert.True(status == "fail",
+                $"{label}: expected FAIL naming actual {expectedActual} — a PASS means a previous " +
+                $"request's dependency module executed. Got {status}: {message}");
+            Assert.Contains($"expected 42, actual {expectedActual}", message);
+        }
+    }
+
+    [SkippableFact]
+    public async Task PackageReplacedWithANewVersion_ExecutesTheNewCode_ColdAndWarm()
+    {
+        TestArtifacts.SkipIfMissing();
+        const string tag = "V";
+        const string subjectId = "3974a000-0000-4000-8000-00000000a001";
+        const string testsId = "3974a000-0000-4000-8000-00000000a002";
+        const int idBase = 63970;
+        var f = Create(tag, subjectId, testsId, idBase);
+        var args = new[] { "--cache", f.CacheDir, "--package-cache", f.PackageDir };
+        try
+        {
+            await using (var cold = await CliServer.StartAsync(args))
+            {
+                PublishSubject(f, subjectId, tag, idBase, "1.0.0.0", multiplier: 2);
+                await AssertRequest(cold, f, "cold 1 (v1.0.0.0, *2)", null);
+                PublishSubject(f, subjectId, tag, idBase, "1.0.0.1", multiplier: 3);
+                await AssertRequest(cold, f, "cold 2 (v1.0.0.1, *3)", 63);
+                PublishSubject(f, subjectId, tag, idBase, "1.0.0.2", multiplier: 2);
+                await AssertRequest(cold, f, "cold 3 (v1.0.0.2, *2)", null);
+            }
+
+            // Fresh process, same --cache root: every dependency compile below is a HIT.
+            await using (var warm = await CliServer.StartAsync(args))
+            {
+                PublishSubject(f, subjectId, tag, idBase, "1.0.0.1", multiplier: 3);
+                await AssertRequest(warm, f, "warm 1 / fresh-server control (v1.0.0.1, *3)", 63);
+                PublishSubject(f, subjectId, tag, idBase, "1.0.0.2", multiplier: 2);
+                await AssertRequest(warm, f, "warm 2 (v1.0.0.2, *2)", null);
+                PublishSubject(f, subjectId, tag, idBase, "1.0.0.1", multiplier: 3);
+                await AssertRequest(warm, f, "warm 3 (v1.0.0.1 again, *3)", 63);
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(f.SubjectDir, recursive: true); } catch { }
+            try { Directory.Delete(Path.GetDirectoryName(f.PackageDir)!, recursive: true); } catch { }
+        }
+    }
+
+    [SkippableFact]
+    public async Task PackageReplacedAtTheSameVersion_ExecutesTheNewCode_ColdAndWarm()
+    {
+        TestArtifacts.SkipIfMissing();
+        const string tag = "S";
+        const string subjectId = "3974b000-0000-4000-8000-00000000b001";
+        const string testsId = "3974b000-0000-4000-8000-00000000b002";
+        const int idBase = 63980;
+        var f = Create(tag, subjectId, testsId, idBase);
+        var args = new[] { "--cache", f.CacheDir, "--package-cache", f.PackageDir };
+        try
+        {
+            await using (var cold = await CliServer.StartAsync(args))
+            {
+                PublishSubject(f, subjectId, tag, idBase, "1.0.0.0", multiplier: 2);
+                await AssertRequest(cold, f, "cold 1 (*2)", null);
+                PublishSubject(f, subjectId, tag, idBase, "1.0.0.0", multiplier: 3);
+                await AssertRequest(cold, f, "cold 2 (same version, *3)", 63);
+                PublishSubject(f, subjectId, tag, idBase, "1.0.0.0", multiplier: 2);
+                await AssertRequest(cold, f, "cold 3 (same version, *2)", null);
+            }
+
+            await using (var warm = await CliServer.StartAsync(args))
+            {
+                PublishSubject(f, subjectId, tag, idBase, "1.0.0.0", multiplier: 3);
+                await AssertRequest(warm, f, "warm 1 / fresh-server control (*3)", 63);
+                PublishSubject(f, subjectId, tag, idBase, "1.0.0.0", multiplier: 2);
+                await AssertRequest(warm, f, "warm 2 (same version, *2)", null);
+                PublishSubject(f, subjectId, tag, idBase, "1.0.0.0", multiplier: 3);
+                await AssertRequest(warm, f, "warm 3 (same version, *3)", 63);
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(f.SubjectDir, recursive: true); } catch { }
+            try { Directory.Delete(Path.GetDirectoryName(f.PackageDir)!, recursive: true); } catch { }
+        }
+    }
+}

--- a/AlRunner.Tests/ServerPackagedDependencyReplacementTests.cs
+++ b/AlRunner.Tests/ServerPackagedDependencyReplacementTests.cs
@@ -112,39 +112,51 @@ public sealed class ServerPackagedDependencyReplacementTests
             Version = version,
         }));
 
-    /// <summary>Rewrite the dependency's source and re-package it at the SAME .app path.</summary>
+    /// <summary>
+    /// Put the (version, multiplier) variant of the dependency at the SAME .app path. Each variant
+    /// is packaged once and its bytes copied in, so publishing a variant again reproduces the exact
+    /// package — which is what lets a later request, or a fresh server, hit the compiled-deps cache
+    /// (a re-packaged zip carries new entry timestamps and would never hit).
+    /// </summary>
     private static void PublishSubject(Fixture f, string subjectAppId, string tag, int idBase, string version, int multiplier)
     {
-        File.WriteAllText(Path.Combine(f.SubjectDir, "app.json"), $$"""
+        var staged = Path.Combine(f.SubjectDir, "staged", $"{version}-x{multiplier}.app");
+        if (!File.Exists(staged))
         {
-          "id": "{{subjectAppId}}",
-          "name": "Repro3974 Subject {{tag}}",
-          "publisher": "Repro3974",
-          "version": "{{version}}",
-          "dependencies": [],
-          "platform": "1.0.0.0",
-          "idRanges": [ { "from": {{idBase}}, "to": {{idBase + 4}} } ],
-          "runtime": "14.0"
+            var src = Path.Combine(f.SubjectDir, "src");
+            Directory.CreateDirectory(src);
+            File.WriteAllText(Path.Combine(src, "app.json"), $$"""
+            {
+              "id": "{{subjectAppId}}",
+              "name": "Repro3974 Subject {{tag}}",
+              "publisher": "Repro3974",
+              "version": "{{version}}",
+              "dependencies": [],
+              "platform": "1.0.0.0",
+              "idRanges": [ { "from": {{idBase}}, "to": {{idBase + 4}} } ],
+              "runtime": "14.0"
+            }
+            """);
+            File.WriteAllText(Path.Combine(src, "Logic.Codeunit.al"), $$"""
+            codeunit {{idBase}} "Repro3974 Logic {{tag}}"
+            {
+                procedure Twice(Value: Integer): Integer
+                begin
+                    exit(Value * {{multiplier}});
+                end;
+            }
+            """);
+            var identity = InProcessAppPackager.ReadIdentity(Path.Combine(src, "app.json"))
+                ?? throw new InvalidOperationException("fixture app.json did not parse");
+            Directory.CreateDirectory(Path.GetDirectoryName(staged)!);
+            InProcessAppPackager.EmitAppPackageToFile(
+                src, identity, staged, SymbolReference(subjectAppId, tag, idBase, version));
         }
-        """);
-        File.WriteAllText(Path.Combine(f.SubjectDir, "Logic.Codeunit.al"), $$"""
-        codeunit {{idBase}} "Repro3974 Logic {{tag}}"
-        {
-            procedure Twice(Value: Integer): Integer
-            begin
-                exit(Value * {{multiplier}});
-            end;
-        }
-        """);
-        var identity = InProcessAppPackager.ReadIdentity(Path.Combine(f.SubjectDir, "app.json"))
-            ?? throw new InvalidOperationException("fixture app.json did not parse");
-        var before = File.Exists(f.AppPath) ? File.GetLastWriteTimeUtc(f.AppPath) : DateTime.MinValue;
-        InProcessAppPackager.EmitAppPackageToFile(
-            f.SubjectDir, identity, f.AppPath, SymbolReference(subjectAppId, tag, idBase, version));
-        // `* 2` and `* 3` package to the same byte length; move mtime forward explicitly so no
-        // (inode, size, mtime) file identity can mistake the rewrite for the previous file.
-        var after = before == DateTime.MinValue ? DateTime.UtcNow : before.AddSeconds(5);
-        File.SetLastWriteTimeUtc(f.AppPath, after);
+        var before = File.Exists(f.AppPath) ? File.GetLastWriteTimeUtc(f.AppPath) : DateTime.UtcNow;
+        File.Copy(staged, f.AppPath, overwrite: true);
+        // Variants can share a byte length; move mtime forward explicitly so no (inode, size,
+        // mtime) file identity can mistake the rewrite for the previous file.
+        File.SetLastWriteTimeUtc(f.AppPath, before.AddSeconds(5));
     }
 
     private static string Req(Fixture f) => JsonSerializer.Serialize(new
@@ -184,6 +196,12 @@ public sealed class ServerPackagedDependencyReplacementTests
         }
     }
 
+    /// <summary>The second server must have served the dependency from the shared --cache root;
+    /// otherwise its half of the fact is a second cold run, not a warm one.</summary>
+    private static void AssertWarm(CliServer warm, string tag) =>
+        Assert.True(warm.StdErr.Contains($"[deps] source-cache HIT: Repro3974 Subject {tag}"),
+            $"the fresh server never hit the compiled-deps cache:\n{warm.StdErr}");
+
     [SkippableFact]
     public async Task PackageReplacedWithANewVersion_ExecutesTheNewCode_ColdAndWarm()
     {
@@ -193,7 +211,7 @@ public sealed class ServerPackagedDependencyReplacementTests
         const string testsId = "3974a000-0000-4000-8000-00000000a002";
         const int idBase = 63970;
         var f = Create(tag, subjectId, testsId, idBase);
-        var args = new[] { "--cache", f.CacheDir, "--package-cache", f.PackageDir };
+        var args = new[] { "--cache", f.CacheDir, "--package-cache", f.PackageDir, "--verbose" };
         try
         {
             await using (var cold = await CliServer.StartAsync(args))
@@ -215,6 +233,7 @@ public sealed class ServerPackagedDependencyReplacementTests
                 await AssertRequest(warm, f, "warm 2 (v1.0.0.2, *2)", null);
                 PublishSubject(f, subjectId, tag, idBase, "1.0.0.1", multiplier: 3);
                 await AssertRequest(warm, f, "warm 3 (v1.0.0.1 again, *3)", 63);
+                AssertWarm(warm, tag);
             }
         }
         finally
@@ -233,7 +252,7 @@ public sealed class ServerPackagedDependencyReplacementTests
         const string testsId = "3974b000-0000-4000-8000-00000000b002";
         const int idBase = 63980;
         var f = Create(tag, subjectId, testsId, idBase);
-        var args = new[] { "--cache", f.CacheDir, "--package-cache", f.PackageDir };
+        var args = new[] { "--cache", f.CacheDir, "--package-cache", f.PackageDir, "--verbose" };
         try
         {
             await using (var cold = await CliServer.StartAsync(args))
@@ -254,6 +273,7 @@ public sealed class ServerPackagedDependencyReplacementTests
                 await AssertRequest(warm, f, "warm 2 (same version, *2)", null);
                 PublishSubject(f, subjectId, tag, idBase, "1.0.0.0", multiplier: 3);
                 await AssertRequest(warm, f, "warm 3 (same version, *3)", 63);
+                AssertWarm(warm, tag);
             }
         }
         finally

--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -443,7 +443,21 @@ public static partial class BcRuntime
     {
         var name = asm.GetName().Name;
         if (name != null) _latestGenerationByAssemblyName[name] = asm;
+        _retiredGenerations.TryRemove(asm, out _);
     }
+
+    /// <summary>
+    /// Assemblies superseded by a module with a DIFFERENT simple name — a Tier-3 dependency's
+    /// module name carries its app version (<c>Dep_&lt;Pub&gt;_&lt;Name&gt;_&lt;Version&gt;</c>), so
+    /// the name-keyed registry above cannot see a version bump as a new generation (#3974).
+    /// </summary>
+    private static readonly ConcurrentDictionary<Assembly, byte> _retiredGenerations = new();
+
+    /// <summary>
+    /// Mark <paramref name="asm"/> as no longer current, whatever its simple name; see
+    /// <see cref="_retiredGenerations"/>. Callers retire only an assembly they are replacing.
+    /// </summary>
+    internal static void RetireAssemblyGeneration(Assembly asm) => _retiredGenerations[asm] = 0;
 
     /// <summary>
     /// True when <paramref name="asm"/> is a previous-cycle generation of a bundle
@@ -465,6 +479,7 @@ public static partial class BcRuntime
     /// </summary>
     internal static bool IsStaleBundleAssembly(Assembly asm)
     {
+        if (_retiredGenerations.ContainsKey(asm)) return true;
         var name = asm.GetName().Name;
         return name != null
             && _latestGenerationByAssemblyName.TryGetValue(name, out var latest)

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -105,6 +105,18 @@ public sealed class DependencyLoader
     }
 
     /// <summary>
+    /// Every write that replaces or evicts an AppId's module retires the one it displaces, so an
+    /// AL object lookup cannot bind to it (#3974). The by-name registry alone misses a Tier-3
+    /// module whose replacement carries a different version in its name.
+    /// </summary>
+    private static void RetireGeneration(IReadOnlyList<Assembly> previous, IReadOnlyList<Assembly>? keep)
+    {
+        foreach (var old in previous)
+            if (keep == null || !keep.Contains(old))
+                BcRuntime.RetireAssemblyGeneration(old);
+    }
+
+    /// <summary>
     /// True when <paramref name="name"/>/<paramref name="publisher"/>/<paramref name="version"/>
     /// match the identity already cached for an AppId — i.e. this is the SAME app being
     /// resolved a second time (own-bundle + dependency, or two sibling bundles that both
@@ -125,18 +137,6 @@ public sealed class DependencyLoader
     /// a source suite) omits `publisher` — both paths, both fields missing at once. If you
     /// change either default, keep the other in sync or this comparison silently drifts.
     /// </summary>
-    /// <summary>
-    /// Every write that replaces or evicts an AppId's module retires the one it displaces, so an
-    /// AL object lookup cannot bind to it (#3974). The by-name registry alone misses a Tier-3
-    /// module whose replacement carries a different version in its name.
-    /// </summary>
-    private static void RetireGeneration(IReadOnlyList<Assembly> previous, IReadOnlyList<Assembly>? keep)
-    {
-        foreach (var old in previous)
-            if (keep == null || !keep.Contains(old))
-                BcRuntime.RetireAssemblyGeneration(old);
-    }
-
     private static bool IdentityMatches(LoadedAppEntry entry, string name, string publisher, string version)
         => string.Equals(entry.Name, name, StringComparison.OrdinalIgnoreCase)
         && string.Equals(entry.Publisher, publisher, StringComparison.OrdinalIgnoreCase)

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -94,6 +94,7 @@ public sealed class DependencyLoader
         foreach (var appId in appIds)
         {
             if (!_cache.TryRemove(appId, out var removed)) continue;
+            RetireGeneration(removed.AllAssemblies, keep: null);
             // The by-name map is what AssemblyResolve answers from (see EnsureResolverInstalled).
             // Leaving the stale module there would let a type load resolve to the assembly this
             // call just evicted, which is the same wrong answer one indirection further away.
@@ -124,6 +125,18 @@ public sealed class DependencyLoader
     /// a source suite) omits `publisher` — both paths, both fields missing at once. If you
     /// change either default, keep the other in sync or this comparison silently drifts.
     /// </summary>
+    /// <summary>
+    /// Every write that replaces or evicts an AppId's module retires the one it displaces, so an
+    /// AL object lookup cannot bind to it (#3974). The by-name registry alone misses a Tier-3
+    /// module whose replacement carries a different version in its name.
+    /// </summary>
+    private static void RetireGeneration(IReadOnlyList<Assembly> previous, IReadOnlyList<Assembly>? keep)
+    {
+        foreach (var old in previous)
+            if (keep == null || !keep.Contains(old))
+                BcRuntime.RetireAssemblyGeneration(old);
+    }
+
     private static bool IdentityMatches(LoadedAppEntry entry, string name, string publisher, string version)
         => string.Equals(entry.Name, name, StringComparison.OrdinalIgnoreCase)
         && string.Equals(entry.Publisher, publisher, StringComparison.OrdinalIgnoreCase)
@@ -174,7 +187,14 @@ public sealed class DependencyLoader
                 // version's compiled module for the new one's tests — the silent wrong answer
                 // #1850 exists to prevent, reached from the other side. The cache entry is
                 // overwritten further down, when this app is loaded afresh.
-                if (identityMatches)
+                // #3974: same identity at the same path is only the same module while the package
+                // still holds the bytes it was compiled from; a package rewritten in place at an
+                // unchanged version falls through to a recompile. A DIFFERENT path with the same
+                // identity keeps reusing (#1892: sibling bundles share one module).
+                var packageRewritten = identityMatches && sameDirectory
+                    && existing.Tier3CacheKey != null
+                    && !string.Equals(existing.Tier3CacheKey, ComputeSourceDependencyCacheKey(m, path), StringComparison.Ordinal);
+                if (identityMatches && !packageRewritten)
                 {
                     // #2593/#2579: this dependency's Assembly is being reused without calling
                     // LoadOne again — but LoadOne is the ONLY place that replays this dependency's
@@ -294,6 +314,8 @@ public sealed class DependencyLoader
             if (asm != null)
             {
                 var appAssemblies = chunks.Count > 0 ? chunks : new List<Assembly> { asm };
+                if (_cache.TryGetValue(m.AppId, out var superseded))
+                    RetireGeneration(superseded.AllAssemblies, keep: appAssemblies);
                 _cache[m.AppId] = new LoadedAppEntry(
                     asm, m.Name, m.Publisher, m.Version.ToString(), path, tier3CacheKey, appAssemblies);
                 RegisterAppAssemblies(appAssemblies, m, path);
@@ -1389,6 +1411,7 @@ public sealed class DependencyLoader
         // that happened to run first.
         if (string.Equals(existing.SourcePath, sourcePath, StringComparison.OrdinalIgnoreCase))
         {
+            RetireGeneration(existing.AllAssemblies, keep: new[] { asm });
             _cache[appId] = newEntry;
             return;
         }


### PR DESCRIPTION
Closes #3974

Written by agent stma-auto2-1 on the account holder's behalf.

## What was wrong

Two separate reuse decisions let a resident `--server` execute a dependency module compiled for an earlier request after the `.app` at the same path was replaced.

1. **Version changed with the package.** A Tier-3 dependency module is named `Dep_<Pub>_<Name>_<Version>`. `BcRuntime.IsStaleBundleAssembly` keys generations by simple name, so `..._1_0_0_6` and `..._1_0_0_7` were each "the latest" of their own name, neither was stale, and `CodeunitPatches.FindCodeunitType`'s all-assemblies fallback bound `Codeunit50781` to the first-loaded (old) one. Measured with a temporary print at that fallback, not inferred: request 2 printed `Codeunit50781 bound to Dep_Codex_Repro_Repro_Subject_1_0_0_6 stale=False all=[..._1_0_0_6:False, ..._1_0_0_7:False]` right after `compiled-on-the-fly: Repro Subject v1.0.0.7`.
2. **Version unchanged, content changed.** `DependencyLoader.LoadAll` reused the cached module whenever Name/Publisher/Version matched, without checking whether the package at that path still held the bytes it was compiled from. No recompile line appeared at all.

## The fix

- `BcRuntime`: a retired-generation set, consulted first by `IsStaleBundleAssembly`. `RegisterAssemblyGeneration` clears an assembly from it, so a module registered as current is never also retired.
- `DependencyLoader`: every write that replaces or evicts an AppId's module retires the one it displaces — `LoadAll`'s replacement, `InvalidateApps`, and `RegisterLoaded`'s same-path overwrite.
- `DependencyLoader.LoadAll`: identity match at the **same path** reuses only if the Tier-3 content key is unchanged; otherwise it falls through to the existing recompile. A **different** path with the same identity still reuses (the #1892 sibling-bundle sharing contract the `InvalidateApps` comment describes). Entries with no Tier-3 key (Tier-1/Tier-2, Base Application) are unchanged.
- Scope of that check: the content key reads the shared content-hash memo, keyed on (inode, size, mtime). A same-size rewrite that also preserves mtime is invisible to it and still reuses the old module; that is a property of the existing memo, and it is why the test fixture moves mtime explicitly.

## Proof

New `AlRunner.Tests/ServerPackagedDependencyReplacementTests.cs` (runner-specific: server lifecycle; no BC-behaviour claim). One source bundle (the tests) plus a dependency supplied only as a source-embedded `.app` (built in-process with `InProcessAppPackager`, BC-shaped `SymbolReference.json`) rewritten at the same path between requests. This differs from `ServerCrossAppStaleGenerationTests` (#1901), which passes the dependency as a second source dir, whose module name carries no version.

Each fact runs cold (3 requests), then on a **fresh server sharing the same `--cache` root** (3 requests), and asserts the fresh server logged `source-cache HIT` for the dependency, so the warm half is measured rather than assumed. The fresh server's first request is the "changed package in a new process" control; the `*2` requests are the restoration control. Failures must name `expected 42, actual 63`.

| run | result |
|---|---|
| RED (final test, runner files at the claim commit) | `Failed: 2, Passed: 0` — both fail at `cold 2 ... Got pass` |
| GREEN | `Failed: 0, Passed: 2` (cold and warm halves both inside each fact) |
| Mutation 1: `IsStaleBundleAssembly` ignores the retired set (`&& false`) | `Failed: 1, Passed: 1` — only the new-version fact reds, at `cold 2 (v1.0.0.1, *3) ... Got pass` |
| Mutation 2: `packageRewritten = false && ...` | `Failed: 1, Passed: 1` — only the same-version fact reds, at `cold 2 (same version, *3) ... Got pass` |

Each mutation reds exactly the fact for its branch, which is what shows the two tests discriminate.

Also run by hand against the fixed build with real `al compile` packages (BC 28.1.49838.53910), 4 requests (`*2` v1, `*3` v2, `*2` v3, `*3` same v3): package-only and the issue's package-plus-sibling layout both now give pass / fail(63) / pass / fail(63); before the fix both gave four passes.

Other local runs at this head: `ServerCrossAppStaleGenerationTests`, `ServerAppVersionBumpTests`, `WatchLayeredDependencyStaleTests`, `ServerCrossBundleModuleIdentityDedupTests`, `LayeredDepSymbolsIncrementalServerTests`, `EnumRegistrationSurvivesReloadTests`, `DependencyCacheKeyContentHashMemoTests` plus the new class: `Failed: 0, Passed: 22`. `GuardTests` filter plus the new class: `Passed: 250, Failed: 1`; the one failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned`, which refuses because this box did not run `tools/engine-test-bootstrap.sh`. `tools/test_*.py`: `test_agent_self_freshness`, `test_corpus_checkout` and `test_preflight` fail on scratch `git commit` hitting the global 1Password signing config (the #4001 class); `test_doc_summary_uniqueness` caught a doc block I had stranded and passes after the fix commit.

Not in the C# test: the issue's ValidRelation / MissingRelation / InstallSeed tests need Base Application (`Customer`), which C# fixtures may not declare (`no-base-app-in-csharp-tests.md`); those behaviours are #3964's subject and PR #3967's test. I did not re-run the four-test Customer fixture.

Corpus-NA: runner-only server lifecycle (which resident dependency module a request executes); there is no BC-side claim to adjudicate.

## Fix the shape

1. **Same pattern at another call site?** The version-in-name is also used by `SiblingCompile`'s `--precompile` (`Dep_..._<ver>`), which writes a DLL to disk rather than loading it; the loader path it feeds (Tier-1 `.deps-bin`) is retired by the same `LoadAll` replacement. The name-keyed staleness check is the single choke point for all type finders (`CodeunitPatches` x5, `EventSubscriberPatches` x13), so the retired set covers them all.
2. **Sibling making the same assumption?** `InvalidateApps` evicted a module and cleaned `_byName` but left it eligible for lookup; `RegisterLoaded` overwrote its entry the same way. Both now retire.
3. **Two writers, same invariant?** The three `_cache` writers (`LoadAll`, `RegisterLoaded`, `InvalidateApps`) now all retire what they displace. `TryGetByAppId` reads only.

## Queue

- **#3967 / #3964 (fbk-1):** no overlap. It changes `RecordPatches.NclMetaTableFromBcDocument.cs` (TableRelation notes); its body defers this defect to #3974.
- **#3250:** same area (cross-bundle reuse) but its fix lands in the server's `TryGetByAppId` reuse path and is about registry replay, not which module runs. Not folded.
- **#3958:** sidecar round-trip coverage for sibling registries; unrelated code. Not folded.
- **Filed #4025:** a dependency supplied **only** as sibling AL source (no `.app`) is compiled once per server and never again; measured unchanged by this PR (four passes, one `compiled-on-the-fly` line). Different route, not diagnosed.
- Searched open issues for `server dependency stale`, `BuildSiblingSourceDeps`, `RegisterAssemblyGeneration`, `FindCodeunitType`, `sibling dependency not recompiled`: nothing else describing this defect.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
