### PR TITLE
test(install-baseline): pin the dependency-set component of the install-baseline cache key

### DIFF
--- a/AlRunner.Tests/InstallBaselineDiskCacheTests.cs
+++ b/AlRunner.Tests/InstallBaselineDiskCacheTests.cs
@@ -414,9 +414,9 @@ public class InstallBaselineDiskCacheTests
             // Measured by mutation (#2364): flattening the WHOLE
             // TestExecutor.CurrentInstallBaselineCacheKey() to a constant fails this test.
             // Flattening only its dependency-set component, or only its symbol-state
-            // component, does NOT — the two are redundant here (#3254), so this pins the key as a
-            // whole rather than the dependency set specifically. See the longer note in
-            // InstallSeedDepCompanyCacheTests.AppGroupWithOwnDependencyApp_*.
+            // component, does NOT — the two are redundant here, so this pins the key as a whole.
+            // The dependency-set term on its own is pinned by
+            // DependencySetTermAlone_SeparatesBaselines_AndIdenticalInputsHitAcrossProcesses (#3254).
             var written = WriteDigests(output);
             Assert.True(written.Count >= 2,
                 $"expected at least 2 distinct dependency-closure keys to be persisted, got "

--- a/AlRunner.Tests/InstallBaselineDiskCacheTests.cs
+++ b/AlRunner.Tests/InstallBaselineDiskCacheTests.cs
@@ -432,4 +432,76 @@ public class InstallBaselineDiskCacheTests
             try { Directory.Delete(root, true); } catch { }
         }
     }
+
+    // ── 5. the dependency-set term on its own (#3254) ──────────────────────────────────
+
+    /// <summary>
+    /// #3254: pins <c>InstallTriggerRunner.CurrentDependencySetKey()</c> specifically, which
+    /// the scoping tests above cannot. Bundle order is the whole trick: the bundle WITH the extra
+    /// dependency runs first, so by the time the seed-only bundle runs, the process-global
+    /// registered .app set already holds both apps and
+    /// <c>RecordPatches.RegisteredBcAppSymbolStateKey()</c> is the same for both app groups.
+    /// Only the dependency-set term tells them apart.
+    ///
+    /// <para>The extra app's install trigger adds a third row to the seed table, so the two
+    /// baselines differ by value: a key that collapsed them hands the seed-only group a
+    /// three-row baseline, and its AL test fails on the row count.</para>
+    ///
+    /// <para>The second process, on the same cache root, checks the other direction: identical
+    /// inputs restore both entries from disk with no recomputation.</para>
+    /// </summary>
+    [SkippableFact]
+    public void DependencySetTermAlone_SeparatesBaselines_AndIdenticalInputsHitAcrossProcesses()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = TestScratch.Dir("al-runner-ib-disk-depset");
+        try
+        {
+            var (seedOnly, _, _) = InstallSeedClosure.WriteSharedClosure(root, "ds", 62120);
+            var withExtra = InstallSeedClosure.WriteBundleWithSeedingExtraDependency(root, "dx", 62140, "ds");
+
+            // ── process 1: the dependency set shrinks between the two app groups ──
+            var (out1, exit1) = RunRunner(null, withExtra, seedOnly);
+
+            // [THEN] Both AL tests passed: the extra-dependency group saw 3 rows and the
+            // seed-only group saw 2. Under a key that ignores the dependency set, the seed-only
+            // group restores the 3-row baseline and fails with "expected 2 seeded row(s), found 3".
+            Assert.True(Count(out1, "1P/0F/0E") >= 2,
+                $"expected both app groups to pass, got:\n{out1}");
+            Assert.Equal(0, exit1);
+
+            // [THEN] Two fresh computations, no reuse of either kind, two distinct entries.
+            Assert.Equal(2, Count(out1, "InstallBaseline.DepCompanyCache MISS"));
+            Assert.Equal(0, Count(out1, "InstallBaseline.DepCompanyCache HIT"));
+            Assert.Equal(0, Count(out1, "InstallBaseline.DepCompanyCache DISK-HIT"));
+            var written = WriteDigests(out1);
+            Assert.Equal(2, written.Count);
+            Assert.Equal(2, WrittenPaths(out1).Count);
+
+            // ── process 2: same inputs, same cache root ──
+            var (out2, exit2) = RunRunner(null, withExtra, seedOnly);
+
+            Assert.True(Count(out2, "1P/0F/0E") >= 2,
+                $"expected both app groups to pass on the warm run, got:\n{out2}");
+            Assert.Equal(0, exit2);
+
+            // [THEN] Nothing recomputed or rewritten; both entries restored from disk with the
+            // digests process 1 recorded.
+            Assert.Equal(0, Count(out2, "InstallBaseline.DepCompanyCache MISS"));
+            Assert.Equal(0, Count(out2, "InstallBaseline.DepCompanyCache HIT"));
+            Assert.Empty(WriteDigests(out2));
+            var hits = HitDigests(out2);
+            Assert.Equal(2, hits.Count);
+            foreach (var (key, digest) in written)
+            {
+                Assert.True(hits.ContainsKey(key), $"key {key} was written but not restored:\n{out2}");
+                Assert.Equal(digest, hits[key]);
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
+        }
+    }
 }

--- a/AlRunner.Tests/InstallSeedClosure.cs
+++ b/AlRunner.Tests/InstallSeedClosure.cs
@@ -84,7 +84,7 @@ internal static class InstallSeedClosure
         var seedName = $"Seed {tag}";
 
         WriteSeedApp(seedDir, tag, baseId, seedId, seedName, marker);
-        WriteBundle(mainDir, tag, baseId, marker, ($"{seedId}", seedName));
+        WriteBundle(mainDir, tag, baseId, marker, SeededRowCount, ($"{seedId}", seedName));
         return new Closure(mainDir, seedDir, marker);
     }
 
@@ -107,8 +107,8 @@ internal static class InstallSeedClosure
         WriteSeedApp(Path.Combine(parent, "seed"), tag, baseId, seedId, seedName, marker);
         var a = Path.Combine(parent, "main-a");
         var b = Path.Combine(parent, "main-b");
-        WriteBundle(a, tag + "A", baseId, marker, (seedId, seedName));
-        WriteBundle(b, tag + "B", baseId + 10, marker, (seedId, seedName));
+        WriteBundle(a, tag + "A", baseId, marker, SeededRowCount, (seedId, seedName));
+        WriteBundle(b, tag + "B", baseId + 10, marker, SeededRowCount, (seedId, seedName));
         return (a, b, marker);
     }
 
@@ -152,7 +152,63 @@ internal static class InstallSeedClosure
         """);
 
         var mainDir = Path.Combine(parent, "main-" + tag);
-        WriteBundle(mainDir, tag, baseId + 5, marker, (seedId, seedName), (extraId, extraName));
+        WriteBundle(mainDir, tag, baseId + 5, marker, SeededRowCount, (seedId, seedName), (extraId, extraName));
+        return mainDir;
+    }
+
+    /// <summary>
+    /// #3254: like <see cref="WriteBundleWithExtraDependency"/>, but the extra app DEPENDS ON the
+    /// seed and its own install trigger inserts a third row into the seed's table. A baseline
+    /// computed for this closure therefore holds <see cref="SeededRowCount"/> + 1 rows, and a
+    /// bundle whose closure is the seed alone can tell it apart by count. The bundle's test
+    /// asserts the three rows.
+    /// </summary>
+    internal static string WriteBundleWithSeedingExtraDependency(
+        string root, string tag, int baseId, string seedTag)
+    {
+        var parent = Path.Combine(root, seedTag);
+        var seedName = $"Seed {seedTag}";
+        var seedId = ReadAppId(Path.Combine(parent, "seed", "app.json"));
+        var marker = ReadMarker(Path.Combine(parent, "seed", "Seed.al"));
+
+        var extraId = Guid.NewGuid().ToString();
+        var extraName = $"Extra {tag}";
+        var extraDir = Path.Combine(parent, "extra-" + tag);
+        Directory.CreateDirectory(extraDir);
+        File.WriteAllText(Path.Combine(extraDir, "app.json"), $$"""
+        {
+          "id": "{{extraId}}",
+          "name": "{{extraName}}",
+          "publisher": "AL Runner Install Seed",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{seedId}}", "name": "{{seedName}}", "publisher": "AL Runner Install Seed", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 4}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(extraDir, "Extra.al"), $$"""
+        codeunit {{baseId}} "Extra {{tag}} Install"
+        {
+            Subtype = Install;
+
+            trigger OnInstallAppPerCompany()
+            var
+                SeedRow: Record "Seed {{seedTag}} Table";
+            begin
+                SeedRow.Init();
+                SeedRow.Code := 'EXTRA-1';
+                SeedRow.Description := 'extra {{tag}}';
+                SeedRow.Amount := 1;
+                SeedRow.Insert(true);
+            end;
+        }
+        """);
+
+        var mainDir = Path.Combine(parent, "main-" + tag);
+        WriteBundle(mainDir, tag, baseId + 5, marker, SeededRowCount + 1, (seedId, seedName), (extraId, extraName));
         return mainDir;
     }
 
@@ -238,7 +294,7 @@ internal static class InstallSeedClosure
     /// than merely being fast.
     /// </summary>
     private static void WriteBundle(
-        string dir, string tag, int baseId, string marker, params (string Id, string Name)[] deps)
+        string dir, string tag, int baseId, string marker, int expectedRows, params (string Id, string Name)[] deps)
     {
         Directory.CreateDirectory(dir);
         var depJson = string.Join(",\n    ", deps.Select(d =>
@@ -276,8 +332,8 @@ internal static class InstallSeedClosure
                 // present, with the values it wrote. Asserted value-by-value rather than as a
                 // bare Get(), so a cache tier that restored an empty or partial snapshot fails
                 // here instead of passing quietly.
-                if SeedRow.Count() <> {{SeededRowCount}} then
-                    Error('expected {{SeededRowCount}} seeded row(s), found %1', SeedRow.Count());
+                if SeedRow.Count() <> {{expectedRows}} then
+                    Error('expected {{expectedRows}} seeded row(s), found %1', SeedRow.Count());
 
                 SeedRow.Get('SEED-1');
                 if SeedRow.Description <> '{{marker}}' then

--- a/AlRunner.Tests/InstallSeedDepCompanyCacheTests.cs
+++ b/AlRunner.Tests/InstallSeedDepCompanyCacheTests.cs
@@ -200,7 +200,8 @@ public class InstallSeedDepCompanyCacheTests
         // in-memory HIT. A cache keyed so that these two closures collide would show one
         // resolution and one HIT; this shows two resolutions and no HIT.
         //
-        // WHAT THIS DOES AND DOES NOT PIN, measured by mutation (#2364; gap tracked in #3254):
+        // WHAT THIS DOES AND DOES NOT PIN, measured by mutation (#2364). The dependency-set term
+        // alone is pinned by InstallBaselineDiskCacheTests.DependencySetTermAlone_* (#3254):
         // TestExecutor.CurrentInstallBaselineCacheKey() concatenates three components, and the
         // first two — InstallTriggerRunner.CurrentDependencySetKey() and
         // RecordPatches.RegisteredBcAppSymbolStateKey() — are REDUNDANT for this scenario:


### PR DESCRIPTION
Closes #3254

Written by agent stma-auto2-8 on the account holder's behalf.

## What changed

Test-only. No runtime code changed.

- New test `InstallBaselineDiskCacheTests.DependencySetTermAlone_SeparatesBaselines_AndIdenticalInputsHitAcrossProcesses`.
- New fixture `InstallSeedClosure.WriteBundleWithSeedingExtraDependency`: an extra dependency app that depends on the seed app, and whose install trigger adds a third row to the seed table. `WriteBundle` now takes the row count the bundle's AL test expects (the existing callers pass `SeededRowCount`, as before).
- The notes in the two existing scoping tests now point at the new test instead of saying the gap is open.

## How the test isolates the dependency-set term

`TestExecutor.CurrentInstallBaselineCacheKey()` is `CurrentDependencySetKey()` + `RegisteredBcAppSymbolStateKey()` + `TestDataOptions.CacheIdentity()`. In one process, `_depAssemblies` is reset per bundle, but the registered .app set only grows. So the test runs the bundle **with** the extra dependency first and the seed-only bundle second. By the time the second app group computes its key, the registered .app set already holds both apps, so the symbol-state term is the same for both groups and only the dependency-set term tells them apart. Mutation M2 below measures that this is true; it is not just inferred from the code.

The two baselines differ by value (3 rows vs 2), so a key that merged them shows up in the AL test itself, not just in a key string.

- **Process 1** (`[withExtra, seedOnly]`): both AL tests pass, 2 MISS, 0 HIT, 0 DISK-HIT, 2 distinct entries written.
- **Process 2** (same inputs, same cache root): both pass, 0 MISS, 0 HIT, nothing rewritten, 2 DISK-HITs whose keys and digests match what process 1 wrote.

I did not take the shape the issue suggested (a direct unit assertion on `CurrentDependencySetKey()` strings). That would pin the string but not the cache behavior, and the function reads process-global state. The end-to-end test checks the HIT/MISS markers and a difference in baseline values.

The "add a dependency" direction can't be built so that only the dependency-set term moves: adding an app also registers its .app, which moves the symbol-state term too. The same goes for any change across two processes, because each process registers only its own apps. So the change case here is "remove a dependency" within one process, and the identical-input case runs across two processes.

## RED -> GREEN (mutations, BC 28.1 Release build, this box)

No RED existed before the test, because the term itself works. The test pins it. The mutation is the proof:

- **M1**: `CurrentDependencySetKey()` returns the constant `"MUTATED"`. Rebuilt, then ran the two install-cache suites (9 tests): `Failed: 1, Passed: 8, Total: 9`. The one red is the new test, failing on the AL assertion `NavNCLDialogException: expected 2 seeded row(s), found 3` (Codeunit62125), not on a build error. The other 8 stayed green under the mutation, which confirms what the issue reported. Restored: `Failed: 0, Passed: 9, Total: 9`.
- **M2**: `RegisteredBcAppSymbolStateKey()` returns the constant `"|bcapps:MUTATED"`. Rebuilt, ran the new test alone: `Failed: 0, Passed: 1`. So the new test does not depend on the symbol-state term. It pins the dependency-set term by itself.

Both mutations were checked with `git diff` before building, and both were reverted. The pushed diff touches only the three test files.

Other runs on the final tree: `PartialCompanyInitializationTests` + `BaseAppFloorFixtureGuardTests` (the other consumers of `InstallSeedClosure`): `Failed: 0, Passed: 22`. `InstallBaselineKeySymbolStateTests` passed too. All `tools/test_*.py` passed.

## Fix the shape

1. **Same pattern elsewhere?** The key has three terms. `InstallBaselineKeySymbolStateTests` pins the bcapps term, and `TestDataProvisioningTests` pins the `--test-data` term (it checks that the key starts with the plain key). This PR covers the third term. Nothing else is left unpinned.
2. **Sibling assumption?** The in-memory tier and the disk tier both key off the same `depKey` string (the disk key is `BuildKeyText(depKey, schema)`). The new test goes through both: process 1 uses the in-memory lookup, and process 2 uses the disk lookup.
3. **Two writers, same invariant?** `ResetForNewBundle` clears `_depAssemblies` per bundle, while `_bcAppPaths` only grows (already recorded in #2710's notes). This test depends on that difference and doesn't change it. No new defect found.

## Queue scan

I searched open issues for `CurrentDependencySetKey`, `RegisteredBcAppSymbolStateKey`, `install baseline`, `InstallBaselineDiskCache` and `DepCompanyCache`. Only #3254 matches the key terms. The `install baseline` hits (#3774 file-stat cost, #3964 server-mode TableRelation verdict, others) are about different behavior in different files, so nothing folds in.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
