### PR TITLE
fix(provisioning): print the explicit --bc-version engine-minor warning once per invocation

### DIFF
--- a/AlRunner.Tests/ExplicitEngineMinorWarningGatingTests.cs
+++ b/AlRunner.Tests/ExplicitEngineMinorWarningGatingTests.cs
@@ -1,6 +1,6 @@
 // ExplicitEngineMinorWarningGatingTests — issue #2037.
 //
-// #2008's DescribeExplicitEngineMinorMismatch/WarnIfExplicitEngineMinorMismatch (see
+// #2008's DescribeExplicitEngineMinorMismatch/ExplicitEngineMinorMismatchWarning (see
 // EngineMinorMismatchWarningTests.cs) fire whenever this binary's OWN compiled-in engine
 // minor differs from the explicitly-selected BC version. That was correct for the
 // single-build install it was written for — there was only ever one engine, so a
@@ -8,7 +8,7 @@
 //
 // #2027 shipped per-BC-minor engine variants (variants/<build>/, see EngineVariants):
 // a packaged install now carries several engines and swaps to whichever one matches the
-// SELECTED version at startup. Program.cs called WarnIfExplicitEngineMinorMismatch
+// SELECTED version at startup. Program.cs called the warning
 // BEFORE that variant swap ran (line 748, swap at 771-801), comparing THIS PROCESS's
 // own compiled-in minor — which is irrelevant once a matching variant is about to be
 // swapped in. Reported live against the published 2.5.0 package: `--bc-version
@@ -36,7 +36,7 @@ public sealed class ExplicitEngineMinorWarningGatingTests
 
     /// <summary>
     /// Structural guard on Program.cs's own source: the call site that decides whether
-    /// to print WarnIfExplicitEngineMinorMismatch must route through
+    /// to print ExplicitEngineMinorMismatchWarning must route through
     /// ShouldWarnExplicitEngineMinorMismatch (which also inspects the shipped-variant
     /// count), not merely `!bcVersionAutoSelected`. A behavioural test on the pure
     /// function alone (the four cases above) would pass equally well whether Program.cs
@@ -48,8 +48,9 @@ public sealed class ExplicitEngineMinorWarningGatingTests
     public void ProgramCs_GatesTheWarnCall_OnShouldWarnExplicitEngineMinorMismatch()
     {
         var programSource = File.ReadAllText(Path.Combine(RepoRoot, "AlRunner", "Program.cs"));
-        var callIdx = programSource.IndexOf("WarnIfExplicitEngineMinorMismatch();", StringComparison.Ordinal);
-        Assert.True(callIdx >= 0, "WarnIfExplicitEngineMinorMismatch() call not found in Program.cs");
+        // #4038: the call now returns the message for the deferred startup queue.
+        var callIdx = programSource.IndexOf("ExplicitEngineMinorMismatchWarning();", StringComparison.Ordinal);
+        Assert.True(callIdx >= 0, "ExplicitEngineMinorMismatchWarning() call not found in Program.cs");
 
         // The `if` guarding the call must be within a short lookbehind window and must
         // name ShouldWarnExplicitEngineMinorMismatch, not just bcVersionAutoSelected alone.

--- a/AlRunner.Tests/ExplicitEngineMinorWarningOncePerInvocationTests.cs
+++ b/AlRunner.Tests/ExplicitEngineMinorWarningOncePerInvocationTests.cs
@@ -79,6 +79,68 @@ public sealed class ExplicitEngineMinorWarningOncePerInvocationTests
         return (root, selected);
     }
 
+    /// <summary>
+    /// Same alias, but a real directory whose entries symlink to the engine's artifacts
+    /// except Microsoft.Dynamics.Nav.Ncl.dll, which is random bytes. That stands in for a
+    /// different minor whose Ncl the Cecil rewrite cannot read: the run crashes before the
+    /// queued startup lines are flushed, which is when the warning matters most.
+    /// </summary>
+    private static (string Root, Version Selected) BuildArtifactsRootWithACorruptNcl(Version engineVersion)
+    {
+        var realHome = TestArtifacts.HomeDir()
+            ?? throw new InvalidOperationException("Cannot determine this machine's HOME.");
+        var realEngineDir = Path.Combine(TestArtifacts.StandardCacheDir(realHome), engineVersion.ToString());
+        TestArtifacts.SkipIfDirectoryMissing(realEngineDir, $"BC {engineVersion} artifacts");
+
+        var root = TestScratch.Dir("al-runner-explicit-minor-warning-corrupt-ncl");
+        var selected = new Version(engineVersion.Major, engineVersion.Minor + 50, engineVersion.Build, engineVersion.Revision);
+        var aliasDir = Path.Combine(root, selected.ToString());
+        Directory.CreateDirectory(aliasDir);
+        const string NclName = "Microsoft.Dynamics.Nav.Ncl.dll";
+        foreach (var entry in Directory.EnumerateFileSystemEntries(realEngineDir))
+        {
+            var name = Path.GetFileName(entry);
+            if (name == NclName) continue;
+            var link = Path.Combine(aliasDir, name);
+            if (Directory.Exists(entry)) Directory.CreateSymbolicLink(link, entry);
+            else File.CreateSymbolicLink(link, entry);
+        }
+        var garbage = new byte[64 * 1024];
+        new Random(4038).NextBytes(garbage);
+        File.WriteAllBytes(Path.Combine(aliasDir, NclName), garbage);
+        return (root, selected);
+    }
+
+    [SkippableFact]
+    public void ExplicitDifferentMinor_RunCrashesBeforeFlush_StillPrintsWarning_ExactlyOnce()
+    {
+        var engineVersion = BcArtifacts.EngineBuiltVersion();
+        TestArtifacts.SkipIf(engineVersion == null,
+            "no baked-in BcEngineVersion on this build — nothing to compare a selection against.");
+        TestArtifacts.SkipIf(EngineVariants.Discover(AppContext.BaseDirectory).Count > 0,
+            "this install ships engine variants, and the warning is gated off for that shape (#2037).");
+
+        var (root, selected) = BuildArtifactsRootWithACorruptNcl(engineVersion!);
+        var cacheDir = TestScratch.Dir("al-runner-explicit-minor-warning-corrupt-ncl-cache");
+        try
+        {
+            var (exit, output) = Run(root, cacheDir, "--no-auto-provision", "--bc-version", selected.ToString());
+
+            Assert.True(exit != 0, $"a random-bytes Ncl.dll must not run cleanly. exit={exit}\n{output}");
+            Assert.Contains("BadImageFormatException", output, StringComparison.Ordinal);
+
+            var count = Regex.Matches(output, Regex.Escape(WarningFragment)).Count;
+            Assert.True(count == 1,
+                $"the KNOWN-DEGRADED warning must print exactly once even when the run crashes before the " +
+                $"startup flush; printed {count} time(s). exit={exit}\n{output}");
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+            try { Directory.Delete(cacheDir, recursive: true); } catch { }
+        }
+    }
+
     [SkippableFact]
     public void ExplicitDifferentMinor_PrintsKnownDegradedWarning_ExactlyOnce()
     {

--- a/AlRunner.Tests/ExplicitEngineMinorWarningOncePerInvocationTests.cs
+++ b/AlRunner.Tests/ExplicitEngineMinorWarningOncePerInvocationTests.cs
@@ -1,0 +1,110 @@
+// ExplicitEngineMinorWarningOncePerInvocationTests — issue #4038.
+//
+// An explicit --bc-version naming a different minor of the engine's own major prints the
+// KNOWN-DEGRADED warning. On a single-build install the runner re-execs into a shadow
+// runtime, and the child repeats startup, so a warning written straight to stderr prints
+// once per generation. This spawns the real runner across that hop and counts.
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ExplicitEngineMinorWarningOncePerInvocationTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static readonly string MinimalBundle =
+        Path.Combine(RepoRoot, "tests", "runner-extras", "esm-xapp-table");
+
+    private const string WarningFragment = "was explicitly selected (--bc-version/--artifact-path)";
+
+    private const int SpawnTimeoutMs = 180_000;
+
+    private static (int ExitCode, string Output) Run(string artifactsRoot, string cacheDir, params string[] args)
+    {
+        var sb = new StringBuilder(TestBuildConfig.RunArgs(Path.Combine(RepoRoot, "AlRunner")));
+        foreach (var a in args) sb.Append(' ').Append(a);
+        sb.Append($" --cache \"{cacheDir}\" \"{MinimalBundle}\"");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = sb.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        psi.Environment["AL_RUNNER_ARTIFACTS_ROOT"] = artifactsRoot;
+        psi.Environment.Remove("AL_RUNNER_VERBOSE");
+
+        var output = new StringBuilder();
+        using var proc = Process.Start(psi)!;
+        proc.OutputDataReceived += (_, e) => { if (e.Data != null) lock (output) output.AppendLine(e.Data); };
+        proc.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (output) output.AppendLine(e.Data); };
+        proc.BeginOutputReadLine();
+        proc.BeginErrorReadLine();
+        if (!proc.WaitForExit(SpawnTimeoutMs))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException($"al-runner did not exit within {SpawnTimeoutMs / 1000}s");
+        }
+        proc.WaitForExit();
+        lock (output) return (proc.ExitCode, output.ToString());
+    }
+
+    /// <summary>
+    /// The engine's own artifacts, reachable under a second name that differs only in the
+    /// minor. Selecting that name is a same-major, different-minor explicit selection, which
+    /// is exactly the warning's condition, and it still runs cleanly because the files are
+    /// the engine's own.
+    /// </summary>
+    private static (string Root, Version Selected) BuildArtifactsRootWithADifferentMinor(Version engineVersion)
+    {
+        var realHome = TestArtifacts.HomeDir()
+            ?? throw new InvalidOperationException("Cannot determine this machine's HOME.");
+        var realEngineDir = Path.Combine(TestArtifacts.StandardCacheDir(realHome), engineVersion.ToString());
+        TestArtifacts.SkipIfDirectoryMissing(realEngineDir, $"BC {engineVersion} artifacts");
+
+        var root = TestScratch.Dir("al-runner-explicit-minor-warning-once");
+        Directory.CreateDirectory(root);
+        // +50 keeps the alias clear of every real BC minor, so nothing else keys on it.
+        var selected = new Version(engineVersion.Major, engineVersion.Minor + 50, engineVersion.Build, engineVersion.Revision);
+        Directory.CreateSymbolicLink(Path.Combine(root, selected.ToString()), realEngineDir);
+        return (root, selected);
+    }
+
+    [SkippableFact]
+    public void ExplicitDifferentMinor_PrintsKnownDegradedWarning_ExactlyOnce()
+    {
+        var engineVersion = BcArtifacts.EngineBuiltVersion();
+        TestArtifacts.SkipIf(engineVersion == null,
+            "no baked-in BcEngineVersion on this build — nothing to compare a selection against.");
+        TestArtifacts.SkipIf(EngineVariants.Discover(AppContext.BaseDirectory).Count > 0,
+            "this install ships engine variants, and the warning is gated off for that shape (#2037).");
+
+        var (root, selected) = BuildArtifactsRootWithADifferentMinor(engineVersion!);
+        var cacheDir = TestScratch.Dir("al-runner-explicit-minor-warning-once-cache");
+        try
+        {
+            var (exit, output) = Run(root, cacheDir, "--no-auto-provision", "--bc-version", selected.ToString());
+
+            Assert.True(exit == 0, $"expected a clean run against the aliased engine artifacts. exit={exit}\n{output}");
+            Assert.Contains($"[bc] selected BC {selected} (", output, StringComparison.Ordinal);
+
+            var count = Regex.Matches(output, Regex.Escape(WarningFragment)).Count;
+            Assert.True(count == 1,
+                $"the KNOWN-DEGRADED warning must print exactly once per invocation; printed {count} time(s).\n{output}");
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+            try { Directory.Delete(cacheDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/AlRunner/Infrastructure/BcArtifacts.cs
+++ b/AlRunner/Infrastructure/BcArtifacts.cs
@@ -438,7 +438,7 @@ public static class BcArtifacts
     /// <summary>
     /// Pure core of <see cref="DefaultProvisionTarget"/>, network-injectable for testing
     /// (see AlRunner.Tests.DefaultProvisionTargetTests) — same shape as
-    /// <see cref="DescribeExplicitEngineMinorMismatch"/>/<see cref="WarnIfExplicitEngineMinorMismatch"/>:
+    /// <see cref="DescribeExplicitEngineMinorMismatch"/>/<see cref="ExplicitEngineMinorMismatchWarning"/>:
     /// a provable pure function plus a thin real-network wrapper.
     ///
     /// Issue #2033: <see cref="DefaultVersionPrefix"/> answers "what does the LOCAL CACHE
@@ -590,7 +590,7 @@ public static class BcArtifacts
     }
 
     /// <summary>
-    /// Pure core of <see cref="WarnIfExplicitEngineMinorMismatch"/>, split out for direct unit
+    /// Pure core of <see cref="ExplicitEngineMinorMismatchWarning"/>, split out for direct unit
     /// testing (see AlRunner.Tests.EngineMinorMismatchWarningTests) — mirrors the
     /// BcEngineReadinessGuard.AssertReadyOnCi(bool,string?,bool) shape: a pure function over
     /// explicit values is provable with no BC engine or CLI invocation involved.
@@ -623,16 +623,14 @@ public static class BcArtifacts
     }
 
     /// <summary>
-    /// Called ONLY when the user explicitly chose the BC version (--bc-version or
+    /// Used ONLY when the user explicitly chose the BC version (--bc-version or
     /// --artifact-path) — never from the auto-select default path, which already prints its
     /// own equivalent warning inside Program.cs and must not be double-warned. See
-    /// DescribeExplicitEngineMinorMismatch for the full rationale.
+    /// DescribeExplicitEngineMinorMismatch for the full rationale. Returns the message rather
+    /// than printing it: Program.cs queues it so only the terminal generation prints (#4038).
     /// </summary>
-    public static void WarnIfExplicitEngineMinorMismatch()
-    {
-        var msg = DescribeExplicitEngineMinorMismatch(EngineBuiltVersion(), SelectedVersion);
-        if (msg != null) Console.Error.WriteLine(msg);
-    }
+    public static string? ExplicitEngineMinorMismatchWarning()
+        => DescribeExplicitEngineMinorMismatch(EngineBuiltVersion(), SelectedVersion);
 
     /// <summary>
     /// Issue #2210: the auto-select default path's cross-major note body — describes the
@@ -685,7 +683,7 @@ public static class BcArtifacts
     }
 
     /// <summary>
-    /// Issue #2037: whether Program.cs should even CALL <see cref="WarnIfExplicitEngineMinorMismatch"/>
+    /// Issue #2037: whether Program.cs should even CALL <see cref="ExplicitEngineMinorMismatchWarning"/>
     /// at all, given how many per-BC-minor engine variants this install ships (see
     /// <see cref="EngineVariants.Discover"/>, called just before the variant-swap block in
     /// Program.cs — the same input, so no rediscovery is needed at the call site).

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1546,7 +1546,9 @@ deferredStartupLines.Add(() => Console.WriteLine(serverMode
 // process's, so one re-exec covers both "Ncl.dll isn't shipped" and "a different BC-minor
 // engine variant is needed" — see the doc comment on EnsureShadowDir.
 {
-    var shadowChildExit = TryShadowReexec(variantSwapDir);
+    int? shadowChildExit;
+    try { shadowChildExit = TryShadowReexec(variantSwapDir); }
+    catch { FlushDeferredStartupLines(); throw; }
     if (shadowChildExit.HasValue) return shadowChildExit.Value;
 }
 
@@ -1557,7 +1559,12 @@ deferredStartupLines.Add(() => Console.WriteLine(serverMode
 {
     var srcDir = AlRunner.Infrastructure.BcArtifacts.ServiceTierDir;
     var binNcl = Path.Combine(AppContext.BaseDirectory, "Microsoft.Dynamics.Nav.Ncl.dll");
-    var didFreshRewrite = AlRunner.Infrastructure.NclCecilRewrite.RewriteInPlace(srcDir, binNcl);
+    // #4038: a throw here (e.g. an Ncl.dll of a different shape) ends the process before the
+    // flush below, so print the queued lines first — they include the engine-minor warning
+    // that explains the crash.
+    bool didFreshRewrite;
+    try { didFreshRewrite = AlRunner.Infrastructure.NclCecilRewrite.RewriteInPlace(srcDir, binNcl); }
+    catch { FlushDeferredStartupLines(); throw; }
 
     // A process that performs the Cecil rewrite and then loads the byte-identical
     // rewritten Ncl in-process intermittently dies with BadImageFormatException
@@ -1601,13 +1608,22 @@ deferredStartupLines.Add(() => Console.WriteLine(serverMode
 
 // #2041/#2066: this generation has now cleared BOTH re-exec decision points above (the
 // shadow hop and the Cecil-fresh-rewrite hop) without returning — it is the terminal
-// generation for this invocation, so this is the one and only point that flushes the
-// startup lines queued in `deferredStartupLines`, in the order they were queued
+// generation for this invocation, so this is the normal point that flushes the
+// startup lines queued in `deferredStartupLines` (the only other one is a throw from the shadow hop
+// or the Cecil rewrite above, #4038), in the order they were queued
 // (provisioning result, selected BC version, any degraded-variant warning, then the
 // running/watch/server-mode banner). Any earlier generation that instead re-exec'd
 // returned from inside one of those blocks and never reaches this line, so its own queued
 // entries are simply discarded — however many generations preceded this one.
-foreach (var deferredLine in deferredStartupLines) deferredLine();
+FlushDeferredStartupLines();
+
+// Prints the queue once and empties it, so the crash-path flushes above and this one cannot
+// print a line twice.
+void FlushDeferredStartupLines()
+{
+    foreach (var deferredLine in deferredStartupLines) deferredLine();
+    deferredStartupLines.Clear();
+}
 
 // --jobs: fan out across worker processes (#2280). Deliberately placed HERE, after the
 // deferred-startup flush, because that line marks the terminal generation — both re-exec

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1021,7 +1021,7 @@ if (artifactPathArg != null)
 // as a clear message instead of a deep failure. All of this stays overridable.
 // Tracks whether bcVersionArg/artifactPathArg came from the auto-select default
 // below, so the explicit-selection engine-minor-mismatch warning further down (see
-// BcArtifacts.WarnIfExplicitEngineMinorMismatch) does not double-warn a case the
+// BcArtifacts.ExplicitEngineMinorMismatchWarning) does not double-warn a case the
 // auto-select branch already covers with its own, richer message.
 bool bcVersionAutoSelected = false;
 if (bcVersionArg == null && artifactPathArg == null)
@@ -1320,9 +1320,18 @@ try
     // all (see ShouldWarnExplicitEngineMinorMismatch) — once any variant is shipped, the
     // variant-swap block below is the sole authority on whether the selection is
     // degraded, not this generic same-process-engine comparison.
+    //
+    // #4038: deferred — see `deferredStartupLines`' declaration above. The shadow child
+    // re-runs this block, so an immediate write printed once per generation. No exit
+    // between here and the flush is one this warning explains: the variant refusal
+    // cannot coexist with it (shippedVariants.Count == 0), and the rest name their own cause.
     if (AlRunner.Infrastructure.BcArtifacts.ShouldWarnExplicitEngineMinorMismatch(
             bcVersionAutoSelected, shippedVariants.Count))
-        AlRunner.Infrastructure.BcArtifacts.WarnIfExplicitEngineMinorMismatch();
+    {
+        var engineMinorMismatchWarning = AlRunner.Infrastructure.BcArtifacts.ExplicitEngineMinorMismatchWarning();
+        if (engineMinorMismatchWarning != null)
+            deferredStartupLines.Add(() => Console.Error.WriteLine(engineMinorMismatchWarning));
+    }
     // #2041/#2066: deferred — see `deferredStartupLines`' declaration above. Captured into
     // locals now (the values are fixed the instant SelectVersion above returns) so the
     // closure below reads exactly what THIS generation selected, not whatever the static


### PR DESCRIPTION
Closes #4038

Written by agent stma-auto2-7 on the account holder's behalf.

## What changed

On a single-build install (no `variants/`), an explicit `--bc-version` on a different minor of the engine's major printed the `KNOWN-DEGRADED` warning twice. The runner re-execs into a shadow runtime, the child runs startup again, and the warning was written straight to stderr in both processes.

- `Program.cs`: the warning now goes into `deferredStartupLines`, the queue that only the terminal generation flushes (#2041/#2066). The message is captured into a local when queued, and it is queued before `[bc] selected BC ...`, so the printed order does not change.
- `BcArtifacts.cs`: `WarnIfExplicitEngineMinorMismatch()` (printed) became `ExplicitEngineMinorMismatchWarning()` (returns the message). It had one caller. The pure `DescribeExplicitEngineMinorMismatch` and the `ShouldWarnExplicitEngineMinorMismatch` gate are unchanged.
- `ExplicitEngineMinorWarningGatingTests.ProgramCs_GatesTheWarnCall_...`: its source anchor was the literal `WarnIfExplicitEngineMinorMismatch();`. It now looks for `ExplicitEngineMinorMismatchWarning();`. The assertion that `ShouldWarnExplicitEngineMinorMismatch` guards the call inside the 400-char window is unchanged, so the anchor moved and the guard did not get weaker.

### Why deferring this line is safe when some neighbors stay immediate

The `deferredStartupLines` header keeps some lines immediate because a loud failure can return from the same generation before the flush and the line would explain it. That does not apply here:
- The `EngineVariants` "no shipped engine variant supports BC ..." `return 2` needs `shippedVariants.Count > 0`. This warning only fires when the count is `0`, so the two cannot happen in the same run.
- The other exits between the warning and the flush are the provisioning completeness gate and the two cache-root checks. Each prints its own message naming the path, and engine/artifact minor skew does not explain any of them.
- The degraded-variant warning in the same function is already deferred for the same reason.

**Correction after review (second commit).** The list above missed two points that can end the process before the flush: the shadow hop and the Ncl Cecil rewrite. The reviewer measured it with `Microsoft.Dynamics.Nav.Ncl.dll` replaced by random bytes, standing in for an Ncl of a different shape. `main` exited 134 and printed the warning once. The first commit exited 134 and printed it zero times, and on a different-minor selection that warning is the line that explains the crash.
- Both calls now sit in `try { ... } catch { FlushDeferredStartupLines(); throw; }`. The queued lines print, and then the original exception propagates with the same exit code.
- `FlushDeferredStartupLines()` prints the queue and empties it. The normal flush point calls it too, so no line prints twice.
- I read the stack for the corrupt-Ncl case: the throw comes from `NclCecilRewrite.RewriteNcl` <- `RewriteInPlace` <- `NclShadowRuntime.EnsureShadowDir` <- `TryShadowReexec`. That is in the **first** process, before any re-launch.

## RED -> GREEN

New `ExplicitEngineMinorWarningOncePerInvocationTests` runs the real runner through the shadow hop. It builds an `AL_RUNNER_ARTIFACTS_ROOT` with one entry: a symlink to the engine's own artifact directory, named with the same major and minor + 50 (`28.51.49838.53910` on a 28.1 build). `--bc-version` then selects a same-major, different-minor version, which is the warning's condition, and the run still passes because the files are the engine's own. The test asserts exit 0, the `[bc] selected BC <alias>` line, and that the warning appears exactly once.

- RED on `main`'s code (new test only): `Failed: 1, Passed: 0, Total: 1`, `printed 2 time(s)`.
- GREEN, filter `~ExplicitEngineMinorWarning` (new test + 5 gating tests): `Failed: 0, Passed: 6, Total: 6`. With `~EngineMinorMismatchWarningTests` added: `Failed: 0, Passed: 11, Total: 11`.

Second commit: `ExplicitDifferentMinor_RunCrashesBeforeFlush_StillPrintsWarning_ExactlyOnce` uses the same alias, but as a real directory. Every entry symlinks to the engine's artifacts except `Microsoft.Dynamics.Nav.Ncl.dll`, which is 64 KiB of seeded random bytes. It asserts a nonzero exit, a `BadImageFormatException` in the output, and the warning exactly once.
- RED at cfdcb9b9: `Failed: 1, Passed: 1, Total: 2`, `printed 0 time(s). exit=134`.
- GREEN: `Failed: 0, Passed: 7, Total: 7` (`~ExplicitEngineMinorWarning`). `~CleanRunStartupVerbosityTests` and `~DefaultProvisionTargetMessagingTests` pass too.

## Mutations (executed, each rebuilt; each red is an `Assert`, 0 `error CS`)

Filter `~ExplicitEngineMinorWarning`, 6 tests:
- Enqueue removed (warning never printed): `Failed: 1, Passed: 5`, `printed 0 time(s)`. This shows the test requires the warning to be present.
- Immediate `Console.Error.WriteLine` put back instead of the enqueue: `Failed: 1, Passed: 5`, `printed 2 time(s)`. This shows the test requires it once.

Second-commit mutations, filter `~ExplicitEngineMinorWarning`, 7 tests:
- Flush removed from the shadow-hop `catch`: `Failed: 1, Passed: 6`, `printed 0 time(s). exit=134`.
- Flush removed from the final-process rewrite `catch`: `Failed: 0, Passed: 7`. **No test covers that site.** On this build every run goes through the shadow hop, and the hop's own rewrite throws first. The final-process rewrite only runs by itself when no shadow is needed, and I could not set that up in a test. I kept the flush there because it holds the same invariant as the hop's flush, but it is unproven.

## Measured by hand, `esm-xapp-table`, 28.1.49838.53910 build, real cached artifacts

| selection | before (main) | after |
|---|---|---|
| `--bc-version 28.4.53241.53955` | exit 0, warning x2 | exit 0, warning x1, one `[reexec]` line |
| `--bc-version 27.5.46862.53931` | exit 3, warning x2 | exit 3, warning x1 |

The 27.5 row is a cross-major selection on a 28.x engine. On this base it is not refused: it reaches the compile and fails there (`compile-fail: 1`), and the warning's "different minor" wording does not fit it. Refusing that selection is #4039's change, not this one. I did not build a 27.x engine to measure a 27.x-minor selection; the deferral does not depend on the major.

## Fix the shape

1. **Same pattern at another call site?** I searched for immediate `Console.Error.WriteLine` calls between `SelectVersion` and the flush. The other lines in that window are either already deferred (selected BC, degraded variant, provisioning result, run banner) or exit with their own message. The one still immediate that repeats per generation is the variants-shipped branch's warnings, which is #2230 (below).
2. **Sibling making the same assumption?** `--precompile` does not call this warning (`SiblingCompile.cs` has no call). Its degraded-variant print is handled in #4024.
3. **Two paths writing the same state?** The auto-select path's own skew warning (`cached-minor`, build skew within the minor) was already deferred; the explicit path's warning was not. Both are deferred now. The auto-select `cdn-exact`/`cdn-minor` notices stay immediate on purpose, because they announce a download that is about to start.

## Not folded

- #2230 (variants-shipped cross-major warning is still worded as an alarm and repeats): the fix belongs in the other arm of the same `if/else`. That issue says deferring it is unsafe because `SelectBestMatch` can `return 2` before the flush, so it needs a split into deferrable and immediate cases. Confirming the duplication also needs a fabricated variants-shipped install. That is different reasoning from this change, so I left it open and commented there.
- #4039 edits `Program.cs` and `BcArtifacts.cs` too. Expect a textual rebase for whichever merges second.

## Local runs not green, all environmental

- `tools/test_agent_self_freshness.py`, `tools/test_corpus_checkout.py`, `tools/test_preflight.py`: `git commit` in a temp repo fails with `1Password: agent returned an error` (commit signing on this machine).
- `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned`: "REFUSING TO SKIP ... in-process engine bootstrap was not performed" (needs `tools/engine-test-bootstrap.sh`). The other 259 tests in `GuardTests` plus these classes passed.

No corpus test: this is runner startup output with no BC behavior in the claim. `Program.cs` and `BcArtifacts.cs` are outside the corpus-linkage path list.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
