### PR TITLE
perf(startup): keep loops out of exception handlers so Main is JIT-compiled at Tier0

### DIFF
--- a/AlRunner.Tests/HandlerLoopJitTierGuardTests.cs
+++ b/AlRunner.Tests/HandlerLoopJitTierGuardTests.cs
@@ -47,6 +47,9 @@ public sealed class HandlerLoopJitTierGuardTests
         Assert.Contains(scan.Offenders, o => o.StartsWith(Name(nameof(HandlerLoopShapes.LoopInFinally)) + " "));
         Assert.Contains(scan.Offenders, o => o.StartsWith(Name(nameof(HandlerLoopShapes.LoopInCatch)) + " "));
         Assert.Contains(scan.Offenders, o => o.StartsWith(Name(nameof(HandlerLoopShapes.LoopInFilteredCatch)) + " "));
+        // A retry loop whose body is a try/catch, inside a catch: its back edge is a leave, and the
+        // JIT still switches the method to FullOpts (measured in review of #4075).
+        Assert.Contains(scan.Offenders, o => o.StartsWith(Name(nameof(HandlerLoopShapes.TryCatchLoopInsideCatch)) + " "));
         // A `leave` out of a catch back to an enclosing loop's head does not force FullOpts
         // (measured: Instrumented Tier0), so it must not be reported.
         Assert.DoesNotContain(scan.Offenders, o => o.StartsWith(Name(nameof(HandlerLoopShapes.TryCatchInsideLoop)) + " "));
@@ -90,8 +93,9 @@ public sealed class HandlerLoopJitTierGuardTests
         // More than one line is legitimate (an OSR recompile of a hot loop adds one).
         var mainLines = File.ReadLines(jitLog).Where(l => l.Contains("Program:<Main>$(")).ToList();
         Assert.True(mainLines.Count > 0, "no JIT summary line for Program:<Main>$ in " + jitLog);
+        // Only the FullOpts switch is the defect; with DOTNET_TieredCompilation=0 every line reads FullOpts
+        // without the "switched" wording, so the tier itself is deliberately not asserted.
         Assert.DoesNotContain(mainLines, l => l.Contains("switched to FullOpts"));
-        Assert.Contains(mainLines, l => l.Contains("Tier0"));
     }
 }
 
@@ -119,6 +123,24 @@ internal static class HandlerLoopShapes
         int s = 0;
         try { s = xs[xs.Length]; }
         catch (Exception e) when (e is IndexOutOfRangeException) { foreach (var x in xs) s += x; }
+        return s;
+    }
+
+    internal static int TryCatchLoopInsideCatch(int[] xs)
+    {
+        int s = 0;
+        try { s = xs[xs.Length]; }
+        catch (IndexOutOfRangeException)
+        {
+            int i = 0;
+            while (true)
+            {
+                i++;
+                if (i > xs.Length) break;
+                try { s += 10 / xs[i - 1]; }
+                catch (DivideByZeroException) { s--; }
+            }
+        }
         return s;
     }
 
@@ -211,7 +233,10 @@ internal static class HandlerBackBranchScanner
                 }
 
                 if (target < 0 || target > start) continue;
-                if (op == OpCodes.Leave || op == OpCodes.Leave_S)
+                // A leave back to a loop head OUTSIDE every handler keeps Tier0 (RunDapLoop's shape);
+                // one whose target is inside a handler is that handler's own loop, and forces FullOpts.
+                if ((op == OpCodes.Leave || op == OpCodes.Leave_S)
+                    && !handlerRanges.Any(h => target >= h.Start && target < h.End))
                 {
                     leaveBacks[name] = leaveBacks.GetValueOrDefault(name) + 1;
                     continue;

--- a/AlRunner.Tests/HandlerLoopJitTierGuardTests.cs
+++ b/AlRunner.Tests/HandlerLoopJitTierGuardTests.cs
@@ -1,0 +1,231 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// A loop inside a catch, filter or finally block makes the JIT compile the WHOLE method
+/// "Tier-0 switched to FullOpts" (OSR cannot place a patchpoint in a handler). For
+/// <c>&lt;Main&gt;$</c>, 33 KB of IL, that cost about 0.26G instructions in every process
+/// generation of every invocation, the shadow re-exec parent and its child alike (#2375).
+/// See docs/startup-cost.md#main-jit-tier.
+/// </summary>
+public sealed class HandlerLoopJitTierGuardTests
+{
+    private static readonly string RunnerAssemblyPath = typeof(AlRunner.BcRuntime).Assembly.Location;
+    private static readonly string BuiltRunnerPath = Path.Combine(
+        Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..")),
+        "AlRunner", "bin", TestBuildConfig.Configuration, TestBuildConfig.Framework, "al-runner.dll");
+
+    [Fact]
+    public void NoRunnerMethod_BranchesBackwardInsideAnExceptionHandler()
+    {
+        var scan = HandlerBackBranchScanner.Scan(RunnerAssemblyPath);
+
+        // Third state: a scan that decoded nothing, or never reached Main, must not read as a pass.
+        Assert.True(scan.MethodsDecoded > 1000, $"decoded only {scan.MethodsDecoded} method bodies in {RunnerAssemblyPath}");
+        Assert.True(scan.BackBranchesByMethod.TryGetValue("Program::<Main>$", out var mainLoops),
+            "Program::<Main>$ was not found in " + RunnerAssemblyPath);
+        Assert.True(mainLoops > 10, $"Program::<Main>$ decoded with {mainLoops} backward branches; the decoder is not reading branches");
+
+        Assert.True(scan.Offenders.Count == 0,
+            "Backward branch inside an exception handler (forces the JIT to compile the whole method " +
+            "FullOpts; move the loop into a helper method, see docs/startup-cost.md#main-jit-tier):\n  " +
+            string.Join("\n  ", scan.Offenders));
+    }
+
+    [Fact]
+    public void Scanner_FlagsLoopsInHandlers_AndNotALeaveBackToTheLoopHead()
+    {
+        var scan = HandlerBackBranchScanner.Scan(typeof(HandlerLoopJitTierGuardTests).Assembly.Location);
+        string Name(string m) => $"{nameof(HandlerLoopShapes)}::{m}";
+
+        Assert.Contains(scan.Offenders, o => o.StartsWith(Name(nameof(HandlerLoopShapes.LoopInFinally)) + " "));
+        Assert.Contains(scan.Offenders, o => o.StartsWith(Name(nameof(HandlerLoopShapes.LoopInCatch)) + " "));
+        Assert.Contains(scan.Offenders, o => o.StartsWith(Name(nameof(HandlerLoopShapes.LoopInFilteredCatch)) + " "));
+        // A `leave` out of a catch back to an enclosing loop's head does not force FullOpts
+        // (measured: Instrumented Tier0), so it must not be reported.
+        Assert.DoesNotContain(scan.Offenders, o => o.StartsWith(Name(nameof(HandlerLoopShapes.TryCatchInsideLoop)) + " "));
+        Assert.True(scan.LeaveBackBranchesByMethod.GetValueOrDefault(Name(nameof(HandlerLoopShapes.TryCatchInsideLoop))) > 0,
+            "the TryCatchInsideLoop fixture no longer compiles to a leave back to the loop head, so it tests nothing");
+    }
+
+    /// <summary>
+    /// The observable itself, on the one path where <c>&lt;Main&gt;$</c> is the only large method
+    /// compiled: the JIT's own summary line for it must not say "switched to FullOpts".
+    /// </summary>
+    [SkippableFact]
+    public void VersionFastPath_MainIsNotCompiledFullOpts()
+    {
+        var debuggable = typeof(AlRunner.BcRuntime).Assembly.GetCustomAttribute<DebuggableAttribute>();
+        Skip.If(debuggable?.IsJITOptimizerDisabled == true,
+            "al-runner.dll was built with the JIT optimizer disabled (Debug), so every method is MinOpts and the tier says nothing");
+
+        Assert.True(File.Exists(BuiltRunnerPath), "runner not built at " + BuiltRunnerPath);
+        var jitLog = Path.Combine(Directory.CreateDirectory(TestScratch.FlatDir("al-runner-jit-tier-")).FullName, "jit.txt");
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        psi.ArgumentList.Add("exec");
+        psi.ArgumentList.Add(BuiltRunnerPath);
+        psi.ArgumentList.Add("--version");
+        psi.Environment["DOTNET_JitDisasmSummary"] = "1";
+        psi.Environment["DOTNET_JitStdOutFile"] = jitLog;
+        using (var p = Process.Start(psi)!)
+        {
+            p.StandardOutput.ReadToEnd();
+            p.StandardError.ReadToEnd();
+            Assert.True(p.WaitForExit(120_000), "al-runner --version did not exit within 120s");
+            Assert.Equal(0, p.ExitCode);
+        }
+
+        Assert.True(File.Exists(jitLog), "DOTNET_JitStdOutFile produced no file; the JIT summary could not be read");
+        // More than one line is legitimate (an OSR recompile of a hot loop adds one).
+        var mainLines = File.ReadLines(jitLog).Where(l => l.Contains("Program:<Main>$(")).ToList();
+        Assert.True(mainLines.Count > 0, "no JIT summary line for Program:<Main>$ in " + jitLog);
+        Assert.DoesNotContain(mainLines, l => l.Contains("switched to FullOpts"));
+        Assert.Contains(mainLines, l => l.Contains("Tier0"));
+    }
+}
+
+/// <summary>Fixture shapes for the scanner's own positive and negative cases.</summary>
+internal static class HandlerLoopShapes
+{
+    internal static int LoopInFinally(int[] xs)
+    {
+        int s = 0;
+        try { s = xs.Length; }
+        finally { foreach (var x in xs) s += x; }
+        return s;
+    }
+
+    internal static int LoopInCatch(int[] xs)
+    {
+        int s = 0;
+        try { s = xs[xs.Length]; }
+        catch (IndexOutOfRangeException) { for (int i = 0; i < xs.Length; i++) s += xs[i]; }
+        return s;
+    }
+
+    internal static int LoopInFilteredCatch(int[] xs)
+    {
+        int s = 0;
+        try { s = xs[xs.Length]; }
+        catch (Exception e) when (e is IndexOutOfRangeException) { foreach (var x in xs) s += x; }
+        return s;
+    }
+
+    internal static int TryCatchInsideLoop(int[] xs)
+    {
+        int i = 0, s = 0;
+        while (true)
+        {
+            i++;
+            if (i > xs.Length) break;
+            try { s += 10 / xs[i - 1]; }
+            catch (DivideByZeroException) { s--; }
+        }
+        return s;
+    }
+}
+
+internal static class HandlerBackBranchScanner
+{
+    internal sealed record Result(int MethodsDecoded, IReadOnlyList<string> Offenders,
+        IReadOnlyDictionary<string, int> BackBranchesByMethod, IReadOnlyDictionary<string, int> LeaveBackBranchesByMethod);
+
+    private static readonly Dictionary<byte, OpCode> OneByte = new();
+    private static readonly Dictionary<byte, OpCode> TwoByte = new();
+
+    static HandlerBackBranchScanner()
+    {
+        foreach (var f in typeof(OpCodes).GetFields(BindingFlags.Public | BindingFlags.Static))
+        {
+            var op = (OpCode)f.GetValue(null)!;
+            if (op.Size == 1) OneByte[(byte)op.Value] = op;
+            else TwoByte[(byte)(op.Value & 0xFF)] = op;
+        }
+    }
+
+    internal static Result Scan(string assemblyPath)
+    {
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        var md = pe.GetMetadataReader();
+        var offenders = new List<string>();
+        var backBranches = new Dictionary<string, int>();
+        var leaveBacks = new Dictionary<string, int>();
+        int decoded = 0;
+
+        foreach (var handle in md.MethodDefinitions)
+        {
+            var method = md.GetMethodDefinition(handle);
+            if (method.RelativeVirtualAddress == 0) continue;
+            var name = $"{md.GetString(md.GetTypeDefinition(method.GetDeclaringType()).Name)}::{md.GetString(method.Name)}";
+            var body = pe.GetMethodBody(method.RelativeVirtualAddress);
+            var il = body.GetILBytes() ?? throw new InvalidOperationException("no IL for " + name);
+            decoded++;
+
+            var handlerRanges = body.ExceptionRegions
+                .Select(r => (Start: r.Kind == ExceptionRegionKind.Filter ? r.FilterOffset : r.HandlerOffset,
+                              End: r.HandlerOffset + r.HandlerLength))
+                .ToList();
+
+            int backs = 0;
+            var sites = new List<string>();
+            int i = 0;
+            while (i < il.Length)
+            {
+                int start = i;
+                OpCode op;
+                if (il[i] == 0xFE)
+                {
+                    if (i + 1 >= il.Length || !TwoByte.TryGetValue(il[i + 1], out op))
+                        throw new InvalidOperationException($"{name}: undecodable opcode at IL_{start:x4}");
+                    i += 2;
+                }
+                else if (!OneByte.TryGetValue(il[i], out op))
+                    throw new InvalidOperationException($"{name}: undecodable opcode at IL_{start:x4}");
+                else
+                    i += 1;
+
+                long target = -1;
+                switch (op.OperandType)
+                {
+                    case OperandType.InlineNone: break;
+                    case OperandType.ShortInlineBrTarget: target = i + 1 + (sbyte)il[i]; i += 1; break;
+                    case OperandType.InlineBrTarget: target = i + 4 + BitConverter.ToInt32(il, i); i += 4; break;
+                    case OperandType.ShortInlineI:
+                    case OperandType.ShortInlineVar: i += 1; break;
+                    case OperandType.InlineVar: i += 2; break;
+                    case OperandType.InlineI8:
+                    case OperandType.InlineR: i += 8; break;
+                    case OperandType.InlineSwitch: i += 4 + 4 * BitConverter.ToInt32(il, i); break;
+                    default: i += 4; break;
+                }
+
+                if (target < 0 || target > start) continue;
+                if (op == OpCodes.Leave || op == OpCodes.Leave_S)
+                {
+                    leaveBacks[name] = leaveBacks.GetValueOrDefault(name) + 1;
+                    continue;
+                }
+                backs++;
+                if (handlerRanges.Any(h => start >= h.Start && start < h.End))
+                    sites.Add($"IL_{start:x4}->IL_{target:x4}");
+            }
+
+            backBranches[name] = backBranches.GetValueOrDefault(name) + backs;
+            if (sites.Count > 0)
+                offenders.Add($"{name} (IL {il.Length} bytes): {string.Join(", ", sites)}");
+        }
+
+        return new Result(decoded, offenders, backBranches, leaveBacks);
+    }
+}

--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -928,6 +928,22 @@ public static partial class BcRuntime
         Console.Error.WriteLine($"[BcRuntime] Ncl in AppDomain: Location='{ncl?.Location}' (empty = byte-array load OK)");
     }
 
+    // Kept out of ApplyAllPatches: a loop inside a catch makes the JIT compile the whole caller
+    // FullOpts (see docs/startup-cost.md#main-jit-tier; HandlerLoopJitTierGuardTests pins it).
+    private static void ReportNavEnvironmentCtorFailure(Exception ex)
+    {
+        var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
+        Console.Error.WriteLine("[BcRuntime] NavEnvironment ctor THREW — falling back to skeleton:");
+        Console.Error.WriteLine($"  {inner.GetType().FullName}: {inner.Message}");
+        var st = new System.Diagnostics.StackTrace(inner, fNeedFileInfo: true);
+        for (int fi = 0; fi < st.FrameCount; fi++)
+        {
+            var frame = st.GetFrame(fi);
+            var m = frame?.GetMethod();
+            Console.Error.WriteLine($"    [{fi}] IL+0x{frame?.GetILOffset():X4} native+0x{frame?.GetNativeOffset():X4}  {m?.DeclaringType?.FullName}.{m?.Name}({string.Join(",", m?.GetParameters().Select(p=>p.ParameterType.Name) ?? Array.Empty<string>())})");
+        }
+    }
+
     private static void ApplyAllPatches(Assembly navNcl)
     {
         var envType = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.NavEnvironment")
@@ -1034,16 +1050,7 @@ public static partial class BcRuntime
             }
             catch (Exception ex)
             {
-                var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
-                Console.Error.WriteLine("[BcRuntime] NavEnvironment ctor THREW — falling back to skeleton:");
-                Console.Error.WriteLine($"  {inner.GetType().FullName}: {inner.Message}");
-                var st = new System.Diagnostics.StackTrace(inner, fNeedFileInfo: true);
-                for (int fi = 0; fi < st.FrameCount; fi++)
-                {
-                    var frame = st.GetFrame(fi);
-                    var m = frame?.GetMethod();
-                    Console.Error.WriteLine($"    [{fi}] IL+0x{frame?.GetILOffset():X4} native+0x{frame?.GetNativeOffset():X4}  {m?.DeclaringType?.FullName}.{m?.Name}({string.Join(",", m?.GetParameters().Select(p=>p.ParameterType.Name) ?? Array.Empty<string>())})");
-                }
+                ReportNavEnvironmentCtorFailure(ex);
             }
         }
         if (!ctorOk && instField != null)

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1619,6 +1619,12 @@ FlushDeferredStartupLines();
 
 // Prints the queue once and empties it, so the crash-path flushes above and this one cannot
 // print a line twice.
+void FlushDeferredStartupLines()
+{
+    foreach (var deferredLine in deferredStartupLines) deferredLine();
+    deferredStartupLines.Clear();
+}
+
 // A loop inside a catch/finally in <Main>$ makes the JIT compile all of Main FullOpts, in every
 // process generation. Keep handler loops in helpers like this one; HandlerLoopJitTierGuardTests
 // pins it. See docs/startup-cost.md#main-jit-tier.
@@ -1626,12 +1632,6 @@ static void WriteRemainingInnerExceptions(AggregateException flat)
 {
     foreach (var inner in flat.InnerExceptions.Skip(1))
         Console.Error.WriteLine($"  → {inner.GetType().Name}: {inner.Message}");
-}
-
-void FlushDeferredStartupLines()
-{
-    foreach (var deferredLine in deferredStartupLines) deferredLine();
-    deferredStartupLines.Clear();
 }
 
 // --jobs: fan out across worker processes (#2280). Deliberately placed HERE, after the

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1619,6 +1619,15 @@ FlushDeferredStartupLines();
 
 // Prints the queue once and empties it, so the crash-path flushes above and this one cannot
 // print a line twice.
+// A loop inside a catch/finally in <Main>$ makes the JIT compile all of Main FullOpts, in every
+// process generation. Keep handler loops in helpers like this one; HandlerLoopJitTierGuardTests
+// pins it. See docs/startup-cost.md#main-jit-tier.
+static void WriteRemainingInnerExceptions(AggregateException flat)
+{
+    foreach (var inner in flat.InnerExceptions.Skip(1))
+        Console.Error.WriteLine($"  → {inner.GetType().Name}: {inner.Message}");
+}
+
 void FlushDeferredStartupLines()
 {
     foreach (var deferredLine in deferredStartupLines) deferredLine();
@@ -3489,8 +3498,7 @@ foreach (var bundle in bundles)
                 Console.Error.WriteLine($"<bundled>: EMIT-FAIL — {rootEx.GetType().Name}: {rootEx.Message}");
                 if (rootEx.StackTrace is { } st) Console.Error.WriteLine(st);
                 if (flat.InnerExceptions.Count > 1)
-                    foreach (var inner in flat.InnerExceptions.Skip(1))
-                        Console.Error.WriteLine($"  → {inner.GetType().Name}: {inner.Message}");
+                    WriteRemainingInnerExceptions(flat);
                 bundleErrors.Add($"<bundled>: EMIT-FAIL: {rootEx.Message.Split('\n')[0]}");
             }
             catch (Exception ex)
@@ -4107,8 +4115,7 @@ if (watchUi)
     }
     finally
     {
-        foreach (var w in watchers) { w.EnableRaisingEvents = false; w.Dispose(); }
-        signal.Dispose();
+        WatchSource.DisposeWatch(signal, watchers);
     }
     if (!changed) return 0;
     PaintWatchRunning(); // flip the header to "⟳ running…" while the next cycle compiles

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -358,6 +358,25 @@ public sealed class TestExecutor
          + AlRunner.Patches.RecordPatches.RegisteredBcAppSymbolStateKey()
          + AlRunner.Infrastructure.TestDataOptions.CacheIdentity();
 
+    // Kept out of Run: a loop inside a catch makes the JIT compile the whole caller FullOpts
+    // (see docs/startup-cost.md#main-jit-tier; HandlerLoopJitTierGuardTests pins it).
+    private static Type[] LoadableTypesAfterPartialLoadFailure(ReflectionTypeLoadException ex)
+    {
+        var types = ex.Types.Where(t => t != null).ToArray()!;
+        var reasons = ex.LoaderExceptions
+            .Where(e => e != null)
+            .Select(e => e!.Message)
+            .Distinct()
+            .Take(10)
+            .ToList();
+        Console.Error.WriteLine(
+            $"[test-exec] WARNING: {ex.LoaderExceptions.Length} type(s) in the test assembly " +
+            $"failed to load; continuing with {types.Length} loadable type(s). Causes:");
+        foreach (var r in reasons)
+            Console.Error.WriteLine($"    {r}");
+        return types!;
+    }
+
     /// <summary>
     /// Runs every [Test] method in <paramref name="assembly"/>. When
     /// <paramref name="onTestComplete"/> is supplied it fires synchronously right
@@ -401,18 +420,7 @@ public sealed class TestExecutor
             // one or more of the requested types". Surface the concrete loader failures (per
             // .claude/rules/loud-failures.md) and continue with the types that DID load — a
             // test codeunit that itself references the missing type will simply not appear.
-            types = ex.Types.Where(t => t != null).ToArray()!;
-            var reasons = ex.LoaderExceptions
-                .Where(e => e != null)
-                .Select(e => e!.Message)
-                .Distinct()
-                .Take(10)
-                .ToList();
-            Console.Error.WriteLine(
-                $"[test-exec] WARNING: {ex.LoaderExceptions.Length} type(s) in the test assembly " +
-                $"failed to load; continuing with {types.Length} loadable type(s). Causes:");
-            foreach (var r in reasons)
-                Console.Error.WriteLine($"    {r}");
+            types = LoadableTypesAfterPartialLoadFailure(ex);
         }
         typeSw.Stop();
         // #2801: Assembly.GetTypes() has no defined order, and this loop's order IS the

--- a/AlRunner/WatchSource.cs
+++ b/AlRunner/WatchSource.cs
@@ -252,9 +252,14 @@ internal static class WatchSource
         }
         finally
         {
-            foreach (var w in watchers) { w.EnableRaisingEvents = false; w.Dispose(); }
-            signal.Dispose();
+            DisposeWatch(signal, watchers);
         }
+    }
+
+    internal static void DisposeWatch(System.Threading.ManualResetEventSlim signal, List<FileSystemWatcher> watchers)
+    {
+        foreach (var w in watchers) { w.EnableRaisingEvents = false; w.Dispose(); }
+        signal.Dispose();
     }
 
     // The bucket-root walk-up (climb parent directories until an app.json is found).

--- a/docs/startup-cost.md
+++ b/docs/startup-cost.md
@@ -1,0 +1,55 @@
+# Fixed per-invocation startup cost
+
+What every `al-runner` invocation pays before its first test, and the rules that keep it down.
+The measurement programme is #2366; the levers it selected are grouped under the
+`area: startup-cost` label.
+
+## Main JIT tier
+
+**Rule: no loop inside a `catch`, exception filter or `finally` block in the runner assembly.**
+Put the loop in a helper method and call the helper from the handler.
+`AlRunner.Tests/HandlerLoopJitTierGuardTests.cs` fails on any backward branch inside a handler
+in `al-runner.dll`, and on `--version` it reads the JIT's own summary line for `<Main>$`.
+
+### Why
+
+The .NET 8 JIT compiles a method with loops at Tier0 and uses on-stack replacement (OSR) to move
+hot loops to optimized code. OSR cannot place a patchpoint inside an exception handler. When a
+method has a backward branch inside a handler, the JIT gives up on Tier0 for the **whole
+method** and compiles it fully optimized on first call. `DOTNET_JitDisasmSummary=1` reports
+this as `Tier-0 switched to FullOpts`.
+
+`<Main>$` holds the top-level statements of `Program.cs`, about 33 KB of IL. Two small loops
+(one in a catch filter, one in a `finally`) made the JIT compile all of it FullOpts, 78,929
+bytes of native code. The runner JITs `Main` **in every process generation**: the shadow
+re-exec parent (`docs/ncl-shadow-runtime.md`) and the child it starts both paid it.
+`BcRuntime.ApplyAllPatches` (10 KB of IL) and `TestExecutor.Run` (3.7 KB) had the same shape.
+
+A `leave` from a catch back to an enclosing loop's head does **not** trigger it (measured:
+`Instrumented Tier0`), so the guard ignores `leave` and `leave.s`.
+
+### Measured (#2375)
+
+Trivial bundle (`"platform": "28.0.0.0"`, one empty `[Test]`), BC 28.1.49838.53910, warm private
+`--cache`, before and after interleaved. `perf stat -e instructions:u`; "whole invocation"
+counts the process tree, "parent only" adds `--no-inherit`. Load average was 9-11 from other
+work, so instruction counts are the claim and wall times are not.
+
+| shape | measure | before (`8b85cf45`) | after |
+|---|---|---|---|
+| CI (`--package-cache ~/.al-runner/platform-apps`) | whole invocation | 12.793 / 12.798 / 12.794G | 12.149 / 12.149 / 12.152G |
+| CI | parent only | 1.194 / 1.194 / 1.194G | 0.931 / 0.930 / 0.931G |
+| no `--package-cache` | whole invocation | 17.71 / 15.80 / 16.16G | 15.86 / 16.32 / 15.37G |
+| no `--package-cache` | parent only | 1.196 / 1.196 / 1.196G | 1.004 / 0.933 / 0.932G |
+| — | `al-runner --version` | 0.752G | 0.471G |
+
+The CI shape drops 0.645G (5.0%); the parent alone drops 0.264G (22%). Without
+`--package-cache` the whole-invocation spread (about 2G, from hashing VS Code's symbol tree,
+#4050) is larger than the change, so that row shows only that the parent moved.
+
+A hello-world `net8.0` console app measures 0.149G on the same box, so the parent's remaining
+0.93G is still mostly JIT and type loading for the pre-dispatch code path.
+
+The whole al-language corpus (corpus `0d9d246b`, 3,348 tests) passed 3,348 of 3,348 with both
+binaries. Its instruction count varies by about 60G between identical warm runs, so it can show
+that nothing regressed, not the size of the gain.

--- a/docs/startup-cost.md
+++ b/docs/startup-cost.md
@@ -25,8 +25,10 @@ bytes of native code. The runner JITs `Main` **in every process generation**: th
 re-exec parent (`docs/ncl-shadow-runtime.md`) and the child it starts both paid it.
 `BcRuntime.ApplyAllPatches` (10 KB of IL) and `TestExecutor.Run` (3.7 KB) had the same shape.
 
-A `leave` from a catch back to an enclosing loop's head does **not** trigger it (measured:
-`Instrumented Tier0`), so the guard ignores `leave` and `leave.s`.
+A `leave` from a catch back to a loop head **outside** every handler does not trigger it
+(measured: `Instrumented Tier0`), so the guard ignores that `leave`. A `leave` whose target is
+inside a handler is that handler's own loop (a retry loop with a try/catch body, sitting in a
+catch) and does trigger it, so the guard counts it.
 
 ### Measured (#2375)
 


### PR DESCRIPTION
Part of #2375

_Written by agent stma-auto2-2 on the account holder's behalf._

## What this changes

The biggest single cost in the shadow re-exec parent was not the parent's work. It was the JIT compiling `Program.<Main>$` fully optimized.

- The .NET 8 JIT compiles a method with loops at Tier0 and relies on OSR to optimize hot loops later.
- OSR cannot patch a loop inside a `catch`, filter or `finally`. If a method has one, the JIT compiles the **whole method** FullOpts on first call (`Tier-0 switched to FullOpts`).
- `<Main>$` is 33 KB of IL. It had two tiny loops in handlers: the `AggregateException` inner-exception print in the bundled emit path, and the watcher disposal in the watch-mode `finally`. So all of Main was compiled to 78,929 bytes of optimized code in **every process generation**: the re-exec parent and its child.
- `BcRuntime.ApplyAllPatches` (10 KB IL) and `TestExecutor.Run` (3.7 KB IL) had the same shape and were also compiled FullOpts in the child.

Each loop moved, unchanged, into a helper method. The watcher disposal was written out twice (`Program.cs` and `WatchSource.WaitForSourceChange`), so both now call one `WatchSource.DisposeWatch`.

JIT summary (`DOTNET_JitDisasmSummary=1`) on the trivial bundle, before and after:

| method | before (`8b85cf45`) | after |
|---|---|---|
| `Program:<Main>$` (logged by both processes) | `Tier-0 switched to FullOpts`, code size 78,929 | `Instrumented Tier0` |
| `BcRuntime:ApplyAllPatches` | `Tier-0 switched to FullOpts` | `Instrumented Tier0` |
| `TestExecutor:Run` | `Tier-0 switched to FullOpts` | `Instrumented Tier0` |

## Numbers

Trivial bundle (`"platform": "28.0.0.0"`, one empty `[Test]`), BC 28.1.49838.53910, warm private `--cache`, before and after runs interleaved. Captured with `perf stat -e instructions:u`. "Whole invocation" counts the process tree. "Parent only" adds `--no-inherit`. Load average was 9-11, so instruction counts are the claim and wall times are not. The "after" numbers in this section and the corpus runs were taken with this diff on `8b85cf45`, before I rebased onto `b52d103b`; the tests below were re-run after the rebase.

| shape | measure | before (`8b85cf45`) | after |
|---|---|---|---|
| CI (`--package-cache ~/.al-runner/platform-apps`) | whole invocation | 12.793 / 12.798 / 12.794G | 12.149 / 12.149 / 12.152G |
| CI | parent only | 1.194 / 1.194 / 1.194G | 0.931 / 0.930 / 0.931G |
| no `--package-cache` | whole invocation | 17.71 / 15.80 / 16.16G | 15.86 / 16.32 / 15.37G |
| no `--package-cache` | parent only | 1.196 / 1.196 / 1.196G | 1.004 / 0.933 / 0.932G |
| — | `al-runner --version` (one process) | 0.752G | 0.471G |

- CI shape: the whole invocation drops **0.645G (5.0%)**. The parent alone drops **0.264G (22%)**, and the child drops the rest.
- Without `--package-cache`, run-to-run spread is about 2G (the `.app` hashing in #4050), so that row shows the parent moved and nothing more.
- Al-language corpus `0d9d246bc8406e93126c95a269064515d2722977` on BC 28.1, CI flags (`--strict`): **3348/3348 pass** with both binaries. Warm instructions were before 496.7G / 431.9G and after 484.5G / 423.7G. Identical runs vary by about 60G, so this only shows nothing regressed with Main at Tier0.

The table and the mechanism are also in `docs/startup-cost.md#main-jit-tier`.

## Proving tests: `AlRunner.Tests/HandlerLoopJitTierGuardTests.cs`

- `NoRunnerMethod_BranchesBackwardInsideAnExceptionHandler` decodes every method body in `al-runner.dll` and fails on a backward branch whose source is inside a handler or filter. It ignores a backward `leave` only when the target is outside every handler range: a `leave` back to a loop head outside the handlers keeps `Instrumented Tier0`, but one whose target is inside a handler closes that handler's own loop and still forces FullOpts (found in review). Third state: it fails if fewer than 1000 bodies were decoded, if `<Main>$` is missing, or if Main decodes with 10 or fewer backward branches.
- `Scanner_FlagsLoopsInHandlers_AndNotALeaveBackToTheLoopHead` runs the decoder against fixture methods: a loop in a `finally`, in a `catch`, in a filtered `catch`, and a retry loop with a try/catch body inside a `catch` (`TryCatchLoopInsideCatch`) must be flagged, and a try/catch inside a loop must not be. It also checks that the last fixture really compiles to a backward `leave`.
- `VersionFastPath_MainIsNotCompiledFullOpts` runs `al-runner --version` with `DOTNET_JitStdOutFile` and reads the JIT's own line for `<Main>$`. It asserts only that no line says `switched to FullOpts`, not which tier was chosen, because `DOTNET_TieredCompilation=0` prints `FullOpts` for every method. It skips when `al-runner.dll` was built with the JIT optimizer disabled (Debug). CI runs tests in Release.

Before the fix, a scratch copy of the same decoder run on the `8b85cf45` build reported 5 sites in 4 methods: Main (2), `ApplyAllPatches`, `TestExecutor.Run` and `WatchSource.WaitForSourceChange`.

Mutations, each rebuilt and run with `--filter FullyQualifiedName~HandlerLoopJitTierGuardTests`:

| mutation | result |
|---|---|
| none | `Failed: 0, Passed: 3` |
| M1: put the watcher `foreach` back inside Main's `finally` | `Failed: 2, Passed: 1`. The IL guard reports `Program::<Main>$ (IL 33413 bytes): IL_6ad8->IL_6ab6`, and the JIT test reports `switched to FullOpts`. Re-run after hardening the JIT-line assertion, same result. |
| M2: add a `foreach` to the `catch` in `TestExecutor.Run` | `Failed: 1, Passed: 2`. Only the IL guard fails (`TestExecutor::Run (IL 3432 bytes)`). The `--version` test stays green because it never compiles `Run`, so the two tests check different things. |
| M3 (reviewer's shape, after the fix in `3ccf5dc2`): a `while` retry loop with a try/catch body inside `TestExecutor.Run`'s `catch` | `Failed: 1, Passed: 2`: `TestExecutor::Run (IL 3439 bytes): IL_0065->IL_0045, IL_0068->IL_0045`. The same build's JIT summary says `TestExecutor:Run ... [Tier-0 switched to FullOpts`. On `bdeb6886` the reviewer measured this shape at `Failed: 0, Passed: 3`. |

## Behaviour checks

The brief asked that the re-exec itself does not change: variant swap, deferred startup lines printed once, exit codes, and the #4041 crash-path flush. This PR does not touch `TryShadowReexec`, `EnsureShadowDir` or the flush logic. After rebasing on `b52d103b` and rebuilding, I ran them anyway (`-c Release`):

- `StartupOutputReexecDedupTests`, `PrecompileNclShadowHopTests`, `PrecompileEngineVariantSelectionTests`, `NclShadowRuntimeTests`, `WatchSourceTests`, `WatchTests`, `ReexecExplanationVisibilityTests`, `ExplicitEngineMinorWarning*` and the new class: `Failed: 0, Passed: 44, Total: 44`.
- `FullyQualifiedName~GuardTests` plus the new class: `Failed: 1, Passed: 256, Total: 257`. The one failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned` ("the in-process engine bootstrap simply was not performed"). It fails the same way on the unmodified `8b85cf45` build, because this box has no `engine.runsettings` bootstrap.
- `tools/test_*.py`: all pass.

## Fix the shape

1. **Same pattern elsewhere?** I scanned every method in `al-runner.dll`, not just Main. It found `ApplyAllPatches`, `TestExecutor.Run` and `WaitForSourceChange`, and all three are fixed here. A first scan also flagged `RunDapLoop`, but that was a `leave` from a catch back to a loop head outside the handler. I built that shape in a scratch program and the JIT kept it at `Instrumented Tier0`, so the guard ignores `leave`. After the fix, no method in the assembly matches. `localloc` also blocks OSR. Six methods have both a loop and `localloc` (111-343 bytes of IL, in `AppLoader`, `MediaPatches` and `RecordPatches`). They are too small to matter, and the guard does not cover them.
2. **Sibling assumption?** Other generation-independent work also runs in both processes. `ScratchDirs.SweepStale` and `PkgDedupCache.Prune` run in the parent and again in the child. Skipping them in the child saved 0.18G on this box, but this box's temp directory holds 12,704 entries, so CI would save less. It also changes when housekeeping runs, so it is not in this PR. It is written up on #2375.
3. **Two writers, one invariant?** The watcher disposal had two copies with the same loop. They now share one helper.

## Queue scan

I searched open issues for `FullOpts`, `JIT tier`, `Tier0`, `tiered compilation`, `OSR`, `re-exec`, `shadow`, `startup cost`, and the `area: startup-cost` label. Nothing reports this mechanism.

- **#2374** (crossgen2 the IL-only DLLs): same cost bucket, different mechanism and files. If `al-runner.dll` is ever shipped precompiled, Main's JIT cost goes away on that path, and this PR's gain shrinks with it. The guard still matters for any method crossgen2 cannot precompile.
- **#4050** (`.app` hashing) and **#2223** / **#2218**: separate work in the worker. Not touched.

## Why `Part of #2375`, not `Closes`

The issue's open question was whether the process hop can be removed. I tested that directly. I copied the build output to a directory without Ncl.dll, removed any leftover Ncl.dll before each run, and ran with `AL_RUNNER_NCL_SHADOW_DONE=1`. The process then did a Cecil cache HIT, wrote the rewritten Ncl next to itself, and loaded it through `DependencyLoader`'s `Resolving` fallback, not through TPA. `--verbose` showed `Ncl in AppDomain: Location='<that dir>/Microsoft.Dynamics.Nav.Ncl.dll'`. The trivial bundle passed 3 of 3 runs. The whole corpus passed 3348/3348 on BC 28.1 with the same setup, measured once and without `--verbose`, so the load location for that run is inferred from the identical setup, not printed.

That is evidence the hop is removable on the cache-hit path. It is not a change I would ship on one BC version. That route also still writes into the install directory, which is the #2065 defect. It does not cover a cache miss or an engine-variant swap. The details are on #2375, which stays open for that work.

## Corpus linkage

No corpus PR. The diff touches `Program.cs`, `BcRuntime.cs`, `TestExecutor.cs` and `WatchSource.cs`. None of these is a path `check_corpus_linkage.sh` gates, and I ran the script against this body and diff to confirm. Nothing here is a claim about BC behaviour; the proving tests are about the runner's own IL and JIT tier.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
