### PR TITLE
fix(watch): parse incremental cycles with the same preprocessor symbols as a full build

### DIFF
--- a/AlRunner.Tests/BcCompilerIncrementalPreprocessorSymbolsTests.cs
+++ b/AlRunner.Tests/BcCompilerIncrementalPreprocessorSymbolsTests.cs
@@ -1,0 +1,191 @@
+// BcCompilerIncrementalPreprocessorSymbolsTests — issue #4064.
+//
+// RUNNER-MECHANISM test. The one-shot Emit parses with CLEANSCHEMA1..25, the --define symbols and
+// the app.json `preprocessorSymbols` (#1943). The --watch/--server incremental path
+// (TryEmitIncremental) parsed with CLEANSCHEMA1..25 only, so after a baseline the fast path
+// compiled the other `#if` branch of an edited file than a cold build of the same tree.
+//
+// Not a corpus test: which symbols the runner hands its own compiler on its fast path is a
+// property of the runner, and a corpus test is always a cold compile.
+using System.Reflection;
+using Xunit;
+using AlRunner;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class BcCompilerIncrementalPreprocessorSymbolsTests : IDisposable
+{
+    private readonly string _root;
+    private readonly BcEngineFixture _engine;
+
+    public BcCompilerIncrementalPreprocessorSymbolsTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = TestScratch.Dir("al-runner-incremental-preprocessor-tests");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private void WriteManifest(string symbolsJson) =>
+        File.WriteAllText(Path.Combine(_root, "app.json"), $$"""
+            { "id": "d3c4b5a6-f7e8-4a91-8b02-d4e5f6071829", "name": "IncrPreproc", "publisher": "Test",
+              "version": "1.0.0.0", "idRanges": [ { "from": 90980, "to": 90989 } ], "runtime": "14.0",
+              "preprocessorSymbols": {{symbolsJson}} }
+            """);
+
+    private void WriteAl(string fileName, string content) => File.WriteAllText(Path.Combine(_root, fileName), content);
+
+    private static string Probe(string suffix, string symbol) => $$"""
+        codeunit 90980 "Incr Preproc Probe"
+        {
+            procedure GetValue(): Text
+            begin
+        #if {{symbol}}
+                exit('branch-defined-{{suffix}}');
+        #else
+                exit('branch-undefined-{{suffix}}');
+        #endif
+            end;
+        }
+        """;
+
+    private static Dictionary<string, string> ByName(BcEmitOutput output)
+        => output.Sources.ToDictionary(s => s.Name, s => s.Code);
+
+    private static string ProbeCode(BcEmitOutput output) => ByName(output)["Incr Preproc Probe"];
+
+    // --define symbols are process-wide static state; restore whatever was there.
+    private static readonly FieldInfo ExtraSymbolsField = typeof(BcCompiler).GetField(
+        "_extraPreprocessorSymbols", BindingFlags.Static | BindingFlags.NonPublic)!;
+
+    private static T WithDefines<T>(IReadOnlyList<string>? symbols, Func<T> body)
+    {
+        var saved = ExtraSymbolsField.GetValue(null);
+        ExtraSymbolsField.SetValue(null, symbols);
+        try { return body(); }
+        finally { ExtraSymbolsField.SetValue(null, saved); }
+    }
+
+    [SkippableFact]
+    public void ManifestSymbol_FastPathCompilesTheSameBranchAsAColdBuild()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        WithDefines<object?>(null, () =>
+        {
+            WriteManifest("""["INCRFOO"]""");
+            WriteAl("Probe.al", Probe("v1", "INCRFOO"));
+            var compiler = new BcCompiler();
+            var baseline = compiler.Emit(new[] { _root }, "IncrPreprocManifest", appRootDir: _root, trackIncrementalBaseline: true);
+            Assert.Empty(baseline.Diagnostics);
+            Assert.Contains("branch-defined-v1", ProbeCode(baseline), StringComparison.Ordinal);
+
+            WriteAl("Probe.al", Probe("v2", "INCRFOO"));
+            var incremental = compiler.TryEmitIncremental(new[] { _root }, "IncrPreprocManifest", appRootDir: _root, out var reason);
+            Assert.True(incremental != null, $"expected the fast path; fell back: {reason}");
+
+            var cold = ProbeCode(new BcCompiler().Emit(new[] { _root }, "IncrPreprocManifestCold", appRootDir: _root));
+            Assert.Contains("branch-defined-v2", cold, StringComparison.Ordinal);
+            Assert.Contains("branch-defined-v2", ProbeCode(incremental!), StringComparison.Ordinal);
+            Assert.Equal(cold, ProbeCode(incremental!));
+            return null;
+        });
+    }
+
+    [SkippableFact]
+    public void DefineSymbol_FastPathCompilesTheSameBranchAsAColdBuild()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        WithDefines<object?>(new List<string> { "INCRBAR" }, () =>
+        {
+            WriteManifest("[]");
+            WriteAl("Probe.al", Probe("v1", "INCRBAR"));
+            var compiler = new BcCompiler();
+            var baseline = compiler.Emit(new[] { _root }, "IncrPreprocDefine", appRootDir: _root, trackIncrementalBaseline: true);
+            Assert.Empty(baseline.Diagnostics);
+            Assert.Contains("branch-defined-v1", ProbeCode(baseline), StringComparison.Ordinal);
+
+            WriteAl("Probe.al", Probe("v2", "INCRBAR"));
+            var incremental = compiler.TryEmitIncremental(new[] { _root }, "IncrPreprocDefine", appRootDir: _root, out var reason);
+            Assert.True(incremental != null, $"expected the fast path; fell back: {reason}");
+
+            var cold = ProbeCode(new BcCompiler().Emit(new[] { _root }, "IncrPreprocDefineCold", appRootDir: _root));
+            Assert.Contains("branch-defined-v2", cold, StringComparison.Ordinal);
+            Assert.Contains("branch-defined-v2", ProbeCode(incremental!), StringComparison.Ordinal);
+            Assert.Equal(cold, ProbeCode(incremental!));
+            return null;
+        });
+    }
+
+    [SkippableFact]
+    public void UndeclaredSymbol_FastPathStillCompilesTheElseBranch()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        // Negative control: a fast path that defined every symbol would satisfy the two tests above.
+        WithDefines<object?>(null, () =>
+        {
+            WriteManifest("""["INCRFOO"]""");
+            WriteAl("Probe.al", Probe("v1", "INCROTHER"));
+            var compiler = new BcCompiler();
+            Assert.Empty(compiler.Emit(new[] { _root }, "IncrPreprocUndeclared", appRootDir: _root, trackIncrementalBaseline: true).Diagnostics);
+
+            WriteAl("Probe.al", Probe("v2", "INCROTHER"));
+            var incremental = compiler.TryEmitIncremental(new[] { _root }, "IncrPreprocUndeclared", appRootDir: _root, out var reason);
+            Assert.True(incremental != null, $"expected the fast path; fell back: {reason}");
+            Assert.Contains("branch-undefined-v2", ProbeCode(incremental!), StringComparison.Ordinal);
+            return null;
+        });
+    }
+
+    [SkippableFact]
+    public void ManifestSymbolsEditedMidSession_ForcesAFullRebuild()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        WithDefines<object?>(null, () =>
+        {
+            WriteManifest("""["INCRFOO"]""");
+            WriteAl("Probe.al", Probe("v1", "INCRFOO"));
+            var compiler = new BcCompiler();
+            Assert.Empty(compiler.Emit(new[] { _root }, "IncrPreprocManifestEdit", appRootDir: _root, trackIncrementalBaseline: true).Diagnostics);
+
+            // Every unchanged file in the baseline was parsed with INCRFOO defined; reusing them
+            // under a symbol set without it would mix two branch choices in one compilation.
+            WriteManifest("[]");
+            WriteAl("Probe.al", Probe("v2", "INCRFOO"));
+            var incremental = compiler.TryEmitIncremental(new[] { _root }, "IncrPreprocManifestEdit", appRootDir: _root, out var reason);
+            Assert.True(incremental == null, "an app.json preprocessorSymbols edit was taken on the incremental fast path");
+            Assert.Contains("preprocessor symbols", reason, StringComparison.Ordinal);
+            return null;
+        });
+    }
+
+    [SkippableFact]
+    public void DefineSymbolsChangedAfterBaseline_ForcesAFullRebuild()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        WriteManifest("[]");
+        WriteAl("Probe.al", Probe("v1", "INCRBAR"));
+        var compiler = new BcCompiler();
+        WithDefines<object?>(new List<string> { "INCRBAR" }, () =>
+        {
+            Assert.Empty(compiler.Emit(new[] { _root }, "IncrPreprocDefineEdit", appRootDir: _root, trackIncrementalBaseline: true).Diagnostics);
+            return null;
+        });
+
+        WriteAl("Probe.al", Probe("v2", "INCRBAR"));
+        string? reason = null;
+        var incremental = WithDefines(null, () =>
+            compiler.TryEmitIncremental(new[] { _root }, "IncrPreprocDefineEdit", appRootDir: _root, out reason));
+        Assert.True(incremental == null, "a changed --define symbol set was taken on the incremental fast path");
+        Assert.Contains("preprocessor symbols", reason, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner/BcCompiler.Incremental.cs
+++ b/AlRunner/BcCompiler.Incremental.cs
@@ -466,7 +466,9 @@ public sealed partial class BcCompiler
     {
         var appJsonHash = manifestAppJsonPath != null && File.Exists(manifestAppJsonPath)
             ? HashFile(manifestAppJsonPath) : "<none>";
-        return $"{appId}|{publisher}|{version}|{manifestInputs.CacheKeyFragment}|{appJsonHash}";
+        // --define symbols pick #if branches like the manifest's do; a baseline parsed under another set cannot be reused (#4064).
+        var defines = string.Join(",", GetExtraPreprocessorSymbols());
+        return $"{appId}|{publisher}|{version}|{manifestInputs.CacheKeyFragment}|{defines}|{appJsonHash}";
     }
 
     /// <summary>
@@ -580,7 +582,7 @@ public sealed partial class BcCompiler
         var manifestFingerprint = RadManifestFingerprint(appId, publisher, version, manifestInputs, manifestAppJsonPath);
         if (manifestFingerprint != baseline.ManifestFingerprint)
         {
-            fallbackReason = "app.json (identity/version/preprocessor symbols/features/help url) changed since the last cycle";
+            fallbackReason = "app.json (identity/version/preprocessor symbols/features/help url) or the --define preprocessor symbols changed since the last cycle";
             return null;
         }
 
@@ -1443,10 +1445,7 @@ public sealed partial class BcCompiler
     /// <summary>Drops the current baseline for a bundle — used when a caller knows the next cycle must be a full rebuild regardless (e.g. a watched suite set changed).</summary>
     public void ClearIncrementalBaseline(string moduleName) => _radBaselines.Remove(moduleName);
 
-    private static NavCA.ParseOptions RadParseOptions(ManifestCompilerInputs manifestInputs) => new(
-        runtimeVersion: null!,
-        preprocessorSymbols: Enumerable.Range(1, 25).Select(n => $"CLEANSCHEMA{n}"),
-        documentationMode: NavCA.DocumentationMode.None);
+    private static NavCA.ParseOptions RadParseOptions(ManifestCompilerInputs manifestInputs) => BuildParseOptions(manifestInputs);
 
     private static NavCA.CompilationOptions RadCompilationOptions(ManifestCompilerInputs manifestInputs) => new(
         continueBuildOnError: true,

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -341,7 +341,7 @@ public sealed partial class BcCompiler
     }
 
     // Extra preprocessor symbols supplied by the caller via --define / --preprocessor-symbols.
-    // Merged with the built-in CLEANSCHEMA1..25 set at both ParseOptions sites.
+    // Merged with the built-in CLEANSCHEMA1..25 set in BuildParseOptions.
     private static IReadOnlyList<string>? _extraPreprocessorSymbols;
 
     /// <summary>
@@ -1768,18 +1768,7 @@ public sealed partial class BcCompiler
             : dirs.Select(d => Path.Combine(d, "app.json")).FirstOrDefault(File.Exists);
         var manifestInputs = ReadManifestCompilerInputs(manifestAppJsonPath);
 
-        // Preprocessor symbols: CLEANSCHEMA1..25 merged with any caller-supplied symbols
-        // (--define / --preprocessor-symbols) AND the app's own manifest `preprocessorSymbols`
-        // (#1943) — union, not override, so a manifest symbol never silently loses to a CLI
-        // one or vice versa. v1 computes per-source max from any #pragma the AL files set
-        // (Program.cs:1454-1462); we use the static 1..25 set v2 was already shipping —
-        // sufficient for the tests/ corpus.
-        var parseOpts = new NavCA.ParseOptions(
-            runtimeVersion: null!,
-            preprocessorSymbols: Enumerable.Range(1, 25).Select(n => $"CLEANSCHEMA{n}")
-                .Concat(_extraPreprocessorSymbols ?? [])
-                .Concat(manifestInputs.PreprocessorSymbols),
-            documentationMode: NavCA.DocumentationMode.None);
+        var parseOpts = BuildParseOptions(manifestInputs);
 
         bool _timing = Environment.GetEnvironmentVariable("BCCOMPILER_TIMING") == "1";
         var _tw = System.Diagnostics.Stopwatch.StartNew();
@@ -2634,15 +2623,8 @@ public sealed partial class BcCompiler
             : dirs.Select(d => Path.Combine(d, "app.json")).FirstOrDefault(File.Exists);
         var manifestInputs = ReadManifestCompilerInputs(foundAppJson);
 
-        // Preprocessor symbols: same union as Emit() — CLEANSCHEMA1..25, any caller-supplied
-        // (--define) symbols, AND this dep's OWN manifest symbols (#1943) — never the
-        // consuming bundle's, since foundAppJson is this dep's own app.json.
-        var parseOpts = new NavCA.ParseOptions(
-            runtimeVersion: null!,
-            preprocessorSymbols: Enumerable.Range(1, 25).Select(n => $"CLEANSCHEMA{n}")
-                .Concat(_extraPreprocessorSymbols ?? [])
-                .Concat(manifestInputs.PreprocessorSymbols),
-            documentationMode: NavCA.DocumentationMode.None);
+        // This dep's OWN manifest symbols, never the consuming bundle's: foundAppJson is the dep's app.json.
+        var parseOpts = BuildParseOptions(manifestInputs);
         var trees = new NavSyntax.SyntaxTree[alFiles.Count];
         Parallel.For(0, alFiles.Count, i =>
         {
@@ -2900,6 +2882,20 @@ public sealed partial class BcCompiler
             "|" + (int)CompilerFeatures + "|" + ContextSensitiveHelpUrl +
             "|" + (int)EffectiveTarget;
     }
+
+    /// <summary>
+    /// The ParseOptions every compile path uses — Emit, EmitDepSymbols and the incremental fast
+    /// path: CLEANSCHEMA1..25, the --define symbols, and the manifest's own
+    /// <c>preprocessorSymbols</c>, as a union (#1943). One builder, because the incremental path
+    /// once derived its own set and chose different <c>#if</c> branches than a cold build (#4064).
+    /// </summary>
+    internal static NavCA.ParseOptions BuildParseOptions(ManifestCompilerInputs manifestInputs) => new(
+        runtimeVersion: null!,
+        preprocessorSymbols: Enumerable.Range(1, 25).Select(n => $"CLEANSCHEMA{n}")
+            .Concat(GetExtraPreprocessorSymbols())
+            .Concat(manifestInputs.PreprocessorSymbols)
+            .ToList(),
+        documentationMode: NavCA.DocumentationMode.None);
 
     /// <summary>
     /// Read <c>preprocessorSymbols</c>, <c>features</c>, and <c>contextSensitiveHelpUrl</c>

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -31,6 +31,7 @@ public static partial class RecordPatches
     // Matches BcCompiler.Emit's options so this parse sees the same source the emit does —
     // notably the CLEANSCHEMA1..25 preprocessor symbols, which gate real field declarations
     // in the BaseApp, PLUS whatever the caller passed via --define / --preprocessor-symbols.
+    // NOT the app.json preprocessorSymbols BcCompiler.BuildParseOptions also adds (#4071).
     // DocumentationMode.None: doc comments are trivia we never read.
     //
     // This MUST be a property recomputed on every call, not a `static readonly` field.

--- a/AlRunner/TddSupport.cs
+++ b/AlRunner/TddSupport.cs
@@ -26,6 +26,7 @@ public static class TddSupport
 {
     // Mirrors BcCompiler's own ParseOptions (CLEANSCHEMA1..25 + whatever --define /
     // --preprocessor-symbols supplied) so this re-parse sees exactly the same source
+    // -- except the app.json preprocessorSymbols, which BuildParseOptions also adds (#4071) --
     // the original (failed) emit attempt saw — same rule RecordPatches.AlSourceParser
     // follows for the same reason (see its AlParseOptions doc comment). Recomputed per
     // call rather than cached: BcCompiler.SetExtraPreprocessorSymbols can run after


### PR DESCRIPTION
Closes #4064

Written by agent stma-auto2-7 on the account holder's behalf.

Corpus-NA: which preprocessor symbols the runner gives its own compiler on the --watch/--server fast path is a runner property, and a corpus test is always a cold compile, so it cannot show a fast-path vs cold-build divergence

## What was wrong (measured)

`RadParseOptions` in `AlRunner/BcCompiler.Incremental.cs` parsed every incremental cycle with only `CLEANSCHEMA1..25`. `Emit` and `EmitDepSymbols` also add the `--define` symbols and the app.json `preprocessorSymbols` (#1943). I measured it with the new tests before changing anything. After a baseline `Emit` of an app with `"preprocessorSymbols": ["INCRFOO"]` and a codeunit using `#if INCRFOO ... #else ... #endif`, I edited the file and called `TryEmitIncremental`. The fast path emitted the `#else` branch, and a cold `Emit` of the same tree emitted the `#if` branch. `--define` symbols behaved the same way.

## What changed

- `BcCompiler.BuildParseOptions(ManifestCompilerInputs)` (in `AlRunner/BcCompiler.cs`) is now the only place that builds the compile's `ParseOptions`. `Emit`, `EmitDepSymbols` and `RadParseOptions` all call it, so nothing derives the symbol set a second time.
- `RadManifestFingerprint` now includes the `--define` set. If that set changes after a baseline, the next cycle does a full rebuild. Otherwise, files parsed under the old set would sit in one compilation with a file parsed under the new one. An app.json `preprocessorSymbols` edit already forced a full rebuild through the app.json hash and `CacheKeyFragment`. The new test `ManifestSymbolsEditedMidSession_ForcesAFullRebuild` now pins that.
- The fallback reason now mentions `--define` symbols.
- I corrected two comments (`TddSupport.cs`, `RecordPatches.AlSourceParser.cs`) that claimed to match the compile's options. See the third question below.

In practice `--define` is set once per process (`Program.cs`), so the fingerprint term matters only if that changes. It costs one string join per cycle.

## RED -> GREEN

`dotnet test AlRunner.Tests -c Release --settings engine.runsettings --filter FullyQualifiedName~BcCompilerIncrementalPreprocessorSymbolsTests` (5 tests):

- Before the fix: `Failed: 3, Passed: 2, Total: 5`. `ManifestSymbol_FastPath...` and `DefineSymbol_FastPath...` failed with `Not found: "branch-defined-v2"`. `DefineSymbolsChangedAfterBaseline_ForcesAFullRebuild` failed with "a changed --define symbol set was taken on the incremental fast path". The manifest-edit guard and the negative control passed, as expected.
- After the fix: `Failed: 0, Passed: 5, Total: 5`.

## Mutations (each one restored after the run)

| mutation | result | failing test |
|---|---|---|
| M1: `RadParseOptions` passes `ManifestCompilerInputs.Empty` | Failed: 1, Passed: 4 | ManifestSymbol_FastPathCompilesTheSameBranchAsAColdBuild |
| M2: fingerprint drops the `--define` term | Failed: 1, Passed: 4 | DefineSymbolsChangedAfterBaseline_ForcesAFullRebuild |
| M3: `RadParseOptions` clears the `--define` symbols while it builds | Failed: 1, Passed: 4 | DefineSymbol_FastPathCompilesTheSameBranchAsAColdBuild |
| M4: fingerprint drops `CacheKeyFragment` and the app.json hash | Failed: 1, Passed: 4 | ManifestSymbolsEditedMidSession_ForcesAFullRebuild |
| M5: `RadParseOptions` also defines `INCROTHER` | Failed: 1, Passed: 4 | UndeclaredSymbol_FastPathStillCompilesTheElseBranch |

Every red came from an assertion, and every build had 0 errors. I ran the mutations on `01b7d1bd`. After that I moved `BuildParseOptions` above the doc comment of `ReadManifestCompilerInputs`, because `test_doc_summary_uniqueness.py` flagged a stranded `<summary>`. That move changed no behavior. After it, the targeted run passed: `Failed: 0, Passed: 323, Total: 323`. That run covered the BcCompilerIncremental* classes, BcCompilerPreprocessorSymbolsTests, ManifestCompilerInputsTests, RecordPatchesWarmReparseTests, RecordPatchesParseOnceTests, EmitDepSymbols* and GuardTests. `tools/test_*.py` all pass.

The assertion that proves the fix is `Assert.Contains("branch-defined-v2", incremental)`. The `Assert.Equal(cold, incremental)` after it is stricter and follows the shape of #4065's test. If a BC leg fails only on that `Equal`, relax the `Equal` and keep the fix.

## Fix the shape

1. **Same pattern at another call site?** Yes. `rg "ParseOptions\(|CLEANSCHEMA" AlRunner` finds five other `ParseOptions` builders. `AlMemberSyntaxIndex.PreprocessorSymbols` and `AlCoverageSourceMap` (whose caller passes the symbols in) already use the full set. `TddSupport.ParseOptions`, `RecordPatches.AlParseOptions` and `Program.IsFullAlObjectDeclaration` leave out the app.json symbols.
2. **A sibling with the same assumption?** Those same three. They are static properties or a helper with no app.json path available, so fixing them means passing a path through hot files. That needs different reasoning from this fix, so I filed #4071 and did not fold it in. I only corrected the two comments that claimed equivalence.
3. **Two write paths, one invariant?** The baseline fingerprint (end of `Emit`) and the per-cycle check both go through `RadManifestFingerprint`, so adding the `--define` term keeps them in agreement.

Issue queue scan (searched: preprocessorSymbols, "preprocessor symbols", --define, RadParseOptions, TryEmitIncremental): nothing else lands in these files except #4071, which I filed here. #4065 (mine, still open) edits `RadCompilationOptions` next to this change. `git merge-tree` against its head is clean, so no rebase is needed.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
