### PR TITLE
fix(record): a User saved by a page's CurrPage.Update gets its User Property row

### DIFF
--- a/AlRunner.Tests/UserPropertyCompanionRowBindingTests.cs
+++ b/AlRunner.Tests/UserPropertyCompanionRowBindingTests.cs
@@ -11,12 +11,13 @@
 // companion User Property (2000000121) row, and the runner bypasses BC's trigger dispatch on
 // insert (RecordWritePatches.NavRecord_InsertAsync), so nothing created that row. The fix
 // prepends UserTableTriggerPatches.OnBeforeUserInsert to
-// NavRecord.ALInsertAsync(DataError, bool, bool) — the single AL insert entry point
-// AssignAutoIncrement and StampSystemFieldsOnInsert are already prepended to.
+// NavRecord.InsertAsync(DataError, bool, bool, bool) — where AL's ALInsertAsync and a page's
+// NavForm.SaveRecordAsync (CurrPage.Update on a new record) both arrive. It used to sit on
+// ALInsertAsync(DataError, bool, bool), which the page route never calls (#4121).
 //
 // The same file now also carries the rest of BC's two `case 2000000120:` arms — the insert
 // arm's uniqueness refusals (#2983) and the delete arm's four table cascades (#2356) — so
-// there are TWO prepends to pin: OnBeforeUserInsert on ALInsertAsync(DataError, bool, bool)
+// there are TWO prepends to pin: OnBeforeUserInsert on InsertAsync(DataError, bool, bool, bool)
 // and OnAfterUserDelete on ALDeleteAsync(DataError, bool, bool). The delete one is the single
 // funnel for `Delete()` AND `DeleteAll()` on this table, because DeleteAllAsync's bulk path is
 // gated on CanUseBulkDeleteAll, which ends in !TableHasSystemDeleteTrigger, whose static switch
@@ -101,7 +102,7 @@ public sealed class UserPropertyCompanionRowBindingTests
     // in-process; a machine where it cannot (a cold Cecil cache, say) can still answer the
     // question these tests ask, and gating on it hid them behind an unrelated skip.
     [SkippableFact]
-    public void AlInsertEntryPoint_CallsTheCompanionRowHelperAsItsFirstAct()
+    public void InsertAsyncFunnel_CallsTheCompanionRowHelperAsItsFirstAct()
     {
         Skip.IfNot(File.Exists(RewrittenNclPath),
             $"the rewritten Ncl is not present at '{RewrittenNclPath}'.");
@@ -109,7 +110,8 @@ public sealed class UserPropertyCompanionRowBindingTests
         using var module = ModuleDefinition.ReadModule(RewrittenNclPath);
         var alInsert = NavRecordMethod(module, "ALInsertAsync", "DataError", "Boolean", "Boolean");
         SkipUnlessRewritten(alInsert);
-        var instructions = alInsert.Body.Instructions;
+        var insert = NavRecordMethod(module, "InsertAsync", "DataError", "Boolean", "Boolean", "Boolean");
+        var instructions = insert.Body.Instructions;
 
         // The prepend is `ldarg.0; call helper` inserted before the original body, so the
         // helper call must sit within the first few instructions — not merely somewhere in
@@ -122,7 +124,7 @@ public sealed class UserPropertyCompanionRowBindingTests
             .FirstOrDefault();
 
         Assert.True(helperIndex.HasValue,
-            "NavRecord.ALInsertAsync(DataError, bool, bool) does not call "
+            "NavRecord.InsertAsync(DataError, bool, bool, bool) does not call "
             + "UserTableTriggerPatches.OnBeforeUserInsert — the User Property row BC's "
             + "own User insert trigger creates would never be written, and every AL path that "
             + "reaches UserManagement.DirectSetUserFieldValue would fail with "
@@ -130,18 +132,32 @@ public sealed class UserPropertyCompanionRowBindingTests
 
         // It must be in the PREPENDED PREFIX, not merely somewhere in the method: the
         // companion row has to be written before the original body runs, exactly as BC's own
-        // OnBeforeInsertAsync does. Several prepends share this entry point (AutoIncrement,
-        // SystemFields, the rowversion write note, the All Profile guard, this one) and each
-        // contributes exactly `ldarg.0; call`, so the prefix is characterised by its SHAPE —
-        // nothing but those two opcodes ahead of us — rather than by a fixed index that a
-        // sixth prepend would invalidate.
+        // OnBeforeInsertAsync does. Each prepend contributes exactly `ldarg.0; call`, so the
+        // prefix is characterised by its SHAPE — nothing but those two opcodes ahead of us —
+        // rather than by a fixed index that another prepend would invalidate.
         Assert.Equal(OpCodes.Ldarg_0, instructions[helperIndex!.Value - 1].OpCode);
         for (var i = 0; i < helperIndex.Value; i++)
             Assert.True(
                 instructions[i].OpCode == OpCodes.Ldarg_0 || instructions[i].OpCode == OpCodes.Call,
-                $"instruction {i} of NavRecord.ALInsertAsync is {instructions[i].OpCode}, so the "
+                $"instruction {i} of NavRecord.InsertAsync is {instructions[i].OpCode}, so the "
                 + "companion-row helper is no longer inside the prepended prefix — it would run "
                 + "after part of the original body instead of before all of it.");
+    }
+
+    [SkippableFact]
+    public void AlInsertEntryPoint_DoesNotCallTheCompanionRowHelper()
+    {
+        // #4121. ALInsertAsync(DataError, bool, bool) forwards to InsertAsync(4), so a helper
+        // left on both would run twice per AL insert, and a helper on ALInsertAsync alone is
+        // the defect: NavForm.SaveRecordAsync calls InsertAsync(4) directly and skipped it.
+        Skip.IfNot(File.Exists(RewrittenNclPath),
+            $"the rewritten Ncl is not present at '{RewrittenNclPath}'.");
+
+        using var module = ModuleDefinition.ReadModule(RewrittenNclPath);
+        var alInsert = NavRecordMethod(module, "ALInsertAsync", "DataError", "Boolean", "Boolean");
+        SkipUnlessRewritten(alInsert);
+
+        Assert.DoesNotContain(HelperFullName, CalledMethods(alInsert));
     }
 
     [SkippableFact]
@@ -243,6 +259,8 @@ public sealed class UserPropertyCompanionRowBindingTests
         SkipUnlessRewritten(alInsert);
 
         Assert.DoesNotContain(DeleteHelperFullName, CalledMethods(alInsert));
+        Assert.DoesNotContain(DeleteHelperFullName, CalledMethods(
+            NavRecordMethod(module, "InsertAsync", "DataError", "Boolean", "Boolean", "Boolean")));
 
         var navRecord = module.GetType("Microsoft.Dynamics.Nav.Runtime.NavRecord");
         foreach (var method in navRecord!.Methods.Where(m => m.Name == "ALModifyAsync" && m.HasBody))

--- a/AlRunner/Infrastructure/NclCecilRewrite.Records.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Records.cs
@@ -1290,25 +1290,29 @@ public static partial class NclCecilRewrite
             Console.Error.WriteLine("[Cecil] Prepended StampSystemFieldsOnInsert → NavRecord.ALInsertAsync(DataError,bool,bool)");
         }
 
-        // ── NavRecord.ALInsertAsync(DataError, bool, bool) — User system-table insert arm ──
+        // ── NavRecord.InsertAsync(DataError, bool, bool, bool) — User system-table insert arm ──
         // On a real tier, SystemTableTriggers.OnBeforeInsertAsync's `case 2000000120:` arm
         // refuses a duplicate user name / Windows SID (#2983) and then inserts the matching
-        // User Property (2000000121) row for every User it accepts — and BC's own
-        // UserManagement.DirectSetUserFieldValue then Gets that row with the RAISING error
-        // level. The runner bypasses BC's trigger dispatch on insert, so none of it ran. Same
-        // prepend shape as AssignAutoIncrement / StampSystemFieldsOnInsert above; a no-op for
-        // every table but User. See AlRunner/Patches/UserTableTriggerPatches.cs and issues
-        // #2355 / #2983.
+        // User Property (2000000121) row for every User it accepts. The runner bypasses BC's
+        // trigger dispatch on insert, so this prepend stands in for it; a no-op for every
+        // table but User. See AlRunner/Patches/UserTableTriggerPatches.cs, #2355 / #2983.
+        //
+        // InsertAsync(4), NOT ALInsertAsync(3): BC's arm sits in the data layer, and two
+        // routes reach it — ALInsertAsync(3) (AL Rec.Insert) and NavForm.SaveRecordAsync
+        // (CurrPage.Update / SaveRecord on a new record), which calls InsertAsync(4) directly.
+        // Prepending ALInsertAsync(3) missed the page route (#4121, corpus 61204). Both
+        // routes funnel through InsertAsync(4); it has no overrides (bc284).
         {
             var navRecord = asm.MainModule.GetType("Microsoft.Dynamics.Nav.Runtime.NavRecord")
                 ?? throw new InvalidOperationException("NavRecord type not found in Ncl");
-            var alInsert3 = navRecord.Methods.FirstOrDefault(m =>
-                m.Name == "ALInsertAsync"
-                && m.Parameters.Count == 3
+            var insert4 = navRecord.Methods.FirstOrDefault(m =>
+                m.Name == "InsertAsync"
+                && m.Parameters.Count == 4
                 && m.Parameters[0].ParameterType.Name == "DataError"
                 && m.Parameters[1].ParameterType.MetadataType == Mono.Cecil.MetadataType.Boolean
-                && m.Parameters[2].ParameterType.MetadataType == Mono.Cecil.MetadataType.Boolean)
-                ?? throw new InvalidOperationException("NavRecord.ALInsertAsync(DataError,bool,bool) not found");
+                && m.Parameters[2].ParameterType.MetadataType == Mono.Cecil.MetadataType.Boolean
+                && m.Parameters[3].ParameterType.MetadataType == Mono.Cecil.MetadataType.Boolean)
+                ?? throw new InvalidOperationException("NavRecord.InsertAsync(DataError,bool,bool,bool) not found");
 
             var helperMi = typeof(AlRunner.Patches.UserTableTriggerPatches).GetMethod(
                 nameof(AlRunner.Patches.UserTableTriggerPatches.OnBeforeUserInsert),
@@ -1316,13 +1320,13 @@ public static partial class NclCecilRewrite
                 ?? throw new InvalidOperationException("UserTableTriggerPatches.OnBeforeUserInsert not found");
             var helperRef = asm.MainModule.ImportReference(helperMi);
 
-            var body = alInsert3.Body;
+            var body = insert4.Body;
             var il = body.GetILProcessor();
             var firstOriginal = body.Instructions[0];
             il.InsertBefore(firstOriginal, il.Create(OpCodes.Ldarg_0));
             il.InsertBefore(firstOriginal, il.Create(OpCodes.Call, helperRef));
             if (body.MaxStackSize < 1) body.MaxStackSize = 1;
-            Console.Error.WriteLine("[Cecil] Prepended OnBeforeUserInsert → NavRecord.ALInsertAsync(DataError,bool,bool)");
+            Console.Error.WriteLine("[Cecil] Prepended OnBeforeUserInsert → NavRecord.InsertAsync(DataError,bool,bool,bool)");
         }
 
         // ── NavRecord.ALDeleteAsync(DataError, bool, bool) — User system-table delete arm ──

--- a/AlRunner/Patches/UserTableTriggerPatches.cs
+++ b/AlRunner/Patches/UserTableTriggerPatches.cs
@@ -33,10 +33,11 @@
 //   Issue #2355. Measured on Microsoft's Tests-SINGLESERVER bucket, BC 28.1.49838.53910.
 //
 // WHY A PREPEND, AND WHY THIS ENTRY POINT
-//   NavRecord.ALInsertAsync(DataError, bool, bool) is the single async entry point every AL
-//   `Insert()` surface funnels through — the same one AssignAutoIncrement and
-//   StampSystemFieldsOnInsert are already prepended to. Running BEFORE the user row is
-//   written matches BC, whose own companion insert happens in OnBEFOREInsert.
+//   NavRecord.InsertAsync(DataError, bool, bool, bool) is where every insert route meets:
+//   AL `Insert()` (via ALInsertAsync) and a page's CurrPage.Update / SaveRecord on a new
+//   record (NavForm.SaveRecordAsync calls it directly). BC's arm is in the data layer, so it
+//   runs on both; a prepend on ALInsertAsync alone missed the page route (#4121). Running
+//   BEFORE the user row is written matches BC's OnBEFOREInsert.
 //
 //   The companion insert itself goes through ALInsert, which re-enters this prepend with
 //   table 2000000121 and returns immediately — the table check below is what bounds it.
@@ -124,7 +125,7 @@ public static class UserTableTriggerPatches
     private const string TenantReportLayoutUserIdFieldName = "User ID";  // Tenant Rep. Layout 5
 
     /// <summary>
-    /// Prepended to NavRecord.ALInsertAsync(DataError, bool, bool). A no-op for every table
+    /// Prepended to NavRecord.InsertAsync(DataError, bool, bool, bool). A no-op for every table
     /// but User (2000000120); for that one it runs BC's
     /// SystemTableTriggers.OnBeforeInsertAsync `case 2000000120:` arm in BC's own order —
     /// the uniqueness refusals first, then the User Property companion row.


### PR DESCRIPTION
Closes #4121

Written by agent stma-auto2-7 (Claude) on the account holder's behalf.

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/352

## Cause

#2355 attached the User insert arm (`UserTableTriggerPatches.OnBeforeUserInsert`: the uniqueness refusals and the User Property companion row) as a Cecil prepend on `NavRecord.ALInsertAsync(DataError, bool, bool)`. That method is what AL `Rec.Insert()` lowers to. But a page saves a new record through `NavForm.SaveRecordAsync(bool, bool)`, which calls `SafeSourceTable.InsertAsync(DataError.ThrowError, true, true, true)` directly and never goes through `ALInsertAsync`. Base Application's "User Card" saves that way: the `User Name` field's `OnValidate` calls `ValidateUserName()`, which ends in `CurrPage.Update()`. So the `User` row was written and the prepend never ran.

In BC, both routes end in `InsertAsync(DataError, bool, bool, bool)`, and the real `case 2000000120:` arm sits below that, in the data layer (`SystemTableTriggers.OnBeforeInsertAsync`, called from `TransactionalDataCache`). I read this from Ncl.dll 28.4 (`bc284`): `ALInsertAsync(DataError, bool, bool)` awaits `InsertAsync(errorLevel, runApplicationTrigger, false, insertWithSystemId)`, `find_callers` on `InsertAsync(4)` lists `NavForm.<SaveRecordAsync>d__43` and `NavRecord.<ALInsertAsync>d__251`, and `get_overrides` finds no overrides. I did not diff `InsertAsync(4)` against a 27.x binary. `compare_symbols` bc275 vs bc284 reported `SaveRecordAsync` and `ALInsertAsync` unchanged, but it resolved the parameterless overloads. The 27.0 PR leg is the measurement for 27.x.

## Fix

The prepend now targets `NavRecord.InsertAsync(DataError, bool, bool, bool)`, where both routes meet. `OnBeforeUserInsert` is unchanged. Its re-entrancy bound is unchanged too: the companion insert goes `ALInsert` -> `ALInsertAsync` -> `InsertAsync`, and it returns right away for table 2000000121. `ALInsertAsync(3)` no longer carries the helper, so an AL insert still runs it exactly once.

- `AlRunner/Infrastructure/NclCecilRewrite.Records.cs`: retargets the prepend
- `AlRunner/Patches/UserTableTriggerPatches.cs`: the header comment now names the new entry point
- `AlRunner.Tests/UserPropertyCompanionRowBindingTests.cs`: pins the helper to `InsertAsync(4)`'s prepended prefix, adds `AlInsertEntryPoint_DoesNotCallTheCompanionRowHelper`, and extends the cascade-helper negative check to `InsertAsync(4)`

## RED -> GREEN (corpus PR #352, codeunit 61204, OnPrem app)

Local runs, BC 28.x platform apps from `~/.al-runner/platform-apps`, corpus master `cd8403f5` plus the new file (corpus branch head `6dd3d26`), `--test UserProperty_`:

- Minimal page without `CurrPage.Update()`: **passed on the unfixed runner.** That route goes through the TestPage write buffer's `ALInsertAsync` call, which was already covered. So I rebuilt the test page in User Card's shape (`DelayedInsert = true`, `OnValidate` -> `CurrPage.Update()`, security id assigned in `OnInsertRecord`) and asserted while the page is still open.
- RED, unfixed runner (`775e3d02`): `Failed: 1, Passed: 3`. `UserProperty_UserInsertedThroughPage_HasCompanionRow` fails on `Assert.IsTrue failed. a User inserted through a page must have a User Property row keyed by its security id`. The control arms in the same test pass: the User row exists and its security id is non-null. `UserProperty_UserInsertedThroughRecord_HasCompanionRow` and 61203 pass.
- GREEN, fix: `Failed: 0, Passed: 4`, run twice against one `--cache` root (cold, then warm), 4/4 both times.

## Mutation

I pointed the prepend back at `ALInsertAsync(DataError, bool, bool)`, rebuilt and re-ran:
- Corpus: `Failed: 1, Passed: 3`. Only the page test fails, with the same assertion. The `Record.Insert(false)` control stays green, so the test depends on the entry point and not on the helper being present at all.
- `UserPropertyCompanionRowBindingTests` (with `tools/engine-test-bootstrap.sh` + `engine.runsettings`): `Failed: 2, Passed: 4` (`InsertAsyncFunnel_CallsTheCompanionRowHelperAsItsFirstAct`, `AlInsertEntryPoint_DoesNotCallTheCompanionRowHelper`). After restoring the fix: `Failed: 0, Passed: 6`.

## Other runs

- runner-extras bundles that insert or delete users: `user-system-table-triggers` 10/10, `session-user-row` 4/4, `user-table-baseapp-subscriber` 5/5, `permission-set-assignment` 8/8
- `dotnet test --filter "UserPropertyCompanionRowBindingTests|GuardTests"` with engine runsettings: `Failed: 0, Passed: 260`
- `tools/test_*.py`: all pass

## Fix the shape

1. **Same wrong pattern at another call site?** Yes. `AssignAutoIncrement`, `StampSystemFieldsOnInsert`, `NoteRecordInsertWrite` (the write-transaction note the rollback snapshot depends on), and the All Profile and Page Background Task insert guards all sit on `ALInsertAsync(3)`, so `SaveRecordAsync` skips them the same way. `SaveRecordAsync`'s modify branch also calls `ModifyAsync` directly, past the `ALModifyAsync` prepends. I did not move these. Moving AutoIncrement or the SystemFields stamp changes what xRec holds in `OnInsert`, because `ALInsertAsync` assigns `OldRecord` before it calls `InsertAsync`, so each needs its own corpus test. Filed as #4142.
2. **Sibling function with the same assumption?** `OnAfterUserDelete` on `ALDeleteAsync`. A page delete may reach `DeleteAsync` directly. I did not measure it; it is listed in #4142.
3. **Two paths writing the same state, same invariant?** The two User insert routes now go through one prepend. The session-user adoption path (`RecordPatches.UserSystemTable`) already calls `EnsureUserPropertyRow` itself, and this change leaves it alone.

Queue scan: searched open issues for `SaveRecordAsync`, `CurrPage.Update insert`, `ALInsertAsync prepend` and `SystemCreatedAt page`, and found nothing matching. #3514 (IsSaaS) is what made the User Card path unreachable in the original report. This change does not touch the environment-type code. #2450 is still blocked on #3514.

Tests updated: runner-side mechanism test in `AlRunner.Tests/`. The BC claim is in corpus PR #352, which should merge first.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
