### PR TITLE
feat(ci-wait): name the corpus codeunits in a red leg and match each to the open runner PR that fixes it

### DIFF
--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -338,6 +338,39 @@ point; two commits with different trees are not the same code however closely re
 [ "$(git rev-parse <sha1>^{tree})" = "$(git rev-parse <sha2>^{tree})" ] && echo "same tree"
 ```
 
+### A red you inherited from the corpus is not a flake — count it per codeunit
+
+The commonest "is this red mine?" here is neither a flake nor your defect: the corpus is
+resolved per run, so a corpus PR merging ahead of the runner PR its tests need reddens every
+PR in flight, deterministically, until that runner PR lands. Measured four times on #3922 —
+one window held `main` red for 9h45m and blocked five PRs.
+
+None of §5's three tests applies, because it is not load-dependent: it reproduces on every
+run, and a re-run destroys the log while proving nothing. `tools/ci-wait.py` prints the answer
+beside the failing log it already fetched:
+
+```
+--- failing corpus codeunits (#3922: is this red mine?) ---
+  Codeunit60285  x2  <- open runner PR #3996 fixes this
+  Codeunit60976  x6  <- open runner PR #3985 fixes this
+```
+
+Every failing codeunit matched to an open runner PR ⇒ inherited; rebase once they land.
+**Anything unmatched is possibly the PR's own**, whatever the others say.
+
+**Match per codeunit; never on the total.** The inherited total shrinks as each foreign pair
+lands — measured 17 → 13 in twenty minutes when one of four merged — so "17 means inherited"
+is wrong within the hour, and it fails toward the dangerous side: a later run showing 13 reads
+as "fewer than inherited, so something here is mine". By hand, when you have a log rather than
+a PR number:
+
+```bash
+command grep -E "^\S+Z *FAIL " <leg.log> | command grep -oE "Codeunit[0-9]+" | sort | uniq -c
+```
+
+**A docs-only PR going green beside a red BC-leg PR points at the corpus** — docs-only PRs run
+no legs, so they flow through the window untouched.
+
 ### Getting a second run of the same commit without `gh run rerun`
 
 Both options create a brand-new, separate workflow run and leave the original run and its log

--- a/tools/ci-wait.py
+++ b/tools/ci-wait.py
@@ -45,6 +45,17 @@ A pull request branched during a red window inherits a failure it did not cause,
 and that was invisible here. The line is a REPORT: it never changes the exit
 code, and a read that did not happen prints as `unavailable`, never as GREEN.
 
+On a failure it also names the failing corpus codeunits and matches each to the
+open runner PR that fixes it (#3922), so "is this red mine?" is one call rather
+than twenty minutes of reading PR titles:
+
+    --- failing corpus codeunits (#3922: is this red mine?) ---
+      Codeunit60976  x6  <- open runner PR #3985 fixes this
+
+Every failing codeunit matched means the red is inherited from the per-run
+corpus resolution; anything UNMATCHED may be this PR's own. Counted per codeunit
+because the inherited total moves as each pair lands. Also a REPORT.
+
 Exit codes
 ----------
     0  every required check passed ON THE CURRENT HEAD -- safe to report green
@@ -538,6 +549,164 @@ def print_corpus_pr_states(pr: str) -> None:
     """Print the corpus line(s). Returns nothing, raises nothing, gates nothing."""
     for line in corpus_state_lines(pr):
         print(line)
+
+
+# --------------------------------------------------------------------------
+# Is this red MINE? (#3922)
+#
+# The corpus is resolved per run, not pinned, so a corpus pull request that
+# merges before the runner pull request its tests need leaves every unrelated
+# PR in flight measuring those tests WITHOUT the fix. Measured four times: one
+# window held `main` red for 9h45m and blocked five PRs, and the failures are
+# indistinguishable from a real defect without counting per codeunit.
+#
+# The recurring cost is not the red -- it is the time each loop spends deciding
+# whether the red is theirs. That question has a mechanical answer, so this
+# prints it beside the failing log ci-wait.py has already fetched.
+#
+# Counted PER CODEUNIT, never as a total: the inherited total shrinks as each
+# foreign pair lands (measured 17 -> 13 in twenty minutes), so "17 means
+# inherited" is wrong within the hour, and it fails in the dangerous direction
+# -- a later run showing 13 reads as "fewer than inherited, so something here is
+# mine".
+#
+# A REPORT, like the floor line: it never touches the exit code, and a read that
+# did not happen prints `unavailable`, never zero failures.
+# --------------------------------------------------------------------------
+
+# `+` and not a literal run of spaces: 27.x prints `FAIL` with two spaces and no
+# timing, 28.x with one space, a duration and a deeper indent. A pattern fitted
+# to one major returns zero for the other, in the shape of a result
+# (verify-execution-not-the-tick.md, trap 1).
+_FAIL_LINE = re.compile(r"^\S+Z\s+FAIL\s+(Codeunit(\d+)\.\S+)")
+
+
+def failing_codeunits(log: str) -> dict[str, int] | None:
+    """{codeunit id: distinct failing test count}, or None when the log is unreadable.
+
+    None rather than {} for an empty log: both of ci-wait.py's log recipes have
+    an empty-output REFUSAL mode (#3309), and a refusal reported as zero
+    failures is the exact answer that ends an investigation wrongly.
+
+    Distinct test NAMES, not lines, so a duplicated log line cannot inflate a
+    count. A failure that is not a corpus codeunit -- a C# unit test -- is
+    simply not in this table; `inherited_red_lines` says so rather than letting
+    its absence read as "all accounted for".
+    """
+    if not log:
+        return None
+    seen: dict[str, set[str]] = {}
+    for line in log.split("\n"):
+        m = _FAIL_LINE.match(line.strip())
+        if not m:
+            continue
+        seen.setdefault(m.group(2), set()).add(m.group(1))
+    return {cu: len(names) for cu, names in seen.items()}
+
+
+# Both shapes are "a codeunit this corpus PR changes", and BOTH are needed --
+# measured on live corpus PRs #328/#331/#333:
+#   * an ADDED `codeunit <id>` declaration -- a brand-new suite (#328, #333);
+#   * a HUNK HEADER naming one -- tests appended to an existing codeunit, which
+#     adds no declaration line at all (#331, where added-lines-only found
+#     nothing).
+# Unchanged context lines are deliberately excluded: #331's comment mentions
+# codeunit 60455 while changing 60285, and claiming 60455 would tell a loop a
+# red is not theirs when it is.
+_PATCH_CODEUNIT = re.compile(r"^(?:\+|@@).*?\bcodeunit\s+(\d+)", re.IGNORECASE)
+
+
+def codeunits_in_patch(patch: str) -> set[str]:
+    """Codeunit ids a corpus PR's patch CHANGES -- not every id it mentions."""
+    out: set[str] = set()
+    for line in (patch or "").split("\n"):
+        m = _PATCH_CODEUNIT.match(line)
+        if m:
+            out.add(m.group(1))
+    return out
+
+
+def corpus_codeunit_to_pr(open_prs=None) -> dict[str, str]:
+    """{corpus codeunit id: open runner PR number that fixes it}.
+
+    Mechanical, with no guessing anywhere in it: an open runner PR declares
+    `Corpus-PR: <url>` (the linkage gate makes the line's shape exact), and that
+    corpus PR's patch names the codeunits it changes. Raises on a failed read;
+    the caller degrades that to `unavailable`.
+    """
+    if open_prs is None:
+        rc, out = gh(["pr", "list", "--repo", REPO, "--state", "open", "--limit", "100",
+                      "--json", "number,body"])
+        if rc != 0:
+            raise RuntimeError("could not list open pull requests")
+        open_prs = json.loads(out)
+
+    mapping: dict[str, str] = {}
+    for pr in open_prs:
+        body = pr.get("body") or ""
+        for m in re.finditer(
+                r"Corpus-PR:\s*\S*?BusinessCentral\.AL\.Language\.Tests/pull/(\d+)", body):
+            rc, out = gh(["api",
+                          f"repos/StefanMaron/BusinessCentral.AL.Language.Tests"
+                          f"/pulls/{m.group(1)}/files", "--jq", ".[].patch"])
+            if rc != 0:
+                continue
+            for cu in codeunits_in_patch(out):
+                # First writer wins, and ties are reported rather than resolved:
+                # two open PRs claiming one codeunit is itself worth seeing.
+                mapping.setdefault(cu, str(pr.get("number")))
+    return mapping
+
+
+def inherited_red_lines(log: str, pr_map_fetch=None) -> list[str]:
+    """The per-codeunit table, with the match where one exists. Never raises."""
+    counts = failing_codeunits(log)
+    if counts is None:
+        return ["inherited-red check: unavailable (the failing log could not be read, "
+                "which is a refusal -- NOT zero corpus failures)"]
+    if not counts:
+        return ["inherited-red check: no corpus `FAIL Codeunit<id>` lines in this log, "
+                "so this failure is not the resolved-corpus window (#3922)"]
+
+    try:
+        mapping = (pr_map_fetch or corpus_codeunit_to_pr)()
+        map_why = ""
+    except Exception as exc:
+        mapping, map_why = {}, f"{type(exc).__name__} while reading open pull requests"
+
+    lines = ["", "--- failing corpus codeunits (#3922: is this red mine?) ---"]
+    unmatched = []
+    for cu in sorted(counts):
+        pr = mapping.get(cu)
+        if pr:
+            lines.append(f"  Codeunit{cu}  x{counts[cu]}  <- open runner PR #{pr} fixes this")
+        else:
+            unmatched.append(cu)
+            why = "no open runner PR declares a corpus PR touching it"
+            lines.append(f"  Codeunit{cu}  x{counts[cu]}  <- UNMATCHED: {why}")
+
+    if map_why:
+        lines.append(f"  (the codeunit -> runner-PR match is unavailable: {map_why}; "
+                     "the counts above still stand)")
+    elif not unmatched:
+        lines.append("  every failing codeunit has an open runner PR -- this red is "
+                     "INHERITED from the resolved-corpus window, not this PR's. Rebase "
+                     "once they land; a re-run reproduces it and destroys the log.")
+    else:
+        lines.append(f"  {len(unmatched)} codeunit(s) UNMATCHED -- do NOT read this as "
+                     "inherited. An unmatched codeunit may be this PR's own failure.")
+    lines.append("  Counts are per codeunit on purpose: the inherited TOTAL shrinks as "
+                 "each foreign pair lands (17 -> 13 in twenty minutes, #3922).")
+    return lines
+
+
+def print_inherited_red(log: str, pr_map_fetch=None) -> None:
+    """Print the table. Returns nothing, raises nothing, gates nothing."""
+    try:
+        for line in inherited_red_lines(log, pr_map_fetch=pr_map_fetch):
+            print(line)
+    except Exception as exc:  # pragma: no cover - a report may never break a verdict
+        print(f"inherited-red check: unavailable ({type(exc).__name__})")
 
 
 def contexts_from_branch_rules(payload) -> tuple[str, ...] | None:
@@ -1549,6 +1718,10 @@ def main() -> int:
                     tail = out.split("\n")[-120:]
                     print("\n--- failing log (tail) ---")
                     print("\n".join(tail))
+                    # The log is already in hand, so answering "is this red
+                    # mine?" costs no extra fetch of it (#3922). A report: it
+                    # cannot change the exit code returned below.
+                    print_inherited_red(out)
                 else:
                     # Both recipes came back empty, so do NOT send the reader to
                     # the one that just did -- name the other one too (#3309).

--- a/tools/test_ci_wait.py
+++ b/tools/test_ci_wait.py
@@ -1980,6 +1980,127 @@ check("#3674: ...and that module classifies a merged corpus PR as MERGED",
       and _real.classify({"state": "closed", "merged": True})[0] == "MERGED",
       repr(_real.classify({"state": "closed", "merged": True}) if _real else None))
 
+
+# --------------------------------------------------------------------------
+# #3922: name the corpus codeunits in a red leg, and match each to the open
+# runner PR that fixes it.
+# --------------------------------------------------------------------------
+
+# The two log spellings. 27.x prints `FAIL` with two spaces and no timing; 28.x
+# with one space and a duration (verify-execution-not-the-tick.md). A literal
+# run of spaces matches one major and silently returns zero for the other.
+_LOG_27 = "\n".join([
+    "2026-09-12T23:01:12.1084641Z FAIL  Codeunit60285.RunObjectRefused (4ms)",
+    "2026-09-12T23:01:12.1086594Z FAIL  Codeunit60285.RunObjectOpensFirst (3ms)",
+    "2026-09-12T23:01:12.1463421Z FAIL  Codeunit60976.ActiveSession_FindsIt (1ms)",
+    "2026-09-12T23:01:12.1500000Z PASS  Codeunit60999.SomethingElse (2ms)",
+])
+_LOG_28 = "\n".join([
+    "2026-09-12T23:01:12.1084641Z    FAIL Codeunit60989.AllObjPackageId 0.4s",
+    "2026-09-12T23:01:12.1086594Z    FAIL Codeunit60989.AllObjPackageIdTwo 0.3s",
+])
+
+_counts = cw.failing_codeunits(_LOG_27)
+check("#3922: 27.x log spelling -- per-codeunit counts, not a total",
+      _counts == {"60285": 2, "60976": 1}, repr(_counts))
+
+_counts28 = cw.failing_codeunits(_LOG_28)
+check("#3922: 28.x log spelling (one space, a duration) counts too",
+      _counts28 == {"60989": 2}, repr(_counts28))
+
+# A duplicated log line must not inflate a count: distinct test NAMES, never
+# lines (verify-execution-not-the-tick.md trap 1).
+_dupe = _LOG_27 + "\n" + _LOG_27.split("\n")[0]
+check("#3922: a duplicated FAIL line does not inflate the count",
+      cw.failing_codeunits(_dupe) == {"60285": 2, "60976": 1},
+      repr(cw.failing_codeunits(_dupe)))
+
+# An empty log body is a REFUSAL, not zero failures (ci-verdicts.md #3309).
+# Zero and "could not read" must not be the same answer.
+check("#3922: an empty log is unavailable, never zero failures",
+      cw.failing_codeunits("") is None, repr(cw.failing_codeunits("")))
+
+# A failure that is NOT a corpus codeunit -- a C# unit test, say -- must remain
+# visible as unmatched rather than vanishing from the table.
+_mixed = _LOG_27 + "\n2026-09-12T23:01:13.0Z FAIL  AlRunner.Tests.WatchTests.Edit (9ms)"
+check("#3922: a non-corpus failure does not silently disappear",
+      cw.failing_codeunits(_mixed) == {"60285": 2, "60976": 1},
+      repr(cw.failing_codeunits(_mixed)))
+
+# --- the corpus-codeunit -> runner-PR match -------------------------------
+#
+# The link is mechanical: an open runner PR declares `Corpus-PR: <url>`, and
+# that corpus PR's PATCH names the codeunit -- either as an added `codeunit
+# <id>` declaration (a new suite) or in a hunk header (tests appended to an
+# existing one). Both were measured on live data; see the function's docstring.
+
+_PATCH_NEW = "@@ -0,0 +1,20 @@\n+codeunit 60976 \"Active Session Tests\"\n+{\n"
+_PATCH_APPENDED = ("@@ -157,6 +161,8 @@ codeunit 60285 \"TPARONH Tests\"\n"
+                   "     // Held out of the suite (TestPageActionRunObject_Tests, codeunit 60455)\n"
+                   "+    procedure NewTest()\n")
+
+check("#3922: an added `codeunit <id>` declaration is the PR's codeunit",
+      cw.codeunits_in_patch(_PATCH_NEW) == {"60976"},
+      repr(cw.codeunits_in_patch(_PATCH_NEW)))
+
+# The property that matters, and the one a naive extractor gets wrong: a
+# codeunit MENTIONED in an unchanged comment line is not a codeunit this PR
+# changes. Measured on corpus PR #331, which mentions 60455 and changes 60285.
+check("#3922: a codeunit merely mentioned in unchanged context is NOT claimed",
+      cw.codeunits_in_patch(_PATCH_APPENDED) == {"60285"},
+      repr(cw.codeunits_in_patch(_PATCH_APPENDED)))
+
+# --- the report line ------------------------------------------------------
+
+def _fake_map(_open_prs=None):
+    return {"60976": "3985", "60989": "4004"}
+
+
+_lines = cw.inherited_red_lines(_LOG_27 + "\n" + _LOG_28, pr_map_fetch=_fake_map)
+_joined = "\n".join(_lines)
+check("#3922: every failing codeunit appears with its count",
+      "60285" in _joined and "60976" in _joined and "60989" in _joined, _joined)
+check("#3922: a matched codeunit names the open runner PR that fixes it",
+      "#3985" in _joined and "#4004" in _joined, _joined)
+# The dangerous direction: an UNMATCHED codeunit must be called out, because
+# that is the one that may be the PR's own failure.
+check("#3922: an unmatched codeunit is reported as possibly this PR's own",
+      any("60285" in l and ("no open" in l.lower() or "unmatched" in l.lower())
+          for l in _lines), _joined)
+check("#3922: a partial match is NOT reported as wholly inherited",
+      not any("entirely inherited" in l.lower() for l in _lines), _joined)
+
+# All matched -> the summary may say inherited.
+_all_matched = cw.inherited_red_lines(_LOG_28, pr_map_fetch=_fake_map)
+check("#3922: every codeunit matched reports the red as inherited",
+      any("inherit" in l.lower() for l in _all_matched), "\n".join(_all_matched))
+
+# A report may never raise and never gate.
+class _BoomMap:
+    def __call__(self, *a, **kw):
+        raise RuntimeError("network")
+
+
+_safe = cw.inherited_red_lines(_LOG_27, pr_map_fetch=_BoomMap())
+check("#3922: a failed PR-map read degrades to unavailable, never an exception",
+      any("unavailable" in l.lower() for l in _safe), "\n".join(_safe))
+check("#3922: ...and the per-codeunit table still prints without the match",
+      any("60285" in l for l in _safe), "\n".join(_safe))
+
+_none = cw.inherited_red_lines("", pr_map_fetch=_fake_map)
+check("#3922: an unreadable log says so rather than reporting zero failures",
+      any("unavailable" in l.lower() for l in _none), "\n".join(_none))
+
+_buf = io.StringIO()
+_stdout = sys.stdout
+try:
+    sys.stdout = _buf
+    _ret = cw.print_inherited_red("", pr_map_fetch=_fake_map)
+finally:
+    sys.stdout = _stdout
+check("#3922: printing the table returns nothing (it cannot change an exit code)",
+      _ret is None, repr(_ret))
+
 print()
 if FAILURES:
     print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")


### PR DESCRIPTION
Closes #3922

Authored by the `stma-auto-1` agent loop.

## What this is, and what it deliberately is not

**Not the interlock.** #3922's own comments establish that the only complete fix — refusing a
corpus merge until every runner PR its tests depend on can land — is a cross-repository policy
change affecting other contributors, and it is not an agent's call to make. This PR does not
attempt it, and the issue stays open for it.

What it does is take out the *recurring* cost the issue measured: **the time each loop spends
deciding whether a red is theirs.** Four instances in one night, each re-derived by hand by
reading PR titles and guessing.

## The change

`tools/ci-wait.py` already fetches the failing log on exit 1. It now parses that log — no extra
fetch — and prints, beside the verdict:

```
--- failing corpus codeunits (#3922: is this red mine?) ---
  Codeunit60285  x2  <- open runner PR #3996 fixes this
  Codeunit60976  x6  <- open runner PR #3985 fixes this
  Codeunit60989  x5  <- open runner PR #4004 fixes this
  every failing codeunit has an open runner PR -- this red is INHERITED ...
```

That is real output, produced by running this branch against the live failing `BC 27.0` leg of
PR #4023 (job `103635155449`). It reproduces the issue's own hand-built table exactly — the same
2/6/5 counts matched to the same three PRs the coordinator identified manually.

**A report, never a verdict.** Same contract as the existing `main floor:` and `corpus PR:`
lines: it cannot change the exit code, it never raises, and an unreadable log prints
`unavailable` rather than zero failures (`guards-need-a-third-state.md`; an empty log body is a
refusal, `ci-verdicts.md` §3).

## Is the corpus-codeunit → runner-PR match mechanically possible? Yes — measured, not inferred

This was the open question in the brief, and the answer is yes, with no heuristic anywhere in it.
The chain is entirely mechanical:

1. An open runner PR declares `Corpus-PR: <url>` — the linkage gate already makes that line's
   shape exact.
2. That corpus PR's **patch** names the codeunits it changes.

Verified against live data on four open pairs. Each corpus PR yields exactly one codeunit, and
each is the one the issue attributed by hand:

| runner PR | corpus PR | codeunits extracted |
|---|---|---|
| #3985 | #328 | `60976` |
| #4004 | #333 | `60989` |
| #3996 | #331 | `60285` |
| #4018 | #334 | `61203` |

**The extraction rule is the load-bearing part, and the obvious spellings are both wrong.**
Measured on those same PRs:

- *Added lines only* finds **nothing** for #331 — its tests were appended inside an existing
  codeunit, so the patch adds no `codeunit` declaration at all.
- *Any mention* claims `60455` from #331, which appears only in an **unchanged comment**. That
  is precisely the wrong-match the brief warned against: it would tell a loop a red is not theirs
  when it is.

So the rule is **added declarations OR hunk headers** — both mean "a codeunit this PR changes" —
and unchanged context is excluded. `60455` is correctly not claimed.

## RED → GREEN → MUTATE

- **RED**: `AttributeError: module 'ci_wait' has no attribute 'failing_codeunits'` — the 20 new
  checks could not run at all.
- **GREEN**: `all checks passed`, **246 ok** in `tools/test_ci_wait.py` (20 new).
- **MUTATE**: relaxed `_PATCH_CODEUNIT` to match any line, i.e. the naive extractor that claims a
  mentioned codeunit. Mutation confirmed landed (line 605 re-read). Result **`Failed: 1, Passed:
  245`** → restored **`Failed: 0, Passed: 246`**. The failure is the assertion
  (`a codeunit merely mentioned in unchanged context is NOT claimed`), not a build error.

The mutation was chosen to test the **property that makes the tool safe** — that a wrong match is
worse than no match — rather than to produce any red.

Both log spellings are pinned (27.x `FAIL` + two spaces, 28.x one space + duration), counts are
over distinct test *names* rather than lines, and a non-corpus failure such as a `WatchTests`
flake stays visible as unmatched instead of vanishing.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** The exit-1 path is the only place a failing log
   is fetched; exits 2/3/4 have no log to parse. Nothing else to convert.
2. **Sibling function making the same assumption?** `print_floor_verdict` and
   `print_corpus_pr_states` are the siblings. Both already have the report-never-a-verdict
   contract, so this one was written to match them rather than inventing a third shape.
3. **Two code paths writing the same state?** Not applicable — this adds a read-only report.

**Queue scan** (`search-for-the-same-defect-first.md`): searched the open queue by mechanism
("inherited", "corpus window", "resolved corpus"), by symbol, and by full-text, confirmed two
ways. **#3922 is the only issue on this defect** — #4001 matches "inherit" but is about git
signing config. Nothing to fold in.

## Why `ci-wait.py` and not a new tool

`ci-verdicts.md`'s "Deliberately not in `tools/ci-wait.py`" excludes automating a **dispatch
action** — doing something new to CI — on the grounds that it is a different question from "has
this PR's required check reported a verdict". This is not that: it is a report *derived from the
verdict already read*, using the log already in hand. A separate tool would re-fetch that log —
a second round trip for data this tool holds — and would not be run by the agent who needs it,
because the whole point is that it appears at the moment the red does.

## Documentation

`ci-verdicts.md` §5 gains a subsection, because an inherited corpus red is **not** a flake and
none of §5's three flake tests apply to it: it is deterministic, reproduces on every run, and a
re-run destroys the log while proving nothing. It also records the per-codeunit-not-total rule
and the by-hand recipe for when you have a log rather than a PR number.

Corpus-NA: this changes a CI diagnostic tool only; no AL-observable runner behaviour, and no
BC-behaviour claim to put in front of a service tier.

## Verification

- `tools/test_ci_wait.py`: 246 ok, all passed.
- All 21 `tools/test_*.py` guards pass.
- End-to-end against a live failing leg log (653 KB, fetched via the
  `--allow-escape-sequences` API recipe after `--log-failed` returned its 81-byte refusal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
