### PR TITLE
fix(server): affectedOnly test selection alternates between narrow and full run on repeated edits

### DIFF
--- a/AlRunner.Tests/ServerAffectedSelectionTests.cs
+++ b/AlRunner.Tests/ServerAffectedSelectionTests.cs
@@ -329,4 +329,97 @@ public class ServerAffectedSelectionTests
         Assert.Equal(0, selection.GetProperty("skipped").GetInt32());
         Assert.Equal(2, events.Count);
     }
+
+    // #3337: a test that selection skipped used to lose its coverage entry when the baseline was
+    // rebuilt, so the next request ran it as "unknown" — narrow and full runs alternated. The
+    // defect has period 2, so every cycle is asserted, not only the last.
+    [SkippableFact]
+    public async Task AffectedOnly_RepeatedEditsToSameObject_NarrowOnEveryCycle()
+    {
+        TestArtifacts.SkipIfMissing();
+        var bundle = MakeBundle(HelperABody(0));
+        await using var server = await CliServer.StartAsync(new[] { "--no-cache" });
+
+        await server.SendRequestStreamingAsync(RunTestsRequest(bundle, affectedOnly: true));
+
+        var observed = new List<string>();
+        for (var cycle = 1; cycle <= 4; cycle++)
+        {
+            File.WriteAllText(Path.Combine(bundle, "HelperA.Codeunit.al"), HelperABody(cycle));
+            var lines = await server.SendRequestStreamingAsync(RunTestsRequest(bundle, affectedOnly: true));
+            var (events, summary) = ProtocolV2Streaming.Split(lines);
+            Assert.True(summary.TryGetProperty("selection", out var selection), string.Join(" | ", lines));
+            observed.Add($"cycle {cycle}: ran={selection.GetProperty("ran").GetInt32()} "
+                + $"skipped={selection.GetProperty("skipped").GetInt32()} "
+                + $"forcedFull={selection.GetProperty("forcedFull").GetBoolean()} "
+                + $"events=[{string.Join(",", events.Select(e => e.GetProperty("name").GetString()))}]");
+        }
+
+        var expected = Enumerable.Range(1, 4)
+            .Select(c => $"cycle {c}: ran=1 skipped=1 forcedFull=False events=[Codeunit60210.OnlyA]")
+            .ToList();
+        Assert.True(expected.SequenceEqual(observed), string.Join("\n", observed));
+    }
+
+    // #3337, the other direction: only a SKIPPED test keeps its previous coverage. A test that was
+    // selected and failed must still become unknown, so an unrelated later edit reruns it rather
+    // than hiding a red test behind its last green coverage.
+    [SkippableFact]
+    public async Task AffectedOnly_SelectedTestThatFailed_RerunsOnUnrelatedLaterEdit()
+    {
+        TestArtifacts.SkipIfMissing();
+        var bundle = MakeBundle(HelperABody(0));
+        await using var server = await CliServer.StartAsync(new[] { "--no-cache" });
+
+        await server.SendRequestStreamingAsync(RunTestsRequest(bundle, affectedOnly: true));
+
+        File.WriteAllText(Path.Combine(bundle, "HelperA.Codeunit.al"), """
+        codeunit 60201 "Affected Helper A SX"
+        {
+            procedure ValueA(): Integer
+            begin
+                exit(99);
+            end;
+        }
+        """);
+        var failLines = await server.SendRequestStreamingAsync(RunTestsRequest(bundle, affectedOnly: true));
+        var (failEvents, _) = ProtocolV2Streaming.Split(failLines);
+        Assert.Single(failEvents);
+        Assert.Equal("fail", failEvents[0].GetProperty("status").GetString());
+
+        File.WriteAllText(Path.Combine(bundle, "HelperB.Codeunit.al"), """
+        codeunit 60202 "Affected Helper B SX"
+        {
+            procedure ValueB(): Integer
+            var
+                Y: Integer;
+            begin
+                Y := 2;
+                exit(Y);
+            end;
+        }
+        """);
+        var lines = await server.SendRequestStreamingAsync(RunTestsRequest(bundle, affectedOnly: true));
+        var (events, summary) = ProtocolV2Streaming.Split(lines);
+
+        Assert.True(summary.TryGetProperty("selection", out var selection), string.Join(" | ", lines));
+        var names = events.Select(e => e.GetProperty("name").GetString()).OrderBy(x => x, StringComparer.Ordinal);
+        Assert.Equal(new[] { "Codeunit60210.OnlyA", "Codeunit60210.OnlyB" }, names);
+        Assert.Equal(2, selection.GetProperty("ran").GetInt32());
+        Assert.Equal(0, selection.GetProperty("skipped").GetInt32());
+    }
+
+    private static string HelperABody(int cycle) => $$"""
+        codeunit 60201 "Affected Helper A SX"
+        {
+            procedure ValueA(): Integer
+            var
+                X: Integer;
+            begin
+                X := {{cycle}};
+                X := 1;
+                exit(X);
+            end;
+        }
+        """;
 }

--- a/AlRunner.Tests/ServerAffectedSelectionTests.cs
+++ b/AlRunner.Tests/ServerAffectedSelectionTests.cs
@@ -409,6 +409,56 @@ public class ServerAffectedSelectionTests
         Assert.Equal(0, selection.GetProperty("skipped").GetInt32());
     }
 
+    // #3337: a FULL request (no narrowing) must not carry old entries forward either. OnlyA fails
+    // during a forced-full run; an unrelated later edit must still rerun it.
+    [SkippableFact]
+    public async Task AffectedOnly_TestFailingDuringForcedFullRun_RerunsOnUnrelatedLaterEdit()
+    {
+        TestArtifacts.SkipIfMissing();
+        var bundle = MakeBundle(HelperABody(0));
+        await using var server = await CliServer.StartAsync(new[] { "--no-cache" });
+
+        await server.SendRequestStreamingAsync(RunTestsRequest(bundle, affectedOnly: true));
+
+        File.WriteAllText(Path.Combine(bundle, "HelperA.Codeunit.al"), """
+        codeunit 60201 "Affected Helper A SX"
+        {
+            procedure ValueA(): Integer
+            begin
+                exit(99);
+            end;
+        }
+        """);
+        File.AppendAllText(Path.Combine(bundle, "app.json"), "\n ");
+        var fullLines = await server.SendRequestStreamingAsync(RunTestsRequest(bundle, affectedOnly: true));
+        var (fullEvents, fullSummary) = ProtocolV2Streaming.Split(fullLines);
+        Assert.True(fullSummary.TryGetProperty("selection", out var fullSelection), string.Join(" | ", fullLines));
+        Assert.True(fullSelection.GetProperty("forcedFull").GetBoolean());
+        Assert.Equal(2, fullEvents.Count);
+        Assert.Equal("fail", fullEvents.Single(e => e.GetProperty("name").GetString() == "Codeunit60210.OnlyA")
+            .GetProperty("status").GetString());
+
+        File.WriteAllText(Path.Combine(bundle, "HelperB.Codeunit.al"), """
+        codeunit 60202 "Affected Helper B SX"
+        {
+            procedure ValueB(): Integer
+            var
+                Y: Integer;
+            begin
+                Y := 2;
+                exit(Y);
+            end;
+        }
+        """);
+        var lines = await server.SendRequestStreamingAsync(RunTestsRequest(bundle, affectedOnly: true));
+        var (events, summary) = ProtocolV2Streaming.Split(lines);
+
+        Assert.True(summary.TryGetProperty("selection", out var selection), string.Join(" | ", lines));
+        Assert.False(selection.GetProperty("forcedFull").GetBoolean(), string.Join(" | ", lines));
+        var names = events.Select(e => e.GetProperty("name").GetString()).OrderBy(x => x, StringComparer.Ordinal);
+        Assert.Equal(new[] { "Codeunit60210.OnlyA", "Codeunit60210.OnlyB" }, names);
+    }
+
     private static string HelperABody(int cycle) => $$"""
         codeunit 60201 "Affected Helper A SX"
         {

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -6714,6 +6714,8 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
             }
 
             var requestDiscoveredTestsByBundle = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+            // #3337: null = no narrowing (every discovered test was selected).
+            var requestSelectedTestsByBundle = new Dictionary<string, HashSet<string>?>(StringComparer.Ordinal);
             var requestModuleByBundle = new Dictionary<string, string>(StringComparer.Ordinal);
             var requestEnvironmentByBundle = new Dictionary<string, string>(StringComparer.Ordinal);
             var selectionByBundle = new Dictionary<string, ServerSelection>(StringComparer.Ordinal);
@@ -6766,6 +6768,7 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                             activeForcedReason);
                     }
 
+                    requestSelectedTestsByBundle[activeBundleKey] = exactSelection;
                     var previousExact = executor.ExactTestFilter;
                     executor.ExactTestFilter = exactSelection;
                     try { return executor.Run(asm, OnTestComplete, cts.Token); }
@@ -6956,8 +6959,24 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                         continue;
                     }
 
+                    // #3337: a test selection deliberately SKIPPED keeps its previous entry. Its
+                    // covered objects did not change, so the entry still holds; dropping it made
+                    // the next request rerun it as unknown, and narrow/full runs alternated. Only
+                    // a skip counts — a selected test with no result (cancelled, never reached)
+                    // stays unknown, or a stale entry would hide it from the change it missed.
+                    requestSelectedTestsByBundle.TryGetValue(bundlePath, out var selectedThisRequest);
+                    affectedCoverageByBundle.TryGetValue(bundlePath, out var previousCoverage);
                     foreach (var testKey in discoveredTests)
                     {
+                        if (selectedThisRequest != null
+                            && !selectedThisRequest.Contains(testKey)
+                            && previousCoverage != null
+                            && previousCoverage.TryGetValue(testKey, out var carried))
+                        {
+                            nextCoverage[testKey] = carried;
+                            continue;
+                        }
+
                         if (!resultByTest.TryGetValue(testKey, out var result)
                             || result.Outcome != TestOutcome.Pass
                             || result.TimedOut)


### PR DESCRIPTION
Closes #3337

Written by agent stma-auto2-3 on the account holder's behalf.

## Cause

The `affectedOnly` baseline is rebuilt after every request from the tests that ran in that request. A test that selection skipped has no result, so the rebuild put it in the "unknown" set and dropped its coverage entry. On the next request every unknown test is selected. So a narrow request made the next one run everything, and that full run made the one after it narrow again: the period-2 alternation in the issue. Nothing fell back, which is why `forcedFull` was `false` and `reason` was `null`.

This needs only one bundle. The two-bundle Pageworks setup in the issue is not part of the mechanism, and the cross-bundle fallback path (#2492/#2603) is not involved.

## Fix (`AlRunner/Program.cs`, `RunServerLoop`)

- Keep each bundle's `exactSelection` for the request. `null` means no narrowing.
- When the baseline is rebuilt, a test that was **not in that selection** and has a previous coverage entry keeps that entry. Selection skipped it because its covered objects did not change, so the entry is still valid.
- Every other test that has no passing result still becomes unknown, as before: tests that were selected and failed, timed out, never reached, or produced no statements. Carrying those forward would hide a red test behind its last green coverage.
- The `scanFailures` (#3884) path still marks every test unknown and is unchanged.

## Tests (`AlRunner.Tests/ServerAffectedSelectionTests.cs`)

- `AffectedOnly_RepeatedEditsToSameObject_NarrowOnEveryCycle`: one warm `--server` process. A baseline request, then **four** consecutive edits to `HelperA`. Each response is recorded and all four are asserted: `ran=1 skipped=1 forcedFull=False events=[Codeunit60210.OnlyA]`.
- `AffectedOnly_TestFailingDuringForcedFullRun_RerunsOnUnrelatedLaterEdit` (added after review): an `app.json` change forces a full run while `OnlyA` fails. An unrelated edit to B must then run `OnlyA` again.
- `AffectedOnly_SelectedTestThatFailed_RerunsOnUnrelatedLaterEdit`: guards the other direction. Edit A so that `OnlyA` fails, then make an unrelated edit to B. `OnlyA` must run again (`ran=2 skipped=0`).

### RED -> GREEN

- RED on unfixed `main` (391df30a): `Failed: 1, Passed: 0, Total: 1`. The recorded cycles were `ran=1, 2, 1, 2`, which is the issue's alternation:
  ```
  cycle 1: ran=1 skipped=1 ...   cycle 2: ran=2 skipped=0 ...
  cycle 3: ran=1 skipped=1 ...   cycle 4: ran=2 skipped=0 ...
  ```
- GREEN with the fix: `Failed: 0, Passed: 2, Total: 2`. That covers both new tests.

The second test is a guard for the fix, not a RED on `main`: unfixed code already treats every test without a result as unknown.

The pre-existing affected-selection tests were re-measured with the fix applied in the 262-test run below. All nine pre-existing `ServerAffectedSelection*` tests passed, including `AffectedOnly_ChangedObjectRunsOnlyIntersectingTests`, the procedure-granularity pair, the cross-bundle fallback, and the multi-sourcePaths classes, plus `ServerCrossAppOverloadRebindTests`.

A request forced to a full run (env-key change, fallback, no baseline) sets `exactSelection = null`. So `selectedThisRequest` is null and nothing is carried forward. `AffectedOnly_TestFailingDuringForcedFullRun_RerunsOnUnrelatedLaterEdit` measures this (see the mutation table).

### Mutations (run, both restored)

| mutation | RepeatedEdits | SelectedTestThatFailed | ForcedFullRun / run |
|---|---|---|---|
| carry-forward disabled (`false && ...`) | **RED** (cycles `1,2,1,2`) | green | not yet written; two-test run: `Failed: 1, Passed: 1, Total: 2` |
| a full request (`exactSelection == null`) treated as selecting nothing, so every old entry is carried forward | green | green | **RED** in `TestFailingDuringForcedFullRun`: `Actual: ["Codeunit60210.OnlyB"]`. Run: `Failed: 1, Passed: 11, Total: 12` over `~ServerAffectedSelection` |
| "skipped only" check removed (carry forward for any test with a previous entry) | green | **RED** (`Actual: ["Codeunit60210.OnlyB"]`: the failing `OnlyA` was hidden) | not yet written; two-test run: `Failed: 1, Passed: 1, Total: 2` |

Each mutation turned exactly one test red, and a different one each time, so each test is tied to one half of the condition. Both reds come from assertions; neither is a build error.

### Wider targeted run

`FullyQualifiedName~ServerAffectedSelection|ServerCrossAppOverloadRebindTests|GuardTests`: `Failed: 1, Passed: 261, Total: 262`. The one failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned`, and it is environmental. It refuses because `tools/engine-test-bootstrap.sh`/`engine.runsettings` was not used for this local run ("Ncl was already loaded before this bootstrap ran"). It does not touch this change, and CI generates the runsettings.

`tools/test_*.py`: all pass except `test_agent_self_freshness`, `test_corpus_checkout` and `test_preflight`. Each one fails inside its own scratch git repo with `git commit ... exit 128: 1Password: agent returned an error`, because this machine's commit signing cannot run in a scratch repo. That is environmental, and none of those tools reads the files this PR changes.

GREEN after restoring the fix, with all three new tests: `Failed: 0, Passed: 14, Total: 14` over `~ServerAffectedSelection|~ServerCrossAppOverloadRebindTests`.

**Behavior change to note:** before this fix, every other request reran the whole suite. That happened to catch changes coverage cannot see, such as a new event subscriber that an unchanged test now reaches, on alternate cycles. That accidental catch is gone. A change coverage cannot attribute now narrows away on every cycle, not just half of them.

## Fix the shape

1. **Same wrong pattern at another call site?** The baseline has two writers in `RunServerLoop`: the `scanFailures` branch and the main loop. The `scanFailures` branch drops everything on purpose (#3884) and must stay that way. No other code writes `affectedCoverageByBundle`.
2. **Sibling making the same assumption?** `affectedUnknownTestsByBundle` is rebuilt in the same loop. A skipped test can never be in the previous unknown set, because unknown tests are always selected. So carrying forward only coverage entries is complete, and a skipped test with no previous entry still becomes unknown.
3. **Two writers, same invariant?** Yes. Both writers now keep "a test absent from coverage is unknown". A skipped test just stays in coverage instead of moving to unknown.

## Queue scan

- Searched open issues for `affectedOnly`, "unknown coverage baseline selection skipped", and the mechanism ("forcedFull false", alternation). I found #3415 (subset of Microsoft's tests; a feature, distinct) and #3965 (Cobertura omits dependency-package source; that is the coverage source map, not this baseline rebuild, so it is distinct and not folded).
- Overlap: #4008 (#3974) touches `BcRuntime.cs`/`DependencyLoader.cs`, and #3967 touches `RecordPatches.NclMetaTableFromBcDocument.cs`. Neither touches `Program.cs`.

Runner-specific (server-mode selection state), so there is no corpus test.
Corpus-NA: server-mode affectedOnly selection bookkeeping; no AL-observable BC behavior

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
