### PR TITLE
feat(ci-wait): the main floor line reports its distance, not only its age

### DIFF
--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -67,9 +67,18 @@ before reading a floor run as a verdict** — `gh api repos/<o>/<r>/actions/runs
 '.jobs[]|"\(.name): \(.conclusion)"'` — and treat `skipped` as "no new measurement", never as green.
 
 **Beside every verdict it prints one line about `main` itself** — `main floor: RED on 8b6885f4
-(main-verdict-floor.yml, 1h ago)` (#3679), so a PR branched during a red window is visible as
-inheriting a failure it did not cause. It is a report: it never changes the exit code, and a
-read that did not happen prints `unavailable`, never a verdict.
+(main-verdict-floor.yml, 1h ago, 6 commits behind main)` (#3679, #4111), so a PR branched during
+a red window is visible as inheriting a failure it did not cause. It is a report: it never
+changes the exit code, and a read that did not happen prints `unavailable`, never a verdict.
+
+**Read the distance, not only the age** (#4111): the age says when the verdict was taken, the
+distance says what it still covers. A correct green about a `main` eight merges back is still
+not a verdict about the commit under suspicion — measured live at filing, `GREEN on d50d41fd`
+beside a true distance of 8. Three spellings, and the third is deliberately not either of the
+first two: `on main's current head`, `N commits behind main`, and `distance unknown: <why>` when
+the comparison could not be read. The count comes from GitHub's compare API rather than a local
+`git rev-list`, because a stale worktree under-reports — the direction that makes a stale verdict
+look current.
 
 **And one line per corpus PR the body cites** — `corpus PR #226: NOT-MERGEABLE (head 321ac71a)`
 (#3674), from `.github/scripts/corpus_pr_state.py`, the same module `pr-gate.yml`'s

--- a/tools/ci-wait.py
+++ b/tools/ci-wait.py
@@ -39,7 +39,7 @@ Usage
 Beside every verdict it prints one more line -- the newest conclusive matrix
 verdict for `main` itself (#3679):
 
-    main floor: RED on 8b6885f4 (main-verdict-floor.yml, 1h ago)
+    main floor: RED on 8b6885f4 (main-verdict-floor.yml, 1h ago, 6 commits behind main)
 
 A pull request branched during a red window inherits a failure it did not cause,
 and that was invisible here. The line is a REPORT: it never changes the exit
@@ -375,6 +375,66 @@ def fetch_floor_runs(branch: str = "main"):
     return out, ""
 
 
+def fetch_distance_behind_main(sha: str, branch: str = "main"):
+    """(n, reason): how many commits `branch` has that `sha` does not.
+
+    Read from GitHub's compare API rather than from a local
+    `git rev-list --count <sha>..origin/main`, because this tool runs from
+    worktrees of varying freshness (ci-verdicts.md, "Run it from a tree you
+    have fetched") and a stale worktree UNDER-reports the distance. That is the
+    dangerous direction: under-reporting makes a stale verdict look current,
+    which is the defect this exists to remove (#4111). The API answers about
+    the remote's `main` whatever the local checkout holds.
+
+    `ahead_by` with `sha` as base and `branch` as head, NOT `behind_by`: the
+    field names describe the HEAD relative to the BASE, so `behind_by` here
+    counts commits the measured commit has that `main` does not -- 0 on a
+    healthy repository, and so a reassuring zero for an eight-commit-stale
+    verdict. Verified against `git rev-list --count <sha>..origin/main`, which
+    returned the same 5 that `ahead_by` did.
+
+    A count that cannot be established returns None and a reason, never 0
+    (guards-need-a-third-state.md): 0 is the healthy case and must stay
+    readable as reassurance.
+    """
+    rc, body = gh(["api", f"repos/{REPO}/compare/{sha}...{branch}",
+                   "--jq", "{ahead_by: .ahead_by, status: .status}"])
+    if rc != 0:
+        return None, f"could not compare {sha[:8]} with {branch}"
+    try:
+        got = json.loads(body)
+    except Exception:
+        # A 404 body ("Not Found") parses, so this is a malformed answer rather
+        # than the force-push case, which falls through to the check below.
+        return None, f"unreadable comparison of {sha[:8]} with {branch}"
+    if not isinstance(got, dict):
+        return None, f"unexpected comparison shape for {sha[:8]}"
+    n = got.get("ahead_by")
+    if not isinstance(n, int):
+        # The commit is gone (force-pushed away) or unrelated to the branch.
+        return None, f"{sha[:8]} is not reachable from {branch}"
+    return n, ""
+
+
+def _distance_phrase(sha: str, distance_fetch) -> str:
+    """The distance clause for the floor line, or its third state.
+
+    Three spellings, and the third must never be either of the first two:
+    `on main's current head` (a genuine zero, the reassuring common case),
+    `N commit(s) behind main`, and `distance unknown: <why>`.
+    """
+    fetch = distance_fetch or fetch_distance_behind_main
+    try:
+        n, why = fetch(sha)
+    except Exception as exc:  # a report may never raise into a verdict
+        n, why = None, f"{type(exc).__name__} while comparing with main"
+    if n is None:
+        return f"distance unknown: {why or 'the comparison could not be read'}"
+    if n == 0:
+        return "on main's current head"
+    return f"{n} commit{'' if n == 1 else 's'} behind main"
+
+
 def fetch_runs_for_sha(sha: str):
     """(runs, reason): EVERY workflow run GitHub has for one commit.
 
@@ -419,7 +479,8 @@ def _commit_order(run: dict) -> str:
 
 
 def floor_verdict(runs: list[dict] | None, reason: str = "",
-                  now: float | None = None, sha_fetch=None) -> str:
+                  now: float | None = None, sha_fetch=None,
+                  distance_fetch=None) -> str:
     """One line: the newest conclusive matrix verdict for `main`.
 
     Two steps, because they answer different questions: `runs` (a recent window)
@@ -452,8 +513,12 @@ def floor_verdict(runs: list[dict] | None, reason: str = "",
     red = [r for r in same if r.get("conclusion") == "failure"]
     decider = max(red or same, key=_commit_order)
     state = "RED" if red else "GREEN"
+    # The age says when the verdict was taken; the distance says what it covers.
+    # Without it a correct verdict about a `main` eight merges back reads
+    # exactly like one about the current head (#4111).
     return (f"main floor: {state} on {sha[:8] or '<unknown sha>'} "
-            f"({_workflow_file(decider)}, {_age_of(decider.get('updated_at'), now)})")
+            f"({_workflow_file(decider)}, {_age_of(decider.get('updated_at'), now)}, "
+            f"{_distance_phrase(sha, distance_fetch)})")
 
 
 def print_floor_verdict() -> None:

--- a/tools/test_ci_wait.py
+++ b/tools/test_ci_wait.py
@@ -1797,6 +1797,152 @@ finally:
 
 
 # --------------------------------------------------------------------------
+# #4111 -- the floor line's DISTANCE, not just its age.
+#
+# The line named the commit measured and how long ago, so a real, correct
+# verdict about a `main` eight merges back rendered identically to one about
+# the current head. Measured live while #4111 was filed: `GREEN on d50d41fd`
+# beside `git rev-list --count d50d41fd..origin/main` -> 8.
+#
+# The distance is read from GitHub's compare API rather than from the local
+# `origin/main`, because ci-wait.py runs from worktrees of varying freshness
+# and a stale one UNDER-reports -- the direction that makes a stale verdict
+# look current, which is the whole defect. The PR body weighs the two.
+#
+# Third state (guards-need-a-third-state.md): a distance that could not be read
+# must not print `0 commits behind`, the one wrong answer shaped exactly like
+# the healthy case. It gets its own spelling, and the healthy case stays
+# truthful and reassuring when it is genuinely true.
+# --------------------------------------------------------------------------
+
+def _line_d(runs, reason="", per_sha=None, distance=None):
+    """floor_verdict with the distance read faked, so no test touches the network."""
+    def _fetch(sha):
+        if per_sha is not None:
+            return per_sha
+        return [r for r in (runs or []) if r.get("head_sha") == sha], ""
+
+    def _dist(sha):
+        return distance if distance is not None else (0, "")
+    return cw.floor_verdict(runs, reason, _NOW, sha_fetch=_fetch, distance_fetch=_dist)
+
+
+_ok_runs = [_fr("main-verdict-floor.yml", "success", "d50d41fd0000", "2026-09-09T11:48:00Z")]
+
+# The reported case: eight commits behind, and the line says so.
+_far = _line_d(_ok_runs, distance=(8, ""))
+check("#4111: the floor line reports how far behind main the measured commit is",
+      "8 commits behind main" in _far, _far)
+check("#4111: ...alongside the verdict and the age it already carried",
+      _far.startswith("main floor: GREEN on d50d41fd") and "12m ago" in _far, _far)
+
+# ...and the singular reads as English, not as `1 commits`.
+_one = _line_d(_ok_runs, distance=(1, ""))
+check("#4111: a distance of one is worded in the singular",
+      "1 commit behind main" in _one and "1 commits" not in _one, _one)
+
+# The healthy case must stay truthful AND reassuring -- it is the common one.
+_cur = _line_d(_ok_runs, distance=(0, ""))
+check("#4111: a verdict on main's current head says so, not '0 commits behind'",
+      "current head" in _cur and "0 commits" not in _cur, _cur)
+
+# THE THIRD STATE. A distance that could not be established is never spelled
+# as the healthy case, in either of its two wordings.
+_unk = _line_d(_ok_runs, distance=(None, "the compare read failed"))
+check("#4111: an unreadable distance says so in the line",
+      "distance unknown" in _unk, _unk)
+check("#4111: ...and is NEVER spelled as the healthy case",
+      "0 commits behind" not in _unk and "current head" not in _unk, _unk)
+check("#4111: ...while the verdict it could read still prints",
+      _unk.startswith("main floor: GREEN on d50d41fd"), _unk)
+check("#4111: ...and names why it could not tell",
+      "compare read failed" in _unk, _unk)
+
+# A force-pushed-away SHA is the same third state, reached by a 404 rather than
+# by a network failure -- it must not degrade into a healthy-looking zero.
+_gone = _line_d(_ok_runs, distance=(None, "d50d41fd is not reachable from main"))
+check("#4111: a SHA unreachable from main is 'distance unknown', not zero",
+      "distance unknown" in _gone and "0 commits" not in _gone
+      and "not reachable" in _gone, _gone)
+
+
+# The report may never gate. A distance read that BLOWS UP is still not an
+# error: floor_verdict swallows it into the third state.
+def _boom_dist(sha):
+    raise RuntimeError("network")
+
+
+_exploded = cw.floor_verdict(_ok_runs, "", _NOW,
+                             sha_fetch=lambda s: (_ok_runs, ""),
+                             distance_fetch=_boom_dist)
+check("#4111: a distance read that raises degrades to unknown, never propagates",
+      "distance unknown" in _exploded and _exploded.startswith("main floor: GREEN"),
+      _exploded)
+
+# The distance is only meaningful beside a verdict: the unavailable and
+# no-conclusive-run lines must not sprout a distance for a commit they never named.
+_no_verdict = _line_d(None, "gh api failed", distance=(4, ""))
+check("#4111: an unavailable verdict carries no distance (there is no commit to measure)",
+      "behind main" not in _no_verdict and "current head" not in _no_verdict, _no_verdict)
+
+# The fetch half: it asks the compare API with the floor SHA as BASE and main as
+# HEAD, and reads `ahead_by`. `behind_by` is the trap -- with this base/head pair
+# it counts commits the floor SHA has that main does not, which is 0 on a healthy
+# repo and would print a reassuring zero for an eight-commit-stale verdict.
+_dcalls = []
+
+
+def _dist_gh(rc_out):
+    def _gh(args, attempts=4):
+        _dcalls.append(list(args))
+        return rc_out
+    return _gh
+
+
+_old_gh = cw.gh
+try:
+    _dcalls.clear()
+    cw.gh = _dist_gh((0, '{"ahead_by": 8, "behind_by": 0, "status": "ahead"}'))
+    _n, _why = cw.fetch_distance_behind_main("d50d41fd0000")
+    check("#4111: the distance read asks the compare API",
+          any("compare" in a[1] for a in _dcalls if len(a) > 1), repr(_dcalls))
+    check("#4111: ...with the measured sha as BASE and main as HEAD",
+          any("compare/d50d41fd0000...main" in a[1] for a in _dcalls if len(a) > 1),
+          repr(_dcalls))
+    check("#4111: ...and reads ahead_by -- the count of commits main has that it does not",
+          _n == 8 and not _why, f"{_n!r} {_why!r}")
+
+    # The third state at the fetch, not only at the line.
+    _dcalls.clear()
+    cw.gh = _dist_gh((1, "dial tcp: lookup api.github.com: no such host"))
+    _n, _why = cw.fetch_distance_behind_main("d50d41fd0000")
+    check("#4111: a failed compare read returns None and a reason, never 0",
+          _n is None and _why, f"{_n!r} {_why!r}")
+
+    _dcalls.clear()
+    cw.gh = _dist_gh((0, '{"message": "Not Found", "status": "404"}'))
+    _n, _why = cw.fetch_distance_behind_main("deadbeef0000")
+    check("#4111: a 404 (force-pushed away) returns None and a reason, never 0",
+          _n is None and _why, f"{_n!r} {_why!r}")
+
+    _dcalls.clear()
+    cw.gh = _dist_gh((0, "not json at all"))
+    _n, _why = cw.fetch_distance_behind_main("d50d41fd0000")
+    check("#4111: an unparseable compare body is a refusal, not a zero",
+          _n is None and _why, f"{_n!r} {_why!r}")
+
+    # A genuine zero IS an answer -- the tool must not confuse "identical" with
+    # "could not tell", or the reassuring case would never print.
+    _dcalls.clear()
+    cw.gh = _dist_gh((0, '{"ahead_by": 0, "behind_by": 0, "status": "identical"}'))
+    _n, _why = cw.fetch_distance_behind_main("d50d41fd0000")
+    check("#4111: a genuine zero is an answer, not a refusal",
+          _n == 0 and not _why, f"{_n!r} {_why!r}")
+finally:
+    cw.gh = _old_gh
+
+
+# --------------------------------------------------------------------------
 # ...and main() must actually print it, on every path that reached GitHub, with
 # the exit code unchanged. This used to be a substring COUNT over the source --
 # which counted the `def` line, so it tolerated four call sites out of five and


### PR DESCRIPTION
Closes #4111

Corpus-NA: repository tooling only. This changes one line of `tools/ci-wait.py`'s console output and touches nothing the AL compiler or runtime can observe — no patch, no rewriter, no emitted assembly — so there is no BC behavior for a service tier to adjudicate.

*(Implemented by the agent `stma-auto-2`.)*

## What was wrong

`ci-wait.py` prints one line about `main` beside every PR verdict. It named the commit measured and how long ago, but not **how far behind `main`'s head that commit is** — so a correct verdict about a `main` several merges back read exactly like a verdict on the current head.

Measured live at filing time, and still reproducible when I picked the issue up:

```
main floor: GREEN on d50d41fd (main-verdict-floor.yml, 5h ago)
git rev-list --count d50d41fd..origin/main  ->  8
```

Eight commits stale, rendered as a healthy green.

## What the line says now

```
main floor: GREEN on d50d41fd (main-verdict-floor.yml, 5h ago, 8 commits behind main)
```

That is the reported case, reproduced and fixed against the same SHA.

Three spellings, and the third is deliberately neither of the first two:

| case | spelling |
|---|---|
| verdict is on `main`'s head | `on main's current head` |
| verdict is stale | `N commits behind main` (singular at 1) |
| distance could not be read | `distance unknown: <why>` |

## Which data source, and why

The issue left this open and asked for justification. I chose **GitHub's compare API**, not a local `git rev-list`.

| source | cost | fails how |
|---|---|---|
| `git rev-list --count <sha>..origin/main` | cheapest, no network | reads the **local** `origin/main`. A worktree that has not fetched **under-reports** the distance. |
| `GET /repos/{o}/{r}/compare/{sha}...main` | one API call, alongside the reads this function already makes | needs the network, which is already true of every other read here |

Under-reporting is the dangerous direction: it makes a stale verdict look current, which is the entire defect. `ci-wait.py` runs from worktrees of varying freshness (`ci-verdicts.md` § "Run it from a tree you have fetched"), and worktrees here are created once and never fast-forwarded (#3020) — so the local read would be wrong in the one direction that matters, on exactly the machines that matter. The function already makes two `gh api` calls, so this adds a third to a code path that cannot work offline anyway.

**One trap worth naming, because the field name invites the error.** With the measured SHA as base and `main` as head, the distance is `ahead_by`, **not** `behind_by` — the fields describe the head relative to the base, so `behind_by` counts commits the *measured commit* has that `main` does not. That is 0 on a healthy repository, so reading it would print a reassuring zero for an eight-commit-stale verdict: the precise wrong answer the issue forbade, reached by picking the field whose name matches the English sentence. Verified against `git rev-list --count`, which returned the same 5 that `ahead_by` did on a `main~5` probe.

## RED to GREEN

18 new checks in `tools/test_ci_wait.py`, which `pr-gate.yml` globs under the required `tools/ unit tests` context.

- **RED** (tests present, implementation absent): `Passed: 190`, then the run aborts at the first new check with `TypeError: floor_verdict() got an unexpected keyword argument 'distance_fetch'` — none of the 18 execute.
- **GREEN**: `Passed: 264, Failed: 0`.

Every new check injects a fake fetch, so none of them touches the network.

## Mutations

Three, each chosen to test a **property** rather than to produce a red, and each reds a *different* subset — which is what shows the tests discriminate rather than ride along.

| # | mutation | result | property established |
|---|---|---|---|
| 1 | read `behind_by` instead of `ahead_by` | `Failed: 1, Passed: 263` | the tests pin **which field** carries the distance, not merely that a number appears. `behind_by` is a real field that parses fine and returns 0 — a suite checking only "some distance clause appears" would stay green. |
| 2 | collapse the third state into `n = 0` | `Failed: 5, Passed: 259` | the unreadable case is **never** spelled as the healthy one. The observable moved to `on main's current head` for an unreachable SHA — the exact forbidden rendering. |
| 3 | the inverse: make a genuine zero read as `distance unknown` | `Failed: 1, Passed: 263` | `0` stays **truthful and reassuring** when it is genuinely true. Mutation 2 proved unknown is not zero; this proves zero is not unknown. Collapsing either way loses the distinction, and only the pair covers both. |

Mutation 2 is the one that proves the third state fires, so it is not a never-fire path.

**Each mutation was confirmed to move the observable the assertion reads**, not merely the source text. Under mutation 1 the live read of the real `d50d41fd` went from `8 commits behind main` to `distance unknown` — so even a wrong field name degrades safe rather than printing a false zero. Under mutation 2 the unreachable SHA rendered as `on main's current head`.

## It is a report, never a gate

- `_distance_phrase` catches every exception from the fetch and degrades to the third state; a proving test injects a fetch that raises and asserts the line still starts with `main floor: GREEN`.
- Verified live end-to-end against PR #4069: the floor line printed with the distance and `ci-wait.py` still exited **0**.
- The `unavailable` and `no conclusive run found` lines get **no** distance clause — there is no commit to measure — and a test pins that.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** No. `_age_of` has exactly one call site, so there is no second place reporting an age without a distance. Confirmed with `command grep -n "_age_of("` (the bare `grep` here is a shell function that exits 0 on a rejected flag).
2. **Does a sibling function make the same assumption?** The corpus-PR line (#3674) reports a head SHA and a state, but it names the PR's *own* head rather than a verdict about a moving branch, so "how far behind" is not a meaningful question there. The inherited-red table (#3922) keys on codeunits, not commits.
3. **Two paths writing the same state with different invariants?** `fetch_floor_runs` and `fetch_runs_for_sha` both refuse rather than answering from a partial read; `fetch_distance_behind_main` follows the same contract — `(None, reason)`, never a zero.

**Doc drift my change would otherwise have caused**, both fixed here: the module docstring sample at `tools/ci-wait.py:42` and the sample in `.claude/rules/ci-verdicts.md` both showed the old two-term format. Neither is pinned by a drift test, so nothing would have failed — they would simply have gone quietly stale.

## Same-defect scan

Searched the open queue on the symbol (`main_floor_line`, `ahead_by`), the observable (`commits behind main`), and the mechanism (`stale verdict`, `floor line distance`). Only #4111 targets this. #4063 (cancellation) and #4110 (starvation) are the two *causes* of staleness that #4111's body already cites — both are workflow-level and neither is fixed in `ci-wait.py`, so nothing folds in under `batch-sibling-issues-by-file.md`.

## Tests run

- `python3 tools/test_ci_wait.py` — 264 passed, 0 failed.
- All 21 `tools/test_*.py` guards — pass.
- Live run of `tools/ci-wait.py 4069 --timeout 0` — exit 0, floor line correct.

Not run: the BC matrix and `AlRunner.Tests`. This PR touches no `AlRunner/` path, so `require-tests.yml` does not trigger and no leg runs AL.

## Note on CI

The account's Actions queue was stalled when this was pushed (#4110), so I pushed once and handed back without chasing CI, per the dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
