### PR TITLE
fix(ci): start every sync-changelog retry attempt from a clean tree

### DIFF
--- a/.github/scripts/sync_changelog_push.sh
+++ b/.github/scripts/sync_changelog_push.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Recompute [Unreleased] against current origin/main and push it, retrying while
+# main moves underneath us (#2630). Extracted from sync-changelog-unreleased.yml
+# so the retry can be tested against a real moving repository (#3231) -- inline
+# in YAML it was reachable only by merging and waiting for a three-way merge race.
+#
+# Each attempt must START FROM A CLEAN TREE, which is the whole of #3231.
+# generate_changelog.py --unreleased writes CHANGELOG.md in place, so by the time
+# any attempt reaches `checkout -B`, that write is sitting unreconciled in the
+# working tree -- put there by the workflow's own preceding "Recompute" step
+# before attempt 1, and by the previous iteration after that. `git checkout -B`
+# refuses to overwrite it whenever origin/main carries a different CHANGELOG.md:
+#
+#     error: Your local changes to the following files would be overwritten by
+#     checkout: CHANGELOG.md
+#
+# which is exactly the case the loop exists for -- another run won the race and
+# pushed its own CHANGELOG. Under `set -e` that ends the step, so the retries
+# never happen and the "main moved 5 times running" error below is unreachable.
+# Measured in run 34053605452: the step failed 0.6s in, having printed no
+# "attempt N of 5" line at all -- attempt 1, not attempt 2.
+#
+# -f is what makes the tree clean, and it is deliberately narrower than the
+# alternatives. `git checkout -- CHANGELOG.md` hardcodes the filename and would
+# silently stop working if the generator ever wrote a second file; `git reset
+# --hard` discards unconditionally and is the sibling of the footgun in #2203.
+# -f discards local modifications only for the paths the checkout must update,
+# names no file, and leaves untracked files alone.
+#
+# Recompute against origin/main rather than rebasing the commit: the section is
+# derived from `git describe --tags`..HEAD, so what it should say depends on
+# which commits are on main NOW, not which were there when this run was queued.
+set -uo pipefail
+
+attempts="${SYNC_CHANGELOG_ATTEMPTS:-5}"
+
+for attempt in $(seq 1 "$attempts"); do
+  # Each of these must still be fatal: the loop retries a LOST PUSH RACE, and
+  # nothing else. A fetch or checkout that fails is a broken checkout, and
+  # retrying it four more times just hides the reason.
+  git fetch origin main || exit 1
+  git checkout -f -B sync-retry origin/main || exit 1
+  out=$(python3 .github/scripts/generate_changelog.py --unreleased) || exit 1
+  echo "$out"
+  case "$out" in
+    *changed=true*) ;;
+    *)
+      echo "nothing left to write against $(git rev-parse --short origin/main) — another run got there first"
+      exit 0
+      ;;
+  esac
+  git add CHANGELOG.md || exit 1
+  # changed=true means the regenerated text differs from what is on disk, and
+  # the checkout above put origin/main's copy there -- so the index genuinely
+  # differs from HEAD and an empty-index commit failure is not reachable here.
+  git commit -m "chore: update changelog [skip ci]" || exit 1
+  if git push origin HEAD:main; then
+    exit 0
+  fi
+  echo "main moved while pushing; recomputing (attempt $attempt of $attempts)"
+done
+echo "::error::main moved under this job $attempts times running — something is pushing to main continuously"
+exit 1

--- a/.github/scripts/test_sync_changelog_push.sh
+++ b/.github/scripts/test_sync_changelog_push.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# Tests for sync_changelog_push.sh -- the CHANGELOG sync's push-retry loop (#3231).
+#
+# The property under test is not "the script mentions -f". It is: WITH A DIRTY
+# CHANGELOG.md IN THE TREE AND origin/main CARRYING A DIFFERENT ONE, the loop
+# still reaches a push. That is the exact state run 34053605452 died in, and it
+# is reproducible here in a scratch repository in well under a second -- no
+# GitHub, no merge wave, no waiting for three PRs to land 6 seconds apart.
+#
+# Every case below drives the REAL script against real git remotes. The
+# generator is stubbed (PATH shim) so the tests are about the retry loop's
+# tree handling rather than about changelog formatting, which
+# test_generate_changelog.py already covers.
+#
+# Run directly: bash .github/scripts/test_sync_changelog_push.sh
+
+set -uo pipefail
+
+# Scratch commits must not reach the user's global/system config: a signing box
+# otherwise fails or blocks on every commit below (#4001).
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_NOSYSTEM=1
+unset GIT_CONFIG_PARAMETERS GIT_CONFIG_COUNT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/sync_changelog_push.sh"
+WORKFLOW="$(cd "$SCRIPT_DIR/../workflows" && pwd)/sync-changelog-unreleased.yml"
+
+pass=0
+fail=0
+ok()  { echo "ok   - $1"; pass=$((pass + 1)); }
+bad() { echo "FAIL - $1"; fail=$((fail + 1)); }
+
+check_eq() {
+  local desc="$1" expected="$2" got="$3"
+  if [ "$expected" = "$got" ]; then ok "$desc"; else
+    bad "$desc: expected '$expected', got '$got'"
+  fi
+}
+
+# --- Scaffolding -------------------------------------------------------------
+#
+# A bare "origin" plus a clone standing in for the runner's checkout, and a
+# second clone standing in for whichever OTHER sync run wins the race. The
+# generator is a stub on PATH that writes a caller-controlled line into
+# CHANGELOG.md and reports changed=true/false the way the real one does.
+
+ROOT="$(mktemp -d)"
+trap 'rm -rf "$ROOT"' EXIT
+
+# $1 = scenario dir. Builds origin + work + rival, all on main.
+build_repo() {
+  local d="$ROOT/$1"
+  mkdir -p "$d"
+  git init -q --bare "$d/origin"
+
+  git clone -q "$d/origin" "$d/work" 2>/dev/null
+  git -C "$d/work" config user.email test@example.com
+  git -C "$d/work" config user.name Test
+  git -C "$d/work" checkout -q -b main
+  printf '# Changelog\n\n## [Unreleased]\n\nbase\n' > "$d/work/CHANGELOG.md"
+  git -C "$d/work" add -A
+  git -C "$d/work" commit -qm "base"
+  git -C "$d/work" push -q -u origin main
+
+  git clone -q "$d/origin" "$d/rival" 2>/dev/null
+  git -C "$d/rival" config user.email rival@example.com
+  git -C "$d/rival" config user.name Rival
+  echo "$d"
+}
+
+# A stub generate_changelog.py. Writes $STUB_TEXT into CHANGELOG.md and prints
+# changed=true when that differs from what is already on disk -- the real
+# script's own contract (update_unreleased returns False when updated ==
+# content), which is what makes an empty-index commit unreachable.
+install_stub() {
+  local d="$1"
+  mkdir -p "$d/bin" "$d/work/.github/scripts"
+  cat > "$d/work/.github/scripts/generate_changelog.py" <<'STUB'
+import os, sys
+text = os.environ.get('STUB_TEXT', 'generated')
+path = 'CHANGELOG.md'
+old = open(path).read() if os.path.exists(path) else ''
+new = '# Changelog\n\n## [Unreleased]\n\n' + text + '\n'
+if new == old:
+    print('changed=false')
+else:
+    open(path, 'w').write(new)
+    print('changed=true')
+STUB
+}
+
+# Runs the script inside $d/work with the stub in place.
+run_sync() {
+  local d="$1"
+  ( cd "$d/work" && STUB_TEXT="${STUB_TEXT:-mine}" \
+      SYNC_CHANGELOG_ATTEMPTS="${SYNC_CHANGELOG_ATTEMPTS:-5}" \
+      bash "$SCRIPT" 2>&1 )
+}
+
+# Makes the rival clone push a different CHANGELOG.md onto origin/main.
+rival_pushes() {
+  local d="$1" text="$2"
+  git -C "$d/rival" fetch -q origin main
+  git -C "$d/rival" checkout -qf -B main origin/main
+  printf '# Changelog\n\n## [Unreleased]\n\n%s\n' "$text" > "$d/rival/CHANGELOG.md"
+  git -C "$d/rival" add -A
+  git -C "$d/rival" commit -qm "rival"
+  git -C "$d/rival" push -q origin main
+}
+
+# --- 1. THE REGRESSION: a dirty tree + a moved origin/main -------------------
+#
+# This is run 34053605452 exactly. The workflow's "Recompute" step has already
+# written CHANGELOG.md, and while this job sat in the Actions queue another run
+# pushed a DIFFERENT CHANGELOG.md. Before #3231 the first `checkout -B` refused
+# and `bash -e` ended the step 0.6s in.
+
+d="$(build_repo dirty-and-moved)"
+install_stub "$d"
+rival_pushes "$d" "rival-content"
+# the tree is dirty exactly as the preceding workflow step leaves it
+printf '# Changelog\n\n## [Unreleased]\n\nstale-local-write\n' > "$d/work/CHANGELOG.md"
+
+out="$(STUB_TEXT=mine run_sync "$d")"; rc=$?
+check_eq "a dirty tree against a moved origin/main still pushes" 0 "$rc"
+
+if printf '%s' "$out" | command grep -q "would be overwritten by checkout"; then
+  bad "the checkout refused -- this is the #3231 regression"
+else
+  ok "the checkout is not refused by the stale local write"
+fi
+
+# Read the last non-blank line: the stub writes the section body there, and a
+# positional tail would pick up the trailing blank line instead.
+pushed="$(git -C "$d/origin" show main:CHANGELOG.md | command grep -v '^$' | tail -1)"
+check_eq "origin/main ends up carrying this run's recomputed section" "mine" "$pushed"
+
+# The rival's commit must still be an ancestor: the fix may not discard
+# somebody else's merged work to clean the tree (#2203's failure mode).
+if git -C "$d/work" merge-base --is-ancestor \
+     "$(git -C "$d/rival" rev-parse HEAD)" "$(git -C "$d/origin" rev-parse main)"; then
+  ok "the rival's commit survives -- nothing was reverted to clean the tree"
+else
+  bad "the rival's commit was discarded"
+fi
+
+# --- 2. A LOST PUSH RACE, which is what the retry is FOR ---------------------
+#
+# Attempt 1 computes against origin/main, and the rival pushes in between the
+# computation and the push, so the push is rejected. Attempt 2 must recover --
+# and it starts from a tree the first attempt dirtied.
+
+d="$(build_repo lost-race)"
+install_stub "$d"
+# A pre-push hook on the bare repo rejects exactly the first push attempt, then
+# lets the rival's own push and the retry through.
+# A pre-receive hook on the bare origin rejects the FIRST push only. The marker
+# lives in the bare repo, so it survives between the two push processes; no
+# environment needs to reach the hook, which a local-path push would not carry.
+mkdir -p "$d/origin/hooks"
+cat > "$d/origin/hooks/pre-receive" <<'HOOK'
+#!/usr/bin/env bash
+marker="$(dirname "$0")/../rejected-once"
+if [ ! -f "$marker" ]; then
+  touch "$marker"
+  echo "simulated: main moved while pushing" >&2
+  exit 1
+fi
+exit 0
+HOOK
+chmod +x "$d/origin/hooks/pre-receive"
+
+printf '# Changelog\n\n## [Unreleased]\n\nstale-local-write\n' > "$d/work/CHANGELOG.md"
+out="$( cd "$d/work" && STUB_TEXT=mine bash "$SCRIPT" 2>&1 )"
+rc=$?
+check_eq "a rejected first push is retried to success" 0 "$rc"
+if printf '%s' "$out" | command grep -q "attempt 1 of"; then
+  ok "the retry actually ran a second iteration"
+else
+  bad "no second iteration happened: $(printf '%s' "$out" | tail -3 | tr '\n' ' ')"
+fi
+if printf '%s' "$out" | command grep -q "would be overwritten by checkout"; then
+  bad "iteration 2's checkout was refused by iteration 1's write"
+else
+  ok "iteration 2 starts from a clean tree"
+fi
+
+# --- 3. Another run got there first: nothing left to write -------------------
+#
+# The rival pushes CONTENT IDENTICAL to what this run would compute. The
+# generator reports changed=false and the loop exits 0 without committing.
+
+d="$(build_repo already-done)"
+install_stub "$d"
+rival_pushes "$d" "mine"
+printf '# Changelog\n\n## [Unreleased]\n\nstale-local-write\n' > "$d/work/CHANGELOG.md"
+before="$(git -C "$d/origin" rev-parse main)"
+out="$(STUB_TEXT=mine run_sync "$d")"; rc=$?
+check_eq "nothing left to write exits 0" 0 "$rc"
+check_eq "and pushes no commit" "$before" "$(git -C "$d/origin" rev-parse main)"
+if printf '%s' "$out" | command grep -q "another run got there first"; then
+  ok "it says why it stopped"
+else
+  bad "no explanation printed"
+fi
+
+# --- 4. Exhausting the retries is still a loud failure -----------------------
+#
+# guards-need-a-third-state.md: the give-up path must be reachable and must
+# fail, not quietly succeed. Before #3231 it was unreachable, because the
+# checkout killed the step first.
+
+d="$(build_repo exhausted)"
+install_stub "$d"
+cat > "$d/origin/hooks/pre-receive" <<'HOOK'
+#!/usr/bin/env bash
+echo "simulated: main always moves" >&2
+exit 1
+HOOK
+chmod +x "$d/origin/hooks/pre-receive"
+printf '# Changelog\n\n## [Unreleased]\n\nstale-local-write\n' > "$d/work/CHANGELOG.md"
+out="$( cd "$d/work" && STUB_TEXT=mine SYNC_CHANGELOG_ATTEMPTS=3 bash "$SCRIPT" 2>&1 )"
+rc=$?
+check_eq "exhausting every attempt exits 1" 1 "$rc"
+if printf '%s' "$out" | command grep -q "::error::main moved under this job 3 times"; then
+  ok "the give-up path is reachable and loud"
+else
+  bad "the give-up error never printed"
+fi
+if [ "$(printf '%s' "$out" | command grep -c "attempt . of 3")" = "3" ]; then
+  ok "all 3 attempts ran"
+else
+  bad "expected 3 attempts, got $(printf '%s' "$out" | command grep -c "attempt . of 3")"
+fi
+
+# --- 5. The workflow calls the script ----------------------------------------
+#
+# Extracting the loop is only a fix if the workflow actually runs the extracted
+# copy; otherwise the tests above grade a file nothing executes.
+
+if command grep -q "sync_changelog_push.sh" "$WORKFLOW"; then
+  ok "the workflow invokes sync_changelog_push.sh"
+else
+  bad "the workflow does not invoke sync_changelog_push.sh"
+fi
+if command grep -qE '^\s+git checkout -B sync-retry' "$WORKFLOW"; then
+  bad "the workflow still carries its own unguarded checkout -B loop"
+else
+  ok "the workflow no longer carries an inline retry loop"
+fi
+
+echo
+echo "passed: $pass, failed: $fail"
+[ "$fail" -eq 0 ]

--- a/.github/workflows/sync-changelog-unreleased.yml
+++ b/.github/workflows/sync-changelog-unreleased.yml
@@ -94,30 +94,14 @@ jobs:
       # never lost -- the next run recomputes it -- but main carried a failed run for a
       # reason unrelated to the commit under it, and a red main is not announced anywhere.
       #
-      # Recompute against origin/main rather than rebasing the commit: the section is
-      # derived from `git describe --tags`..HEAD, so what it should say depends on which
-      # commits are on main NOW, not on which were there when this run was scheduled.
+      # The retry, and the tree handling that #3231 fixed, now live in
+      # .github/scripts/sync_changelog_push.sh -- that file's header carries the
+      # reasoning, and test_sync_changelog_push.sh drives it against real remotes.
       - name: Commit and push if it changed
         if: steps.sync.outputs.changed == 'true'
-        run: |
-          for attempt in 1 2 3 4 5; do
-            git fetch origin main
-            git checkout -B sync-retry origin/main
-            out=$(python3 .github/scripts/generate_changelog.py --unreleased)
-            echo "$out"
-            case "$out" in
-              *changed=true*) ;;
-              *)
-                echo "nothing left to write against $(git rev-parse --short origin/main) — another run got there first"
-                exit 0
-                ;;
-            esac
-            git add CHANGELOG.md
-            git commit -m "chore: update changelog [skip ci]"
-            if git push origin HEAD:main; then
-              exit 0
-            fi
-            echo "main moved while pushing; recomputing (attempt $attempt of 5)"
-          done
-          echo "::error::main moved under this job 5 times running — something is pushing to main continuously"
-          exit 1
+        # The loop lives in a script rather than inline here so it can be tested
+        # against a real moving repository (.github/scripts/test_sync_changelog_push.sh,
+        # #3231). Inline in YAML it was reachable only by merging and hoping to
+        # lose a three-way race, which is why the tree-dirtying bug below
+        # survived the #2630 rewrite that introduced the retry.
+        run: bash .github/scripts/sync_changelog_push.sh

--- a/tools/test_scratch_repo_git_isolation.py
+++ b/tools/test_scratch_repo_git_isolation.py
@@ -35,6 +35,7 @@ SUITES = {
     "tools/test_corpus_checkout.py": "all corpus-checkout tests passed",
     "tools/test_preflight.py": "all checks passed",
     ".github/scripts/test_pr_changed_files.sh": "failed: 0",
+    ".github/scripts/test_sync_changelog_push.sh": "failed: 0",
 }
 
 FAILURES: list[str] = []


### PR DESCRIPTION
Closes #3231

Corpus-NA: CI plumbing for the CHANGELOG sync workflow; no AL is compiled or executed on this path and nothing here changes what AL observes.

## What was broken

`generate_changelog.py --unreleased` writes `CHANGELOG.md` **in the working tree**. The retry loop then ran `git checkout -B sync-retry origin/main` against that unreconciled write, and git refuses to overwrite a modified file when the incoming ref carries a different version of it:

```
error: Your local changes to the following files would be overwritten by checkout:
	CHANGELOG.md
Aborting
```

That is exactly the situation the retry exists for: another sync run won the race and pushed its own `CHANGELOG.md`. Under `bash -e` (GitHub's default `run` shell) the failed checkout ended the step, so the remaining attempts never happened and the `main moved under this job 5 times running` error was unreachable.

## One correction to the issue's diagnosis

The issue titles this as aborting on the **second** iteration. It is the **first**.

Run `34053605452` failed at `19:02:39.59`, 0.6s after the step began at `19:02:38.98`, having printed no `attempt N of 5` line at all. The tree was already dirty when the loop started, because the workflow's own preceding `Recompute [Unreleased]` step (line 87) writes `CHANGELOG.md` before the loop runs.

Iteration 2 is in fact the *safe* one: once an iteration reaches `git commit`, the tree is clean, so its next `checkout -B` succeeds even unfixed. I verified this in a scratch repository, and the test suite records it — the case named `a rejected first push is retried to success` passes both before and after the fix.

This matters for review: the failure is reachable on **every** run that loses the race, not only on runs that get as far as a second attempt.

## The fix

`git checkout -f -B sync-retry origin/main`.

`-f` discards local modifications for the paths the checkout must update. Why this over the two alternatives the issue suggested:

| option | why not |
|---|---|
| `git checkout -- CHANGELOG.md` | hardcodes the filename; silently stops working if the generator ever writes a second file |
| `git reset --hard origin/main` | discards unconditionally — the blunt sibling of the footgun in #2203 |
| **`git checkout -f -B`** | names no file, discards only what the checkout must replace, leaves untracked files alone (verified) |

The stash route was not considered despite the error message suggesting it: `.claude/rules/no-git-stash-with-worktrees.md` forbids it outright, and that stack is repository-wide rather than per-worktree.

The loop also moves out of the YAML into `.github/scripts/sync_changelog_push.sh`. That is what makes it testable — inline it was reachable only by merging and hoping to lose a three-way race, which is how this survived the #2630 rewrite that introduced the retry. `set -e` is replaced by explicit `|| exit 1` on each step, so `git push` may still fail into the retry while a broken fetch/checkout stays fatal.

## RED to GREEN

`.github/scripts/test_sync_changelog_push.sh` drives the real script against real git remotes (a bare origin, a working clone, and a rival clone standing in for the run that wins the race). No GitHub, no merge wave; the whole suite runs in about a second.

```
RED  (checkout -f -B  ->  checkout -B):   passed: 10, failed: 5
GREEN (the fix):                          passed: 15, failed: 0
```

Both numbers are against the **same** test file. RED was re-established after a mid-work assertion correction, so the two figures grade identical tests.

Unfixed, the suite reports `origin/main ends up carrying this run's recomputed section: expected 'mine', got 'rival-content'` — this run's recomputation is lost entirely, not merely mis-exited.

## Mutations

Two, chosen to test properties rather than to produce a red.

**A — a genuinely equivalent fix must still pass.** Replaced `-f` with a `checkout || reset --hard || checkout` fallback: **15/15, still green**. So the suite tests *"every iteration starts clean"*, not my particular spelling of it.

**B — a fix that cleans the tree against the wrong ref must fail.** `checkout -f -B sync-retry HEAD` leaves the tree clean and the checkout succeeding, but resolves against the stale local ref: **passed: 11, failed: 4**, reding on content (`got 'rival-content'`) and on the give-up path. This is what proves the content assertion earns its place — the exit-code assertion alone does not discriminate.

Mutation B is also a recorded near-miss worth flagging: my first attempt at it **silently no-opped**, because the `python3` replacement anchored on text that mutation A had already rewritten, and the suite stayed green. That is `tdd.md`'s "a mutation that silently no-ops reads as 'my test is broken'". I caught it by reading the run log — `branch 'sync-retry' set up to track 'origin/main'` can only be printed by the *unmutated* line — then re-applied it with an asserted anchor count and confirmed the observable changed before trusting the red.

## Fix the shape, not just the reported line

**Q1 — the same wrong pattern at another call site?** No. `checkout -B` / `checkout -f` / `reset --hard` appear nowhere else under `.github/workflows/`, `.github/scripts/` or `tools/` outside test scaffolding. Confirmed with both `command grep` and `rg --hidden`, since each has a silent-empty failure mode.

**Q2 — a sibling function making the same assumption?** One sibling exists and is **already correct**: `publish.yml:671-683` has its own push-retry around the same generator. It is safe for a structural reason worth recording — it **pushes first, then cleans**, running `git fetch` + `git reset --hard origin/<branch>` *before* regenerating, so each iteration starts clean by construction. `rg` found it; the narrower first grep did not, which is why both tools were run.

**Q3 — two paths writing the same state, same invariant?** `CHANGELOG.md` is written by exactly these two workflows (`no-changelog-edits.md`: no PR may touch it). After this change both maintain the same invariant — clean tree before regenerating. Previously only `publish.yml` did.

## Queue scan

Searched open issues for `sync-changelog`, `generate_changelog`, `CHANGELOG`, `checkout -B` and `retry loop`. Nothing folds in: #3231 is the only issue whose fix lands in these files.

The one near-match is **#2203** (`git reset --soft origin/main` silently reverting merged work). It is not foldable — different file (a `.claude/rules/` doc), different mechanism (`--soft` keeps the tree; `checkout -B` refuses outright) — but it is directly load-bearing here, because it is why I did not take the `reset --hard` route the issue suggested. The suite has an explicit assertion for that failure mode: `the rival's commit survives — nothing was reverted to clean the tree`.

## Tests run

- `.github/scripts/test_sync_changelog_push.sh` — 15/15, run twice to confirm determinism (case 2 leaves a rejection marker in its scratch bare repo, so a repeat run is the check that no state leaks between runs).
- **All 20 `.github/scripts/test_*`** — 0 failures.
- **All 23 `tools/test_*.py`** — 0 failures.
- `check_changelog_untouched.sh` and `check_corpus_linkage.sh` run against this diff — both pass.

`tools/test_scratch_repo_git_isolation.py` caught the new suite on the first run (`unguarded: ['.github/scripts/test_sync_changelog_push.sh']`) and is updated: the new entry makes that guard re-run my suite under a hostile signing global config, which it now passes.

No `dotnet` test was run — this diff touches no C#, and `require-tests.yml` does not trigger because nothing under `AlRunner/` changed.

## One thing for the merger

`tools/preflight.py` reports that this box's token has **no `workflow` scope**, so a PR touching `.github/workflows/` may not be mergeable from here. The push itself succeeded; flagging it in case the merge needs an owner-scoped token.

CI was not waited on: the account's Actions queue has been stalled since `04:43Z` (#4110).

---

*Implemented by `stma-auto-3`, an automated agent acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
