### PR TITLE
docs: a double-quoted --body silently deletes backticked spans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,4 +271,9 @@ gh issue comment <N> --body-file /tmp/body.md
 `--body "…"` for prose containing backticks, `$`, or `!`. If you must inline it, re-read the
 posted text before trusting it.
 
+**And pick a delimiter the text cannot contain.** A heredoc ends at the first line equal to its
+delimiter, *including one inside the content*, so a body whose own example shows a heredoc
+terminates early and the shell then parses the remainder as commands. Measured composing the
+very PR that added this section. Writing the file from Python has neither problem.
+
 History: docs/incidents/CLAUDE.md.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,4 +249,26 @@ One more empty-looking answer that is not: **`mise` prints a banner on stdout**,
 instead of — the value you wanted. **Filter a capture to the shape you expect**
 (`| command grep -E '^[0-9]+$'`) rather than testing whether it is non-empty.
 
+**3c. Writing markdown through `--body "..."` silently deletes your backticked spans.**
+
+A double-quoted shell string evaluates backticks as command substitution, so every `` `code
+span` `` in prose becomes the *output* of running it — usually empty, plus a `command not
+found` on stderr that no reader of the posted text ever sees. Measured on a live issue comment
+(#4110): a run id and a timestamp vanished, leaving `Reading the oldest queued run's jobs (,
+queued since ):` published, while `gh` exited 0 and printed the comment URL.
+
+This is the same family as the two traps above — the command succeeds, and the loss is visible
+only on a re-read — and it is worse in one way: the damage is public before you notice.
+
+```bash
+cat > /tmp/body.md <<'MDEOF'      # quoted delimiter: NO substitution at all
+... `code spans` and $vars stay literal ...
+MDEOF
+gh issue comment <N> --body-file /tmp/body.md
+```
+
+**Write any markdown body to a file through a quoted heredoc and pass `--body-file`.** Never
+`--body "…"` for prose containing backticks, `$`, or `!`. If you must inline it, re-read the
+posted text before trusting it.
+
 History: docs/incidents/CLAUDE.md.md

--- a/docs/incidents/CLAUDE.md.md
+++ b/docs/incidents/CLAUDE.md.md
@@ -75,3 +75,36 @@ the capture is non-empty.
 Re-measure with `tools/agent-cost.py <tasks-dir>` rather than trusting that paragraph — the
 previous figure there ("63 greps + 50 file reads out of 180") sat stale for a long time because
 nobody re-ran it.
+
+## Backticks in `--body "..."` silently delete code spans (2026-09-13, #4110)
+
+Posting an issue comment with `--body` and a double-quoted shell string whose prose contained
+backticked code spans: the shell evaluated each span as command substitution before `gh` ever
+saw it.
+
+Published text:
+
+```
+Reading the oldest queued run's jobs (, queued since ):
+```
+
+Intended text named run `34738478169`, queued since `2026-09-13T04:41:30Z`. Both were consumed;
+`bash` wrote `34738478169: command not found` to stderr, `gh` exited 0 and printed the comment
+URL, and the comment was live and wrong.
+
+Three properties make it the same class as the `grep -E` and `rg --hidden` traps already in
+`CLAUDE.md`:
+
+- the command **succeeds** — exit 0, a real URL returned;
+- the loss is **invisible from the caller's side**, since the stderr line scrolls past among
+  tool output and the posted body is never echoed back;
+- it is only findable by **re-reading the artifact**, which is the same remedy those traps need.
+
+It is worse in one respect: the other two produce a wrong *answer* to yourself, and this
+produces a wrong *publication* to everyone else, already sent by the time you look.
+
+Caught here by re-reading the comment after noticing two `command not found` lines in the tool
+output. The remedy in the rule — a quoted heredoc to a file, then `--body-file` — also removes
+the neighbouring hazards (`$` expansion, `!` history), and is what every long body in this
+session already used; the failure came from the one that was written inline because it was
+"short".


### PR DESCRIPTION
`CLAUDE.md` already records two silent-false-negative traps -- `grep -E` (the shell function) rejecting a flag and exiting 0, and `rg` skipping dot-directories. This is a third with the same shape and a worse consequence.

## Measured live, on a real comment

Posting to issue #4110 with `--body` and a double-quoted shell string whose prose carried backticked code spans. The shell evaluated each span as command substitution before `gh` saw it. What was published:

```
Reading the oldest queued run's jobs (, queued since ):
```

It should have named run `34738478169`, queued since `2026-09-13T04:41:30Z`. Both were consumed. `bash` wrote `34738478169: command not found` to stderr; `gh` exited **0** and printed the comment URL.

## Why it belongs beside the other two

| | how it fails | how it looks |
|---|---|---|
| `grep -E` (shell function) | rejects the flag, exits 0, prints nothing | no matches |
| `rg` without `--hidden` | skips dot-directories | no matches |
| **`--body` with backticks** | **spans replaced by command output, exit 0, URL returned** | **a successful post** |

All three succeed, and all three are findable only by re-reading the artifact.

**This one is worse in a way that matters.** The other two give *you* a wrong answer, privately, and you can still catch it before acting. This one publishes a wrong comment to everyone else, and it is already live by the time you look. Here it took a second comment on a public issue to repair.

## The remedy is what the session was already doing everywhere else

Write the body to a file through a heredoc with a **quoted** delimiter, then pass `--body-file`. That also removes the neighbouring hazards (`$` expansion, `!` history).

Worth noting how it happened, because it argues for the rule rather than for care: **every long body in that session already used the heredoc form.** The one that broke was written inline because it was short. A convention that holds only for long bodies is not a convention.

**And a second-order trap found while writing this PR body**, which the rule now carries: a heredoc whose *content* contains the delimiter word terminates early. Composing this very body failed that way, because the example inside it used the same delimiter as the heredoc carrying it. Pick a delimiter that cannot appear in the text, or write the file from Python.

## Form

Claim + citation + trap in `CLAUDE.md` section 3c, beside the traps it belongs with; the derivation goes to `docs/incidents/CLAUDE.md.md`, per "How a rule is written".

Docs-only, so `test-matrix.yml`'s `changes` job skips `bc-tests` and this spends no BC legs -- which matters right now, with the account's Actions queue stalled (#4110).

`tools/test_doc_pointers.py` passes.

Part of #4059

No linked issue: a rules/docs change recording a trap measured in this session. It contributes to #4059 without closing it, so there is no issue for it to auto-close.

Corpus-NA: documentation only; adds no runner behaviour and touches no AL-observable path.

*Written by an agent -- the `stma-auto` loop coordinator -- on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
