### PR TITLE
fix(startup): fail loudly when NavEnvironment's static constructor fails, instead of crashing in the skeleton fallback

### DIFF
--- a/AlRunner.Tests/SkeletonFallbackTests.cs
+++ b/AlRunner.Tests/SkeletonFallbackTests.cs
@@ -8,14 +8,27 @@ namespace AlRunner.Tests;
 /// #2064: a server died at startup with an unhandled TypeInitializationException out of
 /// <c>RtFieldInfo.SetValue</c>, because the skeleton fallback tried to write a static field
 /// of a type whose static constructor had already failed. These pin that the fallback names
-/// that case instead, and still installs the skeleton for every other factory failure.
+/// that case instead, and still installs the skeleton when the type is usable.
 /// </summary>
 public class SkeletonFallbackTests
 {
     private const BindingFlags StaticNonPublic = BindingFlags.NonPublic | BindingFlags.Static;
     private const string Hint = "probe-hint-2064";
 
-    private static Exception InvokeFactory(Type t)
+    // Nested on purpose: the CLR reports a nested type's initializer failure under its simple
+    // name, so this is the shape a type-name match would have missed.
+    private sealed class NestedPoisonedCctor
+    {
+#pragma warning disable CS0169, CS0649
+        private static NestedPoisonedCctor? instance;
+#pragma warning restore CS0169, CS0649
+
+        static NestedPoisonedCctor() => throw new PlatformNotSupportedException("probe-nested-cctor-failure");
+
+        private static void Factory() { }
+    }
+
+    private static void InvokeFactoryExpectingThrow(Type t)
         => Assert.Throws<TargetInvocationException>(
             () => t.GetMethod("Factory", StaticNonPublic)!.Invoke(null, null));
 
@@ -23,11 +36,11 @@ public class SkeletonFallbackTests
     public void FailedStaticConstructor_ThrowsNamedError_InsteadOfTheRawSetValueCrash()
     {
         var type = typeof(SkeletonFallbackProbePoisonedCctor);
-        var failure = InvokeFactory(type);
+        InvokeFactoryExpectingThrow(type);
         var field = type.GetField("instance", StaticNonPublic)!;
 
         var ex = Assert.Throws<InvalidOperationException>(
-            () => SkeletonFallback.InstallOrThrow(type, field, failure, Hint));
+            () => SkeletonFallback.InstallOrThrow(type, field, Hint));
 
         Assert.Contains(type.FullName!, ex.Message);
         Assert.Contains("System.PlatformNotSupportedException", ex.Message);
@@ -39,41 +52,57 @@ public class SkeletonFallbackTests
     }
 
     [Fact]
-    public void OrdinaryFactoryFailure_StillInstallsTheSkeleton()
+    public void FailedFieldInitializers_OnABeforeFieldInitType_ThrowNamedErrorFromTheStaticWrite()
+    {
+        // NavEnvironment's shape: no explicit static constructor, so the allocation succeeds
+        // and the failure surfaces at the static field write, as in the #2064 CI log.
+        var type = typeof(SkeletonFallbackProbeBeforeFieldInitPoisoned);
+        Assert.True(type.Attributes.HasFlag(TypeAttributes.BeforeFieldInit));
+        InvokeFactoryExpectingThrow(type);
+        var field = type.GetField("instance", StaticNonPublic)!;
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => SkeletonFallback.InstallOrThrow(type, field, Hint));
+
+        Assert.Contains("probe-field-initializer-failure", ex.Message);
+        Assert.Contains(Hint, ex.Message);
+        Assert.IsType<TypeInitializationException>(ex.InnerException);
+    }
+
+    [Fact]
+    public void FailedStaticConstructor_OnANestedType_StillThrowsTheNamedError()
+    {
+        var type = typeof(NestedPoisonedCctor);
+        InvokeFactoryExpectingThrow(type);
+        var field = type.GetField("instance", StaticNonPublic)!;
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => SkeletonFallback.InstallOrThrow(type, field, Hint));
+
+        Assert.Contains("probe-nested-cctor-failure", ex.Message);
+        var tie = Assert.IsType<TypeInitializationException>(ex.InnerException);
+        Assert.NotEqual(type.FullName, tie.TypeName);
+    }
+
+    [Fact]
+    public void UsableType_GetsTheSkeletonInstalled()
     {
         var type = typeof(SkeletonFallbackProbeHealthyCctor);
-        var failure = InvokeFactory(type);
+        InvokeFactoryExpectingThrow(type);
         var field = type.GetField("instance", StaticNonPublic)!;
         field.SetValue(null, null);
 
-        SkeletonFallback.InstallOrThrow(type, field, failure, Hint);
+        SkeletonFallback.InstallOrThrow(type, field, Hint);
 
         var skel = Assert.IsType<SkeletonFallbackProbeHealthyCctor>(SkeletonFallbackProbeHealthyCctor.Instance);
         Assert.NotNull(skel.Lock);
     }
-
-    [Fact]
-    public void AnotherTypesInitializerFailure_DoesNotBlockTheSkeleton()
-    {
-        var type = typeof(SkeletonFallbackProbeHealthyCctor);
-        var field = type.GetField("instance", StaticNonPublic)!;
-        var foreign = new TargetInvocationException(
-            new TypeInitializationException(typeof(SkeletonFallbackProbeOtherType).FullName, new PlatformNotSupportedException("elsewhere")));
-        field.SetValue(null, null);
-
-        SkeletonFallback.InstallOrThrow(type, field, foreign, Hint);
-
-        Assert.IsType<SkeletonFallbackProbeHealthyCctor>(SkeletonFallbackProbeHealthyCctor.Instance);
-    }
 }
 
-// Top-level on purpose: the CLR reports a NESTED type's initializer failure under its simple
-// name, while NavEnvironment (top-level) is reported under its full name.
 internal sealed class SkeletonFallbackProbePoisonedCctor
 {
 #pragma warning disable CS0169, CS0649
     private static SkeletonFallbackProbePoisonedCctor? instance;
-    private object? lockObject;
 #pragma warning restore CS0169, CS0649
 
     static SkeletonFallbackProbePoisonedCctor() => throw new PlatformNotSupportedException("probe-cctor-failure");
@@ -94,4 +123,14 @@ internal sealed class SkeletonFallbackProbeHealthyCctor
     internal object? Lock => lockObject;
 }
 
-internal sealed class SkeletonFallbackProbeOtherType { }
+internal sealed class SkeletonFallbackProbeBeforeFieldInitPoisoned
+{
+#pragma warning disable CS0169, CS0649
+    private static SkeletonFallbackProbeBeforeFieldInitPoisoned? instance;
+#pragma warning restore CS0169, CS0649
+    private static readonly int Boom = Throw();
+
+    private static int Throw() => throw new PlatformNotSupportedException("probe-field-initializer-failure");
+
+    private static int Factory() => Boom;
+}

--- a/AlRunner.Tests/SkeletonFallbackTests.cs
+++ b/AlRunner.Tests/SkeletonFallbackTests.cs
@@ -1,0 +1,97 @@
+using System.Reflection;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #2064: a server died at startup with an unhandled TypeInitializationException out of
+/// <c>RtFieldInfo.SetValue</c>, because the skeleton fallback tried to write a static field
+/// of a type whose static constructor had already failed. These pin that the fallback names
+/// that case instead, and still installs the skeleton for every other factory failure.
+/// </summary>
+public class SkeletonFallbackTests
+{
+    private const BindingFlags StaticNonPublic = BindingFlags.NonPublic | BindingFlags.Static;
+    private const string Hint = "probe-hint-2064";
+
+    private static Exception InvokeFactory(Type t)
+        => Assert.Throws<TargetInvocationException>(
+            () => t.GetMethod("Factory", StaticNonPublic)!.Invoke(null, null));
+
+    [Fact]
+    public void FailedStaticConstructor_ThrowsNamedError_InsteadOfTheRawSetValueCrash()
+    {
+        var type = typeof(SkeletonFallbackProbePoisonedCctor);
+        var failure = InvokeFactory(type);
+        var field = type.GetField("instance", StaticNonPublic)!;
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => SkeletonFallback.InstallOrThrow(type, field, failure, Hint));
+
+        Assert.Contains(type.FullName!, ex.Message);
+        Assert.Contains("System.PlatformNotSupportedException", ex.Message);
+        Assert.Contains("probe-cctor-failure", ex.Message);
+        Assert.Contains(type.Assembly.Location, ex.Message);
+        Assert.Contains(Hint, ex.Message);
+        var tie = Assert.IsType<TypeInitializationException>(ex.InnerException);
+        Assert.Equal(type.FullName, tie.TypeName);
+    }
+
+    [Fact]
+    public void OrdinaryFactoryFailure_StillInstallsTheSkeleton()
+    {
+        var type = typeof(SkeletonFallbackProbeHealthyCctor);
+        var failure = InvokeFactory(type);
+        var field = type.GetField("instance", StaticNonPublic)!;
+        field.SetValue(null, null);
+
+        SkeletonFallback.InstallOrThrow(type, field, failure, Hint);
+
+        var skel = Assert.IsType<SkeletonFallbackProbeHealthyCctor>(SkeletonFallbackProbeHealthyCctor.Instance);
+        Assert.NotNull(skel.Lock);
+    }
+
+    [Fact]
+    public void AnotherTypesInitializerFailure_DoesNotBlockTheSkeleton()
+    {
+        var type = typeof(SkeletonFallbackProbeHealthyCctor);
+        var field = type.GetField("instance", StaticNonPublic)!;
+        var foreign = new TargetInvocationException(
+            new TypeInitializationException(typeof(SkeletonFallbackProbeOtherType).FullName, new PlatformNotSupportedException("elsewhere")));
+        field.SetValue(null, null);
+
+        SkeletonFallback.InstallOrThrow(type, field, foreign, Hint);
+
+        Assert.IsType<SkeletonFallbackProbeHealthyCctor>(SkeletonFallbackProbeHealthyCctor.Instance);
+    }
+}
+
+// Top-level on purpose: the CLR reports a NESTED type's initializer failure under its simple
+// name, while NavEnvironment (top-level) is reported under its full name.
+internal sealed class SkeletonFallbackProbePoisonedCctor
+{
+#pragma warning disable CS0169, CS0649
+    private static SkeletonFallbackProbePoisonedCctor? instance;
+    private object? lockObject;
+#pragma warning restore CS0169, CS0649
+
+    static SkeletonFallbackProbePoisonedCctor() => throw new PlatformNotSupportedException("probe-cctor-failure");
+
+    private static void Factory() { }
+}
+
+internal sealed class SkeletonFallbackProbeHealthyCctor
+{
+#pragma warning disable CS0169, CS0649
+    private static SkeletonFallbackProbeHealthyCctor? instance;
+    private object? lockObject;
+#pragma warning restore CS0169, CS0649
+
+    private static void Factory() => throw new InvalidOperationException("probe-ctor-body-failure");
+
+    internal static object? Instance => instance;
+    internal object? Lock => lockObject;
+}
+
+internal sealed class SkeletonFallbackProbeOtherType { }

--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -1014,7 +1014,6 @@ public static partial class BcRuntime
         var factory = envType.GetMethod("InstantiateStandaloneNavEnvironment",
             BindingFlags.NonPublic | BindingFlags.Static);
         bool ctorOk = false;
-        Exception? factoryFailure = null;
         if (factory != null)
         {
             try
@@ -1035,7 +1034,6 @@ public static partial class BcRuntime
             }
             catch (Exception ex)
             {
-                factoryFailure = ex;
                 var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
                 Console.Error.WriteLine("[BcRuntime] NavEnvironment ctor THREW — falling back to skeleton:");
                 Console.Error.WriteLine($"  {inner.GetType().FullName}: {inner.Message}");
@@ -1049,7 +1047,7 @@ public static partial class BcRuntime
             }
         }
         if (!ctorOk && instField != null)
-            AlRunner.Infrastructure.SkeletonFallback.InstallOrThrow(envType, instField, factoryFailure,
+            AlRunner.Infrastructure.SkeletonFallback.InstallOrThrow(envType, instField,
                 "If the cause is WindowsIdentity.GetCurrent(), the loaded Microsoft.Dynamics.Nav.Ncl.dll lacks " +
                 "the Cecil rewrite that removes that call (NclCecilRewrite.Runtime.cs): this process loaded an " +
                 "un-rewritten copy. See #2064.");

--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -1014,6 +1014,7 @@ public static partial class BcRuntime
         var factory = envType.GetMethod("InstantiateStandaloneNavEnvironment",
             BindingFlags.NonPublic | BindingFlags.Static);
         bool ctorOk = false;
+        Exception? factoryFailure = null;
         if (factory != null)
         {
             try
@@ -1034,6 +1035,7 @@ public static partial class BcRuntime
             }
             catch (Exception ex)
             {
+                factoryFailure = ex;
                 var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
                 Console.Error.WriteLine("[BcRuntime] NavEnvironment ctor THREW — falling back to skeleton:");
                 Console.Error.WriteLine($"  {inner.GetType().FullName}: {inner.Message}");
@@ -1047,12 +1049,10 @@ public static partial class BcRuntime
             }
         }
         if (!ctorOk && instField != null)
-        {
-            var skel = RuntimeHelpers.GetUninitializedObject(envType);
-            var instLock = envType.GetField("lockObject", BindingFlags.NonPublic | BindingFlags.Instance);
-            if (instLock != null) instLock.SetValue(skel, new object());
-            instField.SetValue(null, skel);
-        }
+            AlRunner.Infrastructure.SkeletonFallback.InstallOrThrow(envType, instField, factoryFailure,
+                "If the cause is WindowsIdentity.GetCurrent(), the loaded Microsoft.Dynamics.Nav.Ncl.dll lacks " +
+                "the Cecil rewrite that removes that call (NclCecilRewrite.Runtime.cs): this process loaded an " +
+                "un-rewritten copy. See #2064.");
         HookProperty(envType, "Instance", true, nameof(GetInstanceReplacement));
 
         // NavApplicationObjectBase.get_Session — real body is `=> session` (trivial readonly-field

--- a/AlRunner/Infrastructure/SkeletonFallback.cs
+++ b/AlRunner/Infrastructure/SkeletonFallback.cs
@@ -9,12 +9,22 @@ namespace AlRunner.Infrastructure;
 /// </summary>
 internal static class SkeletonFallback
 {
-    internal static void InstallOrThrow(Type type, FieldInfo instanceField, Exception? factoryFailure, string hint)
+    internal static void InstallOrThrow(Type type, FieldInfo instanceField, string hint)
     {
-        // A type whose static constructor failed rethrows on every later static access,
-        // including the SetValue below, so no skeleton can be installed (#2064).
-        if (OwnInitializerFailure(type, factoryFailure) is { } tie)
+        try
         {
+            // The allocation throws for a precise-init type and the static write for a
+            // beforefieldinit one (NavEnvironment), so both stay inside the try.
+            var skel = RuntimeHelpers.GetUninitializedObject(type);
+            var instLock = type.GetField("lockObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (instLock != null) instLock.SetValue(skel, new object());
+            instanceField.SetValue(null, skel);
+        }
+        catch (Exception e) when (AsInitializerFailure(e) is { } tie)
+        {
+            // Keyed on the install failing, not on matching tie.TypeName: the CLR reports a
+            // nested type under its simple name, so a name match can miss and fall through
+            // to the unexplained crash this exists to replace (#2064).
             var root = tie.InnerException ?? tie;
             throw new InvalidOperationException(
                 $"{type.FullName}'s static constructor threw {root.GetType().FullName}: {root.Message} " +
@@ -22,18 +32,9 @@ internal static class SkeletonFallback
                 $"used at all, so the runner cannot fall back to a skeleton instance. {hint}",
                 tie);
         }
-
-        var skel = RuntimeHelpers.GetUninitializedObject(type);
-        var instLock = type.GetField("lockObject", BindingFlags.NonPublic | BindingFlags.Instance);
-        if (instLock != null) instLock.SetValue(skel, new object());
-        instanceField.SetValue(null, skel);
     }
 
-    private static TypeInitializationException? OwnInitializerFailure(Type type, Exception? failure)
-    {
-        for (var e = failure; e != null; e = e.InnerException)
-            if (e is TypeInitializationException tie && tie.TypeName == type.FullName)
-                return tie;
-        return null;
-    }
+    // Reflection's FieldInfo.SetValue wraps it in TargetInvocationException; the allocation does not.
+    private static TypeInitializationException? AsInitializerFailure(Exception e)
+        => e as TypeInitializationException ?? (e as TargetInvocationException)?.InnerException as TypeInitializationException;
 }

--- a/AlRunner/Infrastructure/SkeletonFallback.cs
+++ b/AlRunner/Infrastructure/SkeletonFallback.cs
@@ -1,0 +1,39 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace AlRunner.Infrastructure;
+
+/// <summary>
+/// Installs an uninitialised stand-in into a BC singleton's static <c>instance</c> field
+/// when the real factory could not build one (see <c>BcRuntime.ApplyAllPatches</c>).
+/// </summary>
+internal static class SkeletonFallback
+{
+    internal static void InstallOrThrow(Type type, FieldInfo instanceField, Exception? factoryFailure, string hint)
+    {
+        // A type whose static constructor failed rethrows on every later static access,
+        // including the SetValue below, so no skeleton can be installed (#2064).
+        if (OwnInitializerFailure(type, factoryFailure) is { } tie)
+        {
+            var root = tie.InnerException ?? tie;
+            throw new InvalidOperationException(
+                $"{type.FullName}'s static constructor threw {root.GetType().FullName}: {root.Message} " +
+                $"(type loaded from '{type.Assembly.Location}'). A type whose initializer failed cannot be " +
+                $"used at all, so the runner cannot fall back to a skeleton instance. {hint}",
+                tie);
+        }
+
+        var skel = RuntimeHelpers.GetUninitializedObject(type);
+        var instLock = type.GetField("lockObject", BindingFlags.NonPublic | BindingFlags.Instance);
+        if (instLock != null) instLock.SetValue(skel, new object());
+        instanceField.SetValue(null, skel);
+    }
+
+    private static TypeInitializationException? OwnInitializerFailure(Type type, Exception? failure)
+    {
+        for (var e = failure; e != null; e = e.InnerException)
+            if (e is TypeInitializationException tie && tie.TypeName == type.FullName)
+                return tie;
+        return null;
+    }
+}


### PR DESCRIPTION
Closes #2064

Written by agent stma-auto2-2 on the account holder's behalf.

## What the failing log actually says

The issue asked for the real log first. The rerun overwrote attempt 2, but attempt 1 of run 33008322012 is still readable (job 98308111447, BC 28.0, head `b1f1d860`). The test's own assertion never failed. `SpawnCount` was never checked. The exception came out of `CliServer.StartAsync`: `Server exited before signaling readiness`. The server's stderr shows why:

```
System.TypeInitializationException: The type initializer for 'Microsoft.Dynamics.Nav.Runtime.NavEnvironment' threw an exception.
 ---> System.PlatformNotSupportedException: Windows Principal functionality is not supported on this platform.
   at System.Security.Principal.WindowsIdentity.GetCurrent()
   at Microsoft.Dynamics.Nav.Runtime.NavEnvironment..cctor()
   ...
   at System.Reflection.RtFieldInfo.SetValue(...)
   at AlRunner.BcRuntime.ApplyAllPatches(Assembly navNcl) in BcRuntime.cs:line 855
```

So, to the issue's question (is the race in the test or in the spawn path?): neither. `SharedCliServer`'s gate is fine. The server process failed to boot, and this test was just the first fact in its class to start one.

Two separate things happened in that process:

1. **It loaded an Ncl.dll without the Cecil rewrite.** `NclCecilRewrite.Runtime.cs` replaces the only `WindowsIdentity.GetCurrent()` in `NavEnvironment..cctor` with `ldnull`, and it throws if it finds any count other than one. A cctor that fails at `GetCurrent()` means the rewrite was not in the loaded image. I could not tell from the log which startup race caused this, because the `[Cecil]`/`[reexec]` lines only print with `--verbose`. After that failure, #2512 (09-03), #3368/#3385 (09-07) and #3596 (09-09) each fixed a concurrent-startup defect on this exact path: ncl-shadow publish/prune, and handing out an incomplete or non-executable shadow dir.
2. **The fallback turned that into an unexplained crash.** `ApplyAllPatches` catches the factory's failure, prints it, and then "falls back to the skeleton" with `instField.SetValue(null, skel)`. After a type's static constructor fails, every later static access rethrows, so the fallback could never work. The process died with an unhandled exception from `RtFieldInfo.SetValue`, and nothing in the output named the cause. That code is unchanged on `main`, and it is what this PR fixes.

## What changed

- `AlRunner/Infrastructure/SkeletonFallback.cs` (new): the skeleton install moved out of `BcRuntime` unchanged, now inside a `try`. If the install throws a `TypeInitializationException`, either bare (from the allocation, for a type with an explicit static constructor) or wrapped in `TargetInvocationException` (from the reflection static write, which is the shape in the CI log), it throws an `InvalidOperationException` instead. The message names the type, the root exception type and message, the assembly's on-disk location, and a hint from the caller. If the install works, nothing changes.
- `AlRunner/BcRuntime.cs`: calls the helper. For NavEnvironment, the hint points at the missing Cecil rewrite and this issue.

The check is based on the install failing, not on comparing `TypeInitializationException.TypeName` to the type's name. My first version compared names, but the CLR reports a nested type under its simple name, so that comparison can miss and fall through to the original crash. I measured that while writing the tests.

I saw the new message fire against the **real** NavEnvironment. An engine test host that was not bootstrapped (Ncl preloaded by VSTest, #1813) fails `BcEngineReadinessGuardTests` with: `InvalidOperationException: Microsoft.Dynamics.Nav.Runtime.NavEnvironment's static constructor threw System.PlatformNotSupportedException: Windows Principal functionality is not supported on this platform. (type loaded from '.../AlRunner.Tests/bin/Debug/net8.0/Microsoft.Dynamics.Nav.Ncl.dll')`. That is the same failure the CI log shows, and this time the path of the loaded file is printed.

I kept plain `InvalidOperationException` to match the sibling "NavEnvironment not found" throw a few lines above in `ApplyAllPatches`. This is a broken load, not BC-shape drift, so #2994's `BcShapeGapException` does not apply.

## RED -> GREEN -> MUTATE

`AlRunner.Tests/SkeletonFallbackTests.cs`, 4 facts with synthetic probe types: a top-level type whose static ctor throws, a nested one, a **beforefieldinit** one whose field initializer throws (NavEnvironment's shape: the allocation works and the static write fails), and a usable type whose factory throws an ordinary exception.

- RED, with `main`'s inline fallback body pasted into the helper verbatim: `Failed: 3, Passed: 1, Total: 4`. The two static-ctor facts get `Actual: typeof(System.TypeInitializationException)`. The beforefieldinit fact gets `Actual: typeof(System.Reflection.TargetInvocationException)`, the same exception as the CI crash.
- GREEN: `Failed: 0, Passed: 4, Total: 4`.
- Mutations, each checked by diff and then restored:
  - catch only a bare `TypeInitializationException` (no unwrap): `Failed: 1, Passed: 3`. Only the beforefieldinit fact fails. This is the production shape, and it is the gap an earlier draft of this fix had.
  - move the static write outside the `try`: `Failed: 1, Passed: 3`. Only the beforefieldinit fact fails.
  - catch `ArgumentException` instead of `Exception`: `Failed: 3, Passed: 1`. All three poisoned-type facts fail and the usable-type fact still passes.
  - drop the `lockObject` initialization: `Failed: 1, Passed: 3`. Only the usable-type fact fails, which shows existing skeleton behavior is kept.

Other local runs, on the final head:
- `dotnet test -c Release --settings engine.runsettings` (engine bootstrapped) with filter `GuardTests|SkeletonFallbackTests|SharedCliServerTests`: `Failed: 0, Passed: 256, Total: 256`. This covers the in-process `BcRuntime` boot through the changed code and the server-spawning facts.
- `tools/test_*.py`: 3 failures (`test_agent_self_freshness`, `test_corpus_checkout`, `test_preflight`). All three fail when they `git commit` inside a temp repo, because this box's 1Password commit signing rejects it (`error: 1Password: agent returned an error`). This PR touches nothing under `tools/`.

## Does it still happen?

- **CI history.** I listed every run of `test-matrix.yml`, `main-verdict-floor.yml` and `bc-leg-rerun.yml` created from 2026-08-26 to 2026-09-13, day by day. The unfiltered runs API stops at 1,000 results, and my first pass silently hit that cap. Of those, I kept 398 runs that concluded `failure` or had `run_attempt > 1`. I read every failed BC-leg job in every attempt: 1,925 jobs, 1,924 logs readable, 1 unavailable. I searched them for `NavEnvironment' threw`, `Windows Principal functionality`, `Server exited before signaling readiness`, and this test's `[FAIL]` line. **One hit: the original, 2026-08-26.** No hits since. The search did find that known positive, so the search itself works. One limit on this result: since #3141/#2674, a PR runs 3 legs and only 27.5 and 28.4 run the C# suite, so there are fewer chances to see a failure than in August.
- **Local loop.** Under 12 busy-loop CPU hogs on a 12-core box, I ran the test 148 times, 3 or 4 `dotnet test` processes at a time. Each spawns its own server against the shared `ncl-shadow`/`ncl-cecil` roots (the contended copy path from #2489). Result: 148 passed, 0 failed. This ran on the **warm** cache path. I did not try a cold private cache root, because moving `HOME` also moves the artifacts and the test would skip.

## Fix the shape

1. **Same pattern elsewhere?** I searched `AlRunner/**/*.cs` for the catch-then-skeleton shape (`falling back to skeleton`, `THREW` next to a skeleton install). NavEnvironment is the only factory-with-skeleton-fallback. The other ~90 `GetUninitializedObject` calls build skeletons directly and do not follow a failed factory.
2. **Sibling assumption?** `HookProperty(envType, "Instance", ...)` right after the fallback would have hit the same poisoned type. It is no longer reached in that case, because the fallback throws first.
3. **Two writers, one invariant?** The factory and the fallback both write `NavEnvironment.instance`. The factory's failure was already caught and printed, but the fallback's write had no handling at all. Now both writes fail with a readable error.

**Issue queue scan** (`NavEnvironment`, `"Server exited before signaling readiness"`, `TypeInitializationException`, `"Windows Principal"`, `skeleton fallback`, `SharedCliServer`): nothing to fold in. #2994 (BcShapeGapException sweep) is about BC-shape drift, not a broken type initializer. #1883 lists the orphaned NavEnvironment cctor JmpHook, which is unrelated to this failure.

**What this PR does not do:** it does not prove which race loaded the un-rewritten Ncl in August. If this ever happens again, the log will now show the loaded Ncl's path, which tells you whether it was the shadow dir, the bin dir or the artifact dir. So the next occurrence can be diagnosed without re-running anything.

No corpus linkage needed: this is runner startup plumbing, and `BcRuntime.cs` / `Infrastructure/SkeletonFallback.cs` are outside `check_corpus_linkage.sh`'s path list.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
