### PR TITLE
fix(count-baseline): fail when a declared suite produced no bucket

### DIFF
--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -842,6 +842,10 @@ jobs:
           # one that can exit 4 -- and a 4 arrives with every suite reporting zero
           # failures, which reads as a mystery until someone searches the log for the
           # [count-baseline] line. A leg must be diagnosable from its own log.
+          #
+          # --count-baseline-require-all (#3130): this step is the one invocation that covers
+          # every suite the baseline declares, so a declared suite with no bucket fails here
+          # (MISSING) instead of being skipped without a word.
           rc=0
           dotnet run --no-build --project AlRunner -c Release --framework net8.0 -- \
               tests/runner-extras \
@@ -849,10 +853,11 @@ jobs:
               --package-cache "$HOME/.al-runner/test-apps" \
               --strict \
               --count-baseline tests/expectations/count-baseline/test-count-baseline.json \
+              --count-baseline-require-all \
               --out runner-extras-results.json || rc=$?
           if [ "$rc" -ne 0 ]; then
             if [ "$rc" -eq 4 ]; then
-              echo "::error::runner-extras count-baseline mismatch (exit 4) -- a suite ran a different NUMBER of tests than tests/expectations/count-baseline/test-count-baseline.json declares. Search this log for '[count-baseline]': the DROP/GROWTH line names the suite, the expected count and the actual one. A GROWTH means the baseline needs bumping in this PR; a DROP means an app group stopped being discovered."
+              echo "::error::runner-extras count-baseline mismatch (exit 4) -- a suite ran a different NUMBER of tests than tests/expectations/count-baseline/test-count-baseline.json declares. Search this log for '[count-baseline]': the DROP/GROWTH line names the suite, the expected count and the actual one. A GROWTH means the baseline needs bumping in this PR; a DROP means an app group stopped being discovered; a MISSING means a declared suite produced no bucket at all (vanished, or its key is misspelled)."
             else
               echo "::error::runner-extras run failed (exit $rc: 1=test failure, 2=exec fail, 3=compile fail, 4=count-baseline mismatch, 5=expectations entry matched no test, 134/139=crash)"
             fi

--- a/AlRunner.Tests/CountBaselineIntegrationTests.cs
+++ b/AlRunner.Tests/CountBaselineIntegrationTests.cs
@@ -168,12 +168,15 @@ public sealed class CountBaselineIntegrationTests : IDisposable
     private (string output, int exit) RunRunner(params string[] extraArgs) =>
         RunRunnerOn(_root, extraArgs);
 
-    private (string output, int exit) RunRunnerOn(string bundleRoot, params string[] extraArgs)
+    private (string output, int exit) RunRunnerOn(string bundleRoot, params string[] extraArgs) =>
+        Spawn(withBaseline: true, bundleRoot, extraArgs);
+
+    private (string output, int exit) Spawn(bool withBaseline, string bundleRoot, params string[] extraArgs)
     {
         var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
         args.Append(TestBuildConfig.BcVersionArg);
         args.Append(" --strict");
-        args.Append($" --count-baseline \"{_baselinePath}\"");
+        if (withBaseline) args.Append($" --count-baseline \"{_baselinePath}\"");
         args.Append($" \"{bundleRoot}\"");
         foreach (var a in extraArgs) args.Append($" {a}");
         var psi = new ProcessStartInfo
@@ -392,5 +395,107 @@ public sealed class CountBaselineIntegrationTests : IDisposable
         Assert.DoesNotContain("[count-baseline] DROP", output);
         Assert.DoesNotContain("[count-baseline] GROWTH", output);
         Assert.Equal(1, exit);
+    }
+
+    // #3130: a declared suite that produced no bucket. The fixture suite matches exactly, so
+    // the only thing that can separate these runs' exit codes is the vanished key.
+    private const string VanishedSuite = "vanished-suite-3130";
+
+    private string BaselineWithVanishedSuite() =>
+        $$"""
+        { "suites": {
+            "{{_suiteKey}}": { "tests": { "default": 2 } },
+            "{{VanishedSuite}}": { "tests": { "default": 5 } }
+        } }
+        """;
+
+    /// <summary>#3130 RED: under --count-baseline-require-all a declared suite with no bucket fails with exit 4, named, and distinct from a DROP.</summary>
+    [SkippableFact]
+    public void RequireAll_DeclaredSuiteThatProducedNoBucket_Exits4NamingTheKeyAndFile()
+    {
+        TestArtifacts.SkipIfMissing();
+        WriteBaseline(BaselineWithVanishedSuite());
+
+        var (output, exit) = RunRunner("--count-baseline-require-all");
+
+        Assert.Equal(4, exit);
+        Assert.Contains("[count-baseline] MISSING", output);
+        Assert.Contains($"suite '{VanishedSuite}'", output);
+        Assert.Contains(_baselinePath, output);
+        // A suite that never ran is not "a smaller count" — the message must not say DROP,
+        // and the suite that did run matched, so nothing else can have caused the 4.
+        Assert.DoesNotContain("[count-baseline] DROP", output);
+        Assert.DoesNotContain("[count-baseline] GROWTH", output);
+    }
+
+    /// <summary>#3130: without the flag the same run stays a pass (another invocation may cover the key), but says what it did not check.</summary>
+    [SkippableFact]
+    public void WithoutRequireAll_DeclaredSuiteThatProducedNoBucket_StaysAPassButSaysSo()
+    {
+        TestArtifacts.SkipIfMissing();
+        WriteBaseline(BaselineWithVanishedSuite());
+
+        var (output, exit) = RunRunner();
+
+        Assert.Equal(0, exit);
+        Assert.Contains("[count-baseline] not checked", output);
+        Assert.Contains($"suite '{VanishedSuite}'", output);
+        Assert.DoesNotContain("[count-baseline] MISSING", output);
+    }
+
+    /// <summary>#3130: the flag does not false-positive when every declared suite ran.</summary>
+    [SkippableFact]
+    public void RequireAll_EveryDeclaredSuiteRan_Passes()
+    {
+        TestArtifacts.SkipIfMissing();
+        WriteBaseline(TestsBaseline(testsDefault: 2));
+
+        var (output, exit) = RunRunner("--count-baseline-require-all");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("[count-baseline] MISSING", output);
+        Assert.DoesNotContain("[count-baseline] not checked", output);
+    }
+
+    /// <summary>#3130 third state: the flag with no baseline to hold the run to is refused, never a vacuous pass.</summary>
+    [SkippableFact]
+    public void RequireAll_WithoutCountBaseline_IsRefused()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, exit) = Spawn(withBaseline: false, _root, "--count-baseline-require-all");
+
+        Assert.Equal(2, exit);
+        Assert.Contains("--count-baseline-require-all", output);
+        Assert.Contains("no --count-baseline", output);
+    }
+
+    /// <summary>#3130 third state: a baseline declaring zero suites gives the flag nothing to require, so it is refused.</summary>
+    [SkippableFact]
+    public void RequireAll_WithABaselineDeclaringNoSuites_IsRefused()
+    {
+        TestArtifacts.SkipIfMissing();
+        WriteBaseline("""{ "suites": { } }""");
+
+        var (output, exit) = RunRunner("--count-baseline-require-all");
+
+        Assert.Equal(2, exit);
+        Assert.Contains("declares 0 suites", output);
+    }
+
+    /// <summary>
+    /// #3130 third state: under a --jobs fan-out each worker sees only its shard's bundles, so
+    /// "every declared suite produced a bucket" cannot be decided by any one process. Refused.
+    /// </summary>
+    [SkippableFact]
+    public void RequireAll_WithAJobsFanOut_IsRefused()
+    {
+        TestArtifacts.SkipIfMissing();
+        WriteBaseline(TestsBaseline(testsDefault: 2));
+
+        var (output, exit) = RunRunner($"\"{_failRoot}\"", "--jobs 2", "--count-baseline-require-all");
+
+        Assert.Equal(2, exit);
+        Assert.Contains("--count-baseline-require-all cannot be combined with a --jobs fan-out", output);
     }
 }

--- a/AlRunner.Tests/CountBaselineTests.cs
+++ b/AlRunner.Tests/CountBaselineTests.cs
@@ -250,6 +250,38 @@ public sealed class CountBaselineCheckTests
         Assert.Empty(drops);
         Assert.Empty(growths);
     }
+
+    /// <summary>#3130: the suite Evaluate skipped is the one MissingSuites names — and only that one.</summary>
+    [Fact]
+    public void MissingSuites_NamesExactlyTheDeclaredSuitesWithNoBucket()
+    {
+        var manifest = ManifestWith("""
+        "runner-extras": { "tests": { "default": 116 } },
+        "al-language": { "tests": { "default": 2073 } },
+        "al-language-onprem": { "tests": { "default": 55 } }
+        """);
+        // Ran, but with a count of zero: present-and-empty is a DROP, never "missing".
+        var actual = Actual(("al-language", Tests: 2073, Groups: 1), ("runner-extras", Tests: 0, Groups: 0),
+                            ("some-other-suite", Tests: 3, Groups: 1));
+
+        Assert.Equal(new[] { "al-language-onprem" }, CountBaselineCheck.MissingSuites(manifest, actual));
+    }
+
+    /// <summary>#3130: a misspelled key joins to nothing, so it is reported rather than silently guarding nothing.</summary>
+    [Fact]
+    public void MissingSuites_AMisspelledKeyIsReported_AndEveryCoveredRunIsEmpty()
+    {
+        var misspelled = ManifestWith("""
+        "runner-extra": { "tests": { "default": 116 } }
+        """);
+        var correct = ManifestWith("""
+        "runner-extras": { "tests": { "default": 116 } }
+        """);
+        var actual = Actual(("runner-extras", Tests: 116, Groups: 60));
+
+        Assert.Equal(new[] { "runner-extra" }, CountBaselineCheck.MissingSuites(misspelled, actual));
+        Assert.Empty(CountBaselineCheck.MissingSuites(correct, actual));
+    }
 }
 
 /// <summary>

--- a/AlRunner/Infrastructure/CountBaseline.cs
+++ b/AlRunner/Infrastructure/CountBaseline.cs
@@ -296,9 +296,9 @@ public sealed class CountBaselineManifest
 /// growths (actual above expected) — purely for message wording ("shrank" vs "grew").
 /// BOTH are mismatches that must fail the run: see the header comment on why growth
 /// is not exempted. A suite the manifest does not mention imposes no expectation; a
-/// suite the manifest mentions but this run did not touch is silently skipped (a
-/// baseline written for CI's two legs must not fire when someone points the runner
-/// at an unrelated bundle).
+/// suite the manifest mentions but this run did not touch is skipped by <see cref="Evaluate"/>
+/// (a baseline file may name suites another invocation covers) and reported by
+/// <see cref="MissingSuites"/>, which --count-baseline-require-all turns into a failure (#3130).
 /// </summary>
 public static class CountBaselineCheck
 {
@@ -322,6 +322,19 @@ public static class CountBaselineCheck
 
         return (drops, growths);
     }
+
+    /// <summary>
+    /// Declared suite keys this run produced no bucket for, sorted ordinally. A key here was
+    /// compared against nothing by <see cref="Evaluate"/>: either another invocation covers it,
+    /// or the suite vanished / the key is misspelled — only the caller knows which (#3130).
+    /// </summary>
+    public static IReadOnlyList<string> MissingSuites(
+        CountBaselineManifest manifest,
+        IReadOnlyDictionary<string, SuiteCountActual> actualBySuite) =>
+        manifest.Suites.Keys
+            .Where(suite => !actualBySuite.ContainsKey(suite))
+            .OrderBy(suite => suite, StringComparer.Ordinal)
+            .ToList();
 
     private static void Compare(string suite, string metric, int expected, int actual, string? bcVersionKey,
         List<CountBaselineFinding> drops, List<CountBaselineFinding> growths)

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -451,6 +451,11 @@ bool expectationsRequireMatch = false;
 // xmlport-isolation CI leg passes --test against the SAME al-language root), so this
 // only ever activates when the caller explicitly opts in.
 string? countBaselinePath = null;
+// --count-baseline-require-all (#3130): every suite the baseline declares must produce a
+// bucket in this run. Opt-in for the same reason as --expectations-require-match: the flag
+// is public and a baseline may name suites another invocation covers, so only the caller
+// knows whether this invocation covers them all.
+bool countBaselineRequireAll = false;
 // `--count-out <path>` writes what this run actually ran, per suite, as JSON (#3675).
 // Independent of --count-baseline: it REPORTS a count rather than judging one, and CI
 // judges it against the last count a main run recorded, because the corpus is resolved per
@@ -559,6 +564,7 @@ for (int i = 0; i < args.Length; i++)
     if (args[i] == "--expectations" && i + 1 < args.Length) { expectationsDirArg = args[++i]; continue; }
     if (args[i] == "--expectations-require-match") { expectationsRequireMatch = true; continue; }
     if (args[i] == "--count-baseline" && i + 1 < args.Length) { countBaselinePath = args[++i]; continue; }
+    if (args[i] == "--count-baseline-require-all") { countBaselineRequireAll = true; continue; }
     if (args[i] == "--count-out" && i + 1 < args.Length) { countOutPath = args[++i]; continue; }
     // #1821: the SAME --cache value also becomes the isolation root for every other
     // cache CacheRoots redirects (compiled-deps/workspace-deps/ncl-cecil/bc-symbols/
@@ -973,6 +979,22 @@ if (countBaselinePath != null)
         Console.Error.WriteLine(ex.Message);
         return 2;
     }
+}
+// #3130: the flag asserts coverage of a declared set, so with no set to cover it could only
+// ever pass vacuously. Refused before any test runs.
+if (countBaselineRequireAll && countBaseline == null)
+{
+    Console.Error.WriteLine(
+        "--count-baseline-require-all was given with no --count-baseline manifest, so there is "
+        + "no declared suite to require. Pass --count-baseline PATH, or drop the flag.");
+    return 2;
+}
+if (countBaselineRequireAll && countBaseline!.Suites.Count == 0)
+{
+    Console.Error.WriteLine(
+        $"--count-baseline-require-all was given but {countBaselinePath} declares 0 suites, so "
+        + "the flag would pass without checking anything. Check the --count-baseline path.");
+    return 2;
 }
 // --output-json: stdout must be JSON-only, matching the documented contract ("Replace
 // the normal text output with per-test JSON on stdout") and the convention --server
@@ -1632,6 +1654,16 @@ if (jobs > 1 && bundles.Count > 1 && !watchMode && !serverMode && !dapMode)
             "--count-out cannot be combined with a --jobs fan-out: each shard would write its "
             + "own counts to the same path and the last shard to finish would be recorded as "
             + "the whole run. Run the counted invocation without --jobs, or drop --count-out.");
+        return 2;
+    }
+    // #3130: each worker sees only its shard's bundles, so no single process can decide that
+    // every declared suite produced a bucket; forwarding the flag would fail every shard.
+    if (countBaselineRequireAll)
+    {
+        Console.Error.WriteLine(
+            "--count-baseline-require-all cannot be combined with a --jobs fan-out: each worker "
+            + "sees only its own shard's suites, so every shard would report the others as missing. "
+            + "Run the covering invocation without --jobs, or drop the flag.");
         return 2;
     }
     return AlRunner.Infrastructure.ParallelFanOut.Run(bundles, args, jobs);
@@ -4236,6 +4268,37 @@ if (countBaseline != null)
                 drops = drops.Where(f => f.Metric != "appGroups").ToList();
                 growths = growths.Where(f => f.Metric != "appGroups").ToList();
             }
+        }
+
+        // #3130: a declared suite with no bucket was compared against nothing above. Without
+        // --count-baseline-require-all that stays a pass (another invocation may cover it),
+        // but never a silent one.
+        var missingSuites = AlRunner.Infrastructure.CountBaselineCheck.MissingSuites(countBaseline, actualBySuite);
+        if (missingSuites.Count > 0 && countBaselineRequireAll && carryIncomplete)
+        {
+            // A carried attempt was lost, so a suite it ran would read as missing here. The
+            // run already exits 2 for the lost attempt, so standing down suppresses nothing.
+            Console.Error.WriteLine(
+                "[count-baseline] suite coverage check skipped: a carried attempt file could not be "
+                + "read, so a suite absent from this run's results may simply have been lost.");
+        }
+        else if (missingSuites.Count > 0 && countBaselineRequireAll)
+        {
+            countBaselineMismatch = true;
+            var ran = actualBySuite.Count == 0 ? "none" : string.Join(", ", actualBySuite.Keys.OrderBy(k => k, StringComparer.Ordinal));
+            foreach (var m in missingSuites)
+                Console.Error.WriteLine(
+                    $"[count-baseline] MISSING: suite '{m}' is declared in {countBaselinePath} but this run "
+                    + $"produced no bucket for it (suites that ran: {ran}). Either the suite stopped being "
+                    + "discovered, it was not passed as a bundle root, or the key is misspelled.");
+        }
+        else
+        {
+            foreach (var m in missingSuites)
+                Console.Error.WriteLine(
+                    $"[count-baseline] not checked: suite '{m}' is declared in {countBaselinePath} but this "
+                    + "run produced no bucket for it. Pass --count-baseline-require-all where this "
+                    + "invocation must cover every declared suite.");
         }
 
         // Growth is also a hard failure, not just a notice — see the header comment

--- a/AlRunner/ProgramSupport/CliText.cs
+++ b/AlRunner/ProgramSupport/CliText.cs
@@ -671,7 +671,9 @@ internal static partial class ProgramSupport
         w.WriteLine("                               (docs/partial-company-initialization.md)");
         w.WriteLine("                            3  a bundle could not compile");
         w.WriteLine("                            4  --count-baseline: a suite's test or app-group count did");
-        w.WriteLine("                               not exactly match its declared baseline (see --count-baseline)");
+        w.WriteLine("                               not exactly match its declared baseline (see --count-baseline),");
+        w.WriteLine("                               or under --count-baseline-require-all a declared suite");
+        w.WriteLine("                               produced no bucket");
         w.WriteLine("                            5  --expectations-require-match: an expectations entry matched");
         w.WriteLine("                               no test in this run");
         w.WriteLine("  --no-strict-exit        Always exit 0 regardless of test outcome, so callers can");
@@ -724,6 +726,14 @@ internal static partial class ProgramSupport
         w.WriteLine("                          this never auto-activates. A mismatch in EITHER direction");
         w.WriteLine("                          (growth or drop) fails and prints a diagnostic naming");
         w.WriteLine("                          expected vs actual — bump the baseline in the same PR.");
+        w.WriteLine("  --count-baseline-require-all");
+        w.WriteLine("                          Also fail (exit 4) when a suite the --count-baseline file");
+        w.WriteLine("                          declares produced no bucket in this run, naming the key");
+        w.WriteLine("                          and the file (#3130). Without it such a suite is only");
+        w.WriteLine("                          reported as \"not checked\", because a baseline may name");
+        w.WriteLine("                          suites another invocation covers. Refused without");
+        w.WriteLine("                          --count-baseline, with a baseline declaring no suites, and");
+        w.WriteLine("                          with a --jobs fan-out (no one worker sees every suite).");
         w.WriteLine("  --count-out PATH        Write what this run actually ran, per suite, as JSON:");
         w.WriteLine("                          { \"bcVersion\": \"27.0\", \"suites\": { \"<suite>\":");
         w.WriteLine("                          { \"tests\": N, \"appGroups\": M } } }. The same tally");

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ table is a copy and the CLI is the authority.
 | `1` | At least one test FAILED or ERRORED |
 | `2` | A bundle could not execute — a process-level error, and also a bad invocation (unknown flag, or a bundle path that does not exist) |
 | `3` | A bundle could not compile |
-| `4` | `--count-baseline`: a suite's test or app-group count did not exactly match its declared baseline |
+| `4` | `--count-baseline`: a suite's test or app-group count did not exactly match its declared baseline, or under `--count-baseline-require-all` a declared suite produced no bucket |
 | `5` | `--expectations-require-match`: an expectations entry matched no test in this run |
 
 When a run holds several of these at once it reports the most fundamental, in the order

--- a/docs/manual/cli-reference.md
+++ b/docs/manual/cli-reference.md
@@ -62,7 +62,7 @@ al-runner [OPTIONS] <bundle-dir>...
 | `1` | At least one test failed or errored. |
 | `2` | A bundle could not execute — a process-level error, or a bad invocation such as an unknown flag or a path that does not exist. |
 | `3` | A bundle could not compile. |
-| `4` | A suite's test or app-group count did not match its declared baseline (`--count-baseline`). |
+| `4` | A suite's test or app-group count did not match its declared baseline (`--count-baseline`), or a declared suite produced no bucket (`--count-baseline-require-all`). |
 | `5` | An expectations entry matched no test in this run (`--expectations-require-match`). |
 
 A run can hold several of these at once, and reports the most fundamental: **`3` > `2` > `4` >

--- a/tests/expectations/count-baseline/README.md
+++ b/tests/expectations/count-baseline/README.md
@@ -21,6 +21,14 @@ has to be just as hard, or a stale baseline sits under a passing run nobody read
 of, and a later real drop lands above the stale number and passes unnoticed (#1880, and PR
 #1882's review).
 
+**A suite this file declares but the run never produced** is compared against nothing. With
+`--count-baseline-require-all` — which the `runner-extras` step passes, because it is the one
+invocation covering every suite declared here — that fails with exit 4 and a `MISSING` line
+naming the key and this file, so a vanished suite or a misspelled key cannot stand down
+silently (#3130). Without the flag the runner prints `not checked` for it and passes, because
+`--count-baseline` is a public flag and a caller's baseline may name suites another invocation
+covers.
+
 Nothing about this file is a floor, a tolerance, or auto-updated. If your PR changes a count,
 you edit it, and CI prints the exact numbers to use.
 


### PR DESCRIPTION
Closes #3130

Written by agent `stma-auto2-6` on the account holder's behalf.

## What changed

`CountBaselineCheck.Evaluate` skips a declared suite that produced no bucket (`continue` at `CountBaseline.cs:315`), so a vanished suite or a misspelled key guarded nothing and said nothing. This adds an opt-in `--count-baseline-require-all`, modeled on #3123's `--expectations-require-match`:

| state | result |
|---|---|
| every declared suite produced a bucket | unchanged (DROP / GROWTH / pass) |
| a declared suite produced no bucket, flag given | **exit 4**, `[count-baseline] MISSING: suite '<key>' is declared in <file> but this run produced no bucket for it (suites that ran: …)` — a separate message from DROP |
| same, no flag | pass, but prints `[count-baseline] not checked: suite '<key>' …` instead of saying nothing |
| flag without `--count-baseline`, or a baseline declaring 0 suites | refused, exit 2, before any test runs (it could only pass vacuously) |
| flag with a `--jobs` fan-out | refused, exit 2 (each worker sees only its shard, so no one process can decide coverage) |
| flag with a carried attempt that could not be read | coverage check stands down loudly; the run already exits 2 for the lost attempt |
| `--test` filter / watchdog resume | whole count check already stands down loudly, unchanged |

The check is about **suite keys only**, never `groups` entries, so `absentOn` groups on 27.x are untouched.

CI: the `runner-extras` step in `bc-tests.yml` now passes `--count-baseline-require-all`, and its exit-4 error text names the MISSING case. Help text (`CliText.cs`), `README.md`, `docs/manual/cli-reference.md` and `tests/expectations/count-baseline/README.md` document it. `test-count-baseline.json` is untouched.

### The issue's premise is out of date

The issue describes four baseline keys shared by two `--count-baseline` invocations. At current `main` that is no longer true: #3675 took the corpus suites out of the file, so it declares only `runner-extras`, and the `runner-extras` step is the only one that passes `--count-baseline` (`bc-tests.yml` says so on the corpus step and the isolation-disabled step). The flag is still opt-in rather than always on because `--count-baseline` is a public CLI flag, and an outside caller's baseline can name suites that another invocation covers. The runner cannot tell that apart from a vanished suite, so the caller has to say.

Why a flag rather than deriving coverage from the bundle roots on the command line: that catches neither of the issue's two cases. A suite whose root stops being passed (the `corpus-app-dirs.py` scenario) and a misspelled key both have no matching root.

## RED -> GREEN (`CountBaselineIntegrationTests` + `CountBaselineCheckTests`)

- RED, new integration tests on the unfixed runner: `Failed: 6, Passed: 8, Total: 14`. The flag was rejected as an unknown option, and the assertion that failed was the exit code or message, not the build.
- GREEN: `Failed: 0, Passed: 23, Total: 23` (14 integration + 9 check tests, 2 of them new unit tests for `MissingSuites`).
- Wider GREEN run: `CountBaseline*|CliDocumentationTests|ParallelFanOut*`, `Failed: 0, Passed: 118, Total: 118`.

## Mutations (both executed, both restored)

1. `MissingSuites` returns nothing (`.Where(suite => false)`): `Failed: 4, Passed: 19`. Red: both `MissingSuites_*` unit tests, `RequireAll_DeclaredSuiteThatProducedNoBucket_Exits4NamingTheKeyAndFile`, and `WithoutRequireAll_…_StaysAPassButSaysSo` (its "not checked" line went silent). The refusal tests and `SuiteInManifestButNotInThisRun_IsIgnored` stayed green.
2. The flag is ignored at the audit (`&& countBaselineRequireAll` -> `&& false`): `Failed: 1, Passed: 22`. Only `RequireAll_DeclaredSuiteThatProducedNoBucket…` went red. The flag-off test stayed green, which shows the two tests measure different things.

Each mutation built cleanly (`0 Error(s)`), and the failures were assertion failures.

## Will the CI step stay green?

I did not measure a successful run. I ran `tests/runner-extras` locally with `--count-baseline … --count-baseline-require-all` (BC 28.1, with a local `test-apps-28.1…` package cache instead of CI's `test-apps`). Every group failed to execute on an unrelated local `Microsoft.Bcl.AsyncInterfaces` load error, so that run measured nothing. It printed `DROP: suite 'runner-extras' … actual 0` and no `MISSING`, which shows a bucket keyed `runner-extras` was produced, but only by a failed run. The green path rests on reasoning, not on that run: `CountOut.Tally` keys on the bundle directory's basename (pinned by `CountOutTests.Tally_KeysBySuiteDirectoryName_AndSumsRepeats`), and the step passes the single root `tests/runner-extras`. The CI legs are the measurement.

`RequireAll_WithAJobsFanOut_IsRefused` asserts the fan-out refusal text itself, so its green shows the `jobs > 1 && bundles.Count > 1` branch was reached. An unknown option or a bad-path exit 2 would not produce that text.

## Local guards

`GuardTests`: 248/249. The one failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned` (engine bootstrap not run on this box). `tools/test_*.py`: three fail (`test_agent_self_freshness`, `test_corpus_checkout`, `test_preflight`), all on `git commit` in a scratch repo failing with `1Password: failed to fill whole buffer`. That is the local signing setup, and none of those files are touched here.

## Fix the shape

1. **Same pattern at another call site?** The corpus count guard `.github/scripts/compare_corpus_count.py` joins in the same direction, and it already handles this case: `now.get(name, 0)` turns a vanished suite into a drop to 0. `--expectations-require-match` is the precedent this copies. I found nothing else.
2. **Sibling making the same assumption?** `--count-out` only reports what ran, so it has no declared set to miss. Found while looking: under a `--jobs` fan-out, plain `--count-baseline` is forwarded to each worker. A suite key spanning two roots (which `Tally` sums) would then be judged per shard and DROP falsely. That fails loudly, not silently, nobody has reported it, and no CI step combines the two, so I did not fold it in.
3. **Two paths writing the same state with different invariants?** `countBaselineMismatch` is set by DROP, GROWTH and now MISSING, and all three map to exit 4 with the same precedence (#3350). Nothing found beyond that.

**Queue scan** (`count-baseline`, `CountBaseline`, "declared suite", "no bucket"): #2803 is about the same JSON file but covers merge-time numeric auto-merge, not the check. It is a different defect in a different layer, so I did not fold it in. No duplicate of #3130 found.

Not a claim about BC. No corpus test is owed, and no `Corpus-PR:` line is needed (no gated paths touched). The proving tests are runner-side under `AlRunner.Tests/`.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
