### PR TITLE
fix(report): Base App report 1306 resolves no valid layout

### DIFF
--- a/AlRunner.Tests/DependencyReportLayoutTests.cs
+++ b/AlRunner.Tests/DependencyReportLayoutTests.cs
@@ -1,0 +1,168 @@
+// DependencyReportLayoutTests — #2297: a report in a precompiled dependency declares its layouts
+// only in SymbolReference.json, so the runner must read them there. The BC-observable claims
+// (Report.DefaultLayout, "Report Layout List" rows for Base App reports 1306/1320) live in the
+// corpus; these pin the runner's own parse and emit.
+
+using System.IO.Compression;
+using System.Text;
+using System.Xml.Linq;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(CacheRootsSerialCollection.Name)]
+public class DependencyReportLayoutTests
+{
+    // Real shapes from Base Application 28.1: 1306 uses the rendering syntax (Word default, not
+    // the first-declared RDLC), 1320 the legacy one, 795 neither.
+    private const string SymbolReference = """
+        {
+          "RuntimeVersion": "15.1",
+          "Namespaces": [
+            {
+              "Name": "Sales",
+              "Reports": [
+                {
+                  "Id": 1306,
+                  "Name": "Standard Sales - Invoice",
+                  "Properties": [
+                    { "Name": "Caption", "Value": "Sales - Invoice" },
+                    { "Name": "DefaultRenderingLayout", "Value": "StandardSalesInvoice.docx" }
+                  ],
+                  "Layouts": [
+                    { "Name": "StandardSalesInvoice.rdlc", "Properties": [
+                      { "Name": "Type", "Value": "RDLC" },
+                      { "Name": "LayoutFile", "Value": "./Sales/History/StandardSalesInvoice.rdlc" },
+                      { "Name": "Caption", "Value": "Standard Sales Invoice (RDLC)" } ] },
+                    { "Name": "StandardSalesInvoice.docx", "Properties": [
+                      { "Name": "Type", "Value": "Word" },
+                      { "Name": "LayoutFile", "Value": "./Sales/History/StandardSalesInvoice.docx" },
+                      { "Name": "Summary", "Value": "Simple layout." } ] }
+                  ]
+                },
+                {
+                  "Id": 1320,
+                  "Name": "Notification Email",
+                  "Properties": [
+                    { "Name": "WordLayout", "Value": "./System/Notifications/NotificationEmail.docx" },
+                    { "Name": "DefaultLayout", "Value": "Word" }
+                  ]
+                },
+                {
+                  "Id": 795,
+                  "Name": "Adjust Cost - Item Entries",
+                  "Properties": [ { "Name": "ProcessingOnly", "Value": "1" } ]
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private static IReadOnlyList<BcAppSymbolCache.ReportSymbol> ReadReports(string dir)
+    {
+        var appPath = Path.Combine(dir, Guid.NewGuid().ToString("N") + ".app");
+        using (var fs = new FileStream(appPath, FileMode.Create))
+        using (var za = new ZipArchive(fs, ZipArchiveMode.Create))
+        using (var w = new StreamWriter(za.CreateEntry("SymbolReference.json").Open(), Encoding.UTF8))
+            w.Write(SymbolReference);
+        return BcAppSymbolCache.Get(appPath).Reports;
+    }
+
+    private static void WithReports(Action<IReadOnlyList<BcAppSymbolCache.ReportSymbol>> body)
+    {
+        var dir = TestScratch.Dir("al-runner-dep-report-layout-tests");
+        Directory.CreateDirectory(dir);
+        try { body(ReadReports(dir)); }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Layouts_AreReadVerbatim_WithTheDefaultRenderingLayout()
+    {
+        WithReports(reports =>
+        {
+            var invoice = Assert.Single(reports, r => r.Id == 1306);
+            Assert.Equal("StandardSalesInvoice.docx", invoice.DefaultRenderingLayout);
+            Assert.NotNull(invoice.Layouts);
+            Assert.Equal(new[] { "StandardSalesInvoice.rdlc", "StandardSalesInvoice.docx" },
+                invoice.Layouts!.Select(l => l.Name));
+            Assert.Equal(new[] { "RDLC", "Word" }, invoice.Layouts.Select(l => l.Type));
+            Assert.Equal("./Sales/History/StandardSalesInvoice.docx", invoice.Layouts[1].LayoutFile);
+            Assert.Equal("Standard Sales Invoice (RDLC)", invoice.Layouts[0].Caption);
+            Assert.Null(invoice.Layouts[0].Summary);
+            Assert.Equal("Simple layout.", invoice.Layouts[1].Summary);
+            Assert.Null(invoice.LegacyDefaultLayout);
+
+            var legacy = Assert.Single(reports, r => r.Id == 1320);
+            Assert.Null(legacy.Layouts);
+            Assert.Null(legacy.DefaultRenderingLayout);
+            Assert.Equal("Word", legacy.LegacyDefaultLayout);
+        });
+    }
+
+    [Fact]
+    public void EmittedMetadata_RenderingSyntax_CarriesTheDefaultLayoutsTypeAndTheLayoutNames()
+    {
+        WithReports(reports =>
+        {
+            var root = XDocument.Parse(RecordPatches.EmitReportXml(
+                reports.Single(r => r.Id == 1306), sourceExprByColumn: null)).Root!;
+
+            Assert.Equal("StandardSalesInvoice.docx", root.Element("DefaultLayoutName")?.Value);
+            // The Type of the layout the default NAMES — not the first declared (RDLC).
+            Assert.Equal("Word", root.Element("DefaultRenderingLayoutType")?.Value);
+            Assert.Null(root.Element("DefaultLayout"));
+            Assert.Equal(new[] { "StandardSalesInvoice.rdlc", "StandardSalesInvoice.docx" },
+                root.Element("Layouts")!.Elements("Layout").Select(l => l.Element("Name")!.Value));
+        });
+    }
+
+    [Fact]
+    public void EmittedMetadata_LegacySyntax_CarriesDefaultLayout_AndNoInventedName()
+    {
+        WithReports(reports =>
+        {
+            var root = XDocument.Parse(RecordPatches.EmitReportXml(
+                reports.Single(r => r.Id == 1320), sourceExprByColumn: null)).Root!;
+
+            Assert.Equal("Word", root.Element("DefaultLayout")?.Value);
+            Assert.Null(root.Element("DefaultLayoutName"));
+            Assert.Null(root.Element("DefaultRenderingLayoutType"));
+            Assert.Null(root.Element("Layouts"));
+        });
+    }
+
+    [Fact]
+    public void EmittedMetadata_NoLayoutDeclared_StatesNoDefault()
+    {
+        WithReports(reports =>
+        {
+            var root = XDocument.Parse(RecordPatches.EmitReportXml(
+                reports.Single(r => r.Id == 795), sourceExprByColumn: null)).Root!;
+
+            Assert.Null(root.Element("DefaultLayout"));
+            Assert.Null(root.Element("DefaultLayoutName"));
+            Assert.Null(root.Element("DefaultRenderingLayoutType"));
+            Assert.Null(root.Element("Layouts"));
+        });
+    }
+
+    [Fact]
+    public void LayoutListRows_MarkOnlyTheNamedDefault_AndClaimNoLayoutBytes()
+    {
+        WithReports(reports =>
+        {
+            var rows = RecordPatches.DependencyReportLayouts(reports.Single(r => r.Id == 1306)).ToList();
+
+            Assert.Equal(2, rows.Count);
+            Assert.All(rows, r => Assert.Equal(1306, r.ReportId));
+            Assert.All(rows, r => Assert.Equal(string.Empty, r.ResolvedPath));
+            Assert.Equal("StandardSalesInvoice.docx", Assert.Single(rows, r => r.IsDefault).Name);
+            Assert.Equal("RDLC", rows.Single(r => r.Name == "StandardSalesInvoice.rdlc").LayoutType);
+
+            Assert.Empty(RecordPatches.DependencyReportLayouts(reports.Single(r => r.Id == 1320)));
+        });
+    }
+}

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -827,7 +827,17 @@ internal static partial class BcAppSymbolCache
         // reports states either mask, and it spells both "X". The decoder's indirect bits
         // are therefore unexercised on this kind, which is the reason to carry the letters
         // verbatim rather than rest on a population that happens not to need them.
-        string? InherentEntitlements = null, string? InherentPermissions = null);
+        string? InherentEntitlements = null, string? InherentPermissions = null,
+        // The `rendering { layout(Name) { … } }` declarations and the report's
+        // DefaultRenderingLayout, as the symbol file states them (#2297). Null Layouts means
+        // the report declares no rendering block; 62 of Base Application 28.1's 659 reports do.
+        List<ReportLayoutSymbol>? Layouts = null, string? DefaultRenderingLayout = null,
+        // The legacy `DefaultLayout = RDLC|Word|…` property, verbatim — the other 328 reports.
+        string? LegacyDefaultLayout = null);
+
+    /// <summary>One <c>layout(Name) { Type; MimeType; LayoutFile; Caption; Summary }</c>, verbatim.</summary>
+    internal sealed record ReportLayoutSymbol(
+        string Name, string? Type, string? MimeType, string? LayoutFile, string? Caption, string? Summary);
 
     /// <summary>One entry of a report's data-item tree, flattened in declaration order.</summary>
     internal sealed record ReportDataItemSymbol(
@@ -2271,11 +2281,34 @@ internal static partial class BcAppSymbolCache
             ? rsf.GetString()
             : null;
 
+        props.TryGetValue("DefaultRenderingLayout", out var defaultRenderingLayout);
+        props.TryGetValue("DefaultLayout", out var legacyDefaultLayout);
+
         return new ReportSymbol(reportId, name, caption, processingOnly, useRequestPage,
             wordMergeDataItem, dataItems, referenceSourceFileName,
             string.IsNullOrWhiteSpace(alNamespace) ? null : alNamespace.Trim(),
             string.IsNullOrWhiteSpace(inherentEntitlements) ? null : inherentEntitlements.Trim(),
-            string.IsNullOrWhiteSpace(inherentPermissions) ? null : inherentPermissions.Trim());
+            string.IsNullOrWhiteSpace(inherentPermissions) ? null : inherentPermissions.Trim(),
+            ReadReportLayouts(report),
+            string.IsNullOrWhiteSpace(defaultRenderingLayout) ? null : defaultRenderingLayout,
+            string.IsNullOrWhiteSpace(legacyDefaultLayout) ? null : legacyDefaultLayout.Trim());
+    }
+
+    private static List<ReportLayoutSymbol>? ReadReportLayouts(JsonElement report)
+    {
+        if (!report.TryGetProperty("Layouts", out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return null;
+        var result = new List<ReportLayoutSymbol>();
+        foreach (var layout in arr.EnumerateArray())
+        {
+            var name = layout.TryGetProperty("Name", out var n) ? n.GetString() : null;
+            if (string.IsNullOrEmpty(name)) continue;
+            var p = SymbolProperties(layout);
+            string? Get(string key) => p.TryGetValue(key, out var v) && !string.IsNullOrEmpty(v) ? v : null;
+            result.Add(new ReportLayoutSymbol(name, Get("Type"), Get("MimeType"), Get("LayoutFile"),
+                Get("Caption"), Get("Summary")));
+        }
+        return result.Count == 0 ? null : result;
     }
 
     /// <summary>

--- a/AlRunner/Patches/DependencyReportMetadata.cs
+++ b/AlRunner/Patches/DependencyReportMetadata.cs
@@ -287,21 +287,6 @@ public static partial class RecordPatches
     }
 
     /// <summary>
-    /// The three report-level properties SymbolReference.json states that this derivation was
-    /// leaving at BC's own design-object defaults (#3808) — <c>ALNamespace</c> (null) and both
-    /// inherent masks (<c>None</c>).
-    ///
-    /// <para>BC's <c>MetaReport(XmlElement, …)</c> reader takes <c>ALNAMESPACE</c> as
-    /// <c>InnerText</c> verbatim and both masks through
-    /// <c>Enum.Parse(typeof(PermissionMask), InnerText)</c>, so the masks are written as the
-    /// DECODED NUMBER rather than the AL letter spelling — "X" is not a PermissionMask member
-    /// and would throw where the value the symbol file states is perfectly readable.</para>
-    ///
-    /// <para>Deliberately NOT written here: the <c>&lt;RequestPage&gt;</c> subtree, whose
-    /// element BC deserializes into a whole MetaPageDefinition. That is the other half of
-    /// #3808 and stays open — see docs/metadata-equivalence.md#reports.</para>
-    /// </summary>
-    /// <summary>
     /// The default-layout pair BC's <c>DefaultLayoutInternal</c> reads (#2297), in the element
     /// shape BC's own emit writes for a source-compiled report: rendering syntax gives
     /// <c>DefaultLayoutName</c> + <c>DefaultRenderingLayoutType</c> (the Type of the layout that
@@ -325,6 +310,21 @@ public static partial class RecordPatches
             w.WriteElementString("DefaultLayout", report.LegacyDefaultLayout);
     }
 
+    /// <summary>
+    /// The three report-level properties SymbolReference.json states that this derivation was
+    /// leaving at BC's own design-object defaults (#3808) — <c>ALNamespace</c> (null) and both
+    /// inherent masks (<c>None</c>).
+    ///
+    /// <para>BC's <c>MetaReport(XmlElement, …)</c> reader takes <c>ALNAMESPACE</c> as
+    /// <c>InnerText</c> verbatim and both masks through
+    /// <c>Enum.Parse(typeof(PermissionMask), InnerText)</c>, so the masks are written as the
+    /// DECODED NUMBER rather than the AL letter spelling — "X" is not a PermissionMask member
+    /// and would throw where the value the symbol file states is perfectly readable.</para>
+    ///
+    /// <para>Deliberately NOT written here: the <c>&lt;RequestPage&gt;</c> subtree, whose
+    /// element BC deserializes into a whole MetaPageDefinition. That is the other half of
+    /// #3808 and stays open — see docs/metadata-equivalence.md#reports.</para>
+    /// </summary>
     private static void WriteDerivableReportProperties(XmlWriter w, BcAppSymbolCache.ReportSymbol report)
     {
         if (!string.IsNullOrEmpty(report.ALNamespace))

--- a/AlRunner/Patches/DependencyReportMetadata.cs
+++ b/AlRunner/Patches/DependencyReportMetadata.cs
@@ -259,6 +259,7 @@ public static partial class RecordPatches
             }
             if (!string.IsNullOrEmpty(report.WordMergeDataItem))
                 w.WriteElementString("WordMergeDataItem", report.WordMergeDataItem);
+            WriteDefaultLayout(w, report);
             w.WriteElementString("MetadataVersion", "130000");
             w.WriteElementString("ID", report.Id.ToString(System.Globalization.CultureInfo.InvariantCulture));
             w.WriteElementString("Name", report.Name);
@@ -266,6 +267,19 @@ public static partial class RecordPatches
 
             foreach (var di in report.DataItems)
                 WriteDataItem(w, di, sourceExprByColumn);
+
+            if (report.Layouts is { Count: > 0 })
+            {
+                w.WriteStartElement("Layouts");
+                foreach (var layout in report.Layouts)
+                {
+                    w.WriteStartElement("Layout");
+                    w.WriteElementString("Name", layout.Name);
+                    w.WriteElementString("LayoutFriendlyName", layout.Name);
+                    w.WriteEndElement();
+                }
+                w.WriteEndElement();
+            }
 
             w.WriteEndElement();
         }
@@ -287,6 +301,30 @@ public static partial class RecordPatches
     /// element BC deserializes into a whole MetaPageDefinition. That is the other half of
     /// #3808 and stays open — see docs/metadata-equivalence.md#reports.</para>
     /// </summary>
+    /// <summary>
+    /// The default-layout pair BC's <c>DefaultLayoutInternal</c> reads (#2297), in the element
+    /// shape BC's own emit writes for a source-compiled report: rendering syntax gives
+    /// <c>DefaultLayoutName</c> + <c>DefaultRenderingLayoutType</c> (the Type of the layout that
+    /// name selects), legacy syntax gives <c>DefaultLayout</c>. Absent either way leaves BC's
+    /// own RDLC fallback, which is what it answers for a report stating neither.
+    /// Trap: legacy syntax also gets a compiler-derived DefaultLayoutName (the layout FILE
+    /// path); the symbol file does not state it, so it is not written here.
+    /// </summary>
+    private static void WriteDefaultLayout(XmlWriter w, BcAppSymbolCache.ReportSymbol report)
+    {
+        if (!string.IsNullOrEmpty(report.DefaultRenderingLayout))
+        {
+            var chosen = report.Layouts?.FirstOrDefault(l =>
+                string.Equals(l.Name, report.DefaultRenderingLayout, StringComparison.OrdinalIgnoreCase));
+            w.WriteElementString("DefaultLayoutName", report.DefaultRenderingLayout);
+            if (!string.IsNullOrEmpty(chosen?.Type))
+                w.WriteElementString("DefaultRenderingLayoutType", chosen.Type);
+            return;
+        }
+        if (!string.IsNullOrEmpty(report.LegacyDefaultLayout))
+            w.WriteElementString("DefaultLayout", report.LegacyDefaultLayout);
+    }
+
     private static void WriteDerivableReportProperties(XmlWriter w, BcAppSymbolCache.ReportSymbol report)
     {
         if (!string.IsNullOrEmpty(report.ALNamespace))

--- a/AlRunner/Patches/RecordPatches.ReportLayoutListVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.ReportLayoutListVirtualTable.cs
@@ -103,6 +103,42 @@ public static partial class RecordPatches
             if (!done.TryAdd((layout.ReportId, layout.Name), 0)) continue;
             InsertReportLayoutListRow(provider, metaTable, layout);
         }
+
+        // Reports in a precompiled dependency are never emitted, so the registry above cannot
+        // hold them (#2297). Compiled reports go first: a report both compiled and in a
+        // dependency keeps its compiled rows.
+        foreach (var layout in EnumerateDependencyReportLayouts())
+        {
+            if (!done.TryAdd((layout.ReportId, layout.Name), 0)) continue;
+            InsertReportLayoutListRow(provider, metaTable, layout);
+        }
+    }
+
+    /// <summary>
+    /// Every rendering-syntax layout a loaded dependency's SymbolReference.json declares, with
+    /// no ResolvedPath: the bytes live in the .app, and serving them is rendering (out of scope).
+    /// </summary>
+    internal static IEnumerable<AlReportLayoutInfo> DependencyReportLayouts(BcAppSymbolCache.ReportSymbol report)
+    {
+        if (report.Layouts == null) yield break;
+        foreach (var l in report.Layouts)
+            yield return new AlReportLayoutInfo(
+                ReportId: report.Id,
+                Name: l.Name,
+                LayoutType: l.Type ?? string.Empty,
+                MimeType: l.MimeType ?? string.Empty,
+                LayoutFile: l.LayoutFile ?? string.Empty,
+                ResolvedPath: string.Empty,
+                Caption: l.Caption ?? string.Empty,
+                Summary: l.Summary ?? string.Empty,
+                IsDefault: string.Equals(l.Name, report.DefaultRenderingLayout, System.StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static IEnumerable<AlReportLayoutInfo> EnumerateDependencyReportLayouts()
+    {
+        foreach (var report in EnumerateBcAppReportSymbols())
+            foreach (var layout in DependencyReportLayouts(report))
+                yield return layout;
     }
 
     private static void InsertReportLayoutListRow(object provider, NCLMetaTable metaTable, AlReportLayoutInfo layout)

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -156,7 +156,10 @@ handler chose — the value is never held aside. Data-item filters
 **Layout *selection* is in scope; layout *content* is not.** A report's
 `rendering { layout(Name) { Type; MimeType; LayoutFile; … } }` declarations are
 captured at compile time and published into the "Report Layout List" system
-virtual table (2000000234), which is where BC's own by-name resolution looks. So
+virtual table (2000000234), which is where BC's own by-name resolution looks. A
+report in a precompiled dependency (Base Application's 1306, say) is never
+compiled, so its layouts and its `DefaultRenderingLayout` / legacy `DefaultLayout`
+are read from the package's `SymbolReference.json` instead (#2297). So
 `ReportLayoutSelection.SetTempLayoutSelectedName('<LayoutName>')` resolves the
 named layout through BC's unmodified code path, and the resolved layout's
 `Type` drives the processor fork exactly as on a real tier (an undeclared name


### PR DESCRIPTION
Closes #2297

Written by agent stma-auto2-2 on the account holder's behalf.

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/336

## What was wrong

This was not specific to report 1306. The runner read no layouts at all for any report in a precompiled dependency. `AlReportLayoutRegistry` is filled only when the runner compiles a report itself, and `BcAppSymbolCache` never read the `Layouts` array or the `DefaultRenderingLayout` / `DefaultLayout` properties that each report states in `SymbolReference.json`. Two things went wrong because of that:

| probe at `origin/main` (BC 28.1.49838.53910) | runner | source-compiled report, same run |
|---|---|---|
| "Report Layout List" rows for 1306 | `count=0` (1305 also 0) | `count=2` |
| `Report.DefaultLayout(1306)` | `RDLC` (the platform fallback) | `Word` |
| `Report.DefaultLayout(1320)`, legacy syntax | `RDLC` | `Word` |
| `SetSelectedLayout('StandardSalesInvoice.docx')` + `Report.SaveAs(1306, Pdf)` | `NavNCLReportNoLayoutException: Report 1306 does not have a valid layout` (the reported error) | n/a |

The issue's own question ("check whether other Base App reports resolve layouts correctly") answers no. In Base Application 28.1, 62 of 659 reports use the rendering syntax and 328 use the legacy `DefaultLayout` property.

## What changed

- `BcAppSymbolCache.ReportSymbol` now carries `Layouts` (Name, Type, MimeType, LayoutFile, Caption, Summary), `DefaultRenderingLayout` and `LegacyDefaultLayout`, all copied as the symbol file states them.
- `DependencyReportMetadata.EmitReportXml` writes the same elements BC's own emit writes for a compiled report. I dumped that XML from a source-compiled report in the probe: `DefaultLayoutName` + `DefaultRenderingLayoutType` for rendering syntax, `DefaultLayout` for legacy syntax, and a `<Layouts>` block. `NavReport.DefaultLayoutInternal` reads only that metadata. For legacy syntax, BC's compiler also derives a `DefaultLayoutName` (the layout file path). The symbol file does not state it, so I do not write it.
- `PopulateReportLayoutListVirtualTable` also adds a row for each rendering-syntax layout of each loaded dependency report. Compiled reports go first, so a report that is both compiled and in a dependency keeps its compiled rows. `ResolvedPath` is empty: the layout bytes live in the `.app`, and serving them is rendering, which stays out of scope. After the fix, `SaveAs(1306, Pdf)` reaches BC's Word processor and throws the documented `report-rendering-external` out-of-scope error instead of `NoLayout`. **Expected reason-string change:** a dependency report whose default layout is now Word or Excel reaches `GetWordResultSetProcessor` (or the Excel processor) where it used to reach `GetRdlcResultSetProcessor`. The out-of-scope reason anchor is the same, but the API named in the message changes. The only expectation entry naming the RDLC processor (`oos-reports.json`) is for a source-compiled corpus report, which this PR does not touch.
- `docs/scope.md` section 3.5.1 now says where a dependency report's layouts come from.

No `CacheVersion` bump. `ReportSymbol` is reachable from `CachePayload`, so the new members change `PayloadShape`, and that re-keys the on-disk symbol cache. I checked this by running the probe twice on one `--cache` root: the second run read the new entries from cache, and both runs gave the same results (6 rows, `Word`, `Word`).

## RED -> GREEN (corpus codeunit 60974 from corpus PR #336, run locally against corpus branch head `ffd7e2f`)

- RED, fix files reverted to `origin/main`: `pass: 1, fail: 4`. Both `DefaultLayout` tests got `Actual:<RDLC>`, and both layout-list tests failed `Assert.IsTrue`. The negative test (an undeclared name has no row) passed, as it should.
- GREEN: `pass: 5, fail: 0`.

## Mutations (one per observable, each reverted afterwards)

- M1: skip writing `DefaultRenderingLayoutType` (the name -> Type join). Result `pass: 4, fail: 1`. Only `DefaultLayout_PrecompiledRenderingSyntaxReport_IsWord` failed (`Actual:<RDLC>`). The legacy and layout-list tests stayed green, so the two halves are tested separately.
- M2: stop adding dependency layout rows. Result `pass: 3, fail: 2`. Only the two `LayoutList_…Lists…` tests failed. Both `DefaultLayout` tests stayed green.
- M3: make the legacy parse read a key that does not exist (`DefaultLayoutMUTATED`). Against a **cold** symbol cache the result is `pass: 4, fail: 1`, and only `DefaultLayout_PrecompiledLegacySyntaxReport_IsWord` failed (`Actual:<RDLC>`). Against the warm cache from the earlier runs the same mutation stayed `pass: 5`. The on-disk symbol cache is keyed on payload shape, and a parse-only change does not move that key, so the old value was replayed. That is the `CacheVersion` trap the cache's own comments describe. It does not affect this PR, whose new members change the shape, but anyone re-running M3 needs a fresh `--cache`.
- C# mechanism test `AlRunner.Tests/DependencyReportLayoutTests.cs` (5 tests): `Passed: 5`. M1 gives `Failed: 1, Passed: 4` (`EmittedMetadata_RenderingSyntax_…`). M3 gives `Failed: 2, Passed: 3` (`EmittedMetadata_LegacySyntax_…` and `Layouts_AreReadVerbatim_…`, which also asserts the legacy value).

`require-tests` path: the BC claim lives in the corpus, which is gitignored here, so the runner-side test is `DependencyReportLayoutTests`. It pins the parse, the emitted elements (rendering, legacy, and neither), and which layout row gets marked as the default. Its fixture writes only a `SymbolReference.json`, with no `application` dependency.

## Local runs

- `dotnet test --filter DependencyReportLayoutTests|BcAppSymbolCacheReportTests|DependencyReportDataItemLinkTests|ReportSymbolNamespace|ReportLayoutRegistry`: `Total: 18, Passed: 18`.
- `tools/test_*.py`: all pass except `test_agent_self_freshness`, `test_corpus_checkout` and `test_preflight`. Those three fail on this machine because git commit signing through 1Password fails inside their temporary repos. `test_doc_summary_uniqueness` caught a doc comment my first edit left detached from its method, and I fixed it.
- `GuardTests`: 248 of 249 pass. `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned` fails because the local engine bootstrap was not run (a machine setup issue, not this change).

## Fix the shape

1. **Same wrong pattern at another call site?** The legacy `DefaultLayout` property had the same gap in the same `EmitReportXml`, so I fixed it too (report 1320 test). Legacy-syntax layouts still get no **Report Layout List rows**: BC's compiler names those after the layout file path, and I have no service-tier result for what real BC names them, so I did not guess. That gap is filed as #4043.
2. **Sibling functions with the same assumption?** `ReportLayoutHydration.Choose` reads `AlReportLayoutRegistry` only. For a dependency report it has no bytes to supply either way (the `.app` holds them, and rendering is out of scope), so I did not change it. `GetLayoutFromDefaultLayoutName` reads table 2000000231 keyed on `OwningApp.RuntimePackageId`, which is a different table; I did not touch that path.
   The dependency rows also leave `Obsolete State` and the Excel sheet configuration at BC's default, although the symbol file states them for 26 of Base Application's 146 rendering-syntax layouts. No service-tier result says what BC writes there, so that gap is filed as #4045.
3. **Two writers, same invariant?** The layout-list rows now have two sources: the registry and the dependency symbols. Both go through one `done` set keyed by (Report ID, Name), and compiled rows are added first, so a key is never inserted twice.

**Queue scan** (searched `layout`, `DefaultLayout`, `Report Layout List`, `2000000234`, `1306`, `DependencyReportMetadata`, `precompiled report`). Nothing folded in. #3808 (RequestPage subtree), #3374 (MaxIteration) and #3382 (CalcFields) touch the same derivation file, but each concerns a different element and needs its own reasoning. #2655 (registry loss across `--watch` cycles) does not affect this path, because dependency layouts are read from the symbol cache on each population, not from a registry.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
