### PR TITLE
test(metadata): conditional TableRelation arms on precompiled fields

### DIFF
--- a/AlRunner.Tests/BcAppSymbolCacheTableExtRelationTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCacheTableExtRelationTests.cs
@@ -13,12 +13,8 @@
 // for all of them and Validate() accepted a value with no matching related row. #2528 recorded
 // what that is: a wrong ANSWER, not a missing feature.
 //
-// Two of the four FAIL before the fix and pass after it
-// (PlainRelation_..., ValidateTableRelationZero_...); the other two PASS in both states and are
-// GUARDS on the shape of the fix, not RED -> GREEN evidence. Said plainly so nobody reads
-// "4 passed" as four proofs: FieldWithoutTableRelation_... refuses "invent a relation where the
-// symbol declares none", and FlowFilterTableRelation_... refuses "carry it for every field
-// class". Each is verified by breaking the fix the corresponding way, not by the run below.
+// FieldWithoutTableRelation_... is a guard ("invent a relation where the symbol declares none");
+// the two FlowFilter/FlowField tests are #2789's RED -> GREEN on the extension and table loops.
 //
 // These assert on the parsed symbol rather than on runtime behaviour deliberately. The symbol
 // reader is the layer that lost the property, it is reachable without loading a BC closure
@@ -61,13 +57,48 @@ public class BcAppSymbolCacheTableExtRelationTests
     //   5902 "No Relation"         — declares none. Must arrive with null arms, so "read the
     //                                property" is not confused with "invent one".
     //   5903 "Ship-to Filter"      — FlowFilter carrying a TableRelation, exactly the shape
-    //                                6450 declares. The table loop gates relation parsing on
-    //                                !IsFlowField && !IsFlowFilter with a documented reason
-    //                                (#2528); this pins the extension loop to the same gate, so
-    //                                the two paths cannot disagree in the other direction.
+    //                                6450 declares. BC keeps a FlowFilter's relation (#2789,
+    //                                corpus codeunit 60483), so it MUST arrive with its arm.
+    //
+    // Plus one table, 70789, read by the TABLE loop: a FlowFilter and a FlowField each carrying
+    // a TableRelation (#2789). The two loops read the property the same way for every class.
     private const string SymbolReference = """
         {
           "RuntimeVersion": "15.1",
+          "Tables": [
+            {
+              "Id": 70789,
+              "Name": "Relation Field Class",
+              "Fields": [
+                {
+                  "TypeDefinition": { "Name": "Integer" },
+                  "Properties": [],
+                  "Id": 1,
+                  "Name": "Entry No."
+                },
+                {
+                  "TypeDefinition": { "Name": "Code[20]" },
+                  "Properties": [
+                    { "Name": "FieldClass", "Value": "FlowFilter" },
+                    { "Name": "TableRelation", "Value": "Location" }
+                  ],
+                  "Id": 2,
+                  "Name": "Location Filter"
+                },
+                {
+                  "TypeDefinition": { "Name": "Guid" },
+                  "Properties": [
+                    { "Name": "FieldClass", "Value": "FlowField" },
+                    { "Name": "CalcFormula", "Value": "lookup(\"G/L Account\".SystemId where(\"No.\" = field(\"Location Filter\")))" },
+                    { "Name": "TableRelation", "Value": "\"G/L Account\".SystemId" }
+                  ],
+                  "Id": 3,
+                  "Name": "Account Id"
+                }
+              ],
+              "Keys": [ { "Name": "PK", "FieldNames": [ "Entry No." ] } ]
+            }
+          ],
           "Namespaces": [
             {
               "Name": "Microsoft.Service.Customer",
@@ -182,7 +213,7 @@ public class BcAppSymbolCacheTableExtRelationTests
     }
 
     [Fact]
-    public void FlowFilterTableRelation_IsNotCarried_MatchingTheTablePathsGate()
+    public void FlowFilterTableRelation_IsCarried_OnTheExtensionLoop()
     {
         var dir = TestScratch.Dir("al-runner-bcsym-tableext-relation");
         Directory.CreateDirectory(dir);
@@ -191,10 +222,36 @@ public class BcAppSymbolCacheTableExtRelationTests
             var field = ParseOnce(dir).Fields.Single(f => f.FieldId == 5903);
 
             Assert.True(field.IsFlowFilter);
-            // Refused on purpose (#2528's gate), not missed: a FlowFilter's TableRelation is a
-            // lookup hint for the filter's own UI, and carrying it would pull FlowFilter
-            // pseudo-columns into the rename-propagation reverse index.
-            Assert.Null(field.RelationArms);
+            // #2789: BC keeps it — Relation() answers "Ship-to Address", and rename propagation
+            // skips the field by FieldClass on BC's side, not by a missing relation.
+            Assert.NotNull(field.RelationArms);
+            Assert.Equal("Ship-to Address", Assert.Single(field.RelationArms!).TableName);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void FlowFilterAndFlowFieldTableRelation_AreCarried_OnTheTableLoop()
+    {
+        var dir = TestScratch.Dir("al-runner-bcsym-tableext-relation");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var appPath = WriteApp(dir, SymbolReference);
+            var table = Assert.Single(BcAppSymbolCache.Get(appPath).Tables, t => t.TableId == 70789);
+
+            var filter = table.Fields.Single(f => f.FieldId == 2);
+            Assert.True(filter.IsFlowFilter);
+            Assert.NotNull(filter.RelationArms);
+            Assert.Equal("Location", Assert.Single(filter.RelationArms!).TableName);
+
+            var flow = table.Fields.Single(f => f.FieldId == 3);
+            Assert.True(flow.IsFlowField);
+            Assert.NotNull(flow.RelationArms);
+            Assert.Equal("G/L Account", Assert.Single(flow.RelationArms!).TableName);
+
+            // Control on the same table: a Normal field with no TableRelation stays null.
+            Assert.Null(table.Fields.Single(f => f.FieldId == 1).RelationArms);
         }
         finally { Directory.Delete(dir, recursive: true); }
     }

--- a/AlRunner.Tests/FlowFilterRelationSourceParseTests.cs
+++ b/AlRunner.Tests/FlowFilterRelationSourceParseTests.cs
@@ -1,0 +1,90 @@
+// FlowFilterRelationSourceParseTests — runner-mechanism guard for #2789 on the AL-SOURCE parser.
+//
+// BC keeps a TableRelation declared on a FlowFilter or FlowField (FieldRef.Relation answers it,
+// Validate checks it; corpus codeunit 60483 asserts that on a service tier) and excludes
+// non-Normal fields from rename propagation at the consumer, by FieldClass. The runner's three
+// readers of the property all dropped it for those two classes. BcAppSymbolCacheTableExtRelationTests
+// pins the two symbol-file loops; this file pins the AL-source parser, so the three readers
+// cannot disagree about the same declaration.
+//
+// Drives the real parser by reflection (TryParseTableFile), so it joins
+// RecordPatchesSerialCollection — see ParserStaticsIsolationGuardTests.
+using System.Reflection;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class FlowFilterRelationSourceParseTests
+{
+    private const int TableId = 61789;
+
+    private static ParsedTable Parse()
+    {
+        var text = $$"""
+            table {{TableId}} "FlowFilter Relation Parse"
+            {
+                fields
+                {
+                    field(1; "No."; Code[20]) { }
+                    field(2; "Location Filter"; Code[10])
+                    {
+                        FieldClass = FlowFilter;
+                        TableRelation = Location;
+                    }
+                    field(3; "Account Id"; Guid)
+                    {
+                        FieldClass = FlowField;
+                        CalcFormula = lookup("G/L Account".SystemId where("No." = field("No.")));
+                        TableRelation = "G/L Account".SystemId;
+                    }
+                    field(4; "Plain Filter"; Code[10])
+                    {
+                        FieldClass = FlowFilter;
+                    }
+                }
+                keys
+                {
+                    key(PK; "No.") { Clustered = true; }
+                }
+            }
+            """;
+        typeof(RecordPatches)
+            .GetMethod("TryParseTableFile", BindingFlags.NonPublic | BindingFlags.Static)!
+            .InvokeStatic(text);
+        var tables = (Dictionary<int, ParsedTable>)typeof(RecordPatches)
+            .GetField("_parsedTables", BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetValue(null)!;
+        return tables[TableId];
+    }
+
+    [Fact]
+    public void FlowFilterTableRelation_IsCarried()
+    {
+        var field = Parse().Fields.Single(f => f.FieldId == 2);
+
+        Assert.True(field.IsFlowFilter);
+        Assert.NotNull(field.RelationArms);
+        Assert.Equal("Location", Assert.Single(field.RelationArms!).TableName);
+    }
+
+    [Fact]
+    public void FlowFieldTableRelation_IsCarried()
+    {
+        var field = Parse().Fields.Single(f => f.FieldId == 3);
+
+        Assert.True(field.IsFlowField);
+        Assert.NotNull(field.RelationArms);
+        Assert.Equal("G/L Account", Assert.Single(field.RelationArms!).TableName);
+    }
+
+    [Fact]
+    public void FlowFilterWithoutTableRelation_KeepsNullArms()
+    {
+        var field = Parse().Fields.Single(f => f.FieldId == 4);
+
+        Assert.True(field.IsFlowFilter);
+        Assert.Null(field.RelationArms);
+    }
+}

--- a/AlRunner/Patches/BcAppSymbolCache.TableExtensions.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.TableExtensions.cs
@@ -194,8 +194,8 @@ internal static partial class BcAppSymbolCache
     /// same property.</para>
     ///
     /// <para><b>261</b> tableextension fields across the platform packages carry a
-    /// TableRelation, of which <b>260</b> gain one here — the gate below excludes exactly one,
-    /// <c>Customer."Ship-to Filter"</c> (5903, a FlowFilter). #3177 was filed with 154, which
+    /// TableRelation, and all of them are read here — including the one FlowFilter among them,
+    /// <c>Customer."Ship-to Filter"</c> (5903), since #2789. #3177 was filed with 154, which
     /// is the <b>Base Application share</b>, not an older count: the other 107 are in Business
     /// Foundation, an equally precompiled dependency read through this same loop. The total does
     /// NOT drift with the BC version — measured 154 + 107 = 261 identically on 28.1 and 28.4
@@ -267,22 +267,9 @@ internal static partial class BcAppSymbolCache
                 // Both properties, independently: ValidateTableRelation = 0 turns the CHECK off
                 // while leaving the relation itself readable, so reading only the first would
                 // switch validation on wholesale for fields BC does not validate.
-                //
-                // Gated on field class to match the table loop, whose reason is that a
-                // FlowFilter's TableRelation is a lookup hint for the filter's own UI rather
-                // than a stored value's referential constraint, and that RelationArms also feeds
-                // the reverse index NCLMetaTable_ComputeReferencingRelations builds for rename
-                // propagation, which filters on table id rather than field class. Note the
-                // blast radius here is NOT the 204 fields #2528 cites on the table path: across
-                // the platform packages this gate excludes exactly ONE extension field,
-                // Customer."Ship-to Filter" (5903, FlowFilter), so 260 of the 261 gain relations.
-                // It is kept anyway because the point of the change is that the two loops read
-                // the property the same way; ungated they would disagree again, in the other
-                // direction, over that one field.
+                // Every field class, exactly as the table loop reads it (#2789).
                 props.TryGetValue("TableRelation", out var tableRelation);
-                var relationArms = (!isFlowField && !isFlowFilter)
-                    ? RecordPatches.TryParseRelationArmsText(tableRelation, fieldName)
-                    : null;
+                var relationArms = RecordPatches.TryParseRelationArmsText(tableRelation, fieldName);
                 var relationValidate = !(props.TryGetValue("ValidateTableRelation", out var vtr)
                     && (vtr == "0" || vtr.Equals("false", StringComparison.OrdinalIgnoreCase)));
                 // #3545 — read exactly as the base-table loop reads them, for the same reason

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -24,7 +24,7 @@ internal static partial class BcAppSymbolCache
     //
     // Every bump adds its row to docs/bc-symbol-cache-versions.md#version-history (why that
     // integer was taken); BcAppSymbolCacheVersionHistoryTests holds the page to this constant.
-    private const int CacheVersion = 42;
+    private const int CacheVersion = 43;
     private static readonly ConcurrentDictionary<string, AppSymbols> ProcessCache = new(StringComparer.OrdinalIgnoreCase);
     // Issue #1820's path -> content-hash memo now lives in
     // RunnerFingerprint._fileContentHashes (#2955), because AppLoader's persisted r2r-chunks
@@ -2275,23 +2275,11 @@ internal static partial class BcAppSymbolCache
                 // itself readable (Customer.City is exactly that shape), so the two properties
                 // are read independently — matching the AL-source path's own two lines.
                 props.TryGetValue("TableRelation", out var tableRelation);
-                // Gated on field class exactly as the AL-source path is
-                // (RecordPatches.AlSourceParser.cs's `if (!isFlowField && !isFlowFilter && ...)`).
-                // A FlowFilter's TableRelation is a LOOKUP hint for the filter's own UI, not a
-                // stored value's referential constraint, and in Base Application 28.1 that is 204
-                // fields (196 FlowFilter, 8 FlowField), ~144 of them with a relation this parser
-                // accepts — "Item Statistics Buffer"."Item Filter" -> Item, "Analysis
-                // Line"."Location Filter" -> Location, "Config. Line"."Company Filter" -> Company.
-                // ParsedField.RelationArms feeds BOTH the Validate check AND the reverse index
-                // NCLMetaTable_ComputeReferencingRelations builds for rename propagation, and that
-                // index filters only on TableId >= 2000000000, not on field class — so without
-                // this gate renaming an Item, Location or Company would pull FlowFilter
-                // pseudo-columns into the cascade. The invariant this whole change is for is that
-                // the source-parsed and symbol-read paths agree; ungated, they would disagree for
-                // exactly these 204 fields, and the source path is the one the corpus validates.
-                var relationArms = (!isFlowField && !isFlowFilter)
-                    ? RecordPatches.TryParseRelationArmsText(tableRelation, fieldName)
-                    : null;
+                // Read for every field class (#2789): BC keeps a FlowFilter's or FlowField's
+                // relation (Relation() answers it, Validate checks it) and excludes non-Normal
+                // fields from rename propagation at the consumer, by FieldClass — so do not gate
+                // here. Corpus codeunit 60483.
+                var relationArms = RecordPatches.TryParseRelationArmsText(tableRelation, fieldName);
                 var relationValidate = !(props.TryGetValue("ValidateTableRelation", out var vtr)
                     && (vtr == "0" || vtr.Equals("false", StringComparison.OrdinalIgnoreCase)));
                 // #3545 — Editable / DataClassification / the enum type. All three are stated

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -507,8 +507,9 @@ public static partial class RecordPatches
         // behaviour (no propagation).
         List<ParsedRelationArm>? relationArms = null;
         bool relationValidate = !PropIs(props, "ValidateTableRelation", "false");
-        if (!isFlowField && !isFlowFilter
-            && PropValue(props, "TableRelation") is NavSyntax.TableRelationPropertyValueSyntax tr)
+        // Every field class (#2789): BC keeps a FlowFilter's / FlowField's relation and filters
+        // rename propagation on FieldClass itself.
+        if (PropValue(props, "TableRelation") is NavSyntax.TableRelationPropertyValueSyntax tr)
         {
             relationArms = ParseRelationArms(tr, fname, fromCompiledSource: true);
         }

--- a/docs/bc-symbol-cache-versions.md
+++ b/docs/bc-symbol-cache-versions.md
@@ -119,6 +119,10 @@ v1 and v2 predate this record.
 
   42 was confirmed free immediately before pushing, per v39's own warning: origin/main read 41, and a sweep of every remote branch carrying this file found none above 41.
 
+- **v43**: a FlowFilter's or FlowField's TableRelation is read rather than dropped (#2789). The same trap as v35 through v42: ParsedField.RelationArms is a list either way, so PayloadShape cannot see that 196 FlowFilter and 8 FlowField fields of Base Application 28.1 (counted from its SymbolReference.json) went from no relation to one. Without the bump a warm box replays the gated parse and `FieldRef.Relation()` answers 0 on those fields, the exact pre-fix answer, from cache.
+
+  43 was confirmed free immediately before pushing: origin/main read 42, and a sweep of every remote branch carrying this file found none above 42.
+
 ## Changes that deliberately did not bump
 
 - No CacheVersion bump of its own for PageSymbol.TableView (#2820), deliberately — the numbered bumps above belong to other changes (v28 to #2518, v29 to #2973), and this one rides whatever the current integer is without moving it. That member is reachable from CachePayload, so PayloadShape (issue #2335, merged as #2856) already gives it a different cache key than any payload written without it — the stale-entry hazard every entry in the version history describes is closed by construction, and bumping as well would only be ceremony. CacheVersion means what RecordShapeFingerprint's own summary says it means: the PARSE changed while the SHAPE did not, which no structural hash can see — v28 and v29 are both exactly that case, and this change is the other one. Verified rather than assumed: a cold run of this build wrote fresh entries and a warm second run read them back, on the SHARED ~/.cache/al-runner/bc-symbols with no --cache isolation, and the precompiled-page corpus arm (Base App page 1710) passed in both.


### PR DESCRIPTION
Closes #2789

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/346

Written by agent stma-auto2-2 on the account holder's behalf.

## Which follow-up, and why this one

#2789 listed four follow-ups to #2781. I was asked to take the one with the largest measurable effect, starting from item 1 (conditional `if (...)` arms on precompiled fields, suspected of picking the wrong arm when the discriminator is an Option or Enum). No MS bucket evidence was cited, so I measured instead.

**Item 1 has no defect.** I generated one AL check per (relation, discriminator member) from Base Application 28.1.49838.53910's `SymbolReference.json`: every conditional relation whose arms are all `<field> = const(<value>)` on one Option or Enum discriminator, with the expected table computed from the arm text. 687 relation-bearing fields start with `if (`; my generator skipped 259 it could not model (multiple discriminators, `filter()` conditions, Code/Boolean discriminators), leaving 2,194 cases. On the runner at `origin/main` (85f3566d), **2,184 matched and 10 did not**. The measurement covers only those const-arm, single-discriminator relations, not all 687.

All 10 mismatches were FlowFilter fields answering 0: `"Analysis Line"."Source No. Filter"`, `"Item Statistics Buffer"."Source No. Filter"`, `"Prod. Order Line"."Capacity No. Filter"`, `"Production Order"."Capacity No. Filter"`. That traced to a deliberate gate, which is what this PR fixes.

## The defect

All three readers of a `TableRelation` dropped it for `FieldClass = FlowFilter` and `FlowField`: the `SymbolReference.json` table loop (#2528), the tableextension loop (#3177), and the AL-source parser. So on a precompiled table, `FieldRef.Relation()` answered 0 and `Validate` skipped the check on those fields. On Base Application 28.1 that is 196 FlowFilter and 8 FlowField fields with a `TableRelation` (my count from the same symbol file).

The gate was justified by rename propagation: the reverse index the runner builds filters only on table id. But BC's rename body, `NavRecord.UpdateReferencesOnRenameAsync` (decompiled Ncl.dll 28.4), already skips a referencing field unless `ValidateRelations && FieldClass == FieldClass.Normal`. BC's own `ComputeReferencingRelations` does not filter by field class either; the filter is at the consumer. The runner's metafields carry `FieldClass` (`BuildMetaField`, #1716), so BC's check applies to them. `RecordImplementation.GetRelation` / `EvaluateRelation` and `ValidateNonFlowFieldAsync` have no field-class gate.

A table this app compiles already behaved correctly before the change, because it is built from BC's emitted metadata document (#3552), not from the gated derivation. The corpus fixture tests below pass on `main` for that reason.

## The fix

Remove the field-class gate in `BcAppSymbolCache.TryParseTableSymbol`, `BcAppSymbolCache.TryParseTableExtensionSymbol` and `RecordPatches.ParseFieldSyntax`. Bump bc-symbols `CacheVersion` 42 -> 43, because `RelationArms` changes value, not shape, so `PayloadShape` cannot see it (row added to `docs/bc-symbol-cache-versions.md`; origin/main read 42 and no remote branch carried a higher value when I checked).

## RED -> GREEN

**Corpus** (codeunit 60483, 14 tests, corpus PR #346, run locally against the corpus clone at `master` cd8403f plus the PR's commits, head 2b5ce0e):

| build | result |
|---|---|
| superseded draft (different assertions), `origin/main` before the fix | `pass: 10, fail: 4`. The 4 were the Base Application FlowFilter/FlowField tests, each answering 0 |
| fix, cold cache | `pass: 14, fail: 0` |
| fix, warm second run on the same `--cache` root | `pass: 14, fail: 0` |
| mutation: table-loop gate restored, separate cache | `pass: 11, fail: 3` (`Expected:<14> Actual:<0>`, `Expected:<18> Actual:<0>`, `Expected:<15> Actual:<0>`) |

The first row ran on the first draft of the test file, before I replaced two tests on a FlowFilter discriminator (see "One thing I got wrong first"). The RED evidence for the shipped file is the mutation row.

**Runner-side mechanism tests** (the corpus tests cannot satisfy the `Tests updated` gate):
- `BcAppSymbolCacheTableExtRelationTests`: the old `FlowFilterTableRelation_IsNotCarried_MatchingTheTablePathsGate` is inverted to `..._IsCarried_OnTheExtensionLoop`, and `FlowFilterAndFlowFieldTableRelation_AreCarried_OnTheTableLoop` is new.
- `FlowFilterRelationSourceParseTests` (new): the AL-source parser, FlowFilter and FlowField carried, and a FlowFilter with no relation stays null.

Filtered run of both classes: `Failed: 0, Passed: 8`. Mutations, each rebuilt:
- table-loop gate restored: `Failed: 1, Passed: 4` on `BcAppSymbolCacheTableExtRelationTests`, the table-loop test only
- source-parser and extension-loop gates restored: `Failed: 3, Passed: 5`, exactly the two source FlowFilter/FlowField tests and the extension-loop test

## One thing I got wrong first

My first corpus draft asserted that `"Analysis Line"."Source No. Filter"` with `"Source Type Filter" = Item` answers Item (27). With the fix, the runner answered Customer (18). BC's `RecordImplementation.EvaluateRelation` evaluates arm conditions only from `ConcatenatedFilterNormalFields` and `ConcatenatedFilterFlowFields`. `FilterFieldDictionary` keeps FlowFilter conditions in a separate `ConcatenatedFilterFlowFilters` bucket, so a condition on a FlowFilter does not rule an arm out, and the first arm applies. All four conditional FlowFilter relations in Base Application use a FlowFilter discriminator. The corpus PR now asserts 18, with a fixture twin (`"Kind Filter"` = B still answers the first arm). The runner runs BC's own `EvaluateRelation` over this metadata, so this is BC's code path. To be clear about the order: the runner answered 18 first, and I found the `EvaluateRelation` mechanism afterward to explain it. The corpus legs are what settle it. If a leg answers Item (27), the runner has a second defect on that field and this PR is incomplete.

## Other runs

- `tests/runner-extras/precompiled-table-relation`: 10/10.
- Corpus tests matching `Rename` (37) with the fix: 37/37.
- `dotnet test --filter GuardTests|Relation|BcAppSymbolCache|ParserStatics`: 332 total. 9 failed on the first run only because the in-process engine bootstrap had not run. After `tools/engine-test-bootstrap.sh` those 9 pass (15/15 in their classes).
- `tools/test_*.py`: all pass.
- No `[RecordPatches] TableRelation on ... relation dropped` line appears in the green corpus, Rename or runner-extras logs, so none of the newly carried relations those runs built failed to resolve. Those runs only build the tables they touch.

## Fix the shape

1. **Same pattern at another call site?** The gate was at three sites, and all three are removed. `RecordPatches.NclMetadataCachePopulator.NCLMetaTable_ComputeReferencingRelations` is the one consumer that reads `FieldRelations` without a class filter. It matches BC's own `ComputeReferencingRelations`, and the class filter belongs to BC's rename consumer, which runs unmodified.
2. **Sibling with the same assumption?** The CalcFormula read on those loops is gated to FlowFields on purpose (only FlowFields have one), so it is not the same shape. The unresolved-relation guard (`RecordPatches.RelationUnresolved.cs`) now also sees FlowFilter relations. A FlowFilter relation whose target does not resolve is refused loudly at the seam, the same as a Normal field.
3. **Two paths writing the same state with different invariants?** Yes, and that was the defect: the BC-document route kept FlowFilter/FlowField relations and the derivation route dropped them. They now agree, and corpus codeunit 60483 checks both routes with one fixture table and Base Application fields.

## Issue queue

Searched open issues for `TableRelation`, `FlowFilter relation`, `FieldRef.Relation`, `rename propagation`, `name-only`, `ParseObjectTextCallCount` and `BuildMetaFieldRelations`. Nothing reports this defect. #3568 lists relation differences on system fields (`SystemCreatedBy`/`SystemModifiedBy`), which is a different gap. #3204 is a tableextension Validate corpus test, not folded.

The rest of #2789 is split out, so #2789 can close with this PR:
- item 2, rename cascade untested: #4105
- item 3, name-only target resolution: #4106
- item 4, cold-read parse cost: #4107

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
