### PR TITLE
fix(report): precompiled REPORT.Run hands the request-page handler a page surface

### DIFF
--- a/AlRunner.Tests/FieldTriggerShapeGapCallSiteTests.cs
+++ b/AlRunner.Tests/FieldTriggerShapeGapCallSiteTests.cs
@@ -1003,9 +1003,12 @@ public sealed class FieldTriggerShapeGapCallSiteTests : IDisposable
         // 10 -> 11 / 13 -> 14 (#3375): NavReportSync.RefuseLoopOverSynthesizedDataItems, the
         // first of these guards whose absence was SILENT rather than a crash — an unbounded
         // data-item loop reads as a hang, which is how it survived to be found by profiling.
-        Assert.Equal(11, runnerShapeGapSites);
+        //
+        // 11 -> 12 / 14 -> 15 (#4067): NavReportSync.BindRequestPageOpenedByBc, a request page
+        // BC's own report engine opened whose owner is not a NavReport.
+        Assert.Equal(12, runnerShapeGapSites);
         Assert.Equal(3, installGapSites);
-        Assert.Equal(14, total);
+        Assert.Equal(15, total);
 
         var limitations = File.ReadAllText(Path.Combine(RepoRoot, "docs", "limitations.md"));
         Assert.Contains($"{total} further guards raise `RunnerOutOfScopeException`", limitations,

--- a/AlRunner.Tests/RequestPageOpenedByBcBindingTests.cs
+++ b/AlRunner.Tests/RequestPageOpenedByBcBindingTests.cs
@@ -1,0 +1,73 @@
+// RequestPageOpenedByBcBindingTests — the runner-internal half of #4067.
+//
+// Precompiled AL calls NavReport.RunAsync(NavSession, int); BC's own report engine then opens
+// the request page and hands it to RunnerTestClientSession.GetPage without the runner having
+// bound it. GetPage now binds such a form through NavReportSync.BindRequestPageOpenedByBc
+// instead of building a page surface for the REPORT's id.
+//
+// The BC-behaviour claim (a [RequestPageHandler] reached from Base Application code gets the
+// request page and can Cancel it) is measured upstream: corpus codeunit 60037
+// "Rpt Run Precompiled Caller" (StefanMaron/BusinessCentral.AL.Language.Tests#342).
+//
+// Pinned HERE: how the binding finds the report (Parent, else the AL compiler's CurrReport
+// field, which is where BC-emitted request pages keep it), that the id comes from that report,
+// that the binding is the one GetPage's TryGetFor answers afterwards, and that a form tied to
+// no report is refused loudly rather than handed some page.
+using System;
+using AlRunner;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// IsProcessingOnly reads RecordPatches' parse statics.
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class RequestPageOpenedByBcBindingTests
+{
+    // Stand-ins shaped like the AL compiler's output: a report type named Report<N> deriving
+    // from a type named NavReport, and a nested request page holding it in CurrReport.
+    public class NavReport { }
+    public sealed class Report94067 : NavReport { }
+    public sealed class Report94068 : NavReport { }
+    public sealed class NotAReport { }
+
+    public sealed class FakeRequestPage
+    {
+        public object? CurrReport;
+    }
+
+    [Fact]
+    public void ParentIsNull_BindsToTheReportInCurrReport()
+    {
+        var form = new FakeRequestPage { CurrReport = new Report94067() };
+
+        var page = NavReportSync.BindRequestPageOpenedByBc(form, parent: null);
+
+        Assert.Equal(94067, page.PageId);
+        Assert.Same(page, RequestPageTestPage.TryGetFor(form));
+    }
+
+    [Fact]
+    public void ParentIsANavReport_WinsOverCurrReport()
+    {
+        var form = new FakeRequestPage { CurrReport = new Report94068() };
+
+        var page = NavReportSync.BindRequestPageOpenedByBc(form, parent: new Report94067());
+
+        Assert.Equal(94067, page.PageId);
+    }
+
+    [Fact]
+    public void NoReportAnywhere_IsRefusedByName_NotHandedAPage()
+    {
+        var form = new FakeRequestPage { CurrReport = new NotAReport() };
+
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
+            () => NavReportSync.BindRequestPageOpenedByBc(form, parent: null));
+
+        Assert.Contains("request-page-report", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(typeof(NotAReport).FullName!, ex.Message, StringComparison.Ordinal);
+        Assert.Null(RequestPageTestPage.TryGetFor(form));
+    }
+}

--- a/AlRunner.Tests/RunnerShapeGapClaimTests.cs
+++ b/AlRunner.Tests/RunnerShapeGapClaimTests.cs
@@ -117,6 +117,11 @@ public sealed class RunnerShapeGapClaimTests
             ["report-metadata-unavailable"] = (
                 () => Invoke("ReportMetadataUnavailable", "NavReport.Run(Report 50100)", "the probe detail"),
                 "NavReport.Run(Report 50100)", "report-metadata-unavailable", RuntimeDoc),
+            // #4067. A request page BC's own report engine opened, whose Parent / CurrReport is
+            // not a NavReport — so which report's data items and built-in actions apply is unknown.
+            ["request-page-report"] = (
+                () => Invoke("RequestPageReport", "TestRequestPage (Report50100+RequestPage)", "the probe detail"),
+                "TestRequestPage (Report50100+RequestPage)", "request-page-report", RuntimeDoc),
         };
 
     public static IEnumerable<object[]> SiteNames() => Sites.Keys.Select(k => new object[] { k });
@@ -142,6 +147,7 @@ public sealed class RunnerShapeGapClaimTests
         "UserTableTriggerPatches.cs",
         "RecordPatches.InstallBaseline.cs",
         "RunnerModalDispatch.cs",
+        "NavReportSync.RunRequestPage.cs",   // #4067, added with the factory from the start
     };
 
     /// <summary>
@@ -348,7 +354,8 @@ public sealed class RunnerShapeGapClaimTests
         // and its doc link, and puts it through the [TryFunction] arm — so a refusal cannot be
         // added here without someone stating what it claims. This assertion only holds the
         // floor.
-        Assert.Equal(19, total);
+        // 19 -> 20 (#4067): NavReportSync.BindRequestPageOpenedByBc, with its Sites entry above.
+        Assert.Equal(20, total);
     }
 
     // ── The nine sites the issue's own measurement could not see ─────────────────────────

--- a/AlRunner/Infrastructure/NclCecilRewrite.Reports.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Reports.cs
@@ -701,7 +701,8 @@ public static partial class NclCecilRewrite
         // bypass the Session.Company.SharedObjects deref by calling NavForm 2-arg ctor
         // directly, which assigns masterPage and runs the rest of NavForm init using
         // `parent` (the report instance) as the ITreeObject. RequestPageBase.Parent is
-        // left null — not observable by AL tests; if needed later, set it explicitly.
+        // left null, and NavReportSync.BindRequestPageOpenedByBc depends on that shape (#4067):
+        // it falls back to the compiled CurrReport field. Setting Parent here is safe for it.
         {
             var requestPageBaseT = asm.MainModule.Types
                 .FirstOrDefault(t => t.FullName == "Microsoft.Dynamics.Nav.Runtime.RequestPageBase");

--- a/AlRunner/Patches/NavReportSync.RunRequestPage.cs
+++ b/AlRunner/Patches/NavReportSync.RunRequestPage.cs
@@ -148,8 +148,8 @@ public static partial class NavReportSync
     /// <param name="parent">The form's <c>RequestPageBase.Parent</c> — the report it belongs to.</param>
     internal static AlRunner.Patches.RequestPageTestPage BindRequestPageOpenedByBc(object requestPageForm, object? parent)
     {
-        // Parent is null on a BC-emitted request page here (measured on Report5187+RequestPage);
-        // the AL compiler's nested RequestPage class carries its report as the CurrReport field.
+        // Parent is null because NclCecilRewrite.Reports.cs rewrites the RequestPageBase ctors
+        // past the assignment; the compiled Report<N>+RequestPage keeps its report in CurrReport.
         parent ??= requestPageForm.GetType()
             .GetField("CurrReport", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?
             .GetValue(requestPageForm);
@@ -159,8 +159,9 @@ public static partial class NavReportSync
         if (parent == null || navReportBase == null)
             throw AlRunner.Patches.RunnerShapeGap.RequestPageReport(
                 "TestRequestPage (" + requestPageForm.GetType().FullName + ")",
-                "neither the request page's Parent nor its CurrReport field is a NavReport (found "
-                + (parent?.GetType().FullName ?? "null") + "), so the runner cannot tell which report's data items and "
+                "the request page's owner is not a report: neither its Parent nor a CurrReport field "
+                + "is a NavReport (found " + (parent?.GetType().FullName ?? "null") + "; an XmlPort's "
+                + "request page reaches here too), so the runner cannot tell which data items and "
                 + "built-in actions the [RequestPageHandler] is driving");
 
         int reportId = TryGetObjectId(parent, navReportBase);

--- a/AlRunner/Patches/NavReportSync.RunRequestPage.cs
+++ b/AlRunner/Patches/NavReportSync.RunRequestPage.cs
@@ -137,6 +137,44 @@ public static partial class NavReportSync
         }
     }
 
+    /// <summary>
+    /// The request-page surface for a request page that BC's own report engine opened, rather
+    /// than <see cref="RunRequestPageForHandler"/>. Precompiled AL calls the async entry points
+    /// (<c>NavReport.RunAsync(NavSession, int)</c> and siblings), which the sync-wrapper Cecil
+    /// rewrite never sees, so nothing bound the form before BC dispatched it to the handler
+    /// (#4067). BC's <c>RunRequestPageCoreAsync</c> reads the page's FormResult itself on
+    /// that path, so no confirmation read-back is needed here.
+    /// </summary>
+    /// <param name="parent">The form's <c>RequestPageBase.Parent</c> — the report it belongs to.</param>
+    internal static AlRunner.Patches.RequestPageTestPage BindRequestPageOpenedByBc(object requestPageForm, object? parent)
+    {
+        // Parent is null on a BC-emitted request page here (measured on Report5187+RequestPage);
+        // the AL compiler's nested RequestPage class carries its report as the CurrReport field.
+        parent ??= requestPageForm.GetType()
+            .GetField("CurrReport", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?
+            .GetValue(requestPageForm);
+        Type? navReportBase = parent?.GetType();
+        while (navReportBase != null && navReportBase.Name != "NavReport")
+            navReportBase = navReportBase.BaseType;
+        if (parent == null || navReportBase == null)
+            throw AlRunner.Patches.RunnerShapeGap.RequestPageReport(
+                "TestRequestPage (" + requestPageForm.GetType().FullName + ")",
+                "neither the request page's Parent nor its CurrReport field is a NavReport (found "
+                + (parent?.GetType().FullName ?? "null") + "), so the runner cannot tell which report's data items and "
+                + "built-in actions the [RequestPageHandler] is driving");
+
+        int reportId = TryGetObjectId(parent, navReportBase);
+        // offersOk mirrors RunRequestPageForReportRun: ProcessingOnly decides it for a Run.
+        // A RunRequestPageAsync caller (ReportIntent.Parameters, #3505) would offer OK on every
+        // report; the intent is not readable off the form, so that caller still gets BC's
+        // "OK is not found" on a report that renders.
+        var page = AlRunner.Patches.RequestPageTestPage.Bind(
+            requestPageForm, parent, reportId, offersOk: IsProcessingOnly(parent, navReportBase));
+        if (Environment.GetEnvironmentVariable("AL_RUNNER_DIAG_RP") == "1")
+            Console.Error.WriteLine($"[NavReportSync] request page for report {reportId} opened by BC's report engine — bound on dispatch");
+        return page;
+    }
+
     // ── the test dataset (TestRequestPage.SaveAsXml) ──────────────────────────
 
     private static Type? _reportSaveAsXmlRendererType;

--- a/AlRunner/Patches/RunnerShapeGaps.cs
+++ b/AlRunner/Patches/RunnerShapeGaps.cs
@@ -108,6 +108,10 @@
 //     No form registered under the handle the [ModalPageHandler] is being handed. The runner's
 //     own form registry did not have it; BC's client session would.
 //
+//   NavReportSync.RunRequestPage.cs (1, BindRequestPageOpenedByBc, #4067).
+//     A request page BC's own report engine opened whose Parent is not a NavReport. Added
+//     after this sweep, with the factory from the start.
+//
 //   NavReportSync.cs (2, SyncRunRequestPage / SyncStaticRun).
 //     These two already LED with "not-yet-implemented", so they already tore through a
 //     [TryFunction] correctly — but they appended "See docs/scope.md" by hand, which
@@ -236,6 +240,10 @@ internal static class RunnerShapeGap
     /// <summary>The runner's own modal/page dispatch was handed an incomplete context.</summary>
     internal static RunnerOutOfScopeException ModalDispatchContext(string api, string surface, string detail)
         => Build(api, surface, detail, RuntimeDoc);
+
+    /// <summary>A request page BC's own report engine opened could not be tied back to its report (#4067).</summary>
+    internal static RunnerOutOfScopeException RequestPageReport(string api, string detail)
+        => Build(api, "request-page-report", detail, RuntimeDoc);
 
     /// <summary>The runner could not construct the report object to run it.</summary>
     internal static RunnerOutOfScopeException ReportConstruction(string api, string detail)

--- a/AlRunner/Patches/RunnerTestClientSession.cs
+++ b/AlRunner/Patches/RunnerTestClientSession.cs
@@ -55,6 +55,12 @@ public sealed class RunnerTestClientSession : ITestClientSession
         if (RequestPageTestPage.TryGetFor(form) is { } requestPage)
             return requestPage;
 
+        // Unbound, but still a request page: BC's own report engine opened it (the async
+        // Report.Run entry points precompiled AL calls, #4067). Never fall through to the page
+        // surface below — PageIdOf answers the REPORT's id, which can name an unrelated page.
+        if (form is RequestPageBase requestPageForm)
+            return AlRunner.NavReportSync.BindRequestPageOpenedByBc(requestPageForm, requestPageForm.Parent);
+
         var pageId = PageIdOf(form);
 
         // A page with no SourceTable is ordinary, legal AL — the StandardDialog shape, whose

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1529,7 +1529,7 @@ https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues.
 <a id="runtime-shape-gaps"></a>
 
 - **Runtime shape gaps outside the virtual tables — the runner refuses rather than answering
-  a shape it cannot produce.** 14 further guards raise `RunnerOutOfScopeException` with the
+  a shape it cannot produce.** 15 further guards raise `RunnerOutOfScopeException` with the
   reason anchor `not-yet-implemented`, so an AL `[TryFunction]` cannot absorb one into `false`
   ([#2966](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2966)). The number
   counts refusal **call sites**, which is the rule the original nine were counted under; it is
@@ -1550,6 +1550,11 @@ https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues.
     context or request (`RunnerModalDispatch.cs`);
   - **report construction**, when the runner cannot build the report object at all to run it
     or its request page (`NavReportSync.cs`);
+  - a **request page opened by BC's own report engine** (the async `Report.Run` entry points
+    compiled dependency code calls) whose owner is not a report, so the runner cannot tell
+    which data items and built-in actions the `[RequestPageHandler]` is driving
+    (`NavReportSync.BindRequestPageOpenedByBc`,
+    [#4067](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/4067));
   - a **report's data-item loop**, when neither metadata source describes the report and its
     data items therefore carry a MetaDataItem synthesized from their name alone
     (`NavReportSync.RefuseLoopOverSynthesizedDataItems`,


### PR DESCRIPTION
Closes #4067

_Written by agent stma-auto2-8 on the account holder's behalf._

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/342

## What was wrong

Base Application code compiles `REPORT.Run(id)` to `NavReport.RunAsync(NavSession, int)`. The Cecil rewrite in `NclCecilRewrite.Reports.cs` only replaces the sync wrappers (`Run(int)`, `Run()`, ...), so that call runs BC's own `RunReportAsync` -> `RunReportInternalCoreAsync` -> `RunRequestPageCoreAsync` -> `NavForm.RunModalAsync` -> `TestHandleModalForm`. Nothing on that path calls `RequestPageTestPage.Bind`, so `RunnerTestClientSession.GetPage` did not find a binding and built a `LiveNavTestPage` for `PageIdOf(form)`, which is the report's id. For report 5187 that is page 5187, a List page, so `Cancel()` was "not found". I measured the route with a stack trace from `GetPage` on test C of the issue's repro (page 5134 action -> `NavReport.RunAsync(NavSession, Int32)`).

## What changed

- `RunnerTestClientSession.GetPage`: when the form has no binding but is a `RequestPageBase`, it is bound as a request page instead of falling through to the page surface.
- `NavReportSync.BindRequestPageOpenedByBc` (new, `NavReportSync.RunRequestPage.cs`): finds the report from `RequestPageBase.Parent`, or from the AL compiler's `CurrReport` field when `Parent` is null (it is null on `Report5187+RequestPage` here; I checked by dumping the form's fields), reads the id and ProcessingOnly the same way `RunRequestPageForReportRun` does, and binds. BC's `RunRequestPageCoreAsync` reads the FormResult itself on this path, so there is no confirmation read-back here, unlike the sync path.
- If the form cannot be tied to a `NavReport`, it throws `RunnerShapeGap.RequestPageReport` (`not-yet-implemented — request-page-report`). A request-page handler never silently gets a page surface. Registered in `RunnerShapeGapClaimTests` (Sites entry, corrected-files list, floor 19 -> 20).

I did not rewrite the async `RunAsync` wrappers to call `SyncStaticRun`. Binding at `GetPage` covers every async entry into `RunRequestPageCoreAsync` (`RunAsync`, `RunModalAsync`, instance `RunAsync()`, `Execute`, `Print`) in one place, and the report body keeps running on BC's own engine, which is what these callers already did before this change.

## Tests

**Corpus** (StefanMaron/BusinessCentral.AL.Language.Tests#342, codeunit 60037 "Rpt Run Precompiled Caller", corpus base `0d9d246b`): page 5134 "Contact Duplicates" action runs `REPORT.Run(5187)` from Base Application code. One test cancels the request page and checks the handler ran exactly once. The other has the handler raise `Error()` and checks that text reaches the test through the Base Application caller. A third, added after review (corpus head `8bb07759`), has the handler invoke OK, which this ProcessingOnly report's request page offers, and checks the handler ran once with no error.

**Runner side** (`AlRunner.Tests/RequestPageOpenedByBcBindingTests.cs`, needed for the `Tests updated` gate because the corpus is not part of this diff): binding through `CurrReport` when `Parent` is null, `Parent` winning over `CurrReport`, and the loud refusal when neither is a report.

RED -> GREEN, local probe bundle (Base Application 27.0 floor, `--package-cache ~/.al-runner/platform-apps`) holding the issue's tests A and C plus the corpus codeunit:

- Before the fix: test C failed with `The built-in action = Cancel is not found on the page.`
- After, on head `c1195f53` rebuilt: two runs one after the other on the same `--cache`, `4P/0F/0E across 4 tests` both times (7.8s, then 5.4s).

Mutations (both executed, both restored):

1. Turned off the new `GetPage` branch with an env gate: `2P/2F` -> restored `4P/0F`. Test C and `ReportRun_FromBaseAppPageAction_HandlerCancelsTheRequestPage` went red with the Cancel-not-found error. Test A (bundle caller, sync path) stayed green, and the handler-error test stayed green, as expected, since the handler also runs on the page surface.
2. Renamed the `CurrReport` field lookup: `RequestPageOpenedByBcBindingTests` `Failed: 2, Passed: 1` -> `Failed: 0, Passed: 3`. `ParentIsNull_BindsToTheReportInCurrReport` hit the refusal. `NoReportAnywhere_IsRefusedByName_NotHandedAPage` failed because the message named `null` instead of the non-report type.

3. After review, I set `offersOk: false` at the new call site, with the OK test added to the probe: `4P/1F/0E across 5 tests`. Only `ReportRun_FromBaseAppPageAction_HandlerConfirmsOk` failed, with `The built-in action = OK is not found on the page.` Restored: `5P/0F/0E across 5 tests`, run twice on the same `--cache`, the second on head `84d5e0c6`.

Follow-up commit `84d5e0c6`: the `RequestPageBase` ctor-rewrite comment in `NclCecilRewrite.Reports.cs` no longer calls the null `Parent` unobservable, the `CurrReport` fallback names that rewrite as the cause, and the refusal text says "the request page's owner is not a report" and mentions XmlPort request pages, which also reach it.

Before the `CurrReport` fallback existed, the probe hit the new refusal on test C (`the request page's Parent is null`), so the loud path is reachable in practice, not only in the unit test.

Other local runs: `dotnet test --filter GuardTests|RunnerShapeGapClaimTests|BcShapeGapConventionTests|RequestPageOpenedByBcBindingTests` with `engine.runsettings`: `Failed: 0, Passed: 358, Total: 358`. `tools/test_*.py`: all pass. I did not run the full corpus or the three Tests-Marketing tests from the issue (they need `--test-data`); CI runs the corpus.

## Fix the shape

1. **Same pattern at another call site?** The wrong step was "an unbound form falls through to the page surface". `GetPage` is the one place `TestHandleModalForm` asks for the page, so every async report entry point ends up there. `RunnerModalDispatch.FormRunModal` opens the form first but does not choose the surface.
2. **Sibling assumption?** Yes: the sync-wrapper Cecil rewrites assume AL calls the sync `NavReport` wrappers. Precompiled code calls the `*Async` siblings. #3505 (`RunRequestPageAsync` from Base Application's Job Queue Entry) is the same assumption on the parameters entry point. I did not fold it in. `NclCecilRewrite.cs:377` still rewrites every `RunRequestPageAsync` overload to throw, so that path never reaches `GetPage` today. When #3505 lifts the throw, note that its intent (`ReportIntent.Parameters`, which offers OK on every report) cannot be read off the form in `GetPage`: this binding uses ProcessingOnly, so a handler invoking OK on a report that renders would get BC's "OK is not found". I noted this on #3505.
3. **Two paths writing the same state?** `RequestPageTestPage.Bind` now has two callers. The sync path also calls `RunnerFormInit.MarkSourceExpressionsWanted` before `RunModal`, so request-page controls resolve. On the BC-engine path the form has already run `OnMetadataLoaded` by the time `GetPage` sees it, so a handler that sets a request-page control there still gets the existing loud `request-page-control` refusal rather than a silent value. Not fixed here; I will file it if a test needs it.

Issue search (open queue): `RunAsync report`, `RunModalAsync`, `RunRequestPageAsync`, `RequestPageTestPage`, `built-in action Cancel`, `precompiled Report.Run`, `request page precompiled`. Related: #3505 (above), #2457 (custom request-page action, different surface). No duplicate.

Comment over ten lines: none added; the longest is the 7-line doc comment on `BindRequestPageOpenedByBc`.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
