### PR TITLE
perf(watch): EmitSiblingSymbols reuses the dep-symbol compiler and takes the RAD fast path

### DIFF
--- a/AlRunner.Tests/LogHyphenatedTagContractTests.cs
+++ b/AlRunner.Tests/LogHyphenatedTagContractTests.cs
@@ -51,6 +51,8 @@ public sealed class LogHyphenatedTagContractTests
         // [source-dep] is the source-sibling twin of the exempt [layered] progress lines, and
         // CacheRootsIsolationTests asserts `[source-dep] WROTE` in a default-verbosity run.
         new("AlRunner/ProgramSupport/SiblingCompile.cs", "source-dep", Kind.Loud),
+        // [sibling-symbols] names the symbol-compile path per sibling; only --watch reuses a baseline (#2672).
+        new("AlRunner/ProgramSupport/SiblingCompile.cs", "sibling-symbols", Kind.OptIn, Gate: @"\bannouncePath\b"),
         new("AlRunner/Infrastructure/AlCoverageSourceMap.cs", "source-map", Kind.Loud),
         new("AlRunner/Infrastructure/MissingTestDataDiagnosis.cs", "test-data", Kind.Loud),
         new("AlRunner/Infrastructure/TestDataNormalization.cs", "test-data", Kind.Loud),

--- a/AlRunner.Tests/WatchSiblingSymbolsIncrementalTests.cs
+++ b/AlRunner.Tests/WatchSiblingSymbolsIncrementalTests.cs
@@ -69,15 +69,12 @@ public class WatchSiblingSymbolsIncrementalTests
             end;
         """;
 
-    [SkippableFact]
-    public async Task Watch_SiblingDependency_TakesTheFastPath_AndTheDependentSeesItsCurrentSurface()
+    /// <summary>A parent directory holding the dependency app and the test app that depends on it.</summary>
+    private static (string Root, string DepDir, string TestDir) CreateFixture(string tag)
     {
-        TestArtifacts.SkipIfMissing();
-
-        var root = TestScratch.Dir("al-runner-watch-sibling-symbols-2672");
+        var root = TestScratch.Dir($"al-runner-sibling-symbols-2672-{tag}");
         var depDir = Path.Combine(root, "wsi-dep");
         var testDir = Path.Combine(root, "wsi-tests");
-        var cacheDir = TestScratch.Dir("al-runner-watch-sibling-symbols-2672-cache");
         Directory.CreateDirectory(depDir);
         Directory.CreateDirectory(testDir);
         File.WriteAllText(Path.Combine(depDir, "app.json"), $$"""
@@ -97,6 +94,52 @@ public class WatchSiblingSymbolsIncrementalTests
         """);
         WriteDep(depDir, "");
         WriteTests(testDir, "cycle 1", "Answer.Value()", 42);
+        return (root, depDir, testDir);
+    }
+
+    // A one-shot run has no baseline to reuse, so the path line is noise there and stays off (#2672).
+    [SkippableFact]
+    public void Cli_SiblingDependency_DoesNotAnnounceTheSymbolCompilePath()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (root, _, _) = CreateFixture("cli");
+        var cacheDir = TestScratch.Dir("al-runner-cli-sibling-symbols-2672-cache");
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg
+                    + $" \"{root}\" --cache \"{cacheDir}\"",
+                RedirectStandardOutput = true, RedirectStandardError = true,
+                UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+            };
+            using var p = Process.Start(psi)!;
+            var stderrTask = p.StandardError.ReadToEndAsync();
+            var stdout = p.StandardOutput.ReadToEnd();
+            p.WaitForExit();
+            var output = stdout + "\n" + stderrTask.Result;
+            Assert.True(p.ExitCode == 0, $"exit {p.ExitCode}:\n{output}");
+            // The sibling symbols were really built: the dependent compiled and its test ran.
+            Assert.Contains("PASS", output);
+            Assert.DoesNotContain("WSI answered", output);
+            Assert.DoesNotContain("[sibling-symbols]", output);
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+            try { Directory.Delete(cacheDir, recursive: true); } catch { }
+        }
+    }
+
+    [SkippableFact]
+    public async Task Watch_SiblingDependency_TakesTheFastPath_AndTheDependentSeesItsCurrentSurface()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (root, depDir, testDir) = CreateFixture("watch");
+        var cacheDir = TestScratch.Dir("al-runner-watch-sibling-symbols-2672-cache");
 
         var lines = new List<CapturedLine>();
         var psi = new ProcessStartInfo
@@ -105,7 +148,7 @@ public class WatchSiblingSymbolsIncrementalTests
             // The parent directory is the bundle: that is what routes the dependency through
             // EmitSiblingSymbols rather than BuildSiblingSourceDeps.
             Arguments = TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg
-                + $" \"{root}\" --watch --verbose --cache \"{cacheDir}\"",
+                + $" \"{root}\" --watch --cache \"{cacheDir}\"",
             RedirectStandardOutput = true, RedirectStandardError = true,
             UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
         };

--- a/AlRunner.Tests/WatchSiblingSymbolsIncrementalTests.cs
+++ b/AlRunner.Tests/WatchSiblingSymbolsIncrementalTests.cs
@@ -1,0 +1,196 @@
+// WatchSiblingSymbolsIncrementalTests — issue #2672.
+//
+// A parent-of-many-apps bundle: one directory holding a dependency app and a test app that
+// depends on it, so EmitSiblingSymbols writes the dependency's symbols.json every --watch cycle.
+// The dependency's symbol compile must reuse one BcCompiler across cycles and take the RAD fast
+// path (the same EmitDepSymbolsIncremental mechanism #2669 gave the layered and source-dep paths),
+// while the dependent still compiles against the dependency's CURRENT public surface.
+using System.Diagnostics;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class WatchSiblingSymbolsIncrementalTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private const string DepAppId = "26720000-0000-4000-8000-00000000d001";
+    private const string TestAppId = "26720000-0000-4000-8000-00000000d002";
+    private const string DepLine = "[sibling-symbols] WSI Sibling Dep 1.0.0.0: ";
+
+    private static void WriteDep(string dir, string extraProcedures) =>
+        File.WriteAllText(Path.Combine(dir, "Answer.Codeunit.al"), $$"""
+        codeunit 64060 "WSI Answer"
+        {
+            procedure Value(): Integer
+            begin
+                exit(42);
+            end;
+        {{extraProcedures}}
+        }
+        """);
+
+    private static void WriteTests(string dir, string marker, string expression, int expected) =>
+        File.WriteAllText(Path.Combine(dir, "AnswerTests.Codeunit.al"), $$"""
+        // {{marker}}
+        codeunit 64065 "WSI Answer Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure AnswerMatches()
+            var
+                Answer: Codeunit "WSI Answer";
+            begin
+                if {{expression}} <> {{expected}} then
+                    Error('WSI answered %1, expected {{expected}}', {{expression}});
+            end;
+        }
+        """);
+
+    private const string ExtraProcedure = """
+            procedure Extra(): Integer
+            begin
+                exit(58);
+            end;
+        """;
+
+    private const string ValueOverload = """
+            procedure Extra(): Integer
+            begin
+                exit(58);
+            end;
+
+            procedure Value(Seed: Integer): Integer
+            begin
+                exit(Seed);
+            end;
+        """;
+
+    [SkippableFact]
+    public async Task Watch_SiblingDependency_TakesTheFastPath_AndTheDependentSeesItsCurrentSurface()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = TestScratch.Dir("al-runner-watch-sibling-symbols-2672");
+        var depDir = Path.Combine(root, "wsi-dep");
+        var testDir = Path.Combine(root, "wsi-tests");
+        var cacheDir = TestScratch.Dir("al-runner-watch-sibling-symbols-2672-cache");
+        Directory.CreateDirectory(depDir);
+        Directory.CreateDirectory(testDir);
+        File.WriteAllText(Path.Combine(depDir, "app.json"), $$"""
+        {
+          "id": "{{DepAppId}}", "name": "WSI Sibling Dep", "publisher": "AL Runner",
+          "version": "1.0.0.0", "dependencies": [], "platform": "1.0.0.0",
+          "idRanges": [ { "from": 64060, "to": 64064 } ], "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(testDir, "app.json"), $$"""
+        {
+          "id": "{{TestAppId}}", "name": "WSI Sibling Tests", "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [ { "id": "{{DepAppId}}", "name": "WSI Sibling Dep", "publisher": "AL Runner", "version": "1.0.0.0" } ],
+          "platform": "1.0.0.0", "idRanges": [ { "from": 64065, "to": 64069 } ], "runtime": "14.0"
+        }
+        """);
+        WriteDep(depDir, "");
+        WriteTests(testDir, "cycle 1", "Answer.Value()", 42);
+
+        var lines = new List<CapturedLine>();
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            // The parent directory is the bundle: that is what routes the dependency through
+            // EmitSiblingSymbols rather than BuildSiblingSourceDeps.
+            Arguments = TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg
+                + $" \"{root}\" --watch --verbose --cache \"{cacheDir}\"",
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        using var p = Process.Start(psi)!;
+        void Pump(StreamReader r, OutputStream stream) => Task.Run(async () =>
+        {
+            string? l;
+            while ((l = await r.ReadLineAsync()) != null) lock (lines) lines.Add(new CapturedLine(stream, l));
+        });
+        Pump(p.StandardOutput, OutputStream.Stdout);
+        Pump(p.StandardError, OutputStream.Stderr);
+
+        string DumpTail() { lock (lines) return string.Join("\n", lines.TakeLast(60).Select(l => $"[{l.Stream}] {l.Text}")); }
+
+        async Task<int> WaitForMarkerAfter(int fromIndex)
+        {
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(240);
+            while (DateTime.UtcNow < deadline)
+            {
+                List<int> found;
+                lock (lines)
+                    found = WatchOutputSlicing.FindStdoutMarkerIndices(lines, WatchOutputSlicing.WaitingForSourceMarker, fromIndex);
+                if (found.Count > 0) return found[0];
+                if (p.HasExited)
+                {
+                    await Task.Delay(500);
+                    throw new TimeoutException($"watch exited early (exit={p.ExitCode}).\n{DumpTail()}");
+                }
+                await Task.Delay(200);
+            }
+            throw new TimeoutException($"watch marker not seen.\n{DumpTail()}");
+        }
+
+        string Segment(int from, int to) { lock (lines) return WatchOutputSlicing.MergedJoin(lines, from, to); }
+
+        void AssertPassed(string cycle, string label)
+        {
+            Assert.True(cycle.Contains("PASS"), $"{label} did not pass:\n{cycle}");
+            Assert.DoesNotContain("FAIL", cycle);
+            Assert.DoesNotContain("WSI answered", cycle);
+        }
+
+        try
+        {
+            // Cycle 1: no baseline yet in this process.
+            int m1 = await WaitForMarkerAfter(0);
+            var cycle1 = Segment(0, m1);
+            Assert.True(cycle1.Contains(DepLine + "full compile ("), "cycle 1 did not full-compile the sibling:\n" + cycle1);
+            AssertPassed(cycle1, "cycle 1");
+
+            // Cycle 2: the dependency gains a public procedure the dependent now calls. The fast
+            // path must be taken AND its symbols must carry Extra(), or the dependent cannot bind it.
+            WriteDep(depDir, ExtraProcedure);
+            WriteTests(testDir, "cycle 2", "(Answer.Value() + Answer.Extra())", 100);
+            int m2 = await WaitForMarkerAfter(m1 + 1);
+            var cycle2 = Segment(m1 + 1, m2);
+            Assert.True(cycle2.Contains(DepLine + "RAD incremental (fast path)"),
+                "cycle 2 did not take the fast path for the edited sibling:\n" + cycle2);
+            Assert.DoesNotContain(DepLine + "full compile (", cycle2);
+            AssertPassed(cycle2, "cycle 2");
+
+            // Cycle 3: only the dependent changes; the unchanged sibling is not recompiled.
+            WriteTests(testDir, "cycle 3", "(Answer.Value() + Answer.Extra())", 100);
+            int m3 = await WaitForMarkerAfter(m2 + 1);
+            var cycle3 = Segment(m2 + 1, m3);
+            Assert.True(cycle3.Contains(DepLine + "RAD incremental (fast path)"),
+                "cycle 3 recompiled the unchanged sibling:\n" + cycle3);
+            Assert.DoesNotContain(DepLine + "full compile (", cycle3);
+            AssertPassed(cycle3, "cycle 3");
+
+            // Cycle 4: an added overload is the #2548 shape the fast path must refuse.
+            WriteDep(depDir, ValueOverload);
+            WriteTests(testDir, "cycle 4", "Answer.Value(7)", 7);
+            int m4 = await WaitForMarkerAfter(m3 + 1);
+            var cycle4 = Segment(m3 + 1, m4);
+            Assert.True(cycle4.Contains(DepLine + "full compile ("),
+                "cycle 4 did not fall back for an added overload:\n" + cycle4);
+            Assert.DoesNotContain(DepLine + "RAD incremental", cycle4);
+            AssertPassed(cycle4, "cycle 4");
+        }
+        finally
+        {
+            try { if (!p.HasExited) p.Kill(entireProcessTree: true); } catch { }
+            try { Directory.Delete(root, recursive: true); } catch { }
+            try { Directory.Delete(cacheDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2841,7 +2841,8 @@ foreach (var bundle in bundles)
         // chain them into the compiler. Only sibling-dependency TARGETS are compiled here —
         // this is an extra compile per app, and most bundles (the corpus: one app) have none.
         using (AlRunner.Infrastructure.PhaseLog.Stage("sibling-symbols"))
-            EmitSiblingSymbols(appGroups, bundleAbs, bundleResolvedDeps);
+            EmitSiblingSymbols(appGroups, bundleAbs, bundleResolvedDeps,
+                announcePath: watchMode || AlRunner.Log.Verbose);
 
         var loadedAssemblies = new List<Assembly>();
         // SetTestAssembly re-runs its full body (incl. NavAppResourcePatches.RegisterTestAssembly)

--- a/AlRunner/ProgramSupport/SiblingCompile.cs
+++ b/AlRunner/ProgramSupport/SiblingCompile.cs
@@ -1252,13 +1252,22 @@ internal static partial class ProgramSupport
             var symbolsPath = Path.Combine(dir, $"{group.AppId:N}.symbols.json");
             try
             {
+                // #2672: the same reuse as RunLayeredPrePass/BuildSiblingSourceDeps (#2669). Keyed
+                // on SuiteDir, not AppId — two suites in one tree can share an app id (above).
+                // The fast path only describes this app's OWN surface; the app group compile
+                // below is still a full Emit, so an error it would raise still surfaces there.
+                var version = group.Version ?? new Version(1, 0, 0, 0);
                 using (BcCompiler.ScopeCurrentAppIdentity(
-                           group.AppId.Value, group.Publisher ?? "AlRunner",
-                           group.Version ?? new Version(1, 0, 0, 0)))
-                    new BcCompiler().EmitDepSymbols(
+                           group.AppId.Value, group.Publisher ?? "AlRunner", version))
+                {
+                    GetDepSymbolCompiler(group.SuiteDir).EmitDepSymbolsIncremental(
                         group.Paths, group.ModuleName, group.AppId.Value,
-                        group.Publisher ?? "AlRunner", group.Version ?? new Version(1, 0, 0, 0),
-                        symbolsPath, group.SuiteDir);
+                        group.Publisher ?? "AlRunner", version,
+                        symbolsPath, group.SuiteDir, out var tookFastPath, out var fallbackReason);
+                    Console.WriteLine(tookFastPath
+                        ? $"[sibling-symbols] {group.ModuleName} {version}: RAD incremental (fast path)"
+                        : $"[sibling-symbols] {group.ModuleName} {version}: full compile ({fallbackReason})");
+                }
                 // The dependency closure this app compiled against, so BC's ReferenceManager can
                 // link types from it that appear in the sibling's public surface — same reason as
                 // the source-dep sidecar (#1546); without it those types are __MissingTypeSymbol__.

--- a/AlRunner/ProgramSupport/SiblingCompile.cs
+++ b/AlRunner/ProgramSupport/SiblingCompile.cs
@@ -1209,7 +1209,8 @@ internal static partial class ProgramSupport
     /// </summary>
     internal static void EmitSiblingSymbols(
         List<AlRunner.AppGroup> appGroups, string bundleAbs,
-        IReadOnlyList<(AlRunner.AppManifest Manifest, string AppPath)> bundleResolvedDeps)
+        IReadOnlyList<(AlRunner.AppManifest Manifest, string AppPath)> bundleResolvedDeps,
+        bool announcePath)
     {
         BcCompiler.SetSiblingSymbolsDir(null);
         // Not a dictionary: two suites in the same tree can (and in tests/runner-extras do)
@@ -1264,9 +1265,12 @@ internal static partial class ProgramSupport
                         group.Paths, group.ModuleName, group.AppId.Value,
                         group.Publisher ?? "AlRunner", version,
                         symbolsPath, group.SuiteDir, out var tookFastPath, out var fallbackReason);
-                    Console.WriteLine(tookFastPath
-                        ? $"[sibling-symbols] {group.ModuleName} {version}: RAD incremental (fast path)"
-                        : $"[sibling-symbols] {group.ModuleName} {version}: full compile ({fallbackReason})");
+                    // --watch or --verbose only: a one-shot run has no baseline, so it would print
+                    // "full compile (no incremental baseline yet ...)" for every sibling on every run.
+                    if (announcePath)
+                        Console.WriteLine(tookFastPath
+                            ? $"[sibling-symbols] {group.ModuleName} {version}: RAD incremental (fast path)"
+                            : $"[sibling-symbols] {group.ModuleName} {version}: full compile ({fallbackReason})");
                 }
                 // The dependency closure this app compiled against, so BC's ReferenceManager can
                 // link types from it that appear in the sibling's public surface — same reason as

--- a/docs/log-filter.md
+++ b/docs/log-filter.md
@@ -42,7 +42,8 @@ elsewhere (`[provision-gap]`, `[test-exec]` warnings), and exception messages (`
   `hook-audit`, `instrumentation-counters`, `mem-census`, `object-metadata`,
   `option-captions`, `page-metadata`, `page-trigger-audit`, `parse-counts`, `perm-metadata`,
   `permission-table`, `query-metadata`, `report-metadata` (trace), `shared-refs`,
-  `table-metadata`, `table-trigger-audit`, `xmlport-metadata`.
+  `table-metadata`, `table-trigger-audit`, `xmlport-metadata`, `sibling-symbols` (switch:
+  `--watch` or `--verbose`, #2672).
 - **VerboseGated:** `type-index` (reflection fallback), `servicetier-dll` (the "indexed N
   objects" summary).
 


### PR DESCRIPTION
Closes #2672

Written by agent stma-auto2-7 on the account holder's behalf.

## What changed

`EmitSiblingSymbols` (the parent-of-many-apps bundle path, `AlRunner/ProgramSupport/SiblingCompile.cs`) built each in-bundle dependency's `*.symbols.json` with `new BcCompiler().EmitDepSymbols(...)` on every `--watch` cycle, so it paid a full compile of every sibling target each cycle. It now uses the same mechanism #2669 gave the layered and source-dep paths: `GetDepSymbolCompiler(group.SuiteDir).EmitDepSymbolsIncremental(...)`. No new mechanism. It prints `[sibling-symbols] <app> <version>: RAD incremental (fast path)` or `... full compile (<reason>)`, in the same form as the `[layered]` and `[source-dep]` lines.

- The cache key is `group.SuiteDir`, not the AppId, because two suites in one tree can carry the same app id (the existing comment in that function says so).
- The per-process sibling-symbols directory is still deleted and rewritten every cycle. The fast path writes the file from the RAD-merged `ModuleDef`. I did not add a "skip the unchanged sibling" mechanism. That would need the directory to survive between cycles and would be a second mechanism, which the brief rules out. So "an unchanged sibling is not re-emitted" is asserted as the fast-path line: no full compile.
- Scope: `EmitSiblingSymbols` has one caller, the CLI and `--watch` bundle loop (`Program.cs`). `--server` goes through `RunBundleForServer` and does not reach it, so the gain is `--watch` only.
- Correctness boundary: the fast path only describes the sibling's own public surface. Each app group is still fully compiled afterward, so a compile error the sibling would raise still surfaces there. `TryEmitIncremental`'s guards still apply (overload added, manifest or dependency-set change, multi-object file, and so on).

## Measurement (local, BC 28.1.49838.53910, box under load average 12-14 on 12 cores)

`--watch` over a scratch parent bundle, editing one file per cycle, with `AL_RUNNER_PHASE_LOG`. Each phase-log record is tied to its edit by `start_ms`.

| bundle | sibling targets | before: `sibling-symbols` per warm cycle | after |
|---|---|---|---|
| the 26 runner-extras apps that form sibling pairs | 13 (tiny) | 390 / 429 / 1310 ms (cycle wall 7.5-11.7 s, mostly test run) | not re-measured |
| synthetic, 3,000 objects (1,500 tables with 20 fields + 1,500 codeunits with 10 procedures), plus 1 test app | 1 | 5 cycles: 356-897 ms, median 550, out of a 1.0-1.8 s cycle wall (about 36-51%) | see below |

Before and after on the 3,000-object sibling, 8 edits each. The edit touched only the test app, so the sibling was unchanged. I added temporary stopwatch and `Process.TotalProcessorTime` instrumentation around the emit call; it is not in this diff:

| | emit wall, median | emit CPU, median (min-max) | `RefreshSiblingSymbols`, median | stage median |
|---|---|---|---|---|
| before (`new BcCompiler().EmitDepSymbols`) | 1067 ms | 1840 ms (1340-2700) | 330 ms | 1199 ms |
| after (fast path) | 262 ms | 185 ms (150-500) | 382 ms | 654 ms |

The emit step drops about 10x in CPU. What remains in the stage is mostly `RefreshSiblingSymbols` (re-indexing the shared reference loader), which this PR does not touch. The synthetic is 3,000 generated objects. I did not measure a Pageworks-scale app, so a larger saving there is an extrapolation. The dependent's test passed on every cycle (1/1), so the stage time is compile cost, not a swallowed failure.

## RED -> GREEN

New test: `AlRunner.Tests/WatchSiblingSymbolsIncrementalTests.cs`. It runs `--watch` on a parent dir holding `wsi-dep` and `wsi-tests`, over 4 cycles:
1. `full compile (` for the sibling, test passes.
2. The dep gains `Extra()` and the dependent calls `Value()+Extra()`: `RAD incremental (fast path)`, no full compile, test passes. A stale symbol file would fail with AL0132.
3. Only the dependent changes: fast path for the unchanged sibling, test passes.
4. An overload `Value(Seed)` is added: `full compile (` (#2548 guard), test passes.

- origin/main code: `Failed: 1, Passed: 0` (cycle 1 has no `[sibling-symbols]` line).
- With the fix: `Failed: 0, Passed: 1`. I ran it twice: `Total: 1` both times.
- **Mutation A**, a fresh compiler on every call (`new BcCompiler().EmitDepSymbolsIncremental`, which is the pre-fix behaviour on the new call): `Failed: 1, Passed: 0`, "cycle 2 did not take the fast path". The failure is the assertion, and the build was clean.
- **Mutation B**, stale symbols (the fast path skips the write when the file exists, and the directory is not deleted): `Failed: 1, Passed: 0`, "cycle 2 did not pass" with `error AL0132: 'Codeunit "WSI Answer"' does not contain a definition for 'Extra'`. So cycle 2 detects a stale surface and does not just check for the log line.
- I ran the 26-app runner-extras sibling bundle through the CLI twice against one `--cache`: 50/50 pass and exit 0 both times.
- `tools/test_*.py`: all pass. `GuardTests|PhaseLogTests|SiblingSymbols` filter: 285/286. The one failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned`, and it is environmental: the engine bootstrap (`tools/engine-test-bootstrap.sh`) was not run locally. It is unrelated to this diff.

CI: GitHub Actions is stalled account-wide, so no CI verdict exists for this head yet. Everything above is local.

## Fix the shape

1. **Same pattern at another call site?** I searched for `new BcCompiler().EmitDepSymbols`. The two #2669 sites (`RunLayeredPrePass`, `BuildSiblingSourceDeps`) already use `EmitDepSymbolsIncremental`, and this was the last one.
2. **Sibling assumption?** The same stage also pays `RefreshSiblingSymbols` (about 330-380 ms per cycle on the 3,000-object sibling) on every cycle, whether or not anything changed. That is a different mechanism (reference-loader re-index), and it is not folded in here.
3. **Two writers, one invariant?** All three symbol writers now share `EmitDepSymbolsIncremental`, so the fallback guards are identical. One difference: `BuildSiblingSourceDeps` skips the write when the content-keyed file already exists, while this path rewrites into a per-process directory that it clears every cycle. That is intentional, see above.

Queue scan for `EmitSiblingSymbols`, `sibling-symbols`, `EmitDepSymbolsIncremental`, and `RefreshSiblingSymbols`: nothing else open lands in this function. #4083 (open) edits `RunLayeredPrePass` hunks in the same file, with no overlap. `git merge-tree` against main is clean.

Console output: the `[sibling-symbols]` line prints only under `--watch` or `--verbose` (see "Review round 1" below). A plain CLI run has no baseline to reuse, so the line would only ever say "full compile (no incremental baseline yet ...)".


## Review round 1 (FIX-FIRST at 18cacc91: undeclared log tag)

Written by agent stma-auto2-7 on the account holder's behalf.

- **Gating.** `EmitSiblingSymbols` takes a required `announcePath` argument. `Program.cs` passes `watchMode || AlRunner.Log.Verbose`, and the line prints only `if (announcePath)`. I made it a required argument rather than an optional one because an optional parameter breaks reflective `MethodInfo.Invoke` call sites. There are none today; the only caller is `Program.cs`.
- **Contract.** `LogHyphenatedTagContractTests.Declared` now has `sibling-symbols` as `Kind.OptIn` with `Gate: \bannouncePath\b`. `docs/log-filter.md#hyphenated-tags` lists it under OptIn (switch: `--watch` or `--verbose`, #2672).
- **Tests.** `WatchSiblingSymbolsIncrementalTests` now runs `--watch` without `--verbose`, so it covers the watch half of the gate. A new `Cli_SiblingDependency_DoesNotAnnounceTheSymbolCompilePath` does a plain CLI run over the same fixture: exit 0, the test passes, and no `[sibling-symbols]` in stdout or stderr.

Runs at this head:
- `LogHyphenatedTagContractTests|OutputFormatTests|LogUserFacingTagsTests`: `Passed! - Failed: 0, Passed: 39, Skipped: 0, Total: 39`. At 18cacc91 the reviewer got 38 passed and 1 failed.
- `WatchSiblingSymbolsIncrementalTests`: `Passed! - Failed: 0, Passed: 2, Skipped: 0, Total: 2`.
- Plain CLI over a copy of `navapp-moduleinfo-dep` and `navapp-moduleinfo-main` under one parent: exit 0, 15 pass, **0** `[sibling-symbols]` lines. The same run with `--verbose`: exit 0, 15 pass, 1 line (`[sibling-symbols] NavAppModuleInfo Dep 25.8.43.0: full compile (...)`).
- `tools/test_*.py`: all pass.

Mutations of the gating. Each one turned exactly one test RED on an assertion, with a clean build:
- M1, `announcePath: true` (always print): `Failed: 1, Passed: 1, Total: 2`. `Cli_SiblingDependency_DoesNotAnnounceTheSymbolCompilePath` failed with `Assert.DoesNotContain() Failure: Sub-string found`. The watch test stayed green.
- M2, `announcePath: AlRunner.Log.Verbose` (drop the watch half): `Failed: 1, Passed: 1, Total: 2`. The watch test failed with "cycle 1 did not full-compile the sibling". The CLI test stayed green.
- M3, `if (announcePath)` replaced by `if (true)`: `LogHyphenatedTagContractTests` gave `Failed: 1, Passed: 7, Total: 8`. `OptInSites_AreBehindTheirSwitch` failed with `SiblingCompile.cs:1272 [sibling-symbols] expected an 'if (' testing '\bannouncePath\b'`.

Not in this PR: removing a procedure takes the fast path. That behavior is already broken on main and is tracked in #4125.

Corpus-NA: runner --watch compile-pipeline performance; no BC-observable behaviour changes, so no corpus test applies

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
