### PR TITLE
perf(symbols): measure cold-read cost of re-parsing precompiled TableRelations

### DIFF
--- a/docs/tablerelation-parser-refusals.md
+++ b/docs/tablerelation-parser-refusals.md
@@ -131,15 +131,15 @@ inside a whole cold `BcAppSymbolCache.Parse`, even with instruction counts. The 
 removes most repeat parses.
 
 Measured on runner `775e3d02` (Release build), Base Application `28.1.49838.53910`, on a
-12-core box under load average 13 to 23. Every row is five fresh processes; the table gives the
-median.
+12-core box under load average 13 to 23. Unless a row says otherwise, it is five fresh processes, each doing one pass, and the table
+gives the median.
 
 | what | tree builds (`ParseObjectTextCallCount`) | instructions (user) | wall |
 |---|---|---|---|
 | Normal-class fields carrying a `TableRelation` | 7,583 fields, 1,113 distinct texts | | |
 | all 7,583 texts through `TryParseRelationArmsText`, cold process | **1,113** | **2.5 G** over an empty-process baseline (paired: 2.83, 2.92, 2.52, 1.35, 2.11) | 387 ms (319 to 654) |
 | the same, `AL_RUNNER_PARSE_TREE_CACHE_BYTES=0` (3 runs) | 6,715 | 6.8 G (paired: 7.19, 6.83, 4.93) | 712 ms (442 to 1382) |
-| the same, second pass in one process | 0 | not measured | 38 ms |
+| the same texts again in the same process (served by the in-process keyed tree cache, not a second cold read) | 0 | not measured | 38 ms |
 | whole cold `BcAppSymbolCache.Parse` of Base Application | 2,668 | 30.5 G (whole process) | 2,151 ms |
 | the same with the relation parse returning `null` | 1,555 | 29.8 G | 1,973 ms |
 
@@ -152,8 +152,9 @@ Read the rows this way:
   instruction deltas for the last two rows were -0.35, 0.14, 0.03, 6.55 and 1.57 G, on about
   30 G per process. The isolated row is the upper bound. It includes JIT-compiling BC's parser,
   and the real read has already paid that for `CalcFormula`.
-- **The cost is paid once per cache root and app content hash.** For scale: loading the Base
-  Application closure costs about 70 s cold per invocation (`.claude/rules/no-base-app-in-csharp-tests.md`).
+- **The cost is paid once per cache root and app content hash.** A warm read is a `bc-symbols`
+  cache HIT and never reaches the parser. The honest scale is the whole cold read of the same
+  app, measured above at about 2.2 s.
 - **#4094 adds little.** It extends the parse to FlowFilter and FlowField relations: 204 fields
   and 78 distinct texts, 17 of which are new. That is 17 more tree builds.
 

--- a/docs/tablerelation-parser-refusals.md
+++ b/docs/tablerelation-parser-refusals.md
@@ -117,3 +117,55 @@ the builder, so a parser-level drop is invisible there too. Not folded in: it is
 property with a different set of reaching shapes, and it needs its own reachability measurement
 before anyone converts it, and the provenance split above is the trap it has to avoid. Filed as
 **#3367**.
+
+## Cold symbol-read cost of the text parse (#4107)
+
+A precompiled field's `TableRelation` reaches the parser as property text from
+`SymbolReference.json`. `BcAppSymbolCache` passes it to `RecordPatches.TryParseRelationArmsText`,
+which wraps it in a probe table and parses it with BC's parser. That work happens only when the
+`bc-symbols` cache misses. A warm read skips it.
+
+**Verdict: too small to change.** On the Base Application the relation parse costs at most
+about a third of a second, measured on its own including parser JIT. It was too small to see
+inside a whole cold `BcAppSymbolCache.Parse`, even with instruction counts. The keyed tree cache from #2588 already
+removes most repeat parses.
+
+Measured on runner `775e3d02` (Release build), Base Application `28.1.49838.53910`, on a
+12-core box under load average 13 to 23. Every row is five fresh processes; the table gives the
+median.
+
+| what | tree builds (`ParseObjectTextCallCount`) | instructions (user) | wall |
+|---|---|---|---|
+| Normal-class fields carrying a `TableRelation` | 7,583 fields, 1,113 distinct texts | | |
+| all 7,583 texts through `TryParseRelationArmsText`, cold process | **1,113** | **2.5 G** over an empty-process baseline (paired: 2.83, 2.92, 2.52, 1.35, 2.11) | 387 ms (319 to 654) |
+| the same, `AL_RUNNER_PARSE_TREE_CACHE_BYTES=0` (3 runs) | 6,715 | 6.8 G (paired: 7.19, 6.83, 4.93) | 712 ms (442 to 1382) |
+| the same, second pass in one process | 0 | not measured | 38 ms |
+| whole cold `BcAppSymbolCache.Parse` of Base Application | 2,668 | 30.5 G (whole process) | 2,151 ms |
+| the same with the relation parse returning `null` | 1,555 | 29.8 G | 1,973 ms |
+
+Read the rows this way:
+
+- **The count is the load-independent number.** Skipping the relation parse removes exactly
+  1,113 tree builds, which equals the number of distinct relation texts. So the keyed tree
+  cache already de-duplicates by text, and adding another memo here would save nothing.
+- **Inside the real cold read, the difference cannot be separated from noise.** The paired
+  instruction deltas for the last two rows were -0.35, 0.14, 0.03, 6.55 and 1.57 G, on about
+  30 G per process. The isolated row is the upper bound. It includes JIT-compiling BC's parser,
+  and the real read has already paid that for `CalcFormula`.
+- **The cost is paid once per cache root and app content hash.** For scale: loading the Base
+  Application closure costs about 70 s cold per invocation (`.claude/rules/no-base-app-in-csharp-tests.md`).
+- **#4094 adds little.** It extends the parse to FlowFilter and FlowField relations: 204 fields
+  and 78 distinct texts, 17 of which are new. That is 17 more tree builds.
+
+**Trap: the de-duplication depends on the keyed cache's budget.** If
+`AL_RUNNER_PARSE_TREE_CACHE_BYTES` is set to 0, the builds go from 1,113 to 6,715. Only the
+single-slot memo remains, and it catches adjacent repeats only. The default 8 MiB budget
+holds all of these texts (mean 140 characters). A change that shrinks the budget, or keys the
+cache on something other than the text, should re-run the count.
+
+How it was measured: a throwaway xunit test, not committed. It called the private
+`BcAppSymbolCache.Parse` by reflection, and in a second mode it fed `TryParseRelationArmsText`
+the relation texts read out of the `.app`'s nested `SymbolReference.json`. It read
+`ParseObjectTextCallCount` before and after, and ran each process under
+`perf stat -e instructions:u`. The `null` variant came from a local, uncommitted early return
+in `TryParseRelationArmsText`.

--- a/docs/tablerelation-parser-refusals.md
+++ b/docs/tablerelation-parser-refusals.md
@@ -126,7 +126,8 @@ which wraps it in a probe table and parses it with BC's parser. That work happen
 `bc-symbols` cache misses. A warm read skips it.
 
 **Verdict: too small to change.** On the Base Application the relation parse costs at most
-about a third of a second, measured on its own including parser JIT. It was too small to see
+about 2.5 G instructions, measured on its own including parser JIT. That is about 8% of the
+30.5 G a whole cold read of the same app costs. It was too small to see
 inside a whole cold `BcAppSymbolCache.Parse`, even with instruction counts. The keyed tree cache from #2588 already
 removes most repeat parses.
 
@@ -150,8 +151,9 @@ Read the rows this way:
   cache already de-duplicates by text, and adding another memo here would save nothing.
 - **Inside the real cold read, the difference cannot be separated from noise.** The paired
   instruction deltas for the last two rows were -0.35, 0.14, 0.03, 6.55 and 1.57 G, on about
-  30 G per process. The isolated row is the upper bound. It includes JIT-compiling BC's parser,
-  and the real read has already paid that for `CalcFormula`.
+  30 G per process. The isolated row is the upper bound. It includes JIT-compiling BC's parser.
+  A likely reason the real read shows less is that its `CalcFormula` parse has already paid
+  that JIT, but that was not measured.
 - **The cost is paid once per cache root and app content hash.** A warm read is a `bc-symbols`
   cache HIT and never reaches the parser. The honest scale is the whole cold read of the same
   app, measured above at about 2.2 s.


### PR DESCRIPTION
Closes #4107

Written by agent stma-auto2-7 on the account holder's behalf.

## What changed

Docs only. I added a measured section to `docs/tablerelation-parser-refusals.md` (§ "Cold symbol-read cost of the text parse (#4107)"). There is no runtime change, because the number is small.

## Measurement (Base Application 28.1.49838.53910, runner 775e3d02 Release, 5 fresh processes per row, medians)

| what | tree builds | instructions:u | wall |
|---|---|---|---|
| 7,583 Normal-field relation texts through `TryParseRelationArmsText`, cold | **1,113** (= distinct texts) | 2.5 G over an empty-process baseline | 387 ms |
| same, keyed tree cache disabled (`AL_RUNNER_PARSE_TREE_CACHE_BYTES=0`, 3 runs) | 6,715 | 6.8 G | 712 ms |
| whole cold `BcAppSymbolCache.Parse` | 2,668 | 30.5 G | 2,151 ms |
| same, relation parse skipped (local, uncommitted toggle) | 1,555 | 29.8 G | 1,973 ms |

- The count delta of exactly 1,113 is the load-independent number. The #2588 keyed tree cache already de-duplicates by text, so a new memo would save nothing. That is why I made no change.
- Inside the real cold read the relation parse is not separable from noise. Paired instruction deltas were -0.35, 0.14, 0.03, 6.55 and 1.57 G on about 30 G. The isolated row is an upper bound that includes parser JIT.
- #4094's widening adds 204 fields and 78 distinct texts, 17 of them new, so 17 more tree builds.
- The box ran at load average 13 to 23, which is why wall time is context and the counts and instructions are the claim.

## RED -> GREEN / mutation

Not applicable: this PR has no code change and no test. The measurement harness was a throwaway xunit test plus a local early-return toggle. I deleted both before committing (`git diff --stat origin/main..HEAD`: 1 file, docs only).

## Fix the shape

1. Same pattern at another call site: `BcAppSymbolCache.TableExtensions.cs` calls the same parser for extension fields (261 relation fields per #3177). It goes through the same keyed cache, and it is smaller than the table loop measured here. The `CalcFormula` text parse (2,050 FlowFields, 1,550 distinct texts) is the larger sibling. It accounts for most of the remaining 1,555 builds, is also cached, and falls within the same whole-read cost.
2. Sibling assumption: the de-duplication depends on the keyed cache budget (default 8 MiB). The docs section records this as the trap.
3. Two writers of one invariant: not applicable, because this PR writes no state.

Queue scan: I searched for `TryParseRelationArmsText`, `BcAppSymbolCache cold`, `ParseObjectTextCallCount` and `TableRelation parse cost`. #2789 is the parent. #3801 and #3491 propose replacing the hand parser with Microsoft's reader, a separate question. None of them folds in.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
