### PR TITLE
test(guards): discover the refusal-count file set instead of hard-coding it

### DIFF
--- a/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
+++ b/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
@@ -472,6 +472,8 @@ public sealed class VirtualTableRefusalClaimTests
     /// Read each number out of this test's failure message, never by adding a delta by hand.
     private static readonly Dictionary<string, int> DeclaredOutsideTheCount = new(StringComparer.Ordinal)
     {
+        // ActiveSessionShapeGap (#3233): its surface is in Surfaces(), its file not on CoveredFiles.
+        ["RecordPatches.ActiveSessionSystemTable.cs"] = 6,
         // CodeunitMetadataShapeGap, reached from the equivalence projection and the BC-document reader.
         ["RecordPatches.CodeunitMetadataEquivalence.cs"] = 1,
         ["RecordPatches.CodeunitMetadataFromBcDocument.cs"] = 3,

--- a/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
+++ b/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
@@ -434,8 +434,9 @@ public sealed class VirtualTableRefusalClaimTests
         // DataAccessSource with no skeleton session, without which BC's own
         // PermissionDataProvider cannot be constructed. Its own file,
         // RecordPatches.PermissionSystemTable.cs, raises two more that this count does not see:
-        // CoveredFiles is a hard-coded list (#3118) and the new file is deliberately not on it,
-        // so those two are outside the scanned set. The delta is therefore +1, not +3.
+        // the new file is deliberately not on CoveredFiles, so those two are counted instead by
+        // EveryRefusalSiteOutsideTheCount_IsInADeclaredFile_WithItsOwnExactCount (#3118).
+        // The delta is therefore +1, not +3.
         // 76 was READ OUT of this test's own failure message ("Expected: 75, Actual: 76"), and
         // independently confirmed by counting the same regex across CoveredFiles ∪ SiblingFiles
         // on origin/main (75) and on this branch (76): the ONLY per-file movement is
@@ -459,6 +460,57 @@ public sealed class VirtualTableRefusalClaimTests
         // CodeunitMetadataShapeGap like every other refusal in that file.
         // 79 was READ OUT of this test's own failure message ("Expected: 77, Actual: 79").
         Assert.Equal(79, total);
+    }
+
+    private static readonly Regex RefusalSite = new(@"throw (RecordPatches\.)?[A-Za-z]+(?<!Bc)ShapeGap\(");
+
+    /// <summary>
+    /// Files that raise the same refusals but sit outside the count above, each with its own
+    /// exact count (#3118). A narrowing that is asserted, not assumed: a deletion here reds the
+    /// file's own row, and a refusal in a file on no list reds the membership check below.
+    /// </summary>
+    /// Read each number out of this test's failure message, never by adding a delta by hand.
+    private static readonly Dictionary<string, int> DeclaredOutsideTheCount = new(StringComparer.Ordinal)
+    {
+        // CodeunitMetadataShapeGap, reached from the equivalence projection and the BC-document reader.
+        ["RecordPatches.CodeunitMetadataEquivalence.cs"] = 1,
+        ["RecordPatches.CodeunitMetadataFromBcDocument.cs"] = 3,
+        // ObjectMetadataShapeGap: #2894's own factory, scoped out of #2945's count by design.
+        ["RecordPatches.NoSourceColumns.cs"] = 1,
+        ["RecordPatches.ObjectMetadataSystemTable.cs"] = 10,
+        // PermissionSetSystemTableShapeGap / PermissionSystemTableShapeGap (the latter joined at #3695).
+        ["RecordPatches.PermissionSetSystemTable.cs"] = 1,
+        ["RecordPatches.PermissionSystemTable.cs"] = 2,
+    };
+
+    [Fact]
+    public void EveryRefusalSiteOutsideTheCount_IsInADeclaredFile_WithItsOwnExactCount()
+    {
+        var files = Directory
+            .EnumerateFiles(Path.Combine(RepoRoot, "AlRunner"), "*.cs", SearchOption.AllDirectories)
+            .Where(p => !p.Split(Path.DirectorySeparatorChar).Any(s => s is "bin" or "obj"))
+            .ToList();
+        // Third state: a discovery that reads nothing must not pass as "nothing undeclared".
+        Assert.True(files.Count > 0, $"discovered no .cs files under {Path.Combine(RepoRoot, "AlRunner")}");
+
+        var perFile = files
+            .Select(p => (Name: Path.GetFileName(p), Count: RefusalSite.Matches(File.ReadAllText(p)).Count))
+            .Where(f => f.Count > 0)
+            .ToList();
+        var counted = new HashSet<string>(CoveredFiles.Concat(SiblingFiles), StringComparer.Ordinal);
+
+        // And a regex that stopped matching reads as zero everywhere; the counted set alone holds 79.
+        var insideTotal = perFile.Where(f => counted.Contains(f.Name)).Sum(f => f.Count);
+        Assert.True(insideTotal >= 79, $"the counted files yield {insideTotal} sites — the scan is not reading what the count above reads");
+
+        var outside = perFile.Where(f => !counted.Contains(f.Name))
+                             .ToDictionary(f => f.Name, f => f.Count, StringComparer.Ordinal);
+        static string Render(IEnumerable<KeyValuePair<string, int>> rows) =>
+            string.Join("\n", rows.OrderBy(kv => kv.Key, StringComparer.Ordinal).Select(kv => $"  {kv.Key} = {kv.Value}"));
+        var actual = Render(outside);
+        var expected = Render(DeclaredOutsideTheCount);
+        Assert.True(expected == actual,
+            $"refusal sites outside CoveredFiles ∪ SiblingFiles do not match DeclaredOutsideTheCount.\ndeclared:\n{expected}\nfound:\n{actual}");
     }
 
 


### PR DESCRIPTION
Closes #3118

*Written by agent `stma-auto2-4` on the account holder's behalf.*

## What changed

One file: `AlRunner.Tests/VirtualTableRefusalClaimTests.cs`. No runtime code.

The exact count in `AllFortyEightRefusalsStillExist_SoNoneWasDeletedRatherThanCorrected` scans only the hard-coded `CoveredFiles` + `SiblingFiles` lists. I re-measured at `main` (same regex, over `AlRunner/**/*.cs`):

| | sites |
|---|---|
| repo-wide | 97 |
| inside `CoveredFiles` ∪ `SiblingFiles` (the asserted count) | 79 |
| outside, with no count at all | **18**, in six files |

The 18: `RecordPatches.ObjectMetadataSystemTable.cs` 10, `RecordPatches.CodeunitMetadataFromBcDocument.cs` 3, `RecordPatches.PermissionSystemTable.cs` 2, `RecordPatches.CodeunitMetadataEquivalence.cs` 1, `RecordPatches.NoSourceColumns.cs` 1, `RecordPatches.PermissionSetSystemTable.cs` 1. The issue's figure of 68 + 10 is out of date. Since it was filed, the count moved to 79 and five more files started raising refusals outside the list. Raw-text counts and comment-stripped counts are identical for every file.

New test `EveryRefusalSiteOutsideTheCount_IsInADeclaredFile_WithItsOwnExactCount`:

- discovers every `.cs` under `AlRunner/` (skipping `bin`/`obj`) instead of reading a list;
- requires the set of files with refusal sites outside `CoveredFiles` ∪ `SiblingFiles` to equal `DeclaredOutsideTheCount` exactly: same files, same per-file counts. It prints both lists in full on failure;
- **third state:** fails if discovery finds no files, or if the counted files give fewer than 79 sites. Either one means the scan read nothing, and without this check it would pass as "nothing undeclared".

`Assert.Equal(79, total)` and its delta history stay as they are. Widening that count would change a claim #2945 owns.

### Why both of the issue's options, not "either"

The issue says to pick one. Option 2 alone (a membership check: no site outside the declared files) still passes if all 10 `ObjectMetadataSystemTable.cs` sites are deleted, because zero sites is trivially inside the union. That deletion is the exact failure the issue says goes undetected. Only a per-file count (option 1) catches it, and only the membership check catches a refusal added in an undeclared file. So the test does both, in one comparison.

## RED → GREEN → MUTATE

Filter `FullyQualifiedName~VirtualTableRefusalClaimTests`, 87 tests:

- **RED** (membership check, nothing declared): `Failed: 1, Passed: 86, Total: 87`. The failure listed exactly the six files above.
- **GREEN** (six files declared, counts copied from that failure message): `Failed: 0, Passed: 87, Total: 87`.
- **MUTATE**: in `RecordPatches.ObjectMetadataSystemTable.cs`, I replaced `throw ObjectMetadataShapeGap("NavEnvironment.EmitVersion not found")` with a direct `throw new AlRunner.Infrastructure.RunnerOutOfScopeException(...)` carrying the same text. It still compiles and throws the same type, and it is the drift this suite exists to catch. Result: `Failed: 1, Passed: 86, Total: 87`, and the failure was the assertion, not a build error: `found: RecordPatches.ObjectMetadataSystemTable.cs = 9` against `declared: ... = 10`. The 79 count stayed green, so the new assertion is what caught it. The file is restored, and the branch diff is only the test file.

Other local runs: `GuardTests|VirtualTableRefusalClaimTests` gave 335 passed, 1 failed. The failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned`, which needs `tools/engine-test-bootstrap.sh` first. `tools/test_agent_self_freshness.py`, `test_corpus_checkout.py` and `test_preflight.py` fail on this machine at `git commit -> 128: 1Password: failed to fill whole buffer` (commit signing in temp repos). All four are environmental, not caused by this diff.

## Rebased onto #3985

#3985 merged while this PR was open. It added `RecordPatches.ActiveSessionSystemTable.cs` with refusal sites, and did not add that file to `CoveredFiles`. After rebasing onto it, the new test failed with `found: RecordPatches.ActiveSessionSystemTable.cs = 6`. The `(?<!Bc)` lookbehind leaves out its `BcShapeGapException` call. I declared that row using the number from the failure message, then re-ran: `Failed: 0, Passed: 91, Total: 91`. The count went from 87 to 91 because #3985's `Surfaces()` row adds 4 theory cases. The 79 count is still correct after the rebase. The declared table now covers 24 sites in 7 files.

## Fix the shape

1. **Same pattern at another call site?** `CoveredFiles` also drives `NoCoveredFileStillConstructsTheRefusalDirectly_OrCitesScopeMd`. I checked a wider glob (`*VirtualTable.cs` and `*SystemTable.cs`). Every `*VirtualTable.cs` file is already clean. `RecordPatches.UserSystemTable.cs` constructs the exception directly and cites `docs/scope.md`, which may be a legitimately permanent refusal. So I did not widen that guard. That is a classification question, not a counting one.
2. **Sibling making the same assumption?** `EveryDiscoveredFactory_ClaimsNotYetImplemented` already discovers its factories by reflection. All 97 text sites call a factory that returns `RunnerOutOfScopeException` (checked against every `*ShapeGap` definition), so the regex and the type contract agree repo-wide today.
3. **Two paths, same invariant?** The 79 and the new per-file table now cover all 97 sites between them, and the membership check guarantees nothing falls between the two.

Queue scan: I searched open issues for `VirtualTableRefusalClaimTests`, `ShapeGap` count, `CoveredFiles`, and `ObjectMetadataSystemTable`. Nothing else lands in this file apart from #3985's open PR, covered above. Two related issues are not folded in: #2994 (moving the BC-internals guards onto `BcShapeGapException`) and #3236 (the Object Metadata payload refusal being bypassed at runtime). Both are runtime changes in patch files, not changes to this count. If #2994 moves a site from a `*ShapeGap` factory to a `*BcShapeGap` one, this test will red with the new per-file number, which is the intended behavior. Not changed on purpose: the test name `AllFortyEightRefusals...` and the "seventeen"/"48" header text are already stale against 79. The issue title cites that name, so renaming it would only add diff noise.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
