### PR TITLE
perf(cache): identify packages for the app-manifests index without hashing every byte

### DIFF
--- a/AlRunner.Tests/AppLoaderManifestIndexIdentityTests.cs
+++ b/AlRunner.Tests/AppLoaderManifestIndexIdentityTests.cs
@@ -585,6 +585,30 @@ public sealed class AppLoaderManifestIndexIdentityTests
             Path.GetFileName(AppLoader.ManifestIndexPathForTests(appPath)));
     }
 
+    [Fact]
+    public void FullContentFallback_UnknownHash_StaysTheRefusedSentinel_AndPublishesNothing()
+    {
+        Assert.Equal("sha256-abc123", AppLoader.FullContentIdentity("abc123"));
+        Assert.Equal(RunnerFingerprint.UnknownContentHash, AppLoader.FullContentIdentity(RunnerFingerprint.UnknownContentHash));
+        Assert.Equal(RunnerFingerprint.UnknownContentHash, AppLoader.FullContentIdentity(""));
+
+        WithCacheRoot(cacheRoot =>
+        {
+            var dir = NewDir("manifest-identity-fallback-unknown-");
+            var depId = new Guid("14141414-1414-1414-1414-141414141414");
+            var pathA = Path.Combine(dir, "A.app");
+            var pathB = Path.Combine(dir, "B.app");
+            File.WriteAllBytes(pathA, BuildApp(new Guid("1a1a1a1a-1a1a-1a1a-1a1a-1a1a1a1a1a1a"), "AAA", "Pub", "1.0.0.0", depId, "Dep", true, 0));
+            File.WriteAllBytes(pathB, BuildApp(new Guid("1b1b1b1b-1b1b-1b1b-1b1b-1b1b1b1b1b1b"), "BBB", "Pub", "1.0.0.0", depId, "Dep", true, 0));
+
+            // The default provider's fallback half, with the full-content hash unavailable.
+            static string Unreadable(string _) => AppLoader.FullContentIdentity(RunnerFingerprint.UnknownContentHash);
+            Assert.Equal("AAA", AppLoader.ReadManifestCore(pathA, Unreadable)!.Name);
+            Assert.Equal("BBB", AppLoader.ReadManifestCore(pathB, Unreadable)!.Name);
+            Assert.Empty(IndexEntries(cacheRoot));
+        });
+    }
+
     private sealed class CountingStream(Stream inner) : Stream
     {
         public long BytesRead { get; private set; }

--- a/AlRunner.Tests/AppLoaderManifestIndexIdentityTests.cs
+++ b/AlRunner.Tests/AppLoaderManifestIndexIdentityTests.cs
@@ -50,7 +50,7 @@ public sealed class AppLoaderManifestIndexIdentityTests
     /// </summary>
     private static byte[] BuildApp(
         Guid appId, string name, string publisher, string version,
-        Guid depId, string depName, bool symbolReference, int padBytes)
+        Guid depId, string depName, bool symbolReference, int padBytes, byte padFill = 0)
     {
         var xml = $"""
             <?xml version="1.0" encoding="utf-8"?>
@@ -63,25 +63,54 @@ public sealed class AppLoaderManifestIndexIdentityTests
             </Package>
             """;
 
+        var entries = new List<(string, byte[])> { ("NavxManifest.xml", Encoding.UTF8.GetBytes(xml)) };
+        if (symbolReference) entries.Add(("SymbolReference.json", "{}"u8.ToArray()));
+        if (padBytes > 0) entries.Add(("pad.bin", Enumerable.Repeat(padFill, padBytes).ToArray()));
+        return Navx(StoredZip(entries.ToArray()));
+    }
+
+    /// <summary>
+    /// A zip of STORED entries under one fixed timestamp. The fixed timestamp matters to the
+    /// central-directory arms (#4050): with <c>CreateEntry</c>'s default of "now", two packages
+    /// built a second apart differ in every entry's DOS time, and an arm meant to show that the
+    /// CRC-32 alone separates them would pass on the timestamp instead.
+    /// </summary>
+    private static byte[] StoredZip(params (string Name, byte[] Data)[] entries)
+    {
         using var ms = new MemoryStream();
         using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
         {
-            using (var s = zip.CreateEntry("NavxManifest.xml", CompressionLevel.NoCompression).Open())
-                s.Write(Encoding.UTF8.GetBytes(xml));
-            if (symbolReference)
-                using (var s = zip.CreateEntry("SymbolReference.json", CompressionLevel.NoCompression).Open())
-                    s.Write("{}"u8);
-            if (padBytes > 0)
-                using (var s = zip.CreateEntry("pad.bin", CompressionLevel.NoCompression).Open())
-                    s.Write(new byte[padBytes]);
+            foreach (var (name, data) in entries)
+            {
+                var entry = zip.CreateEntry(name, CompressionLevel.NoCompression);
+                entry.LastWriteTime = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+                using var s = entry.Open();
+                s.Write(data);
+            }
         }
-        var zipBytes = ms.ToArray();
+        return ms.ToArray();
+    }
 
+    /// <summary>The 8-byte NAVX header (magic + zip offset 8), then the zip.</summary>
+    private static byte[] Navx(byte[] zipBytes)
+    {
         var result = new byte[8 + zipBytes.Length];
         result[0] = (byte)'N'; result[1] = (byte)'A'; result[2] = (byte)'V'; result[3] = (byte)'X';
         BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
         zipBytes.CopyTo(result, 8);
         return result;
+    }
+
+    /// <summary>The central directory's bytes, located the way a reader locates them: the EOCD
+    /// record's size and offset fields, relative to the zip's start.</summary>
+    private static (int Start, byte[] Bytes) CentralDirectory(byte[] app)
+    {
+        int zipStart = BitConverter.ToInt32(app, 4);
+        int eocd = app.Length - 22; // no zip comment in anything these tests build
+        Assert.Equal(0x06054b50u, BitConverter.ToUInt32(app, eocd));
+        int cdSize = BitConverter.ToInt32(app, eocd + 12);
+        int cdStart = zipStart + BitConverter.ToInt32(app, eocd + 16);
+        return (cdStart, app.AsSpan(cdStart, cdSize).ToArray());
     }
 
     /// <summary>
@@ -396,16 +425,192 @@ public sealed class AppLoaderManifestIndexIdentityTests
         });
     }
 
+    // ── #4050: the identity is the package's central directory, not all of its bytes ──
+    //
+    // Hashing every byte of every scanned package cost ~4.2G instructions on a warm trivial run
+    // (#4050). The central directory records every entry's name, sizes and CRC-32, and the index
+    // payload is a function of entry names plus two entries' contents, so a directory-level
+    // identity still separates the #2987 pairs above. These arms pin the cases that argument
+    // rests on, each constructed so the ONLY difference the directory can see is the one named.
+
+    [Fact]
+    public void CentralDirectoriesDifferingOnlyInTheManifestsCrc32_AreTwoPackages()
+    {
+        WithCacheRoot(cacheRoot =>
+        {
+            var dir = NewDir("manifest-identity-crc-only-");
+            var appPath = Path.Combine(dir, "Pkg.app");
+            var stamp = new DateTime(2023, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+            var depId = new Guid("88888888-8888-8888-8888-888888888888");
+            var appIdA = new Guid("a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1");
+            var appIdB = new Guid("b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2");
+            var bytesA = BuildApp(appIdA, "Same", "Pub", "1.0.0.0", depId, "Dep", true, 64);
+            var bytesB = BuildApp(appIdB, "Same", "Pub", "1.0.0.0", depId, "Dep", true, 64);
+
+            // The construction, asserted: same length, and central directories that differ
+            // ONLY inside the first record's CRC-32 field (offset 16, 4 bytes) — NavxManifest.xml's.
+            Assert.Equal(bytesA.Length, bytesB.Length);
+            var (cdStartA, cdA) = CentralDirectory(bytesA);
+            var (cdStartB, cdB) = CentralDirectory(bytesB);
+            Assert.Equal(cdStartA, cdStartB);
+            Assert.Equal(cdA.Length, cdB.Length);
+            var differing = Enumerable.Range(0, cdA.Length).Where(i => cdA[i] != cdB[i]).ToArray();
+            Assert.NotEmpty(differing);
+            Assert.All(differing, i => Assert.InRange(i, 16, 19));
+            Assert.Equal(bytesA[^22..], bytesB[^22..]); // the EOCD record alone cannot tell them apart
+
+            File.WriteAllBytes(appPath, bytesA);
+            File.SetLastWriteTimeUtc(appPath, stamp);
+            Assert.Equal(appIdA, AppLoader.ReadManifest(appPath)!.AppId);
+
+            SimulateProcessRestart();
+            File.WriteAllBytes(appPath, bytesB);
+            File.SetLastWriteTimeUtc(appPath, stamp);
+
+            var served = AppLoader.ReadManifest(appPath);
+            Assert.Equal(appIdB, served!.AppId);
+            Assert.Equal(2, AppLoader.ManifestParseInvocationCountForTests(appPath));
+            Assert.Equal(2, IndexEntries(cacheRoot).Length);
+        });
+    }
+
+    [Fact]
+    public void R2rShapedPackage_NestedManifestDiffers_SameOuterLengthAndMtime_ServesTheNewIdentity()
+    {
+        WithCacheRoot(cacheRoot =>
+        {
+            var dir = NewDir("manifest-identity-nested-");
+            var appPath = Path.Combine(dir, "Pkg.app");
+            var stamp = new DateTime(2024, 7, 8, 9, 10, 11, DateTimeKind.Utc);
+            var depId = new Guid("99999999-9999-9999-9999-999999999999");
+            var appIdA = new Guid("c3c3c3c3-c3c3-c3c3-c3c3-c3c3c3c3c3c3");
+            var appIdB = new Guid("d4d4d4d4-d4d4-d4d4-d4d4-d4d4d4d4d4d4");
+
+            // Microsoft's R2R layout: no NavxManifest.xml in the outer archive; the manifest is
+            // inside the nested .app, which the outer directory sees as ONE entry.
+            byte[] Outer(Guid inner) => Navx(StoredZip(
+                ("readytorunappmanifest.json", "{}"u8.ToArray()),
+                ("inner.app", BuildApp(inner, "Nested", "Microsoft", "28.0.0.0", depId, "Dep", true, 128)),
+                ("[Content_Types].xml", "<Types/>"u8.ToArray())));
+            var bytesA = Outer(appIdA);
+            var bytesB = Outer(appIdB);
+            Assert.Equal(bytesA.Length, bytesB.Length);
+            Assert.NotEqual(bytesA, bytesB);
+
+            File.WriteAllBytes(appPath, bytesA);
+            File.SetLastWriteTimeUtc(appPath, stamp);
+            var metaA = AppLoader.ReadPackageMeta(appPath);
+            Assert.Equal(appIdA, metaA.Manifest!.AppId);
+            Assert.True(metaA.HasSymbolReference);
+
+            SimulateProcessRestart();
+            File.WriteAllBytes(appPath, bytesB);
+            File.SetLastWriteTimeUtc(appPath, stamp);
+
+            var metaB = AppLoader.ReadPackageMeta(appPath);
+            Assert.Equal(appIdB, metaB.Manifest!.AppId);
+            Assert.True(metaB.HasSymbolReference);
+            Assert.Equal(2, IndexEntries(cacheRoot).Length);
+        });
+    }
+
+    [Fact]
+    public void SameManifest_DifferentNonManifestEntryBytes_IsIndexedAsASecondPackage()
+    {
+        WithCacheRoot(cacheRoot =>
+        {
+            var dir = NewDir("manifest-identity-pad-content-");
+            var appPath = Path.Combine(dir, "Pkg.app");
+            var stamp = new DateTime(2025, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+            var appId = new Guid("e5e5e5e5-e5e5-e5e5-e5e5-e5e5e5e5e5e5");
+            var depId = new Guid("12121212-1212-1212-1212-121212121212");
+            var bytesA = BuildApp(appId, "Pad", "Pub", "1.0.0.0", depId, "Dep", true, 256, padFill: 0x00);
+            var bytesB = BuildApp(appId, "Pad", "Pub", "1.0.0.0", depId, "Dep", true, 256, padFill: 0x5A);
+            Assert.Equal(bytesA.Length, bytesB.Length);
+            Assert.NotEqual(bytesA, bytesB);
+
+            File.WriteAllBytes(appPath, bytesA);
+            File.SetLastWriteTimeUtc(appPath, stamp);
+            Assert.Equal(appId, AppLoader.ReadManifest(appPath)!.AppId);
+
+            SimulateProcessRestart();
+            File.WriteAllBytes(appPath, bytesB);
+            File.SetLastWriteTimeUtc(appPath, stamp);
+            Assert.Equal(appId, AppLoader.ReadManifest(appPath)!.AppId);
+
+            // The identity does not decide which entries matter to the payload: any entry's bytes
+            // changing makes it a different package, reparsed and indexed on its own.
+            Assert.Equal(2, AppLoader.ManifestParseInvocationCountForTests(appPath));
+            Assert.Equal(2, IndexEntries(cacheRoot).Length);
+        });
+    }
+
+    [Fact]
+    public void Identity_ReadsTheCentralDirectory_NotTheEntryData()
+    {
+        var dir = NewDir("manifest-identity-bytes-read-");
+        var appPath = Path.Combine(dir, "Big.app");
+        const int pad = 8 * 1024 * 1024;
+        File.WriteAllBytes(appPath, BuildApp(
+            new Guid("f6f6f6f6-f6f6-f6f6-f6f6-f6f6f6f6f6f6"), "Big", "Pub", "1.0.0.0",
+            new Guid("13131313-1313-1313-1313-131313131313"), "Dep", true, pad, padFill: 0x33));
+
+        using var counting = new CountingStream(File.OpenRead(appPath));
+        var identity = AppLoader.ComputeManifestIndexIdentityCore(
+            counting, static () => throw new InvalidOperationException("must not fall back to the full-content hash"));
+
+        Assert.StartsWith("zipcd-", identity);
+        Assert.InRange(counting.BytesRead, 1, 70_000);
+    }
+
+    [Fact]
+    public void NeaRuntimePackage_FallsBackToTheFullContentHash()
+    {
+        var dir = NewDir("manifest-identity-nea-");
+        var appPath = Path.Combine(dir, "Runtime.app");
+        // The directory of a runtime package lives inside an RC4 layer, so there is no plain
+        // central directory to read: the identity is the full-content hash, as before #4050.
+        var payload = new byte[4096];
+        new Random(4050).NextBytes(payload);
+        byte[] nea = [0x2E, 0x4E, 0x45, 0x41, 0x00, 0x00, 0x00, 0x01, .. payload];
+        File.WriteAllBytes(appPath, Navx(nea));
+
+        using var s = File.OpenRead(appPath);
+        Assert.Equal("sha256-full", AppLoader.ComputeManifestIndexIdentityCore(s, static () => "sha256-full"));
+        Assert.Equal(
+            "sha256-" + RunnerFingerprint.ComputeContentHash(appPath) + ".json",
+            Path.GetFileName(AppLoader.ManifestIndexPathForTests(appPath)));
+    }
+
+    private sealed class CountingStream(Stream inner) : Stream
+    {
+        public long BytesRead { get; private set; }
+        public override bool CanRead => true;
+        public override bool CanSeek => inner.CanSeek;
+        public override bool CanWrite => false;
+        public override long Length => inner.Length;
+        public override long Position { get => inner.Position; set => inner.Position = value; }
+        public override int Read(byte[] buffer, int offset, int count)
+        { var n = inner.Read(buffer, offset, count); BytesRead += n; return n; }
+        public override int Read(Span<byte> buffer)
+        { var n = inner.Read(buffer); BytesRead += n; return n; }
+        public override long Seek(long offset, SeekOrigin origin) => inner.Seek(offset, origin);
+        public override void Flush() { }
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        protected override void Dispose(bool disposing) { if (disposing) inner.Dispose(); base.Dispose(disposing); }
+    }
+
     // ── the entry-name convention ────────────────────────────────────────────────
 
     /// <summary>
-    /// A pre-#2987 stat-keyed entry name is also 64 lowercase hex characters plus
-    /// <c>.json</c> — indistinguishable from a content hash by shape. The <c>sha256-</c>
-    /// prefix is what makes a warm pre-fix cache directory unreadable as a content-keyed one
-    /// rather than silently misread (#2955's convention).
+    /// Entries are named for the scheme that produced the identity. <c>zipcd-</c> (#4050) is a
+    /// hash of the package's central directory; <c>sha256-</c> is the full-content hash #2987
+    /// introduced and which a package without a plain directory still uses. A scheme prefix is
+    /// what keeps an entry written under one from being read as the other.
     /// </summary>
     [Fact]
-    public void IndexEntryName_CarriesTheSha256Prefix()
+    public void IndexEntryName_CarriesTheCentralDirectoryScheme()
     {
         WithCacheRoot(cacheRoot =>
         {
@@ -420,8 +625,7 @@ public sealed class AppLoaderManifestIndexIdentityTests
             var entries = IndexEntries(cacheRoot);
             Assert.Single(entries);
             var name = Path.GetFileName(entries[0]);
-            Assert.StartsWith("sha256-", name);
-            Assert.Equal("sha256-" + RunnerFingerprint.ComputeContentHash(appPath) + ".json", name);
+            Assert.Matches("^zipcd-[0-9a-f]{64}\\.json$", name);
             Assert.Equal(entries[0], AppLoader.ManifestIndexPathForTests(appPath));
         });
     }

--- a/AlRunner.Tests/AppLoaderManifestIndexIdentityTests.cs
+++ b/AlRunner.Tests/AppLoaderManifestIndexIdentityTests.cs
@@ -570,9 +570,12 @@ public sealed class AppLoaderManifestIndexIdentityTests
         var appPath = Path.Combine(dir, "Runtime.app");
         // The directory of a runtime package lives inside an RC4 layer, so there is no plain
         // central directory to read: the identity is the full-content hash, as before #4050.
+        // The body ENDS in bytes shaped like an empty zip's EOCD record, so a reader that skipped
+        // the .NEA check would find a "directory" in RC4 output and key on it.
         var payload = new byte[4096];
         new Random(4050).NextBytes(payload);
-        byte[] nea = [0x2E, 0x4E, 0x45, 0x41, 0x00, 0x00, 0x00, 0x01, .. payload];
+        byte[] fakeEocd = [0x50, 0x4B, 0x05, 0x06, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0];
+        byte[] nea = [0x2E, 0x4E, 0x45, 0x41, 0x00, 0x00, 0x00, 0x01, .. payload, .. fakeEocd];
         File.WriteAllBytes(appPath, Navx(nea));
 
         using var s = File.OpenRead(appPath);

--- a/AlRunner/AppLoader.cs
+++ b/AlRunner/AppLoader.cs
@@ -243,14 +243,17 @@ public static class AppLoader
     internal static string ComputeManifestIndexIdentity(string fullPath)
     {
         using var fs = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 1, useAsync: false);
-        return ComputeManifestIndexIdentityCore(fs, () =>
-        {
-            var full = RunnerFingerprint.ComputeFileContentHashMemoized(fullPath);
-            return string.IsNullOrEmpty(full) || full == RunnerFingerprint.UnknownContentHash
-                ? RunnerFingerprint.UnknownContentHash
-                : "sha256-" + full;
-        });
+        return ComputeManifestIndexIdentityCore(
+            fs, () => FullContentIdentity(RunnerFingerprint.ComputeFileContentHashMemoized(fullPath)));
     }
+
+    /// <summary>The fallback identity. An unknown hash must stay the bare sentinel so
+    /// <see cref="TryPackageIdentity"/> refuses it; prefixed, every unreadable package would share
+    /// one <c>sha256-unknown</c> entry.</summary>
+    internal static string FullContentIdentity(string? contentHash)
+        => string.IsNullOrEmpty(contentHash) || contentHash == RunnerFingerprint.UnknownContentHash
+            ? RunnerFingerprint.UnknownContentHash
+            : "sha256-" + contentHash;
 
     // Largest EOCD comment a zip may carry, plus the fixed 22-byte record.
     private const int MaxEocdSearch = 22 + 0xFFFF;

--- a/AlRunner/AppLoader.cs
+++ b/AlRunner/AppLoader.cs
@@ -155,7 +155,7 @@ public static class AppLoader
     }
 
     /// <summary>
-    /// The package's content hash, or null when it cannot be computed — the signal that this
+    /// The package's index identity, or null when it cannot be computed — the signal that this
     /// package gets NO shared index entry, in either direction (#2955's guard, same reasoning).
     ///
     /// <para>Keying on the <see cref="RunnerFingerprint.UnknownContentHash"/> sentinel instead
@@ -280,8 +280,8 @@ public static class AppLoader
         long zipStart = 0;
         if (ReadFully(package, navx) == 8 && navx[..4].SequenceEqual("NAVX"u8))
             zipStart = BitConverter.ToUInt32(navx[4..]);
-        // A zip start past the tail window leaves bytes between header and directory we would
-        // not hash; runtime packages (.NEA, #3537) keep their directory inside an RC4 layer.
+        // BC writes a 40-byte NAVX header; an offset past 4 KB is not a shape this reads. Runtime
+        // packages (.NEA, #3537) keep their directory inside an RC4 layer, so there is none here.
         if (zipStart > 4096 || zipStart + 22 > length || PayloadIsNeaContainer(package, zipStart))
             return fullContentIdentity();
 

--- a/AlRunner/AppLoader.cs
+++ b/AlRunner/AppLoader.cs
@@ -74,8 +74,7 @@ public static class AppLoader
     /// because such a package has no index entry in either direction (#2987).</summary>
     internal static string? ManifestIndexPathForTests(string appPath)
     {
-        var identity = TryPackageIdentity(
-            Path.GetFullPath(appPath), static p => RunnerFingerprint.ComputeFileContentHashMemoized(p));
+        var identity = TryPackageIdentity(Path.GetFullPath(appPath), ComputeManifestIndexIdentity);
         return identity == null ? null : ManifestIndexPath(identity);
     }
 
@@ -94,41 +93,19 @@ public static class AppLoader
     /// last-write-time-UTC). It cannot outlive the process, so the only thing it has to get
     /// right is noticing a file rewritten underneath it, which a stat does.</para>
     ///
-    /// <para><b>The on-disk index</b> is keyed on the SHA-256 of the package's own bytes, via
-    /// <see cref="RunnerFingerprint.ComputeFileContentHashMemoized"/> — the one memo shared
-    /// with the bc-symbols cache, the r2r-chunks cache (#2955) and the AL-output key's
-    /// dependency terms (#2847), so a package any of them has already hashed costs a
-    /// dictionary lookup here. It is persisted and read by other processes, so a stat is not
-    /// good enough: two runs can agree on (path, length, mtime) and disagree on the bytes —
-    /// a checkout, a rebuild landing on the same size, a copy preserving mtime — and the
-    /// loser then reads an entry describing a package it does not have. What it would read is
-    /// not a derived detail but the package's IDENTITY: Publisher, Name, Version, AppId and
-    /// the whole declared Dependencies list, feeding DependencyResolver. The comment that
-    /// used to sit here called that "not a correctness hazard, only a cache miss", citing a
-    /// test (AppLoaderManifestCacheTests.ReadManifest_TouchedMtime_IsReparsedNotServedStale)
-    /// that only ever covered the case where the stat MOVES.</para>
-    ///
-    /// <para><b>What it costs.</b> Hashing every scanned package is not free, and unlike
-    /// #2955's call site this one runs over every <c>.app</c> in every package-cache
-    /// directory during DependencyResolver.EnsureIndexed, including packages the run never
-    /// loads. Measured on this repo's own CI package set — <c>~/.al-runner/platform-apps</c>
-    /// plus <c>~/.al-runner/test-apps</c>, 108 packages, 143 MB, warm page cache,
-    /// instructions-retired over 3 runs each: the stat costs 221 M instructions (5.9 ms), the
-    /// content hash 643 M (100.6 ms), and the uncached parse this index exists to avoid
-    /// 1,112 M (157 ms). So the index still saves the larger half of what it always saved,
-    /// and the marginal cost in a REAL run is far below that 95 ms delta because the packages
-    /// a run actually loads are hashed by the caches above regardless — see the PR for #2987
-    /// for the end-to-end numbers.</para>
-    ///
-    /// <para>Entries are named <c>sha256-&lt;hash&gt;.json</c>. A pre-#2987 stat-keyed entry
-    /// name was also 64 lowercase hex characters plus <c>.json</c> — identical in shape,
-    /// meaning something else entirely — so the prefix is what stops a warm pre-fix cache
-    /// directory from being silently misread as a content-keyed one.</para>
+    /// <para><b>The on-disk index</b> is persisted and read by other processes, so a stat is
+    /// not good enough: two runs can agree on (path, length, mtime) and disagree on the bytes,
+    /// and the loser would read another package's Publisher/Name/Version/AppId/Dependencies
+    /// (#2987). It is keyed on <see cref="ComputeManifestIndexIdentity"/> — a hash of the
+    /// package's zip central directory, not of every byte, because this runs for every
+    /// <c>.app</c> in every package-cache directory whether the run loads it or not (#4050).
+    /// Never key it on a stat again; the arms in AppLoaderManifestIndexIdentityTests construct
+    /// the same-stat, different-bytes pairs.</para>
     /// </summary>
     public static AppManifest? ReadManifest(string appPath)
-        => ReadManifestCore(appPath, static p => RunnerFingerprint.ComputeFileContentHashMemoized(p));
+        => ReadManifestCore(appPath, ComputeManifestIndexIdentity);
 
-    internal static AppManifest? ReadManifestCore(string appPath, Func<string, string> contentHashOf)
+    internal static AppManifest? ReadManifestCore(string appPath, Func<string, string> identityOf)
     {
         string fullPath;
         long length;
@@ -153,7 +130,7 @@ public static class AppLoader
         if (_manifestMemo.TryGetValue(memoKey, out var memoized))
             return memoized;
 
-        var identity = TryPackageIdentity(fullPath, contentHashOf);
+        var identity = TryPackageIdentity(fullPath, identityOf);
         if (identity != null)
         {
             var indexed = TryReadManifestIndex(identity);
@@ -187,10 +164,10 @@ public static class AppLoader
     /// one's — the exact wrong-answer shape content addressing exists to remove, reintroduced
     /// by the fix. Costing a reparse is the only thing this branch can ever do.</para>
     /// </summary>
-    private static string? TryPackageIdentity(string fullPath, Func<string, string> contentHashOf)
+    private static string? TryPackageIdentity(string fullPath, Func<string, string> identityOf)
     {
         string hash;
-        try { hash = contentHashOf(fullPath); }
+        try { hash = identityOf(fullPath); }
         catch (Exception ex)
         {
             // Hashing reads the file; a package we cannot read is one we cannot identify.
@@ -250,13 +227,114 @@ public static class AppLoader
 
     // ── on-disk manifest index (issue #perf-B) ─────────────────────────────────
 
-    /// <summary>The entry for one package CONTENT (#2987). The <c>sha256-</c> prefix is load
-    /// bearing: a pre-fix entry name was 64 lowercase hex characters plus <c>.json</c> too,
-    /// and named the hash of a <c>path|length|mtime</c> string instead — indistinguishable by
-    /// shape from what this returns, so without the prefix a warm pre-fix cache directory
-    /// would be read as if its entries were content-keyed.</summary>
-    private static string ManifestIndexPath(string contentHash)
-        => Path.Combine(CacheRoots.Resolve("app-manifests"), "sha256-" + contentHash + ".json");
+    /// <summary>The entry for one package identity. The identity carries its scheme as a prefix
+    /// (<c>zipcd-</c> or <c>sha256-</c>, see <see cref="ComputeManifestIndexIdentityCore"/>), and
+    /// the prefix is load bearing: a pre-#2987 entry name was 64 bare hex characters naming a
+    /// stat, so an unprefixed name must never be produced here.</summary>
+    private static string ManifestIndexPath(string identity)
+        => Path.Combine(CacheRoots.Resolve("app-manifests"), identity + ".json");
+
+    /// <summary>
+    /// The index identity for the package at <paramref name="fullPath"/>: a hash of its central
+    /// directory where it has a plain one, the full-content hash where it does not. Returns
+    /// <see cref="RunnerFingerprint.UnknownContentHash"/> when neither can be computed, which
+    /// <see cref="TryPackageIdentity"/> refuses.
+    /// </summary>
+    internal static string ComputeManifestIndexIdentity(string fullPath)
+    {
+        using var fs = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 1, useAsync: false);
+        return ComputeManifestIndexIdentityCore(fs, () =>
+        {
+            var full = RunnerFingerprint.ComputeFileContentHashMemoized(fullPath);
+            return string.IsNullOrEmpty(full) || full == RunnerFingerprint.UnknownContentHash
+                ? RunnerFingerprint.UnknownContentHash
+                : "sha256-" + full;
+        });
+    }
+
+    // Largest EOCD comment a zip may carry, plus the fixed 22-byte record.
+    private const int MaxEocdSearch = 22 + 0xFFFF;
+
+    /// <summary>
+    /// <c>zipcd-</c> + SHA-256 over (a scheme tag, the file length, the bytes before the zip, and
+    /// every byte from the central directory's start to the end of the file) — about 1.5 KB of
+    /// Base Application's 98 MB (#4050).
+    ///
+    /// <para>Sound for the index payload because that payload is a function of entry names and
+    /// entry contents, and the directory records every entry's name, sizes and CRC-32; an R2R
+    /// package's nested manifest is one outer entry, so its CRC covers it. CRC-32 is a checksum:
+    /// a DELIBERATELY built same-size collision would get past it, the accidental rewrites #2987
+    /// is about (checkout, same-size rebuild, mtime-preserving copy) do not.</para>
+    ///
+    /// <para>Trap: hashing the EOCD record alone is NOT enough — two packages with equal entry
+    /// names and sizes have identical EOCDs (pinned by
+    /// <c>CentralDirectoriesDifferingOnlyInTheManifestsCrc32_AreTwoPackages</c>). Anything this
+    /// method cannot read as one plain, non-zip64 directory falls back to
+    /// <paramref name="fullContentIdentity"/>, never to a stat.</para>
+    /// </summary>
+    internal static string ComputeManifestIndexIdentityCore(Stream package, Func<string> fullContentIdentity)
+    {
+        long length = package.Length;
+        package.Position = 0;
+        Span<byte> navx = stackalloc byte[8];
+        long zipStart = 0;
+        if (ReadFully(package, navx) == 8 && navx[..4].SequenceEqual("NAVX"u8))
+            zipStart = BitConverter.ToUInt32(navx[4..]);
+        // A zip start past the tail window leaves bytes between header and directory we would
+        // not hash; runtime packages (.NEA, #3537) keep their directory inside an RC4 layer.
+        if (zipStart > 4096 || zipStart + 22 > length || PayloadIsNeaContainer(package, zipStart))
+            return fullContentIdentity();
+
+        int tailLength = (int)Math.Min(length - zipStart, MaxEocdSearch);
+        var tail = new byte[tailLength];
+        package.Position = length - tailLength;
+        if (ReadFully(package, tail) != tailLength) return fullContentIdentity();
+
+        int eocd = -1;
+        for (int i = tailLength - 22; i >= 0; i--)
+        {
+            if (tail[i] == 0x50 && tail[i + 1] == 0x4B && tail[i + 2] == 0x05 && tail[i + 3] == 0x06)
+            { eocd = i; break; }
+        }
+        if (eocd < 0) return fullContentIdentity();
+
+        ushort entries = BitConverter.ToUInt16(tail, eocd + 10);
+        uint cdSize = BitConverter.ToUInt32(tail, eocd + 12);
+        uint cdOffset = BitConverter.ToUInt32(tail, eocd + 16);
+        long eocdAbsolute = length - tailLength + eocd;
+        long cdStart = zipStart + cdOffset;
+        bool zip64 = entries == 0xFFFF || cdSize == 0xFFFFFFFF || cdOffset == 0xFFFFFFFF
+            || (eocd >= 20 && BitConverter.ToUInt32(tail, eocd - 20) == 0x07064b50);
+        if (zip64 || cdStart + cdSize > eocdAbsolute || length - cdStart > 64L * 1024 * 1024)
+            return fullContentIdentity();
+
+        using var sha = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        sha.AppendData("al-runner app-manifests zipcd v1\n"u8);
+        Span<byte> len = stackalloc byte[8];
+        BitConverter.TryWriteBytes(len, length);
+        sha.AppendData(len);
+        var buffer = new byte[(int)Math.Max(zipStart, length - cdStart)];
+        package.Position = 0;
+        if (ReadFully(package, buffer.AsSpan(0, (int)zipStart)) != zipStart) return fullContentIdentity();
+        sha.AppendData(buffer, 0, (int)zipStart);
+        int directoryAndTail = (int)(length - cdStart);
+        package.Position = cdStart;
+        if (ReadFully(package, buffer.AsSpan(0, directoryAndTail)) != directoryAndTail) return fullContentIdentity();
+        sha.AppendData(buffer, 0, directoryAndTail);
+        return "zipcd-" + Convert.ToHexString(sha.GetHashAndReset()).ToLowerInvariant();
+    }
+
+    private static int ReadFully(Stream s, Span<byte> buffer)
+    {
+        int total = 0;
+        while (total < buffer.Length)
+        {
+            int n = s.Read(buffer[total..]);
+            if (n == 0) break;
+            total += n;
+        }
+        return total;
+    }
 
     private static AppManifest? TryReadManifestIndex(string contentHash)
         => TryReadIndexPayload(contentHash) is { } hit ? hit.Manifest : null;
@@ -368,7 +446,7 @@ public static class AppLoader
     /// <c>.app</c>. Asking them separately opened every package twice.</para>
     ///
     /// <para>Keyed exactly like <see cref="ReadManifest"/> — stat for the process memo, the
-    /// package's content hash for the persisted index (#2987). See that method for why the two
+    /// package identity for the persisted index (#2987, #4050). See that method for why the two
     /// differ, and note that the index entry is SHARED between them, so the two must never
     /// compute the identity differently.</para>
     ///
@@ -382,10 +460,10 @@ public static class AppLoader
     /// every process after the first. See issue #2607.</para>
     /// </summary>
     public static (AppManifest? Manifest, bool HasSymbolReference) ReadPackageMeta(string appPath)
-        => ReadPackageMetaCore(appPath, static p => RunnerFingerprint.ComputeFileContentHashMemoized(p));
+        => ReadPackageMetaCore(appPath, ComputeManifestIndexIdentity);
 
     internal static (AppManifest? Manifest, bool HasSymbolReference) ReadPackageMetaCore(
-        string appPath, Func<string, string> contentHashOf)
+        string appPath, Func<string, string> identityOf)
     {
         string fullPath;
         long length;
@@ -410,11 +488,11 @@ public static class AppLoader
             && _manifestMemo.TryGetValue(memoKey, out var memoManifest))
             return (memoManifest, memoFlag);
 
-        // Content-keyed exactly like ReadManifest's, and it MUST be the same key: the two
+        // Identified exactly like ReadManifest's, and it MUST be the same key: the two
         // methods read and write the same entries, so a package they identified differently
         // would have ReadManifest's entry (HasSymbolReference null) and ReadPackageMeta's
         // entry (the flag recorded) sitting under two names for the same bytes.
-        var identity = TryPackageIdentity(fullPath, contentHashOf);
+        var identity = TryPackageIdentity(fullPath, identityOf);
 
         // Only a FULL index entry can serve this: an entry written before the flag existed has
         // HasSymbolReference null, and null means "go and look", never false.


### PR DESCRIPTION
Closes #4050

_Written by agent stma-auto2-2 on the account holder's behalf._

## What changed

The persisted `app-manifests` index (`AppLoader.ReadManifest` / `ReadPackageMeta`) was keyed on the SHA-256 of every byte of every scanned `.app` (#3035, fixing #2987). `ProvisioningCheck.CheckPlatformApps` asks for that identity for every package in every package-cache directory on every run, loaded or not.

It is now keyed on `AppLoader.ComputeManifestIndexIdentity`: SHA-256 over a scheme tag, the file length, the bytes before the zip (the NAVX header), and every byte from the zip central directory's start to the end of the file. That is 1,559 bytes of Base Application's 98,070,128 (measured on `~/.al-runner/platform-apps`). Anything that is not one plain, non-zip64 central directory — a `.NEA` runtime package (#3537), no EOCD record, a zip64 marker, a NAVX offset past 4 KB, a directory past 64 MB — falls back to the full-content hash, never to a stat.

Entries are named `zipcd-<hash>.json`. The fallback keeps `sha256-<hash>.json`, which already meant "SHA-256 of the whole package": before this change the name was `"sha256-" + contentHash + ".json"`, and the fallback now produces `FullContentIdentity(contentHash) + ".json"` = `"sha256-" + contentHash + ".json"`, the same name for the same payload, so existing entries of that kind stay valid. An unknown hash stays the bare sentinel, which `TryPackageIdentity` refuses. The first run after upgrading reparses every package once to write the `zipcd-` entries.

The in-process memo stays keyed on the stat, as before. `RunnerFingerprint.ComputeFileContentHashMemoized` is untouched, so the bc-symbols, r2r-chunks and AL-output keys are unchanged.

## Why this keeps #2987's guarantee

The index payload (Publisher, Name, Version, AppId, Dependencies, HasSymbolReference) depends only on entry names and on the contents of `NavxManifest.xml`, or of the nested `.app` for Microsoft's R2R packages. The central directory records every entry's name, compressed and uncompressed size, and CRC-32. So any rewrite that changes the payload changes the directory: the nested `.app` is one outer entry, so a change to its manifest changes that entry's CRC-32.

The limit: CRC-32 is a checksum, not a cryptographic hash. Someone who deliberately builds a same-size CRC-32 collision could get past it. #2987's scenarios are accidental: a checkout, a rebuild landing on the same size, or a copy that keeps the mtime. Each of those changes entry data. CRC-32 detects every change confined to a 32-bit burst and misses a random accidental change with probability about 2^-32, and a collision also needs the same compressed and uncompressed sizes. I am not claiming this is as strong as SHA-256 over the bytes.

The EOCD record alone would not be enough. Two packages with the same entry names and sizes have identical EOCD records, and one of the new arms asserts that directly.

## RED → GREEN

`AlRunner.Tests/AppLoaderManifestIndexIdentityTests.cs`. The existing #2987 arms stay as they were. The fixture now writes entries under a fixed timestamp, so no arm can pass because two packages were built a second apart. New arms:

- `CentralDirectoriesDifferingOnlyInTheManifestsCrc32_AreTwoPackages`: same length and mtime; the test asserts that the two central directories differ **only** in bytes 16-19 of the first record (NavxManifest.xml's CRC-32) and that the EOCD records are byte-identical. The second package's identity is served.
- `R2rShapedPackage_NestedManifestDiffers_SameOuterLengthAndMtime_ServesTheNewIdentity`: Microsoft's layout, with the manifest only inside a nested `.app`.
- `SameManifest_DifferentNonManifestEntryBytes_IsIndexedAsASecondPackage`: identical manifests with different pad bytes get two index entries and two parses.
- `Identity_ReadsTheCentralDirectory_NotTheEntryData`: an 8 MB package is identified while reading at most 70,000 bytes, through a counting stream, with no full-content fallback.
- `NeaRuntimePackage_FallsBackToTheFullContentHash`: the RC4 body ends in bytes shaped like an EOCD record, so this arm fails if the `.NEA` check is removed.
- `FullContentFallback_UnknownHash_StaysTheRefusedSentinel_AndPublishesNothing`: the fallback never turns an unknown hash into a shared `sha256-unknown` entry.
- `IndexEntryName_CarriesTheCentralDirectoryScheme` replaces `IndexEntryName_CarriesTheSha256Prefix`.

RED, with a stub that kept today's full-content hash: `Failed: 3, Passed: 10, Total: 13`. GREEN: `Failed: 0, Passed: 13, Total: 13`, and `Failed: 0, Passed: 14, Total: 14` after the fallback-sentinel arm was added (that arm came after the implementation, so its evidence is the mutation below rather than a RED).

### Mutations (executed, restored, and each red came from an assertion, not the build)

| mutation | result | what went red |
|---|---|---|
| hash only the EOCD record, not the central directory | `Failed: 4, Passed: 9` | the #2987 arm (`Expected: bbbbbbbb-… Actual: aaaaaaaa-…`), the CRC-only arm, the nested R2R arm, the pad-content arm |
| zero every central-directory record's CRC-32 field before hashing | `Failed: 4, Passed: 9` | the same four; the symbol-reference arm stays green because its packages differ in entry names, which is correct |
| drop the `.NEA` check | `Failed: 1, Passed: 12` | `NeaRuntimePackage_FallsBackToTheFullContentHash` (`Actual: "zipcd-…"`) |
| prefix the unknown sentinel in `FullContentIdentity` | `Failed: 1, Passed: 13` | `FullContentFallback_UnknownHash_…` (`Expected: "unknown" Actual: "sha256-unknown"`) |

The first version of the `.NEA` arm used a random body and stayed **green** under the third mutation, because random bytes have no EOCD record to find. I added the fake EOCD tail so that arm now depends on the check.

## Measured

I used the same method as #2366: a trivial bundle (one codeunit, one empty `[Test]`, `platform` only, no dependencies), a warm private `--cache` per build, and `perf stat -e instructions:u` over the whole invocation. I alternated before and after, 3 reps each. Before is `741ce130` (origin/main when branched), after is this branch. Both caches were warmed on their own key scheme first, and each run passed 1/1. Load average was 6-7, so I am not reporting CPU or wall time.

| shape | before | after | delta |
|---|---|---|---|
| no `--package-cache` (366 index entries; #4050 counted 471 `.app` opens) | 15.76 / 16.41 / 16.52 G | 12.13 / 12.13 / 12.28 G | **about -3.5 to -4.4 G (-23 to -27%)** |
| `--package-cache ~/.al-runner/platform-apps` (CI shape, 119 index entries) | 12.499 / 12.499 / 12.499 G | 11.743 / 11.743 / 11.744 G | **-0.756 G (-6.0%)** |

For comparison, #4050's stat-keyed counterfactual measured 12.07 G and 11.67 G, so this recovers nearly all of the cost without the stat key.

I ran the proving path twice on one cache root: repeated warm runs against `cache-after` kept exactly 366 `zipcd-` entries (119 on the CI-shape root), passed each time, and stayed at the numbers above.

## Local runs

- `dotnet test --filter "FullyQualifiedName~AppLoader|FullyQualifiedName~DependencyResolver|FullyQualifiedName~ProvisioningCheck|FullyQualifiedName~GuardTests|FullyQualifiedName~PackageScan|FullyQualifiedName~Dedup"`: `Failed: 1, Passed: 567, Total: 568`. The one failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned`, which refuses because `engine.runsettings` was not generated on this box. It is environmental and unrelated.
- `tools/test_*.py`: three failures (`test_agent_self_freshness`, `test_corpus_checkout`, `test_preflight`), each on a `git commit` inside a scratch repository (exit 128). All three pass on a current `origin/main` checkout, which has since added `tools/scratch_git_config.py` for that isolation. This branch does not touch `tools/`.

## Fix the shape

1. **Same wrong pattern at another call site?** The other full-content keys (`RunnerFingerprint.ComputeFileContentHashMemoized` for bc-symbols, r2r-chunks in `ExtractAllDllPaths`, the AL-output dependency terms, `DependencyLoader.ComputeSourceDependencyCacheKey`) run only for packages the run actually loads, and they key payloads that depend on the whole package (DLL bytes, symbols). A central-directory identity would not be sound for them, so I left them alone. Only the manifest index scans every package regardless of use.
2. **Sibling making the same assumption?** `ReadPackageMeta` shares the index with `ReadManifest`, so both now use the same identity through the same default (`ComputeManifestIndexIdentity`), and `ManifestIndexPathForTests` uses it too.
3. **Two writers, one invariant?** Both writers go through `TryPackageIdentity`, so the guard against an unknown identity (no entry, reparse) applies to both unchanged. The fallback maps an unknown full hash to `UnknownContentHash`, so it cannot produce a shared `sha256-unknown` entry.

## Queue scan

I searched open issues for `app-manifests`, `ReadManifest`, `ComputeContentHash`, "content hash" and the `area: startup-cost` label. Nothing folds in. #2218 (the `.alpackages` discovery walk) and #2219 (symlink-loop dedup) are about finding packages, not identifying them, and would land elsewhere. #3042, #3056 and #3085, which #4050 names, are merged.

## Notes

- Doc comments: the `ReadManifest` comment went from about 45 lines to about 20. The long measurement paragraph from #3035 moved out, since those numbers are in #3035's PR and this one. `ComputeManifestIndexIdentityCore` has a comment of about 15 lines covering the claim, the CRC-32 limit, and the EOCD-only trap. I kept it next to the code because the trap is the edit a later reader is most likely to make.
- Runner-infra only, so no corpus test is needed. This change is not an AL-observable BC behavior.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
