### PR TITLE
fix(server): recompile a sibling source dependency when its source changes

### DIFF
--- a/AlRunner.Tests/ServerSiblingSourceDependencyReloadTests.cs
+++ b/AlRunner.Tests/ServerSiblingSourceDependencyReloadTests.cs
@@ -1,0 +1,178 @@
+// ServerSiblingSourceDependencyReloadTests — issue #4025.
+//
+// One --server process, one requested bundle (the tests), and a dependency that exists only as
+// AL source in a sibling directory, so BuildSiblingSourceDeps is the only route that supplies it.
+// The dependency answers Twice(21); the test asserts 42 and names the value it saw, so a PASS after
+// the source changed to `Value * 3` means an earlier request's compile executed.
+//
+// Sibling of ServerPackagedDependencyReplacementTests (#3974), which supplies the dependency as a
+// packaged .app instead.
+
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ServerSiblingSourceDependencyReloadTests
+{
+    private sealed record Fixture(string Root, string SubjectDir, string TestsDir, string CacheDir);
+
+    private static Fixture Create(string tag, string subjectAppId, string testsAppId, int idBase)
+    {
+        var root = TestScratch.Dir($"al-runner-4025-{tag}");
+        var subjectDir = Path.Combine(root, "subject");
+        var testsDir = Path.Combine(root, "tests");
+        var cacheDir = TestScratch.Dir($"al-runner-4025-{tag}-cache");
+        Directory.CreateDirectory(subjectDir);
+        Directory.CreateDirectory(testsDir);
+
+        File.WriteAllText(Path.Combine(testsDir, "app.json"), $$"""
+        {
+          "id": "{{testsAppId}}",
+          "name": "Repro4025 Tests {{tag}}",
+          "publisher": "Repro4025",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{subjectAppId}}", "name": "Repro4025 Subject {{tag}}", "publisher": "Repro4025", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": {{idBase + 5}}, "to": {{idBase + 9}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(testsDir, "Tests.Codeunit.al"), $$"""
+        codeunit {{idBase + 5}} "Repro4025 Tests {{tag}}"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure DependencyLogic()
+            var
+                Logic: Codeunit "Repro4025 Logic {{tag}}";
+                Actual: Integer;
+            begin
+                Actual := Logic.Twice(21);
+                if Actual <> 42 then
+                    Error('dependency result: expected 42, actual %1', Actual);
+            end;
+        }
+        """);
+        return new Fixture(root, subjectDir, testsDir, cacheDir);
+    }
+
+    /// <summary>Write the (version, multiplier) variant of the sibling dependency's source.</summary>
+    private static void WriteSubject(Fixture f, string subjectAppId, string tag, int idBase, string version, int multiplier)
+    {
+        File.WriteAllText(Path.Combine(f.SubjectDir, "app.json"), $$"""
+        {
+          "id": "{{subjectAppId}}",
+          "name": "Repro4025 Subject {{tag}}",
+          "publisher": "Repro4025",
+          "version": "{{version}}",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": {{idBase}}, "to": {{idBase + 4}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(f.SubjectDir, "Logic.Codeunit.al"), $$"""
+        codeunit {{idBase}} "Repro4025 Logic {{tag}}"
+        {
+            procedure Twice(Value: Integer): Integer
+            begin
+                exit(Value * {{multiplier}});
+            end;
+        }
+        """);
+    }
+
+    private static string Req(Fixture f) => JsonSerializer.Serialize(new
+    {
+        command = "runTests",
+        sourcePaths = new[] { f.TestsDir },
+        coverage = false,
+    });
+
+    /// <summary>
+    /// Run one request and assert its single test's verdict. <paramref name="expectedActual"/>
+    /// null means PASS (the dependency answered 42); otherwise the failure must name that value,
+    /// which is what says WHICH compile of the dependency executed.
+    /// </summary>
+    private static async Task AssertRequest(CliServer server, Fixture f, string label, int? expectedActual)
+    {
+        var lines = await server.SendRequestStreamingAsync(Req(f), TimeSpan.FromSeconds(240));
+        var (events, summary) = ProtocolV2Streaming.Split(lines);
+        var joined = string.Join("\n", lines);
+        var ev = events.SingleOrDefault(e => e.GetProperty("name").GetString()!.EndsWith("DependencyLogic"));
+        Assert.True(ev.ValueKind == JsonValueKind.Object,
+            $"{label}: DependencyLogic did not run.\n{joined}\n--- stderr ---\n{server.StdErr}");
+        var status = ev.GetProperty("status").GetString();
+        var message = ev.TryGetProperty("message", out var m) ? m.GetString() ?? "" : "";
+        if (expectedActual is null)
+        {
+            Assert.True(status == "pass", $"{label}: expected PASS (answer 42), got {status}: {message}\n--- stderr ---\n{server.StdErr}");
+            Assert.Equal(0, summary.GetProperty("failed").GetInt32());
+        }
+        else
+        {
+            Assert.True(status == "fail",
+                $"{label}: expected FAIL naming actual {expectedActual} — a PASS means an earlier " +
+                $"request's compile of the sibling dependency executed. Got {status}: {message}\n--- stderr ---\n{server.StdErr}");
+            Assert.Contains($"expected 42, actual {expectedActual}", message);
+        }
+    }
+
+    /// <summary>The second server must have served the dependency from the shared --cache root;
+    /// otherwise its half of the fact is a second cold run, not a warm one.</summary>
+    private static void AssertWarm(CliServer warm, string tag) =>
+        Assert.True(warm.StdErr.Contains($"[deps] source-cache HIT: Repro4025 Subject {tag}"),
+            $"the fresh server never hit the compiled-deps cache:\n{warm.StdErr}");
+
+    private static async Task RunSequence(string tag, string subjectId, string testsId, int idBase,
+        (string Version, int Multiplier)[] cold, (string Version, int Multiplier)[] warm)
+    {
+        TestArtifacts.SkipIfMissing();
+        var f = Create(tag, subjectId, testsId, idBase);
+        var args = new[] { "--cache", f.CacheDir, "--verbose" };
+        static int? Expect(int multiplier) => multiplier == 2 ? null : 21 * multiplier;
+        try
+        {
+            await using (var server = await CliServer.StartAsync(args))
+            {
+                for (int i = 0; i < cold.Length; i++)
+                {
+                    WriteSubject(f, subjectId, tag, idBase, cold[i].Version, cold[i].Multiplier);
+                    await AssertRequest(server, f, $"cold {i + 1} (v{cold[i].Version}, *{cold[i].Multiplier})", Expect(cold[i].Multiplier));
+                }
+            }
+
+            // Fresh process, same --cache root.
+            await using (var server = await CliServer.StartAsync(args))
+            {
+                for (int i = 0; i < warm.Length; i++)
+                {
+                    WriteSubject(f, subjectId, tag, idBase, warm[i].Version, warm[i].Multiplier);
+                    await AssertRequest(server, f, $"warm {i + 1} (v{warm[i].Version}, *{warm[i].Multiplier})", Expect(warm[i].Multiplier));
+                }
+                AssertWarm(server, tag);
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(f.Root, recursive: true); } catch { }
+            try { Directory.Delete(f.CacheDir, recursive: true); } catch { }
+        }
+    }
+
+    [SkippableFact]
+    public Task SiblingSourceChangedWithAVersionBump_ExecutesTheNewCode_ColdAndWarm() =>
+        RunSequence("V", "4025a000-0000-4000-8000-00000000a001", "4025a000-0000-4000-8000-00000000a002", 64030,
+            cold: new[] { ("1.0.0.0", 2), ("1.0.0.1", 3), ("1.0.0.2", 2) },
+            warm: new[] { ("1.0.0.1", 3), ("1.0.0.2", 2), ("1.0.0.1", 3) });
+
+    [SkippableFact]
+    public Task SiblingSourceChangedAtTheSameVersion_ExecutesTheNewCode_ColdAndWarm() =>
+        RunSequence("S", "4025b000-0000-4000-8000-00000000b001", "4025b000-0000-4000-8000-00000000b002", 64040,
+            cold: new[] { ("1.0.0.0", 2), ("1.0.0.0", 3), ("1.0.0.0", 2) },
+            warm: new[] { ("1.0.0.0", 3), ("1.0.0.0", 2), ("1.0.0.0", 3) });
+}

--- a/AlRunner.Tests/ServerSiblingSourceDependencyReloadTests.cs
+++ b/AlRunner.Tests/ServerSiblingSourceDependencyReloadTests.cs
@@ -185,4 +185,37 @@ public sealed class ServerSiblingSourceDependencyReloadTests
         RunSequence("S", "4025b000-0000-4000-8000-00000000b001", "4025b000-0000-4000-8000-00000000b002", 64040,
             cold: new[] { ("1.0.0.0", 2), ("1.0.0.0", 3), ("1.0.0.0", 2) },
             warm: new[] { ("1.0.0.0", 3), ("1.0.0.0", 2), ("1.0.0.0", 3) });
+
+    /// <summary>
+    /// A request for an unrelated workspace between two requests for P must not make the server
+    /// forget where P's dependency module came from (the previous-path map is merged per AppId,
+    /// not replaced). Written from the reviewer's probe on PR #4027.
+    /// </summary>
+    [SkippableFact]
+    public async Task InterveningRequestForAnotherWorkspace_DoesNotForgetTheDependency()
+    {
+        TestArtifacts.SkipIfMissing();
+        const string pSubject = "4025e000-0000-4000-8000-00000000e001", pTests = "4025e000-0000-4000-8000-00000000e002";
+        const string qSubject = "4025f000-0000-4000-8000-00000000f001", qTests = "4025f000-0000-4000-8000-00000000f002";
+        var p = Create("P", pSubject, pTests, 64060);
+        var q = Create("Q", qSubject, qTests, 64070);
+        try
+        {
+            await using var server = await CliServer.StartAsync(new[] { "--cache", p.CacheDir, "--verbose" });
+            WriteSubject(p, pSubject, "P", 64060, "1.0.0.0", 2);
+            await AssertRequest(server, p, "P request 1 (*2)", null);
+            WriteSubject(q, qSubject, "Q", 64070, "1.0.0.0", 2);
+            await AssertRequest(server, q, "Q request (other workspace)", null);
+            WriteSubject(p, pSubject, "P", 64060, "1.0.0.0", 3);
+            await AssertRequest(server, p, "P request 2 (*3) after an intervening request", 63);
+        }
+        finally
+        {
+            foreach (var f in new[] { p, q })
+            {
+                try { Directory.Delete(f.Root, recursive: true); } catch { }
+                try { Directory.Delete(f.CacheDir, recursive: true); } catch { }
+            }
+        }
+    }
 }

--- a/AlRunner.Tests/ServerSiblingSourceDependencyReloadTests.cs
+++ b/AlRunner.Tests/ServerSiblingSourceDependencyReloadTests.cs
@@ -5,8 +5,8 @@
 // The dependency answers Twice(21); the test asserts 42 and names the value it saw, so a PASS after
 // the source changed to `Value * 3` means an earlier request's compile executed.
 //
-// Sibling of ServerPackagedDependencyReplacementTests (#3974), which supplies the dependency as a
-// packaged .app instead.
+// Same AppId and version throughout: a version bump additionally needs the displaced module
+// retired, which is #3974's fix (PR #4008), not this one.
 
 using System.Text.Json;
 using Xunit;
@@ -40,7 +40,15 @@ public sealed class ServerSiblingSourceDependencyReloadTests
           "runtime": "14.0"
         }
         """);
-        File.WriteAllText(Path.Combine(testsDir, "Tests.Codeunit.al"), $$"""
+        var f = new Fixture(root, subjectDir, testsDir, cacheDir);
+        WriteTests(f, tag, idBase, "request 1");
+        return f;
+    }
+
+    /// <summary>The test bundle; <paramref name="marker"/> lets a request change only this bundle.</summary>
+    private static void WriteTests(Fixture f, string tag, int idBase, string marker) =>
+        File.WriteAllText(Path.Combine(f.TestsDir, "Tests.Codeunit.al"), $$"""
+        // {{marker}}
         codeunit {{idBase + 5}} "Repro4025 Tests {{tag}}"
         {
             Subtype = Test;
@@ -57,8 +65,6 @@ public sealed class ServerSiblingSourceDependencyReloadTests
             end;
         }
         """);
-        return new Fixture(root, subjectDir, testsDir, cacheDir);
-    }
 
     /// <summary>Write the (version, multiplier) variant of the sibling dependency's source.</summary>
     private static void WriteSubject(Fixture f, string subjectAppId, string tag, int idBase, string version, int multiplier)
@@ -144,6 +150,16 @@ public sealed class ServerSiblingSourceDependencyReloadTests
                     WriteSubject(f, subjectId, tag, idBase, cold[i].Version, cold[i].Multiplier);
                     await AssertRequest(server, f, $"cold {i + 1} (v{cold[i].Version}, *{cold[i].Multiplier})", Expect(cold[i].Multiplier));
                 }
+
+                // Negative arm: only the TEST bundle changes. Rebuilding from the base caches
+                // every request must still serve the unchanged dependency from its content-keyed
+                // workspace directory rather than re-synthesising it.
+                var mark = server.StdErrMark;
+                WriteTests(f, tag, idBase, "tests-only edit");
+                await AssertRequest(server, f, "cold, tests-only edit", Expect(cold[^1].Multiplier));
+                var slice = await server.StdErrSinceAsync(mark, $"→ Repro4025_Repro4025_Subject_{tag}_");
+                Assert.Contains($"[source-dep] cache HIT Repro4025 Subject {tag} ", slice);
+                Assert.DoesNotContain($"[source-dep] WROTE Repro4025 Subject {tag} ", slice);
             }
 
             // Fresh process, same --cache root.
@@ -163,12 +179,6 @@ public sealed class ServerSiblingSourceDependencyReloadTests
             try { Directory.Delete(f.CacheDir, recursive: true); } catch { }
         }
     }
-
-    [SkippableFact]
-    public Task SiblingSourceChangedWithAVersionBump_ExecutesTheNewCode_ColdAndWarm() =>
-        RunSequence("V", "4025a000-0000-4000-8000-00000000a001", "4025a000-0000-4000-8000-00000000a002", 64030,
-            cold: new[] { ("1.0.0.0", 2), ("1.0.0.1", 3), ("1.0.0.2", 2) },
-            warm: new[] { ("1.0.0.1", 3), ("1.0.0.2", 2), ("1.0.0.1", 3) });
 
     [SkippableFact]
     public Task SiblingSourceChangedAtTheSameVersion_ExecutesTheNewCode_ColdAndWarm() =>

--- a/AlRunner.Tests/WatchSiblingSourceDependencyStaleTests.cs
+++ b/AlRunner.Tests/WatchSiblingSourceDependencyStaleTests.cs
@@ -134,13 +134,24 @@ public class WatchSiblingSourceDependencyStaleTests
             Assert.True(cycle2.Contains("WSS dependency answered 99"),
                 "cycle 2 did not run the edited sibling dependency:\n" + cycle2);
 
-            // Back to 42: both caches HIT for content this process already compiled.
-            WriteDepSource(depDir, 42);
+            // Negative: only the test bundle changes, so the dependency is served from its
+            // content-keyed workspace directory, not re-synthesised — and still answers 99.
             WriteTestSource(testDir, "cycle 3");
             int m3 = await WaitForMarkerAfter(m2 + 1);
             var cycle3 = Segment(m2 + 1, m3);
-            Assert.True(cycle3.Contains("PASS"), "cycle 3 did not go back to passing:\n" + cycle3);
-            Assert.DoesNotContain("FAIL", cycle3);
+            Assert.True(cycle3.Contains("[source-dep] cache HIT Watch Sibling Dep WSS "),
+                "cycle 3 did not serve the unchanged dependency from cache:\n" + cycle3);
+            Assert.DoesNotContain("[source-dep] WROTE Watch Sibling Dep WSS ", cycle3);
+            Assert.True(cycle3.Contains("WSS dependency answered 99"),
+                "cycle 3 did not run the edited sibling dependency:\n" + cycle3);
+
+            // Back to 42: both caches HIT for content this process already compiled.
+            WriteDepSource(depDir, 42);
+            WriteTestSource(testDir, "cycle 4");
+            int m4 = await WaitForMarkerAfter(m3 + 1);
+            var cycle4 = Segment(m3 + 1, m4);
+            Assert.True(cycle4.Contains("PASS"), "cycle 4 did not go back to passing:\n" + cycle4);
+            Assert.DoesNotContain("FAIL", cycle4);
         }
         finally
         {

--- a/AlRunner.Tests/WatchSiblingSourceDependencyStaleTests.cs
+++ b/AlRunner.Tests/WatchSiblingSourceDependencyStaleTests.cs
@@ -1,0 +1,152 @@
+// WatchSiblingSourceDependencyStaleTests — the --watch half of issue #4025.
+//
+// WatchLayeredDependencyStaleTests (#2683) covers a dependency passed as a second bundle. This one
+// passes only the test bundle and leaves the dependency as AL source in a sibling directory, so
+// BuildSiblingSourceDeps supplies it. Each cycle re-synthesises the dependency into a new
+// content-keyed workspace directory; the dependent must then EXECUTE that new package, not the
+// module DependencyLoader compiled from the first cycle's package under the same AppId and version.
+using System.Diagnostics;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class WatchSiblingSourceDependencyStaleTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private const string DepAppId = "4025c000-0000-4000-8000-00000000c001";
+    private const string TestAppId = "4025c000-0000-4000-8000-00000000c002";
+
+    private static void WriteDepSource(string dir, int answer) =>
+        File.WriteAllText(Path.Combine(dir, "Answer.Codeunit.al"), $$"""
+        codeunit 64050 "WSS Answer"
+        {
+            procedure Value(): Integer
+            begin
+                exit({{answer}});
+            end;
+        }
+        """);
+
+    // The watcher observes the requested bundle; each cycle's edit touches this file too.
+    private static void WriteTestSource(string dir, string marker) =>
+        File.WriteAllText(Path.Combine(dir, "AnswerTests.Codeunit.al"), $$"""
+        // {{marker}}
+        codeunit 64055 "WSS Answer Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure DependencyAnswerIs42()
+            var
+                Answer: Codeunit "WSS Answer";
+            begin
+                if Answer.Value() <> 42 then
+                    Error('WSS dependency answered %1, expected 42', Answer.Value());
+            end;
+        }
+        """);
+
+    [SkippableFact]
+    public async Task Watch_SiblingSourceDependencyEdited_ExecutesTheEditedCode()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = TestScratch.Dir("al-runner-watch-sibling-4025");
+        var depDir = Path.Combine(root, "dep-app");
+        var testDir = Path.Combine(root, "test-app");
+        var cacheDir = TestScratch.Dir("al-runner-watch-sibling-4025-cache");
+        Directory.CreateDirectory(depDir);
+        Directory.CreateDirectory(testDir);
+        File.WriteAllText(Path.Combine(depDir, "app.json"), $$"""
+        {
+          "id": "{{DepAppId}}", "name": "Watch Sibling Dep WSS", "publisher": "AL Runner",
+          "version": "1.0.0.0", "dependencies": [], "platform": "1.0.0.0",
+          "idRanges": [ { "from": 64050, "to": 64054 } ], "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(testDir, "app.json"), $$"""
+        {
+          "id": "{{TestAppId}}", "name": "Watch Sibling Dep Tests WSS", "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [ { "id": "{{DepAppId}}", "name": "Watch Sibling Dep WSS", "publisher": "AL Runner", "version": "1.0.0.0" } ],
+          "platform": "1.0.0.0", "idRanges": [ { "from": 64055, "to": 64059 } ], "runtime": "14.0"
+        }
+        """);
+        WriteDepSource(depDir, 42);
+        WriteTestSource(testDir, "cycle 1");
+
+        var lines = new List<CapturedLine>();
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg
+                + $" \"{testDir}\" --watch --cache \"{cacheDir}\"",
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        using var p = Process.Start(psi)!;
+        void Pump(StreamReader r, OutputStream stream) => Task.Run(async () =>
+        {
+            string? l;
+            while ((l = await r.ReadLineAsync()) != null) lock (lines) lines.Add(new CapturedLine(stream, l));
+        });
+        Pump(p.StandardOutput, OutputStream.Stdout);
+        Pump(p.StandardError, OutputStream.Stderr);
+
+        string DumpTail() { lock (lines) return string.Join("\n", lines.TakeLast(60).Select(l => $"[{l.Stream}] {l.Text}")); }
+
+        async Task<int> WaitForMarkerAfter(int fromIndex)
+        {
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(240);
+            while (DateTime.UtcNow < deadline)
+            {
+                List<int> found;
+                lock (lines)
+                    found = WatchOutputSlicing.FindStdoutMarkerIndices(lines, WatchOutputSlicing.WaitingForSourceMarker, fromIndex);
+                if (found.Count > 0) return found[0];
+                if (p.HasExited)
+                {
+                    await Task.Delay(500);
+                    throw new TimeoutException($"watch exited early (exit={p.ExitCode}).\n{DumpTail()}");
+                }
+                await Task.Delay(200);
+            }
+            throw new TimeoutException($"watch marker not seen.\n{DumpTail()}");
+        }
+
+        string Segment(int from, int to) { lock (lines) return WatchOutputSlicing.MergedJoin(lines, from, to); }
+
+        try
+        {
+            int m1 = await WaitForMarkerAfter(0);
+            var cycle1 = Segment(0, m1);
+            Assert.True(cycle1.Contains("PASS"), "cycle 1 did not pass:\n" + cycle1);
+            Assert.DoesNotContain("FAIL", cycle1);
+
+            // Same AppId, same version, new answer: only the dependency's code moved.
+            WriteDepSource(depDir, 99);
+            WriteTestSource(testDir, "cycle 2");
+            int m2 = await WaitForMarkerAfter(m1 + 1);
+            var cycle2 = Segment(m1 + 1, m2);
+            Assert.True(cycle2.Contains("WSS dependency answered 99"),
+                "cycle 2 did not run the edited sibling dependency:\n" + cycle2);
+
+            // Back to 42: both caches HIT for content this process already compiled.
+            WriteDepSource(depDir, 42);
+            WriteTestSource(testDir, "cycle 3");
+            int m3 = await WaitForMarkerAfter(m2 + 1);
+            var cycle3 = Segment(m2 + 1, m3);
+            Assert.True(cycle3.Contains("PASS"), "cycle 3 did not go back to passing:\n" + cycle3);
+            Assert.DoesNotContain("FAIL", cycle3);
+        }
+        finally
+        {
+            try { if (!p.HasExited) p.Kill(entireProcessTree: true); } catch { }
+            try { Directory.Delete(root, recursive: true); } catch { }
+            try { Directory.Delete(cacheDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2170,7 +2170,7 @@ int? RunDependencyPrePasses()
     // Same #2095 provisioning/version-gap special-case as RunLayeredPrePass above.
     try
     {
-        packageCacheDirs = BuildSiblingSourceDeps(bundles, packageCacheDirs, layeredWorkspaceDirs);
+        packageCacheDirs = BuildSiblingSourceDeps(bundles, packageCacheDirs, layeredWorkspaceDirs, implAppPaths);
     }
     catch (Exception ex) when (ex is AlRunner.Infrastructure.IDependencyProvisioningDiagnostic diag)
     {
@@ -2190,14 +2190,26 @@ int? RunDependencyPrePasses()
     compilerPackageDirs.AddRange(packageCacheDirs
         .Where(d => !layeredWorkspaceDirs.Contains(d, StringComparer.OrdinalIgnoreCase)));
 
+    InvalidateMovedWorkspacePackages(implAppPaths);
+    return null;
+}
+
+// Shared by RunDependencyPrePasses (--watch cycles) and RunAllBundlesForServer (--server
+// requests, #4025). Merged per AppId rather than replaced, so a server request that does not
+// mention an app does not forget where that app's module came from.
+void InvalidateMovedWorkspacePackages(IReadOnlyDictionary<Guid, string> implAppPaths)
+{
+    changedImplAppIds.Clear();
     // An impl counts as changed only if it was ALSO present last time: on the very first call
     // nothing has been compiled or loaded against it yet, so there is nothing to invalidate and
     // reporting every impl as "changed" would force a pointless full rebuild of cycle 1.
     foreach (var (appId, appPath) in implAppPaths)
+    {
         if (previousImplAppPaths.TryGetValue(appId, out var before)
             && !string.Equals(before, appPath, StringComparison.OrdinalIgnoreCase))
             changedImplAppIds.Add(appId);
-    previousImplAppPaths = implAppPaths;
+        previousImplAppPaths[appId] = appPath;
+    }
 
     // #2683, the runtime half. A dependency that was re-synthesised has new CODE, and
     // DependencyLoader caches the compiled module per AppId with a reuse gate that compares
@@ -2206,7 +2218,6 @@ int? RunDependencyPrePasses()
     // EXECUTES the module built in the first cycle, and the only symptom is a test that keeps
     // passing.
     DependencyLoader.InvalidateApps(changedImplAppIds);
-    return null;
 }
 
 {
@@ -4799,11 +4810,16 @@ return strictExitCode ? computedExitCode : 0;
 
         var bundleList = sourcePaths.ToList();
         var workspaceScratch = new List<string>();
+        // #4025: from the caches as the user gave them, never from the previous request's output —
+        // see basePackageCacheDirs. That output holds the previous request's synthesized workspace
+        // packages, which BuildSiblingSourceDeps reads as "already packaged" and stops rebuilding.
+        packageCacheDirs = basePackageCacheDirs.ToList();
+        var requestImplAppPaths = new Dictionary<Guid, string>();
         if (sourcePaths.Length > 1)
         {
             try
             {
-                packageCacheDirs = RunLayeredPrePass(bundleList, packageCacheDirs, workspaceScratch);
+                packageCacheDirs = RunLayeredPrePass(bundleList, packageCacheDirs, workspaceScratch, requestImplAppPaths);
             }
             // #2956: the same #2095 special case the CLI path applies, which server mode
             // never had — a missing/too-old package reported as "LAYERED-PREPASS-FAIL:
@@ -4832,7 +4848,7 @@ return strictExitCode ? computedExitCode : 0;
 
         try
         {
-            packageCacheDirs = BuildSiblingSourceDeps(bundleList, packageCacheDirs, workspaceScratch);
+            packageCacheDirs = BuildSiblingSourceDeps(bundleList, packageCacheDirs, workspaceScratch, requestImplAppPaths);
         }
         // Same #2956 provisioning-gap special case as the layered pre-pass above.
         catch (Exception ex) when (ex is AlRunner.Infrastructure.IDependencyProvisioningDiagnostic diag)
@@ -4851,6 +4867,7 @@ return strictExitCode ? computedExitCode : 0;
                 ServerRunResult.Failure(3, "<sibling-source-deps>", $"SIBLING-SOURCE-DEPS-FAIL: {ex.Message}", new())
             };
         }
+        InvalidateMovedWorkspacePackages(requestImplAppPaths);
 
         var results = new List<ServerRunResult>(sourcePaths.Length);
         // #1888: open/close a phase-log bundle+app row per request bundle, mirroring

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -4814,12 +4814,15 @@ return strictExitCode ? computedExitCode : 0;
         // see basePackageCacheDirs. That output holds the previous request's synthesized workspace
         // packages, which BuildSiblingSourceDeps reads as "already packaged" and stops rebuilding.
         packageCacheDirs = basePackageCacheDirs.ToList();
-        var requestImplAppPaths = new Dictionary<Guid, string>();
+        // Sibling source apps only. A layered impl is itself a bundle of this request, and its
+        // module is registered by the bundle loop (#1892); evicting it here loses that registration
+        // (LayeredDepSymbolsIncrementalServerTests).
+        var siblingAppPaths = new Dictionary<Guid, string>();
         if (sourcePaths.Length > 1)
         {
             try
             {
-                packageCacheDirs = RunLayeredPrePass(bundleList, packageCacheDirs, workspaceScratch, requestImplAppPaths);
+                packageCacheDirs = RunLayeredPrePass(bundleList, packageCacheDirs, workspaceScratch);
             }
             // #2956: the same #2095 special case the CLI path applies, which server mode
             // never had — a missing/too-old package reported as "LAYERED-PREPASS-FAIL:
@@ -4848,7 +4851,7 @@ return strictExitCode ? computedExitCode : 0;
 
         try
         {
-            packageCacheDirs = BuildSiblingSourceDeps(bundleList, packageCacheDirs, workspaceScratch, requestImplAppPaths);
+            packageCacheDirs = BuildSiblingSourceDeps(bundleList, packageCacheDirs, workspaceScratch, siblingAppPaths);
         }
         // Same #2956 provisioning-gap special case as the layered pre-pass above.
         catch (Exception ex) when (ex is AlRunner.Infrastructure.IDependencyProvisioningDiagnostic diag)
@@ -4867,7 +4870,7 @@ return strictExitCode ? computedExitCode : 0;
                 ServerRunResult.Failure(3, "<sibling-source-deps>", $"SIBLING-SOURCE-DEPS-FAIL: {ex.Message}", new())
             };
         }
-        InvalidateMovedWorkspacePackages(requestImplAppPaths);
+        InvalidateMovedWorkspacePackages(siblingAppPaths);
 
         var results = new List<ServerRunResult>(sourcePaths.Length);
         // #1888: open/close a phase-log bundle+app row per request bundle, mirroring

--- a/AlRunner/ProgramSupport/SiblingCompile.cs
+++ b/AlRunner/ProgramSupport/SiblingCompile.cs
@@ -736,7 +736,11 @@ internal static partial class ProgramSupport
     // any other dep. This is what lets the corpus's two-app internalsVisibleTo
     // fixture (tests/.../al-language-internals-fixture next to tests/.../al-language)
     // resolve. Inert when no declared dep matches a sibling source app.
-    internal static List<string> BuildSiblingSourceDeps(List<string> bundles, List<string> packageCacheDirs, List<string> workspaceDirsOut)
+    // implAppPathsOut: same contract as RunLayeredPrePass's (#2683) — every sibling source app this
+    // call handled, mapped to the workspace package it resolves from, so a caller that runs again in
+    // the same process can tell which modules moved (#4025).
+    internal static List<string> BuildSiblingSourceDeps(List<string> bundles, List<string> packageCacheDirs, List<string> workspaceDirsOut,
+        IDictionary<Guid, string>? implAppPathsOut = null)
     {
         // 1. Collect each bundle's declared (non-implicit) deps + their bundle roots.
         var neededDeps = new List<DependencyRef>();
@@ -917,6 +921,7 @@ internal static partial class ProgramSupport
             var appFileName = $"{Sanitize(sid.Publisher)}_{Sanitize(sid.Name)}_{sid.Version.ToString().Replace('.', '_')}.app";
             var outPath = Path.Combine(wsDir, appFileName);
             var hadApp = File.Exists(outPath);
+            if (implAppPathsOut != null) implAppPathsOut[sid.AppId] = outPath;
             if (!hadApp)
             {
                 try


### PR DESCRIPTION
Closes #4025

Written by agent stma-auto2-1 on the account holder's behalf.

Corpus-NA: --server/--watch reload wiring; a service tier has no resident process to reload, so the claim is runner-only

**Merge order: after #4008.** This PR alone fixes the same-version edit (the one in the issue's request 4). The issue's request 2, a version bump, also needs #4008's change that retires the displaced `Dep_..._<old version>` module. Measured below.

## Cause

`RunAllBundlesForServer` assigned `BuildSiblingSourceDeps`'s output back into the process-wide `packageCacheDirs` and fed that list into the next request. So request 2 started with request 1's synthesized `workspace-deps/<key>/..._1_0_0_0.app` already in the package list, `IsDependencyPackageAvailable` answered true, `toBuild` was empty, and the pre-pass returned before rebuilding anything. That is why the issue's stderr had one `[source-dep]`/`compiled-on-the-fly` pair and nothing after it. `--watch` already guards against this with `basePackageCacheDirs` (#2683); the server path never used it.

## Change

- `AlRunner/Program.cs`, server path: each request starts from `basePackageCacheDirs`. After the pre-passes, AppIds whose sibling workspace package moved are passed to `DependencyLoader.InvalidateApps`, the same call `--watch` makes. Without that call, the new package has the same AppId and version as the cached module and `LoadAll` reuses the old one.
- The change-tracking block from `RunDependencyPrePasses` is now a local function, `InvalidateMovedWorkspacePackages`, used by both paths. It merges the previous-path map per AppId instead of replacing it, so a server request that does not mention an app does not lose track of where that app came from.
- `AlRunner/ProgramSupport/SiblingCompile.cs`: `BuildSiblingSourceDeps` takes the same optional `implAppPathsOut` map that `RunLayeredPrePass` already takes.
- The server path only invalidates **sibling source apps**. My first version also invalidated layered impls there. That broke `LayeredDepSymbolsIncrementalServerTests.AddingAnOverloadInTheDependency_StillFallsBackToAFullCompile` (`Codeunit 60560 is not present in the test assembly`), because a layered impl is also a bundle in the request and the bundle loop registers its module (#1892). The final version passes that test, and main passes it too.
- Does not touch `BcRuntime.cs` or `DependencyLoader.cs` (#4008's files).

## RED -> GREEN

New tests: `ServerSiblingSourceDependencyReloadTests` (one fact) and `WatchSiblingSourceDependencyStaleTests` (one fact).

- The server fact runs on one server: dependency `*2` -> `*3` -> `*2` at version 1.0.0.0, then a request that edits only the tests bundle. That request must print `[source-dep] cache HIT` and must not print `WROTE`. Then a fresh server on the same `--cache` runs `*3` -> `*2` -> `*3`, and `[deps] source-cache HIT` must appear.
- The watch fact edits the dependency 42 -> 99, then edits only the tests bundle (cache HIT, still 99), then goes back to 42.

| state | result |
|---|---|
| `Program.cs` + `SiblingCompile.cs` from origin/main, new tests | `Failed: 2, Passed: 0, Total: 2`. Server: `cold 2 (v1.0.0.0, *3): expected FAIL naming actual 63 ... Got pass`. Watch: `cycle 2 did not run the edited sibling dependency` (cycle 2 printed `PASS Codeunit64055.DependencyAnswerIs42`) |
| this branch | `Failed: 0, Passed: 2, Total: 2` |

## Mutations (each landed, built with `0 Error(s)`, then restored)

1. Server request starts from the accumulated list again (`packageCacheDirs = packageCacheDirs.ToList()`): `Failed: 2, Passed: 0`. Both failed on the assertion at cold 2.
2. Server skips invalidation (`InvalidateMovedWorkspacePackages(new Dictionary<Guid, string>())`). The same-version arm failed on the assertion (`Got pass`). The version-bump arm, which was in the file then, failed loudly with `DEP-RESOLVE-FAIL: duplicate app id ... loaded at two different versions`. So the invalidation matters in both cases.
3. Watch sibling call without the map (`BuildSiblingSourceDeps(..., null)`): `Failed: 1, Passed: 0`. Cycle 2 ran the stale 42 module.
4. Negative arm, re-synthesize every time (`var hadApp = false && File.Exists(outPath)`): `Failed: 2, Passed: 0`. Server failed on `Assert.Contains("[source-dep] cache HIT ...")`; watch failed with `cycle 3 did not serve the unchanged dependency from cache`.

## Version bump, and why that arm is not in this PR

I also wrote `SiblingSourceChangedWithAVersionBump_ExecutesTheNewCode_ColdAndWarm` (1.0.0.0 `*2` -> 1.0.0.1 `*3` -> 1.0.0.2 `*2`, cold and warm). On origin/main plus this fix it fails at `cold 2 ... Got pass`. The pre-pass now rebuilds (`[source-dep] WROTE ... 1.0.0.1`, `compiled-on-the-fly ... v1.0.0.1`), but the v1.0.0.0 assembly is still loaded under a different simple name, and codeunit lookup binds to it. That is the #3974 mechanism. With #4008's `BcRuntime.cs`/`DependencyLoader.cs` diff applied on top of this branch, both arms pass: `Failed: 0, Passed: 2`. I left the arm out so this PR is not red on its own base. I noted the measurement on #3974 so the combined sequence gets covered when #4008 lands.

## Fix the shape

1. **Same pattern at another call site?** Yes, one: `--watch` rebuilt sibling source deps each cycle from the base list, but never invalidated them. `changedImplAppIds` only ever held layered impls, so an edited sibling dependency at the same version kept running cycle 1's module. It is fixed here and covered by mutation 3. No other caller feeds a pre-pass its own output.
2. **Sibling function with the same assumption?** `RunLayeredPrePass` in the server path also read the accumulated list. It now starts from the base list too. I deliberately did not add invalidation for it, for the #1892 reason above.
3. **Two writers, same invariant?** The watch and server paths now go through one function for the previous-path map. Before this, only the watch path kept the map.

Queue scan (symbol `BuildSiblingSourceDeps` / `workspace-deps`, observable "stale dependency after edit", mechanism "pre-pass fed its own output"): #3974/#4008 is the packaged-`.app` counterpart and a prerequisite, as explained above. #3250 (enum/query replay on cross-bundle reuse), #3964 (Tier-3 TableRelation cold/warm) and #2672 (`EmitSiblingSymbols` incremental) are in the same area but have different mechanisms and fixes, so I did not fold them in. #3337/PR #4020 (affectedOnly selection) does not overlap.

## Local runs

- Wider filter (`AlRunner.Tests.Server*`, `*Layered*`, `*SiblingSource*`, both watch dependency classes): `Failed: 0, Passed: 144, Total: 144`.
- `GuardTests`: `Failed: 1, Passed: 248`. The one failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned`, because the local engine bootstrap was not run (`tools/engine-test-bootstrap.sh`). That is environmental.
- `tools/test_*.py`: `test_agent_self_freshness`, `test_corpus_checkout` and `test_preflight` fail locally because `git commit` in their temp repos goes through 1Password signing (`failed to fill whole buffer`). None of them read the files changed here.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
