### PR TITLE
test(permissions): make the vanished-app warning test prove what its comment claims

### DIFF
--- a/AlRunner.Tests/PermissionSetSymbolReadFailureTests.cs
+++ b/AlRunner.Tests/PermissionSetSymbolReadFailureTests.cs
@@ -90,7 +90,7 @@ public sealed class PermissionSetSymbolReadFailureTests : IDisposable
     private const string AppGuid = "b1b0d3e4-3031-4a31-9a31-000000003031";
 
     // Object ids process-wide unique among AlRunner.Tests statics: 939xx is taken by the
-    // #2712 / warm-reload / eviction tests, so this file uses 94100-94102.
+    // #2712 / warm-reload / eviction tests, so this file uses 94100-94104.
     private static string SymbolReference(int permissionSetId, string roleId, bool poison)
     {
         // The root "AppId" is the ONLY difference: a string (parseable) or a number (throws in

--- a/AlRunner.Tests/PermissionSetSymbolReadFailureTests.cs
+++ b/AlRunner.Tests/PermissionSetSymbolReadFailureTests.cs
@@ -16,9 +16,9 @@
 //        "does not exist" — a WRONG answer, not a missing one.
 //
 //   Site 2's warning did not even reach the user: Log's default-verbosity filter drops lines
-//   starting with a `[Component]` tag, and `[RecordPatches]` matches it. Measured by
-//   VanishedApp_WarningSurvivesLogsDefaultFilter below, which drives the REAL filter rather
-//   than re-implementing its regex.
+//   starting with a `[Component]` tag, and `[RecordPatches]` matches it. Both
+//   *_SurvivesLogsDefaultFilter tests below drive the REAL filter, each against a
+//   `[RecordPatches]` control line written through the same writer.
 //
 // WHICH FAILURES ARE STILL TOLERATED, AND WHY
 //   Exactly the distinction #2712 already settled for the table-symbol read in
@@ -243,10 +243,9 @@ public sealed class PermissionSetSymbolReadFailureTests : IDisposable
     [Fact]
     public void VanishedApp_WarningSurvivesLogsDefaultFilter()
     {
-        // The skip above is only honest if the user is TOLD. This drives Log's REAL filter
-        // (Log.Install wraps whatever Console.Error currently is) rather than re-implementing
-        // its regex, because the bug being guarded against is precisely a tag that the regex
-        // eats — `[RecordPatches]` did, which is why the pre-fix warning was invisible.
+        // The skip above is only honest if the user is TOLD, by BOTH sites. Drives Log's REAL
+        // filter rather than its regex; the `[RecordPatches]` control line through the same
+        // writer is what shows the filter was live, so the warnings survived it (#3191).
         var appPath = Path.Combine(_root, "vanishing2.app");
         WriteApp(appPath, SymbolReference(94104, "BUG3031 VANISH2", poison: false));
         RecordPatches.ResetForReload();
@@ -266,6 +265,8 @@ public sealed class PermissionSetSymbolReadFailureTests : IDisposable
             Log.Install();            // wrap `captured` in the same FilteredWriter users get
             InvokeBuildKnownAppNameIndex();
             DrainKnownPermissionSets();
+            // The control: the tag the pre-#3031 warning used, through the same writer.
+            Console.Error.WriteLine($"[RecordPatches] control line: {appPath}");
             Console.Error.Flush();
             text = captured.ToString();
         }
@@ -276,11 +277,11 @@ public sealed class PermissionSetSymbolReadFailureTests : IDisposable
             Log.Verbose = savedVerbose;
         }
 
-        Assert.Contains("vanishing2.app", text);
-        Assert.Contains("[warn]", text);
-        // The specific claim: a `[Component]`-tagged line would NOT have survived. Proven by
-        // pushing one through the very same writer and finding it absent.
-        Console.Error.Flush();
+        // Each site's warning reaches the terminal, naming the .app ...
+        var lines = text.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Contains(lines, l => l.StartsWith("[warn] Aggregate Permission Set:") && l.Contains("vanishing2.app"));
+        Assert.Contains(lines, l => l.StartsWith("[warn] Metadata Permission Set:") && l.Contains("vanishing2.app"));
+        // ... and the control line, written through the very same writer, does not.
         Assert.DoesNotContain("[RecordPatches]", text);
     }
 


### PR DESCRIPTION
Closes #3191

Written by agent stma-auto2-8, an automated agent acting on the account holder's behalf.

## What changed

Test-only, one file: `AlRunner.Tests/PermissionSetSymbolReadFailureTests.cs`.

`VanishedApp_WarningSurvivesLogsDefaultFilter` said it proved that a `[Component]`-tagged line would not survive Log's default filter, but it never wrote one. Its `DoesNotContain("[RecordPatches]")` could not fail, because nothing in production writes that tag any more. It also accepted either permission site's warning as proof for both, since `Contains("[warn]")` and `Contains("vanishing2.app")` are satisfied by one line.

The test now:
- writes a `[RecordPatches]` control line through the same `FilteredWriter` before the snapshot, and asserts it is absent. That is what shows the filter was live, so the warnings got past it.
- asserts each site's warning on its own line (`[warn] Aggregate Permission Set:` and `[warn] Metadata Permission Set:`, each naming the .app).
- no longer calls `Console.Error.Flush()` after the `finally` has restored stderr. The `Flush()` inside the `try`, before the snapshot, stays; it is live.

The file header and the test comment now say only what the test shows. The object-id comment in the same file also claimed `94100-94102`, but the file uses `94100-94104` (94103 and 94104 come from the two vanished-app tests). It now says `94100-94104`.

## RED -> GREEN, as mutations (filter: `FullyQualifiedName~PermissionSetSymbolReadFailureTests`, 7 tests)

| mutation | old test (origin/main) | new test |
|---|---|---|
| none | `Failed: 0, Passed: 7` | `Failed: 0, Passed: 7` |
| A: `FilteredWriter.WriteLine` never drops (`if (false && ...)` in `AlRunner/Log.cs`) | `Failed: 1, Passed: 6`: only `RefusalMessage_...` red; **`VanishedApp_...` green** | `Failed: 2, Passed: 5`: `RefusalMessage_...` and `VanishedApp_...`, both on `Assert.DoesNotContain() Failure: Sub-string found` |
| B: Aggregate site's warning retagged `[warn]` -> `[RecordPatches]` | `Failed: 0, Passed: 7` | `Failed: 1, Passed: 6`: `VanishedApp_...` only, `Assert.Contains() Failure: Filter not matched` |
| C: Metadata site's warning retagged the same way | not run on the old test (same shape as B) | `Failed: 1, Passed: 6`: `VanishedApp_...` only, same assertion |

Each mutation reds only the tests that depend on the property it breaks. B and C leave `RefusalMessage_...` green, which is right: that test does not read either site. Every red is an `Assert` failure, not a build error. After each mutation I restored the file and checked `git status --porcelain`. Final clean run: `Failed: 0, Passed: 7`.

## Fix the shape

1. **Same pattern at another call site?** I scanned `AlRunner.Tests/**/*.cs` for a `Console.Error.Flush()` after a `finally` that restores `Console.SetError`. I checked the scanner against the `origin/main` copy of this file, where it finds the old instance at line 275. Nowhere else matched.
2. **Siblings with the same blind spot?** Nine other test files call `Log.Install()`. `DependencySymbolReadFailureTests` writes a component-tagged control line. `TestPageDemotionIsAnnouncedTests` asserts a tagged line is dropped and a `[warn]` line is kept through the same sink. `CorruptSidecarLoudnessTests`, `ProcedureBoundPropertyWarningTests` and `LoudDiagnosisReachesTheUserTests` go through a helper that sets `Log.Verbose = verbose` and writes the line. Each calls it with both `true` and `false` and has a `DoesNotContain` assertion, so their control is verbosity rather than a second tagged line. I counted those calls and assertions; I did not read every call site's pairing. `PhaseLogIntegrationTests` and the collection/guard files do not assert a warning survives the filter.
3. **Two paths writing the same state, same invariant?** Both vanished-app sites write `[warn] <Surface>: ...`. The test now pins each one separately, which it did not before (mutations B and C).

Open-queue scan: I searched for `FilteredWriter`, "control line" and "Log's default filter". Only #3191 came back. Nothing to fold in.

## Scope and corpus

No runtime code changed and nothing here is a claim about BC, so no corpus test applies. The diff is test-only, one file under `AlRunner.Tests/`. I ran `.github/scripts/check_corpus_linkage.sh` locally with this body and `git diff --name-only origin/main...HEAD`: rc=0, "No file in this diff can change what AL observes". `require-tests.yml` only checks for tests when a path matches `^AlRunner/`, and `AlRunner.Tests/` does not match that.

## Local guards

`GuardTests` filter: `Failed: 1, Passed: 248, Total: 249`. The one failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned`, which refuses because `tools/engine-test-bootstrap.sh` was not run on this box. That is environmental. `tools/test_*.py`: `test_agent_self_freshness.py`, `test_corpus_checkout.py` and `test_preflight.py` failed locally because `git commit` in their temp repos hits the 1Password signing agent (`error: 1Password: failed to fill whole buffer`). Neither touches this file. CI runs both properly.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
