### PR TITLE
fix(cli): --emit-app refuses --package-cache instead of ignoring it

### DIFF
--- a/AlRunner.Tests/EmitAppPackageCacheRefusalTests.cs
+++ b/AlRunner.Tests/EmitAppPackageCacheRefusalTests.cs
@@ -1,0 +1,87 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #4032: `--emit-app` only packages app.json and the *.al sources, so it reads no
+/// package cache. It used to parse `--package-cache PATH` and drop it, with no message.
+/// It now refuses any argument after its two positionals with exit 2, naming the argument.
+///
+/// Both tests use a bundle directory that does not exist, so the run ends at the
+/// identity read with exit 2 unless the argument guard fires first. The two cases share
+/// the exit code and differ only in the message, which is what the assertions read.
+/// </summary>
+public sealed class EmitAppPackageCacheRefusalTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static (int ExitCode, string StdOut, string StdErr) RunCli(params string[] args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        psi.Arguments = TestBuildConfig.RunArgs(Path.Combine(RepoRoot, "AlRunner"));
+        foreach (var a in args) psi.Arguments += $" \"{a}\"";
+        // Drain both pipes asynchronously: see CliDocumentationTests.RunCli for the deadlock.
+        using var proc = Process.Start(psi)!;
+        var outSb = new StringBuilder();
+        var errSb = new StringBuilder();
+        proc.OutputDataReceived += (_, e) => { if (e.Data != null) lock (outSb) outSb.AppendLine(e.Data); };
+        proc.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (errSb) errSb.AppendLine(e.Data); };
+        proc.BeginOutputReadLine();
+        proc.BeginErrorReadLine();
+        if (!proc.WaitForExit(240_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException($"al-runner did not exit within 240s for args: {string.Join(' ', args)}");
+        }
+        proc.WaitForExit();
+        lock (outSb) lock (errSb) return (proc.ExitCode, outSb.ToString(), errSb.ToString());
+    }
+
+    private static string MissingBundle() =>
+        Path.Combine(TestScratch.Dir("emit-app-4032"), "missing-bundle");
+
+    [Fact]
+    public void EmitApp_WithPackageCache_ExitsTwoNamingTheFlag()
+    {
+        var bundle = MissingBundle();
+        var (exit, _, stderr) = RunCli("--emit-app", bundle, bundle + ".app", "--package-cache", "/some/cache");
+
+        Assert.Equal(2, exit);
+        Assert.Contains("--emit-app: --package-cache has no effect", stderr, StringComparison.Ordinal);
+        Assert.DoesNotContain("could not read identity", stderr, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmitApp_WithUnknownTrailingArgument_ExitsTwoNamingIt()
+    {
+        var bundle = MissingBundle();
+        var (exit, _, stderr) = RunCli("--emit-app", bundle, bundle + ".app", "--bogus-flag");
+
+        Assert.Equal(2, exit);
+        Assert.Contains("--emit-app: unexpected argument '--bogus-flag'", stderr, StringComparison.Ordinal);
+        Assert.DoesNotContain("could not read identity", stderr, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmitApp_WithOnlyPositionals_IsNotRefusedByTheArgumentGuard()
+    {
+        var bundle = MissingBundle();
+        var (exit, _, stderr) = RunCli("--emit-app", bundle, bundle + ".app");
+
+        Assert.Equal(2, exit);
+        Assert.Contains("--emit-app: could not read identity", stderr, StringComparison.Ordinal);
+        Assert.DoesNotContain("has no effect", stderr, StringComparison.Ordinal);
+        Assert.DoesNotContain("unexpected argument", stderr, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner.Tests/PrecompileEmitAppVersionHelpTextTests.cs
+++ b/AlRunner.Tests/PrecompileEmitAppVersionHelpTextTests.cs
@@ -44,7 +44,7 @@ public sealed class PrecompileEmitAppVersionHelpTextTests
     [Fact]
     public void Help_EmitAppEntry_SaysItCompilesNothingAndSelectsNoVersion()
     {
-        var entry = Entry(FlatHelp(), "  --emit-app <bundleDir> <outPath> [--package-cache PATH ...] ");
+        var entry = Entry(FlatHelp(), "  --emit-app <bundleDir> <outPath> ");
 
         Assert.DoesNotContain("Compile a bundle dir", entry);
         Assert.Contains("Compiles nothing and selects no BC version", entry);

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -246,7 +246,7 @@ if (args[0] == "--precompile")
 }
 
 // ── --emit-app subcommand (debug tool: emit a bundle dir as a .app in-process) ──
-// Usage: --emit-app <bundleDir> <outPath> [--package-cache PATH ...]
+// Usage: --emit-app <bundleDir> <outPath>
 if (args[0] == "--emit-app")
 {
     return RunEmitApp(args.Skip(1).ToArray());

--- a/AlRunner/ProgramSupport/CliText.cs
+++ b/AlRunner/ProgramSupport/CliText.cs
@@ -369,7 +369,7 @@ internal static partial class ProgramSupport
         w.WriteLine("  al-runner --server [--package-cache PATH ...] [--cache DIR]");
         w.WriteLine("  al-runner --dap [PORT|stdio] <bundle-dir>");
         w.WriteLine("  al-runner --precompile <input.app> --out <output.dll> [--package-cache PATH ...]");
-        w.WriteLine("  al-runner --emit-app <bundleDir> <outPath> [--package-cache PATH ...]");
+        w.WriteLine("  al-runner --emit-app <bundleDir> <outPath>");
         w.WriteLine("  al-runner --guide      (operating manual for automated callers)");
         w.WriteLine("  al-runner --version   (also: -v, -V, version)");
         w.WriteLine("  al-runner --help");
@@ -776,7 +776,7 @@ internal static partial class ProgramSupport
         w.WriteLine("                          directory exists. On a multi-variant install it then");
         w.WriteLine("                          picks the matching engine variant, or exits 2 when none");
         w.WriteLine("                          is shipped for that version.");
-        w.WriteLine("  --emit-app <bundleDir> <outPath> [--package-cache PATH ...]");
+        w.WriteLine("  --emit-app <bundleDir> <outPath>");
         w.WriteLine("                          Package a bundle dir's app.json identity and *.al sources");
         w.WriteLine("                          as a .app, without running tests. Compiles nothing and");
         w.WriteLine("                          selects no BC version, so no BC artifacts are needed.");

--- a/AlRunner/ProgramSupport/SiblingCompile.cs
+++ b/AlRunner/ProgramSupport/SiblingCompile.cs
@@ -273,24 +273,27 @@ internal static partial class ProgramSupport
     }
 
     // ── --emit-app subcommand ──────────────────────────────────────────────────
-    // Usage: --emit-app <bundleDir> <outPath> [--package-cache PATH ...]
+    // Usage: --emit-app <bundleDir> <outPath>
     // Emits the bundle dir as a real NAVX .app package using PackageModuleOutputter.
     // Useful as a standalone debug tool and as the core of the layered pre-pass.
     internal static int RunEmitApp(string[] args)
     {
         if (args.Length < 2)
         {
-            Console.Error.WriteLine("Usage: al-runner --emit-app <bundleDir> <outPath> [--package-cache PATH ...]");
+            Console.Error.WriteLine("Usage: al-runner --emit-app <bundleDir> <outPath>");
+            return 2;
+        }
+        // #4032: the packager reads only app.json and *.al, so any further argument would be
+        // accepted and ignored. Refuse before the identity read, which also exits 2.
+        if (args.Length > 2)
+        {
+            Console.Error.WriteLine(args[2] == "--package-cache"
+                ? "--emit-app: --package-cache has no effect (--emit-app packages app.json and the *.al sources and reads no package cache); remove it."
+                : $"--emit-app: unexpected argument '{args[2]}'. Usage: al-runner --emit-app <bundleDir> <outPath>");
             return 2;
         }
         var bundleDir = Path.GetFullPath(args[0]);
         var outPath = Path.GetFullPath(args[1]);
-        var caches = new List<string>();
-        for (int i = 2; i < args.Length; i++)
-        {
-            if ((args[i] == "--package-cache") && i + 1 < args.Length)
-                caches.Add(args[++i]);
-        }
 
         var appJsonPath = Path.Combine(bundleDir, "app.json");
         var identity = AlRunner.Infrastructure.InProcessAppPackager.ReadIdentity(appJsonPath);

--- a/tests/runner-extras/report-stubmeta-unbounded-loop/REGENERATE-FIXTURES.txt
+++ b/tests/runner-extras/report-stubmeta-unbounded-loop/REGENERATE-FIXTURES.txt
@@ -121,8 +121,7 @@ Regenerate, from the repo root (AlRunner already built, -c Release):
   # 1. The .alpackages symbol/identity package. `--emit-app` writes src/*.al +
   #    NavxManifest.xml and NO SymbolReference.json, which is the whole point --
   #    see above.
-  ./AlRunner/bin/Release/net8.0/al-runner --emit-app /tmp/rsm-dep \
-      /tmp/rsm-dep/out/dep.app --package-cache "$HOME/.al-runner/platform-apps"
+  ./AlRunner/bin/Release/net8.0/al-runner --emit-app /tmp/rsm-dep /tmp/rsm-dep/out/dep.app
 
   # 2. The raw compiled DLL (Tier-1 target), by running the dep as a normal
   #    bundle once (bundled Emit+Compile writes a cache entry) and copying the


### PR DESCRIPTION
Closes #4032

Written by agent stma-auto2-7 on the account holder's behalf.

## What changed

`--emit-app` packages `app.json` and the `*.al` sources (`InProcessAppPackager.EmitAppPackageToFile`) and reads no package cache, but `RunEmitApp` parsed `--package-cache PATH` into a list that nothing read, and `--help` advertised the flag. I chose to refuse the flag rather than honour it, because there is nothing for a package cache to feed on this path: the issue measured exit 0 in 55 ms with `AL_RUNNER_ARTIFACTS_ROOT` pointing at an empty directory.

- `AlRunner/ProgramSupport/SiblingCompile.cs`: any argument after the two positionals now exits 2 before the identity read. `--package-cache` gets `--emit-app: --package-cache has no effect (...); remove it.`; anything else gets `--emit-app: unexpected argument '<arg>'`. The unused list is gone. This follows the existing #2085 guard in `Program.cs` ("Reject early rather than silently accepting-and-ignoring"), which also exits 2.
- `AlRunner/ProgramSupport/CliText.cs`: dropped `[--package-cache PATH ...]` from the `--emit-app` USAGE synopsis and flag entry.
- `AlRunner/Program.cs`: the usage comment above the dispatch, one line.
- `AlRunner.Tests/EmitAppPackageCacheRefusalTests.cs`: new, spawns the CLI.

No corpus test: this is CLI argument handling, not BC behavior.

## RED -> GREEN, and the mutation

All three tests point at a bundle directory that does not exist, so without the guard the run ends at the identity read, which also exits 2. The assertions read the message, not only the exit code. The third test (positionals only) checks that the guard does not fire when there are no extra arguments.

- RED (before the fix): `Failed: 2, Passed: 1, Total: 3`. The two refusal tests failed on `Assert.Contains() Failure: Sub-string not found`.
- GREEN: `Failed: 0, Passed: 3, Total: 3`.
- Mutation: changed the guard to `args.Length > 99` (a value mutation, so the build stays clean), rebuilt: `Failed: 2, Passed: 1, Total: 3`, both on `Assert.Contains()`, and the positionals-only test stayed green. Restored, rebuilt: `Failed: 0, Passed: 3`.

Also ran, after a full build: `CliDocumentationTests` + `GuardTests` + the new class, `Failed: 1, Passed: 271, Total: 272`. The one failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned`, which refuses because `tools/engine-test-bootstrap.sh` was not run on this box. It does not touch these files. `tools/test_*.py`: `test_agent_self_freshness.py` and `test_corpus_checkout.py` fail here because `git commit` in their scratch repos hits the local 1Password signing agent; `test_preflight.py` also fails locally. None of them read the files this PR changes.

## Fix the shape

1. **Same wrong pattern at another call site?** No. `RunPrecompile` parses `--package-cache` too and uses it (`new DependencyResolver(packageCacheDirs)`). The main run path and `--server` use it too.
2. **Sibling function with the same assumption?** `RunPrecompile` is the sibling. It consumes the flag, so it does not have this defect.
3. **Two paths writing the same state, same invariant?** `--precompile` and `--emit-app` both parsed the flag; only one consumed it. After this PR, every subcommand that accepts `--package-cache` reads it.

## Queue scan

I searched open issues for `emit-app`, `package-cache ignored` and `silently ignored flag`. The only related issue is #2227 (the implicit BC-version default for `--precompile`/`--emit-app`), handled by open PR #4024. Its fix is different, so I did not fold it in.

**Rebased onto #4024 (merged):** I kept #4024's longer `--precompile`/`--emit-app` help entries and removed only `[--package-cache PATH ...]` from the `--emit-app` entry. The string #4024's `PrecompileEmitAppVersionHelpTextTests` looks up is now `"  --emit-app <bundleDir> <outPath> "`. After the rebase, `PrecompileEmitAppVersionHelpTextTests` + `EmitAppPackageCacheRefusalTests` + `CliDocumentationTests` gave `Failed: 0, Passed: 26, Total: 26`.

**Fixture recipe:** `tests/runner-extras/report-stubmeta-unbounded-loop/REGENERATE-FIXTURES.txt` passed `--package-cache` to `--emit-app`, which now exits 2. I dropped the flag there. That was the only `--emit-app` call passing it, checked with `rg --hidden` over the non-C# files. Found in review.

## Deliberately left out

The #4032 issue body also points out that `InProcessAppPackager`'s header comment says callers must first call `BcRuntime.EnsureApplied()` and `DependencyLoader.EnsureResolverInstalled_Public()`, while `RunEmitApp` calls neither and still works. That comment is untouched here, because it is a separate file and does not change behavior.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
