### PR TITLE
fix(metadata): resolve a precompiled table's relation and CalcFormula target names in its own app's scope

### DIFF
--- a/AlRunner.Tests/RelationTargetDeclaringScopeTests.cs
+++ b/AlRunner.Tests/RelationTargetDeclaringScopeTests.cs
@@ -1,0 +1,142 @@
+// RelationTargetDeclaringScopeTests — runner-side guard for #4106.
+//
+// The BC half (a Base Application TableRelation and CalcFormula keep pointing at Base
+// Application tables when a dependent app declares a same-named table in its own namespace)
+// is proved upstream by BusinessCentral.AL.Language.Tests "Test Relation Name Collision"
+// (60988). These tests pin the runner's own selection rule in
+// RecordPatches.ResolveTableNameInDeclaringScope, staged without a .app on disk: which table a
+// NAME resolves to depends on whether the table that wrote the name came from a dependency's
+// symbols, and a same-.app candidate wins over another dependency's.
+using System.Collections;
+using System.Reflection;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(RecordPatchesSerialCollection.Name)]
+public class RelationTargetDeclaringScopeTests
+{
+    private static readonly Type RecordPatchesType = typeof(RecordPatches);
+
+    private const string AppA = "/deps/Microsoft_Base Application.app";
+    private const string AppB = "/deps/Contoso_Other.app";
+
+    // Ids outside every other parser test's range so a leak is obvious.
+    private const int DeclaringId = 61940;   // dependency table writing the name (app A)
+    private const int BundleTargetId = 61941; // bundle table sharing the name
+    private const int DepTargetId = 61942;   // dependency table with the name (app A)
+    private const int OtherDepTargetId = 61943; // same name, another dependency (app B)
+    private const int BundleDeclaringId = 61944;
+    private const int PlatformOnlyId = 61945;
+
+    private const string TargetName = "RTS Shipping Agent";
+
+    private static ParsedTable Table(int id, string name, Guid? owningApp = null) =>
+        new(id, name, new List<ParsedField>(), new List<int>(), OwningAppId: owningApp);
+
+    [Fact]
+    public void DependencyDeclaredName_ResolvesToTheDependencyTable_NotTheSameNamedBundleTable()
+    {
+        var bundleApp = Guid.NewGuid();
+        WithState(
+            parsed: new[] { Table(BundleTargetId, TargetName, bundleApp) },
+            index: new[]
+            {
+                (AppA, Table(DeclaringId, "RTS Customer")),
+                (AppA, Table(DepTargetId, TargetName)),
+            },
+            act: () =>
+            {
+                var declaring = SymbolTable(DeclaringId);
+                var resolved = RecordPatches.ResolveTableNameInDeclaringScope(TargetName, declaring);
+
+                Assert.NotNull(resolved);
+                Assert.Equal(DepTargetId, resolved!.TableId);
+                // Materialised into _parsedTables, so metadata built from it later finds it.
+                Assert.True(ParsedTables().Contains(DepTargetId));
+            });
+    }
+
+    [Fact]
+    public void DependencyDeclaredName_PrefersTheDeclaringApp_OverAnotherDependency()
+    {
+        WithState(
+            parsed: Array.Empty<ParsedTable>(),
+            index: new[]
+            {
+                (AppB, Table(OtherDepTargetId, TargetName)),
+                (AppA, Table(DepTargetId, TargetName)),
+                (AppA, Table(DeclaringId, "RTS Customer")),
+            },
+            act: () =>
+            {
+                var resolved = RecordPatches.ResolveTableNameInDeclaringScope(TargetName, SymbolTable(DeclaringId));
+                Assert.Equal(DepTargetId, resolved?.TableId);
+            });
+    }
+
+    [Fact]
+    public void BundleDeclaredName_KeepsTheByNameLookup()
+    {
+        var bundleApp = Guid.NewGuid();
+        var bundleDeclaring = Table(BundleDeclaringId, "RTS Bundle Referencing", bundleApp);
+        WithState(
+            parsed: new[] { Table(BundleTargetId, TargetName, bundleApp), bundleDeclaring },
+            index: new[] { (AppA, Table(DepTargetId, TargetName)) },
+            act: () =>
+            {
+                // A bundle table's names resolve in the bundle's own scope, which this change
+                // does not model; the pre-#4106 lookup (parsed tables first) stands.
+                var resolved = RecordPatches.ResolveTableNameInDeclaringScope(TargetName, bundleDeclaring);
+                Assert.Equal(BundleTargetId, resolved?.TableId);
+            });
+    }
+
+    [Fact]
+    public void DependencyDeclaredName_NotInAnySymbolFile_FallsBackToParsedTables()
+    {
+        WithState(
+            parsed: new[] { Table(PlatformOnlyId, "RTS Platform Table") },
+            index: new[] { (AppA, Table(DeclaringId, "RTS Customer")) },
+            act: () =>
+            {
+                var resolved = RecordPatches.ResolveTableNameInDeclaringScope("RTS Platform Table", SymbolTable(DeclaringId));
+                Assert.Equal(PlatformOnlyId, resolved?.TableId);
+                Assert.Null(RecordPatches.ResolveTableNameInDeclaringScope("RTS Nowhere", SymbolTable(DeclaringId)));
+            });
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static IDictionary ParsedTables() => (IDictionary)RecordPatchesType
+        .GetField("_parsedTables", BindingFlags.NonPublic | BindingFlags.Static)!.GetValue(null)!;
+
+    private static FieldInfo IndexField() =>
+        RecordPatchesType.GetField("_bcSymbolTableIndex", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static ParsedTable SymbolTable(int id) =>
+        ((Dictionary<int, (string AppPath, ParsedTable Table)>)IndexField().GetValue(null)!)[id].Table;
+
+    private static void WithState(ParsedTable[] parsed, (string App, ParsedTable Table)[] index, Action act)
+    {
+        var ids = parsed.Select(t => t.TableId).Concat(index.Select(e => e.Table.TableId)).ToArray();
+        var parsedTables = ParsedTables();
+        var previousIndex = IndexField().GetValue(null);
+        foreach (var id in ids)
+            Assert.False(parsedTables.Contains(id), $"table id {id} is already in _parsedTables; pick another range");
+        try
+        {
+            foreach (var t in parsed) parsedTables[t.TableId] = t;
+            var staged = new Dictionary<int, (string AppPath, ParsedTable Table)>();
+            foreach (var (app, t) in index) staged[t.TableId] = (app, t);
+            IndexField().SetValue(null, staged);
+            act();
+        }
+        finally
+        {
+            foreach (var id in ids) parsedTables.Remove(id);
+            IndexField().SetValue(null, previousIndex);
+        }
+    }
+}

--- a/AlRunner/Patches/RecordPatches.BcAppFallback.cs
+++ b/AlRunner/Patches/RecordPatches.BcAppFallback.cs
@@ -632,6 +632,55 @@ public static partial class RecordPatches
         return null;
     }
 
+    /// <summary>
+    /// Resolve a table NAME written inside <paramref name="referencingTable"/> — a TableRelation
+    /// target or a CalcFormula source — in the scope of the app that declared it (#4106).
+    /// A precompiled table's metadata carries the target's id, fixed when its own app compiled,
+    /// and that app cannot see the bundle under test; the symbol file keeps only the name. So
+    /// for a table read from a dependency's symbols the name is looked up among dependency
+    /// tables first (same .app preferred), and a bundle table sharing the name under another
+    /// namespace never takes over. Everything else keeps the original by-name lookup.
+    /// </summary>
+    internal static ParsedTable? ResolveTableNameInDeclaringScope(string tableName, ParsedTable? referencingTable)
+    {
+        if (string.IsNullOrEmpty(tableName)) return null;
+        // A bundle table carries the OwningAppId of its app.json; a symbol-read one never does,
+        // so this skips the index for the common bundle case.
+        if (referencingTable is { OwningAppId: null })
+        {
+            lock (_bcTableIndexLock)
+            {
+                EnsureBcSymbolTableIndex();
+                if (_bcSymbolTableIndex != null
+                    && _bcSymbolTableIndex.TryGetValue(referencingTable.TableId, out var declaring)
+                    && string.Equals(declaring.Table.TableName, referencingTable.TableName, StringComparison.OrdinalIgnoreCase))
+                {
+                    int? sameApp = null, otherApp = null;
+                    foreach (var (id, entry) in _bcSymbolTableIndex)
+                    {
+                        if (!string.Equals(entry.Table.TableName, tableName, StringComparison.OrdinalIgnoreCase))
+                            continue;
+                        if (string.Equals(entry.AppPath, declaring.AppPath, StringComparison.Ordinal))
+                        {
+                            sameApp = id;
+                            break;
+                        }
+                        otherApp ??= id;
+                    }
+                    if ((sameApp ?? otherApp) is int found)
+                    {
+                        if (!_parsedTables.ContainsKey(found))
+                            _parsedTables[found] = _bcSymbolTableIndex[found].Table;
+                        return _parsedTables[found];
+                    }
+                }
+            }
+        }
+        return _parsedTables.Values.FirstOrDefault(t =>
+                   string.Equals(t.TableName, tableName, StringComparison.OrdinalIgnoreCase))
+               ?? TryPopulateParsedTableByName(tableName);
+    }
+
     private static readonly Regex _rxAnyTableId = new(
         @"\btable\s+(\d+)\s+(?:""[^""]+""|[A-Za-z_]\w*)[^{]*?\{",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -974,10 +974,7 @@ public static partial class RecordPatches
             return null;
         }
 
-        ParsedTable? Resolve(string name) =>
-            _parsedTables.Values.FirstOrDefault(t =>
-                string.Equals(t.TableName, name, StringComparison.OrdinalIgnoreCase))
-            ?? TryPopulateParsedTableByName(name);
+        ParsedTable? Resolve(string name) => ResolveTableNameInDeclaringScope(name, referencingTable);
 
         var relationObjects = new List<object>();
         foreach (var arm in arms)
@@ -1505,18 +1502,10 @@ public static partial class RecordPatches
     {
         if (_tMetaCalcFormula == null || _tMetaFilter == null || _tFilterType == null) return null;
 
-        // Resolve source table by name
-        var srcTable = _parsedTables.Values.FirstOrDefault(t =>
-            string.Equals(t.TableName, cf.SourceTableName, StringComparison.OrdinalIgnoreCase));
-        if (srcTable == null)
-        {
-            // Lazily materialise the source table from the BC .app symbol index by name.
-            // Base App FlowFields commonly reference a sibling Base App table that wasn't
-            // parsed yet when this table was built (e.g. Purchase Line "Matched Order Lines"
-            // → "Matched Order Line"). Without this the formula falls back to the null
-            // EmptyFormula, which later throws on EmptyFormula.SourceField (table 0).
-            srcTable = TryPopulateParsedTableByName(cf.SourceTableName);
-        }
+        // By name, in the declaring app's scope (#4106); on a miss this lazily materialises the
+        // table from the .app symbol index, so a Base App FlowField naming a sibling not parsed
+        // yet ("Matched Order Lines" -> "Matched Order Line") still gets a real formula.
+        var srcTable = ResolveTableNameInDeclaringScope(cf.SourceTableName, parentTable);
         if (srcTable == null)
         {
             Console.Error.WriteLine($"[RecordPatches] BuildMetaCalcFormula: source table '{cf.SourceTableName}' not found in parsed tables");


### PR DESCRIPTION
Closes #4106

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/347

Written by agent stma-auto2-3 on the account holder's behalf.

## Measurement first

#4106 had no reproducer. I wrote one before touching code. It is a bundle that depends on Base Application and declares `namespace Test.Dup; table 50100 "Shipping Agent"`. On `main` (775e3d02):

- `Customer."Shipping Agent Code"` (field 31) `FieldRef.Relation()` answered **50100**, when Base Application's answer is 291.
- `Customer.Validate("Shipping Agent Code", X)` with X inserted into Base Application `"Shipping Agent"` failed with `cannot be found in the related table (Shipping Agent)`.
- Same shape on the CalcFormula side: with a bundle table named `"Config. Package Table"`, `"Config. Package"."No. of Tables"` counted the bundle table (0 where BC answers 1).

A control run of the same probe without the duplicate tables passed 2/2 on the same cache root, so the duplicate name is the cause.

The issue's suggested instance, `Item."Location Code"`, does not exist. `Item."Location Filter"` is a FlowFilter, and `BcAppSymbolCache` drops FlowFilter relations, so that shape would have shown no defect.

## BC semantics

A precompiled table's relation and CalcFormula targets are object ids, fixed when its own app compiled. That app cannot see the bundle under test. `SymbolReference.json` keeps only the name (for example `"User Setup"."User ID"`, `Location`), so the runner has to resolve the name again. The corpus PR above asserts the BC half on a service tier: relation id 291, Validate accepts the Base App value and refuses a value that exists only in the same-named local table, and the FlowField counts 1 rather than 2.

## Change

`RecordPatches.ResolveTableNameInDeclaringScope(name, referencingTable)` (in `RecordPatches.BcAppFallback.cs`):

- When the table that wrote the name was read from a dependency's symbols, the name resolves among symbol-index tables first. A table from the same `.app` wins over one from another dependency. A symbol-read table has no `OwningAppId` and its id is in `_bcSymbolTableIndex`.
- Otherwise, or when no dependency table has that name (for example platform tables that are not in the symbol index), the lookup is unchanged: parsed tables by name, then `TryPopulateParsedTableByName`.

Both call sites of this shape now use it: `BuildMetaFieldRelations`'s `Resolve` and `BuildMetaCalcFormula`'s source table.

No change to the cached `BcAppSymbolCache` payload, so no CacheVersion bump. This does not collide with #4094's 42 -> 43.

## RED -> GREEN -> MUTATE

Probe bundle (5 tests: 2 relation, 1 FlowField, a `"User Setup"` -> system `User` control, a bundle -> Base App relation control):
- before: `pass: 2, fail: 3`
- after: `pass: 5, fail: 0`, run **twice against one `--cache` root**, both 5/5
- mutation A (relation call site passes `null` scope): `pass: 3, fail: 2`, only the two relation tests
- mutation B (CalcFormula call site passes `null` scope): `pass: 4, fail: 1`, only the FlowField test

Corpus: master cd8403f5 plus corpus PR #347's two files, run locally with `--package-cache ~/.al-runner/platform-apps --strict`:
- both call sites reverted to the old lookup: `Tests: 3376, pass: 3372, fail: 4`. The 4 are the new `RelationNameCollision_*` tests, and each failure message is the defect: `Actual:<60990>`, `Actual:<2>`, no error raised, and a false "cannot be found".
- with the fix: `Tests: 3376, pass: 3376, fail: 0`, rc=0, run twice against one cache.

`AlRunner.Tests/RelationTargetDeclaringScopeTests.cs` (4 tests) pins the selection rule without a `.app` on disk. This is the runner-side mechanism test for the `Tests updated` gate.
- `Failed: 0, Passed: 4, Total: 4`
- mutation "prefer another dependency over the declaring app" (`otherApp ?? sameApp`): `Failed: 1, Passed: 3`, only the same-app test
- mutation "skip the dependency branch" (`OwningAppId: not null`): `Failed: 2, Passed: 2`, the two dependency-declared tests. The bundle and fallback tests stay green.

Guards: `tools/test_*.py` all pass. `GuardTests` filter: 253/254. The one failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned`, which refuses because `tools/engine-test-bootstrap.sh` was not run on this box. It is unrelated to this diff.

CI is stalled account-wide as I write this, so nothing here has a CI verdict yet, and corpus PR #347's BC legs are pending.

## Fix the shape

1. **Same pattern at another call site?** I searched for the by-name `_parsedTables.Values.FirstOrDefault(... TableName ...)` lookup. `BuildMetaFieldRelations` and `BuildMetaCalcFormula` are fixed here. `GetSourceTableIdForPage` (`RecordPatches.AlPageParser.cs`) resolves a **bundle-declared** page's SourceTable, which is the bundle's own namespace scope. That needs `using`/namespace modeling, not this rule, so I did not fold it. `CalcFormulaRetry` asks only whether a pending name has become resolvable, and a false yes costs one rebuild, not a wrong answer.
2. **Sibling with the same assumption?** `TryPopulateParsedTableByName` still returns the first by-name match for callers without a declaring table (pages, the retry). For a dependency-declared name the new helper now runs first. A bundle table naming a Base App table while the bundle also declares a same-named table resolves bundle-first, as before. Real BC decides that case by the bundle's namespaces and usings, which the runner does not model. Filed as #4133 and not changed here.
3. **Two paths writing the same state?** Relation arms and CalcFormula sources now share one resolver, so they cannot disagree about which table a precompiled name means.

Queue scan (`TableRelation`, `namespace`, `by name`, `same name`, `CalcFormula`, both symbol names): no duplicate. #2264 (`--test-data` same-named tables) is a different subsystem. #3964 (`--server` Tier-3 relation verdict differs cold vs warm) is a cache-path question, and this change does not touch it. #2789 is the parent, closing via #4094.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
