### PR TITLE
fix(scan): a directory symlink loop no longer multiplies scan results

### DIFF
--- a/AlRunner.Tests/SafeDirectoryScanSymlinkLoopTests.cs
+++ b/AlRunner.Tests/SafeDirectoryScanSymlinkLoopTests.cs
@@ -1,0 +1,136 @@
+// SafeDirectoryScanSymlinkLoopTests — RED->GREEN guard for issue #2219.
+//
+// A directory symlink back to an ancestor made SafeDirectoryScan re-walk the same tree under
+// ever-longer spellings until PATH_MAX stopped it: one real `.alpackages` came back as 41
+// hits, and the ENAMETOOLONG at the bottom was reported as an unreadable directory. The walk
+// now refuses to descend into a directory whose real path is already on the current descent
+// chain. The negative tests pin that a symlink to a directory NOT on the chain is still
+// followed, so "skip every symlink" cannot pass here.
+using Xunit;
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Tests;
+
+public sealed class SafeDirectoryScanSymlinkLoopTests : IDisposable
+{
+    private const string NoSymlinks = "the filesystem does not allow creating directory symlinks here";
+
+    private readonly string _root;
+
+    public SafeDirectoryScanSymlinkLoopTests()
+    {
+        _root = TestScratch.Dir("al-runner-scan-symlink-loop");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    [SkippableFact]
+    public void LinkBackToTheRoot_FindsTheOneRealAlpackages_Once()
+    {
+        var real = Path.Combine(_root, "a", "b", ".alpackages");
+        Directory.CreateDirectory(real);
+        Skip.IfNot(TryCreateSymlink(_root, Path.Combine(_root, "a", "b", "back")), NoSymlinks);
+
+        var hits = SafeDirectoryScan.Directories(_root, ".alpackages", out var inaccessible);
+
+        Assert.Equal(new[] { real }, hits);
+        // The loop used to end in ENAMETOOLONG, which surfaced as an "unreadable" directory.
+        Assert.Empty(inaccessible);
+    }
+
+    [SkippableFact]
+    public void LinkBackToTheRoot_ListsEachRealFileOnce()
+    {
+        Directory.CreateDirectory(Path.Combine(_root, "a", "b"));
+        File.WriteAllText(Path.Combine(_root, "Root.al"), "x");
+        File.WriteAllText(Path.Combine(_root, "a", "b", "Leaf.al"), "x");
+        Skip.IfNot(TryCreateSymlink(_root, Path.Combine(_root, "a", "b", "back")), NoSymlinks);
+
+        var hits = SafeDirectoryScan.Files(_root, "*.al", out var inaccessible);
+
+        Assert.Equal(
+            new[] { Path.Combine("Root.al"), Path.Combine("a", "b", "Leaf.al") }
+                .OrderBy(p => p, StringComparer.Ordinal).ToArray(),
+            hits.Select(p => Path.GetRelativePath(_root, p)).ToArray());
+        Assert.Empty(inaccessible);
+    }
+
+    [SkippableFact]
+    public void MutualLinksBetweenSiblings_Terminate_WithoutReportingUnreadableDirectories()
+    {
+        Directory.CreateDirectory(Path.Combine(_root, "left", ".alpackages"));
+        Directory.CreateDirectory(Path.Combine(_root, "right"));
+        Skip.IfNot(TryCreateSymlink(Path.Combine(_root, "right"), Path.Combine(_root, "left", "to-right")), NoSymlinks);
+        Skip.IfNot(TryCreateSymlink(Path.Combine(_root, "left"), Path.Combine(_root, "right", "to-left")), NoSymlinks);
+
+        var hits = SafeDirectoryScan.Directories(_root, ".alpackages", out var inaccessible);
+
+        // Two spellings of one directory, each reached by a chain that is not itself a cycle:
+        // left/.alpackages directly, and right/to-left/.alpackages. Not 40-odd.
+        Assert.Equal(
+            new[]
+            {
+                Path.Combine("left", ".alpackages"),
+                Path.Combine("right", "to-left", ".alpackages"),
+            },
+            hits.Select(p => Path.GetRelativePath(_root, p)).ToArray());
+        Assert.Empty(inaccessible);
+    }
+
+    // ── negative direction: a symlink that is not a cycle must still be followed ────────
+
+    [SkippableFact]
+    public void LinkToADirectoryOutsideTheWalk_IsStillFollowed()
+    {
+        var outside = TestScratch.Dir("al-runner-scan-symlink-target");
+        Directory.CreateDirectory(Path.Combine(outside, "vendored", ".alpackages"));
+        File.WriteAllText(Path.Combine(outside, "vendored", "Shared.al"), "x");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(_root, "app"));
+            Skip.IfNot(TryCreateSymlink(outside, Path.Combine(_root, "app", "linked")), NoSymlinks);
+
+            Assert.Equal(
+                new[] { Path.Combine("app", "linked", "vendored", ".alpackages") },
+                SafeDirectoryScan.Directories(_root, ".alpackages")
+                    .Select(p => Path.GetRelativePath(_root, p)).ToArray());
+            Assert.Equal(
+                new[] { Path.Combine("app", "linked", "vendored", "Shared.al") },
+                SafeDirectoryScan.Files(_root, "*.al")
+                    .Select(p => Path.GetRelativePath(_root, p)).ToArray());
+        }
+        finally
+        {
+            try { Directory.Delete(outside, recursive: true); } catch { }
+        }
+    }
+
+    [SkippableFact]
+    public void LinkToASiblingDirectory_IsFollowed_BecauseASiblingIsNotAnAncestor()
+    {
+        Directory.CreateDirectory(Path.Combine(_root, "shared", ".alpackages"));
+        Directory.CreateDirectory(Path.Combine(_root, "app"));
+        Skip.IfNot(TryCreateSymlink(Path.Combine(_root, "shared"), Path.Combine(_root, "app", "shared-link")), NoSymlinks);
+
+        Assert.Equal(
+            new[]
+            {
+                Path.Combine("app", "shared-link", ".alpackages"),
+                Path.Combine("shared", ".alpackages"),
+            },
+            SafeDirectoryScan.Directories(_root, ".alpackages")
+                .Select(p => Path.GetRelativePath(_root, p)).ToArray());
+    }
+
+    private static bool TryCreateSymlink(string target, string link)
+    {
+        try { Directory.CreateSymbolicLink(link, target); return Directory.Exists(link); }
+        catch (IOException) { return false; }
+        catch (UnauthorizedAccessException) { return false; }
+        catch (PlatformNotSupportedException) { return false; }
+    }
+}

--- a/AlRunner/Infrastructure/SafeDirectoryScan.cs
+++ b/AlRunner/Infrastructure/SafeDirectoryScan.cs
@@ -39,9 +39,15 @@ namespace AlRunner.Infrastructure;
 /// each inside its own guard. Measured against this repository's checkout (94,740
 /// directories): 787 ms for the explicit walk versus 792 ms for the framework's native
 /// recursive enumerator — no measurable penalty, because both do the same number of
-/// <c>getdents</c> calls. Symlink loops terminate identically under both (verified: a
-/// self-referencing tree yields the same 41 results and the same 123 directories visited),
-/// so this introduces no new hazard.</para>
+/// <c>getdents</c> calls.</para>
+///
+/// <para><b>Symlink cycles are cut, which the framework enumerator does not do (issue
+/// #2219).</b> A subdirectory whose real path is already on the current descent chain is
+/// neither reported nor entered, so a link back to an ancestor yields each real directory once
+/// instead of once per spelling until <c>PATH_MAX</c> (41 hits for one <c>.alpackages</c>, and
+/// the final <c>ENAMETOOLONG</c> reported as an unreadable directory). A link to anything not on
+/// the chain is still followed, so two links to one directory still give two spellings.
+/// <c>SafeDirectoryScanSymlinkLoopTests</c> pins both directions.</para>
 ///
 /// <para>Matching is delegated to <see cref="FileSystemName.MatchesWin32Expression"/> with
 /// platform-default casing, which is exactly what <c>EnumerationOptions.Compatible</c>
@@ -156,18 +162,19 @@ public static class SafeDirectoryScan
 
         // Iterative rather than recursive: a deep tree (or a symlink chain) must not be able
         // to overflow the stack in a code path whose entire job is to survive hostile input.
-        var pending = new Stack<string>();
-        pending.Push(root);
+        var pending = new Stack<Frame>();
+        pending.Push(new Frame(root, BundleRootDeduplication.Canonicalize(root), null, CrossedLink: false));
 
         while (pending.Count > 0)
         {
-            var dir = pending.Pop();
+            var frame = pending.Pop();
+            var dir = frame.Path;
 
             // The whole point of this class: the listing is materialised INSIDE the guard,
             // so a denial on this directory is caught here and the walk continues with the
             // rest of the tree instead of unwinding out of the caller's foreach.
-            string[] subdirs;
-            try { subdirs = Directory.GetDirectories(dir); }
+            List<(string Path, string Name, bool IsLink)> subdirs;
+            try { subdirs = ListSubdirectories(dir); }
             catch (UnauthorizedAccessException) { denied.Add(dir); continue; }
             catch (DirectoryNotFoundException) { continue; }   // raced away mid-walk
             catch (IOException) { denied.Add(dir); continue; }
@@ -185,17 +192,65 @@ public static class SafeDirectoryScan
                         hits.Add(f);
             }
 
-            foreach (var sub in subdirs)
+            foreach (var (sub, name, isLink) in subdirs)
             {
-                if (!matchFiles && Matches(searchPattern, Path.GetFileName(sub)))
+                // Issue #2219: a subdirectory whose real path is already on this descent chain
+                // is a symlink cycle — neither reported nor entered. Only a chain that crossed
+                // a link can revisit anything, so a link-free chain pays nothing here.
+                // Keep the test "on the chain", never "is a symlink": a link to a directory
+                // not on the chain (a sibling, a vendored cache elsewhere) must still be walked.
+                var real = isLink
+                    ? BundleRootDeduplication.Canonicalize(Path.Combine(frame.RealPath, name))
+                    : Path.Combine(frame.RealPath, name);
+                var crossedLink = frame.CrossedLink || isLink;
+                if (crossedLink && frame.ChainContains(real)) continue;
+
+                if (!matchFiles && Matches(searchPattern, name))
                     hits.Add(sub);
                 // Recurse into it regardless of whether it matched: SearchOption.AllDirectories
                 // descends into matching directories too (a `.alpackages` nested inside another
                 // `.alpackages` is still reported by the call this replaces).
-                if (recurse) pending.Push(sub);
+                if (recurse) pending.Push(new Frame(sub, real, frame, crossedLink));
             }
         }
     }
+
+    /// <summary>A directory being walked: its spelled path, its real path, and its parent frame.</summary>
+    private sealed record Frame(string Path, string RealPath, Frame? Parent, bool CrossedLink)
+    {
+        public bool ChainContains(string realPath)
+        {
+            for (var f = this; f != null; f = f.Parent)
+                if (string.Equals(f.RealPath, realPath, PathComparison)) return true;
+            return false;
+        }
+    }
+
+    private static readonly StringComparison PathComparison =
+        IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+    // Directory.GetDirectories' result, plus whether each entry is itself a link, read from the
+    // same directory listing (no extra stat per entry). Fully materialised by the caller's guard.
+    // AttributesToSkip = None is load-bearing: the EnumerationOptions default skips Hidden, and
+    // on Unix every dot-directory — `.alpackages` included — is Hidden.
+    private static readonly EnumerationOptions ListOptions = new()
+    {
+        AttributesToSkip = 0,
+        IgnoreInaccessible = false,
+        RecurseSubdirectories = false,
+        ReturnSpecialDirectories = false,
+        MatchType = MatchType.Win32,
+        MatchCasing = MatchCasing.PlatformDefault,
+    };
+
+    private static List<(string Path, string Name, bool IsLink)> ListSubdirectories(string dir)
+        => new FileSystemEnumerable<(string, string, bool)>(
+                dir,
+                (ref FileSystemEntry e) => (e.ToSpecifiedFullPath(), e.FileName.ToString(),
+                                            (e.Attributes & FileAttributes.ReparsePoint) != 0),
+                ListOptions)
+            { ShouldIncludePredicate = (ref FileSystemEntry e) => e.IsDirectory }
+            .ToList();
 
     private static bool Matches(string pattern, string name)
         => FileSystemName.MatchesWin32Expression(pattern, name, IgnoreCase);


### PR DESCRIPTION
Closes #2219

Written by agent stma-auto2-6 on the account holder's behalf.

## What changed

`SafeDirectoryScan.Walk` now cuts directory symlink cycles. Before it enters or reports a subdirectory, it checks whether that directory's real path is already on the current descent chain (the directory's walk ancestors). If it is, the walk skips it. Re-verified at current `main` first: the walk had no visited check, and its doc comment said loops "terminate identically" to the framework enumerator. That was true, but both of them stopped only at `PATH_MAX`.

- Real paths are carried down the walk. A plain subdirectory's real path is `parentReal/name`, which costs no syscall. Only a symlinked entry is resolved, through the existing `BundleRootDeduplication.Canonicalize` (the #2136 shape the issue pointed at).
- The link flag comes from the same directory listing (`FileSystemEnumerable`, `AttributesToSkip = 0`, fully materialized inside the existing guard), so a non-link directory gets no extra stat. A chain that never crossed a link skips the ancestor check entirely.
- The rule is "on the chain", never "is a symlink". A link to a sibling or to a directory outside the walked tree is still followed.
- The final `ENAMETOOLONG` used to be reported through `inaccessible`, so a loop also set off the "could not read some directories" warning. That no longer happens.

Because the fix is in the walk, it covers every caller, not just `CollectBundleAlpackagesDirs`. That includes the `.alpackages` scans in `SiblingCompile`, `BcCompiler`, `BcCompiler.Incremental`, `Program.cs` and `ProgramSupport/Dependencies.cs`, and every `Files(*.al)` compile-input collection, which a loop multiplied the same way (`a/b/back/Root.al`, ...).

## RED -> GREEN

New `AlRunner.Tests/SafeDirectoryScanSymlinkLoopTests.cs` builds real symlinks under `TestScratch.Dir`. All five tests are `[SkippableFact]` with `Skip.IfNot(TryCreateSymlink(...))`, so a filesystem that cannot create symlinks reports Skipped, never Passed.

- RED (before the fix): `Failed: 3, Passed: 2, Total: 5`. The 3 are the two loop tests and the mutual-links test (the actual lists were `a/b/back/a/b/.alpackages`, ...). The 2 negatives pass on purpose, because following non-cycle links is existing behavior.
- GREEN: `Failed: 0, Passed: 5, Total: 5`. The wider run over `SafeDirectoryScan|InaccessibleDirectoryScanTests|BundleRootDeduplicationTests` gave `Failed: 0, Passed: 35, Total: 35`.

## Mutations (executed)

1. `Frame.ChainContains` returns `false` on a match, so no cycle is ever detected: `Failed: 3, Passed: 2`. The two loop tests and the mutual-links test go red, and the two negatives stay green.
2. The check replaced with `if (isLink) continue;` ("skip every symlink"): `Failed: 3, Passed: 2`. This time `LinkToADirectoryOutsideTheWalk_IsStillFollowed`, `LinkToASiblingDirectory_IsFollowed_...` and the mutual-links test go red, and the two loop tests stay green. So the negatives catch the over-eager fix.

Both mutations landed and were confirmed by diff. Both reds were `Assert.Equal` failures, not build errors. The file was restored and re-run green (`Passed: 5`).

## Fix the shape

1. **Same wrong pattern at another call site?** Yes, at all of them. Every recursive scan in `AlRunner/` goes through `SafeDirectoryScan` (`Directories` and `Files`), which is why the fix is in `Walk` and not in `CollectBundleAlpackagesDirs`.
2. **Sibling with the same assumption?** `BundleRootDeduplication.ResolveOneLink` already caps hops at 40, so it is loop-safe. Not fixed here, and not reported: a link to a directory that is not on the chain still gives two spellings (for example two symlinks to one shared `.alpackages`). That is aliasing, not a cycle, and it is bounded. I considered a whole-walk visited set, but it would make the surviving spelling depend on traversal order, which is the determinism #2872 made load-bearing in this file. The chain rule depends only on a path's own ancestors, so it gives the same answer in any traversal order.
3. **Two paths writing the same state with different invariants?** `Directories` and `Files` share `Walk`, so they now keep the same invariant. `CollectBundleAlpackagesDirs` still dedupes hits across bundles on the path string. With cycles gone, its remaining duplicates are aliases between two bundle roots, which is a separate, bounded question.

## Queue scan

- Searched open issues for `symlink`, `SafeDirectoryScan`, `alpackages` and `41`. Only #2219 and #2218 are about this walk. #2211, #3322, #3797, #3774 and #2776 matched on words only and are different defects.
- **#2218 is not folded in.** Its fix is a per-invocation cache across the call sites (`Program.cs`, `BcCompiler`, `SiblingCompile`), not a change to `Walk`, and the issue itself raises an unresolved correctness question (can a run create `.alpackages` mid-flight?). This PR does not reduce that repetition. I left a note on #2218.

## Not run / caveats

- I did not measure walk cost. Non-link directories get no extra syscall (link flag from the same readdir, real path built as a string), and a link costs one `Canonicalize`. That is reasoning, not a number.
- Local guards: `GuardTests` gave `Failed: 1, Passed: 248`. The one failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned`, which says the engine bootstrap (`tools/engine-test-bootstrap.sh`) was not run on this box. It is environmental and unrelated. In the `tools/test_*.py` loop, `test_agent_self_freshness.py` and `test_corpus_checkout.py` fail on `git commit` inside their temporary repos (`1Password: failed to fill whole buffer`, commit signing on this box), also unrelated. Every other `tools/test_*.py` exited 0 in that full loop (`python3 "$t" || echo FAILED`, run to completion). A later diagnostic re-run of `test_preflight.py` alone was stopped unfinished and is not counted.
- No corpus test: this is runner infrastructure and does not change what AL observes. `check_corpus_linkage.sh` agrees ("no corpus declaration is required").

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
