### PR TITLE
feat(cli): reproducible Random() via a per-test derived seed and --seed

### DIFF
--- a/AlRunner.Tests/CliDocumentationTests.cs
+++ b/AlRunner.Tests/CliDocumentationTests.cs
@@ -297,6 +297,8 @@ public sealed class CliDocumentationTests
         // against, so two runs differing only by this flag produce different pass/fail counts.
         // That is squarely "what gets executed", not "how the result is reported".
         "--test-data-normalize-company",
+        // Issue #2502: --seed changes the Random() values the run executes against.
+        "--seed",
     };
 
     /// <summary>Negative: an unknown documentation flag must not be silently accepted.</summary>

--- a/AlRunner.Tests/JUnitCollateralFailureTests.cs
+++ b/AlRunner.Tests/JUnitCollateralFailureTests.cs
@@ -445,7 +445,9 @@ public sealed class JUnitCollateralFailureTests : IDisposable
     {
         // Written against a checked-in expected document rather than a second call to the same
         // method: comparing WriteJUnit to itself would be satisfied by any change applied to both
-        // sides. This is the shape the emitter produced before #2919.
+        // sides. This is the shape the emitter produced before #2919, plus #2502's per-suite seed
+        // property, pinned to a fixed run seed so the document stays byte-stable.
+        Infrastructure.RunSeed.Set(4271833);
         var path = P("clean.xml");
         JUnitReport.WriteJUnit(path, new[] { CleanBucketWithFailures() });
 
@@ -454,14 +456,23 @@ public sealed class JUnitCollateralFailureTests : IDisposable
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
             "<testsuites tests=\"3\" failures=\"1\" errors=\"1\" skipped=\"0\" time=\"0.013\">",
             "  <testsuite name=\"Codeunit60100\" tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\"0.003\">",
+            "    <properties>",
+            "      <property name=\"seed\" value=\"4271833\" />",
+            "    </properties>",
             "    <testcase name=\"Healthy_StillPasses\" classname=\"Codeunit60100\" time=\"0.003\" />",
             "  </testsuite>",
             "  <testsuite name=\"Codeunit60391\" tests=\"1\" failures=\"0\" errors=\"1\" skipped=\"0\" time=\"0.005\">",
+            "    <properties>",
+            "      <property name=\"seed\" value=\"4271833\" />",
+            "    </properties>",
             "    <testcase name=\"RightOuterJoin_IsOutOfScope_ThrowsNamedReason\" classname=\"Codeunit60391\" time=\"0.005\">",
             "      <error message=\"object not found\">object not found</error>",
             "    </testcase>",
             "  </testsuite>",
             "  <testsuite name=\"Codeunit64535\" tests=\"1\" failures=\"1\" errors=\"0\" skipped=\"0\" time=\"0.005\">",
+            "    <properties>",
+            "      <property name=\"seed\" value=\"4271833\" />",
+            "    </properties>",
             "    <testcase name=\"JoinWithLeftOuterJoin_ReturnsRows\" classname=\"Codeunit64535\" time=\"0.005\">",
             "      <failure message=\"Assert.AreEqual failed\">Assert.AreEqual failed</failure>",
             "    </testcase>",

--- a/AlRunner.Tests/JUnitCollateralFailureTests.cs
+++ b/AlRunner.Tests/JUnitCollateralFailureTests.cs
@@ -445,9 +445,7 @@ public sealed class JUnitCollateralFailureTests : IDisposable
     {
         // Written against a checked-in expected document rather than a second call to the same
         // method: comparing WriteJUnit to itself would be satisfied by any change applied to both
-        // sides. This is the shape the emitter produced before #2919, plus #2502's per-suite seed
-        // property, pinned to a fixed run seed so the document stays byte-stable.
-        Infrastructure.RunSeed.Set(4271833);
+        // sides. This is the shape the emitter produced before #2919.
         var path = P("clean.xml");
         JUnitReport.WriteJUnit(path, new[] { CleanBucketWithFailures() });
 
@@ -456,23 +454,14 @@ public sealed class JUnitCollateralFailureTests : IDisposable
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
             "<testsuites tests=\"3\" failures=\"1\" errors=\"1\" skipped=\"0\" time=\"0.013\">",
             "  <testsuite name=\"Codeunit60100\" tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\"0.003\">",
-            "    <properties>",
-            "      <property name=\"seed\" value=\"4271833\" />",
-            "    </properties>",
             "    <testcase name=\"Healthy_StillPasses\" classname=\"Codeunit60100\" time=\"0.003\" />",
             "  </testsuite>",
             "  <testsuite name=\"Codeunit60391\" tests=\"1\" failures=\"0\" errors=\"1\" skipped=\"0\" time=\"0.005\">",
-            "    <properties>",
-            "      <property name=\"seed\" value=\"4271833\" />",
-            "    </properties>",
             "    <testcase name=\"RightOuterJoin_IsOutOfScope_ThrowsNamedReason\" classname=\"Codeunit60391\" time=\"0.005\">",
             "      <error message=\"object not found\">object not found</error>",
             "    </testcase>",
             "  </testsuite>",
             "  <testsuite name=\"Codeunit64535\" tests=\"1\" failures=\"1\" errors=\"0\" skipped=\"0\" time=\"0.005\">",
-            "    <properties>",
-            "      <property name=\"seed\" value=\"4271833\" />",
-            "    </properties>",
             "    <testcase name=\"JoinWithLeftOuterJoin_ReturnsRows\" classname=\"Codeunit64535\" time=\"0.005\">",
             "      <failure message=\"Assert.AreEqual failed\">Assert.AreEqual failed</failure>",
             "    </testcase>",

--- a/AlRunner.Tests/RunSeedTests.cs
+++ b/AlRunner.Tests/RunSeedTests.cs
@@ -1,0 +1,194 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #2502: every run has a run seed, each [Test] starts from <c>new Random(RunSeed.Derive(...))</c>,
+/// <c>Randomize(seed)</c> is honored and <c>Randomize()</c> is reseeded from the test's derived
+/// seed. A runner feature, not a BC-behaviour claim, so it is proven here rather than upstream.
+/// </summary>
+public class RunSeedTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private const int CodeunitId = 62502;
+    private const int Max = 1000000;
+
+    // Golden values: a change here silently invalidates every seed a user has recorded.
+    [Theory]
+    [InlineData(4271833, 50100, "PostingRoundsAmountCorrectly", -1379714443)]
+    [InlineData(4271833, 50100, "PostingRoundsAmountCorrectlY", -842830635)]
+    [InlineData(4271834, 50100, "PostingRoundsAmountCorrectly", -1936696938)]
+    [InlineData(4271833, 50101, "PostingRoundsAmountCorrectly", 1186558372)]
+    [InlineData(0, 0, "", -1742010779)]
+    public void Derive_IsFnv1aOverRunSeedCodeunitAndMethod(int runSeed, int codeunitId, string method, int expected)
+        => Assert.Equal(expected, RunSeed.Derive(runSeed, codeunitId, method));
+
+    [Theory]
+    [InlineData("4271833", true, 4271833)]
+    [InlineData(" -17 ", true, -17)]
+    [InlineData("12a", false, 0)]
+    [InlineData("", false, 0)]
+    [InlineData("99999999999", false, 0)]
+    public void TryParse_AcceptsOnlyWholeInt32(string raw, bool ok, int expected)
+    {
+        Assert.Equal(ok, RunSeed.TryParse(raw, out var seed));
+        if (ok) Assert.Equal(expected, seed);
+    }
+
+    [SkippableFact]
+    public void Seed_ReproducesRandomPerTest_InSeparateProcesses_AndIsolatedRerun()
+    {
+        TestArtifacts.SkipIfMissing();
+        var bundle = WriteFixture();
+        var junit = Path.Combine(TestScratch.Dir("al-runner-run-seed-2502-junit"), "r.xml");
+        Directory.CreateDirectory(Path.GetDirectoryName(junit)!);
+
+        const int seed = 4271833;
+        var full = RunRunner($"--seed {seed} --output-junit \"{junit}\" \"{bundle}\"");
+        var alone = RunRunner($"--seed {seed} --filter B_Plain \"{bundle}\"");
+        var unseeded = RunRunner($"\"{bundle}\"");
+
+        // Seeded run reports its seed on the console and in JUnit.
+        Assert.Contains($"seed: {seed}", full.Output);
+        Assert.Contains($"<property name=\"seed\" value=\"{seed}\"", File.ReadAllText(junit));
+
+        // Each plain test starts on exactly its derived sequence.
+        var a = Values(full.Output, "A_Plain");
+        var b = Values(full.Output, "B_Plain");
+        Assert.Equal(Expected(RunSeed.Derive(seed, CodeunitId, "A_Plain")), a);
+        Assert.Equal(Expected(RunSeed.Derive(seed, CodeunitId, "B_Plain")), b);
+        Assert.NotEqual(a, b);
+
+        // B alone, in a second process, sees what B saw in the full suite.
+        Assert.Equal(b, Values(alone.Output, "B_Plain"));
+        Assert.DoesNotContain("A_Plain=values", alone.Output);
+
+        // Randomize(42) is honored: BC's own seeded sequence, whatever the run seed.
+        Assert.Equal(Expected(42), Values(full.Output, "C_RandomizeSeeded"));
+        Assert.Equal(Expected(42), Values(unseeded.Output, "C_RandomizeSeeded"));
+
+        // Randomize() reseeds from the test's derived seed and warns.
+        Assert.Equal(Expected(RunSeed.Derive(seed, CodeunitId, "D_RandomizeNoSeed")),
+            Values(full.Output, "D_RandomizeNoSeed"));
+        Assert.Contains($"Codeunit{CodeunitId}.D_RandomizeNoSeed called Randomize() without a seed", full.Output);
+
+        // No --seed: a generated seed is printed, and it is the one the tests used.
+        var printed = Regex.Match(unseeded.Output, @"^seed: (-?\d+)\r?$", RegexOptions.Multiline);
+        Assert.True(printed.Success, "no `seed: N` line without --seed:\n" + unseeded.Output);
+        var generated = int.Parse(printed.Groups[1].Value);
+        Assert.NotEqual(seed, generated);
+        Assert.Equal(Expected(RunSeed.Derive(generated, CodeunitId, "A_Plain")), Values(unseeded.Output, "A_Plain"));
+        Assert.NotEqual(a, Values(unseeded.Output, "A_Plain"));
+    }
+
+    [Fact]
+    public void Seed_NotAWholeNumber_ExitsTwo()
+    {
+        var r = RunRunner($"--seed nope \"{WriteFixture()}\"");
+        Assert.Equal(2, r.Exit);
+        Assert.Contains("--seed: 'nope' is not a whole number.", r.Output);
+    }
+
+    private static int[] Expected(int seed)
+    {
+        var rng = new Random(seed);
+        return new[] { rng.Next(Max) + 1, rng.Next(Max) + 1, rng.Next(Max) + 1 };
+    }
+
+    private static int[] Values(string output, string method)
+    {
+        var m = Regex.Match(output, method + @"=values:(\d+),(\d+),(\d+)");
+        Assert.True(m.Success, $"{method} did not report its values:\n{output}");
+        return new[] { int.Parse(m.Groups[1].Value), int.Parse(m.Groups[2].Value), int.Parse(m.Groups[3].Value) };
+    }
+
+    private static string WriteFixture()
+    {
+        var root = TestScratch.Dir("al-runner-run-seed-2502");
+        Directory.CreateDirectory(root);
+        File.WriteAllText(Path.Combine(root, "app.json"), """
+        {
+          "id": "b2502000-0000-4000-8000-000000002502",
+          "name": "RunSeed2502",
+          "publisher": "Repro2502",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62502, "to": 62502 } ],
+          "runtime": "14.0"
+        }
+        """);
+        // Each test fails on purpose: its Error() text is how the drawn values reach the output.
+        File.WriteAllText(Path.Combine(root, "RunSeedProbe.al"), """
+        codeunit 62502 "Run Seed Probe"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure A_Plain()
+            begin
+                Error('A_Plain=values:' + Draw());
+            end;
+
+            [Test]
+            procedure B_Plain()
+            begin
+                Error('B_Plain=values:' + Draw());
+            end;
+
+            [Test]
+            procedure C_RandomizeSeeded()
+            begin
+                Randomize(42);
+                Error('C_RandomizeSeeded=values:' + Draw());
+            end;
+
+            [Test]
+            procedure D_RandomizeNoSeed()
+            var
+                Discarded: Integer;
+            begin
+                // Draw first, so a Randomize() that did nothing would leave a different sequence.
+                Discarded := Random(1000);
+                Randomize();
+                Error('D_RandomizeNoSeed=values:' + Draw());
+            end;
+
+            local procedure Draw(): Text
+            begin
+                exit(Format(Random(1000000), 0, 9) + ',' + Format(Random(1000000), 0, 9) + ',' + Format(Random(1000000), 0, 9));
+            end;
+        }
+        """);
+        return root;
+    }
+
+    private static (string Output, int Exit) RunRunner(string extraArgs)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg + " " + extraArgs,
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        // An inherited AL_RUNNER_SEED would stand in for the generated seed this test checks.
+        psi.Environment.Remove(RunSeed.EnvVar);
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(240_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+}

--- a/AlRunner.Tests/RunSeedTests.cs
+++ b/AlRunner.Tests/RunSeedTests.cs
@@ -88,6 +88,30 @@ public class RunSeedTests
         Assert.NotEqual(a, Values(unseeded.Output, "A_Plain"));
     }
 
+    /// <summary>
+    /// --jobs workers are separate processes: each must use the parent's run seed, not generate
+    /// its own, or the one printed seed reproduces nothing.
+    /// </summary>
+    [SkippableFact]
+    public void Jobs_WorkersShareOneGeneratedRunSeed()
+    {
+        TestArtifacts.SkipIfMissing();
+        const int otherId = 62503;
+        var r = RunRunner($"--jobs 2 \"{WriteFixture()}\" \"{WriteFixture(otherId)}\"");
+
+        var seeds = Regex.Matches(r.Output, @"^seed: (-?\d+)\r?$", RegexOptions.Multiline)
+            .Select(m => int.Parse(m.Groups[1].Value)).ToList();
+        Assert.True(seeds.Count == 2, $"expected one seed line per worker, got {seeds.Count}:\n{r.Output}");
+        Assert.Single(seeds.Distinct());
+        var reported = Regex.Matches(r.Output, @"A_Plain=values:(\d+),(\d+),(\d+)")
+            .Select(m => string.Join(",", m.Groups[1].Value, m.Groups[2].Value, m.Groups[3].Value))
+            .Distinct().OrderBy(x => x, StringComparer.Ordinal).ToList();
+        var expected = new[] { CodeunitId, otherId }
+            .Select(id => string.Join(",", Expected(RunSeed.Derive(seeds[0], id, "A_Plain"))))
+            .OrderBy(x => x, StringComparer.Ordinal).ToList();
+        Assert.Equal(expected, reported);
+    }
+
     [Fact]
     public void Seed_NotAWholeNumber_ExitsTwo()
     {
@@ -109,25 +133,25 @@ public class RunSeedTests
         return new[] { int.Parse(m.Groups[1].Value), int.Parse(m.Groups[2].Value), int.Parse(m.Groups[3].Value) };
     }
 
-    private static string WriteFixture()
+    private static string WriteFixture(int codeunitId = CodeunitId)
     {
         var root = TestScratch.Dir("al-runner-run-seed-2502");
         Directory.CreateDirectory(root);
-        File.WriteAllText(Path.Combine(root, "app.json"), """
+        File.WriteAllText(Path.Combine(root, "app.json"), $$"""
         {
-          "id": "b2502000-0000-4000-8000-000000002502",
-          "name": "RunSeed2502",
+          "id": "b2502000-0000-4000-8000-0000000{{codeunitId}}",
+          "name": "RunSeed{{codeunitId}}",
           "publisher": "Repro2502",
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "idRanges": [ { "from": 62502, "to": 62502 } ],
+          "idRanges": [ { "from": {{codeunitId}}, "to": {{codeunitId}} } ],
           "runtime": "14.0"
         }
         """);
         // Each test fails on purpose: its Error() text is how the drawn values reach the output.
-        File.WriteAllText(Path.Combine(root, "RunSeedProbe.al"), """
-        codeunit 62502 "Run Seed Probe"
+        File.WriteAllText(Path.Combine(root, "RunSeedProbe.al"), $$"""
+        codeunit {{codeunitId}} "Run Seed Probe {{codeunitId}}"
         {
             Subtype = Test;
 

--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -2437,25 +2437,6 @@ public static partial class BcRuntime
         // NavSession.GetPermissionSet (both 3-arg overloads) is Cecil-owned (see
         // NclCecilRewrite.cs, Batch 8).
 
-        // ALSystemNumeric.ALRandomize/ALRandom — real impls reach NavCurrentThread.Session.Random
-        // (null on skeleton). Back with a process-static Random.
-        var alSysNumType = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.ALSystemNumeric");
-        if (alSysNumType != null)
-        {
-            var randomizeNoArg = alSysNumType.GetMethod("ALRandomize",
-                BindingFlags.Public | BindingFlags.Static, null, Type.EmptyTypes, null);
-            if (randomizeNoArg != null)
-                Hook(randomizeNoArg, nameof(ALSystemNumeric_ALRandomize), "ALSystemNumeric.ALRandomize()");
-            var randomizeSeed = alSysNumType.GetMethod("ALRandomize",
-                BindingFlags.Public | BindingFlags.Static, null, new[] { typeof(int) }, null);
-            if (randomizeSeed != null)
-                Hook(randomizeSeed, nameof(ALSystemNumeric_ALRandomize_Seed), "ALSystemNumeric.ALRandomize(int)");
-            var alRandom = alSysNumType.GetMethod("ALRandom",
-                BindingFlags.Public | BindingFlags.Static, null, new[] { typeof(int) }, null);
-            if (alRandom != null)
-                Hook(alRandom, nameof(ALSystemNumeric_ALRandom), "ALSystemNumeric.ALRandom(int)");
-        }
-
         // NavDialog.ALOpen — UI dialog open NREs reaching Tree.Session on skeleton. No-op.
         var navDialogType2 = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.NavDialog");
         if (navDialogType2 != null)

--- a/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
@@ -2058,7 +2058,8 @@ public static partial class NclCecilRewrite
             throw new InvalidOperationException(
                 $"[Cecil] ALSystemNumeric.ALRandomize(): expected one `new Random()`, found {ctorCalls.Count} — Ncl shape changed; do not commit");
         var helper = typeof(RunSeed).GetMethod(nameof(RunSeed.CreateRandomizeRandom),
-            BindingFlags.Public | BindingFlags.Static)!;
+            BindingFlags.Public | BindingFlags.Static)
+            ?? throw new InvalidOperationException("[Cecil] RunSeed.CreateRandomizeRandom not found");
         ctorCalls[0].OpCode = OpCodes.Call;
         ctorCalls[0].Operand = nclMod.ImportReference(helper);
         Console.Error.WriteLine("[Cecil] Rewrote ALSystemNumeric.ALRandomize() → Session.Random = RunSeed.CreateRandomizeRandom() (#2502)");

--- a/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
@@ -2031,6 +2031,37 @@ public static partial class NclCecilRewrite
         }
 
         RewriteExecutionSchedulerThreadToBackground(asm.MainModule);
+        RewriteNoSeedRandomizeToRunSeed(asm.MainModule);
+    }
+
+    /// <summary>
+    /// #2502 — <c>ALSystemNumeric.ALRandomize()</c> is <c>Session.Random = new Random()</c>.
+    /// Only the <c>newobj Random::.ctor()</c> is swapped for <see cref="RunSeed.CreateRandomizeRandom"/>;
+    /// BC's own session setter stays. The one imported memberRef is the same forwarding shape as
+    /// <c>NCLEnumMetadata.Create(int)</c> → <c>BcRuntime.NCLEnumMetadata_CreateByIdAlAware</c>.
+    /// <c>ALRandomize(int)</c> and <c>ALRandom(int)</c> are not touched.
+    /// </summary>
+    private static void RewriteNoSeedRandomizeToRunSeed(ModuleDefinition nclMod)
+    {
+        var numericT = nclMod.GetType("Microsoft.Dynamics.Nav.Runtime.ALSystemNumeric")
+            ?? throw new InvalidOperationException(
+                "[Cecil] ALSystemNumeric not found — Ncl shape changed; do not commit");
+        var randomize = numericT.Methods.FirstOrDefault(m =>
+                m.Name == "ALRandomize" && m.IsStatic && m.HasBody && m.Parameters.Count == 0)
+            ?? throw new InvalidOperationException(
+                "[Cecil] ALSystemNumeric.ALRandomize() not found — Ncl shape changed; do not commit");
+        var ctorCalls = randomize.Body.Instructions.Where(i => i.OpCode == OpCodes.Newobj
+            && i.Operand is MethodReference mr
+            && mr.DeclaringType.FullName == "System.Random"
+            && mr.Parameters.Count == 0).ToList();
+        if (ctorCalls.Count != 1)
+            throw new InvalidOperationException(
+                $"[Cecil] ALSystemNumeric.ALRandomize(): expected one `new Random()`, found {ctorCalls.Count} — Ncl shape changed; do not commit");
+        var helper = typeof(RunSeed).GetMethod(nameof(RunSeed.CreateRandomizeRandom),
+            BindingFlags.Public | BindingFlags.Static)!;
+        ctorCalls[0].OpCode = OpCodes.Call;
+        ctorCalls[0].Operand = nclMod.ImportReference(helper);
+        Console.Error.WriteLine("[Cecil] Rewrote ALSystemNumeric.ALRandomize() → Session.Random = RunSeed.CreateRandomizeRandom() (#2502)");
     }
 
     /// <summary>
@@ -2140,6 +2171,8 @@ public static partial class NclCecilRewrite
         // See the RewriteNcl block below for the detail. Additive: does not touch
         // NavForm.GetPart (#2600) or the page-background-task routing (#2628).
         set.Add("Microsoft.Dynamics.Nav.Runtime.Media.NavMediaFactory::ProcessMediaObject/3");
+        // #2502: the no-argument overload only; ALRandomize(int) stays BC's own.
+        set.Add("Microsoft.Dynamics.Nav.Runtime.ALSystemNumeric::ALRandomize/0");
     }
 
 }

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -30,7 +30,7 @@ namespace AlRunner.Infrastructure;
 
 public static partial class NclCecilRewrite
 {
-    private const int CACHE_VERSION = 131;
+    private const int CACHE_VERSION = 132;
 
     // ─────────────────────────────────────────────────────────────────────────
     // Cecil-owned skip registry (JmpHook→Cecil migration enabler).

--- a/AlRunner/Infrastructure/ParallelFanOut.cs
+++ b/AlRunner/Infrastructure/ParallelFanOut.cs
@@ -32,7 +32,7 @@ internal static class ParallelFanOut
         "--coverage-out", "--define", "--dump-csharp", "--expectations", "--filter",
         "--isolation", "--out", "--output-junit", "--package-cache", "--preprocessor-symbols",
         "--resolve-version", "--test", "--test-data-company", "--test-isolation",
-        "--test-timeout", "--jobs",
+        "--test-timeout", "--jobs", "--seed",
         // Both take a value and both must reach a worker: a shard that lost --exclude-test would
         // walk straight back into the hang the parent already excluded, and one that lost
         // --resume-aborts would fall back to the default budget and start its own resume chain.

--- a/AlRunner/Infrastructure/RunSeed.cs
+++ b/AlRunner/Infrastructure/RunSeed.cs
@@ -20,8 +20,9 @@ public static class RunSeed
     private static int? _runSeed;
     private static PropertyInfo? _sessionRandom;
 
-    // The test currently executing, for the no-argument Randomize() rewrite. Tests run one at a
-    // time per process, so a plain static is enough.
+    // The test currently executing, for the no-argument Randomize() rewrite. Plain statics hold
+    // only while tests run one at a time per process: make them [ThreadStatic]/AsyncLocal before
+    // test codeunits run concurrently.
     private static string? _currentTest;
     private static int _currentTestSeed;
     private static string? _warnedFor;
@@ -38,6 +39,15 @@ public static class RunSeed
             _runSeed = seed;
             Environment.SetEnvironmentVariable(EnvVar, seed.ToString(CultureInfo.InvariantCulture));
         }
+    }
+
+    /// <summary>
+    /// The run seed if this process has resolved one, else null. Reporters read this rather than
+    /// <see cref="Value"/>, so writing a report never mints a seed nobody ran with.
+    /// </summary>
+    public static int? Resolved
+    {
+        get { lock (Gate) return _runSeed; }
     }
 
     /// <summary>

--- a/AlRunner/Infrastructure/RunSeed.cs
+++ b/AlRunner/Infrastructure/RunSeed.cs
@@ -1,0 +1,131 @@
+// RunSeed — reproducible AL Random() (#2502). See docs/run-seed.md.
+//
+// Every run has a run seed: --seed N, else AL_RUNNER_SEED, else a fresh one. Resolving it
+// writes AL_RUNNER_SEED into this process's environment, so every child the runner spawns
+// (--jobs workers, watchdog resumes, re-execs) inherits the SAME run seed instead of choosing
+// its own — a printed seed that only one of several processes used reproduces nothing.
+
+using System.Globalization;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace AlRunner.Infrastructure;
+
+public static class RunSeed
+{
+    public const string EnvVar = "AL_RUNNER_SEED";
+
+    private static readonly object Gate = new();
+    private static int? _runSeed;
+    private static PropertyInfo? _sessionRandom;
+
+    // The test currently executing, for the no-argument Randomize() rewrite. Tests run one at a
+    // time per process, so a plain static is enough.
+    private static string? _currentTest;
+    private static int _currentTestSeed;
+    private static string? _warnedFor;
+
+    /// <summary>Parses a seed as written on the command line or in the environment.</summary>
+    public static bool TryParse(string? raw, out int seed)
+        => int.TryParse(raw?.Trim(), NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out seed);
+
+    /// <summary>Fixes the run seed for this process and every child it spawns.</summary>
+    public static void Set(int seed)
+    {
+        lock (Gate)
+        {
+            _runSeed = seed;
+            Environment.SetEnvironmentVariable(EnvVar, seed.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+
+    /// <summary>
+    /// The run seed: the one <see cref="Set"/> fixed, else <c>AL_RUNNER_SEED</c>, else a newly
+    /// generated one (which is then written to the environment, see the header).
+    /// </summary>
+    public static int Value
+    {
+        get
+        {
+            lock (Gate)
+            {
+                if (_runSeed is { } s) return s;
+                var raw = Environment.GetEnvironmentVariable(EnvVar);
+                if (!string.IsNullOrWhiteSpace(raw))
+                {
+                    if (!TryParse(raw, out var fromEnv))
+                        throw new InvalidOperationException(
+                            $"{EnvVar}='{raw}' is not a whole number; set it to an integer seed or unset it.");
+                    Set(fromEnv);
+                    return fromEnv;
+                }
+                var generated = RandomNumberGenerator.GetInt32(1, int.MaxValue);
+                Set(generated);
+                return generated;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The seed one test starts from. FNV-1a (32-bit) over the UTF-8 bytes of
+    /// <c>"{runSeed}|{codeunitId}|{methodName}"</c>. Never <c>string.GetHashCode()</c>: that is
+    /// randomized per process, so the same seed would give a different sequence every run.
+    /// Changing this function changes every seed users have recorded — RunSeedTests pins it.
+    /// </summary>
+    public static int Derive(int runSeed, int codeunitId, string methodName)
+    {
+        var text = string.Create(CultureInfo.InvariantCulture, $"{runSeed}|{codeunitId}|{methodName}");
+        uint hash = 2166136261;
+        foreach (var b in Encoding.UTF8.GetBytes(text))
+        {
+            hash ^= b;
+            hash *= 16777619;
+        }
+        return unchecked((int)hash);
+    }
+
+    /// <summary>
+    /// Called before each [Test] method: installs <c>new Random(Derive(...))</c> as the skeleton
+    /// session's RNG, so the test's Random() sequence depends only on the run seed and its own
+    /// identity, not on how many Random() calls earlier tests made.
+    /// </summary>
+    public static void BeginTest(string codeunitTypeName, string methodName)
+    {
+        var codeunitId = TestExecutor.ParseAlObjectId(codeunitTypeName) ?? 0;
+        var derived = Derive(Value, codeunitId, methodName);
+        _currentTest = $"{codeunitTypeName}.{methodName}";
+        _currentTestSeed = derived;
+
+        var session = BcRuntime.SkeletonSession
+            ?? throw new InvalidOperationException(
+                "RunSeed.BeginTest: no skeleton session to seed; a [Test] cannot run before BC is booted.");
+        var prop = _sessionRandom ??= session.GetType().GetProperty("Random",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException(
+                "RunSeed.BeginTest: NavSession.Random not found; the Ncl shape changed and Random() "
+                + "can no longer be seeded per test.");
+        prop.SetValue(session, new Random(derived));
+    }
+
+    /// <summary>
+    /// Replaces the <c>new Random()</c> inside BC's no-argument <c>ALSystemNumeric.ALRandomize()</c>
+    /// (NclCecilRewrite.Runtime.cs). Deliberately NOT observably equivalent to BC: BC reseeds
+    /// from entropy, which no run can reproduce, so the runner reseeds from the current test's
+    /// derived seed and says so on stderr once per test. <c>Randomize(seed)</c> is untouched.
+    /// Owner's design decision on #2502.
+    /// </summary>
+    public static Random CreateRandomizeRandom()
+    {
+        var test = _currentTest;
+        var seed = test == null ? Derive(Value, 0, string.Empty) : _currentTestSeed;
+        if (test != null && !string.Equals(_warnedFor, test, StringComparison.Ordinal))
+        {
+            _warnedFor = test;
+            Console.Error.WriteLine(
+                $"warning: {test} called Randomize() without a seed; reseeded from the test's derived seed "
+                + $"(run seed: {Value}) so the run stays reproducible. See docs/run-seed.md.");
+        }
+        return new Random(seed);
+    }
+}

--- a/AlRunner/JUnitReport.cs
+++ b/AlRunner/JUnitReport.cs
@@ -121,12 +121,15 @@ public static class JUnitReport
             writer.WriteAttributeString("skipped", suiteSkipped.ToString());
             writer.WriteAttributeString("time", suiteSeconds.ToString("F3", CultureInfo.InvariantCulture));
             // #2502: the run seed that reproduces this suite's Random() values (--seed).
-            writer.WriteStartElement("properties");
-            writer.WriteStartElement("property");
-            writer.WriteAttributeString("name", "seed");
-            writer.WriteAttributeString("value", Infrastructure.RunSeed.Value.ToString(CultureInfo.InvariantCulture));
-            writer.WriteEndElement(); // property
-            writer.WriteEndElement(); // properties
+            if (Infrastructure.RunSeed.Resolved is { } seed)
+            {
+                writer.WriteStartElement("properties");
+                writer.WriteStartElement("property");
+                writer.WriteAttributeString("name", "seed");
+                writer.WriteAttributeString("value", seed.ToString(CultureInfo.InvariantCulture));
+                writer.WriteEndElement(); // property
+                writer.WriteEndElement(); // properties
+            }
 
             foreach (var (bucket, test) in suiteTests)
             {

--- a/AlRunner/JUnitReport.cs
+++ b/AlRunner/JUnitReport.cs
@@ -120,6 +120,13 @@ public static class JUnitReport
             writer.WriteAttributeString("errors", suiteErrors.ToString());
             writer.WriteAttributeString("skipped", suiteSkipped.ToString());
             writer.WriteAttributeString("time", suiteSeconds.ToString("F3", CultureInfo.InvariantCulture));
+            // #2502: the run seed that reproduces this suite's Random() values (--seed).
+            writer.WriteStartElement("properties");
+            writer.WriteStartElement("property");
+            writer.WriteAttributeString("name", "seed");
+            writer.WriteAttributeString("value", Infrastructure.RunSeed.Value.ToString(CultureInfo.InvariantCulture));
+            writer.WriteEndElement(); // property
+            writer.WriteEndElement(); // properties
 
             foreach (var (bucket, test) in suiteTests)
             {

--- a/AlRunner/Patches/NavRecordRefPatches.cs
+++ b/AlRunner/Patches/NavRecordRefPatches.cs
@@ -663,31 +663,6 @@ public static partial class BcRuntime
         return shared;
     }
 
-    // ALSystemNumeric.ALRandomize / ALRandom — real impls hit NavCurrentThread.Session.Random
-    // which is null on the skeleton. Back the statics with a process-static Random.
-    private static System.Random _alRandom = new System.Random();
-    private static readonly object _alRandomLock = new object();
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    public static void ALSystemNumeric_ALRandomize()
-    {
-        lock (_alRandomLock) _alRandom = new System.Random();
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    public static void ALSystemNumeric_ALRandomize_Seed(int seed)
-    {
-        lock (_alRandomLock) _alRandom = new System.Random(seed);
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    public static int ALSystemNumeric_ALRandom(int maxNumber)
-    {
-        if (maxNumber < 0) maxNumber = -maxNumber;
-        if (maxNumber == 0) maxNumber = 1;
-        lock (_alRandomLock) return _alRandom.Next(maxNumber) + 1;
-    }
-
     // NavDialog.ALOpen — UI dialog open. Real impl reaches Tree.Session which is null.
     // No-op for skeleton tests; AL test code just needs the call to not throw.
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -630,6 +630,17 @@ for (int i = 0; i < args.Length; i++)
         testTimeoutSeconds = parsedTimeout;
         continue;
     }
+    if (args[i] == "--seed" && i + 1 < args.Length)
+    {
+        var rawSeed = args[++i];
+        if (!AlRunner.Infrastructure.RunSeed.TryParse(rawSeed, out var parsedSeed))
+        {
+            Console.Error.WriteLine($"--seed: '{rawSeed}' is not a whole number.");
+            return 2;
+        }
+        AlRunner.Infrastructure.RunSeed.Set(parsedSeed);
+        continue;
+    }
     if (args[i] == "--preprocessor-symbols" && i + 1 < args.Length)
     {
         foreach (var raw in args[++i].Split(','))
@@ -687,6 +698,9 @@ if (serverMode && watchMode)
     Console.Error.WriteLine("--server and --watch are mutually exclusive (both stay warm in-process; pick one).");
     return 2;
 }
+// #2502: resolve the run seed before anything can spawn a child, so every process shares it.
+try { _ = AlRunner.Infrastructure.RunSeed.Value; }
+catch (InvalidOperationException seedProblem) { Console.Error.WriteLine(seedProblem.Message); return 2; }
 // #2403: every file-producing flag's parent directory is created HERE, before the run,
 // because all three writers open their file only after it finishes — so a missing
 // directory used to cost the whole run (measured: 103s and 834 classified results, lost
@@ -4506,6 +4520,8 @@ int computedExitCode = 0;
 // Set when the --output-json document is owed to stdout, printed after the output writes
 // below have had their say on computedExitCode. See the branch that sets it.
 bool printJsonOutput = false;
+// #2502: the value that reproduces this run's Random() sequences. stdout is the JSON document in --output-json mode.
+(outputJson ? Console.Error : Console.Out).WriteLine($"seed: {AlRunner.Infrastructure.RunSeed.Value}");
 if (outputJson && willResume)
 {
     // The final attempt prints the whole run. If Rerun then fails to START that attempt it

--- a/AlRunner/ProgramSupport/CliText.cs
+++ b/AlRunner/ProgramSupport/CliText.cs
@@ -197,6 +197,12 @@ internal static partial class ProgramSupport
         w.WriteLine("  Date/DateTime/Time/DateFormula values are rebuilt; BLOB/media values are NOT yet,");
         w.WriteLine("  and a table carrying one is refused whole. Every skipped or refused table is named on");
         w.WriteLine("  stderr with the reason. See docs/limitations.md.");
+        w.WriteLine("  Random(): every run prints `seed: N`. Each [Test] starts from its own RNG, derived");
+        w.WriteLine("  from N, its codeunit id and its method name, so a test sees the same Random() values");
+        w.WriteLine("  alone or in the full suite. To replay a failure: al-runner --seed N --test <id> ...");
+        w.WriteLine("  Randomize(seed) is honored as in BC; Randomize() with no seed is reseeded from the");
+        w.WriteLine("  test's derived seed (stderr warns). CreateGuid(), and so Any's text values, stay");
+        w.WriteLine("  nondeterministic. See docs/run-seed.md.");
         w.WriteLine("  If a provisioning-gap message names a specific missing set, force just that one");
         w.WriteLine("  (bypasses need-detection entirely — useful when the default `provision` mis-detects,");
         w.WriteLine("  issue #2085):");
@@ -409,6 +415,10 @@ internal static partial class ProgramSupport
         w.WriteLine("                          the AL_RUNNER_TEST_TIMEOUT_SEC env var if set; this flag");
         w.WriteLine("                          takes precedence over both. On timeout the test fails with");
         w.WriteLine("                          \"Test exceeded {N}s timeout.\" (v1-compatible message text).");
+        w.WriteLine("  --seed N                Run seed for AL Random() (default: AL_RUNNER_SEED, else a");
+        w.WriteLine("                          fresh one). Printed as `seed: N`, and in --output-json and");
+        w.WriteLine("                          --output-junit; pass it back to replay a run's Random()");
+        w.WriteLine("                          values, even for one test alone. See docs/run-seed.md.");
         w.WriteLine();
         w.WriteLine("EXECUTION");
         w.WriteLine("  --jobs N, -j N          Run the given bundle dirs across N worker PROCESSES and");

--- a/AlRunner/Reporter.cs
+++ b/AlRunner/Reporter.cs
@@ -766,6 +766,8 @@ public static class Reporter
             skipped = tests.Count(x => x.Test.Outcome == TestOutcome.Skipped),
             total = tests.Count,
             exitCode,
+            // #2502: pass it back as --seed to reproduce this run's Random() values.
+            seed = Infrastructure.RunSeed.Value,
             compilationErrors = compileErrors.Count > 0 ? compileErrors : null,
             executionErrors = executionErrors.Count > 0 ? executionErrors : null,
             suiteErrors = suiteErrors.Count > 0 ? suiteErrors : null,

--- a/AlRunner/Reporter.cs
+++ b/AlRunner/Reporter.cs
@@ -767,7 +767,7 @@ public static class Reporter
             total = tests.Count,
             exitCode,
             // #2502: pass it back as --seed to reproduce this run's Random() values.
-            seed = Infrastructure.RunSeed.Value,
+            seed = Infrastructure.RunSeed.Resolved,
             compilationErrors = compileErrors.Count > 0 ? compileErrors : null,
             executionErrors = executionErrors.Count > 0 ? executionErrors : null,
             suiteErrors = suiteErrors.Count > 0 ? suiteErrors : null,

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -1561,6 +1561,8 @@ public sealed class TestExecutor
         // uses on the wire (see AlCoverageTracker.BeginTest's doc comment) — always
         // called, cheap even when perTestCoverage was never requested.
         AlRunner.Infrastructure.AlCoverageTracker.BeginTest($"{codeunit}.{m.Name}");
+        // #2502: this test's Random() sequence depends only on the run seed and its own identity.
+        AlRunner.Infrastructure.RunSeed.BeginTest(codeunit, m.Name);
         // Enter BC's own "in test" scope for the duration of this test (mirrors
         // NavTestExecution.EnterTestCodeunit/LeaveTestCodeunit) — see BcRuntime.EnterTestExecutionScope
         // for why: it's what makes NavTenantSettingsHelper.IsSandbox()/IsProduction() (Codeunit 457

--- a/docs/run-seed.md
+++ b/docs/run-seed.md
@@ -1,0 +1,60 @@
+# Reproducible `Random()`: the run seed
+
+Issue #2502. Every run has a **run seed**, and every `[Test]` draws its `Random()` values from
+an RNG derived from that seed and the test's own identity. A failing test's values can be
+replayed with `--seed`, alone or in the full suite.
+
+## What the runner does
+
+| situation | behavior |
+|---|---|
+| no `--seed` | the run seed is `AL_RUNNER_SEED` if set, otherwise a freshly generated one |
+| `--seed N` | the run seed is `N` |
+| before each `[Test]` method | the session RNG is set to `new Random(Derive(runSeed, codeunitId, methodName))` |
+| AL calls `Randomize(seed)` | honored exactly as BC does: `new Random(seed)` |
+| AL calls `Randomize()` | reseeded from the current test's derived seed, not from entropy; stderr warns once per test |
+| `CreateGuid()` | unchanged, and still nondeterministic |
+
+The run seed is printed as `seed: N` (on stdout, or stderr under `--output-json`), written as
+the top-level `seed` field of `--output-json`, and as a `<property name="seed">` on every
+`<testsuite>` of `--output-junit`.
+
+To replay a failure:
+
+```console
+al-runner <bundle> --seed 4271833 --test PostingRoundsAmountCorrectly
+```
+
+## What it does not cover
+
+**Text from `Any` and `Library - Random`.** `Any.AlphanumericText`, `Any.GuidValue` and
+`LibraryRandom.RandText` are built from `CreateGuid()`, so they differ on every run whatever the
+seed. Only numeric randomness reproduces.
+
+**`Randomize(seed)` inside a test library.** `Library - Random` and `Any` call `SetSeed(1)` on
+first use, which reaches `Randomize(1)`, and the runner honors it. Values drawn after that call
+follow the library's seed, not the runner's. They were already deterministic.
+
+**`Random()` outside a test**, such as in install triggers, draws from the session RNG as BC
+leaves it. A no-argument `Randomize()` there is reseeded from `Derive(runSeed, 0, "")`.
+
+## The derivation
+
+`Derive` is FNV-1a (32-bit) over the UTF-8 bytes of `"{runSeed}|{codeunitId}|{methodName}"`,
+cast to `int`. `codeunitId` is the number in the test codeunit's compiled type name
+(`Codeunit50100` → 50100). `methodName` is the name `--test` matches. `RunSeedTests` pins
+golden values, because changing the function silently invalidates every seed anyone recorded.
+
+It must never use `string.GetHashCode()`, which .NET randomizes per process: the same seed would
+then give a different sequence on every run. Seeded `System.Random` is stable across .NET
+versions (.NET 6 kept the legacy algorithm for `new Random(seed)`).
+
+## How it reaches BC
+
+- The per-test RNG is skeleton state: `RunSeed.BeginTest` sets `NavSession.Random` on the
+  skeleton session from `TestExecutor.RunOne`. No BC method is patched for it.
+- `ALSystemNumeric.ALRandomize()` is the one Ncl rewrite: its `new Random()` becomes a call to
+  `RunSeed.CreateRandomizeRandom()` (`NclCecilRewrite.Runtime.cs`). `ALRandomize(int)` and
+  `ALRandom(int)` stay BC's own bodies, which read the session RNG.
+- Resolving the run seed writes `AL_RUNNER_SEED` into the process environment, so `--jobs`
+  workers, watchdog resumes and re-execs inherit the same seed instead of choosing their own.


### PR DESCRIPTION
Closes #2502

Written by agent stma-auto2-7 on the account holder's behalf.

Corpus-NA: runner-controlled RNG seeding and reporting; BC's own Randomize(seed)/Random bodies are left unchanged, and the one departure (no-argument Randomize) is a deliberate runner behavior, not a BC claim

## What this implements

The design from the owner's comment on #2502, which `vhn` agreed to, not the opt-in table in the issue body. The reason given there: "Opt-in only helps a team that already turned it on before their first bad day." So:

- **Every run has a run seed.** `--seed N`, else `AL_RUNNER_SEED`, else a generated one. It is printed as `seed: N` (stderr under `--output-json`), written as `seed` in `--output-json`, and as `<property name="seed">` on every JUnit `<testsuite>`.
- **Before each `[Test]`**, `TestExecutor.RunOne` sets the skeleton session's `NavSession.Random` to `new Random(RunSeed.Derive(runSeed, codeunitId, methodName))`. Derive is FNV-1a over UTF-8, never `string.GetHashCode()`. No BC method is patched for this.
- **`Randomize(seed)` is honored** (BC's own body, untouched).
- **`Randomize()` with no seed** is reseeded from the current test's derived seed. This is the one Ncl rewrite: the `newobj Random::.ctor()` in `ALSystemNumeric.ALRandomize()` becomes `call RunSeed.CreateRandomizeRandom()`, keeping BC's own session setter. stderr warns once per test. It imports one memberRef, the same forwarding shape as `NCLEnumMetadata.Create(int)` → `BcRuntime.NCLEnumMetadata_CreateByIdAlAware`. `CACHE_VERSION` bumped to 132, and the key is registered in `AddRuntimeOwned`.
- **`CreateGuid()` stays nondeterministic**, so `Any`'s text values do not reproduce. This is stated first in `docs/run-seed.md` and in `--guide`.
- **Child processes share the seed.** Resolving it writes `AL_RUNNER_SEED` into the process environment before anything spawns, so `--jobs` workers, watchdog resumes (`AbortResume`) and the re-exec paths all inherit it. I used the environment instead of adding `--seed` to each `BuildChildArgs` because there are five re-exec sites, and the environment covers all of them in one place.
- **The three orphaned JmpHook RNG patches are deleted** (`BcRuntime.cs` registrations and the `NavRecordRefPatches.cs` bodies). `AL_RUNNER_HOOK_AUDIT` listed them as never firing. This is the `ALSystemNumeric` cluster of #1883.

Docs: `docs/run-seed.md` (new), `--help` and `--guide` (`CliText.cs`, 10 lines). The Program.cs hunks are 16 lines.

## RED -> GREEN, and the mutations

`AlRunner.Tests/RunSeedTests.cs`: golden `Derive` values (5), `TryParse` (5), and three that spawn the runner against a platform-only fixture whose tests report their `Random()` draws through `Error()`:

- `Seed_ReproducesRandomPerTest_InSeparateProcesses_AndIsolatedRerun`. It runs 3 processes: `--seed 4271833` for the full suite, `--seed 4271833 --filter B_Plain`, and no seed. It asserts that each test's values equal `new Random(Derive(...))`, that A and B differ, that B alone equals B in the suite, that `Randomize(42)` gives .NET's `Random(42)` sequence under both seeds, that `Randomize()` after a prior draw restarts the derived sequence and warns, that no `--seed` prints a seed, and that the tests used that printed seed.
- `Jobs_WorkersShareOneGeneratedRunSeed`: `--jobs 2` over two bundles prints one distinct seed, and both workers' values derive from it.
- `Seed_NotAWholeNumber_ExitsTwo`.

| step | result |
|---|---|
| RED: `RunSeed.BeginTest` call and the Cecil rewrite call removed | `Failed: 1, Passed: 11, Total: 12` (values `[189869, 739099, 996367]`, expected `[900583, 334236, 984100]`) |
| GREEN | `Failed: 0, Passed: 12, Total: 12`, then the same again warm on one cache root |
| mutation 1: drop `methodName` from `Derive` | `Failed: 5, Passed: 7`. Four golden rows go red, the `(0, 0, "")` row stays green as it should, and the process test goes red on `Assert.NotEqual` (A == B). The reproducibility assertions before that one still passed, so the tests separate isolation from reproducibility. |
| mutation 2: `CreateRandomizeRandom` returns `new Random()` | `Failed: 1, Passed: 11`, on the `Randomize()` values only |
| mutation 3: `RunSeed.Set` stops writing `AL_RUNNER_SEED` (after the jobs test was added) | `Failed: 1, Passed: 12, Total: 13`, `Assert.Single() Failure: The collection contained 2 items` in the jobs test |
| mutation 4: the rewrite also turns `ALRandomize(int)` into `ret` (the issue body's original "both overloads are no-ops") | `Failed: 1, Passed: 12`, on the `Randomize(42)` values (expected `.NET Random(42)`, got the derived sequence), with the A/B assertions before it green |
| final | `Failed: 0, Passed: 13, Total: 13` |

All mutation reds are assertion failures, and every mutated build reported `0 Error(s)`.

## Existing tests touched

- None of the byte-stable report tests change. `JUnitReport` and `SerializeJsonOutput` read `RunSeed.Resolved`, which is null unless the process resolved a seed. Program.cs always resolves one, so real runs always carry it, but writing a report from a library caller never mints a seed and never adds the property. An earlier revision pinned a seed inside `JUnitCollateralFailureTests`, which leaked process-global state from a non-serial test. That change is reverted.
- `BcInternalsNullForgivingGuardTests` flagged a `GetMethod(...)!` in the new rewrite. It now uses `?? throw`.
- `CliDocumentationTests.BehaviorChangingFlags` gains `--seed`, and `ParallelFanOut.ValueTakingFlags` gains `--seed`.

Filtered local run on the head commit: `RunSeedTests|JUnit|Json|Reporter|GuardTests|CliDocumentationTests|ParallelFanOut` gave `Failed: 2, Passed: 408`. The two failures are `bc-engine-serial` tests (`BcEngineReadinessGuardTests`, `BcCompilerIncrementalTests`), which refuse to run without `tools/engine-test-bootstrap.sh` on this box. An earlier, wider filter also covering `Hook|Watch|AbortResume` showed only that same class of refusal. Three `tools/test_*.py` scripts (`agent_self_freshness`, `corpus_checkout`, `preflight`) fail locally because `git commit` in their scratch repos hits 1Password signing. That is unrelated to this diff. I did not run the unfiltered suite or the corpus.

## Fix the shape

1. **Same pattern at another call site?** The RNG reaches BC through `NavSession.Random` only: `ALRandom(int)`, `ALRandomize(int)` and `ALRandomize()` are its three users in `ALSystemNumeric`, identical on bc270 and bc284. No other runner code drew from its own `System.Random` for AL except the deleted process-static in `NavRecordRefPatches.cs`.
2. **Sibling functions with the same assumption?** `CreateGuid()` has the same reproducibility gap. It is out of scope per the issue discussion and documented as the remaining nondeterminism. `Random()` outside a test (install triggers) is not reseeded. A no-argument `Randomize()` there uses `Derive(runSeed, 0, "")`.
3. **Two paths writing the same state?** `NavSession.Random` is written by `RunSeed.BeginTest` (per test), BC's `ALRandomize(int)` (honored) and the rewritten `ALRandomize()` (derived seed). All three now yield a seeded `Random`, and none uses entropy. The run seed is written by `--seed`, `AL_RUNNER_SEED` and generation, all through `RunSeed.Set`, which also updates the environment.

**Trap for later:** `RunSeed`'s current-test fields are plain statics. That is correct only while tests run one at a time per process. They need to become `[ThreadStatic]`/`AsyncLocal` before test codeunits run concurrently, and the code says so.

Not done: the per-failure `(seed: N)` annotation from the issue body's example (the run-level `seed:` line, JSON field and JUnit property carry it), and seed reporting over `--server`/`--watch`/`--dap` responses. Those modes do seed each test, but they do not print the seed.

## Queue scan

I searched open issues for `Random`, `Randomize`, `seed`, `CreateGuid`, `ALSystemNumeric` and `orphaned hook`. Only #1883 overlaps: this PR removes its 3-hook `ALSystemNumeric` cluster, and I will note that on the issue. #1883 stays open for its other clusters.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
