### PR TITLE
fix(test-data): map a backup column named by its SQL name onto its field instead of dropping it

### DIFF
--- a/AlRunner.Tests/TestDataSqlNamedColumnTests.cs
+++ b/AlRunner.Tests/TestDataSqlNamedColumnTests.cs
@@ -1,0 +1,93 @@
+// #2273: the backup reader names a same-app tableextension field's column by its SQL name
+// (`Routing No_` for Item."Routing No."). That field is in the run's metatable, so dropping the
+// column blanks a value AL reads. Measured on BC 28.1 W1 CRONUS: 11 such columns across Item,
+// Purchase Line, Inventory Setup, Cash Flow Setup and No. Series Line, e.g. item SP-BOM2000's
+// Routing No. read '' while the backup stores 'SP-BOM2000'. The end-to-end proof is
+// tests/test-data-fixture (needs the backup, not run by CI); these pin the mapping itself.
+using AlRunner.Patches;
+using Xunit;
+
+public class TestDataSqlNamedColumnTests
+{
+    static IReadOnlySet<string> Fields(params string[] names)
+        => new HashSet<string>(names, StringComparer.Ordinal);
+
+    static IReadOnlyDictionary<string, string> Aliases(params (string Field, string Sql)[] fields)
+        => RecordPatches.BuildTestDataSqlColumnAliases(
+            fields.Select(f => (f.Field, (Func<string?>)(() => f.Sql))));
+
+    [Fact]
+    public void ASqlNamedColumnOfAFieldTheTableHasIsMappedOntoThatField()
+    {
+        var aliases = Aliases(("No.", "No_"), ("Description", "Description"), ("Routing No.", "Routing No_"));
+        var plan = RecordPatches.PlanTestDataColumns(
+            Fields("No.", "Description", "Routing No."),
+            new[] { "No.", "Description", "Routing No_" },
+            aliases);
+
+        Assert.Equal(new[] { "No.", "Description" }, plan.Mapped);
+        Assert.Equal("Routing No.", Assert.Single(plan.MappedBySqlName, kv => kv.Key == "Routing No_").Value);
+        Assert.Empty(plan.NotInThisBuild);
+    }
+
+    [Fact]
+    public void AColumnMatchingNoFieldsSqlNameIsStillDroppedAndCounted()
+    {
+        var plan = RecordPatches.PlanTestDataColumns(
+            Fields("No.", "Routing No."),
+            new[] { "No.", "Gone Field_" },
+            Aliases(("No.", "No_"), ("Routing No.", "Routing No_")));
+
+        Assert.Empty(plan.MappedBySqlName);
+        Assert.Equal(new[] { "Gone Field_" }, plan.NotInThisBuild);
+    }
+
+    [Fact]
+    public void AnAlNamedColumnWinsOverTheSqlNamedDuplicate()
+    {
+        // Both spellings for one field: the AL name is the reader's resolved answer, so the SQL
+        // one must not overwrite it, and it is counted rather than silently discarded.
+        var plan = RecordPatches.PlanTestDataColumns(
+            Fields("Routing No."),
+            new[] { "Routing No.", "Routing No_" },
+            Aliases(("Routing No.", "Routing No_")));
+
+        Assert.Equal(new[] { "Routing No." }, plan.Mapped);
+        Assert.Empty(plan.MappedBySqlName);
+        Assert.Equal(new[] { "Routing No_" }, plan.NotInThisBuild);
+    }
+
+    [Fact]
+    public void ASqlNameTwoFieldsClaimIsNotAssignedToEither()
+    {
+        var aliases = Aliases(("A.B", "A_B"), ("A/B", "A_B"), ("Routing No.", "Routing No_"));
+
+        Assert.False(aliases.ContainsKey("A_B"));
+        Assert.Equal("Routing No.", aliases["Routing No_"]);
+
+        var plan = RecordPatches.PlanTestDataColumns(Fields("A.B", "A/B", "X"), new[] { "X", "A_B" }, aliases);
+        Assert.Empty(plan.MappedBySqlName);
+        Assert.Equal(new[] { "A_B" }, plan.NotInThisBuild);
+    }
+
+    [Fact]
+    public void AFieldWhoseSqlNameCannotBeReadContributesNoAlias()
+    {
+        var aliases = RecordPatches.BuildTestDataSqlColumnAliases(new (string, Func<string?>)[]
+        {
+            ("Broken.", () => throw new NullReferenceException("parent")),
+            ("Routing No.", () => "Routing No_"),
+        });
+
+        Assert.Equal(new[] { "Routing No_" }, aliases.Keys);
+    }
+
+    [Fact]
+    public void ARowOfOnlySqlNamedColumnsCanHydrate()
+    {
+        var plan = RecordPatches.PlanTestDataColumns(
+            Fields("Routing No."), new[] { "Routing No_" }, Aliases(("Routing No.", "Routing No_")));
+
+        Assert.True(plan.CanHydrate);
+    }
+}

--- a/AlRunner.Tests/TestDataUnmappedColumnTests.cs
+++ b/AlRunner.Tests/TestDataUnmappedColumnTests.cs
@@ -9,10 +9,12 @@
 //
 // `Allow Gaps in Nos.` is ObsoleteState = Removed / ObsoleteTag '27.0' (Business Foundation's
 // NoSeriesLineObsolete.TableExt.al, behind `#if not CLEANSCHEMA27`). The shipped
-// SymbolReference.json still declares it, so the reader names it, while the compiled app this
-// runner loads has no such field. A column absent from the target NCLMetaTable cannot be read
-// by ANY AL code in this run — it is not addressable — so dropping it hides nothing a test
-// could observe, while refusing the table hands AL an empty table it silently believes.
+// SymbolReference.json still declares it. On 28.1.49838.53910 the runner's metatable carries it
+// too (field 11), so its SQL-named column now maps rather than drops (#2273,
+// TestDataSqlNamedColumnTests); the name is kept below as a stand-in for a column that names no
+// field. A column absent from the target NCLMetaTable cannot be read by ANY AL code in this
+// run — it is not addressable — so dropping it hides nothing a test could observe, while
+// refusing the table hands AL an empty table it silently believes.
 using AlRunner.Patches;
 using Xunit;
 

--- a/AlRunner/Patches/RecordPatches.TestDataHydration.cs
+++ b/AlRunner/Patches/RecordPatches.TestDataHydration.cs
@@ -87,6 +87,10 @@
 //      IS the metadata every AL statement in this run resolves field access against, so a
 //      column absent from it is unaddressable here and its absence cannot change an answer AL
 //      can read.
+//      That argument holds only for a column that truly names no field: a column the reader
+//      named by SQL name (`Routing No_` for Item."Routing No.", a same-app tableextension
+//      field) is mapped through NCLMetaField.SqlColumnName first, and only an unmatched or
+//      ambiguous one is dropped (#2273; BuildTestDataSqlColumnAliases).
 //      One refusal remains, for the mismatch the old rule was aimed at: a row shape that
 //      shares NO column with the table. Dropping every column of that would insert rows made
 //      entirely of defaults.
@@ -148,9 +152,51 @@ public static partial class RecordPatches
     internal readonly record struct TestDataColumnPlan(
         IReadOnlyList<string> Mapped,
         IReadOnlyList<string> FromUninstalledApps,
-        IReadOnlyList<string> NotInThisBuild)
+        IReadOnlyList<string> NotInThisBuild,
+        IReadOnlyDictionary<string, string> MappedBySqlName)
     {
-        internal bool CanHydrate => Mapped.Count > 0 || (FromUninstalledApps.Count == 0 && NotInThisBuild.Count == 0);
+        internal bool CanHydrate => Mapped.Count > 0 || MappedBySqlName.Count > 0
+            || (FromUninstalledApps.Count == 0 && NotInThisBuild.Count == 0);
+    }
+
+    private static readonly IReadOnlyDictionary<string, string> NoSqlAliases =
+        new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// SQL column name -> AL field name, for every field whose BC-computed
+    /// <see cref="NCLMetaField.SqlColumnName"/> differs from its AL name (#2273).
+    ///
+    /// The backup reader names a column of a same-app tableextension field (Item."Routing No.",
+    /// declared by Base Application's own tableextension "Mfg. Item" and stored in the Item table
+    /// itself) by its SQL name, `Routing No_`. That field IS in this run's metatable, so the
+    /// column is not "absent from this build" and dropping it blanks a value AL reads.
+    /// The SQL name is BC's own answer, not a re-implementation of its escaping.
+    ///
+    /// A SQL name two fields claim is left out, so it stays dropped-and-counted rather than being
+    /// assigned to either. A field whose getter throws (it dereferences parent/app state the
+    /// runner's metadata may not carry) contributes no alias, which is the pre-#2273 answer.
+    /// </summary>
+    internal static IReadOnlyDictionary<string, string> BuildTestDataSqlColumnAliases(
+        IEnumerable<(string FieldName, Func<string?> SqlColumnName)> fields)
+    {
+        var aliases = new Dictionary<string, string>(StringComparer.Ordinal);
+        var ambiguous = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var (fieldName, sqlColumnName) in fields)
+        {
+            string? sql;
+            try { sql = sqlColumnName(); }
+            catch (Exception) { continue; }
+            if (string.IsNullOrEmpty(sql) || string.Equals(sql, fieldName, StringComparison.Ordinal)) continue;
+            if (ambiguous.Contains(sql)) continue;
+            if (aliases.TryGetValue(sql, out var existing) && !string.Equals(existing, fieldName, StringComparison.Ordinal))
+            {
+                aliases.Remove(sql);
+                ambiguous.Add(sql);
+                continue;
+            }
+            aliases[sql] = fieldName;
+        }
+        return aliases;
     }
 
     /// <summary>
@@ -176,17 +222,34 @@ public static partial class RecordPatches
     /// </summary>
     internal static TestDataColumnPlan PlanTestDataColumns(
         IReadOnlySet<string> fieldNames, IEnumerable<string> columnNames)
+        => PlanTestDataColumns(fieldNames, columnNames, NoSqlAliases);
+
+    /// <summary>
+    /// As above, but a bare column that is not an AL field name and equals a field's SQL column
+    /// name (<see cref="BuildTestDataSqlColumnAliases"/>) is mapped onto that field, never
+    /// dropped. An AL-name column for the same field wins; the SQL-name duplicate is then
+    /// dropped and counted.
+    /// </summary>
+    internal static TestDataColumnPlan PlanTestDataColumns(
+        IReadOnlySet<string> fieldNames, IEnumerable<string> columnNames,
+        IReadOnlyDictionary<string, string> sqlColumnAliases)
     {
+        var distinct = columnNames.Distinct(StringComparer.Ordinal).ToList();
+        var present = new HashSet<string>(distinct, StringComparer.Ordinal);
         var mapped = new List<string>();
+        var bySqlName = new Dictionary<string, string>(StringComparer.Ordinal);
         var fromUninstalledApps = new List<string>();
         var notInThisBuild = new List<string>();
-        foreach (var name in columnNames.Distinct(StringComparer.Ordinal))
+        foreach (var name in distinct)
         {
             if (fieldNames.Contains(name)) mapped.Add(name);
             else if (BackupCatalog.TryParseUnresolvedExtensionColumn(name, out _, out _)) fromUninstalledApps.Add(name);
+            else if (sqlColumnAliases.TryGetValue(name, out var field) && fieldNames.Contains(field)
+                     && !present.Contains(field))
+                bySqlName[name] = field;
             else notInThisBuild.Add(name);
         }
-        return new TestDataColumnPlan(mapped, fromUninstalledApps, notInThisBuild);
+        return new TestDataColumnPlan(mapped, fromUninstalledApps, notInThisBuild, bySqlName);
     }
 
     /// <summary>
@@ -294,7 +357,13 @@ public static partial class RecordPatches
         // metatable's own field names, so a dropped column is simply never asked for.
         var plan = PlanTestDataColumns(
             (IReadOnlySet<string>)new HashSet<string>(fieldByName.Keys, StringComparer.Ordinal),
-            rows.SelectMany(r => r.Keys));
+            rows.SelectMany(r => r.Keys),
+            BuildTestDataSqlColumnAliases(
+                fieldByName.Values.Select(f => (f.FieldName, (Func<string?>)(() => f.SqlColumnName)))));
+        if (plan.MappedBySqlName.Count > 0)
+            rows = rows.Select(r => (IReadOnlyDictionary<string, JsonElement>)r.ToDictionary(
+                kv => plan.MappedBySqlName.TryGetValue(kv.Key, out var field) ? field : kv.Key,
+                kv => kv.Value, StringComparer.Ordinal)).ToList();
         if (!plan.CanHydrate)
             throw new TestDataHydrationRefusal(
                 $"table {tableId} '{tableNameForDiagnostics}': not one of the backup's "

--- a/AlRunner/Patches/RecordPatches.TestDataHydration.cs
+++ b/AlRunner/Patches/RecordPatches.TestDataHydration.cs
@@ -90,7 +90,10 @@
 //      That argument holds only for a column that truly names no field: a column the reader
 //      named by SQL name (`Routing No_` for Item."Routing No.", a same-app tableextension
 //      field) is mapped through NCLMetaField.SqlColumnName first, and only an unmatched or
-//      ambiguous one is dropped (#2273; BuildTestDataSqlColumnAliases).
+//      ambiguous one is dropped (#2273; BuildTestDataSqlColumnAliases). Measured on 28.1.49838.53910,
+//      that includes `Allow Gaps in Nos_`: the metatable DOES carry field 11 (Business
+//      Foundation's tableextension 309 declares it ObsoleteState = Removed), so it maps; the
+//      "compiled out" reading above no longer describes this build.
 //      One refusal remains, for the mismatch the old rule was aimed at: a row shape that
 //      shares NO column with the table. Dropping every column of that would insert rows made
 //      entirely of defaults.


### PR DESCRIPTION
Closes #2273

Written by agent stma-auto2-6 on the account holder's behalf.

Corpus-NA: --test-data hydrates rows from a SQL Server .bak through an external reader; no corpus test on a service tier can express reading a backup file

## What I measured first, at current `main` (81ab2733)

The issue's premise is out of date. Drop-and-count already landed in #2307 (for #2301), and at `main` **0 tables refuse**. What is left is the other half of the problem, and it is worse: the columns are now dropped, and data a test reads goes blank.

Measured with `tests/test-data-fixture` against `~/Downloads/BusinessCentral-W1.bak`, company `CRONUS International Ltd_`, BC 28.1.49838.53910, reader `bcdb 0.1.2+68df0f96`:

- `Codeunit64408.ItemHydratesAFieldFromBaseAppsOwnTableExtension` FAILS: `Expected:<SP-BOM2000>. Actual:<>` for `Item."Routing No."`.
- Summary line: `11 column(s) dropped that this build's AL tables have no field for`.
- Reading `Item` straight from the reader with the same closure: it emits `Routing No_` and `Production BOM No_` (SQL names), while every other base field comes back under its AL name. 3 of 64 items store a Routing No. and 5 a Production BOM No.

So the issue's question "(1) absent field or (2) naming mismatch" comes out as (2) for all 11: the fields are in the run's metatable (the fixture compiles and reads `Item."Routing No."`). The reader names same-app tableextension fields by their SQL name. The runner cannot pin the reader binary, so the fix belongs on the runner side.

## What changed

`AlRunner/Patches/RecordPatches.TestDataHydration.cs` only.

- `BuildTestDataSqlColumnAliases` builds SQL column name -> AL field name from BC's own `NCLMetaField.SqlColumnName` (decompiled, bc281: `ConvertToSqlIdentifier(fieldName)` for a base-table field). It does not re-implement the `.` -> `_` escaping. A SQL name two fields share is left out, and a field whose getter throws adds no alias.
- `PlanTestDataColumns` gets an overload taking those aliases. A bare column that is not an AL field name but equals a field's SQL name goes to `MappedBySqlName`. An AL-name column for the same field wins, and the SQL-name duplicate is dropped and counted. Anything else stays dropped and counted as before.
- `HydrateTestDataTable` renames those keys before building rows.

The SQL-name mappings the fixed build made on the fixture run (11, which matches the 11 dropped on `main`; the fixed run drops 0). I printed each target field's id and name from the metatable to confirm each one is a field with exactly that AL name:

| table | column -> field |
|---|---|
| 27 Item | `Routing No_` -> 99000750 `Routing No.`, `Production BOM No_` -> 99000751 |
| 39 Purchase Line | `Prod_ Order No_`, `Routing No_`, `Operation No_`, `Work Center No_`, `Prod_ Order Line No_`, `Routing Reference No_` |
| 313 Inventory Setup | `Disable Cost Adjmt_ Signals` -> 5840 |
| 843 Cash Flow Setup | `Service CF Account No_` -> 10 |
| 309 No. Series Line | `Allow Gaps in Nos_` -> 11 `Allow Gaps in Nos.` |

`Allow Gaps in Nos_` needs a note, because it reverses an earlier finding. The existing comments (case (c) in the Patches header, and the header of `TestDataUnmappedColumnTests.cs`) said this field was compiled out of the app the runner loads. I checked on this build: the runner's `NCLMetaTable` for 309 has 24 fields, and one of them is id 11, named exactly `Allow Gaps in Nos.`. Business Foundation 28.1.49838.53910 declares it in tableextension 309 `NoSeriesLineObsolete` with `ObsoleteState = Removed`, `ObsoleteTag = '27.0'` (read from the app's `SymbolReference.json` and `NoSeriesLineObsolete.TableExt.al`). AL cannot reference a Removed field by name, so for AL code, mapping this column and dropping it look the same. Mapping keeps the stored value, which is what a restore does. I corrected both comments in the second commit. The unit test keeps using that name as an example of a column that names no field.

I did not touch `TestDataProvisioner.cs` or `BackupCatalog.cs`, which #4048 changes. The summary line's wording is unchanged because its count is now accurate.

## RED -> GREEN

Fixture (local only, needs the backup; CI does not run this bundle, see its README):
- `main`: `PASS=23 FAIL=1` (the Routing No. test), `11 column(s) dropped`
- fix, cold: `PASS=24 FAIL=0`, `0 column(s) dropped`
- fix, warm (second run, same `--cache` root): `PASS=24 FAIL=0`, `0 column(s) dropped`

Unit tests that run on CI without a backup: new `AlRunner.Tests/TestDataSqlNamedColumnTests.cs` (6 tests) plus the existing `TestDataUnmappedColumnTests` (5): `Failed: 0, Passed: 11, Total: 11`.

Note: `AnItemWithoutARoutingReadsBlank` passed on `main` too, because the dropped column read blank. It only means something now that the column maps.

## Mutation

In `BuildTestDataSqlColumnAliases`, `aliases[sql] = fieldName` -> `aliases[sql] = sql` (the alias points at a name that is not a field):
- unit: `Failed: 3, Passed: 8, Total: 11`. Exactly the three that depend on the resolved target went red (mapped-onto-field, ambiguous-name-leaves-the-unique-one, SQL-only row can hydrate), all on `Assert.*`, not the build. The dropped, AL-name-wins and throwing-getter tests stayed green, as they should.
- fixture: `PASS=23 FAIL=1`, same failure as `main`, `11 column(s) dropped`.
Restored afterwards.

## Fix the shape

1. **Same pattern at another call site?** The one place backup column names are joined to AL fields is `PlanTestDataColumns`/`BuildTestDataRow`. `TestDataProvisioner` matches tables by name, which is a different join, and #2264 covers it.
2. **Sibling with the same assumption?** #2260 (system columns not mapped to fields 2000000000-2000000004) rests on "no service tier has confirmed the convention". `NCLMetaField.SqlColumnName` is that confirmation for the audit fields (`"$s" + fieldName.Substring(1)`). I did not fold it in: the system columns are removed in `TestDataProvisioner` before they reach this code, and that file is in #4048's diff. I will note this on #2260.
3. **Two write paths, same invariant?** The eager and on-demand loaders both go through the one `HydrateTestDataTable` overload, so both get the mapping.

## Queue scan

`area: test-data` (#2260, #2263, #2264, #2271, #2277), plus searches for `SqlColumnName`, `Routing No`, `not a field of the AL table`, `same-app tableextension` and `TestDataHydration`. Nothing else reports this defect. #2260 is the only one in the same file, and it is covered above.

## Local checks

- `tools/test_*.py`: three fail in this box's environment only (`test_agent_self_freshness`, `test_corpus_checkout`, `test_preflight`), all on `git commit` in temp repos: `1Password: agent returned an error`.
- `GuardTests|TestData` filter: `Failed: 1, Passed: 399, Total: 400`. The one failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned`, which refuses to run without `engine.runsettings`. It does not touch this code.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
