### PR TITLE
fix(watch): compile incremental cycles under the app.json target so AL0296 fires there too

### DIFF
--- a/AlRunner.Tests/BcCompilerIncrementalCompilationTargetTests.cs
+++ b/AlRunner.Tests/BcCompilerIncrementalCompilationTargetTests.cs
@@ -1,0 +1,148 @@
+// BcCompilerIncrementalCompilationTargetTests — issue #2316.
+//
+// RUNNER-MECHANISM test. The one-shot Emit hands BC's compiler the app.json `target` (#2725,
+// pinned end to end by DotNetCompilationTargetScopeTests), so a Cloud app calling an
+// OnPrem-scoped method gets BC's own AL0296. The --watch/--server incremental path
+// (TryEmitIncremental) built its CompilationOptions with a hardcoded OnPrem target instead, so
+// the same edit made during a watch session compiled green on the fast path, and every
+// target-dependent literal it emitted disagreed with a cold build of the same tree.
+//
+// Not a corpus test: the diagnostic is BC's compiler applying its own rule, and a bundle that
+// deliberately fails to compile cannot express a passing corpus test.
+using Xunit;
+using AlRunner;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class BcCompilerIncrementalCompilationTargetTests : IDisposable
+{
+    private readonly string _root;
+    private readonly BcEngineFixture _engine;
+
+    public BcCompilerIncrementalCompilationTargetTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = TestScratch.Dir("al-runner-incremental-target-tests");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private void WriteManifest(string target) =>
+        File.WriteAllText(Path.Combine(_root, "app.json"), $$"""
+            { "id": "c2b3c4d5-e6f7-4a81-9b02-c3d4e5f60718", "name": "IncrTarget", "publisher": "Test",
+              "version": "1.0.0.0", "idRanges": [ { "from": 90960, "to": 90969 } ], "runtime": "14.0",
+              "target": "{{target}}" }
+            """);
+
+    private void WriteAl(string fileName, string content) => File.WriteAllText(Path.Combine(_root, fileName), content);
+
+    private const string CleanProbe = """
+        codeunit 90960 "Incr Target Probe"
+        {
+            procedure GetValue(): Text
+            begin
+                exit('clean');
+            end;
+        }
+        """;
+
+    // Sid() is Scope('OnPrem'): BC's compiler refuses it for a Cloud target with AL0296.
+    private const string SidProbe = """
+        codeunit 90960 "Incr Target Probe"
+        {
+            procedure GetValue(): Text
+            begin
+                exit(Sid('SOMEUSER'));
+            end;
+        }
+        """;
+
+    // RegisterTableConnection compiles for both targets, and the compiler passes the target into
+    // the emitted ALRegisterTableConnection call as a literal.
+    private const string TableConnectionProbe = """
+        codeunit 90960 "Incr Target Probe"
+        {
+            procedure GetValue(): Text
+            begin
+                Database.RegisterTableConnection(TableConnectionType::ExternalSQL, 'x', 'y');
+                exit('connected');
+            end;
+        }
+        """;
+
+    private static Dictionary<string, string> ByName(BcEmitOutput output)
+        => output.Sources.ToDictionary(s => s.Name, s => s.Code);
+
+    [SkippableFact]
+    public void CloudTarget_EditAddingAnOnPremScopedCall_IsRefusedWithAL0296_NotTakenOnTheFastPath()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        WriteManifest("Cloud");
+        WriteAl("Probe.al", CleanProbe);
+        var compiler = new BcCompiler();
+        var baseline = compiler.Emit(new[] { _root }, "IncrTargetCloud", appRootDir: _root, trackIncrementalBaseline: true);
+        Assert.Empty(baseline.Diagnostics);
+
+        WriteAl("Probe.al", SidProbe);
+        var incremental = compiler.TryEmitIncremental(new[] { _root }, "IncrTargetCloud", appRootDir: _root, out var reason);
+
+        Assert.True(incremental == null,
+            "the incremental path compiled a Cloud app's call to the OnPrem-scoped Sid() without a diagnostic; "
+            + "a cold compile of the same tree refuses it with AL0296.");
+        // The fallback reason carries the compiler's message text, not its diagnostic id.
+        Assert.Contains("has scope 'OnPrem' and cannot be used for 'Cloud' development", reason, StringComparison.Ordinal);
+
+        // The full compile the caller falls back to refuses it too.
+        var full = compiler.Emit(new[] { _root }, "IncrTargetCloud", appRootDir: _root, trackIncrementalBaseline: true);
+        Assert.Contains(full.Diagnostics, d => d.Contains("AL0296", StringComparison.Ordinal));
+    }
+
+    [SkippableFact]
+    public void OnPremTarget_SameEdit_StaysOnTheFastPath()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        // Positive control: without it, a fast path that refused Sid() for every target would
+        // satisfy the Cloud test above.
+        WriteManifest("OnPrem");
+        WriteAl("Probe.al", CleanProbe);
+        var compiler = new BcCompiler();
+        var baseline = compiler.Emit(new[] { _root }, "IncrTargetOnPrem", appRootDir: _root, trackIncrementalBaseline: true);
+        Assert.Empty(baseline.Diagnostics);
+
+        WriteAl("Probe.al", SidProbe);
+        var incremental = compiler.TryEmitIncremental(new[] { _root }, "IncrTargetOnPrem", appRootDir: _root, out var reason);
+
+        Assert.True(incremental != null, $"expected the fast path for an OnPrem app; fell back: {reason}");
+        Assert.Contains("Incr Target Probe", ByName(incremental!).Keys);
+    }
+
+    [SkippableFact]
+    public void CloudTarget_FastPathOutput_CarriesTheSameTargetLiteralAsAColdBuild()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        WriteManifest("Cloud");
+        WriteAl("Probe.al", CleanProbe);
+        var compiler = new BcCompiler();
+        Assert.Empty(compiler.Emit(new[] { _root }, "IncrTargetLiteral", appRootDir: _root, trackIncrementalBaseline: true).Diagnostics);
+
+        WriteAl("Probe.al", TableConnectionProbe);
+        var incremental = compiler.TryEmitIncremental(new[] { _root }, "IncrTargetLiteral", appRootDir: _root, out var reason);
+        Assert.True(incremental != null, $"expected the fast path; fell back: {reason}");
+
+        var coldCloud = ByName(new BcCompiler().Emit(new[] { _root }, "IncrTargetLiteralColdCloud", appRootDir: _root))["Incr Target Probe"];
+        WriteManifest("OnPrem");
+        var coldOnPrem = ByName(new BcCompiler().Emit(new[] { _root }, "IncrTargetLiteralColdOnPrem", appRootDir: _root))["Incr Target Probe"];
+
+        // Fixture guard: the probe really emits something target-dependent.
+        Assert.NotEqual(coldCloud, coldOnPrem);
+        Assert.Equal(coldCloud, ByName(incremental!)["Incr Target Probe"]);
+    }
+}

--- a/AlRunner/BcCompiler.Incremental.cs
+++ b/AlRunner/BcCompiler.Incremental.cs
@@ -1450,7 +1450,8 @@ public sealed partial class BcCompiler
 
     private static NavCA.CompilationOptions RadCompilationOptions(ManifestCompilerInputs manifestInputs) => new(
         continueBuildOnError: true,
-        target: NavCA.CompilationTarget.OnPrem,
+        // #2316: must match Emit()'s target, or a fast-path cycle skips AL0296 for a Cloud app.
+        target: manifestInputs.EffectiveTarget,
         generateOptions: NavCA.CompilationGenerationOptions.Code | NavCA.CompilationGenerationOptions.Navigation,
         compilerFeatures: manifestInputs.CompilerFeatures,
         contextSensitiveHelpUrl: manifestInputs.ContextSensitiveHelpUrl);


### PR DESCRIPTION
Closes #2316

Written by agent stma-auto2-7 on the account holder's behalf.

Corpus-NA: compile-time diagnostic; a corpus app that deliberately fails to compile cannot express a passing corpus test, and the corpus adjudicates by compiling and running

## What I found when I re-checked at current main

The one-shot compile already enforces AL0296. I ran the issue's exact reproducer (Cloud target, `Sid('...')`) against `origin/main` 8908e999 on BC 28.1.49838.53910:

```
error AL0296: The application object or method 'SID' has scope 'OnPrem' and cannot be used for 'Cloud' development.
=== repro — COMPILE FAIL ===
```

#2737 fixed that by passing the app.json `target` to `CompilationOptions` (`ManifestCompilerInputs.EffectiveTarget`). `DotNetCompilationTargetScopeTests` already covers it end to end for the DotNet form of AL0296.

The defect was still present on the incremental path that `--watch` and `--server` use. `BcCompiler.RadCompilationOptions` (`AlRunner/BcCompiler.Incremental.cs`) received `manifestInputs` and still hardcoded `target: CompilationTarget.OnPrem`. In a watch session, the first cycle (a full `Emit`) compiled as Cloud and every later fast-path cycle compiled as OnPrem. So:

- an edit that adds `Sid()` to a Cloud app compiled green on the fast path, with no AL0296;
- any target-dependent literal the compiler emits (for example the target passed into `ALRegisterTableConnection`) differed from a cold build of the same tree.

## Change

One line: `RadCompilationOptions` now uses `manifestInputs.EffectiveTarget`, the same value `Emit()` and `EmitDepSymbols()` use. When the incremental compile reports an error, `TryEmitIncremental` already falls back to a full `Emit`, and that full `Emit` reports AL0296 in the normal way.

## Tests: `AlRunner.Tests/BcCompilerIncrementalCompilationTargetTests.cs`

This is a runner-mechanism test that does not need the Base Application. The diagnostic comes from BC's own compiler; the runner only has to pass it the right target.

1. `CloudTarget_EditAddingAnOnPremScopedCall_IsRefusedWithAL0296_NotTakenOnTheFastPath`: a clean Cloud baseline, then an edit that adds `Sid()`. The incremental cycle must refuse it with the compiler's scope message, and the full compile it falls back to must report AL0296.
2. `OnPremTarget_SameEdit_StaysOnTheFastPath`: the positive control. Without it, a fast path that refused `Sid()` for every target would pass test 1.
3. `CloudTarget_FastPathOutput_CarriesTheSameTargetLiteralAsAColdBuild`: a Cloud edit adding `Database.RegisterTableConnection`. The fast-path C# must match a cold Cloud build. A fixture guard checks that the cold Cloud and cold OnPrem C# really differ.

**RED → GREEN** (`--filter FullyQualifiedName~BcCompilerIncrementalCompilationTargetTests`, run with `engine.runsettings`):
- before the fix: `Failed: 2, Passed: 1, Total: 3` (tests 1 and 3 red, the OnPrem control green)
- after the fix: `Failed: 0, Passed: 3, Total: 3`

**Mutation (executed):** I changed the value back to the literal `NavCA.CompilationTarget.OnPrem`, rebuilt and re-ran `~BcCompilerIncremental` (8 classes): `Failed: 2, Passed: 35, Total: 37`. The two red tests were exactly tests 1 and 3, both failing on their assertions (not `error CS`). After restoring: `Failed: 0, Passed: 37, Total: 37`, re-run after rebasing onto current main.

## Blast radius (measured locally, with the fix, BC 28.1.49838.53910)

The fix only changes the incremental path, which CI's corpus and runner-extras runs do not use. I ran both anyway, with the CI flags from `bc-tests.yml`:

- corpus `0d9d246bc8406e93126c95a269064515d2722977` (master), all three corpus apps: `3377 total, 3377 pass, 0 fail, 0 error, compile-fail: 0`, rc=0
- `tests/runner-extras` with `--count-baseline`: `438 total, 438 pass, 0 fail, compile-fail: 0`, rc=0
- `tools/test_*.py`: all pass; `~GuardTests`: `Passed: 254, Total: 254`

## Fix the shape

1. **Same wrong pattern at another call site?** I checked every `CompilationOptions` construction: `Emit` (plus its TDD re-compile and emit-retry compilations, which reuse the same `compOpts`), `EmitDepSymbols`, and `RadCompilationOptions`. Only the RAD one ignored the target. `ClassifyDeclaredObject` gets the RAD options passed in, so it is fixed by the same line.
2. **Does a sibling function make the same assumption?** Yes. `RadParseOptions`, right next to it, also ignores `manifestInputs`. It drops the manifest `preprocessorSymbols` and `--define` symbols that `Emit` includes (#1943). That is a different defect (which `#if` branch is parsed, not the target) and I have not measured it yet, so I filed it as #4064 instead of folding it in.
3. **Two paths writing the same state with different invariants?** Yes, and that is this defect: full `Emit` and the RAD cycle build options for the same app, and only one of them honored the target. Both now use `EffectiveTarget`. If `target` is edited in app.json during a watch session, the baseline is invalidated rather than reused: `RadManifestFingerprint` includes `CacheKeyFragment`, which carries `(int)EffectiveTarget`, and it also includes a hash of the app.json file.

The issue's last paragraph: `tests/runner-extras/standalone-suites/app.json` declares no `target`, so it compiles under the runner's OnPrem default (`EffectiveTarget`, pinned by `ManifestCompilationTargetTests.ReadManifestCompilerInputs_NoTarget_KeepsOnPremDefault`). Its `Database.Sid` calls are legal there, not a hidden bug. Changing that default to alc's own default (Cloud) would be a separate decision.

**Queue scan:** I searched open issues for `RadCompilationOptions`, `RadParseOptions`, `AL0296`, "watch preprocessorSymbols", "incremental target" and "OnPrem scope watch". The only match was #2316 itself. #4064 was filed from this work.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
