### PR TITLE
fix(preflight): derive expected decompiler contexts from bc-versions.txt

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -371,11 +371,12 @@ Settling "what does BC actually do" means reading `Microsoft.Dynamics.Nav.Ncl.dl
 
 | alias | | alias | |
 |---|---|---|---|
-| `bc260` | 26.0 | `bc281` | 28.1 (current) |
-| `bc270` | 27.0 | `bc282` | 28.2 |
-| `bc273` | 27.3 | `bc283` | 28.3 |
-| `bc275` | 27.5 | `bc284` | 28.4 |
-| `bc280` | 28.0 | | |
+| `bc270` | 27.0 | `bc281` | 28.1 (current) |
+| `bc273` | 27.3 | `bc282` | 28.2 |
+| `bc275` | 27.5 | `bc283` | 28.3 |
+| `bc280` | 28.0 | `bc284` | 28.4 |
+
+One alias per version in `.github/bc-versions.txt`; `tools/preflight.py` expects exactly that set.
 
 Always **find the id, then use it**:
 

--- a/.claude/agents/triager.md
+++ b/.claude/agents/triager.md
@@ -113,11 +113,12 @@ Settling "what does BC actually do" means reading `Microsoft.Dynamics.Nav.Ncl.dl
 
 | alias | | alias | |
 |---|---|---|---|
-| `bc260` | 26.0 | `bc281` | 28.1 (current) |
-| `bc270` | 27.0 | `bc282` | 28.2 |
-| `bc273` | 27.3 | `bc283` | 28.3 |
-| `bc275` | 27.5 | `bc284` | 28.4 |
-| `bc280` | 28.0 | | |
+| `bc270` | 27.0 | `bc281` | 28.1 (current) |
+| `bc273` | 27.3 | `bc282` | 28.2 |
+| `bc275` | 27.5 | `bc283` | 28.3 |
+| `bc280` | 28.0 | `bc284` | 28.4 |
+
+One alias per version in `.github/bc-versions.txt`; `tools/preflight.py` expects exactly that set.
 
 Always **find the id, then use it**:
 

--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -507,7 +507,7 @@ Otherwise the next agent starts from the wrong premise — which has happened he
 
 - `tools/context-pack.py <Name>...` — definition + source + call sites, one round trip.
 - `tools/lsp-query.py callers|symbol <Name>` — exit 2 means the server failed, **not** "none".
-- `mcp__bc-decompiler__*` — BC's own code. Contexts `bc260` … `bc284` are pre-registered;
+- `mcp__bc-decompiler__*` — BC's own code. Contexts `bc270` … `bc284` are pre-registered;
   `search_members` → `memberId` → `get_decompiled_source` / `find_callers`.
   `compare_symbols` diffs a method between BC versions, which is how a Cecil rewrite that
   stopped being reached gets caught.

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -162,10 +162,11 @@ GRAPHIFY_DIR = "AlRunner"
 GRAPHIFY_REL = os.path.join("graphify-out", "graph.json")
 GRAPHIFY_PROBE_QUERY = f"{LSP_PROBE_SYMBOL} callers"
 
-# The BC contexts CLAUDE.md's table promises. common284/navlang275/... also exist
-# on some boxes; they are extra, not required, so their absence is not a finding.
-DECOMPILER_ALIASES = ["bc260", "bc270", "bc273", "bc275",
-                      "bc280", "bc281", "bc282", "bc283", "bc284"]
+# The expected BC contexts are one per version in .github/bc-versions.txt, the list
+# the test matrix reads -- never a second hardcoded list (#3264). Any other registered
+# alias (bc260, common284, navlang275, ...) is extra, not required, and not a finding.
+BC_VERSIONS_REL = os.path.join(".github", "bc-versions.txt")
+_BC_VERSION_PREFIX = re.compile(r"^(\d+)\.(\d)$")   # 28.4 -> bc284; a two-digit minor would collide
 DECOMPILER_SERVER = "bc-decompiler"
 
 EXIT_MEANING = {
@@ -1938,6 +1939,33 @@ class DecompilerState:
     probe_rc: Optional[int] = None  # 0 = the server answered over stdio
     aliases: list = field(default_factory=list)
     error: str = ""
+    expected: Optional[list] = None  # aliases bc-versions.txt requires; None = unknown
+    expected_error: str = ""
+
+
+def decompiler_aliases_from_versions(text: str) -> tuple[Optional[list], str]:
+    """Expected decompiler aliases from bc-versions.txt content, or (None, reason)."""
+    out = []
+    for line in text.splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        for tok in line.split():
+            m = _BC_VERSION_PREFIX.match(tok)
+            if not m:
+                return None, f"unrecognised BC version prefix {tok!r} in {BC_VERSIONS_REL}"
+            out.append(f"bc{m.group(1)}{m.group(2)}")
+    if not out:
+        return None, f"{BC_VERSIONS_REL} lists no BC versions"
+    return out, ""
+
+
+def read_expected_decompiler_aliases(repo: str) -> tuple[Optional[list], str]:
+    path = os.path.join(repo, BC_VERSIONS_REL)
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return decompiler_aliases_from_versions(fh.read())
+    except OSError as exc:
+        return None, f"cannot read {BC_VERSIONS_REL}: {exc}"
 
 
 def classify_lsp(st: LspState) -> CheckResult:
@@ -2157,7 +2185,16 @@ def classify_decompiler(st: DecompilerState) -> CheckResult:
             detail=[st.error.strip()[:400] or "no output"],
             remedy="Run it by hand to see the error:\n"
                    f"  dotnet {st.target}\n" + setup)
-    missing = [a for a in DECOMPILER_ALIASES if a not in st.aliases]
+    if not st.expected:
+        return CheckResult(
+            name=name, status="WARN", command=cmd,
+            summary=f"the server answers, but the expected BC contexts are unknown: "
+                    f"{BC_VERSIONS_REL} could not be read",
+            detail=[st.expected_error or f"{BC_VERSIONS_REL} yielded no versions",
+                    f"present: {', '.join(st.aliases) or '(none)'}"],
+            remedy=f"Run preflight from a full checkout; {BC_VERSIONS_REL} is the list of "
+                   "BC versions the matrix tests.")
+    missing = [a for a in st.expected if a not in st.aliases]
     if missing:
         return CheckResult(
             name=name, status="WARN", command=cmd,
@@ -2170,7 +2207,8 @@ def classify_decompiler(st: DecompilerState) -> CheckResult:
                    "see the end of " + setup)
     return CheckResult(
         name=name, status="PASS", command=cmd,
-        summary=f"server answers and all {len(DECOMPILER_ALIASES)} BC contexts are registered",
+        summary=f"server answers and all {len(st.expected)} BC contexts "
+                f"{BC_VERSIONS_REL} lists are registered",
         detail=["Registered, and proven to answer -- but a .mcp.json change still needs a "
                 "SESSION RESTART before this session or its subagents can call it. "
                 "In-session, confirm with mcp__bc-decompiler__status."],
@@ -2382,6 +2420,7 @@ def mcp_call(argv: list[str], tool: str, *, cwd: Optional[str] = None,
 
 def probe_decompiler(repo: str, timeout: float = 90) -> DecompilerState:
     st = DecompilerState()
+    st.expected, st.expected_error = read_expected_decompiler_aliases(repo)
     st.config, entry = read_mcp_entry(repo, DECOMPILER_SERVER)
     if st.config is None or entry is None:
         return st

--- a/tools/setup-bc-decompiler.sh
+++ b/tools/setup-bc-decompiler.sh
@@ -48,4 +48,4 @@ echo "  load_assembly(assemblyPath: \"<artifacts>/<ver>/Microsoft.Dynamics.Nav.N
 echo "                additionalSearchDirs: [\"<artifacts>/<ver>\"],"
 echo "                contextAlias: \"bc281\")"
 echo
-echo "Aliases already in use on this machine follow the pattern bc260, bc270 ... bc284."
+echo "Alias pattern: bc<major><minor>, one per version in .github/bc-versions.txt (bc270 ... bc284)."

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -1224,15 +1224,18 @@ for _exp, _why in ((None, "bc-versions.txt unreadable"), ([], "empty expected se
 
 # Docs that name a decompiler alias must name one the repository tests.
 _alias_re = re.compile(r"\bbc(\d{3})\b")
-_doc_hits = {}
+_doc_hits, _silent_docs = {}, []
 for _rel in (".claude/agents/impl-agent.md", ".claude/agents/triager.md",
              ".claude/skills/orchestrating-a-session/SKILL.md", "CLAUDE.md",
              "tools/setup-bc-decompiler.sh"):
     with open(os.path.join(REPO_ROOT, _rel), encoding="utf-8") as fh:
-        for _m in _alias_re.finditer(fh.read()):
-            _doc_hits.setdefault("bc" + _m.group(1), set()).add(_rel)
-check("the alias docs scan read something (a zero here is a broken pattern)",
-      len(_doc_hits) > 0, str(_doc_hits))
+        _found = list(_alias_re.finditer(fh.read()))
+    if not _found:
+        _silent_docs.append(_rel)
+    for _m in _found:
+        _doc_hits.setdefault("bc" + _m.group(1), set()).add(_rel)
+check("every scanned doc yields at least one alias (a zero here is a broken pattern or a moved table)",
+      not _silent_docs, str(_silent_docs))
 _stray = {a: sorted(f) for a, f in _doc_hits.items() if a not in _EXPECTED_ALIASES}
 check("every decompiler alias the docs name is a version in bc-versions.txt",
       not _stray, str(_stray))

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -899,6 +899,12 @@ check("--json documents what the exit code means",
 # constructed here rather than arranged on the box -- the same reason the disk and
 # memory thresholds are proven against captured `df` output.
 
+REPO_ROOT = os.path.dirname(HERE)
+# The expected decompiler contexts come from .github/bc-versions.txt, read from this
+# checkout (#3264). Read once so every healthy state below uses the same set.
+_EXPECTED_ALIASES, _EXPECTED_ERR = pf.read_expected_decompiler_aliases(REPO_ROOT)
+
+
 def nav_states():
     """A healthy state for each of the three checks, to mutate one field at a time."""
     lsp = pf.LspState(script=True, server_on_path=True, fixture_ok=True, rc=0,
@@ -911,7 +917,8 @@ def nav_states():
     # the classifier ever sees them, so a healthy state carries no trace of either.
     dec = pf.DecompilerState(config="/repo/.mcp.json", registered=True,
                              target="/opt/DecompilerServer.dll", target_exists=True,
-                             probe_rc=0, aliases=list(pf.DECOMPILER_ALIASES))
+                             probe_rc=0, aliases=list(_EXPECTED_ALIASES),
+                             expected=list(_EXPECTED_ALIASES))
     return lsp, graph, dec
 
 
@@ -1158,9 +1165,77 @@ check("a registered server that does not answer is not reported as PASS",
 check("the non-answering server's error is shown",
       "did not respond" in " ".join(r.detail), str(r.detail))
 
-r = dec_with(aliases=[a for a in pf.DECOMPILER_ALIASES if a != "bc284"])
+r = dec_with(aliases=[a for a in _EXPECTED_ALIASES if a != "bc284"])
 check("a missing BC context is reported", r.status == "WARN", r.summary)
 check("the missing BC context is named", "bc284" in r.summary, r.summary)
+
+# ---- #3264: the expected contexts are .github/bc-versions.txt, not a second list
+def _versions_file_prefixes():
+    out = []
+    with open(os.path.join(REPO_ROOT, ".github", "bc-versions.txt"), encoding="utf-8") as fh:
+        for line in fh:
+            if not line.lstrip().startswith("#"):
+                out.extend(line.split())
+    return out
+
+
+_prefixes = _versions_file_prefixes()
+check("bc-versions.txt: the file this check derives from lists versions at all",
+      len(_prefixes) > 0, str(_prefixes))
+check("bc-versions.txt: expected aliases were read without error",
+      _EXPECTED_ERR == "", _EXPECTED_ERR)
+check("bc-versions.txt: every listed version has exactly one expected context",
+      sorted(_EXPECTED_ALIASES) == sorted("bc" + p.replace(".", "") for p in _prefixes)
+      and len(set(_EXPECTED_ALIASES)) == len(_prefixes),
+      f"expected={_EXPECTED_ALIASES} prefixes={_prefixes}")
+check("bc-versions.txt: BC 26 is not expected, because the repository does not test it",
+      "bc260" not in _EXPECTED_ALIASES, str(_EXPECTED_ALIASES))
+
+_parsed, _err = pf.decompiler_aliases_from_versions("# header\n27.0 27.5\n# x\n28.4\n")
+check("the versions parser maps prefixes to aliases and skips comments",
+      _parsed == ["bc270", "bc275", "bc284"] and _err == "", f"{_parsed} {_err!r}")
+_parsed, _err = pf.decompiler_aliases_from_versions("# only a header\n")
+check("a versions file listing nothing is an error, not an empty expected set",
+      _parsed is None and "no BC versions" in _err, f"{_parsed} {_err!r}")
+_parsed, _err = pf.decompiler_aliases_from_versions("27.0 28\n")
+check("a malformed version prefix is an error naming the token",
+      _parsed is None and "'28'" in _err, f"{_parsed} {_err!r}")
+_parsed, _err = pf.read_expected_decompiler_aliases(tempfile.mkdtemp())
+check("an absent bc-versions.txt is an error, not an empty expected set",
+      _parsed is None and "bc-versions.txt" in _err, f"{_parsed} {_err!r}")
+
+# A context registered for a version the repo does not test is extra, not a finding:
+# this box has bc260 registered, and it must not start warning the other way.
+r = dec_with(aliases=list(_EXPECTED_ALIASES) + ["bc260"])
+check("an extra registered context (bc260) does not stop the check passing",
+      r.status == "PASS", r.summary)
+r = dec_with(aliases=["bc260"] + [a for a in _EXPECTED_ALIASES if a != "bc273"])
+check("bc260 being registered does not stand in for a missing tested version",
+      r.status == "WARN" and "bc273" in r.summary and "bc260" not in r.summary, r.summary)
+
+# The third state: the expected set could not be established. Never PASS, and the
+# message names the file rather than claiming "all 0 contexts are registered".
+for _exp, _why in ((None, "bc-versions.txt unreadable"), ([], "empty expected set")):
+    r = dec_with(expected=_exp, expected_error=_why)
+    check(f"expected contexts unknown ({_why}) is not reported as PASS",
+          r.status == "WARN", f"{r.status} {r.summary}")
+    check(f"expected contexts unknown ({_why}) names bc-versions.txt",
+          "bc-versions.txt" in r.summary, r.summary)
+
+# Docs that name a decompiler alias must name one the repository tests.
+_alias_re = re.compile(r"\bbc(\d{3})\b")
+_doc_hits = {}
+for _rel in (".claude/agents/impl-agent.md", ".claude/agents/triager.md",
+             ".claude/skills/orchestrating-a-session/SKILL.md", "CLAUDE.md",
+             "tools/setup-bc-decompiler.sh"):
+    with open(os.path.join(REPO_ROOT, _rel), encoding="utf-8") as fh:
+        for _m in _alias_re.finditer(fh.read()):
+            _doc_hits.setdefault("bc" + _m.group(1), set()).add(_rel)
+check("the alias docs scan read something (a zero here is a broken pattern)",
+      len(_doc_hits) > 0, str(_doc_hits))
+_stray = {a: sorted(f) for a, f in _doc_hits.items() if a not in _EXPECTED_ALIASES}
+check("every decompiler alias the docs name is a version in bc-versions.txt",
+      not _stray, str(_stray))
 
 check("the passing decompiler report says a .mcp.json change needs a session restart",
       "SESSION RESTART" in " ".join(pf.classify_decompiler(_dec).detail),


### PR DESCRIPTION
Closes #3264

Written by agent stma-auto2-5 on the account holder's behalf.

## What changed

`tools/preflight.py`'s `nav-bc-decompiler` check used a hardcoded `DECOMPILER_ALIASES` list that included `bc260`. BC 26 is deliberately absent from `.github/bc-versions.txt`, so that WARN could only be cleared by provisioning a version the repository does not test.

- The expected contexts are now read from `.github/bc-versions.txt`, the same file `test-matrix.yml` and `publish.yml` read (`28.4` -> `bc284`). `probe_decompiler` reads the file and stores the result on `DecompilerState.expected`, so `classify_decompiler` still works only from captured state.
- Third state: if the file is missing, lists no versions, or has a malformed prefix, the check reports a WARN that names `.github/bc-versions.txt`. Before, an empty list would have produced "all 0 BC contexts are registered".
- Extra registered contexts, such as `bc260` on a box that already loaded it, still pass. They are not a finding.
- Docs that named `bc260` now list the tested set: the alias tables in `.claude/agents/impl-agent.md` and `.claude/agents/triager.md`, `.claude/skills/orchestrating-a-session/SKILL.md`, and `tools/setup-bc-decompiler.sh`. `CLAUDE.md` already said `bc270` ... `bc284`. A new test fails if any of those files names an alias that is not in `bc-versions.txt`.

**Why this was still live even though today's preflight said "all 9 BC contexts are registered":** `origin/main:tools/preflight.py:167` still listed `bc260`. This box passed only because someone had provisioned and registered BC 26, which is the wasted work the issue predicted.

## RED -> GREEN

All tests are in `tools/test_preflight.py`, run as `python3 tools/test_preflight.py`.

- RED: the new tests against `main`'s `preflight.py` crash with `AttributeError: module 'preflight' has no attribute 'read_expected_decompiler_aliases'`. After the code change, the docs guard was still RED on exactly the four files: `FAIL every decompiler alias the docs name is a version in bc-versions.txt {'bc260': [impl-agent.md, triager.md, orchestrating-a-session/SKILL.md, setup-bc-decompiler.sh]}`.
- GREEN: `ok=405 fail=0`, `all checks passed`.

Mutations, each run on the committed tree and then restored. Each one turned exactly the targeted tests red, and every failure was an assertion, not a traceback:

| mutation | result |
|---|---|
| parser also returns `bc260` | `Failed: 3, Passed: 402` (agreement, BC 26 not expected, parser mapping) |
| third state removed (`if False:`; empty set falls through) | `Failed: 2, Passed: 403` (both "unknown is not PASS" cases; the output was `PASS ... all 0 BC contexts`) |
| reader returns the old hardcoded 9-alias list | `Failed: 2, Passed: 403` (agreement, BC 26 not expected) |
| a scanned doc (orchestrating-a-session skill) stops naming any alias | `Failed: 1, Passed: 404` (every scanned doc yields an alias) |

Live run from this worktree: `PASS nav-bc-decompiler server answers and all 8 BC contexts .github/bc-versions.txt lists are registered`.

The full `tools/test_*.py` loop passes, run under the same `GIT_CONFIG_*` setting as the 405/0 result. Local note: the scratch-repo tests in `test_preflight.py` fail on this box at `git commit` with a 1Password signing-agent error. That also happens on `origin/main`, so it is not caused by this change. I ran with `commit.gpgsign=false` set through `GIT_CONFIG_*` environment variables.

## Fix the shape

1. **Same pattern at another call site?** I searched for `bc2[0-9][0-9]` and `DECOMPILER_ALIASES` (with `rg --hidden` and `command grep`). The only hardcoded version-to-alias list was in `preflight.py`. Every doc site that named `bc260` is fixed and now covered by the new test.
2. **A sibling that makes the same assumption?** `tools/test_matrix_docs_drift.py` already derives version lists in prose from `bc-versions.txt`. I found no other check that expects a version set.
3. **Two writers, one invariant?** The expected set now has one source, so there is no second list to drift.

## Not folded

The issue's second part is only partly handled elsewhere. #3878 (closed) added the `artifacts` preflight check, which now names partially provisioned directories on this box (`8 of 36 artifact directories are partially provisioned ...`). It does not repair or prune them, and `provision --force` still writes a sibling build directory instead of filling the partial one. I filed that gap as #4016 rather than folding it in: it changes provisioning code and needs a decision about pruning directories cited as measurement provenance.

Queue scan for `preflight`, `bc260`, `decompiler context` and `bc-versions`: I found no other open issue whose fix lands in these files.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
