### PR TITLE
fix(session): StartSession returns false during the install pass, as BC does

### DIFF
--- a/AlRunner.Tests/StartSessionInstallPassTests.cs
+++ b/AlRunner.Tests/StartSessionInstallPassTests.cs
@@ -15,7 +15,16 @@ using Xunit;
 
 namespace AlRunner.Tests;
 
-[Collection("InstallPassFlag")]
+// Serial: the install-pass flag is process-wide, and so is the TestIsolation state the #2805 guard
+// reads first. Any class running an install pass or an AL test concurrently would change what
+// these assertions see.
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class InstallPassFlagSerialCollection
+{
+    public const string Name = "InstallPassFlag";
+}
+
+[Collection(InstallPassFlagSerialCollection.Name)]
 public sealed class StartSessionInstallPassTests
 {
     // No loaded assembly declares this codeunit, so outside the install pass StartSession

--- a/AlRunner.Tests/StartSessionInstallPassTests.cs
+++ b/AlRunner.Tests/StartSessionInstallPassTests.cs
@@ -1,0 +1,83 @@
+// The runner-side mechanism behind #3292: InstallTriggerRunner's install-pass flag, and
+// AlRunnerStartSession's refusal while it is set.
+//
+// The BC behaviour (StartSession during install returns false, leaves SessionId alone, runs no
+// worker) is pinned upstream by corpus codeunit 60449, and end to end through a real install
+// trigger by tests/runner-extras/install-trigger-seed. What only C# can pin is the scope's
+// lifetime: cleared on dispose, cleared when the install body throws, and nesting-safe. A flag
+// left latched would refuse every StartSession for the rest of the process.
+
+using System;
+using AlRunner;
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection("InstallPassFlag")]
+public sealed class StartSessionInstallPassTests
+{
+    // No loaded assembly declares this codeunit, so outside the install pass StartSession
+    // reaches dispatch and fails on lookup. That failure is the negative control: it shows the
+    // install-pass refusal, not the lookup, is what answers false inside the pass.
+    private const int NoSuchCodeunit = 1_999_999_999;
+
+    [Fact]
+    public void InsideTheInstallPass_StartSessionReturnsFalse_AndLeavesSessionIdAlone()
+    {
+        int slot = 777;
+        var sessionId = new ByRef<int>(() => slot, v => slot = v);
+
+        bool result;
+        using (InstallTriggerRunner.EnterInstallPass())
+            result = BcRuntime.AlRunnerStartSession(
+                DataError.ThrowError, sessionId, NoSuchCodeunit, null, null);
+
+        Assert.False(result);
+        Assert.Equal(777, slot);
+    }
+
+    [Fact]
+    public void OutsideTheInstallPass_StartSessionReachesDispatch()
+    {
+        int slot = 777;
+        var sessionId = new ByRef<int>(() => slot, v => slot = v);
+
+        Assert.False(InstallTriggerRunner.InInstallPass);
+        var ex = Record.Exception(() => BcRuntime.AlRunnerStartSession(
+            DataError.ThrowError, sessionId, NoSuchCodeunit, null, null));
+
+        Assert.IsType<InvalidOperationException>(ex);
+        Assert.Contains($"codeunit {NoSuchCodeunit} is not present", ex!.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheFlag_IsClearedWhenTheInstallBodyThrows()
+    {
+        Action installBody = () =>
+        {
+            using (InstallTriggerRunner.EnterInstallPass())
+            {
+                Assert.True(InstallTriggerRunner.InInstallPass);
+                throw new InvalidOperationException("install trigger failed");
+            }
+        };
+        Assert.Throws<InvalidOperationException>(installBody);
+
+        Assert.False(InstallTriggerRunner.InInstallPass);
+    }
+
+    [Fact]
+    public void NestedScopes_KeepTheFlagUntilTheOutermostEnds_AndDoubleDisposeIsHarmless()
+    {
+        var outer = InstallTriggerRunner.EnterInstallPass();
+        var inner = InstallTriggerRunner.EnterInstallPass();
+        inner.Dispose();
+        inner.Dispose();
+        Assert.True(InstallTriggerRunner.InInstallPass);
+
+        outer.Dispose();
+        Assert.False(InstallTriggerRunner.InInstallPass);
+    }
+}

--- a/AlRunner/BcAssembler.cs
+++ b/AlRunner/BcAssembler.cs
@@ -429,7 +429,8 @@ public sealed class BcAssembler
         // they NRE'd only because NavDatabase.Tenant was null on the skeleton, and that is now
         // populated (RecordPatches.Register), so BC's own bodies run and compute the answer —
         // including Install / Uninstall / Upgrade from session.AppInstallationContext and
-        // session.AppUpgradeContext, which a hardcoded Normal got wrong inside an install trigger.
+        // session.AppUpgradeContext (still Normal inside a runner install trigger: the runner does
+        // not populate AppInstallationContext, #4049).
         // ALSession.ALSendTraceTag NREs via session.Diagnostics; telemetry is a no-op here.
         ("ALSession.ALSendTraceTag(",  "global::AlRunnerShim.NavRuntimeHelpersShim.ALSession_SendTraceTag("),
         // ALSessionInformation static properties NRE via session.SqlDebuggingStatisticsCheckPoint.

--- a/AlRunner/Infrastructure/NclCecilRewrite.Records.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Records.cs
@@ -1171,9 +1171,9 @@ public static partial class NclCecilRewrite
         // at the source (RecordPatches.Register wires the skeleton NavDatabase's tenant field,
         // MetadataPatches seeds NavSystemTenant.upgradeMetadata), so BC's own getter runs:
         // Install / Uninstall from session.AppInstallationContext, Upgrade from
-        // session.AppUpgradeContext, and Normal otherwise — which the hardcoded 0 got wrong
-        // inside an install trigger, where the runner does populate AppInstallationContext.
-        // See AlRunner#2353.
+        // session.AppUpgradeContext, and Normal otherwise. The runner does NOT populate
+        // AppInstallationContext (measured null inside install triggers), so this still answers
+        // Normal there: #4049. See AlRunner#2353.
 
         // ── ALNavApp.GetDataVersionForUpgrade(NavAppRuntimeMetadata) → return null ──
         // The method probes whether an app data-upgrade is in progress, via

--- a/AlRunner/InstallTriggerRunner.cs
+++ b/AlRunner/InstallTriggerRunner.cs
@@ -131,8 +131,34 @@ public static class InstallTriggerRunner
         return string.Join("|", ordered.Select(a => a.ManifestModule.ModuleVersionId.ToString("N")));
     }
 
+    private static int _installPassDepth;
+
+    /// <summary>True while an install pass is running — the runner's stand-in for BC's
+    /// <c>NavSession.AppInstallationContext</c>, which the runner never populates (measured
+    /// null inside FireAll, #3292). Read by <see cref="BcRuntime.AlRunnerStartSession"/>.</summary>
+    internal static bool InInstallPass => System.Threading.Volatile.Read(ref _installPassDepth) > 0;
+
+    /// <summary>Marks an install pass for the lifetime of the returned scope. Dispose is what
+    /// clears it, so a throwing trigger cannot leave every later StartSession refused.</summary>
+    internal static IDisposable EnterInstallPass()
+    {
+        System.Threading.Interlocked.Increment(ref _installPassDepth);
+        return new InstallPassScope();
+    }
+
+    private sealed class InstallPassScope : IDisposable
+    {
+        private int _disposed;
+        public void Dispose()
+        {
+            if (System.Threading.Interlocked.Exchange(ref _disposed, 1) == 0)
+                System.Threading.Interlocked.Decrement(ref _installPassDepth);
+        }
+    }
+
     private static void FireAll(IEnumerable<Assembly> asms)
     {
+        using var installPass = EnterInstallPass();
         foreach (var asm in asms)
             foreach (var cu in Scan(asm))
             {

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -812,8 +812,8 @@ public static partial class RecordPatches
         //
         // Populating the field rather than rewriting the property is what keeps the answer
         // faithful: BC's own GetModuleExecutionContext body still returns Install / Uninstall from
-        // session.AppInstallationContext and Upgrade from session.AppUpgradeContext — both of which
-        // the runner does populate while running install triggers — and only falls through to
+        // session.AppInstallationContext and Upgrade from session.AppUpgradeContext — neither of
+        // which the runner populates yet, measured null inside install triggers (#4049) — and only falls through to
         // Normal when no upgrade workflow is in progress, which on the skeleton is always
         // (GetUpgradeInformation answers NavWorkflowState.NotStarted when no workflow was started).
         // A blanket "return Normal" replacement would answer Normal inside an install trigger,

--- a/AlRunner/Patches/SessionPatches.cs
+++ b/AlRunner/Patches/SessionPatches.cs
@@ -514,7 +514,7 @@ public static partial class BcRuntime
     /// which is faithful for this runtime: the runner drives AL synchronously, and BC's own
     /// callers await the result before reading <c>sessionId</c>.</para>
     ///
-    /// <para>SCOPE AUDIT — two things BC's body does that this one does not
+    /// <para>SCOPE AUDIT — two things BC's body does, and where each is handled here
     /// (.claude/rules/loud-failures.md asks for each to be named rather than left implicit):</para>
     ///
     /// <para>1. <c>timeout</c> IS DROPPED, and it is not purely decorative in BC. BC turns it
@@ -532,32 +532,8 @@ public static partial class BcRuntime
     /// caller passing a sane timeout. Tracked as <b>#3291</b>, which stays open after this
     /// merges — the divergence is real and is not fixed here.</para>
     ///
-    /// <para>2. BC REFUSES StartSession outright during an install or upgrade. Its body has,
-    /// before any of the work above:</para>
-    ///
-    /// <code>
-    ///   if (session.AppInstallationContext != null || session.AppUpgradeContext != null)
-    ///   {
-    ///       // trace: "StartSession ignored due to ongoing installation/upgrade
-    ///       //         to avoid inconsistent data in case of rollback"
-    ///       return false;
-    ///   }
-    /// </code>
-    ///
-    /// <para>That is not reproduced here, and it is worth being precise about why rather than
-    /// claiming equivalence. The runner has no <c>AppInstallationContext</c> — its install pass
-    /// is its own mechanism and never populates BC's field — so the guard has nothing to read
-    /// even if it were copied in, and it would be dead code that looked like coverage. The
-    /// consequence is real and observable: the very call this patch was written for
-    /// (<c>Codeunit8705.UpdateFeatureUptakeStatus</c>, reached from a Base App install trigger)
-    /// runs its worker here where a real tier would skip it and return false. Modelling the
-    /// install context faithfully is a separate piece of work; it is filed as <b>#3292</b>
-    /// rather than guessed at, because "run the worker" and "skip the worker" are different
-    /// answers to an AL-visible question and picking one by assumption is what
-    /// .claude/rules/no-assumption-fixes.md rules out. #3292 stays open after this merges, and
-    /// it is related to #3268 (install-trigger ordering) by the same missing state: the runner's
-    /// install pass does not record that an install is in progress, which is what both would
-    /// read.</para>
+    /// <para>2. BC refuses StartSession during an install or upgrade. That arm lives in
+    /// <see cref="AlRunnerStartSession"/>, reading the runner's install-pass flag (#3292).</para>
     /// </summary>
     public static System.Threading.Tasks.ValueTask<bool> ALSession_ALStartSessionAsyncImpl(
         Microsoft.Dynamics.Nav.Runtime.NavSession session,
@@ -630,6 +606,14 @@ public static partial class BcRuntime
         // [Test] body — `execute` mode, an install trigger, a report — nothing is refused.
         if (InTestExecutionScope && TestExecutor.ActiveIsolation != TestIsolation.Disabled)
             throw MakeStartSessionNotAllowedInTestException();
+
+        // #3292 — BC's install/upgrade refusal, next in BC's order: after the TestIsolation guard,
+        // before the try (so no error under either errorLevel) and before sessionId is written.
+        // BC reads session.AppInstallationContext, which the runner never populates; its own
+        // install pass is InstallTriggerRunner, so that is the state read here. Corpus 60449.
+        // BC's AppUpgradeContext arm has no counterpart: the runner has no upgrade pass.
+        if (InstallTriggerRunner.InInstallPass)
+            return false;
 
         bool trap = errorLevel == Microsoft.Dynamics.Nav.Types.DataError.TrapError;
         try

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -20,7 +20,7 @@
         "field-virtual-table-item-tracking-ext": { "tests": 0, "absentOn": ["27.0", "27.3", "27.5"] },
         "field-virtual-table-item-tracking-test": { "tests": 1, "absentOn": ["27.0", "27.3", "27.5"] },
         "http-egress-boundary-oos": { "tests": 4 },
-        "install-trigger-seed": { "tests": 3 },
+        "install-trigger-seed": { "tests": 4 },
         "install-trigger-text-constant": { "tests": 2 },
         "integer-virtual-table-window": { "tests": 10 },
         "manual-binding-dep": { "tests": 3, "absentOn": ["27.0", "27.3", "27.5"] },

--- a/tests/runner-extras/install-trigger-seed/InstallSeeder.Codeunit.al
+++ b/tests/runner-extras/install-trigger-seed/InstallSeeder.Codeunit.al
@@ -19,6 +19,7 @@ codeunit 60711 "ITS Installer"
     trigger OnInstallAppPerCompany()
     var
         Seed: Record "Install Seed";
+        Marker: Record "ITS Session Marker";
     begin
         Seed.Init();
         Seed."Code" := 'COMPANY1';
@@ -30,13 +31,22 @@ codeunit 60711 "ITS Installer"
         Seed."Value" := 22;
         Seed.Insert();
 
-        // #2805's guard refuses StartSession from inside a [Test] unless the TestRunner
-        // declares TestIsolation = Disabled. An install trigger is NOT a test, so the guard
-        // must be inert here and this must dispatch normally. Nothing outside a [Test] had
-        // ever exercised it, and "inert by construction" (BcRuntime.InTestExecutionScope is
-        // false) is exactly the claim that stops being true when someone changes the
-        // construction. "ITS StartSession Outside Test" reads the row the worker writes.
-        StartSession(SessionId, Codeunit::"ITS Session Worker");
+        // StartSession from an install trigger. Two claims ride on it:
+        //   * #2805's guard refuses StartSession only inside a [Test]; an install trigger is not
+        //     one, so the guard must not throw here. If it did, this trigger would fail loudly
+        //     and the INSTALL-RESULT row below would never be written.
+        //   * BC skips StartSession while an install runs and returns false without writing
+        //     SessionId (#3292; the BC half is pinned upstream by corpus codeunit 60449). The
+        //     runner models that with its own install-pass flag, so the worker must not run.
+        // "ITS StartSession Outside Test" reads both back.
+        SessionId := 777;
+        Marker.Init();
+        Marker."Code" := 'INSTALL-RESULT';
+        if StartSession(SessionId, Codeunit::"ITS Session Worker") then
+            Marker."Value" := 1
+        else
+            Marker."Value" := SessionId;
+        Marker.Insert();
     end;
 
     var

--- a/tests/runner-extras/install-trigger-seed/ItsSessionMarker.Table.al
+++ b/tests/runner-extras/install-trigger-seed/ItsSessionMarker.Table.al
@@ -1,7 +1,7 @@
-// Written ONLY by "ITS Session Worker", and only when an install trigger's StartSession
-// actually dispatches it. Deliberately a different table from "Install Seed": the baseline
-// isolation tests next door count that table's rows exactly, and a row added there would
-// break them for a reason unrelated to what they pin.
+// Rows: INSTALL-RESULT, written by the install trigger with StartSession's outcome, and
+// FROM-INSTALL, written only by "ITS Session Worker" (which must not run from install: #3292).
+// Deliberately a different table from "Install Seed": the baseline isolation tests next door
+// count that table's rows exactly.
 table 60714 "ITS Session Marker"
 {
     DataClassification = CustomerContent;

--- a/tests/runner-extras/install-trigger-seed/ItsSessionWorker.Codeunit.al
+++ b/tests/runner-extras/install-trigger-seed/ItsSessionWorker.Codeunit.al
@@ -1,8 +1,6 @@
-// The worker an install trigger starts. A Normal codeunit, source-compiled in this bundle:
-// the claim here is about the GUARD, not about resolving the async OnRunAsync flavour BC's
-// compiler emits for precompiled codeunits — that is issue #2826's suite, which needs a real
-// Base Application worker and its own isolation-disabled invocation. Keeping this one
-// source-compiled means this bundle needs no Base App and costs nothing extra.
+// The worker the install trigger asks StartSession to run. The install pass refuses the call
+// (#3292), so on a correct runner this OnRun never executes from there; its FROM-INSTALL row is
+// the evidence if it does. Source-compiled, so this bundle needs no Base App.
 codeunit 60717 "ITS Session Worker"
 {
     trigger OnRun()

--- a/tests/runner-extras/install-trigger-seed/ItsStartSessionOutsideTest.Codeunit.al
+++ b/tests/runner-extras/install-trigger-seed/ItsStartSessionOutsideTest.Codeunit.al
@@ -1,27 +1,20 @@
-// Issue #2826 follow-up: #2805's StartSession guard must be INERT outside a [Test].
+// StartSession called from the runner's install pass (#2826 follow-up, #3292).
 //
-// BC refuses StartSession from inside a [Test] unless the TestRunner declares
-// TestIsolation = Disabled — real BC, pinned upstream by corpus codeunit 60397 on all eight
-// versions, and implemented by the runner. Outside a test there is no such rule: an install
-// trigger, an `execute` entry point or an ordinary codeunit may start a session freely.
+// Two claims, both read back from rows "ITS Installer".OnInstallAppPerCompany writes:
 //
-// The runner gets that right by construction — BcRuntime.InTestExecutionScope is false
-// outside a test — but #2825's own report lists it as unverified, and a guarantee that rests
-// on construction is precisely the one that breaks silently when the construction changes.
+//   * #2805's guard is INERT outside a [Test]. BC refuses StartSession from inside a [Test]
+//     unless the TestRunner declares TestIsolation = Disabled (corpus codeunit 60397); an install
+//     trigger is not a test. If the guard fired here, the install trigger would throw before it
+//     writes INSTALL-RESULT, so the row's existence is the proof.
+//   * The runner's install-pass flag refuses StartSession the way BC's AppInstallationContext
+//     check does: false, SessionId untouched, worker not run. The BC behaviour itself is pinned
+//     upstream by corpus codeunit 60449; this test pins that the runner's install pass sets the
+//     flag its StartSession reads.
 //
-// This is an install trigger rather than a new entry point because the runner already fires
-// this bundle's Subtype=Install codeunit before its tests run, inside the existing
-// runner-extras CI invocation. No new step, no Base App, no extra wall clock.
-//
-// WHY THIS FAILS IF THE GUARD STARTS FIRING
-//   The assertion reads a row that ONLY "ITS Session Worker".OnRun writes, and only when
-//   StartSession actually dispatched it from the install trigger:
-//     * guard fires outside a test  -> StartSession throws inside OnInstallAppPerCompany,
-//                                      the install fails loudly, the row is absent;
-//     * dispatch silently no-ops    -> StartSession returns true having run nothing (the
-//                                      #2733 shape), the row is absent.
-//   It never asserts that StartSession returned or did not throw, because both of those are
-//   satisfied by the broken behaviours above.
+// INSTALL-RESULT."Value" encodes the outcome so one field discriminates all three wrong answers:
+//   1    -> StartSession returned true (the install flag was not set, or not consulted);
+//   777  -> returned false and left SessionId alone (correct);
+//   else -> returned false but wrote a session id first (refused after allocating one).
 codeunit 60718 "ITS StartSession Outside Test"
 {
     Subtype = Test;
@@ -30,15 +23,25 @@ codeunit 60718 "ITS StartSession Outside Test"
         Assert: Codeunit "ITS Assert";
 
     [Test]
-    procedure InstallTrigger_StartSession_IsNotRefused_AndRunsTheWorker()
+    procedure InstallTrigger_StartSession_IsNotRefusedByTheTestGuard()
     var
         Marker: Record "ITS Session Marker";
     begin
-        Assert.IsTrue(Marker.Get('FROM-INSTALL'),
-            'the install trigger''s StartSession must have dispatched "ITS Session Worker", whose ' +
-            'OnRun writes this row. An absent row means either the [Test]-only guard fired outside ' +
-            'a test, or the dispatch returned without running the worker.');
-        Assert.AreEqual(42, Marker."Value",
-            'the row must carry the value the worker''s OnRun body wrote, not a default');
+        Assert.IsTrue(Marker.Get('INSTALL-RESULT'),
+            'the install trigger must have run past its StartSession call and written INSTALL-RESULT. ' +
+            'An absent row means the [Test]-only guard fired outside a test.');
+    end;
+
+    [Test]
+    procedure InstallTrigger_StartSession_ReturnsFalse_LeavesSessionId_RunsNoWorker()
+    var
+        Marker: Record "ITS Session Marker";
+    begin
+        Assert.IsTrue(Marker.Get('INSTALL-RESULT'), 'precondition: the install trigger wrote INSTALL-RESULT');
+        Assert.AreEqual(777, Marker."Value",
+            'StartSession during the install pass must return false without writing SessionId ' +
+            '(1 = it returned true; any other value = it wrote a session id)');
+        Assert.IsFalse(Marker.Get('FROM-INSTALL'),
+            'the worker passed to StartSession during the install pass must not have run');
     end;
 }


### PR DESCRIPTION
Closes #3292

*Written by agent stma-auto2-3 on the account holder's behalf.*

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/338

## What changed

BC skips `StartSession` while an app install runs. `ALSession.ALStartSessionAsyncImpl` checks `session.AppInstallationContext` / `AppUpgradeContext` right after the TestIsolation guard and returns `false` before the try block and before `sessionId` is written. That body is identical on two distinct Ncl binaries (`compare_symbols` bc270 vs bc284: `bodyChanged: false`).

The runner ran the worker instead. Now:

- `InstallTriggerRunner` has an install-pass scope (`EnterInstallPass()` / `InInstallPass`), entered in `FireAll`. `RunAll`, `RunDependenciesOnly` and `RunTestAssemblyOnly` all go through `FireAll`, so all three install paths set it. It is a depth counter cleared on `Dispose`, so a throwing install trigger cannot leave it set.
- `BcRuntime.AlRunnerStartSession` returns `false` when the flag is set. It sits where BC's check sits: after the #2805 TestIsolation throw and before the try, so neither `errorLevel` raises and `sessionId` is untouched. The Cecil patch for precompiled callers and the three `BcAssembler` polyfill overloads all go through this one method, so there is one guard for both paths.
- Upgrade: the runner has no upgrade pass, so there is no second arm. The code says so in one line.

### Why a runner flag and not BC's own `AppInstallationContext`

I checked before writing either version. Three comments (`NclCecilRewrite.Records.cs`, `RecordPatches.cs`, `BcAssembler.cs`, from #2353) said the runner populates `AppInstallationContext` during install triggers. The issue said it does not. I printed it from inside `FireAll` on `tests/runner-extras/install-trigger-seed`: 16 firings, `AppInstallationContext` and `AppUpgradeContext` both null. So a copy of BC's check would never fire. This PR corrects those three comments.

The same missing state affects `Session.GetExecutionContext()`. I measured it answering `Normal` (and `GetCurrentModuleExecutionContext()` too) inside a runner install trigger. BC reads `AppInstallationContext` for that, so it should answer `Install`. I filed that as #4049 and did not fold it in. Fixing it means setting BC's real `NavAppInstallationContext`, whose setter also recomputes `IsNotInNormalAppContext`, which other BC code reads. That needs different review, and no service tier has been asked about it yet.

## Tests

**Upstream (the BC claim):** corpus PR #338 adds a Subtype=Install probe (60445) that calls `StartSession` in both forms from `OnInstallAppPerCompany`, with `SessionId` preset to 777. `Test Install StartSession` (60449) asserts: the probe ran; it returned false; `SessionId` is still 777 (both forms); the form without a return value raised no error; and the worker's marker table is empty.

Run locally with this branch's runner against corpus head `43f3aa14798c32f4c093c3b49084cba404ad3d17`, `--test Codeunit60449`:
- fixed runner: `pass: 4, fail: 0`
- mutation A below: `pass: 1, fail: 3` (the probe-ran precondition stays green; `Expected:<777> Actual:<3>` on SessionId)

**runner-extras, `install-trigger-seed`:** `ITS StartSession Outside Test` used to assert the worker **ran** from the install trigger. That matched the runner, not BC, so I inverted it. The claim it existed for (#2805's `[Test]`-only guard does not fire outside a test) is kept: the install trigger now writes an `INSTALL-RESULT` row after its `StartSession` call, and the row can only exist if the guard did not throw. A second test reads the row's value (1 = returned true, 777 = correct, anything else = session id written) and checks the worker row is absent. `test-count-baseline.json`: `install-trigger-seed` 3 → 4.

- RED, measured with the rewritten tests already in place and the runner fix absent (branch-base runner plus only the print probe above): `Failed: 1, Passed: 3` (`Expected:<777>. Actual:<1>`). The 3 passes are 60715, 60716 and the new guard-inert test; the old single test is not part of either number.
- GREEN: `Failed: 0, Passed: 4`, run twice against one `--cache` root (the install baseline is snapshotted), both 4/4

**C# mechanism tests, `AlRunner.Tests/StartSessionInstallPassTests.cs`** (serial collection, since the flag and the TestIsolation state are process-wide): inside the scope `AlRunnerStartSession` returns false and leaves the by-ref at 777; outside, the same call reaches dispatch and throws "codeunit … is not present" (negative control); the flag clears when the scope body throws; nested scopes and double dispose. `Total: 4, Passed: 4`.

**`runner-extras-isolation-disabled`** (Base App install pass fires first, then `[Test]`s call `StartSession`): 3/3 pass, so the flag is cleared after a real install pass.

### Mutations

| mutation | runner-extras AL | C# (4) | corpus 60449 |
|---|---|---|---|
| A: `FireAll` does not enter the scope | Failed 1, Passed 3 (guard-inert test stays green) | Passed 4 | pass 1, fail 3 |
| B: write `sessionId = 4242` before returning false | Failed 1, Passed 3 (`Actual:<4242>`) | Failed 1, Passed 3 (`Actual: 4242`) | not run |
| C: `Dispose` does not decrement | not run | Failed 3, Passed 1 | not run |

A and C partition the two mechanisms: A removes the flag from `FireAll`, which only the AL suites drive, and C breaks `Dispose`, which only the C# suite drives. So the green C# cell under A is the expected split, not a gap. Each red was an assertion, not a build error. Everything was restored and rebuilt before the final runs.

### Other local checks

- `dotnet test --filter GuardTests`: 248 passed, 1 failed. The failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned`, which refuses because the engine bootstrap (`tools/engine-test-bootstrap.sh`) was not run on this box. It is not related to this diff.
- `tools/test_*.py`: 3 failed (`test_agent_self_freshness`, `test_corpus_checkout`, `test_preflight`). Two of them reproduce as `git commit` failures in temp repos with `1Password: failed to fill whole buffer` (commit signing on this machine). `test_preflight` exited non-zero without output matching my filter, so its cause is inferred rather than measured. None of the three touches a file in this diff.

## Fix the shape

1. **Same wrong pattern at another call site?** Every `StartSession` path (Cecil patch + 3 polyfill overloads) goes through `AlRunnerStartSession`, so one guard covers all of them. The other place that reads the install state BC keeps is `GetExecutionContext` / `GetModuleExecutionContext`, and it is wrong the same way: #4049.
2. **Sibling making the same assumption?** Yes, the three comments claiming `AppInstallationContext` is populated. Corrected here, pointing to #4049.
3. **Two paths writing the same state?** The three install entry points all set the flag through `FireAll`, and it is cleared in `Dispose`, which the C# test proves for the throwing case.

## Queue scan

Searched open issues for `StartSession`, `AppInstallationContext`, `ExecutionContext`, `install trigger`, `install context`. Related but not folded:
- #2751 (StartSession drops the record): a different mechanism, threading the record into worker dispatch.
- #4015 (`GuiAllowed()` inside an inline StartSession worker): about the worker's session state, not the refusal.
- #2912 (unexplained precompiled StartSession flake): no overlap with this path.
- #3268 (session-user adoption happens after install triggers), which the issue lists as related, is already closed.

The upgrade arm is intentionally not implemented, because the runner has no upgrade pass.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
