### PR TITLE
fix(server): replay enum-registry and query-symbol sidecars on cross-bundle module reuse

### DIFF
--- a/AlRunner.Tests/ServerCrossBundleReuseRegistryReplayTests.cs
+++ b/AlRunner.Tests/ServerCrossBundleReuseRegistryReplayTests.cs
@@ -62,6 +62,37 @@ public sealed class ServerCrossBundleReuseRegistryReplayTests
             }
         }
 
+        table 62404 "R3250 Line"
+        {
+            fields
+            {
+                field(1; "Row No."; Integer) { }
+                field(2; "Line No."; Integer) { }
+                field(3; Qty; Integer) { }
+            }
+            keys
+            {
+                key(PK; "Row No.", "Line No.") { Clustered = true; }
+            }
+        }
+
+        query 62405 "R3250 Row Lines"
+        {
+            elements
+            {
+                dataitem(Row; "R3250 Row")
+                {
+                    column(RowNo; "No.") { }
+                    dataitem(Line; "R3250 Line")
+                    {
+                        DataItemLink = "Row No." = Row."No.";
+                        SqlJoinType = InnerJoin;
+                        column(LineQty; Qty) { }
+                    }
+                }
+            }
+        }
+
         query 62402 "R3250 Rows"
         {
             elements
@@ -105,6 +136,28 @@ public sealed class ServerCrossBundleReuseRegistryReplayTests
                 if Rows.Amount <> 7 then
                     Error('query column Amount answered <%1>, expected <7>', Rows.Amount);
             end;
+
+            [Test]
+            procedure JoinQueryReadsItsOwnColumns()
+            var
+                Row: Record "R3250 Row";
+                Line: Record "R3250 Line";
+                RowLines: Query "R3250 Row Lines";
+            begin
+                Row.Init();
+                Row."No." := 5;
+                Row.Insert();
+                Line.Init();
+                Line."Row No." := 5;
+                Line."Line No." := 1;
+                Line.Qty := 11;
+                Line.Insert();
+                RowLines.Open();
+                if not RowLines.Read() then
+                    Error('join query returned no row');
+                if (RowLines.RowNo <> 5) or (RowLines.LineQty <> 11) then
+                    Error('join query answered <%1>/<%2>, expected <5>/<11>', RowLines.RowNo, RowLines.LineQty);
+            end;
         }
         """);
     }
@@ -125,8 +178,8 @@ public sealed class ServerCrossBundleReuseRegistryReplayTests
         var (_, d1) = ProtocolV2Streaming.Split(lines1);
         // Request 1 is the control: the same AL, the same assertions, green. A red here is a
         // general failure of the fixture, not this issue.
-        Assert.True(d1.GetProperty("passed").GetInt32() == 2 && d1.GetProperty("failed").GetInt32() == 0,
-            $"[{label}] request 1 (directory A) must pass both tests: {joined1}");
+        Assert.True(d1.GetProperty("passed").GetInt32() == 3 && d1.GetProperty("failed").GetInt32() == 0,
+            $"[{label}] request 1 (directory A) must pass all three tests: {joined1}");
 
         var mark = server.StdErrMark;
         var lines2 = await server.SendRequestStreamingAsync(Req(dirB), TimeSpan.FromSeconds(240));
@@ -143,8 +196,8 @@ public sealed class ServerCrossBundleReuseRegistryReplayTests
         var joined2 = string.Join(" | ", lines2);
         Assert.Contains(ReuseLine, stderr2, StringComparison.Ordinal);
         var (_, d2) = ProtocolV2Streaming.Split(lines2);
-        Assert.True(d2.GetProperty("passed").GetInt32() == 2 && d2.GetProperty("failed").GetInt32() == 0,
-            $"[{label}] request 2 (directory B, reused module) must pass both tests: {joined2}");
+        Assert.True(d2.GetProperty("passed").GetInt32() == 3 && d2.GetProperty("failed").GetInt32() == 0,
+            $"[{label}] request 2 (directory B, reused module) must pass all three tests: {joined2}");
     }
 
     [SkippableFact]

--- a/AlRunner.Tests/ServerCrossBundleReuseRegistryReplayTests.cs
+++ b/AlRunner.Tests/ServerCrossBundleReuseRegistryReplayTests.cs
@@ -169,9 +169,11 @@ public sealed class ServerCrossBundleReuseRegistryReplayTests
         packagePaths = Array.Empty<string>(),
     });
 
-    private static async Task<(List<string> Lines, string StdErr)> RunSessionAsync(string dirA, string dirB, IEnumerable<string> args, string label)
+    private static async Task<(List<string> Lines, string StdErr)> RunSessionAsync(
+        string dirA, string dirB, IEnumerable<string> args, string label,
+        IReadOnlyDictionary<string, string>? env = null, Action? betweenRequests = null)
     {
-        await using var server = await CliServer.StartAsync(args);
+        await using var server = await CliServer.StartAsync(args, extraEnv: env);
 
         var lines1 = await server.SendRequestStreamingAsync(Req(dirA), TimeSpan.FromSeconds(240));
         var joined1 = string.Join(" | ", lines1);
@@ -181,6 +183,7 @@ public sealed class ServerCrossBundleReuseRegistryReplayTests
         Assert.True(d1.GetProperty("passed").GetInt32() == 3 && d1.GetProperty("failed").GetInt32() == 0,
             $"[{label}] request 1 (directory A) must pass all three tests: {joined1}");
 
+        betweenRequests?.Invoke();
         var mark = server.StdErrMark;
         var lines2 = await server.SendRequestStreamingAsync(Req(dirB), TimeSpan.FromSeconds(240));
         // Without the reuse line the request did not exercise #3250 at all — a green would be
@@ -235,6 +238,75 @@ public sealed class ServerCrossBundleReuseRegistryReplayTests
         try
         {
             AssertRequest2(await RunSessionAsync(dirA, dirB, new[] { "--no-cache" }, "no-cache"), "no-cache");
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+
+    private static void AssertRequest2Refused((List<string> Lines, string StdErr) run, string expectedReason, string label)
+    {
+        var (lines2, stderr2) = run;
+        var joined2 = string.Join(" | ", lines2);
+        Assert.Contains(ReuseLine, stderr2, StringComparison.Ordinal);
+        var (_, d2) = ProtocolV2Streaming.Split(lines2);
+        // A refusal, not a run: no test may execute against a module missing its metadata.
+        Assert.True(d2.GetProperty("exitCode").GetInt32() != 0 && d2.GetProperty("passed").GetInt32() == 0,
+            $"[{label}] request 2 must refuse the reuse: {joined2}");
+        // Read from the parsed summary: the raw JSON escapes the apostrophe in the message.
+        var errors = d2.TryGetProperty("compilationErrors", out var groups) && groups.ValueKind == JsonValueKind.Array
+            ? string.Join(" | ", groups.EnumerateArray().SelectMany(g => g.GetProperty("errors").EnumerateArray()).Select(e => e.GetString()))
+            : "";
+        Assert.Contains("reused module's registry replay failed", errors, StringComparison.Ordinal);
+        Assert.Contains(expectedReason, errors, StringComparison.Ordinal);
+    }
+
+    [SkippableFact]
+    public async Task ReusedModule_WhoseRecordedSidecarIsGone_RefusesWithANamedReason()
+    {
+        TestArtifacts.SkipIfMissing();
+        var root = TestScratch.Dir("al-runner-server-reuse-replay-3250-gone");
+        var dirA = Path.Combine(root, "checkout-a");
+        var dirB = Path.Combine(root, "checkout-b");
+        var cache = Path.Combine(root, "cache");
+        WriteBundle(dirA);
+        WriteBundle(dirB);
+        try
+        {
+            // Cold: request 1 is a MISS that writes the cache entry, and that entry's sidecar is
+            // what the replay records. Deleting it between the requests is the missing-file case.
+            var run = await RunSessionAsync(dirA, dirB, new[] { "--cache", cache }, "gone", betweenRequests: () =>
+            {
+                var sidecars = Directory.EnumerateFiles(cache, "*.enum-registry.json", SearchOption.AllDirectories).ToList();
+                Assert.NotEmpty(sidecars);
+                foreach (var f in sidecars) File.Delete(f);
+            });
+            AssertRequest2Refused(run, "the registry snapshot recorded for the reused module is gone", "gone");
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+
+    [SkippableFact]
+    public async Task ReusedModule_WhoseCaptureFailed_RefusesInsteadOfRunningWithoutReplay()
+    {
+        TestArtifacts.SkipIfMissing();
+        const string injected = "injected capture failure 3250";
+        var root = TestScratch.Dir("al-runner-server-reuse-replay-3250-capturefail");
+        var dirA = Path.Combine(root, "checkout-a");
+        var dirB = Path.Combine(root, "checkout-b");
+        WriteBundle(dirA);
+        WriteBundle(dirB);
+        try
+        {
+            // Request 1 still passes — a failed capture only matters to a later reuse — and
+            // request 2 must refuse rather than read "no replay recorded" as nothing to replay.
+            var run = await RunSessionAsync(dirA, dirB, new[] { "--no-cache" }, "capture-failed",
+                env: new Dictionary<string, string> { ["AL_RUNNER_TEST_FAIL_OWN_BUNDLE_REPLAY_CAPTURE"] = injected });
+            AssertRequest2Refused(run, injected, "capture-failed");
         }
         finally
         {

--- a/AlRunner.Tests/ServerCrossBundleReuseRegistryReplayTests.cs
+++ b/AlRunner.Tests/ServerCrossBundleReuseRegistryReplayTests.cs
@@ -1,0 +1,189 @@
+// ServerCrossBundleReuseRegistryReplayTests — issue #3250.
+//
+// A --server session that loads app X from directory A in request 1 and the same app X from
+// directory B in request 2 takes RunBundleForServer's cross-bundle reuse (#1683/#1892) in
+// request 2: B is served A's already-loaded module. ResetForNewBundleReload cleared the
+// emit-derived registries at the top of request 2, and the reuse path skipped the only block
+// that replays them, so the module ran with no enum metadata and no query symbols.
+//
+// Dedicated server per session, never SharedCliServer: one AppId at two SourcePaths poisons
+// the shared AppId cache (ServerAppVersionBumpTests says the same).
+//
+// Each session runs twice against ONE cache root, because the two runs reach request 2
+// through different request-1 branches: cold is an emit MISS, warm is an AL-output cache HIT
+// (.claude/rules/local-test-scope.md). The --no-cache case has no sidecar on disk at all.
+
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ServerCrossBundleReuseRegistryReplayTests
+{
+    private const string AppId = "e3250325-0325-4325-8325-032503250325";
+    private const string ReuseLine = "reusing that module instead of recompiling";
+
+    private static void WriteBundle(string root)
+    {
+        Directory.CreateDirectory(root);
+        // No Base Application floor (.claude/rules/no-base-app-in-csharp-tests.md). Both
+        // directories get the byte-identical manifest: same id, name, publisher and version,
+        // which is what makes request 2 a reuse rather than a #1850 collision.
+        File.WriteAllText(Path.Combine(root, "app.json"), $$"""
+        {
+          "id": "{{AppId}}",
+          "name": "Reuse Replay 3250",
+          "publisher": "Repro3250",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62400, "to": 62409 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "Objects.al"), """
+        enum 62400 "R3250 Color"
+        {
+            Extensible = false;
+            value(0; Red) { Caption = 'Crimson Red'; }
+            value(1; Blue) { Caption = 'Deep Blue'; }
+        }
+
+        table 62401 "R3250 Row"
+        {
+            fields
+            {
+                field(1; "No."; Integer) { }
+                field(2; Amount; Integer) { }
+            }
+            keys
+            {
+                key(PK; "No.") { Clustered = true; }
+            }
+        }
+
+        query 62402 "R3250 Rows"
+        {
+            elements
+            {
+                dataitem(Row; "R3250 Row")
+                {
+                    column(No; "No.") { }
+                    column(Amount; Amount) { }
+                }
+            }
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "Tests.Codeunit.al"), """
+        codeunit 62403 "R3250 Replay Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure EnumCaptionComesFromTheRegistry()
+            var
+                Color: Enum "R3250 Color";
+            begin
+                Color := Color::Blue;
+                if Format(Color) <> 'Deep Blue' then
+                    Error('Format(enum) answered <%1>, expected <Deep Blue>', Format(Color));
+            end;
+
+            [Test]
+            procedure QueryReadsItsOwnColumns()
+            var
+                Row: Record "R3250 Row";
+                Rows: Query "R3250 Rows";
+            begin
+                Row.Init();
+                Row."No." := 1;
+                Row.Amount := 7;
+                Row.Insert();
+                Rows.Open();
+                if not Rows.Read() then
+                    Error('query returned no row');
+                if Rows.Amount <> 7 then
+                    Error('query column Amount answered <%1>, expected <7>', Rows.Amount);
+            end;
+        }
+        """);
+    }
+
+    private static string Req(string bundle) => JsonSerializer.Serialize(new
+    {
+        command = "runTests",
+        sourcePaths = new[] { bundle },
+        packagePaths = Array.Empty<string>(),
+    });
+
+    private static async Task<(List<string> Lines, string StdErr)> RunSessionAsync(string dirA, string dirB, IEnumerable<string> args, string label)
+    {
+        await using var server = await CliServer.StartAsync(args);
+
+        var lines1 = await server.SendRequestStreamingAsync(Req(dirA), TimeSpan.FromSeconds(240));
+        var joined1 = string.Join(" | ", lines1);
+        var (_, d1) = ProtocolV2Streaming.Split(lines1);
+        // Request 1 is the control: the same AL, the same assertions, green. A red here is a
+        // general failure of the fixture, not this issue.
+        Assert.True(d1.GetProperty("passed").GetInt32() == 2 && d1.GetProperty("failed").GetInt32() == 0,
+            $"[{label}] request 1 (directory A) must pass both tests: {joined1}");
+
+        var mark = server.StdErrMark;
+        var lines2 = await server.SendRequestStreamingAsync(Req(dirB), TimeSpan.FromSeconds(240));
+        // Without the reuse line the request did not exercise #3250 at all — a green would be
+        // a plain compile, and a red could be a collision or a cache defect. The diagnostic is
+        // on stderr, not the protocol stream; StdErrSinceAsync times out when it never arrives.
+        var stderr2 = await server.StdErrSinceAsync(mark, ReuseLine);
+        return (lines2, stderr2);
+    }
+
+    private static void AssertRequest2((List<string> Lines, string StdErr) run, string label)
+    {
+        var (lines2, stderr2) = run;
+        var joined2 = string.Join(" | ", lines2);
+        Assert.Contains(ReuseLine, stderr2, StringComparison.Ordinal);
+        var (_, d2) = ProtocolV2Streaming.Split(lines2);
+        Assert.True(d2.GetProperty("passed").GetInt32() == 2 && d2.GetProperty("failed").GetInt32() == 0,
+            $"[{label}] request 2 (directory B, reused module) must pass both tests: {joined2}");
+    }
+
+    [SkippableFact]
+    public async Task ReusedModule_ReplaysEnumAndQueryRegistries_ColdThenWarmCache()
+    {
+        TestArtifacts.SkipIfMissing();
+        var root = TestScratch.Dir("al-runner-server-reuse-replay-3250");
+        var dirA = Path.Combine(root, "checkout-a");
+        var dirB = Path.Combine(root, "checkout-b");
+        var cache = Path.Combine(root, "cache");
+        WriteBundle(dirA);
+        WriteBundle(dirB);
+        try
+        {
+            AssertRequest2(await RunSessionAsync(dirA, dirB, new[] { "--cache", cache }, "cold"), "cold");
+            AssertRequest2(await RunSessionAsync(dirA, dirB, new[] { "--cache", cache }, "warm"), "warm");
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+
+    [SkippableFact]
+    public async Task ReusedModule_ReplaysEnumAndQueryRegistries_NoCache()
+    {
+        TestArtifacts.SkipIfMissing();
+        var root = TestScratch.Dir("al-runner-server-reuse-replay-3250-nocache");
+        var dirA = Path.Combine(root, "checkout-a");
+        var dirB = Path.Combine(root, "checkout-b");
+        WriteBundle(dirA);
+        WriteBundle(dirB);
+        try
+        {
+            AssertRequest2(await RunSessionAsync(dirA, dirB, new[] { "--no-cache" }, "no-cache"), "no-cache");
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+}

--- a/AlRunner.Tests/ServerCrossBundleReuseRegistryReplayTests.cs
+++ b/AlRunner.Tests/ServerCrossBundleReuseRegistryReplayTests.cs
@@ -160,6 +160,8 @@ public sealed class ServerCrossBundleReuseRegistryReplayTests
         try
         {
             AssertRequest2(await RunSessionAsync(dirA, dirB, new[] { "--cache", cache }, "cold"), "cold");
+            // The warm session is only a different branch if the cold one left an entry to HIT.
+            Assert.NotEmpty(Directory.EnumerateFiles(cache, "*.enum-registry.json", SearchOption.AllDirectories));
             AssertRequest2(await RunSessionAsync(dirA, dirB, new[] { "--cache", cache }, "warm"), "warm");
         }
         finally

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -2547,10 +2547,14 @@ public sealed partial class BcCompiler
     // LastBundleQuerySymbolsPath static below still exists for Program.cs (which copies the
     // file next to the AL-output cache DLL), but it is process-global and must not be read by
     // anything that cannot prove the current Emit set it — see CaptureRadMetadataSnapshotFull.
+    /// <summary>Where <see cref="EmitAndRegisterBundleQuerySymbols"/> writes this module's query
+    /// symbols in this process (#3250 reads it back for a reused module's replay).</summary>
+    internal static string BundleQuerySymbolsPathFor(string moduleName)
+        => Path.Combine(PerProcessScratch.Dir("al-runner-query-symbols", moduleName), "SymbolReference.json");
+
     private static string EmitAndRegisterBundleQuerySymbols(NavCA.Compilation compilation, string moduleName)
     {
-        var dir = PerProcessScratch.Dir("al-runner-query-symbols", moduleName);
-        var path = Path.Combine(dir, "SymbolReference.json");
+        var path = BundleQuerySymbolsPathFor(moduleName);
         using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None))
             SymbolJsonWriter.WriteSymbolJson(compilation, fs);
         AlRunner.Patches.RecordPatches.RegisterBundleQuerySymbolsJson(path);

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -55,7 +55,11 @@ public sealed class DependencyLoader
         // across all of them, so a cache hit has to hand back the whole set — re-registering
         // only Asm would put the later app groups in a run back into the pre-fix state that
         // LoadAll's registration loop exists to prevent.
-        IReadOnlyList<Assembly>? Assemblies = null)
+        IReadOnlyList<Assembly>? Assemblies = null,
+        // #3250: what RunBundleForServer replays when it hands this module to a bundle at a
+        // DIFFERENT directory — the registering bundle's own emit-derived registries, which
+        // ResetForNewBundleReload clears every request. Recorded for THIS Asm only.
+        OwnBundleRegistryReplay? OwnBundleReplay = null)
     {
         /// <summary>Every assembly of this app, primary first; never empty.</summary>
         internal IReadOnlyList<Assembly> AllAssemblies => Assemblies ?? new[] { Asm };
@@ -1377,6 +1381,21 @@ public sealed class DependencyLoader
     /// each rerun's freshly-compiled module must become the one a LATER sibling
     /// bundle in a subsequent request resolves to, not whatever compiled first.
     /// </summary>
+    /// <summary>
+    /// #3250: attach the registering bundle's registry replay to the entry holding
+    /// <paramref name="asm"/>. Does nothing when the entry for <paramref name="appId"/> holds a
+    /// different module, so a replay can never be paired with code it was not captured from.
+    /// </summary>
+    internal static void RecordOwnBundleReplay(Guid appId, Assembly asm, OwnBundleRegistryReplay replay)
+    {
+        if (_cache.TryGetValue(appId, out var entry) && ReferenceEquals(entry.Asm, asm))
+            _cache[appId] = entry with { OwnBundleReplay = replay };
+    }
+
+    /// <summary>The replay recorded for <paramref name="asm"/> under <paramref name="appId"/>, or null.</summary>
+    internal static OwnBundleRegistryReplay? TryGetOwnBundleReplay(Guid appId, Assembly asm)
+        => _cache.TryGetValue(appId, out var entry) && ReferenceEquals(entry.Asm, asm) ? entry.OwnBundleReplay : null;
+
     public static void RegisterLoaded(Guid appId, Assembly asm, string name, string publisher, string version, string sourcePath)
     {
         var newEntry = new LoadedAppEntry(asm, name, publisher, version, sourcePath);
@@ -1398,3 +1417,12 @@ public sealed class DependencyLoader
                 name, publisher, version, sourcePath);
     }
 }
+
+/// <summary>
+/// #3250: the files that put a bundle's emit-derived registries back after
+/// <c>BcRuntime.ResetForNewBundleReload</c>. <see cref="EnumRegistrySidecar"/> is the
+/// <c>.enum-registry.json</c> shape, which carries the enum, report, report-layout, page,
+/// xmlport and object-metadata registries; <see cref="QuerySymbolsJson"/> is null for a bundle
+/// that declares no query.
+/// </summary>
+internal sealed record OwnBundleRegistryReplay(string EnumRegistrySidecar, string? QuerySymbolsJson);

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -1423,6 +1423,11 @@ public sealed class DependencyLoader
 /// <c>BcRuntime.ResetForNewBundleReload</c>. <see cref="EnumRegistrySidecar"/> is the
 /// <c>.enum-registry.json</c> shape, which carries the enum, report, report-layout, page,
 /// xmlport and object-metadata registries; <see cref="QuerySymbolsJson"/> is null for a bundle
-/// that declares no query.
+/// that declares no query. <see cref="CaptureFailure"/> is set, and the paths are null, when
+/// capturing failed: a reuse must refuse rather than read it as "nothing to replay", which is
+/// what a module <c>LoadAll</c> registered looks like.
 /// </summary>
-internal sealed record OwnBundleRegistryReplay(string EnumRegistrySidecar, string? QuerySymbolsJson);
+internal sealed record OwnBundleRegistryReplay(string? EnumRegistrySidecar, string? QuerySymbolsJson, string? CaptureFailure = null)
+{
+    internal static OwnBundleRegistryReplay Failed(string reason) => new(null, null, reason);
+}

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -1356,6 +1356,21 @@ public sealed class DependencyLoader
     }
 
     /// <summary>
+    /// #3250: attach the registering bundle's registry replay to the entry holding
+    /// <paramref name="asm"/>. Does nothing when the entry for <paramref name="appId"/> holds a
+    /// different module, so a replay can never be paired with code it was not captured from.
+    /// </summary>
+    internal static void RecordOwnBundleReplay(Guid appId, Assembly asm, OwnBundleRegistryReplay replay)
+    {
+        if (_cache.TryGetValue(appId, out var entry) && ReferenceEquals(entry.Asm, asm))
+            _cache[appId] = entry with { OwnBundleReplay = replay };
+    }
+
+    /// <summary>The replay recorded for <paramref name="asm"/> under <paramref name="appId"/>, or null.</summary>
+    internal static OwnBundleRegistryReplay? TryGetOwnBundleReplay(Guid appId, Assembly asm)
+        => _cache.TryGetValue(appId, out var entry) && ReferenceEquals(entry.Asm, asm) ? entry.OwnBundleReplay : null;
+
+    /// <summary>
     /// Record that <paramref name="asm"/> is the loaded module for AL app identity
     /// <paramref name="appId"/> — used by the bundle loop's own-AppGroup compile path
     /// (Program.cs) so an app compiled as ITS OWN bundle is visible here too, not just
@@ -1381,21 +1396,6 @@ public sealed class DependencyLoader
     /// each rerun's freshly-compiled module must become the one a LATER sibling
     /// bundle in a subsequent request resolves to, not whatever compiled first.
     /// </summary>
-    /// <summary>
-    /// #3250: attach the registering bundle's registry replay to the entry holding
-    /// <paramref name="asm"/>. Does nothing when the entry for <paramref name="appId"/> holds a
-    /// different module, so a replay can never be paired with code it was not captured from.
-    /// </summary>
-    internal static void RecordOwnBundleReplay(Guid appId, Assembly asm, OwnBundleRegistryReplay replay)
-    {
-        if (_cache.TryGetValue(appId, out var entry) && ReferenceEquals(entry.Asm, asm))
-            _cache[appId] = entry with { OwnBundleReplay = replay };
-    }
-
-    /// <summary>The replay recorded for <paramref name="asm"/> under <paramref name="appId"/>, or null.</summary>
-    internal static OwnBundleRegistryReplay? TryGetOwnBundleReplay(Guid appId, Assembly asm)
-        => _cache.TryGetValue(appId, out var entry) && ReferenceEquals(entry.Asm, asm) ? entry.OwnBundleReplay : null;
-
     public static void RegisterLoaded(Guid appId, Assembly asm, string name, string publisher, string version, string sourcePath)
     {
         var newEntry = new LoadedAppEntry(asm, name, publisher, version, sourcePath);

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -5358,7 +5358,7 @@ return strictExitCode ? computedExitCode : 0;
                 catch (Exception ex)
                 {
                     return ServerRunResult.Failure(2, moduleName,
-                        $"reused module's registry replay failed ({ex.Message}: {ownReplay.EnumRegistrySidecar}) "
+                        $"reused module's registry replay failed: {ex.Message} "
                         + "— its enum, page, report, xmlport and query metadata would be missing (#3250)", fileHashes);
                 }
             }
@@ -5626,21 +5626,25 @@ return strictExitCode ? computedExitCode : 0;
                     // #3250: capture what a later request reusing this module from another
                     // directory must replay. The probe re-reads AL text only on a compile, which
                     // has just read all of it; a HIT reuses the cache gate's answer.
+                    OwnBundleRegistryReplay ownReplayCapture;
                     try
                     {
                         bool declaresQuery = cacheGateDeclaresQuery ?? BcCompiler.BundleDeclaresQuery(allPaths);
-                        DependencyLoader.RecordOwnBundleReplay(bundleId.AppId, asm, CaptureOwnBundleReplay(
+                        ownReplayCapture = CaptureOwnBundleReplay(
                             bundleId.AppId, moduleName, sidecarPath,
                             declaresQuery ? BcCompiler.BundleQuerySymbolsPathFor(moduleName) : null,
-                            querySidecarPath));
+                            querySidecarPath);
                     }
                     catch (Exception ex)
                     {
+                        // Recorded, not dropped: with nothing recorded a later reuse cannot tell
+                        // this module from one LoadAll registered, and runs without replaying.
+                        ownReplayCapture = OwnBundleRegistryReplay.Failed(ex.Message);
                         Console.Error.WriteLine(
                             $"  [server] {moduleName}: could not capture the registry replay for a later "
-                            + $"cross-bundle reuse of this module ({ex.Message}); that reuse would run "
-                            + "without this bundle's enum/page/report/xmlport/query metadata (#3250).");
+                            + $"cross-bundle reuse of this module ({ex.Message}); that reuse will refuse (#3250).");
                     }
+                    DependencyLoader.RecordOwnBundleReplay(bundleId.AppId, asm, ownReplayCapture);
                 }
             }
 

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -5348,6 +5348,20 @@ return strictExitCode ? computedExitCode : 0;
                     $"  [server] {moduleName}: AppId {bundleId.AppId} already loaded earlier in " +
                     "this request/session — reusing that module instead of recompiling " +
                     "(see issue #1683/#1892).");
+            // #3250: this request's ResetForNewBundleReload cleared the registries the reused
+            // module's emit populated, and the cache block below is skipped on reuse. Null for a
+            // module DependencyLoader.LoadAll registered, which replays its own Tier-3 sidecars.
+            if (reusedAsm != null
+                && DependencyLoader.TryGetOwnBundleReplay(bundleId.AppId, reusedAsm) is { } ownReplay)
+            {
+                try { ApplyOwnBundleReplay(ownReplay); }
+                catch (Exception ex)
+                {
+                    return ServerRunResult.Failure(2, moduleName,
+                        $"reused module's registry replay failed ({ex.Message}: {ownReplay.EnumRegistrySidecar}) "
+                        + "— its enum, page, report, xmlport and query metadata would be missing (#3250)", fileHashes);
+                }
+            }
         }
 
         // #1888: one app row per server-mode module (this mode never groups several
@@ -5367,6 +5381,7 @@ return strictExitCode ? computedExitCode : 0;
             // the request, exactly like an AL-output cache hit.
             bool cached = reusedAsm != null;
             string? cacheKey = null, cachePath = null, sidecarPath = null, querySidecarPath = null;
+            bool? cacheGateDeclaresQuery = null;
             if (reusedAsm == null && alCacheDir != null)
             {
                 // See AlCacheSidecars: a query bundle without its query-symbols sidecar must
@@ -5394,6 +5409,7 @@ return strictExitCode ? computedExitCode : 0;
                 bool bundleDeclaresQuery;
                 using (AlRunner.Infrastructure.PhaseLog.AppStage("query-decl-probe"))
                     bundleDeclaresQuery = BcCompiler.BundleDeclaresQuery(allPaths);
+                cacheGateDeclaresQuery = bundleDeclaresQuery;
                 cacheKey = ComputeAlCacheKey(allPaths, moduleName,
                     ordered: serverDepIds.Terms, appRootDir: bucketRoot);
                 cachePath = Path.Combine(alCacheDir, cacheKey + ".dll");
@@ -5606,6 +5622,24 @@ return strictExitCode ? computedExitCode : 0;
                         // this process, one request at a time) race window between
                         // that check and this registration — see loud-failures.md.
                         return ServerRunResult.Failure(3, moduleName, $"FATAL: {ex.Message}", fileHashes);
+                    }
+                    // #3250: capture what a later request reusing this module from another
+                    // directory must replay. The probe re-reads AL text only on a compile, which
+                    // has just read all of it; a HIT reuses the cache gate's answer.
+                    try
+                    {
+                        bool declaresQuery = cacheGateDeclaresQuery ?? BcCompiler.BundleDeclaresQuery(allPaths);
+                        DependencyLoader.RecordOwnBundleReplay(bundleId.AppId, asm, CaptureOwnBundleReplay(
+                            bundleId.AppId, moduleName, sidecarPath,
+                            declaresQuery ? BcCompiler.BundleQuerySymbolsPathFor(moduleName) : null,
+                            querySidecarPath));
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine(
+                            $"  [server] {moduleName}: could not capture the registry replay for a later "
+                            + $"cross-bundle reuse of this module ({ex.Message}); that reuse would run "
+                            + "without this bundle's enum/page/report/xmlport/query metadata (#3250).");
                     }
                 }
             }

--- a/AlRunner/ProgramSupport/OwnBundleReplay.cs
+++ b/AlRunner/ProgramSupport/OwnBundleReplay.cs
@@ -1,0 +1,73 @@
+namespace AlRunner;
+
+// #3250: RunBundleForServer's cross-bundle reuse hands a bundle at directory B the module an
+// earlier request loaded from directory A. The request's ResetForNewBundleReload has already
+// cleared the emit-derived registries, and the AL-output cache block that replays them is
+// skipped on reuse — so the replay is captured when A's module is registered and applied
+// when it is handed back.
+internal static partial class ProgramSupport
+{
+    /// <summary>
+    /// The replay for a module just loaded from <paramref name="moduleName"/>. Prefers the
+    /// AL-output cache's own sidecars when they are on disk; otherwise (no cache, NOKEY, a
+    /// failed cache write) writes a per-process snapshot, because the registries are about to
+    /// be cleared by the next request and nothing else keeps them.
+    /// </summary>
+    /// <param name="querySymbolsJson">
+    /// This bundle's query-symbols file, or null when it declares no query. Not
+    /// <c>BcCompiler.LastBundleQuerySymbolsPath</c>: the incremental emit path does not reset it,
+    /// so it can name another module's file.
+    /// </param>
+    internal static OwnBundleRegistryReplay CaptureOwnBundleReplay(
+        Guid appId, string moduleName, string? cacheEnumSidecar, string? querySymbolsJson, string? cacheQuerySidecar)
+    {
+        string? dir = null;
+        string ScratchDir() => dir ??= AlRunner.Infrastructure.PerProcessScratch.Dir(
+            "al-runner-own-bundle-replay", $"{moduleName}-{appId:N}");
+
+        string enumPath;
+        if (cacheEnumSidecar != null && File.Exists(cacheEnumSidecar))
+            enumPath = cacheEnumSidecar;
+        else
+        {
+            enumPath = Path.Combine(ScratchDir(), "enum-registry.json");
+            SaveEnumRegistrySidecar(enumPath);
+        }
+
+        string? queryPath = null;
+        if (querySymbolsJson != null)
+        {
+            if (cacheQuerySidecar != null && File.Exists(cacheQuerySidecar))
+                queryPath = cacheQuerySidecar;
+            else if (File.Exists(querySymbolsJson))
+            {
+                // Copied: BcCompiler's per-process file is keyed on the module NAME, which a
+                // later bundle of another app can share and overwrite.
+                queryPath = Path.Combine(ScratchDir(), "SymbolReference.json");
+                File.Copy(querySymbolsJson, queryPath, overwrite: true);
+            }
+        }
+        return new OwnBundleRegistryReplay(enumPath, queryPath);
+    }
+
+    /// <summary>
+    /// Replays <paramref name="replay"/> into the registries. Returns the enum entries replayed.
+    /// Throws when a recorded file is gone: running the reused module without its metadata is the
+    /// silent wrong answer #3250 is about (loud-failures.md).
+    /// </summary>
+    internal static int ApplyOwnBundleReplay(OwnBundleRegistryReplay replay)
+    {
+        if (!File.Exists(replay.EnumRegistrySidecar))
+            throw new FileNotFoundException(
+                "the registry snapshot recorded for the reused module is gone", replay.EnumRegistrySidecar);
+        int replayed = LoadEnumRegistrySidecar(replay.EnumRegistrySidecar);
+        if (replay.QuerySymbolsJson != null)
+        {
+            if (!File.Exists(replay.QuerySymbolsJson))
+                throw new FileNotFoundException(
+                    "the query symbols recorded for the reused module are gone", replay.QuerySymbolsJson);
+            AlRunner.Patches.RecordPatches.RegisterBundleQuerySymbolsJson(replay.QuerySymbolsJson);
+        }
+        return replayed;
+    }
+}

--- a/AlRunner/ProgramSupport/OwnBundleReplay.cs
+++ b/AlRunner/ProgramSupport/OwnBundleReplay.cs
@@ -7,6 +7,8 @@ namespace AlRunner;
 // when it is handed back.
 internal static partial class ProgramSupport
 {
+    private const string InjectCaptureFailureEnvVar = "AL_RUNNER_TEST_FAIL_OWN_BUNDLE_REPLAY_CAPTURE";
+
     /// <summary>
     /// The replay for a module just loaded from <paramref name="moduleName"/>. Prefers the
     /// AL-output cache's own sidecars when they are on disk; otherwise (no cache, NOKEY, a
@@ -21,6 +23,11 @@ internal static partial class ProgramSupport
     internal static OwnBundleRegistryReplay CaptureOwnBundleReplay(
         Guid appId, string moduleName, string? cacheEnumSidecar, string? querySymbolsJson, string? cacheQuerySidecar)
     {
+        // Test-only seam, same family and gating as AL_RUNNER_TEST_FAIL_COMPANY_INIT: no shipped
+        // path sets it, and a capture failure has no other deterministic trigger. Its value
+        // becomes the exception message.
+        if (Environment.GetEnvironmentVariable(InjectCaptureFailureEnvVar) is { Length: > 0 } injected)
+            throw new IOException(injected);
         string? dir = null;
         string ScratchDir() => dir ??= AlRunner.Infrastructure.PerProcessScratch.Dir(
             "al-runner-own-bundle-replay", $"{moduleName}-{appId:N}");
@@ -57,15 +64,22 @@ internal static partial class ProgramSupport
     /// </summary>
     internal static int ApplyOwnBundleReplay(OwnBundleRegistryReplay replay)
     {
+        if (replay.CaptureFailure != null || replay.EnumRegistrySidecar == null)
+            throw new InvalidOperationException(
+                $"capturing the registries failed when the module was loaded: {replay.CaptureFailure}");
         if (!File.Exists(replay.EnumRegistrySidecar))
             throw new FileNotFoundException(
-                "the registry snapshot recorded for the reused module is gone", replay.EnumRegistrySidecar);
+                $"the registry snapshot recorded for the reused module is gone: {replay.EnumRegistrySidecar}",
+                replay.EnumRegistrySidecar);
         int replayed = LoadEnumRegistrySidecar(replay.EnumRegistrySidecar);
         if (replay.QuerySymbolsJson != null)
         {
+            // The fallback when BC's captured query document is missing, as on the cache-HIT
+            // branch (#4040).
             if (!File.Exists(replay.QuerySymbolsJson))
                 throw new FileNotFoundException(
-                    "the query symbols recorded for the reused module are gone", replay.QuerySymbolsJson);
+                    $"the query symbols recorded for the reused module are gone: {replay.QuerySymbolsJson}",
+                    replay.QuerySymbolsJson);
             AlRunner.Patches.RecordPatches.RegisterBundleQuerySymbolsJson(replay.QuerySymbolsJson);
         }
         return replayed;


### PR DESCRIPTION
Closes #3250

Written by agent stma-auto2-3 on the account holder's behalf.

Corpus-NA: server-mode cross-bundle module reuse across two requests; the corpus runs one app per service tier and has no warm multi-request session to express this in

## What was wrong

In `--server`, `RunBundleForServer` reuses an already-loaded module when an earlier request loaded the same AppId from a different directory (#1683/#1892). That reuse skipped the AL-output cache block, and that block is the only place two things get put back after the request's `ResetForNewBundleReload`:

- the `.enum-registry.json` sidecar. Despite the name, `SaveEnumRegistrySidecar` writes six registries into it: enum, report, report-layout, page, xmlport and object metadata. `ResetForNewBundleReload` clears all six.
- the bundle's query symbols (`RegisterBundleQuerySymbolsJson`).

Measured on `main` with the new test: directory A in request 1 passes. Directory B (same app.json) in request 2 takes the reuse path, and then `Format(Enum::"R3250 Color"::Blue)` returns `1` instead of `Deep Blue`. The query tests fail with a `NullReferenceException`.

## The fix

- `DependencyLoader.LoadedAppEntry` now carries an `OwnBundleRegistryReplay` (enum-registry sidecar path, plus a query-symbols path when the bundle declares a query). `RunBundleForServer` records it right after `RegisterLoaded` for a freshly loaded module, and `RecordOwnBundleReplay` refuses to attach it to an entry holding a different `Assembly`. That way the replay always matches the code that runs, even if B's AL differs from A's under the same identity.
- On reuse, `ApplyOwnBundleReplay` replays it. If a recorded file is gone, the request fails with a named reason instead of running without metadata.
- Capture prefers the AL-output cache's own sidecars (no extra I/O on HIT, or on a MISS whose cache write succeeded). With `--no-cache`, NOKEY or a failed cache write, it writes a per-process snapshot. The query symbols are copied there because `BcCompiler`'s per-process file is keyed on the module name, and another app can share that name.
- I did not use `BcCompiler.LastBundleQuerySymbolsPath` for the capture. The incremental emit path does not reset it, so it can name another module's file. I added `BcCompiler.BundleQuerySymbolsPathFor(moduleName)`, which is the path `EmitAndRegisterBundleQuerySymbols` writes to (it now calls the helper too). Whether the bundle declares a query comes from the cache gate's existing probe on HIT/MISS, and from a probe after the compile otherwise. The #2557 concern (a whole-tree scan on the reuse path) does not apply, because nothing probes on reuse.

## RED -> GREEN

`AlRunner.Tests/ServerCrossBundleReuseRegistryReplayTests.cs`: a dedicated server per session (never `SharedCliServer`, same reason as `ServerAppVersionBumpTests`). Request 1 runs directory A, request 2 runs directory B, same manifest. The fixture has an enum with per-value captions, a single-dataitem query and a two-dataitem join query. Request 1 must be green (the control). Request 2 must print the reuse line on stderr (so the test proves the reuse path actually ran) and pass all three tests. Two facts: cold then warm against **one** `--cache` root (asserting the cold session left an entry for the warm one to HIT), and `--no-cache`.

- RED (fix absent, two-test fixture): `Failed: 2, Passed: 0, Total: 2`. Both facts fail in request 2 with `Format(enum) answered <1>, expected <Deep Blue>` and a query `NullReferenceException`.
- GREEN (three-test fixture): `Failed: 0, Passed: 2, Total: 2`. Cold, warm and no-cache all pass.

## Mutations (one per observable)

1. Enum/metadata half: `ApplyOwnBundleReplay` skips `LoadEnumRegistrySidecar` -> `Failed: 2, Passed: 0`. Only `EnumCaptionComesFromTheRegistry` fails. Both query tests pass. With the sidecar replay gone, only the query-symbols replay is left, so the query-symbols half is live and sufficient on its own.
2. Query-symbols half alone: skip `RegisterBundleQuerySymbolsJson` -> `Failed: 0, Passed: 2`. **Every test stays green.** I first probed that the recorded paths were non-null and correct in all three sessions (scratch copy for no-cache, `<key>.query-symbols.json` on cold/warm). They were, so the mutation did land. Either replay alone makes the query tests pass. I did not establish which mechanism serves the query metadata when the query symbols are not registered, so I am not naming one. Adding the join query did not separate the two.
3. Both halves off -> `Failed: 2, Passed: 0`. All three tests fail, including both queries.

So the tests prove the enum/metadata replay directly. For the query-symbols replay, they prove it is sufficient but not that it is necessary: for these two query shapes, either replay alone fixes the query. I kept the query-symbols replay anyway, because it matches what the cache-HIT branch already does. Removing it is a separate decision that needs a query shape the object metadata cannot serve.

## Review round 1 (two refusal paths)

The reviewer found two gaps at `2cabb022`. Both are fixed, and each has a test and a mutation. The fixture now also has the join query, so the class has four facts.

1. **A recorded replay file that is gone.** New fact `ReusedModule_WhoseRecordedSidecarIsGone_RefusesWithANamedReason`: a cold `--cache` session deletes the cache's `.enum-registry.json` between request 1 and request 2. Request 2 must print the reuse line, report a non-zero exit with `passed: 0`, and carry `reused module's registry replay failed` plus `the registry snapshot recorded for the reused module is gone` in its `compilationErrors`. The test reads the parsed summary, because the raw JSON escapes the apostrophe.
   - Mutation: `ApplyOwnBundleReplay` returns 0 silently when the file is missing -> `Failed: 1, Passed: 3, Total: 4`. Only this fact fails, on the named-reason assertion.
2. **A failed capture.** A failed capture used to be logged and nothing recorded, so a later reuse could not tell it apart from a module `LoadAll` registered, and ran with no replay. Now `OwnBundleRegistryReplay.Failed(reason)` is recorded, and `ApplyOwnBundleReplay` refuses on it. The capture failure is triggered by a new test-only env var, `AL_RUNNER_TEST_FAIL_OWN_BUNDLE_REPLAY_CAPTURE`. It is gated like `AL_RUNNER_TEST_FAIL_COMPANY_INIT`: no shipped path sets it, and its value becomes the exception message. New fact `ReusedModule_WhoseCaptureFailed_RefusesInsteadOfRunningWithoutReplay` (`--no-cache`): request 1 still passes, and request 2 must refuse naming the injected reason.
   - Mutation A, pre-review behavior (nothing recorded on failure) -> `Failed: 1, Passed: 3, Total: 4`. Only this fact fails.
   - Mutation B, the refusal returns 0 silently -> `Failed: 1, Passed: 3, Total: 4`. Only this fact fails.
3. The query-symbols replay stays, with a one-clause note at the call: it is the fallback when BC's captured query document is missing, the same as on the cache-HIT branch (#4040).

GREEN after the round: `Failed: 0, Passed: 4, Total: 4`. `GuardTests` filter: `Failed: 1, Passed: 248, Total: 249`. The one failure is again `BcEngineReadinessGuardTests` (the engine bootstrap was not run on this box). `tools/test_doc_summary_uniqueness.py` passes.

## Fix the shape

1. **Same pattern at another call site:** the CLI bundle loop (`Program.cs`, the `reusedAsm` check in the per-AppGroup loop) has the same skip. I did not change it, and here is why: within one invocation, and within each `--watch` cycle, the app group that first registers an AppId runs in the same cycle as the group that reuses it. It recompiles or cache-HITs after that cycle's reset, so it has already repopulated the registries before the reuse. The server can hit the bug because the registering bundle ran in an **earlier request** whose registries the reset has since wiped. The CLI has no such cross-cycle shape: `TryGetByAppId` returns null for a same-SourcePath lookup, so the first group always re-registers. This is reasoning, not a test.
2. **Sibling assumptions:** `DependencyLoader.LoadAll`'s reuse replays Tier-3 sidecars but no query symbols (the issue notes this). That needs a different mechanism (writing the file at Tier-3 compile time), so I filed it separately as #4040. It records the missing write path as the fact and leaves open whether AL can observe it, because I did not measure that. Also unmeasured: a server bundle reusing a module that `LoadAll` registered as a Tier-3 dependency in an earlier request. That entry has no own-bundle replay (`TryGetOwnBundleReplay` returns null), so it behaves as before this PR.
3. **Two writers, one invariant:** the cache-HIT branch and the reuse branch now both replay the same two things before the module runs. One property the snapshot shares with the existing cache sidecar: it captures the process-wide registries at registration time, so it also carries whatever earlier bundles in that request had registered. That is the same behavior a HIT replay already has, not a new one.

## Queue scan

I searched open issues for `ReplayDependencyMetadataSidecars`, `query-symbols`, `cross-bundle reuse`, `TryGetByAppId`, `enum-registry sidecar`, `RunBundleForServer` and `ResetForNewBundleReload`. None to fold in:
- #2655 (watch cycles losing an unchanged app group's metadata) is a different site (`BcCompiler.Incremental` RAD snapshot) and not verified.
- #3958 (sidecar round-trip coverage) is claimed by another loop in PR #4023, which only adds `AlRunner.Tests/MetadataRegistrySidecarRoundTripTests.cs`. It does not overlap this diff.
- #3282 and #3499 are different mechanisms.

## Local runs

- Filtered: `ServerCrossBundleReuseRegistryReplayTests|GuardTests|AppIdCollisionLoudFailureTests|ServerCrossBundleModuleIdentityDedupTests|ServerAppVersionBumpTests` -> `Failed: 1, Passed: 259, Total: 260`. The one failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned`, which refuses because this box did not run `tools/engine-test-bootstrap.sh`. That also means every in-process `bc-engine-serial` test in that count asserted nothing. The proving tests are `CliServer` subprocess tests and are not affected by that, but the 259 is not broad engine coverage.
- `tools/test_*.py`: `test_doc_summary_uniqueness.py` caught a doc comment I had split from `RegisterLoaded`. That is fixed and passes now. `test_agent_self_freshness.py`, `test_corpus_checkout.py` and `test_preflight.py` fail here only because `git commit` in their temp repos hits this box's 1Password signing (`failed to fill whole buffer`).

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
