### PR TITLE
feat(tools): report armed pull requests that are not green

### DIFF
--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -162,6 +162,14 @@ nobody gave the new head. Measured on #3978: armed at exit 2 with 0 failing, two
 `Failed: 2, Passed: 5506` twenty minutes later, and the coordinator found it only by sweeping.
 **Disarm before dispatching the repair**, then re-arm on a fresh verdict.
 
+**`tools/armed-prs.py` is that re-read, as one command with no arguments.** It lists the armed
+set and reports only the PRs that are failing or whose verdict could not be read; a PR whose
+checks are still running is the ordinary armed state and stays quiet. Exit 0 nothing to do,
+1 something is failing, **3 a verdict could not be read** — which is not "fine", because nobody
+measured it. It reports and never disarms: the repair sequence above stays the coordinator's
+call. Timings that justify a tool over the sweep alone: two armed PRs sat red for **12 and 119
+minutes** on a night with nineteen armed at once (#4006).
+
 Arm **only** when all of these hold. Any one missing means report it to the coordinator instead:
 
 - **The PR is on a branch this loop owns.** Check the **branch prefix**, never the author field

--- a/tools/armed-prs.py
+++ b/tools/armed-prs.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Report the armed pull requests that are NOT green. One question, one answer.
+
+Why this exists
+---------------
+A PR armed with `--auto` lands the moment its required checks pass, with nobody
+present. That is the point of arming, and it is safe: `--auto` holds at BLOCKED
+and merges nothing red. What it does not do is **tell anyone** when an armed PR
+goes red after the fact -- the reviewer has returned, the coordinator has moved
+on, and the PR sits armed and failing until somebody happens to sweep.
+
+Measured, rather than suspected (#4006): two instances in one hour sat armed and
+red for **12 and 119 minutes** before a manual `ci-wait.py` pass found them --
+on a night with an attentive coordinator sweeping every few ticks and **nineteen
+PRs armed at once**. The consequence is not a bad merge but the harder thing to
+notice: a silently stalled PR. Nothing is red on `main`, nothing is broken, and
+the work simply does not land.
+
+This is the two calls such a sweep already makes, with nobody having to remember
+to make them.
+
+Usage
+-----
+    tools/armed-prs.py              # the whole answer, no arguments
+    tools/armed-prs.py --all        # also list the quiet ones, to see the set
+    tools/armed-prs.py --json       # machine-readable rows
+
+What it does NOT do
+-------------------
+It reports. It does not disarm, merge, re-run, schedule itself, or act on
+anything it finds -- deliberately, because the repair sequence is **disarm ->
+repair -> re-arm on a fresh verdict** (#4006), and the ordering matters: pushing
+a fix to a still-armed red PR makes the fix commit itself the green thing that
+triggers the merge, at a head nobody reviewed. Choosing to disarm is a merge
+decision, and a merge decision stays with the coordinator.
+
+Exit codes
+----------
+    0  every armed PR is green or still running -- nothing to do
+    1  at least one armed PR is FAILING (`ci-wait.py` exit 1 or 4)
+    3  at least one armed PR's verdict COULD NOT BE READ, and none is failing
+
+Exit 2 from `ci-wait.py` -- required checks still running -- is the **ordinary**
+state of an armed PR and is deliberately quiet. Reporting it would have named
+twenty-one PRs on the night that motivated this tool, and a report that names
+everything is ignored, which is the same as not existing.
+
+Exit 3 is deliberately not folded into 0. An armed PR whose verdict could not be
+read is not "fine" -- nobody measured it, and calling an unmeasured thing green
+is the defect `guards-need-a-third-state.md` exists to prevent. It gets its own
+exit code and its own visibly distinct line, because the remedy differs: a
+FAILING PR needs disarming, an UNREADABLE one needs asking again.
+
+Where the verdict comes from
+----------------------------
+`tools/ci-wait.py <N> --timeout 0` per armed PR, whose exit code carries the
+whole answer -- read directly via `subprocess.run(...).returncode`, never
+through a pipe. `tools/ci-wait.py <N> --timeout 0 | tail` leaves `$?` as
+**tail's** status, which is 0 whatever the verdict was; `ci-verdicts.md` §0
+records that biting twice in one night, once being the coordinator.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+try:
+    import agent_stdio as _stdio
+except Exception:  # pragma: no cover - a copy detached from its sibling module
+    _stdio = None
+if _stdio is not None:
+    _stdio.enable_utf8_stdio()
+
+REPO = "StefanMaron/BusinessCentral.AL.Runner"
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+# The three verdicts. Distinct values, because collapsing UNREADABLE into either
+# neighbour is the whole defect: into OK it asserts a PR is fine having failed to
+# measure it, into FAILING it sends a coordinator to disarm a PR that may be green.
+OK = "ok"
+FAILING = "failing"
+UNREADABLE = "unreadable"
+
+# ci-wait.py's exit codes, per its own docstring and `ci-verdicts.md` §0. Only
+# these five are mapped; anything else falls through to UNREADABLE below, which
+# is what makes a future exit code safe to add there before it is handled here.
+_RC = {
+    0: OK,          # every required check passed on the current head
+    2: OK,          # no verdict yet -- the ordinary state of an armed PR
+    1: FAILING,     # a required check failed
+    4: FAILING,     # green but blocked, and nothing else says why
+    3: UNREADABLE,  # could not determine (auth, network, narrowed ruleset, stale copy)
+}
+
+
+@dataclass
+class Row:
+    number: int
+    verdict: str
+    rc: int
+    head: str = ""
+    armed_for: str = "unknown"
+
+
+def classify(rc: int) -> str:
+    """Map a `ci-wait.py` exit code to one of the three verdicts.
+
+    An UNMAPPED code is UNREADABLE, never OK. That direction is the point: an
+    exit code this tool does not recognise means the verdict was not
+    established, and the failure mode worth avoiding is a new or anomalous code
+    -- a signal death reported as a negative returncode, a future exit 5 --
+    being silently absorbed into the green set.
+    """
+    return _RC.get(rc, UNREADABLE)
+
+
+def armed(prs: list[dict]) -> list[dict]:
+    """The PRs with auto-merge enabled: `autoMergeRequest` present and non-null."""
+    return [p for p in prs if p.get("autoMergeRequest")]
+
+
+def armed_for(enabled_at: str | None, now: str | None = None) -> str:
+    """How long an arming has stood, as `1h59m` / `12m`, or `unknown`.
+
+    `unknown` rather than `0m` for an absent or unparseable timestamp: a report
+    saying a PR was armed seconds ago when nobody knows is worse than one saying
+    nobody knows, because it is the reading that makes a stale arming look fresh.
+    """
+    if not enabled_at:
+        return "unknown"
+    try:
+        then = _dt.datetime.fromisoformat(enabled_at.replace("Z", "+00:00"))
+        ref = (_dt.datetime.fromisoformat(now.replace("Z", "+00:00")) if now
+               else _dt.datetime.now(_dt.timezone.utc))
+    except (ValueError, AttributeError):
+        return "unknown"
+    mins = int((ref - then).total_seconds() // 60)
+    if mins < 0:
+        return "unknown"
+    return f"{mins // 60}h{mins % 60:02d}m" if mins >= 60 else f"{mins}m"
+
+
+def _gh_pr_list() -> list[dict]:
+    """Open PRs with the three fields a sweep needs. Exits 3 on a failed read."""
+    p = subprocess.run(
+        ["gh", "pr", "list", "--repo", REPO, "--state", "open", "--limit", "100",
+         "--json", "number,autoMergeRequest,headRefOid"],
+        capture_output=True, text=True, encoding="utf-8", errors="replace")
+    if p.returncode != 0:
+        print(f"could not list pull requests: {(p.stderr or '').strip()}",
+              file=sys.stderr)
+        sys.exit(3)
+    # mise prints a banner on stdout, which is not JSON (CLAUDE.md).
+    body = "\n".join(l for l in (p.stdout or "").split("\n")
+                     if not l.startswith("mise "))
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError as exc:
+        print(f"could not parse the pull-request list: {exc}", file=sys.stderr)
+        sys.exit(3)
+
+
+def _ci_wait_rc(number: int, timeout_s: int = 240) -> int:
+    """`ci-wait.py <N> --timeout 0`'s exit code, read directly.
+
+    `.returncode`, never a pipeline's `$?`, and never `check=True`: a non-zero
+    exit IS the answer here, so raising on it would discard every verdict this
+    tool exists to collect.
+    """
+    p = subprocess.run(
+        [sys.executable, os.path.join(HERE, "ci-wait.py"), str(number),
+         "--timeout", "0", "--no-log"],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+        timeout=timeout_s)
+    return p.returncode
+
+
+def sweep(prs: list[dict], ci_wait_rc=_ci_wait_rc) -> tuple[int, list[Row]]:
+    """Read every armed PR's verdict. Returns (exit code, rows worth reporting).
+
+    Only armed PRs are handed to `ci-wait.py`: each one is a subprocess making
+    live API calls, and asking about the unarmed ones would have spent 35 of
+    them to answer a question about 21 (measured on the live queue, 2026-09-13).
+    """
+    rows: list[Row] = []
+    for p in armed(prs):
+        number = p["number"]
+        try:
+            rc = ci_wait_rc(number)
+        except Exception as exc:
+            # A ci-wait.py that could not run at all is exactly the third state:
+            # this PR's verdict was not established. One PR's broken read must
+            # not abort the sweep, or a single unreachable PR hides every other
+            # armed-and-red one behind it.
+            rows.append(Row(number, UNREADABLE, 3, p.get("headRefOid", "")[:8],
+                            f"could not run ci-wait.py: {exc}"))
+            continue
+        verdict = classify(rc)
+        if verdict == OK:
+            continue
+        rows.append(Row(number, verdict, rc, p.get("headRefOid", "")[:8],
+                        armed_for((p.get("autoMergeRequest") or {}).get("enabledAt"))))
+    if any(r.verdict == FAILING for r in rows):
+        return 1, rows
+    if rows:
+        return 3, rows
+    return 0, rows
+
+
+def report(rows: list[Row]) -> str:
+    """The human report. Empty for an empty sweep -- never an all-clear string.
+
+    An empty string is what lets a caller print nothing at all on the quiet
+    path, which is what keeps a tool run every sweep from becoming noise.
+    """
+    if not rows:
+        return ""
+    out = []
+    failing = [r for r in rows if r.verdict == FAILING]
+    unreadable = [r for r in rows if r.verdict == UNREADABLE]
+    if failing:
+        out.append("FAILING -- armed and not green. Disarm before repairing:")
+        out.append("  (a fix pushed to a still-armed PR is itself the green "
+                   "thing that merges it, at a head nobody reviewed)")
+        for r in failing:
+            out.append(f"  #{r.number}  head {r.head}  armed {r.armed_for} ago"
+                       f"  (ci-wait.py exit {r.rc})")
+    if unreadable:
+        if failing:
+            out.append("")
+        out.append("UNREADABLE -- could not read the verdict. NOT established "
+                   "as green; ask again:")
+        for r in unreadable:
+            out.append(f"  #{r.number}  head {r.head}  armed {r.armed_for} ago"
+                       f"  (ci-wait.py exit {r.rc})")
+    return "\n".join(out)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--all", action="store_true",
+                   help="also print the armed PRs that are green or running")
+    p.add_argument("--json", action="store_true", dest="as_json",
+                   help="print rows as JSON")
+    args = p.parse_args()
+
+    prs = _gh_pr_list()
+    all_armed = armed(prs)
+    rc, rows = sweep(prs)
+
+    if args.as_json:
+        print(json.dumps(
+            {"armed": len(all_armed), "exit": rc,
+             "rows": [r.__dict__ for r in rows]}, indent=2))
+        return rc
+
+    quiet = len(all_armed) - len(rows)
+    print(f"{len(all_armed)} armed pull request(s): {quiet} green or still "
+          f"running, {len(rows)} needing attention")
+    text = report(rows)
+    if text:
+        print()
+        print(text)
+    if args.all and all_armed:
+        flagged = {r.number for r in rows}
+        rest = [a for a in all_armed if a["number"] not in flagged]
+        if rest:
+            print()
+            print("quiet (green or still running):")
+            print("  " + " ".join(f"#{a['number']}" for a in rest))
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_armed_prs.py
+++ b/tools/test_armed_prs.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/armed-prs.py's classification and exit code.
+
+The defect this tool exists for is a PR armed on a green verdict that goes red
+afterwards and sits there (#4006): measured windows of 12 and 119 minutes on a
+night with an attentive coordinator and nineteen PRs armed at once. So the
+property under test is not "does it call gh" but **which of the five per-PR
+verdicts each `ci-wait.py` exit code maps to, and what the run-level exit code
+is for each mix of them**.
+
+Two of those mappings carry the whole value of the tool and are the ones a
+plausible-looking rewrite gets wrong:
+
+  * exit 2 (checks still running) is the ORDINARY state of an armed PR and must
+    be QUIET. A tool that reports it reports twenty-one PRs on a busy night and
+    is then ignored, which is indistinguishable from not existing.
+  * exit 3 (could not read the verdict) is NOT quiet. Folding an unreadable
+    verdict into the green set is precisely the defect
+    `guards-need-a-third-state.md` exists to prevent -- it asserts a PR is fine
+    having failed to measure it.
+
+`ci_wait_rc` is injected rather than mocked at the subprocess layer, because the
+thing worth pinning is the mapping, not gh's argv.
+
+Run: python3 tools/test_armed_prs.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location(
+    "armed_prs", os.path.join(HERE, "armed-prs.py"))
+ap = importlib.util.module_from_spec(_spec)
+sys.modules["armed_prs"] = ap
+_spec.loader.exec_module(ap)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        FAILURES.append(name)
+
+
+def pr(number: int, armed: bool = True, enabled_at: str | None = None) -> dict:
+    """A `gh pr list --json number,autoMergeRequest,headRefOid` element."""
+    return {
+        "number": number,
+        "headRefOid": f"{number:040x}",
+        "autoMergeRequest": (
+            {"enabledAt": enabled_at or "2026-09-13T04:00:00Z",
+             "mergeMethod": "SQUASH"} if armed else None),
+    }
+
+
+# --------------------------------------------------------------------------
+# armed(): which PRs are armed at all
+# --------------------------------------------------------------------------
+print("armed():")
+
+check("armed selects autoMergeRequest != null",
+      [p["number"] for p in ap.armed([pr(1), pr(2, armed=False), pr(3)])]
+      == [1, 3])
+
+check("armed on an empty list is empty", ap.armed([]) == [])
+
+check("armed ignores a PR whose autoMergeRequest key is absent entirely",
+      ap.armed([{"number": 9, "headRefOid": "a" * 40}]) == [])
+
+
+# --------------------------------------------------------------------------
+# classify(): ci-wait.py's exit code -> this tool's verdict
+# --------------------------------------------------------------------------
+print("classify():")
+
+# The two quiet ones. Exit 2 being quiet is the whole reason this tool is
+# usable on a night with 21 armed PRs.
+check("rc 0 (green) is OK", ap.classify(0) == ap.OK)
+check("rc 2 (still running) is OK -- the ordinary armed state",
+      ap.classify(2) == ap.OK)
+
+# The reported ones.
+check("rc 1 (a required check failed) is FAILING", ap.classify(1) == ap.FAILING)
+check("rc 4 (blocked, not failing) is FAILING", ap.classify(4) == ap.FAILING)
+
+# The third state.
+check("rc 3 (could not determine) is UNREADABLE",
+      ap.classify(3) == ap.UNREADABLE)
+check("an unmapped rc is UNREADABLE, never OK",
+      ap.classify(99) == ap.UNREADABLE)
+check("a negative rc (killed by a signal) is UNREADABLE, never OK",
+      ap.classify(-9) == ap.UNREADABLE)
+
+check("UNREADABLE is a distinct value from OK and FAILING",
+      len({ap.OK, ap.FAILING, ap.UNREADABLE}) == 3)
+
+
+# --------------------------------------------------------------------------
+# sweep(): the run-level verdict over a set of armed PRs
+# --------------------------------------------------------------------------
+print("sweep():")
+
+
+def sweep(rcs: dict[int, int], prs: list[dict] | None = None):
+    """Run a sweep with ci-wait's exit code injected per PR number."""
+    prs = prs if prs is not None else [pr(n) for n in sorted(rcs)]
+    return ap.sweep(prs, ci_wait_rc=lambda n, **kw: rcs[n])
+
+
+rc, rows = sweep({1: 0, 2: 2})
+check("all green-or-running exits 0", rc == 0)
+check("...and reports no rows", rows == [])
+
+rc, rows = sweep({1: 0, 2: 1, 3: 2})
+check("one failing among green exits 1", rc == 1)
+check("...and reports exactly the failing PR",
+      [(r.number, r.verdict) for r in rows] == [(2, ap.FAILING)])
+
+rc, rows = sweep({1: 0, 2: 3})
+check("one unreadable among green exits 3 -- NOT 0", rc == 3)
+check("...and reports it as UNREADABLE, not as failing",
+      [(r.number, r.verdict) for r in rows] == [(2, ap.UNREADABLE)])
+
+# The precedence question: a run carrying both must not let the unreadable
+# verdict hide the failing one, nor the reverse. Exit 1 is the actionable
+# verdict, so it wins -- but BOTH rows are still reported, which is the half
+# that matters. An exit code carrying only one of them is still a report that
+# names both.
+rc, rows = sweep({1: 1, 2: 3})
+check("failing + unreadable exits 1 (the actionable verdict wins)", rc == 1)
+check("...and BOTH are reported, so neither is lost to the exit code",
+      sorted((r.number, r.verdict) for r in rows)
+      == [(1, ap.FAILING), (2, ap.UNREADABLE)])
+
+rc, rows = sweep({}, prs=[pr(1, armed=False)])
+check("no armed PRs at all exits 0 -- a legitimate absence, not a refusal",
+      rc == 0 and rows == [])
+
+# ci-wait.py is asked ONLY about armed PRs. Asking about every open PR would
+# spend 35 subprocesses to answer a question about 21 (measured on the live
+# queue, 2026-09-13).
+asked: list[int] = []
+ap.sweep([pr(1), pr(2, armed=False), pr(3)],
+         ci_wait_rc=lambda n, **kw: asked.append(n) or 0)
+check("an unarmed PR is never handed to ci-wait.py", asked == [1, 3])
+
+
+# --------------------------------------------------------------------------
+# A crashing ci_wait_rc is UNREADABLE, not a crashed sweep
+# --------------------------------------------------------------------------
+print("robustness:")
+
+
+def boom(n, **kw):
+    if n == 2:
+        raise OSError("gh not found")
+    return 0
+
+
+rc, rows = ap.sweep([pr(1), pr(2), pr(3)], ci_wait_rc=boom)
+check("a raising ci_wait_rc yields UNREADABLE for that PR only",
+      [(r.number, r.verdict) for r in rows] == [(2, ap.UNREADABLE)])
+check("...and the sweep still exits 3 rather than dying", rc == 3)
+check("...and the other PRs were still swept",
+      rc == 3 and len(rows) == 1)
+
+
+# --------------------------------------------------------------------------
+# The report itself must name the distinction, not merely carry it
+# --------------------------------------------------------------------------
+print("report():")
+
+_, rows = sweep({1: 1, 2: 3})
+text = ap.report(rows)
+check("the report names the failing PR number", "#1" in text)
+check("the report names the unreadable PR number", "#2" in text)
+check("the report distinguishes the two verdicts in its TEXT",
+      "FAILING" in text and "UNREADABLE" in text)
+check("the unreadable row says the verdict was not read, not that it is fine",
+      "could not" in text.lower() or "unreadable" in text.lower())
+
+check("an empty report is empty rather than a misleading all-clear string",
+      ap.report([]) == "")
+
+
+# --------------------------------------------------------------------------
+# armed_for(): the age an armed PR has carried its arming, for the report
+# --------------------------------------------------------------------------
+print("armed_for():")
+
+check("a 119-minute arming reports in hours-and-minutes",
+      ap.armed_for("2026-09-13T02:22:00Z",
+                   now="2026-09-13T04:21:00Z") == "1h59m")
+check("a 12-minute arming reports in minutes",
+      ap.armed_for("2026-09-13T04:14:00Z",
+                   now="2026-09-13T04:26:00Z") == "12m")
+check("an absent enabledAt is 'unknown', never 0m",
+      ap.armed_for(None, now="2026-09-13T04:26:00Z") == "unknown")
+check("an unparseable enabledAt is 'unknown', never a crash",
+      ap.armed_for("not-a-date", now="2026-09-13T04:26:00Z") == "unknown")
+
+
+print()
+if FAILURES:
+    print(f"FAILED: {len(FAILURES)}")
+    for f in FAILURES:
+        print(f"  - {f}")
+    sys.exit(1)
+print("all armed-prs tests passed")


### PR DESCRIPTION
Closes #4006

Corpus-NA: repository tooling only. This adds a Python script under `tools/` that reads the GitHub API; it changes no AL-observable runner behaviour, touches nothing under `AlRunner/`, and there is no BC claim for a service tier to adjudicate.

*(Implemented by agent `stma-auto-2`.)*

## What this is

`tools/armed-prs.py` — one command, no arguments, answering exactly one question: **which armed pull requests are not green?**

```
$ tools/armed-prs.py
21 armed pull request(s): 21 green or still running, 0 needing attention
```

It makes the two calls a coordinator sweep already makes — `gh pr list --json number,autoMergeRequest,headRefOid` for the armed set, then `tools/ci-wait.py <N> --timeout 0` per armed PR — with nobody having to remember to make them.

## Why a tool rather than more prose

The issue deliberately held itself open on one unmeasured quantity: *how long an armed PR typically sits red before anyone looks*. The coordinator's measurement comment answered it — **12 minutes and 119 minutes**, on a night with an attentive coordinator sweeping every few ticks and nineteen PRs armed at once. The procedural fix already in `orchestrating-a-session` is what caught both, so it works; its latency is just bounded by how often somebody happens to sweep.

The consequence is the harder one to notice: not a bad merge, but a **silently stalled PR**. Nothing is red on `main`, nothing is broken, and the work simply does not land.

## Three verdicts, not two

`guards-need-a-third-state.md` applies directly, and two of the three mappings carry the whole value:

| `ci-wait.py` exit | verdict | reported? |
|---|---|---|
| 0 (green), **2 (still running)** | `OK` | **no — quiet** |
| 1 (a check failed), 4 (blocked, not failing) | `FAILING` | yes |
| 3 (could not determine), **anything unmapped** | `UNREADABLE` | yes, in its own block |

**Exit 2 is quiet on purpose.** It is the *ordinary* state of an armed PR — the whole point of arming is that the PR lands when its checks pass. Reporting it would have named twenty-one PRs on the night that motivated this, and a report that names everything is ignored, which is indistinguishable from not existing.

**Exit 3 is not folded into green.** An armed PR whose verdict could not be read is not "fine" — nobody measured it. It gets its own exit code (3), its own visibly distinct block, and wording that says the verdict was not read rather than that the PR is healthy. An *unmapped* exit code also falls to `UNREADABLE`, never `OK`, so a future `ci-wait.py` exit 5 or a signal death cannot be silently absorbed into the green set.

Run-level exit: `1` if anything is failing, else `3` if anything is unreadable, else `0`. Both kinds are always listed even though the exit code can only carry one.

## Why a separate tool and not a flag on `ci-wait.py`

`ci-wait.py` takes a required positional `pr` and answers "has *this* PR's required check reported a verdict on its current head". That is a different question from "which of the armed set needs attention", and it is the same distinction `ci-verdicts.md` §5 already draws in its "Deliberately not in `tools/ci-wait.py`" note for the second-run question. This tool *consumes* `ci-wait.py` as its verdict source rather than reimplementing any of it — all the hard parts (head-SHA matching, superseded runs, cancelled leftovers, the live ruleset read) stay in the one place that does them correctly.

## What it deliberately does not do

It reports. No daemon, no scheduler, no workflow, and **it never disarms, merges or re-runs anything**. The repair sequence is `disarm → repair → re-arm on a fresh verdict`, and the ordering matters: pushing a fix to a still-armed red PR makes the fix commit itself the green thing that triggers the merge, at a head nobody reviewed. Choosing to disarm is a merge decision, and that stays with the coordinator.

## RED → GREEN

`tools/test_armed_prs.py`, 33 assertions. `ci_wait_rc` is injected rather than mocked at the subprocess layer, because the thing worth pinning is the exit-code mapping, not `gh`'s argv.

- **RED:** `FileNotFoundError: tools/armed-prs.py`, exit 1 — test written first, module absent.
- **GREEN:** `all armed-prs tests passed`, exit 0, 33 `ok` lines.

### Mutations — two, chosen to test different properties

Per `tdd.md`, a mutation that reds *everything* proves coverage exists; one that reds *exactly the right subset* proves the tests discriminate. Each mutation's **observable** was confirmed changed by importing the mutated module and printing `classify()`, not merely by confirming the source edit landed.

**Mutation 1 — fold the third state into the success state** (`3: UNREADABLE` → `3: OK`, and the `.get` default `UNREADABLE` → `OK`). This is the plausible-looking rewrite, not a compile break, and it is the exact defect `guards-need-a-third-state.md` exists to prevent.

- Observable confirmed: `classify(3)` `unreadable` → `ok`; `classify(99)` `unreadable` → `ok`.
- **`FAILED: 9, Passed: 24`** → restored **`FAILED: 0, Passed: 33`**.

**Mutation 2 — make the ordinary state noisy** (`2: OK` → `2: FAILING`), the plausible "be conservative, report everything" rewrite. A *different property*: that exit 2 stays quiet.

- Observable confirmed: `classify(2)` `ok` → `failing`, while `classify(3)` **stayed** `unreadable` — so this mutation does not disturb the third state, which is what makes the two results independent.
- **`FAILED: 4, Passed: 29`** → restored **`FAILED: 0, Passed: 33`**.

The two failing sets are **disjoint in size and content** (9 vs 4), which is the discrimination evidence: the third-state tests and the quiet-state tests are pinned to different behaviours rather than all riding on one.

All failures were assertion failures with the suite running to completion, never `error`/import breaks — the run printed its per-check lines and its `FAILED: N` summary in both cases.

### Live end-to-end, not only injected

The injected tests pin the mapping; these confirm the real subprocess path works:

- `tools/armed-prs.py` against the live queue: **21 armed PRs swept, exit 0**, `21 green or still running, 0 needing attention`.
- `tools/armed-prs.py --json` a few minutes later: **23 armed**, exit 0, `"rows": []`.
- `_ci_wait_rc(4103)` invoking the real `ci-wait.py` against this very PR: **rc=2 → `ok`** — the "ordinary armed state" case, measured rather than assumed.

Exit codes were read from `$?` directly after a redirect to a file, never through a pipe (`ci-verdicts.md` §0).

## Fix the shape, not just the reported line

1. **Does the same wrong pattern appear at another call site?** The pattern is "read `ci-wait.py`'s exit code and decide". Scanned `tools/**/*.py`, `.github/**/*.py` and `.github/**/*.yml` for actual *invocations* rather than mentions (a regex for `subprocess … ci-wait`, `python3 … ci-wait.py`, and `ci-wait.py … returncode|$?|exit`). The only code that executes `ci-wait.py` and consumes its exit code is its own test suites — `test_ci_wait.py:1436`, `test_ci_wait.py:1593`, `test_agent_workflow_hooks.py:118` — and this new tool. Every other hit (`check_required_contexts.py:161,392`, the workflows) is prose describing the exit codes, not a caller. **So no sibling call site folds exit 3 into success, because there is no sibling call site.**
2. **Does a sibling function make the same assumption?** `_gh_pr_list()` is the other read that can fail. It does **not** return an empty list on a failed `gh` call or unparseable JSON — both `sys.exit(3)` with the reason, because an empty armed set and an unreadable one would otherwise both print "0 armed PRs, nothing to do". Same third-state discipline as `classify()`.
3. **If two code paths write the same state, do they maintain the same invariant?** Two paths produce an `UNREADABLE` row — `classify(3)` from a verdict `ci-wait.py` returned, and the `except` arm when `ci-wait.py` could not be run at all. Both produce the same verdict value and both feed the same exit-3 rule, so one unreachable PR cannot abort the sweep and hide every other armed-and-red one behind it. That is pinned by the `robustness:` block.

## Queue scan

Per `batch-sibling-issues-by-file.md` and `search-for-the-same-defect-first.md`, searched the open queue on the symbol (`ci-wait`), the observable (`armed`, `auto-merge`), the mechanism (`verdict`, `sweep`) and the measurement. **Nothing folded**, and here is the map of what is adjacent:

- **#3961** (*Review briefs demanded ci-wait exit 0 before arming*) — settled the arming *decision*; this PR is about the *after-state*. The issue body explicitly says it is not an argument against #3961, and this tool encodes #3961's conclusion (exit 0 **or** 2 is a fine state to be in) as the quiet path. Distinct, and already closed.
- **#3942** (*A PR carrying another author's commit is BLOCKED with every check green*) — genuinely related and deliberately **not** folded. It is an *arming-time prerequisite* (read the commit authors before arming), not a post-arm re-check, and its own point 3 says the author should first establish whether the signal is reachable from what `ci-wait.py` already fetches. I checked: `ci-wait.py` has no handling for it today (no reference to `unattributed` or `commits[].authors`), so folding it would mean adding a new API read and a new heuristic — `ci-verdicts.md` warns that keying on "any login that is not the pushing identity" false-positives on every PR this loop writes. That is a different change with its own measurement burden. Left open; noted here so the overlap is recorded rather than silent.
- **#3459** (*ci-verdicts.md quotes its own superseded --timeout advice*) — a docs defect in the same file, no code overlap.

## Where the prose went

The module docstring carries the claim, the citation (#4006 and its measured windows) and the trap (exit 2 is quiet on purpose; exit 3 is not green). The coordinator-facing instruction went to `.claude/skills/orchestrating-a-session/SKILL.md`, in the existing paragraph that already told coordinators to re-read every armed PR each sweep — eight lines naming the tool, its three exit codes, and that it reports rather than disarms. No derivation left in the code.

## What I ran

- `python3 tools/test_armed_prs.py` — 33 ok, exit 0 (and the two mutation runs above).
- **All 24 `tools/test_*.py` guards** — no failures, before and after the SKILL.md edit.
- `pr-gate.yml` line 424 globs `tools/test_*.py`, so `test_armed_prs.py` gates the day it lands; confirmed by reading the workflow rather than assuming.

No `dotnet` build or BC legs are relevant — nothing under `AlRunner/` is touched, so `require-tests.yml`'s gate does not trigger and the matrix measures a diff with no AL surface in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
