### PR TITLE
fix(server): two workspaces declaring the same page id can both build its TestPage in one process

### DIFF
--- a/AlRunner.Tests/ServerSamePageIdTwoWorkspacesTests.cs
+++ b/AlRunner.Tests/ServerSamePageIdTwoWorkspacesTests.cs
@@ -1,0 +1,140 @@
+// ServerSamePageIdTwoWorkspacesTests — issue #4100.
+//
+// One --server process serves two unrelated workspaces that both declare page 64090, each over
+// its own table and with its own page-variable control. Whichever workspace's TestPage opened
+// second got no AL page object, and its page-variable control refused with
+// testpage-control-binding. Each order is its own session, and each session runs against ONE
+// cache root twice (cold, then warm), because the second session reaches request 1 through an
+// AL-output cache HIT (.claude/rules/local-test-scope.md).
+//
+// Dedicated server per session, never SharedCliServer.
+
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ServerSamePageIdTwoWorkspacesTests
+{
+    private static void WriteWorkspace(string root, string appId, string tag, int tableId, int testCuId)
+    {
+        Directory.CreateDirectory(root);
+        // No Base Application floor (.claude/rules/no-base-app-in-csharp-tests.md).
+        File.WriteAllText(Path.Combine(root, "app.json"), $$"""
+        {
+          "id": "{{appId}}",
+          "name": "Same Page Id {{tag}}",
+          "publisher": "Repro4100",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 64090, "to": 64109 } ],
+          "runtime": "14.0"
+        }
+        """);
+        // Different table, different control name, different page-variable value per workspace:
+        // a page object built from the OTHER workspace's type cannot answer this control.
+        File.WriteAllText(Path.Combine(root, "Objects.al"), $$"""
+        table {{tableId}} "R4100 {{tag}} Rec"
+        {
+            fields { field(1; "Code"; Code[10]) { } }
+            keys { key(PK; "Code") { } }
+        }
+
+        page 64090 "R4100 {{tag}} Card"
+        {
+            PageType = Card;
+            SourceTable = "R4100 {{tag}} Rec";
+            layout { area(Content) { field({{tag}}VarCtl; {{tag}}Text) { ApplicationArea = All; } } }
+            var
+                {{tag}}Text: Text[30];
+            trigger OnOpenPage()
+            begin
+                {{tag}}Text := '{{tag}}-value';
+            end;
+        }
+
+        codeunit {{testCuId}} "R4100 {{tag}} Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure PageVariableControl()
+            var
+                TP: TestPage "R4100 {{tag}} Card";
+            begin
+                TP.OpenView();
+                if TP.{{tag}}VarCtl.Value <> '{{tag}}-value' then
+                    Error('{{tag}} page control: expected {{tag}}-value, actual %1', TP.{{tag}}VarCtl.Value);
+                TP.Close();
+            end;
+        }
+        """);
+    }
+
+    private static string Req(string bundle) => JsonSerializer.Serialize(new
+    {
+        command = "runTests",
+        sourcePaths = new[] { bundle },
+        packagePaths = Array.Empty<string>(),
+    });
+
+    private static async Task AssertPassesAsync(CliServer server, string bundle, string label)
+    {
+        var lines = await server.SendRequestStreamingAsync(Req(bundle), TimeSpan.FromSeconds(240));
+        var (_, d) = ProtocolV2Streaming.Split(lines);
+        Assert.True(d.GetProperty("passed").GetInt32() == 1 && d.GetProperty("failed").GetInt32() == 0,
+            $"[{label}] must pass its one TestPage test: {string.Join(" | ", lines)}");
+    }
+
+    private static async Task RunSessionAsync(string first, string second, string cache, string label)
+    {
+        await using var server = await CliServer.StartAsync(new[] { "--cache", cache });
+        await AssertPassesAsync(server, first, $"{label} request 1");
+        await AssertPassesAsync(server, second, $"{label} request 2 (same page id, other workspace)");
+    }
+
+    private static (string Root, string X, string Y) Fixture(string name)
+    {
+        var root = TestScratch.Dir(name);
+        var x = Path.Combine(root, "xws");
+        var y = Path.Combine(root, "yws");
+        WriteWorkspace(x, "e4100410-0410-4410-8410-041004100001", "X", 64101, 64102);
+        WriteWorkspace(y, "e4100410-0410-4410-8410-041004100002", "Y", 64103, 64104);
+        return (root, x, y);
+    }
+
+    [SkippableFact]
+    public async Task XThenY_BothBuildTheirOwnPage_ColdThenWarm()
+    {
+        TestArtifacts.SkipIfMissing();
+        var (root, x, y) = Fixture("al-runner-server-same-page-id-4100-xy");
+        var cache = Path.Combine(root, "cache");
+        try
+        {
+            await RunSessionAsync(x, y, cache, "X->Y cold");
+            await RunSessionAsync(x, y, cache, "X->Y warm");
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+
+    [SkippableFact]
+    public async Task YThenX_BothBuildTheirOwnPage_ColdThenWarm()
+    {
+        TestArtifacts.SkipIfMissing();
+        var (root, x, y) = Fixture("al-runner-server-same-page-id-4100-yx");
+        var cache = Path.Combine(root, "cache");
+        try
+        {
+            await RunSessionAsync(y, x, cache, "Y->X cold");
+            await RunSessionAsync(y, x, cache, "Y->X warm");
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+}

--- a/AlRunner.Tests/ServerSamePageIdTwoWorkspacesTests.cs
+++ b/AlRunner.Tests/ServerSamePageIdTwoWorkspacesTests.cs
@@ -1,7 +1,8 @@
 // ServerSamePageIdTwoWorkspacesTests — issue #4100.
 //
 // One --server process serves two unrelated workspaces that both declare page 64090, each over
-// its own table and with its own page-variable control. Whichever workspace's TestPage opened
+// its own table and with its own page-variable control; in workspace B the page is in a sibling
+// source dependency (the issue's reproducer). Whichever workspace's TestPage opened
 // second got no AL page object, and its page-variable control refused with
 // testpage-control-binding. Each order is its own session, and each session runs against ONE
 // cache root twice (cold, then warm), because the second session reaches request 1 through an
@@ -16,56 +17,110 @@ namespace AlRunner.Tests;
 
 public sealed class ServerSamePageIdTwoWorkspacesTests
 {
-    private static void WriteWorkspace(string root, string appId, string tag, int tableId, int testCuId)
+    private static void Write(string path, string text)
     {
-        Directory.CreateDirectory(root);
-        // No Base Application floor (.claude/rules/no-base-app-in-csharp-tests.md).
-        File.WriteAllText(Path.Combine(root, "app.json"), $$"""
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, text);
+    }
+
+    // No Base Application floor in any manifest (.claude/rules/no-base-app-in-csharp-tests.md).
+    private static string Manifest(string id, string name, int from, int to, string dependencies = "") => $$"""
         {
-          "id": "{{appId}}",
-          "name": "Same Page Id {{tag}}",
+          "id": "{{id}}",
+          "name": "{{name}}",
           "publisher": "Repro4100",
           "version": "1.0.0.0",
-          "dependencies": [],
+          "dependencies": [ {{dependencies}} ],
           "platform": "1.0.0.0",
-          "idRanges": [ { "from": 64090, "to": 64109 } ],
+          "idRanges": [ { "from": {{from}}, "to": {{to}} } ],
           "runtime": "14.0"
         }
-        """);
-        // Different table, different control name, different page-variable value per workspace:
-        // a page object built from the OTHER workspace's type cannot answer this control.
-        File.WriteAllText(Path.Combine(root, "Objects.al"), $$"""
-        table {{tableId}} "R4100 {{tag}} Rec"
+        """;
+
+    // Workspace X: one app declaring page 64090 over its own table, with its own tests.
+    private static void WriteWorkspaceX(string app)
+    {
+        Write(Path.Combine(app, "app.json"), Manifest("e4100410-0410-4410-8410-041004100011", "R4100 X", 64090, 64109));
+        Write(Path.Combine(app, "X.al"), """
+        table 64101 "R4100 X Rec"
         {
             fields { field(1; "Code"; Code[10]) { } }
             keys { key(PK; "Code") { } }
         }
 
-        page 64090 "R4100 {{tag}} Card"
+        page 64090 "R4100 X Card"
         {
             PageType = Card;
-            SourceTable = "R4100 {{tag}} Rec";
-            layout { area(Content) { field({{tag}}VarCtl; {{tag}}Text) { ApplicationArea = All; } } }
+            SourceTable = "R4100 X Rec";
+            layout { area(Content) { field(XVarCtl; XText) { ApplicationArea = All; } } }
             var
-                {{tag}}Text: Text[30];
+                XText: Text[30];
             trigger OnOpenPage()
             begin
-                {{tag}}Text := '{{tag}}-value';
+                XText := 'x-A';
             end;
         }
 
-        codeunit {{testCuId}} "R4100 {{tag}} Tests"
+        codeunit 64102 "R4100 X Tests"
         {
             Subtype = Test;
 
             [Test]
-            procedure PageVariableControl()
+            procedure XPageControl()
             var
-                TP: TestPage "R4100 {{tag}} Card";
+                TP: TestPage "R4100 X Card";
             begin
                 TP.OpenView();
-                if TP.{{tag}}VarCtl.Value <> '{{tag}}-value' then
-                    Error('{{tag}} page control: expected {{tag}}-value, actual %1', TP.{{tag}}VarCtl.Value);
+                if TP.XVarCtl.Value <> 'x-A' then
+                    Error('x page control: expected x-A, actual %1', TP.XVarCtl.Value);
+                TP.Close();
+            end;
+        }
+        """);
+    }
+
+    // Workspace B: page 64090 lives in a sibling source dependency and the tests app is the
+    // module that executes, so the page type is NOT in CurrentTestAssembly. Its later requests
+    // reuse both modules (DependencyLoader's identity-match branch) rather than reloading them.
+    private static void WriteWorkspaceB(string root)
+    {
+        const string depId = "e4100410-0410-4410-8410-041004100021";
+        Write(Path.Combine(root, "dep", "app.json"), Manifest(depId, "R4100 Dep", 64090, 64094));
+        Write(Path.Combine(root, "dep", "Dep.al"), """
+        table 64090 "R4100 Dep Rec"
+        {
+            fields { field(1; "Code"; Code[10]) { } }
+            keys { key(PK; "Code") { } }
+        }
+
+        page 64090 "R4100 Dep Card"
+        {
+            PageType = Card;
+            SourceTable = "R4100 Dep Rec";
+            layout { area(Content) { field(DepVarCtl; DepText) { ApplicationArea = All; } } }
+            var
+                DepText: Text[30];
+            trigger OnOpenPage()
+            begin
+                DepText := 'dep-A';
+            end;
+        }
+        """);
+        Write(Path.Combine(root, "tests", "app.json"), Manifest("e4100410-0410-4410-8410-041004100022", "R4100 Dep Tests", 64095, 64099,
+            $$"""{ "id": "{{depId}}", "name": "R4100 Dep", "publisher": "Repro4100", "version": "1.0.0.0" }"""));
+        Write(Path.Combine(root, "tests", "T.al"), """
+        codeunit 64095 "R4100 Dep Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure DepPageControl()
+            var
+                TP: TestPage "R4100 Dep Card";
+            begin
+                TP.OpenView();
+                if TP.DepVarCtl.Value <> 'dep-A' then
+                    Error('dep page control: expected dep-A, actual %1', TP.DepVarCtl.Value);
                 TP.Close();
             end;
         }
@@ -87,33 +142,36 @@ public sealed class ServerSamePageIdTwoWorkspacesTests
             $"[{label}] must pass its one TestPage test: {string.Join(" | ", lines)}");
     }
 
+    // Four requests: each workspace loads once, then each is served again. The second pair is
+    // the one that failed after a partial fix (a reused dependency module was not preferred).
     private static async Task RunSessionAsync(string first, string second, string cache, string label)
     {
         await using var server = await CliServer.StartAsync(new[] { "--cache", cache });
         await AssertPassesAsync(server, first, $"{label} request 1");
         await AssertPassesAsync(server, second, $"{label} request 2 (same page id, other workspace)");
+        await AssertPassesAsync(server, first, $"{label} request 3");
+        await AssertPassesAsync(server, second, $"{label} request 4");
     }
 
-    private static (string Root, string X, string Y) Fixture(string name)
+    private static (string Root, string X, string B) Fixture(string name)
     {
         var root = TestScratch.Dir(name);
-        var x = Path.Combine(root, "xws");
-        var y = Path.Combine(root, "yws");
-        WriteWorkspace(x, "e4100410-0410-4410-8410-041004100001", "X", 64101, 64102);
-        WriteWorkspace(y, "e4100410-0410-4410-8410-041004100002", "Y", 64103, 64104);
-        return (root, x, y);
+        var x = Path.Combine(root, "xws", "x");
+        WriteWorkspaceX(x);
+        WriteWorkspaceB(Path.Combine(root, "ws"));
+        return (root, x, Path.Combine(root, "ws", "tests"));
     }
 
     [SkippableFact]
-    public async Task XThenY_BothBuildTheirOwnPage_ColdThenWarm()
+    public async Task XThenB_BothBuildTheirOwnPage_ColdThenWarm()
     {
         TestArtifacts.SkipIfMissing();
-        var (root, x, y) = Fixture("al-runner-server-same-page-id-4100-xy");
+        var (root, x, b) = Fixture("al-runner-server-same-page-id-4100-xb");
         var cache = Path.Combine(root, "cache");
         try
         {
-            await RunSessionAsync(x, y, cache, "X->Y cold");
-            await RunSessionAsync(x, y, cache, "X->Y warm");
+            await RunSessionAsync(x, b, cache, "X->B cold");
+            await RunSessionAsync(x, b, cache, "X->B warm");
         }
         finally
         {
@@ -122,15 +180,15 @@ public sealed class ServerSamePageIdTwoWorkspacesTests
     }
 
     [SkippableFact]
-    public async Task YThenX_BothBuildTheirOwnPage_ColdThenWarm()
+    public async Task BThenX_BothBuildTheirOwnPage_ColdThenWarm()
     {
         TestArtifacts.SkipIfMissing();
-        var (root, x, y) = Fixture("al-runner-server-same-page-id-4100-yx");
+        var (root, x, b) = Fixture("al-runner-server-same-page-id-4100-bx");
         var cache = Path.Combine(root, "cache");
         try
         {
-            await RunSessionAsync(y, x, cache, "Y->X cold");
-            await RunSessionAsync(y, x, cache, "Y->X warm");
+            await RunSessionAsync(b, x, cache, "B->X cold");
+            await RunSessionAsync(b, x, cache, "B->X warm");
         }
         finally
         {

--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -443,6 +443,7 @@ public static partial class BcRuntime
     {
         var name = asm.GetName().Name;
         if (name != null) _latestGenerationByAssemblyName[name] = asm;
+        NoteCurrentBundleAssembly(asm);
         _retiredGenerations.TryRemove(asm, out _);
     }
 
@@ -452,6 +453,33 @@ public static partial class BcRuntime
     /// the name-keyed registry above cannot see a version bump as a new generation (#3974).
     /// </summary>
     private static readonly ConcurrentDictionary<Assembly, byte> _retiredGenerations = new();
+
+    // #4100: the assemblies registered since the last ResetForNewBundleReload, in order. A
+    // different workspace's module is not a stale generation, so IsStaleBundleAssembly cannot
+    // keep its same-id objects from answering; a finder asks this set first instead.
+    private static readonly List<Assembly> _currentBundleAssemblies = new();
+
+    /// <summary>
+    /// <see cref="CurrentTestAssembly"/>, then every other assembly registered for the bundle
+    /// now loading (its dependency modules), newest first. Empty before the first registration.
+    /// </summary>
+    /// <summary>Add <paramref name="asm"/> to <see cref="CurrentBundleAssemblies"/> without
+    /// re-registering its generation — for a dependency module reused as-is (#4100).</summary>
+    internal static void NoteCurrentBundleAssembly(Assembly asm)
+    {
+        lock (_currentBundleAssemblies)
+            if (!_currentBundleAssemblies.Contains(asm)) _currentBundleAssemblies.Add(asm);
+    }
+
+    internal static IReadOnlyList<Assembly> CurrentBundleAssemblies()
+    {
+        var ordered = new List<Assembly>();
+        if (_currentTestAssembly != null) ordered.Add(_currentTestAssembly);
+        lock (_currentBundleAssemblies)
+            for (var i = _currentBundleAssemblies.Count - 1; i >= 0; i--)
+                if (!ordered.Contains(_currentBundleAssemblies[i])) ordered.Add(_currentBundleAssemblies[i]);
+        return ordered;
+    }
 
     /// <summary>
     /// Mark <paramref name="asm"/> as no longer current, whatever its simple name; see
@@ -647,6 +675,7 @@ public static partial class BcRuntime
     public static void ResetForNewBundleReload()
     {
         _currentTestAssembly = null;
+        lock (_currentBundleAssemblies) _currentBundleAssemblies.Clear();
         // AL-output type caches that live on this partial class (CodeunitPatches,
         // XmlPortPatches). Their finders already prefer CurrentTestAssembly; the
         // caches just need dropping so the rebuild re-resolves against the new asm.

--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -459,10 +459,6 @@ public static partial class BcRuntime
     // keep its same-id objects from answering; a finder asks this set first instead.
     private static readonly List<Assembly> _currentBundleAssemblies = new();
 
-    /// <summary>
-    /// <see cref="CurrentTestAssembly"/>, then every other assembly registered for the bundle
-    /// now loading (its dependency modules), newest first. Empty before the first registration.
-    /// </summary>
     /// <summary>Add <paramref name="asm"/> to <see cref="CurrentBundleAssemblies"/> without
     /// re-registering its generation — for a dependency module reused as-is (#4100).</summary>
     internal static void NoteCurrentBundleAssembly(Assembly asm)
@@ -471,6 +467,10 @@ public static partial class BcRuntime
             if (!_currentBundleAssemblies.Contains(asm)) _currentBundleAssemblies.Add(asm);
     }
 
+    /// <summary>
+    /// <see cref="CurrentTestAssembly"/>, then every other assembly registered for the bundle
+    /// now loading (its dependency modules), newest first. Empty before the first registration.
+    /// </summary>
     internal static IReadOnlyList<Assembly> CurrentBundleAssemblies()
     {
         var ordered = new List<Assembly>();

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -222,6 +222,8 @@ public sealed class DependencyLoader
                     // LoadedAppEntry.Assemblies. Handing back only the cached primary here
                     // would put every app group after the first back into the pre-fix state.
                     list.AddRange(existing.AllAssemblies);
+                    // #4100: still one of this bundle's modules, for the page type finder.
+                    foreach (var reused in existing.AllAssemblies) BcRuntime.NoteCurrentBundleAssembly(reused);
                     continue;
                 }
             }

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -403,13 +403,8 @@ public static partial class RecordPatches
         // says it is avoiding, and the same shape as #2478 and #2755 in this same reset path.
         _objectRefConstIds.Clear();
         _fieldTriggersWiredTables.Clear();
-        // #4100: PopulateNclMetadataCache skips an id BC's metadataCacheEntries[Page] already
-        // holds, so without this the next bundle's page N is served this bundle's NCLMetaForm
-        // while _metaFormCache (cleared below) builds a fresh one. Must run before the two
-        // clears under it: they are the id list. Source-parsed ids only — the populator fills
-        // the Page slot from exactly these, and nothing re-registers any other entry.
-        foreach (var pageId in _parsedPages.Keys.Concat(_parsedPageExtensions.Keys).Distinct().ToArray())
-            TryMutatePageMetadataCacheEntries(dict => dict.Remove(pageId));
+        // #4100: BC's page-definition cache keys on (owner package id, page id) and the runner
+        // supplies no owner, so every bundle's page N shares one key.
         RunnerMetaApplicationObjectLoader.Instance.ResetMetaObjectCache();
         _parsedPages.Clear();
         _parsedPageExtensions.Clear();

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -403,6 +403,14 @@ public static partial class RecordPatches
         // says it is avoiding, and the same shape as #2478 and #2755 in this same reset path.
         _objectRefConstIds.Clear();
         _fieldTriggersWiredTables.Clear();
+        // #4100: PopulateNclMetadataCache skips an id BC's metadataCacheEntries[Page] already
+        // holds, so without this the next bundle's page N is served this bundle's NCLMetaForm
+        // while _metaFormCache (cleared below) builds a fresh one. Must run before the two
+        // clears under it: they are the id list. Source-parsed ids only — the populator fills
+        // the Page slot from exactly these, and nothing re-registers any other entry.
+        foreach (var pageId in _parsedPages.Keys.Concat(_parsedPageExtensions.Keys).Distinct().ToArray())
+            TryMutatePageMetadataCacheEntries(dict => dict.Remove(pageId));
+        RunnerMetaApplicationObjectLoader.Instance.ResetMetaObjectCache();
         _parsedPages.Clear();
         _parsedPageExtensions.Clear();
         _parsedReports.Clear();

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -2931,15 +2931,14 @@ internal sealed partial class RunnerPageInstance
     private static Type? FindPageExtensionType(int extensionId)
     {
         var name = "PageExtension" + extensionId;
-        // #4100: the executing bundle's own type first, as BcRuntime.FindFormType does — a
-        // foreign workspace's same-id PageExtension{id} is not stale and would otherwise answer.
-        var current = BcRuntime.CurrentTestAssembly;
-        if (current != null)
+        // #4100: the loading bundle's own modules first — a foreign workspace's same-id
+        // PageExtension{id} is not a stale generation, so the scan below would let it answer.
+        foreach (var own in BcRuntime.CurrentBundleAssemblies())
         {
             try
             {
-                var own = AlRunner.Infrastructure.AssemblyTypeIndex.For(current).FindFirst(name, typeof(Microsoft.Dynamics.Nav.Runtime.Extensions.NavFormExtension).IsAssignableFrom);
-                if (own != null) return own;
+                var t = AlRunner.Infrastructure.AssemblyTypeIndex.For(own).FindFirst(name, typeof(Microsoft.Dynamics.Nav.Runtime.Extensions.NavFormExtension).IsAssignableFrom);
+                if (t != null) return t;
             }
             catch { }
         }
@@ -3247,15 +3246,14 @@ internal sealed partial class RunnerPageInstance
     private static Type? FindPageType(int pageId)
     {
         var name = "Page" + pageId;
-        // #4100: the executing bundle's own type first, as BcRuntime.FindFormType does — a
-        // foreign workspace's same-id Page{id} is not stale and would otherwise answer.
-        var current = BcRuntime.CurrentTestAssembly;
-        if (current != null)
+        // #4100: the loading bundle's own modules first — a foreign workspace's same-id
+        // Page{id} is not a stale generation, so the scan below would let it answer.
+        foreach (var own in BcRuntime.CurrentBundleAssemblies())
         {
             try
             {
-                var own = AlRunner.Infrastructure.AssemblyTypeIndex.For(current).FindFirst(name, typeof(NavForm).IsAssignableFrom);
-                if (own != null) return own;
+                var t = AlRunner.Infrastructure.AssemblyTypeIndex.For(own).FindFirst(name, typeof(NavForm).IsAssignableFrom);
+                if (t != null) return t;
             }
             catch { }
         }

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -2931,17 +2931,6 @@ internal sealed partial class RunnerPageInstance
     private static Type? FindPageExtensionType(int extensionId)
     {
         var name = "PageExtension" + extensionId;
-        // #4100: the loading bundle's own modules first — a foreign workspace's same-id
-        // PageExtension{id} is not a stale generation, so the scan below would let it answer.
-        foreach (var own in BcRuntime.CurrentBundleAssemblies())
-        {
-            try
-            {
-                var t = AlRunner.Infrastructure.AssemblyTypeIndex.For(own).FindFirst(name, typeof(Microsoft.Dynamics.Nav.Runtime.Extensions.NavFormExtension).IsAssignableFrom);
-                if (t != null) return t;
-            }
-            catch { }
-        }
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
         {
             try

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -2931,6 +2931,18 @@ internal sealed partial class RunnerPageInstance
     private static Type? FindPageExtensionType(int extensionId)
     {
         var name = "PageExtension" + extensionId;
+        // #4100: the executing bundle's own type first, as BcRuntime.FindFormType does — a
+        // foreign workspace's same-id PageExtension{id} is not stale and would otherwise answer.
+        var current = BcRuntime.CurrentTestAssembly;
+        if (current != null)
+        {
+            try
+            {
+                var own = AlRunner.Infrastructure.AssemblyTypeIndex.For(current).FindFirst(name, typeof(Microsoft.Dynamics.Nav.Runtime.Extensions.NavFormExtension).IsAssignableFrom);
+                if (own != null) return own;
+            }
+            catch { }
+        }
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
         {
             try
@@ -3235,6 +3247,18 @@ internal sealed partial class RunnerPageInstance
     private static Type? FindPageType(int pageId)
     {
         var name = "Page" + pageId;
+        // #4100: the executing bundle's own type first, as BcRuntime.FindFormType does — a
+        // foreign workspace's same-id Page{id} is not stale and would otherwise answer.
+        var current = BcRuntime.CurrentTestAssembly;
+        if (current != null)
+        {
+            try
+            {
+                var own = AlRunner.Infrastructure.AssemblyTypeIndex.For(current).FindFirst(name, typeof(NavForm).IsAssignableFrom);
+                if (own != null) return own;
+            }
+            catch { }
+        }
         // Metadata-backed lookup — see AlRunner/Infrastructure/AssemblyTypeIndex.cs.
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
         {

--- a/AlRunner/Patches/RunnerXmlMetadataLoader.cs
+++ b/AlRunner/Patches/RunnerXmlMetadataLoader.cs
@@ -234,8 +234,6 @@ public sealed class RunnerMetaApplicationObjectLoader : INCLMetaApplicationObjec
         lock (_metaObjectCacheLock) _metaObjectCache = null;
     }
 
-    internal bool HasMetaObjectCacheForTests => _metaObjectCache != null;
-
     public INavAppClrTypeRetriever AppClrTypeRetriever =>
         throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
             "INCLMetaApplicationObjectLoader.AppClrTypeRetriever",

--- a/AlRunner/Patches/RunnerXmlMetadataLoader.cs
+++ b/AlRunner/Patches/RunnerXmlMetadataLoader.cs
@@ -223,6 +223,19 @@ public sealed class RunnerMetaApplicationObjectLoader : INCLMetaApplicationObjec
         }
     }
 
+    /// <summary>
+    /// Drop the MetaObjectCache on a bundle reload (#4100). It keys on the object owner's
+    /// runtime package id, which the runner's app group never supplies, so every app's page N
+    /// shares the key (Guid.Empty, N) and the first bundle's parsed definition answered every
+    /// later bundle. The next read rebuilds from the registries, which the reload repopulated.
+    /// </summary>
+    internal void ResetMetaObjectCache()
+    {
+        lock (_metaObjectCacheLock) _metaObjectCache = null;
+    }
+
+    internal bool HasMetaObjectCacheForTests => _metaObjectCache != null;
+
     public INavAppClrTypeRetriever AppClrTypeRetriever =>
         throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
             "INCLMetaApplicationObjectLoader.AppClrTypeRetriever",


### PR DESCRIPTION
Closes #4100

Written by agent stma-auto2-2 on the account holder's behalf.

Corpus-NA: server-mode request-boundary state (two workspaces in one --server process); a service tier runs one app set per tenant and cannot express it

## Cause

In one `--server` process, two per-page-id answers survived into the next workspace's request:

1. **The page type.** `RunnerPageInstance.FindPageType` took the first `Page{id}` in the AppDomain. The other workspace's module is not a stale generation (different simple name, `V2_x` vs `V2_tests`), so `IsStaleBundleAssembly` does not skip it. `BcRuntime.FindFormType` and its siblings already try `CurrentTestAssembly` first; this one did not. When the page lives in a dependency module (the issue's reproducer), `CurrentTestAssembly` is the tests module, so preferring it alone is not enough.
2. **BC's page-definition cache.** The runner builds BC's own `MetaObjectCache` once per process. `GetMetaPage` keys it on `(appGroup.GetObjectOwner(Page, id).RuntimePackageId, id)`, and the runner's app group returns no owner, so every app's page N shares the key `(Guid.Empty, N)`. The first workspace's parsed definition then answered later ones, and `SetSourceTable` failed with `The metadata object Table 64101 was not found` (64101 is the first workspace's table) while serving the second workspace.

Either failure made `RunnerPageInstance.TryCreate` return null, which is the `_page == null` refusal in the issue.

## Change

- `BcRuntime`: a per-bundle assembly list, cleared in `ResetForNewBundleReload`, filled by `RegisterAssemblyGeneration`. `CurrentBundleAssemblies()` returns `CurrentTestAssembly` first, then the rest of the list.
- `DependencyLoader`: a dependency module reused as-is (identity-match branch) is added to that list. That branch does not call `RegisterAssemblyGeneration`.
- `RunnerPageInstance.FindPageType`: tries `CurrentBundleAssemblies()` before the AppDomain scan.
- `RunnerMetaApplicationObjectLoader.ResetMetaObjectCache()`, called from `RecordPatches.ResetForReload`: the next read rebuilds from the registries the reload filled again.

## RED -> GREEN

`AlRunner.Tests/ServerSamePageIdTwoWorkspacesTests.cs`. Workspace X is one app with page 64090. Workspace B is the issue's `dep` + `tests` pair, with page 64090 in the dependency. Each fact starts one server, sends four requests (X, B, X, B or B, X, B, X), and repeats cold and then warm against one cache root. The repeat requests go through the cross-bundle reuse path.

- runner files at `origin/main`: `Failed: 2, Passed: 0`. Both failed at request 2 with the `testpage-control-binding` refusal.
- this branch: `Failed: 0, Passed: 2`.

Corroboration beyond pass/fail, from `AL_RUNNER_TRACE_PAGE_METADATA=1`: before the fix, the second workspace's page built with the first workspace's control id (`Control418466112` in both requests). After the fix, each request prints its own id (`Control418466112`, then `Control1745227783`).

## Mutations (one per hunk, each run separately and restored)

| mutation | result |
|---|---|
| `ResetMetaObjectCache` body emptied | `Failed: 2, Passed: 0`, request 2 of both orders |
| `FindPageType` bundle loop over an empty list | `Failed: 2, Passed: 0`, request 2 of both orders |
| reused-dependency note in `DependencyLoader` loops over an empty list | `Failed: 1, Passed: 1`: only `X->B cold request 4` fails, which is the reused dependency module |

The failing sets differ. The first two hunks fail request 2 in both orders. The third fails only the request where B's dependency module is reused, so the tests tell the three mechanisms apart instead of all failing on the same one.

Two hunks from an earlier revision were dropped because no mutation could make a test fail:
- evicting page ids from BC's `metadataCacheEntries[Page]` (the populator skips an id already present, and the log showed `skipped=1`; with the evicted entry put back, all tests stayed green)
- the same bundle preference in `FindPageExtensionType` (no test reaches it)

## Fix the shape

1. **Same pattern at another call site?** `FindPageExtensionType` next to it has the same AppDomain-first scan. I left it unchanged because nothing here proves it, and filed it as #4137. The `CodeunitPatches` finders (`FindFormType`, `FindTestPageType`, `FindReportType`, `FindQueryType`, codeunit `CreateTarget`) prefer only `CurrentTestAssembly`, so a dependency-owned object with a foreign same id has the same gap there. That gap is not measured, and it is in #4137 too.
2. **Sibling assumption?** `MetaObjectCache.GetMetaTable` and `GetMetaEnum` use the same owner-less key. Dropping the cache instance on reload covers them too. I did not measure a same-id table or enum across workspaces.
3. **Two writers, same invariant?** `RegisterAssemblyGeneration` (a fresh load) and the `DependencyLoader` reuse branch both put a module into the bundle. Before this change only the first recorded it. Both now add to the bundle list, and the third mutation above is the test that separates them.

## Overlaps and related work

- **#4101** (stma-auto2-5, #4099) adds an `IsStaleBundleAssembly` skip inside the same two `RunnerPageInstance` find loops. That skip handles an earlier generation of the same module. This PR handles a different app's module. I did not copy #4101's changes. `git merge-tree` of this branch against #4101's head `a954a2e3` is clean.
- **#4099**: no verdict. I tried an in-place edit of the dependency page (`dep-A` -> `dep-B`) between two requests. Both this branch and runner files at `origin/main` fail the second request with `EMIT-ZERO` on the dependency recompile, so the edited page code never ran on either tree. #4099 is not measured by this PR and stays open.
- **#4072**: its ownership model ("ids claimed by two groups are unowned") and the owner-less `MetaObjectCache` key come from the same missing app-group object owner. Linked here, not folded in.

Duplicate search (open issues): `FindPageType`, `MetaObjectCache`, `testpage-control-binding`, "same page id", "two workspaces". Found only #4099, #4072 and #4101, all covered above.

## Local runs

- `ServerSamePageIdTwoWorkspacesTests`: `Passed: 2` (final tree, after rebase onto `origin/main`)
- Filter `ServerSamePageIdTwoWorkspacesTests|WatchPageMetadataReload|ServerSiblingSourceDependencyReload|PageRealMetadataEpochRevalidation|ServerCrossBundle|GuardTests`: 270 passed, 1 failed. The failure was `BcEngineReadinessGuardTests`, which refuses when the in-process engine bootstrap was not run. After `tools/engine-test-bootstrap.sh` on a Release build, `PageRealMetadataEpochRevalidation|BcEngineReadinessGuardTests|BuiltMetadataCacheBundleBoundary|BcAppRegistrationEpochInvalidation|BundleQuerySymbolsReset` gave `Passed: 30`.
- Filter `BcRuntime|StaleBundle|AssemblyGeneration`: `Passed: 1` (one test matched). `RegisterAssemblyGeneration` now also adds to the bundle list for every caller (`SetTestAssembly`, `DependencyLoader.RegisterAppAssemblies`). The list is cleared on every reload and read only by `FindPageType`. That shared path is not otherwise measured locally, so CI is the check.
- `tools/test_*.py`: all pass. `test_doc_summary_uniqueness.py` first caught a doc summary I had put on the wrong member, and I fixed it.

https://claude.ai/code/session_01XX63f2j1mMf64XkfxcAS2X
