### PR TITLE
fix(allobj): AllObj and Table Metadata in one app group list another app group's objects

### DIFF
--- a/AlRunner.Tests/AppGroupObjectVisibilityTests.cs
+++ b/AlRunner.Tests/AppGroupObjectVisibilityTests.cs
@@ -1,0 +1,157 @@
+// #2279: AllObj, AllObjWithCaption and Table Metadata list only the executing app group's
+// objects and those of its declared dependency closure. The CLI half is proven by
+// tests/runner-extras/app-group-visibility-{a,b,c}; this file pins the decision functions and
+// the --server multi-bundle request, which runner-extras does not reach.
+using System.Text.Json;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class AppGroupObjectVisibilityTests
+{
+    private static readonly Guid AppA = new("3b0e6f52-0000-4c38-9e25-00000000000a");
+    private static readonly Guid AppB = new("3b0e6f52-0000-4c38-9e25-00000000000b");
+    private static readonly Guid AppC = new("3b0e6f52-0000-4c38-9e25-00000000000c");
+    private static readonly Guid AppD = new("3b0e6f52-0000-4c38-9e25-00000000000d");
+
+    [Fact]
+    public void VisibleAppClosure_FollowsDeclaredDependenciesTransitively_AndNothingElse()
+    {
+        var deps = new Dictionary<Guid, Guid[]>
+        {
+            [AppC] = new[] { AppA },
+            [AppA] = new[] { AppD },
+            [AppB] = Array.Empty<Guid>(),
+        };
+
+        Assert.Equal(new[] { AppA, AppC, AppD }.OrderBy(g => g), RecordPatches.VisibleAppClosure(AppC, deps).OrderBy(g => g));
+        Assert.Equal(new[] { AppB }, RecordPatches.VisibleAppClosure(AppB, deps));
+    }
+
+    [Fact]
+    public void VisibleAppClosure_TerminatesOnADependencyCycle()
+    {
+        var deps = new Dictionary<Guid, Guid[]> { [AppA] = new[] { AppB }, [AppB] = new[] { AppA } };
+        Assert.Equal(2, RecordPatches.VisibleAppClosure(AppA, deps).Count);
+    }
+
+    [Fact]
+    public void IsHiddenFromAppGroup_HidesOnlyAKnownOwnerOutsideTheVisibleSet()
+    {
+        var owners = new Dictionary<(string Kind, int Id), Guid>
+        {
+            [("table", 62600)] = AppA,
+            [("table", 62610)] = AppB,
+        };
+        var visible = new HashSet<Guid> { AppA };
+
+        Assert.True(RecordPatches.IsHiddenFromAppGroup("Table", 62610, visible, owners));
+        Assert.False(RecordPatches.IsHiddenFromAppGroup("Table", 62600, visible, owners));
+        // No recorded owner (a precompiled dependency or platform object): never hidden.
+        Assert.False(RecordPatches.IsHiddenFromAppGroup("Table", 18, visible, owners));
+        // Same id, different kind: the owner map is keyed by kind too.
+        Assert.False(RecordPatches.IsHiddenFromAppGroup("Codeunit", 62610, visible, owners));
+        // No executing app group: nothing is filtered.
+        Assert.False(RecordPatches.IsHiddenFromAppGroup("Table", 62610, null, owners));
+    }
+
+    [Fact]
+    public void CheckInventoryScope_RefusesAStoreReadByADifferentAppGroup()
+    {
+        RecordPatches.CheckInventoryScope(AppA, AppA, "AllObj (virtual table 2000000038)");
+        RecordPatches.CheckInventoryScope(null, null, "AllObj (virtual table 2000000038)");
+
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
+            () => RecordPatches.CheckInventoryScope(AppA, AppB, "AllObj (virtual table 2000000038)"));
+        Assert.Contains(AppA.ToString(), ex.Message);
+        Assert.Contains(AppB.ToString(), ex.Message);
+        Assert.Contains("app-group-visibility", ex.Message);
+
+        Assert.Throws<RunnerOutOfScopeException>(
+            () => RecordPatches.CheckInventoryScope(null, AppB, "Table Metadata (virtual table 2000000136)"));
+    }
+
+    private static string WriteGroup(string root, string letter, int baseId, Guid appId, Guid? dependsOn, int[] foreignIds, int[] visibleIds)
+    {
+        var dir = Path.Combine(root, "group-" + letter);
+        Directory.CreateDirectory(dir);
+        var deps = dependsOn is { } d
+            ? $$"""[ { "id": "{{d}}", "name": "Visibility Probe A", "publisher": "AL Runner", "version": "1.0.0.0" } ]"""
+            : "[]";
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{appId}}",
+          "name": "Visibility Probe {{letter}}",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": {{deps}},
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 9}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        var checks = string.Concat(
+            visibleIds.Select(id => $$"""
+                    if not AllObj.Get(AllObj."Object Type"::Table, {{id}}) then Error('AllObj misses visible table {{id}}');
+                    if not TableMetadata.Get({{id}}) then Error('Table Metadata misses visible table {{id}}');
+
+            """).Concat(foreignIds.Select(id => $$"""
+                    if AllObj.Get(AllObj."Object Type"::Table, {{id}}) then Error('LEAK: AllObj lists foreign table {{id}}');
+                    if TableMetadata.Get({{id}}) then Error('LEAK: Table Metadata lists foreign table {{id}}');
+
+            """)));
+        File.WriteAllText(Path.Combine(dir, "Probe.al"), $$"""
+        table {{baseId}} "Visibility Probe {{letter}} Table"
+        {
+            fields { field(1; "Code"; Code[20]) { } }
+            keys { key(PK; "Code") { Clustered = true; } }
+        }
+
+        codeunit {{baseId + 1}} "Visibility Probe {{letter}} Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure InventoryIsScopedToThisAppGroup()
+            var
+                AllObj: Record AllObj;
+                TableMetadata: Record "Table Metadata";
+            begin
+        {{checks}}    end;
+        }
+        """);
+        return dir;
+    }
+
+    private static string RunTests(params string[] dirs)
+        => JsonSerializer.Serialize(new { command = "runTests", sourcePaths = dirs, packagePaths = Array.Empty<string>() });
+
+    [SkippableFact]
+    public async Task Server_MultiBundleRequest_AndASecondRequest_EachAppGroupSeesOnlyItsClosure()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = TestScratch.Dir("al-runner-app-group-visibility-server");
+        Directory.CreateDirectory(root);
+        var a = WriteGroup(root, "A", 62630, AppA, null, new[] { 62640, 62650 }, new[] { 62630 });
+        var b = WriteGroup(root, "B", 62640, AppB, null, new[] { 62630, 62650 }, new[] { 62640 });
+        var c = WriteGroup(root, "C", 62650, AppC, AppA, new[] { 62640 }, new[] { 62650, 62630 });
+
+        await using var server = await CliServer.StartAsync(new[] { "--no-cache" });
+
+        // One request, three bundles: before #2279 B saw A's table and C saw B's, following run order.
+        var lines1 = await server.SendRequestStreamingAsync(RunTests(a, b, c));
+        var (events1, _) = ProtocolV2Streaming.Split(lines1);
+        Assert.Equal(3, events1.Count);
+        foreach (var e in events1)
+            Assert.True(e.GetProperty("status").GetString() == "pass", string.Join(" | ", lines1));
+
+        // A second request on the warm process, B alone after A and C were loaded.
+        var lines2 = await server.SendRequestStreamingAsync(RunTests(b));
+        var (events2, _) = ProtocolV2Streaming.Split(lines2);
+        Assert.Single(events2);
+        Assert.True(events2[0].GetProperty("status").GetString() == "pass", string.Join(" | ", lines2));
+    }
+}

--- a/AlRunner.Tests/AppGroupObjectVisibilityTests.cs
+++ b/AlRunner.Tests/AppGroupObjectVisibilityTests.cs
@@ -2,6 +2,8 @@
 // objects and those of its declared dependency closure. The CLI half is proven by
 // tests/runner-extras/app-group-visibility-{a,b,c}; this file pins the decision functions and
 // the --server multi-bundle request, which runner-extras does not reach.
+using System.Diagnostics;
+using System.Text;
 using System.Text.Json;
 using AlRunner.Infrastructure;
 using AlRunner.Patches;
@@ -11,6 +13,9 @@ namespace AlRunner.Tests;
 
 public class AppGroupObjectVisibilityTests
 {
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
     private static readonly Guid AppA = new("3b0e6f52-0000-4c38-9e25-00000000000a");
     private static readonly Guid AppB = new("3b0e6f52-0000-4c38-9e25-00000000000b");
     private static readonly Guid AppC = new("3b0e6f52-0000-4c38-9e25-00000000000c");
@@ -153,5 +158,155 @@ public class AppGroupObjectVisibilityTests
         var (events2, _) = ProtocolV2Streaming.Split(lines2);
         Assert.Single(events2);
         Assert.True(events2[0].GetProperty("status").GetString() == "pass", string.Join(" | ", lines2));
+    }
+    [Fact]
+    public void AppGroupOwningFile_TakesTheLongestRegisteredDir_NotTheNearestAppJson()
+    {
+        var root = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "agv-owner"));
+        var outer = Path.Combine(root, "outer");
+        var owners = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase)
+        {
+            [outer] = AppA,
+            [Path.Combine(root, "outer-sibling")] = AppB,
+            [Path.Combine(root, "shared")] = Guid.Empty,
+        };
+
+        // A nested inner/app.json is still compiled by the outer group, and only the dir map says so.
+        Assert.Equal(AppA, RecordPatches.AppGroupOwningFile(Path.Combine(outer, "inner", "Inner.al"), owners));
+        // A prefix match on the NAME is not containment.
+        Assert.Equal(AppB, RecordPatches.AppGroupOwningFile(Path.Combine(root, "outer-sibling", "X.al"), owners));
+        Assert.Equal(Guid.Empty, RecordPatches.AppGroupOwningFile(Path.Combine(root, "shared", "S.al"), owners));
+        Assert.Equal(Guid.Empty, RecordPatches.AppGroupOwningFile(Path.Combine(root, "elsewhere", "E.al"), owners));
+    }
+
+    [Fact]
+    public void RecordObjectOwner_AnIdClaimedByTwoAppsHasNoOwner_AndStaysThatWay()
+    {
+        var owners = new Dictionary<(string Kind, int Id), Guid>();
+        var ambiguous = new HashSet<(string Kind, int Id)>();
+
+        RecordPatches.RecordObjectOwner(owners, ambiguous, ("table", 62680), AppA);
+        RecordPatches.RecordObjectOwner(owners, ambiguous, ("table", 62680), AppA);
+        Assert.Equal(AppA, owners[("table", 62680)]);
+
+        RecordPatches.RecordObjectOwner(owners, ambiguous, ("table", 62680), AppB);
+        RecordPatches.RecordObjectOwner(owners, ambiguous, ("table", 62680), AppA);
+        Assert.False(owners.ContainsKey(("table", 62680)));
+        Assert.Contains(("table", 62680), ambiguous);
+        Assert.False(RecordPatches.IsHiddenFromAppGroup("Table", 62680, new HashSet<Guid> { AppA }, owners));
+    }
+
+    private static string WriteApp(string dir, Guid appId, string name, int from, int to)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        { "id": "{{appId}}", "name": "{{name}}", "publisher": "AL Runner", "version": "1.0.0.0",
+          "dependencies": [], "platform": "1.0.0.0", "idRanges": [ { "from": {{from}}, "to": {{to}} } ], "runtime": "14.0" }
+        """);
+        return dir;
+    }
+
+    /// <summary>
+    /// Two shapes where "who owns this object" is not "the nearest app.json above the file":
+    /// a suite compiling a sub-folder that carries its own app.json, and two unrelated groups
+    /// declaring the same table id. Both groups must still list the objects they compile.
+    /// </summary>
+    private static string[] WriteOwnershipEdgeFixtures(string root)
+    {
+        var outer = WriteApp(Path.Combine(root, "outer"), AppA, "Nest Outer", 62660, 62679);
+        WriteApp(Path.Combine(outer, "inner"), AppB, "Nest Inner", 62665, 62669);
+        File.WriteAllText(Path.Combine(outer, "inner", "Inner.al"), """
+        table 62665 "Nest Inner Table" { fields { field(1; "Code"; Code[20]) { } } keys { key(PK; "Code") { Clustered = true; } } }
+        """);
+        File.WriteAllText(Path.Combine(outer, "Outer.al"), """
+        codeunit 62661 "Nest Outer Tests"
+        {
+            Subtype = Test;
+            [Test]
+            procedure InnerTableCompiledHereIsListed()
+            var
+                AllObj: Record AllObj;
+                TableMetadata: Record "Table Metadata";
+                Inner: Record "Nest Inner Table";
+            begin
+                Inner.Code := 'X';
+                Inner.Insert();
+                if not Inner.Get('X') then Error('record access to 62665 broken');
+                if not AllObj.Get(AllObj."Object Type"::Table, 62665) then Error('MISSING: AllObj does not list compiled table 62665');
+                if not TableMetadata.Get(62665) then Error('MISSING: Table Metadata does not list compiled table 62665');
+            end;
+        }
+        """);
+
+        var dirs = new List<string> { outer };
+        foreach (var (letter, appId, cu) in new[] { ("X", AppC, 62681), ("Y", AppD, 62682) })
+        {
+            var dir = WriteApp(Path.Combine(root, "dup" + letter), appId, "Dup " + letter, 62680, 62689);
+            File.WriteAllText(Path.Combine(dir, "Dup.al"), $$"""
+            table 62680 "Dup {{letter}} Table" { fields { field(1; "Code"; Code[20]) { } } keys { key(PK; "Code") { Clustered = true; } } }
+            codeunit {{cu}} "Dup {{letter}} Tests"
+            {
+                Subtype = Test;
+                [Test]
+                procedure OwnTableWithASharedIdIsListed()
+                var
+                    AllObj: Record AllObj;
+                    TableMetadata: Record "Table Metadata";
+                begin
+                    if not AllObj.Get(AllObj."Object Type"::Table, 62680) then Error('MISSING: AllObj does not list own table 62680 in {{letter}}');
+                    if not TableMetadata.Get(62680) then Error('MISSING: Table Metadata does not list own table 62680 in {{letter}}');
+                end;
+            }
+            """);
+            dirs.Add(dir);
+        }
+        return dirs.ToArray();
+    }
+
+    [SkippableFact]
+    public void Cli_NestedAppJsonAndSharedTableId_EachGroupStillListsWhatItCompiles()
+    {
+        TestArtifacts.SkipIfMissing();
+        var root = TestScratch.Dir("al-runner-app-group-visibility-edges-cli");
+        Directory.CreateDirectory(root);
+        WriteOwnershipEdgeFixtures(root);
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg + $" --no-cache \"{root}\"",
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(240_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        string output;
+        lock (sb) output = sb.ToString();
+
+        Assert.Contains("3P/0F/0E across 3 tests", output);
+        Assert.DoesNotContain("MISSING:", output);
+        Assert.Equal(0, p.ExitCode);
+    }
+
+    [SkippableFact]
+    public async Task Server_NestedAppJsonAndSharedTableId_EachGroupStillListsWhatItCompiles()
+    {
+        TestArtifacts.SkipIfMissing();
+        var root = TestScratch.Dir("al-runner-app-group-visibility-edges-server");
+        Directory.CreateDirectory(root);
+        var dirs = WriteOwnershipEdgeFixtures(root);
+
+        await using var server = await CliServer.StartAsync(new[] { "--no-cache" });
+        var lines = await server.SendRequestStreamingAsync(RunTests(dirs));
+        var (events, _) = ProtocolV2Streaming.Split(lines);
+        Assert.Equal(3, events.Count);
+        foreach (var e in events)
+            Assert.True(e.GetProperty("status").GetString() == "pass", string.Join(" | ", lines));
     }
 }

--- a/AlRunner.Tests/AppGroupObjectVisibilityTests.cs
+++ b/AlRunner.Tests/AppGroupObjectVisibilityTests.cs
@@ -162,7 +162,7 @@ public class AppGroupObjectVisibilityTests
     [Fact]
     public void AppGroupOwningFile_TakesTheLongestRegisteredDir_NotTheNearestAppJson()
     {
-        var root = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "agv-owner"));
+        var root = Path.GetFullPath(TestScratch.Dir("al-runner-app-group-visibility-owner"));
         var outer = Path.Combine(root, "outer");
         var owners = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase)
         {

--- a/AlRunner/Patches/RecordPatches.AllObjVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AllObjVirtualTable.cs
@@ -130,6 +130,7 @@ public static partial class RecordPatches
 
         var ordinals = EnsureAllObjObjectTypeOrdinals(allObjMetaTable);
         var done = _aovPopulatedByProvider.GetValue(provider, static _ => new ConcurrentDictionary<(int, int), byte>());
+        var visibleApps = PinInventoryScope(provider, "AllObj (virtual table 2000000038)");
 
         // #3117: built on FIRST ACTUAL INSERT, not on entry. PopulateAllObjVirtualTable runs on
         // every AllObj data-access handout, but `done` makes all but the first few handouts
@@ -153,7 +154,7 @@ public static partial class RecordPatches
         foreach (var (kind, id, name, _, _) in EnumerateKnownAlObjects())
         {   // AllObj has no caption column; the shared inventory carries one for
             // AllObjWithCaption (2000000058), which reads the same rows.
-            if (id <= 0) continue;
+            if (id <= 0 || IsHiddenFromCurrentAppGroup(kind, id, visibleApps)) continue;
             var normalized = NormalizeObjectTypeName(kind);
             if (!ordinals.TryGetValue(normalized, out var typeOrdinal))
                 // This AL object kind has no column in THIS BC version's AllObj option

--- a/AlRunner/Patches/RecordPatches.AllObjWithCaptionVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AllObjWithCaptionVirtualTable.cs
@@ -96,12 +96,13 @@ public static partial class RecordPatches
         // than an assumption.
         var ordinals = EnsureAllObjWithCaptionObjectTypeOrdinals(metaTable);
         var done = _awcPopulatedByProvider.GetValue(provider, static _ => new ConcurrentDictionary<(int, int), byte>());
+        var visibleApps = PinInventoryScope(provider, "AllObjWithCaption (virtual table 2000000058)");
         // Built lazily after the `done` guard, as PopulateAllObjVirtualTable does (#3117).
         Dictionary<(string Kind, int Id), Guid>? ownerIndex = null;
 
         foreach (var (kind, id, name, caption, subtype) in EnumerateKnownAlObjects())
         {
-            if (id <= 0) continue;
+            if (id <= 0 || IsHiddenFromCurrentAppGroup(kind, id, visibleApps)) continue;
             var normalized = NormalizeObjectTypeName(kind);
             if (!ordinals.TryGetValue(normalized, out var typeOrdinal))
                 // This AL object kind has no ordinal in THIS BC version's option set.

--- a/AlRunner/Patches/RecordPatches.AppGroupObjectVisibility.cs
+++ b/AlRunner/Patches/RecordPatches.AppGroupObjectVisibility.cs
@@ -1,0 +1,123 @@
+// RecordPatches.AppGroupObjectVisibility — which source-parsed objects the EXECUTING app group
+// may see in the object-inventory virtual tables (AllObj, AllObjWithCaption, Table Metadata).
+// See docs/virtual-tables-allobj.md#app-group-visibility (#2279).
+using System.Runtime.CompilerServices;
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    // (normalized kind, id) -> the app whose app.json owns the .al file declaring it. Source-parsed
+    // objects only: a precompiled dependency .app never reaches ParseSourceFileIntoAllExtractors.
+    private static readonly Dictionary<(string Kind, int Id), Guid> _sourceObjectOwners = new();
+    // Source app id -> the app ids its app.json declares as dependencies (implicit floors excluded).
+    private static readonly Dictionary<Guid, Guid[]> _sourceAppDependencies = new();
+    private static readonly Dictionary<string, string?> _owningManifestByDir = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Record which app declares every object in one source file, and that app's declared
+    /// dependencies. A file under no readable app.json records nothing, so its objects stay
+    /// visible everywhere, which is the behaviour before #2279.
+    /// </summary>
+    private static void RecordSourceObjectOwners(string text, string filePath)
+    {
+        var manifest = ResolveOwningManifest(filePath);
+        if (manifest == null) return;
+        var identity = InProcessAppPackager.ReadIdentity(manifest);
+        if (identity == null || identity.AppId == Guid.Empty) return;
+
+        _sourceAppDependencies[identity.AppId] = identity.Dependencies
+            .Select(d => d.AppId).Where(id => id != Guid.Empty).Distinct().ToArray();
+
+        foreach (var obj in ParseAlObjects(text))
+        {
+            if (AlObjectKindName(obj) is not string kind) continue;
+            if (ObjectIdOf(obj) is not int id || id <= 0) continue;
+            _sourceObjectOwners[(NormalizeObjectTypeName(kind), id)] = identity.AppId;
+        }
+    }
+
+    private static string? ResolveOwningManifest(string filePath)
+    {
+        var dir = Path.GetDirectoryName(Path.GetFullPath(filePath));
+        if (dir == null) return null;
+        if (_owningManifestByDir.TryGetValue(dir, out var memo)) return memo;
+        string? found = null;
+        for (var probe = dir; probe != null; probe = Path.GetDirectoryName(probe))
+        {
+            var candidate = Path.Combine(probe, "app.json");
+            if (File.Exists(candidate)) { found = candidate; break; }
+        }
+        _owningManifestByDir[dir] = found;
+        return found;
+    }
+
+    private static void ResetAppGroupObjectVisibilityForReload()
+    {
+        _sourceObjectOwners.Clear();
+        _sourceAppDependencies.Clear();
+        _owningManifestByDir.Clear();
+    }
+
+    /// <summary>
+    /// <paramref name="appId"/> plus every app its app.json declares as a dependency,
+    /// transitively through other source apps.
+    /// </summary>
+    internal static HashSet<Guid> VisibleAppClosure(Guid appId, IReadOnlyDictionary<Guid, Guid[]> dependencies)
+    {
+        var visible = new HashSet<Guid> { appId };
+        var pending = new Stack<Guid>();
+        pending.Push(appId);
+        while (pending.Count > 0)
+            if (dependencies.TryGetValue(pending.Pop(), out var deps))
+                foreach (var dep in deps)
+                    if (visible.Add(dep)) pending.Push(dep);
+        return visible;
+    }
+
+    /// <summary>
+    /// True only when the object's declaring source app is KNOWN and outside
+    /// <paramref name="visibleApps"/>. An object with no recorded owner (a precompiled
+    /// dependency, a platform object) is never hidden: dropping it would remove rows this
+    /// change has no evidence about.
+    /// </summary>
+    internal static bool IsHiddenFromAppGroup(
+        string kind, int id, HashSet<Guid>? visibleApps, IReadOnlyDictionary<(string Kind, int Id), Guid> owners)
+        => visibleApps != null
+           && owners.TryGetValue((NormalizeObjectTypeName(kind), id), out var owner)
+           && !visibleApps.Contains(owner);
+
+    private static bool IsHiddenFromCurrentAppGroup(string kind, int id, HashSet<Guid>? visibleApps)
+        => IsHiddenFromAppGroup(kind, id, visibleApps, _sourceObjectOwners);
+
+    private sealed class ProviderScope { public Guid? AppId; }
+    private static readonly ConditionalWeakTable<object, ProviderScope> _inventoryScopeByProvider = new();
+
+    /// <summary>
+    /// The executing app group's app id, pinned to <paramref name="provider"/> on first use. The
+    /// per-provider "already inserted" sets are add-only, so a store populated for one app group
+    /// and handed out under another would keep the first group's rows: that refuses instead.
+    /// </summary>
+    private static HashSet<Guid>? PinInventoryScope(object provider, string table)
+    {
+        var asm = AlRunner.BcRuntime.CurrentTestAssembly;
+        Guid? current = null;
+        if (asm != null)
+            foreach (var (registered, appId) in AlRunner.BcRuntime.RegisteredModuleAssemblies())
+                if (ReferenceEquals(registered, asm)) { current = appId; break; }
+
+        var scope = _inventoryScopeByProvider.GetValue(provider, _ => new ProviderScope { AppId = current });
+        CheckInventoryScope(scope.AppId, current, table);
+        return current is { } id ? VisibleAppClosure(id, _sourceAppDependencies) : null;
+    }
+
+    internal static void CheckInventoryScope(Guid? pinned, Guid? current, string table)
+    {
+        if (pinned == current) return;
+        throw VirtualTableShapeGap(table, "app-group-visibility",
+            $"the in-memory store was populated while app group {pinned?.ToString() ?? "<none>"} was executing "
+            + $"and is now read by app group {current?.ToString() ?? "<none>"}; its rows cannot be removed, so "
+            + "the second group would see the first group's objects — see AlRunner#2279");
+    }
+}

--- a/AlRunner/Patches/RecordPatches.AppGroupObjectVisibility.cs
+++ b/AlRunner/Patches/RecordPatches.AppGroupObjectVisibility.cs
@@ -8,64 +8,96 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
-    // (normalized kind, id) -> the app whose app.json owns the .al file declaring it. Source-parsed
-    // objects only: a precompiled dependency .app never reaches ParseSourceFileIntoAllExtractors.
+    // (normalized kind, id) -> the app group that compiled the file declaring it. An id two
+    // different app groups declare is in _ambiguousSourceObjects instead and is never hidden.
     private static readonly Dictionary<(string Kind, int Id), Guid> _sourceObjectOwners = new();
-    // Source app id -> the app ids its app.json declares as dependencies (implicit floors excluded).
+    private static readonly HashSet<(string Kind, int Id)> _ambiguousSourceObjects = new();
+    // App group id -> the app ids its app.json declares as dependencies (implicit floors excluded).
     private static readonly Dictionary<Guid, Guid[]> _sourceAppDependencies = new();
-    private static readonly Dictionary<string, string?> _owningManifestByDir = new(StringComparer.OrdinalIgnoreCase);
-    // One app.json read per manifest, not per .al file.
-    private static readonly Dictionary<string, BundleIdentity?> _identityByManifest = new(StringComparer.OrdinalIgnoreCase);
+    // Full source dir -> the app group that compiles it; Guid.Empty when two groups share the dir
+    // or the group has no app id. Not the nearest app.json: a suite compiles a sub-folder carrying
+    // its own app.json into itself (CollectSuitePaths).
+    private static readonly Dictionary<string, Guid> _appGroupBySourceDir = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
-    /// Record which app declares every object in one source file, and that app's declared
-    /// dependencies. A file under no readable app.json records nothing, so its objects stay
-    /// visible everywhere, which is the behaviour before #2279.
+    /// Record that <paramref name="dirs"/> compile into the app group rooted at
+    /// <paramref name="suiteDir"/>. Call before <see cref="AddSourceDirs"/> parses them.
     /// </summary>
+    internal static void RegisterAppGroupSourceDirs(string suiteDir, IEnumerable<string> dirs)
+    {
+        var identity = InProcessAppPackager.ReadIdentity(Path.Combine(suiteDir, "app.json"));
+        var appId = identity?.AppId ?? Guid.Empty;
+        if (identity != null && appId != Guid.Empty)
+            _sourceAppDependencies[appId] = identity.Dependencies
+                .Select(d => d.AppId).Where(id => id != Guid.Empty).Distinct().ToArray();
+        foreach (var dir in dirs)
+        {
+            var full = Path.TrimEndingDirectorySeparator(Path.GetFullPath(dir));
+            _appGroupBySourceDir[full] = _appGroupBySourceDir.TryGetValue(full, out var existing) && existing != appId
+                ? Guid.Empty
+                : appId;
+        }
+    }
+
+    /// <summary>
+    /// The app group owning <paramref name="filePath"/>: the longest registered source dir
+    /// containing it. Guid.Empty when none is registered, or the dir is shared or unidentified.
+    /// </summary>
+    internal static Guid AppGroupOwningFile(string filePath, IReadOnlyDictionary<string, Guid> ownerByDir)
+    {
+        var bestLength = -1;
+        var owner = Guid.Empty;
+        var full = Path.GetFullPath(filePath);
+        foreach (var (dir, appId) in ownerByDir)
+        {
+            if (dir.Length <= bestLength) continue;
+            if (full.Length > dir.Length
+                && full.StartsWith(dir, StringComparison.OrdinalIgnoreCase)
+                && (full[dir.Length] == Path.DirectorySeparatorChar || full[dir.Length] == Path.AltDirectorySeparatorChar))
+            {
+                bestLength = dir.Length;
+                owner = appId;
+            }
+        }
+        return owner;
+    }
+
+    /// <summary>
+    /// Record <paramref name="appId"/> as the owner of one object, unless a DIFFERENT app already
+    /// claimed that (kind, id): then the object has no single owner and is never hidden.
+    /// </summary>
+    internal static void RecordObjectOwner(
+        Dictionary<(string Kind, int Id), Guid> owners, HashSet<(string Kind, int Id)> ambiguous,
+        (string Kind, int Id) key, Guid appId)
+    {
+        if (ambiguous.Contains(key)) return;
+        if (owners.TryGetValue(key, out var existing) && existing != appId)
+        {
+            owners.Remove(key);
+            ambiguous.Add(key);
+            return;
+        }
+        owners[key] = appId;
+    }
+
     private static void RecordSourceObjectOwners(string text, string filePath)
     {
-        var manifest = ResolveOwningManifest(filePath);
-        if (manifest == null) return;
-        if (!_identityByManifest.TryGetValue(manifest, out var identity))
-        {
-            identity = InProcessAppPackager.ReadIdentity(manifest);
-            _identityByManifest[manifest] = identity;
-            if (identity != null && identity.AppId != Guid.Empty)
-                _sourceAppDependencies[identity.AppId] = identity.Dependencies
-                    .Select(d => d.AppId).Where(id => id != Guid.Empty).Distinct().ToArray();
-        }
-        if (identity == null || identity.AppId == Guid.Empty) return;
-
+        var appId = AppGroupOwningFile(filePath, _appGroupBySourceDir);
+        if (appId == Guid.Empty) return;
         foreach (var obj in ParseAlObjects(text))
         {
             if (AlObjectKindName(obj) is not string kind) continue;
             if (ObjectIdOf(obj) is not int id || id <= 0) continue;
-            _sourceObjectOwners[(NormalizeObjectTypeName(kind), id)] = identity.AppId;
+            RecordObjectOwner(_sourceObjectOwners, _ambiguousSourceObjects, (NormalizeObjectTypeName(kind), id), appId);
         }
-    }
-
-    // Not ResolveOwningApp: that returns (id, name) only, and the dependencies need the manifest path.
-    private static string? ResolveOwningManifest(string filePath)
-    {
-        var dir = Path.GetDirectoryName(Path.GetFullPath(filePath));
-        if (dir == null) return null;
-        if (_owningManifestByDir.TryGetValue(dir, out var memo)) return memo;
-        string? found = null;
-        for (var probe = dir; probe != null; probe = Path.GetDirectoryName(probe))
-        {
-            var candidate = Path.Combine(probe, "app.json");
-            if (File.Exists(candidate)) { found = candidate; break; }
-        }
-        _owningManifestByDir[dir] = found;
-        return found;
     }
 
     private static void ResetAppGroupObjectVisibilityForReload()
     {
         _sourceObjectOwners.Clear();
+        _ambiguousSourceObjects.Clear();
         _sourceAppDependencies.Clear();
-        _owningManifestByDir.Clear();
-        _identityByManifest.Clear();
+        _appGroupBySourceDir.Clear();
         _scopeAssembly = null;
         _scopeAppId = Guid.Empty;
     }

--- a/AlRunner/Patches/RecordPatches.AppGroupObjectVisibility.cs
+++ b/AlRunner/Patches/RecordPatches.AppGroupObjectVisibility.cs
@@ -14,6 +14,8 @@ public static partial class RecordPatches
     // Source app id -> the app ids its app.json declares as dependencies (implicit floors excluded).
     private static readonly Dictionary<Guid, Guid[]> _sourceAppDependencies = new();
     private static readonly Dictionary<string, string?> _owningManifestByDir = new(StringComparer.OrdinalIgnoreCase);
+    // One app.json read per manifest, not per .al file.
+    private static readonly Dictionary<string, BundleIdentity?> _identityByManifest = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Record which app declares every object in one source file, and that app's declared
@@ -24,11 +26,15 @@ public static partial class RecordPatches
     {
         var manifest = ResolveOwningManifest(filePath);
         if (manifest == null) return;
-        var identity = InProcessAppPackager.ReadIdentity(manifest);
+        if (!_identityByManifest.TryGetValue(manifest, out var identity))
+        {
+            identity = InProcessAppPackager.ReadIdentity(manifest);
+            _identityByManifest[manifest] = identity;
+            if (identity != null && identity.AppId != Guid.Empty)
+                _sourceAppDependencies[identity.AppId] = identity.Dependencies
+                    .Select(d => d.AppId).Where(id => id != Guid.Empty).Distinct().ToArray();
+        }
         if (identity == null || identity.AppId == Guid.Empty) return;
-
-        _sourceAppDependencies[identity.AppId] = identity.Dependencies
-            .Select(d => d.AppId).Where(id => id != Guid.Empty).Distinct().ToArray();
 
         foreach (var obj in ParseAlObjects(text))
         {
@@ -38,6 +44,7 @@ public static partial class RecordPatches
         }
     }
 
+    // Not ResolveOwningApp: that returns (id, name) only, and the dependencies need the manifest path.
     private static string? ResolveOwningManifest(string filePath)
     {
         var dir = Path.GetDirectoryName(Path.GetFullPath(filePath));
@@ -58,6 +65,9 @@ public static partial class RecordPatches
         _sourceObjectOwners.Clear();
         _sourceAppDependencies.Clear();
         _owningManifestByDir.Clear();
+        _identityByManifest.Clear();
+        _scopeAssembly = null;
+        _scopeAppId = Guid.Empty;
     }
 
     /// <summary>
@@ -91,8 +101,15 @@ public static partial class RecordPatches
     private static bool IsHiddenFromCurrentAppGroup(string kind, int id, HashSet<Guid>? visibleApps)
         => IsHiddenFromAppGroup(kind, id, visibleApps, _sourceObjectOwners);
 
-    private sealed class ProviderScope { public Guid? AppId; }
+    private sealed class ProviderScope
+    {
+        public Guid? AppId;
+        public HashSet<Guid>? VisibleApps;
+    }
     private static readonly ConditionalWeakTable<object, ProviderScope> _inventoryScopeByProvider = new();
+    // Last successful CurrentTestAssembly -> app id lookup; populators run on every data-access handout.
+    private static System.Reflection.Assembly? _scopeAssembly;
+    private static Guid _scopeAppId;
 
     /// <summary>
     /// The executing app group's app id, pinned to <paramref name="provider"/> on first use. The
@@ -101,15 +118,28 @@ public static partial class RecordPatches
     /// </summary>
     private static HashSet<Guid>? PinInventoryScope(object provider, string table)
     {
-        var asm = AlRunner.BcRuntime.CurrentTestAssembly;
-        Guid? current = null;
-        if (asm != null)
-            foreach (var (registered, appId) in AlRunner.BcRuntime.RegisteredModuleAssemblies())
-                if (ReferenceEquals(registered, asm)) { current = appId; break; }
-
-        var scope = _inventoryScopeByProvider.GetValue(provider, _ => new ProviderScope { AppId = current });
+        var current = CurrentAppGroupAppId();
+        var scope = _inventoryScopeByProvider.GetValue(provider, _ => new ProviderScope
+        {
+            AppId = current,
+            VisibleApps = current is { } id ? VisibleAppClosure(id, _sourceAppDependencies) : null,
+        });
         CheckInventoryScope(scope.AppId, current, table);
-        return current is { } id ? VisibleAppClosure(id, _sourceAppDependencies) : null;
+        return scope.VisibleApps;
+    }
+
+    private static Guid? CurrentAppGroupAppId()
+    {
+        var asm = AlRunner.BcRuntime.CurrentTestAssembly;
+        if (asm == null) return null;
+        if (ReferenceEquals(asm, _scopeAssembly)) return _scopeAppId;
+        foreach (var (registered, appId) in AlRunner.BcRuntime.RegisteredModuleAssemblies())
+            if (ReferenceEquals(registered, asm))
+            {
+                (_scopeAssembly, _scopeAppId) = (asm, appId);
+                return appId;
+            }
+        return null;
     }
 
     internal static void CheckInventoryScope(Guid? pinned, Guid? current, string table)

--- a/AlRunner/Patches/RecordPatches.TableMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.TableMetadataVirtualTable.cs
@@ -129,9 +129,12 @@ public static partial class RecordPatches
             ?? throw TableMetadataShapeGap("data access has no in-memory provider");
 
         var done = _tmvPopulatedByProvider.GetValue(provider, static _ => new ConcurrentDictionary<int, byte>());
+        // Filtered here, never in EnumerateKnownTableMetadata: that list is cached per process.
+        var visibleApps = PinInventoryScope(provider, "Table Metadata (virtual table 2000000136)");
 
         foreach (var row in EnumerateKnownTableMetadata())
         {
+            if (IsHiddenFromCurrentAppGroup("Table", row.Id, visibleApps)) continue;
             if (!done.TryAdd(row.Id, 0)) continue;
             InsertVirtualRow(provider, metaTable,
                 new object[] { TableMetadataVirtualTableId, row.Id, 0, 0 },

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -428,6 +428,7 @@ public static partial class RecordPatches
         // this one only re-reads the declarations, not who owns them. Cost: one app.json
         // walk-up per source directory per cycle (measured in #3226's PR body).
         _owningAppByDir.Clear();
+        ResetAppGroupObjectVisibilityForReload();
         _metaFormCache.Clear();
         // #1957: the "already (successfully|un-)loaded" bookkeeping is a statement about
         // the NCLMetaForm instances _metaFormCache.Clear() just discarded — it must go
@@ -544,6 +545,8 @@ public static partial class RecordPatches
         // "Metadata Permission Set" row carries the declaring app's id, only knowable from
         // the app.json that owns the file (#2357).
         TryParsePermissionSetFile(text, filePath);
+        // #2279: which app group each object belongs to, for the object-inventory tables.
+        if (filePath != null) RecordSourceObjectOwners(text, filePath);
     }
 
     /// <summary>

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2749,10 +2749,15 @@ foreach (var bundle in bundles)
     {
         var dirsToRegister = new List<string>();
         foreach (var suite in suites)
+        {
             // #3735: exactly what the compile reads. Deriving it a second time here is what let
             // a page or table under test/ or app2/ compile and never be parsed — see
             // ProgramSupport.SuiteRegistrationDirs.
-            dirsToRegister.AddRange(SuiteRegistrationDirs(suite, bucketRoot));
+            var suiteDirs = SuiteRegistrationDirs(suite, bucketRoot);
+            // #2279: which app group compiles each dir, for the object-inventory tables.
+            AlRunner.Patches.RecordPatches.RegisterAppGroupSourceDirs(suite, suiteDirs);
+            dirsToRegister.AddRange(suiteDirs);
+        }
         AlRunner.Patches.RecordPatches.AddSourceDirs(dirsToRegister);
     }
 
@@ -5391,6 +5396,7 @@ return strictExitCode ? computedExitCode : 0;
             // #3735: same one function as the CLI loop above, computed once and used for both
             // the compile's paths and the registration — they are the same set by construction.
             var suitePaths = SuiteRegistrationDirs(suite, bucketRoot);
+            AlRunner.Patches.RecordPatches.RegisterAppGroupSourceDirs(suite, suitePaths);
             dirsToRegister.AddRange(suitePaths);
             allPaths.AddRange(suitePaths);
         }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3934,6 +3934,12 @@ foreach (var bundle in bundles)
                 // is consistent whichever compile boundary --isolation chose.
                 using (AlRunner.Infrastructure.PhaseLog.AppStage("set-test-assembly"))
                 {
+                    // #2279: the suite is the app group here, so its assembly carries the suite's own
+                    // app identity, as the bundled loop's SetCurrentBundleInfo gives each app group.
+                    if (AlRunner.Infrastructure.InProcessAppPackager.ReadIdentity(Path.Combine(suite, "app.json"))
+                            is { } suiteIdentity && suiteIdentity.AppId != Guid.Empty)
+                        BcRuntime.SetCurrentBundleInfo(suiteIdentity.AppId, suiteIdentity.Name,
+                            suiteIdentity.Publisher, suiteIdentity.Version.ToString());
                     BcRuntime.SetTestAssembly(asm);
                     BcRuntime.RegisterTestAssemblyInfo(asm);
                 }

--- a/docs/virtual-tables-allobj.md
+++ b/docs/virtual-tables-allobj.md
@@ -165,6 +165,11 @@ them at once, because source dirs are registered for the whole bundle before any
 runs, and resetting them per group breaks record access on app-defined tables (see
 `BcRuntime.ResetForNewBundleReload`).
 
+**This is a runner model, not measured BC behaviour.** On a real tenant AllObj is tenant-wide
+and lists every installed app's objects, related or not. The runner treats each app group as its
+own tenant holding that group and its declared dependencies, because unrelated app groups sharing
+one runner process is not a state a service tier has.
+
 So the three object-inventory tables filter at insert time instead:
 
 | table | populator |
@@ -175,8 +180,12 @@ So the three object-inventory tables filter at insert time instead:
 
 An object is left out when **both** of these hold:
 
-1. Its declaring app is known. `RecordSourceObjectOwners` records, for every source file the
-   runner parses, the app whose nearest `app.json` owns that file.
+1. Its owning app group is known. The run loops call `RegisterAppGroupSourceDirs` with each
+   suite's source dirs before parsing, and `RecordSourceObjectOwners` gives every object in a
+   file the app group whose registered dir contains it (the longest match). It is **not** the
+   nearest `app.json`: a suite compiles a sub-folder carrying its own `app.json` into itself, and
+   that app group's objects must stay listed for it. A dir shared by two groups, and a
+   `(kind, id)` declared by two different groups, have no owner and are always listed.
 2. That app is not the executing app group and not in its declared dependency closure.
    The executing app group is the app id of `BcRuntime.CurrentTestAssembly`; the closure
    follows each source app's `app.json` `dependencies` transitively.

--- a/docs/virtual-tables-allobj.md
+++ b/docs/virtual-tables-allobj.md
@@ -155,3 +155,44 @@ Subtype and is indistinguishable from the pre-fix behaviour.
 
 The BC-behaviour claim is adjudicated upstream in corpus codeunit 60802
 `"Test AllObj Virtual Table"`.
+
+## App group visibility
+
+Issue #2279. One runner process can compile and run several app groups: every app group under
+one bundle root, every bundle on one command line, and every `sourcePaths` entry of one
+`--server` request. The parsed-object registries behind `EnumerateKnownAlObjects` hold all of
+them at once, because source dirs are registered for the whole bundle before any app group
+runs, and resetting them per group breaks record access on app-defined tables (see
+`BcRuntime.ResetForNewBundleReload`).
+
+So the three object-inventory tables filter at insert time instead:
+
+| table | populator |
+|---|---|
+| AllObj (2000000038) | `PopulateAllObjVirtualTable` |
+| AllObjWithCaption (2000000058) | `PopulateAllObjWithCaptionVirtualTable` |
+| Table Metadata (2000000136) | `PopulateTableMetadataVirtualTable` |
+
+An object is left out when **both** of these hold:
+
+1. Its declaring app is known. `RecordSourceObjectOwners` records, for every source file the
+   runner parses, the app whose nearest `app.json` owns that file.
+2. That app is not the executing app group and not in its declared dependency closure.
+   The executing app group is the app id of `BcRuntime.CurrentTestAssembly`; the closure
+   follows each source app's `app.json` `dependencies` transitively.
+
+An object with no recorded owner is always listed. That covers precompiled dependency `.app`
+objects and platform objects, which this filter has no evidence about. Objects of a precompiled
+`.app` registered by a different bundle in the same process are therefore not filtered here.
+
+Table Metadata's cached row list (`EnumerateKnownTableMetadata`) stays process-wide; the filter
+runs on the way into each store, so one group's filtered view is never cached for another.
+
+Each store is pinned to the app group that first populated it (`PinInventoryScope`). The
+"already inserted" sets are add-only, so if a store were handed out to a second app group its
+rows would still carry the first group's objects. That case refuses with an
+`app-group-visibility` shape gap rather than answering with the wrong inventory. In measured
+CLI and `--server` runs each app group gets a fresh store, so the refusal has not fired.
+
+Proven by `tests/runner-extras/app-group-visibility-{a,b,c}` (C depends on A, so A's table is
+visible to C and B's is not) and `AlRunner.Tests/AppGroupObjectVisibilityTests`.

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -3,6 +3,9 @@
   "suites": {
     "runner-extras": {
       "groups": {
+        "app-group-visibility-a": { "tests": 9 },
+        "app-group-visibility-b": { "tests": 9 },
+        "app-group-visibility-c": { "tests": 9 },
         "bundle-page-over-dep-table": { "tests": 2 },
         "date-virtual-table-window": { "tests": 8 },
         "db-trigger-inject-timing": { "tests": 2 },

--- a/tests/runner-extras/app-group-visibility-a/AgvAAssert.Codeunit.al
+++ b/tests/runner-extras/app-group-visibility-a/AgvAAssert.Codeunit.al
@@ -1,0 +1,20 @@
+codeunit 62601 "AGV A Assert"
+{
+    procedure AreEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        if Format(Expected) <> Format(Actual) then
+            Error('Assert.AreEqual failed. Expected <%1>, actual <%2>. %3', Expected, Actual, Msg);
+    end;
+
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then
+            Error('Assert.IsTrue failed. %1', Msg);
+    end;
+
+    procedure IsFalse(Condition: Boolean; Msg: Text)
+    begin
+        if Condition then
+            Error('Assert.IsFalse failed. %1', Msg);
+    end;
+}

--- a/tests/runner-extras/app-group-visibility-a/AgvATable.Table.al
+++ b/tests/runner-extras/app-group-visibility-a/AgvATable.Table.al
@@ -1,0 +1,15 @@
+table 62600 "AGV A Table"
+{
+    Caption = 'AGV A Table Caption';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Code"; Code[20]) { }
+    }
+
+    keys
+    {
+        key(PK; "Code") { Clustered = true; }
+    }
+}

--- a/tests/runner-extras/app-group-visibility-a/AgvATests.Codeunit.al
+++ b/tests/runner-extras/app-group-visibility-a/AgvATests.Codeunit.al
@@ -1,0 +1,98 @@
+// App group A declares no dependencies, so its object inventory holds its own objects and
+// nothing from the sibling groups B and C, whichever of them compiled or ran first.
+// Issue #2279; the mechanism is docs/virtual-tables-allobj.md#app-group-visibility.
+codeunit 62602 "AGV A Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit "AGV A Assert";
+
+    [Test]
+    procedure AllObj_OwnTable_IsListed()
+    var
+        AllObj: Record AllObj;
+    begin
+        Assert.IsTrue(AllObj.Get(AllObj."Object Type"::Table, 62600), 'AllObj in app group A must list its own table 62600');
+        Assert.AreEqual('AGV A Table', AllObj."Object Name", 'AllObj row for table 62600');
+    end;
+
+    [Test]
+    procedure AllObjWithCaption_OwnTable_IsListed()
+    var
+        AllObjWithCaption: Record AllObjWithCaption;
+    begin
+        Assert.IsTrue(AllObjWithCaption.Get(AllObjWithCaption."Object Type"::Table, 62600), 'AllObjWithCaption in app group A must list its own table 62600');
+        Assert.AreEqual('AGV A Table Caption', AllObjWithCaption."Object Caption", 'AllObjWithCaption row for table 62600');
+    end;
+
+    [Test]
+    procedure TableMetadata_OwnTable_IsListed()
+    var
+        TableMetadata: Record "Table Metadata";
+    begin
+        Assert.IsTrue(TableMetadata.Get(62600), 'Table Metadata in app group A must list its own table 62600');
+        Assert.AreEqual('AGV A Table', TableMetadata.Name, 'Table Metadata row for table 62600');
+    end;
+
+    [Test]
+    procedure AllObj_GroupBTable_IsNotListed()
+    var
+        AllObj: Record AllObj;
+    begin
+        Assert.IsFalse(AllObj.Get(AllObj."Object Type"::Table, 62610), 'AllObj in app group A lists table 62610 of unrelated app group B');
+        AllObj.SetRange("Object ID", 62610, 62619);
+        Assert.IsTrue(AllObj.IsEmpty(), 'AllObj in app group A lists an object in the id range of unrelated app group B');
+    end;
+
+    [Test]
+    procedure AllObjWithCaption_GroupBTable_IsNotListed()
+    var
+        AllObjWithCaption: Record AllObjWithCaption;
+    begin
+        Assert.IsFalse(AllObjWithCaption.Get(AllObjWithCaption."Object Type"::Table, 62610), 'AllObjWithCaption in app group A lists table 62610 of unrelated app group B');
+        AllObjWithCaption.SetRange("Object ID", 62610, 62619);
+        Assert.IsTrue(AllObjWithCaption.IsEmpty(), 'AllObjWithCaption in app group A lists an object in the id range of unrelated app group B');
+    end;
+
+    [Test]
+    procedure TableMetadata_GroupBTable_IsNotListed()
+    var
+        TableMetadata: Record "Table Metadata";
+    begin
+        Assert.IsFalse(TableMetadata.Get(62610), 'Table Metadata in app group A lists table 62610 of unrelated app group B');
+        TableMetadata.SetRange(ID, 62610, 62619);
+        Assert.IsTrue(TableMetadata.IsEmpty(), 'Table Metadata in app group A lists a table in the id range of unrelated app group B');
+    end;
+
+    [Test]
+    procedure AllObj_GroupCTable_IsNotListed()
+    var
+        AllObj: Record AllObj;
+    begin
+        Assert.IsFalse(AllObj.Get(AllObj."Object Type"::Table, 62620), 'AllObj in app group A lists table 62620 of unrelated app group C');
+        AllObj.SetRange("Object ID", 62620, 62629);
+        Assert.IsTrue(AllObj.IsEmpty(), 'AllObj in app group A lists an object in the id range of unrelated app group C');
+    end;
+
+    [Test]
+    procedure AllObjWithCaption_GroupCTable_IsNotListed()
+    var
+        AllObjWithCaption: Record AllObjWithCaption;
+    begin
+        Assert.IsFalse(AllObjWithCaption.Get(AllObjWithCaption."Object Type"::Table, 62620), 'AllObjWithCaption in app group A lists table 62620 of unrelated app group C');
+        AllObjWithCaption.SetRange("Object ID", 62620, 62629);
+        Assert.IsTrue(AllObjWithCaption.IsEmpty(), 'AllObjWithCaption in app group A lists an object in the id range of unrelated app group C');
+    end;
+
+    [Test]
+    procedure TableMetadata_GroupCTable_IsNotListed()
+    var
+        TableMetadata: Record "Table Metadata";
+    begin
+        Assert.IsFalse(TableMetadata.Get(62620), 'Table Metadata in app group A lists table 62620 of unrelated app group C');
+        TableMetadata.SetRange(ID, 62620, 62629);
+        Assert.IsTrue(TableMetadata.IsEmpty(), 'Table Metadata in app group A lists a table in the id range of unrelated app group C');
+    end;
+}

--- a/tests/runner-extras/app-group-visibility-a/app.json
+++ b/tests/runner-extras/app-group-visibility-a/app.json
@@ -1,0 +1,18 @@
+{
+  "id": "3b0e6f52-7a1d-4c38-9e25-1f6d8a4c2600",
+  "name": "Runner Extras - App Group Visibility A",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Issue #2279, app group A of three: declares one table and no dependencies. Neither B nor C may appear in its object inventory.",
+  "description": "Issue #2279. Every app group under one bundle root compiles as its own module but runs in one process, and the runner's parsed-object registries hold every group's objects. AllObj, AllObjWithCaption and Table Metadata must list only the objects of the executing app group and of the apps it declares as dependencies (transitively), never those of an unrelated sibling group. Runner-specific: the corpus runs one app set per service tier, so it cannot express a second, unrelated app group in the same process.",
+  "dependencies": [],
+  "idRanges": [
+    {
+      "from": 62600,
+      "to": 62609
+    }
+  ],
+  "platform": "27.0.0.0",
+  "runtime": "15.0",
+  "target": "Cloud"
+}

--- a/tests/runner-extras/app-group-visibility-b/AgvBAssert.Codeunit.al
+++ b/tests/runner-extras/app-group-visibility-b/AgvBAssert.Codeunit.al
@@ -1,0 +1,20 @@
+codeunit 62611 "AGV B Assert"
+{
+    procedure AreEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        if Format(Expected) <> Format(Actual) then
+            Error('Assert.AreEqual failed. Expected <%1>, actual <%2>. %3', Expected, Actual, Msg);
+    end;
+
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then
+            Error('Assert.IsTrue failed. %1', Msg);
+    end;
+
+    procedure IsFalse(Condition: Boolean; Msg: Text)
+    begin
+        if Condition then
+            Error('Assert.IsFalse failed. %1', Msg);
+    end;
+}

--- a/tests/runner-extras/app-group-visibility-b/AgvBTable.Table.al
+++ b/tests/runner-extras/app-group-visibility-b/AgvBTable.Table.al
@@ -1,0 +1,15 @@
+table 62610 "AGV B Table"
+{
+    Caption = 'AGV B Table Caption';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Code"; Code[20]) { }
+    }
+
+    keys
+    {
+        key(PK; "Code") { Clustered = true; }
+    }
+}

--- a/tests/runner-extras/app-group-visibility-b/AgvBTests.Codeunit.al
+++ b/tests/runner-extras/app-group-visibility-b/AgvBTests.Codeunit.al
@@ -1,0 +1,99 @@
+// App group B declares no dependencies, so its object inventory holds its own objects and
+// nothing from the sibling groups A and C. B runs after A, which is the direction #2279 was
+// first measured in.
+// Issue #2279; the mechanism is docs/virtual-tables-allobj.md#app-group-visibility.
+codeunit 62612 "AGV B Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit "AGV B Assert";
+
+    [Test]
+    procedure AllObj_OwnTable_IsListed()
+    var
+        AllObj: Record AllObj;
+    begin
+        Assert.IsTrue(AllObj.Get(AllObj."Object Type"::Table, 62610), 'AllObj in app group B must list its own table 62610');
+        Assert.AreEqual('AGV B Table', AllObj."Object Name", 'AllObj row for table 62610');
+    end;
+
+    [Test]
+    procedure AllObjWithCaption_OwnTable_IsListed()
+    var
+        AllObjWithCaption: Record AllObjWithCaption;
+    begin
+        Assert.IsTrue(AllObjWithCaption.Get(AllObjWithCaption."Object Type"::Table, 62610), 'AllObjWithCaption in app group B must list its own table 62610');
+        Assert.AreEqual('AGV B Table Caption', AllObjWithCaption."Object Caption", 'AllObjWithCaption row for table 62610');
+    end;
+
+    [Test]
+    procedure TableMetadata_OwnTable_IsListed()
+    var
+        TableMetadata: Record "Table Metadata";
+    begin
+        Assert.IsTrue(TableMetadata.Get(62610), 'Table Metadata in app group B must list its own table 62610');
+        Assert.AreEqual('AGV B Table', TableMetadata.Name, 'Table Metadata row for table 62610');
+    end;
+
+    [Test]
+    procedure AllObj_GroupATable_IsNotListed()
+    var
+        AllObj: Record AllObj;
+    begin
+        Assert.IsFalse(AllObj.Get(AllObj."Object Type"::Table, 62600), 'AllObj in app group B lists table 62600 of unrelated app group A');
+        AllObj.SetRange("Object ID", 62600, 62609);
+        Assert.IsTrue(AllObj.IsEmpty(), 'AllObj in app group B lists an object in the id range of unrelated app group A');
+    end;
+
+    [Test]
+    procedure AllObjWithCaption_GroupATable_IsNotListed()
+    var
+        AllObjWithCaption: Record AllObjWithCaption;
+    begin
+        Assert.IsFalse(AllObjWithCaption.Get(AllObjWithCaption."Object Type"::Table, 62600), 'AllObjWithCaption in app group B lists table 62600 of unrelated app group A');
+        AllObjWithCaption.SetRange("Object ID", 62600, 62609);
+        Assert.IsTrue(AllObjWithCaption.IsEmpty(), 'AllObjWithCaption in app group B lists an object in the id range of unrelated app group A');
+    end;
+
+    [Test]
+    procedure TableMetadata_GroupATable_IsNotListed()
+    var
+        TableMetadata: Record "Table Metadata";
+    begin
+        Assert.IsFalse(TableMetadata.Get(62600), 'Table Metadata in app group B lists table 62600 of unrelated app group A');
+        TableMetadata.SetRange(ID, 62600, 62609);
+        Assert.IsTrue(TableMetadata.IsEmpty(), 'Table Metadata in app group B lists a table in the id range of unrelated app group A');
+    end;
+
+    [Test]
+    procedure AllObj_GroupCTable_IsNotListed()
+    var
+        AllObj: Record AllObj;
+    begin
+        Assert.IsFalse(AllObj.Get(AllObj."Object Type"::Table, 62620), 'AllObj in app group B lists table 62620 of unrelated app group C');
+        AllObj.SetRange("Object ID", 62620, 62629);
+        Assert.IsTrue(AllObj.IsEmpty(), 'AllObj in app group B lists an object in the id range of unrelated app group C');
+    end;
+
+    [Test]
+    procedure AllObjWithCaption_GroupCTable_IsNotListed()
+    var
+        AllObjWithCaption: Record AllObjWithCaption;
+    begin
+        Assert.IsFalse(AllObjWithCaption.Get(AllObjWithCaption."Object Type"::Table, 62620), 'AllObjWithCaption in app group B lists table 62620 of unrelated app group C');
+        AllObjWithCaption.SetRange("Object ID", 62620, 62629);
+        Assert.IsTrue(AllObjWithCaption.IsEmpty(), 'AllObjWithCaption in app group B lists an object in the id range of unrelated app group C');
+    end;
+
+    [Test]
+    procedure TableMetadata_GroupCTable_IsNotListed()
+    var
+        TableMetadata: Record "Table Metadata";
+    begin
+        Assert.IsFalse(TableMetadata.Get(62620), 'Table Metadata in app group B lists table 62620 of unrelated app group C');
+        TableMetadata.SetRange(ID, 62620, 62629);
+        Assert.IsTrue(TableMetadata.IsEmpty(), 'Table Metadata in app group B lists a table in the id range of unrelated app group C');
+    end;
+}

--- a/tests/runner-extras/app-group-visibility-b/app.json
+++ b/tests/runner-extras/app-group-visibility-b/app.json
@@ -1,0 +1,18 @@
+{
+  "id": "3b0e6f52-7a1d-4c38-9e25-1f6d8a4c2610",
+  "name": "Runner Extras - App Group Visibility B",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Issue #2279, app group B of three: declares one table and no dependencies. Neither A nor C may appear in its object inventory.",
+  "description": "Issue #2279. Every app group under one bundle root compiles as its own module but runs in one process, and the runner's parsed-object registries hold every group's objects. AllObj, AllObjWithCaption and Table Metadata must list only the objects of the executing app group and of the apps it declares as dependencies (transitively), never those of an unrelated sibling group. Runner-specific: the corpus runs one app set per service tier, so it cannot express a second, unrelated app group in the same process.",
+  "dependencies": [],
+  "idRanges": [
+    {
+      "from": 62610,
+      "to": 62619
+    }
+  ],
+  "platform": "27.0.0.0",
+  "runtime": "15.0",
+  "target": "Cloud"
+}

--- a/tests/runner-extras/app-group-visibility-c/AgvCAssert.Codeunit.al
+++ b/tests/runner-extras/app-group-visibility-c/AgvCAssert.Codeunit.al
@@ -1,0 +1,20 @@
+codeunit 62621 "AGV C Assert"
+{
+    procedure AreEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        if Format(Expected) <> Format(Actual) then
+            Error('Assert.AreEqual failed. Expected <%1>, actual <%2>. %3', Expected, Actual, Msg);
+    end;
+
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then
+            Error('Assert.IsTrue failed. %1', Msg);
+    end;
+
+    procedure IsFalse(Condition: Boolean; Msg: Text)
+    begin
+        if Condition then
+            Error('Assert.IsFalse failed. %1', Msg);
+    end;
+}

--- a/tests/runner-extras/app-group-visibility-c/AgvCTable.Table.al
+++ b/tests/runner-extras/app-group-visibility-c/AgvCTable.Table.al
@@ -1,0 +1,15 @@
+table 62620 "AGV C Table"
+{
+    Caption = 'AGV C Table Caption';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Code"; Code[20]) { }
+    }
+
+    keys
+    {
+        key(PK; "Code") { Clustered = true; }
+    }
+}

--- a/tests/runner-extras/app-group-visibility-c/AgvCTests.Codeunit.al
+++ b/tests/runner-extras/app-group-visibility-c/AgvCTests.Codeunit.al
@@ -1,0 +1,96 @@
+// App group C declares a dependency on A, so A's table IS part of its object inventory and
+// B's is not. The visible tests here are what separate 'own objects plus the declared
+// dependency closure' from 'own objects only'.
+// Issue #2279; the mechanism is docs/virtual-tables-allobj.md#app-group-visibility.
+codeunit 62622 "AGV C Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit "AGV C Assert";
+
+    [Test]
+    procedure AllObj_OwnTable_IsListed()
+    var
+        AllObj: Record AllObj;
+    begin
+        Assert.IsTrue(AllObj.Get(AllObj."Object Type"::Table, 62620), 'AllObj in app group C must list its own table 62620');
+        Assert.AreEqual('AGV C Table', AllObj."Object Name", 'AllObj row for table 62620');
+    end;
+
+    [Test]
+    procedure AllObjWithCaption_OwnTable_IsListed()
+    var
+        AllObjWithCaption: Record AllObjWithCaption;
+    begin
+        Assert.IsTrue(AllObjWithCaption.Get(AllObjWithCaption."Object Type"::Table, 62620), 'AllObjWithCaption in app group C must list its own table 62620');
+        Assert.AreEqual('AGV C Table Caption', AllObjWithCaption."Object Caption", 'AllObjWithCaption row for table 62620');
+    end;
+
+    [Test]
+    procedure TableMetadata_OwnTable_IsListed()
+    var
+        TableMetadata: Record "Table Metadata";
+    begin
+        Assert.IsTrue(TableMetadata.Get(62620), 'Table Metadata in app group C must list its own table 62620');
+        Assert.AreEqual('AGV C Table', TableMetadata.Name, 'Table Metadata row for table 62620');
+    end;
+
+    [Test]
+    procedure AllObj_DependencyATable_IsListed()
+    var
+        AllObj: Record AllObj;
+    begin
+        Assert.IsTrue(AllObj.Get(AllObj."Object Type"::Table, 62600), 'AllObj in app group C must list the table of its dependency A, 62600');
+        Assert.AreEqual('AGV A Table', AllObj."Object Name", 'AllObj row for table 62600');
+    end;
+
+    [Test]
+    procedure AllObjWithCaption_DependencyATable_IsListed()
+    var
+        AllObjWithCaption: Record AllObjWithCaption;
+    begin
+        Assert.IsTrue(AllObjWithCaption.Get(AllObjWithCaption."Object Type"::Table, 62600), 'AllObjWithCaption in app group C must list the table of its dependency A, 62600');
+        Assert.AreEqual('AGV A Table Caption', AllObjWithCaption."Object Caption", 'AllObjWithCaption row for table 62600');
+    end;
+
+    [Test]
+    procedure TableMetadata_DependencyATable_IsListed()
+    var
+        TableMetadata: Record "Table Metadata";
+    begin
+        Assert.IsTrue(TableMetadata.Get(62600), 'Table Metadata in app group C must list the table of its dependency A, 62600');
+        Assert.AreEqual('AGV A Table', TableMetadata.Name, 'Table Metadata row for table 62600');
+    end;
+
+    [Test]
+    procedure AllObj_GroupBTable_IsNotListed()
+    var
+        AllObj: Record AllObj;
+    begin
+        Assert.IsFalse(AllObj.Get(AllObj."Object Type"::Table, 62610), 'AllObj in app group C lists table 62610 of unrelated app group B');
+        AllObj.SetRange("Object ID", 62610, 62619);
+        Assert.IsTrue(AllObj.IsEmpty(), 'AllObj in app group C lists an object in the id range of unrelated app group B');
+    end;
+
+    [Test]
+    procedure AllObjWithCaption_GroupBTable_IsNotListed()
+    var
+        AllObjWithCaption: Record AllObjWithCaption;
+    begin
+        Assert.IsFalse(AllObjWithCaption.Get(AllObjWithCaption."Object Type"::Table, 62610), 'AllObjWithCaption in app group C lists table 62610 of unrelated app group B');
+        AllObjWithCaption.SetRange("Object ID", 62610, 62619);
+        Assert.IsTrue(AllObjWithCaption.IsEmpty(), 'AllObjWithCaption in app group C lists an object in the id range of unrelated app group B');
+    end;
+
+    [Test]
+    procedure TableMetadata_GroupBTable_IsNotListed()
+    var
+        TableMetadata: Record "Table Metadata";
+    begin
+        Assert.IsFalse(TableMetadata.Get(62610), 'Table Metadata in app group C lists table 62610 of unrelated app group B');
+        TableMetadata.SetRange(ID, 62610, 62619);
+        Assert.IsTrue(TableMetadata.IsEmpty(), 'Table Metadata in app group C lists a table in the id range of unrelated app group B');
+    end;
+}

--- a/tests/runner-extras/app-group-visibility-c/app.json
+++ b/tests/runner-extras/app-group-visibility-c/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "3b0e6f52-7a1d-4c38-9e25-1f6d8a4c2620",
+  "name": "Runner Extras - App Group Visibility C",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Issue #2279, app group C of three: declares a dependency on A, so A's table IS in its object inventory and B's is not. This is the control that a filter to the executing app alone would fail.",
+  "description": "Issue #2279. Every app group under one bundle root compiles as its own module but runs in one process, and the runner's parsed-object registries hold every group's objects. AllObj, AllObjWithCaption and Table Metadata must list only the objects of the executing app group and of the apps it declares as dependencies (transitively), never those of an unrelated sibling group. Runner-specific: the corpus runs one app set per service tier, so it cannot express a second, unrelated app group in the same process.",
+  "dependencies": [
+    {
+      "id": "3b0e6f52-7a1d-4c38-9e25-1f6d8a4c2600",
+      "name": "Runner Extras - App Group Visibility A",
+      "publisher": "AL Runner",
+      "version": "1.0.0.0"
+    }
+  ],
+  "idRanges": [
+    {
+      "from": 62620,
+      "to": 62629
+    }
+  ],
+  "platform": "27.0.0.0",
+  "runtime": "15.0",
+  "target": "Cloud"
+}


### PR DESCRIPTION
Closes #2279

Written by agent stma-auto2-6 on the account holder's behalf.

Corpus-NA: multi-app-group scoping inside one runner process; the corpus runs one app set per service tier, so two unrelated app groups sharing one process cannot be expressed there

## A runner model, not measured BC behaviour

On a real tenant AllObj is tenant-wide: it lists every installed app's objects, related or not. "C sees A because C depends on A" matches BC. "A cannot see B" is a deliberate runner choice: each app group is treated as its own tenant holding that group and its declared dependencies, because unrelated app groups sharing one runner process is not a state a service tier has. No service tier has measured this rule, and none can.

## What was wrong

One runner process can run several app groups: every app group under one bundle root, every bundle on the command line, and every `sourcePaths` entry of one `--server` request. Source dirs for all of them are registered before any group runs, and the parsed-object registries are never reset per group (resetting them breaks record access on app-defined tables). `EnumerateKnownAlObjects` reads those registries, so AllObj, AllObjWithCaption and Table Metadata in one group listed every other group's objects.

Re-verified on `main` (8908e999) before changing anything: with two groups in one bundle, both directions leaked (A saw B's table and B saw A's), because registration happens for the whole bundle up front.

## What changed

- `AlRunner/Patches/RecordPatches.AppGroupObjectVisibility.cs` (new): both run loops (CLI and `--server`) call `RegisterAppGroupSourceDirs(suite, dirs)` before parsing, so every parsed object is owned by the **app group that compiles the file** (longest registered dir containing it), with that group's declared dependencies. A dir registered by two groups, and a `(kind, id)` declared by two different groups, get no owner and stay listed. At populate time, the executing app group is the app id of `BcRuntime.CurrentTestAssembly` (measured first with a probe: it tracks the group in the run loop; each group also got a fresh store).
- The three populators skip an object only when its owner is **known** and outside the executing group's dependency closure. An object with no recorded owner (precompiled `.app`, platform) is still listed, as before.
- Table Metadata filters at insert time, not in its process-wide cached row list, so one group's view is never cached for another.
- Each store is pinned to the app group that first populated it. The "already inserted" sets are add-only, so a store reused by a second group would carry the first group's rows; that now throws a `not-yet-implemented — app-group-visibility` shape gap instead of answering wrong. It did not fire in any run below.
- The app.json of each source app is read once per manifest, and the scope (app id plus dependency closure) is resolved once per store rather than on every data-access handout, keeping to the #3117 note in `PopulateAllObjVirtualTable`. `ResolveOwningManifest` walks up like `ResolveOwningApp` does, but returns the manifest path, which `ResolveOwningApp` does not and the dependency list needs.
- `--per-suite` (`Program.cs`): the per-suite loop never gave a suite's assembly its app identity, so the filter had no executing app group there and failed open (measured: `12P/15F`, the same as unfixed). It now sets the suite's own identity before `RegisterTestAssemblyInfo`, as the bundled loop does per app group. After: `27P/0F`.
- Docs: `docs/virtual-tables-allobj.md#app-group-visibility`.

## Tests

`tests/runner-extras/app-group-visibility-{a,b,c}` (ids 62600-62629), 9 tests each. A and B declare no dependencies; C depends on A. Each group asserts its own table is listed in all three tables, unrelated groups' tables are not (by `Get` and by an id-range `IsEmpty`), and C asserts A's table **is** listed, which is the control that separates "own objects plus dependency closure" from "own objects only". Count baseline bumped for the three groups.

`AlRunner.Tests/AppGroupObjectVisibilityTests.cs`: closure (transitive, cycle-safe), the hide decision (known foreign hidden, dependency visible, unknown owner visible, kind-keyed, no executing group means no filter), the store-scope refusal, and a `--server` test sending one request with A, B and C as three bundles and then a second request with B alone.

## Review fix (FIX-FIRST on 07798f84)

The first version took the owner from the nearest `app.json` above each file. Two shapes broke, both silently:

- **Nested `app.json`.** A suite compiles a sub-folder carrying its own `app.json` into itself (`CollectSuitePaths`), so the outer group hid a table it compiled: AllObj said missing while `Insert`/`Get` worked.
- **Same table id in two unrelated groups.** The last parsed owner won, so the other group's own table vanished from AllObj and Table Metadata.

Proving tests in `AppGroupObjectVisibilityTests`: `Cli_NestedAppJsonAndSharedTableId_EachGroupStillListsWhatItCompiles` and `Server_...` (outer + nested inner app, and two groups X, Y each declaring table 62680), plus unit tests `AppGroupOwningFile_TakesTheLongestRegisteredDir_NotTheNearestAppJson` and `RecordObjectOwner_AnIdClaimedByTwoAppsHasNoOwner_AndStaysThatWay`.

- **RED on 07798f84's runner code:** the same fixture as a CLI bundle gave `1P/2F` (X's own 62680 and the outer group's inner 62665 missing from AllObj); both spawned C# tests failed (`MISSING: AllObj does not list compiled table 62665`).
- **GREEN:** `3P/0F`, cold and warm on one cache root, and with `--per-suite`; both C# tests pass.

| mutation (each rebuilt and restored) | edge fixture | three proving groups |
|---|---|---|
| owner from the nearest `app.json` again (`ResolveOwningApp`) | `2P/1F` — only the nested inner table | `27P/0F` |
| no ambiguity (a second claimant overwrites the owner) | `2P/1F` — only X's shared-id table | `27P/0F` |

## RED -> GREEN (the three groups as one bundle, BC 28.1.49838.53910 artifacts)

- RED on `main`: `12P/15F/0E across 27 tests` — every "IsNotListed" test failed, every "IsListed" test passed.
- GREEN: `27P/0F/0E across 27 tests`, cold and then warm against one fresh cache root (warm run 0.3s, so the AL-output cache was hit), and again with `--isolation disabled`, `--isolation test` and `--per-suite`.

## Mutations (executed, each rebuilt and restored)

| mutation | result |
|---|---|
| filter to the executing app id alone (no dependency closure) | `24P/3F` — exactly C's three `DependencyATable_IsListed` tests (re-run on the final code) |
| remove only the Table Metadata filter | `22P/5F` — exactly the five `TableMetadata_Group*_IsNotListed` tests |
| no filter at all + `CheckInventoryScope` always returns | C#: the server test failed (`LEAK: AllObj lists foreign table`) and `CheckInventoryScope_RefusesAStoreReadByADifferentAppGroup` failed; 3 of 5 still passed (the pure closure/decision tests, which do not go through the populators) |

## --server

Measured by hand with four requests on one warm server, with and without the filter:

- Across requests (A, then B) there was **no** leak even on the unfiltered build. That is the measured effect; it is consistent with `RecordPatches.ResetForReload` clearing the parsed registries, which the server path reaches through `BcRuntime.ResetForNewBundleReload`.
- Within one multi-bundle request (A, B, C) the unfiltered build failed 6 of 27 (B saw A, C saw B, following run order). With the fix: 27/27.

The C# server test covers both shapes.

## Wider runs (final head, BC 28.1.49838.53910 artifacts)

- `tests/runner-extras` exactly as CI runs it (`--strict --count-baseline`, both package caches): `465P/0F/0E`, exit 0, cold and then warm on one cache root.
- Corpus `524b9945be68c6f1c5928bc9b268668c2aa71ace` (master): `3350P/7F/0E`, cold and warm alike. All 7 are `Codeunit60576` (`handlers/TestPageBlankKeyInsert.al`, from corpus PR #340, merged after my previous run). The file does not reference AllObj or Table Metadata. On the earlier corpus `0d9d246b` this branch was `3348P/0F`. I believe the red is inherited and has nothing to do with this change; I did not measure `main` against `524b9945`.
- `dotnet test --settings engine.runsettings` filtered to `GuardTests|CountBaselineMergeShapeTests|RunnerExtrasIdRange|AllObj|TableMetadata|InstallBaselineVirtualTable|AppGroupObjectVisibility|RecordPatches|CliDocumentation|SuiteRootAlFiles`: 437 passed, 1 failed (`ScratchDirOwnershipGuardTests`, which caught my unit test building a path under the temp dir); fixed, then that guard plus `AppGroupObjectVisibilityTests`: `Failed: 0, Passed: 22`.
- `tools/test_*.py`: all pass.
- `--per-suite` is proven only by these local runs; no CI leg runs runner-extras with `--per-suite`.

## Fix the shape

1. **Same pattern at another call site?** Yes. The other virtual tables fed by the same registries leak too. Measured with a probe in group A: `Field` (2000000041) lists B's table fields and `CodeUnit Metadata` (2000000137) lists B's codeunit. Not folded: each populator needs its own assertions and the diff would stop being one reviewable change. Filed as #4070 with the probe and the measurement.
2. **Sibling making the same assumption?** `EnumerateKnownAlObjects` also feeds name-to-id resolution (`ResolveObjectIdByKindAndName`, `ResolveObjectNameAsPage`, page-name lookup for Table Metadata). Those are deliberately left unscoped: they resolve references, and a dependency's objects must stay resolvable. Objects of a precompiled `.app` registered by a different bundle are not filtered (no source owner); noted in #4070.
3. **Two paths writing the same state, same invariant?** AllObj and AllObjWithCaption share one inventory and now share one filter and one scope pin; Table Metadata uses the same decision on its own row list. The three stores all pin their scope the same way.

## Queue scan

Searched open issues for "AllObj", "another app group", "CodeUnit Metadata app group", "Field virtual table bundle leak" and "cross-bundle registries". Related but not folded: #4000 / PR #4004 (owning-app *columns* for extension, enum and permission set kinds — a different question from which rows exist; it edits the adjacent `TryParseObjectDeclFile` line in `RecordPatches.cs`, so whichever lands second may need a trivial rebase). #4034's server replay restores emit registries, not source parse owners; a replayed foreign enum that is not re-parsed has no owner and stays listed. No duplicate of this defect found.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
