### PR TITLE
fix(testpage): no blank new-row line on a lookup / declared non-editable list re-enabled in OnOpenPage

### DIFF
--- a/AlRunner.Tests/TestPageNewRowLineRuleTests.cs
+++ b/AlRunner.Tests/TestPageNewRowLineRuleTests.cs
@@ -38,7 +38,7 @@ public sealed class TestPageNewRowLineRuleTests
     public void OpenMode_WhenPresent_DecidesOutright(
         bool? openModeEditable, bool? hostStaticEditable, bool pageEditable, bool expected)
         => Assert.Equal(expected,
-            TestPageNewRowLineRule.ResolveStaticEditable(openModeEditable, hostStaticEditable, pageEditable));
+            TestPageNewRowLineRule.ResolveStaticEditable(openModeEditable, hostStaticEditable, pageEditable, lookupMode: false));
 
     [Theory]
     // No open mode (a handler-driven page): the page's OWN Editable is the answer. The second
@@ -47,7 +47,7 @@ public sealed class TestPageNewRowLineRuleTests
     [InlineData(false, false)]
     public void NoOpenMode_TopLevelPage_FallsBackToThePagesOwnEditable(bool pageEditable, bool expected)
         => Assert.Equal(expected,
-            TestPageNewRowLineRule.ResolveStaticEditable(null, hostStaticEditable: null, pageEditable));
+            TestPageNewRowLineRule.ResolveStaticEditable(null, hostStaticEditable: null, pageEditable, lookupMode: false));
 
     [Theory]
     // A part: editable only if BOTH the host and the part's own property say so.
@@ -58,7 +58,26 @@ public sealed class TestPageNewRowLineRuleTests
     public void NoOpenMode_Part_RequiresBothHostAndItsOwnEditable(
         bool hostStaticEditable, bool pageEditable, bool expected)
         => Assert.Equal(expected,
-            TestPageNewRowLineRule.ResolveStaticEditable(null, hostStaticEditable, pageEditable));
+            TestPageNewRowLineRule.ResolveStaticEditable(null, hostStaticEditable, pageEditable, lookupMode: false));
+
+    // A handler-driven page opened with LookupMode(true) is not editable, whatever it declares
+    // (corpus 60309 Plain_LookupModeTrue_HasNoNewRowLine / _EditableAnswer). Without lookup
+    // mode the declared Editable still decides (Plain_RunModalById_HasTheNewRowLine,
+    // NotEditable_RunModalById_HasNoNewRowLine).
+    [Theory]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, false)]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, false)]
+    public void NoOpenMode_LookupMode_IsNotEditable(bool declaredPageEditable, bool lookupMode, bool expected)
+        => Assert.Equal(expected,
+            TestPageNewRowLineRule.ResolveStaticEditable(null, hostStaticEditable: null, declaredPageEditable, lookupMode));
+
+    // The open mode of a page the test opened still wins outright; lookup mode cannot arise
+    // there, and must not be read as overriding it.
+    [Fact]
+    public void OpenMode_WhenPresent_IgnoresLookupMode()
+        => Assert.True(TestPageNewRowLineRule.ResolveStaticEditable(true, hostStaticEditable: null, true, lookupMode: true));
 
     // ---- ShowsNewRowLine ------------------------------------------------------------------
 

--- a/AlRunner.Tests/TestPageNewRowLineRuleTests.cs
+++ b/AlRunner.Tests/TestPageNewRowLineRuleTests.cs
@@ -69,9 +69,9 @@ public sealed class TestPageNewRowLineRuleTests
     [InlineData(true, true, false)]
     [InlineData(false, false, false)]
     [InlineData(false, true, false)]
-    public void NoOpenMode_LookupMode_IsNotEditable(bool declaredPageEditable, bool lookupMode, bool expected)
+    public void NoOpenMode_LookupMode_IsNotEditable(bool pageEditable, bool lookupMode, bool expected)
         => Assert.Equal(expected,
-            TestPageNewRowLineRule.ResolveStaticEditable(null, hostStaticEditable: null, declaredPageEditable, lookupMode));
+            TestPageNewRowLineRule.ResolveStaticEditable(null, hostStaticEditable: null, pageEditable, lookupMode));
 
     // The open mode of a page the test opened still wins outright; lookup mode cannot arise
     // there, and must not be read as overriding it.

--- a/AlRunner/Patches/MockTestPage.LivePage.Actions.cs
+++ b/AlRunner/Patches/MockTestPage.LivePage.Actions.cs
@@ -333,7 +333,7 @@ internal partial class LiveNavTestPage
     }
 
     /// <summary>The page's declared <c>Editable</c>, true for a page with no metadata here.</summary>
-    internal bool DeclaredPageEditable => _page?.PageEditable ?? true;
+    internal bool DeclaredPageEditable => _page?.DeclaredPageEditable ?? true;
 
     /// <summary>This page's current static editability — what <c>TestPage.Editable()</c> answers.</summary>
     internal bool StaticEditableNow => _staticEditable;

--- a/AlRunner/Patches/MockTestPage.LivePage.Actions.cs
+++ b/AlRunner/Patches/MockTestPage.LivePage.Actions.cs
@@ -333,7 +333,7 @@ internal partial class LiveNavTestPage
     }
 
     /// <summary>The page's declared <c>Editable</c>, true for a page with no metadata here.</summary>
-    internal bool DeclaredPageEditable => _page?.DeclaredPageEditable ?? true;
+    internal bool DeclaredPageEditable => _page?.PageEditable ?? true;
 
     /// <summary>This page's current static editability — what <c>TestPage.Editable()</c> answers.</summary>
     internal bool StaticEditableNow => _staticEditable;

--- a/AlRunner/Patches/MockTestPage.LivePage.Lifecycle.cs
+++ b/AlRunner/Patches/MockTestPage.LivePage.Lifecycle.cs
@@ -159,7 +159,7 @@ internal partial class LiveNavTestPage
     {
         _opened = true;
         _staticEditableOverride = viewMode != Microsoft.Dynamics.Nav.Types.Metadata.ViewMode.View
-                                  && (_page?.PageEditable ?? true);
+                                  && DeclaredPageEditable;
     }
 
     // Set only by MarkOpened — i.e. only for a page the TEST opened, where the open MODE is
@@ -187,7 +187,7 @@ internal partial class LiveNavTestPage
     /// </summary>
     private bool _staticEditable
         => TestPageNewRowLineRule.ResolveStaticEditable(
-            _staticEditableOverride, _editabilityHost?._staticEditable, _page?.PageEditable ?? true);
+            _staticEditableOverride, _editabilityHost?._staticEditable, DeclaredPageEditable, _page?.LookupMode == true);
 
     /// <summary>
     /// Bind a subpage part to its host for editability. Deliberately does NOT touch _opened:

--- a/AlRunner/Patches/MockTestPage.LivePage.Lifecycle.cs
+++ b/AlRunner/Patches/MockTestPage.LivePage.Lifecycle.cs
@@ -159,7 +159,7 @@ internal partial class LiveNavTestPage
     {
         _opened = true;
         _staticEditableOverride = viewMode != Microsoft.Dynamics.Nav.Types.Metadata.ViewMode.View
-                                  && DeclaredPageEditable;
+                                  && (_page?.PageEditable ?? true);
     }
 
     // Set only by MarkOpened — i.e. only for a page the TEST opened, where the open MODE is
@@ -187,7 +187,8 @@ internal partial class LiveNavTestPage
     /// </summary>
     private bool _staticEditable
         => TestPageNewRowLineRule.ResolveStaticEditable(
-            _staticEditableOverride, _editabilityHost?._staticEditable, DeclaredPageEditable, _page?.LookupMode == true);
+            _staticEditableOverride, _editabilityHost?._staticEditable,
+            (_page?.PageEditable ?? true) && (_page?.DeclaredPageEditable ?? true), _page?.LookupMode == true);
 
     /// <summary>
     /// Bind a subpage part to its host for editability. Deliberately does NOT touch _opened:

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -769,6 +769,16 @@ internal sealed partial class RunnerPageInstance
     internal bool PageEditable => _form is not NavForm form || form.Editable;
 
     /// <summary>
+    /// The page's DECLARED <c>Editable</c> property — <c>MasterPage.PageProperties.Editable</c>,
+    /// the value BC's <c>NavForm.InitializeFromMetadata</c> seeds <see cref="PageEditable"/> from
+    /// before any trigger can move it. Falls back to <see cref="PageEditable"/> for a form with
+    /// no page metadata. What <c>TestPage.Editable()</c> and the new-row line follow (#4066).
+    /// </summary>
+    internal bool DeclaredPageEditable
+        => _form is not NavForm form
+           || (form.MasterPage?.PageProperties is { } properties ? properties.Editable : form.Editable);
+
+    /// <summary>
     /// What a control DECLARES for one of the three boolean properties, whichever metadata
     /// states it — the merged runtime tree for a page the runner compiled, the declaring
     /// dependency's SymbolReference.json for one that ships precompiled (issue #3504).

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -772,7 +772,8 @@ internal sealed partial class RunnerPageInstance
     /// The page's DECLARED <c>Editable</c> property — <c>MasterPage.PageProperties.Editable</c>,
     /// the value BC's <c>NavForm.InitializeFromMetadata</c> seeds <see cref="PageEditable"/> from
     /// before any trigger can move it. Falls back to <see cref="PageEditable"/> for a form with
-    /// no page metadata. What <c>TestPage.Editable()</c> and the new-row line follow (#4066).
+    /// no page metadata. It narrows what <c>TestPage.Editable()</c> and the new-row line answer
+    /// for a page handed to a handler (#4066).
     /// </summary>
     internal bool DeclaredPageEditable
         => _form is not NavForm form

--- a/AlRunner/Patches/TestPageNewRowLineRule.cs
+++ b/AlRunner/Patches/TestPageNewRowLineRule.cs
@@ -41,9 +41,18 @@ internal static class TestPageNewRowLineRule
     ///
     /// <paramref name="hostStaticEditable"/> is the host's answer for a subpage part, null for
     /// a top-level page. A part is only editable if the page hosting it is.
+    ///
+    /// <paramref name="declaredPageEditable"/> is the page's DECLARED <c>Editable</c>, never the
+    /// runtime <c>CurrPage.Editable</c>, and <paramref name="lookupMode"/> is
+    /// <c>Page.LookupMode(true)</c>: either makes a handler-driven page not editable. Corpus
+    /// codeunit 60309 (#4066), green on BC 27.0 and 28.2: a page declaring
+    /// <c>Editable = false</c> that sets <c>CurrPage.Editable := true</c> in OnOpenPage still
+    /// answers <c>Editable() = false</c> and has no new-row line. Trap: <c>Page.RunModal(0, Rec)</c>
+    /// is NOT lookup mode here — the same suite shows it keeps the new-row line.
     /// </summary>
-    internal static bool ResolveStaticEditable(bool? openModeEditable, bool? hostStaticEditable, bool pageEditable)
-        => openModeEditable ?? ((hostStaticEditable ?? true) && pageEditable);
+    internal static bool ResolveStaticEditable(
+        bool? openModeEditable, bool? hostStaticEditable, bool declaredPageEditable, bool lookupMode)
+        => openModeEditable ?? ((hostStaticEditable ?? true) && declaredPageEditable && !lookupMode);
 
     /// <summary>
     /// Whether the page shows the implicit new-row line. BOTH conditions gate it, and each was

--- a/AlRunner/Patches/TestPageNewRowLineRule.cs
+++ b/AlRunner/Patches/TestPageNewRowLineRule.cs
@@ -42,17 +42,16 @@ internal static class TestPageNewRowLineRule
     /// <paramref name="hostStaticEditable"/> is the host's answer for a subpage part, null for
     /// a top-level page. A part is only editable if the page hosting it is.
     ///
-    /// <paramref name="declaredPageEditable"/> is the page's DECLARED <c>Editable</c>, never the
-    /// runtime <c>CurrPage.Editable</c>, and <paramref name="lookupMode"/> is
-    /// <c>Page.LookupMode(true)</c>: either makes a handler-driven page not editable. Corpus
-    /// codeunit 60309 (#4066), green on BC 27.0 and 28.2: a page declaring
-    /// <c>Editable = false</c> that sets <c>CurrPage.Editable := true</c> in OnOpenPage still
-    /// answers <c>Editable() = false</c> and has no new-row line. Trap: <c>Page.RunModal(0, Rec)</c>
-    /// is NOT lookup mode here — the same suite shows it keeps the new-row line.
+    /// <paramref name="pageEditable"/> is the page's <c>Editable</c> as the caller has it, and
+    /// must already be narrowed by the DECLARED property: <c>CurrPage.Editable := true</c> in
+    /// OnOpenPage cannot widen it. <paramref name="lookupMode"/> is <c>Page.LookupMode(true)</c>,
+    /// which makes a handler-driven page not editable too. Both measured by corpus codeunit 60309
+    /// (#4066) on BC 27.0 and 28.2. Trap: <c>Page.RunModal(0, Rec)</c> is NOT lookup mode here —
+    /// the same suite shows it keeps the new-row line.
     /// </summary>
     internal static bool ResolveStaticEditable(
-        bool? openModeEditable, bool? hostStaticEditable, bool declaredPageEditable, bool lookupMode)
-        => openModeEditable ?? ((hostStaticEditable ?? true) && declaredPageEditable && !lookupMode);
+        bool? openModeEditable, bool? hostStaticEditable, bool pageEditable, bool lookupMode)
+        => openModeEditable ?? ((hostStaticEditable ?? true) && pageEditable && !lookupMode);
 
     /// <summary>
     /// Whether the page shows the implicit new-row line. BOTH conditions gate it, and each was


### PR DESCRIPTION
_Written by agent stma-auto2-4 on the account holder's behalf._

Closes #4066

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/341

## What changed

A page BC hands to a `[ModalPageHandler]` / `[PageHandler]` has no open mode, so `LiveNavTestPage._staticEditable` fell back to `RunnerPageInstance.PageEditable`, which is the **runtime** `NavForm.Editable`. A page declaring `Editable = false` that sets `CurrPage.Editable := true` in OnOpenPage therefore answered `TestPage.Editable()` = true and showed the blank new-row line, so `Next()` walked one extra blank row. That is the extra opportunity in Microsoft's codeunit 136215 (page 5123 "Opportunity List").

- `RunnerPageInstance.DeclaredPageEditable`: new, reads `MasterPage.PageProperties.Editable`, the value `NavForm.InitializeFromMetadata` seeds `Editable` from. Falls back to the runtime value for a form with no page metadata. Measured on the precompiled page too (below), so it is not only source-compiled pages.
- `_staticEditable` for a handler-driven page is now `runtime Editable AND declared Editable AND NOT LookupMode`.
- `TestPageNewRowLineRule.ResolveStaticEditable` takes `lookupMode`.

The runtime value is **narrowed** by the declared one, not replaced. My first version replaced it and turned corpus `Codeunit60461.ListViewActionOpensTheCardOnTheListsCurrentRowReadOnly` red, because a built-in View action opens its card read-only by setting the runtime `NavForm.Editable := false` (`RunnerModalDispatch.ApplyPendingPageOpenMode`). Narrowing keeps that, and keeps the old answer for a page that sets `CurrPage.Editable := false` itself.

## What BC does (corpus PR #341, codeunit 60309)

Green on all 8 cloud legs, run 34734924235 at corpus `583bf12bdae99d5de2a52863543d3df04f13f2f8`; `tools/corpus-pass-count.py` shows all 11 arms ran on each leg:

- Declared `Editable = false` + `CurrPage.Editable := true`: no new-row line via `RunModal(0, Rec)`, `RunModal(id, Rec)`, `LookupMode(true)` or `OpenEdit`, and `TestPage.Editable()` = false.
- No `Editable` property: `LookupMode(true)` gives no new-row line and `Editable()` = false; `RunModal(id, Rec)`, `LookupMode(false)` and `RunModal(0, Rec)` all show the new-row line. So `Page.RunModal(0, Rec)` is not lookup mode for this.

Tier check: `MsDyn365Bc.On.Linux` StartupHook has no patch on the client form builders, `DraftLinePattern` or AL `Page.RunModal`. The Windows nightly gave **no verdict**: its job could not reach the Docker daemon and parsed 0 tests (run 34734924950). Existing corpus 60743 / 60747 / 60757 stay green locally (below).

## RED -> GREEN

Codeunit 60309 as a platform-only app, runner at this branch:

- Before the fix (both gates reverted at once, rebuilt): `Failed: 6, Passed: 5` (ReEditable RunModalZero / LookupModeTrue / RunModalById / EditableAnswer, Plain LookupModeTrue / LookupModeTrue_EditableAnswer).
- After: `Failed: 0, Passed: 11`.

Mutations, each rebuilt and run (no `error CS`; every red is an `Assert.AreEqual`):

- Drop the declared narrowing (`&& DeclaredPageEditable`): `Failed: 3, Passed: 8`: ReEditable_RunModalZero, ReEditable_RunModalById, ReEditable_RunModalById_EditableAnswer. (ReEditable_LookupModeTrue stays green because lookup mode alone hides it, which is what BC does.)
- Drop `&& !lookupMode`: `Failed: 2, Passed: 9`: Plain_LookupModeTrue_HasNoNewRowLine, Plain_LookupModeTrue_EditableAnswer. Against `TestPageNewRowLineRuleTests`: `Failed: 1, Passed: 15`.

**The precompiled page from the issue.** A probe app depending on Base Application, driving page 5123 "Opportunity List" itself (declares `Editable = false`, sets `CurrPage.Editable := true` in OnOpenPage) with two seeded opportunities:

- `Page.RunModal(0, Opportunity)` + a handler walking `First()`/`Next()`: with the fix walks `[P1][P2]`; with the declared narrowing mutated out walks `[P1][P2][]`.
- `TestPage.Editable()` in the handler after `Page.RunModal(Page::"Opportunity List", Opportunity)`: with the fix `No`; mutated `Yes`.
- Totals: `Failed: 0, Passed: 2` with the fix, `Failed: 2, Passed: 0` mutated. So `MasterPage.PageProperties` does resolve for this dependency page. I did not re-run Microsoft's Codeunit136215 itself.

Runner-side mechanism test (the `Tests updated` gate): `AlRunner.Tests/TestPageNewRowLineRuleTests.cs` gains `NoOpenMode_LookupMode_IsNotEditable` and `OpenMode_WhenPresent_IgnoresLookupMode`; `Passed: 16, Total: 16`.

## What I ran

- Full corpus at `583bf12b`, after rebasing on `main`: `Tests: 3359 total, pass: 3359, fail: 0` (`--strict`, `--package-cache ~/.al-runner/platform-apps`). The cache was warm from two earlier runs on the same cache root.
- `dotnet test --filter TestPageNewRowLineRuleTests`: `Passed: 16`.
- A wider filter including `GuardTests` and `TestPageViewEditAction*`: 296 passed, 12 refused with "REFUSING TO SKIP ... engine bootstrap was not performed" (in-process BC engine tests, not bootstrapped on this box). Those 12 did not run, so I am not claiming a result for them; CI runs them.

## Fix the shape

1. **Same pattern at another call site?** `LiveNavTestPage.DeclaredPageEditable` (feeds `BuiltInPageModeActionRule.ResolveShape` and `SwitchViewModeInPlace`) also reads the runtime value under a "declared" name. I left it: on the View-action card it is the runtime `false` that makes those rules work today, and no corpus test measures Edit/View on a re-enabled page reached through a handler. `MarkOpened` reads the runtime value before OnOpenPage, where runtime and declared are equal.
2. **Sibling assumption?** `TestPage.Editable()` (`RuntimeEditable`) reads the same `_staticEditable`, so it had the same blank spot; the corpus measured it (`*_EditableAnswer`) and this fixes it too. `RunnerPageInstance.ControlEditable` still uses the runtime value on purpose: per-control editability follows `CurrPage.Editable`, which is a separate mechanism.
3. **Two writers, same invariant?** `_staticEditableOverride` (test-opened pages) and the handler fallback now both start from the page's editability at open; lookup mode only applies to the fallback, since a test-opened page cannot be in lookup mode.

Open-queue scan: searched open issues for `LookupMode`, `CurrPage.Editable`, `new-row line`, `ShowsNewRowLine`, `TestPage Editable`; nothing else lands in these files. #4066's own search lists the related closed ones.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
