### PR TITLE
test(rename): rename a Base Application record referenced by precompiled TableRelations

### DIFF
--- a/AlRunner.Tests/BcAppSymbolCacheTableRelationReadTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCacheTableRelationReadTests.cs
@@ -1,0 +1,103 @@
+// BcAppSymbolCacheTableRelationReadTests — issue #4105.
+//
+// RUNNER-MECHANISM claim. That renaming a Base Application Location carries Item Journal
+// Line."Location Code" along, and leaves Item Analysis View."Location Filter"
+// (ValidateTableRelation = false) alone, is BC behaviour and is asserted upstream by corpus
+// codeunit 60975 "Test Rename Prop BaseApp". What is pinned HERE is the one runner layer that
+// test reaches and nothing else pins directly: BcAppSymbolCache.TryParseTableSymbol reading
+// both properties off a precompiled TABLE field. BcAppSymbolCacheTableExtRelationTests pins
+// the tableextension copy of that loop; this is the table loop itself.
+//
+// The field shapes are copied from Base Application 28.1.49838.53910's SymbolReference.json.
+// FlowFilter relations are deliberately not asserted: PR #4094 changes that gate.
+
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// BcAppSymbolCache.Get resolves its on-disk path through the process-global CacheRoots override.
+[Collection(CacheRootsSerialCollection.Name)]
+public class BcAppSymbolCacheTableRelationReadTests
+{
+    private const string SymbolReference = """
+        {
+          "RuntimeVersion": "15.1",
+          "Namespaces": [
+            {
+              "Name": "Microsoft.Inventory",
+              "Tables": [
+                {
+                  "Id": 83,
+                  "Name": "Item Journal Line",
+                  "Fields": [
+                    {
+                      "TypeDefinition": { "Name": "Code[10]" },
+                      "Properties": [ { "Name": "TableRelation", "Value": "Location" } ],
+                      "Id": 9,
+                      "Name": "Location Code"
+                    }
+                  ]
+                },
+                {
+                  "Id": 7152,
+                  "Name": "Item Analysis View",
+                  "Fields": [
+                    {
+                      "TypeDefinition": { "Name": "Code[250]" },
+                      "Properties": [
+                        { "Name": "TableRelation", "Value": "Location" },
+                        { "Name": "ValidateTableRelation", "Value": "0" }
+                      ],
+                      "Id": 10,
+                      "Name": "Location Filter"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private static ParsedField ReadField(int tableId, int fieldId)
+    {
+        var dir = TestScratch.Dir("al-runner-bcsym-table-relation");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var appPath = Path.Combine(dir, Guid.NewGuid().ToString("N") + ".app");
+            using (var fs = new FileStream(appPath, FileMode.Create))
+            using (var za = new ZipArchive(fs, ZipArchiveMode.Create))
+            using (var w = new StreamWriter(za.CreateEntry("SymbolReference.json").Open(), Encoding.UTF8))
+                w.Write(SymbolReference);
+
+            var table = Assert.Single(BcAppSymbolCache.Get(appPath).Tables, t => t.TableId == tableId);
+            return Assert.Single(table.Fields, f => f.FieldId == fieldId);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void PlainTableRelation_ReachesRelationArms_AndValidates()
+    {
+        var field = ReadField(83, 9);
+
+        Assert.NotNull(field.RelationArms);
+        Assert.Equal("Location", Assert.Single(field.RelationArms!).TableName);
+        Assert.True(field.RelationValidate);
+    }
+
+    [Fact]
+    public void ValidateTableRelationZero_KeepsTheArm_ButDoesNotValidate()
+    {
+        var field = ReadField(7152, 10);
+
+        // The relation stays readable; only the check (and with it rename propagation) is off.
+        Assert.NotNull(field.RelationArms);
+        Assert.Equal("Location", Assert.Single(field.RelationArms!).TableName);
+        Assert.False(field.RelationValidate);
+    }
+}


### PR DESCRIPTION
Closes #4105

Written by agent stma-auto2-3 on the account holder's behalf.

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/351

## What this is

This is a coverage PR. The runner already gets this right. No runtime code changes.

- **Corpus PR #351** adds codeunit 60975 "Test Rename Prop BaseApp". It renames a Base Application `Location` and checks three things:
  - `Item Journal Line."Location Code"` (`TableRelation = Location`) follows the rename.
  - `Item Analysis View."Location Filter"` (a Normal field with `ValidateTableRelation = false`) keeps the old code.
  - `Item Ledger Entry."Location Code"` follows the rename. With an `Item` row present and the `Item."Location Filter"` FlowFilter set to the new code, `CalcFields(Inventory)` sums the entry. With the old code it sums 0.
- **`AlRunner.Tests/BcAppSymbolCacheTableRelationReadTests.cs`** pins the runner layer that corpus test depends on: `BcAppSymbolCache.TryParseTableSymbol` reading `TableRelation` and `ValidateTableRelation` off a precompiled table field. The field shapes are copied from Base Application 28.1's `SymbolReference.json`. `BcAppSymbolCacheTableExtRelationTests` already covers the tableextension copy of this loop. Nothing covered the table loop directly. The test does not assert anything about FlowFilter relations, because #4094 changes that gate.

## Where the test lives, and why

It goes in the corpus. The corpus app's `app.json` declares `"application"` and a Base Application dependency, and existing corpus tests already use `Location`, `Item` and `Customer`. So a corpus test runs Base Application's precompiled tables and their SymbolReference-derived relations on the runner. It also puts the BC claim in front of a real service tier. A runner-extras or Base App C# fixture would test the same path without a BC verdict, and the C# fixture would break `no-base-app-in-csharp-tests`. The C# test above uses a hand-written SymbolReference and no `application` floor.

Note: the header of `tests/runner-extras/precompiled-table-relation/PtrTests.Codeunit.al` says the corpus "has no way to express a table this app did not compile". That is out of date for the reason above. I did not change it here.

## Measurements (local, BC 28.1 platform apps, corpus `f19c74ef39af13385c2d8c6326eebdd16619b329`)

Corpus test on this branch, run twice against one `--cache`:
- cold: 3 passed, 0 failed (AL emit + C# compile ran)
- warm: 3 passed, 0 failed (AL emit 0.0s, C# compile 0.0s, cache hit)

Corpus test on #4094's head (`80c76029`): 3 passed, 0 failed. The FlowFilter case holds with that PR applied.

Mutations in `BcAppSymbolCache.TryParseTableSymbol`, one at a time, each on a **fresh** cache:

| mutation | corpus 60975 | C# tests |
|---|---|---|
| none | Failed: 0, Passed: 3 | Failed: 0, Passed: 2 |
| M1: `relationArms = null` (no precompiled relations) | Failed: 2, Passed: 1. Both are `Assert.AreEqual` `Expected:<ALTRN-NEW> Actual:<ALTRN-OLD>` on Item Journal Line and Item Ledger Entry. The ValidateTableRelation=false control stays green. | Failed: 2, Passed: 0 (`Assert.NotNull`) |
| M2: `relationValidate = true` (ignore ValidateTableRelation) | Failed: 1, Passed: 2. Only the control fails: `Expected:<ALTRN-OLD> Actual:<ALTRN-NEW>` | Failed: 1, Passed: 1 (`Assert.False`) |

Cache note: M1 on the **warm** cache stayed 3/3 green. `bc-symbols` is keyed on app content plus the manual `CacheVersion` constant (42), not on the reader's code. So a reader change replays the old parse until `CacheVersion` is bumped. That is how the cache is designed (`BcAppSymbolCacheVersionHistoryTests`), not a new defect. It does mean a mutation of this reader only counts on a fresh cache or with a version bump.

Other runs: `dotnet test --filter "FullyQualifiedName~BcAppSymbolCache|FullyQualifiedName~GuardTests"`: Failed: 1, Passed: 304. The one failure is `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned`, which refuses because the in-process engine bootstrap (`tools/engine-test-bootstrap.sh`) was not run on this box. It is unrelated to this diff. All `tools/test_*.py` passed.

## Fix the shape

1. **Same pattern at another call site?** The two readers that turn a symbol `TableRelation` into `RelationArms` are the table loop (`BcAppSymbolCache.cs`) and the tableextension copy (`BcAppSymbolCache.TableExtensions.cs`). The copy is pinned by `BcAppSymbolCacheTableExtRelationTests`, and the table loop is now pinned here. The AL-source path (`RecordPatches.AlSourceParser.cs`) is covered by corpus 60236 and 60239.
2. **Sibling with the same assumption?** `NCLMetaTable_ComputeReferencingRelations` builds the reverse index from `_metaTableCache`. Its note says a table that is not in the cache holds no rows. The corpus test inserts every referencing row itself, so each referencing table is loaded before the rename. I did not find a case where a referencing table holds rows but is not cached.
3. **Two paths writing the same state?** The table and tableextension loops read `ValidateTableRelation` with the same expression (`"0"` or `false`), and the M2 mutation shows the table loop's read reaches rename propagation.

## Queue scan

I searched open issues for `rename`, `UpdateReferencesOnRename`, `ComputeReferencingRelations` and `RelationArms`. Results:
- #2789 is the parent. #4094 closes it.
- #2325 is about tenant profile rename cascades on system tables. That is a different mechanism, so I did not fold it in.
- #3204 is about Validate on a tableextension-contributed relation in the corpus. That is a different surface, so I did not fold it in.

I found no duplicate of this issue.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
