### PR TITLE
fix(provision): platform-app sub-step targets the engine's build, not the CDN's latest

### DIFF
--- a/AlRunner.Tests/ManifestAppsBuildTargetTests.cs
+++ b/AlRunner.Tests/ManifestAppsBuildTargetTests.cs
@@ -1,0 +1,113 @@
+// Issue #2226: provision's platform-app / test-toolkit sub-step must target the selected
+// engine's own 4-part build, not the CDN's latest build of that major.minor. Fake CDN
+// delegates only; no network.
+using AlRunner;
+using AlRunner.Infrastructure;
+using AlRunner.Provisioning;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ManifestAppsBuildTargetTests : IDisposable
+{
+    private const string Engine = "28.1.49838.53910";
+    private const string CdnLatest = "28.1.49838.54044";
+
+    private readonly string _root;
+    private readonly List<string> _log = new();
+    private readonly List<string> _prefixQueries = new();
+
+    public ManifestAppsBuildTargetTests()
+    {
+        _root = TestScratch.Dir("al-runner-manifest-apps-build");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private CdnPrefixResult FakeIndex(string prefix)
+    {
+        _prefixQueries.Add(prefix);
+        return prefix == "28.1" ? CdnPrefixResult.Resolved(CdnLatest) : CdnPrefixResult.NoMatch;
+    }
+
+    [Fact]
+    public void PublishedEngineBuild_IsTargeted_NotTheCdnLatestOfItsMinor()
+    {
+        var result = ProvisioningCheck.ResolveManifestAppsBuildCore(Engine,
+            v => v == Engine ? CdnProbeResult.Published : CdnProbeResult.NotPublished,
+            FakeIndex, _log.Add);
+
+        Assert.Equal(Engine, result);
+        Assert.Empty(_prefixQueries);
+        Assert.Empty(_log);
+    }
+
+    [Fact]
+    public void UnansweredProbe_HoldsTheEngineBuild()
+    {
+        var result = ProvisioningCheck.ResolveManifestAppsBuildCore(Engine,
+            _ => CdnProbeResult.Undetermined(NetworkFailureKind.Timeout),
+            FakeIndex, _log.Add);
+
+        Assert.Equal(Engine, result);
+        Assert.Empty(_prefixQueries);
+    }
+
+    [Fact]
+    public void WithdrawnEngineBuild_FallsBackToLatestOfMinor_AndSaysSo()
+    {
+        var result = ProvisioningCheck.ResolveManifestAppsBuildCore(Engine,
+            _ => CdnProbeResult.NotPublished,
+            FakeIndex, _log.Add);
+
+        Assert.Equal(CdnLatest, result);
+        Assert.Equal(new[] { "28.1" }, _prefixQueries);
+        var note = Assert.Single(_log);
+        Assert.Contains($"BC {Engine} is not published", note);
+        Assert.Contains($"fetching BC {CdnLatest} instead", note);
+    }
+
+    [Fact]
+    public void WithdrawnEngineBuild_NothingInIndex_ReturnsNull()
+    {
+        var result = ProvisioningCheck.ResolveManifestAppsBuildCore("27.9.1.2",
+            _ => CdnProbeResult.NotPublished,
+            FakeIndex, _log.Add);
+
+        Assert.Null(result);
+        Assert.Empty(_log);
+    }
+
+    [Fact]
+    public void MajorMinorPrefix_ResolvesLatestOfThatMinor_WithoutProbing()
+    {
+        var probed = false;
+        var result = ProvisioningCheck.ResolveManifestAppsBuildCore("28.1",
+            _ => { probed = true; return CdnProbeResult.Published; },
+            FakeIndex, _log.Add);
+
+        Assert.Equal(CdnLatest, result);
+        Assert.False(probed);
+    }
+
+    [Fact]
+    public void WarmReuse_PrefersTheEngineBuild_OverANewerCompleteBuildOfTheSameMinor()
+    {
+        Directory.CreateDirectory(Path.Combine(_root, Engine));
+        Directory.CreateDirectory(Path.Combine(_root, CdnLatest));
+
+        // No required apps and no toolkit: every candidate is vacuously complete, so the
+        // answer is purely the candidate order.
+        var preferred = ProgramSupport.FindWarmProvisionedVersion(
+            _root, "28.1", Array.Empty<string>(), needTest: false, preferredVersion: Engine);
+        var unpreferred = ProgramSupport.FindWarmProvisionedVersion(
+            _root, "28.1", Array.Empty<string>(), needTest: false);
+
+        Assert.Equal(Engine, preferred);
+        Assert.Equal(CdnLatest, unpreferred);
+    }
+}

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -278,6 +278,46 @@ public static class ProvisioningCheck
     /// </summary>
     public static string ResolveProvisionMajorMinor(string selectedVersion) => MajorMinorOf(selectedVersion);
 
+    /// <summary>
+    /// Issue #2226: the 4-part build to download platform apps / the test toolkit for, so one
+    /// invocation provisions exactly one BC build. A 4-part <paramref name="selectedVersion"/>
+    /// is targeted as-is while the CDN publishes it (or cannot be asked — held, as #2981 holds
+    /// the engine tier); only a build the CDN answers NotPublished for (withdrawn, #2010) falls
+    /// back to the latest build of its major.minor, and says so. A shorter prefix resolves to
+    /// that latest build, as before. Null when nothing could be resolved.
+    /// </summary>
+    /// <remarks>
+    /// Skew between the engine and the R2R platform apps is observed to run (the #2226 report,
+    /// and warm reuse of another build in the minor relies on it) but was never measured to be
+    /// safe, so a fresh download does not choose it.
+    /// </remarks>
+    public static string? ResolveManifestAppsBuildCore(string selectedVersion,
+        Func<string, AlRunner.Provisioning.CdnProbeResult> probeExact,
+        Func<string, AlRunner.Provisioning.CdnPrefixResult> resolvePrefix,
+        Action<string> log)
+    {
+        var mm = MajorMinorOf(selectedVersion);
+        if (selectedVersion.Split('.').Length == 4 && Version.TryParse(selectedVersion, out _))
+        {
+            var probe = probeExact(selectedVersion);
+            if (probe.IsPublished || probe.IsUndetermined)
+                return selectedVersion;
+            var fallback = resolvePrefix(mm);
+            if (fallback.IsResolved)
+                log($"BC {selectedVersion} is not published on the CDN; fetching BC {fallback.Version} " +
+                    $"instead, so these apps are a different build than the selected engine {selectedVersion}.");
+            return fallback.Version;
+        }
+        return resolvePrefix(mm).Version;
+    }
+
+    /// <summary>Real-network wrapper around <see cref="ResolveManifestAppsBuildCore"/>.</summary>
+    public static string? ResolveManifestAppsBuild(string selectedVersion, Action<string> log)
+        => ResolveManifestAppsBuildCore(selectedVersion,
+            v => AlRunner.Provisioning.ArtifactDownloader.ProbeVersion(v, log),
+            p => AlRunner.Provisioning.ArtifactDownloader.ProbeVersionPrefix(p, log),
+            log);
+
     /// <summary>Shared major.minor extraction used by the Derive*/Resolve* helpers above.</summary>
     private static string MajorMinorOf(string version)
     {

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1797,10 +1797,10 @@ if (!provisionSubcommand)
                 ? FindWarmProvisionedVersion(
                     AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, mm,
                     decision.RequiredPlatformApps, decision.ShouldDownloadTest,
-                    versionFloors, m => Console.Error.WriteLine(m))
+                    versionFloors, m => Console.Error.WriteLine(m), preferredVersion: version)
                 : null)
-            ?? AlRunner.Provisioning.ArtifactDownloader.ResolveVersion(
-                mm, m => Console.Error.WriteLine($"[provision] {m}"));
+            ?? AlRunner.Infrastructure.ProvisioningCheck.ResolveManifestAppsBuild(
+                version, m => Console.Error.WriteLine($"[provision] {m}"));
         if (full == null)
         {
             Console.Error.WriteLine($"[provision] could not resolve a full BC artifact version for '{mm}'; cannot continue.");

--- a/AlRunner/ProgramSupport/Provisioning.cs
+++ b/AlRunner/ProgramSupport/Provisioning.cs
@@ -261,7 +261,8 @@ internal static partial class ProgramSupport
         string artifactsRootDir, string majorMinorPrefix,
         IReadOnlyList<string> requiredPlatformApps, bool needTest,
         IReadOnlyDictionary<string, Version>? versionFloors = null,
-        Action<string>? onRejected = null)
+        Action<string>? onRejected = null,
+        string? preferredVersion = null)
     {
         if (!Directory.Exists(artifactsRootDir)) return null;
         var candidates = Directory.EnumerateDirectories(artifactsRootDir)
@@ -270,7 +271,10 @@ internal static partial class ProgramSupport
                 && (n == majorMinorPrefix || n!.StartsWith(majorMinorPrefix + ".", StringComparison.Ordinal)))
             .Select(n => (Name: n!, Ver: Version.TryParse(n, out var v) ? v : null))
             .Where(t => t.Ver != null)
-            .OrderByDescending(t => t.Ver)
+            // #2226: the selected engine's own build first, so a complete set for it is reused
+            // over a newer build of the same minor that happens to be on disk.
+            .OrderByDescending(t => t.Name == preferredVersion)
+            .ThenByDescending(t => t.Ver)
             .Select(t => t.Name);
 
         foreach (var name in candidates)
@@ -832,7 +836,7 @@ internal static partial class ProgramSupport
             ? FindWarmProvisionedVersion(
                 AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, mm,
                 decision.RequiredPlatformApps, needTest: false,
-                provisionFloors, m => Console.Error.WriteLine(m))
+                provisionFloors, m => Console.Error.WriteLine(m), preferredVersion: engineVersion)
             : null;
         if (warmVersion != null)
         {
@@ -846,8 +850,8 @@ internal static partial class ProgramSupport
             return;
         }
 
-        var platformFull = AlRunner.Provisioning.ArtifactDownloader.ResolveVersion(
-            mm, m => Console.Error.WriteLine($"[provision] {m}"));
+        var platformFull = AlRunner.Infrastructure.ProvisioningCheck.ResolveManifestAppsBuild(
+            engineVersion, m => Console.Error.WriteLine($"[provision] {m}"));
         if (platformFull == null)
         {
             Console.Error.WriteLine(


### PR DESCRIPTION
Closes #2226

Written by agent stma-auto2-7 on the account holder's behalf.

## What changed

Both provision paths picked the platform-app build (and, on the `--auto-provision` path, the test-toolkit build too) with `ArtifactDownloader.ResolveVersion(major.minor)`. That returns the CDN's latest build of the minor, not the engine's build. I re-checked this against current `main` (391df30a) before starting, and the call was still at `ProgramSupport/Provisioning.cs:849` and `Program.cs:1802`.

- `ProvisioningCheck.ResolveManifestAppsBuildCore` (new, pure, takes fake-able CDN delegates), plus a real-network wrapper `ResolveManifestAppsBuild`:
  - For a 4-part selected build, it targets that build when the CDN publishes it. It also targets that build when the CDN probe gets no answer, which matches how #2981 handles the engine tier.
  - It falls back to the latest build of the minor only when the CDN answers that the build is not published (a withdrawn build, #2010). When that happens, it logs a note that names both builds.
  - A major.minor prefix resolves to the latest build, same as before.
- `EnsurePlatformAppsProvisioned` (the `provision` subcommand) and the `--auto-provision` gate in `Program.cs` now call it. This is the sibling call site with the same defect. On that path it also decides the test-toolkit build.
- `FindWarmProvisionedVersion` takes `preferredVersion`, and both callers pass the selected build. When the selected build's set is already complete on disk, it is reused before a newer complete build of the same minor. Before this, warm reuse always took the highest build.

Before choosing the exact build, I checked the CDN by hand: `/platform`, `/w1` and `/us` all return 200 for 28.1.49838.53910 (the engine build in the report), 28.1.49838.54044, 28.4.53241.53989, 27.5.46862.53931 and 27.0.38460.53260.

**On the issue's question of whether the R2R apps tolerate build skew:** that has not been measured. It is only observed. Runs passed in the #2226 report, and warm reuse of another build in the same minor still depends on it when the selected build's set is not on disk. A fresh download no longer picks a different build. I recorded this in a `<remarks>` on the resolver, so nobody reads the skew as deliberate.

## RED -> GREEN and mutations

`dotnet test AlRunner.Tests --filter FullyQualifiedName~ManifestAppsBuildTargetTests`: 6 tests, all using fake CDN delegates and no network.

- GREEN: `Failed: 0, Passed: 6, Total: 6`.
- Mutation 1 puts back the pre-fix behavior: the resolver always takes latest-of-minor (`if (probe.IsPublished && !probe.IsPublished)`). Result: `Failed: 2, Passed: 4`. The two that go red are `PublishedEngineBuild_IsTargeted_NotTheCdnLatestOfItsMinor` and `UnansweredProbe_HoldsTheEngineBuild`, both failing on `Assert.Equal() Failure: Strings differ`. The withdrawn-build and prefix tests stay green, which they should.
- Mutation 2 removes the warm-reuse preference (`t.Name == null`). Result: `Failed: 1, Passed: 5`. `WarmReuse_PrefersTheEngineBuild...` fails with Expected `28.1.49838.53910`, Actual `28.1.49838.54044`.
- The RED came from mutating the fix back to the old behavior. The new pure function did not exist before this change, so a test written first would have been a compile failure, not a failing assertion.

**Not covered by a test:** the two call sites that now call the wrapper. The download functions reach the network directly, and I found no seam for them. Pointing a call site back at `ResolveVersion(mm)` would stay green.

Wider local run: `ProvisioningCheckTests`, `DefaultProvisionTarget*`, `ProvisionExplicitModesTests` and `*GuardTests` gave `Failed: 1, Passed: 402, Total: 403`. The one failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned`, which refuses to run because the engine bootstrap (`tools/engine-test-bootstrap.sh`) was not run in this test host. It is not related to this change. In `tools/test_*.py`, three tests fail locally (`agent_self_freshness`, `corpus_checkout`, `preflight`). Each one fails at `git commit` in a scratch repo, because commit signing through 1Password is refused on this box. This diff touches no `tools/` file.

## Fix the shape

1. **Same pattern at another call site?** Yes. `Program.cs`'s `--auto-provision` gate had the same `ResolveVersion(mm)` fallback, and it is fixed here. I also checked the other `ResolveVersion` callers in `ProgramSupport/Provisioning.cs`. The one in `RunExplicitProvisionModes` handles `--resolve-version`, which resolves a prefix on purpose because the user asked for "latest of X". The two in `ResolveFullVersionForExplicitProvision` and `RunProvisioning` are the last resort when there is no engine build info.
2. **Sibling function with the same assumption?** Yes. `FindWarmProvisionedVersion` took the newest complete build of the minor no matter what the selection was. It now prefers the selected build.
3. **Two paths writing the same state with different invariants?** Yes: the engine closure/test toolkit (exact build) versus platform apps (latest of minor). This change makes them target the same build, except when the CDN says that build is not published. In that case the log names both builds.

## Queue scan

Area `provisioning-version`: nothing folded.
- #2190 and #2227 (`--precompile` variant selection and its docs) touch a different dispatch path.
- #2230 is cross-major warning text in `BcArtifacts`.
- #2232 is about whether platform apps are needed at all, which is a decision in `DecideManifestProvisioning`. It needs a different, architectural fix.
- #4016 (`--force` writing a sibling build directory) goes through the explicit `--resolve-version` path. It is waiting on a decision about repairing or pruning. One thing relevant to it: after this PR, warm reuse prefers the selected build over the newest complete build in the minor.

Searches for `ResolveVersion`, `54044`, `latest build platform apps`, `EnsurePlatformAppsProvisioned` and `FindWarmProvisionedVersion` found no other open issue describing this defect.

No corpus test: this is runner provisioning behavior, not BC behavior. No change under the paths that require corpus linkage.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
