### PR TITLE
test(guards): make a local unbootstrapped engine run a visible skip, not a false mutation RED

### DIFF
--- a/.claude/rules/tdd.md
+++ b/.claude/rules/tdd.md
@@ -64,6 +64,15 @@ wearing the shape of a caught regression. Measured twice on one guard in one hou
 agent and its coordinator independently. Prefer mutating a **value** the assertion reads over
 editing code structure, and read the error text before believing a red.
 
+**Trap: a red from the engine-bootstrap guard prints `Total:` and reads as a caught regression.**
+On a box with BC artifacts but no `tools/engine-test-bootstrap.sh` run, every `bc-engine-serial`
+test fails before doing any work, so the missing-`Total:` tell above does not fire: #3948's
+premise mutation read `Failed: 18` and meant `Failed: 0` once bootstrapped. Sub-millisecond
+durations and the text `REFUSING TO SKIP` are not enough either, because a mutation of the guard
+itself produces both and is a genuine red. Pipe the run through `tools/mutation-verdict.py` before
+believing a red: exit 1 is a real one, 4 a build break, 5 the engine guard, 3 unmeasured (#3957;
+`docs/incidents/tdd.md`).
+
 **Trap: a failed mutation and a working guard look identical.** Measured twice in one session
 (#3895): a backslash edit that a heredoc collapsed, so the file never changed; and a
 `-p:` override whose build was incremental and skipped `CoreCompile`, reporting the clean

--- a/docs/incidents/tdd.md
+++ b/docs/incidents/tdd.md
@@ -205,3 +205,31 @@ where, and "somewhere" is exactly what a reader infers as "everywhere".
 Generalises past enums and codeunits: wherever a derivation feeds both an equivalence projection
 and an AL-observable surface — pages, queries, reports, permission sets — those are two
 observables and each owes its own red.
+
+
+## A red from the engine-bootstrap guard reads as a caught regression (2026-09-12, #3948 / #3957)
+
+`BcEngineUnbootstrappedGuard` (`AlRunner.Tests/BcEngineCollection.cs`) fails a `bc-engine-serial`
+test on a box that has BC artifacts but never ran `tools/engine-test-bootstrap.sh`. That is
+deliberate (#3078, #3835): the skip it replaced printed `Failed: 0, Passed: 0` and exit 0, a
+**false green**. The same design produces a **false red** during a mutation check.
+
+An agent running #3948's premise mutation — destroy a sidecar write, see whether the suite notices
+— got `Failed: 18, Passed: 163`, which reads as "already covered, close the issue". All 18 failed in
+under 1 ms with `REFUSING TO SKIP`. After a Release build, the bootstrap and
+`--settings engine.runsettings`, the same mutation gave `Failed: 0, Passed: 181, Skipped: 0` —
+nothing noticed, the opposite conclusion. Four more agents hit the guard locally the same day on
+`BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned`, reproduced here at `bb66be98`
+as `Failed: 1, Passed: 3, Total: 4` with `[1 ms]`.
+
+Unlike the build break above, this shape **prints a `Total:` line**, so the missing-summary tell
+does not catch it.
+
+**Neither tell the issue proposed is enough on its own.** Inverting the guard's own
+`IsRecoverableLocally` check and running `BcEngineUnbootstrappedGuardTests` gave
+`Failed: 9, Passed: 20` — a genuine mutation RED — with five failures at `[< 1 ms]` and two
+carrying `REFUSING TO SKIP` under `Actual:`. What separates the two is where the text sits: the
+guard's failure puts it on the **first line** of `Error Message:`; a test asserting over the guard
+puts it inside an assertion's `Actual:`. `tools/mutation-verdict.py` keys on that, and
+`tools/test_mutation_verdict.py` holds both recordings; keying on the whole failure block instead
+reds exactly those two checks.

--- a/tools/mutation-verdict.py
+++ b/tools/mutation-verdict.py
@@ -22,9 +22,19 @@ guard itself fails the guard's own tests in < 1 ms with `REFUSING TO SKIP` neste
 """
 from __future__ import annotations
 
+import os
 import re
 import sys
 from dataclasses import dataclass, field
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+try:
+    import agent_stdio as _stdio
+except Exception:  # pragma: no cover - a copy detached from its sibling module
+    _stdio = None
+if _stdio is not None:
+    # Before any print: a failure message carries an em dash, which cp1252 stdout cannot encode.
+    _stdio.enable_utf8_stdio()
 
 GREEN, RED, UNMEASURED, BUILD_BROKE, ENGINE_NOT_BOOTSTRAPPED = 0, 1, 3, 4, 5
 

--- a/tools/mutation-verdict.py
+++ b/tools/mutation-verdict.py
@@ -10,7 +10,7 @@ print a non-zero one (#3957, .claude/rules/tdd.md):
   exit 0  GREEN        every test that ran passed, none skipped: the mutation was NOT caught
   exit 1  RED          assertion failures, none of them the engine guard: the mutation WAS caught
   exit 3  UNMEASURED   no summary line, a filter that matched nothing, zero tests, or skips
-  exit 4  BUILD-BROKE  compiler errors, so no test ran against the mutation (#3900)
+  exit 4  BUILD-BROKE  MSBuild errors and no summary, so no test ran against the mutation (#3900)
   exit 5  ENGINE-NOT-BOOTSTRAPPED
                        failures raised by BcEngineUnbootstrappedGuard before any test work:
                        run tools/engine-test-bootstrap.sh, then --settings engine.runsettings
@@ -49,7 +49,9 @@ SUMMARY_RE = re.compile(
     r"^\s*(?:Passed|Failed|Skipped)!\s+-\s+Failed:\s*(\d+),\s*Passed:\s*(\d+),"
     r"\s*Skipped:\s*(\d+),\s*Total:\s*(\d+)", re.M)
 FAILED_HEADER_RE = re.compile(r"^\s*Failed (\S.*?) \[[^\]]*\]\s*$")
-BUILD_ERROR_RE = re.compile(r": error [A-Z]{2,}\d+:", re.M)
+# MSBuild's shape: a diagnostic line ending in the project it belongs to. A bare ": error AL0118:"
+# also appears in assertion messages about compiler output, which are genuine test failures.
+BUILD_ERROR_RE = re.compile(r"^\S.*: error [A-Z]{2,}\d+: .*\[[^\]]+\.csproj\]\s*$", re.M)
 NO_MATCH = "No test matches the given testcase filter"
 
 
@@ -81,10 +83,10 @@ def first_message_lines(text: str) -> dict[str, str]:
 
 
 def classify(text: str) -> Result:
-    if BUILD_ERROR_RE.search(text):
-        return Result(BUILD_BROKE, reason="the build failed, so no test ran against the mutation")
-
     sums = SUMMARY_RE.findall(text)
+    build_error = BUILD_ERROR_RE.search(text) is not None
+    if not sums and build_error:
+        return Result(BUILD_BROKE, reason="the build failed, so no test ran against the mutation")
     if not sums:
         why = ("the test filter matched nothing" if NO_MATCH in text
                else "no `Total:` summary line: the output is empty, truncated, or not dotnet test's")
@@ -95,6 +97,11 @@ def classify(text: str) -> Result:
 
     if total == 0:
         r.verdict, r.reason = UNMEASURED, "zero tests ran"
+        return r
+    if build_error:
+        r.verdict = UNMEASURED
+        r.reason = ("a project failed to build alongside the tests that ran, so the mutated code "
+                    "may not be in what was measured")
         return r
 
     firsts = first_message_lines(text)

--- a/tools/mutation-verdict.py
+++ b/tools/mutation-verdict.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Did a `dotnet test` run measure your mutation? Classify its console output.
+
+    dotnet test AlRunner.Tests --filter ... > run.txt 2>&1
+    tools/mutation-verdict.py run.txt          # or: ... | tools/mutation-verdict.py -
+
+A mutation check reads one number -- `Failed: N` -- and three different things
+print a non-zero one (#3957, .claude/rules/tdd.md):
+
+  exit 0  GREEN        every test that ran passed, none skipped: the mutation was NOT caught
+  exit 1  RED          assertion failures, none of them the engine guard: the mutation WAS caught
+  exit 3  UNMEASURED   no summary line, a filter that matched nothing, zero tests, or skips
+  exit 4  BUILD-BROKE  compiler errors, so no test ran against the mutation (#3900)
+  exit 5  ENGINE-NOT-BOOTSTRAPPED
+                       failures raised by BcEngineUnbootstrappedGuard before any test work:
+                       run tools/engine-test-bootstrap.sh, then --settings engine.runsettings
+
+Exit 5 is keyed on the FIRST LINE of a failure's `Error Message:`. Neither the guard's
+text anywhere in the block nor a sub-millisecond duration is enough: a mutation of the
+guard itself fails the guard's own tests in < 1 ms with `REFUSING TO SKIP` nested under
+`Actual:`, and that red is genuine (fixture in tools/test_mutation_verdict.py).
+"""
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass, field
+
+GREEN, RED, UNMEASURED, BUILD_BROKE, ENGINE_NOT_BOOTSTRAPPED = 0, 1, 3, 4, 5
+
+# Both of BcEngineUnbootstrappedGuard.AssertBootstrapWasRun's Assert.Fail messages
+# (AlRunner.Tests/BcEngineCollection.cs). Change them together.
+ENGINE_GUARD_TOKENS = (
+    "REFUSING TO SKIP",
+    "carries no recognisable cause token",
+)
+
+SUMMARY_RE = re.compile(
+    r"^\s*(?:Passed|Failed|Skipped)!\s+-\s+Failed:\s*(\d+),\s*Passed:\s*(\d+),"
+    r"\s*Skipped:\s*(\d+),\s*Total:\s*(\d+)", re.M)
+FAILED_HEADER_RE = re.compile(r"^\s*Failed (\S.*?) \[[^\]]*\]\s*$")
+BUILD_ERROR_RE = re.compile(r": error [A-Z]{2,}\d+:", re.M)
+NO_MATCH = "No test matches the given testcase filter"
+
+
+@dataclass
+class Result:
+    verdict: int
+    failed: int = 0
+    passed: int = 0
+    skipped: int = 0
+    total: int = 0
+    engine_guard: list[str] = field(default_factory=list)
+    reason: str = ""
+
+
+def first_message_lines(text: str) -> dict[str, str]:
+    """Test name -> the first line after that failure's `Error Message:`."""
+    out: dict[str, str] = {}
+    lines = text.splitlines()
+    current: str | None = None
+    for i, line in enumerate(lines):
+        m = FAILED_HEADER_RE.match(line)
+        if m:
+            current = m.group(1)
+            continue
+        if current is not None and line.strip() == "Error Message:":
+            out[current] = lines[i + 1].strip() if i + 1 < len(lines) else ""
+            current = None
+    return out
+
+
+def classify(text: str) -> Result:
+    if BUILD_ERROR_RE.search(text):
+        return Result(BUILD_BROKE, reason="the build failed, so no test ran against the mutation")
+
+    sums = SUMMARY_RE.findall(text)
+    if not sums:
+        why = ("the test filter matched nothing" if NO_MATCH in text
+               else "no `Total:` summary line: the output is empty, truncated, or not dotnet test's")
+        return Result(UNMEASURED, reason=why)
+
+    failed, passed, skipped, total = (sum(int(s[i]) for s in sums) for i in range(4))
+    r = Result(RED, failed, passed, skipped, total)
+
+    if total == 0:
+        r.verdict, r.reason = UNMEASURED, "zero tests ran"
+        return r
+
+    firsts = first_message_lines(text)
+    r.engine_guard = sorted(name for name, first in firsts.items()
+                            if any(tok in first for tok in ENGINE_GUARD_TOKENS))
+    if r.engine_guard:
+        r.verdict = ENGINE_NOT_BOOTSTRAPPED
+        r.reason = (f"{len(r.engine_guard)} of {failed} failure(s) came from the engine-bootstrap "
+                    "guard, not from an assertion over your change")
+        return r
+
+    if failed > 0:
+        if len(firsts) < failed:
+            r.verdict = UNMEASURED
+            r.reason = (f"`Failed: {failed}` but only {len(firsts)} failure message(s) could be read, "
+                        "so the engine guard cannot be ruled out")
+            return r
+        r.reason = "assertion failures, none raised by the engine guard"
+        return r
+
+    if skipped > 0:
+        r.verdict = UNMEASURED
+        r.reason = f"{skipped} test(s) skipped: a green says nothing about whether they saw the mutation"
+        return r
+
+    r.verdict, r.reason = GREEN, "every test ran and passed"
+    return r
+
+
+NAMES = {GREEN: "GREEN", RED: "RED", UNMEASURED: "UNMEASURED",
+         BUILD_BROKE: "BUILD-BROKE", ENGINE_NOT_BOOTSTRAPPED: "ENGINE-NOT-BOOTSTRAPPED"}
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2 or argv[1] in ("-h", "--help"):
+        print(__doc__)
+        return 2
+    text = sys.stdin.read() if argv[1] == "-" else open(argv[1], encoding="utf-8", errors="replace").read()
+    r = classify(text)
+    print(f"{NAMES[r.verdict]}: {r.reason}")
+    if r.total:
+        print(f"  Failed: {r.failed}, Passed: {r.passed}, Skipped: {r.skipped}, Total: {r.total}")
+    for name in r.engine_guard:
+        print(f"  engine guard: {name}")
+    if r.verdict == ENGINE_NOT_BOOTSTRAPPED:
+        print("  remedy: build Release, run tools/engine-test-bootstrap.sh, re-run with "
+              "--settings engine.runsettings -- again after EVERY build")
+    return r.verdict
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tools/test_mutation_verdict.py
+++ b/tools/test_mutation_verdict.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/mutation-verdict.py (#3957).
+
+The fixtures under tools/testdata/mutation-verdict/ are recorded `dotnet test` output from
+one box on 2026-09-12, with the checkout path rewritten to /repo; build-break.txt keeps only
+the restore lines and the error line of a 661-line log. Two are what this tool exists to
+tell apart, and both fail in under a millisecond with `REFUSING TO SKIP` in the text:
+
+  engine-guard-unbootstrapped.txt  BcEngineReadinessGuardTests on a box with artifacts but no
+                                   tools/engine-test-bootstrap.sh run: the guard, not a mutation
+  genuine-red-guard-mutation.txt   BcEngineUnbootstrappedGuardTests with the guard's
+                                   IsRecoverableLocally check inverted: a real mutation RED
+
+Cases marked "derived" edit a recorded fixture in memory, and say what they changed.
+
+Run: python3 tools/test_mutation_verdict.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import os
+import sys
+from contextlib import redirect_stdout
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location("mutation_verdict", os.path.join(HERE, "mutation-verdict.py"))
+mv = importlib.util.module_from_spec(_spec)
+sys.modules["mutation_verdict"] = mv
+_spec.loader.exec_module(mv)
+
+FIXTURES = os.path.join(HERE, "testdata", "mutation-verdict")
+FAILURES: list[str] = []
+
+
+def fixture(name: str) -> str:
+    with open(os.path.join(FIXTURES, name), encoding="utf-8") as f:
+        return f.read()
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    print(f"  {'ok  ' if cond else 'FAIL'} {name}{'' if cond else ' ' + detail}")
+    if not cond:
+        FAILURES.append(name)
+
+
+def expect(name: str, text: str, verdict: int) -> "mv.Result":
+    r = mv.classify(text)
+    check(name, r.verdict == verdict,
+          f"expected {mv.NAMES[verdict]}, got {mv.NAMES.get(r.verdict, r.verdict)}: {r.reason}")
+    return r
+
+
+print("recorded fixtures")
+r = expect("unbootstrapped engine guard is not a mutation RED",
+           fixture("engine-guard-unbootstrapped.txt"), mv.ENGINE_NOT_BOOTSTRAPPED)
+check("  names the guarded test",
+      r.engine_guard == ["AlRunner.Tests.BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned"],
+      repr(r.engine_guard))
+check("  keeps the counts", (r.failed, r.passed, r.total) == (1, 3, 4), repr((r.failed, r.passed, r.total)))
+
+r = expect("a mutation of the guard itself is a genuine RED, though its text says REFUSING TO SKIP",
+           fixture("genuine-red-guard-mutation.txt"), mv.RED)
+check("  the fixture really carries the token and a sub-ms failure",
+      "REFUSING TO SKIP" in fixture("genuine-red-guard-mutation.txt")
+      and "[< 1 ms]" in fixture("genuine-red-guard-mutation.txt"))
+check("  counts 9 of 29", (r.failed, r.total) == (9, 29), repr((r.failed, r.total)))
+
+expect("an inverted readiness guard is a genuine RED", fixture("genuine-red-readiness-mutation.txt"), mv.RED)
+expect("compiler errors are BUILD-BROKE, not RED", fixture("build-break.txt"), mv.BUILD_BROKE)
+expect("a clean run is GREEN", fixture("green.txt"), mv.GREEN)
+r = expect("a filter matching nothing is UNMEASURED, though dotnet exits 0",
+           fixture("no-filter-match.txt"), mv.UNMEASURED)
+check("  says the filter matched nothing", "filter matched nothing" in r.reason, r.reason)
+
+print("derived cases")
+engine = fixture("engine-guard-unbootstrapped.txt")
+expect("derived: engine fixture with its summary line cut off is UNMEASURED",
+       "\n".join(l for l in engine.splitlines() if "Total:" not in l), mv.UNMEASURED)
+expect("derived: empty input is UNMEASURED", "", mv.UNMEASURED)
+expect("derived: green fixture with Passed 0 / Skipped 3 is UNMEASURED",
+       fixture("green.txt").replace("Passed:     3, Skipped:     0", "Passed:     0, Skipped:     3"),
+       mv.UNMEASURED)
+expect("derived: green fixture with Total 0 is UNMEASURED",
+       fixture("green.txt").replace("Passed:     3, Skipped:     0, Total:     3",
+                                    "Passed:     0, Skipped:     0, Total:     0"), mv.UNMEASURED)
+expect("derived: engine fixture with its Error Message block removed cannot rule the guard out",
+       engine.replace("  Error Message:\n", ""), mv.UNMEASURED)
+unknown = engine.replace(
+    "REFUSING TO SKIP: BC artifacts are provisioned on this machine",
+    "the in-process BC engine is not ready and the reason carries no recognisable cause token")
+expect("derived: the guard's unknown-cause message is also ENGINE-NOT-BOOTSTRAPPED", unknown,
+       mv.ENGINE_NOT_BOOTSTRAPPED)
+genuine = fixture("genuine-red-readiness-mutation.txt")
+expect("derived: one engine-guard failure alongside genuine ones still refuses the RED",
+       genuine.replace("Assert.NotNull() Failure: Value is null",
+                       "[bc-engine-serial] REFUSING TO SKIP: BC artifacts are provisioned", 1),
+       mv.ENGINE_NOT_BOOTSTRAPPED)
+
+print("the CLI")
+for name, code in (("engine-guard-unbootstrapped.txt", 5), ("genuine-red-guard-mutation.txt", 1),
+                   ("build-break.txt", 4), ("green.txt", 0), ("no-filter-match.txt", 3)):
+    with redirect_stdout(io.StringIO()) as out:
+        rc = mv.main(["mutation-verdict.py", os.path.join(FIXTURES, name)])
+    check(f"exit {code} for {name}", rc == code, f"got {rc}: {out.getvalue()}")
+with redirect_stdout(io.StringIO()) as out:
+    mv.main(["mutation-verdict.py", os.path.join(FIXTURES, "engine-guard-unbootstrapped.txt")])
+check("ENGINE-NOT-BOOTSTRAPPED prints the remedy", "tools/engine-test-bootstrap.sh" in out.getvalue(),
+      out.getvalue())
+
+if FAILURES:
+    print(f"\n{len(FAILURES)} failure(s)")
+    sys.exit(1)
+print("\nall passed")

--- a/tools/test_mutation_verdict.py
+++ b/tools/test_mutation_verdict.py
@@ -11,6 +11,10 @@ tell apart, and both fail in under a millisecond with `REFUSING TO SKIP` in the 
   genuine-red-guard-mutation.txt   BcEngineUnbootstrappedGuardTests with the guard's
                                    IsRecoverableLocally check inverted: a real mutation RED
 
+genuine-red-quoting-al-diagnostic.txt is DotNetCompilationTargetScopeTests.CloudTarget_* with one
+assertion added, `Assert.DoesNotContain(": error AL0296:", output)`: a real failure whose message
+quotes an AL compiler diagnostic, which an unanchored build-error pattern read as a build break.
+
 Cases marked "derived" edit a recorded fixture in memory, and say what they changed.
 
 Run: python3 tools/test_mutation_verdict.py
@@ -68,6 +72,10 @@ check("  counts 9 of 29", (r.failed, r.total) == (9, 29), repr((r.failed, r.tota
 
 expect("an inverted readiness guard is a genuine RED", fixture("genuine-red-readiness-mutation.txt"), mv.RED)
 expect("compiler errors are BUILD-BROKE, not RED", fixture("build-break.txt"), mv.BUILD_BROKE)
+r = expect("a genuine red whose assertion quotes `: error AL0296:` is RED, not BUILD-BROKE",
+           fixture("genuine-red-quoting-al-diagnostic.txt"), mv.RED)
+check("  the fixture really quotes an AL diagnostic",
+      ": error AL0296:" in fixture("genuine-red-quoting-al-diagnostic.txt"))
 expect("a clean run is GREEN", fixture("green.txt"), mv.GREEN)
 r = expect("a filter matching nothing is UNMEASURED, though dotnet exits 0",
            fixture("no-filter-match.txt"), mv.UNMEASURED)
@@ -78,6 +86,8 @@ engine = fixture("engine-guard-unbootstrapped.txt")
 expect("derived: engine fixture with its summary line cut off is UNMEASURED",
        "\n".join(l for l in engine.splitlines() if "Total:" not in l), mv.UNMEASURED)
 expect("derived: empty input is UNMEASURED", "", mv.UNMEASURED)
+expect("derived: a green run beside an MSBuild error line is UNMEASURED",
+       fixture("green.txt") + fixture("build-break.txt").splitlines()[-1] + "\n", mv.UNMEASURED)
 expect("derived: green fixture with Passed 0 / Skipped 3 is UNMEASURED",
        fixture("green.txt").replace("Passed:     3, Skipped:     0", "Passed:     0, Skipped:     3"),
        mv.UNMEASURED)
@@ -99,7 +109,7 @@ expect("derived: one engine-guard failure alongside genuine ones still refuses t
 
 print("the CLI")
 for name, code in (("engine-guard-unbootstrapped.txt", 5), ("genuine-red-guard-mutation.txt", 1),
-                   ("build-break.txt", 4), ("green.txt", 0), ("no-filter-match.txt", 3)):
+                   ("build-break.txt", 4), ("genuine-red-quoting-al-diagnostic.txt", 1), ("green.txt", 0), ("no-filter-match.txt", 3)):
     with redirect_stdout(io.StringIO()) as out:
         rc = mv.main(["mutation-verdict.py", os.path.join(FIXTURES, name)])
     check(f"exit {code} for {name}", rc == code, f"got {rc}: {out.getvalue()}")

--- a/tools/testdata/mutation-verdict/build-break.txt
+++ b/tools/testdata/mutation-verdict/build-break.txt
@@ -1,0 +1,6 @@
+  Determining projects to restore...
+  All projects are up-to-date for restore.
+  AlRunner.Provisioning -> /repo/AlRunner.Provisioning/bin/Debug/net8.0/AlRunner.Provisioning.dll
+  AlRunner.QueryJoin -> /repo/AlRunner.QueryJoin/bin/Debug/net8.0/AlRunner.QueryJoin.dll
+  AlRunner -> /repo/AlRunner/bin/Debug/net8.0/al-runner.dll
+/repo/AlRunner.Tests/BcEngineCollection.cs(334,35): error CS0127: Since 'BcEngineReadinessGuard.AssertReadyOnCi(bool, string?, bool)' returns void, a return keyword must not be followed by an object expression [/repo/AlRunner.Tests/AlRunner.Tests.csproj]

--- a/tools/testdata/mutation-verdict/engine-guard-unbootstrapped.txt
+++ b/tools/testdata/mutation-verdict/engine-guard-unbootstrapped.txt
@@ -1,0 +1,17 @@
+Test run for /repo/AlRunner.Tests/bin/Debug/net8.0/AlRunner.Tests.dll (.NETCoreApp,Version=v8.0)
+VSTest version 18.0.2-dev (x64)
+
+Starting test execution, please wait...
+A total of 1 test files matched the specified pattern.
+[xUnit.net 00:00:01.03]     AlRunner.Tests.BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned [FAIL]
+  Failed AlRunner.Tests.BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned [1 ms]
+  Error Message:
+   [bc-engine-serial] REFUSING TO SKIP: BC artifacts are provisioned on this machine, so these tests CAN run — the in-process engine bootstrap simply was not performed. Run `tools/engine-test-bootstrap.sh` and re-run `dotnet test` with `--settings engine.runsettings`; a build restores a pristine bin/Microsoft.Dynamics.Nav.Ncl.dll, so this is needed again after EVERY build. This used to be a silent skip: the run reported `Skipped! - Failed: 0, Passed: 0` and exit 0, which reads exactly like a passing mutation check and has invalidated a real RED baseline (issues #3078, #3835). [bc-engine-serial] SKIPPED — this test asserted NOTHING. The in-process BC engine bootstrap did not complete, so every test in the 'bc-engine-serial' collection is skipping. Cause (NclPreloaded): Microsoft.Dynamics.Nav.Ncl was already loaded before this bootstrap ran, so the Cecil rewrite had no effect and applying the runtime patches failed with TypeInitializationException: The type initializer for 'Microsoft.Dynamics.Nav.Runtime.NavEnvironment' threw an exception. (via TargetInvocationException). Remedy: DOTNET_STARTUP_HOOKS is not wired into this test host, so VSTest's own DiaSession loaded Microsoft.Dynamics.Nav.Ncl before the Cecil rewrite could take effect (issue #1813). Run `tools/engine-test-bootstrap.sh` — it generates engine.runsettings — then re-run `dotnet test --settings engine.runsettings`. CI does this in the 'Generate .runsettings for in-process BC engine tests' step of .github/workflows/bc-tests.yml.
+  Stack Trace:
+     at AlRunner.Tests.BcEngineUnbootstrappedGuard.AssertBootstrapWasRun(Boolean ready, String reason) in /_/AlRunner.Tests/BcEngineCollection.cs:line 293
+   at AlRunner.Tests.BcEngineFixture.get_SkipReason() in /_/AlRunner.Tests/BcEngineCollection.cs:line 241
+   at AlRunner.Tests.BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned() in /_/AlRunner.Tests/BcEngineReadinessGuardTests.cs:line 67
+   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
+
+Failed!  - Failed:     1, Passed:     3, Skipped:     0, Total:     4, Duration: 28 ms - AlRunner.Tests.dll (net8.0)

--- a/tools/testdata/mutation-verdict/genuine-red-guard-mutation.txt
+++ b/tools/testdata/mutation-verdict/genuine-red-guard-mutation.txt
@@ -1,0 +1,88 @@
+Starting test execution, please wait...
+A total of 1 test files matched the specified pattern.
+[xUnit.net 00:00:01.87]     AlRunner.Tests.BcEngineUnbootstrappedGuardTests.EveryLocallyRecoverableCause_Fails(cause: BinRewrittenThisProcess) [FAIL]
+[xUnit.net 00:00:01.92]     AlRunner.Tests.BcEngineUnbootstrappedGuardTests.EveryLocallyRecoverableCause_Fails(cause: NclPreloaded) [FAIL]
+[xUnit.net 00:00:01.93]     AlRunner.Tests.BcEngineUnbootstrappedGuardTests.EveryLocallyRecoverableCause_Fails(cause: BootstrapThrew) [FAIL]
+[xUnit.net 00:00:01.93]     AlRunner.Tests.BcEngineUnbootstrappedGuardTests.EveryLocallyRecoverableCause_Fails(cause: BootstrapDidNotRun) [FAIL]
+[xUnit.net 00:00:01.93]     AlRunner.Tests.BcEngineUnbootstrappedGuardTests.EveryLocallyRecoverableCause_Fails(cause: CecilCacheCold) [FAIL]
+  Failed AlRunner.Tests.BcEngineUnbootstrappedGuardTests.EveryLocallyRecoverableCause_Fails(cause: BinRewrittenThisProcess) [16 ms]
+  Error Message:
+   Assert.NotNull() Failure: Value is null
+  Stack Trace:
+     at AlRunner.Tests.BcEngineUnbootstrappedGuardTests.EveryLocallyRecoverableCause_Fails(BcEngineSkipCause cause) in /_/AlRunner.Tests/BcEngineUnbootstrappedGuardTests.cs:line 93
+   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+  Failed AlRunner.Tests.BcEngineUnbootstrappedGuardTests.EveryLocallyRecoverableCause_Fails(cause: NclPreloaded) [< 1 ms]
+  Error Message:
+   Assert.NotNull() Failure: Value is null
+  Stack Trace:
+     at AlRunner.Tests.BcEngineUnbootstrappedGuardTests.EveryLocallyRecoverableCause_Fails(BcEngineSkipCause cause) in /_/AlRunner.Tests/BcEngineUnbootstrappedGuardTests.cs:line 93
+   at InvokeStub_BcEngineUnbootstrappedGuardTests.EveryLocallyRecoverableCause_Fails(Object, Span`1)
+   at System.Reflection.MethodBaseInvoker.InvokeWithOneArg(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+  Failed AlRunner.Tests.BcEngineUnbootstrappedGuardTests.EveryLocallyRecoverableCause_Fails(cause: BootstrapThrew) [2 ms]
+  Error Message:
+   Assert.NotNull() Failure: Value is null
+  Stack Trace:
+     at AlRunner.Tests.BcEngineUnbootstrappedGuardTests.EveryLocallyRecoverableCause_Fails(BcEngineSkipCause cause) in /_/AlRunner.Tests/BcEngineUnbootstrappedGuardTests.cs:line 93
+   at InvokeStub_BcEngineUnbootstrappedGuardTests.EveryLocallyRecoverableCause_Fails(Object, Span`1)
+   at System.Reflection.MethodBaseInvoker.InvokeWithOneArg(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+  Failed AlRunner.Tests.BcEngineUnbootstrappedGuardTests.EveryLocallyRecoverableCause_Fails(cause: BootstrapDidNotRun) [< 1 ms]
+  Error Message:
+   Assert.NotNull() Failure: Value is null
+  Stack Trace:
+     at AlRunner.Tests.BcEngineUnbootstrappedGuardTests.EveryLocallyRecoverableCause_Fails(BcEngineSkipCause cause) in /_/AlRunner.Tests/BcEngineUnbootstrappedGuardTests.cs:line 93
+   at InvokeStub_BcEngineUnbootstrappedGuardTests.EveryLocallyRecoverableCause_Fails(Object, Span`1)
+   at System.Reflection.MethodBaseInvoker.InvokeWithOneArg(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+  Failed AlRunner.Tests.BcEngineUnbootstrappedGuardTests.EveryLocallyRecoverableCause_Fails(cause: CecilCacheCold) [< 1 ms]
+  Error Message:
+   Assert.NotNull() Failure: Value is null
+  Stack Trace:
+     at AlRunner.Tests.BcEngineUnbootstrappedGuardTests.EveryLocallyRecoverableCause_Fails(BcEngineSkipCause cause) in /_/AlRunner.Tests/BcEngineUnbootstrappedGuardTests.cs:line 93
+   at InvokeStub_BcEngineUnbootstrappedGuardTests.EveryLocallyRecoverableCause_Fails(Object, Span`1)
+   at System.Reflection.MethodBaseInvoker.InvokeWithOneArg(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+[xUnit.net 00:00:02.04]     AlRunner.Tests.BcEngineUnbootstrappedGuardTests.ARecoverableBootstrapGap_Fails_RatherThanSkipping [FAIL]
+[xUnit.net 00:00:02.04]     AlRunner.Tests.BcEngineUnbootstrappedGuardTests.AnEngineLessBox_StillSkips_RatherThanFailing(cause: ArtifactsMissing) [FAIL]
+[xUnit.net 00:00:02.05]     AlRunner.Tests.BcEngineUnbootstrappedGuardTests.AnEngineLessBox_StillSkips_RatherThanFailing(cause: ArtifactsIncomplete) [FAIL]
+[xUnit.net 00:00:02.05]     AlRunner.Tests.BcEngineUnbootstrappedGuardTests.WiredInto_TheRealFixture_SkipReasonProperty [FAIL]
+  Failed AlRunner.Tests.BcEngineUnbootstrappedGuardTests.ARecoverableBootstrapGap_Fails_RatherThanSkipping [< 1 ms]
+  Error Message:
+   Assert.NotNull() Failure: Value is null
+  Stack Trace:
+     at AlRunner.Tests.BcEngineUnbootstrappedGuardTests.ARecoverableBootstrapGap_Fails_RatherThanSkipping() in /_/AlRunner.Tests/BcEngineUnbootstrappedGuardTests.cs:line 67
+   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
+  Failed AlRunner.Tests.BcEngineUnbootstrappedGuardTests.AnEngineLessBox_StillSkips_RatherThanFailing(cause: ArtifactsMissing) [2 ms]
+  Error Message:
+   Assert.Null() Failure: Value is not null
+Expected: null
+Actual:   Xunit.Sdk.FailException: [bc-engine-serial] REFUSING TO SKIP: BC artifacts are provisioned on this machine, so these tests CAN run — the in-process engine bootstrap simply was not performed. Run `tools/engine-test-bootstrap.sh` and re-run `dotnet test` with `--settings engine.runsettings`; a build restores a pristine bin/Microsoft.Dynamics.Nav.Ncl.dll, so this is needed again after EVERY build. This used to be a silent skip: the run reported `Skipped! - Failed: 0, Passed: 0` and exit 0, which reads exactly like a passing mutation check and has invalidated a real RED baseline (issues #3078, #3835). [bc-engine-serial] SKIPPED — this test asserted NOTHING. The in-process BC engine bootstrap did not complete, so every test in the 'bc-engine-serial' collection is skipping. Cause (ArtifactsMissing): no artifacts here Remedy: provision the BC service tier with `dotnet build AlRunner.slnx -p:AllowBcArtifactDownload=true`, then run `tools/engine-test-bootstrap.sh` and re-run `dotnet test` with `--settings engine.runsettings`.
+   at Xunit.Assert.Fail(String message) in /_/src/xunit.assert/Asserts/FailAsserts.cs:line 38
+   at AlRunner.Tests.BcEngineUnbootstrappedGuard.AssertBootstrapWasRun(Boolean ready, String reason) in /_/AlRunner.Tests/BcEngineCollection.cs:line 293
+   at AlRunner.Tests.BcEngineUnbootstrappedGuardTests.<>c__DisplayClass2_0.<AnEngineLessBox_StillSkips_RatherThanFailing>b__0() in /_/AlRunner.Tests/BcEngineUnbootstrappedGuardTests.cs:line 111
+   at Xunit.Record.Exception(Action testCode) in /_/src/xunit.core/Record.cs:line 25
+  Stack Trace:
+     at AlRunner.Tests.BcEngineUnbootstrappedGuardTests.AnEngineLessBox_StillSkips_RatherThanFailing(BcEngineSkipCause cause) in /_/AlRunner.Tests/BcEngineUnbootstrappedGuardTests.cs:line 111
+   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+  Failed AlRunner.Tests.BcEngineUnbootstrappedGuardTests.AnEngineLessBox_StillSkips_RatherThanFailing(cause: ArtifactsIncomplete) [9 ms]
+  Error Message:
+   Assert.Null() Failure: Value is not null
+Expected: null
+Actual:   Xunit.Sdk.FailException: [bc-engine-serial] REFUSING TO SKIP: BC artifacts are provisioned on this machine, so these tests CAN run — the in-process engine bootstrap simply was not performed. Run `tools/engine-test-bootstrap.sh` and re-run `dotnet test` with `--settings engine.runsettings`; a build restores a pristine bin/Microsoft.Dynamics.Nav.Ncl.dll, so this is needed again after EVERY build. This used to be a silent skip: the run reported `Skipped! - Failed: 0, Passed: 0` and exit 0, which reads exactly like a passing mutation check and has invalidated a real RED baseline (issues #3078, #3835). [bc-engine-serial] SKIPPED — this test asserted NOTHING. The in-process BC engine bootstrap did not complete, so every test in the 'bc-engine-serial' collection is skipping. Cause (ArtifactsIncomplete): no artifacts here Remedy: provision the BC service tier with `dotnet build AlRunner.slnx -p:AllowBcArtifactDownload=true`, then run `tools/engine-test-bootstrap.sh` and re-run `dotnet test` with `--settings engine.runsettings`.
+   at Xunit.Assert.Fail(String message) in /_/src/xunit.assert/Asserts/FailAsserts.cs:line 38
+   at AlRunner.Tests.BcEngineUnbootstrappedGuard.AssertBootstrapWasRun(Boolean ready, String reason) in /_/AlRunner.Tests/BcEngineCollection.cs:line 293
+   at AlRunner.Tests.BcEngineUnbootstrappedGuardTests.<>c__DisplayClass2_0.<AnEngineLessBox_StillSkips_RatherThanFailing>b__0() in /_/AlRunner.Tests/BcEngineUnbootstrappedGuardTests.cs:line 111
+   at Xunit.Record.Exception(Action testCode) in /_/src/xunit.core/Record.cs:line 25
+  Stack Trace:
+     at AlRunner.Tests.BcEngineUnbootstrappedGuardTests.AnEngineLessBox_StillSkips_RatherThanFailing(BcEngineSkipCause cause) in /_/AlRunner.Tests/BcEngineUnbootstrappedGuardTests.cs:line 111
+   at InvokeStub_BcEngineUnbootstrappedGuardTests.AnEngineLessBox_StillSkips_RatherThanFailing(Object, Span`1)
+   at System.Reflection.MethodBaseInvoker.InvokeWithOneArg(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+  Failed AlRunner.Tests.BcEngineUnbootstrappedGuardTests.WiredInto_TheRealFixture_SkipReasonProperty [< 1 ms]
+  Error Message:
+   Assert.NotNull() Failure: Value is null
+  Stack Trace:
+     at AlRunner.Tests.BcEngineUnbootstrappedGuardTests.WiredInto_TheRealFixture_SkipReasonProperty() in /_/AlRunner.Tests/BcEngineUnbootstrappedGuardTests.cs:line 247
+   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
+
+Failed!  - Failed:     9, Passed:    20, Skipped:     0, Total:    29, Duration: 213 ms - AlRunner.Tests.dll (net8.0)

--- a/tools/testdata/mutation-verdict/genuine-red-quoting-al-diagnostic.txt
+++ b/tools/testdata/mutation-verdict/genuine-red-quoting-al-diagnostic.txt
@@ -1,0 +1,15 @@
+Starting test execution, please wait...
+A total of 1 test files matched the specified pattern.
+[xUnit.net 00:00:18.73]     AlRunner.Tests.DotNetCompilationTargetScopeTests.CloudTarget_DeclaringADotNetBlock_IsRefusedByTheCompiler [FAIL]
+  Failed AlRunner.Tests.DotNetCompilationTargetScopeTests.CloudTarget_DeclaringADotNetBlock_IsRefusedByTheCompiler [16 s]
+  Error Message:
+   Assert.DoesNotContain() Failure: Sub-string found
+                                ↓ (pos 749)
+String: ···"be.Codeunit.al@8:14): error AL0296: The a"···
+Found:  ": error AL0296:"
+  Stack Trace:
+     at AlRunner.Tests.DotNetCompilationTargetScopeTests.CloudTarget_DeclaringADotNetBlock_IsRefusedByTheCompiler() in /_/AlRunner.Tests/DotNetCompilationTargetScopeTests.cs:line 144
+   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
+
+Failed!  - Failed:     1, Passed:     0, Skipped:     0, Total:     1, Duration: 16 s - AlRunner.Tests.dll (net8.0)

--- a/tools/testdata/mutation-verdict/genuine-red-readiness-mutation.txt
+++ b/tools/testdata/mutation-verdict/genuine-red-readiness-mutation.txt
@@ -1,0 +1,26 @@
+Starting test execution, please wait...
+A total of 1 test files matched the specified pattern.
+[xUnit.net 00:00:02.18]     AlRunner.Tests.BcEngineReadinessGuardTests.AssertReadyOnCi_Throws_WhenNotReadyOnCi [FAIL]
+[xUnit.net 00:00:02.19]     AlRunner.Tests.BcEngineReadinessGuardTests.AssertReadyOnCi_DoesNothing_WhenNotReadyButOffCi [FAIL]
+  Failed AlRunner.Tests.BcEngineReadinessGuardTests.AssertReadyOnCi_Throws_WhenNotReadyOnCi [1 ms]
+  Error Message:
+   Assert.NotNull() Failure: Value is null
+  Stack Trace:
+     at AlRunner.Tests.BcEngineReadinessGuardTests.AssertReadyOnCi_Throws_WhenNotReadyOnCi() in /_/AlRunner.Tests/BcEngineReadinessGuardTests.cs:line 88
+   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
+  Failed AlRunner.Tests.BcEngineReadinessGuardTests.AssertReadyOnCi_DoesNothing_WhenNotReadyButOffCi [2 ms]
+  Error Message:
+   Assert.Null() Failure: Value is not null
+Expected: null
+Actual:   Xunit.Sdk.FailException: BcEngineBootstrap.Ready is false on a CI leg where BC artifacts are provisioned and the Cecil cache is pre-warmed before `dotnet test` runs (see the 'Warm the Ncl Cecil rewrite cache' and 'Generate .runsettings for in-process BC engine tests' steps in .github/workflows/bc-tests.yml). That combination means the DOTNET_STARTUP_HOOKS wiring that makes BcEngineBootstrap's [ModuleInitializer] run before VSTest's own DiaSession (see AlRunner.Tests/EngineStartupHook.cs) has silently stopped taking effect — issue #1813 all over again — and every test in the bc-engine-serial collection is now executing NOTHING while this leg still reports green. SkipReason: BC artifacts not provisioned
+   at Xunit.Assert.Fail(String message) in /_/src/xunit.assert/Asserts/FailAsserts.cs:line 38
+   at AlRunner.Tests.BcEngineReadinessGuard.AssertReadyOnCi(Boolean ready, String skipReason, Boolean runningOnCi) in /_/AlRunner.Tests/BcEngineCollection.cs:line 336
+   at AlRunner.Tests.BcEngineReadinessGuardTests.<>c.<AssertReadyOnCi_DoesNothing_WhenNotReadyButOffCi>b__5_0() in /_/AlRunner.Tests/BcEngineReadinessGuardTests.cs:line 107
+   at Xunit.Record.Exception(Action testCode) in /_/src/xunit.core/Record.cs:line 25
+  Stack Trace:
+     at AlRunner.Tests.BcEngineReadinessGuardTests.AssertReadyOnCi_DoesNothing_WhenNotReadyButOffCi() in /_/AlRunner.Tests/BcEngineReadinessGuardTests.cs:line 106
+   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
+
+Failed!  - Failed:     2, Passed:     1, Skipped:     0, Total:     3, Duration: 17 ms - AlRunner.Tests.dll (net8.0)

--- a/tools/testdata/mutation-verdict/green.txt
+++ b/tools/testdata/mutation-verdict/green.txt
@@ -1,0 +1,7 @@
+Test run for /repo/AlRunner.Tests/bin/Debug/net8.0/AlRunner.Tests.dll (.NETCoreApp,Version=v8.0)
+VSTest version 18.0.2-dev (x64)
+
+Starting test execution, please wait...
+A total of 1 test files matched the specified pattern.
+
+Passed!  - Failed:     0, Passed:     3, Skipped:     0, Total:     3, Duration: 16 ms - AlRunner.Tests.dll (net8.0)

--- a/tools/testdata/mutation-verdict/no-filter-match.txt
+++ b/tools/testdata/mutation-verdict/no-filter-match.txt
@@ -1,0 +1,7 @@
+Test run for /repo/AlRunner.Tests/bin/Debug/net8.0/AlRunner.Tests.dll (.NETCoreApp,Version=v8.0)
+VSTest version 18.0.2-dev (x64)
+
+Starting test execution, please wait...
+A total of 1 test files matched the specified pattern.
+No test matches the given testcase filter `FullyQualifiedName~NoSuchClassXyz3957` in /repo/AlRunner.Tests/bin/Debug/net8.0/AlRunner.Tests.dll
+


### PR DESCRIPTION
Closes #3957

Written by agent stma-auto2-3 on the account holder's behalf.

## What changed

- **`tools/mutation-verdict.py`** (new): reads `dotnet test` console output and says whether the run measured a mutation. Exit 0 GREEN, 1 RED (genuine assertion failures), 3 UNMEASURED (no `Total:` line, a filter that matched nothing, zero tests, skips, or an MSBuild error beside a summary), 4 BUILD-BROKE (MSBuild errors and no summary), 5 ENGINE-NOT-BOOTSTRAPPED (prints the remedy).
- **`tools/test_mutation_verdict.py`** + `tools/testdata/mutation-verdict/`: 28 checks over seven recorded runs from this box (checkout path rewritten to `/repo`), plus derived edge cases, each labelled as derived. Picked up by `pr-gate.yml`'s `tools/test_*.py` glob.
- **`.claude/rules/tdd.md`**: one trap paragraph beside the build-break trap. **`docs/incidents/tdd.md`**: the measurements behind it.

The issue asked only for the rule line. I added the tool first because `CLAUDE.md` says a governance tool lands before the prose that cites it, and because the obvious prose tell turned out to be wrong (see below).

**Not changed:** `BcEngineCollection.cs`. The issue says the fail-not-skip design from #3835 is right, and `BcEngineUnbootstrappedGuardTests` pins it. Making a local unbootstrapped box skip again would bring back the `Failed: 0, Passed: 0`, exit 0 run that #3835 removed. The CI-fails / local-skips split that `TestArtifacts.SkipIfMissingIn` models already exists one level up, in `BcEngineSkipReason.IsRecoverableLocally`: no artifacts means a local skip, and artifacts without a bootstrap means a failure.

## Current shape at `main` (`bb66be98`), measured

Unbootstrapped Debug build, `dotnet test --filter FullyQualifiedName~BcEngineReadinessGuardTests`:
```
  Failed AlRunner.Tests.BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned [1 ms]
  Error Message:
   [bc-engine-serial] REFUSING TO SKIP: BC artifacts are provisioned on this machine, ...
Failed!  - Failed:     1, Passed:     3, Skipped:     0, Total:     4, Duration: 28 ms
```
I reproduced this once and did not repeat it. I did not do the Release build and bootstrap for a clean contrast run on this box. The post-bootstrap number, `Failed: 0, Passed: 181`, is #3948's measurement from the issue body, not mine.

## The finding that shaped the tool

The issue proposed two tells: failures under 1 ms, or `REFUSING TO SKIP` in the message. **Neither is enough.** I inverted the guard's own `IsRecoverableLocally` check and ran `BcEngineUnbootstrappedGuardTests`. That is a genuine mutation RED, `Failed: 9, Passed: 20, Total: 29`. I checked with `--list-tests` that all 29 belong to that one class, with five failures at `[< 1 ms]` and two carrying `REFUSING TO SKIP` under an assertion's `Actual:`. What tells the two apart is where the text sits. The guard puts it on the **first line** of `Error Message:`, and a test asserting over the guard puts it inside `Actual:`. The classifier keys on that first line. Both recordings are fixtures.

## Review fix (FIX-FIRST at `5b41ddcd`)

The reviewer found that a genuine test failure whose assertion message quotes an AL diagnostic was classified BUILD-BROKE. The build-error pattern was a bare `: error [A-Z]+\d+:`, and it was checked before the summary line. I reproduced it with a recording: `DotNetCompilationTargetScopeTests.CloudTarget_*` with one added assertion, `Assert.DoesNotContain(": error AL0296:", output)`, gives `Failed: 1, Total: 1`. The message contains `String: ···"be.Codeunit.al@8:14): error AL0296: The a"···`, and the tool returned exit 4. That recording is now fixture `genuine-red-quoting-al-diagnostic.txt`.

The fix has two parts. A build error now has to be in MSBuild's shape: a line ending in `[<project>.csproj]`. It also counts as BUILD-BROKE only when no summary line exists. An MSBuild error next to a summary (one project failed, another ran) is UNMEASURED.

Mutations on the fix, each confirmed landed and then restored:
- Put the reviewed code back (unanchored pattern, build error checked first): **3 of 28 red**. Two are the new fixture's checks (RED, got BUILD-BROKE, and CLI exit 1, got 4). The third is the derived mixed case.
- Only the unanchored pattern: **2 of 28 red**, exactly the new fixture's RED check and its CLI exit check. They now get UNMEASURED.
- Only the precedence change (build error wins even with a summary): **1 of 28 red**, the derived green-plus-MSBuild-error check.

## RED -> GREEN and mutations

- RED: `python3 tools/test_mutation_verdict.py` with the tool absent, exit 1 (`FileNotFoundError` on import). That only shows the test depends on the tool. The mutations below are the real proof.
- GREEN: 28 of 28 checks, `all passed`, exit 0.
- Mutation 1, the issue's naive tell (match the token anywhere in the text instead of on the first message line): **2 of 28 red** (re-run at the new head). Those are exactly the two checks on the guard-mutation fixture: `a mutation of the guard itself is a genuine RED` (got ENGINE-NOT-BOOTSTRAPPED) and `exit 1 for genuine-red-guard-mutation.txt` (got 5).
- Mutation 2 (drop the `carries no recognisable cause token` token): **1 of 28 red**, the unknown-cause check only.
- Mutation 3 (disable build-error detection): **3 of 28 red**: the build-break classification, its CLI exit, and the mixed green-plus-MSBuild-error case. Every other check stayed green, so each check is tied to its own case.
- Each mutation was confirmed landed by diff and then restored. Final run: `all passed`.

## Fix the shape

1. **Same pattern elsewhere?** `tools/engine-test-bootstrap.sh` already reads `Passed: [1-9]` from a run to decide the engine came up, which is a different question. I found no other tool that reads a `dotnet test` result as a mutation verdict (`rg "Total:|Failed!" tools`).
2. **Sibling assumption?** `BcEngineReadinessGuard.AssertReadyOnCi` has a message that would read as a guard red. I did not add it as a token: it only fires on CI, never on a local mutation run, and my inverted-readiness mutation fixture shows its text inside a **genuine** red. The first-line rule would still classify a real CI firing correctly if the token were added later.
3. **Two writers, one invariant?** Both of `AssertBootstrapWasRun`'s `Assert.Fail` messages are covered, and the token list names that method so the two get changed together.

**Queue scan** (open issues, quoted phrases): `REFUSING TO SKIP`, `engine-test-bootstrap`, `bc-engine-serial`, `mutation RED`. The hits were #3958, #2768, #3567, #3568 and #3282. All of them mention these words in passing, and none reports this defect. #3078 and #3835 are the closed ancestors. Nothing to fold in.

**Not measured:** whether any merged PR ever reported a mutation RED that was really this guard. The issue says the same.

## Local runs

- `python3 tools/test_mutation_verdict.py`: 28/28.
- Every `tools/test_*.py`: all pass except `test_agent_self_freshness.py`, `test_corpus_checkout.py` and `test_preflight.py`. Those three fail the same way from the main checkout, because `git commit` in their temp repos fails on this box's 1Password commit signing (`error: 1Password: failed to fill whole buffer`). `test_preflight.py`'s traceback ends in `Command '['git', 'commit', '-q', '-m', 'base']' returned non-zero exit status 128`, and the other two print that 1Password error directly. That is an environment problem, not this change. It also means this branch's commits are unsigned. `test_agent_stdio.py` caught the new tool missing `enable_utf8_stdio()`, and that is fixed.
- No `AlRunner/` changes, so `Tests updated` does not trigger and no C# guard tests were needed.

Corpus: none. This is runner test infrastructure with no BC-behavior claim. I ran `check_corpus_linkage.sh` locally against this body and diff, and it answered `No file in this diff can change what AL observes, so no corpus declaration is required.` (rc 0).

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
