### PR TITLE
perf(events): index per-construction subscriber lookups by table and drop the per-call GetAssemblies() gate

### DIFF
--- a/AlRunner.Tests/EventSubscriberIndexTests.cs
+++ b/AlRunner.Tests/EventSubscriberIndexTests.cs
@@ -1,0 +1,164 @@
+// Issue #2369: the injectors that run on every record construction look subscribers up through
+// a per-table index instead of scanning every registered subscriber. The index is derived state,
+// so the risk it adds is staleness: a subscriber registered after the index was first built must
+// still be found. These tests load a NEW assembly after the first lookup — the shape a --server
+// reload, a --watch cycle or a lazily loaded dependency produces — and assert the lookup sees it.
+//
+// The subscriber assemblies are compiled here with a duck-typed NavEventSubscriberAttribute, the
+// same shape ObjectEventSubscriberRegistrationMechanismTests uses: discovery matches the attribute
+// by simple type name and reads TargetObjectId / TargetMethodName / TargetFieldName reflectively.
+// End-to-end dispatch through a real runner is ServerValidateSubscriberReloadTests.
+
+using System.Reflection;
+using AlRunner.Patches;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(EventSubscriberRegistrySerialCollection.Name)]
+public sealed class EventSubscriberIndexTests
+{
+    // Assemblies never unload, so every subscriber a test loads stays registered for the rest of
+    // the process. Each test takes its own table ids so an earlier test's subscribers cannot
+    // satisfy a later test's assertion.
+    private static int _nextTableId = 79900;
+
+    private static int NextTableId() => Interlocked.Add(ref _nextTableId, 10);
+
+    private static byte[] Compile(string assemblyName, string source)
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { CSharpSyntaxTree.ParseText(source) },
+            new[]
+            {
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
+            },
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using var ms = new MemoryStream();
+        var result = compilation.Emit(ms);
+        Assert.True(result.Success,
+            string.Join("; ", result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+        return ms.ToArray();
+    }
+
+    /// <summary>A codeunit-shaped type whose subscribers target <paramref name="table"/> and
+    /// <paramref name="otherTable"/>. Declaration order is the order discovery reads.</summary>
+    private static string SubscriberSource(int table, int otherTable) => $$"""
+        using System;
+        namespace Fx.SubscriberIndex
+        {
+            public sealed class FakeObjectId
+            {
+                public FakeObjectId(int objectType, int objectNumber) { ObjectType = objectType; ObjectNumber = objectNumber; }
+                public int ObjectType { get; }
+                public int ObjectNumber { get; }
+            }
+
+            public sealed class NavEventSubscriberAttribute : Attribute
+            {
+                public NavEventSubscriberAttribute(int objectType, int objectId, string methodName, string fieldName)
+                {
+                    TargetObjectId = new FakeObjectId(objectType, objectId);
+                    TargetMethodName = methodName;
+                    TargetFieldName = fieldName;
+                }
+                public object TargetObjectId { get; }
+                public string TargetMethodName { get; }
+                public string TargetFieldName { get; }
+                public int TargetFieldId => 0;
+            }
+
+            public class CodeunitSubscriberIndexProbe
+            {
+                [NavEventSubscriber(1, {{table}}, "OnAfterValidateEvent", "Qty")]
+                public void QtyValidated() { }
+
+                [NavEventSubscriber(1, {{otherTable}}, "OnAfterValidateEvent", "Qty")]
+                public void OtherTableQtyValidated() { }
+
+                [NavEventSubscriber(1, {{table}}, "OnBeforeValidateEvent", "Note")]
+                public void NoteValidating() { }
+
+                [NavEventSubscriber(1, {{table}}, "OnAfterInsertEvent", "")]
+                public void Inserted() { }
+            }
+        }
+        """;
+
+    private static Assembly LoadSubscribers(int table, int otherTable)
+        => Assembly.Load(Compile($"al-runner-subscriber-index-{Guid.NewGuid():N}", SubscriberSource(table, otherTable)));
+
+    private static string[] Names(IEnumerable<MethodInfo> methods) => methods.Select(m => m.Name).ToArray();
+
+    [Fact]
+    public void AssemblyLoadHandler_RunsAfterTheLoadedAssemblyIsEnumerable()
+    {
+        // EnsureRegistryFresh's gate reads an epoch that AppDomain.AssemblyLoad bumps, then calls
+        // GetAssemblies(). That is only complete if a handler never runs BEFORE the new assembly
+        // shows up in GetAssemblies() — otherwise a scan could record the epoch and miss the
+        // assembly that bumped it. This pins the platform property the gate depends on.
+        var name = $"al-runner-load-order-{Guid.NewGuid():N}";
+        var bytes = Compile(name, "public class Probe { }");
+        bool? enumerableInHandler = null;
+        AssemblyLoadEventHandler handler = (_, e) =>
+        {
+            if (e.LoadedAssembly.GetName().Name == name)
+                enumerableInHandler = AppDomain.CurrentDomain.GetAssemblies().Contains(e.LoadedAssembly);
+        };
+        AppDomain.CurrentDomain.AssemblyLoad += handler;
+        try { Assembly.Load(bytes); }
+        finally { AppDomain.CurrentDomain.AssemblyLoad -= handler; }
+
+        Assert.True(enumerableInHandler.HasValue, "AssemblyLoad was not raised for Assembly.Load(byte[])");
+        Assert.True(enumerableInHandler.Value, "the handler ran before the assembly was in GetAssemblies()");
+    }
+
+    [Fact]
+    public void SubscribersLoadedAfterTheIndexWasBuilt_AreFoundForTheirTableOnly()
+    {
+        int table = NextTableId(), otherTable = table + 1, untouched = table + 2;
+        EventSubscriberPatches.ResetForReload();
+
+        // Build the index before the subscribers exist, the way a record construction early in a
+        // run does. Nothing targets these ids yet.
+        Assert.Empty(EventSubscriberPatches.ValidateSubscriberMethodsForTable(table));
+        Assert.Empty(EventSubscriberPatches.TriggerSubscribersForTable(table));
+
+        LoadSubscribers(table, otherTable);
+
+        // Both validate subscribers on `table`, in declaration order; the one on otherTable is not
+        // mixed in.
+        Assert.Equal(new[] { "QtyValidated", "NoteValidating" },
+            Names(EventSubscriberPatches.ValidateSubscriberMethodsForTable(table)));
+        Assert.Equal(new[] { "OtherTableQtyValidated" },
+            Names(EventSubscriberPatches.ValidateSubscriberMethodsForTable(otherTable)));
+        Assert.Empty(EventSubscriberPatches.ValidateSubscriberMethodsForTable(untouched));
+
+        // The table-trigger half: OnAfterInsertEvent is ordinal 2, and it is not reported as a
+        // validate subscriber (nor the validate ones as triggers).
+        var triggers = EventSubscriberPatches.TriggerSubscribersForTable(table);
+        Assert.Equal(new[] { (2, "Inserted") }, triggers.Select(t => (t.EventTypeOrdinal, t.Method.Name)).ToArray());
+        Assert.Empty(EventSubscriberPatches.TriggerSubscribersForTable(otherTable));
+    }
+
+    [Fact]
+    public void AReloadResetRebuildsTheIndexFromTheRescan()
+    {
+        int table = NextTableId(), otherTable = table + 1;
+        EventSubscriberPatches.ResetForReload();
+        LoadSubscribers(table, otherTable);
+        Assert.Equal(2, EventSubscriberPatches.ValidateSubscriberMethodsForTable(table).Count);
+
+        // A reload clears the registries; the next lookup rescans every loaded assembly and must
+        // answer the same, not an empty index left over from the clear and not a doubled one.
+        EventSubscriberPatches.ResetForReload();
+        Assert.Equal(new[] { "QtyValidated", "NoteValidating" },
+            Names(EventSubscriberPatches.ValidateSubscriberMethodsForTable(table)));
+        Assert.Single(EventSubscriberPatches.TriggerSubscribersForTable(table));
+    }
+}

--- a/AlRunner.Tests/EventSubscriberRegistrySerialCollection.cs
+++ b/AlRunner.Tests/EventSubscriberRegistrySerialCollection.cs
@@ -1,0 +1,14 @@
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Test classes that reset or read EventSubscriberPatches' process-wide registries in-process
+/// (ResetForReload, the subscriber lookups). One class resetting while another scans would
+/// interleave on the same static dictionaries.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class EventSubscriberRegistrySerialCollection
+{
+    public const string Name = "event-subscriber-registry-serial";
+}

--- a/AlRunner.Tests/ObjectEventSubscriberRegistrationMechanismTests.cs
+++ b/AlRunner.Tests/ObjectEventSubscriberRegistrationMechanismTests.cs
@@ -84,16 +84,8 @@ public class Codeunit99989ObjectEventMechanismFixture
 /// lookup for all four kinds, proving the RED state. Post-fix it is GREEN.
 ///
 /// SHARED-STATE NOTE: ResetForReload() clears EventSubscriberPatches' global static
-/// registries process-wide. Safe today only because no other test SOURCE FILE touches
-/// EventSubscriberPatches (DispatchEventPublisherDeclTypeTests.cs only exercises the pure,
-/// state-free TryDecodeEventPublisherDeclType seam) and because xUnit here runs one test
-/// class's methods sequentially by default — this class isn't itself parallel-unsafe
-/// against itself. If a SECOND test class is ever added that also calls ResetForReload/
-/// EnsureRegistryFresh/GetObjectEventSubscribers (or any other EventSubscriberPatches
-/// registry accessor), both classes must join a shared serial xUnit collection (see
-/// BcEngineCollection.cs for the established DisableParallelization pattern) — otherwise
-/// xUnit's cross-class parallelization will interleave two tests' resets/scans of the
-/// same static dictionaries.
+/// registries process-wide, so every test class that resets or reads them in-process joins
+/// EventSubscriberRegistrySerialCollection (EventSubscriberIndexTests is the other one).
 /// </summary>
 [Collection(EventSubscriberRegistrySerialCollection.Name)]
 public class ObjectEventSubscriberRegistrationMechanismTests

--- a/AlRunner.Tests/ObjectEventSubscriberRegistrationMechanismTests.cs
+++ b/AlRunner.Tests/ObjectEventSubscriberRegistrationMechanismTests.cs
@@ -95,6 +95,7 @@ public class Codeunit99989ObjectEventMechanismFixture
 /// xUnit's cross-class parallelization will interleave two tests' resets/scans of the
 /// same static dictionaries.
 /// </summary>
+[Collection(EventSubscriberRegistrySerialCollection.Name)]
 public class ObjectEventSubscriberRegistrationMechanismTests
 {
     [Theory]

--- a/AlRunner.Tests/ServerValidateSubscriberReloadTests.cs
+++ b/AlRunner.Tests/ServerValidateSubscriberReloadTests.cs
@@ -1,0 +1,138 @@
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #2369, end to end: the per-record-construction subscriber injectors read a per-table
+/// index that is built on first use. Request 1 builds it for a table with no subscribers; request
+/// 2, in the same --server process and for the same bundle, adds a field-validate subscriber and a
+/// table-trigger subscriber on that table. Both must fire, and the validate subscriber must stay
+/// scoped to its own field. A stale index answers request 2 with request 1's "nobody subscribes".
+/// </summary>
+public class ServerValidateSubscriberReloadTests
+{
+    private const string TableAl = """
+        table 79931 "SVSR Probe"
+        {
+            fields
+            {
+                field(1; "Code"; Code[20]) { }
+                field(2; Qty; Integer) { }
+                field(3; Other; Integer) { }
+                field(4; Note; Text[30]) { }
+                field(5; InsertNote; Text[30]) { }
+            }
+            keys { key(PK; "Code") { Clustered = true; } }
+        }
+        """;
+
+    private const string SubscriberAl = """
+        codeunit 79932 "SVSR Subscribers"
+        {
+            [EventSubscriber(ObjectType::Table, Database::"SVSR Probe", 'OnAfterValidateEvent', 'Qty', false, false)]
+            local procedure QtyValidated(var Rec: Record "SVSR Probe")
+            begin
+                Rec.Note := 'QTY SUBSCRIBER';
+            end;
+
+            [EventSubscriber(ObjectType::Table, Database::"SVSR Probe", 'OnBeforeInsertEvent', '', false, false)]
+            local procedure BeforeInsert(var Rec: Record "SVSR Probe")
+            begin
+                Rec.InsertNote := 'INSERT SUBSCRIBER';
+            end;
+        }
+        """;
+
+    private static void WriteBundle(string dir, bool withSubscribers)
+    {
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "0b4c2369-7d1e-4f55-9a3c-2369a1b2c3d4",
+          "name": "Runner Extras - Server Validate Subscriber Reload",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 79931, "to": 79939 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Probe.Table.al"), TableAl);
+        var subscriberFile = Path.Combine(dir, "Subscribers.Codeunit.al");
+        if (withSubscribers) File.WriteAllText(subscriberFile, SubscriberAl);
+        else if (File.Exists(subscriberFile)) File.Delete(subscriberFile);
+
+        var expectedNote = withSubscribers ? "QTY SUBSCRIBER" : "";
+        var expectedInsertNote = withSubscribers ? "INSERT SUBSCRIBER" : "";
+        File.WriteAllText(Path.Combine(dir, "Probe.Codeunit.al"), $$"""
+        codeunit 79933 "SVSR Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure ValidateQtyAndInsert()
+            var
+                Rec: Record "SVSR Probe";
+                Stored: Record "SVSR Probe";
+            begin
+                Rec.Init();
+                Rec."Code" := 'A';
+                Rec.Validate(Qty, 5);
+                if Rec.Note <> '{{expectedNote}}' then
+                    Error('Qty validate: expected Note ''{{expectedNote}}'', got ''%1''', Rec.Note);
+                Rec.Insert();
+                Stored.Get('A');
+                if Stored.InsertNote <> '{{expectedInsertNote}}' then
+                    Error('insert: expected InsertNote ''{{expectedInsertNote}}'', got ''%1''', Stored.InsertNote);
+            end;
+
+            [Test]
+            procedure ValidateOtherFieldDoesNotFireQtySubscriber()
+            var
+                Rec: Record "SVSR Probe";
+            begin
+                Rec.Init();
+                Rec.Validate(Other, 7);
+                if Rec.Note <> '' then
+                    Error('Other validate fired a Qty-scoped subscriber: Note = ''%1''', Rec.Note);
+            end;
+        }
+        """);
+    }
+
+    private static string Req(string bundleDir)
+        => JsonSerializer.Serialize(new
+        {
+            command = "runTests",
+            sourcePaths = new[] { bundleDir },
+            packagePaths = Array.Empty<string>(),
+        });
+
+    private static void AssertAllPassed(List<string> lines, string request)
+    {
+        var (events, summary) = ProtocolV2Streaming.Split(lines);
+        var failures = string.Join(" | ", events
+            .Where(e => e.TryGetProperty("status", out var s) && s.GetString() != "pass")
+            .Select(e => e.GetRawText()));
+        Assert.True(summary.GetProperty("failed").GetInt32() == 0, $"{request}: {failures} | {summary.GetRawText()}");
+        Assert.Equal(2, summary.GetProperty("total").GetInt32());
+        Assert.Equal(2, summary.GetProperty("passed").GetInt32());
+    }
+
+    [SkippableFact]
+    public async Task SubscribersAddedByAReload_FireOnATableTheIndexAlreadyKnew()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var dir = TestScratch.Dir("al-runner-server-validate-subscriber-reload");
+        Directory.CreateDirectory(dir);
+        await using var server = await CliServer.StartAsync();
+
+        WriteBundle(dir, withSubscribers: false);
+        AssertAllPassed(await server.SendRequestStreamingAsync(Req(dir)), "request 1 (no subscribers)");
+
+        WriteBundle(dir, withSubscribers: true);
+        AssertAllPassed(await server.SendRequestStreamingAsync(Req(dir)), "request 2 (subscribers added)");
+    }
+}

--- a/AlRunner/Patches/EventSubscriberPatches.cs
+++ b/AlRunner/Patches/EventSubscriberPatches.cs
@@ -88,7 +88,8 @@ public static partial class EventSubscriberPatches
     // record construction (#2369). Derived, never written directly: GetSubscriberIndex rebuilds
     // it when _registryVersion has moved. Bump _registryVersion, under _lock, anywhere either
     // registry gains or loses an entry — a mutation that skips the bump leaves the injectors
-    // blind to that subscriber for the rest of the process.
+    // blind to that subscriber for the rest of the process. EnsureRegistryFresh bumps BEFORE it
+    // mutates; that is safe only because the rebuild takes _lock and so waits for the scan to end.
     private sealed record SubscriberIndex(
         int Version,
         Dictionary<int, Key[]> TriggerKeysByTable,

--- a/AlRunner/Patches/EventSubscriberPatches.cs
+++ b/AlRunner/Patches/EventSubscriberPatches.cs
@@ -196,11 +196,25 @@ public static partial class EventSubscriberPatches
         }
     }
     private static readonly HashSet<MethodInfo> _injectedSubscriberMethods = new();
-    private static int _lastScannedCount = 0;
+    // Discovery gate (#2369): AppDomain.AssemblyLoad bumps the epoch, and a scan pass records the
+    // epoch it covered. Replaces comparing GetAssemblies().Length, which allocated the whole
+    // assembly array on every call — and this runs on every record construction and every event
+    // lookup. Equivalent because nothing here unloads an assembly, and a handler runs after the
+    // loaded assembly is enumerable (EventSubscriberIndexTests pins that). Capture the epoch
+    // BEFORE GetAssemblies, so a load racing the scan leaves the gate open.
+    private static int _assemblyLoadEpoch;
+    private static int _scannedLoadEpoch = -1;
+    private static readonly bool _assemblyLoadHookInstalled = InstallAssemblyLoadHook();
+
+    private static bool InstallAssemblyLoadHook()
+    {
+        AppDomain.CurrentDomain.AssemblyLoad += (_, _) => Interlocked.Increment(ref _assemblyLoadEpoch);
+        return true;
+    }
 
     /// <summary>
     /// Assemblies whose [NavEventSubscriberAttribute] methods have already been discovered.
-    /// The <c>_lastScannedCount</c> gate only tells us that SOMETHING new loaded; without this
+    /// The assembly-load epoch gate only tells us that SOMETHING new loaded; without this
     /// set every re-scan re-walked every assembly, so the Base Application chunks were rescanned
     /// each time the AppDomain grew. Reference identity, deliberately: a reloaded bundle
     /// generation is a DIFFERENT Assembly object, so it is not in this set and IS scanned, while
@@ -467,7 +481,7 @@ public static partial class EventSubscriberPatches
     /// Drop the subscriber registries and per-bundle codeunit-type cache so a server
     /// reload of the same-identity bundle rebuilds them from the freshly-emitted
     /// assembly instead of accumulating (or double-firing) the previous run's
-    /// subscribers. Resetting <c>_lastScannedCount</c> forces a full re-scan; the
+    /// subscribers. Resetting the scanned load epoch forces a full re-scan; the
     /// stale previous bundle assembly is then skipped via
     /// <see cref="BcRuntime.IsStaleBundleAssembly"/>. The installed injection hook
     /// (<c>_registered</c>) and any reflection-failure latch are preserved.
@@ -489,7 +503,7 @@ public static partial class EventSubscriberPatches
             _injectedSubscriberMethods.Clear();
             _seededScopeTypes.Clear();
             _scannedAssemblies.Clear();
-            _lastScannedCount = 0;
+            _scannedLoadEpoch = -1;
             _registryVersion++;
         }
         AlRunner.BcRuntime.ResetManualBindingCacheForReload();
@@ -1054,7 +1068,7 @@ public static partial class EventSubscriberPatches
     /// Discovery: walk loaded assemblies for [NavEventSubscriberAttribute] methods, index
     /// by (publisher id, NavTriggerEventType ordinal).
     ///
-    /// Incremental in two layers: the cheap <c>_lastScannedCount</c> gate skips the whole
+    /// Incremental in two layers: the cheap assembly-load epoch gate skips the whole
     /// pass while no assembly has loaded since the last one, and <c>_scannedAssemblies</c>
     /// then makes each individual assembly's scan happen exactly ONCE for its lifetime.
     /// Before the boot-overhead perf pass this re-walked EVERY loaded assembly from scratch on every
@@ -1070,12 +1084,12 @@ public static partial class EventSubscriberPatches
     /// </summary>
     private static void EnsureRegistryFresh()
     {
-        var asms = AppDomain.CurrentDomain.GetAssemblies();
-        if (asms.Length == _lastScannedCount) return;
+        if (Volatile.Read(ref _assemblyLoadEpoch) == _scannedLoadEpoch) return;
         lock (_lock)
         {
-            asms = AppDomain.CurrentDomain.GetAssemblies();
-            if (asms.Length == _lastScannedCount) return;
+            int loadEpoch = Volatile.Read(ref _assemblyLoadEpoch);
+            if (loadEpoch == _scannedLoadEpoch) return;
+            var asms = AppDomain.CurrentDomain.GetAssemblies();
             _registryVersion++; // this pass may add or prune entries in both registries
 
             // A discovery scan can run BEFORE every app in the current cycle has
@@ -1253,7 +1267,7 @@ public static partial class EventSubscriberPatches
                         $"[Subscribers] {name}: {unreadable} of {subscriberMethods.Count} " +
                         "[NavEventSubscriber] attribute instance(s) could not be read — will re-scan.");
             }
-            _lastScannedCount = asms.Length;
+            _scannedLoadEpoch = loadEpoch;
             int total = _byKey.Values.Sum(v => v.Count);
             if (added > 0 || scannedAttrs == 0)
                 Console.Error.WriteLine(

--- a/AlRunner/Patches/EventSubscriberPatches.cs
+++ b/AlRunner/Patches/EventSubscriberPatches.cs
@@ -84,6 +84,78 @@ public static partial class EventSubscriberPatches
     private static readonly Dictionary<ObjectEventKey, List<MethodInfo>> _byObjectEventKey = new();
     private static readonly List<ValidateSub> _validateSubs = new();
 
+    // _byKey and _validateSubs grouped by publisher table, for the injectors that run on every
+    // record construction (#2369). Derived, never written directly: GetSubscriberIndex rebuilds
+    // it when _registryVersion has moved. Bump _registryVersion, under _lock, anywhere either
+    // registry gains or loses an entry — a mutation that skips the bump leaves the injectors
+    // blind to that subscriber for the rest of the process.
+    private sealed record SubscriberIndex(
+        int Version,
+        Dictionary<int, Key[]> TriggerKeysByTable,
+        Dictionary<int, ValidateSub[]> ValidateSubsByTable);
+
+    private static int _registryVersion;
+    private static SubscriberIndex _subscriberIndex = new(-1, new(), new());
+
+    private static SubscriberIndex GetSubscriberIndex()
+    {
+        var idx = _subscriberIndex;
+        if (idx.Version == Volatile.Read(ref _registryVersion)) return idx;
+        lock (_lock)
+        {
+            idx = _subscriberIndex;
+            int version = _registryVersion;
+            if (idx.Version == version) return idx;
+
+            var triggerKeys = new Dictionary<int, List<Key>>();
+            foreach (var key in _byKey.Keys)
+            {
+                if (!triggerKeys.TryGetValue(key.PublisherId, out var keys))
+                    triggerKeys[key.PublisherId] = keys = new List<Key>();
+                keys.Add(key);
+            }
+            var validateSubs = new Dictionary<int, List<ValidateSub>>();
+            foreach (var vs in _validateSubs)
+            {
+                if (!validateSubs.TryGetValue(vs.Handle.PublisherId, out var subs))
+                    validateSubs[vs.Handle.PublisherId] = subs = new List<ValidateSub>();
+                subs.Add(vs);
+            }
+            _subscriberIndex = idx = new SubscriberIndex(
+                version,
+                triggerKeys.ToDictionary(kv => kv.Key, kv => kv.Value.ToArray()),
+                validateSubs.ToDictionary(kv => kv.Key, kv => kv.Value.ToArray()));
+            return idx;
+        }
+    }
+
+    /// <summary>Test seam: the field-validate subscriber methods the per-construction injector
+    /// would consider for <paramref name="tableId"/>, in injection order.</summary>
+    internal static IReadOnlyList<MethodInfo> ValidateSubscriberMethodsForTable(int tableId)
+    {
+        EnsureRegistryFresh();
+        return GetSubscriberIndex().ValidateSubsByTable.TryGetValue(tableId, out var subs)
+            ? subs.Select(s => s.Handle.Method).ToArray()
+            : Array.Empty<MethodInfo>();
+    }
+
+    /// <summary>Test seam: the table-trigger subscriber methods (Insert/Modify/Delete/Rename
+    /// ordinals) the per-construction injector would consider for <paramref name="tableId"/>.</summary>
+    internal static IReadOnlyList<(int EventTypeOrdinal, MethodInfo Method)> TriggerSubscribersForTable(int tableId)
+    {
+        EnsureRegistryFresh();
+        lock (_lock)
+        {
+            if (!GetSubscriberIndex().TriggerKeysByTable.TryGetValue(tableId, out var keys))
+                return Array.Empty<(int, MethodInfo)>();
+            return keys
+                .SelectMany(k => _byKey.TryGetValue(k, out var l)
+                    ? l.Select(h => (k.EventTypeOrdinal, h.Method))
+                    : Enumerable.Empty<(int, MethodInfo)>())
+                .ToArray();
+        }
+    }
+
     /// <summary>
     /// Look up codeunit-event subscribers registered for a (publisherCodeunitId, eventMethodName).
     /// Called by CodeunitEventDispatcher at runtime from the Cecil-rewritten OnRunEventAsync.
@@ -418,6 +490,7 @@ public static partial class EventSubscriberPatches
             _seededScopeTypes.Clear();
             _scannedAssemblies.Clear();
             _lastScannedCount = 0;
+            _registryVersion++;
         }
         AlRunner.BcRuntime.ResetManualBindingCacheForReload();
     }
@@ -446,17 +519,15 @@ public static partial class EventSubscriberPatches
     {
         lock (_lock)
         {
-            foreach (var kv in _byKey)
-            {
-                if (kv.Key.PublisherId != tableId) continue;
-                foreach (var sub in kv.Value)
-                    _injectedSubscriberMethods.Remove(sub.Method);
-            }
-            foreach (var vs in _validateSubs)
-            {
-                if (vs.Handle.PublisherId != tableId) continue;
-                _injectedSubscriberMethods.Remove(vs.Handle.Method);
-            }
+            var idx = GetSubscriberIndex();
+            if (idx.TriggerKeysByTable.TryGetValue(tableId, out var keys))
+                foreach (var key in keys)
+                    if (_byKey.TryGetValue(key, out var subs))
+                        foreach (var sub in subs)
+                            _injectedSubscriberMethods.Remove(sub.Method);
+            if (idx.ValidateSubsByTable.TryGetValue(tableId, out var validateSubs))
+                foreach (var vs in validateSubs)
+                    _injectedSubscriberMethods.Remove(vs.Handle.Method);
         }
     }
 
@@ -644,15 +715,16 @@ public static partial class EventSubscriberPatches
         // built before the first bulk injection pass — e.g. a platform table built during runtime
         // bring-up, before EventSubscriberPatches.Register/EnsureRegistryFresh have ever run).
         try { EnsureRegistryFresh(); } catch { }
-        if (_byKey.Count == 0) return;
+        if (!GetSubscriberIndex().TriggerKeysByTable.ContainsKey(tableId)) return;
 
         lock (_lock)
         {
+            if (!GetSubscriberIndex().TriggerKeysByTable.TryGetValue(tableId, out var tableKeys)) return;
             int injected = 0, failed = 0;
-            foreach (var kv in _byKey)
+            foreach (var tableKey in tableKeys)
             {
-                if (kv.Key.PublisherId != tableId) continue;
-                int ord = kv.Key.EventTypeOrdinal;
+                if (!_byKey.TryGetValue(tableKey, out var tableSubs)) continue;
+                int ord = tableKey.EventTypeOrdinal;
 
                 var ordEnum = Enum.ToObject(_tNavTriggerEventType!, ord);
                 var createIfNotFound = Enum.ToObject(_tEventScopeGetOption!, 1); // CreateIfNotFound
@@ -663,14 +735,14 @@ public static partial class EventSubscriberPatches
                     var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
                     Console.Error.WriteLine($"[Subscribers] GetEventScope({tableId},{ord}) failed (lazy): " +
                         $"{inner.GetType().Name}: {inner.Message}");
-                    failed += kv.Value.Count(s => !_injectedSubscriberMethods.Contains(s.Method));
+                    failed += tableSubs.Count(s => !_injectedSubscriberMethods.Contains(s.Method));
                     continue;
                 }
-                if (scope == null) { failed += kv.Value.Count(s => !_injectedSubscriberMethods.Contains(s.Method)); continue; }
+                if (scope == null) { failed += tableSubs.Count(s => !_injectedSubscriberMethods.Contains(s.Method)); continue; }
 
                 var existing = (Array?)_fRegisteredSubscriptions!.GetValue(scope);
                 var newOnes = new List<object>();
-                foreach (var sub in kv.Value)
+                foreach (var sub in tableSubs)
                 {
                     if (_injectedSubscriberMethods.Contains(sub.Method)) continue;
                     object? subscription;
@@ -754,14 +826,14 @@ public static partial class EventSubscriberPatches
         // Ensure discovery has run so _validateSubs is populated (it may not have been if this
         // table is built before the first bulk injection pass).
         try { EnsureRegistryFresh(); } catch { }
-        if (_validateSubs.Count == 0) return;
+        if (!GetSubscriberIndex().ValidateSubsByTable.ContainsKey(tableId)) return;
 
         lock (_lock)
         {
+            if (!GetSubscriberIndex().ValidateSubsByTable.TryGetValue(tableId, out var tableSubs)) return;
             int injected = 0, failed = 0;
-            foreach (var vs in _validateSubs)
+            foreach (var vs in tableSubs)
             {
-                if (vs.Handle.PublisherId != tableId) continue;
                 if (_injectedSubscriberMethods.Contains(vs.Handle.Method)) continue;
                 TryInjectOneValidateSub(vs, metaTable, ref injected, ref failed);
             }
@@ -1004,6 +1076,7 @@ public static partial class EventSubscriberPatches
         {
             asms = AppDomain.CurrentDomain.GetAssemblies();
             if (asms.Length == _lastScannedCount) return;
+            _registryVersion++; // this pass may add or prune entries in both registries
 
             // A discovery scan can run BEFORE every app in the current cycle has
             // (re)compiled — e.g. PopulateNclMetadataCache's own InjectAll call fires


### PR DESCRIPTION
_Written by agent stma-auto2-2 on the account holder's behalf._

Closes #2369

Corpus-NA: internal subscriber-registry lookup and discovery gate; no AL-observable behaviour change, pinned by runner-side in-process and --server reload tests

## The finding: most of the cost was not the scan the issue described

I re-measured at current `main` before changing anything. The per-table scan in `InjectValidateSubsForTable` is real, but it is the small part. The larger cost on every record construction was `EnsureRegistryFresh` calling `AppDomain.CurrentDomain.GetAssemblies()` just to compare its length with the last scan. That was the issue's parenthetical third bullet. It runs on every record construction (from both injectors) and on every event lookup.

Instructions per loop iteration (each iteration constructs and initializes one local record), read as the slope between a 20,000-iteration and a 2,000-iteration run of the same bundle. The slope cancels the fixed boot cost.

| bundle | `main` 8908e999 | index only | index + load-epoch gate |
|---|---|---|---|
| platform-only table, no subscribers | 196.4k | 193.2k | **80.6k** |
| same test with a Base Application dependency (49 validate subscribers, 475 table-trigger keys registered) | 298.3k | 246.4k | **98.6k** |

So indexing by table saves about 50k instructions per iteration once Base Application's subscribers are registered, and nothing when no subscribers are registered. Replacing the `GetAssemblies()` gate saves about 115-150k in both cases. The issue's 16% self-time came from a Microsoft `Tests-SINGLESERVER` codeunit with `--test-data`. That is a different subscriber population, and I did not re-run it.

Whole-invocation instruction counts (`perf stat -e instructions:u`, whole process tree, 3 reps per cell, builds alternated within each rep, warm private caches per build, BC 28.1.49838.53910, `--package-cache ~/.al-runner/platform-apps`). I quote **medians** because the load average was 3.6-5 from other agents, and one `main` rep on the platform-only bundle read 18.254G against 16.811G and 16.853G.

| bundle | `main` | index only | index + gate |
|---|---|---|---|
| trivial (one empty test; negative control) | 12.741G (12.741 / 12.741 / 12.747) | 12.743G | 12.746G (12.746 / 12.741 / 12.746) |
| platform-only, 2k iterations | 13.318G (13.316 / 13.318 / 13.320) | 13.328G | 13.166G (13.167 / 13.165 / 13.166) |
| platform-only, 20k iterations | 16.853G (16.811 / 16.853 / 18.254) | 16.806G | 14.617G (14.412 / 14.617 / 14.656) |
| Base App dep, 2k iterations | 68.593G (68.593 / 68.541 / 69.648) | 68.422G | 67.949G (68.193 / 67.949 / 67.853) |
| Base App dep, 20k iterations | 73.963G (73.314 / 74.281 / 73.963) | 72.858G | 69.723G (69.723 / 67.600 / 69.909) |

The trivial bundle does not change, which says the effect is on the record-construction path. The Base App rows are noisy (about 1G spread on 70G), so read their slopes to the nearest 50k, not closer. Wall and CPU time are not claims here.

## What changed (`AlRunner/Patches/EventSubscriberPatches.cs`)

1. **Per-table index.** `_byKey` (table-trigger subscribers) and `_validateSubs` are grouped by publisher table in a derived `SubscriberIndex`. It is rebuilt under `_lock` when `_registryVersion` has moved. The version is bumped at the top of every discovery scan pass and in `ResetForReload`, which are the only places either registry gains or loses entries. `InjectValidateSubsForTable`, `InjectTriggerSubsForTable` and `ForgetInjectedForTable` look up their table instead of iterating everything. Order within a table is discovery order, as before.
2. **Discovery gate.** `EnsureRegistryFresh` no longer compares `GetAssemblies().Length`. An `AppDomain.AssemblyLoad` handler bumps an epoch. A scan pass captures the epoch before calling `GetAssemblies()` and records it when done. `ResetForReload` sets the recorded epoch to -1, where it used to zero the count. This is equivalent because nothing in the runner unloads an assembly (no collectible load contexts), so a count change and a load were the same event. It also relies on the load handler running after the new assembly is in `GetAssemblies()`, and a test pins that.

`--server` (`Program.cs:4781`) and `--watch` (`Program.cs:2451`) both reach `EventSubscriberPatches.ResetForReload` through `BcRuntime.ResetForNewBundleReload`, so both reload paths share the invalidation the tests exercise.

## Tests

These are behaviour-preservation tests, which is the right bar for a performance refactor. They pin that the index never answers from stale state. They do not test the index's internals.

- `EventSubscriberIndexTests` (in-process; a duck-typed subscriber assembly compiled with Roslyn, the same technique as `ObjectEventSubscriberRegistrationMechanismTests`):
  - `SubscribersLoadedAfterTheIndexWasBuilt_AreFoundForTheirTableOnly`: builds the index, then loads a new assembly. Its validate subscribers appear for their table in declaration order and not for a neighbouring table or an untouched id. Its `OnAfterInsertEvent` subscriber appears as trigger ordinal 2 and not as a validate subscriber.
  - `AReloadResetRebuildsTheIndexFromTheRescan`: after `ResetForReload` the answer is the same, neither empty nor doubled.
  - `AssemblyLoadHandler_RunsAfterTheLoadedAssemblyIsEnumerable`: the platform property the gate depends on.
- `ServerValidateSubscriberReloadTests` (real `--server` process): request 1 runs a bundle with no subscribers, which builds the index for the table. Request 2 adds an `OnAfterValidateEvent` subscriber scoped to `Qty` and an `OnBeforeInsertEvent` subscriber to the same bundle. Both must fire, and validating a different field must not fire the `Qty` subscriber.
- `ObjectEventSubscriberRegistrationMechanismTests` joins the new `EventSubscriberRegistrySerialCollection`, as its own note asked for once a second in-process class used the registry.

This is a runner-infrastructure change with nothing AL-observable to put upstream. Field-scoped validate dispatch is covered unchanged by the existing corpus and runner-extras suites, which I ran below.

### Mutations (executed; each landed as a one-line diff, and each red is an assertion, not a build error)

Filter `EventSubscriberIndexTests|ServerValidateSubscriberReloadTests` (4 tests):

| mutation | result |
|---|---|
| none | `Failed: 0, Passed: 4` |
| M1: drop the scan pass's `_registryVersion++` | `Failed: 1, Passed: 3`: `SubscribersLoadedAfterTheIndexWasBuilt…` ("Collections differ"). The `--server` test stays green because the reload's own bump rebuilds the index. |
| M2: drop both version bumps (index never invalidated) | `Failed: 2, Passed: 2`: the in-process test, plus the `--server` test on **request 2 only**: `Qty validate: expected Note 'QTY SUBSCRIBER', got ''` |
| M3: load handler does not bump the epoch | `Failed: 2, Passed: 8` (with the 6 object-event tests in the filter): the same two tests, the `--server` one again on request 2 |

## Local runs (all on this branch's code)

- Subscriber-related unit tests (`EventSubscriberIndexTests`, `ServerValidateSubscriberReloadTests`, `ObjectEventSubscriberRegistrationMechanismTests`, `PageTriggerEventDispatchTests`, `ServerCrossAppStaleGenerationTests`), run twice against one cache root: `Passed: 13, Total: 13` both times.
- Guards: `tools/test_*.py` all pass. `GuardTests` plus the four classes above plus `AssemblyTypeIndexTests`, after `tools/engine-test-bootstrap.sh` with `--settings engine.runsettings`: `Passed: 269, Total: 269`.
- `tests/runner-extras`, with the CI flags (`--strict --count-baseline`, both package caches): 438 total, 438 pass, rc 0.
- Corpus at `0d9d246bc8406e93126c95a269064515d2722977` (master): 3348 total, 3348 pass, rc 0.

The corpus and runner-extras runs used a build whose `AlRunner/` tree matched the final code except for one added comment. After I rebased onto `main` (8b85cf45, a rules markdown change only), I did not re-run them.

## Fix the shape

1. **Same pattern at another call site?** Yes. `InjectTriggerSubsForTable` had the same loop over `_byKey` (`if (kv.Key.PublisherId != tableId) continue;`) at the same three per-construction call sites, and it was the larger of the two (475 keys against 49 validate subscribers with Base Application loaded). `ForgetInjectedForTable` scanned both registries the same way. All three now use the index.
2. **Sibling making the same assumption?** `EnsureRegistryFresh` fronts every lookup (`GetCodeunitSubscribers`, `GetTableEventSubscribers`, `GetObjectEventSubscribers` and the page-trigger path). The gate change removes the per-call allocation from all of them. `DoInject` and `DoInjectValidate` still iterate everything, and that is correct: they are bulk passes that run once per bundle or codeunit.
3. **Two writers, one invariant?** The registries are written by the scan pass, by `PruneStaleSubscribers` (called only from inside the scan pass) and by `ResetForReload`. The version bump sits at the scan pass entry and in `ResetForReload`, so every write is covered. The bump happens before the scan mutates. That is safe because the rebuild takes `_lock` and waits for the scan to finish, and the code comment says so for the next editor.

Open-queue scan for `InjectTriggerSubsForTable`, `EnsureRegistryFresh`, `GetAssemblies`, `_byKey` and "record construction": no sibling issue. The only other `GetAssemblies` hit is #3880 (`DapBreakpointResolver`), which is a module-provenance problem, not this per-call cost. Nothing folded.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
