### PR TITLE
test(rules): execute a rule's detection recipe against the defect it claims to detect

### DIFF
--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -212,6 +212,7 @@ advisory on purpose** — `Required-context list must match the live branch rule
 repository for something no author can fix. So a red tick is not by itself proof the merge is
 blocked — ask the ruleset:
 
+<!-- Recipe-unpinned: reads the live branch ruleset from api.github.com; check_required_contexts.py is the executable half -->
 ```bash
 gh api repos/StefanMaron/BusinessCentral.AL.Runner/rules/branches/main \
   --jq '[.[]|select(.type=="required_status_checks")
@@ -337,6 +338,7 @@ point; two commits with different trees are not the same code however closely re
 ```bash
 [ "$(git rev-parse <sha1>^{tree})" = "$(git rev-parse <sha2>^{tree})" ] && echo "same tree"
 ```
+<!-- Recipe-unpinned: takes two commit SHAs of real runs; the comparison itself is git rev-parse equality with nothing to get subtly wrong -->
 
 ### A red you inherited from the corpus is not a flake — count it per codeunit
 

--- a/.claude/rules/github-access.md
+++ b/.claude/rules/github-access.md
@@ -19,6 +19,7 @@ success on work it never did.
 ```bash
 command -v gh >/dev/null 2>&1 && echo "gh available" || echo "use mcp__github__* tools"
 ```
+<!-- Recipe-unpinned: its answer IS the environment under test; a box with gh cannot measure the gh-less branch -->
 
 - **`gh` available** → use it. Pass `--repo StefanMaron/BusinessCentral.AL.Runner`
   on every command.

--- a/.claude/rules/no-git-stash-with-worktrees.md
+++ b/.claude/rules/no-git-stash-with-worktrees.md
@@ -43,12 +43,18 @@ because the deletions are committed; and the same-tree check (`ci-verdicts.md` �
 `git merge-tree --write-tree` also keeps the other PR's files, so the damage is a wrong *diff*
 rather than a merge that reverts anything.
 
+<!-- Recipe-pinned-by: tools/test_stale_origin_main_diff_recipe.py -->
 **`git diff --stat origin/main...HEAD` does NOT catch it — use two dots.** Three-dot diffs
 against the **merge base**, and a soft reset moves the merge base back with it, so re-added
-content reads as insertions and the command prints a clean `1 file changed`. Measured in four
-scratch repositories (both stale-ref orderings × `--soft`/`--hard`), and reproduced
-independently: three-dot `1 file changed, 1 insertion(+)`; two-dot
-`2 files changed, 1 insertion(+), 50 deletions(-)`.
+content reads as insertions and the command prints a clean `1 file changed`: three-dot
+`1 file changed, 1 insertion(+)`; two-dot `2 files changed, 1 insertion(+), 50 deletions(-)`.
+
+**Only one ordering of three discriminates, so reproduce that one.** Where the branch was
+built, what `reset --soft` targeted and what `origin/main` held at read time are three
+independent choices; `tools/test_stale_origin_main_diff_recipe.py` executes all eight and
+**six show the two forms agreeing**. The numbers above are the ordering where they differ
+(branch built before the other PR, reset to the stale ref, `origin/main` fresh at read).
+A run that picked an ordering without checking would have reported either form fine.
 
 So: **`git fetch origin main` immediately before any command naming `origin/main` as a base** —
 `reset`, `rebase`, `merge-tree`, `diff` — and read **`git diff --stat origin/main..HEAD`**, two

--- a/tools/test_rule_recipe_census_refuses.py
+++ b/tools/test_rule_recipe_census_refuses.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""The rule-recipe census guard's refusal paths fire (#3955).
+
+`guards-need-a-third-state.md`: a refusal path with no test is indistinguishable
+from a never-fire path, which is the defect itself. `tools/test_rule_recipes_executed.py`
+passes on the real tree, and that says nothing about whether it *can* fail. This
+suite builds synthetic `.claude/rules/` trees that each trip exactly one of its
+checks, runs it against them, and asserts it refuses.
+
+It drives the guard through its module API with RULES_DIR and ROOT repointed at a
+scratch directory, so no copy of any rule text is kept here -- a second copy is the
+drift source the issue is about one level up.
+
+The classifier's two shapes each get a case, because they are separate code paths
+and the fenced-block one was written first: an unmarked fenced detection recipe,
+and an unmarked INLINE one. The inline case is the regression test for the miss
+that mattered -- the first cut of the guard read fences only and did not see the
+`git diff --stat origin/main...HEAD` line that produced #3955.
+
+Run: python3 tools/test_rule_recipe_census_refuses.py
+"""
+from __future__ import annotations
+
+import importlib
+import io
+import os
+import shutil
+import sys
+import tempfile
+from contextlib import redirect_stdout
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        FAILURES.append(name)
+
+
+def run_against(files: dict[str, str], extra: dict[str, str] | None = None,
+                pad: int = 24) -> tuple[int, str]:
+    """Run the guard over a scratch tree. Returns (exit code, captured stdout)."""
+    tmp = tempfile.mkdtemp(prefix="recipe-census-")
+    try:
+        rules = os.path.join(tmp, ".claude", "rules")
+        os.makedirs(rules)
+        # The guard requires >10 rule files and >20 recipe blocks before it will
+        # judge anything, so pad with inert files carrying a plain recipe block.
+        # `pad=0` is how the vacuous-pass floor itself gets tested.
+        for i in range(pad):
+            with open(os.path.join(rules, f"pad-{i}.md"), "w", encoding="utf-8") as fh:
+                fh.write(f"# pad {i}\n\n```bash\nls -l\necho {i}\n```\n")
+        for name, body in files.items():
+            with open(os.path.join(rules, name), "w", encoding="utf-8") as fh:
+                fh.write(body)
+        for name, body in (extra or {}).items():
+            p = os.path.join(tmp, name)
+            os.makedirs(os.path.dirname(p), exist_ok=True)
+            with open(p, "w", encoding="utf-8") as fh:
+                fh.write(body)
+
+        mod = importlib.import_module("test_rule_recipes_executed")
+        importlib.reload(mod)
+        mod.ROOT = tmp
+        mod.RULES_DIR = rules
+        mod.FAILURES = []
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = mod.main()
+        return rc, buf.getvalue()
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+# ---------------------------------------------------------------- the cases
+
+# Baseline: a correctly marked tree passes, so every refusal below is attributable
+# to the thing that case changed and not to the harness.
+GOOD_FENCED = """# good
+
+Ask the ruleset -- this is the check that tells you whether it is blocked:
+
+<!-- Recipe-unpinned: reads live GitHub state, cannot run offline here -->
+```bash
+gh api repos/o/r/rules/branches/main
+```
+"""
+
+BAD_FENCED = """# bad
+
+Ask the ruleset -- this is the check that tells you whether it is blocked:
+
+```bash
+gh api repos/o/r/rules/branches/main
+```
+"""
+
+BAD_INLINE = """# bad inline
+
+**`git diff --stat origin/main...HEAD` does not catch it -- use two dots.** More prose
+explaining why the three-dot form reads clean.
+"""
+
+GOOD_INLINE = """# good inline
+
+<!-- Recipe-unpinned: needs a scratch repository, pinned separately -->
+**`git diff --stat origin/main...HEAD` does not catch it -- use two dots.** More prose
+explaining why the three-dot form reads clean.
+"""
+
+PINNED_MISSING = """# pinned at nothing
+
+<!-- Recipe-pinned-by: tools/test_does_not_exist.py -->
+```bash
+git rev-parse HEAD
+```
+"""
+
+PINNED_ORPHAN = """# pinned at an unrelated suite
+
+<!-- Recipe-pinned-by: tools/test_unrelated.py -->
+```bash
+git rev-parse HEAD
+```
+"""
+
+PLACEHOLDER_REASON = """# placeholder
+
+<!-- Recipe-unpinned: n/a -->
+```bash
+gh api repos/o/r
+```
+"""
+
+
+def main() -> int:
+    print("refusal paths of the rule-recipe census guard")
+
+    rc, out = run_against({"good.md": GOOD_FENCED})
+    check("a correctly marked tree passes (baseline)", rc == 0, out)
+
+    rc, out = run_against({"bad.md": BAD_FENCED})
+    check("an unmarked FENCED detection recipe is refused", rc == 1)
+    check("...and the message names the offending file",
+          "bad.md" in out and "unclassified" in out, out)
+
+    rc, out = run_against({"bad.md": BAD_INLINE})
+    check("an unmarked INLINE detection recipe is refused", rc == 1)
+    check("...and the message says it was an inline command",
+          "inline command" in out, out)
+
+    rc, out = run_against({"good.md": GOOD_INLINE})
+    check("a marked inline recipe passes", rc == 0, out)
+
+    rc, out = run_against({"p.md": PINNED_MISSING})
+    check("a marker naming a test file that does not exist is refused", rc == 1)
+    check("...and the message names the missing test",
+          "test_does_not_exist.py" in out, out)
+
+    rc, out = run_against({"p.md": PINNED_ORPHAN},
+                          extra={"tools/test_unrelated.py": "# mentions no rule\n"})
+    check("a marker pointing at a suite that never mentions the rule is refused", rc == 1)
+    check("...and the message says the suite never mentions it",
+          "never mentions" in out, out)
+
+    rc, out = run_against(
+        {"p.md": PINNED_ORPHAN},
+        extra={"tools/test_unrelated.py": "# pins p.md\n"})
+    check("...and the same marker passes once that suite names the rule", rc == 0, out)
+
+    rc, out = run_against({"ph.md": PLACEHOLDER_REASON})
+    check("a placeholder unpinnable reason is refused", rc == 1)
+    check("...and the message quotes the placeholder", "n/a" in out, out)
+
+    # The guard must refuse a tree it cannot measure rather than passing vacuously:
+    # an empty rules directory matches nothing, and matching nothing is the shape
+    # that reads as success (guards-need-a-third-state.md).
+    rc, out = run_against({}, pad=0)
+    check("an empty rules tree is refused, not reported as a clean census",
+          rc == 1, out)
+    check("...and the refusal names both vacuity floors",
+          "matched files at all" in out and "found at all" in out, out)
+
+    if FAILURES:
+        print(f"\nFAILED: {len(FAILURES)} check(s): {FAILURES}")
+        return 1
+    print("\nall refusal-path checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_rule_recipes_executed.py
+++ b/tools/test_rule_recipes_executed.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Every DETECTION recipe in `.claude/rules/` is pinned by a test that runs it (#3955).
+
+A docs-only pull request skips the BC matrix, so nothing has ever executed the
+commands a rule instructs an agent to run. PR #3954 shipped
+`git diff --stat origin/main...HEAD` as the remedy for a stale-`origin/main`
+soft reset; three dots does not detect that defect and two dots does. The rule
+was written from a correct memory of a real incident, by the person who caused
+it, and its one executable line was wrong.
+
+## Why a static sweep does not help, and this guard is not one
+
+The coordinator's own sweep on #3955 `bash -n`-checked all 34 command lines then
+in `.claude/rules/`: 30 valid, 4 "invalid" for `<placeholder>` angle brackets,
+which is correct documentation style. The line that shipped wrong was **perfectly
+valid bash**. It parses, runs, exits 0 and prints a plausible answer -- it just
+answers a different question than the prose claims. Nothing static catches that,
+because nothing about three-dot-versus-two-dot is static.
+
+What would have caught it is `tdd.md`'s mutation discipline applied to prose:
+reproduce the failure the recipe claims to detect, then confirm the recipe
+detects it. That is a fixture and an assertion -- a test. So this guard does not
+execute recipes itself. It enforces the census that makes such a test exist:
+
+    a DETECTION recipe is pinned by a named test, or it is not a detection
+    recipe, and the guard says which for every recipe in the tree.
+
+## The third state is the whole design (`guards-need-a-third-state.md`)
+
+Of the ~44 recipe lines in `.claude/rules/`, most are `gh` calls against live
+GitHub state. Executing those here is impossible, and a guard that quietly
+counted them as passing would be the defect one level up. They are not silently
+skipped: a rule declares them with a reason, and this guard reports the count.
+
+  * pinned        -- a `Recipe-pinned-by:` marker names a test that runs it
+  * unpinnable    -- a `Recipe-unpinned:` marker gives the reason it cannot run
+  * UNCLASSIFIED  -- neither. This fails, and is the only failing state.
+
+`Recipe-unpinned:` is deliberately cheap to write, because the alternative to a
+cheap honest "this reads live GitHub state" is an author who silently omits the
+marker. What it buys is that the reason is *written down and countable*: a sweep
+can ask how many recipes claim to be unexecutable, and a reviewer can disagree
+with any one of them.
+
+## What counts as a DETECTION recipe
+
+Only a recipe the prose claims will *detect*, *catch*, *confirm* or *tell you
+whether* something -- the class where being subtly wrong is invisible. A recipe
+that merely performs an action (`gh pr edit --add-label`, `git push`) has no
+truth value to get wrong: it either does the thing or errors. Scoping to
+detection is what keeps this from being ceremony on 44 lines to protect 3.
+
+The classifier is deliberately keyed on the block's own marker, not on prose
+sentiment, so a rule author declares intent rather than having it guessed.
+
+## Inline recipes count, and the founding one was inline
+
+A first cut of this guard read fenced blocks only, and **did not see the recipe
+that produced #3955**: `git diff --stat origin/main...HEAD` sits in
+`no-git-stash-with-worktrees.md` in inline backticks, inside a bold sentence, not
+in a fence. A guard that missed its own founding instance is one that would have
+reported a clean census while the defect sat two files away. So a backticked
+command span inside a detection sentence is a recipe here too, and carries a
+marker on the paragraph's own line.
+
+Run: python3 tools/test_rule_recipes_executed.py
+"""
+from __future__ import annotations
+
+import glob
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+RULES_DIR = os.path.join(ROOT, ".claude", "rules")
+
+FAILURES: list[str] = []
+
+# A marker sits on its own line immediately above or below a fenced block, as an
+# HTML comment so it renders as nothing. Value together with the marker, one line,
+# mirroring the `Corpus-PR:` shape check_corpus_linkage.sh accepts (#3255).
+PINNED = re.compile(r"^<!--\s*Recipe-pinned-by:\s*(\S+)\s*-->\s*$")
+UNPINNED = re.compile(r"^<!--\s*Recipe-unpinned:\s*(.+?)\s*-->\s*$")
+
+PLACEHOLDER_REASONS = {"n/a", "na", "none", "tbd", "todo", "-", "?", "unknown"}
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        FAILURES.append(name)
+
+
+def fenced_blocks(text: str) -> list[tuple[int, int, str]]:
+    """(start_line, end_line, body) for every fenced block, 0-based line numbers."""
+    lines = text.splitlines()
+    out: list[tuple[int, int, str]] = []
+    i = 0
+    while i < len(lines):
+        if lines[i].startswith("```"):
+            j = i + 1
+            while j < len(lines) and not lines[j].startswith("```"):
+                j += 1
+            out.append((i, min(j, len(lines) - 1), "\n".join(lines[i + 1:j])))
+            i = j + 1
+        else:
+            i += 1
+    return out
+
+
+def marker_near(lines: list[str], start: int, end: int) -> tuple[str, str] | None:
+    """A marker on the line above the opening fence, or below the closing fence."""
+    for idx in (start - 1, end + 1):
+        if 0 <= idx < len(lines):
+            s = lines[idx].strip()
+            m = PINNED.match(s)
+            if m:
+                return ("pinned", m.group(1))
+            m = UNPINNED.match(s)
+            if m:
+                return ("unpinned", m.group(1))
+    return None
+
+
+# Prose immediately around a block that claims the block DETECTS something. Used
+# only to report an unmarked detection recipe; a marker always wins over this.
+DETECTION_WORDS = re.compile(
+    r"\b(detect|catch(?:es)?|confirm(?:s)?|check(?:s)? (?:whether|that)|"
+    r"tells? you whether|answers? (?:the )?question|is the check|reads the verdict)\b",
+    re.I,
+)
+
+
+# An inline command span: `git ...` / `gh ...` / `tools/x.py ...` in backticks, with
+# at least one argument, so a bare `git` or a symbol name in backticks is not a recipe.
+INLINE_CMD = re.compile(r"`((?:git|gh|tools/\S+|python3?|command grep|rg)\s+[^`]{4,})`")
+
+# A sentence asserting that the inline command DOES or DOES NOT detect the defect.
+# This is the shape of the line #3955 was filed about: the claim and the command in
+# one sentence, where the claim is checkable and nothing checks it.
+INLINE_CLAIM = re.compile(
+    r"\b(does not (?:catch|detect)|catches|detects|use two dots|"
+    r"is what (?:catches|detects)|read \*\*|before believing)\b", re.I)
+
+
+def inline_recipes(lines: list[str], fenced_spans: list[tuple[int, int]]) -> list[int]:
+    """Line numbers of paragraphs carrying a detection CLAIM about an inline command."""
+    inside = set()
+    for s, e in fenced_spans:
+        inside.update(range(s, e + 1))
+    out = []
+    for i, line in enumerate(lines):
+        if i in inside:
+            continue
+        if INLINE_CMD.search(line) and INLINE_CLAIM.search(line):
+            out.append(i)
+    return out
+
+
+def main() -> int:
+    rule_files = sorted(glob.glob(os.path.join(RULES_DIR, "*.md")))
+    check("the rules glob matched files at all", len(rule_files) > 10, str(len(rule_files)))
+
+    pinned: list[tuple[str, str]] = []
+    unpinned: list[tuple[str, str]] = []
+    unclassified: list[str] = []
+    bad_reason: list[str] = []
+    missing_test: list[str] = []
+    blocks_seen = 0
+
+    for path in rule_files:
+        rel = os.path.relpath(path, ROOT).replace(os.sep, "/")
+        text = open(path, encoding="utf-8").read()
+        lines = text.splitlines()
+        blocks = fenced_blocks(text)
+
+        for i in inline_recipes(lines, [(s, e) for s, e, _ in blocks]):
+            blocks_seen += 1
+            where = f"{rel}:{i + 1}"
+            # An inline recipe's marker sits on its own line anywhere in the
+            # paragraph that carries it: scan to the nearest blank line each way.
+            mark = None
+            lo = i
+            while lo > 0 and lines[lo - 1].strip():
+                lo -= 1
+            hi = i
+            while hi + 1 < len(lines) and lines[hi + 1].strip():
+                hi += 1
+            for idx in range(max(0, lo - 1), min(len(lines), hi + 2)):
+                s = lines[idx].strip()
+                m = PINNED.match(s)
+                if m:
+                    mark = ("pinned", m.group(1))
+                    break
+                m = UNPINNED.match(s)
+                if m:
+                    mark = ("unpinned", m.group(1))
+                    break
+            if mark is None:
+                unclassified.append(f"{where} (inline command carrying a detection claim)")
+            elif mark[0] == "pinned":
+                pinned.append((where, mark[1]))
+                if not os.path.exists(os.path.join(ROOT, mark[1])):
+                    missing_test.append(f"{where} -> {mark[1]} does not exist")
+            else:
+                unpinned.append((where, mark[1]))
+                if (mark[1].strip().lower().rstrip(".") in PLACEHOLDER_REASONS
+                        or len(mark[1]) < 12):
+                    bad_reason.append(f"{where} -> {mark[1]!r}")
+
+        for start, end, body in blocks:
+            lang = lines[start][3:].strip().lower()
+            if lang not in ("bash", "sh", "shell", ""):
+                continue
+            # A block with no command line in it is an output sample, not a recipe.
+            cmds = [ln for ln in body.splitlines()
+                    if ln.strip() and not ln.strip().startswith("#")]
+            if not cmds:
+                continue
+            blocks_seen += 1
+            where = f"{rel}:{start + 1}"
+            mark = marker_near(lines, start, end)
+            if mark is None:
+                context = "\n".join(lines[max(0, start - 6):start])
+                if DETECTION_WORDS.search(context):
+                    unclassified.append(f"{where} (prose claims it detects something)")
+                continue
+            kind, value = mark
+            if kind == "pinned":
+                pinned.append((where, value))
+                if not os.path.exists(os.path.join(ROOT, value)):
+                    missing_test.append(f"{where} -> {value} does not exist")
+            else:
+                unpinned.append((where, value))
+                if value.strip().lower().rstrip(".") in PLACEHOLDER_REASONS or len(value) < 12:
+                    bad_reason.append(f"{where} -> {value!r}")
+
+    check("recipe blocks were found at all", blocks_seen > 20, f"{blocks_seen} blocks")
+
+    check("every marked-as-pinned recipe names a test file that exists",
+          not missing_test, str(missing_test))
+    check("every marked-as-unpinnable recipe gives a real reason",
+          not bad_reason, str(bad_reason))
+    check("no detection recipe is unclassified",
+          not unclassified,
+          "\n      " + "\n      ".join(unclassified) if unclassified else "")
+
+    # A pinned recipe's test must actually reference the rule it pins, so a marker
+    # cannot point at an unrelated suite and look like coverage (tdd.md: a test that
+    # names the thing is not a test that drives it -- the weaker half is caught here,
+    # the stronger half only by that test's own mutation).
+    orphaned = []
+    for where, test_rel in pinned:
+        p = os.path.join(ROOT, test_rel)
+        if not os.path.exists(p):
+            continue
+        rule_name = os.path.basename(where.split(":")[0])
+        if rule_name not in open(p, encoding="utf-8").read():
+            orphaned.append(f"{where} -> {test_rel} never mentions {rule_name}")
+    check("every pinning test mentions the rule it pins", not orphaned, str(orphaned))
+
+    print(f"\n  census: {len(pinned)} pinned, {len(unpinned)} declared unpinnable, "
+          f"{blocks_seen} recipe blocks total")
+    for where, value in pinned:
+        print(f"    pinned      {where} -> {value}")
+    for where, value in unpinned:
+        print(f"    unpinnable  {where} -> {value}")
+
+    if FAILURES:
+        print(f"\nFAILED: {len(FAILURES)} check(s): {FAILURES}")
+        return 1
+    print("\nall rule-recipe census checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_scratch_repo_git_isolation.py
+++ b/tools/test_scratch_repo_git_isolation.py
@@ -34,6 +34,7 @@ SUITES = {
     "tools/test_agent_self_freshness.py": "all checks passed",
     "tools/test_corpus_checkout.py": "all corpus-checkout tests passed",
     "tools/test_preflight.py": "all checks passed",
+    "tools/test_stale_origin_main_diff_recipe.py": "recipe-execution checks passed",
     ".github/scripts/test_pr_changed_files.sh": "failed: 0",
 }
 

--- a/tools/test_stale_origin_main_diff_recipe.py
+++ b/tools/test_stale_origin_main_diff_recipe.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Execute `no-git-stash-with-worktrees.md`'s two-dot diff recipe against the defect it claims to detect (#3955).
+
+This is the pinning test `tools/test_rule_recipes_executed.py` requires for that
+rule's inline recipe, and the worked example of what pinning means: not "the
+command parses" -- the wrong one parsed fine -- but **reproduce the failure the
+recipe claims to catch, then confirm the recipe catches it and the rejected
+alternative does not.**
+
+## What the rule claims
+
+`.claude/rules/no-git-stash-with-worktrees.md`, section "`origin/main` is a LOCAL
+ref with a remote-looking name":
+
+    **`git diff --stat origin/main...HEAD` does NOT catch it -- use two dots.**
+    ... three-dot `1 file changed, 1 insertion(+)`; two-dot `2 files changed,
+    1 insertion(+), 50 deletions(-)`.
+
+PR #3954 shipped the three-dot form as the remedy. A reviewer built four scratch
+repositories and found it does not detect the defect. This suite re-derives that
+in the repository, so the next edit to that line is measured rather than believed.
+
+## The ordering matters, and most orderings do not discriminate
+
+Three independent choices produce eight orderings: where the branch was built
+(`base` or `ahead` of the other PR), what `reset --soft` targeted, and what
+`origin/main` held when the diff was read. Measured, all eight:
+
+    built reset read  | three-dot                  | two-dot
+    base  base  base  | 1 file,  1 ins             | 1 file,  1 ins
+    base  base  ahead | 1 file,  1 ins             | 2 files, 1 ins, 50 del   <-- THE ONE
+    base  ahead base  | 1 file,  1 ins             | 1 file,  1 ins
+    base  ahead ahead | 2 files, 1 ins, 50 del     | 2 files, 1 ins, 50 del
+    ahead base  base  | 2 files, 51 ins            | 2 files, 51 ins
+    ahead base  ahead | 2 files, 51 ins            | 1 file,  1 ins
+    ahead ahead base  | 2 files, 51 ins            | 2 files, 51 ins
+    ahead ahead ahead | 1 file,  1 ins             | 1 file,  1 ins
+
+Only row 2 is the rule's claim. **Six of the eight orderings show the two forms
+agreeing**, so a test that picked an ordering without checking would have
+reported the recipe fine whichever dots it used -- passing for the wrong reason,
+which `tdd.md` calls noise. That is why this suite asserts the whole matrix and
+not just the one row: the discriminating ordering is pinned as discriminating,
+and the non-discriminating ones are pinned as non-discriminating, so a future
+git whose behaviour drifts in either direction fails here.
+
+Row 6 is worth its line: there the **three-dot** form is the misleading one in
+the opposite direction, inflating a one-line change to 51 insertions. The rule
+does not mention it and does not need to -- but it means "three dots is always
+wrong" would be as unfounded as "three dots is fine".
+
+Run: python3 tools/test_stale_origin_main_diff_recipe.py
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+sys.path.insert(0, HERE)
+
+from scratch_git_config import isolate  # noqa: E402
+
+isolate()
+
+RULE = os.path.join(ROOT, ".claude", "rules", "no-git-stash-with-worktrees.md")
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        FAILURES.append(name)
+
+
+def git(repo: str, *args: str) -> str:
+    out = subprocess.run(
+        ["git", "-C", repo, "-c", "user.email=a@b", "-c", "user.name=A", *args],
+        capture_output=True, text=True)
+    if out.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {out.stderr.strip()}")
+    return out.stdout
+
+
+def build(tmp: str, built: str, reset: str, read: str) -> tuple[str, str]:
+    """Return (three_dot_stat, two_dot_stat) for one ordering."""
+    up = os.path.join(tmp, "up")
+    work = os.path.join(tmp, "work")
+    os.makedirs(up)
+    subprocess.run(["git", "init", "-q", "--initial-branch=main", up], check=True)
+    with open(os.path.join(up, "f.md"), "w") as fh:
+        fh.write("base\n")
+    git(up, "add", "-A")
+    git(up, "commit", "-qm", "base")
+    subprocess.run(["git", "clone", "-q", up, work], check=True)
+    base = git(work, "rev-parse", "HEAD").strip()
+
+    # another pull request lands 50 lines upstream
+    with open(os.path.join(up, "other.md"), "w") as fh:
+        fh.write("".join(f"l{i}\n" for i in range(1, 51)))
+    git(up, "add", "-A")
+    git(up, "commit", "-qm", "other PR: 50 lines")
+    git(work, "fetch", "-q", "origin")
+    ahead = git(work, "rev-parse", "origin/main").strip()
+
+    ref = {"base": base, "ahead": ahead}
+    git(work, "checkout", "-q", "-B", "mybranch", ref[built])
+    with open(os.path.join(work, "f.md"), "a") as fh:
+        fh.write("my line\n")
+    git(work, "add", "-A")
+    git(work, "commit", "-qm", "my docs change")
+
+    # the incident: reset --soft to a ref that is not what you think it is
+    git(work, "reset", "-q", "--soft", ref[reset])
+    git(work, "commit", "-qm", "rewritten: docs change")
+
+    # what origin/main holds at the moment the diff is read
+    git(work, "update-ref", "refs/remotes/origin/main", ref[read])
+
+    three = git(work, "diff", "--stat", "origin/main...HEAD").strip().splitlines()
+    two = git(work, "diff", "--stat", "origin/main..HEAD").strip().splitlines()
+    return (three[-1].strip() if three else "no change",
+            two[-1].strip() if two else "no change")
+
+
+def parse(stat: str) -> tuple[int, int, int]:
+    """(files, insertions, deletions) from a --stat summary line."""
+    def n(pat: str) -> int:
+        m = re.search(pat, stat)
+        return int(m.group(1)) if m else 0
+    return (n(r"(\d+) files? changed"), n(r"(\d+) insertions?"), n(r"(\d+) deletions?"))
+
+
+# built, reset, read -> (three_dot, two_dot) as (files, ins, del)
+EXPECTED = {
+    ("base", "base", "base"):   ((1, 1, 0), (1, 1, 0)),
+    ("base", "base", "ahead"):  ((1, 1, 0), (2, 1, 50)),   # the rule's claim
+    ("base", "ahead", "base"):  ((1, 1, 0), (1, 1, 0)),
+    ("base", "ahead", "ahead"): ((2, 1, 50), (2, 1, 50)),
+    ("ahead", "base", "base"):  ((2, 51, 0), (2, 51, 0)),
+    ("ahead", "base", "ahead"): ((2, 51, 0), (1, 1, 0)),
+    ("ahead", "ahead", "base"): ((2, 51, 0), (2, 51, 0)),
+    ("ahead", "ahead", "ahead"): ((1, 1, 0), (1, 1, 0)),
+}
+
+DISCRIMINATING = ("base", "base", "ahead")
+
+
+def main() -> int:
+    if shutil.which("git") is None:
+        # guards-need-a-third-state.md: unmeasurable is not the success state.
+        print("  UNMEASURABLE: git is not on PATH; this suite cannot run here")
+        return 3
+
+    print("executing the recipe against the defect it claims to detect")
+    measured: dict[tuple[str, str, str], tuple[str, str]] = {}
+    for key in EXPECTED:
+        tmp = tempfile.mkdtemp(prefix="stale-ref-recipe-")
+        try:
+            measured[key] = build(tmp, *key)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    for key, (want3, want2) in EXPECTED.items():
+        got3, got2 = measured[key]
+        label = "/".join(key)
+        check(f"three-dot on {label}", parse(got3) == want3, f"want {want3} got {got3!r}")
+        check(f"two-dot on {label}", parse(got2) == want2, f"want {want2} got {got2!r}")
+
+    # The claim the rule actually makes, asserted as a claim rather than as two numbers.
+    three, two = measured[DISCRIMINATING]
+    f3, i3, d3 = parse(three)
+    f2, i2, d2 = parse(two)
+    check("on the discriminating ordering the three-dot form reports no deletions",
+          d3 == 0, f"three-dot said {three!r}")
+    check("on the discriminating ordering the two-dot form reports the lost content",
+          d2 == 50, f"two-dot said {two!r}")
+    check("so the two forms disagree there, which is what makes the recipe worth stating",
+          (f3, i3, d3) != (f2, i2, d2), f"{three!r} vs {two!r}")
+
+    # Six of eight agree: the ordering was chosen, not stumbled into.
+    agreeing = sum(1 for k in EXPECTED if parse(measured[k][0]) == parse(measured[k][1]))
+    check("six of the eight orderings do not discriminate between the two forms",
+          agreeing == 6, f"{agreeing} agreed")
+
+    # The rule still says what this suite measured. Drift in either direction is a
+    # failure: a rule edited to three dots, or a suite left pinning a deleted claim.
+    # Match on the claim, never on layout: an earlier cut of this check spanned a
+    # line wrap ("...HEAD**, two\ndots") and failed on unedited prose -- the same
+    # brittleness this whole suite exists to catch, one level up.
+    text = open(RULE, encoding="utf-8").read()
+    flat = re.sub(r"\s+", " ", text)
+    check("the rule still tells the reader to use two dots",
+          "git diff --stat origin/main..HEAD" in text
+          and re.search(r"origin/main\.\.HEAD`\*\*,? two dots", flat) is not None,
+          "the two-dot remedy is no longer the rule's stated remedy")
+    check("the rule still names the three-dot form as the one that does not catch it",
+          re.search(r"`git diff --stat origin/main\.\.\.HEAD` does NOT catch it", text)
+          is not None,
+          "the rejected form is no longer named")
+
+    if FAILURES:
+        print(f"\nFAILED: {len(FAILURES)} check(s)")
+        return 1
+    print(f"\nall {len(EXPECTED) * 2 + 6} recipe-execution checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #3955

Corpus-NA: repository tooling only -- three Python guard suites and four marker comments in `.claude/rules/`. No AL-observable surface, no `AlRunner/` code, nothing a BC service tier could adjudicate.

Agent-authored (`stma-auto-2`).

## What the issue asked, and what I concluded

A docs-only PR skips the BC matrix, so **nothing has ever executed the commands a rule instructs an agent to run**. PR #3954 shipped `git diff --stat origin/main...HEAD` as the remedy for a stale-`origin/main` soft reset; three dots does not detect that defect and two dots does.

The issue deliberately left the mechanism open and listed three dispositions. **I am not proposing a general "extract and execute every recipe" guard, and the measurement is why.**

I classified all ~44 command lines in `.claude/rules/`. The great majority are `gh` calls against live GitHub state, genuinely unexecutable offline. A general executor would classify almost everything into the third state and prove nothing — ceremony on 44 lines to protect 3. The coordinator's own sweep already killed the static-check option: all 34 lines it checked were valid bash, and **the line that shipped wrong was valid bash too**. It parses, runs, exits 0 and prints a plausible answer; it just answers a different question than the prose claims.

So the scope here is **detection recipes only** — the class where being subtly wrong is invisible, because the command still succeeds. A recipe that merely performs an action (`gh pr edit --add-label`, `git push`) has no truth value to get wrong. The classifier found **4** such recipes in 26 blocks, which is the right order of magnitude for the problem.

## What landed

Three suites, all discovered by `pr-gate.yml`'s glob, so they gate the day they land.

**1. `tools/test_stale_origin_main_diff_recipe.py` — executes the founding recipe against the defect it claims to detect.**

Not "the command parses". It builds throwaway repositories reproducing the stale-ref soft reset and asserts the recipe catches it while the rejected alternative does not. This is `tdd.md`'s mutation discipline applied to prose.

**The ordering matters far more than I expected, and this is the load-bearing finding.** Three independent choices (where the branch was built, what `reset --soft` targeted, what `origin/main` held at read time) give eight orderings. Measured, all eight:

```
built reset read  | three-dot                  | two-dot
base  base  base  | 1 file,  1 ins             | 1 file,  1 ins
base  base  ahead | 1 file,  1 ins             | 2 files, 1 ins, 50 del   <-- THE ONE
base  ahead base  | 1 file,  1 ins             | 1 file,  1 ins
base  ahead ahead | 2 files, 1 ins, 50 del     | 2 files, 1 ins, 50 del
ahead base  base  | 2 files, 51 ins            | 2 files, 51 ins
ahead base  ahead | 2 files, 51 ins            | 1 file,  1 ins
ahead ahead base  | 2 files, 51 ins            | 2 files, 51 ins
ahead ahead ahead | 1 file,  1 ins             | 1 file,  1 ins
```

**Six of the eight show the two forms agreeing.** A test that picked an ordering without checking would have reported the recipe fine whichever dots it used — passing for the wrong reason. So the suite asserts the whole matrix: the discriminating ordering is pinned as discriminating, the others as not.

Row 6 is worth noting and the rule does not mention it: there the **three-dot** form is the misleading one in the opposite direction, inflating a one-line change to 51 insertions. "Three dots is always wrong" would be as unfounded as "three dots is fine".

I reached row 2 only after four wrong constructions. That is itself evidence for the issue's thesis: reproducing the defect a recipe claims to catch is real work, and it is exactly the work nothing currently forces.

**2. `tools/test_rule_recipes_executed.py` — the census.** A detection recipe is `Recipe-pinned-by:` a named test, or `Recipe-unpinned:` with a reason. Neither is the only failing state.

The third state is the design, per `guards-need-a-third-state.md`: the `gh` recipes cannot run here, and a guard that quietly counted them as passing would be the defect one level up. They are declared with a reason rather than silently skipped, so the count is visible and a reviewer can disagree with any individual one. `Recipe-unpinned:` is cheap on purpose — the alternative to a cheap honest declaration is an author who omits the marker entirely. Placeholder reasons (`n/a`, `TBD`) are rejected, mirroring `check_corpus_linkage.sh`.

**3. `tools/test_rule_recipe_census_refuses.py` — proves each refusal path fires**, against synthetic scratch trees driven through the guard's module API. No copy of any rule text is kept, so there is nothing to drift.

## The inline miss — the most important thing I found

My first cut read fenced blocks only. **It did not see the recipe that produced this issue.** `git diff --stat origin/main...HEAD` lives in `no-git-stash-with-worktrees.md` in inline backticks inside a bold sentence, not in a fence.

A guard that misses its own founding instance would have reported a clean census while the defect sat two files away — the same false-green shape the issue is about. The classifier now reads inline command spans carrying a detection claim, and the refusal suite has a dedicated regression case for it.

## RED to GREEN

RED — the census guard on the unmodified tree, before any marker existed:

```
FAIL no detection recipe is unclassified
      .claude/rules/ci-verdicts.md:215
      .claude/rules/ci-verdicts.md:337
      .claude/rules/github-access.md:19
      .claude/rules/no-git-stash-with-worktrees.md:46   <-- the #3954 line
  census: 0 pinned, 0 declared unpinnable, 26 recipe blocks total
FAILED: 1 check(s)   EXIT=1
```

GREEN — after pinning one and declaring three:

```
  census: 1 pinned, 3 declared unpinnable, 26 recipe blocks total
all rule-recipe census checks passed   EXIT=0
```

All three suites green:

```
tools/test_rule_recipes_executed.py        -> exit 0 | all rule-recipe census checks passed
tools/test_rule_recipe_census_refuses.py   -> exit 0 | all refusal-path checks passed
tools/test_stale_origin_main_diff_recipe.py-> exit 0 | all 22 recipe-execution checks passed
```

## Mutations — chosen to test a property, not to produce a red

**Mutation 1: swap the two-dot command for three dots in the pinning suite** — literally the defect PR #3954 shipped.

`Failed: 0, Passed: 22` -> `FAILED: 5 check(s)`, exit 1.

Reds **2 of 8 orderings**, not all of them; the six non-discriminating ones stay green, which is what proves the whole-matrix assertion is real rather than padding. The summary check flipped to `8 agreed` — precisely the signal that would have told #3954's author their recipe was wrong. The RED is assertions (`want (2, 1, 50) got '1 file changed, 1 insertion(+)'`), not a broken build.

**Mutation 2: disable the inline classifier path** (`if False and ...`), i.e. revert the widening.

Reds **exactly 2 of 19** refusal checks — both inline cases — every fenced case green. Three properties this establishes that mutation 1 could not:

- The refusal suite **discriminates between the two classifier paths** rather than riding along on one.
- `a marked inline recipe passes` correctly stays **GREEN**: with the path disabled the recipe is not seen, so it passes for a different reason. That test is pinned to the marker case, not to the classifier being on — the `tdd.md` / PR #3947 shape.
- **The census on the real tree went GREEN** at `0 pinned, 3 unpinnable, 25 blocks`, silently dropping the founding recipe. So the census guard alone cannot catch this regression; only the refusal suite can. That is the argument for suite 3 existing.

Both mutations confirmed landed by re-reading the file, and restored afterwards (`grep -c MUTANT` = 0, all three suites green).

## Fix the shape, not just the reported line

**Does the same wrong pattern appear at another call site?** Yes — that is the inline miss above, found by running my own guard against the tree rather than reasoning about it. Fixed in this PR.

**Does a sibling function make the same assumption?** The census's two marker paths (fenced, inline) were separate code paths with the fenced one written first. Mutation 2 confirmed the refusal suite covers both independently.

**If two code paths write the same state, do they maintain the same invariant?** Yes, deliberately: both paths funnel into one `pinned`/`unpinned`/`unclassified` classification with one set of validity checks, so a marker means the same thing in either position.

## Queue scan

Per `search-for-the-same-defect-first.md` and `batch-sibling-issues-by-file.md`, searched the open queue on the symbol (`recipe`, `rule`), the observable (`docs-only green by construction`), and the mechanism (`nothing executes`). **Nothing folds** — #3955 is the only issue in this area, and no other open issue's fix lands in `tools/test_*.py` for this concern. #3562 and #3491 surfaced on one query and are metadata-derivation work, unrelated.

Confirmed every empty result a second way (`command grep` and `rg --hidden`), since `.claude/rules/` is a dot-directory.

## What I deliberately left out

- **No general recipe executor.** Measured above: it would classify almost everything into the third state. If a future sweep shows detection recipes growing well past four, that judgement is worth revisiting — the census makes the count readable, which is the input such a decision needs.
- **The other 3 detection recipes are declared, not pinned**, each with the reason. The `gh api` ruleset read already has an executable half in `check_required_contexts.py`; the `rev-parse` tree comparison is equality with nothing subtle; the `command -v gh` check's answer *is* the environment under test, so a box with `gh` cannot measure the other branch.
- **The remaining ~40 action recipes are unmarked and stay that way.** The guard only demands a marker where prose claims detection.

## One correction to the rule's own text

`no-git-stash-with-worktrees.md` said the measurement came from "four scratch repositories (both stale-ref orderings x `--soft`/`--hard`)". The discriminating variable is a **three**-way choice giving eight orderings, and `--hard` is not one of them. Replaced with the ordering that actually discriminates, naming the suite that re-derives it.

## Local verification

- 26 of 26 `tools/test_*.py` suites pass (includes registering the new suite in #4001's scratch-repo isolation census, which correctly caught my new file).
- 18 of 18 `.github/scripts/test_*` guards pass.
- `dotnet test AlRunner.Tests --filter FullyQualifiedName~GuardTests --settings engine.runsettings`: **`Failed: 0, Passed: 254, Skipped: 0, Total: 254`**. An earlier run without the engine bootstrap failed `BcEngineReadinessGuardTests` — that is the documented unbootstrapped-engine guard (#3078, #3835), not this change: the diff contains no C# at all.
- No cache sits between these guards and their observables (each reads files and shells out to `git` in a fresh temp directory), so the `local-test-scope.md` warm-run condition does not apply.

## CI note

Actions has been stalled since `04:43:54Z` (#4110), so this PR is handed back without a CI verdict. Every suite above was run locally and both mutations recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY5y5oYXmYevefn9tFF1S1
