### PR TITLE
fix(testpage): insert a new page record when focus moves to a non-key control

### DIFF
--- a/AlRunner.Tests/TestPageInsertOnFocusTests.cs
+++ b/AlRunner.Tests/TestPageInsertOnFocusTests.cs
@@ -202,7 +202,9 @@ public sealed class TestPageInsertOnFocusTests : IDisposable
                     Error('rows after Close: %1, expected 1', Row.Count());
             end;
 
-            // Rule 4: on a repeater, focus arriving from another row does not insert.
+            // Rule 4: on a repeater, focus arriving from another row does not insert. After New(),
+            // Description already has focus (on the old row), so its write moves nothing; Note takes
+            // focus from the old row (no insert); Description then takes it from Note on the new row.
             [Test]
             procedure Repeater_FocusFromAnotherRow_DoesNotInsert()
             var
@@ -214,11 +216,12 @@ public sealed class TestPageInsertOnFocusTests : IDisposable
                 Rows.Description.SetValue('a');
                 Rows.New();
                 Rows.Description.SetValue('b');
-                if Row.Count() <> 1 then
-                    Error('rows after the first write on the second line: %1, expected 1', Row.Count());
                 Rows.Note.SetValue('c');
+                if Row.Count() <> 1 then
+                    Error('rows after focus came from the other row: %1, expected 1', Row.Count());
+                Rows.Description.SetValue('d');
                 if Row.Count() <> 2 then
-                    Error('rows after the second control on the second line: %1, expected 2', Row.Count());
+                    Error('rows after focus moved within the new row: %1, expected 2', Row.Count());
                 Rows.Close();
             end;
         }

--- a/AlRunner.Tests/TestPageInsertOnFocusTests.cs
+++ b/AlRunner.Tests/TestPageInsertOnFocusTests.cs
@@ -1,0 +1,269 @@
+// TestPageInsertOnFocusTests — issue #4062. Pins the four rules LiveNavTestPage.ActivateControl
+// applies when it decides a started new row is written, one AL test per rule, so removing any
+// one rule reds exactly one test. The BC behaviour itself is adjudicated upstream by corpus
+// codeunit 60576 "TPBK Tests"; see docs/testpage-write-buffer.md#insert-on-focus.
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestPageInsertOnFocusTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private readonly string _root;
+
+    public TestPageInsertOnFocusTests()
+    {
+        _root = TestScratch.Dir("al-runner-testpage-insert-on-focus");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private static string[] ExtraPackageCacheArgs()
+    {
+        var platformApps = TestArtifacts.PlatformAppsDir();
+        return Directory.Exists(platformApps)
+            ? new[] { "--package-cache", platformApps }
+            : Array.Empty<string>();
+    }
+
+    private void WriteBundle()
+    {
+        File.WriteAllText(Path.Combine(_root, "app.json"), """
+        {
+          "id": "b1c2d3e4-5f60-4a7b-8c9d-0e1f2a3b4c62",
+          "name": "Runner Mechanism - TestPage Insert On Focus",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62790, "to": 62799 } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "Objects.al"), """
+        table 62790 "Iof Row"
+        {
+            DataClassification = CustomerContent;
+            fields
+            {
+                field(1; "No."; Code[20]) { }
+                field(2; Description; Text[100]) { }
+                field(3; Note; Text[100]) { }
+                field(4; "Desc At Insert"; Text[100]) { }
+            }
+            keys { key(PK; "No.") { Clustered = true; } }
+
+            trigger OnInsert()
+            var
+                Existing: Record "Iof Row";
+            begin
+                if "No." = '' then
+                    "No." := 'AUTO' + Format(Existing.Count() + 1);
+                "Desc At Insert" := CopyStr('[' + Description + ']', 1, 100);
+            end;
+        }
+
+        page 62791 "Iof Card"
+        {
+            PageType = Card;
+            SourceTable = "Iof Row";
+            ApplicationArea = All;
+            layout
+            {
+                area(Content)
+                {
+                    group(General)
+                    {
+                        field("No."; Rec."No.") { ApplicationArea = All; }
+                        field(Description; Rec.Description) { ApplicationArea = All; }
+                    }
+                }
+            }
+        }
+
+        page 62792 "Iof Delayed Card"
+        {
+            PageType = Card;
+            SourceTable = "Iof Row";
+            DelayedInsert = true;
+            ApplicationArea = All;
+            layout
+            {
+                area(Content)
+                {
+                    group(General)
+                    {
+                        field("No."; Rec."No.") { ApplicationArea = All; }
+                        field(Description; Rec.Description) { ApplicationArea = All; }
+                    }
+                }
+            }
+        }
+
+        page 62793 "Iof List"
+        {
+            PageType = List;
+            SourceTable = "Iof Row";
+            ApplicationArea = All;
+            layout
+            {
+                area(Content)
+                {
+                    repeater(Rows)
+                    {
+                        field("No."; Rec."No.") { ApplicationArea = All; }
+                        field(Description; Rec.Description) { ApplicationArea = All; }
+                        field(Note; Rec.Note) { ApplicationArea = All; }
+                    }
+                }
+            }
+        }
+
+        page 62795 "Iof Key Locked Card"
+        {
+            PageType = Card;
+            SourceTable = "Iof Row";
+            ApplicationArea = All;
+            layout
+            {
+                area(Content)
+                {
+                    group(General)
+                    {
+                        field(Description; Rec.Description) { ApplicationArea = All; }
+                        field("No."; Rec."No.") { ApplicationArea = All; Editable = false; }
+                    }
+                }
+            }
+        }
+
+        codeunit 62794 "Iof Tests"
+        {
+            Subtype = Test;
+
+            // Rule 1: focus moving to a non-key control inserts, before that control's value is written.
+            [Test]
+            procedure NonKeyWrite_InsertsBeforeTheWrite()
+            var
+                Row: Record "Iof Row";
+                Card: TestPage "Iof Card";
+            begin
+                Row.DeleteAll();
+                Card.OpenNew();
+                Card.Description.SetValue('x');
+                if Row.Count() <> 1 then
+                    Error('rows before Close: %1, expected 1', Row.Count());
+                Row.FindFirst();
+                if (Row."No." <> 'AUTO1') or (Row."Desc At Insert" <> '[]') then
+                    Error('No.=%1, Description seen by OnInsert=%2; expected AUTO1 and []', Row."No.", Row."Desc At Insert");
+                Card.Close();
+            end;
+
+            // Rule 2: focus moving to a KEY control does not insert. "No." is not editable here, so
+            // the initial control is Description and the move to "No." leaves a field control.
+            [Test]
+            procedure KeyActivation_DoesNotInsert()
+            var
+                Row: Record "Iof Row";
+                Card: TestPage "Iof Key Locked Card";
+            begin
+                Row.DeleteAll();
+                Card.OpenNew();
+                Card."No.".Activate();
+                if not Row.IsEmpty() then
+                    Error('focus on the key control inserted a row before Close');
+                Card.Close();
+            end;
+
+            // Rule 3: DelayedInsert = true never inserts on focus.
+            [Test]
+            procedure DelayedInsert_DoesNotInsertOnFocus()
+            var
+                Row: Record "Iof Row";
+                Card: TestPage "Iof Delayed Card";
+            begin
+                Row.DeleteAll();
+                Card.OpenNew();
+                Card.Description.SetValue('x');
+                if not Row.IsEmpty() then
+                    Error('a DelayedInsert page inserted before Close');
+                Card.Close();
+                if Row.Count() <> 1 then
+                    Error('rows after Close: %1, expected 1', Row.Count());
+            end;
+
+            // Rule 4: on a repeater, focus arriving from another row does not insert.
+            [Test]
+            procedure Repeater_FocusFromAnotherRow_DoesNotInsert()
+            var
+                Row: Record "Iof Row";
+                Rows: TestPage "Iof List";
+            begin
+                Row.DeleteAll();
+                Rows.OpenNew();
+                Rows.Description.SetValue('a');
+                Rows.New();
+                Rows.Description.SetValue('b');
+                if Row.Count() <> 1 then
+                    Error('rows after the first write on the second line: %1, expected 1', Row.Count());
+                Rows.Note.SetValue('c');
+                if Row.Count() <> 2 then
+                    Error('rows after the second control on the second line: %1, expected 2', Row.Count());
+                Rows.Close();
+            end;
+        }
+        """);
+    }
+
+    private (string output, int exit) RunBundled()
+    {
+        var args = new StringBuilder(
+            TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg + $" \"{_root}\"");
+        foreach (var a in ExtraPackageCacheArgs()) args.Append($" \"{a}\"");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(600_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    [SkippableFact]
+    public void EachInsertOnFocusRule_HoldsOnItsOwnTest()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        WriteBundle();
+        var (output, exit) = RunBundled();
+
+        Assert.True(exit == 0, $"Expected the bundle to pass; exit={exit}\n{output}");
+        foreach (var name in new[]
+                 {
+                     "NonKeyWrite_InsertsBeforeTheWrite",
+                     "KeyActivation_DoesNotInsert",
+                     "DelayedInsert_DoesNotInsertOnFocus",
+                     "Repeater_FocusFromAnotherRow_DoesNotInsert",
+                 })
+            Assert.Contains("PASS  Codeunit62794." + name, output);
+        Assert.DoesNotContain("FAIL", output);
+    }
+}

--- a/AlRunner/Patches/MockTestPage.Fields.cs
+++ b/AlRunner/Patches/MockTestPage.Fields.cs
@@ -32,12 +32,17 @@ internal sealed class LiveNavTestField : ITestField
     // the row its keys.
     private readonly Action? _onBeforeEdit;
 
+    // Told when this control takes focus — LiveNavTestPage.ActivateControl, which is where a
+    // started new row is inserted (#4062). Called by Activate() and before every write.
+    private readonly Action<int>? _onActivate;
+
     public LiveNavTestField(NavRecord record, int fieldNo)
         : this(record, fieldNo, page: null, controlId: 0, onEdited: null, onBeforeEdit: null,
-               pageValidationErrors: null) { }
+               onActivate: null, pageValidationErrors: null) { }
 
     public LiveNavTestField(NavRecord record, int fieldNo, RunnerPageInstance? page, int controlId,
-        Action? onEdited, Action? onBeforeEdit, TestPageValidationErrors? pageValidationErrors)
+        Action? onEdited, Action? onBeforeEdit, Action<int>? onActivate,
+        TestPageValidationErrors? pageValidationErrors)
     {
         _record = record;
         _fieldNo = fieldNo;
@@ -45,6 +50,7 @@ internal sealed class LiveNavTestField : ITestField
         _controlId = controlId;
         _onEdited = onEdited;
         _onBeforeEdit = onBeforeEdit;
+        _onActivate = onActivate;
         _validationErrors = new TestFieldValidationErrors(pageValidationErrors);
     }
 
@@ -99,6 +105,10 @@ internal sealed class LiveNavTestField : ITestField
         // starting it is recorded and re-raised by BC's NavTestField.CheckError exactly as a
         // refusal of the value itself would be.
         _onBeforeEdit?.Invoke();
+
+        // BC's TestFieldProxy.Value setter activates the control before it writes, and focus
+        // arriving on a non-key control is what inserts a started new row (#4062).
+        _onActivate?.Invoke(_controlId);
 
         // #3640: everything from here on can mutate Rec — the field's own OnValidate, the
         // control's, and any pageextension modify() trigger around them — and real BC discards
@@ -255,7 +265,7 @@ internal sealed class LiveNavTestField : ITestField
     public bool ShowMandatory => false;
 
     public string GetValidationError(int index) => _validationErrors.Get(index);
-    public void Activate() { }
+    public void Activate() => _onActivate?.Invoke(_controlId);
 
     /// <summary>
     /// Run the control's OnLookup trigger — the AL a user's F4 would run. The base mock does

--- a/AlRunner/Patches/MockTestPage.LivePage.Fields.cs
+++ b/AlRunner/Patches/MockTestPage.LivePage.Fields.cs
@@ -52,7 +52,7 @@ internal partial class LiveNavTestPage
             if (!_fields.TryGetValue(id, out var field))
                 _fields[id] = field =
                     new LiveNavTestField(_record!, tableFieldNo, _page, id,
-                        MarkEdited, PromoteNewRowLineForWrite, _validationErrors);
+                        MarkEdited, PromoteNewRowLineForWrite, ActivateControl, _validationErrors);
             return field;
         }
 

--- a/AlRunner/Patches/MockTestPage.LivePage.WriteBuffer.cs
+++ b/AlRunner/Patches/MockTestPage.LivePage.WriteBuffer.cs
@@ -45,6 +45,9 @@ internal partial class LiveNavTestPage
         // before touching any of the state below, rather than NRE-ing inside CaptureInsertPosition.
         RequireRecord("New()");
 
+        // A new row is a different row for focus: see ActivateControl.
+        _rowEpoch++;
+
         // New() from the new-row line starts the row explicitly; the draft bookkeeping is
         // superseded by the CaptureInsertPosition below, and its saved return position must
         // not survive to drag the cursor back off the row being created.
@@ -153,6 +156,12 @@ internal partial class LiveNavTestPage
         // THIS New()'s cursor, and leaving it armed would offer them to the next insert, which
         // may be on another row or another part entirely.
         if (!RowValuesChangedSinceLoad()) { _insertPositionCaptured = false; return; }
+        InsertPendingRow();
+    }
+
+    /// <summary>Write the started row, in BC's order. False when OnInsertRecord vetoed it.</summary>
+    private bool InsertPendingRow()
+    {
         // AutoSplitKey, in BC's own order: SplitKey, then OnInsertRecord, then the record's
         // Insert (NavForm.SaveRecordAsync / NavForm.InsertAsync(belowXRec) both do exactly
         // this). Skipping it left the last primary-key field at its Init() default, so a page
@@ -166,7 +175,7 @@ internal partial class LiveNavTestPage
         // is a veto — a page can refuse the insert outright. Running it and discarding the
         // answer would be worse than not running it: the row lands anyway, but now it also
         // carries whatever the trigger wrote on its way to saying no.
-        if (_page != null && !_page.RaiseOnInsertRecord(false)) return;
+        if (_page != null && !_page.RaiseOnInsertRecord(false)) return false;
         // runApplicationTrigger: true. Inserting a row from a page runs the table's OnInsert, the
         // same as Rec.Insert(true) — that trigger is where a table assigns its number series,
         // stamps its own derived fields, and enforces what it will not accept. Passing false
@@ -180,6 +189,7 @@ internal partial class LiveNavTestPage
         // next write on the same page instance would compare against, and report as xRec, the
         // blank row New() started (issue #3440).
         if (_record!.HasBeenInserted) SnapshotBeforeImage();
+        return true;
     }
 
     /// <summary>
@@ -532,39 +542,122 @@ internal partial class LiveNavTestPage
         // as well would try to Modify a row that does not exist yet.
         if (!_pendingNewRow) { _pendingModify = true; return; }
 
-        InsertOnCompletePrimaryKey();
+        // A top-level page inserts on FOCUS (ActivateControl), not here. A part keeps the
+        // key-complete insert until part focus is modelled — see docs/testpage-write-buffer.md#insert-on-focus.
+        if (this is LiveNavTestPart) InsertOnCompletePrimaryKey();
+    }
+
+    // ---- insert on focus (issue #4062) — see docs/testpage-write-buffer.md#insert-on-focus ----
+
+    private bool _focusInitialized;
+    private int _activeControlId;      // 0: no control holds focus
+    private int _rowEpoch;             // bumped by InsertEmptyRow
+    private int _activeRowEpoch;
+
+    /// <summary>
+    /// What BC's <c>TestPageProxy</c> constructor does when the page opens: activate the page's
+    /// initial control. Called at the end of RunnerTestPageState.MarkOpened; a page opened by
+    /// another route is focused lazily by its first <see cref="ActivateControl"/>.
+    /// </summary>
+    internal void FocusInitialControl()
+    {
+        _focusInitialized = true;
+        _activeRowEpoch = _rowEpoch;
+        _activeControlId = InitialActiveControlId();
     }
 
     /// <summary>
-    /// Write a page-driven insert as soon as the row's PRIMARY KEY is complete, rather than
-    /// holding it back until the page is left — issue #3441.
+    /// A control took focus — <c>TestField.Activate()</c>, and the first step of every
+    /// <c>SetValue</c> (BC's <c>TestFieldProxy.Value</c> setter activates before it writes).
     ///
-    /// Measured on real BC 28.4 and adjudicated on eight cloud legs (corpus codeunit 60636
-    /// <c>NewAndInsertRecordEvents_PageDrivenInsert_FireForTheKeyOnly</c>): typing the key of a
-    /// new row on a <c>DelayedInsert = false</c> list inserts the row THERE, so
-    /// <c>OnInsertRecord</c> and <c>OnInsertRecordEvent</c> see the key set and every later
-    /// control still blank, and the next control write is an ordinary page-driven MODIFY with
-    /// its own trigger and event. The runner deferred the whole thing to the flush, so the
-    /// insert trigger saw a finished row and the modify never happened at all.
-    ///
-    /// <para>Three limits. A page that saves one RECORD rather than rows keeps the
-    /// flush-on-leave timing — see RunnerPageInstance.WritesRowsAsTheyAreCompleted, where both
-    /// directions are measured. <c>DelayedInsert = true</c> keeps it too, which is that
-    /// property's own definition. And "complete" is BC's own emptiness test —
-    /// <c>NavValue.IsZeroOrEmpty</c>, what <c>NavForm.SplitKey</c> uses on the last key field —
-    /// so a page whose last key field is filled in BY <c>AutoSplitKey</c> reads as incomplete
-    /// while that field is still 0 and keeps the deferred path. Every editable line grid in BC
-    /// is that shape, and moving them would change insert timing for the draft-line tests
-    /// (corpus 60358/60648) on no evidence.</para>
+    /// Observably equivalent to BC's client <c>AutoInsertPattern.OnActiveControlChangedOnDraftRow</c>
+    /// (Microsoft.Dynamics.Nav.Client.UI, 28.4): on a started new row of a page whose
+    /// <c>DelayedInsert</c> is false, focus moving from a field control to a NON-KEY field
+    /// control inserts the row — with no changed-values gate, so a blank-key row the table's
+    /// OnInsert numbers is written — before the new control's value is. A repeater does not
+    /// insert when focus arrives on a different row. Adjudicated by corpus codeunit 60576
+    /// "TPBK Tests"; also consistent with 60844 (a key write alone does not insert a Card row)
+    /// and 60636 (a List insert sees the next control still blank).
+    /// </summary>
+    internal void ActivateControl(int controlId)
+    {
+        // Part focus crosses forms in BC (HostedForm_ActiveControlChanged), which is not modelled.
+        if (this is LiveNavTestPart || _page == null || controlId == 0) return;
+        if (!_focusInitialized) FocusInitialControl();
+
+        var repeater = _page.WritesRowsAsTheyAreCompleted;
+        var rowChanged = repeater && _activeRowEpoch != _rowEpoch;
+        if (controlId == _activeControlId && !rowChanged) return;
+
+        var previous = _activeControlId;
+        _activeControlId = controlId;
+        _activeRowEpoch = _rowEpoch;
+        if (rowChanged) return;
+
+        if (!IsFieldControl(previous) || !IsFieldControl(controlId) || IsKeyControl(controlId)) return;
+        if (!_pendingNewRow || _page.DelaysInsertUntilTheRowIsLeft || !_page.PageEditable) return;
+        // InsertIfFormEditable: a form showing validation errors does not insert.
+        if (_validationErrors.Count > 0) return;
+
+        _pendingNewRow = false;
+        // A vetoed insert leaves the row a started draft, as the client's does.
+        if (!InsertPendingRow()) _pendingNewRow = true;
+    }
+
+    // BC's IsFieldControl needs a column binder and a row: a Rec-bound control. Page-variable
+    // controls are not counted — no corpus test measures them either way.
+    private bool IsFieldControl(int controlId)
+        => controlId != 0 && _controlIdToFieldNo.ContainsKey(controlId);
+
+    // ControlHelper.IsKeyControl: bound to a primary-key field of the source table.
+    private bool IsKeyControl(int controlId)
+    {
+        if (!_controlIdToFieldNo.TryGetValue(controlId, out var fieldNo)) return false;
+        var primaryKey = _record?.MetaTable?.PrimaryKey;
+        if (primaryKey == null) return false;
+        for (var i = 0; i < primaryKey.KeyFieldCount; i++)
+            if (primaryKey.KeyFieldsList[i].FieldNo == fieldNo) return true;
+        return false;
+    }
+
+    /// <summary>
+    /// BC's <c>InitialActiveControlStrategy</c>: the first visible editable QuickEntry field
+    /// (not on a repeater page, whose <c>InitialActiveControlInRepeaterStrategy</c> skips that
+    /// step), else the first editable primary-key field in key order, else the first editable
+    /// field preferring QuickEntry. 0 when the page has no editable field control.
+    /// </summary>
+    private int InitialActiveControlId()
+    {
+        if (_page == null) return 0;
+        var editable = _page.ControlIdsInPageOrder()
+            .Where(c => IsFieldControl(c.Id) && _page.ControlEditable(c.Id))
+            .ToList();
+
+        if (!_page.WritesRowsAsTheyAreCompleted)
+            foreach (var c in editable)
+                if (c.QuickEntry && _page.ControlVisible(c.Id)) return c.Id;
+
+        var primaryKey = _record?.MetaTable?.PrimaryKey;
+        if (primaryKey != null)
+            for (var i = 0; i < primaryKey.KeyFieldCount; i++)
+                foreach (var c in editable)
+                    if (_controlIdToFieldNo[c.Id] == primaryKey.KeyFieldsList[i].FieldNo) return c.Id;
+
+        foreach (var c in editable)
+            if (c.QuickEntry) return c.Id;
+        return editable.Count > 0 ? editable[0].Id : 0;
+    }
+
+    /// <summary>
+    /// A LINKED PART writes its row as soon as the primary key is complete — issue #3441, corpus
+    /// codeunit 60636. A top-level page uses <see cref="ActivateControl"/> instead, which agrees
+    /// with 60636 on a List. Limits: repeater part types only (WritesRowsAsTheyAreCompleted),
+    /// not <c>DelayedInsert = true</c>, and "complete" is <c>NavValue.IsZeroOrEmpty</c>, so an
+    /// AutoSplitKey line still at 0 keeps the deferred path (corpus 60358/60648).
     /// </summary>
     private void InsertOnCompletePrimaryKey()
     {
-        // No page: record-only mode has no DelayedInsert property to read and no page triggers
-        // to get the timing wrong, so it keeps the flush-time insert.
         if (_page == null || _page.DelaysInsertUntilTheRowIsLeft) return;
-        // A Card saves its one record when the page is left, not when its key is typed — corpus
-        // codeunit 60844 Close_WithoutOK_StillPersistsTheNewRow asserts the row is absent right
-        // up to Close(), and says in its own message that it is there to catch an eager insert.
         if (!_page.WritesRowsAsTheyAreCompleted) return;
         if (!PrimaryKeyIsComplete(_record!)) return;
         // The same call the flush points make, so the insert keeps BC's order — the write gate,

--- a/AlRunner/Patches/MockTestPage.LivePage.WriteBuffer.cs
+++ b/AlRunner/Patches/MockTestPage.LivePage.WriteBuffer.cs
@@ -585,9 +585,11 @@ internal partial class LiveNavTestPage
         if (this is LiveNavTestPart || _page == null || controlId == 0) return;
         if (!_focusInitialized) FocusInitialControl();
 
-        var repeater = _page.WritesRowsAsTheyAreCompleted;
-        var rowChanged = repeater && _activeRowEpoch != _rowEpoch;
-        if (controlId == _activeControlId && !rowChanged) return;
+        // TestPageProxy.ActivateControl skips a control that already has focus, even when the
+        // cursor has since moved to another row, so focus stays on the OLD row (corpus 60576,
+        // List_NewRow_*).
+        if (controlId == _activeControlId) return;
+        var rowChanged = _page.WritesRowsAsTheyAreCompleted && _activeRowEpoch != _rowEpoch;
 
         var previous = _activeControlId;
         _activeControlId = controlId;

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -1146,6 +1146,22 @@ internal sealed partial class RunnerPageInstance
     /// from ordinary AL — <c>GetField(Rec.FieldNo(X))</c> confuses the two spaces — and it is
     /// what corpus codeunit 60346 measures.</para>
     /// </summary>
+    /// <summary>Every control the page declares, in page-tree order, with a literal-true QuickEntry flag.</summary>
+    internal IReadOnlyList<(int Id, bool QuickEntry)> ControlIdsInPageOrder()
+    {
+        if (_form is not NavForm form || form.MasterPage is not { } masterPage)
+            return Array.Empty<(int, bool)>();
+        var result = new List<(int, bool)>();
+        foreach (var element in masterPage.FindAll(e => e is Microsoft.Dynamics.Nav.Types.Metadata.ControlDefinition))
+        {
+            var control = (Microsoft.Dynamics.Nav.Types.Metadata.ControlDefinition)element;
+            var quickEntry = string.Equals(control.QuickEntry, "true", StringComparison.OrdinalIgnoreCase)
+                             || control.QuickEntry == "1";
+            result.Add((control.ID, quickEntry));
+        }
+        return result;
+    }
+
     internal bool DeclaresControl(int controlId)
         => _form is NavForm form && form.MetadataHelper.TryGetControlDefinitionById(controlId, out _);
 
@@ -2551,19 +2567,12 @@ internal sealed partial class RunnerPageInstance
            && form.MasterPage?.PageProperties?.SourceObject?.DelayedInsert == true;
 
     /// <summary>
-    /// Whether the page writes ROWS — a repeater the cursor moves through — rather than one
-    /// record it saves when it is left. Read off <c>MasterPage.PageProperties.PageType</c>, the
-    /// same property <c>NavTestExecution.FindPageType</c> reads.
-    ///
-    /// Both directions are measured on real BC and adjudicated upstream. A List inserts the row
-    /// as soon as its key is complete (corpus codeunit 60636
-    /// <c>NewAndInsertRecordEvents_PageDrivenInsert_FireForTheKeyOnly</c>); a Card does not —
-    /// its row does not exist until the page is closed, which corpus codeunit 60844
-    /// <c>Close_WithoutOK_StillPersistsTheNewRow</c> asserts by name ("this assertion catches a
-    /// test environment where the record was already inserted eagerly on SetValue"). ListPart
-    /// and Worksheet are the other two repeater page types and ride the same client mechanism;
-    /// no corpus test distinguishes them from List, and none contradicts them either. See
-    /// MockTestPage.InsertOnCompletePrimaryKey.
+    /// Whether the page shows ROWS in a repeater rather than one record — List, ListPart,
+    /// Worksheet, read off <c>MasterPage.PageProperties.PageType</c> (what
+    /// <c>NavTestExecution.FindPageType</c> reads). The insert-on-focus model uses it for BC's
+    /// repeater-only rules (a row change never inserts; the initial control skips QuickEntry);
+    /// a linked part uses it to gate the key-complete insert. See
+    /// LiveNavTestPage.ActivateControl and docs/testpage-write-buffer.md#insert-on-focus.
     /// </summary>
     internal bool WritesRowsAsTheyAreCompleted
         => _form is NavForm form

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -1126,6 +1126,22 @@ internal sealed partial class RunnerPageInstance
         => path?.OfType<Microsoft.Dynamics.Nav.Types.Metadata.ActionGroupBaseDefinition>()
            ?? Array.Empty<Microsoft.Dynamics.Nav.Types.Metadata.ActionGroupBaseDefinition>();
 
+    /// <summary>Every control the page declares, in page-tree order, with a literal-true QuickEntry flag.</summary>
+    internal IReadOnlyList<(int Id, bool QuickEntry)> ControlIdsInPageOrder()
+    {
+        if (_form is not NavForm form || form.MasterPage is not { } masterPage)
+            return Array.Empty<(int, bool)>();
+        var result = new List<(int, bool)>();
+        foreach (var element in masterPage.FindAll(e => e is Microsoft.Dynamics.Nav.Types.Metadata.ControlDefinition))
+        {
+            var control = (Microsoft.Dynamics.Nav.Types.Metadata.ControlDefinition)element;
+            var quickEntry = string.Equals(control.QuickEntry, "true", StringComparison.OrdinalIgnoreCase)
+                             || control.QuickEntry == "1";
+            result.Add((control.ID, quickEntry));
+        }
+        return result;
+    }
+
     /// <summary>
     /// Whether <paramref name="controlId"/> names a control this page DECLARES at all — the
     /// question "is this id in the page's control-id space", asked of the page's own merged
@@ -1146,22 +1162,6 @@ internal sealed partial class RunnerPageInstance
     /// from ordinary AL — <c>GetField(Rec.FieldNo(X))</c> confuses the two spaces — and it is
     /// what corpus codeunit 60346 measures.</para>
     /// </summary>
-    /// <summary>Every control the page declares, in page-tree order, with a literal-true QuickEntry flag.</summary>
-    internal IReadOnlyList<(int Id, bool QuickEntry)> ControlIdsInPageOrder()
-    {
-        if (_form is not NavForm form || form.MasterPage is not { } masterPage)
-            return Array.Empty<(int, bool)>();
-        var result = new List<(int, bool)>();
-        foreach (var element in masterPage.FindAll(e => e is Microsoft.Dynamics.Nav.Types.Metadata.ControlDefinition))
-        {
-            var control = (Microsoft.Dynamics.Nav.Types.Metadata.ControlDefinition)element;
-            var quickEntry = string.Equals(control.QuickEntry, "true", StringComparison.OrdinalIgnoreCase)
-                             || control.QuickEntry == "1";
-            result.Add((control.ID, quickEntry));
-        }
-        return result;
-    }
-
     internal bool DeclaresControl(int controlId)
         => _form is NavForm form && form.MetadataHelper.TryGetControlDefinitionById(controlId, out _);
 

--- a/AlRunner/Patches/RunnerTestPageState.cs
+++ b/AlRunner/Patches/RunnerTestPageState.cs
@@ -118,6 +118,8 @@ public static class RunnerTestPageState
                 // already positioned on a specific row must not be silently reset to the
                 // table's own first row.
                 live.MoveFirstDuringOpen();
+            // BC's TestPageProxy activates the initial control once the page is open (#4062).
+            live.FocusInitialControl();
         }
         // Issue #2677: EagerlyBuildParts + Loaded's own part-refresh can now run AL trigger
         // code (a subpage part's OnAfterGetRecord/OnAfterGetCurrRecord, and whatever that

--- a/docs/testpage-write-buffer.md
+++ b/docs/testpage-write-buffer.md
@@ -169,6 +169,53 @@ local function would have kept the old test green while hiding the ordering mark
 the hazard caught only by the ordering test failing for a reason that does not name it.
 Verified by applying exactly that rewrite: the old shape passed, the current one fails.
 
+## Insert on focus
+
+When a started new row (`OpenNew()`, `New()`, or a draft line a write promoted) is written to
+the table is decided by focus, not by the key being complete (issue #4062).
+
+**What BC does.** Read from the client, `Microsoft.Dynamics.Nav.Client.UI` 28.4:
+
+- `AutoInsertPattern` is bound only when the page's `DelayedInsert` is false.
+- `OnActiveControlChangedOnDraftRow` inserts the draft row (`TransactionManager.Save(row,
+  SaveDraft)`, no changed-values gate) when focus moves from a field control to a field or group
+  control that is **not a key control**, the form is editable and has no validation errors.
+- `ActiveControlChanged` ignores a change that also changed the row, unless the page is bound
+  to a single entity (a Card). So on a repeater, focus arriving on a new line from another line
+  does not insert.
+- `TestFieldProxy.Value`'s setter calls `Activate()` before it writes, so `SetValue` on a
+  non-key control inserts first and writes second. Reading `Value` does not activate.
+- `TestPageProxy`'s constructor activates the form's initial control
+  (`InitialActiveControlStrategy`: first visible editable QuickEntry field, then first editable
+  key field in key order, then first editable field; a repeater skips the QuickEntry step).
+
+**What measured it.** Corpus codeunit 60576 "TPBK Tests" (StefanMaron/BusinessCentral.AL.Language.Tests#340):
+a blank-key Card row is numbered by `OnInsert` right after the first non-key `SetValue`, and
+`OnInsert` sees that control still blank; `Activate()` alone inserts on a non-key control and
+not on the key; `DelayedInsert = true` waits for `Close()`; a List behaves the same, and a
+second line's first write does not insert. It also agrees with the two older claims: typing
+only the key of a Card inserts nothing (60844), and a List insert sees the next control blank
+(60636).
+
+**How the runner does it.** `LiveNavTestPage.ActivateControl`, called from
+`LiveNavTestField.Activate()` and at the start of `LiveNavTestField.Write`;
+`FocusInitialControl` at the end of `RunnerTestPageState.MarkOpened`; a row change is
+`InsertEmptyRow` bumping `_rowEpoch`. `AlRunner.Tests/TestPageInsertOnFocusTests.cs` has one AL
+test per rule, and removing any one rule reds only its test.
+
+**Not modelled.**
+
+- **Parts.** A linked part keeps #3441's key-complete insert (`InsertOnCompletePrimaryKey`).
+  In BC a control in a part moves focus across forms (`HostedForm_ActiveControlChanged`
+  inserts the *host's* draft row), which the runner does not track.
+- **Page-variable controls** do not count as field controls either way; no corpus test
+  measures them.
+- **Actions.** BC's `TestActionProxy.Invoke` activates the action control too, so a field
+  control activated right after an action has no field control to come from and does not
+  insert. The runner does not move focus on an action.
+- BC dedupes activation per TestPage session (`session.FocusedControl`); the runner tracks
+  focus per page.
+
 ## Sister documents
 
 - `.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md` — why the tier's eight legs

--- a/docs/testpage-write-buffer.md
+++ b/docs/testpage-write-buffer.md
@@ -183,6 +183,9 @@ the table is decided by focus, not by the key being complete (issue #4062).
 - `ActiveControlChanged` ignores a change that also changed the row, unless the page is bound
   to a single entity (a Card). So on a repeater, focus arriving on a new line from another line
   does not insert.
+- `TestPageProxy.ActivateControl` does nothing for the control that already has focus, even
+  after the cursor moved to another row, so focus stays on the old row until a different
+  control takes it.
 - `TestFieldProxy.Value`'s setter calls `Activate()` before it writes, so `SetValue` on a
   non-key control inserts first and writes second. Reading `Value` does not activate.
 - `TestPageProxy`'s constructor activates the form's initial control
@@ -192,8 +195,9 @@ the table is decided by focus, not by the key being complete (issue #4062).
 **What measured it.** Corpus codeunit 60576 "TPBK Tests" (StefanMaron/BusinessCentral.AL.Language.Tests#340):
 a blank-key Card row is numbered by `OnInsert` right after the first non-key `SetValue`, and
 `OnInsert` sees that control still blank; `Activate()` alone inserts on a non-key control and
-not on the key; `DelayedInsert = true` waits for `Close()`; a List behaves the same, and a
-second line's first write does not insert. It also agrees with the two older claims: typing
+not on the key; `DelayedInsert = true` waits for `Close()`; a List behaves the same, and after
+`New()` a List inserts the second line only once focus moves between two of that line's
+controls (the first revision of that test assumed one move was enough; three legs said no). It also agrees with the two older claims: typing
 only the key of a Card inserts nothing (60844), and a List insert sees the next control blank
 (60636).
 
@@ -213,8 +217,8 @@ test per rule, and removing any one rule reds only its test.
 - **Actions.** BC's `TestActionProxy.Invoke` activates the action control too, so a field
   control activated right after an action has no field control to come from and does not
   insert. The runner does not move focus on an action.
-- BC dedupes activation per TestPage session (`session.FocusedControl`); the runner tracks
-  focus per page.
+- BC skips activating the control that already has focus per TestPage *session*
+  (`session.FocusedControl`); the runner skips it per page.
 
 ## Sister documents
 


### PR DESCRIPTION
Closes #4062

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/340

## What changed

A started new row on a TestPage (`OpenNew()`, `New()`) is now written when **focus moves to a non-key field control**, not when the primary key becomes complete. So on a card with `DelayedInsert = false`, `OpenNew()` + `Description.SetValue(...)` inserts the blank-key row first; the table's `OnInsert` numbers it; then the value is written as a modify. The `"No."` control reads the number before `Close()`, which is what `"ERM Fixed Asset Card".SetFAPostingGroupOnNewFixedAsset` (and the six `FixedAssetJourneyAs*` tests) expect.

Where the rule comes from: BC's client, `Microsoft.Dynamics.Nav.Client.UI` 28.4, `AutoInsertPattern.OnActiveControlChangedOnDraftRow`, plus `TestFieldProxy.Value` (activates before writing) and `TestPageProxy` (activates the initial control on open, skips a control that already has focus). Details and what is not modelled: `docs/testpage-write-buffer.md#insert-on-focus`.

- `LiveNavTestPage.ActivateControl` (WriteBuffer.cs): focus tracking plus the insert rule: previous and new control are Rec-bound, new is not a key field, row is a started new row, `DelayedInsert` false, page editable, no validation errors. On a repeater page, focus arriving from another row does not insert. No changed-values gate, since `NavForm.InsertAsync` has none. An `OnInsertRecord` veto leaves the row pending.
- `FocusInitialControl` runs at the end of `RunnerTestPageState.MarkOpened` and follows BC's `InitialActiveControlStrategy` (QuickEntry, then key fields in key order, then first editable field).
- `LiveNavTestField.Write` activates right after the new-row-line promotion; `Activate()` is no longer a no-op.
- `FlushPendingNewRow`'s insert body moved into `InsertPendingRow()` so both paths share it.
- **Linked parts keep #3441's key-complete insert.** In BC, focus in a part crosses forms (`HostedForm_ActiveControlChanged` inserts the host's draft row), and the runner does not track that.

## Corpus verdict so far (PR 340)

Run `34733561130` tested the second revision (head `263880e`). I read three cloud leg logs: 27.5 (job `103660953097`), 27.3 (job `103660953074`) and 28.0 (job `103660953039`). 27.3 and 27.5 are the same `Ncl.dll` binary, so that is two independent measurements. On each leg, the first 8 TPBK tests passed and one test failed: the List row-change test, which was my wrong guess. It asserted that on a second new List line, the second control's write already inserts. The tier kept `rows=1`. The harness cuts off the rest of that log line after `after c: rows=1;inserts=`.

What followed from that: a write to the control that already has focus does not move focus, so focus was still on the previous line. I changed the runner to match (`if (controlId == _activeControlId) return;`) and rewrote the corpus test as three steps.

**Not yet adjudicated: step 3 of `List_NewRow_FocusStaysOnTheOldRowUntilTwoControlsOfTheNewRowTakeIt`** (`d[r2 i2 db]`: the next move, back to Description, inserts). The same prediction appears as the second check of the runner test `Repeater_FocusFromAnotherRow_DoesNotInsert` (`rows=2` after the third write). Steps 1 and 2 match what the tier reported. Step 3 follows from the decompiled client, but no leg has measured it yet. The third corpus revision (head `7c243db`, run `34734238666`) was still running when I opened this PR. **This PR should not merge until that run's cloud legs report.** If step 3 comes back red, the runner's rule for a repeater row change changes with it.

`run-nightly-windows` is on the corpus PR. `MsDyn365Bc.On.Linux`'s StartupHook patches nothing on insert timing; its only UI patch is #21 `ShowForm`.

## RED → GREEN

- Corpus codeunit 60576 on this box (BC 28.1 artifacts, corpus master `0d9d246b` + PR 340). On `main` (8908e999): `Failed: 6, Passed: 2` of the first 8 tests. On this branch: all 9 pass. The full corpus run on this branch is `3357 total, pass 3357, fail 0`. The baseline on `main` was 3356 total with only the 6 TPBK failures, so nothing else moved.
- `AlRunner.Tests/TestPageInsertOnFocusTests.cs` (new; the runner-side mechanism test the `Tests updated` gate needs): one AL bundle, one AL test per rule. `Failed: 0, Passed: 1`.

## Mutations (each rebuilt; each red is an AL `Error`, not a compile error)

| mutation in `ActivateControl` | AL tests red |
|---|---|
| drop `IsKeyControl(controlId)` | `KeyActivation_DoesNotInsert` only |
| drop the `DelaysInsertUntilTheRowIsLeft` check | `DelayedInsert_DoesNotInsertOnFocus` only |
| `if (false && rowChanged) return;` | `Repeater_FocusFromAnotherRow_DoesNotInsert` only |
| skip focus dedupe when the row changed | `Repeater_FocusFromAnotherRow_DoesNotInsert` only. Same check and message as the row above (`rows after focus came from the other row: 2, expected 1`), reached a different way: without the row-change rule, Note arriving from the old row inserts; without the dedupe, Description's write on the new row takes focus there, so Note arrives from the same row and inserts |
| disable the whole method | `NonKeyWrite_InsertsBeforeTheWrite` and `Repeater_...` |

xunit: `Failed: 1, Passed: 0` for each mutation, then `Failed: 0, Passed: 1` after restoring.

## Other local runs

- `dotnet test --filter` over `TestPageInsertOnFocusTests|TestPageNewRowLinePromotionTests|TestPageModalClosePartFlushTests|TestPageOnNewRecordCountTests`: `Passed: 9`, after rebasing on `origin/main`.
- runner-extras bundles that use `OpenNew`/`New()` (`bundle-page-over-dep-table`, `testpage-close-message-consumed`, `testpage-precompiled-member-names`, `testpage-trigger-inject-timing`, `microsoft-dependencies`): all pass.
- `tools/test_*.py`: all pass. A wider `GuardTests|TestPage|PageTrigger` filter had 17 failures on this box. 16 of them refuse because the in-process engine bootstrap was not run (`bc-engine-serial`, `engine.runsettings`). The 17th is `TestPageEvaluatorFaultTests`, the order dependence tracked in #3486. None of them touch this change. CI runs them with the bootstrap.

## Fix the shape

1. **Same wrong pattern elsewhere?** The key-complete gate had one call site (`MarkEdited`). It is replaced on top-level pages and kept only for parts, as described above. `PageVariableTestField` writes do not activate. BC's `IsFieldControl` might count them, but no test measures that, so I left them out and documented it.
2. **Sibling assumptions?** Action invoke also moves focus in BC (`TestActionProxy.Invoke` activates the action), so a field activated right after an action would not insert. The runner does not move focus on actions. That is documented as not modelled.
3. **Two paths writing the same state?** `_pendingNewRow` is cleared by `FlushPendingNewRow` (close, navigation, New) and by `ActivateControl`. Both now go through `InsertPendingRow()`, so they keep the same order (SplitKey, OnInsertRecord veto, Insert, before-image snapshot). The only intended difference is the changed-values gate, which only the close/save path has in BC.

Queue scan (symbol `InsertOnCompletePrimaryKey`, file `MockTestPage.LivePage.WriteBuffer.cs`, observable "No. empty until Close", "OnInsert" / "OpenNew" in titles): #3029 (OnNewRecord twice on draft-line promotion) and #3586 (page write under TransactionModel::None) touch this area but need different fixes. Nothing folded. I did not file a follow-up for part focus or action focus; a coordinator may want one.

Written by agent stma-auto2-1 (Claude) on the account holder's behalf.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
