### PR TITLE
fix(transactions): Report.Run commit point in default-model tests

### DIFF
--- a/AlRunner.Tests/ReportRunTransactionWorldTests.cs
+++ b/AlRunner.Tests/ReportRunTransactionWorldTests.cs
@@ -1,0 +1,68 @@
+// ReportRunTransactionWorldTests — AlRunner#2904.
+//
+// A RUNNER-MECHANISM test. The BC claim — a Report.Run that enters a transaction world is
+// refused with a pending write and otherwise commits the report's writes — is measured by
+// corpus codeunit 60040 "Test TxModel Report Run" (StefanMaron/BusinessCentral.AL.Language.Tests
+// PR #344). This pins the runner's copy of BC's guard, because the runner replaces NavReport.Run
+// outright (NavReportSync.SyncRun) and BC's own RunReportCoreAsync never runs here.
+
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class ReportRunTransactionWorldTests
+{
+    private const int UpdateNoLocks = 0;
+    private const int Update = 1;
+    private const int Browse = 3;
+
+    private readonly BcEngineFixture _engine;
+
+    public ReportRunTransactionWorldTests(BcEngineFixture engine) => _engine = engine;
+
+    private void Arrange(int currentTransactionType)
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+        ALDatabasePatches.ResetWriteTransactionState();
+        ALDatabasePatches.ALDatabase_SetCurrentTransactionType(currentTransactionType);
+        Assert.Equal(currentTransactionType, ALDatabasePatches.ALDatabase_GetCurrentTransactionType());
+    }
+
+    [SkippableFact]
+    public void RequestPage_EntersTheWorld_WhateverTheTransactionType()
+    {
+        Arrange(UpdateNoLocks);
+        Assert.True(ALDatabasePatches.ReportRunEntersTransactionWorld(useRequestForm: true, UpdateNoLocks));
+    }
+
+    [SkippableFact]
+    public void NoRequestPage_DefaultTransactionType_DoesNotEnterTheWorld()
+    {
+        Arrange(UpdateNoLocks);
+        Assert.False(ALDatabasePatches.ReportRunEntersTransactionWorld(useRequestForm: false, UpdateNoLocks));
+    }
+
+    [SkippableFact]
+    public void NoRequestPage_TransactionTypeDiffersFromTheSession_EntersTheWorld()
+    {
+        Arrange(UpdateNoLocks);
+        Assert.True(ALDatabasePatches.ReportRunEntersTransactionWorld(useRequestForm: false, Update));
+    }
+
+    [SkippableFact]
+    public void NoRequestPage_TransactionTypeEqualToTheSession_DoesNotEnterTheWorld()
+    {
+        Arrange(Browse);
+        Assert.False(ALDatabasePatches.ReportRunEntersTransactionWorld(useRequestForm: false, Browse));
+    }
+
+    [SkippableFact]
+    public void NoRequestPage_UpdateNoLocksReport_DoesNotEnterTheWorldEvenWhenTheSessionDiffers()
+    {
+        Arrange(Browse);
+        Assert.False(ALDatabasePatches.ReportRunEntersTransactionWorld(useRequestForm: false, UpdateNoLocks));
+    }
+}

--- a/AlRunner/Patches/ALDatabasePatches.cs
+++ b/AlRunner/Patches/ALDatabasePatches.cs
@@ -293,6 +293,22 @@ public static class ALDatabasePatches
     }
 
     /// <summary>
+    /// Whether <c>Report.Run</c> / <c>Report.RunModal</c> enters a transaction world — BC's
+    /// guard in <c>NavReport.RunReportCoreAsync</c> (Ncl 28.4), with TransactionType ordinals
+    /// (UpdateNoLocks = 0):
+    /// <c>(UseRequestForm || (current != report &amp;&amp; report != UpdateNoLocks))
+    /// &amp;&amp; (!InTest || model != AutoRollback)</c>. Corpus 60040 "Test TxModel Report Run"
+    /// pins both consequences — refused with a pending write, otherwise the report's own
+    /// writes commit (#2904).
+    /// </summary>
+    internal static bool ReportRunEntersTransactionWorld(bool useRequestForm, int reportTransactionType)
+    {
+        bool typeDiffers = ALDatabase_GetCurrentTransactionType() != reportTransactionType
+                           && reportTransactionType != 0;
+        return (useRequestForm || typeDiffers) && !CurrentTestIsAutoRollback();
+    }
+
+    /// <summary>
     /// BC's TransactionManager PUSH of the nested logical transaction a GUARDED
     /// <c>Codeunit.Run</c> opens — the counterpart of <see cref="EndGuardedRunTransaction"/>.
     /// Call before invoking the guarded run's OnRun, for BOTH the instance form

--- a/AlRunner/Patches/NavReportSync.cs
+++ b/AlRunner/Patches/NavReportSync.cs
@@ -639,7 +639,45 @@ public static partial class NavReportSync
                 null, Type.EmptyTypes, null);
         }
 
-        TryRunOrControlFlow(navReport, navReportBase);
+        // #2904: BC's RunReportCoreAsync decides BEFORE the request page whether this run
+        // enters a transaction world. Entering one is refused while a write is pending, and
+        // the report's own transaction then commits on return — the same Begin/End pair a
+        // guarded Codeunit.Run models, so the same two calls stand in for it.
+        // Observably equivalent: corpus 60040 Test04-Test08 on a real service tier.
+        if (!AlRunner.Patches.ALDatabasePatches.ReportRunEntersTransactionWorld(
+                ReadBoolProperty(navReport, "UseRequestForm", fallback: true),
+                ReadReportTransactionType(navReport)))
+        {
+            TryRunOrControlFlow(navReport, navReportBase);
+            return;
+        }
+
+        AlRunner.Patches.ALDatabasePatches.ThrowIfWriteTransactionStarted();
+        AlRunner.Patches.ALDatabasePatches.BeginGuardedRunTransaction();
+        try
+        {
+            TryRunOrControlFlow(navReport, navReportBase);
+        }
+        catch
+        {
+            // BC: EndTransaction(false) rolls the report's writes back before the error leaves.
+            AlRunner.Patches.ALDatabasePatches.EndGuardedRunTransaction(commit: false);
+            throw;
+        }
+        AlRunner.Patches.ALDatabasePatches.EndGuardedRunTransaction(commit: true);
+    }
+
+    /// <summary><c>Metadata.TransactionType</c> as its ordinal; 0 (UpdateNoLocks, the report
+    /// default) when the report carries no metadata at all.</summary>
+    private static int ReadReportTransactionType(object navReport)
+    {
+        var meta = FindProperty(navReport.GetType(), "Metadata")?.GetValue(navReport);
+        if (meta == null) return 0;
+        var p = FindProperty(meta.GetType(), "TransactionType")
+            ?? throw new AlRunner.Infrastructure.BcShapeGapException(
+                "NavReport.Run", "MetaReport.TransactionType",
+                "property not found, so whether the run enters a transaction world cannot be decided");
+        return Convert.ToInt32(p.GetValue(meta));
     }
 
     // Runs the full lifecycle (OnInitReport → OnPreReport → DataItems →

--- a/AlRunner/Patches/NavReportSync.cs
+++ b/AlRunner/Patches/NavReportSync.cs
@@ -645,7 +645,7 @@ public static partial class NavReportSync
         // guarded Codeunit.Run models, so the same two calls stand in for it.
         // Observably equivalent: corpus 60040 Test04-Test08 on a real service tier.
         if (!AlRunner.Patches.ALDatabasePatches.ReportRunEntersTransactionWorld(
-                ReadBoolProperty(navReport, "UseRequestForm", fallback: true),
+                ReadUseRequestForm(navReport),
                 ReadReportTransactionType(navReport)))
         {
             TryRunOrControlFlow(navReport, navReportBase);
@@ -665,6 +665,18 @@ public static partial class NavReportSync
             throw;
         }
         AlRunner.Patches.ALDatabasePatches.EndGuardedRunTransaction(commit: true);
+    }
+
+    /// <summary><c>NavReport.UseRequestForm</c>, read strictly: a missing property would
+    /// silently decide whether the run is refused or commits.</summary>
+    private static bool ReadUseRequestForm(object navReport)
+    {
+        var p = FindProperty(navReport.GetType(), "UseRequestForm");
+        if (p == null || p.PropertyType != typeof(bool))
+            throw new AlRunner.Infrastructure.BcShapeGapException(
+                "NavReport.Run", "NavReport.UseRequestForm",
+                "bool property not found, so whether the run enters a transaction world cannot be decided");
+        return (bool)p.GetValue(navReport)!;
     }
 
     /// <summary><c>Metadata.TransactionType</c> as its ordinal; 0 (UpdateNoLocks, the report


### PR DESCRIPTION
Closes #2904

Written by agent stma-auto2-8 on the account holder's behalf.

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/344

## What BC does

`NavReport.RunReportCoreAsync` (Ncl 28.4) enters a transaction world when the report uses a request page, or declares a `TransactionType` other than `UpdateNoLocks` that differs from the session's. It skips this only for a test running under `TransactionModel::AutoRollback`. `TransactionManager.BeginTransactionWorld` throws `TransactionWorldWithActiveWriteTransactionError` if a write is pending. Otherwise the report's own `BeginTransaction`/`EndTransaction(true)` pushes and pops a fresh logical transaction, and popping it commits.

So the issue's premise is half right. BC does not commit a test's *prior* writes. With a pending write the run is **refused**. With no pending write, the **report's own writes** are committed.

Corpus codeunit 60040 "Test TxModel Report Run" (corpus PR #344) puts all of this in front of the service tier: a plain report as the control, request page with `Run` and `RunModal`, `TransactionType = Update`, and AutoRollback. It is labelled `run-nightly-windows`. The Linux StartupHook has no patch on the transaction manager or on `NavReport`'s run path (its only report patch is #19, rendering), and these reports are ProcessingOnly. **The corpus legs had not reported when I handed this back, so this PR must not merge until #344 is green and merged.**

## What changed

- `ALDatabasePatches.ReportRunEntersTransactionWorld(useRequestForm, reportTransactionType)` is the runner's copy of BC's guard. It uses the runner's own current transaction type and `CurrentTestIsAutoRollback()`.
- `NavReportSync.SyncRun`, which replaces `NavReport.Run`/`RunModal`, now wraps the run when the guard says so. It calls `ThrowIfWriteTransactionStarted()` and then `BeginGuardedRunTransaction()`. On return it calls `EndGuardedRunTransaction(commit: true)`; on an exception it calls `EndGuardedRunTransaction(commit: false)` and rethrows. These are the same calls a guarded `Codeunit.Run` uses, so the two paths keep the same invariant.
- `AlRunner.Tests/ReportRunTransactionWorldTests.cs` is a mechanism test of the guard. The BC claim lives upstream, so the "Tests updated" gate needs a runner-side test here.

## RED -> GREEN

I ran a scratch bundle holding only the corpus PR's files (Assert, "ALT Base", the three reports and codeunit 60040), with the platform-apps package cache:

- Before the fix: `Failed: 5, Passed: 6`. Test04, 05 and 08 were not refused, and Test06 and 07 did not commit.
- After the fix: `Failed: 0, Passed: 11`, run twice against one `--cache` root (cold, then warm).

## Mutations (executed)

| mutation | result |
|---|---|
| guard returns `false` | `Failed: 5, Passed: 6` (Test04-08) |
| drop the TransactionType term (`typeDiffers && false`) | `Failed: 2, Passed: 9` (only Test07, Test08) |
| drop the AutoRollback exemption | `Failed: 1, Passed: 10` (only Test09, refused) |
| C# test: drop `report != UpdateNoLocks` | `Failed: 1, Passed: 4, Total: 5` |
| failure branch: `EndGuardedRunTransaction(commit: false)` -> `commit: true` (added after review) | `Failed: 1, Passed: 11` (only Test12) |

After review I added corpus Test12 (`TxReportRun_Test12_RequestPageReportThatFailsCommitsNothing`, report 60029). A request-page report writes a row and then raises. Under `asserterror`, the row must be gone. Before that arm existed, the `commit: true` mutation above left all 11 tests green. With the fix, the bundle is `Failed: 0, Passed: 12`, run twice against one cache. I also changed the `UseRequestForm` read to raise a shape gap when the property is missing, the same way the `TransactionType` read already did.

## Other runs on this head

- `dotnet test --filter ReportRunTransactionWorldTests|CodeunitRunWriteTransactionRefusalTests` (engine bootstrapped, `Skipped: 0`): `Passed: 10, Total: 10`
- `GuardTests`: `Passed: 254, Total: 254`. All `tools/test_*.py` pass.
- Full corpus at master `0d9d246b` with `--strict`: `3348 total, pass 3348, fail 0`.
- Full corpus at corpus PR #344's earlier head `e4dbb2ce` (before Test12) with `--strict`: `3359 total, pass 3359, fail 0`. All eleven `TxReportRun_*` tests run and pass inside the whole suite, not only in the scratch bundle.
- runner-extras `report-dep-maxiteration`, `report-precompiled-dep-metadata`, `report-stubmeta-unbounded-loop`: all pass.

## Fix the shape

1. **Same pattern at another call site?** BC enters the same world from every `RunReportAsync` caller: `RunRequestPage` (requestWindow true), `Execute` and `Print` (requestWindow false, so only through the TransactionType term), and the static `RunAsync(session, options)`. This PR covers `Run`/`RunModal`, instance and static, because both reach `SyncRun`. The other entry points have their own runner seams and no corpus arm yet, so I filed #4089 rather than changing them unmeasured.
2. **A sibling that makes the same assumption?** The guarded `Codeunit.Run` already had this guard. The report path is the one that was missing it. Page `RunModal` does not need it, because under a test that path never reaches `BeginTransactionWorld` (corpus 60903).
3. **Two paths writing the same state, same invariant?** Yes. Both now go through `ThrowIfWriteTransactionStarted` plus `Begin/EndGuardedRunTransaction`, so the commit goes through `CommitWithoutTestExecutionGuard` and honours `CommitBehavior` the same way.

Not measured: a report ended by `CurrReport.Quit()` inside a world now commits, just like a normal return (before this PR nothing about it committed). BC may roll it back through `iteratorCompleted.rollback`. No test pins that either way.

Two more things are not measured (all three unmeasured points are tracked in #4095):
- The guard reads the runner's flat `_currentTransactionType` static. BC keeps that value on its logical-transaction stack, so it is restored when a transaction pops. A codeunit that leaves the static at another value could change Test07/Test08's answer. It did not change it inside the full corpus run above.
- The commit goes through `CommitWithoutTestExecutionGuard`, the same as a guarded `Codeunit.Run`, so it honours `[CommitBehavior]`. BC's report path reaches `IssueEndTransaction`, not `ALDatabase.ALCommit`, so under `CommitBehavior::Ignore`/`Error` the runner may differ from BC. No corpus arm combines a report with `[CommitBehavior]`.

## For the merge

Confirm the corpus tests ran with `tools/corpus-pass-count.py <run-id> TxReportRun`: 12 on each of the eight cloud legs, with OnPrem `not-run`. If a cloud leg shows fewer than 12, that is not a flake. It most likely means a refusal prediction failed, an unhandled request page stopped the codeunit, and the assertion needs to change.

## Queue scan

I searched for "transaction world", "Report.Run commit", "write transaction report", "RunRequestPage transaction", "Report.Execute" and "TransactionType report". #2184 asks the same refusal question for `Report.RunModal` and `XmlPort.Import`. Test05 answers the `Report.RunModal` half, but the `XmlPort.Import` half is still open, so I am not closing #2184 here. #3773 (`Commit()` inside a guarded `Codeunit.Run`) is a different path.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
