### PR TITLE
docs(orchestrating): a transport error arms nothing and still exits 0

### DIFF
--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -243,10 +243,17 @@ still exits 0 with the PR neither merged nor armed. There the state is *not* cle
 `--auto` would be wrong; a plain retry of the same command takes. Measured three times on
 2026-09-13 while `gh pr create` was also failing with 502s and the REST endpoint was healthy.
 
-Telling them apart is cheap: the clean-status error names
-`enablePullRequestAutoMerge`, a transport error names an HTTP status. When in doubt, retry the
-same command once and re-read; if it is the clean-status race, the retry fails the same way and
-*then* you drop `--auto`.
+Telling them apart is cheap **when there is a message at all**: the clean-status error names
+`enablePullRequestAutoMerge`, a transport error names an HTTP status. But a degraded endpoint
+also returns an **empty body**, which parses as nothing — measured minutes later on this same
+outage, where two `gh api ... -X POST` calls produced `unexpected end of JSON input` from the
+*parser* rather than any status from GitHub, and the third attempt succeeded. So the absence of
+a recognisable error is not evidence of the clean-status race.
+
+When in doubt, retry the same command once and re-read; if it is the clean-status race, the
+retry fails the same way and *then* you drop `--auto`. **Retrying is the safe default**, because
+it cannot merge anything: the wrong guess costs one call, while dropping `--auto` on a PR that
+is not clean asks GitHub to merge on unpassed checks.
 
 **So the exit code is not the check — the PR's state is.** After any `gh pr merge`, re-read it:
 

--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -236,6 +236,18 @@ produce it, because it skips the mutation on a mergeable PR — does not follow,
 mergeable" there means *as cached at fetch time*, and the gap between the two reads is the race.
 `--auto` on a settled-green PR still merges on the spot (#3095); that is not in question.
 
+**A second cause reaches the same exit-0-but-unarmed state, and its fix is the opposite one.**
+The race above is a *clean-status* one, cleared by re-running **without** `--auto`. During an
+API degradation the call instead fails in transport — a bare **GraphQL 502 or 500** — and `gh`
+still exits 0 with the PR neither merged nor armed. There the state is *not* clean, so dropping
+`--auto` would be wrong; a plain retry of the same command takes. Measured three times on
+2026-09-13 while `gh pr create` was also failing with 502s and the REST endpoint was healthy.
+
+Telling them apart is cheap: the clean-status error names
+`enablePullRequestAutoMerge`, a transport error names an HTTP status. When in doubt, retry the
+same command once and re-read; if it is the clean-status race, the retry fails the same way and
+*then* you drop `--auto`.
+
 **So the exit code is not the check — the PR's state is.** After any `gh pr merge`, re-read it:
 
 ```bash


### PR DESCRIPTION
`orchestrating-a-session` records one way `gh pr merge --auto` exits 0 while arming nothing: a **clean-status race**, whose error names `enablePullRequestAutoMerge`, cleared by re-running **without** `--auto` (#3336, #3772).

Tonight produced a second cause with the same observable and the **opposite** fix.

## Measured three times in one session

During the API degradation tracked in #4110, `gh pr merge --auto` failed in transport — a bare **GraphQL 502/500** — and still **exited 0**, leaving the PR neither merged nor armed. Each instance was caught only by re-reading `autoMergeRequest`, never by the exit code:

- twice by a reviewer agent arming PRs #4119 and #4120;
- once more on a sibling call in the same window.

The same degradation was failing `gh pr create` with 502s while the REST endpoint stayed healthy, which is what marks it as transport rather than state.

## Why it needs saying rather than folding into the existing note

**The fixes are opposite, and applying the wrong one is not harmless.** In the clean-status race the PR genuinely *is* mergeable, so dropping `--auto` merges it — correct there, and it is why that remedy is written down. Under a transport failure the PR is **not** clean; dropping `--auto` would ask GitHub to merge a PR whose checks have not passed, which on a stalled queue is every PR in flight.

A shared symptom with divergent remedies is exactly the case where a rule has to name the discriminator, and it is cheap: **the clean-status error names the mutation (`enablePullRequestAutoMerge`); a transport error names an HTTP status.** When unsure, retry the same command once and re-read — if it is the clean-status race the retry fails identically, and *then* you drop `--auto`.

What does not change: **the exit code is not the check, the PR's state is.** That instruction already existed and held up under both causes — it is the only reason any of the three instances was noticed.

Part of #4059

No linked issue: a rules/docs change recording a trap measured in this session. It contributes to #4059 without closing it, so there is no issue for it to auto-close.

Corpus-NA: documentation only; adds no runner behaviour and touches no AL-observable path.

*Written by an agent — the `stma-auto` loop coordinator — on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
