### PR TITLE
fix(reports): a precompiled report's nested data item joins its parent when no DataItemLinkReference is stated

### DIFF
--- a/AlRunner.Tests/DependencyReportDataItemLinkTests.cs
+++ b/AlRunner.Tests/DependencyReportDataItemLinkTests.cs
@@ -265,6 +265,18 @@ public class DependencyReportDataItemLinkTests
                           "Indentation": 1,
                           "Properties": [
                             { "Name": "DataItemLink", "Value": "\"Vendor No.\" = field(\"No.\")" }
+                          ],
+                          "DataItems": [
+                            {
+                              "Id": 6,
+                              "Name": "SecondDetail",
+                              "OwningDataItemName": "SecondJoin",
+                              "RelatedTable": "Detailed Vendor Ledg. Entry",
+                              "Indentation": 2,
+                              "Properties": [
+                                { "Name": "DataItemLink", "Value": "\"Vendor Ledger Entry No.\" = field(\"Entry No.\")" }
+                              ]
+                            }
                           ]
                         }
                       ]
@@ -300,6 +312,9 @@ public class DependencyReportDataItemLinkTests
             // After a deeper item has closed, the parent is still the enclosing item, not the
             // item written just before.
             Assert.Equal("Vendor", ReferenceOf("SecondJoin"));
+            // A second level-2 item under a different level-1 parent: the deeper levels opened
+            // under "Vendor Ledger Entry" must be closed, or this joins to the wrong item.
+            Assert.Equal("SecondJoin", ReferenceOf("SecondDetail"));
 
             // Negative: an item with no link acquires no reference.
             Assert.Null(ReferenceOf("Vendor"));

--- a/AlRunner.Tests/DependencyReportDataItemLinkTests.cs
+++ b/AlRunner.Tests/DependencyReportDataItemLinkTests.cs
@@ -200,4 +200,114 @@ public class DependencyReportDataItemLinkTests
             Directory.Delete(dir, recursive: true);
         }
     }
+
+    // Report 304 "Vendor - Detail Trial Balance" as the Base Application's symbol file states
+    // it, trimmed: the AL writes DataItemLink with no DataItemLinkReference, so the symbol file
+    // carries none (264 of the 391 Base Application links are like this). A deeper item and a
+    // sibling at the parent's level sit around the joined item so the parent has to be found by
+    // nesting, not by position (#2521).
+    private const string ReferencelessLinkSymbolReference = """
+        {
+          "RuntimeVersion": "15.1",
+          "Namespaces": [
+            {
+              "Name": "Purchases",
+              "Reports": [
+                {
+                  "Id": 304,
+                  "Name": "Vendor - Detail Trial Balance",
+                  "DataItems": [
+                    {
+                      "Id": 1,
+                      "Name": "Vendor",
+                      "RelatedTable": "Vendor",
+                      "Properties": [
+                        { "Name": "DataItemTableView", "Value": "sorting(\"No.\")" }
+                      ],
+                      "DataItems": [
+                        {
+                          "Id": 2,
+                          "Name": "Vendor Ledger Entry",
+                          "OwningDataItemName": "Vendor",
+                          "RelatedTable": "Vendor Ledger Entry",
+                          "Indentation": 1,
+                          "Properties": [
+                            { "Name": "DataItemLink", "Value": "\"Vendor No.\" = field(\"No.\"), \"Posting Date\" = field(\"Date Filter\")" }
+                          ],
+                          "DataItems": [
+                            {
+                              "Id": 3,
+                              "Name": "Detailed Vendor Ledg. Entry",
+                              "OwningDataItemName": "Vendor Ledger Entry",
+                              "RelatedTable": "Detailed Vendor Ledg. Entry",
+                              "Indentation": 2,
+                              "Properties": [
+                                { "Name": "DataItemLink", "Value": "\"Vendor Ledger Entry No.\" = field(\"Entry No.\")" }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "Id": 4,
+                          "Name": "Integer",
+                          "OwningDataItemName": "Vendor",
+                          "RelatedTable": "#8874ed3a064342479ced7a7002f7135d#Integer",
+                          "Indentation": 1,
+                          "Properties": [
+                            { "Name": "DataItemTableView", "Value": "sorting(Number) where(Number = const(1))" }
+                          ]
+                        },
+                        {
+                          "Id": 5,
+                          "Name": "SecondJoin",
+                          "OwningDataItemName": "Vendor",
+                          "RelatedTable": "Vendor Ledger Entry",
+                          "Indentation": 1,
+                          "Properties": [
+                            { "Name": "DataItemLink", "Value": "\"Vendor No.\" = field(\"No.\")" }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    [Fact]
+    public void ReportMetadataXml_ReferencelessLink_JoinsToTheEnclosingDataItem()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-report-dataitemlink-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var appPath = WriteApp(dir, ReferencelessLinkSymbolReference);
+            var report = Assert.Single(BcAppSymbolCache.Get(appPath).Reports, r => r.Id == 304);
+            var doc = System.Xml.Linq.XDocument.Parse(RecordPatches.EmitReportXml(report, sourceExprByColumn: null));
+
+            string? ReferenceOf(string varName) => doc.Root!.Elements("DataItem")
+                .Single(e => (string?)e.Element("DataItemVarName") == varName)
+                .Element("DataItemLinkReference")?.Value;
+
+            // DataItemIterator.SetDataItemLink applies a link only when some data item's
+            // DataItemVarName equals DataItemLinkReference; with none written the nested item
+            // iterated its whole table. BC's compiler writes the enclosing item's name here.
+            Assert.Equal("Vendor", ReferenceOf("Vendor Ledger Entry"));
+            Assert.Equal("Vendor Ledger Entry", ReferenceOf("Detailed Vendor Ledg. Entry"));
+            // After a deeper item has closed, the parent is still the enclosing item, not the
+            // item written just before.
+            Assert.Equal("Vendor", ReferenceOf("SecondJoin"));
+
+            // Negative: an item with no link acquires no reference.
+            Assert.Null(ReferenceOf("Vendor"));
+            Assert.Null(ReferenceOf("Integer"));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
 }

--- a/AlRunner/Patches/DependencyReportMetadata.cs
+++ b/AlRunner/Patches/DependencyReportMetadata.cs
@@ -264,8 +264,19 @@ public static partial class RecordPatches
             w.WriteElementString("Name", report.Name);
             WriteDerivableReportProperties(w, report);
 
+            // enclosing[d] = DataItemVarName of the innermost open data item at indentation d.
+            var enclosing = new List<string>();
             foreach (var di in report.DataItems)
-                WriteDataItem(w, di, sourceExprByColumn);
+            {
+                string? parent = di.Indentation > 0 && di.Indentation <= enclosing.Count
+                    ? enclosing[di.Indentation - 1]
+                    : null;
+                WriteDataItem(w, di, sourceExprByColumn, parent);
+                if (di.Indentation < enclosing.Count)
+                    enclosing.RemoveRange(di.Indentation, enclosing.Count - di.Indentation);
+                if (di.Indentation == enclosing.Count)
+                    enclosing.Add(di.Name);
+            }
 
             w.WriteEndElement();
         }
@@ -305,7 +316,8 @@ public static partial class RecordPatches
     }
 
     private static void WriteDataItem(
-        XmlWriter w, BcAppSymbolCache.ReportDataItemSymbol di, Dictionary<string, string>? sourceExprByColumn)
+        XmlWriter w, BcAppSymbolCache.ReportDataItemSymbol di, Dictionary<string, string>? sourceExprByColumn,
+        string? enclosingDataItemName)
     {
         int tableId = ResolveTableIdByName(di.RelatedTable);
 
@@ -329,8 +341,15 @@ public static partial class RecordPatches
         // Omitting them left every nested data item of a precompiled report unrestricted.
         if (!string.IsNullOrEmpty(di.DataItemLink))
             w.WriteElementString("DataItemLink", di.DataItemLink);
-        if (!string.IsNullOrEmpty(di.DataItemLinkReference))
-            w.WriteElementString("DataItemLinkReference", di.DataItemLinkReference);
+        // SetDataItemLink applies the link only to a data item whose DataItemVarName equals this
+        // reference, so a missing one silently drops the join. The symbol file states it only
+        // when the AL spelled it (264 of 391 Base Application links do not); BC's own compiler
+        // writes the enclosing data item's name in that case, which is what we write (#2521).
+        var linkReference = !string.IsNullOrEmpty(di.DataItemLinkReference)
+            ? di.DataItemLinkReference
+            : string.IsNullOrEmpty(di.DataItemLink) ? null : enclosingDataItemName;
+        if (!string.IsNullOrEmpty(linkReference))
+            w.WriteElementString("DataItemLinkReference", linkReference);
         if (di.PrintOnlyIfDetail)
             w.WriteElementString("PrintOnlyIfDetail", "1");
         // MetaDataItem reads MAXITERATION from this same node through int.Parse, and


### PR DESCRIPTION
Part of #2521
Closes #2899

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/337

Written by agent stma-auto2-1 on the account holder's behalf.

## What was wrong

This was not a FlowField or FlowFilter defect, which is how #2521 framed it. I checked that first: inside Microsoft's own `Codeunit134335` setup, `Vendor.CalcFields("Net Change (LCY)")` with the report's date filters and `VendorLedgerEntry.CalcFields("Amount (LCY)")` both returned the right numbers (`NCbefore=0; NCin=3,227.44; VLE amtLCY=-3,227.44`).

The real cause is the join between nested data items in a **precompiled** report. Running report 304 "Vendor - Detail Trial Balance" for a newly created vendor with no ledger entries produced 867 dataset rows. The nested `Vendor Ledger Entry` data item was iterating the whole table under the one vendor, so `VendBalanceLCY` added up the company's entries.

- The runner rebuilds a dependency report's metadata from `SymbolReference.json` (`DependencyReportMetadata.EmitReportXml`).
- The symbol file states `DataItemLinkReference` only when the AL spells it. Report 304's `Vendor Ledger Entry` has `DataItemLink` and no reference. Across Base Application 28.1, 264 of the 391 linked data items are like this.
- BC's `DataItemIterator.SetDataItemLink` (decompiled, 28.1) applies the link only to a data item whose `DataItemVarName` equals `DataItemLinkReference`. With no reference it matches nothing and skips the link without any error.
- BC's own compiler writes the enclosing data item's name in that case. I confirmed this from the runner's source-compiled metadata for a probe report whose AL has no reference: `<DataItemLinkReference>P</DataItemLinkReference>`.

## The fix

`EmitReportXml` tracks the enclosing data item at each indentation level. When a data item has `DataItemLink` and no stated reference, `WriteDataItem` writes the enclosing data item's name. An item with no link still gets no reference. A stated reference is still written as stated.

The parent comes from the flattened list's `Indentation`, not from the symbol file's `OwningDataItemName`. Reading `OwningDataItemName` would have changed `ReportDataItemSymbol` and needed a `BcAppSymbolCache` version bump. Without the bump, a warm cache would replay the missing reference. The emitted XML is only memoized in memory (`_depReportMetadataXml`), so this change cannot be replayed from disk.

## Tests

**Corpus (BC behavior):** corpus PR 337 adds codeunit 60224. It runs Base Application report 508 "Change Log Setup List" through `Report.SaveAs(Xml)` and reads which child rows sit under each parent row. That report has a nested link with no reference. Because it comes from the Base Application, the test reaches the precompiled path, so the corpus can express this. Run locally through the runner against a scratch bundle holding that file and the corpus `Assert` fixture:

- with the fix: `pass: 2, fail: 0`
- with the default removed (mutation below): `pass: 0, fail: 2`, where `Actual:<18:18,18,23|23:18,18,23>` should be `18:18,18|23:23`, and `Actual:<23:18,18,23>` should be `23:23`

**Runner mechanism:** `DependencyReportDataItemLinkTests.ReportMetadataXml_ReferencelessLink_JoinsToTheEnclosingDataItem` uses report 304's shape: a two-level link, a sibling after a deeper item has closed, and two unlinked items. Filtered run over `DependencyReportDataItemLinkTests`:

- RED before the fix: `Failed: 1, Passed: 2, Total: 3` (`Expected: "Vendor" / Actual: null`)
- GREEN: `Failed: 0, Passed: 3`. The wider `~DependencyReport` filter gives `Failed: 0, Passed: 19, Total: 19`.

**Mutations (both executed, both restored):**

- A: take the reference from the root data item instead of the enclosing one (`enclosing[0]`). Result: `Failed: 1, Passed: 2` with `Expected: "Vendor Ledger Entry" / Actual: "Vendor"`. The one-level and unlinked assertions stay correct, so the test tells the enclosing item apart from the root.
- B: never default the reference (`: null`). C# test: `Failed: 1, Passed: 2`. Corpus test: `pass 0 / fail 2`. Microsoft's `Codeunit134335` (see below): back to `38 pass / 23 fail`.

- C (asked for in review): remove the step that closes deeper levels when the indentation goes back up. The original fixture stayed green under it. I added `SecondDetail` under `SecondJoin` to the fixture; with the mutation the test gives `Failed: 1, Passed: 2, Total: 3` (`Expected: "SecondJoin" / Actual: "Vendor Ledger Entry"`), and restored it gives `Failed: 0, Passed: 3, Total: 3`.

**Microsoft's `Tests-SINGLESERVER` `Codeunit134335`**, BC 28.1.49838.53910, `--test-data` from 28.1.49838.54308, private cache, 61 tests:

| build | pass | fail |
|---|---|---|
| mutation B (the behavior on `main`) | 38 | 23 |
| fix, run 1 (on a cache already warmed by pre-fix runs) | 45 | 16 |
| fix, run 2 (same cache) | 45 | 16 |

Exactly seven tests flip from fail to pass, and none go the other way. The set difference is taken name by name:

- #2521: `DetailTrialBalance`, `DetailTrialBalanceAmountLCY`, `VendorOrderDetailWithReleasedDocument`, `VendorOrderSummaryWithDurationAmount`, `VendorOrderSummaryWithReleasedDocument`
- #2899: `OrderSummaryPostingDate`, `OrderSummaryCurrency`

**One proving test for two issues, on purpose.** #2899 and the five #2521 tests share one root cause, so the C# test and corpus codeunit 60224 prove both. What shows #2899 specifically is its own per-test flip: `OrderSummaryPostingDate` and `OrderSummaryCurrency` fail under mutation B and pass with the fix.

**Corpus legs:** report 508 has the same data items, link, and `Table_No` column names in the Base Application symbol files for 27.0.38460.53260 and 28.4.53241.53955, so the test's XPath strings should hold across the corpus span.

## Why `Part of #2521` and not `Closes`

The four report-321 "Vendor - Balance to Date" tests in #2521 still fail with the same messages (`OriginalAmt` / `CurrTotalBufferTotalAmt`). Report 321's only link (`Detailed Vendor Ledg. Entry` under `VendLedgEntry3`) now gets its reference, but those tests build their data with `MockVendorLedgerEntry` plus applied/unapplied detailed entries, and the report works from a temporary vendor ledger entry buffer. That is a different mechanism, and I have not diagnosed it. I left a comment on #2521 with this.

## Fix the shape

1. **Same wrong pattern at another call site?** The metadata for precompiled pages (`SubPageLink`) and queries (link text names its parent data item) has no reference concept. `WriteDataItem` is the only writer of `DataItemLinkReference`. Nothing found.
2. **Sibling making the same assumption?** `CollectReportDataItems` reads the reference as stated, which is correct for the cache. The defaulting belongs at emission, where the nesting is known. #3382 (`CalcFields` dropped from dependency report data items) is in the same file, but it needs its own wire-format reasoning and is blocked on the metadata emitter, so I did not fold it in. #3374 (`MaxIteration`) already has its property emitted.
3. **Two paths writing the same state with different invariants?** Yes, and that was the defect. A source-compiled report's metadata always has a reference on a linked item, because BC's compiler writes one. The dependency path wrote one only when the AL spelled it. Both paths now agree.

**Queue scan:** I searched for `DataItemLink`, "nested data item", and "precompiled report dataset". That found #2899 (folded in, measured above), #3374, and #3382 (see 2).

**Guards:** the `tools/test_*.py` loop and `~GuardTests` ran locally. Four failures, none from this change: `test_agent_self_freshness.py` and `test_corpus_checkout.py` die making commits in temporary repositories (this machine's 1Password commit signing), `test_preflight.py` fails for the same environment reason, and `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned` needs `tools/engine-test-bootstrap.sh`.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
