### PR TITLE
fix(test-data): disambiguate same-named tables by owning app instead of refusing them

### DIFF
--- a/AlRunner.Tests/TestDataProvisioningTests.cs
+++ b/AlRunner.Tests/TestDataProvisioningTests.cs
@@ -440,7 +440,7 @@ public sealed class TestDataProvisioningTests : IDisposable
             new(  7, "page", "My Company", "No_ Series", 308, "Business Foundation"),
         };
 
-        var plan = TestDataProvisioner.BuildPlan(entries, cronus);
+        var plan = TestDataProvisioner.BuildPlan(entries, cronus, Array.Empty<AppManifest>());
 
         Assert.Equal(
             new[] { "No_ Series", "Source Code Setup" },
@@ -477,7 +477,7 @@ public sealed class TestDataProvisioningTests : IDisposable
             new(0, "page", cronus, "Currency$ext", null, null),
         };
 
-        var plan = TestDataProvisioner.BuildPlan(entries, cronus);
+        var plan = TestDataProvisioner.BuildPlan(entries, cronus, Array.Empty<AppManifest>());
 
         Assert.Equal(new[] { "Currency" }, plan.Hydratable.Select(e => e.TableName).ToArray());
         Assert.Empty(plan.ExtendedTableNames);

--- a/AlRunner.Tests/TestDataSameNamedTablesTests.cs
+++ b/AlRunner.Tests/TestDataSameNamedTablesTests.cs
@@ -1,0 +1,261 @@
+// TestDataSameNamedTablesTests — the proving tests for issue #2264: two installed apps may each
+// declare a table of the same AL name in one company (Base Application's and Power BI Report
+// embeddings' "Dimension Set Entry"), and --test-data now reads each one by the app that owns
+// the AL table id the runner resolved, instead of refusing both.
+//
+// Runner policy, not BC behaviour: which `--app` the runner hands its backup reader. The row-level
+// half (AL reads 480's rows back) needs a real backup and lives in tests/test-data-fixture/.
+using AlRunner;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestDataSameNamedTablesPlanTests
+{
+    private const string Company = "CRONUS International Ltd_";
+    private static readonly Guid BaseAppId = Guid.Parse("437dbf0e-84ff-417a-965d-ed2bb9650972");
+    private static readonly Guid PowerBiId = Guid.Parse("6d72c93d-164a-494c-8d65-24d7f41d7b61");
+
+    private static AppManifest App(string name, Guid id)
+        => new("Microsoft", name, new Version(28, 1, 0, 0), id, Array.Empty<DependencyRef>());
+
+    private static readonly AppManifest[] Closure =
+    {
+        App("Base Application", BaseAppId),
+        App("Power BI Report embeddings", PowerBiId),
+    };
+
+    [Fact]
+    public void SameNamedTablesFromTwoClosureApps_AreBothPlanned_EachWithItsOwnApp()
+    {
+        var entries = new List<BackupTableEntry>
+        {
+            new(89, "page", Company, "Dimension Set Entry", 480, "Base Application"),
+            new(5, "page", Company, "Dimension Set Entry", 36950, "Power BI Report embeddings"),
+        };
+
+        var plan = TestDataProvisioner.BuildPlan(entries, Company, Closure);
+
+        Assert.Equal(0, plan.SkippedAmbiguous);
+        Assert.Empty(plan.AmbiguousRefusals);
+        Assert.Equal(2, plan.Hydratable.Count);
+        // The id, per table — not merely that an --app was attached to something.
+        Assert.Equal(BaseAppId.ToString("D"), plan.Hydratable.Single(e => e.AlTableId == 480).ReadAppId);
+        Assert.Equal(PowerBiId.ToString("D"), plan.Hydratable.Single(e => e.AlTableId == 36950).ReadAppId);
+    }
+
+    [Fact]
+    public void AnUnambiguousTable_IsReadWithoutAnAppSelector()
+    {
+        var entries = new List<BackupTableEntry>
+        {
+            new(119, "page", Company, "No_ Series", 308, "Base Application"),
+            // Same name in ANOTHER company is not ambiguity: --company already separates it.
+            new(7, "page", "My Company", "No_ Series", 308, "Base Application"),
+        };
+
+        var plan = TestDataProvisioner.BuildPlan(entries, Company, Closure);
+
+        Assert.Null(Assert.Single(plan.Hydratable).ReadAppId);
+    }
+
+    [Fact]
+    public void OwningAppNameMatchingNoClosureApp_StaysRefused_AndSaysWhy()
+    {
+        var entries = new List<BackupTableEntry>
+        {
+            new(89, "page", Company, "Dimension Set Entry", 480, "Base Application"),
+            new(5, "page", Company, "Dimension Set Entry", 36950, "Some Renamed App"),
+        };
+
+        var plan = TestDataProvisioner.BuildPlan(entries, Company, Closure);
+
+        // The resolvable candidate is still planned; only the one with no app id is refused.
+        Assert.Equal(480, Assert.Single(plan.Hydratable).AlTableId);
+        Assert.Equal(1, plan.SkippedAmbiguous);
+        Assert.Contains("Some Renamed App", plan.AmbiguousRefusals[36950], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TwoClosureAppsSharingTheOwningAppName_StayRefused()
+    {
+        var entries = new List<BackupTableEntry>
+        {
+            new(89, "page", Company, "Dimension Set Entry", 480, "Base Application"),
+            new(5, "page", Company, "Dimension Set Entry", 36950, "Power BI Report embeddings"),
+        };
+        var closure = Closure.Append(App("Power BI Report embeddings", Guid.NewGuid())).ToArray();
+
+        var plan = TestDataProvisioner.BuildPlan(entries, Company, closure);
+
+        Assert.Equal(480, Assert.Single(plan.Hydratable).AlTableId);
+        Assert.Equal(1, plan.SkippedAmbiguous);
+        Assert.Contains("2 apps", plan.AmbiguousRefusals[36950], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TwoCandidatesOfOneApp_StayRefused_BecauseAnAppSelectorCannotSeparateThem()
+    {
+        var entries = new List<BackupTableEntry>
+        {
+            new(89, "page", Company, "Dimension Set Entry", 480, "Base Application"),
+            new(5, "page", Company, "Dimension Set Entry", 481, "Base Application"),
+        };
+
+        var plan = TestDataProvisioner.BuildPlan(entries, Company, Closure);
+
+        Assert.Empty(plan.Hydratable);
+        Assert.Equal(2, plan.SkippedAmbiguous);
+        Assert.Contains("Base Application", plan.AmbiguousRefusals[480], StringComparison.Ordinal);
+        Assert.Contains("Base Application", plan.AmbiguousRefusals[481], StringComparison.Ordinal);
+    }
+}
+
+// SetResolvedDeps writes BcCompiler's process-wide statics (see BcCompilerSharedReferenceCollection).
+[Collection(BcCompilerSharedReferenceCollection.Name)]
+public sealed class TestDataSameNamedTablesLoadTests : IDisposable
+{
+    private const int AppOneTableId = 61013;
+    private const int AppTwoTableId = 61014;
+    private const int UnownedTableId = 61015;
+    private static readonly Guid AppOneId = Guid.Parse("11111111-aaaa-4aaa-8aaa-111111111111");
+    private static readonly Guid AppTwoId = Guid.Parse("22222222-bbbb-4bbb-8bbb-222222222222");
+
+    private readonly DirectoryInfo _dir;
+    private readonly string _log;
+    private readonly string? _previousEnv;
+
+    public TestDataSameNamedTablesLoadTests()
+    {
+        _dir = Directory.CreateDirectory(TestScratch.Dir("al-runner-same-named-testdata"));
+        _log = Path.Combine(_dir.FullName, "reader-invocations.log");
+        var backup = Path.Combine(_dir.FullName, "BusinessCentral-W1.bak");
+        File.WriteAllBytes(backup, new byte[256]);
+
+        var reader = Path.Combine(_dir.FullName, "bcbak");
+        File.WriteAllText(reader, FakeReaderScript(_log));
+        File.SetUnixFileMode(reader, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        _previousEnv = Environment.GetEnvironmentVariable(BackupReaderTool.ExecutableEnvVar);
+        Environment.SetEnvironmentVariable(BackupReaderTool.ExecutableEnvVar, reader);
+        BackupReaderTool.ResetForTests();
+        TestDataOptions.ResetForTests();
+        TestDataProvisioner.ResetForTests();
+
+        var appOne = Path.Combine(_dir.FullName, "Fake_App One_1_0_0_0.app");
+        var appTwo = Path.Combine(_dir.FullName, "Fake_App Two_1_0_0_0.app");
+        File.WriteAllBytes(appOne, new byte[8]);
+        File.WriteAllBytes(appTwo, new byte[8]);
+        BcCompiler.SetResolvedDeps(
+            new[]
+            {
+                (new AppManifest("Fake", "App One", new Version(1, 0, 0, 0), AppOneId, Array.Empty<DependencyRef>()), appOne),
+                (new AppManifest("Fake", "App Two", new Version(1, 0, 0, 0), AppTwoId, Array.Empty<DependencyRef>()), appTwo),
+            },
+            new[] { _dir.FullName });
+
+        TestDataOptions.Enabled = true;
+        TestDataOptions.ExplicitBackupPath = backup;
+        TestDataOptions.CompanyOverride = "CRONUS";
+    }
+
+    public void Dispose()
+    {
+        TestDataProvisioner.ResetForTests();
+        TestDataOptions.ResetForTests();
+        Environment.SetEnvironmentVariable(BackupReaderTool.ExecutableEnvVar, _previousEnv);
+        BackupReaderTool.ResetForTests();
+        BcCompiler.SetResolvedDeps(Array.Empty<(AppManifest, string)>(), Array.Empty<string>());
+        try { _dir.Delete(recursive: true); } catch (IOException) { }
+    }
+
+    /// <summary>
+    /// A `bcbak` stand-in that behaves like the real reader on a shared name: a `read` of
+    /// `Dim Set` without `--app` fails with the reader's own "ambiguous table" error, and with an
+    /// app prefix it answers. It logs `cmd|table|app|top|merge`. The third `Dim Set`, owned by an
+    /// app outside the closure, is what keeps "refuse when the closure cannot say" reachable.
+    /// App Two's `$ext` companion carries rows, so the merge probe lands on a shared name too.
+    /// </summary>
+    private static string FakeReaderScript(string logPath) =>
+        "#!/bin/sh\n"
+        + $"log='{logPath}'\n"
+        + "cmd=\"$1\"\n"
+        + "table=''\n"
+        + "app=''\n"
+        + "top=''\n"
+        + "merge='plain'\n"
+        + "while [ $# -gt 0 ]; do\n"
+        + "  case \"$1\" in\n"
+        + "    --table) table=\"$2\" ;;\n"
+        + "    --app) app=\"$2\" ;;\n"
+        + "    --top) top=\"top$2\" ;;\n"
+        + "    --merge-extensions) merge='merged' ;;\n"
+        + "  esac\n"
+        + "  shift\n"
+        + "done\n"
+        + "echo \"$cmd|$table|$app|$top|$merge\" >> \"$log\"\n"
+        + "case \"$cmd\" in\n"
+        + "  companies) echo 'CRONUS' ;;\n"
+        + "  tables) printf '%s\\n' "
+            + $"'  89 page\tCRONUS\tDim Set\t{AppOneTableId} \"Dim Set\" (App One)' "
+            + $"'   5 page\tCRONUS\tDim Set\t{AppTwoTableId} \"Dim Set\" (App Two)' "
+            + $"'   3 page\tCRONUS\tDim Set\t{UnownedTableId} \"Dim Set\" (App Three)' "
+            + $"'   2 page\tCRONUS\tDim Set$ext\t{AppTwoTableId} \"Dim Set\" (App Two)' ;;\n"
+        + "  read)\n"
+        + "    if [ \"$table\" = 'Dim Set' ] && [ -z \"$app\" ]; then\n"
+        + "      echo \"error: ambiguous table 'Dim Set' — use --app <app-id-prefix> to select the defining app\" >&2\n"
+        + "      exit 1\n"
+        + "    fi\n"
+        + "    if [ -n \"$top\" ]; then\n"
+        + "      if [ \"$merge\" = 'merged' ]; then echo '[{\"A\":1,\"B\":2}]'; else echo '[{\"A\":1}]'; fi\n"
+        + "    else\n"
+        + "      echo '[]'\n"
+        + "    fi ;;\n"
+        + "esac\n";
+
+    private string[] Reads()
+        => File.Exists(_log)
+            ? File.ReadAllLines(_log).Where(l => l.StartsWith("read|", StringComparison.Ordinal)).ToArray()
+            : Array.Empty<string>();
+
+    [Fact]
+    public void EachSameNamedTable_IsReadWithTheAppThatOwnsItsAlTableId()
+    {
+        TestDataProvisioner.Arm();
+
+        // The probe hit a shared name, so it had to carry App Two's id or Arm would have thrown.
+        Assert.All(Reads(), r => Assert.Equal($"read|Dim Set|{AppTwoId:D}", string.Join('|', r.Split('|')[..3])));
+
+        RecordPatches.TestDataOnDemandLoader!(new object(), AppOneTableId);
+        RecordPatches.TestDataOnDemandLoader!(new object(), AppTwoTableId);
+
+        var loads = Reads().Where(r => !r.Contains("|top1|", StringComparison.Ordinal)).ToArray();
+        Assert.Equal(new[]
+        {
+            $"read|Dim Set|{AppOneId:D}||merged",
+            $"read|Dim Set|{AppTwoId:D}||merged",
+        }, loads);
+
+        var summary = TestDataProvisioner.LastSummary;
+        Assert.NotNull(summary);
+        Assert.Equal(0, summary!.TablesRefusedByReader);
+        Assert.Equal(1, summary.TablesSkippedAmbiguous);
+    }
+
+    [Fact]
+    public void ASameNamedTableTheClosureCannotAttribute_RunsNoReader_AndItsOutcomeSaysWhy()
+    {
+        TestDataProvisioner.Arm();
+        var before = Reads().Length;
+
+        RecordPatches.TestDataOnDemandLoader!(new object(), UnownedTableId);
+
+        Assert.Equal(before, Reads().Length);
+        var outcome = TestDataProvisioner.TableOutcome(UnownedTableId);
+        Assert.NotNull(outcome);
+        Assert.Contains("App Three", outcome!, StringComparison.Ordinal);
+        Assert.DoesNotContain("has no table with this id", outcome, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -829,6 +829,17 @@ public sealed partial class BcCompiler
                 : _resolvedDeps.Select(d => d.AppPath).ToList();
     }
 
+    /// <summary>The same closure as <see cref="ResolvedDepAppPaths"/>, with each package's
+    /// manifest. --test-data joins the backup catalog's app NAME to the app id the reader's
+    /// `--app` selects on (#2264).</summary>
+    public static IReadOnlyList<(AppManifest Manifest, string AppPath)> ResolvedDeps()
+    {
+        lock (_refSync)
+            return _resolvedDeps == null
+                ? Array.Empty<(AppManifest, string)>()
+                : _resolvedDeps.ToList();
+    }
+
     /// <summary>
     /// A stable content signature of the inputs the reference loader is built from, so the
     /// loader (and its ~40s warm) is rebuilt only when the dependency closure actually

--- a/AlRunner/Infrastructure/BackupCatalog.cs
+++ b/AlRunner/Infrastructure/BackupCatalog.cs
@@ -37,6 +37,11 @@ internal sealed record BackupTableEntry(
 
     /// <summary>The base table an extension companion belongs to.</summary>
     internal string BaseTableName => IsExtensionCompanion ? TableName[..^"$ext".Length] : TableName;
+
+    /// <summary>The app id a `read` must pass as `--app`, set by the plan only when another
+    /// installed app declares a table of the same name in the same company (#2264). The
+    /// catalog carries the owning app's NAME, never its id, so this is not parsed here.</summary>
+    internal string? ReadAppId { get; init; }
 }
 
 internal static class BackupCatalog

--- a/AlRunner/TestDataProvisioner.cs
+++ b/AlRunner/TestDataProvisioner.cs
@@ -93,12 +93,12 @@
 //   The end-to-end fixture asserts an extension field's VALUE for the same reason.
 //
 // THIS SLICE'S DECLARED EXCLUSIONS — reported, never silent
-//   1. Tables whose AL name is ambiguous in the backup — two installed apps may each declare
-//      a table of the same name (namespaces make that legal; Base Application's
-//      "Dimension Set Entry" and Power BI Report embeddings' are the shipped example). The
-//      reader refuses the name, and so does this: picking whichever candidate has rows would
-//      be exactly the silent guess this feature exists to prevent. #2264 resolves it properly,
-//      by naming the owning app the runner's own closure already resolved.
+//   1. Same-named tables no app id can select. Two installed apps may each declare a table of
+//      the same name (Base Application's and Power BI Report embeddings' "Dimension Set
+//      Entry"). Each is read with `--app` set to the app owning the AL table id the catalog
+//      resolved it to (#2264); refused, per table and by reason, only when the owning app name
+//      matches no app, or several apps, in this run's closure, or one app owns two candidates.
+//      Picking whichever candidate has rows would be the silent guess this feature must not make.
 //   2. Value types this runner build cannot rebuild yet — refused per table by the mechanism,
 //      counted and reported here. This used to gate most of the data (every extended CRONUS
 //      table carries a Date somewhere), and no longer does: #2259 took Date/DateTime/Time/
@@ -150,7 +150,7 @@ internal static class TestDataProvisioner
         internal string Describe() =>
             $"[test-data] loaded {RowsHydrated} row(s) in {TablesHydrated} table(s) this run touched, "
             + $"from '{Path.GetFileName(BackupPath)}' company '{Company}'; "
-            + $"skipped {TablesSkippedAmbiguous} ambiguous by name, "
+            + $"skipped {TablesSkippedAmbiguous} sharing a name no app id could select, "
             + $"{TablesRefused} refused (unsupported value types or unknown columns), "
             + $"{TablesRefusedByReader} refused by the backup reader, "
             + $"{ColumnsFromUninstalledApps} extension column(s) dropped for apps this run does not install, "
@@ -164,7 +164,8 @@ internal static class TestDataProvisioner
     /// for every default run.</summary>
     private sealed record ArmedPlan(
         string Backup, string SymbolKey, IReadOnlyList<string> Symbols, string Company,
-        IReadOnlyDictionary<int, BackupTableEntry> ByTableId, int SkippedAmbiguous);
+        IReadOnlyDictionary<int, BackupTableEntry> ByTableId, int SkippedAmbiguous,
+        IReadOnlyDictionary<int, string> AmbiguousRefusals);
 
     private static ArmedPlan? _armed;
 
@@ -449,11 +450,11 @@ internal static class TestDataProvisioner
         var tablesOutput = BackupReaderTool.Run(SymbolArgs(new[] { "tables", backup }, symbols));
         var entries = BackupCatalog.ParseTables(tablesOutput);
 
-        var plan = BuildPlan(entries, company);
+        var plan = BuildPlan(entries, company, SymbolManifests(symbols));
         Console.Error.WriteLine(
             $"[test-data] backup '{backup}', company '{company}', {plan.Hydratable.Count} table(s) in scope "
             + $"({plan.ExtendedTableNames.Count} with table-extension data to merge, "
-            + $"{plan.SkippedAmbiguous} ambiguous by name); loading on first touch.");
+            + $"{plan.SkippedAmbiguous} sharing a name no app id could select); loading on first touch.");
 
         // BEFORE any hydration: prove the reader is actually merging. A run that got this
         // wrong would hydrate every extended table with its extension fields blank and report
@@ -464,16 +465,18 @@ internal static class TestDataProvisioner
         // table, so asking it again per table would buy nothing and cost two extra reader
         // invocations per loaded table. It stays here, at arm time, where it still runs before
         // any row is hydrated.
-        if (plan.ExtendedTableNames.Count > 0)
-            AssertMergeIsHonoured(backup, symbols, company,
-                plan.ExtendedTableNames.OrderBy(n => n, StringComparer.Ordinal).First());
+        if (plan.MergeProbe != null)
+            AssertMergeIsHonoured(backup, symbols, company, plan.MergeProbe.TableName, plan.MergeProbe.ReadAppId);
 
         var byTableId = new Dictionary<int, BackupTableEntry>();
         foreach (var e in plan.Hydratable)
             if (e.AlTableId != null)
                 byTableId[e.AlTableId.Value] = e;
 
-        _armed = new ArmedPlan(backup, symbolKey, symbols, company, byTableId, plan.SkippedAmbiguous);
+        foreach (var (tableId, reason) in plan.AmbiguousRefusals)
+            Console.Error.WriteLine($"[test-data] REFUSED table {tableId}: {reason}.");
+
+        _armed = new ArmedPlan(backup, symbolKey, symbols, company, byTableId, plan.SkippedAmbiguous, plan.AmbiguousRefusals);
         InstallLoader();
     }
 
@@ -512,6 +515,11 @@ internal static class TestDataProvisioner
     {
         var armed = _armed;
         if (armed == null) return;
+        if (armed.AmbiguousRefusals.TryGetValue(tableId, out var ambiguity))
+        {
+            _tableOutcome[tableId] = $"the backup's rows for it were not loaded — {ambiguity}";
+            return;
+        }
         if (!armed.ByTableId.TryGetValue(tableId, out var entry))
         {
             // #2240: recorded, not just skipped. "This backup's plan does not offer the table"
@@ -602,7 +610,8 @@ internal static class TestDataProvisioner
                 "read", backup, "--table", entry.TableName, "--company", company, "--format", "json",
                 // HYPHENATED. `--mergeExtensions` is accepted, ignored, and exits 0.
                 "--merge-extensions",
-            }, symbols);
+            }.Concat(entry.ReadAppId == null ? Array.Empty<string>() : new[] { "--app", entry.ReadAppId }).ToArray(),
+            symbols);
         var json = BackupReaderTool.Run(readArgs);
 
         List<IReadOnlyDictionary<string, System.Text.Json.JsonElement>> rows;
@@ -635,9 +644,10 @@ internal static class TestDataProvisioner
     /// two reads must differ.
     /// </summary>
     internal static void AssertMergeIsHonoured(
-        string backup, IReadOnlyList<string> symbols, string company, string probeTable)
+        string backup, IReadOnlyList<string> symbols, string company, string probeTable, string? appId = null)
     {
-        var head = new[] { "read", backup, "--table", probeTable, "--company", company, "--format", "json", "--top", "1" };
+        var head = new[] { "read", backup, "--table", probeTable, "--company", company, "--format", "json", "--top", "1" }
+            .Concat(appId == null ? Array.Empty<string>() : new[] { "--app", appId }).ToArray();
         var plain = ParseRows(BackupReaderTool.Run(SymbolArgs(head, symbols)));
         var merged = ParseRows(BackupReaderTool.Run(
             SymbolArgs(head.Append("--merge-extensions").ToArray(), symbols)));
@@ -697,45 +707,101 @@ internal static class TestDataProvisioner
     internal sealed record Plan(
         IReadOnlyList<BackupTableEntry> Hydratable,
         IReadOnlySet<string> ExtendedTableNames,
-        int SkippedAmbiguous);
+        int SkippedAmbiguous)
+    {
+        /// <summary>Why each refused same-named table was refused, by AL table id (#2264).</summary>
+        internal IReadOnlyDictionary<int, string> AmbiguousRefusals { get; init; } = new Dictionary<int, string>();
+
+        /// <summary>The planned table with companion rows that the once-per-run merge probe
+        /// reads, carrying its `--app` when its name is shared; null when there is none.</summary>
+        internal BackupTableEntry? MergeProbe { get; init; }
+    }
 
     /// <summary>
     /// Decide which tables this slice hydrates. Pure over the catalog so the exclusion rules
     /// are testable without a backup — they are the part a reader has to be able to check.
     /// </summary>
-    internal static Plan BuildPlan(IReadOnlyList<BackupTableEntry> entries, string company)
+    internal static Plan BuildPlan(
+        IReadOnlyList<BackupTableEntry> entries, string company, IReadOnlyList<AppManifest> closure)
     {
         var forCompany = entries.Where(e => string.Equals(e.Company, company, StringComparison.Ordinal)).ToList();
 
-        // Base tables whose $ext companion carries rows. Before #2261 these were excluded
-        // whole; now they are hydrated WITH the companion merged in, and this set is the
-        // per-table assertion that the merge actually ran.
-        var extendedBaseNames = forCompany
-            .Where(e => e.IsExtensionCompanion && e.RowCount > 0)
-            .Select(e => e.BaseTableName)
-            .ToHashSet(StringComparer.Ordinal);
-
-        // A (company, table name) appearing more than once is ambiguous (exclusion 1).
-        var nameCounts = forCompany
+        // Every candidate per (company, table name). More than one is a name two installed apps
+        // both declare (exclusion 1), which the reader will only read with `--app`.
+        var candidatesByName = forCompany
             .Where(e => !e.IsExtensionCompanion)
             .GroupBy(e => e.TableName, StringComparer.Ordinal)
-            .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.Ordinal);
+
+        var appIdsByName = closure
+            .GroupBy(m => m.Name, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.Select(m => m.AppId).Distinct().ToList(), StringComparer.Ordinal);
 
         var hydratable = new List<BackupTableEntry>();
+        var refusals = new Dictionary<int, string>();
         var skippedAmbiguous = 0;
         foreach (var e in forCompany)
         {
             if (e.IsExtensionCompanion) continue;
             if (e.RowCount == 0) continue;
             if (e.AlTableId == null) continue;                 // not defined by this run's app closure
-            if (nameCounts.TryGetValue(e.TableName, out var n) && n > 1) { skippedAmbiguous++; continue; }
-            hydratable.Add(e);
+            var candidates = candidatesByName[e.TableName];
+            if (candidates.Count == 1) { hydratable.Add(e); continue; }
+
+            var reason = WhyTheOwningAppCannotBeSelected(e, candidates, appIdsByName, out var appId);
+            if (reason != null)
+            {
+                skippedAmbiguous++;
+                refusals[e.AlTableId.Value] = reason;
+                continue;
+            }
+            hydratable.Add(e with { ReadAppId = appId });
         }
-        // Only the tables actually in the plan can carry the requirement; keeping companions of
-        // excluded tables in the set would make it read as a claim about tables nobody reads.
-        var planned = hydratable.Select(e => e.TableName).ToHashSet(StringComparer.Ordinal);
-        extendedBaseNames.IntersectWith(planned);
-        return new Plan(hydratable, extendedBaseNames, skippedAmbiguous);
+
+        // Base tables whose $ext companion carries rows (#2261). A companion of a shared name is
+        // attributed by the AL table id the reader resolved it to; one it could not resolve is
+        // attributed to no base, since flagging the wrong candidate would point the merge probe
+        // at a table with no extension columns and fail a healthy run.
+        var extended = new HashSet<BackupTableEntry>();
+        foreach (var c in forCompany.Where(e => e.IsExtensionCompanion && e.RowCount > 0))
+        {
+            var bases = hydratable.Where(h => string.Equals(h.TableName, c.BaseTableName, StringComparison.Ordinal)).ToList();
+            if (bases.Count == 1 && candidatesByName[c.BaseTableName].Count == 1) extended.Add(bases[0]);
+            else if (c.AlTableId != null)
+                foreach (var b in bases.Where(b => b.AlTableId == c.AlTableId)) extended.Add(b);
+        }
+        return new Plan(hydratable, extended.Select(e => e.TableName).ToHashSet(StringComparer.Ordinal), skippedAmbiguous)
+        {
+            AmbiguousRefusals = refusals,
+            MergeProbe = extended
+                .OrderBy(e => e.TableName, StringComparer.Ordinal).ThenBy(e => e.AlTableId)
+                .FirstOrDefault(),
+        };
+    }
+
+    /// <summary>
+    /// Null when `--app &lt;id&gt;` selects exactly <paramref name="entry"/> among the same-named
+    /// <paramref name="candidates"/>, with that id in <paramref name="appId"/>; otherwise the
+    /// reason no selector can, which stays a refusal (#2264). The catalog names the owning app,
+    /// so the id comes from the closure's manifest of that name.
+    /// </summary>
+    private static string? WhyTheOwningAppCannotBeSelected(
+        BackupTableEntry entry, IReadOnlyList<BackupTableEntry> candidates,
+        IReadOnlyDictionary<string, List<Guid>> appIdsByName, out string? appId)
+    {
+        appId = null;
+        var prefix = $"table '{entry.TableName}' appears {candidates.Count} times in this company";
+        if (entry.AppName == null || !appIdsByName.TryGetValue(entry.AppName, out var ids))
+            return $"{prefix}, and its owning app '{entry.AppName}' matches no app this run resolved, "
+                + "so there is no app id to select it with";
+        if (ids.Count > 1)
+            return $"{prefix}, and {ids.Count} apps this run resolved are named '{entry.AppName}', "
+                + "so the owning app id cannot be chosen";
+        if (candidates.Count(c => string.Equals(c.AppName, entry.AppName, StringComparison.Ordinal)) > 1)
+            return $"{prefix}, more than once owned by the app '{entry.AppName}', so an app selector "
+                + "cannot separate them";
+        appId = ids[0].ToString("D");
+        return null;
     }
 
     /// <summary>
@@ -837,6 +903,14 @@ internal static class TestDataProvisioner
         foreach (var a in apps)
             (hasSymbolReference(a) ? keep : skipped).Add(a);
         return (keep, skipped);
+    }
+
+    /// <summary>The manifests of exactly the packages handed to the reader as symbols — the
+    /// apps whose names the catalog's resolution column can carry.</summary>
+    private static IReadOnlyList<AppManifest> SymbolManifests(IReadOnlyList<string> symbols)
+    {
+        var handed = symbols.ToHashSet(StringComparer.Ordinal);
+        return BcCompiler.ResolvedDeps().Where(d => handed.Contains(d.AppPath)).Select(d => d.Manifest).ToList();
     }
 
     private static string[] SymbolArgs(IReadOnlyList<string> head, IReadOnlyList<string> symbols)

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1874,7 +1874,10 @@ https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues.
   1 ambiguous by name, 293 companion columns dropped for apps outside the closure. All 12
   remaining refusals are a bare column the backup holds that this build's AL table has no
   field for ([#2273](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2273)) —
-  none is a value type any more.
+  none is a value type any more. The one table skipped as ambiguous by name, Base Application's
+  `Dimension Set Entry` (89 rows), is read with `--app` since
+  [#2264](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2264): measured on the
+  same backup, the fixture's `Dimension Set Entry` count went from 0 to 89.
 
 <a id="precompiled-xmlport-node-schema"></a>
 

--- a/tests/test-data-fixture/README.md
+++ b/tests/test-data-fixture/README.md
@@ -31,6 +31,11 @@ back through ordinary AL `Record` calls with the right values.
   "You cannot assign new numbers from the number series CONT" against a backup where that series
   has 99,977 numbers left.
 
+- `TestDataSameNamedTable.Codeunit.al` (#2264) — "Dimension Set Entry", a name Base Application
+  and Power BI Report embeddings both declare in one company. Before #2264 the runner refused
+  both; now each is read with `--app` set to the app owning the AL table id it resolved. The
+  assertion is the exact count (89, all Base Application's) plus one row's values.
+
 **CI does not run this bundle, and that is deliberate.** It only passes with `--test-data`
 and a BC sandbox backup on the machine (~1 GB, shipped inside the sandbox artifact). CI runs
 `tests/runner-extras/` wholesale, without the flag — a bundle asserting hydrated rows would

--- a/tests/test-data-fixture/README.md
+++ b/tests/test-data-fixture/README.md
@@ -32,9 +32,9 @@ back through ordinary AL `Record` calls with the right values.
   has 99,977 numbers left.
 
 - `TestDataSameNamedTable.Codeunit.al` (#2264) — "Dimension Set Entry", a name Base Application
-  and Power BI Report embeddings both declare in one company. Before #2264 the runner refused
-  both; now each is read with `--app` set to the app owning the AL table id it resolved. The
-  assertion is the exact count (89, all Base Application's) plus one row's values.
+  and Power BI Report embeddings both use in one company. Before #2264 the runner refused the
+  name; now the candidate the closure resolves (480) is read with `--app` set to its owning app.
+  The assertion is the exact count (89) plus one row's values.
 
 **CI does not run this bundle, and that is deliberate.** It only passes with `--test-data`
 and a BC sandbox backup on the machine (~1 GB, shipped inside the sandbox artifact). CI runs

--- a/tests/test-data-fixture/TestDataSameNamedTable.Codeunit.al
+++ b/tests/test-data-fixture/TestDataSameNamedTable.Codeunit.al
@@ -2,10 +2,13 @@
 /// End-to-end proof for issue #2264: a table whose AL name another installed app also declares
 /// in the same company is hydrated from the physical table owned by the app this run resolved.
 ///
-/// "Dimension Set Entry" is the shipped case: Base Application declares table 480 and Power BI
-/// Report embeddings declares table 36950 under the same name. In the W1 CRONUS backup the Base
-/// Application one holds 89 rows and the Power BI one none, so the count below tells the two
-/// apart as well as the refused-and-empty state this replaced.
+/// "Dimension Set Entry" is the shipped case. The W1 CRONUS backup holds two physical tables of that
+/// name in one company: Base Application's (table 480, 89 rows) and Power BI Report embeddings'
+/// (0 rows). This fixture's closure does not include Power BI, so the catalog resolves only 480 and
+/// leaves the sibling unresolved, yet the reader still refuses the bare name
+/// (`ambiguous table ... $437dbf0e... | ...$e4e86220...`). So this proves the one-resolvable-candidate
+/// case: 89 rows instead of the refused-and-empty 0. Choosing between TWO resolvable candidates is
+/// proved by AlRunner.Tests/TestDataSameNamedTablesTests.cs.
 ///
 /// NOT RUN BY CI — see README.md in this directory.
 /// </summary>

--- a/tests/test-data-fixture/TestDataSameNamedTable.Codeunit.al
+++ b/tests/test-data-fixture/TestDataSameNamedTable.Codeunit.al
@@ -1,0 +1,32 @@
+/// <summary>
+/// End-to-end proof for issue #2264: a table whose AL name another installed app also declares
+/// in the same company is hydrated from the physical table owned by the app this run resolved.
+///
+/// "Dimension Set Entry" is the shipped case: Base Application declares table 480 and Power BI
+/// Report embeddings declares table 36950 under the same name. In the W1 CRONUS backup the Base
+/// Application one holds 89 rows and the Power BI one none, so the count below tells the two
+/// apart as well as the refused-and-empty state this replaced.
+///
+/// NOT RUN BY CI — see README.md in this directory.
+/// </summary>
+codeunit 64409 "Test Data Same-Named Table"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "TDF Assert";
+
+    [Test]
+    procedure DimensionSetEntry_IsHydratedFromTheBaseApplicationTable()
+    var
+        DimensionSetEntry: Record "Dimension Set Entry";
+    begin
+        Assert.AreEqual(89, DimensionSetEntry.Count(), 'every Base Application Dimension Set Entry row in the CRONUS backup');
+
+        Assert.IsTrue(DimensionSetEntry.Get(2, 'DEPARTMENT'), 'Dimension Set 2 / DEPARTMENT must exist');
+        Assert.AreEqual('SALES', DimensionSetEntry."Dimension Value Code", 'set 2 DEPARTMENT value');
+        Assert.AreEqual(20, DimensionSetEntry."Dimension Value ID", 'set 2 DEPARTMENT value id');
+
+        Assert.IsFalse(DimensionSetEntry.Get(2, 'NOT-A-DIMENSION'), 'hydration must not invent rows');
+    end;
+}


### PR DESCRIPTION
Closes #2264

Written by agent stma-auto2-6 on the account holder's behalf.

Corpus-NA: runner policy for which --app the backup reader is asked for; no BC service tier reads a .bak through AL Runner, and the only BcCompiler change is a read accessor over the resolved dependency list

## Re-verified at current main first

Still open at `f27714de`: `TestDataProvisioner.BuildPlan` counted every (company, table name) seen more than once into `SkippedAmbiguous` and dropped all candidates. On the 28.1 W1 CRONUS backup that dropped Base Application's `Dimension Set Entry` (89 rows), so AL read it as empty.

## What changed

- **The plan keeps same-named candidates.** The `tables` catalog names the owning app by NAME (`480 "Dimension Set Entry" (Base Application)`), while the reader's `--app` matches the app-id prefix in the SQL object name. The plan joins the two through the manifests of the packages the reader was given as `--symbols` (new `BcCompiler.ResolvedDeps()`, the same list `ResolvedDepAppPaths()` already read). A planned entry carries `ReadAppId`, and `HydrateOne` passes `--app <id>`. The CLI and serve transports both already map `--app` (`BackupReaderServe.TryBuildReadRequest`).
- **Still refused, per table, with a reason**, when no single app id can select the table: the owning app name matches no app in the closure, or matches more than one, or one app owns two of the candidates. Each refusal is printed at arm time (`[test-data] REFUSED table <id>: <reason>`) and recorded as that table's `TableOutcome`. Before, a refused table got the misleading outcome "has no table with this id".
- **Only shared names get `--app`.** Every table that loads today keeps the exact read it had.
- **Merge probe and `$ext` attribution.** `AssertMergeIsHonoured` read its probe table by name alone, so a probe landing on a shared name would have failed the whole run. The plan now picks the probe entry (`Plan.MergeProbe`) and passes its `--app`. A companion under a shared name is attributed by the AL table id the reader resolved it to, and one it could not resolve is attributed to no base, so the probe can never point at a table with no extension columns.
- The summary wording "ambiguous by name" is now "sharing a name no app id could select", because the count means that narrower thing.
- Docs: `docs/limitations.md` (the 28.1 measurement line now notes the one ambiguous table is read) and `tests/test-data-fixture/README.md`.

## RED -> GREEN

Unit (`AlRunner.Tests/TestDataSameNamedTablesTests.cs`, no backup needed, runs on CI):
- Plan tests: two same-named tables from two closure apps, with different row counts and AL ids, are both planned, each with **its own** app id. There are also three refusal cases (app not in closure, two closure apps sharing the name, one app owning two candidates) and one regression guard (an unambiguous table carries no selector).
- Load tests: a fake `bcbak` behaves like the real reader. `read` of a shared name without `--app` exits 1 with the reader's "ambiguous table" text. The tests assert the exact logged reads, `read|Dim Set|<App One id>||merged` for table 61013 and `<App Two id>` for 61014, that the merge probe carried App Two's id, and that a table owned by an app outside the closure runs no reader and has an outcome naming that app.

Run with the new API stubbed in and the old behaviour kept: `Failed: 6, Passed: 1, Total: 7` -> with the fix: `Failed: 0, Passed: 7`. Targeted suites (`TestDataSameNamedTables|TestDataProvisioning|TestDataLazy|TestDataSummary|BackupReaderServe`): `Passed: 70, Total: 70`.

End-to-end, locally only (needs the ~900 MB backup, which no CI leg has): new `tests/test-data-fixture/TestDataSameNamedTable.Codeunit.al` (codeunit 64409) asserts `Dimension Set Entry` Count = 89 plus set 2 / DEPARTMENT = SALES, value id 20. I ran it against `~/Downloads/BusinessCentral-W1.bak` with reader `BakReader 4d2b5df` and company `CRONUS International Ltd_`, on one cache root:
- fix: `24P/1F/0E across 25 tests`, 64409 PASS, `0 sharing a name no app id could select`
- refusal restored (mutation below): `23P/2F/0E`, 64409 FAIL `Expected:<89>. Actual:<0>`, `[test-data] REFUSED table 480: MUTATION.`
- The one failure in both runs is `Codeunit64408.ItemHydratesAFieldFromBaseAppsOwnTableExtension` (`Routing No.` blank). It failed identically in the mutated run, where same-named tables are refused as before. It asserts a field on `Item`, which has no shared name. I did not investigate it and did not run it on `main`.

**Which proof carries which claim.** The end-to-end run proves the case the shipped W1 backup actually has: one candidate the closure resolves (480, 89 rows) and a same-named sibling it cannot attribute. That sibling is unresolved under this Base/Business Foundation/System Application closure and holds 0 rows. The plan skips it as "not defined by this run's closure" without counting a refusal (`0 sharing a name no app id could select`). Choosing between TWO resolvable candidates does not happen on that backup. It is proved by the unit tests plus mutation 1, not end-to-end.

I also checked the reader directly on that backup. `read --table "Dimension Set Entry"` without `--app` answers `ambiguous table ... CRONUS International Ltd_$Dimension Set Entry$437dbf0e-... | ...$e4e86220-...`, and with `--app 437dbf0e` it returns 89 rows.

## Mutations (executed)

1. **Plan picks the first candidate's app id for every candidate** (`appId = appIdsByName[candidates[0].AppName!][0]`, a value change): `Failed: 2, Passed: 5`. Exactly the per-table id assertions went red: the plan test (`Expected 6d72c93d... Actual 437dbf0e...`) and the load test. The refusal tests stayed green, which is correct because they do not depend on which id is chosen.
2. **`HydrateOne` drops `--app`** (plan untouched): `Failed: 1, Passed: 6`. Only the load test went red, with `Actual: ["read|Dim Set|||merged", ...]`, so the read path is covered separately from the plan.
3. **End-to-end: every shared-name candidate refused again** (`?? "MUTATION"`): fixture 64409 went red, 89 -> 0 (above).

## Fix the shape

1. **Same pattern at another call site?** Every reader call that names a table: `HydrateOne` and `AssertMergeIsHonoured` (the probe). Both now pass `--app`. The probe was the second instance, and it would have failed a run outright.
2. **Sibling making the same assumption?** The `$ext` companion -> base attribution was keyed by name alone. It now uses the AL table id for shared names.
3. **Two write paths, one invariant?** CLI and serve-mode reads both carry `--app` (`BackupReaderServe` already mapped it). The refusal count and the per-table outcome are now written from the same `AmbiguousRefusals` map, so they cannot disagree.

## Queue scan

- Same file / area (`area: test-data`): #2263 (serve mode), #2271 (TableFilter wire shape), #2273 (bare columns), #2260 (system columns). None folded. #2271, #2273 and #2260 land in the hydration mechanism (`RecordPatches.TestDataHydration`), not the plan. #2263's transport appears to have landed in `5ed14077` ("read backup tables over serve mode"), which already maps `app`. I left that issue alone for the coordinator to confirm against its work list.
- Same defect, other words: searched open issues for "ambiguous", "Dimension Set Entry", "--app", and "same name". Nothing else reports this.

## Local guards

`GuardTests|TestData|BackupReader|BcCompilerWarm`: `Failed: 1, Passed: 431`. The one failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned`, because the engine bootstrap (`tools/engine-test-bootstrap.sh`) was not run on this box. `tools/test_agent_self_freshness.py`, `test_corpus_checkout.py` and `test_preflight.py` failed locally because `git commit` inside their scratch repos hits 1Password signing (`1Password: agent returned an error`). Both are environment problems unrelated to this diff.

Not in this PR: the row-level proof on CI. It needs a booted engine plus a real backup, so it lives in `tests/test-data-fixture/` and was run locally only (above).

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
